### PR TITLE
M_ShipmentSchedule: functional index on effective delivery date (fix slow Shipment Schedule window open)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805660_sys_M_ShipmentSchedule_DeliveryDate_Eff_Index.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805660_sys_M_ShipmentSchedule_DeliveryDate_Eff_Index.sql
@@ -1,0 +1,18 @@
+-- M_ShipmentSchedule: speed up opening the "Lieferdisposition" WebUI window.
+--
+-- The window's default ordering is the effective delivery date
+-- COALESCE(DeliveryDate_Override, DeliveryDate) DESC. With no matching index the
+-- WebUI view-selection build (INSERT INTO T_WEBUI_ViewSelection ... row_number()
+-- OVER (ORDER BY COALESCE(DeliveryDate_Override, DeliveryDate) DESC ...) ... LIMIT)
+-- has to seq-scan and sort the entire table on every open. On a large installation
+-- (2.2M+ rows) that is several seconds per open.
+--
+-- This functional index matches the sort exactly (DESC NULLS LAST, then the key as a
+-- stable tie-breaker), so the planner reads the first page pre-sorted from the index
+-- and stops early at the LIMIT instead of scanning + sorting the whole table.
+-- Measured on a 2.26M-row instance: ~7.4 s cold -> ~48 ms; buffers 255k -> 7.5k.
+--
+-- NULLS LAST is mandatory: the query orders DESC NULLS LAST, and a plain DESC index
+-- (which defaults to NULLS FIRST) does not match the requested order and is ignored.
+CREATE INDEX IF NOT EXISTS M_ShipmentSchedule_DeliveryDate_Eff
+    ON M_ShipmentSchedule (COALESCE(DeliveryDate_Override, DeliveryDate) DESC NULLS LAST, M_ShipmentSchedule_ID ASC);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805660_sys_M_ShipmentSchedule_DeliveryDate_Eff_Index.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805660_sys_M_ShipmentSchedule_DeliveryDate_Eff_Index.sql
@@ -16,3 +16,8 @@
 -- (which defaults to NULLS FIRST) does not match the requested order and is ignored.
 CREATE INDEX IF NOT EXISTS M_ShipmentSchedule_DeliveryDate_Eff
     ON M_ShipmentSchedule (COALESCE(DeliveryDate_Override, DeliveryDate) DESC NULLS LAST, M_ShipmentSchedule_ID ASC);
+
+-- Remove the ad-hoc diagnostic index created manually while investigating this
+-- problem; the canonical index above supersedes it (functionally identical).
+-- No-op where it was never created.
+DROP INDEX IF EXISTS idx_m_shipmentschedule_deliverydate_eff;


### PR DESCRIPTION
## Problem

Opening the Shipment Schedule ("Lieferdisposition") WebUI window with no filter is slow
on large installations. The window's view-selection build orders by the effective
delivery date `COALESCE(DeliveryDate_Override, DeliveryDate) DESC` with no matching index,
so it sequential-scans and sorts the **entire** `M_ShipmentSchedule` table on every open,
then keeps only the top 10 000 rows.

## Root cause

`pg_stat_statements` + `EXPLAIN (ANALYZE, BUFFERS)` on a 2.26M-row instance: the
`INSERT INTO T_WEBUI_ViewSelection ... row_number() OVER (ORDER BY COALESCE(DeliveryDate_Override, DeliveryDate) DESC NULLS LAST, M_ShipmentSchedule_ID) ... LIMIT 10000`
statement runs a parallel Seq Scan + full Sort (~2 GB heap, ~255k shared buffers) — ~7.4 s
cold. The per-row display sub-selects are **not** the bottleneck (they run only for the
visible page).

## Fix

A functional index matching the sort exactly:

```
M_ShipmentSchedule_DeliveryDate_Eff
  ON M_ShipmentSchedule (COALESCE(deliverydate_override, deliverydate) DESC NULLS LAST,
                         m_shipmentschedule_id ASC)
```

The planner reads the first page pre-sorted from the index and stops early at the `LIMIT`,
instead of scanning + sorting the whole table. `NULLS LAST` is required — a plain `DESC`
index defaults to `NULLS FIRST` and does not match the requested order, so the planner
ignores it.

The migration also drops a superseded ad-hoc diagnostic index (`DROP INDEX IF EXISTS`,
no-op where it was never created).

## Measured impact (2.26M-row instance, verified via EXPLAIN ANALYZE)

| | before | after |
|---|---|---|
| Execution (cold) | ~7.4 s | **~48 ms** |
| Shared buffers | 255 066 (~2 GB) | **7 484 (~58 MB)** |
| Plan | parallel Seq Scan + full Sort | Index Scan, early stop at LIMIT |

## Migration

`backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5805660_sys_M_ShipmentSchedule_DeliveryDate_Eff_Index.sql`

Plain `CREATE INDEX IF NOT EXISTS` (transaction-safe, idempotent).
