### PR TITLE
Qty reservation — reconcile reservation to ordered qty on sales-order completion

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_orderReactivation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_orderReactivation.feature
@@ -57,10 +57,10 @@ Feature: Qty Reservation — reconcile reservation to ordered qty on order react
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 |
       | plv_1                  | product      | 10.00    | PCE               |
 
-    # 100 PCE on-hand stock (10 complete TUs of 10 PCE each)
+    # 100 PCE on-hand stock (10 complete TUs of 10 PCE each → 10 HUs)
     And metasfresh contains single line completed inventories
-      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
-      | inventory      | warehouse_1    | 2026-03-15   | product      | 0 PCE   | 100 PCE  | huPIP_10PCE             | hu      |
+      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID | M_HU_ID2 | M_HU_ID3 | M_HU_ID4 | M_HU_ID5 | M_HU_ID6 | M_HU_ID7 | M_HU_ID8 | M_HU_ID9 | M_HU_ID10 |
+      | inventory      | warehouse_1    | 2026-03-15   | product      | 0 PCE   | 100 PCE  | huPIP_10PCE             | hu1     | hu2      | hu3      | hu4      | hu5      | hu6      | hu7      | hu8      | hu9      | hu10      |
     And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
 
     And metasfresh contains C_Orders:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_orderReactivation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_orderReactivation.feature
@@ -101,6 +101,14 @@ Feature: Qty Reservation — reconcile reservation to ordered qty on order react
       | Identifier  | Qty     | QtyDelivered | Processed |
       | reservation | 100 PCE | 0 PCE        | false     |
 
+    # Let the reversal's async processing settle before reactivating the order:
+    # drain the material queue and wait for the shipment schedule recompute/close to finish,
+    # so the order-reactivation interceptor does not race the not-yet-settled schedule.
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And after not more than 60s, shipment schedule is recomputed
+      | M_ShipmentSchedule_ID |
+      | shipmentSchedule      |
+
     # Customer reduces the order: reactivate, cut the line from 100 to 75 PCE, re-complete
     And the order identified by order is reactivated
     And update C_OrderLine:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_orderReactivation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_orderReactivation.feature
@@ -108,7 +108,8 @@ Feature: Qty Reservation — reconcile reservation to ordered qty on order react
       | orderLine                 | 75             | 75             |
     And the order identified by order is completed
 
-    # Reconcile assertion: the reservation is shrunk to the new ordered qty
+    # Reconcile assertion: the reservation is shrunk to the new ordered qty,
+    # not yet re-delivered (QtyDelivered back to 0, Processed=false)
     And validate M_QtyReservations:
-      | Identifier  | Qty    |
-      | reservation | 75 PCE |
+      | Identifier  | Qty    | QtyDelivered | Processed |
+      | reservation | 75 PCE | 0 PCE        | false     |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_orderReactivation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_orderReactivation.feature
@@ -3,9 +3,9 @@
 @allure.label.feature:F_QtyReservation
 @ghActions:run_on_executor5
 Feature: Qty Reservation — reconcile reservation to ordered qty on order reactivation
-## Validates that a qty reservation is reconciled (shrunk) to the order line's ordered
-## quantity when a completed sales order is reactivated, its line quantity reduced, and
-## the order re-completed.
+# Validates that a qty reservation is reconciled (shrunk) to the order line's ordered
+# quantity when a completed sales order is reactivated, its line quantity reduced, and
+# the order re-completed.
 
   Background:
     Given infrastructure and metasfresh are running
@@ -32,11 +32,11 @@ Feature: Qty Reservation — reconcile reservation to ordered qty on order react
   @from:cucumber
   @Id:S_QtyRes_300
   Scenario: Reservation is reconciled to reduced ordered qty after order reactivation
-  ## _Given a product with 100 PCE (10 TUs) on-hand stock and a sales order for 100 PCE
-  ## _And an M_QtyReservation for 100 PCE
-  ## _When shipment is generated for the full 100, then reversed (reservation restored)
-  ## _And the order is reactivated, the order line reduced to 75 PCE, and the order re-completed
-  ## _Then the reservation is reconciled down to 75 PCE (shrink-on-complete)
+  # Given a product with 100 PCE (10 TUs) on-hand stock and a sales order for 100 PCE
+  # And an M_QtyReservation for 100 PCE
+  # When shipment is generated for the full 100, then reversed (reservation restored)
+  # And the order is reactivated, the order line reduced to 75 PCE, and the order re-completed
+  # Then the reservation is reconciled down to 75 PCE (shrink-on-complete)
 
     Given metasfresh contains M_Products:
       | Identifier | IsStocked |
@@ -104,8 +104,8 @@ Feature: Qty Reservation — reconcile reservation to ordered qty on order react
     # Customer reduces the order: reactivate, cut the line from 100 to 75 PCE, re-complete
     And the order identified by order is reactivated
     And update C_OrderLine:
