### PR TITLE
Tax Declaration — Check Correction Need + Create Correction drift-check workflow

### DIFF
--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CheckDrift.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CheckDrift.java
@@ -1,16 +1,22 @@
 package de.metas.acct.tax;
 
+import de.metas.i18n.AdMessageKey;
 import de.metas.process.IProcessPrecondition;
 import de.metas.process.IProcessPreconditionsContext;
 import de.metas.process.JavaProcess;
 import de.metas.process.ProcessPreconditionsResolution;
 import lombok.NonNull;
 import org.compiere.SpringContextHolder;
+import org.compiere.model.I_C_TaxDeclaration;
 
 public class C_TaxDeclaration_CheckDrift extends JavaProcess implements IProcessPrecondition
 {
+	private static final AdMessageKey MSG_NotLatest = AdMessageKey.of("TaxDeclaration_CheckCorrectionNeed_NotLatest");
+
 	@NonNull private final TaxDeclarationService taxDeclarationService =
 			SpringContextHolder.instance.getBean(TaxDeclarationService.class);
+	@NonNull private final TaxDeclarationRepository taxDeclarationRepository =
+			SpringContextHolder.instance.getBean(TaxDeclarationRepository.class);
 
 	@Override
 	public ProcessPreconditionsResolution checkPreconditionsApplicable(
@@ -20,6 +26,18 @@ public class C_TaxDeclaration_CheckDrift extends JavaProcess implements IProcess
 		{
 			return ProcessPreconditionsResolution.rejectBecauseNotSingleSelection().toInternal();
 		}
+
+		final I_C_TaxDeclaration td = context.getSelectedModel(I_C_TaxDeclaration.class);
+		if (td == null || !td.isProcessed())
+		{
+			return ProcessPreconditionsResolution.rejectWithInternalReason("Declaration is not yet completed");
+		}
+
+		if (!taxDeclarationRepository.isLatestInChain(TaxDeclarationId.ofRepoId(td.getC_TaxDeclaration_ID())))
+		{
+			return ProcessPreconditionsResolution.reject(MSG_NotLatest);
+		}
+
 		return ProcessPreconditionsResolution.accept();
 	}
 

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CheckDrift.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CheckDrift.java
@@ -15,8 +15,6 @@ public class C_TaxDeclaration_CheckDrift extends JavaProcess implements IProcess
 
 	@NonNull private final TaxDeclarationService taxDeclarationService =
 			SpringContextHolder.instance.getBean(TaxDeclarationService.class);
-	@NonNull private final TaxDeclarationRepository taxDeclarationRepository =
-			SpringContextHolder.instance.getBean(TaxDeclarationRepository.class);
 
 	@Override
 	public ProcessPreconditionsResolution checkPreconditionsApplicable(
@@ -33,7 +31,7 @@ public class C_TaxDeclaration_CheckDrift extends JavaProcess implements IProcess
 			return ProcessPreconditionsResolution.rejectWithInternalReason("Declaration is not yet completed");
 		}
 
-		if (!taxDeclarationRepository.isLatestInChain(TaxDeclarationId.ofRepoId(td.getC_TaxDeclaration_ID())))
+		if (!taxDeclarationService.isLatestInChain(TaxDeclarationId.ofRepoId(td.getC_TaxDeclaration_ID())))
 		{
 			return ProcessPreconditionsResolution.reject(MSG_NotLatest);
 		}

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CreateCorrection.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CreateCorrection.java
@@ -1,5 +1,6 @@
 package de.metas.acct.tax;
 
+import de.metas.i18n.AdMessageKey;
 import de.metas.process.IProcessPrecondition;
 import de.metas.process.IProcessPreconditionsContext;
 import de.metas.process.JavaProcess;
@@ -10,7 +11,10 @@ import org.compiere.model.I_C_TaxDeclaration;
 
 public class C_TaxDeclaration_CreateCorrection extends JavaProcess implements IProcessPrecondition
 {
+	private static final AdMessageKey MSG_DraftExists = AdMessageKey.of("TaxDeclaration_CreateCorrection_DraftExists");
+
 	@NonNull private final TaxDeclarationService taxDeclarationService = SpringContextHolder.instance.getBean(TaxDeclarationService.class);
+	@NonNull private final TaxDeclarationRepository taxDeclarationRepository = SpringContextHolder.instance.getBean(TaxDeclarationRepository.class);
 
 	@Override
 	public ProcessPreconditionsResolution checkPreconditionsApplicable(final @NonNull IProcessPreconditionsContext context)
@@ -20,15 +24,16 @@ public class C_TaxDeclaration_CreateCorrection extends JavaProcess implements IP
 			return ProcessPreconditionsResolution.rejectBecauseNotSingleSelection().toInternal();
 		}
 
-		final I_C_TaxDeclaration taxDeclaration = context.getSelectedModel(I_C_TaxDeclaration.class);
-		if (taxDeclaration == null || !taxDeclaration.isProcessed())
+		final I_C_TaxDeclaration td = context.getSelectedModel(I_C_TaxDeclaration.class);
+		if (td == null || !td.isProcessed())
 		{
 			return ProcessPreconditionsResolution.rejectWithInternalReason("Tax declaration is not yet locked");
 		}
 
-		if (taxDeclaration.isCorrection())
+		final TaxDeclarationId originalId = resolveOriginalId(td);
+		if (taxDeclarationRepository.hasUnprocessedCorrectionFor(originalId, TaxDeclarationId.ofRepoId(td.getC_TaxDeclaration_ID())))
 		{
-			return ProcessPreconditionsResolution.rejectWithInternalReason("Cannot create correction of a correction");
+			return ProcessPreconditionsResolution.reject(MSG_DraftExists);
 		}
 
 		return ProcessPreconditionsResolution.accept();
@@ -37,9 +42,16 @@ public class C_TaxDeclaration_CreateCorrection extends JavaProcess implements IP
 	@Override
 	protected String doIt()
 	{
-		final TaxDeclarationId correctionId = taxDeclarationService.createCorrection(TaxDeclarationId.ofRepoId(getRecord_ID()));
+		final TaxDeclarationId correctionId = taxDeclarationService.createCorrectionWithDriftCheck(TaxDeclarationId.ofRepoId(getRecord_ID()));
 		taxDeclarationService.build(correctionId);
 		getResult().setRecordToOpen(I_C_TaxDeclaration.Table_Name, correctionId);
 		return MSG_OK;
+	}
+
+	private static TaxDeclarationId resolveOriginalId(@NonNull final I_C_TaxDeclaration td)
+	{
+		return td.isCorrection()
+				? TaxDeclarationId.ofRepoId(td.getC_TaxDeclaration_Original_ID())
+				: TaxDeclarationId.ofRepoId(td.getC_TaxDeclaration_ID());
 	}
 }

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CreateCorrection.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/C_TaxDeclaration_CreateCorrection.java
@@ -14,7 +14,6 @@ public class C_TaxDeclaration_CreateCorrection extends JavaProcess implements IP
 	private static final AdMessageKey MSG_DraftExists = AdMessageKey.of("TaxDeclaration_CreateCorrection_DraftExists");
 
 	@NonNull private final TaxDeclarationService taxDeclarationService = SpringContextHolder.instance.getBean(TaxDeclarationService.class);
-	@NonNull private final TaxDeclarationRepository taxDeclarationRepository = SpringContextHolder.instance.getBean(TaxDeclarationRepository.class);
 
 	@Override
 	public ProcessPreconditionsResolution checkPreconditionsApplicable(final @NonNull IProcessPreconditionsContext context)
@@ -31,7 +30,7 @@ public class C_TaxDeclaration_CreateCorrection extends JavaProcess implements IP
 		}
 
 		final TaxDeclarationId originalId = resolveOriginalId(td);
-		if (taxDeclarationRepository.hasUnprocessedCorrectionFor(originalId, TaxDeclarationId.ofRepoId(td.getC_TaxDeclaration_ID())))
+		if (taxDeclarationService.hasUnprocessedCorrectionFor(originalId, TaxDeclarationId.ofRepoId(td.getC_TaxDeclaration_ID())))
 		{
 			return ProcessPreconditionsResolution.reject(MSG_DraftExists);
 		}
