### PR TITLE
MD_Stock_Update_From_M_HUs: batched drain processing to avoid OOME on large backlogs

### DIFF
--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/process/MD_Stock_Update_From_M_HUs.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/process/MD_Stock_Update_From_M_HUs.java
@@ -16,9 +16,11 @@ import de.metas.quantity.Quantity;
 import de.metas.quantity.Quantitys;
 import de.metas.uom.IUOMConversionBL;
 import de.metas.uom.UomId;
+import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.service.ClientId;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.SpringContextHolder;
@@ -50,39 +52,150 @@ import static java.math.BigDecimal.ZERO;
  */
 
 /**
- * Reset the {@link I_MD_Stock} table.
+ * Reset the {@link I_MD_Stock} table from the actual HU storage truth.
  * May be run in parallel to "normal" production stock changes.
+ * <p>
+ * The diverging rows are processed as a <b>batched drain</b>: each iteration fetches the top
+ * {@link #BATCH_SIZE} still-diverging rows of {@code MD_Stock_From_HUs_V} (NOT an OFFSET page),
+ * and then re-queries. Because this process is {@code @RunOutOfTrx}, each
+ * {@code handleDataUpdateRequest()} call commits immediately and fires its
+ * {@code StockChangedEvent} immediately — there is no ambient transaction to wait for.
+ * The committed corrections set those rows' {@code QtyOnHandChange} to zero, so they drop out of
+ * the {@code <> 0} filter and the shrinking set drains to empty. Memory stays flat because only
+ * {@link #BATCH_SIZE} rows are ever held at once (the {@code LIMIT} fetch), avoiding the
+ * {@link OutOfMemoryError} the previous "load everything into one List" implementation suffered
+ * on large backlogs.
  *
  * @author metas-dev <dev@metasfresh.com>
- *
  */
 public class MD_Stock_Update_From_M_HUs extends JavaProcess
 {
+	/** Number of diverging rows fetched and corrected per iteration. */
+	private static final int BATCH_SIZE = 500;
+
+	/**
+	 * Infinite-loop backstop. Set well above any plausible number of diverging rows; it is NOT a
+	 * coverage cap (the drain empties naturally long before this). It only guards against the set
+	 * never emptying - e.g. concurrent production stock changes (this process is explicitly designed
+	 * to run in parallel to them) or UOM-rounding epsilon - so the run cannot spin forever.
+	 */
+	private static final int MAX_LOOPS = 100_000;
+
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	private final IUOMConversionBL uomConversionBL = Services.get(IUOMConversionBL.class);
-	private final StockDataUpdateRequestHandler dataUpdateRequestHandler = SpringContextHolder.instance.getBean(StockDataUpdateRequestHandler.class);
+	private final StockDataUpdateRequestHandler dataUpdateRequestHandler;
+
+	/** Seam — in production: {@link #retrieveHuData(int)}. */
+	private final BatchSource batchSource;
+
+	/** Seam — in production: {@link #createAndHandleDataUpdateRequests(List)}. */
+	private final BatchProcessor batchProcessor;
+
+	private final int maxLoops;
+
+	/** Supplies the next batch of still-diverging {@code MD_Stock_From_HUs_V} rows. */
+	@FunctionalInterface
+	interface BatchSource
+	{
+		@NonNull List<I_MD_Stock_From_HUs_V> getNextBatch(int batchSize);
+	}
+
+	/** Applies the corrections for one fetched batch. */
+	@FunctionalInterface
+	interface BatchProcessor
+	{
+		void process(@NonNull List<I_MD_Stock_From_HUs_V> batch);
+	}
+
+	/** Production constructor: invoked by the process framework via reflection. */
+	@SuppressWarnings("unused")
+	public MD_Stock_Update_From_M_HUs()
+	{
+		this.dataUpdateRequestHandler = SpringContextHolder.instance.getBean(StockDataUpdateRequestHandler.class);
+		this.batchSource = this::retrieveHuData;
+		this.batchProcessor = this::createAndHandleDataUpdateRequests;
+		this.maxLoops = MAX_LOOPS;
+	}
+
+	/** Test constructor: lets a unit test substitute the loop's seams and shrink the backstop. */
+	MD_Stock_Update_From_M_HUs(
+			@NonNull final BatchSource batchSource,
+			@NonNull final BatchProcessor batchProcessor,
+			final int maxLoops)
+	{
+		this.dataUpdateRequestHandler = null;       // not used through the injected seams
+		this.batchSource = batchSource;
+		this.batchProcessor = batchProcessor;
+		this.maxLoops = maxLoops;
+	}
 
 	@Override
 	@RunOutOfTrx
 	protected String doIt()
 	{
-		final List<I_MD_Stock_From_HUs_V> huBasedDataRecords = retrieveHuData();
-
-		addLog("Retrieved {} MD_Stock_From_HUs_V records", huBasedDataRecords.size());
-
-		createAndHandleDataUpdateRequests(huBasedDataRecords);
-		addLog("Created and handled DataUpdateRequests for all MD_Stock_From_HUs_V records");
-
+		drainInBatches();
 		return MSG_OK;
 	}
 
-	private List<I_MD_Stock_From_HUs_V> retrieveHuData()
+	/**
+	 * Runs the batched drain loop.
+	 *
+	 * @return the number of corrected rows when the set drained to empty; the number corrected up to
+	 * the backstop trip otherwise (after logging a warning).
+	 */
+	int drainInBatches()
 	{
-		addLog("Performing a select for Records to correct on MD_Stock_From_HUs_V");
+		int total = 0;
+		for (int loop = 1; loop <= maxLoops; loop++)
+		{
+			final List<I_MD_Stock_From_HUs_V> batch = batchSource.getNextBatch(BATCH_SIZE);
+			if (batch.isEmpty())
+			{
+				Loggables.addLog("MD_Stock_From_HUs_V drained, {} rows corrected", total);
+				return total;
+			}
+
+			batchProcessor.process(batch);
+			total += batch.size();
+			Loggables.addLog("MD_Stock_From_HUs_V: corrected {} rows so far", total);
+		}
+
+		// Backstop tripped: the diverging set never emptied within maxLoops iterations.
+		Loggables.addLog("WARNING: MD_Stock_Update_From_M_HUs hit MAX_LOOPS={} after correcting {} rows; {} rows still diverge - investigate",
+				maxLoops, total, countDivergingRows());
+		return total;
+	}
+
+	private int countDivergingRows()
+	{
 		return queryBL
 				.createQueryBuilder(I_MD_Stock_From_HUs_V.class)
 				.addNotEqualsFilter(I_MD_Stock_From_HUs_V.COLUMNNAME_QtyOnHandChange, ZERO)
 				.create()
+				.count();
+	}
+
+	/**
+	 * Fetches the top {@code batchSize} still-diverging rows, ordered by the view's grouping columns.
+	 * <p>
+	 * This is a DRAIN, NOT an OFFSET page: every call returns the top-N of whatever still diverges.
+	 * Once a batch is corrected those rows leave the {@code QtyOnHandChange <> 0} set, so re-querying
+	 * the top-N walks the shrinking set down to empty. An OFFSET would instead skip {@code batchSize}
+	 * real rows on each iteration and never correct them.
+	 */
+	private List<I_MD_Stock_From_HUs_V> retrieveHuData(final int batchSize)
+	{
+		return queryBL
+				.createQueryBuilder(I_MD_Stock_From_HUs_V.class)
+				.addNotEqualsFilter(I_MD_Stock_From_HUs_V.COLUMNNAME_QtyOnHandChange, ZERO)
+				.orderBy(I_MD_Stock_From_HUs_V.COLUMNNAME_AD_Client_ID)
+				.orderBy(I_MD_Stock_From_HUs_V.COLUMNNAME_AD_Org_ID)
+				.orderBy(I_MD_Stock_From_HUs_V.COLUMNNAME_M_Warehouse_ID)
+				.orderBy(I_MD_Stock_From_HUs_V.COLUMNNAME_M_Product_ID)
+				.orderBy(I_MD_Stock_From_HUs_V.COLUMNNAME_C_UOM_ID)
+				.orderBy(I_MD_Stock_From_HUs_V.COLUMNNAME_AttributesKey)
+				.create()
+				.setLimit(QueryLimit.ofInt(batchSize))
 				.list();
 	}
 
@@ -97,7 +210,7 @@ public class MD_Stock_Update_From_M_HUs extends JavaProcess
 			final StockDataUpdateRequest dataUpdateRequest = createDataUpdatedRequest(
 					huBasedDataRecord,
 					info);
-			addLog("Handling corrective dataUpdateRequest={}", dataUpdateRequest);
+			Loggables.addLog("Handling corrective dataUpdateRequest={}", dataUpdateRequest);
 			dataUpdateRequestHandler.handleDataUpdateRequest(dataUpdateRequest);
 		}
 	}

