### PR TITLE
Auswahl Liefern — expose hidden IsOnTheFlyPickToPackingInstructions param (pack picked CUs into TUs)

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_shipment.feature
@@ -1006,3 +1006,86 @@ Feature: Qty Reservation — shipment attribute and project propagation
     And validate the created shipment lines
       | M_InOut_ID | M_Product_ID | movementqty |
       | shipment   | product      | 10          |
+
+
+  @from:cucumber
+  @Id:S_QtyRes_310
+  Scenario: On-the-fly pick to packing instructions packs CUs into a TU (not a bare CU)
+  ## _Given a product with 1 TU (10 PCE on-hand) and a sales order for 10 PCE
+  ## _And an M_QtyReservation for 10 PCE
+  ## _When shipment is generated with IsOnTheFlyPickToPackingInstructions=true
+  ## _Then the HU assigned to the shipment is a TU (its effective PI version is the TU version),
+  ## _     not a bare CU ("No Packing Item")
+  ## _This locks the capability the 'Auswahl Liefern' process now exposes via the hidden
+  ## _IsOnTheFlyPickToPackingInstructions param: on-the-fly picking honours the flag and packs
+  ## _to packing instructions, so the picked HU is TU-shaped and remains re-reservable after a reversal.
+
+    Given metasfresh contains M_Products:
+      | Identifier | IsStocked |
+      | product    | true      |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID |
+      | huPI       |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType |
+      | huPIV              | huPI       | TU          |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID | M_HU_PI_Version_ID | ItemType |
+      | huPIItem        | huPIV              | MI       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID | Qty    |
+      | huPIP_10PCE             | huPIItem        | product      | 10 PCE |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 |
+      | plv_1                  | product      | 10.00    | PCE               |
+
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_Warehouse_ID | MovementDate | M_Product_ID | QtyBook | QtyCount | M_HU_PI_Item_Product_ID | M_HU_ID |
+      | inventory      | warehouse_1    | 2026-03-15   | product      | 0 PCE   | 10 PCE   | huPIP_10PCE             | hu      |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And M_HU_Attribute is changed
+      | M_HU_ID | M_Attribute_ID.Value | ValueStr |
+      | hu      | ProjectValue         | P200     |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | DeliveryRule |
+      | order      | true    | bp_1          | 2026-03-15  | warehouse_1    | F            |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | orderLine  | order      | product      | 10         | huPIP_10PCE             |
+    And the order identified by order is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier       | C_OrderLine_ID | IsToRecompute |
+      | shipmentSchedule | orderLine      | N             |
+
+    And metasfresh contains M_QtyReservations:
+      | Identifier  | C_OrderLine_ID | M_Product_ID | M_Warehouse_ID | Qty    | QtyTU |
+      | reservation | orderLine      | product      | warehouse_1    | 10 PCE | 1     |
+
+    And after not more than 60s, shipment schedule is recomputed
+      | M_ShipmentSchedule_ID |
+      | shipmentSchedule      |
+
+    When 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday | IsOnTheFlyPickToPackingInstructions |
+      | shipmentSchedule      | D            | true                | false       | true                                |
+
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | shipmentSchedule      | shipment   |
+    And validate the created shipment lines
+      | M_InOut_ID | M_Product_ID | movementqty |
+      | shipment   | product      | 10          |
+
+    # The picked HU must be TU-shaped: its effective PI version is the TU version (huPIV),
+    # proving the flag caused packing-to-instructions instead of a bare CU.
+    And load HUs assigned to M_InOut
+      | M_InOut_ID | M_HU_ID    |
+      | shipment   | pickedHU   |
+    And validate M_HUs:
+      | M_HU_ID  | M_HU_PI_Version_ID |
+      | pickedHU | huPIV              |
+
+    And validate M_QtyReservations:
+      | Identifier  | Qty    | QtyDelivered | Processed |
+      | reservation | 10 PCE | 10 PCE       | true      |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/process/M_ShipmentSchedule_EnqueueSelection.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/process/M_ShipmentSchedule_EnqueueSelection.java
@@ -72,8 +72,7 @@ public class M_ShipmentSchedule_EnqueueSelection
 	@Param(parameterName = "IsShipToday", mandatory = true)
 	private boolean isShipToday; // introduced in task #2940
 
-	// Hidden process param (default N): when on, on-the-fly picking packs CUs into TUs (PackingInstructions),
-	// instead of creating bare CUs ("No Packing Item"). Required for TU-based re-reservation after reversal.
+	// Hidden param (DisplayLogic '1=0', default N); opted in per instance via DefaultValue.
 	@Param(parameterName = "IsOnTheFlyPickToPackingInstructions")
 	private boolean isOnTheFlyPickToPackingInstructions;
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/process/M_ShipmentSchedule_EnqueueSelection.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/process/M_ShipmentSchedule_EnqueueSelection.java
@@ -72,6 +72,11 @@ public class M_ShipmentSchedule_EnqueueSelection
 	@Param(parameterName = "IsShipToday", mandatory = true)
 	private boolean isShipToday; // introduced in task #2940
 
