### PR TITLE
DD_Order mobileUI distribution: add E2E negative test for unknown scanned product code

### DIFF
--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 10 | 80% |
 | Picking | 44 | 47 | 94% |
-| Distribution | 33 | 36 | 92% |
+| Distribution | 34 | 37 | 92% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
 | HU Consolidation | 4 | 5 | 80% |
@@ -210,11 +210,12 @@
 | GTIN-validation mode: scan HU by M_HU_ID, confirm with product GTIN | `distribution/pickFrom_validate_GTIN.spec.js` |
 | GTIN-validation mode: scan HU by ExternalBarcode, confirm with product GTIN | `distribution/pickFrom_validate_GTIN.spec.js` |
 | Only 1 matching unit → qty dialog skipped | `distribution/pickFrom_validate_GTIN.spec.js` |
+| GTIN-validation mode: scan unknown product code → "no product found" error, line stays unpicked | `distribution/pickFrom_validate_GTIN.spec.js` |
 | Scan distribution HU by QR code | `distribution/scan_HU_barcodes.spec.js` |
 | Scan distribution HU by M_HU_ID | `distribution/scan_HU_barcodes.spec.js` |
 | Scan distribution HU by ExternalBarcode | `distribution/scan_HU_barcodes.spec.js` |
 
-**7/7 — 100%**
+**8/8 — 100%**
 
 ### Distribution + Manufacturing cross-flow
 

--- a/e2e/mobile-webui/tests/spec/distribution/pickFrom_validate_GTIN.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/pickFrom_validate_GTIN.spec.js
@@ -5,7 +5,10 @@ import { LoginScreen } from "../../utils/screens/LoginScreen";
 import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
 import { DistributionJobsListScreen } from "../../utils/screens/distribution/DistributionJobsListScreen";
 import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
+import { DistributionLinePickFromScreen } from '../../utils/screens/distribution/DistributionLinePickFromScreen';
 import { generateEAN13 } from '../../utils/ean13';
+import { expectErrorToast } from '../../utils/common';
+import { expect } from '@playwright/test';
 
 const createMasterdata = async ({ qtyToMove, externalBarcode }) => {
     return await Backend.createMasterdata({
@@ -133,4 +136,45 @@ test('Do not ask for picked qty when it is one', async ({ page }) => {
         expectQuantityDialog: false,
     });
     await DistributionJobScreen.expectLineButton({ index: 1, qtyToPick: '1 Stk', qtyPicked: '1 Stk', color: 'yellow' });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Scan an unknown product code yields a "no product found" error and the line stays unpicked', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114.3');
+    allure.story('Validate GTIN during pick from');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdataAndStartJob({ qtyToMove: 100 });
+
+    // A second EAN13 that resolves to NO product (guard against the 1-in-a-trillion
+    // collision with P1's gtin by regenerating if equal).
+    let bogusProductCode = generateEAN13().ean13;
+    while (bogusProductCode === masterdata.products.P1.gtin) {
+        bogusProductCode = generateEAN13().ean13;
+    }
+
+    await DistributionJobScreen.expectLineButton({ index: 1, qtyToPick: '100 Stk', qtyPicked: '0 Stk', color: 'red' });
+
+    // Scan the (valid) HU first → lands on the pick-from screen asking for the product code.
+    await DistributionJobScreen.scanHU({ huQRCode: masterdata.handlingUnits.HU1.qrCode });
+
+    // Scan a product code that matches no product → user-friendly error toast; covers the fix
+    // that replaced the raw exception string with the translatable AD_Message
+    // MobileUI_Distribution_NoProductForScannedCode (run language is en_US per the factory).
+    await expectErrorToast(
+        'Expect "no product found for scanned code" error',
+        async () => {
+            await DistributionLinePickFromScreen.typeProductCode(bogusProductCode);
+        },
+        ({ textContent }) => {
+            expect(textContent).toContain('No product found for the scanned product code');
+        }
+    );
+
+    // The error kept us on the pick-from screen; go back to the job screen and assert the
+    // line is still unpicked (no quantity dialog appeared, no qty committed).
+    await DistributionLinePickFromScreen.goBackToJobScreen();
+    await DistributionJobScreen.expectLineButton({ index: 1, qtyToPick: '100 Stk', qtyPicked: '0 Stk', color: 'red' });
 });

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobScreen.js
@@ -43,6 +43,13 @@ export const DistributionJobScreen = {
         })
     }),
 
+    // Split variant of scanHUToMove: use when the product-code scan must be asserted
+    // on its own (e.g. wrapped in expectErrorToast).
+    scanHU: async ({ huQRCode }) => await test.step(`${NAME} - Scan HU ${huQRCode}`, async () => {
+        await BarcodeScannerComponent.type({ scannedCode: huQRCode });
+        await DistributionLinePickFromScreen.waitForScreen();
+    }),
+
     clickLineButton: async ({ index }) => await test.step(`${NAME} - Click line ${index}`, async () => {
         await lineButtonLocator({ index }).tap({ timeout: FAST_ACTION_TIMEOUT });
         await DistributionLineScreen.waitForScreen();

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLinePickFromScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLinePickFromScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page, SLOW_ACTION_TIMEOUT } from '../../common';
+import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from '../../common';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
 import { GetQuantityDialog } from '../picking/GetQuantityDialog';
 import { DistributionUtils } from './DistributionUtils';
@@ -52,6 +52,11 @@ export const DistributionLinePickFromScreen = {
 
         typeProductCode: async (productScannedCode) => await test.step(`${NAME} - Type Product Scanned Code: ${productScannedCode}`, async () => {
             await BarcodeScannerComponent.type({ scannedCode: productScannedCode, testId: 'scanProductCode-input' });
+        }),
+
+        goBackToJobScreen: async () => await test.step(`${NAME} - Go back to job screen`, async () => {
+            await page.locator(ID_BACK_BUTTON).tap();
+            await DistributionJobScreen.waitForScreen();
         }),
 
         fillQuantityDialog: async ({ qtyToMove, expectedQtyToMove, expectedError }) => await test.step(`${NAME} - Fill Quantity Dialog`, async () => {


### PR DESCRIPTION
Test-only follow-up to https://github.com/metasfresh/metasfresh/pull/24350.

That PR replaced the raw exception string in `DistributionProductService.getProductIdByScannedProductCode` with a translatable `AdMessageKey` (`MobileUI_Distribution_NoProductForScannedCode`, ErrorCode `NoProductForScannedCode`), so an unknown scanned product code now surfaces a user-friendly, localized error toast on the mobile UI instead of a raw technical string.

This PR adds the E2E coverage for that negative path:

- New Playwright mobile-webui test in `pickFrom_validate_GTIN.spec.js`: with `requireScanningProductCode: true`, scan a valid HU then an unknown product code → assert the friendly "No product found for the scanned product code: <code>" toast appears and the line stays unpicked.
- Two small screen-object methods (`DistributionJobScreen.scanHU`, `DistributionLinePickFromScreen.goBackToJobScreen`) to keep selectors out of the spec.
- `TEST-COVERAGE.md` updated.

No production code, no migration changes — all under `e2e/mobile-webui/`.
