### PR TITLE
gh30196: add carrier tracking infos to Historical Shipments JSON

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipper/nShiftShipment.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipper/nShiftShipment.feature
@@ -228,6 +228,113 @@ Feature: nShift Shipment
       | Carrier_Product_ID | Carrier_Goods_Type_ID | Carrier_Service_ID | Carrier_Service_ID2 | NumParcels | SenderCompanyName | SenderCountryCode | ReceiverCompanyName | ReceiverCompanyName2   | ReceiverStreet | ReceiverAdditionalAddressInfo | ReceiverHouseNo | ReceiverZip | ReceiverCity | ReceiverCountryCode | ReceiverAttention | ReceiverContactName     | ReceiverContactPhone | ReceiverContactEmail        | ParcelGrossWeightKg |
       | cp1                | cgt1                  | cs1                | cs2                 | 1          | metasfresh AG     | DE                | nShift Customer     | nShift Logistics Dept. | street         | Floor 2                       | 1               | 12345       | city         | CH                  | Attention Test       | nShift Customer Contact | +41791234567         | contact@nshift-test.example | 21                  |
 
+  @Id:S30196_TC1
+  Scenario: nShift Delivery Order exported via Historical Shipments JSON includes parcel tracking
+    Given set sys config boolean value true for sys config de.metas.handlingunits.picking.addToDailyShipperTransportationOrder
+    # Test env has no AD_Printer_Config for the system user; auto-print would otherwise fail the WP.
+    And set sys config boolean value false for sys config de.metas.shipper.gateway.printLabels.enabled
+    And the nShift ship advisor service is stubbed to return a successful response based on the request
+      | Carrier_Product_ID | Carrier_Goods_Type_ID | Carrier_Service_ID | Carrier_Service_ID2 |
+      | cp1                | cgt1                  | cs1                | cs2                 |
+    And the nShift shipment service is stubbed to return a successful shipment creation response
+    # The export process ANDs ExternalSystemCode ILIKE '%'; a shipment without an external system is excluded,
+    # so the order must carry an AD_InputDataSource + External System.
+    # Explicit Value+Name so reruns reuse the same AD_InputDataSource (upserts by Value) and don't
+    # collide on the AD_InputDataSource_InternalName unique index.
+    And metasfresh contains AD_InputDataSource:
+      | Identifier     | Value      | Name       | InternalName |
+      | dataSource_exp | nshift_exp | nshift_exp | nshift_exp   |
+    And metasfresh contains External System
+      | Name           | Value      |
+      | nShiftExport   | nshift_exp |
+    # Stable Name + EMail so reruns reuse the same AD_User and don't repoint it to a different bpartner —
+    # the composite FK c_order(c_bpartner_id, ad_user_id) would otherwise block the update.
+    And metasfresh contains AD_Users:
+      | Identifier         | Name                    | OPT.C_BPartner_ID.Identifier | OPT.EMail                    | OPT.Phone        |
+      | customerContact    | nShift Customer Contact | customer                     | contact@nshift-test.example  | +41 79 123 45 67 |
+    And metasfresh contains C_Orders:
+      | Identifier | REST.Context | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | M_Shipper_ID | OPT.AD_User_ID.Identifier | AD_InputDataSource_ID | ExternalSystem.Value |
+      | so_exp     | order_exp_ID | true    | customer      | 2025-04-01  | wh             | nShift       | customerContact           | dataSource_exp        | nshift_exp           |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | so_exp_l1  | so_exp     | product      | 10         |
+    When the order identified by so_exp is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute | Carrier_Product_ID | Carrier_Goods_Type_ID |
+      | ss_exp     | so_exp_l1      | N             | cp1                | cgt1                  |
+    And shipment is generated for the following shipment schedule
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | ss_exp                | inout_exp  |
+    And after not more than 60s, Transportation Order is found for Shipment:
+      | M_InOut_ID | M_ShipperTransportation_ID |
+      | inout_exp  | transpOrder_exp            |
+    And after not more than 60s, Carrier_ShipmentOrder is found:
+      | Identifier | M_InOut_ID |
+      | cso_exp    | inout_exp  |
+    And validate Carrier_ShipmentOrder_Parcels:
+      | Carrier_ShipmentOrder_ID | awb | TrackingURL | HasPdfLabel |
+      | cso_exp                  | awb | trackingUrl | true        |
+    # 10 PCE / 10 PCE-per-TU => 1 parcel; total weight = product.GrossWeight (2.1) × qty (10) = 21 kg.
+    And validate Carrier_ShipmentOrder_Items:
+      | Carrier_ShipmentOrder_ID | ProductName    | ArticleValue   | CustomsTariffNumber | QtyShipped | Price | TotalPrice | TotalWeightInKg |
+      | cso_exp                  | nShift Product | nshift_product | 12345678            | 10         | 10    | 100        | 21              |
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID | REST.Context.M_InOut_ID | REST.Context.DocumentNo |
+      | ss_exp                | inout_exp  | shipment_exp_ID         | shipment_exp_DocumentNo |
+    And the following API_Audit_Config records are created:
+      | Identifier | SeqNo | OPT.Method | OPT.PathPrefix   | IsForceProcessedAsync | IsSynchronousAuditLoggingEnabled | IsWrapApiResponse |
+      | c_exp      | 10    | GET        | api/v2/processes | N                     | Y                                | N                 |
+    And add HTTP headers
+      | Key          | Value                          |
+      | Content-Type | application/json;charset=UTF-8 |
+      | accept       | application/json;charset=UTF-8 |
+    When a 'POST' request with the below payload and headers from context is sent to the metasfresh REST-API 'api/v2/processes/Historical_Shipments_JSON/invoke' and fulfills with '200' status code
+    """
+{
+  "processParameters": [
+    {
+      "name": "Order_ID",
+      "value": "@order_exp_ID@"
+    }
+  ]
+}
+    """
+    Then the metasfresh REST-API responds with
+    """
+[
+  {
+    "Order_ID": @order_exp_ID@,
+    "Shipment_DocumentNo": "@shipment_exp_DocumentNo@",
+    "DocStatus": "CO",
+    "Lines": [
+      {
+        "LineNo": 10,
+        "ProductValue": "nshift_product",
+        "ProductName": "nShift Product",
+        "QtyEntered": 10,
+        "UOM": "Stk"
+      }
+    ],
+    "Parcels": [
+      {
+        "TrackingNumber": "awb",
+        "TrackingURL": "trackingUrl",
+        "Carrier": "nShift",
+        "Items": [
+          {
+            "ProductValue": "nshift_product",
+            "ProductName": "nShift Product",
+            "QtyShipped": 10,
+            "TotalWeightInKg": 21,
+            "CustomsTariffNumber": "12345678"
+          }
+        ]
+      }
+    ]
+  }
+]
+    """
+
   Scenario: nShift Carrier Advise uses ExternalSystem-specific service level
     Given metasfresh contains External System
       | Name      | Value     |

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inout/5805750_sys_gh30196_historical_m_inout_json_v.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inout/5805750_sys_gh30196_historical_m_inout_json_v.sql
@@ -1,7 +1,12 @@
-DROP VIEW IF EXISTS historical_m_inout_json_v
+-- Source DDL: backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/views/historical_m_inout_json_v.sql
+-- gh30196: add carrier / parcel tracking infos ("Parcels" -> "Items") to the Historical Shipments JSON view.
+-- Tracking number (awb) and TrackingURL come from Carrier_ShipmentOrder_Parcel; carrier from M_Shipper.
+-- Parcels are matched to the shipment per-package via M_Package_ID (M_ShippingPackage <-> Carrier_ShipmentOrder_Parcel).
+
+DROP VIEW IF EXISTS historical_m_inout_json_v$new
 ;
 
