### PR TITLE
M_HU_Attribute picking performance: covering index + weekly destroyed-HU attribute archival

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/deactivate_destroyed_hu_attributes.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/deactivate_destroyed_hu_attributes.sql
@@ -25,7 +25,9 @@ AS $func$
 DECLARE
     v_deactivated integer;
 BEGIN
-    -- self-provisioning (idempotent)
+    -- self-provisioning (idempotent): schema + log table. The log table may already exist from an
+    -- earlier run that predated the deactivated_at column, so add it if missing (existing rows
+    -- backfill to now()).
     CREATE SCHEMA IF NOT EXISTS dlm;
     CREATE TABLE IF NOT EXISTS dlm.m_hu_attribute_deactivated (
         m_hu_attribute_id numeric(10,0) PRIMARY KEY,

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/deactivate_destroyed_hu_attributes.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/deactivate_destroyed_hu_attributes.sql
@@ -59,6 +59,7 @@ BEGIN
     )
     SELECT count(*) INTO v_deactivated FROM upd;
 
+    RAISE NOTICE 'dlm.deactivate_destroyed_hu_attributes: % attribute rows deactivated', v_deactivated;
     RETURN COALESCE(v_deactivated, 0);
 END;
 $func$;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/deactivate_destroyed_hu_attributes.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/deactivate_destroyed_hu_attributes.sql
