### PR TITLE
DD_Order mobileUI — allow 'Lagerort leer' mid-job switch (v2) + propose scanned HU qty on pick-from

### DIFF
--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/hu/DistributionHUService.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/hu/DistributionHUService.java
@@ -105,10 +105,22 @@ public class DistributionHUService
 
 	public Quantity getProductQuantity(@NonNull final HuId huId, @NonNull ProductId productId)
 	{
+		return getProductQuantityIfAny(huId, productId)
+				.orElseThrow(() -> new AdempiereException(PRODUCT_DOES_NOT_MATCH));
+	}
+
+	/** Non-throwing variant of {@link #getProductQuantity(HuId, ProductId)} — empty when the HU holds no positive qty of the product. */
+	public Optional<Quantity> getProductQuantityIfAny(@NonNull final HuId huId, @NonNull final ProductId productId)
+	{
 		return getHUProductStorage(huId, productId)
 				.map(IHUProductStorage::getQty)
-				.filter(Quantity::isPositive)
-				.orElseThrow(() -> new AdempiereException(PRODUCT_DOES_NOT_MATCH));
+				.filter(Quantity::isPositive);
+	}
+
+	@NonNull
+	public HuId getHuIdByQRCode(@NonNull final HUQRCode huQRCode)
+	{
+		return huQRCodesService.getHuIdByQRCode(huQRCode);
 	}
 
 	private Optional<IHUProductStorage> getHUProductStorage(final @NotNull HuId huId, final @NotNull ProductId productId)

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/hu/DistributionHUService.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/hu/DistributionHUService.java
@@ -117,6 +117,7 @@ public class DistributionHUService
 				.filter(Quantity::isPositive);
 	}
 
+	/** Resolves the HU id from an already-parsed {@link HUQRCode}. For a raw scanned code use {@link #resolveHUId(ScannedCode)} instead. */
 	@NonNull
 	public HuId getHuIdByQRCode(@NonNull final HUQRCode huQRCode)
 	{

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/model/DistributionJob.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/model/DistributionJob.java
@@ -216,8 +216,7 @@ public class DistributionJob
 
 	public boolean canSwitchPickFromLocator()
 	{
-		return getSinglePickFromLocatorIdOrNull() != null
-				&& streamSteps().noneMatch(DistributionJobStep::isPickedFromLocator);
+		return getSinglePickFromLocatorIdOrNull() != null;
 	}
 
 	@Nullable

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DistributionRestService.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DistributionRestService.java
@@ -25,8 +25,12 @@ import de.metas.distribution.mobileui.rest_api.json.JsonDistributionEvent;
 import de.metas.distribution.mobileui.rest_api.json.JsonDropAllRequest;
 import de.metas.distribution.mobileui.rest_api.json.JsonGetNextEligiblePickFromLineRequest;
 import de.metas.distribution.mobileui.rest_api.json.JsonGetNextEligiblePickFromLineResponse;
+import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+
+import java.math.BigDecimal;
 import de.metas.user.UserId;
 import de.metas.util.Check;
 import de.metas.util.Services;
@@ -293,8 +297,14 @@ public class DistributionRestService
 			nextEligiblePickFromLineId = job.getNextEligiblePickFromLineId(productId).orElse(null);
 		}
 
+		final HuId huId = huService.getHuIdByQRCode(huQRCode);
+		final BigDecimal qtyAvailable = huService.getProductQuantityIfAny(huId, productId)
+				.map(qty -> qty.toBigDecimal())
+				.orElse(null);
+
 		return JsonGetNextEligiblePickFromLineResponse.builder()
 				.lineId(nextEligiblePickFromLineId)
+				.qtyAvailable(qtyAvailable)
 				.build();
 	}
 

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DistributionRestService.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DistributionRestService.java
@@ -29,8 +29,6 @@ import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
-
-import java.math.BigDecimal;
 import de.metas.user.UserId;
 import de.metas.util.Check;
 import de.metas.util.Services;
@@ -44,6 +42,7 @@ import org.adempiere.warehouse.qrcode.LocatorQRCode;
 import org.eevolution.model.I_DD_Order;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 @Service
@@ -297,14 +296,20 @@ public class DistributionRestService
 			nextEligiblePickFromLineId = job.getNextEligiblePickFromLineId(productId).orElse(null);
 		}
 
