### PR TITLE
gh30196: Historical Shipments JSON — include non-external-system & processed shipments

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/historicalShipmentsExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/historicalShipmentsExport.feature
@@ -670,6 +670,10 @@ Feature: Shipments export via postgREST
     {
       "name": "Limit",
       "value": "1"
+    },
+    {
+      "name": "Offset",
+      "value": "1"
     }
   ]
 }
@@ -767,7 +771,7 @@ Feature: Shipments export via postgREST
     },
     {
       "name": "Offset",
-      "value": "1"
+      "value": "0"
     }
   ]
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inout/5806060_sys_gh30196_historical_m_inout_json_v.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inout/5806060_sys_gh30196_historical_m_inout_json_v.sql
@@ -1,7 +1,15 @@
-DROP VIEW IF EXISTS historical_m_inout_json_v
+-- Source DDL: backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/views/historical_m_inout_json_v.sql
+-- gh30196: make the Historical Shipments JSON export usable for non-external-system shipments.
+--   * ExternalSystemCode -> COALESCE(esystem.value, '')::varchar(40): never NULL, so the process's
+--     mandatory "ExternalSystemCode ILIKE '%'" clause is always-true again (it was turned exclusionary
+--     when #21515 swapped the original never-null DataSource wrapper for the null-able ExternalSystemCode).
+--   * WHERE io.processed = 'Y': only export processed shipments (drafts may still change/disappear).
+--   * ORDER BY io.movementdate, io.m_inout_id.
+
+DROP VIEW IF EXISTS historical_m_inout_json_v$new
 ;
 
-CREATE OR REPLACE VIEW historical_m_inout_json_v AS
+CREATE OR REPLACE VIEW historical_m_inout_json_v$new AS
 SELECT io.m_inout_id                                      AS "Shipment_ID",
        io.documentno                                      AS "Shipment_DocumentNo",
        io.movementdate                                    AS "Shipment_Date",
@@ -118,4 +126,15 @@ FROM m_inout io
 WHERE io.isactive = 'Y'
   AND io.processed = 'Y' /*only output items where movementdate won't change */
 ORDER BY io.movementdate, io.m_inout_id
+;
+
+SELECT db_alter_view(
+    'historical_m_inout_json_v',
+    (SELECT view_definition
+     FROM information_schema.views
+     WHERE lower(views.table_name) = lower('historical_m_inout_json_v$new'))
+)
+;
+
+DROP VIEW IF EXISTS historical_m_inout_json_v$new
 ;


### PR DESCRIPTION
## What

Makes the **Historical Shipments JSON** export (`Historical_Shipments_JSON`, view `historical_m_inout_json_v`) usable for **normal (non-external-system) shipments**.

Issue: https://github.com/metasfresh/me03/issues/30196 (follow-up to the carrier-tracking PR https://github.com/metasfresh/metasfresh/pull/24367)

## Why

On https://danthermuat.metasfresh.com the export returned **nothing** for normal shipments. The process JSONPath ANDs a mandatory `ExternalSystemCode ILIKE '%'` clause, and `ExternalSystemCode` (`esystem.value` via `LEFT JOIN`) is **NULL** when the shipment has no external system → `NULL ILIKE '%'` is false → excluded. This became exclusionary when https://github.com/metasfresh/metasfresh/pull/21515 swapped the original **never-null** `DataSource` wrapper for the **null-able** `ExternalSystemCode` (the original `DataSource` is `''` when absent, so the clause was always-true).

## How

In `historical_m_inout_json_v`:
- `ExternalSystemCode = COALESCE(esystem.value, '')::varchar(40)` — never NULL, so the mandatory `ILIKE '%'` clause is **always-true again** (matching the `DataSource` column); non-external-system shipments are returned, and filtering by a real `ExternalSystemCode` still works (`'' ILIKE 'CODE'` is false).
- `WHERE io.processed = 'Y'` — only export processed shipments (drafts may still change their `movementdate` or be deleted).
- `ORDER BY io.movementdate, io.m_inout_id` — ascending, stable order for paged incremental export (dropping `io.updated` from the sort, which made records jump pages).

Reflected in the DDL file + applied via `db_alter_view` in migration `5806060`.

## Testing

- Local cucumber `historicalShipmentsExport` — **8/8 green** (against a clean deep_tundra_uat DB). Confirms completed shipments (`processed='Y'`) still flow through, and the new fields/order are correct.
- The `limit it to 1` paging scenario's two `Offset` values were swapped so each paged call still asserts the correct shipment under the new ASC order (expected response blocks unchanged).
- Migration applies cleanly; the view compiles.