@@ -1,0 +1,64 @@
+-- dlm.deactivate_destroyed_hu_attributes(p_max_hus)
+-- Soft-archive (IsActive='N') M_HU_Attribute rows of DESTROYED HUs so the picking
+-- source-HU search (HUStorageQuery) stays fast and the partial index m_hu_attribute_hu_attr_valnum
+-- (WHERE IsActive='Y') stays small / cache-resident.
+--
+-- Self-provisioning (idempotent): creates the dlm schema, the reversibility log table, and its
+-- deactivated_at timestamp column if missing.
+--
+-- Bounded per run by p_max_hus -> one small transaction, suitable for a weekly AD_Scheduler. The
+-- one-time large backlog is handled separately by a manual, per-batch-commit operational runbook.
+--
+-- SCOPE = HUStatus='D' (Destroyed) ONLY. NOT Active('A')/Shipped('E')/Picked('S')/Planning('P')/
+-- Issued('I'): 'A' would become unpickable; 'E' can be REACTIVATED by shipment reversal and would
+-- come back attribute-less. Destroyed HUs have no un-destroy path -> safe.
+--
+-- References public.* explicitly: under DLM the dlm schema shadows public tables with filtered views;
+-- this maintenance job must see the REAL tables.
+
+CREATE SCHEMA IF NOT EXISTS dlm;
+
+CREATE OR REPLACE FUNCTION dlm.deactivate_destroyed_hu_attributes(p_max_hus integer DEFAULT 100000)
+    RETURNS integer
+    LANGUAGE plpgsql
+AS $func$
+DECLARE
+    v_deactivated integer;
+BEGIN
+    -- self-provisioning (idempotent)
+    CREATE SCHEMA IF NOT EXISTS dlm;
+    CREATE TABLE IF NOT EXISTS dlm.m_hu_attribute_deactivated (
+        m_hu_attribute_id numeric(10,0) PRIMARY KEY,
+        deactivated_at    timestamp without time zone NOT NULL DEFAULT now()
+    );
+    ALTER TABLE dlm.m_hu_attribute_deactivated
+        ADD COLUMN IF NOT EXISTS deactivated_at timestamp without time zone NOT NULL DEFAULT now();
+
+    WITH huids AS (
+        SELECT h.m_hu_id
+        FROM public.m_hu h
+        WHERE h.hustatus = 'D'
+          AND EXISTS (SELECT 1
+                      FROM public.m_hu_attribute a
+                      WHERE a.m_hu_id = h.m_hu_id
+                        AND a.isactive = 'Y')
+        LIMIT p_max_hus
+    ),
+    upd AS (
+        UPDATE public.m_hu_attribute a
+           SET isactive = 'N', updatedby = 99, updated = now()
+        FROM huids
+        WHERE a.m_hu_id = huids.m_hu_id
+          AND a.isactive = 'Y'
+        RETURNING a.m_hu_attribute_id
+    ),
+    trk AS (
+        INSERT INTO dlm.m_hu_attribute_deactivated (m_hu_attribute_id, deactivated_at)
+        SELECT m_hu_attribute_id, now() FROM upd
+        ON CONFLICT DO NOTHING
+    )
+    SELECT count(*) INTO v_deactivated FROM upd;
+
+    RETURN COALESCE(v_deactivated, 0);
+END;
+$func$;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806000_sys_M_HU_Attribute_picking_source_hu_index.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806000_sys_M_HU_Attribute_picking_source_hu_index.sql
@@ -1,0 +1,22 @@
+-- Speed up the picking "find pickable source HUs" search on large M_HU_Attribute datasets.
+--
+-- WHY: HUStorageQuery.createQueryBuilder_for_M_HU_Storages builds an EXISTS over M_HU_Attribute with
+-- predicate (M_HU_ID = ?, M_Attribute_ID = ?, ValueNumber = ?, IsActive = 'Y'), probed once per
+-- candidate HU during ForcePick* / source-HU retrieval. The existing index
+-- m_hu_attribute_parent_index (M_HU_ID, M_Attribute_ID) does NOT cover ValueNumber, so each probe
+-- heap-fetches to evaluate it. On large datasets (m_hu_attribute can reach hundreds of millions of
+-- rows) that is millions of cold random reads -> seconds per pick. This partial covering index lets
+-- the EXISTS be satisfied
+-- index-only and (together with the destroyed-HU attribute soft-archive) keeps the active slice
+-- cache-resident.
+--
+-- NON-CONCURRENT ON PURPOSE: CREATE INDEX CONCURRENTLY cannot run inside the migration tool's single
+-- transaction / multi-command string (see de.metas.dlm 5453734_sys_gh489_DDL.sql:148-151). On small
+-- and CI databases the statement below is instant. On LARGE production databases the index MUST be
+-- pre-created CONCURRENTLY off-peak BEFORE this rollout runs (via an operational DBA
+-- runbook) so that this IF NOT EXISTS statement is a no-op and does not
+-- take an ACCESS EXCLUSIVE lock on the picking-critical M_HU_Attribute table.
+
+CREATE INDEX IF NOT EXISTS m_hu_attribute_hu_attr_valnum
+    ON M_HU_Attribute (M_HU_ID, M_Attribute_ID, ValueNumber)
+    WHERE IsActive = 'Y';

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806000_sys_M_HU_Attribute_picking_source_hu_index.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806000_sys_M_HU_Attribute_picking_source_hu_index.sql
@@ -1,21 +1,5 @@
--- Speed up the picking "find pickable source HUs" search on large M_HU_Attribute datasets.
---
--- WHY: HUStorageQuery.createQueryBuilder_for_M_HU_Storages builds an EXISTS over M_HU_Attribute with
--- predicate (M_HU_ID = ?, M_Attribute_ID = ?, ValueNumber = ?, IsActive = 'Y'), probed once per
--- candidate HU during ForcePick* / source-HU retrieval. The existing index
--- m_hu_attribute_parent_index (M_HU_ID, M_Attribute_ID) does NOT cover ValueNumber, so each probe
--- heap-fetches to evaluate it. On large datasets (m_hu_attribute can reach hundreds of millions of
--- rows) that is millions of cold random reads -> seconds per pick. This partial covering index lets
--- the EXISTS be satisfied
--- index-only and (together with the destroyed-HU attribute soft-archive) keeps the active slice
--- cache-resident.
---
--- NON-CONCURRENT ON PURPOSE: CREATE INDEX CONCURRENTLY cannot run inside the migration tool's single
--- transaction / multi-command string (see de.metas.dlm 5453734_sys_gh489_DDL.sql:148-151). On small
--- and CI databases the statement below is instant. On LARGE production databases the index MUST be
--- pre-created CONCURRENTLY off-peak BEFORE this rollout runs (via an operational DBA
--- runbook) so that this IF NOT EXISTS statement is a no-op and does not
--- take an ACCESS EXCLUSIVE lock on the picking-critical M_HU_Attribute table.
+-- Partial covering index for the picking source-HU search: makes the per-candidate-HU
+-- M_HU_Attribute EXISTS (M_HU_ID, M_Attribute_ID, ValueNumber, IsActive='Y') index-only.
 
 CREATE INDEX IF NOT EXISTS m_hu_attribute_hu_attr_valnum
     ON M_HU_Attribute (M_HU_ID, M_Attribute_ID, ValueNumber)

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806010_sys_fn_deactivate_destroyed_hu_attributes.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806010_sys_fn_deactivate_destroyed_hu_attributes.sql
@@ -12,6 +12,9 @@ AS $func$
 DECLARE
     v_deactivated integer;
 BEGIN
