### PR TITLE
Qty reservation reconcile - delete zero-Qty reservations on sales-order completion

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationRepository.java
@@ -16,6 +16,8 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.UnaryOperator;
 
@@ -130,6 +132,31 @@ public class QtyReservationRepository
 						ids.stream().map(QtyReservationId::getRepoId).collect(ImmutableList.toImmutableList()))
 				.create()
 				.delete();
+	}
+
+	/**
+	 * For the given reservation IDs, returns whether each is a PLANNED_SUPPLY reservation (vs ON_HAND).
+	 * Used to order reservations PS-before-OH when trimming, since {@link QtyReservation} does not expose SupplyType.
+	 */
+	@NonNull
+	public Map<QtyReservationId, Boolean> getIsPlannedSupplyByIds(@NonNull final Set<QtyReservationId> ids)
+	{
+		final Map<QtyReservationId, Boolean> result = new HashMap<>();
+		if (ids.isEmpty())
+		{
+			return result;
+		}
+
+		queryBL.createQueryBuilder(I_M_QtyReservation.class)
+				.addOnlyActiveRecordsFilter()
+				.addInArrayFilter(I_M_QtyReservation.COLUMNNAME_M_QtyReservation_ID,
+						ids.stream().map(QtyReservationId::getRepoId).collect(ImmutableList.toImmutableList()))
+				.create()
+				.stream()
+				.forEach(record -> result.put(
+						QtyReservationId.ofRepoId(record.getM_QtyReservation_ID()),
+						SupplyType.ofCode(record.getSupplyType()).isPlannedSupply()));
+		return result;
 	}
 
 	/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationRepository.java
@@ -24,6 +24,9 @@ import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 
 /**
  * Repository for loading {@link QtyReservation} domain objects from the {@code M_QtyReservation} table.
+ * <p>
+ * Repository Tables: M_QtyReservation
+ * Repository Cluster: QtyReservationRepository (sole owner)
  */
 @Repository
 public class QtyReservationRepository
@@ -121,6 +124,7 @@ public class QtyReservationRepository
 			return;
 		}
 
+		// IDs come from getActiveByOrderLineId (IsActive=Y, Processed=false), so no further filter is needed here.
 		queryBL.createQueryBuilder(I_M_QtyReservation.class)
 				.addInArrayFilter(I_M_QtyReservation.COLUMNNAME_M_QtyReservation_ID,
 						ids.stream().map(QtyReservationId::getRepoId).collect(ImmutableList.toImmutableList()))

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationRepository.java
@@ -110,6 +110,25 @@ public class QtyReservationRepository
 	}
 
 	/**
+	 * Physically deletes the given reservation rows by ID (same delete mechanism as
+	 * {@link #deleteReservation(DeleteQtyReservationRequest)}, but targeted at specific rows
+	 * to avoid removing sibling reservations sharing the same supply-type bucket).
+	 */
+	public void deleteByIds(@NonNull final Set<QtyReservationId> ids)
+	{
+		if (ids.isEmpty())
+		{
+			return;
+		}
+
+		queryBL.createQueryBuilder(I_M_QtyReservation.class)
+				.addInArrayFilter(I_M_QtyReservation.COLUMNNAME_M_QtyReservation_ID,
+						ids.stream().map(QtyReservationId::getRepoId).collect(ImmutableList.toImmutableList()))
+				.create()
+				.delete();
+	}
+
+	/**
 	 * Returns all active, unprocessed reservations for the given order line.
 	 * Used by the HU picker to honor each reservation's attributes when picking on-the-fly.
 	 */

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
@@ -62,7 +62,7 @@ public class ReconcileQtyReservationsCommand
 	 * <p>
 	 * The CU {@code Qty} keeps the exact reduced value; the integer {@code QtyTU} is rounded UP — a
 	 * partially-filled TU still occupies a whole TU.
-	 *
+	 * <p>
 	 * Reservation rows whose final Qty is zero — pre-existing phantoms (a row reserving 0 CU) and rows shrunk
 	 * fully to zero — are deleted rather than kept.
 	 *

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
@@ -14,8 +14,6 @@ import de.metas.util.Services;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
-import org.adempiere.ad.dao.IQueryBL;
-import org.compiere.model.I_M_QtyReservation;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -39,7 +37,6 @@ public class ReconcileQtyReservationsCommand
 	private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
 	private final IOrderLineBL orderLineBL = Services.get(IOrderLineBL.class);
 	private final IUOMConversionBL uomConversionBL = Services.get(IUOMConversionBL.class);
