### PR TITLE
Make 5805580 M_InOut.TrackingURL column INSERT idempotent

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inout/5805580_sys_M_InOut_TrackingURL_virtualcol.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inout/5805580_sys_M_InOut_TrackingURL_virtualcol.sql
@@ -1,6 +1,12 @@
 -- virtual column M_InOut.TrackingURL — carrier tracking link(s) for the shipment.
 -- Nullable (no coalesce); the ' - ' display fallback belongs to the email-body rendering.
 -- Reuses existing AD_Element_ID=2127 (ColumnName 'TrackingURL').
+-- Idempotent guard: some customer DBs already carry an M_InOut.TrackingURL column
+-- (added customer-side before this core feature). A plain INSERT collides with the
+-- ad_column_name unique constraint (AD_Table_ID, ColumnName) and — under
+-- ON_ERROR_STOP=1 in a single transaction — aborts the whole migration run, blocking
+-- every later script. Insert only when the column is absent; on a DB that already has
+-- it this script becomes a no-op (the existing column is left untouched).
 INSERT INTO AD_Column (
   AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,
   AllowZoomTo,ColumnName,ColumnSQL,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,
@@ -8,7 +14,8 @@ INSERT INTO AD_Column (
   IsDimension,IsEncrypted,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,
   IsLazyLoading,IsMandatory,IsParent,IsSelectionColumn,IsStaleable,IsSyncDatabase,
   IsTranslated,IsUpdateable,IsUseDocSequence,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version
-) VALUES (
+)
+SELECT
   0,592668 /*From ID Server*/,2127,0,10,(SELECT AD_Table_ID FROM AD_Table WHERE TableName='M_InOut'),
   'N','TrackingURL',
   '(SELECT lp.TrackingURL FROM M_ShippingPackage p JOIN Carrier_ShipmentOrder cso ON cso.M_ShipperTransportation_ID = p.M_ShipperTransportation_ID JOIN Carrier_ShipmentOrder_Parcel lp ON lp.Carrier_ShipmentOrder_ID = cso.Carrier_ShipmentOrder_ID WHERE p.M_InOut_ID = M_InOut.M_InOut_ID LIMIT 1)',
@@ -17,4 +24,8 @@ INSERT INTO AD_Column (
   'N','N','N','N','N','N',
   'Y','N','N','N','N','N',
   'N','N','N','Tracking URL','NP',0,TO_TIMESTAMP('2026-06-01 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,0
+WHERE NOT EXISTS (
+  SELECT 1 FROM AD_Column
+  WHERE AD_Table_ID = (SELECT AD_Table_ID FROM AD_Table WHERE TableName='M_InOut')
+    AND ColumnName = 'TrackingURL'
 );


### PR DESCRIPTION
## Problem

The migration `5805580_sys_M_InOut_TrackingURL_virtualcol.sql` (added by https://github.com/metasfresh/metasfresh/pull/24356) INSERTs the virtual `AD_Column` `M_InOut.TrackingURL` unconditionally. On any database that already has an `M_InOut.TrackingURL` column, the INSERT violates the `ad_column_name` unique constraint `(AD_Table_ID, ColumnName)`.

Because the migration runner applies scripts with `ON_ERROR_STOP=1` inside a single transaction, that single failure **aborts the entire migration run** — every later script is skipped and the database image build fails. The vanilla seed DB has no pre-existing `TrackingURL` column, so the collision surfaces only on databases that already have the column.

## Fix

Convert the unconditional `INSERT ... VALUES` into `INSERT ... SELECT ... WHERE NOT EXISTS (… AD_Table_ID = M_InOut AND ColumnName = 'TrackingURL')`, so it runs only when the column is absent. On a database that already has the column the script becomes a no-op and the existing column is left untouched; on a database without it, it inserts exactly as before (same `AD_Column_ID`, element, `ColumnSQL`, flags).

Edited in place rather than via a follow-up script, per the documented migration-immutability exception for a script that aborts the whole `ON_ERROR_STOP` run (no later script can run to fix it).

## Note for the reviewer (@adi-stefan)

The guard unblocks the migration chain by **skipping** the INSERT where the column already exists — it deliberately does **not** overwrite the existing column's `ColumnSQL`. If a pre-existing `TrackingURL` column is not a suitable virtual column for the delayed-notification feature, it would need separate reconciliation. Please confirm that skipping is acceptable, or whether the existing column's `ColumnSQL` should instead be reconciled to match the core definition.

Relates to https://github.com/metasfresh/metasfresh/pull/24356 (which introduced the script).