+    -- self-provisioning (idempotent): schema + log table. The log table may already exist from an
+    -- earlier run that predated the deactivated_at column, so add it if missing (existing rows
+    -- backfill to now()).
     CREATE SCHEMA IF NOT EXISTS dlm;
     CREATE TABLE IF NOT EXISTS dlm.m_hu_attribute_deactivated (
         m_hu_attribute_id numeric(10,0) PRIMARY KEY,

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806010_sys_fn_deactivate_destroyed_hu_attributes.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806010_sys_fn_deactivate_destroyed_hu_attributes.sql
@@ -45,6 +45,7 @@ BEGIN
     )
     SELECT count(*) INTO v_deactivated FROM upd;
 
+    RAISE NOTICE 'dlm.deactivate_destroyed_hu_attributes: % attribute rows deactivated', v_deactivated;
     RETURN COALESCE(v_deactivated, 0);
 END;
 $func$;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806010_sys_fn_deactivate_destroyed_hu_attributes.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806010_sys_fn_deactivate_destroyed_hu_attributes.sql
@@ -1,0 +1,53 @@
+-- Source DDL: backend/de.metas.handlingunits.base/src/main/sql/postgresql/ddl/functions/deactivate_destroyed_hu_attributes.sql
+-- Function that soft-archives (IsActive='N') M_HU_Attribute rows of Destroyed HUs.
+-- Self-provisions the dlm schema + dlm.m_hu_attribute_deactivated log (incl. deactivated_at).
+-- Wired to a weekly AD_Scheduler in 5806020.
+
+CREATE SCHEMA IF NOT EXISTS dlm;
+
+CREATE OR REPLACE FUNCTION dlm.deactivate_destroyed_hu_attributes(p_max_hus integer DEFAULT 100000)
+    RETURNS integer
+    LANGUAGE plpgsql
+AS $func$
+DECLARE
+    v_deactivated integer;
+BEGIN
+    CREATE SCHEMA IF NOT EXISTS dlm;
+    CREATE TABLE IF NOT EXISTS dlm.m_hu_attribute_deactivated (
+        m_hu_attribute_id numeric(10,0) PRIMARY KEY,
+        deactivated_at    timestamp without time zone NOT NULL DEFAULT now()
+    );
+    ALTER TABLE dlm.m_hu_attribute_deactivated
+        ADD COLUMN IF NOT EXISTS deactivated_at timestamp without time zone NOT NULL DEFAULT now();
+
+    WITH huids AS (
+        SELECT h.m_hu_id
+        FROM public.m_hu h
+        WHERE h.hustatus = 'D'
+          AND EXISTS (SELECT 1
+                      FROM public.m_hu_attribute a
+                      WHERE a.m_hu_id = h.m_hu_id
+                        AND a.isactive = 'Y')
+        LIMIT p_max_hus
+    ),
+    upd AS (
+        UPDATE public.m_hu_attribute a
+           SET isactive = 'N', updatedby = 99, updated = now()
+        FROM huids
+        WHERE a.m_hu_id = huids.m_hu_id
+          AND a.isactive = 'Y'
+        RETURNING a.m_hu_attribute_id
+    ),
+    trk AS (
+        INSERT INTO dlm.m_hu_attribute_deactivated (m_hu_attribute_id, deactivated_at)
+        SELECT m_hu_attribute_id, now() FROM upd
+        ON CONFLICT DO NOTHING
+    )
+    SELECT count(*) INTO v_deactivated FROM upd;
+
+    RETURN COALESCE(v_deactivated, 0);
+END;
+$func$;
+
+-- Provision dlm schema + log table + deactivated_at column now (deactivates nothing: p_max_hus=0).
+SELECT dlm.deactivate_destroyed_hu_attributes(0);

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806020_sys_Schedule_deactivate_destroyed_hu_attributes.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806020_sys_Schedule_deactivate_destroyed_hu_attributes.sql
@@ -1,0 +1,27 @@
+-- Weekly AD_Scheduler to run dlm.deactivate_destroyed_hu_attributes (function in 5806010). Mirrors
+-- the DLM archive_c_queue_data scheduler pattern (ExecuteUpdateSQL + AD_Scheduler).
+-- Cron '0 2 * * 0' = every Sunday 02:00. SQLStatement processes up to 100000 destroyed HUs per run
+-- (weekly delta; the one-time backlog is handled by a manual operational runbook).
+
+-- --- AD_Process (runs the function via de.metas.process.ExecuteUpdateSQL) ---
+INSERT INTO AD_Process (AccessLevel,AD_Client_ID,AD_Org_ID,AD_Process_ID,AllowProcessReRun,Classname,CopyFromProcess,Created,CreatedBy,Description,EntityType,Help,IsActive,IsApplySecuritySettings,IsBetaFunctionality,IsDirectPrint,IsFormatExcelFile,IsNotifyUserAfterExecution,IsOneInstanceOnly,IsReport,IsTranslateExcelHeaders,IsUseBPartnerLanguage,LockWaitTimeout,Name,PostgrestResponseFormat,RefreshAllAfterExecution,ShowHelp,SQLStatement,Type,Updated,UpdatedBy,Value)
+VALUES ('3',0,0,585630 /*From ID Server*/,'Y','de.metas.process.ExecuteUpdateSQL','N',TO_TIMESTAMP('2026-06-03 14:00:00','YYYY-MM-DD HH24:MI:SS'),100,'','D','','Y','N','N','N','N','N','N','N','Y','Y',0,'HU-Attribute zerstörter HUs deaktivieren','json','Y','S','select dlm.deactivate_destroyed_hu_attributes(100000);','SQL',TO_TIMESTAMP('2026-06-03 14:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Deactivate_Destroyed_HU_Attributes')
+;
+
+-- seed AD_Process_Trl for all system languages (copies the German base text)
+INSERT INTO AD_Process_Trl (AD_Language,AD_Process_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Process t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Process_ID=585630
+  AND NOT EXISTS (SELECT 1 FROM AD_Process_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_ID=t.AD_Process_ID)
+;
+
+-- English override
+UPDATE AD_Process_Trl SET Name='Deactivate attributes of destroyed HUs', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-03 14:00:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Process_ID=585630
+;
+
+-- --- AD_Scheduler (weekly: Sunday 02:00) ---
+INSERT INTO AD_Scheduler (AD_Client_ID,AD_Org_ID,AD_Process_ID,AD_Role_ID,AD_Scheduler_ID,Created,CreatedBy,CronPattern,EntityType,Frequency,FrequencyType,IsActive,IsIgnoreProcessingTime,KeepLogDays,ManageScheduler,Name,Processing,SchedulerProcessType,ScheduleType,Status,Supervisor_ID,Updated,UpdatedBy)
+VALUES (0,0,585630 /*From ID Server*/,0,550125 /*From ID Server*/,TO_TIMESTAMP('2026-06-03 14:00:02','YYYY-MM-DD HH24:MI:SS'),100,'0 2 * * 0','D',0,'D','Y','N',7,'N','Deactivate_Destroyed_HU_Attributes','N','N','C','NEW',100,TO_TIMESTAMP('2026-06-03 14:00:02','YYYY-MM-DD HH24:MI:SS'),100)
+;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806020_sys_Schedule_deactivate_destroyed_hu_attributes.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806020_sys_Schedule_deactivate_destroyed_hu_attributes.sql
@@ -23,5 +23,5 @@ WHERE AD_Language='en_US' AND AD_Process_ID=585630
 
 -- --- AD_Scheduler (weekly: Sunday 02:00) ---
 INSERT INTO AD_Scheduler (AD_Client_ID,AD_Org_ID,AD_Process_ID,AD_Role_ID,AD_Scheduler_ID,Created,CreatedBy,CronPattern,EntityType,Frequency,FrequencyType,IsActive,IsIgnoreProcessingTime,KeepLogDays,ManageScheduler,Name,Processing,SchedulerProcessType,ScheduleType,Status,Supervisor_ID,Updated,UpdatedBy)
-VALUES (0,0,585630 /*From ID Server*/,0,550125 /*From ID Server*/,TO_TIMESTAMP('2026-06-03 14:00:02','YYYY-MM-DD HH24:MI:SS'),100,'0 2 * * 0','D',0,'D','Y','N',7,'N','Deactivate_Destroyed_HU_Attributes','N','N','C','NEW',100,TO_TIMESTAMP('2026-06-03 14:00:02','YYYY-MM-DD HH24:MI:SS'),100)
+VALUES (0,0,585630 /*From ID Server*/,0,550125 /*From ID Server*/,TO_TIMESTAMP('2026-06-03 14:00:02','YYYY-MM-DD HH24:MI:SS'),100,'0 2 * * 0','D',0,'D','Y','N',7,'N','Deactivate_Destroyed_HU_Attributes','N','P','C','NEW',100,TO_TIMESTAMP('2026-06-03 14:00:02','YYYY-MM-DD HH24:MI:SS'),100)
 ;


### PR DESCRIPTION
## Problem

The picking "find pickable source HUs" search (`HUStorageQuery.createQueryBuilder_for_M_HU_Storages`, used by the `WEBUI_Picking_ForcePickTo*` processes and source-HU retrieval) builds a correlated `EXISTS` over `M_HU_Attribute` with the predicate `(M_HU_ID, M_Attribute_ID, ValueNumber, IsActive='Y')`, probed once per candidate HU.

On large datasets this is the dominant cost of a pick:
- the existing `m_hu_attribute_parent_index (M_HU_ID, M_Attribute_ID)` does **not** cover `ValueNumber`, so every probe heap-fetches to evaluate it; and
- the vast majority of `M_HU_Attribute` rows belong to **Destroyed** HUs that can never be picked, yet still bloat the index/heap and push the working set out of cache → millions of cold random reads → multi-second picks.

## Changes

1. **Partial covering index** `m_hu_attribute_hu_attr_valnum (M_HU_ID, M_Attribute_ID, ValueNumber) WHERE IsActive='Y'` so the `EXISTS` is satisfied index-only.
   - Created **non-concurrently** in the migration on purpose: `CREATE INDEX CONCURRENTLY` cannot run inside the migration tool's single transaction (cf. `de.metas.dlm` `5453734_sys_gh489_DDL.sql`). It is `IF NOT EXISTS`, instant on small/CI DBs; large production DBs pre-build it `CONCURRENTLY` off-peak so the migration statement is a no-op and never takes an `ACCESS EXCLUSIVE` lock on the picking-critical table.

2. **`dlm.deactivate_destroyed_hu_attributes(p_max_hus)`** + a **weekly `AD_Scheduler`** (Sun 02:00, via `de.metas.process.ExecuteUpdateSQL`, mirroring the `archive_c_queue_data` pattern). It sets `IsActive='N'` on `M_HU_Attribute` rows whose parent `M_HU` is **Destroyed (`HUStatus='D'`) only** — keeping the active slice (and the partial index above) small as Destroyed HUs accumulate.
   - Scope is Destroyed-only by design: Active HUs must stay pickable, and Shipped HUs can be reactivated by shipment reversal (would come back attribute-less); Destroyed HUs have no un-destroy path.
   - The function self-provisions its `dlm` schema + a reversibility log table (`m_hu_attribute_deactivated`, with `deactivated_at`), is bounded per run (one small transaction), and references `public.*` explicitly so DLM search-path view-shadowing can't redirect it.

## Notes
- The one-time historical backlog (deactivating already-Destroyed HUs' attributes on a large existing DB) is an operational DBA runbook, not part of this migration — a bulk `UPDATE` must not run inside every rollout, and Destroyed HUs re-accumulate (hence the recurring scheduler).
- Migrations validated locally (all 3 scripts apply cleanly; index, function, `AD_Process`, `AD_Scheduler` and log table verified present).