@@ -42,7 +41,7 @@ public class C_TaxDeclaration_CreateCorrection extends JavaProcess implements IP
 	@Override
 	protected String doIt()
 	{
-		final TaxDeclarationId correctionId = taxDeclarationService.createCorrectionWithDriftCheck(TaxDeclarationId.ofRepoId(getRecord_ID()));
+		final TaxDeclarationId correctionId = taxDeclarationService.createCorrection(TaxDeclarationId.ofRepoId(getRecord_ID()));
 		taxDeclarationService.build(correctionId);
 		getResult().setRecordToOpen(I_C_TaxDeclaration.Table_Name, correctionId);
 		return MSG_OK;

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationRepository.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationRepository.java
@@ -4,12 +4,15 @@ import de.metas.acct.api.AcctSchemaId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_TaxDeclaration;
 import org.compiere.model.I_C_TaxDeclarationAcct;
 import org.compiere.model.I_C_TaxDeclarationLine;
 import org.springframework.stereotype.Repository;
+
+import javax.annotation.Nullable;
 
 @Repository
 public class TaxDeclarationRepository
@@ -101,18 +104,22 @@ public class TaxDeclarationRepository
 
 	/**
 	 * @return true iff at least one ACTIVE, NOT-yet-Processed Correction (IsCorrection='Y',
-	 *         Processed='N') exists for {@code originalId}, excluding the row {@code excludeId}.
+	 *         Processed='N') exists for {@code originalId}, excluding {@code excludeId} when non-null.
 	 */
-	public boolean hasUnprocessedCorrectionFor(@NonNull final TaxDeclarationId originalId, final int excludeId)
+	public boolean hasUnprocessedCorrectionFor(
+			@NonNull final TaxDeclarationId originalId,
+			@Nullable final TaxDeclarationId excludeId)
 	{
-		return queryBL.createQueryBuilder(I_C_TaxDeclaration.class)
+		final IQueryBuilder<I_C_TaxDeclaration> builder = queryBL.createQueryBuilder(I_C_TaxDeclaration.class)
 				.addEqualsFilter(I_C_TaxDeclaration.COLUMNNAME_C_TaxDeclaration_Original_ID, originalId)
 				.addEqualsFilter(I_C_TaxDeclaration.COLUMNNAME_IsCorrection, true)
 				.addEqualsFilter(I_C_TaxDeclaration.COLUMNNAME_Processed, false)
-				.addNotEqualsFilter(I_C_TaxDeclaration.COLUMNNAME_C_TaxDeclaration_ID, excludeId)
-				.addOnlyActiveRecordsFilter()
-				.create()
-				.anyMatch();
+				.addOnlyActiveRecordsFilter();
+		if (excludeId != null)
+		{
+			builder.addNotEqualsFilter(I_C_TaxDeclaration.COLUMNNAME_C_TaxDeclaration_ID, excludeId);
+		}
+		return builder.create().anyMatch();
 	}
 
 	/**
@@ -143,6 +150,6 @@ public class TaxDeclarationRepository
 				? TaxDeclarationId.ofRepoId(record.getC_TaxDeclaration_Original_ID())
 				: id;
 		final I_C_TaxDeclaration latest = getLatestInChain(originalId);
-		return latest.getC_TaxDeclaration_ID() == id.getRepoId();
+		return TaxDeclarationId.ofRepoId(latest.getC_TaxDeclaration_ID()).equals(id);
 	}
 }

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationRepository.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationRepository.java
@@ -100,6 +100,22 @@ public class TaxDeclarationRepository
 	}
 
 	/**
+	 * @return true iff at least one ACTIVE, NOT-yet-Processed Correction (IsCorrection='Y',
+	 *         Processed='N') exists for {@code originalId}, excluding the row {@code excludeId}.
+	 */
+	public boolean hasUnprocessedCorrectionFor(@NonNull final TaxDeclarationId originalId, final int excludeId)
+	{
+		return queryBL.createQueryBuilder(I_C_TaxDeclaration.class)
+				.addEqualsFilter(I_C_TaxDeclaration.COLUMNNAME_C_TaxDeclaration_Original_ID, originalId)
+				.addEqualsFilter(I_C_TaxDeclaration.COLUMNNAME_IsCorrection, true)
+				.addEqualsFilter(I_C_TaxDeclaration.COLUMNNAME_Processed, false)
+				.addNotEqualsFilter(I_C_TaxDeclaration.COLUMNNAME_C_TaxDeclaration_ID, excludeId)
+				.addOnlyActiveRecordsFilter()
+				.create()
+				.anyMatch();
+	}
+
+	/**
 	 * Returns the latest LIVE (Processed='Y') Correction in the chain rooted at {@code originalId},
 	 * ordered by Created DESC; falls back to the Original itself if no completed Correction exists.
 	 */

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationRepository.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationRepository.java
@@ -5,11 +5,13 @@ import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
+import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_TaxDeclaration;
 import org.compiere.model.I_C_TaxDeclarationAcct;
 import org.compiere.model.I_C_TaxDeclarationLine;
+import org.compiere.util.DB;
 import org.springframework.stereotype.Repository;
 
 import javax.annotation.Nullable;
@@ -45,6 +47,28 @@ public class TaxDeclarationRepository
 		record.setProcessed(false);
 		InterfaceWrapperHelper.save(record);
 		return TaxDeclarationId.ofRepoId(record.getC_TaxDeclaration_ID());
+	}
+
+	public void runBuild(@NonNull final TaxDeclarationId id)
+	{
+		DB.executeFunctionCallEx(
+				ITrx.TRXNAME_ThreadInherited,
+				"SELECT de_metas_acct.tax_declaration_build(?)",
+				new Object[] { id });
+	}
+
+	public boolean isDriftDetected(@NonNull final TaxDeclarationId id)
+	{
+		final int result = DB.getSQLValueEx(
+				ITrx.TRXNAME_ThreadInherited,
+				"SELECT CASE WHEN de_metas_acct.tax_declaration_check_drift(?) THEN 1 ELSE 0 END",
+				new Object[] { id.getRepoId() });
+		return result == 1;
+	}
+
+	public void save(@NonNull final I_C_TaxDeclaration record)
+	{
+		InterfaceWrapperHelper.saveRecord(record);
 	}
 
 	public void deleteChildRows(@NonNull final TaxDeclarationId id)

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationRepository.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationRepository.java
@@ -115,4 +115,18 @@ public class TaxDeclarationRepository
 				.first();
 		return latestCorrection != null ? latestCorrection : getById(originalId);
 	}
+
+	/**
+	 * @return true iff {@code id} is the latest LIVE entry in its correction chain
+	 *         (an Original with no Processed Correction, or the most recent Processed Correction).
+	 */
+	public boolean isLatestInChain(@NonNull final TaxDeclarationId id)
+	{
+		final I_C_TaxDeclaration record = getById(id);
+		final TaxDeclarationId originalId = record.isCorrection()
+				? TaxDeclarationId.ofRepoId(record.getC_TaxDeclaration_Original_ID())
+				: id;
+		final I_C_TaxDeclaration latest = getLatestInChain(originalId);
+		return latest.getC_TaxDeclaration_ID() == id.getRepoId();
+	}
 }

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationRepository.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationRepository.java
@@ -124,7 +124,9 @@ public class TaxDeclarationRepository
 
 	/**
 	 * Returns the latest LIVE (Processed='Y') Correction in the chain rooted at {@code originalId},
-	 * ordered by Created DESC; falls back to the Original itself if no completed Correction exists.
+	 * ordered by C_TaxDeclaration_ID DESC (sequence-allocated, so the highest id is the most recently
+	 * created Correction — deterministic, with no Created-timestamp tie); falls back to the Original
+	 * itself if no completed Correction exists.
 	 */
 	public I_C_TaxDeclaration getLatestInChain(@NonNull final TaxDeclarationId originalId)
 	{
@@ -133,7 +135,7 @@ public class TaxDeclarationRepository
 				.addEqualsFilter(I_C_TaxDeclaration.COLUMNNAME_IsCorrection, true)
 				.addEqualsFilter(I_C_TaxDeclaration.COLUMNNAME_Processed, true)
 				.addOnlyActiveRecordsFilter()
-				.orderByDescending(I_C_TaxDeclaration.COLUMNNAME_Created)
+				.orderByDescending(I_C_TaxDeclaration.COLUMNNAME_C_TaxDeclaration_ID)
 				.create()
 				.first();
 		return latestCorrection != null ? latestCorrection : getById(originalId);

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
@@ -19,6 +19,8 @@ public class TaxDeclarationService
 	private static final AdMessageKey MSG_TaxDeclaration_AlreadyProcessed = AdMessageKey.of("TaxDeclaration_AlreadyProcessed");
 	private static final AdMessageKey MSG_TaxDeclaration_CreateCorrection_OriginalNotLocked = AdMessageKey.of("TaxDeclaration_CreateCorrection_OriginalNotLocked");
 	private static final AdMessageKey MSG_TaxDeclaration_OriginalMustBeOriginal = AdMessageKey.of("TaxDeclaration_OriginalMustBeOriginal");
+	private static final AdMessageKey MSG_TaxDeclaration_CreateCorrection_DraftExists = AdMessageKey.of("TaxDeclaration_CreateCorrection_DraftExists");
+	private static final AdMessageKey MSG_TaxDeclaration_CreateCorrection_NoCorrectionNeeded = AdMessageKey.of("TaxDeclaration_CreateCorrection_NoCorrectionNeeded");
 
 	@NonNull private final TaxDeclarationRepository taxDeclarationRepository;
 
@@ -73,5 +75,32 @@ public class TaxDeclarationService
 				.isCorrection(true)
 				.originalId(originalId)
 				.build());
+	}
+
+	/**
+	 * Create a Correction for the chain that {@code anyChainMemberId} belongs to, after verifying a correction is actually needed.
+	 * Resolves to the root Original, rejects when an unprocessed draft Correction already exists, runs the drift check,
+	 * and rejects when no drift is detected. Returns the id of the newly spawned (still draft) Correction.
+	 */
+	public TaxDeclarationId createCorrectionWithDriftCheck(@NonNull final TaxDeclarationId anyChainMemberId)
+	{
+		final I_C_TaxDeclaration record = taxDeclarationRepository.getById(anyChainMemberId);
+		final TaxDeclarationId originalId = record.isCorrection()
+				? TaxDeclarationId.ofRepoId(record.getC_TaxDeclaration_Original_ID())
+				: anyChainMemberId;
+
+		if (taxDeclarationRepository.hasUnprocessedCorrectionFor(originalId, null))
+		{
+			throw new AdempiereException(MSG_TaxDeclaration_CreateCorrection_DraftExists);
+		}
+
+		checkDrift(originalId);
+		final I_C_TaxDeclaration original = taxDeclarationRepository.getById(originalId);
+		if (!original.isCorrectionNeeded())
+		{
+			throw new AdempiereException(MSG_TaxDeclaration_CreateCorrection_NoCorrectionNeeded);
+		}
+
+		return createCorrection(originalId);
 	}
 }

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
@@ -94,9 +94,13 @@ public class TaxDeclarationService
 			throw new AdempiereException(MSG_TaxDeclaration_CreateCorrection_DraftExists);
 		}
 
