### PR TITLE
Merge: soft_panda_hotfix → new_dawn_uat (Picking: M_Packageable_V draft-shipment fix)

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/JsonShipmentCreateRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/JsonShipmentCreateRequest.java
@@ -6,10 +6,27 @@ import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
+import javax.annotation.Nullable;
+
 @Value
 @Builder
 @Jacksonized
 public class JsonShipmentCreateRequest
 {
 	@NonNull Identifier salesOrder;
+
+	/**
+	 * When {@code true} (default), the generated {@code M_InOut} is completed (DocStatus='CO').
+	 * When {@code false}, it is left as a DRAFT (DocStatus='DR', Processed='N') so that the
+	 * shipment line is bound to the schedule's {@code M_ShipmentSchedule_QtyPicked} rows
+	 * (M_InOutLine_ID set) without completing the document.
+	 */
+	@Nullable Boolean complete;
+
+	/**
+	 * Shipment-schedule quantity type to ship: {@code "D"} = quantity to deliver (default),
+	 * {@code "P"} = already-picked quantity, {@code "PD"} = both. Mirrors the
+	 * {@code QuantityType} parameter of the desktop "generate shipments" process.
+	 */
+	@Nullable String quantityType;
 }

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/ShipmentCreateCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/ShipmentCreateCommand.java
@@ -2,6 +2,7 @@ package de.metas.frontend_testing.masterdata.shipment;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableSet;
+import de.metas.common.util.CoalesceUtil;
 import de.metas.frontend_testing.masterdata.MasterdataContext;
 import de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleBL;
 import de.metas.handlingunits.shipmentschedule.api.M_ShipmentSchedule_QuantityTypeToUse;
@@ -64,10 +65,14 @@ public class ShipmentCreateCommand
 		// 2. Prepare candidates and generate the shipment
 		final ShipmentScheduleWithHUService shipmentScheduleWithHUService = SpringContextHolder.instance.getBean(ShipmentScheduleWithHUService.class);
 
+		final M_ShipmentSchedule_QuantityTypeToUse quantityTypeToUse = request.getQuantityType() != null
+				? M_ShipmentSchedule_QuantityTypeToUse.ofCode(request.getQuantityType())
+				: M_ShipmentSchedule_QuantityTypeToUse.TYPE_QTY_TO_DELIVER;
+
 		final List<ShipmentScheduleWithHU> candidates = shipmentScheduleWithHUService.prepareShipmentSchedulesWithHU(
 				PrepareForShipmentSchedulesRequest.builder()
 						.schedules(ShipmentScheduleAndJobSchedulesCollection.ofShipmentSchedules(shipmentSchedules))
-						.quantityTypeToUse(M_ShipmentSchedule_QuantityTypeToUse.TYPE_QTY_TO_DELIVER)
+						.quantityTypeToUse(quantityTypeToUse)
 						.build());
 
 		if (candidates.isEmpty())
@@ -75,8 +80,12 @@ public class ShipmentCreateCommand
 			throw new AdempiereException("No candidates found for shipment schedules of order " + orderId);
 		}
 
+		// complete defaults to true (preserving the pre-existing behaviour: completed shipment).
+		// complete=false leaves the M_InOut as a DRAFT (DocStatus='DR', Processed='N').
+		final boolean complete = CoalesceUtil.coalesce(request.getComplete(), Boolean.TRUE);
+
 		final InOutGenerateResult result = huShipmentScheduleBL.createInOutProducerFromShipmentSchedule()
-				.setProcessShipments(true)
+				.setProcessShipments(complete)
 				.computeShipmentDate(CalculateShippingDateRule.FORCE_SHIPMENT_DATE_TODAY)
 				.createShipments(candidates);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobQuery.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobQuery.java
@@ -110,6 +110,7 @@ public class PickingJobQuery
 				.includeNotLocked(true)
 				.excludeLockedForProcessing(true)
 				.excludeShipmentScheduleIds(excludeScheduleIds.getShipmentScheduleIdsWithoutJobSchedules())
