### PR TITLE
Qty reservation reconcile — round QtyTU up on shrink (partially-filled TU occupies a whole TU)

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
@@ -58,6 +58,9 @@ public class ReconcileQtyReservationsCommand
 	 * One-directional (only reduces, never grows). A row's {@code Qty} is never shrunk below that row's
 	 * already-delivered qty ({@code QtyDelivered}). All comparison/subtraction arithmetic is performed in the
 	 * order-line UOM; per-row reductions are converted back to each reservation's own UOM before being applied.
+	 * <p>
+	 * The CU {@code Qty} keeps the exact reduced value; the integer {@code QtyTU} is rounded UP — a
+	 * partially-filled TU still occupies a whole TU.
 	 *
 	 * @return the order-line IDs whose reservations were actually modified (empty if nothing changed)
 	 */
@@ -152,10 +155,11 @@ public class ReconcileQtyReservationsCommand
 				// clamp: never shrink below already-delivered qty
 				final BigDecimal newQtyBD = rowQty.subtract(reductionInRowUOM).max(rowQtyDelivered);
 
+				// QtyTU is rounded UP — a partially-filled TU still occupies a whole TU.
 				final BigDecimal rowQtyTU = reservation.getQtyTU().toBigDecimal();
 				final BigDecimal newQtyTUBD = rowQtyTU
 						.multiply(newQtyBD)
-						.divide(rowQty, 0, RoundingMode.HALF_UP);
+						.divide(rowQty, 0, RoundingMode.CEILING);
 
 				final Quantity newQty = reservation.getQty().toZero().add(newQtyBD);
 				newQtyByReservationId.put(reservation.getId(), new NewQty(newQty, QtyTU.ofBigDecimal(newQtyTUBD)));

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
@@ -63,6 +63,25 @@ class ReconcileQtyReservationsCommandTest
 	}
 
 	@Test
+	void roundsQtyTU_up_whenPartiallyFilled()
+	{
+		final OrderId orderId = createSalesOrder();
+		final OrderLineId orderLineId = createOrderLine(orderId, new BigDecimal("71"));
+
+		// Qty=100 in 10 TUs (10 PCE per TU). Shrinking to 71 leaves 7.1 TU worth of CUs.
+		createReservationRecord(orderLineId, SupplyType.ON_HAND, new BigDecimal("100"), new BigDecimal("10"));
+
+		service.reconcileToOrderedQty(orderId);
+
+		final List<I_M_QtyReservation> records = loadRecords(orderLineId);
+		assertThat(records).hasSize(1);
+		// CU Qty is the exact reduced value
+		assertThat(records.get(0).getQty()).isEqualByComparingTo(new BigDecimal("71"));
+		// QtyTU rounds UP: 10 * 71 / 100 = 7.1 TU -> CEILING = 8 (a partially-filled TU still occupies a whole TU)
+		assertThat(records.get(0).getQtyTU()).isEqualByComparingTo(new BigDecimal("8"));
+	}
+
+	@Test
 	void doesNotShrinkBelowDelivered()
 	{
 		final OrderId orderId = createSalesOrder();


### PR DESCRIPTION
## What

Follow-up to the reservation reconcile-on-completion feature: when a reservation is shrunk to a reduced order-line qty, its `QtyTU` now rounds **up** (`RoundingMode.CEILING`) instead of HALF_UP.

## Why

A partially-filled transport unit still physically occupies a whole TU. So when the CU `Qty` is reduced to a value that is not a whole multiple of the TU capacity (e.g. 71 PCE at 10 PCE/TU = 7.1 TU), the occupied-TU count must round up to 8, not down to 7. The CU `Qty` itself stays the exact reduced value; only the `QtyTU` integer rounds up.

## How

- `ReconcileQtyReservationsCommand`: the per-row `QtyTU` recomputation uses `RoundingMode.CEILING`.
- New unit test `roundsQtyTU_up_whenPartiallyFilled` (Qty=100/QtyTU=10, line reduced to 71 → Qty=71, QtyTU=8) — distinguishes CEILING from HALF_UP/FLOOR (both would give 7).

No DB migration, no Application-Dictionary changes.