-      | C_OrderLine_ID | QtyEntered | QtyOrdered |
-      | orderLine      | 75         | 75         |
+      | C_OrderLine_ID.Identifier | OPT.QtyEntered | OPT.QtyOrdered |
+      | orderLine                 | 75             | 75             |
     And the order identified by order is completed
 
     # Reconcile assertion: the reservation is shrunk to the new ordered qty

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_orderReactivation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_orderReactivation.feature
@@ -1,0 +1,114 @@
+@from:cucumber
+@allure.label.epic:E0155_Material_Disposition
+@allure.label.feature:F_QtyReservation
+@ghActions:run_on_executor5
+Feature: Qty Reservation — reconcile reservation to ordered qty on order reactivation
+## Validates that a qty reservation is reconciled (shrunk) to the order line's ordered
+## quantity when a completed sales order is reactivated, its line quantity reduced, and
+## the order re-completed.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+    And metasfresh has date and time 2026-03-15T13:30:13+01:00[Europe/Berlin]
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_1       |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Currency.ISO_Code | SOTrx |
+      | pl_1       | ps_1               | EUR                 | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_1      | pl_1           |
+    And metasfresh contains M_Warehouse:
+      | Identifier  |
+      | warehouse_1 |
+    And metasfresh contains C_BPartners:
+      | Identifier | IsCustomer | M_PricingSystem_ID | DeliveryRule |
+      | bp_1       | true       | ps_1               | A            |
+
+
+  @from:cucumber
+  @Id:S_QtyRes_300
+  Scenario: Reservation is reconciled to reduced ordered qty after order reactivation
+  ## _Given a product with 100 PCE (10 TUs) on-hand stock and a sales order for 100 PCE
+  ## _And an M_QtyReservation for 100 PCE
+  ## _When shipment is generated for the full 100, then reversed (reservation restored)
+  ## _And the order is reactivated, the order line reduced to 75 PCE, and the order re-completed
+  ## _Then the reservation is reconciled down to 75 PCE (shrink-on-complete)
+
+    Given metasfresh contains M_Products:
+      | Identifier | IsStocked |
+      | product    | true      |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID |
+      | huPI       |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType |
+      | huPIV              | huPI       | TU          |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID | M_HU_PI_Version_ID | ItemType |
+      | huPIItem        | huPIV              | MI       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID | Qty    |
+      | huPIP_10PCE             | huPIItem        | product      | 10 PCE |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 |
+      | plv_1                  | product      | 10.00    | PCE               |
+
+    # 100 PCE on-hand stock (10 complete TUs of 10 PCE each)
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
+      | inventory      | warehouse_1    | 2026-03-15   | product      | 0 PCE   | 100 PCE  | huPIP_10PCE             | hu      |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | order      | true    | bp_1          | 2026-03-15  | warehouse_1    | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | orderLine  | order      | product      | 100        | huPIP_10PCE             |
+    And the order identified by order is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier       | C_OrderLine_ID | IsToRecompute |
+      | shipmentSchedule | orderLine      | N             |
+
+    And metasfresh contains M_QtyReservations:
+      | Identifier  | C_OrderLine_ID | M_Product_ID | M_Warehouse_ID | Qty     | QtyTU |
+      | reservation | orderLine      | product      | warehouse_1    | 100 PCE | 10    |
+
+    And after not more than 60s, shipment schedule is recomputed
+      | M_ShipmentSchedule_ID |
+      | shipmentSchedule      |
+
+    When 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | shipmentSchedule      | D            | true                | false       |
+
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | shipmentSchedule      | shipment   |
+
+    # Reservation is fully delivered after the shipment
+    And validate M_QtyReservations:
+      | Identifier  | Qty     | QtyDelivered | Processed |
+      | reservation | 100 PCE | 100 PCE      | true      |
+
+    # Reverse the shipment — reservation is restored (QtyDelivered back to 0, Processed=false)
+    And the shipment identified by shipment is reversed as shipmentReversal
+    And validate M_QtyReservations:
+      | Identifier  | Qty     | QtyDelivered | Processed |
+      | reservation | 100 PCE | 0 PCE        | false     |
+
+    # Customer reduces the order: reactivate, cut the line from 100 to 75 PCE, re-complete
+    And the order identified by order is reactivated
+    And update C_OrderLine:
+      | C_OrderLine_ID | QtyEntered | QtyOrdered |
+      | orderLine      | 75         | 75         |
+    And the order identified by order is completed
+
+    # Reconcile assertion: the reservation is shrunk to the new ordered qty
+    And validate M_QtyReservations:
+      | Identifier  | Qty    |
+      | reservation | 75 PCE |

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order.java
@@ -47,7 +47,7 @@ public class C_Order
 	private final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
 	private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
 	private final IOrderBL orderBL = Services.get(IOrderBL.class);
-	private final QtyReservationService qtyReservationService = SpringContextHolder.instance.getBean(QtyReservationService.class);
+	private final SpringContextHolder.Lazy<QtyReservationService> qtyReservationService = SpringContextHolder.lazyBean(QtyReservationService.class);
 
 	private static final AdMessageKey MSG_CannotCompleteOrder_DeliveryStop = AdMessageKey.of("CannotCompleteOrder_DeliveryStop");
 	private static final AdMessageKey MSG_PO_REACTIVATION_VOID_NOT_ALLOWED = AdMessageKey.of("purchaseorder.shipmentschedule.exported");
@@ -144,6 +144,6 @@ public class C_Order
 		{
 			return;
 		}
-		qtyReservationService.reconcileToOrderedQty(OrderId.ofRepoId(order.getC_Order_ID()));
+		qtyReservationService.get().reconcileToOrderedQty(OrderId.ofRepoId(order.getC_Order_ID()));
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_Order.java
@@ -5,6 +5,7 @@ import de.metas.i18n.AdMessageKey;
 import de.metas.inoutcandidate.api.IReceiptScheduleDAO;
 import de.metas.inoutcandidate.api.IShipmentConstraintsBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
+import de.metas.inoutcandidate.qty_reservation.QtyReservationService;
 import de.metas.order.IOrderBL;
 import de.metas.order.OrderId;
 import de.metas.order.model.I_C_Order;
@@ -15,6 +16,7 @@ import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.SpringContextHolder;
 import org.compiere.model.ModelValidator;
 
 /*
@@ -45,6 +47,7 @@ public class C_Order
 	private final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
 	private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
 	private final IOrderBL orderBL = Services.get(IOrderBL.class);
+	private final QtyReservationService qtyReservationService = SpringContextHolder.instance.getBean(QtyReservationService.class);
 
 	private static final AdMessageKey MSG_CannotCompleteOrder_DeliveryStop = AdMessageKey.of("CannotCompleteOrder_DeliveryStop");
 	private static final AdMessageKey MSG_PO_REACTIVATION_VOID_NOT_ALLOWED = AdMessageKey.of("purchaseorder.shipmentschedule.exported");
@@ -132,5 +135,15 @@ public class C_Order
 
 		throw new AdempiereException(ERR_ORDER_MODIFICATION_NOT_ALLOWED_RECEIPT_EXISTS)
 				.markAsUserValidationError();
+	}
+
+	@DocValidate(timings = ModelValidator.TIMING_BEFORE_COMPLETE)
+	public void reconcileQtyReservations(final I_C_Order order)
+	{
+		if (!order.isSOTrx())
+		{
+			return;
+		}
+		qtyReservationService.reconcileToOrderedQty(OrderId.ofRepoId(order.getC_Order_ID()));
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservation.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservation.java
@@ -38,6 +38,12 @@ public class QtyReservation
 	}
 
 	@NonNull
+	public QtyReservation withQty(@NonNull final Quantity newQty, @NonNull final QtyTU newQtyTU)
+	{
+		return toBuilder().qty(newQty).qtyTU(newQtyTU).build();
+	}
+
+	@NonNull
 	public Quantity getEffectiveQty()
 	{
 		return qty.subtract(qtyDelivered).toZeroIfNegative();

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationLoaderAndSaver.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationLoaderAndSaver.java
@@ -108,6 +108,8 @@ class QtyReservationLoaderAndSaver
 			@NonNull final I_M_QtyReservation record,
 			@NonNull final QtyReservation domain)
 	{
+		record.setQty(domain.getQty().toBigDecimal());
+		record.setQtyTU(domain.getQtyTU().toBigDecimal());
 		record.setQtyDelivered(domain.getQtyDelivered().toBigDecimal());
 		record.setProcessed(domain.isFullyDelivered());
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
@@ -1,11 +1,13 @@
 package de.metas.inoutcandidate.qty_reservation;
 
+import com.google.common.collect.ImmutableSet;
 import de.metas.handlingunits.QtyTU;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
 import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleSegments;
 import de.metas.order.IOrderLineBL;
 import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderId;
+import de.metas.order.OrderLineId;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -114,15 +116,24 @@ public class QtyReservationService
 	/**
 	 * Shrinks the active reservations of each sales-order line of the given order so that
 	 * the line's total reserved Qty never exceeds the line's current {@code QtyOrdered}.
-	 * One-directional: only reduces, never grows.
+	 * One-directional: only reduces, never grows; a reservation is never shrunk below its
+	 * already-delivered qty. Shipment schedules of changed lines are invalidated afterwards.
 	 */
 	public void reconcileToOrderedQty(@NonNull final OrderId orderId)
 	{
-		ReconcileQtyReservationsCommand.builder()
+		final ImmutableSet<OrderLineId> changedOrderLineIds = ReconcileQtyReservationsCommand.builder()
 				.qtyReservationRepository(repository)
 				.orderId(orderId)
 				.build()
 				.execute();
+
+		// invalidate shipment schedules of the lines whose reservations actually changed,
+		// consistent with makeReservation()/deleteReservation()
+		for (final OrderLineId orderLineId : changedOrderLineIds)
+		{
+			final I_C_OrderLine orderLine = orderLineBL.getOrderLineById(orderLineId);
+			invalidateShipmentSchedulesForSalesOrderLine(orderLine);
+		}
 	}
 
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
@@ -5,6 +5,7 @@ import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
 import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleSegments;
 import de.metas.order.IOrderLineBL;
 import de.metas.order.OrderAndLineId;