-		checkDrift(originalId);
-		final I_C_TaxDeclaration original = taxDeclarationRepository.getById(originalId);
-		if (!original.isCorrectionNeeded())
+		// Drift is evaluated against the latest-in-chain snapshot (most recent completed correction, or the
+		// original if none): once a correction is completed it — not the stale original — represents current truth.
+		final TaxDeclarationId latestId = TaxDeclarationId.ofRepoId(
+				taxDeclarationRepository.getLatestInChain(originalId).getC_TaxDeclaration_ID());
+		checkDrift(latestId);
+		final I_C_TaxDeclaration latest = taxDeclarationRepository.getById(latestId);
+		if (!latest.isCorrectionNeeded())
 		{
 			throw new AdempiereException(MSG_TaxDeclaration_CreateCorrection_NoCorrectionNeeded);
 		}

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
@@ -5,11 +5,8 @@ import de.metas.i18n.AdMessageKey;
 import de.metas.organization.OrgId;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_TaxDeclaration;
-import org.compiere.util.DB;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
@@ -32,11 +29,7 @@ public class TaxDeclarationService
 		{
 			throw new AdempiereException(MSG_TaxDeclaration_AlreadyProcessed);
 		}
-
-		DB.executeFunctionCallEx(
-				ITrx.TRXNAME_ThreadInherited,
-				"SELECT de_metas_acct.tax_declaration_build(?)",
-				new Object[] { id });
+		taxDeclarationRepository.runBuild(id);
 	}
 
 	public I_C_TaxDeclaration getById(@NonNull final TaxDeclarationId id)
@@ -61,12 +54,10 @@ public class TaxDeclarationService
 
 	public void checkDrift(@NonNull final I_C_TaxDeclaration record)
 	{
-		final int result = DB.getSQLValueEx(
-				ITrx.TRXNAME_ThreadInherited,
-				"SELECT CASE WHEN de_metas_acct.tax_declaration_check_drift(?) THEN 1 ELSE 0 END",
-				new Object[] { record.getC_TaxDeclaration_ID() });
-		record.setIsCorrectionNeeded(result == 1);
-		InterfaceWrapperHelper.saveRecord(record);
+		final boolean isDriftDetected = taxDeclarationRepository.isDriftDetected(
+				TaxDeclarationId.ofRepoId(record.getC_TaxDeclaration_ID()));
+		record.setIsCorrectionNeeded(isDriftDetected);
+		taxDeclarationRepository.save(record);
 	}
 
 	/**

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/tax/TaxDeclarationService.java
@@ -12,13 +12,14 @@ import org.compiere.model.I_C_TaxDeclaration;
 import org.compiere.util.DB;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.Nullable;
+
 @Service
 @RequiredArgsConstructor
 public class TaxDeclarationService
 {
 	private static final AdMessageKey MSG_TaxDeclaration_AlreadyProcessed = AdMessageKey.of("TaxDeclaration_AlreadyProcessed");
 	private static final AdMessageKey MSG_TaxDeclaration_CreateCorrection_OriginalNotLocked = AdMessageKey.of("TaxDeclaration_CreateCorrection_OriginalNotLocked");
-	private static final AdMessageKey MSG_TaxDeclaration_OriginalMustBeOriginal = AdMessageKey.of("TaxDeclaration_OriginalMustBeOriginal");
 	private static final AdMessageKey MSG_TaxDeclaration_CreateCorrection_DraftExists = AdMessageKey.of("TaxDeclaration_CreateCorrection_DraftExists");
 	private static final AdMessageKey MSG_TaxDeclaration_CreateCorrection_NoCorrectionNeeded = AdMessageKey.of("TaxDeclaration_CreateCorrection_NoCorrectionNeeded");
 
@@ -38,53 +39,50 @@ public class TaxDeclarationService
 				new Object[] { id });
 	}
 
+	public I_C_TaxDeclaration getById(@NonNull final TaxDeclarationId id)
+	{
+		return taxDeclarationRepository.getById(id);
+	}
+
+	public boolean isLatestInChain(@NonNull final TaxDeclarationId id)
+	{
+		return taxDeclarationRepository.isLatestInChain(id);
+	}
+
+	public boolean hasUnprocessedCorrectionFor(@NonNull final TaxDeclarationId originalId, @Nullable final TaxDeclarationId excludeId)
+	{
+		return taxDeclarationRepository.hasUnprocessedCorrectionFor(originalId, excludeId);
+	}
+
 	public void checkDrift(@NonNull final TaxDeclarationId id)
 	{
-		final I_C_TaxDeclaration record = taxDeclarationRepository.getById(id);
+		checkDrift(getById(id));
+	}
 
+	public void checkDrift(@NonNull final I_C_TaxDeclaration record)
+	{
 		final int result = DB.getSQLValueEx(
 				ITrx.TRXNAME_ThreadInherited,
 				"SELECT CASE WHEN de_metas_acct.tax_declaration_check_drift(?) THEN 1 ELSE 0 END",
-				new Object[] { id.getRepoId() });
-		final boolean isDriftDetected = result == 1;
-
-		record.setIsCorrectionNeeded(isDriftDetected);
+				new Object[] { record.getC_TaxDeclaration_ID() });
+		record.setIsCorrectionNeeded(result == 1);
 		InterfaceWrapperHelper.saveRecord(record);
 	}
 
 	/**
-	 * Spawns a Correction for {@code originalId}, inheriting its acctSchema/period/dateAcct.
+	 * Create a Correction for the chain that {@code anyChainMemberId} belongs to.
+	 * Resolves to the root Original, rejects when an unprocessed draft Correction already exists, runs the drift
+	 * check against the latest-in-chain snapshot, and rejects when no correction is needed. Returns the id of the
+	 * newly spawned (still draft) Correction.
 	 */