-CREATE OR REPLACE VIEW historical_m_inout_json_v AS
+CREATE OR REPLACE VIEW historical_m_inout_json_v$new AS
 SELECT io.m_inout_id                                   AS "Shipment_ID",
        io.documentno                                   AS "Shipment_DocumentNo",
        io.movementdate                                 AS "Shipment_Date",
@@ -54,7 +59,7 @@ SELECT io.m_inout_id                                   AS "Shipment_ID",
         WHERE iol.m_inout_id = io.m_inout_id
           AND iol.isactive = 'Y')                      AS "Lines",
 
-       -- Carrier / parcel tracking infos.
+       -- Carrier / parcel tracking infos (gh30196).
        -- A shipment's physical packages are M_ShippingPackage rows (linked by M_InOut_ID).
        -- Each carrier parcel (Carrier_ShipmentOrder_Parcel) carries the same M_Package_ID,
        -- so we match per-package via M_Package_ID (precise; avoids the transport-level cartesian).
@@ -117,4 +122,15 @@ FROM m_inout io
          LEFT JOIN ExternalSystem esystem ON esystem.externalsystem_id = io.externalsystem_id
 WHERE io.isactive = 'Y'
 ORDER BY io.movementdate DESC, io.updated DESC, io.m_inout_id DESC
+;
+
+SELECT db_alter_view(
+    'historical_m_inout_json_v',
+    (SELECT view_definition
+     FROM information_schema.views
+     WHERE lower(views.table_name) = lower('historical_m_inout_json_v$new'))
+)
+;
+
+DROP VIEW IF EXISTS historical_m_inout_json_v$new
 ;


### PR DESCRIPTION
## What

Adds carrier / tracking data to the Historical Shipments JSON API by extending the view `historical_m_inout_json_v` with a nested `Parcels` → `Items` aggregate.


## Why

The shipment JSON export exposed lines but no carrier/tracking information. Customers consuming `Historical_Shipments_JSON` need the tracking number, tracking URL, the carrier (Versender) and the package contents (which items are in which parcel).

## How

- Extended the view (canonical DDL + migration `5805750_sys_gh30196`, applied via `db_alter_view`).
- **No new process** — the existing `Historical_Shipments_JSON` process (`AD_Process_ID=585488`) already passes `&limit=@Limit/2000@&offset=@Offset/0@` to PostgREST, so the issue's Limit/Offset requirement is already satisfied.
- Per shipment, a `Parcels` array; each parcel:
  - `TrackingNumber` (awb), `TrackingURL`, `Carrier` + `CarrierCode` (`M_Shipper`), `WeightInKg`, `LengthInCm`, `WidthInCm`, `HeightInCm`, `PackageDescription`, `M_Package_ID`
  - `Items`: `ProductValue`, `ProductName`, `QtyShipped`, `UOM`, `TotalWeightInKg`, `CustomsTariffNumber`
- **Join:** parcels are matched to the shipment **per package** via `M_Package_ID` (`M_ShippingPackage ↔ Carrier_ShipmentOrder_Parcel`). This is the precise link and avoids the transport-level cartesian (a `M_ShipperTransportation_ID`-only join expands a single shipment to thousands of parcels).

## Testing

- Migration applies cleanly against the `new_dawn_uat` schema; the view compiles and the `Parcels` column is present.
- Existing cucumber feature `historicalShipmentsExport` (8 scenarios) passes locally — the additive `Parcels` key does not affect existing assertions (`JSONCompareMode.LENIENT`).
- Validated against a real-data DB: `M_Package_ID` is 100% populated on both join sides; the per-package join returns the correct 1–2 parcels per shipment (the transport-level join over-counts to ~11,350); the emitted JSON carries real tracking numbers, tracking URLs, carrier and item contents.
