### PR TITLE
retrieve_available_for_sales: push date filters into source subqueries (fix slow order quick-input)

### DIFF
--- a/backend/de.metas.material/cockpit/src/main/sql/postgresql/ddl/functions/de_metas_material/Retrieve_available_for_Sales.sql
+++ b/backend/de.metas.material/cockpit/src/main/sql/postgresql/ddl/functions/de_metas_material/Retrieve_available_for_Sales.sql
@@ -124,6 +124,5 @@ COMMENT ON FUNCTION de_metas_material.retrieve_available_for_sales(integer, nume
     * p_salesOrderLookBehindHours: Used to ignore old/stale sales order lines. Returned rows have a SalesOrderLastUpdated date not before now() minus the given number of hours.
     * p_M_Warehouse_ID: optional filter by p_M_Warehouse_ID if the caller passes one
 
-    Also see https://github.com/metasfresh/metasfresh/issues/5108
-    Also see https://github.com/metasfresh/me03/issues/7048'
+    Also see https://github.com/metasfresh/metasfresh/issues/5108'
 ;

--- a/backend/de.metas.material/cockpit/src/main/sql/postgresql/system/75-material-cockpit/5805670_sys_retrieve_available_for_sales_perf.sql
+++ b/backend/de.metas.material/cockpit/src/main/sql/postgresql/system/75-material-cockpit/5805670_sys_retrieve_available_for_sales_perf.sql
@@ -1,3 +1,19 @@
+-- Source DDL: backend/de.metas.material/cockpit/src/main/sql/postgresql/ddl/functions/de_metas_material/Retrieve_available_for_Sales.sql
+--
+-- Performance rewrite of de_metas_material.retrieve_available_for_sales (Available-for-Sales,
+-- gh#5108). The previous body read from de_metas_material.MD_ShipmentQty_V and applied the
+-- look-behind / look-ahead date filters on top of the view. Because the view FULL-OUTER-JOINs
+-- the order-line side and the shipment-schedule side, and the filter contained
+-- "... OR SalesOrderLastUpdated IS NULL", Postgres could not push the date filters down: for a
+-- high-runner product it materialised the product's ENTIRE C_OrderLine history (150k+ rows) and
+-- only then discarded almost all of it -> several seconds per order-line entry.
+--
+-- The view's two demand sides are disjoint (the order-line side excludes lines that already have
+-- a shipment schedule; the schedule side is the schedules), so the join is effectively a
+-- concatenation. We inline both sides as separate branches and push the date filters INTO each
+-- source, so the look-behind prunes order lines (via the existing C_OrderLine(Updated, M_Product_ID)
+-- index) before any join. Output semantics are unchanged.
+
 SELECT db_drop_functions('*.retrieve_available_for_sales')
 ;
 
@@ -23,20 +39,6 @@ CREATE FUNCTION de_metas_material.retrieve_available_for_sales(
             )
 AS
 $BODY$
--- Performance rewrite: the previous implementation read from
--- de_metas_material.MD_ShipmentQty_V and applied the look-behind / look-ahead date filters
--- on top of the view. Because the view FULL-OUTER-JOINs the order-line side and the
--- shipment-schedule side, and the filter contained "... OR SalesOrderLastUpdated IS NULL",
--- Postgres could not push the date filters down: for a high-runner product it built the
--- product's ENTIRE C_OrderLine history (150k+ rows) and only then discarded almost all of
--- it -> several seconds per order-line entry (the Available-for-Sales calc, gh#5108).
---
--- The view's two demand sides are disjoint (the order-line side excludes lines that already
--- have a shipment schedule; the schedule side is the schedules), so the join is effectively a
--- concatenation. We inline both sides as separate branches and push the date filters INTO each
--- source, so the look-behind prunes order lines (using the existing
--- C_OrderLine(Updated, M_Product_ID) index) before any join. Result on a 2.2M-shipment-schedule
--- / 150k-order-line instance: ~7.6 s -> sub-second. Output semantics are unchanged.
 SELECT p_QueryNo,
        p_M_Product_ID,
        final.AttributesKey,
@@ -124,6 +126,5 @@ COMMENT ON FUNCTION de_metas_material.retrieve_available_for_sales(integer, nume
     * p_salesOrderLookBehindHours: Used to ignore old/stale sales order lines. Returned rows have a SalesOrderLastUpdated date not before now() minus the given number of hours.
     * p_M_Warehouse_ID: optional filter by p_M_Warehouse_ID if the caller passes one
 
-    Also see https://github.com/metasfresh/metasfresh/issues/5108
-    Also see https://github.com/metasfresh/me03/issues/7048'
+    Also see https://github.com/metasfresh/metasfresh/issues/5108'
 ;


### PR DESCRIPTION
## Problem

Adding a product line to an order (quick-input) is slow — several seconds after pressing
Enter before the line appears. The cost is the Available-for-Sales calculation (gh#5108):
its `C_OrderLine` interceptor calls `de_metas_material.retrieve_available_for_sales(...)` on
every line create/change, and that function is slow for high-runner products.

## Root cause

The function read `de_metas_material.MD_ShipmentQty_V` and applied the look-behind /
look-ahead date filters **on top of** the view. The view `FULL OUTER JOIN`s two disjoint
demand sides (open sales-order lines that have no shipment schedule yet; open shipment
schedules), and the filter's `... OR SalesOrderLastUpdated IS NULL` blocked predicate
push-down. So for a high-runner product Postgres materialised the product's **entire
`C_OrderLine` history** and only then discarded almost all of it.

`EXPLAIN (ANALYZE, BUFFERS)` on a large instance (2.2M shipment schedules, one product with
~150k order lines): the order-line demand branch alone took ~1.9 s; ~7.6 s observed per
order-line entry in `pg_stat_statements`.

## Fix

The view's two demand sides are disjoint (the order-line side excludes lines that already
have a shipment schedule; the schedule side is the schedules), so the join is effectively a
concatenation. Inline both sides into the function as separate branches (plus the unchanged
stock branch) and push the date filters **into each source**, so the look-behind prunes order
lines via the existing `C_OrderLine(Updated, M_Product_ID)` index before any join.

No new index is required — the supporting index already exists.

## Validation

- **Performance** — `EXPLAIN (ANALYZE, BUFFERS)` of the rewritten order-line branch for the
  worst product: **1905 ms → 0.109 ms**; the planner now uses the `C_OrderLine(Updated, …)`
  index and stops early.
- **Output equivalence** — diffed the rewritten function against the previous one across
  **51 real products** (symmetric `EXCEPT`): **0 rows differ**.

## Files

- `backend/de.metas.material/cockpit/src/main/sql/postgresql/ddl/functions/de_metas_material/Retrieve_available_for_Sales.sql`
- `backend/de.metas.material/cockpit/src/main/sql/postgresql/system/75-material-cockpit/5805670_sys_retrieve_available_for_sales_perf.sql`

## Note

`MD_ShipmentQty_V` is now unused (this function was its only consumer). Left in place to keep
this change focused; removing it can be a separate follow-up.