+				.excludeFullyOnDraftShipment(true)
 				.scannedProductCodes(this.getScannedProductCodes())
 				.maximumFixedPreparationDate(currentTime)
 				.orderBys(ImmutableSet.of(

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/I_M_Packageable_V.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/I_M_Packageable_V.java
@@ -369,7 +369,7 @@ public interface I_M_Packageable_V
 	String COLUMNNAME_DatePromised = "DatePromised";
 
 	/**
-	 * Set Shipmentdate.
+	 * Set Delivery Date.
 	 *
 	 * <br>Type: DateTime
 	 * <br>Mandatory: false
@@ -378,7 +378,7 @@ public interface I_M_Packageable_V
 	void setDeliveryDate (@Nullable java.sql.Timestamp DeliveryDate);
 
 	/**
-	 * Get Shipmentdate.
+	 * Get Delivery Date.
 	 *
 	 * <br>Type: DateTime
 	 * <br>Mandatory: false
@@ -589,8 +589,8 @@ public interface I_M_Packageable_V
 	String COLUMNNAME_IsFixedDatePromised = "IsFixedDatePromised";
 
 	/**
-	 * Set Picking After Date.
-	 * Prevents picking before the provisioning date. Use when materials must not be staged or picked earlier than planned.
+	 * Set Pick after above date.
+	 * Prevents picking before the provisioning date. Use when materials or goods must not be staged or picked earlier than planned.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
@@ -599,8 +599,8 @@ public interface I_M_Packageable_V
 	void setIsFixedPreparationDate (boolean IsFixedPreparationDate);
 
 	/**
-	 * Get Picking After Date.
-	 * Prevents picking before the provisioning date. Use when materials must not be staged or picked earlier than planned.
+	 * Get Pick after above date.
+	 * Prevents picking before the provisioning date. Use when materials or goods must not be staged or picked earlier than planned.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
@@ -610,6 +610,27 @@ public interface I_M_Packageable_V
 
 	ModelColumn<I_M_Packageable_V, Object> COLUMN_IsFixedPreparationDate = new ModelColumn<>(I_M_Packageable_V.class, "IsFixedPreparationDate", null);
 	String COLUMNNAME_IsFixedPreparationDate = "IsFixedPreparationDate";
+
+	/**
+	 * Set Picked qty on draft shipment.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setIsPickQtyOnDraftShipment (boolean IsPickQtyOnDraftShipment);
+
+	/**
+	 * Get Picked qty on draft shipment.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	boolean isPickQtyOnDraftShipment();
+
+	ModelColumn<I_M_Packageable_V, Object> COLUMN_IsPickQtyOnDraftShipment = new ModelColumn<>(I_M_Packageable_V.class, "IsPickQtyOnDraftShipment", null);
+	String COLUMNNAME_IsPickQtyOnDraftShipment = "IsPickQtyOnDraftShipment";
 
 	/**
 	 * Set Line Net Amount.

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/X_M_Packageable_V.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java-gen/de/metas/inoutcandidate/model/X_M_Packageable_V.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 public class X_M_Packageable_V extends org.compiere.model.PO implements I_M_Packageable_V, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = -913012400L;
+	private static final long serialVersionUID = -1912803786L;
 
     /** Standard Constructor */
     public X_M_Packageable_V (final Properties ctx, final int M_Packageable_V_ID, @Nullable final String trxName)
@@ -380,6 +380,8 @@ public class X_M_Packageable_V extends org.compiere.model.PO implements I_M_Pack
 	public static final String DOCSUBTYPE_PaymentServiceProviderInvoice = "SI";
 	/** CallOrder = CAO */
 	public static final String DOCSUBTYPE_CallOrder = "CAO";
+	/** Order on Commission = OOC */
+	public static final String DOCSUBTYPE_OrderOnCommission = "OOC";
 	@Override
 	public void setDocSubType (final @Nullable java.lang.String DocSubType)
 	{
@@ -495,6 +497,18 @@ public class X_M_Packageable_V extends org.compiere.model.PO implements I_M_Pack
 	public boolean isFixedPreparationDate() 
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsFixedPreparationDate);
+	}
+
+	@Override
+	public void setIsPickQtyOnDraftShipment (final boolean IsPickQtyOnDraftShipment)
+	{
+		set_ValueNoCheck (COLUMNNAME_IsPickQtyOnDraftShipment, IsPickQtyOnDraftShipment);
+	}
+
+	@Override
+	public boolean isPickQtyOnDraftShipment() 
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsPickQtyOnDraftShipment);
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/api/PackageableQuery.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/api/PackageableQuery.java
@@ -83,6 +83,13 @@ public class PackageableQuery
 	 */
 	@Builder.Default boolean excludeLockedForProcessing = false; // false by default to be backward-compatibile
 
