### PR TITLE
Process to change costing method to Moving Average Invoice

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/C_AcctSchema_InitMovingAvgInvoice.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/C_AcctSchema_InitMovingAvgInvoice.sql
@@ -69,9 +69,9 @@ BEGIN
             v_AD_Client_ID;
     END IF;
 
-    -- Backup affected tables before making changes (suffix includes schema ID to avoid collision)
-    PERFORM backup_table('m_cost',       '_pre_mai_' || p_C_AcctSchema_ID);
-    PERFORM backup_table('c_acctschema', '_pre_mai_' || p_C_AcctSchema_ID);
+    -- Backup affected tables before making changes
+    PERFORM backup_table('m_cost',       '_pre_mai');
+    PERFORM backup_table('c_acctschema', '_pre_mai');
 
     -- Seed M_Cost records for the MAI cost element.
     -- Skip products that already have a record for the target cost element + cost type.

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/C_AcctSchema_InitMovingAvgInvoice.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/C_AcctSchema_InitMovingAvgInvoice.sql
@@ -11,7 +11,7 @@
 CREATE OR REPLACE FUNCTION public.C_AcctSchema_InitMovingAvgInvoice(
     p_C_AcctSchema_ID numeric
 )
-    RETURNS void
+    RETURNS text
     LANGUAGE plpgsql
 AS
 $$
@@ -34,7 +34,7 @@ BEGIN
 
     IF v_CurrentCostingMethod = 'M' THEN
         RAISE NOTICE 'C_AcctSchema_ID % is already on MovingAverageInvoice, nothing to do', p_C_AcctSchema_ID;
-        RETURN;
+        RETURN 'C_AcctSchema_ID ' || p_C_AcctSchema_ID || ' is already on MovingAverageInvoice, nothing to do';
     END IF;
 
     -- Find the material cost element for the current costing method
@@ -45,6 +45,7 @@ BEGIN
       AND costelementtype  = 'M'
       AND costingmethod    = v_CurrentCostingMethod
       AND isactive         = 'Y'
+    ORDER BY m_costelement_id
     LIMIT 1;
 
     IF v_CurrentCostElementId IS NULL THEN
@@ -60,6 +61,7 @@ BEGIN
       AND costelementtype = 'M'
       AND costingmethod   = 'M'
       AND isactive        = 'Y'
+    ORDER BY m_costelement_id
     LIMIT 1;
 
     IF v_MAICostElementId IS NULL THEN
@@ -67,12 +69,12 @@ BEGIN
             v_AD_Client_ID;
     END IF;
 
-    -- Backup affected tables before making changes
-    PERFORM backup_table('m_cost',       '_pre_mai');
-    PERFORM backup_table('c_acctschema', '_pre_mai');
+    -- Backup affected tables before making changes (suffix includes schema ID to avoid collision)
+    PERFORM backup_table('m_cost',       '_pre_mai_' || p_C_AcctSchema_ID);
+    PERFORM backup_table('c_acctschema', '_pre_mai_' || p_C_AcctSchema_ID);
 
     -- Seed M_Cost records for the MAI cost element.
-    -- Skip products that already have a record for the target cost element.
+    -- Skip products that already have a record for the target cost element + cost type.
     INSERT INTO m_cost (
         ad_client_id, ad_org_id,
         m_product_id, m_costtype_id, c_acctschema_id,
@@ -94,8 +96,8 @@ BEGIN
         src.m_attributesetinstance_id,
         src.currentcostprice,
         src.currentqty,
-        src.currentcostprice * src.currentqty,      -- seeds cumulatedamt for weighted-average formula
-        src.currentqty,                             -- seeds cumulatedqty
+        src.currentcostprice * src.currentqty,  -- seeds cumulatedamt for weighted-average formula
+        src.currentqty,                         -- seeds cumulatedqty
         src.currentcostpricell,
         src.c_currency_id,
         src.c_uom_id,
@@ -112,6 +114,7 @@ BEGIN
             AND tgt.m_product_id              = src.m_product_id
             AND tgt.m_costelement_id          = v_MAICostElementId
             AND tgt.m_attributesetinstance_id = src.m_attributesetinstance_id
+            AND tgt.m_costtype_id             = src.m_costtype_id
       );
 
     GET DIAGNOSTICS v_RowsInserted = ROW_COUNT;