+	// Hidden process param (default N): when on, on-the-fly picking packs CUs into TUs (PackingInstructions),
+	// instead of creating bare CUs ("No Packing Item"). Required for TU-based re-reservation after reversal.
+	@Param(parameterName = "IsOnTheFlyPickToPackingInstructions")
+	private boolean isOnTheFlyPickToPackingInstructions;
+
 	@Override
 	public ProcessPreconditionsResolution checkPreconditionsApplicable(@NonNull final IProcessPreconditionsContext context)
 	{
@@ -99,6 +104,7 @@ public class M_ShipmentSchedule_EnqueueSelection
 				.quantityType(quantityType)
 				.completeShipments(isCompleteShipments)
 				.isShipmentDateToday(isShipToday)
+				.onTheFlyPickToPackingInstructions(isOnTheFlyPickToPackingInstructions)
 				.build();
 
 		final Result result = ShipmentScheduleEnqueuer.newInstance(getCtx(), getTrxName())

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806370_sys_Auswahl_Liefern_IsOnTheFlyPickToPackingInstructions_param.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806370_sys_Auswahl_Liefern_IsOnTheFlyPickToPackingInstructions_param.sql
@@ -1,0 +1,62 @@
+-- Auswahl Liefern (AD_Process 540458 = M_ShipmentSchedule_EnqueueSelection):
+-- expose a HIDDEN process parameter IsOnTheFlyPickToPackingInstructions (Yes-No, default 'N').
+-- When on, on-the-fly picking packs CUs into TUs (PackingInstructions) instead of creating bare CUs
+-- ("No Packing Item"), which is required for TU-based re-reservation after a shipment reversal.
+-- Global default stays 'N' (no behaviour change); a customer flips DefaultValue on their instance only.
+--
+-- HIDDEN via DisplayLogic='1=0' (AD_Process_Para has no IsDisplayed column; '1=0' is the standard
+-- never-true expression used to hide process params). IsMandatory='N', DefaultValue='N'.
+-- The @Param resolves to false when absent, so the param is safe even on instances that never set it.
+--
+-- IDs from idserver.metas.de on 2026-06-04:
+--   AD_Element        584950 (IsOnTheFlyPickToPackingInstructions label)
+--   AD_Process_Para   543244 (on AD_Process 540458)
+-- Yes-No reference: AD_Reference_ID=17 (List) + AD_Reference_Value_ID=319 (_YesNo) — same as the
+-- canonical boolean process-param pattern (e.g. de.metas.fresh IsSOTrx in 5439480_..._ADR_Auswertung_Process.sql).
+
+-- 2026-06-04T10:00:00.000Z
+-- AD_Element (German base name; English via AD_Element_Trl)
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,ColumnName,EntityType,Name,PrintName,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+VALUES (584950 /*From ID Server*/,0,0,'IsOnTheFlyPickToPackingInstructions','de.metas.handlingunits','Im Lauf in Packvorschrift kommissionieren','Im Lauf in Packvorschrift kommissionieren',TO_TIMESTAMP('2026-06-04 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-06-04 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Y')
+;
+
+-- 2026-06-04T10:00:01.000Z
+-- AD_Element_Trl skeleton rows for all system languages (copies German base text)
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, Name,PrintName, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.Name,t.PrintName, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Element_ID=584950
+AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- 2026-06-04T10:00:12.000Z
+-- English override
+UPDATE AD_Element_Trl SET Name='Pick to packing instructions on the fly',PrintName='Pick to packing instructions on the fly',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-04 10:00:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Element_ID=584950
+;
+
+-- 2026-06-04T10:00:13.000Z
+-- Mark German rows as translated (same as base)
+UPDATE AD_Element_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-04 10:00:13','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Element_ID=584950
+;
+
+-- 2026-06-04T10:01:00.000Z
+-- AD_Process_Para: hidden Yes-No param, default 'N', on AD_Process 540458, SeqNo 40 (after the existing 10/20/30)
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,AD_Reference_Value_ID,ColumnName,Created,CreatedBy,DefaultValue,DisplayLogic,EntityType,FieldLength,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,Updated,UpdatedBy)
+VALUES (0,584950,0,540458,543244 /*From ID Server*/,17,319,'IsOnTheFlyPickToPackingInstructions',TO_TIMESTAMP('2026-06-04 10:01:00','YYYY-MM-DD HH24:MI:SS'),100,'N','1=0','de.metas.handlingunits',0,'Y','N','Y','N','N','N','Im Lauf in Packvorschrift kommissionieren',40,TO_TIMESTAMP('2026-06-04 10:01:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2026-06-04T10:01:01.000Z
+-- AD_Process_Para_Trl skeleton rows for all system languages
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID, Name,Description,Help, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_Para_ID, t.Name,t.Description,t.Help, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Process_Para t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Process_Para_ID=543244
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+-- 2026-06-04T10:02:00.000Z
+-- Propagate Name/Description/Help from AD_Element to the new AD_Process_Para_Trl rows
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584950)
+;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806370_sys_Auswahl_Liefern_IsOnTheFlyPickToPackingInstructions_param.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5806370_sys_Auswahl_Liefern_IsOnTheFlyPickToPackingInstructions_param.sql
@@ -16,14 +16,14 @@
 
 -- 2026-06-04T10:00:00.000Z
 -- AD_Element (German base name; English via AD_Element_Trl)
-INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,ColumnName,EntityType,Name,PrintName,Created,CreatedBy,Updated,UpdatedBy,IsActive)
-VALUES (584950 /*From ID Server*/,0,0,'IsOnTheFlyPickToPackingInstructions','de.metas.handlingunits','Im Lauf in Packvorschrift kommissionieren','Im Lauf in Packvorschrift kommissionieren',TO_TIMESTAMP('2026-06-04 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-06-04 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Y')
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,ColumnName,EntityType,Name,PrintName,Description,Help,Created,CreatedBy,Updated,UpdatedBy,IsActive)
+VALUES (584950 /*From ID Server*/,0,0,'IsOnTheFlyPickToPackingInstructions','de.metas.handlingunits','Im Lauf in Packvorschrift kommissionieren','Im Lauf in Packvorschrift kommissionieren','Wenn aktiviert, kommissioniert die fliegende Kommissionierung in Transporteinheiten (gemäß Packvorschrift) statt loser CUs.','Wenn aktiviert, kommissioniert die fliegende Kommissionierung in Transporteinheiten (gemäß Packvorschrift) statt loser CUs.',TO_TIMESTAMP('2026-06-04 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-06-04 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Y')
 ;
 
 -- 2026-06-04T10:00:01.000Z
 -- AD_Element_Trl skeleton rows for all system languages (copies German base text)
-INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, Name,PrintName, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
-SELECT l.AD_Language, t.AD_Element_ID, t.Name,t.PrintName, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, Name,PrintName,Description,Help, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.Name,t.PrintName,t.Description,t.Help, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
 FROM AD_Language l, AD_Element t
 WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Element_ID=584950
 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
@@ -36,8 +36,8 @@ WHERE AD_Language='en_US' AND AD_Element_ID=584950
 ;
 
 -- 2026-06-04T10:00:13.000Z
--- Mark German rows as translated (same as base)
-UPDATE AD_Element_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-04 10:00:13','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+-- German is the base language → de_DE/de_CH rows are NOT translations: IsTranslated='N'
+UPDATE AD_Element_Trl SET IsTranslated='N',Updated=TO_TIMESTAMP('2026-06-04 10:00:13','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
 WHERE AD_Language IN ('de_DE','de_CH') AND AD_Element_ID=584950
 ;
 


### PR DESCRIPTION
## What
Add a **hidden** process parameter `IsOnTheFlyPickToPackingInstructions` (Yes-No, default `N`) to the *Auswahl Liefern* shipment-generation process (`M_ShipmentSchedule_EnqueueSelection`).

## Why
On-the-fly picking creates picked HUs as **bare CUs** ('No Packing Item') by default, because this process never set `onTheFlyPickToPackingInstructions` on the work-package parameters. Bare CUs have no TU, which breaks TU-based qty re-reservation after a shipment reversal (the returned stock shows 0 TUs and cannot be reserved). The full plumbing for packing picked CUs into TUs already exists end-to-end — only this process never exposed/set the flag.

## How
- `M_ShipmentSchedule_EnqueueSelection`: new non-mandatory `@Param` boolean, passed into `ShipmentScheduleWorkPackageParameters.builder().onTheFlyPickToPackingInstructions(...)`.
- Migration: new `AD_Element` + a hidden `AD_Process_Para` (`DisplayLogic='1=0'`, `DefaultValue='N'`, Yes-No) on the process. Global default `N` preserves current behavior for every other caller/customer; an instance opts in by setting the param's DefaultValue to `Y`.
- Cucumber: generates a shipment with the flag on and asserts the picked HU is a **TU** (not a bare CU).

No behavior change unless the DefaultValue is flipped per instance.