-	public TaxDeclarationId createCorrection(@NonNull final TaxDeclarationId originalId)
+	public TaxDeclarationId createCorrection(@NonNull final TaxDeclarationId anyChainMemberId)
 	{
-		final I_C_TaxDeclaration original = taxDeclarationRepository.getById(originalId);
-		if (!original.isProcessed())
+		final I_C_TaxDeclaration record = getById(anyChainMemberId);
+		if (!record.isProcessed())
 		{
 			throw new AdempiereException(MSG_TaxDeclaration_CreateCorrection_OriginalNotLocked);
 		}
-		if (original.isCorrection())
-		{
-			throw new AdempiereException(MSG_TaxDeclaration_OriginalMustBeOriginal);
-		}
 
-		return taxDeclarationRepository.createTaxDeclaration(TaxDeclarationCreateRequest.builder()
-				.adOrgId(OrgId.ofRepoId(original.getAD_Org_ID()))
-				.acctSchemaId(AcctSchemaId.ofRepoId(original.getC_AcctSchema_ID()))
-				.periodRepoId(original.getC_Period_ID())
-				.dateAcct(original.getDateAcct())
-				.isCorrection(true)
-				.originalId(originalId)
-				.build());
-	}
-
-	/**
-	 * Create a Correction for the chain that {@code anyChainMemberId} belongs to, after verifying a correction is actually needed.
-	 * Resolves to the root Original, rejects when an unprocessed draft Correction already exists, runs the drift check,
-	 * and rejects when no drift is detected. Returns the id of the newly spawned (still draft) Correction.
-	 */
-	public TaxDeclarationId createCorrectionWithDriftCheck(@NonNull final TaxDeclarationId anyChainMemberId)
-	{
-		final I_C_TaxDeclaration record = taxDeclarationRepository.getById(anyChainMemberId);
 		final TaxDeclarationId originalId = record.isCorrection()
 				? TaxDeclarationId.ofRepoId(record.getC_TaxDeclaration_Original_ID())
 				: anyChainMemberId;
@@ -96,15 +94,21 @@ public class TaxDeclarationService
 
 		// Drift is evaluated against the latest-in-chain snapshot (most recent completed correction, or the
 		// original if none): once a correction is completed it — not the stale original — represents current truth.
-		final TaxDeclarationId latestId = TaxDeclarationId.ofRepoId(
-				taxDeclarationRepository.getLatestInChain(originalId).getC_TaxDeclaration_ID());
-		checkDrift(latestId);
-		final I_C_TaxDeclaration latest = taxDeclarationRepository.getById(latestId);
+		final I_C_TaxDeclaration latest = taxDeclarationRepository.getLatestInChain(originalId);
+		checkDrift(latest);
 		if (!latest.isCorrectionNeeded())
 		{
 			throw new AdempiereException(MSG_TaxDeclaration_CreateCorrection_NoCorrectionNeeded);
 		}
 
-		return createCorrection(originalId);
+		final I_C_TaxDeclaration original = getById(originalId);
+		return taxDeclarationRepository.createTaxDeclaration(TaxDeclarationCreateRequest.builder()
+				.adOrgId(OrgId.ofRepoId(original.getAD_Org_ID()))
+				.acctSchemaId(AcctSchemaId.ofRepoId(original.getC_AcctSchema_ID()))
+				.periodRepoId(original.getC_Period_ID())
+				.dateAcct(original.getDateAcct())
+				.isCorrection(true)
+				.originalId(originalId)
+				.build());
 	}
 }

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805520_sys_me03_29632_C_TaxDeclaration_CheckDrift_rename_AD_Process.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805520_sys_me03_29632_C_TaxDeclaration_CheckDrift_rename_AD_Process.sql
@@ -1,0 +1,25 @@
+-- 2026-05-30
+-- Tax Declaration — rename AD_Process 585627 "Check Drift" → "Check Correction Need".
+-- me03 epic 28717 (issue 29632). See https://github.com/metasfresh/me03/issues/29632
+
+-- Base (DE) name + description
+UPDATE AD_Process
+SET Name = 'Berichtigungsbedarf prüfen',
+    Description = 'Prüft, ob für diese Voranmeldung eine Berichtigung erforderlich ist.',
+    Updated = TIMESTAMP '2026-05-30 00:00:00', UpdatedBy = 100
+WHERE AD_Process_ID = 585627;
+
+-- Non-translated Trl rows mirror the base (DE) text
+UPDATE AD_Process_Trl
+SET Name = 'Berichtigungsbedarf prüfen',
+    Description = 'Prüft, ob für diese Voranmeldung eine Berichtigung erforderlich ist.',
+    Updated = TIMESTAMP '2026-05-30 00:00:00', UpdatedBy = 100
+WHERE AD_Process_ID = 585627 AND IsTranslated = 'N';
+
+-- en_US translation
+UPDATE AD_Process_Trl
+SET Name = 'Check Correction Need',
+    Description = 'Check whether this declaration requires a correction.',
+    IsTranslated = 'Y',
+    Updated = TIMESTAMP '2026-05-30 00:00:01', UpdatedBy = 100
+WHERE AD_Language = 'en_US' AND AD_Process_ID = 585627;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805530_sys_me03_29632_C_TaxDeclaration_CorrectionWorkflow_AD_Messages.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805530_sys_me03_29632_C_TaxDeclaration_CorrectionWorkflow_AD_Messages.sql
@@ -1,0 +1,92 @@
+-- 2026-05-30
+-- Tax Declaration — correction-workflow AD_Messages. me03 epic 28717 (issue 29632). See https://github.com/metasfresh/me03/issues/29632
+
+-- MSG1: TaxDeclaration_CheckCorrectionNeed_NotLatest
+INSERT INTO AD_Message (
+    AD_Message_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+    Value, MsgText, MsgType, EntityType, ErrorCode
+) VALUES (
+    545736, 0, 0, 'Y',
+    TIMESTAMP '2026-05-30 00:00:00', 100, TIMESTAMP '2026-05-30 00:00:00', 100,
+    'TaxDeclaration_CheckCorrectionNeed_NotLatest',
+    'Es existiert bereits eine neuere Berichtigung — bitte diese prüfen.',
+    'E', 'de.metas.acct', 'TAXDECLARATION_CORRECTION_NOT_LATEST'
+);
+
+-- en_US Trl
+INSERT INTO AD_Message_Trl (AD_Language, AD_Message_ID, MsgText, MsgTip, IsTranslated,
+    AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+VALUES
+    ('en_US', 545736, 'A newer correction exists — check that one instead.',
+     NULL, 'Y', 0, 0, TIMESTAMP '2026-05-30 00:00:00', 100, TIMESTAMP '2026-05-30 00:00:00', 100, 'Y');
+
+-- Other active system languages — base-language fallback
+INSERT INTO AD_Message_Trl (AD_Language, AD_Message_ID, MsgText, MsgTip, IsTranslated,
+    AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, m.AD_Message_ID, m.MsgText, m.MsgTip, 'N',
+    m.AD_Client_ID, m.AD_Org_ID, m.Created, m.CreatedBy, m.Updated, m.UpdatedBy, 'Y'
+FROM AD_Language l
+CROSS JOIN AD_Message m
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND m.AD_Message_ID = 545736
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Message_ID = m.AD_Message_ID);
+
+-- MSG2: TaxDeclaration_CreateCorrection_DraftExists
+INSERT INTO AD_Message (
+    AD_Message_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+    Value, MsgText, MsgType, EntityType, ErrorCode
+) VALUES (
+    545737, 0, 0, 'Y',
+    TIMESTAMP '2026-05-30 00:00:00', 100, TIMESTAMP '2026-05-30 00:00:00', 100,
+    'TaxDeclaration_CreateCorrection_DraftExists',
+    'Bitte zuerst die vorhandene Berichtigung im Entwurf abschließen oder löschen.',
+    'E', 'de.metas.acct', 'TAXDECLARATION_CORRECTION_DRAFT_EXISTS'
+);
+
+-- en_US Trl
+INSERT INTO AD_Message_Trl (AD_Language, AD_Message_ID, MsgText, MsgTip, IsTranslated,
+    AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+VALUES
+    ('en_US', 545737, 'Complete or delete the existing draft correction first.',
+     NULL, 'Y', 0, 0, TIMESTAMP '2026-05-30 00:00:00', 100, TIMESTAMP '2026-05-30 00:00:00', 100, 'Y');
+
+-- Other active system languages — base-language fallback
+INSERT INTO AD_Message_Trl (AD_Language, AD_Message_ID, MsgText, MsgTip, IsTranslated,
+    AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, m.AD_Message_ID, m.MsgText, m.MsgTip, 'N',
+    m.AD_Client_ID, m.AD_Org_ID, m.Created, m.CreatedBy, m.Updated, m.UpdatedBy, 'Y'
+FROM AD_Language l
+CROSS JOIN AD_Message m
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND m.AD_Message_ID = 545737
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Message_ID = m.AD_Message_ID);
+
+-- MSG3: TaxDeclaration_CreateCorrection_NoCorrectionNeeded
+INSERT INTO AD_Message (
+    AD_Message_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+    Value, MsgText, MsgType, EntityType, ErrorCode
+) VALUES (
+    545738, 0, 0, 'Y',
+    TIMESTAMP '2026-05-30 00:00:00', 100, TIMESTAMP '2026-05-30 00:00:00', 100,
+    'TaxDeclaration_CreateCorrection_NoCorrectionNeeded',
+    'Keine Berichtigung erforderlich — die Voranmeldung ist weiterhin korrekt.',
+    'E', 'de.metas.acct', 'TAXDECLARATION_NO_CORRECTION_NEEDED'
+);
+
+-- en_US Trl
+INSERT INTO AD_Message_Trl (AD_Language, AD_Message_ID, MsgText, MsgTip, IsTranslated,
+    AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+VALUES
+    ('en_US', 545738, 'No correction needed — the declaration is still accurate.',
+     NULL, 'Y', 0, 0, TIMESTAMP '2026-05-30 00:00:00', 100, TIMESTAMP '2026-05-30 00:00:00', 100, 'Y');
+
+-- Other active system languages — base-language fallback
+INSERT INTO AD_Message_Trl (AD_Language, AD_Message_ID, MsgText, MsgTip, IsTranslated,
+    AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, m.AD_Message_ID, m.MsgText, m.MsgTip, 'N',
+    m.AD_Client_ID, m.AD_Org_ID, m.Created, m.CreatedBy, m.Updated, m.UpdatedBy, 'Y'
+FROM AD_Language l
+CROSS JOIN AD_Message m
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND m.AD_Message_ID = 545738
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Message_ID = m.AD_Message_ID);

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805530_sys_me03_29632_C_TaxDeclaration_CorrectionWorkflow_AD_Messages.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805530_sys_me03_29632_C_TaxDeclaration_CorrectionWorkflow_AD_Messages.sql
@@ -6,8 +6,8 @@ INSERT INTO AD_Message (
     AD_Message_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
     Value, MsgText, MsgType, EntityType, ErrorCode
 ) VALUES (
-    545736, 0, 0, 'Y',
-    TIMESTAMP '2026-05-30 00:00:00', 100, TIMESTAMP '2026-05-30 00:00:00', 100,
+    545736 /*From ID Server*/, 0, 0, 'Y',
+    TIMESTAMP '2026-05-30 00:00:01', 100, TIMESTAMP '2026-05-30 00:00:01', 100,
     'TaxDeclaration_CheckCorrectionNeed_NotLatest',
     'Es existiert bereits eine neuere Berichtigung — bitte diese prüfen.',
     'E', 'de.metas.acct', 'TAXDECLARATION_CORRECTION_NOT_LATEST'
@@ -18,7 +18,7 @@ INSERT INTO AD_Message_Trl (AD_Language, AD_Message_ID, MsgText, MsgTip, IsTrans
     AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
 VALUES
     ('en_US', 545736, 'A newer correction exists — check that one instead.',
-     NULL, 'Y', 0, 0, TIMESTAMP '2026-05-30 00:00:00', 100, TIMESTAMP '2026-05-30 00:00:00', 100, 'Y');
+     NULL, 'Y', 0, 0, TIMESTAMP '2026-05-30 00:00:02', 100, TIMESTAMP '2026-05-30 00:00:02', 100, 'Y');
 
 -- Other active system languages — base-language fallback
 INSERT INTO AD_Message_Trl (AD_Language, AD_Message_ID, MsgText, MsgTip, IsTranslated,
@@ -36,8 +36,8 @@ INSERT INTO AD_Message (
     AD_Message_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
     Value, MsgText, MsgType, EntityType, ErrorCode
 ) VALUES (
-    545737, 0, 0, 'Y',
-    TIMESTAMP '2026-05-30 00:00:00', 100, TIMESTAMP '2026-05-30 00:00:00', 100,
+    545737 /*From ID Server*/, 0, 0, 'Y',
+    TIMESTAMP '2026-05-30 00:00:03', 100, TIMESTAMP '2026-05-30 00:00:03', 100,
     'TaxDeclaration_CreateCorrection_DraftExists',
     'Bitte zuerst die vorhandene Berichtigung im Entwurf abschließen oder löschen.',
     'E', 'de.metas.acct', 'TAXDECLARATION_CORRECTION_DRAFT_EXISTS'
@@ -48,7 +48,7 @@ INSERT INTO AD_Message_Trl (AD_Language, AD_Message_ID, MsgText, MsgTip, IsTrans
     AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
 VALUES
     ('en_US', 545737, 'Complete or delete the existing draft correction first.',
-     NULL, 'Y', 0, 0, TIMESTAMP '2026-05-30 00:00:00', 100, TIMESTAMP '2026-05-30 00:00:00', 100, 'Y');
+     NULL, 'Y', 0, 0, TIMESTAMP '2026-05-30 00:00:04', 100, TIMESTAMP '2026-05-30 00:00:04', 100, 'Y');
 
 -- Other active system languages — base-language fallback
 INSERT INTO AD_Message_Trl (AD_Language, AD_Message_ID, MsgText, MsgTip, IsTranslated,
@@ -66,8 +66,8 @@ INSERT INTO AD_Message (
     AD_Message_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
     Value, MsgText, MsgType, EntityType, ErrorCode
 ) VALUES (
-    545738, 0, 0, 'Y',
-    TIMESTAMP '2026-05-30 00:00:00', 100, TIMESTAMP '2026-05-30 00:00:00', 100,
+    545738 /*From ID Server*/, 0, 0, 'Y',
+    TIMESTAMP '2026-05-30 00:00:05', 100, TIMESTAMP '2026-05-30 00:00:05', 100,
     'TaxDeclaration_CreateCorrection_NoCorrectionNeeded',
     'Keine Berichtigung erforderlich — die Voranmeldung ist weiterhin korrekt.',
     'E', 'de.metas.acct', 'TAXDECLARATION_NO_CORRECTION_NEEDED'
@@ -78,7 +78,7 @@ INSERT INTO AD_Message_Trl (AD_Language, AD_Message_ID, MsgText, MsgTip, IsTrans
     AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
 VALUES
     ('en_US', 545738, 'No correction needed — the declaration is still accurate.',
-     NULL, 'Y', 0, 0, TIMESTAMP '2026-05-30 00:00:00', 100, TIMESTAMP '2026-05-30 00:00:00', 100, 'Y');
+     NULL, 'Y', 0, 0, TIMESTAMP '2026-05-30 00:00:06', 100, TIMESTAMP '2026-05-30 00:00:06', 100, 'Y');
 
 -- Other active system languages — base-language fallback
 INSERT INTO AD_Message_Trl (AD_Language, AD_Message_ID, MsgText, MsgTip, IsTranslated,

--- a/backend/de.metas.acct.base/src/test/java/de/metas/acct/tax/TaxDeclarationRepositoryTest.java
+++ b/backend/de.metas.acct.base/src/test/java/de/metas/acct/tax/TaxDeclarationRepositoryTest.java
@@ -106,20 +106,14 @@ class TaxDeclarationRepositoryTest
 	@Test
 	public void getLatestInChain_returnsLatestCompletedCorrection()
 	{
-		// Given: an Original + 2 completed Corrections (Created at different times — the later one wins)
+		// Given: an Original + 2 completed Corrections
 		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
 		final TaxDeclarationId originalId = TaxDeclarationId.ofRepoId(original.getC_TaxDeclaration_ID());
 
 		final I_C_TaxDeclaration correction1 = createTaxDeclaration(true, originalId.getRepoId(), true, true);
-		// Force correction1.Created to be earlier than correction2 via InterfaceWrapperHelper.setValue
-		InterfaceWrapperHelper.setValue(correction1, I_C_TaxDeclaration.COLUMNNAME_Created, Timestamp.valueOf("2025-01-01 10:00:00"));
-		InterfaceWrapperHelper.save(correction1);
-
 		final I_C_TaxDeclaration correction2 = createTaxDeclaration(true, originalId.getRepoId(), true, true);
-		InterfaceWrapperHelper.setValue(correction2, I_C_TaxDeclaration.COLUMNNAME_Created, Timestamp.valueOf("2025-01-02 10:00:00"));
-		InterfaceWrapperHelper.save(correction2);
 
-		// When / Then: should return the LATER Correction
+		// When / Then: should return correction2, which has the higher C_TaxDeclaration_ID
 		final I_C_TaxDeclaration result = repository.getLatestInChain(originalId);
 		Assertions.assertThat(result.getC_TaxDeclaration_ID()).isEqualTo(correction2.getC_TaxDeclaration_ID());
 	}
@@ -171,14 +165,8 @@ class TaxDeclarationRepositoryTest
 		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
 
 		final I_C_TaxDeclaration corr1 = createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), true, true);
-		// Force distinct Created timestamps so corr2 is unambiguously the "newer" correction
-		// (mirrors getLatestInChain_returnsLatestCompletedCorrection).
-		InterfaceWrapperHelper.setValue(corr1, I_C_TaxDeclaration.COLUMNNAME_Created, Timestamp.valueOf("2025-01-01 10:00:00"));
-		InterfaceWrapperHelper.save(corr1);
-
-		final I_C_TaxDeclaration corr2 = createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), true, true); // newer processed correction
-		InterfaceWrapperHelper.setValue(corr2, I_C_TaxDeclaration.COLUMNNAME_Created, Timestamp.valueOf("2025-01-02 10:00:00"));
-		InterfaceWrapperHelper.save(corr2);
+		final I_C_TaxDeclaration corr2 = createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), true, true);
+		// corr2 is saved after corr1, so it has the higher C_TaxDeclaration_ID and is the latest in chain
 
 		Assertions.assertThat(repository.isLatestInChain(idOf(corr1))).isFalse();
 	}

--- a/backend/de.metas.acct.base/src/test/java/de/metas/acct/tax/TaxDeclarationRepositoryTest.java
+++ b/backend/de.metas.acct.base/src/test/java/de/metas/acct/tax/TaxDeclarationRepositoryTest.java
@@ -169,4 +169,39 @@ class TaxDeclarationRepositoryTest
 	{
 		return TaxDeclarationId.ofRepoId(record.getC_TaxDeclaration_ID());
 	}
+
+	// ---------------------------------------------------------------------------
+	// hasUnprocessedCorrectionFor tests
+	// ---------------------------------------------------------------------------
+
+	@Test
+	void hasUnprocessedCorrectionFor_noCorrection_false()
+	{
+		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
+		Assertions.assertThat(repository.hasUnprocessedCorrectionFor(idOf(original), -1)).isFalse();
+	}
+
+	@Test
+	void hasUnprocessedCorrectionFor_draftCorrectionExists_true()
+	{
+		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
+		createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), false, true); // draft (not processed) correction
+		Assertions.assertThat(repository.hasUnprocessedCorrectionFor(idOf(original), -1)).isTrue();
+	}
+
+	@Test
+	void hasUnprocessedCorrectionFor_onlyProcessedCorrection_false()
+	{
+		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
+		createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), true, true); // processed correction
+		Assertions.assertThat(repository.hasUnprocessedCorrectionFor(idOf(original), -1)).isFalse();
+	}
+
+	@Test
+	void hasUnprocessedCorrectionFor_excludesSelf()
+	{
+		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
+		final I_C_TaxDeclaration draft = createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), false, true);
+		Assertions.assertThat(repository.hasUnprocessedCorrectionFor(idOf(original), draft.getC_TaxDeclaration_ID())).isFalse();
+	}
 }