@@ -127,5 +130,7 @@ BEGIN
 
     RAISE NOTICE 'C_AcctSchema_InitMovingAvgInvoice: C_AcctSchema_ID=% switched to costingmethod=M',
         p_C_AcctSchema_ID;
+
+    RETURN 'Seeded ' || v_RowsInserted || ' M_Cost records for C_AcctSchema_ID=' || p_C_AcctSchema_ID || ', switched to costingmethod=M';
 END;
 $$;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/C_AcctSchema_InitMovingAvgInvoice.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/C_AcctSchema_InitMovingAvgInvoice.sql
@@ -33,7 +33,8 @@ BEGIN
     END IF;
 
     IF v_CurrentCostingMethod = 'M' THEN
-        RAISE EXCEPTION 'C_AcctSchema_ID % is already on MovingAverageInvoice', p_C_AcctSchema_ID;
+        RAISE NOTICE 'C_AcctSchema_ID % is already on MovingAverageInvoice, nothing to do', p_C_AcctSchema_ID;
+        RETURN;
     END IF;
 
     -- Find the material cost element for the current costing method
@@ -66,6 +67,10 @@ BEGIN
             v_AD_Client_ID;
     END IF;
 
+    -- Backup affected tables before making changes
+    PERFORM backup_table('m_cost',       '_pre_mai');
+    PERFORM backup_table('c_acctschema', '_pre_mai');
+
     -- Seed M_Cost records for the MAI cost element.
     -- Skip products that already have a record for the target cost element.
     INSERT INTO m_cost (
@@ -96,7 +101,7 @@ BEGIN
         src.c_uom_id,
         0,
         'Y',
-        now(), 0, now(), 0
+        now(), 99, now(), 99
     FROM m_cost src
     WHERE src.c_acctschema_id  = p_C_AcctSchema_ID
       AND src.m_costelement_id = v_CurrentCostElementId
@@ -117,7 +122,7 @@ BEGIN
     UPDATE c_acctschema
     SET  costingmethod = 'M',
          updated       = now(),
-         updatedby     = 0
+         updatedby     = 99
     WHERE c_acctschema_id = p_C_AcctSchema_ID;
 
     RAISE NOTICE 'C_AcctSchema_InitMovingAvgInvoice: C_AcctSchema_ID=% switched to costingmethod=M',

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/C_AcctSchema_InitMovingAvgInvoice.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/C_AcctSchema_InitMovingAvgInvoice.sql
@@ -1,0 +1,126 @@
+-- gh26253: PL/pgSQL function to initialize Moving Average Invoice costing.
+--
+-- Seeds M_Cost records for the MAI cost element (costingmethod='M') from the
+-- existing material cost records of the schema's current costing method,
+-- then switches the accounting schema's costing method to 'M'.
+--
+-- cumulatedamt is seeded as currentcostprice * currentqty so that the first
+-- incoming receipt/invoice computes a correct weighted average from the existing stock.
+--
+-- Usage: SELECT C_AcctSchema_InitMovingAvgInvoice(<C_AcctSchema_ID>);
+CREATE OR REPLACE FUNCTION public.C_AcctSchema_InitMovingAvgInvoice(
+    p_C_AcctSchema_ID numeric
+)
+    RETURNS void
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    v_CurrentCostingMethod char;
+    v_AD_Client_ID         numeric;
+    v_CurrentCostElementId numeric;
+    v_MAICostElementId     numeric;
+    v_RowsInserted         int;
+BEGIN
+    -- Fetch current costing method and client
+    SELECT costingmethod, ad_client_id
+    INTO v_CurrentCostingMethod, v_AD_Client_ID
+    FROM c_acctschema
+    WHERE c_acctschema_id = p_C_AcctSchema_ID;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'C_AcctSchema_ID % not found', p_C_AcctSchema_ID;
+    END IF;
+
+    IF v_CurrentCostingMethod = 'M' THEN
+        RAISE EXCEPTION 'C_AcctSchema_ID % is already on MovingAverageInvoice', p_C_AcctSchema_ID;
+    END IF;
+
+    -- Find the material cost element for the current costing method
+    SELECT m_costelement_id
+    INTO v_CurrentCostElementId
+    FROM m_costelement
+    WHERE ad_client_id     = v_AD_Client_ID
+      AND costelementtype  = 'M'
+      AND costingmethod    = v_CurrentCostingMethod
+      AND isactive         = 'Y'
+    LIMIT 1;
+
+    IF v_CurrentCostElementId IS NULL THEN
+        RAISE EXCEPTION 'No active material cost element found for method=% client=%',
+            v_CurrentCostingMethod, v_AD_Client_ID;
+    END IF;
+
+    -- Find the MovingAverageInvoice cost element for this client
+    SELECT m_costelement_id
+    INTO v_MAICostElementId
+    FROM m_costelement
+    WHERE ad_client_id    = v_AD_Client_ID
+      AND costelementtype = 'M'
+      AND costingmethod   = 'M'
+      AND isactive        = 'Y'
+    LIMIT 1;
+
+    IF v_MAICostElementId IS NULL THEN
+        RAISE EXCEPTION 'No active MovingAverageInvoice cost element (costingmethod=M) found for client=%',
+            v_AD_Client_ID;
+    END IF;
+
+    -- Seed M_Cost records for the MAI cost element.
+    -- Skip products that already have a record for the target cost element.
+    INSERT INTO m_cost (
+        ad_client_id, ad_org_id,
+        m_product_id, m_costtype_id, c_acctschema_id,
+        m_costelement_id, m_attributesetinstance_id,
+        currentcostprice, currentqty,
+        cumulatedamt, cumulatedqty,
+        currentcostpricell,
+        c_currency_id, c_uom_id,
+        percent, isactive,
+        created, createdby, updated, updatedby
+    )
+    SELECT
+        src.ad_client_id,
+        src.ad_org_id,
+        src.m_product_id,
+        src.m_costtype_id,
+        src.c_acctschema_id,
+        v_MAICostElementId,
+        src.m_attributesetinstance_id,
+        src.currentcostprice,
+        src.currentqty,
+        src.currentcostprice * src.currentqty,      -- seeds cumulatedamt for weighted-average formula
+        src.currentqty,                             -- seeds cumulatedqty
+        src.currentcostpricell,
+        src.c_currency_id,
+        src.c_uom_id,
+        0,
+        'Y',
+        now(), 0, now(), 0
+    FROM m_cost src
+    WHERE src.c_acctschema_id  = p_C_AcctSchema_ID
+      AND src.m_costelement_id = v_CurrentCostElementId
+      AND NOT EXISTS (
+          SELECT 1
+          FROM m_cost tgt
+          WHERE tgt.c_acctschema_id           = p_C_AcctSchema_ID
+            AND tgt.m_product_id              = src.m_product_id
+            AND tgt.m_costelement_id          = v_MAICostElementId
+            AND tgt.m_attributesetinstance_id = src.m_attributesetinstance_id
+      );
+
+    GET DIAGNOSTICS v_RowsInserted = ROW_COUNT;
+    RAISE NOTICE 'C_AcctSchema_InitMovingAvgInvoice: seeded % M_Cost records for C_AcctSchema_ID=%',
+        v_RowsInserted, p_C_AcctSchema_ID;
+
+    -- Switch the accounting schema costing method to MovingAverageInvoice
+    UPDATE c_acctschema
+    SET  costingmethod = 'M',
+         updated       = now(),
+         updatedby     = 0
+    WHERE c_acctschema_id = p_C_AcctSchema_ID;
+
+    RAISE NOTICE 'C_AcctSchema_InitMovingAvgInvoice: C_AcctSchema_ID=% switched to costingmethod=M',
+        p_C_AcctSchema_ID;
+END;
+$$;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805700_sys_gh26253_init_moving_avg_invoice_costing.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805700_sys_gh26253_init_moving_avg_invoice_costing.sql
@@ -1,0 +1,128 @@
+-- Run mode: SWING_CLIENT
+
+-- gh26253: PL/pgSQL function to initialize Moving Average Invoice costing.
+--
+-- Seeds M_Cost records for the MAI cost element (costingmethod='M') from the
+-- existing material cost records of the schema's current costing method,
+-- then switches the accounting schema's costing method to 'M'.
+--
+-- cumulatedamt is seeded as currentcostprice * currentqty so that the first
+-- incoming receipt/invoice computes a correct weighted average from the existing stock.
+--
+-- Usage: SELECT C_AcctSchema_InitMovingAvgInvoice(<C_AcctSchema_ID>);
+CREATE OR REPLACE FUNCTION public.C_AcctSchema_InitMovingAvgInvoice(
+    p_C_AcctSchema_ID numeric
+)
+    RETURNS void
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    v_CurrentCostingMethod char;
+    v_AD_Client_ID         numeric;
+    v_CurrentCostElementId numeric;
+    v_MAICostElementId     numeric;
+    v_RowsInserted         int;
+BEGIN
+    -- Fetch current costing method and client
+    SELECT costingmethod, ad_client_id
+    INTO v_CurrentCostingMethod, v_AD_Client_ID
+    FROM c_acctschema
+    WHERE c_acctschema_id = p_C_AcctSchema_ID;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'C_AcctSchema_ID % not found', p_C_AcctSchema_ID;
+    END IF;
+
+    IF v_CurrentCostingMethod = 'M' THEN
+        RAISE EXCEPTION 'C_AcctSchema_ID % is already on MovingAverageInvoice', p_C_AcctSchema_ID;
+    END IF;
+
+    -- Find the material cost element for the current costing method
+    SELECT m_costelement_id
+    INTO v_CurrentCostElementId
+    FROM m_costelement
+    WHERE ad_client_id     = v_AD_Client_ID
+      AND costelementtype  = 'M'
+      AND costingmethod    = v_CurrentCostingMethod
+      AND isactive         = 'Y'
+    LIMIT 1;
+
+    IF v_CurrentCostElementId IS NULL THEN
+        RAISE EXCEPTION 'No active material cost element found for method=% client=%',
+            v_CurrentCostingMethod, v_AD_Client_ID;
+    END IF;
+
+    -- Find the MovingAverageInvoice cost element for this client
+    SELECT m_costelement_id
+    INTO v_MAICostElementId
+    FROM m_costelement
+    WHERE ad_client_id    = v_AD_Client_ID
+      AND costelementtype = 'M'
+      AND costingmethod   = 'M'
+      AND isactive        = 'Y'
+    LIMIT 1;
+
+    IF v_MAICostElementId IS NULL THEN
+        RAISE EXCEPTION 'No active MovingAverageInvoice cost element (costingmethod=M) found for client=%',
+            v_AD_Client_ID;
+    END IF;
+
+    -- Seed M_Cost records for the MAI cost element.
+    -- Skip products that already have a record for the target cost element.
+    INSERT INTO m_cost (
+        ad_client_id, ad_org_id,
+        m_product_id, m_costtype_id, c_acctschema_id,
+        m_costelement_id, m_attributesetinstance_id,
+        currentcostprice, currentqty,
+        cumulatedamt, cumulatedqty,
+        currentcostpricell,
+        c_currency_id, c_uom_id,
+        percent, isactive,
+        created, createdby, updated, updatedby
+    )
+    SELECT
+        src.ad_client_id,
+        src.ad_org_id,
+        src.m_product_id,
+        src.m_costtype_id,
+        src.c_acctschema_id,
+        v_MAICostElementId,
+        src.m_attributesetinstance_id,
+        src.currentcostprice,
+        src.currentqty,
+        src.currentcostprice * src.currentqty,      -- seeds cumulatedamt for weighted-average formula
+        src.currentqty,                             -- seeds cumulatedqty
+        src.currentcostpricell,
+        src.c_currency_id,
+        src.c_uom_id,
+        0,
+        'Y',
+        now(), 0, now(), 0
+    FROM m_cost src
+    WHERE src.c_acctschema_id  = p_C_AcctSchema_ID
+      AND src.m_costelement_id = v_CurrentCostElementId
+      AND NOT EXISTS (
+          SELECT 1
+          FROM m_cost tgt
+          WHERE tgt.c_acctschema_id           = p_C_AcctSchema_ID
+            AND tgt.m_product_id              = src.m_product_id
+            AND tgt.m_costelement_id          = v_MAICostElementId
+            AND tgt.m_attributesetinstance_id = src.m_attributesetinstance_id
+      );
+
+    GET DIAGNOSTICS v_RowsInserted = ROW_COUNT;
+    RAISE NOTICE 'C_AcctSchema_InitMovingAvgInvoice: seeded % M_Cost records for C_AcctSchema_ID=%',
+        v_RowsInserted, p_C_AcctSchema_ID;
+
+    -- Switch the accounting schema costing method to MovingAverageInvoice
+    UPDATE c_acctschema
+    SET  costingmethod = 'M',
+         updated       = now(),
+         updatedby     = 0
+    WHERE c_acctschema_id = p_C_AcctSchema_ID;
+
+    RAISE NOTICE 'C_AcctSchema_InitMovingAvgInvoice: C_AcctSchema_ID=% switched to costingmethod=M',
+        p_C_AcctSchema_ID;
+END;
+$$;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805700_sys_gh26253_init_moving_avg_invoice_costing.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805700_sys_gh26253_init_moving_avg_invoice_costing.sql
@@ -35,7 +35,8 @@ BEGIN
     END IF;
 
     IF v_CurrentCostingMethod = 'M' THEN
-        RAISE EXCEPTION 'C_AcctSchema_ID % is already on MovingAverageInvoice', p_C_AcctSchema_ID;
+        RAISE NOTICE 'C_AcctSchema_ID % is already on MovingAverageInvoice, nothing to do', p_C_AcctSchema_ID;
+        RETURN;
     END IF;
 
     -- Find the material cost element for the current costing method
@@ -68,6 +69,10 @@ BEGIN
             v_AD_Client_ID;
     END IF;
 
+    -- Backup affected tables before making changes
+    PERFORM backup_table('m_cost',       '_pre_mai');
+    PERFORM backup_table('c_acctschema', '_pre_mai');
+
     -- Seed M_Cost records for the MAI cost element.
     -- Skip products that already have a record for the target cost element.
     INSERT INTO m_cost (
@@ -98,7 +103,7 @@ BEGIN
         src.c_uom_id,
         0,
         'Y',
-        now(), 0, now(), 0
+        now(), 99, now(), 99
     FROM m_cost src
     WHERE src.c_acctschema_id  = p_C_AcctSchema_ID
       AND src.m_costelement_id = v_CurrentCostElementId
@@ -119,7 +124,7 @@ BEGIN
     UPDATE c_acctschema
     SET  costingmethod = 'M',
          updated       = now(),
-         updatedby     = 0
+         updatedby     = 99
     WHERE c_acctschema_id = p_C_AcctSchema_ID;
 
     RAISE NOTICE 'C_AcctSchema_InitMovingAvgInvoice: C_AcctSchema_ID=% switched to costingmethod=M',

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805700_sys_gh26253_init_moving_avg_invoice_costing.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805700_sys_gh26253_init_moving_avg_invoice_costing.sql
@@ -13,7 +13,7 @@
 CREATE OR REPLACE FUNCTION public.C_AcctSchema_InitMovingAvgInvoice(
     p_C_AcctSchema_ID numeric
 )
-    RETURNS void
+    RETURNS text
     LANGUAGE plpgsql
 AS
 $$
@@ -36,7 +36,7 @@ BEGIN
 
     IF v_CurrentCostingMethod = 'M' THEN
         RAISE NOTICE 'C_AcctSchema_ID % is already on MovingAverageInvoice, nothing to do', p_C_AcctSchema_ID;
-        RETURN;
+        RETURN 'C_AcctSchema_ID ' || p_C_AcctSchema_ID || ' is already on MovingAverageInvoice, nothing to do';
     END IF;
 
     -- Find the material cost element for the current costing method
@@ -47,6 +47,7 @@ BEGIN
       AND costelementtype  = 'M'
       AND costingmethod    = v_CurrentCostingMethod
       AND isactive         = 'Y'
+    ORDER BY m_costelement_id
     LIMIT 1;
 
     IF v_CurrentCostElementId IS NULL THEN
@@ -62,6 +63,7 @@ BEGIN
       AND costelementtype = 'M'
       AND costingmethod   = 'M'
       AND isactive        = 'Y'
+    ORDER BY m_costelement_id
     LIMIT 1;
 
     IF v_MAICostElementId IS NULL THEN
@@ -69,12 +71,12 @@ BEGIN
             v_AD_Client_ID;
     END IF;
 
-    -- Backup affected tables before making changes
-    PERFORM backup_table('m_cost',       '_pre_mai');
-    PERFORM backup_table('c_acctschema', '_pre_mai');
+    -- Backup affected tables before making changes (suffix includes schema ID to avoid collision)
+    PERFORM backup_table('m_cost',       '_pre_mai_' || p_C_AcctSchema_ID);
+    PERFORM backup_table('c_acctschema', '_pre_mai_' || p_C_AcctSchema_ID);
 
     -- Seed M_Cost records for the MAI cost element.
-    -- Skip products that already have a record for the target cost element.
+    -- Skip products that already have a record for the target cost element + cost type.
     INSERT INTO m_cost (
         ad_client_id, ad_org_id,
         m_product_id, m_costtype_id, c_acctschema_id,
@@ -96,8 +98,8 @@ BEGIN
         src.m_attributesetinstance_id,
         src.currentcostprice,
         src.currentqty,
-        src.currentcostprice * src.currentqty,      -- seeds cumulatedamt for weighted-average formula
-        src.currentqty,                             -- seeds cumulatedqty
+        src.currentcostprice * src.currentqty,  -- seeds cumulatedamt for weighted-average formula
+        src.currentqty,                         -- seeds cumulatedqty
         src.currentcostpricell,
         src.c_currency_id,
         src.c_uom_id,
@@ -114,6 +116,7 @@ BEGIN
             AND tgt.m_product_id              = src.m_product_id
             AND tgt.m_costelement_id          = v_MAICostElementId
             AND tgt.m_attributesetinstance_id = src.m_attributesetinstance_id
+            AND tgt.m_costtype_id             = src.m_costtype_id
       );
 
     GET DIAGNOSTICS v_RowsInserted = ROW_COUNT;
@@ -129,5 +132,7 @@ BEGIN
 
     RAISE NOTICE 'C_AcctSchema_InitMovingAvgInvoice: C_AcctSchema_ID=% switched to costingmethod=M',
         p_C_AcctSchema_ID;
+
+    RETURN 'Seeded ' || v_RowsInserted || ' M_Cost records for C_AcctSchema_ID=' || p_C_AcctSchema_ID || ', switched to costingmethod=M';
 END;
 $$;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805700_sys_gh26253_init_moving_avg_invoice_costing.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805700_sys_gh26253_init_moving_avg_invoice_costing.sql
@@ -71,9 +71,9 @@ BEGIN
             v_AD_Client_ID;
     END IF;
 
-    -- Backup affected tables before making changes (suffix includes schema ID to avoid collision)
-    PERFORM backup_table('m_cost',       '_pre_mai_' || p_C_AcctSchema_ID);
-    PERFORM backup_table('c_acctschema', '_pre_mai_' || p_C_AcctSchema_ID);
+    -- Backup affected tables before making changes
+    PERFORM backup_table('m_cost',       '_pre_mai');
+    PERFORM backup_table('c_acctschema', '_pre_mai');
 
     -- Seed M_Cost records for the MAI cost element.
     -- Skip products that already have a record for the target cost element + cost type.

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805710_sys_gh26253_register_AD_Process_InitMovingAvgInvoice.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805710_sys_gh26253_register_AD_Process_InitMovingAvgInvoice.sql
@@ -7,7 +7,7 @@
 -- AD_Element
 -- 2026-06-02
 INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
-VALUES (0,584927 /*From ID Server*/,0,now(),100,'D','Y','Gleitenden Durchschnitt (Rechnungspreis) initialisieren','Gleitenden Durchschnitt (Rechnungspreis) initialisieren',now(),100)
+VALUES (0,584927 /*From ID Server*/,0,now(),100,'D','Y','Initialize Moving Average Invoice Costing','Initialize Moving Average Invoice Costing',now(),100)
 ;
 
 INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
@@ -19,17 +19,20 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y')
 ;
 
 UPDATE AD_Element_Trl
-SET IsTranslated='Y', Name='Initialize Moving Average Invoice Costing', PrintName='Initialize Moving Average Invoice Costing', Updated=now(), UpdatedBy=100
-WHERE AD_Element_ID=584927 AND AD_Language='en_US'
+SET IsTranslated='Y', Name='Moving Average Invoice initialisieren', PrintName='Moving Average Invoice initialisieren', Updated=now(), UpdatedBy=100
+WHERE AD_Element_ID=584927 AND AD_Language IN ('de_DE','de_CH')
 ;
 
-SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584927,'en_US')
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584927,'de_DE')
+;
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584927,'de_CH')
 ;
 
 -- AD_Process
 -- 2026-06-02