+import de.metas.order.OrderId;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -108,6 +109,20 @@ public class QtyReservationService
 	public QtyTU getReservedQtyTU(@NonNull final OrderAndLineId orderLineId)
 	{
 		return repository.getReservedQtyTU(orderLineId);
+	}
+
+	/**
+	 * Shrinks the active reservations of each sales-order line of the given order so that
+	 * the line's total reserved Qty never exceeds the line's current {@code QtyOrdered}.
+	 * One-directional: only reduces, never grows.
+	 */
+	public void reconcileToOrderedQty(@NonNull final OrderId orderId)
+	{
+		ReconcileQtyReservationsCommand.builder()
+				.qtyReservationRepository(repository)
+				.orderId(orderId)
+				.build()
+				.execute();
 	}
 
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
@@ -1,0 +1,184 @@
+package de.metas.inoutcandidate.qty_reservation;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import de.metas.handlingunits.QtyTU;
+import de.metas.order.IOrderDAO;
+import de.metas.order.IOrderLineBL;
+import de.metas.order.OrderAndLineId;
+import de.metas.order.OrderId;
+import de.metas.order.OrderLineId;
+import de.metas.quantity.Quantity;
+import de.metas.uom.IUOMConversionBL;
+import de.metas.util.Services;
+import lombok.Builder;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.compiere.model.I_M_QtyReservation;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Command that shrinks the active {@code M_QtyReservation} rows of each sales-order line
+ * so that the line's TOTAL reserved Qty never exceeds the line's current {@code QtyOrdered}.
+ * <p>
+ * <b>One-directional</b>: it only ever reduces reservations; it never grows them.
+ * <p>
+ * Within a line, the excess is removed from PLANNED_SUPPLY (PS) rows before ON_HAND (OH) rows.
+ */
+public class ReconcileQtyReservationsCommand
+{
+	private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
+	private final IOrderLineBL orderLineBL = Services.get(IOrderLineBL.class);
+	private final IUOMConversionBL uomConversionBL = Services.get(IUOMConversionBL.class);
+	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@NonNull private final QtyReservationRepository qtyReservationRepository;
+	@NonNull private final OrderId orderId;
+
+	@Builder
+	private ReconcileQtyReservationsCommand(
+			@NonNull final QtyReservationRepository qtyReservationRepository,
+			@NonNull final OrderId orderId)
+	{
+		this.qtyReservationRepository = qtyReservationRepository;
+		this.orderId = orderId;
+	}
+
+	public void execute()
+	{
+		final List<OrderAndLineId> orderLineIds = orderDAO.retrieveAllOrderLineIds(orderId);
+
+		// QtyReservationId -> (newQty, newQtyTU) for the rows that must shrink
+		final Map<QtyReservationId, NewQty> newQtyByReservationId = new HashMap<>();
+		final ImmutableSet.Builder<OrderLineId> affectedOrderLineIds = ImmutableSet.builder();
+
+		for (final OrderAndLineId orderAndLineId : orderLineIds)
+		{
+			final OrderLineId orderLineId = orderAndLineId.getOrderLineId();
+			final Quantity qtyOrdered = orderLineBL.getQtyOrdered(orderAndLineId);
+
+			final ImmutableList<QtyReservation> reservations = qtyReservationRepository.getActiveByOrderLineId(orderLineId);
+			if (reservations.isEmpty())
+			{
+				continue;
+			}
+
+			// total reserved, expressed in the order-line UOM
+			Quantity totalReserved = null;
+			for (final QtyReservation reservation : reservations)
+			{
+				final Quantity qtyInLineUOM = uomConversionBL.convertQuantityTo(
+						reservation.getQty(),
+						reservation.getProductId(),
+						qtyOrdered.getUomId());
+				totalReserved = totalReserved == null ? qtyInLineUOM : totalReserved.add(qtyInLineUOM);
+			}
+
+			if (totalReserved == null || totalReserved.compareTo(qtyOrdered) <= 0)
+			{
+				continue; // nothing to shrink for this line
+			}
+
+			BigDecimal excess = totalReserved.subtract(qtyOrdered).toBigDecimal();
+
+			// Reduce PS rows before OH rows. Within a group: stable by reservation id.
+			final List<QtyReservation> ordered = sortPlannedSupplyBeforeOnHand(reservations);
+
+			for (final QtyReservation reservation : ordered)
+			{
+				if (excess.signum() <= 0)
+				{
+					break;
+				}
+
+				final BigDecimal rowQty = reservation.getQty().toBigDecimal();
+				if (rowQty.signum() <= 0)
+				{
+					continue;
+				}
+
+				final BigDecimal reductionFromThisRow = excess.min(rowQty);
+				final BigDecimal newQtyBD = rowQty.subtract(reductionFromThisRow).max(BigDecimal.ZERO);
+
+				final BigDecimal rowQtyTU = reservation.getQtyTU().toBigDecimal();
+				final BigDecimal newQtyTUBD = rowQtyTU
+						.multiply(newQtyBD)
+						.divide(rowQty, 0, RoundingMode.HALF_UP);
+
+				final Quantity newQty = reservation.getQty().toZero().add(newQtyBD);
+				newQtyByReservationId.put(reservation.getId(), new NewQty(newQty, QtyTU.ofBigDecimal(newQtyTUBD)));
+
+				excess = excess.subtract(reductionFromThisRow);
+			}
+
+			affectedOrderLineIds.add(orderLineId);
+		}
+
+		if (newQtyByReservationId.isEmpty())
+		{
+			return;
+		}
+
+		qtyReservationRepository.updateByOrderLineIds(
+				affectedOrderLineIds.build(),
+				before -> {
+					final NewQty newQty = newQtyByReservationId.get(before.getId());
+					return newQty != null ? before.withQty(newQty.qty, newQty.qtyTU) : before;
+				});
+	}
+
+	/**
+	 * Returns the reservations ordered PLANNED_SUPPLY first, then ON_HAND;
+	 * within each group ordered by reservation id for determinism.
+	 * <p>
+	 * The {@link QtyReservation} domain object does not expose SupplyType, so it is
+	 * read directly from the {@code M_QtyReservation} records here.
+	 */
+	private List<QtyReservation> sortPlannedSupplyBeforeOnHand(@NonNull final List<QtyReservation> reservations)
+	{
+		final Map<QtyReservationId, Boolean> isPlannedSupplyById = loadIsPlannedSupplyById(reservations);
+
+		return reservations.stream()
+				.sorted(Comparator
+						// PS (true) before OH (false): reverse boolean order
+						.comparing((QtyReservation r) -> !isPlannedSupplyById.getOrDefault(r.getId(), Boolean.FALSE))
+						.thenComparing(r -> r.getId().getRepoId()))
+				.collect(ImmutableList.toImmutableList());
+	}
+
+	private Map<QtyReservationId, Boolean> loadIsPlannedSupplyById(@NonNull final List<QtyReservation> reservations)
+	{
+		final Set<Integer> ids = reservations.stream()
+				.map(r -> r.getId().getRepoId())
+				.collect(ImmutableSet.toImmutableSet());
+
+		final Map<QtyReservationId, Boolean> result = new HashMap<>();
+		queryBL.createQueryBuilder(I_M_QtyReservation.class)
+				.addInArrayFilter(I_M_QtyReservation.COLUMNNAME_M_QtyReservation_ID, ids)
+				.create()
+				.stream()
+				.forEach(record -> result.put(
+						QtyReservationId.ofRepoId(record.getM_QtyReservation_ID()),
+						SupplyType.PLANNED_SUPPLY.getCode().equals(record.getSupplyType())));
+		return result;
+	}
+
+	private static final class NewQty
+	{
+		final Quantity qty;
+		final QtyTU qtyTU;
+
+		NewQty(@NonNull final Quantity qty, @NonNull final QtyTU qtyTU)
+		{
+			this.qty = qty;
+			this.qtyTU = qtyTU;
+		}
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
@@ -13,6 +13,7 @@ import de.metas.uom.IUOMConversionBL;
 import de.metas.util.Services;
 import lombok.Builder;
 import lombok.NonNull;
+import lombok.Value;
 import org.adempiere.ad.dao.IQueryBL;
 import org.compiere.model.I_M_QtyReservation;
 
@@ -51,7 +52,16 @@ public class ReconcileQtyReservationsCommand
 		this.orderId = orderId;
 	}
 
-	public void execute()
+	/**
+	 * Shrinks the total reserved Qty of each sales-order line down to the line's current {@code QtyOrdered}.
+	 * <p>
+	 * One-directional (only reduces, never grows). A row's {@code Qty} is never shrunk below that row's
+	 * already-delivered qty ({@code QtyDelivered}). All comparison/subtraction arithmetic is performed in the
+	 * order-line UOM; per-row reductions are converted back to each reservation's own UOM before being applied.
+	 *
+	 * @return the order-line IDs whose reservations were actually modified (empty if nothing changed)
+	 */
+	public ImmutableSet<OrderLineId> execute()
 	{
 		final List<OrderAndLineId> orderLineIds = orderDAO.retrieveAllOrderLineIds(orderId);
 
@@ -63,6 +73,12 @@ public class ReconcileQtyReservationsCommand
 		{
 			final OrderLineId orderLineId = orderAndLineId.getOrderLineId();
 			final Quantity qtyOrdered = orderLineBL.getQtyOrdered(orderAndLineId);
+
+			// cancelled / zero-qty lines have nothing to reconcile against
+			if (qtyOrdered.signum() <= 0)
+			{
+				continue;
+			}
 
 			final ImmutableList<QtyReservation> reservations = qtyReservationRepository.getActiveByOrderLineId(orderLineId);
 			if (reservations.isEmpty())
@@ -81,19 +97,22 @@ public class ReconcileQtyReservationsCommand
 				totalReserved = totalReserved == null ? qtyInLineUOM : totalReserved.add(qtyInLineUOM);
 			}
 
-			if (totalReserved == null || totalReserved.compareTo(qtyOrdered) <= 0)
+			// reservations is non-empty, so totalReserved is non-null here
+			if (totalReserved.compareTo(qtyOrdered) <= 0)
 			{
 				continue; // nothing to shrink for this line
 			}
 
-			BigDecimal excess = totalReserved.subtract(qtyOrdered).toBigDecimal();
+			// excess to remove, expressed in the order-line UOM
+			BigDecimal excessInLineUOM = totalReserved.subtract(qtyOrdered).toBigDecimal();
 
 			// Reduce PS rows before OH rows. Within a group: stable by reservation id.
 			final List<QtyReservation> ordered = sortPlannedSupplyBeforeOnHand(reservations);
 
+			boolean lineChanged = false;
 			for (final QtyReservation reservation : ordered)
 			{
-				if (excess.signum() <= 0)
+				if (excessInLineUOM.signum() <= 0)
 				{
 					break;
 				}
@@ -104,8 +123,34 @@ public class ReconcileQtyReservationsCommand
 					continue;
 				}
 
-				final BigDecimal reductionFromThisRow = excess.min(rowQty);
-				final BigDecimal newQtyBD = rowQty.subtract(reductionFromThisRow).max(BigDecimal.ZERO);
+				// already-delivered qty is the floor below which this row must never shrink
+				final BigDecimal rowQtyDelivered = reservation.getQtyDelivered().toBigDecimal().max(BigDecimal.ZERO);
+
+				// the most this row can give up (in the reservation's own UOM), never below delivered
+				final BigDecimal reducibleRowQty = rowQty.subtract(rowQtyDelivered).max(BigDecimal.ZERO);
+				if (reducibleRowQty.signum() <= 0)
+				{
+					continue;
+				}
+
+				// convert this row's reducible qty to the order-line UOM so excess/min/subtract are all in one UOM
+				final BigDecimal reducibleRowQtyInLineUOM = uomConversionBL.convertQuantityTo(
+								reservation.getQty().toZero().add(reducibleRowQty),
+								reservation.getProductId(),
+								qtyOrdered.getUomId())
+						.toBigDecimal();
+
+				final BigDecimal reductionInLineUOM = excessInLineUOM.min(reducibleRowQtyInLineUOM);
+
+				// convert the reduction back to the reservation's own UOM
+				final BigDecimal reductionInRowUOM = uomConversionBL.convertQuantityTo(
+								qtyOrdered.toZero().add(reductionInLineUOM),
+								reservation.getProductId(),
+								reservation.getQty().getUomId())
+						.toBigDecimal();
+
+				// clamp: never shrink below already-delivered qty
+				final BigDecimal newQtyBD = rowQty.subtract(reductionInRowUOM).max(rowQtyDelivered);
 
 				final BigDecimal rowQtyTU = reservation.getQtyTU().toBigDecimal();
 				final BigDecimal newQtyTUBD = rowQtyTU
@@ -114,24 +159,31 @@ public class ReconcileQtyReservationsCommand
 
 				final Quantity newQty = reservation.getQty().toZero().add(newQtyBD);
 				newQtyByReservationId.put(reservation.getId(), new NewQty(newQty, QtyTU.ofBigDecimal(newQtyTUBD)));
+				lineChanged = true;
 
-				excess = excess.subtract(reductionFromThisRow);
+				excessInLineUOM = excessInLineUOM.subtract(reductionInLineUOM);
 			}
 
-			affectedOrderLineIds.add(orderLineId);
+			if (lineChanged)
+			{
+				affectedOrderLineIds.add(orderLineId);
+			}
 		}
 