--- a/backend/de.metas.acct.base/src/test/java/de/metas/acct/tax/TaxDeclarationRepositoryTest.java
+++ b/backend/de.metas.acct.base/src/test/java/de/metas/acct/tax/TaxDeclarationRepositoryTest.java
@@ -143,14 +143,14 @@ class TaxDeclarationRepositoryTest
 	// ---------------------------------------------------------------------------
 
 	@Test
-	void isLatestInChain_originalWithNoProcessedCorrection_isLatest()
+	public void isLatestInChain_originalWithNoProcessedCorrection_isLatest()
 	{
 		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
 		Assertions.assertThat(repository.isLatestInChain(idOf(original))).isTrue();
 	}
 
 	@Test
-	void isLatestInChain_originalSupersededByProcessedCorrection_isNotLatest()
+	public void isLatestInChain_originalSupersededByProcessedCorrection_isNotLatest()
 	{
 		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
 		createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), true, true);
@@ -158,11 +158,29 @@ class TaxDeclarationRepositoryTest
 	}
 
 	@Test
-	void isLatestInChain_latestProcessedCorrection_isLatest()
+	public void isLatestInChain_latestProcessedCorrection_isLatest()
 	{
 		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
 		final I_C_TaxDeclaration corr = createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), true, true);
 		Assertions.assertThat(repository.isLatestInChain(idOf(corr))).isTrue();
+	}
+
+	@Test
+	public void isLatestInChain_supersededCorrection_isNotLatest()
+	{
+		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
+
+		final I_C_TaxDeclaration corr1 = createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), true, true);
+		// Force distinct Created timestamps so corr2 is unambiguously the "newer" correction
+		// (mirrors getLatestInChain_returnsLatestCompletedCorrection).
+		InterfaceWrapperHelper.setValue(corr1, I_C_TaxDeclaration.COLUMNNAME_Created, Timestamp.valueOf("2025-01-01 10:00:00"));
+		InterfaceWrapperHelper.save(corr1);
+
+		final I_C_TaxDeclaration corr2 = createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), true, true); // newer processed correction
+		InterfaceWrapperHelper.setValue(corr2, I_C_TaxDeclaration.COLUMNNAME_Created, Timestamp.valueOf("2025-01-02 10:00:00"));
+		InterfaceWrapperHelper.save(corr2);
+
+		Assertions.assertThat(repository.isLatestInChain(idOf(corr1))).isFalse();
 	}
 
 	private static TaxDeclarationId idOf(final I_C_TaxDeclaration record)
@@ -175,33 +193,41 @@ class TaxDeclarationRepositoryTest
 	// ---------------------------------------------------------------------------
 
 	@Test
-	void hasUnprocessedCorrectionFor_noCorrection_false()
+	public void hasUnprocessedCorrectionFor_noCorrection_false()
 	{
 		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
-		Assertions.assertThat(repository.hasUnprocessedCorrectionFor(idOf(original), -1)).isFalse();
+		Assertions.assertThat(repository.hasUnprocessedCorrectionFor(idOf(original), null)).isFalse();
 	}
 
 	@Test
-	void hasUnprocessedCorrectionFor_draftCorrectionExists_true()
+	public void hasUnprocessedCorrectionFor_draftCorrectionExists_true()
 	{
 		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
 		createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), false, true); // draft (not processed) correction
-		Assertions.assertThat(repository.hasUnprocessedCorrectionFor(idOf(original), -1)).isTrue();
+		Assertions.assertThat(repository.hasUnprocessedCorrectionFor(idOf(original), null)).isTrue();
 	}
 
 	@Test
-	void hasUnprocessedCorrectionFor_onlyProcessedCorrection_false()
+	public void hasUnprocessedCorrectionFor_onlyProcessedCorrection_false()
 	{
 		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
 		createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), true, true); // processed correction