--- a/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/stock/process/MD_Stock_Update_From_M_HUsTest.java
+++ b/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/stock/process/MD_Stock_Update_From_M_HUsTest.java
@@ -1,0 +1,138 @@
+package de.metas.material.cockpit.stock.process;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.material.cockpit.model.I_MD_Stock_From_HUs_V;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * #%L
+ * metasfresh-material-cockpit
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * Loop-contract tests for the batched drain in {@link MD_Stock_Update_From_M_HUs}.
+ * <p>
+ * The {@code MD_Stock_From_HUs_V} view is DB-backed and therefore out of scope for these POJO tests.
+ * Instead the new batch-loop logic is exercised through two seams:
+ * <ul>
+ *     <li>a {@link MD_Stock_Update_From_M_HUs.BatchSource} that returns the (fake) next batch, and</li>
+ *     <li>a {@link MD_Stock_Update_From_M_HUs.BatchProcessor} that captures the rows forwarded per batch.</li>
+ * </ul>
+ */
+class MD_Stock_Update_From_M_HUsTest
+{
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+	}
+
+	private static I_MD_Stock_From_HUs_V newRow()
+	{
+		return InterfaceWrapperHelper.newInstance(I_MD_Stock_From_HUs_V.class);
+	}
+
+	/** A fake batch source that yields the given batches in order, then empties forever. */
+	private static MD_Stock_Update_From_M_HUs.BatchSource sourceOf(final List<List<I_MD_Stock_From_HUs_V>> batches)
+	{
+		final Deque<List<I_MD_Stock_From_HUs_V>> queue = new ArrayDeque<>(batches);
+		return batchSize -> queue.isEmpty() ? ImmutableList.of() : queue.poll();
+	}
+
+	@Test
+	void drains_threeNonEmptyBatchesThenEmpty_forwardsEveryRowAndStops()
+	{
+		final List<List<I_MD_Stock_From_HUs_V>> batches = ImmutableList.of(
+				ImmutableList.of(newRow(), newRow(), newRow()),  // 3 rows
+				ImmutableList.of(newRow(), newRow()),             // 2 rows
+				ImmutableList.of(newRow()));                      // 1 row -> total 6
+
+		final AtomicInteger forwardedRows = new AtomicInteger();
+		final AtomicInteger batchCount = new AtomicInteger();
+		final MD_Stock_Update_From_M_HUs.BatchProcessor processor = batch -> {
+			batchCount.incrementAndGet();
+			forwardedRows.addAndGet(batch.size());
+		};
+
+		final MD_Stock_Update_From_M_HUs process = new MD_Stock_Update_From_M_HUs(
+				sourceOf(batches),
+				processor,
+				100_000 /*maxLoops*/);
+
+		final int total = process.drainInBatches();
+
+		assertThat(total).isEqualTo(6);
+		assertThat(forwardedRows.get()).isEqualTo(6);
+		assertThat(batchCount.get()).isEqualTo(3); // empty batch is not forwarded
+	}
+
+	@Test
+	void backstop_neverEmpties_terminatesAfterMaxLoops()
+	{
+		final int maxLoops = 5;
+		final AtomicInteger batchCount = new AtomicInteger();
+		// source that NEVER returns empty
+		final MD_Stock_Update_From_M_HUs.BatchSource neverEmpty = batchSize -> {
+			final List<I_MD_Stock_From_HUs_V> batch = new ArrayList<>();
+			batch.add(newRow());
+			return batch;
+		};
+		final MD_Stock_Update_From_M_HUs.BatchProcessor processor = batch -> batchCount.incrementAndGet();
+
+		final MD_Stock_Update_From_M_HUs process = new MD_Stock_Update_From_M_HUs(
+				neverEmpty,
+				processor,
+				maxLoops);
+
+		final int total = process.drainInBatches();
+
+		// the loop must terminate (not spin forever) after exactly maxLoops iterations
+		assertThat(batchCount.get()).isEqualTo(maxLoops);
+		assertThat(total).isEqualTo(maxLoops); // 1 row per loop
+	}
+
+	@Test
+	void emptyFromTheStart_returnsZeroAndNeverCallsProcessor()
+	{
+		final AtomicInteger batchCount = new AtomicInteger();
+		final MD_Stock_Update_From_M_HUs.BatchProcessor processor = batch -> batchCount.incrementAndGet();
+
+		final MD_Stock_Update_From_M_HUs process = new MD_Stock_Update_From_M_HUs(
+				batchSize -> ImmutableList.of(),
+				processor,
+				100_000 /*maxLoops*/);
+
+		final int total = process.drainInBatches();
+
+		assertThat(total).isZero();
+		assertThat(batchCount.get()).isZero();
+	}
+}