+		final ImmutableSet<OrderLineId> changedOrderLineIds = affectedOrderLineIds.build();
 		if (newQtyByReservationId.isEmpty())
 		{
-			return;
+			return ImmutableSet.of();
 		}
 
 		qtyReservationRepository.updateByOrderLineIds(
-				affectedOrderLineIds.build(),
+				changedOrderLineIds,
 				before -> {
 					final NewQty newQty = newQtyByReservationId.get(before.getId());
-					return newQty != null ? before.withQty(newQty.qty, newQty.qtyTU) : before;
+					return newQty != null ? before.withQty(newQty.getQty(), newQty.getQtyTU()) : before;
 				});
+
+		return changedOrderLineIds;
 	}
 
 	/**
@@ -166,19 +218,14 @@ public class ReconcileQtyReservationsCommand
 				.stream()
 				.forEach(record -> result.put(
 						QtyReservationId.ofRepoId(record.getM_QtyReservation_ID()),
-						SupplyType.PLANNED_SUPPLY.getCode().equals(record.getSupplyType())));
+						SupplyType.ofCode(record.getSupplyType()).isPlannedSupply()));
 		return result;
 	}
 
-	private static final class NewQty
+	@Value
+	private static class NewQty
 	{
-		final Quantity qty;
-		final QtyTU qtyTU;
-
-		NewQty(@NonNull final Quantity qty, @NonNull final QtyTU qtyTU)
-		{
-			this.qty = qty;
-			this.qtyTU = qtyTU;
-		}
+		@NonNull Quantity qty;
+		@NonNull QtyTU qtyTU;
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
@@ -161,7 +161,18 @@ public class ReconcileQtyReservationsCommand
 				newQtyByReservationId.put(reservation.getId(), new NewQty(newQty, QtyTU.ofBigDecimal(newQtyTUBD)));
 				lineChanged = true;
 
-				excessInLineUOM = excessInLineUOM.subtract(reductionInLineUOM);
+				// Subtract the ACTUAL applied reduction, not the intended one. The row is written `newQtyBD`,
+				// which may differ from `rowQty - reductionInRowUOM` when the delivered-clamp kicks in or when a
+				// non-integer UOM round-trip shifts the value. Tracking the real reduction (converted back to the
+				// order-line UOM) keeps `excessInLineUOM` accurate and avoids a phantom residual across rows.
+				// In same-UOM scenarios the conversion is the identity, so this equals `reductionInLineUOM` exactly.
+				final BigDecimal actualReductionInRowUOM = rowQty.subtract(newQtyBD);
+				final BigDecimal actualReductionInLineUOM = uomConversionBL.convertQuantityTo(
+								reservation.getQty().toZero().add(actualReductionInRowUOM),
+								reservation.getProductId(),
+								qtyOrdered.getUomId())
+						.toBigDecimal();
+				excessInLineUOM = excessInLineUOM.subtract(actualReductionInLineUOM);
 			}
 
 			if (lineChanged)
@@ -213,6 +224,7 @@ public class ReconcileQtyReservationsCommand
 
 		final Map<QtyReservationId, Boolean> result = new HashMap<>();
 		queryBL.createQueryBuilder(I_M_QtyReservation.class)
+				.addOnlyActiveRecordsFilter()
 				.addInArrayFilter(I_M_QtyReservation.COLUMNNAME_M_QtyReservation_ID, ids)
 				.create()
 				.stream()

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/QtyReservationRepositoryTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/QtyReservationRepositoryTest.java
@@ -130,6 +130,27 @@ class QtyReservationRepositoryTest
 			// OH (qty=60) should be processed before PS (qty=40), regardless of insertion order
 			assertThat(supplyTypeOrder).containsExactly("60", "40");
 		}
+
+		@Test
+		void update_persistsShrunkQty()
+		{
+			final OrderLineId orderLineId = OrderLineId.ofRepoId(105);
+
+			final I_M_QtyReservation rec = createReservationRecord(orderLineId, SupplyType.ON_HAND, new BigDecimal("100"));
+			rec.setQtyTU(new BigDecimal("100"));
+			InterfaceWrapperHelper.save(rec);
+
+			repo.updateByOrderLineIds(
+					Collections.singleton(orderLineId),
+					r -> r.withQty(
+							Quantity.of(75, uom),
+							de.metas.handlingunits.QtyTU.ofInt(75)));
+
+			final List<I_M_QtyReservation> records = loadRecords(orderLineId);
+			assertThat(records).hasSize(1);
+			assertThat(records.get(0).getQty()).isEqualByComparingTo(new BigDecimal("75"));
+			assertThat(records.get(0).getQtyTU()).isEqualByComparingTo(new BigDecimal("75"));
+		}
 	}
 
 	// --- helpers ---

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/QtyReservationTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/QtyReservationTest.java
@@ -1,0 +1,51 @@
+package de.metas.inoutcandidate.qty_reservation;
+
+import de.metas.business.BusinessTestHelper;
+import de.metas.handlingunits.QtyTU;
+import de.metas.material.event.commons.AttributesKey;
+import de.metas.order.OrderLineId;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QtyReservationTest
+{
+	private I_C_UOM uom;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		uom = BusinessTestHelper.createUOM("PCE");
+	}
+
+	@Test
+	void withQty_replacesQtyAndQtyTU()
+	{
+		final QtyReservation original = QtyReservation.builder()
+				.id(QtyReservationId.ofRepoId(1))
+				.orderLineId(OrderLineId.ofRepoId(100))
+				.productId(ProductId.ofRepoId(1))
+				.warehouseId(WarehouseId.ofRepoId(1))
+				.attributesKey(AttributesKey.NONE)
+				.qtyTU(QtyTU.ofInt(100))
+				.qty(Quantity.of(100, uom))
+				.qtyDelivered(Quantity.of(0, uom))
+				.build();
+
+		final QtyReservation result = original.withQty(Quantity.of(75, uom), QtyTU.ofInt(75));
+
+		assertThat(result.getQty()).isEqualTo(Quantity.of(75, uom));
+		assertThat(result.getQtyTU()).isEqualTo(QtyTU.ofInt(75));
+
+		// original instance must be unchanged
+		assertThat(original.getQty()).isEqualTo(Quantity.of(100, uom));
+		assertThat(original.getQtyTU()).isEqualTo(QtyTU.ofInt(100));
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
@@ -12,6 +12,7 @@ import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_OrderLine;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_QtyReservation;
+import org.compiere.model.I_M_Warehouse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,6 +29,7 @@ class ReconcileQtyReservationsCommandTest
 	private QtyReservationService service;
 	private I_C_UOM uom;
 	private int productId;
+	private int warehouseId;
 
 	@BeforeEach
 	void beforeEach()
@@ -35,6 +37,7 @@ class ReconcileQtyReservationsCommandTest
 		AdempiereTestHelper.get().init();
 		uom = BusinessTestHelper.createUOM("Kg");
 		productId = BusinessTestHelper.createProductId("P1", uom).getRepoId();
+		warehouseId = createWarehouseId();
 
 		final QtyReservationRepository repository = new QtyReservationRepository();
 		service = new QtyReservationService(mock(IShipmentScheduleInvalidateBL.class), repository);
@@ -53,6 +56,26 @@ class ReconcileQtyReservationsCommandTest
 		final List<I_M_QtyReservation> records = loadRecords(orderLineId);
 		assertThat(records).hasSize(1);
 		assertThat(records.get(0).getQty()).isEqualByComparingTo(new BigDecimal("75"));
+		assertThat(records.get(0).getQtyTU()).isEqualByComparingTo(new BigDecimal("75"));
+	}
+
+	@Test
+	void doesNotShrinkBelowDelivered()
+	{
+		final OrderId orderId = createSalesOrder();
+		final OrderLineId orderLineId = createOrderLine(orderId, new BigDecimal("40"));
+
+		final I_M_QtyReservation record = createReservationRecord(orderLineId, SupplyType.ON_HAND, new BigDecimal("100"), new BigDecimal("100"));
+		record.setQtyDelivered(new BigDecimal("50"));
+		InterfaceWrapperHelper.save(record);
+
+		service.reconcileToOrderedQty(orderId);
+
+		final List<I_M_QtyReservation> records = loadRecords(orderLineId);
+		assertThat(records).hasSize(1);
+		// clamped to delivered (50), NOT down to QtyOrdered (40)
+		assertThat(records.get(0).getQty()).isEqualByComparingTo(new BigDecimal("50"));
+		assertThat(records.get(0).getQtyDelivered()).isEqualByComparingTo(new BigDecimal("50"));
 	}
 
 	@Test
@@ -117,6 +140,15 @@ class ReconcileQtyReservationsCommandTest
 
 	// --- helpers ---
 
+	private int createWarehouseId()
+	{
+		final I_M_Warehouse warehouse = InterfaceWrapperHelper.newInstance(I_M_Warehouse.class);
+		warehouse.setValue("WH");
+		warehouse.setName("WH");
+		InterfaceWrapperHelper.save(warehouse);
+		return warehouse.getM_Warehouse_ID();
+	}
+
 	private OrderId createSalesOrder()
 	{
 		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
@@ -130,6 +162,7 @@ class ReconcileQtyReservationsCommandTest
 		final I_C_OrderLine orderLine = InterfaceWrapperHelper.newInstance(I_C_OrderLine.class);
 		orderLine.setC_Order_ID(orderId.getRepoId());
 		orderLine.setM_Product_ID(productId);
+		orderLine.setM_Warehouse_ID(warehouseId);
 		orderLine.setC_UOM_ID(uom.getC_UOM_ID());
 		orderLine.setQtyOrdered(qtyOrdered);
 		orderLine.setQtyEntered(qtyOrdered);

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
@@ -4,6 +4,9 @@ import de.metas.business.BusinessTestHelper;
 import de.metas.order.IOrderDAO;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
+import de.metas.uom.CreateUOMConversionRequest;
+import de.metas.uom.IUOMConversionDAO;
+import de.metas.uom.UomId;
 import de.metas.util.Services;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -172,6 +175,95 @@ class ReconcileQtyReservationsCommandTest
 		// The processed 30 is intentionally excluded from the excess computation (not (70+30)-50).
 		assertThat(unprocessedReloaded.getQty()).isEqualByComparingTo(new BigDecimal("50"));
 		assertThat(unprocessedReloaded.getQtyTU()).isEqualByComparingTo(new BigDecimal("50"));
+	}
+
+	@Test
+	void shrinksCorrectly_whenReservationUomDiffersFromOrderLine()
+	{
+		// product stocking UOM is "Kg" (the order-line / qtyOrdered UOM).
+		// the reservation is held in a different UOM "Box", with conversion 1 Box = 5 Kg.
+		final I_C_UOM boxUom = BusinessTestHelper.createUOM("Box");
+		Services.get(IUOMConversionDAO.class).createUOMConversion(CreateUOMConversionRequest.builder()
+				.fromUomId(UomId.ofRepoId(boxUom.getC_UOM_ID()))
+				.toUomId(UomId.ofRepoId(uom.getC_UOM_ID()))
+				.fromToMultiplier(new BigDecimal("5"))
+				.build());
+
+		final OrderId orderId = createSalesOrder();
+		// QtyOrdered = 50 Kg
+		final OrderLineId orderLineId = createOrderLine(orderId, new BigDecimal("50"));
+
+		// reservation = 20 Box = 100 Kg → 50 Kg excess → must shrink to 10 Box (= 50 Kg)
+		final I_M_QtyReservation record = createReservationRecord(orderLineId, SupplyType.ON_HAND, new BigDecimal("20"), new BigDecimal("20"));
+		record.setC_UOM_ID(boxUom.getC_UOM_ID());
+		InterfaceWrapperHelper.save(record);
+
+		service.reconcileToOrderedQty(orderId);
+
+		final List<I_M_QtyReservation> records = loadRecords(orderLineId);
+		assertThat(records).hasSize(1);
+		// shrunk to the order-line qty (50 Kg) expressed in the reservation's own UOM (10 Box)
+		assertThat(records.get(0).getQty()).isEqualByComparingTo(new BigDecimal("10"));
+	}
+
+	@Test
+	void setsProcessed_whenShrunkToDelivered()
+	{
+		final OrderId orderId = createSalesOrder();
+		final OrderLineId orderLineId = createOrderLine(orderId, new BigDecimal("40"));
+
+		// Qty=100, QtyDelivered=40, Processed=false → shrinks to 40, then Qty==QtyDelivered ⇒ Processed=true
+		final I_M_QtyReservation record = createReservationRecord(orderLineId, SupplyType.ON_HAND, new BigDecimal("100"), new BigDecimal("100"));
+		record.setQtyDelivered(new BigDecimal("40"));
+		record.setProcessed(false);
+		InterfaceWrapperHelper.save(record);
+		final int recordId = record.getM_QtyReservation_ID();
+
+		service.reconcileToOrderedQty(orderId);
+
+		final I_M_QtyReservation reloaded = InterfaceWrapperHelper.load(recordId, I_M_QtyReservation.class);
+		assertThat(reloaded.getQty()).isEqualByComparingTo(new BigDecimal("40"));
+		assertThat(reloaded.isProcessed()).isTrue();
+	}
+
+	@Test
+	void skipsLine_whenQtyOrderedIsZero()
+	{
+		final OrderId orderId = createSalesOrder();
+		final OrderLineId orderLineId = createOrderLine(orderId, BigDecimal.ZERO);
+
+		createReservationRecord(orderLineId, SupplyType.ON_HAND, new BigDecimal("10"), new BigDecimal("10"));
+
+		service.reconcileToOrderedQty(orderId);
+
+		// QtyOrdered=0 → line is skipped (the `qtyOrdered.signum() <= 0` guard), reservation untouched
+		final List<I_M_QtyReservation> records = loadRecords(orderLineId);
+		assertThat(records).hasSize(1);
+		assertThat(records.get(0).getQty()).isEqualByComparingTo(new BigDecimal("10"));
+	}
+
+	@Test
+	void reconcilesEachLineIndependently()
+	{
+		final OrderId orderId = createSalesOrder();
+
+		// lineA: over-reserved (80 reserved vs 50 ordered) → must shrink to 50
+		final OrderLineId lineA = createOrderLine(orderId, new BigDecimal("50"));
+		createReservationRecord(lineA, SupplyType.ON_HAND, new BigDecimal("80"), new BigDecimal("80"));
+
+		// lineB: exactly reserved (100 reserved vs 100 ordered) → must stay 100
+		final OrderLineId lineB = createOrderLine(orderId, new BigDecimal("100"));
+		createReservationRecord(lineB, SupplyType.ON_HAND, new BigDecimal("100"), new BigDecimal("100"));
+
+		service.reconcileToOrderedQty(orderId);
+
+		final List<I_M_QtyReservation> recordsA = loadRecords(lineA);
+		assertThat(recordsA).hasSize(1);
+		assertThat(recordsA.get(0).getQty()).isEqualByComparingTo(new BigDecimal("50"));
+
+		final List<I_M_QtyReservation> recordsB = loadRecords(lineB);
+		assertThat(recordsB).hasSize(1);
+		assertThat(recordsB.get(0).getQty()).isEqualByComparingTo(new BigDecimal("100"));
 	}
 
 	// --- helpers ---

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
@@ -1,0 +1,168 @@
+package de.metas.inoutcandidate.qty_reservation;
+
+import de.metas.business.BusinessTestHelper;
+import de.metas.order.IOrderDAO;
+import de.metas.order.OrderId;
+import de.metas.order.OrderLineId;
+import de.metas.util.Services;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_OrderLine;
+import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_M_QtyReservation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ReconcileQtyReservationsCommandTest
+{
+	private QtyReservationService service;
+	private I_C_UOM uom;
+	private int productId;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		uom = BusinessTestHelper.createUOM("Kg");
+		productId = BusinessTestHelper.createProductId("P1", uom).getRepoId();
+
+		final QtyReservationRepository repository = new QtyReservationRepository();
+		service = new QtyReservationService(mock(IShipmentScheduleInvalidateBL.class), repository);
+	}
+
+	@Test
+	void shrinksSingleReservation_whenLineReduced()
+	{
+		final OrderId orderId = createSalesOrder();
+		final OrderLineId orderLineId = createOrderLine(orderId, new BigDecimal("75"));
+
+		createReservationRecord(orderLineId, SupplyType.ON_HAND, new BigDecimal("100"), new BigDecimal("100"));
+
+		service.reconcileToOrderedQty(orderId);
+
+		final List<I_M_QtyReservation> records = loadRecords(orderLineId);
+		assertThat(records).hasSize(1);
+		assertThat(records.get(0).getQty()).isEqualByComparingTo(new BigDecimal("75"));
+	}
+
+	@Test
+	void noChange_whenReservedEqualsOrdered()
+	{
+		final OrderId orderId = createSalesOrder();
+		final OrderLineId orderLineId = createOrderLine(orderId, new BigDecimal("75"));
+
+		createReservationRecord(orderLineId, SupplyType.ON_HAND, new BigDecimal("75"), new BigDecimal("75"));
+
+		service.reconcileToOrderedQty(orderId);
+
+		final List<I_M_QtyReservation> records = loadRecords(orderLineId);
+		assertThat(records).hasSize(1);
+		assertThat(records.get(0).getQty()).isEqualByComparingTo(new BigDecimal("75"));
+	}
+
+	@Test
+	void noChange_whenReservedBelowOrdered()
+	{
+		final OrderId orderId = createSalesOrder();
+		final OrderLineId orderLineId = createOrderLine(orderId, new BigDecimal("75"));
+
+		createReservationRecord(orderLineId, SupplyType.ON_HAND, new BigDecimal("50"), new BigDecimal("50"));
+
+		service.reconcileToOrderedQty(orderId);
+
+		final List<I_M_QtyReservation> records = loadRecords(orderLineId);
+		assertThat(records).hasSize(1);
+		assertThat(records.get(0).getQty()).isEqualByComparingTo(new BigDecimal("50"));
+	}
+
+	@Test
+	void multiReservation_reducesToTotalOrdered()
+	{
+		final OrderId orderId = createSalesOrder();
+		final OrderLineId orderLineId = createOrderLine(orderId, new BigDecimal("75"));
+
+		createReservationRecord(orderLineId, SupplyType.ON_HAND, new BigDecimal("60"), new BigDecimal("60"));
+		createReservationRecord(orderLineId, SupplyType.PLANNED_SUPPLY, new BigDecimal("40"), new BigDecimal("40"));
+
+		service.reconcileToOrderedQty(orderId);
+
+		final List<I_M_QtyReservation> records = loadRecords(orderLineId);
+		assertThat(records).hasSize(2);
+
+		final BigDecimal total = records.stream()
+				.map(I_M_QtyReservation::getQty)
+				.reduce(BigDecimal.ZERO, BigDecimal::add);
+		assertThat(total).isEqualByComparingTo(new BigDecimal("75"));
+
+		// PS-before-OH: PS reduced first (40 -> 15), OH untouched (60)
+		final I_M_QtyReservation oh = records.stream()
+				.filter(r -> SupplyType.ON_HAND.getCode().equals(r.getSupplyType()))
+				.findFirst().get();
+		final I_M_QtyReservation ps = records.stream()
+				.filter(r -> SupplyType.PLANNED_SUPPLY.getCode().equals(r.getSupplyType()))
+				.findFirst().get();
+		assertThat(oh.getQty()).isEqualByComparingTo(new BigDecimal("60"));
+		assertThat(ps.getQty()).isEqualByComparingTo(new BigDecimal("15"));
+	}
+
+	// --- helpers ---
+
+	private OrderId createSalesOrder()
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setIsSOTrx(true);
+		InterfaceWrapperHelper.save(order);
+		return OrderId.ofRepoId(order.getC_Order_ID());
+	}
+
+	private OrderLineId createOrderLine(final OrderId orderId, final BigDecimal qtyOrdered)
+	{
+		final I_C_OrderLine orderLine = InterfaceWrapperHelper.newInstance(I_C_OrderLine.class);
+		orderLine.setC_Order_ID(orderId.getRepoId());
+		orderLine.setM_Product_ID(productId);
+		orderLine.setC_UOM_ID(uom.getC_UOM_ID());
+		orderLine.setQtyOrdered(qtyOrdered);
+		orderLine.setQtyEntered(qtyOrdered);
+		InterfaceWrapperHelper.save(orderLine);
+		return OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
+	}
+
+	private I_M_QtyReservation createReservationRecord(
+			final OrderLineId orderLineId,
+			final SupplyType supplyType,
+			final BigDecimal qty,
+			final BigDecimal qtyTU)
+	{
+		final I_M_QtyReservation record = InterfaceWrapperHelper.newInstance(I_M_QtyReservation.class);
+		record.setC_OrderLine_ID(orderLineId.getRepoId());
+		record.setM_Product_ID(productId);
+		record.setM_Warehouse_ID(1);
+		record.setC_UOM_ID(uom.getC_UOM_ID());
+		record.setSupplyType(supplyType.getCode());
+		record.setQty(qty);
+		record.setQtyDelivered(BigDecimal.ZERO);
+		record.setQtyTU(qtyTU);
+		InterfaceWrapperHelper.save(record);
+		return record;
+	}
+
+	private List<I_M_QtyReservation> loadRecords(final OrderLineId orderLineId)
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_M_QtyReservation.class)
+				.addEqualsFilter(I_M_QtyReservation.COLUMNNAME_C_OrderLine_ID, orderLineId)
+				.orderBy(I_M_QtyReservation.COLUMNNAME_SupplyType)
+				.create()
+				.list();
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
@@ -138,6 +138,42 @@ class ReconcileQtyReservationsCommandTest
 		assertThat(ps.getQty()).isEqualByComparingTo(new BigDecimal("15"));
 	}
 
+	@Test
+	void doesNotTouchProcessedReservations()
+	{
+		final OrderId orderId = createSalesOrder();
+		final OrderLineId orderLineId = createOrderLine(orderId, new BigDecimal("50"));
+
+		// UNPROCESSED reservation: Qty=70, QtyTU=70, QtyDelivered=0, Processed=false
+		final I_M_QtyReservation unprocessed = createReservationRecord(orderLineId, SupplyType.ON_HAND, new BigDecimal("70"), new BigDecimal("70"));
+		final int unprocessedId = unprocessed.getM_QtyReservation_ID();
+
+		// PROCESSED reservation on the SAME line: Qty=30, QtyTU=30, QtyDelivered=30, Processed=true
+		final I_M_QtyReservation processed = createReservationRecord(orderLineId, SupplyType.ON_HAND, new BigDecimal("30"), new BigDecimal("30"));
+		processed.setQtyDelivered(new BigDecimal("30"));
+		processed.setProcessed(true);
+		InterfaceWrapperHelper.save(processed);
+		final int processedId = processed.getM_QtyReservation_ID();
+
+		service.reconcileToOrderedQty(orderId);
+
+		// reload from the embedded DB to catch any silent save by the command
+		final I_M_QtyReservation processedReloaded = InterfaceWrapperHelper.load(processedId, I_M_QtyReservation.class);
+		final I_M_QtyReservation unprocessedReloaded = InterfaceWrapperHelper.load(unprocessedId, I_M_QtyReservation.class);
+
+		// the PROCESSED reservation is UNCHANGED — Qty/QtyTU/QtyDelivered untouched and Processed not overwritten
+		assertThat(processedReloaded.getQty()).isEqualByComparingTo(new BigDecimal("30"));
+		assertThat(processedReloaded.getQtyTU()).isEqualByComparingTo(new BigDecimal("30"));
+		assertThat(processedReloaded.getQtyDelivered()).isEqualByComparingTo(new BigDecimal("30"));
+		assertThat(processedReloaded.isProcessed()).isTrue();
+
+		// getActiveByOrderLineId() filters Processed=false, so only the unprocessed 70 is visible to the command.
+		// excess = 70 (total unprocessed reserved) - 50 (QtyOrdered) = 20; 70 -> 50.
+		// The processed 30 is intentionally excluded from the excess computation (not (70+30)-50).
+		assertThat(unprocessedReloaded.getQty()).isEqualByComparingTo(new BigDecimal("50"));
+		assertThat(unprocessedReloaded.getQtyTU()).isEqualByComparingTo(new BigDecimal("50"));
+	}
+
 	// --- helpers ---
 
 	private int createWarehouseId()


### PR DESCRIPTION
## What

At sales-order completion, reconcile each line's active `M_QtyReservation` so the line's total reserved quantity never exceeds the line's current `QtyOrdered`. **One-directional — shrink only** (never grows a reservation).

## Why

When a partially-shipped sales order is corrected via the standard workflow — reverse the shipment, reactivate the order, **reduce the short line's ordered qty** (e.g. 100 → 75), re-complete — the line's existing qty reservation kept its original `Qty` (100). After re-shipping the reduced qty, the reservation was left as `Qty=100, QtyDelivered=75, Processed=false` — a permanent phantom reservation for 25 that can never ship, polluting demand/availability signals and the Material Cockpit. There was previously **no mechanism to shrink a reservation's `Qty`**.

## How

- `QtyReservation` gains `withQty(Quantity, QtyTU)` (immutable copy, mirrors `withQtyDelivered`).
- `QtyReservationLoaderAndSaver.updateRecord` now also persists `Qty`/`QtyTU` (previously only `QtyDelivered`/`Processed`).
- New `ReconcileQtyReservationsCommand` + `QtyReservationService.reconcileToOrderedQty(OrderId)`: per sales line, if total active reserved (UOM-converted) exceeds `QtyOrdered`, remove the excess — reducing `PLANNED_SUPPLY` rows before `ON_HAND` rows so the reservation stays backed by real stock.
- The existing `de.metas.inoutcandidate.modelvalidator.C_Order` interceptor gains a `@DocValidate(TIMING_BEFORE_COMPLETE)` method that invokes the reconcile for sales orders only.

No DB migration, no Application-Dictionary changes.

## Tests

- Unit (offline, AdempiereTestHelper): `QtyReservationTest`, `QtyReservationRepositoryTest#update_persistsShrunkQty`, `ReconcileQtyReservationsCommandTest` (single-reservation shrink, no-change-when-equal, no-change-when-below, multi-reservation PS-before-OH). All GREEN locally.
- Cucumber: `qtyReservation_orderReactivation.feature` `S_QtyRes_300` — full reverse → reactivate → reduce → re-complete workflow, asserting the reservation shrinks to the new ordered qty (CI-verified).

## Scope notes

- The "reserved < ordered" case (unreserved residual) is intentionally **not** signalled here — pre-existing behaviour, handled by user training.
- Reusing the reversed shipment's document number on the new shipment is **out of scope** for this PR (tracked separately).