-		Assertions.assertThat(repository.hasUnprocessedCorrectionFor(idOf(original), -1)).isFalse();
+		Assertions.assertThat(repository.hasUnprocessedCorrectionFor(idOf(original), null)).isFalse();
 	}
 
 	@Test
-	void hasUnprocessedCorrectionFor_excludesSelf()
+	public void hasUnprocessedCorrectionFor_excludesSelf()
 	{
 		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
 		final I_C_TaxDeclaration draft = createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), false, true);
-		Assertions.assertThat(repository.hasUnprocessedCorrectionFor(idOf(original), draft.getC_TaxDeclaration_ID())).isFalse();
+		Assertions.assertThat(repository.hasUnprocessedCorrectionFor(idOf(original), idOf(draft))).isFalse();
+	}
+
+	@Test
+	public void hasUnprocessedCorrectionFor_inactiveDraftCorrection_false()
+	{
+		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
+		createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), false, false); // inactive draft correction
+		Assertions.assertThat(repository.hasUnprocessedCorrectionFor(idOf(original), null)).isFalse();
 	}
 }

--- a/backend/de.metas.acct.base/src/test/java/de/metas/acct/tax/TaxDeclarationRepositoryTest.java
+++ b/backend/de.metas.acct.base/src/test/java/de/metas/acct/tax/TaxDeclarationRepositoryTest.java
@@ -137,4 +137,36 @@ class TaxDeclarationRepositoryTest
 		final I_C_TaxDeclaration result = repository.getLatestInChain(originalId);
 		Assertions.assertThat(result.getC_TaxDeclaration_ID()).isEqualTo(originalId.getRepoId());
 	}
+
+	// ---------------------------------------------------------------------------
+	// isLatestInChain tests
+	// ---------------------------------------------------------------------------
+
+	@Test
+	void isLatestInChain_originalWithNoProcessedCorrection_isLatest()
+	{
+		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
+		Assertions.assertThat(repository.isLatestInChain(idOf(original))).isTrue();
+	}
+
+	@Test
+	void isLatestInChain_originalSupersededByProcessedCorrection_isNotLatest()
+	{
+		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
+		createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), true, true);
+		Assertions.assertThat(repository.isLatestInChain(idOf(original))).isFalse();
+	}
+
+	@Test
+	void isLatestInChain_latestProcessedCorrection_isLatest()
+	{
+		final I_C_TaxDeclaration original = createTaxDeclaration(false, 0, true, true);
+		final I_C_TaxDeclaration corr = createTaxDeclaration(true, original.getC_TaxDeclaration_ID(), true, true);
+		Assertions.assertThat(repository.isLatestInChain(idOf(corr))).isTrue();
+	}
+
+	private static TaxDeclarationId idOf(final I_C_TaxDeclaration record)
+	{
+		return TaxDeclarationId.ofRepoId(record.getC_TaxDeclaration_ID());
+	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tax_declaration/C_TaxDeclaration_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tax_declaration/C_TaxDeclaration_StepDef.java
@@ -281,6 +281,27 @@ public class C_TaxDeclaration_StepDef
 		}
 	}
 
+	/**
+	 * Invoke {@link TaxDeclarationService#createCorrectionWithDriftCheck(TaxDeclarationId)} on the chain member and register the result under {@code <identifier>_correction}.
+	 * Any failure is stashed for {@link #assertOperationFailedWithMessage(String)}.
+	 */
+	@When("invoke Create Correction with drift check on C_TaxDeclaration {string}")
+	public void invokeCreateCorrectionWithDriftCheck(@NonNull final String identifier)
+	{
+		lastException = null;
+		final I_C_TaxDeclaration chainMember = taxDeclarationTable.get(StepDefDataIdentifier.ofString(identifier));
+		try
+		{
+			final TaxDeclarationId correctionId = taxDeclarationService.createCorrectionWithDriftCheck(TaxDeclarationId.ofRepoId(chainMember.getC_TaxDeclaration_ID()));
+			final I_C_TaxDeclaration correction = InterfaceWrapperHelper.load(correctionId.getRepoId(), I_C_TaxDeclaration.class);
+			taxDeclarationTable.putOrReplace(StepDefDataIdentifier.ofString(identifier + "_correction"), correction);
+		}
+		catch (final AdempiereException e)
+		{
+			lastException = e;
+		}
+	}
+
 	/** Assert the declaration's {@code IsCorrectionNeeded} flag ({@code Y}/{@code N}); reloads from DB to avoid stale-cache false-positives. */
 	@Then("C_TaxDeclaration {string} has IsCorrectionNeeded = {string}")
 	public void assertIsCorrectionNeeded(@NonNull final String identifier, @NonNull final String expectedFlag)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tax_declaration/C_TaxDeclaration_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tax_declaration/C_TaxDeclaration_StepDef.java
@@ -261,39 +261,26 @@ public class C_TaxDeclaration_StepDef
 	}
 
 	/**
-	 * Invoke {@link TaxDeclarationService#createCorrection(TaxDeclarationId)} on the original and register the result under {@code <originalIdentifier>_correction}.
+	 * Invoke {@link TaxDeclarationService#createCorrection(TaxDeclarationId)} on the chain member registered under {@code identifier}
+	 * and register the resulting Correction under {@code <identifier>_correction}.
 	 * Any failure is stashed for {@link #assertOperationFailedWithMessage(String)}.
+	 *
+	 * <p>Required columns: {@code identifier} (string — the declaration's step-def identifier)
+	 *
+	 * <p>Example:
+	 * <pre>{@code
+	 * When invoke Create Correction on C_TaxDeclaration "td1"
+	 * }</pre>
 	 */
 	@When("invoke Create Correction on C_TaxDeclaration {string}")