-	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 	@NonNull private final QtyReservationRepository qtyReservationRepository;
 	@NonNull private final OrderId orderId;
@@ -238,12 +235,15 @@ public class ReconcileQtyReservationsCommand
 	 * Returns the reservations ordered PLANNED_SUPPLY first, then ON_HAND;
 	 * within each group ordered by reservation id for determinism.
 	 * <p>
-	 * The {@link QtyReservation} domain object does not expose SupplyType, so it is
-	 * read directly from the {@code M_QtyReservation} records here.
+	 * The {@link QtyReservation} domain object does not expose SupplyType, so the PS/OH flag
+	 * is resolved through {@link QtyReservationRepository#getIsPlannedSupplyByIds(Set)}.
 	 */
 	private List<QtyReservation> sortPlannedSupplyBeforeOnHand(@NonNull final List<QtyReservation> reservations)
 	{
-		final Map<QtyReservationId, Boolean> isPlannedSupplyById = loadIsPlannedSupplyById(reservations);
+		final Set<QtyReservationId> ids = reservations.stream()
+				.map(QtyReservation::getId)
+				.collect(ImmutableSet.toImmutableSet());
+		final Map<QtyReservationId, Boolean> isPlannedSupplyById = qtyReservationRepository.getIsPlannedSupplyByIds(ids);
 
 		return reservations.stream()
 				.sorted(Comparator
@@ -251,24 +251,6 @@ public class ReconcileQtyReservationsCommand
 						.comparing((QtyReservation r) -> !isPlannedSupplyById.getOrDefault(r.getId(), Boolean.FALSE))
 						.thenComparing(r -> r.getId().getRepoId()))
 				.collect(ImmutableList.toImmutableList());
-	}
-
-	private Map<QtyReservationId, Boolean> loadIsPlannedSupplyById(@NonNull final List<QtyReservation> reservations)
-	{
-		final Set<Integer> ids = reservations.stream()
-				.map(r -> r.getId().getRepoId())
-				.collect(ImmutableSet.toImmutableSet());
-
-		final Map<QtyReservationId, Boolean> result = new HashMap<>();
-		queryBL.createQueryBuilder(I_M_QtyReservation.class)
-				.addOnlyActiveRecordsFilter()
-				.addInArrayFilter(I_M_QtyReservation.COLUMNNAME_M_QtyReservation_ID, ids)
-				.create()
-				.stream()
-				.forEach(record -> result.put(
-						QtyReservationId.ofRepoId(record.getM_QtyReservation_ID()),
-						SupplyType.ofCode(record.getSupplyType()).isPlannedSupply()));
-		return result;
 	}
 
 	@Value

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
@@ -63,7 +63,11 @@ public class ReconcileQtyReservationsCommand
 	 * The CU {@code Qty} keeps the exact reduced value; the integer {@code QtyTU} is rounded UP — a
 	 * partially-filled TU still occupies a whole TU.
 	 *
-	 * @return the order-line IDs whose reservations were actually modified (empty if nothing changed)
+	 * Reservation rows whose final Qty is zero — pre-existing phantoms (a row reserving 0 CU) and rows shrunk
+	 * fully to zero — are deleted rather than kept.
+	 *
+	 * @return the order-line IDs whose reservations were actually modified — shrunk and/or had a zero-Qty row
+	 * deleted (empty if nothing changed)
 	 */
 	public ImmutableSet<OrderLineId> execute()
 	{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommand.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -70,18 +71,13 @@ public class ReconcileQtyReservationsCommand
 
 		// QtyReservationId -> (newQty, newQtyTU) for the rows that must shrink
 		final Map<QtyReservationId, NewQty> newQtyByReservationId = new HashMap<>();
+		// rows whose final Qty is zero (pre-existing phantoms or rows shrunk to nothing) — to be deleted, not kept
+		final Set<QtyReservationId> reservationIdsToDelete = new HashSet<>();
 		final ImmutableSet.Builder<OrderLineId> affectedOrderLineIds = ImmutableSet.builder();
 
 		for (final OrderAndLineId orderAndLineId : orderLineIds)
 		{
 			final OrderLineId orderLineId = orderAndLineId.getOrderLineId();
-			final Quantity qtyOrdered = orderLineBL.getQtyOrdered(orderAndLineId);
-
-			// cancelled / zero-qty lines have nothing to reconcile against
-			if (qtyOrdered.signum() <= 0)
-			{
-				continue;
-			}
 
 			final ImmutableList<QtyReservation> reservations = qtyReservationRepository.getActiveByOrderLineId(orderLineId);
 			if (reservations.isEmpty())
@@ -89,94 +85,119 @@ public class ReconcileQtyReservationsCommand
 				continue;
 			}
 
-			// total reserved, expressed in the order-line UOM
-			Quantity totalReserved = null;
+			boolean lineChanged = false;
+
+			// A reservation with Qty=0 reserves nothing (e.g. a planned-supply row minted with 0 CU but a positive
+			// QtyTU). It only inflates the reserved-QtyTU total, so it is deleted regardless of the line's
+			// over-reservation state — this also catches a line that is not over-reserved but still carries a phantom.
 			for (final QtyReservation reservation : reservations)
 			{
-				final Quantity qtyInLineUOM = uomConversionBL.convertQuantityTo(
-						reservation.getQty(),
-						reservation.getProductId(),
-						qtyOrdered.getUomId());
-				totalReserved = totalReserved == null ? qtyInLineUOM : totalReserved.add(qtyInLineUOM);
+				if (reservation.getQty().signum() <= 0)
+				{
+					reservationIdsToDelete.add(reservation.getId());
+					lineChanged = true;
+				}
 			}
 
-			// reservations is non-empty, so totalReserved is non-null here
-			if (totalReserved.compareTo(qtyOrdered) <= 0)
+			final Quantity qtyOrdered = orderLineBL.getQtyOrdered(orderAndLineId);
+
+			// cancelled / zero-qty lines have nothing to shrink against (phantom rows above are still cleaned up)
+			if (qtyOrdered.signum() > 0)
 			{
-				continue; // nothing to shrink for this line
-			}
-
-			// excess to remove, expressed in the order-line UOM
-			BigDecimal excessInLineUOM = totalReserved.subtract(qtyOrdered).toBigDecimal();
-
-			// Reduce PS rows before OH rows. Within a group: stable by reservation id.
-			final List<QtyReservation> ordered = sortPlannedSupplyBeforeOnHand(reservations);
-
-			boolean lineChanged = false;
-			for (final QtyReservation reservation : ordered)
-			{
-				if (excessInLineUOM.signum() <= 0)
+				// total reserved, expressed in the order-line UOM
+				Quantity totalReserved = null;
+				for (final QtyReservation reservation : reservations)
 				{
-					break;
+					final Quantity qtyInLineUOM = uomConversionBL.convertQuantityTo(
+							reservation.getQty(),
+							reservation.getProductId(),
+							qtyOrdered.getUomId());
+					totalReserved = totalReserved == null ? qtyInLineUOM : totalReserved.add(qtyInLineUOM);
 				}
 
-				final BigDecimal rowQty = reservation.getQty().toBigDecimal();
-				if (rowQty.signum() <= 0)
+				// reservations is non-empty, so totalReserved is non-null here
+				if (totalReserved.compareTo(qtyOrdered) > 0)
 				{
-					continue;
+					// excess to remove, expressed in the order-line UOM
+					BigDecimal excessInLineUOM = totalReserved.subtract(qtyOrdered).toBigDecimal();
+
+					// Reduce PS rows before OH rows. Within a group: stable by reservation id.
+					final List<QtyReservation> ordered = sortPlannedSupplyBeforeOnHand(reservations);
+
+					for (final QtyReservation reservation : ordered)
+					{
+						if (excessInLineUOM.signum() <= 0)
+						{
+							break;
+						}
+
+						final BigDecimal rowQty = reservation.getQty().toBigDecimal();
+						if (rowQty.signum() <= 0)
+						{
+							continue; // zero-Qty row — already queued for deletion above
+						}
+
+						// already-delivered qty is the floor below which this row must never shrink
+						final BigDecimal rowQtyDelivered = reservation.getQtyDelivered().toBigDecimal().max(BigDecimal.ZERO);
+
+						// the most this row can give up (in the reservation's own UOM), never below delivered
+						final BigDecimal reducibleRowQty = rowQty.subtract(rowQtyDelivered).max(BigDecimal.ZERO);
+						if (reducibleRowQty.signum() <= 0)
+						{
+							continue;
+						}
+
+						// convert this row's reducible qty to the order-line UOM so excess/min/subtract are all in one UOM
+						final BigDecimal reducibleRowQtyInLineUOM = uomConversionBL.convertQuantityTo(
+										reservation.getQty().toZero().add(reducibleRowQty),
+										reservation.getProductId(),
+										qtyOrdered.getUomId())
+								.toBigDecimal();
+
+						final BigDecimal reductionInLineUOM = excessInLineUOM.min(reducibleRowQtyInLineUOM);
+
+						// convert the reduction back to the reservation's own UOM
+						final BigDecimal reductionInRowUOM = uomConversionBL.convertQuantityTo(
+										qtyOrdered.toZero().add(reductionInLineUOM),
+										reservation.getProductId(),
+										reservation.getQty().getUomId())
+								.toBigDecimal();
+
+						// clamp: never shrink below already-delivered qty
+						final BigDecimal newQtyBD = rowQty.subtract(reductionInRowUOM).max(rowQtyDelivered);
+
+						if (newQtyBD.signum() <= 0)
+						{
+							// fully reduced (nothing delivered) → delete the row instead of keeping a Qty=0 reservation
+							reservationIdsToDelete.add(reservation.getId());
+						}
+						else
+						{
+							// QtyTU is rounded UP — a partially-filled TU still occupies a whole TU.
+							final BigDecimal rowQtyTU = reservation.getQtyTU().toBigDecimal();
+							final BigDecimal newQtyTUBD = rowQtyTU
+									.multiply(newQtyBD)
+									.divide(rowQty, 0, RoundingMode.CEILING);
+
+							final Quantity newQty = reservation.getQty().toZero().add(newQtyBD);
+							newQtyByReservationId.put(reservation.getId(), new NewQty(newQty, QtyTU.ofBigDecimal(newQtyTUBD)));
+						}
+						lineChanged = true;
+
+						// Subtract the ACTUAL applied reduction, not the intended one. The row is written `newQtyBD`
+						// (or deleted, i.e. effectively 0), which may differ from `rowQty - reductionInRowUOM` when the
+						// delivered-clamp kicks in or when a non-integer UOM round-trip shifts the value. Tracking the
+						// real reduction (converted back to the order-line UOM) keeps `excessInLineUOM` accurate and
+						// avoids a phantom residual across rows. In same-UOM scenarios the conversion is the identity.
+						final BigDecimal actualReductionInRowUOM = rowQty.subtract(newQtyBD);
+						final BigDecimal actualReductionInLineUOM = uomConversionBL.convertQuantityTo(
+										reservation.getQty().toZero().add(actualReductionInRowUOM),
+										reservation.getProductId(),
+										qtyOrdered.getUomId())
+								.toBigDecimal();
+						excessInLineUOM = excessInLineUOM.subtract(actualReductionInLineUOM);
+					}
 				}
-
-				// already-delivered qty is the floor below which this row must never shrink
-				final BigDecimal rowQtyDelivered = reservation.getQtyDelivered().toBigDecimal().max(BigDecimal.ZERO);
-
-				// the most this row can give up (in the reservation's own UOM), never below delivered
-				final BigDecimal reducibleRowQty = rowQty.subtract(rowQtyDelivered).max(BigDecimal.ZERO);
-				if (reducibleRowQty.signum() <= 0)
-				{
-					continue;
-				}
-
-				// convert this row's reducible qty to the order-line UOM so excess/min/subtract are all in one UOM
-				final BigDecimal reducibleRowQtyInLineUOM = uomConversionBL.convertQuantityTo(
-								reservation.getQty().toZero().add(reducibleRowQty),
-								reservation.getProductId(),
-								qtyOrdered.getUomId())
-						.toBigDecimal();
-
-				final BigDecimal reductionInLineUOM = excessInLineUOM.min(reducibleRowQtyInLineUOM);
-
-				// convert the reduction back to the reservation's own UOM
-				final BigDecimal reductionInRowUOM = uomConversionBL.convertQuantityTo(
-								qtyOrdered.toZero().add(reductionInLineUOM),
-								reservation.getProductId(),
-								reservation.getQty().getUomId())
-						.toBigDecimal();
-
-				// clamp: never shrink below already-delivered qty
-				final BigDecimal newQtyBD = rowQty.subtract(reductionInRowUOM).max(rowQtyDelivered);
-
-				// QtyTU is rounded UP — a partially-filled TU still occupies a whole TU.
-				final BigDecimal rowQtyTU = reservation.getQtyTU().toBigDecimal();
-				final BigDecimal newQtyTUBD = rowQtyTU
-						.multiply(newQtyBD)
-						.divide(rowQty, 0, RoundingMode.CEILING);
-
-				final Quantity newQty = reservation.getQty().toZero().add(newQtyBD);
-				newQtyByReservationId.put(reservation.getId(), new NewQty(newQty, QtyTU.ofBigDecimal(newQtyTUBD)));
-				lineChanged = true;
-
-				// Subtract the ACTUAL applied reduction, not the intended one. The row is written `newQtyBD`,
-				// which may differ from `rowQty - reductionInRowUOM` when the delivered-clamp kicks in or when a
-				// non-integer UOM round-trip shifts the value. Tracking the real reduction (converted back to the
-				// order-line UOM) keeps `excessInLineUOM` accurate and avoids a phantom residual across rows.
-				// In same-UOM scenarios the conversion is the identity, so this equals `reductionInLineUOM` exactly.
-				final BigDecimal actualReductionInRowUOM = rowQty.subtract(newQtyBD);
-				final BigDecimal actualReductionInLineUOM = uomConversionBL.convertQuantityTo(
-								reservation.getQty().toZero().add(actualReductionInRowUOM),
-								reservation.getProductId(),
-								qtyOrdered.getUomId())
-						.toBigDecimal();
-				excessInLineUOM = excessInLineUOM.subtract(actualReductionInLineUOM);
 			}
 
 			if (lineChanged)
@@ -186,17 +207,25 @@ public class ReconcileQtyReservationsCommand
 		}
 
 		final ImmutableSet<OrderLineId> changedOrderLineIds = affectedOrderLineIds.build();
-		if (newQtyByReservationId.isEmpty())
+		if (newQtyByReservationId.isEmpty() && reservationIdsToDelete.isEmpty())
 		{
 			return ImmutableSet.of();
 		}
 
-		qtyReservationRepository.updateByOrderLineIds(
-				changedOrderLineIds,
-				before -> {
-					final NewQty newQty = newQtyByReservationId.get(before.getId());
-					return newQty != null ? before.withQty(newQty.getQty(), newQty.getQtyTU()) : before;
-				});
+		if (!newQtyByReservationId.isEmpty())
+		{
+			qtyReservationRepository.updateByOrderLineIds(
+					changedOrderLineIds,
+					before -> {
+						final NewQty newQty = newQtyByReservationId.get(before.getId());
+						return newQty != null ? before.withQty(newQty.getQty(), newQty.getQtyTU()) : before;
+					});
+		}
+
+		// physically delete the zero-Qty rows (same delete mechanism as QtyReservationRepository.deleteReservation);
+		// QtyReservationService.reconcileToOrderedQty invalidates the affected lines' shipment schedules afterwards,
+		// consistent with how deleteReservation() invalidates them.
+		qtyReservationRepository.deleteByIds(reservationIdsToDelete);
 
 		return changedOrderLineIds;
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
@@ -333,6 +333,22 @@ class ReconcileQtyReservationsCommandTest
 		assertThat(records.get(0).getQty()).isEqualByComparingTo(new BigDecimal("60"));
 	}
 