-INSERT INTO AD_Process (AccessLevel,AD_Client_ID,AD_Org_ID,AD_Process_ID,AllowProcessReRun,CopyFromProcess,Created,CreatedBy,EntityType,IsActive,IsApplySecuritySettings,IsBetaFunctionality,IsDirectPrint,IsNotifyUserAfterExecution,IsOneInstanceOnly,IsReport,IsTranslateExcelHeaders,IsUseBPartnerLanguage,LockWaitTimeout,Name,PostgrestResponseFormat,RefreshAllAfterExecution,ShowHelp,SQLStatement,Type,Updated,UpdatedBy,Value)
-VALUES ('3',0,0,585629 /*From ID Server*/,'Y','N',now(),100,'D','Y','N','N','N','Y','N','N','Y','Y',0,'Gleitenden Durchschnitt (Rechnungspreis) initialisieren','json','Y','N','SELECT public.C_AcctSchema_InitMovingAvgInvoice(@C_AcctSchema_ID@)','SQL',now(),100,'C_AcctSchema_InitMovingAvgInvoice')
+INSERT INTO AD_Process (AccessLevel,AD_Client_ID,AD_Org_ID,AD_Process_ID,AllowProcessReRun,Classname,CopyFromProcess,Created,CreatedBy,EntityType,IsActive,IsApplySecuritySettings,IsBetaFunctionality,IsDirectPrint,IsNotifyUserAfterExecution,IsOneInstanceOnly,IsReport,IsTranslateExcelHeaders,IsUseBPartnerLanguage,LockWaitTimeout,Name,PostgrestResponseFormat,RefreshAllAfterExecution,ShowHelp,SQLStatement,Type,Updated,UpdatedBy,Value)
+VALUES ('3',0,0,585629 /*From ID Server*/,'Y','de.metas.process.ExecuteUpdateSQL','N',now(),100,'D','Y','N','N','N','Y','N','N','Y','Y',0,'Initialize Moving Average Invoice Costing','json','Y','N','SELECT public.C_AcctSchema_InitMovingAvgInvoice(@C_AcctSchema_ID@)','SQL',now(),100,'C_AcctSchema_InitMovingAvgInvoice')
 ;
 
 INSERT INTO AD_Process_Trl (AD_Language,AD_Process_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
@@ -41,12 +44,25 @@ WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y')
 ;
 
 UPDATE AD_Process_Trl
-SET IsTranslated='Y', Name='Initialize Moving Average Invoice Costing', Updated=now(), UpdatedBy=100
-WHERE AD_Language='en_US' AND AD_Process_ID=585629
+SET IsTranslated='Y', Name='Moving Average Invoice initialisieren', Updated=now(), UpdatedBy=100
+WHERE AD_Process_ID=585629 AND AD_Language IN ('de_DE','de_CH')
 ;
 
 -- AD_Table_Process: attach to C_AcctSchema (AD_Table_ID=265) as a document action
 -- 2026-06-02
 INSERT INTO AD_Table_Process (AD_Client_ID,AD_Org_ID,AD_Process_ID,AD_Table_ID,AD_Table_Process_ID,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy,WEBUI_DocumentAction,WEBUI_IncludedTabTopAction,WEBUI_ViewAction,WEBUI_ViewQuickAction,WEBUI_ViewQuickAction_Default)
 VALUES (0,0,585629,265,541647 /*From ID Server*/,now(),100,'D','Y',now(),100,'Y','N','N','N','N')
+;
+
+-- Make CostingMethod read-only: users must use the initialization process to change it
+-- 2026-06-02
+UPDATE AD_Field
+SET IsReadOnly='Y', Updated=now(), UpdatedBy=100
+WHERE IsActive='Y'
+  AND AD_Column_ID IN (
+      SELECT c.AD_Column_ID
+      FROM AD_Column c
+      JOIN AD_Table t ON t.AD_Table_ID = c.AD_Table_ID
+      WHERE t.TableName = 'C_AcctSchema' AND c.ColumnName = 'CostingMethod'
+  )
 ;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805710_sys_gh26253_register_AD_Process_InitMovingAvgInvoice.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805710_sys_gh26253_register_AD_Process_InitMovingAvgInvoice.sql
@@ -1,0 +1,52 @@
+-- Run mode: SWING_CLIENT
+
+-- gh26253: Register AD_Process for C_AcctSchema_InitMovingAvgInvoice.
+-- Adds a document action on the Accounting Schema window that calls the
+-- C_AcctSchema_InitMovingAvgInvoice() PL/pgSQL function.
+
+-- AD_Element
+-- 2026-06-02
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,584927 /*From ID Server*/,0,now(),100,'D','Y','Gleitenden Durchschnitt (Rechnungspreis) initialisieren','Gleitenden Durchschnitt (Rechnungspreis) initialisieren',now(),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y')
+  AND t.AD_Element_ID=584927
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+UPDATE AD_Element_Trl
+SET IsTranslated='Y', Name='Initialize Moving Average Invoice Costing', PrintName='Initialize Moving Average Invoice Costing', Updated=now(), UpdatedBy=100
+WHERE AD_Element_ID=584927 AND AD_Language='en_US'
+;
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584927,'en_US')
+;
+
+-- AD_Process
+-- 2026-06-02
+INSERT INTO AD_Process (AccessLevel,AD_Client_ID,AD_Org_ID,AD_Process_ID,AllowProcessReRun,CopyFromProcess,Created,CreatedBy,EntityType,IsActive,IsApplySecuritySettings,IsBetaFunctionality,IsDirectPrint,IsNotifyUserAfterExecution,IsOneInstanceOnly,IsReport,IsTranslateExcelHeaders,IsUseBPartnerLanguage,LockWaitTimeout,Name,PostgrestResponseFormat,RefreshAllAfterExecution,ShowHelp,SQLStatement,Type,Updated,UpdatedBy,Value)
+VALUES ('3',0,0,585629 /*From ID Server*/,'Y','N',now(),100,'D','Y','N','N','N','Y','N','N','Y','Y',0,'Gleitenden Durchschnitt (Rechnungspreis) initialisieren','json','Y','N','SELECT public.C_AcctSchema_InitMovingAvgInvoice(@C_AcctSchema_ID@)','SQL',now(),100,'C_AcctSchema_InitMovingAvgInvoice')
+;
+
+INSERT INTO AD_Process_Trl (AD_Language,AD_Process_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Process_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Process t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y')
+  AND t.AD_Process_ID=585629
+  AND NOT EXISTS (SELECT 1 FROM AD_Process_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_ID=t.AD_Process_ID)
+;
+
+UPDATE AD_Process_Trl
+SET IsTranslated='Y', Name='Initialize Moving Average Invoice Costing', Updated=now(), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Process_ID=585629
+;
+
+-- AD_Table_Process: attach to C_AcctSchema (AD_Table_ID=265) as a document action
+-- 2026-06-02
+INSERT INTO AD_Table_Process (AD_Client_ID,AD_Org_ID,AD_Process_ID,AD_Table_ID,AD_Table_Process_ID,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy,WEBUI_DocumentAction,WEBUI_IncludedTabTopAction,WEBUI_ViewAction,WEBUI_ViewQuickAction,WEBUI_ViewQuickAction_Default)
+VALUES (0,0,585629,265,541647 /*From ID Server*/,now(),100,'D','Y',now(),100,'Y','N','N','N','N')
+;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805710_sys_gh26253_register_AD_Process_InitMovingAvgInvoice.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5805710_sys_gh26253_register_AD_Process_InitMovingAvgInvoice.sql
@@ -54,7 +54,8 @@ INSERT INTO AD_Table_Process (AD_Client_ID,AD_Org_ID,AD_Process_ID,AD_Table_ID,A
 VALUES (0,0,585629,265,541647 /*From ID Server*/,now(),100,'D','Y',now(),100,'Y','N','N','N','N')
 ;
 
--- Make CostingMethod read-only: users must use the initialization process to change it
+-- Make CostingMethod read-only across all windows: users must use the initialization
+-- process to change it. Intentionally global — direct editing of this field is never safe.
 -- 2026-06-02
 UPDATE AD_Field
 SET IsReadOnly='Y', Updated=now(), UpdatedBy=100


### PR DESCRIPTION

This PR adds a one-time initialization utility for switching an accounting schema from any costing method to Moving Average Invoice (MAI).

What was added:
- 5805700 — PL/pgSQL function C_AcctSchema_InitMovingAvgInvoice(p_C_AcctSchema_ID) that seeds M_Cost records for the MAI cost element from the existing cost records, then switches c_acctschema.costingmethod = 'M'. If the schema is already on MAI it returns silently.
- 5805710 — registers the function as an AD_Process (Type=SQL, class ExecuteUpdateSQL) attached to the Accounting Schema window as a document action. Also makes CostingMethod field read-only so users can't bypass the process.
- DDL counterpart at ddl/functions/C_AcctSchema_InitMovingAvgInvoice.sql

Key design decisions to be aware of:
- The MAI cost element is looked up dynamically (costingmethod='M', costelementtype='M', isactive='Y') — no hardcoded IDs
- Both m_cost and c_acctschema are backed up via backup_table() before any data change
- createdby/updatedby in the function body use 99 (migration user)
- No Java class — the SQL function is called directly via ExecuteUpdateSQL