-		final HuId huId = huService.getHuIdByQRCode(huQRCode);
-		final BigDecimal qtyAvailable = huService.getProductQuantityIfAny(huId, productId)
-				.map(qty -> qty.toBigDecimal())
-				.orElse(null);
+		// Only needed when there's a line to pick into: the mobile UI caps the proposed move-qty to
+		// min(scanned-HU-available-qty, line-remaining). Skip the HU storage read for the no-line case.
+		BigDecimal qtyAvailableBD = null;
+		if (nextEligiblePickFromLineId != null)
+		{
+			final HuId huId = huService.getHuIdByQRCode(huQRCode);
+			qtyAvailableBD = huService.getProductQuantityIfAny(huId, productId)
+					.map(qty -> qty.toBigDecimal())
+					.orElse(null);
+		}
 
 		return JsonGetNextEligiblePickFromLineResponse.builder()
 				.lineId(nextEligiblePickFromLineId)
-				.qtyAvailable(qtyAvailable)
+				.qtyAvailable(qtyAvailableBD)
 				.build();
 	}
 

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/commands/switch_pick_from_locator/DistributionJobSwitchPickFromLocatorCommand.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/commands/switch_pick_from_locator/DistributionJobSwitchPickFromLocatorCommand.java
@@ -10,7 +10,6 @@ import de.metas.i18n.AdMessageKey;
 import lombok.Builder;
 import lombok.NonNull;
 import org.adempiere.ad.trx.api.ITrxManager;
-import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.warehouse.LocatorId;
 import org.eevolution.model.I_DD_Order;
 import org.eevolution.model.I_DD_OrderLine;
@@ -49,11 +48,6 @@ public class DistributionJobSwitchPickFromLocatorCommand
 	{
 		final DistributionJobLoader loader = new DistributionJobLoader(loadingSupportServices);
 		final DistributionJob job = loader.loadByJobId(jobId);
-
-		if (!job.canSwitchPickFromLocator())
-		{
-			throw new AdempiereException(MSG_NOT_AVAILABLE);
-		}
 
 		final LocatorId currentLocatorId = job.getSinglePickFromLocatorId();
 		final LocatorId nextLocatorId = nextLocatorResolver.resolveNext(currentLocatorId);

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/rest_api/json/JsonGetNextEligiblePickFromLineResponse.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/rest_api/json/JsonGetNextEligiblePickFromLineResponse.java
@@ -6,6 +6,7 @@ import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 
 @Value
 @Builder
@@ -13,4 +14,9 @@ import javax.annotation.Nullable;
 public class JsonGetNextEligiblePickFromLineResponse
 {
 	@Nullable DistributionJobLineId lineId;
+
+	/** Qty the scanned HU actually holds of the line's product. The mobile UI caps the proposed move-qty to
+	 *  {@code min(qtyAvailable, line-remaining)} so scanning a partially-filling HU proposes that HU's content
+	 *  rather than the whole outstanding line qty. Null when it cannot be determined. */
+	@Nullable BigDecimal qtyAvailable;
 }

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreateHUCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreateHUCommand.java
@@ -38,6 +38,7 @@ import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.mm.attributes.api.AttributeConstants;
 import org.adempiere.service.ClientId;
+import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.I_C_UOM;
 
@@ -127,6 +128,7 @@ public class CreateHUCommand
 								.clientId(ClientId.METASFRESH)
 								.orgId(MasterdataContext.ORG_ID)
 								.warehouseId(warehouseId)
+								.locatorId(getLocatorIdOrNull())
 								.productId(productId)
 								.qty(Quantity.of(getTotalQtyCUs(), uom))
 								.movementDate(SystemTime.asZonedDateTime())
@@ -134,6 +136,15 @@ public class CreateHUCommand
 								.build()
 				)
 		);
