### PR TITLE
Add SQL script to update `From_User_ID` parameter reference for `EMailConfigTest` process

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/40-sw01_swat/5805570_EMailConfigTest_fromUser_Search.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/40-sw01_swat/5805570_EMailConfigTest_fromUser_Search.sql
@@ -1,0 +1,8 @@
+-- Run mode: SWING_CLIENT
+
+-- Process: EMailConfigTest(de.metas.email.process.EMailConfigTest)
+-- ParameterName: From_User_ID
+-- 2026-06-01T08:10:12.194Z
+UPDATE AD_Process_Para SET AD_Reference_ID=30,Updated=TO_TIMESTAMP('2026-06-01 08:10:12.194000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Process_Para_ID=540258
+;
+


### PR DESCRIPTION
From User parameter rendering as a combobox (due to reference = Table) may break if too many users in the system. Switched to a reference= Search instead