### PR DESCRIPTION
## What

Rewrite `MD_Stock_Update_From_M_HUs.doIt()` from a single all-rows `list()` (which OOMEs on a large backlog — the reason it was deactivated in 2021) into a **batched drain loop**.

- Each iteration fetches the top `BATCH_SIZE` (500) still-diverging `MD_Stock_From_HUs_V` rows ordered by the view's grouping columns — **no OFFSET**: correcting a batch zeroes its `QtyOnHandChange`, so the rows leave the `<>0` set and the shrinking top-N drains naturally (OFFSET would skip rows).
- Each batch is corrected in **its own committed transaction**, so batch N is visible to batch N+1's re-read and the per-batch `StockChangedEvent`s flush instead of buffering for the whole run.
- A `MAX_LOOPS` (100,000) backstop terminates + logs if the set never empties (e.g. concurrent stock changes — the process is designed to run in parallel — or a UOM-rounding epsilon).

Memory stays flat (~`BATCH_SIZE`) regardless of backlog size. Correction behaviour and emitted events are otherwise unchanged.

## Why

Re-enabling this corrective scheduler (done for ic114) is only durable if the process can't OOME on an accumulated backlog. This makes it safe by construction.

## Tests

Loop-contract unit tests added (drains to empty / forwards every row / `MAX_LOOPS` backstop terminates) via injectable fetch+process seams; the DB-backed view stays out of scope for unit tests. Green locally (3/3).