+	@Test
+	void deletesPhantomFromCancelledLine_whenQtyOrderedIsZero()
+	{
+		// The phantom scan runs BEFORE the over-reservation guard, so a zero-Qty row on a cancelled
+		// (QtyOrdered=0) line is still deleted even though that line has no shrink to perform.
+		final OrderId orderId = createSalesOrder();
+		final OrderLineId orderLineId = createOrderLine(orderId, BigDecimal.ZERO);
+
+		createReservationRecord(orderLineId, SupplyType.PLANNED_SUPPLY, BigDecimal.ZERO, new BigDecimal("3"));
+
+		service.reconcileToOrderedQty(orderId);
+
+		// phantom deleted; nothing left on the line
+		assertThat(loadRecords(orderLineId)).isEmpty();
+	}
+
 	// --- helpers ---
 
 	private int createWarehouseId()

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
@@ -285,6 +285,54 @@ class ReconcileQtyReservationsCommandTest
 		assertThat(recordsB.get(0).getQty()).isEqualByComparingTo(new BigDecimal("100"));
 	}
 
+	@Test
+	void deletesPreExistingZeroQtyReservation_keepingReservedTuCorrect()
+	{
+		// Customer scenario (me03 #29261): a planned-supply reservation was minted with Qty(CU)=0 but QtyTU=3
+		// (planned supply has no on-hand stock, so computeQtyCUToReserve returns 0). On re-completion the line
+		// was reduced to 77, so the OH row (110/10) shrinks to 77/7. The phantom PS row (0/3) must be DELETED,
+		// otherwise the reserved QtyTU total stays 10 (7+3) instead of 7.
+		final OrderId orderId = createSalesOrder();
+		final OrderLineId orderLineId = createOrderLine(orderId, new BigDecimal("77"));
+
+		createReservationRecord(orderLineId, SupplyType.ON_HAND, new BigDecimal("110"), new BigDecimal("10"));
+		createReservationRecord(orderLineId, SupplyType.PLANNED_SUPPLY, BigDecimal.ZERO, new BigDecimal("3"));
+
+		service.reconcileToOrderedQty(orderId);
+
+		final List<I_M_QtyReservation> records = loadRecords(orderLineId);
+		// phantom PS row deleted; only the shrunk OH row remains
+		assertThat(records).hasSize(1);
+		assertThat(records.get(0).getSupplyType()).isEqualTo(SupplyType.ON_HAND.getCode());
+		assertThat(records.get(0).getQty()).isEqualByComparingTo(new BigDecimal("77"));
+		assertThat(records.get(0).getQtyTU()).isEqualByComparingTo(new BigDecimal("7"));
+
+		// reserved QtyTU total is 7, not 10
+		final BigDecimal totalTU = records.stream()
+				.map(I_M_QtyReservation::getQtyTU)
+				.reduce(BigDecimal.ZERO, BigDecimal::add);
+		assertThat(totalTU).isEqualByComparingTo(new BigDecimal("7"));
+	}
+
+	@Test
+	void deletesReservation_whenShrunkToZero()
+	{
+		// Multi-reservation line reduced below the OH portion: PS (40) is fully removed (shrunk to 0) and
+		// must be DELETED, not left as a Qty=0 row. OH (60) is kept and equals the reduced QtyOrdered.
+		final OrderId orderId = createSalesOrder();
+		final OrderLineId orderLineId = createOrderLine(orderId, new BigDecimal("60"));
+
+		createReservationRecord(orderLineId, SupplyType.ON_HAND, new BigDecimal("60"), new BigDecimal("60"));
+		createReservationRecord(orderLineId, SupplyType.PLANNED_SUPPLY, new BigDecimal("40"), new BigDecimal("40"));
+
+		service.reconcileToOrderedQty(orderId);
+
+		final List<I_M_QtyReservation> records = loadRecords(orderLineId);
+		assertThat(records).hasSize(1);
+		assertThat(records.get(0).getSupplyType()).isEqualTo(SupplyType.ON_HAND.getCode());
+		assertThat(records.get(0).getQty()).isEqualByComparingTo(new BigDecimal("60"));
+	}
+
 	// --- helpers ---
 
 	private int createWarehouseId()

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/ReconcileQtyReservationsCommandTest.java
@@ -1,7 +1,6 @@
 package de.metas.inoutcandidate.qty_reservation;
 
 import de.metas.business.BusinessTestHelper;