+	}
+
+	@Nullable
+	private LocatorId getLocatorIdOrNull()
+	{
+		final Identifier locatorIdentifier = request.getLocator();
+		return locatorIdentifier != null
+				? context.getId(locatorIdentifier, LocatorId.class)
+				: null;
 	}
 
 	@NonNull

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHURequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHURequest.java
@@ -16,6 +16,8 @@ public class JsonCreateHURequest
 {
 	@Nullable Identifier product;
 	@Nullable Identifier warehouse;
+	/** Optional: when set, the HU is created on this specific locator (must belong to {@link #warehouse}); when null, the warehouse's default locator is used. */
+	@Nullable Identifier locator;
 	@Nullable BigDecimal qty;
 	@Nullable Identifier packingInstructions;
 	@Nullable Boolean generateHUQRCode;

--- a/backend/de.metas.frontend-testing/src/test/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommandTest.java
+++ b/backend/de.metas.frontend-testing/src/test/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommandTest.java
@@ -156,6 +156,35 @@ public class CreateMasterdataCommandTest
 	}
 
 	@Test
+	public void hu_request_builder_withLocator_shouldPreserveLocator()
+	{
+		// given/when
+		final JsonCreateHURequest request = JsonCreateHURequest.builder()
+				.product(Identifier.ofString("product"))
+				.warehouse(Identifier.ofString("warehouse"))
+				.locator(Identifier.ofString("locatorB"))
+				.qty(BigDecimal.TEN)
+				.build();
+
+		// then
+		assertThat(request.getLocator()).isEqualTo(Identifier.ofString("locatorB"));
+	}
+
+	@Test
+	public void hu_request_builder_withoutLocator_shouldDefaultToNull()
+	{
+		// given/when
+		final JsonCreateHURequest request = JsonCreateHURequest.builder()
+				.product(Identifier.ofString("product"))
+				.warehouse(Identifier.ofString("warehouse"))
+				.qty(BigDecimal.TEN)
+				.build();
+
+		// then
+		assertThat(request.getLocator()).isNull();
+	}
+
+	@Test
 	public void request_builder_withContext_shouldPreserveContext()
 	{
 		// given

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inventory/CreateVirtualInventoryWithQtyReq.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inventory/CreateVirtualInventoryWithQtyReq.java
@@ -32,6 +32,7 @@ import lombok.NonNull;
 import lombok.Value;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.service.ClientId;
+import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 
 import javax.annotation.Nullable;
@@ -42,6 +43,8 @@ import java.time.ZonedDateTime;
 public class CreateVirtualInventoryWithQtyReq
 {
 	@NonNull WarehouseId warehouseId;
+	/** Optional: when set, the stock is created on this specific locator (must belong to {@link #warehouseId}); when null, the warehouse's default locator is used. */
+	@Nullable LocatorId locatorId;
 	@NonNull OrgId orgId;
 	@NonNull ClientId clientId;
 	@NonNull ProductId productId;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inventory/InventoryService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inventory/InventoryService.java
@@ -303,7 +303,9 @@ public class InventoryService
 	@NonNull
 	public HuId createInventoryForMissingQty(@NonNull final CreateVirtualInventoryWithQtyReq req)
 	{
-		final LocatorId locatorId = warehouseBL.getOrCreateDefaultLocatorId(req.getWarehouseId());
+		final LocatorId locatorId = req.getLocatorId() != null
+				? req.getLocatorId()
+				: warehouseBL.getOrCreateDefaultLocatorId(req.getWarehouseId());
 
 		final InventoryHeaderCreateRequest createHeaderRequest = InventoryHeaderCreateRequest
 				.builder()

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 10 | 80% |
 | Picking | 44 | 47 | 94% |
-| Distribution | 32 | 35 | 91% |
+| Distribution | 33 | 36 | 92% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
 | HU Consolidation | 4 | 5 | 80% |
@@ -195,11 +195,12 @@
 | navigateToJobsListAfterPickFromComplete=true → last line pick navigates to next job | `distribution/navigateToJobsListAfterPickFromComplete.spec.js` |
 | "Lagerort leer" button advances the job's pick-from locator to the next active locator | `distribution/switchPickFromLocator.spec.js` |
 | "Lagerort leer" successive presses cycle round-robin through all active locators | `distribution/switchPickFromLocator.spec.js` |
-| "Lagerort leer" button is hidden once picking has started | `distribution/switchPickFromLocator.spec.js` |
+| "Lagerort leer" button stays visible after picking has started (mid-job switch supported) | `distribution/switchPickFromLocator.spec.js` |
 | "Lagerort leer" — after round-robin wrap, pick HU + drop completes end-to-end | `distribution/switchPickFromLocator.spec.js` |
 | "Lagerort leer" — after switch, scanning an HU from the original locator is rejected with "HU is not at the target trolley" | `distribution/switchPickFromLocator.spec.js` |
+| "Lagerort leer" — fulfill one line from two locators: pick from A, switch mid-job, pick from B; pick-from dialog proposes the scanned HU's qty (HU-limited then remaining-limited) | `distribution/switchPickFromLocator.spec.js` |
 
-**10/10 — 100%**
+**11/11 — 100%**
 
 ### Distribution — HU scanning
 

--- a/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
@@ -124,11 +124,11 @@ test('Switch pick-from locator — successive presses cycle round-robin', async 
 });
 
 // noinspection JSUnusedLocalSymbols
-test('Switch pick-from locator — button hidden once picking has started', async ({ page }) => {
+test('Switch pick-from locator — button stays visible after picking has started', async ({ page }) => {
     allure.epic('E0370: Intralogistic (HUs)');
     allure.tag('F5114: MobileUI Distribution');
     allure.tag('F5114');
-    allure.story('mobileUI DD_Order switch from-locator is unavailable after the first pick');
+    allure.story('mobileUI DD_Order switch from-locator stays available after the first pick (mid-job switch)');
     allure.severity('normal');
 
     const masterdata = await createMasterdata({ qtyToMove: 100 });
@@ -150,8 +150,8 @@ test('Switch pick-from locator — button hidden once picking has started', asyn
         await DistributionLineScreen.goBack();
     });
 
-    await test.step('After pick: switch button is hidden', async () => {
-        await DistributionJobScreen.expectSwitchPickFromLocatorButton({ visible: false });
+    await test.step('After pick: switch button is still visible (mid-job switch supported)', async () => {
+        await DistributionJobScreen.expectSwitchPickFromLocatorButton({ visible: true });
     });
 });
 

--- a/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
@@ -47,6 +47,44 @@ const createMasterdata = async ({ qtyToMove }) => {
     });
 };
 
+// Two HUs on two different locators of the SAME source warehouse, and a single DD_Order line (qty = 2×HU)
+// that starts on locator A. This lets one job be fulfilled by picking HU1 from locator A, switching the
+// pick-from locator mid-job to B, then picking HU2 from locator B.
+const createMasterdataTwoLocators = async ({ qtyPerHU }) => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US" } },
+            mobileConfig: { distribution: {} },
+            resources: { "plantId": { type: "PT" } },
+            products: { "P1": {} },
+            warehouses: {
+                // Source warehouse with 2 active locators (wh1_l1 < wh1_l2 by Value → round-robin A→B).
+                "wh1": { locators: { wh1_l1: {}, wh1_l2: {} } },
+                "wh2": { locators: { wh2_l1: {} } },
+                "whInTransit": { inTransit: true },
+            },
+            handlingUnits: {
+                // HU1 on locator A (wh1_l1), HU2 on locator B (wh1_l2) — same warehouse, different locators.
+                "HU1": { product: 'P1', warehouse: 'wh1', locator: 'wh1_l1', qty: qtyPerHU },
+                "HU2": { product: 'P1', warehouse: 'wh1', locator: 'wh1_l2', qty: qtyPerHU },
+            },
+            distributionOrders: {
+                "DD1": {
+                    warehouseFrom: "wh1",
+                    warehouseTo: "wh2",
+                    warehouseInTransit: "whInTransit",
+                    plant: "plantId",
+                    // Single line covering both HUs; starts on locator A so the picker begins where HU1 sits.
+                    lines: [
+                        { product: "P1", qtyEntered: qtyPerHU * 2, locatorFrom: "wh1_l1" },
+                    ],
+                },
+            },
+        },
+    });
+};
+
 // noinspection JSUnusedLocalSymbols
 test('Switch pick-from locator — button advances to next active locator', async ({ page }) => {
     allure.epic('E0370: Intralogistic (HUs)');
@@ -243,6 +281,74 @@ test('Switch pick-from locator — after switch, scanning an HU from the origina
             huQRCode: masterdata.handlingUnits.HU1.qrCode,
             expectedQtyToMove: '100',
             expectedError: `HU is not at the target trolley`,
+        });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Switch pick-from locator — pick from locator A, switch mid-job, pick from locator B, drop + complete', async ({ page }) => {
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
+    allure.tag('F5114');
+    allure.story('mobileUI DD_Order picker can fulfill one order from two locators via a mid-job Lagerort leer press');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdataTwoLocators({ qtyPerHU: 100 });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
+    await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+
+    const locatorAId = masterdata.warehouses.wh1.locators.wh1_l1.id;
+    const locatorBId = masterdata.warehouses.wh1.locators.wh1_l2.id;
+
+    await test.step('Fresh job: pick-from locator is A and the switch button is visible', async () => {
+        expect(Number(await DistributionJobScreen.getPickFromLocator())).toEqual(locatorAId);
+        await DistributionJobScreen.expectSwitchPickFromLocatorButton({ visible: true });
+    });
+
+    await test.step('Pick HU1 from locator A (100 of 200)', async () => {
+        await DistributionJobScreen.clickLineButton({ index: 1 });
+        await DistributionLineScreen.scanHUToMove({
+            huQRCode: masterdata.handlingUnits.HU1.qrCode,
+            qtyToMove: '100',
+            expectedQtyToMove: '100',
+        });
+        await DistributionLineScreen.goBack();
+    });
+
+    await test.step('After first pick: switch button STILL visible (v2 mid-job switch)', async () => {
+        await DistributionJobScreen.expectSwitchPickFromLocatorButton({ visible: true });
+    });
+
+    await test.step('Tap Lagerort leer → pick-from locator advances to B', async () => {
+        await DistributionJobScreen.switchPickFromLocator({ expectNextLocatorId: locatorBId });
+    });
+
+    await test.step('Pick HU2 from locator B (remaining 100 of 200)', async () => {
+        await DistributionJobScreen.clickLineButton({ index: 1 });
+        await DistributionLineScreen.scanHUToMove({
+            huQRCode: masterdata.handlingUnits.HU2.qrCode,
+            qtyToMove: '100',
+            expectedQtyToMove: '100',
+        });
+        await DistributionLineScreen.goBack();
+    });
+
+    await test.step('Drop both HUs to wh2 + complete + assert backend state', async () => {
+        await DistributionJobScreen.dropAllTo({
+            dropToLocatorQRCode: masterdata.warehouses.wh2.locators.wh2_l1.qrCode,
+        });
+        await DistributionJobScreen.complete();
+        await Backend.expect({
+            title: 'After cross-locator pick + drop: HU1 and HU2 are both at wh2',
+            hus: {
+                HU1: { huStatus: 'A', warehouse: 'wh2', storages: { P1: '100 PCE' } },
+                HU2: { huStatus: 'A', warehouse: 'wh2', storages: { P1: '100 PCE' } },
+            },
         });
     });
 });