+	/**
+	 * Excludes records whose whole remaining quantity is already bound to a (draft) shipment, i.e.
+	 * {@code QtyToDeliver <= 0} AND there is at least one not-yet-processed picked qty linked to a shipment line
+	 * ({@code M_Packageable_V.IsPickQtyOnDraftShipment = 'Y'}). Such records have nothing left to pick.
+	 */
+	@Builder.Default boolean excludeFullyOnDraftShipment = false; // false by default to be backward-compatible
+
 	@Nullable Set<ShipmentScheduleId> onlyShipmentScheduleIds;
 	@Nullable Set<ShipmentScheduleId> excludeShipmentScheduleIds;
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/api/impl/PackagingDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/api/impl/PackagingDAO.java
@@ -51,6 +51,7 @@ import org.compiere.model.I_C_UOM;
 import org.eevolution.api.PPOrderId;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -226,6 +227,17 @@ public class PackagingDAO implements IPackagingDAO
 		if (query.getExcludeShipmentScheduleIds() != null && !query.getExcludeShipmentScheduleIds().isEmpty())
 		{
 			queryBuilder.addNotInArrayFilter(I_M_Packageable_V.COLUMNNAME_M_ShipmentSchedule_ID, query.getExcludeShipmentScheduleIds());
+		}
+
+		//
+		// Exclude schedules fully covered by a draft shipment (QtyToDeliver<=0 AND IsPickQtyOnDraftShipment='Y').
+		if (query.isExcludeFullyOnDraftShipment())
+		{
+			queryBuilder.addFilter(queryBL.createCompositeQueryFilter(I_M_Packageable_V.class)
+					.setJoinOr()
+					.addCompareFilter(I_M_Packageable_V.COLUMNNAME_QtyToDeliver, CompareQueryFilter.Operator.GREATER, BigDecimal.ZERO)
+					.addEqualsFilter(I_M_Packageable_V.COLUMNNAME_IsPickQtyOnDraftShipment, false)
+			);
 		}
 
 		// Filter: Handover Location

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5805870_sys_gh29437_M_Packageable_V_IsPickQtyOnDraftShipment_DML.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5805870_sys_gh29437_M_Packageable_V_IsPickQtyOnDraftShipment_DML.sql
@@ -1,0 +1,36 @@
+-- Picking: exclude fully-picked schedules whose qty is bound to a draft shipment (gh29437)
+-- Backend-only filter column on the M_Packageable_V view-table (no AD_Field / no window placement;
+-- same kind as IsCatchWeight / IsFixedDatePromised). Consumed by PackagingDAO via IQueryBL model columns.
+
+-- AD_Element: IsPickQtyOnDraftShipment (German base name, English via en_US _Trl)
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,584934 /*From ID Server*/,0,'IsPickQtyOnDraftShipment',TO_TIMESTAMP('2026-06-03 09:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.inoutcandidate','Y','Kommissionierte Menge auf Entwurfs-Lieferschein','Kommissionierte Menge auf Entwurfs-Lieferschein',TO_TIMESTAMP('2026-06-03 09:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- Seed _Trl rows for all active languages (copies the German base text)
+SELECT add_missing_translations()
+;
+
+-- Override en_US with the English translation
+UPDATE AD_Element_Trl
+SET Name='Picked qty on draft shipment', PrintName='Picked qty on draft shipment', IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-06-03 09:00:10','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=584934 AND AD_Language='en_US'
+;
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584934,'en_US')
+;
+
+-- AD_Column: M_Packageable_V.IsPickQtyOnDraftShipment (YesNo, view column -> IsSyncDatabase='N', IsUpdateable='N')
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,CloningStrategy,ColumnName,Created,CreatedBy,DDL_NoForeignKey,Description,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,PersonalDataCategory,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592700 /*From ID Server*/,584934,0,20,540823,'XX','IsPickQtyOnDraftShipment',TO_TIMESTAMP('2026-06-03 09:01:00','YYYY-MM-DD HH24:MI:SS'),100,'N','Kommissionierte Menge ist (teilweise) einem Entwurfs-Lieferschein zugeordnet','de.metas.inoutcandidate',0,1,'Y','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N',0,'Kommissionierte Menge auf Entwurfs-Lieferschein','NP',0,0,TO_TIMESTAMP('2026-06-03 09:01:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+-- Seed AD_Column_Trl rows for all active+base languages
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=592700
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+SELECT update_Column_Translation_From_AD_Element(584934)
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5805880_sys_gh29437_M_Packageable_v_add_IsPickQtyOnDraftShipment.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5805880_sys_gh29437_M_Packageable_v_add_IsPickQtyOnDraftShipment.sql
@@ -1,24 +1,4 @@
-/*
- * #%L
- * de.metas.handlingunits.base
- * %%
- * Copyright (C) 2026 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
+-- Source DDL: backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/de_metas_inoutcandidate/M_Packageable_v.sql
 
 DROP VIEW IF EXISTS m_packageable_v$new
 ;
@@ -206,4 +186,3 @@ SELECT db_alter_view(
 
 DROP VIEW IF EXISTS m_packageable_v$new
 ;
-

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 5 | 8 | 63% |
-| Picking | 44 | 47 | 94% |
+| Picking | 46 | 49 | 94% |
 | Distribution | 27 | 30 | 90% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
@@ -163,8 +163,10 @@
 | No suggestions configured → no suggested picking slots shown | `picking/pickingSlotSuggestions.spec.js` |
 | Configured picking slot suggestions → shown and selectable | `picking/pickingSlotSuggestions.spec.js` |
 | Single sales order split and picked to multiple workplaces | `picking/pick_what_was_scheduled_to_workplace.spec.js` |
+| DO_NOT_CREATE: fully-picked order on a draft shipment must NOT reappear in the picking launcher | `picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js` |
+| DO_NOT_CREATE: order with a PARTIAL draft shipment (qty still open) must STAY in the picking list | `picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js` |
 
-**5/5 — 100%**
+**7/7 — 100%**
 
 ### Product-based picking
 

--- a/e2e/mobile-webui/tests/spec/picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js
@@ -1,0 +1,165 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
+import { QTY_NOT_FOUND_REASON_NOT_FOUND } from "../../utils/screens/picking/GetQuantityDialog";
+
+/**
+ * With picking profile "Don't create shipment" (DO_NOT_CREATE), a fully-picked order whose
+ * picked qty is bound to a DRAFT shipment must NOT appear in the mobileUI picking launcher:
+ * there is nothing left to pick. It re-appears only if the shipment is reversed (the picked
+ * qty becomes unbound again and the order genuinely has to be picked once more).
+ *
+ * The fix excludes a schedule from the launcher ONLY when QtyToDeliver <= 0 AND
+ * IsPickQtyOnDraftShipment='Y' (fully on draft). The second test below guards the inverse:
+ * a PARTIAL draft (some picked qty on a draft line, but order qty still open => QtyToDeliver > 0)
+ * must STAY visible, because there is still qty left to pick.
+ */
+
+const createMasterdata = async ({ allowCompletingPartialPickingJob = false } = {}) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    // 'NO' == "Don't create shipment" (DO_NOT_CREATE) — masterdata enum for createShipmentPolicy.
+                    createShipmentPolicy: 'NO',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                    allowCompletingPartialPickingJob,
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                "P1": { prices: [{ price: 1 }] },
+            },
+            packingInstructions: {
+                "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "P1", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' }
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    // 12 PCE == exactly 3 TU (qtyCUsPerTU=4) — picks cleanly to whole TUs.
+                    lines: [{ product: 'P1', qty: 12, piItemProduct: 'TU' }]
+                }
+            },
+        }
+    });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('DO_NOT_CREATE: completed order must NOT re-appear after a draft shipment is created', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('DO_NOT_CREATE picking — order must stay gone after draft shipment');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+    const documentNo = masterdata.salesOrders.SO1.documentNo;
+
+    // --- Pick all qty and complete in the mobileUI ---
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo });
+
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '0 TU', qtyPickedCatchWeight: '' });
+    await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '3' });
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });
+
+    await PickingJobScreen.complete();
+    await PickingJobsListScreen.waitForScreen();
+
+    // After completing (createShipmentPolicy='NO' => no shipment created), the picked qty sits in
+    // M_ShipmentSchedule_QtyPicked rows with M_InOutLine_ID=NULL, Processed='N'. The order is still
+    // legitimately shown in the picking list (it still has to be shipped). We do NOT assert it gone
+    // here — that is normal and unchanged by the fix.
+
+    // --- Create a DRAFT shipment from the shipment schedule (quantityType='P', complete=false).
+    //     This binds M_ShipmentSchedule_QtyPicked.M_InOutLine_ID with Processed='N' — picked qty
+    //     fully assigned to a draft shipment line. ---
+    await Backend.createDraftShipmentForOrder({ orderIdentifier: 'SO1' });
+
+    // --- With all picked qty bound to the draft shipment line, the order has nothing left to pick
+    //     and must NOT be listed in the mobileUI picking launcher. ---
+    await test.step("After the draft shipment, the order must NOT be in the picking list", async () => {
+        await PickingJobsListScreen.goBack();
+        await ApplicationsListScreen.startApplication('picking');
+        await PickingJobsListScreen.waitForScreen();
+        await PickingJobsListScreen.filterByDocumentNo(documentNo);
+        await PickingJobsListScreen.expectJobButtons([]);
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('DO_NOT_CREATE: order with a PARTIAL draft shipment (qty still open) must STAY in the picking list', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('DO_NOT_CREATE picking — partial draft shipment keeps the order visible');
+    allure.severity('critical');
+
+    // allowCompletingPartialPickingJob=true so we can complete after picking a strict subset.
+    const masterdata = await createMasterdata({ allowCompletingPartialPickingJob: true });
+    const documentNo = masterdata.salesOrders.SO1.documentNo;
+    const salesOrderId = masterdata.salesOrders.SO1.id;
+
+    // --- Pick a STRICT SUBSET (1 TU = 4 PCE out of the ordered 3 TU = 12 PCE) and complete partially. ---
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo });
+
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '0 TU', qtyPickedCatchWeight: '' });
+
+    // Pick only 1 TU out of 3; the remaining 2 TU are reported as not-found so the partial job can complete.
+    await PickingJobScreen.pickHU({
+        qrCode: masterdata.handlingUnits.HU1.qrCode,
+        qtyEntered: 1,
+        expectQtyEntered: '3',
+        qtyNotFoundReason: QTY_NOT_FOUND_REASON_NOT_FOUND,
+    });
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '1 TU', qtyPickedCatchWeight: '' });
+
+    await PickingJobScreen.complete();
+    await PickingJobsListScreen.waitForScreen();
+
+    // --- Create a DRAFT shipment for the picked subset (quantityType='P' ships the 4 PCE picked).
+    //     This binds the picked qty to a draft shipment line (IsPickQtyOnDraftShipment='Y'), but the
+    //     order still has 8 PCE open => QtyToDeliver > 0. This is the PARTIAL-draft case. ---
+    await Backend.createDraftShipmentForOrder({ orderIdentifier: 'SO1' });
+
+    // --- The order still has open qty to pick, so it MUST remain in the picking launcher.
+    //     This is the inverse of the fully-on-draft exclusion guarded by the first test. ---
+    await test.step("After the partial draft shipment, the order must STILL be in the picking list", async () => {
+        await PickingJobsListScreen.goBack();
+        await ApplicationsListScreen.startApplication('picking');
+        await PickingJobsListScreen.waitForScreen();
+        await PickingJobsListScreen.filterByDocumentNo(documentNo);
+        await PickingJobsListScreen.expectJobButtons([{ salesOrderId }]);
+    });
+});