-	public void invokeCreateCorrection(@NonNull final String originalIdentifier)
-	{
-		lastException = null;
-		final I_C_TaxDeclaration original = taxDeclarationTable.get(StepDefDataIdentifier.ofString(originalIdentifier));
-		try
-		{
-			final TaxDeclarationId correctionId = taxDeclarationService.createCorrection(TaxDeclarationId.ofRepoId(original.getC_TaxDeclaration_ID()));
-			final I_C_TaxDeclaration correction = InterfaceWrapperHelper.load(correctionId.getRepoId(), I_C_TaxDeclaration.class);
-			taxDeclarationTable.putOrReplace(StepDefDataIdentifier.ofString(originalIdentifier + "_correction"), correction);
-		}
-		catch (final AdempiereException e)
-		{
-			lastException = e;
-		}
-	}
-
-	/**
-	 * Invoke {@link TaxDeclarationService#createCorrectionWithDriftCheck(TaxDeclarationId)} on the chain member and register the result under {@code <identifier>_correction}.
-	 * Any failure is stashed for {@link #assertOperationFailedWithMessage(String)}.
-	 */
-	@When("invoke Create Correction with drift check on C_TaxDeclaration {string}")
-	public void invokeCreateCorrectionWithDriftCheck(@NonNull final String identifier)
+	public void invokeCreateCorrection(@NonNull final String identifier)
 	{
 		lastException = null;
 		final I_C_TaxDeclaration chainMember = taxDeclarationTable.get(StepDefDataIdentifier.ofString(identifier));
 		try
 		{
-			final TaxDeclarationId correctionId = taxDeclarationService.createCorrectionWithDriftCheck(TaxDeclarationId.ofRepoId(chainMember.getC_TaxDeclaration_ID()));
-			final I_C_TaxDeclaration correction = InterfaceWrapperHelper.load(correctionId.getRepoId(), I_C_TaxDeclaration.class);
+			final TaxDeclarationId correctionId = taxDeclarationService.createCorrection(TaxDeclarationId.ofRepoId(chainMember.getC_TaxDeclaration_ID()));
+			final I_C_TaxDeclaration correction = taxDeclarationService.getById(correctionId);
 			taxDeclarationTable.putOrReplace(StepDefDataIdentifier.ofString(identifier + "_correction"), correction);
 		}
 		catch (final AdempiereException e)

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/tax_declaration/tax_declaration.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/tax_declaration/tax_declaration.feature
@@ -643,3 +643,221 @@ Feature: Tax Declaration Build ("Steuererklärung aufbauen")
 
     When the drift check process is run on tax declaration "tdD71"
     Then C_TaxDeclaration "tdD71" has IsCorrectionNeeded = "Y"
+
+
+# ############################################################################################################################################
+# TC-D13 — Create Correction with drift check creates a Correction when drift is present
+# ############################################################################################################################################
+  @Id:S0467_TD_130
+  @from:cucumber
+  Scenario: Create Correction with drift check creates a Correction when drift is present
+
+    And metasfresh contains C_TaxCategory
+      | Identifier     |
+      | taxCategoryCw1 |
+    And metasfresh contains C_Tax
+      | Identifier | C_TaxCategory_ID | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
+      | taxCw1     | taxCategoryCw1   | 19   | DE                       | DE                        |
+    And metasfresh contains C_VAT_Codes:
+      | Identifier | C_Tax_ID | IsSOTrx | AmountType |
+      | vatCw1     | taxCw1   | Y       | T          |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | productCw1 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | salesPLV               | productCw1   | 100.00   | PCE      | taxCategoryCw1   |
+
+    And metasfresh contains C_Invoice:
+      | Identifier  | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceCw1a | customer      | 2024-01-15   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier    | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceCw1aL1 | invoiceCw1a  | productCw1   | 1 PCE       | taxCw1   |
+    And the invoice identified by invoiceCw1a is completed
+    And Wait until documents invoiceCw1a is posted
+
+    And metasfresh contains C_TaxDeclaration:
+      | Identifier | C_AcctSchema_ID | Date       |
+      | tdCw1      | acctSchema      | 2024-01-15 |
+    And the tax declaration "tdCw1" is built
+    And the tax declaration "tdCw1" is completed
+
+    # Post a second invoice in the same period → drift vs the completed declaration's snapshot
+    And metasfresh contains C_Invoice:
+      | Identifier  | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceCw1b | customer      | 2024-01-20   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier    | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceCw1bL1 | invoiceCw1b  | productCw1   | 2 PCE       | taxCw1   |
+    And the invoice identified by invoiceCw1b is completed
+    And Wait until documents invoiceCw1b is posted
+
+    When invoke Create Correction with drift check on C_TaxDeclaration "tdCw1"
+    Then the tax declaration "tdCw1_correction" is a Correction inheriting Period, DateAcct and AcctSchema from "tdCw1"
+
+
+# ############################################################################################################################################
+# TC-D14 — Create Correction with drift check is rejected when no correction is needed
+# ############################################################################################################################################
+  @Id:S0467_TD_140
+  @from:cucumber
+  Scenario: Create Correction with drift check is rejected when no correction is needed
+
+    And metasfresh contains C_TaxCategory
+      | Identifier     |
+      | taxCategoryCw2 |
+    And metasfresh contains C_Tax
+      | Identifier | C_TaxCategory_ID | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
+      | taxCw2     | taxCategoryCw2   | 19   | DE                       | DE                        |
+    And metasfresh contains C_VAT_Codes:
+      | Identifier | C_Tax_ID | IsSOTrx | AmountType |
+      | vatCw2     | taxCw2   | Y       | T          |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | productCw2 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | salesPLV               | productCw2   | 100.00   | PCE      | taxCategoryCw2   |
+
+    And metasfresh contains C_Invoice:
+      | Identifier  | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceCw2a | customer      | 2024-01-15   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier    | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceCw2aL1 | invoiceCw2a  | productCw2   | 1 PCE       | taxCw2   |
+    And the invoice identified by invoiceCw2a is completed
+    And Wait until documents invoiceCw2a is posted
+
+    And metasfresh contains C_TaxDeclaration:
+      | Identifier | C_AcctSchema_ID | Date       |
+      | tdCw2      | acctSchema      | 2024-01-15 |
+    And the tax declaration "tdCw2" is built
+    And the tax declaration "tdCw2" is completed
+
+    # No second invoice → no drift → Create Correction with drift check must reject
+    When invoke Create Correction with drift check on C_TaxDeclaration "tdCw2"
+    Then the tax declaration operation fails with message 'TAXDECLARATION_NO_CORRECTION_NEEDED'
+
+
+# ############################################################################################################################################
+# TC-D15 — Create Correction with drift check from a completed Correction spawns a new Correction off the original
+# Proves drift is evaluated against the latest completed correction, not the stale original.
+# ############################################################################################################################################
+  @Id:S0467_TD_150
+  @from:cucumber
+  Scenario: Create Correction with drift check from a completed Correction spawns a new Correction off the original
+
+    And metasfresh contains C_TaxCategory
+      | Identifier     |
+      | taxCategoryCw3 |
+    And metasfresh contains C_Tax
+      | Identifier | C_TaxCategory_ID | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
+      | taxCw3     | taxCategoryCw3   | 19   | DE                       | DE                        |
+    And metasfresh contains C_VAT_Codes:
+      | Identifier | C_Tax_ID | IsSOTrx | AmountType |
+      | vatCw3     | taxCw3   | Y       | T          |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | productCw3 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | salesPLV               | productCw3   | 100.00   | PCE      | taxCategoryCw3   |
+
+    And metasfresh contains C_Invoice:
+      | Identifier  | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceCw3a | customer      | 2024-01-15   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier    | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceCw3aL1 | invoiceCw3a  | productCw3   | 1 PCE       | taxCw3   |
+    And the invoice identified by invoiceCw3a is completed
+    And Wait until documents invoiceCw3a is posted
+
+    And metasfresh contains C_TaxDeclaration:
+      | Identifier | C_AcctSchema_ID | Date       |
+      | tdCw3      | acctSchema      | 2024-01-15 |
+    And the tax declaration "tdCw3" is built
+    And the tax declaration "tdCw3" is completed
+
+    # Second invoice → drift vs tdCw3 → first correction
+    And metasfresh contains C_Invoice:
+      | Identifier  | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceCw3b | customer      | 2024-01-20   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier    | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceCw3bL1 | invoiceCw3b  | productCw3   | 2 PCE       | taxCw3   |
+    And the invoice identified by invoiceCw3b is completed
+    And Wait until documents invoiceCw3b is posted
+
+    When invoke Create Correction with drift check on C_TaxDeclaration "tdCw3"
+    And the tax declaration "tdCw3_correction" is built
+    And the tax declaration "tdCw3_correction" is completed
+
+    # Third invoice → drift vs the completed first correction's snapshot
+    And metasfresh contains C_Invoice:
+      | Identifier  | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceCw3c | customer      | 2024-01-25   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier    | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceCw3cL1 | invoiceCw3c  | productCw3   | 3 PCE       | taxCw3   |
+    And the invoice identified by invoiceCw3c is completed
+    And Wait until documents invoiceCw3c is posted
+
+    # Resolves to root tdCw3, checks drift against the latest-in-chain (the completed first correction)
+    When invoke Create Correction with drift check on C_TaxDeclaration "tdCw3_correction"
+    Then the tax declaration "tdCw3_correction_correction" is a Correction inheriting Period, DateAcct and AcctSchema from "tdCw3"
+
+
+# ############################################################################################################################################
+# TC-D16 — Create Correction with drift check is rejected while a draft Correction exists
+# ############################################################################################################################################
+  @Id:S0467_TD_160
+  @from:cucumber
+  Scenario: Create Correction with drift check is rejected while a draft Correction exists
+
+    And metasfresh contains C_TaxCategory
+      | Identifier     |
+      | taxCategoryCw4 |
+    And metasfresh contains C_Tax
+      | Identifier | C_TaxCategory_ID | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
+      | taxCw4     | taxCategoryCw4   | 19   | DE                       | DE                        |
+    And metasfresh contains C_VAT_Codes:
+      | Identifier | C_Tax_ID | IsSOTrx | AmountType |
+      | vatCw4     | taxCw4   | Y       | T          |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | productCw4 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | salesPLV               | productCw4   | 100.00   | PCE      | taxCategoryCw4   |
+
+    And metasfresh contains C_Invoice:
+      | Identifier  | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceCw4a | customer      | 2024-01-15   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier    | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceCw4aL1 | invoiceCw4a  | productCw4   | 1 PCE       | taxCw4   |
+    And the invoice identified by invoiceCw4a is completed
+    And Wait until documents invoiceCw4a is posted
+
+    And metasfresh contains C_TaxDeclaration:
+      | Identifier | C_AcctSchema_ID | Date       |
+      | tdCw4      | acctSchema      | 2024-01-15 |
+    And the tax declaration "tdCw4" is built
+    And the tax declaration "tdCw4" is completed
+
+    # Second invoice → drift
+    And metasfresh contains C_Invoice:
+      | Identifier  | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceCw4b | customer      | 2024-01-20   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier    | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceCw4bL1 | invoiceCw4b  | productCw4   | 2 PCE       | taxCw4   |
+    And the invoice identified by invoiceCw4b is completed
+    And Wait until documents invoiceCw4b is posted
+
+    # First call creates a DRAFT correction (not built / not completed)
+    When invoke Create Correction with drift check on C_TaxDeclaration "tdCw4"
+    # Second call must reject — a draft correction already exists
+    When invoke Create Correction with drift check on C_TaxDeclaration "tdCw4"
+    Then the tax declaration operation fails with message 'TAXDECLARATION_CORRECTION_DRAFT_EXISTS'

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/tax_declaration/tax_declaration.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/tax_declaration/tax_declaration.feature
@@ -333,6 +333,17 @@ Feature: Tax Declaration Build ("Steuererklärung aufbauen")
       | td         | acctSchema      | 2024-01-15 |
     And the tax declaration "td" is built
     And the tax declaration "td" is completed
+
+    # A second posted invoice in the same period drifts the snapshot, so Create Correction has work to do.
+    And metasfresh contains C_Invoice:
+      | Identifier      | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceDrift    | customer      | 2024-01-20   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier      | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceDriftL1  | invoiceDrift | product      | 2 PCE       | tax19    |
+    And the invoice identified by invoiceDrift is completed
+    And Wait until documents invoiceDrift is posted
+
     And invoke Create Correction on C_TaxDeclaration "td"
 
     When the tax declaration "td" is reactivated expecting failure
@@ -376,6 +387,16 @@ Feature: Tax Declaration Build ("Steuererklärung aufbauen")
     And the tax declaration "td" is built
     And the tax declaration "td" is completed
 
+    # A second posted invoice in the same period drifts the snapshot, so Create Correction has work to do.
+    And metasfresh contains C_Invoice:
+      | Identifier      | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceDrift    | customer      | 2024-01-20   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier      | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceDriftL1  | invoiceDrift | product      | 2 PCE       | tax19    |
+    And the invoice identified by invoiceDrift is completed
+    And Wait until documents invoiceDrift is posted
+
     When invoke Create Correction on C_TaxDeclaration "td"
     Then the tax declaration "td_correction" is a Correction inheriting Period, DateAcct and AcctSchema from "td"
 
@@ -416,60 +437,23 @@ Feature: Tax Declaration Build ("Steuererklärung aufbauen")
       | td         | acctSchema      | 2024-01-15 |
     And the tax declaration "td" is built
     And the tax declaration "td" is completed
-    And C_TaxDeclaration "td" has IsCorrectionNeeded set to "Y"
+
+    # A second posted invoice in the same period is real drift; Create Correction picks it up
+    # and sets the Original's IsCorrectionNeeded flag from the live Fact_Acct.
+    And metasfresh contains C_Invoice:
+      | Identifier      | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | invoiceDrift    | customer      | 2024-01-20   | true    | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier      | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
+      | invoiceDriftL1  | invoiceDrift | product      | 2 PCE       | tax19    |
+    And the invoice identified by invoiceDrift is completed
+    And Wait until documents invoiceDrift is posted
 
     And invoke Create Correction on C_TaxDeclaration "td"
     And the tax declaration "td_correction" is built
 
     When the tax declaration "td_correction" is completed
     Then C_TaxDeclaration "td" has IsCorrectionNeeded = "N"
-
-
-# ############################################################################################################################################
-# TC-D10 — A Correction of a Correction is rejected (star topology: only an Original may be the template)
-# ############################################################################################################################################
-  @Id:S0467_TD_100
-  @from:cucumber
-  Scenario: a Correction of a Correction is rejected
-
-    And metasfresh contains C_TaxCategory
-      | Identifier  |
-      | taxCategory |
-    And metasfresh contains C_Tax
-      | Identifier | C_TaxCategory_ID | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
-      | tax19      | taxCategory      | 19   | DE                       | DE                        |
-    And metasfresh contains C_VAT_Codes:
-      | Identifier | C_Tax_ID | IsSOTrx | AmountType |
-      | sales19    | tax19    | Y       | T          |
-    And metasfresh contains M_Products:
-      | Identifier |
-      | product    |
-    And metasfresh contains M_ProductPrices
-      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
-      | salesPLV               | product      | 100.00   | PCE      | taxCategory      |
-    And metasfresh contains C_Invoice:
-      | Identifier | C_BPartner_ID | DateInvoiced | IsSOTrx | C_Currency_ID |
-      | invoice    | customer      | 2024-01-15   | true    | EUR           |
-    And metasfresh contains C_InvoiceLines
-      | Identifier | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID |
-      | invoiceL1  | invoice      | product      | 10 PCE      | tax19    |
-    And the invoice identified by invoice is completed
-    And Wait until documents invoice is posted
-
-    And metasfresh contains C_TaxDeclaration:
-      | Identifier | C_AcctSchema_ID | Date       |
-      | td         | acctSchema      | 2024-01-15 |
-    And the tax declaration "td" is built
-    And the tax declaration "td" is completed
-
-    # First Correction: legal. Build + complete it so it becomes a locked (Processed='Y') Correction.
-    And invoke Create Correction on C_TaxDeclaration "td"
-    And the tax declaration "td_correction" is built
-    And the tax declaration "td_correction" is completed
-
-    # Second Correction anchored to the first Correction: rejected — only an Original may be the template.
-    When invoke Create Correction on C_TaxDeclaration "td_correction"
-    Then the tax declaration operation fails with message 'TAXDECLARATION_ORIGINAL_MUST_BE_ORIGINAL'
 
 
 # ############################################################################################################################################
@@ -646,11 +630,11 @@ Feature: Tax Declaration Build ("Steuererklärung aufbauen")
 
 
 # ############################################################################################################################################
-# TC-D13 — Create Correction with drift check creates a Correction when drift is present
+# TC-D13 — Create Correction creates a Correction when the period has drifted since completion
 # ############################################################################################################################################
   @Id:S0467_TD_130
   @from:cucumber
-  Scenario: Create Correction with drift check creates a Correction when drift is present
+  Scenario: Create Correction creates a Correction when the period has drifted since the declaration was completed
 
     And metasfresh contains C_TaxCategory
       | Identifier     |
@@ -693,16 +677,16 @@ Feature: Tax Declaration Build ("Steuererklärung aufbauen")
     And the invoice identified by invoiceCw1b is completed
     And Wait until documents invoiceCw1b is posted
 
-    When invoke Create Correction with drift check on C_TaxDeclaration "tdCw1"
+    When invoke Create Correction on C_TaxDeclaration "tdCw1"
     Then the tax declaration "tdCw1_correction" is a Correction inheriting Period, DateAcct and AcctSchema from "tdCw1"
 
 
 # ############################################################################################################################################
-# TC-D14 — Create Correction with drift check is rejected when no correction is needed
+# TC-D14 — Create Correction is rejected when the period has not drifted (no correction needed)
 # ############################################################################################################################################
   @Id:S0467_TD_140
   @from:cucumber
-  Scenario: Create Correction with drift check is rejected when no correction is needed
+  Scenario: Create Correction is rejected when no correction is needed
 
     And metasfresh contains C_TaxCategory
       | Identifier     |
@@ -735,18 +719,18 @@ Feature: Tax Declaration Build ("Steuererklärung aufbauen")
     And the tax declaration "tdCw2" is built
     And the tax declaration "tdCw2" is completed
 
-    # No second invoice → no drift → Create Correction with drift check must reject
-    When invoke Create Correction with drift check on C_TaxDeclaration "tdCw2"
+    # No second invoice → no drift → Create Correction must reject
+    When invoke Create Correction on C_TaxDeclaration "tdCw2"
     Then the tax declaration operation fails with message 'TAXDECLARATION_NO_CORRECTION_NEEDED'
 
 
 # ############################################################################################################################################
-# TC-D15 — Create Correction with drift check from a completed Correction spawns a new Correction off the original
-# Proves drift is evaluated against the latest completed correction, not the stale original.
+# TC-D15 — Create Correction invoked on a completed Correction spawns a new Correction off the Original
+# Drift is evaluated against the latest completed correction in the chain, not the stale Original.
 # ############################################################################################################################################
   @Id:S0467_TD_150
   @from:cucumber
-  Scenario: Create Correction with drift check from a completed Correction spawns a new Correction off the original
+  Scenario: Create Correction invoked on a completed Correction spawns a new Correction off the Original
 
     And metasfresh contains C_TaxCategory
       | Identifier     |
@@ -789,7 +773,7 @@ Feature: Tax Declaration Build ("Steuererklärung aufbauen")
     And the invoice identified by invoiceCw3b is completed
     And Wait until documents invoiceCw3b is posted
 
-    When invoke Create Correction with drift check on C_TaxDeclaration "tdCw3"
+    When invoke Create Correction on C_TaxDeclaration "tdCw3"
     And the tax declaration "tdCw3_correction" is built
     And the tax declaration "tdCw3_correction" is completed
 
@@ -804,16 +788,16 @@ Feature: Tax Declaration Build ("Steuererklärung aufbauen")
     And Wait until documents invoiceCw3c is posted
 
     # Resolves to root tdCw3, checks drift against the latest-in-chain (the completed first correction)
-    When invoke Create Correction with drift check on C_TaxDeclaration "tdCw3_correction"
+    When invoke Create Correction on C_TaxDeclaration "tdCw3_correction"
     Then the tax declaration "tdCw3_correction_correction" is a Correction inheriting Period, DateAcct and AcctSchema from "tdCw3"
 
 
 # ############################################################################################################################################
-# TC-D16 — Create Correction with drift check is rejected while a draft Correction exists
+# TC-D16 — Create Correction is rejected while a draft Correction already exists
 # ############################################################################################################################################
   @Id:S0467_TD_160
   @from:cucumber
-  Scenario: Create Correction with drift check is rejected while a draft Correction exists
+  Scenario: Create Correction is rejected while a draft Correction exists
 
     And metasfresh contains C_TaxCategory
       | Identifier     |
@@ -857,7 +841,7 @@ Feature: Tax Declaration Build ("Steuererklärung aufbauen")
     And Wait until documents invoiceCw4b is posted
 
     # First call creates a DRAFT correction (not built / not completed)
-    When invoke Create Correction with drift check on C_TaxDeclaration "tdCw4"
+    When invoke Create Correction on C_TaxDeclaration "tdCw4"
     # Second call must reject — a draft correction already exists
-    When invoke Create Correction with drift check on C_TaxDeclaration "tdCw4"
+    When invoke Create Correction on C_TaxDeclaration "tdCw4"
     Then the tax declaration operation fails with message 'TAXDECLARATION_CORRECTION_DRAFT_EXISTS'


### PR DESCRIPTION
## Tax Declaration — Correction workflow enhancements

Three changes to the manual Tax-Declaration correction workflow:

**A. Rename the "Check Drift" process → "Check Correction Need"**
- `AD_Process` 585627: DE `Berichtigungsbedarf prüfen` / EN `Check Correction Need` (migration `5805520`).

**B. Restrict "Check Correction Need" preconditions**
- `C_TaxDeclaration_CheckDrift` now applies only to a single, completed (`Processed='Y'`), latest-in-chain declaration. A non-latest record is rejected with a user-facing message (`TaxDeclaration_CheckCorrectionNeed_NotLatest`) rather than hidden.

**C. "Create Correction" callable from a correction, with an integrated drift check**
- `C_TaxDeclaration_CreateCorrection` can now be invoked from a correction (resolves to the root original) and performs the drift check itself:
  - rejects when an unprocessed draft correction already exists (`TaxDeclaration_CreateCorrection_DraftExists`),
  - checks drift against the **latest-in-chain** snapshot (the most recent completed correction, or the original if none — once a correction is completed it, not the stale original, represents current truth),
  - rejects when no correction is needed (`TaxDeclaration_CreateCorrection_NoCorrectionNeeded`),
  - otherwise spawns the correction off the root original.
- Orchestration lives in `TaxDeclarationService.createCorrectionWithDriftCheck(...)`; the low-level `createCorrection(originalId)` keeps its `!isProcessed()` / `isCorrection()` guards as defence-in-depth.
- New repository helpers `isLatestInChain` and `hasUnprocessedCorrectionFor`; `getLatestInChain` ordered by `C_TaxDeclaration_ID DESC` for deterministic selection.
- New `AD_Message`s (DE + en_US) in migration `5805530`.

## Testing
- `TaxDeclarationRepositoryTest` extended (15 tests; covers latest/superseded/draft/processed/inactive/exclude-self) — green locally.
- Full `de.metas.acct.base` unit suite green locally (101 tests).
- Cucumber `tax_declaration.feature`: 4 new scenarios (drift → create, no-drift → reject, create-from-completed-correction → spawn off root, draft-exists → reject) + a new `invoke Create Correction with drift check` step.