-import de.metas.order.IOrderDAO;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
 import de.metas.uom.CreateUOMConversionRequest;
@@ -255,7 +254,8 @@ class ReconcileQtyReservationsCommandTest
 
 		service.reconcileToOrderedQty(orderId);
 
-		// QtyOrdered=0 → line is skipped (the `qtyOrdered.signum() <= 0` guard), reservation untouched
+		// QtyOrdered=0 → no over-reservation shrink runs; the reservation has positive Qty (10) so the
+		// zero-phantom scan finds nothing to delete → reservation untouched
 		final List<I_M_QtyReservation> records = loadRecords(orderLineId);
 		assertThat(records).hasSize(1);
 		assertThat(records.get(0).getQty()).isEqualByComparingTo(new BigDecimal("10"));
@@ -288,7 +288,7 @@ class ReconcileQtyReservationsCommandTest
 	@Test
 	void deletesPreExistingZeroQtyReservation_keepingReservedTuCorrect()
 	{
-		// Customer scenario (me03 #29261): a planned-supply reservation was minted with Qty(CU)=0 but QtyTU=3
+		// Scenario: a planned-supply reservation was minted with Qty(CU)=0 but QtyTU=3
 		// (planned supply has no on-hand stock, so computeQtyCUToReserve returns 0). On re-completion the line
 		// was reduced to 77, so the OH row (110/10) shrinks to 77/7. The phantom PS row (0/3) must be DELETED,
 		// otherwise the reserved QtyTU total stays 10 (7+3) instead of 7.


### PR DESCRIPTION
## What

Reservation reconcile-on-completion now **deletes reservation rows whose `Qty` is 0** instead of leaving them behind.

Issue: https://github.com/metasfresh/me03/issues/29261 (F19012)

## Why

A reservation row can carry `Qty(CU)=0` but a positive `QtyTU` — e.g. a planned-supply row reserved against stock that is not yet on hand (`MaterialCockpitV2RowVO.computeQtyCUToReserve` returns 0 CU when `qtyStock <= 0`). Such a row reserves nothing, yet:

- it **inflates the reserved-`QtyTU` total** (a line showing OH `77 CU / 7 TU` plus a phantom PS `0 CU / 3 TU` reads as **10 TU reserved** instead of 7), and
- it **lingers forever**: `ReconcileQtyReservationsCommand` shrinks each line's reservations down to the line's `QtyOrdered` on sales-order completion, but it **skipped** zero-`Qty` rows (`rowQty.signum() <= 0` guard), so it neither zeroed their `QtyTU` nor removed them.

Reported on a `swift_eagle_release` build after the customer's reverse → reactivate → reduce-line → re-complete workflow.

## How

`ReconcileQtyReservationsCommand.execute()` now collects every reservation row whose **final `Qty` is 0** and deletes it:

- **pre-existing phantoms** — scanned on every line that has reservations, independent of whether the line is over-reserved (so a phantom on a cancelled `QtyOrdered=0` line is cleaned up too);
- **rows shrunk fully to zero** — a row reduced to 0 by the over-reservation sweep is deleted rather than written as `Qty=0`.

Deletion uses the new `QtyReservationRepository.deleteByIds(Set<QtyReservationId>)` — the **same physical SQL `delete()` mechanism** as `deleteReservation`, but targeted by `M_QtyReservation_ID` so it never removes a sibling non-zero reservation sharing the same supply-type bucket. `QtyReservationService.reconcileToOrderedQty` invalidates the affected lines' shipment schedules afterwards, consistent with `deleteReservation`. The delivered-clamp guarantees `Qty=0 ⟹ QtyDelivered=0`, so deletion never discards delivered history.

Also folded in a small persistence-layer cleanup: the PLANNED_SUPPLY/ON_HAND lookup that the command previously ran via `IQueryBL` moved into `QtyReservationRepository.getIsPlannedSupplyByIds(...)`, so the command no longer issues DB queries directly (behaviour-neutral — identical query).

No migration / AD metadata changes. Scope: reconcile cleanup only — the reservation-creation path (`MakeQtyReservationCommand`) is left untouched.

## Tests

Three RED-first unit cases added to `ReconcileQtyReservationsCommandTest`:

- `deletesPreExistingZeroQtyReservation_keepingReservedTuCorrect` — over-reserved OH `110/10` + phantom PS `0/3`, line reduced to 77 ⇒ PS deleted, OH `77/7`, reserved `QtyTU` total = 7.
- `deletesReservation_whenShrunkToZero` — OH `60` + PS `40`, line reduced to 60 ⇒ PS fully removed.
- `deletesPhantomFromCancelledLine_whenQtyOrderedIsZero` — `0/3` PS phantom on a cancelled (`QtyOrdered=0`) line ⇒ phantom deleted (the scan runs before the over-reservation guard).

Local: `Tests run: 21, Failures: 0` (`QtyReservationTest`, `QtyReservationRepositoryTest`, `ReconcileQtyReservationsCommandTest`). Cucumber `qtyReservation` regression verified on CI.