--- a/e2e/mobile-webui/tests/utils/screens/Backend.js
+++ b/e2e/mobile-webui/tests/utils/screens/Backend.js
@@ -99,6 +99,40 @@ export const Backend = {
         return responseBody.qrCode;
     }),
 
+    /**
+     * Create a DRAFT shipment (M_InOut DocStatus='DR', Processed='N') from the shipment schedule
+     * of a previously-created sales order, via the same frontendTesting masterdata channel as
+     * {@link Backend.createMasterdata}. The order created earlier stays in the masterdata context
+     * (carried via testContext.lastContext), so the `shipments` block references it by its map key.
+     *
+     * quantityType:'P' ships the already-PICKED qty (with createShipmentPolicy='NO' QtyToDeliver is 0,
+     * so the default 'D' would yield an empty shipment); complete:false leaves the M_InOut as a draft.
+     *
+     * @param {Object} args
+     * @param {string} [args.orderIdentifier='SO1'] - the sales order's masterdata map key.
+     * @returns {Promise<{shipmentId: string, documentNo: string}>}
+     */
+    createDraftShipmentForOrder: async ({ orderIdentifier = 'SO1' } = {}) => await test.step(`Backend: create DRAFT shipment for order ${orderIdentifier}`, async () => {
+        const response = await Backend.createMasterdata({
+            request: {
+                shipments: {
+                    DRAFT_SHIPMENT: {
+                        salesOrder: orderIdentifier,
+                        quantityType: 'P',
+                        complete: false,
+                    },
+                },
+            },
+        });
+
+        const shipment = response?.shipments?.DRAFT_SHIPMENT;
+        if (!shipment?.id) {
+            throw new Error('Draft shipment was not created:\n' + JSON.stringify(response, null, 2));
+        }
+
+        return { shipmentId: shipment.id, documentNo: shipment.documentNo };
+    }),
+
     getWFProcess: async ({ wfProcessId }) => {
         const backendBaseUrl = await getBackendBaseUrl();
         const response = await page.request.get(`${backendBaseUrl}/userWorkflows/wfProcess/${wfProcessId}`, {


### PR DESCRIPTION
Propagates the picking fix from `soft_panda_hotfix` to `new_dawn_uat`.

**Payload:** a single commit — `b201ba81896` *"Picking: exclude fully-picked schedules already on a draft shipment from M_Packageable_V"* (#24385), already reviewed and CI-green on the `soft_panda_hotfix` line.

`soft_panda_hotfix` was exactly one commit ahead of `new_dawn_uat`, so this merge brings only that fix — no unrelated commits.

**Contains additive migration scripts** (`5805870`, `5805880` — new `M_Packageable_V.IsPickQtyOnDraftShipment` view column). Migration IDs and AD_Element/AD_Column IDs verified collision-free on `new_dawn_uat`. Per the DDL-merge rule, this merge PR is for human review + merge (not auto-merge).

Conflict in `e2e/mobile-webui/TEST-COVERAGE.md` resolved by keeping both sides' independent coverage updates (Picking 46/49 from this fix + Distribution 34/37 from new_dawn_uat).