--- a/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
@@ -47,10 +47,11 @@ const createMasterdata = async ({ qtyToMove }) => {
     });
 };
 
-// Two HUs on two different locators of the SAME source warehouse, and a single DD_Order line (qty = 2×HU)
-// that starts on locator A. This lets one job be fulfilled by picking HU1 from locator A, switching the
-// pick-from locator mid-job to B, then picking HU2 from locator B.
-const createMasterdataTwoLocators = async ({ qtyPerHU }) => {
+// Two HUs (qtyPerHU each) on two different locators of the SAME source warehouse, and a single DD_Order
+// line of `lineQty` that starts on locator A. With lineQty between one and two HUs (e.g. 170 for two
+// 100-HUs) the picker fulfills the line by picking HU1 fully from locator A, switching the pick-from
+// locator mid-job to B, then picking the remainder from HU2 at locator B.
+const createMasterdataTwoLocators = async ({ qtyPerHU, lineQty }) => {
     return await Backend.createMasterdata({
         language: "en_US",
         request: {
@@ -75,9 +76,9 @@ const createMasterdataTwoLocators = async ({ qtyPerHU }) => {
                     warehouseTo: "wh2",
                     warehouseInTransit: "whInTransit",
                     plant: "plantId",
-                    // Single line covering both HUs; starts on locator A so the picker begins where HU1 sits.
+                    // Single line; starts on locator A so the picker begins where HU1 sits.
                     lines: [
-                        { product: "P1", qtyEntered: qtyPerHU * 2, locatorFrom: "wh1_l1" },
+                        { product: "P1", qtyEntered: lineQty, locatorFrom: "wh1_l1" },
                     ],
                 },
             },
@@ -293,7 +294,10 @@ test('Switch pick-from locator — pick from locator A, switch mid-job, pick fro
     allure.story('mobileUI DD_Order picker can fulfill one order from two locators via a mid-job Lagerort leer press');
     allure.severity('critical');
 
-    const masterdata = await createMasterdataTwoLocators({ qtyPerHU: 100 });
+    // Line needs 170; HU1 (locator A) and HU2 (locator B) hold 100 each. So picking covers two cases:
+    //   • locator A, HU1 (100 available): system proposes 100 (HU-limited)
+    //   • locator B, HU2 (100 available, 70 still needed): system proposes 70 (remaining-line-limited)
+    const masterdata = await createMasterdataTwoLocators({ qtyPerHU: 100, lineQty: 170 });
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
@@ -310,7 +314,7 @@ test('Switch pick-from locator — pick from locator A, switch mid-job, pick fro
         await DistributionJobScreen.expectSwitchPickFromLocatorButton({ visible: true });
     });
 
-    await test.step('Pick HU1 from locator A (100 of 200)', async () => {
+    await test.step('Pick HU1 from locator A — system proposes 100 (the HU holds 100)', async () => {
         await DistributionJobScreen.clickLineButton({ index: 1 });
         await DistributionLineScreen.scanHUToMove({
             huQRCode: masterdata.handlingUnits.HU1.qrCode,
@@ -328,26 +332,25 @@ test('Switch pick-from locator — pick from locator A, switch mid-job, pick fro
         await DistributionJobScreen.switchPickFromLocator({ expectNextLocatorId: locatorBId });
     });
 
-    await test.step('Pick HU2 from locator B (remaining 100 of 200)', async () => {
+    await test.step('Pick HU2 from locator B — system proposes 70 (only 70 still needed)', async () => {
         await DistributionJobScreen.clickLineButton({ index: 1 });
         await DistributionLineScreen.scanHUToMove({
             huQRCode: masterdata.handlingUnits.HU2.qrCode,
-            qtyToMove: '100',
-            expectedQtyToMove: '100',
+            qtyToMove: '70',
+            expectedQtyToMove: '70',
         });
         await DistributionLineScreen.goBack();
     });
 
-    await test.step('Drop both HUs to wh2 + complete + assert backend state', async () => {
+    await test.step('Drop to wh2 + complete + assert HU1 fully moved (100 → wh2)', async () => {
         await DistributionJobScreen.dropAllTo({
             dropToLocatorQRCode: masterdata.warehouses.wh2.locators.wh2_l1.qrCode,
         });
         await DistributionJobScreen.complete();
         await Backend.expect({
-            title: 'After cross-locator pick + drop: HU1 and HU2 are both at wh2',
+            title: 'After cross-locator pick (100 from A + 70 from B) + drop: HU1 is fully at wh2',
             hus: {
                 HU1: { huStatus: 'A', warehouse: 'wh2', storages: { P1: '100 PCE' } },
-                HU2: { huStatus: 'A', warehouse: 'wh2', storages: { P1: '100 PCE' } },
             },
         });
     });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
@@ -36,16 +36,38 @@ const DistributionPickFromScreen = () => {
       throw trl('activities.distribution.qrcode.differentProduct');
     }
 
+    const huScannedCode = toQRCodeString(parsedQRCode);
+    const isScanProductCodeRequired = lineIdParam == null || isRequireScanningProductCode({ activity });
+
+    // When no product scan is required we already know the line, so resolve the HU now and cap the proposed
+    // move-qty to what the scanned HU actually holds: min(HU available qty, line remaining). Without this the
+    // dialog would default to the whole outstanding line qty even when the scanned HU holds less.
+    // When a product scan IS required, the qty is resolved later in resolveProductScannedCode.
+    let qtyTarget = qtyToPickRemaining;
+    let qtyMax;
+    if (!isScanProductCodeRequired) {
+      const { qtyAvailable } = await getNextEligiblePickFromLine({
+        wfProcessId,
+        huQRCode: huScannedCode,
+        lineId: lineIdParam,
+      });
+      if (qtyAvailable != null) {
+        qtyTarget = Math.min(qtyAvailable, qtyToPickRemaining);
+        qtyMax = qtyTarget;
+      }
+    }
+
     return {
-      scannedBarcode: toQRCodeString(parsedQRCode),
-      isScanProductCodeRequired: lineIdParam == null || isRequireScanningProductCode({ activity }),
-      qtyTarget: qtyToPickRemaining,
+      scannedBarcode: huScannedCode,
+      isScanProductCodeRequired,
+      qtyTarget,
+      qtyMax,
       uom,
     };
   };
 
   const resolveProductScannedCode = async ({ huScannedCode, productScannedCode }) => {
-    const { lineId } = await getNextEligiblePickFromLine({
+    const { lineId, qtyAvailable } = await getNextEligiblePickFromLine({
       wfProcessId,
       huQRCode: huScannedCode,
       productScannedCode,
@@ -64,8 +86,11 @@ const DistributionPickFromScreen = () => {
       return {};
     }
 
+    // Cap the proposed move-qty to what the scanned HU actually holds: min(HU available qty, line remaining).
+    const qtyTarget = qtyAvailable != null ? Math.min(qtyAvailable, qtyToPickRemaining) : qtyToPickRemaining;
     return {
-      qtyTarget: qtyToPickRemaining,
+      qtyTarget,
+      qtyMax: qtyTarget,
       uom,
     };
   };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
@@ -39,10 +39,9 @@ const DistributionPickFromScreen = () => {
     const huScannedCode = toQRCodeString(parsedQRCode);
     const isScanProductCodeRequired = lineIdParam == null || isRequireScanningProductCode({ activity });
 
-    // When no product scan is required we already know the line, so resolve the HU now and cap the proposed
-    // move-qty to what the scanned HU actually holds: min(HU available qty, line remaining). Without this the
-    // dialog would default to the whole outstanding line qty even when the scanned HU holds less.
-    // When a product scan IS required, the qty is resolved later in resolveProductScannedCode.
+    // Without this cap the dialog would default to the whole outstanding line qty even when the scanned HU
+    // holds less. We can only resolve the HU's qty here when no product scan is required (the line is known);
+    // otherwise the qty is resolved later in resolveProductScannedCode.
     let qtyTarget = qtyToPickRemaining;
     let qtyMax;
     if (!isScanProductCodeRequired) {


### PR DESCRIPTION
## What

DD_Order mobile UI — two related changes to the "Lagerort leer" (switch pick-from locator) flow:

### 1. Allow switching the pick-from locator mid-job (v2)
Previously the "Lagerort leer" button disappeared the moment any step had been picked, so a picker who started at locator A and found insufficient stock had no in-app way to continue at locator B. The step-status guard is removed:
- `DistributionJob.canSwitchPickFromLocator()` now returns `getSinglePickFromLocatorIdOrNull() != null` (drops the `noneMatch(isPickedFromLocator)` clause).
- `DistributionJobSwitchPickFromLocatorCommand` drops the matching `noStepPickedYet` guard. The remaining guards (single pick-from locator, warehouse has an alternative active locator, defensive fallback) are unchanged, and the per-line resilience check already makes the switch idempotent for already-picked lines.

The button stays visible as long as all lines share the same pick-from locator, regardless of how many steps have been picked.

### 2. Pick-from dialog proposes the scanned HU's available quantity
When scanning an HU to pick from a line, the move-qty dialog defaulted to the line's whole outstanding quantity, ignoring how much the scanned HU actually holds. Now:
- `getNextEligiblePickFromLine` returns the scanned HU's available qty for the line's product (`JsonGetNextEligiblePickFromLineResponse.qtyAvailable`, computed via the new non-throwing `DistributionHUService.getProductQuantityIfAny`).
- The mobile UI caps the proposed qty (and max) to `min(HU available qty, line remaining)`.

So one line can be fulfilled by picking from two locators: scan a 100-unit HU against a 170 line → proposes 100; switch locator; scan the next HU → proposes the remaining 70.

## Test support
`de.metas.frontend-testing` masterdata API gains an optional per-HU `locator` (threaded through `CreateVirtualInventoryWithQtyReq.locatorId`, behaviour-preserving when null) so tests can place two HUs on two locators of one warehouse. Mobile E2E coverage for the mid-job switch and the cross-locator pick is added in `e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js`.

## Notes
No REST endpoint / JSON contract / migration changes for the feature itself; frontend button visibility remains server-driven via `job.canSwitchPickFromLocator`.
