### PR TITLE
me03 29966 follow-ups: DD_Order replenishment async context + warehouse/DocumentNo fixes

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/impl/WarehouseBL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/impl/WarehouseBL.java
@@ -426,6 +426,11 @@ public class WarehouseBL implements IWarehouseBL
 		{
 			return false;
 		}
+		
+		if(warehouse.isAutoDistributionOrder())
+		{
+			return true;
+		}
 
 		final Boolean mrpExclude = StringUtils.toBooleanOrNull(warehouse.getMRP_Exclude());
 		return mrpExclude != null ? mrpExclude : warehouse.isDropShipWarehouse();

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/impl/WarehouseBL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/impl/WarehouseBL.java
@@ -426,8 +426,8 @@ public class WarehouseBL implements IWarehouseBL
 		{
 			return false;
 		}
-		
-		if(warehouse.isAutoDistributionOrder())
+
+		if (warehouse.isAutoDistributionOrder())
 		{
 			return true;
 		}

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/warehouse/api/impl/WarehouseBLTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/warehouse/api/impl/WarehouseBLTest.java
@@ -36,7 +36,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Covers the precedence rule of {@link WarehouseBL#isIgnoreInMaterialDispo(WarehouseId)}:
- * an explicit {@code MRP_Exclude} value (Y/N) wins over {@code IsDropShipWarehouse};
+ * {@code IsAutoDistributionOrder=Y} always returns {@code true} (highest priority);
+ * otherwise an explicit {@code MRP_Exclude} value (Y/N) wins over {@code IsDropShipWarehouse};
  * a null/empty {@code MRP_Exclude} falls back to {@code IsDropShipWarehouse}.
  */
 class WarehouseBLTest

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/warehouse/api/impl/WarehouseBLTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/warehouse/api/impl/WarehouseBLTest.java
@@ -102,11 +102,35 @@ class WarehouseBLTest
 		assertThat(warehouseBL.isIgnoreInMaterialDispo(id)).isFalse();
 	}
 
+	@Test
+	void isAutoDistributionOrderY_returnsTrue()
+	{
+		final WarehouseId id = createWarehouse(null, false, true);
+		assertThat(warehouseBL.isIgnoreInMaterialDispo(id)).isTrue();
+	}
+
+	/**
+	 * Guard against a future "regression-fix" that drops the auto-distribution-order guard:
+	 * {@code IsAutoDistributionOrder=Y} MUST win even when {@code MRP_Exclude=N} and {@code IsDropShipWarehouse=N}.
+	 */
+	@Test
+	void isAutoDistributionOrderY_mrpExcludeN_isDropShipN_returnsTrue_guardCase()
+	{
+		final WarehouseId id = createWarehouse("N", false, true);
+		assertThat(warehouseBL.isIgnoreInMaterialDispo(id)).isTrue();
+	}
+
 	private WarehouseId createWarehouse(@Nullable final String mrpExclude, final boolean isDropShipWarehouse)
+	{
+		return createWarehouse(mrpExclude, isDropShipWarehouse, false);
+	}
+
+	private WarehouseId createWarehouse(@Nullable final String mrpExclude, final boolean isDropShipWarehouse, final boolean isAutoDistributionOrder)
 	{
 		final I_M_Warehouse warehouse = InterfaceWrapperHelper.newInstance(I_M_Warehouse.class);
 		warehouse.setMRP_Exclude(mrpExclude);
 		warehouse.setIsDropShipWarehouse(isDropShipWarehouse);
+		warehouse.setIsAutoDistributionOrder(isAutoDistributionOrder);
 		InterfaceWrapperHelper.saveRecord(warehouse);
 		return WarehouseId.ofRepoId(warehouse.getM_Warehouse_ID());
 	}

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5806510_sys_DD_Order_M_ShipmentSchedule_ID_zoom_target.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5806510_sys_DD_Order_M_ShipmentSchedule_ID_zoom_target.sql
@@ -1,0 +1,17 @@
+-- DD_Order / DD_OrderLine.M_ShipmentSchedule_ID: make them valid zoom / related-document targets of M_ShipmentSchedule.
+--
+-- Why: the columns were created (5804730 / 5804740) with AD_Column.IsExcludeFromZoomTargets='Y'. The generic
+-- related-documents view ad_table_related_windows_v filters with
+--   WHERE COALESCE(NULLIF(field.IsExcludeFromZoomTargets,''), column.IsExcludeFromZoomTargets) = 'N'
+-- The DD_Order header field (780487) has no field-level override, so it falls back to the column flag 'Y' →
+-- the Distributionsauftrag window was excluded from the Lieferdisposition (M_ShipmentSchedule) "Related Documents"
+-- panel, even though the reconcile DD_Order correctly carries M_ShipmentSchedule_ID. Flip the flag to 'N' so a
+-- shipment schedule surfaces its reconcile DD_Order(s) as related documents (matching e.g. M_Picking_Candidate).
+
+UPDATE AD_Column SET IsExcludeFromZoomTargets='N',
+    Updated=TO_TIMESTAMP('2026-06-05 12:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Column_ID=592625 /*DD_Order.M_ShipmentSchedule_ID*/ AND COALESCE(IsExcludeFromZoomTargets,'Y')<>'N';
+
+UPDATE AD_Column SET IsExcludeFromZoomTargets='N',
+    Updated=TO_TIMESTAMP('2026-06-05 12:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Column_ID=592666 /*DD_OrderLine.M_ShipmentSchedule_ID*/ AND COALESCE(IsExcludeFromZoomTargets,'Y')<>'N';

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderPickingReplenishmentService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderPickingReplenishmentService.java
@@ -318,6 +318,10 @@ public class DDOrderPickingReplenishmentService
 		ddOrder.setM_Warehouse_ID(request.getInTransitWarehouseId().getRepoId());
 		ddOrder.setM_Warehouse_From_ID(request.getSourceWarehouseId().getRepoId());
 		ddOrder.setM_Warehouse_To_ID(request.getTargetWarehouseId().getRepoId());
+		// PP_Plant from the target warehouse (mirrors HUs2DDOrderProducer) — the libero DD_OrderLine interceptor
+		// derives PP_Plant_From_ID from it; without it that interceptor logs a benign "@NotFound@ @PP_Plant_ID@" WARN.
+		warehouseBL.getPlantId(request.getTargetWarehouseId())
+				.ifPresent(plantId -> ddOrder.setPP_Plant_ID(plantId.getRepoId()));
 		ddOrder.setM_ShipmentSchedule_ID(request.getShipmentScheduleId().getRepoId());
 		ddOrder.setDateOrdered(TimeUtil.asTimestamp(request.getDatePromised()));
 		ddOrder.setDatePromised(TimeUtil.asTimestamp(request.getDatePromised()));

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/event/DDOrderReplenishmentEventHandler.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/event/DDOrderReplenishmentEventHandler.java
@@ -10,9 +10,11 @@ import de.metas.distribution.ddorder.replenishment.DDOrderPickingReplenishmentSe
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.organization.ClientAndOrgId;
 import de.metas.util.Services;
+import de.metas.util.StringUtils;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.trx.api.ITrxManager;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.util.lang.IAutoCloseable;
 import org.compiere.util.Env;
 import org.springframework.context.annotation.Profile;
@@ -43,12 +45,16 @@ public class DDOrderReplenishmentEventHandler implements IEventListener
 		final ShipmentScheduleId scheduleId = ShipmentScheduleId.ofRepoId(event.getPropertyAsInt(
 				DDOrderReplenishmentEventPublisher.PROPERTY_shipmentScheduleId, -1));
 
-		// This handler runs on an EventBus pool thread where Env has no AD_Client_ID/AD_Org_ID.
-		// Restore the originating AD context (carried in the event) so downstream model creation
-		// (e.g. newInstance(I_DD_Order.class)) inherits the right client/org instead of AD_Client_ID=0.
-		final ClientAndOrgId clientAndOrgId = ClientAndOrgId.ofClientAndOrg(
-				event.getPropertyAsInt(DDOrderReplenishmentEventPublisher.PROPERTY_AD_Client_ID, -1),
-				event.getPropertyAsInt(DDOrderReplenishmentEventPublisher.PROPERTY_AD_Org_ID, -1));
+		// EventBus pool threads carry no Env client — restore it; see docs/coding-rules/event-bus.md
+		final int adClientId = event.getPropertyAsInt(DDOrderReplenishmentEventPublisher.PROPERTY_AD_Client_ID, -1);
+		final int adOrgId = event.getPropertyAsInt(DDOrderReplenishmentEventPublisher.PROPERTY_AD_Org_ID, -1);
+		if (adClientId <= 0 || adOrgId < 0)
+		{
+			throw new AdempiereException(StringUtils.formatMessage(
+					"DD_Order replenishment event is missing AD_Client_ID/AD_Org_ID (old publisher?): clientId={0}, orgId={1}",
+					adClientId, adOrgId));
+		}
+		final ClientAndOrgId clientAndOrgId = ClientAndOrgId.ofClientAndOrg(adClientId, adOrgId);
 
 		try (final IAutoCloseable ignored = switchCtx(clientAndOrgId))
 		{

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/event/DDOrderReplenishmentEventHandler.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/event/DDOrderReplenishmentEventHandler.java
@@ -42,10 +42,10 @@ public class DDOrderReplenishmentEventHandler implements IEventListener
 	@Override
 	public void onEvent(@NonNull final IEventBus eventBus, @NonNull final Event event)
 	{
-		final ShipmentScheduleId scheduleId = extractShipmentScheduleId(event);
-
 		try (final IAutoCloseable ignored = switchCtx(event))
 		{
+			final ShipmentScheduleId scheduleId = extractShipmentScheduleId(event);
+
 			eventLogUserService.invokeHandlerAndLog(EventLogUserService.InvokeHandlerAndLogRequest.builder()
 					.handlerClass(DDOrderReplenishmentEventHandler.class)
 					.invokaction(() -> trxManager.runInThreadInheritedTrx(() -> replenishmentService.reconcile(scheduleId)))
@@ -74,13 +74,9 @@ public class DDOrderReplenishmentEventHandler implements IEventListener
 
 	private IAutoCloseable switchCtx(final @NonNull Event event)
 	{
-		return switchCtx(extractClientAndOrgId(event));
-	}
-
-	private IAutoCloseable switchCtx(@NonNull final ClientAndOrgId clientAndOrgId)
-	{
 		final Properties ctx = Env.newTemporaryCtx();
-		Env.setClientAndOrgId(ctx, clientAndOrgId);
+		Env.setClientAndOrgId(ctx, extractClientAndOrgId(event));
 		return Env.switchContext(ctx);
 	}
+
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/event/DDOrderReplenishmentEventHandler.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/event/DDOrderReplenishmentEventHandler.java
@@ -1,12 +1,12 @@
 package de.metas.distribution.ddorder.replenishment.event;
 
 import de.metas.Profiles;
+import de.metas.distribution.ddorder.replenishment.DDOrderPickingReplenishmentService;
 import de.metas.event.Event;
 import de.metas.event.IEventBus;
 import de.metas.event.IEventBusFactory;
 import de.metas.event.IEventListener;
 import de.metas.event.log.EventLogUserService;
-import de.metas.distribution.ddorder.replenishment.DDOrderPickingReplenishmentService;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.organization.ClientAndOrgId;
 import de.metas.util.Services;
@@ -42,10 +42,24 @@ public class DDOrderReplenishmentEventHandler implements IEventListener
 	@Override
 	public void onEvent(@NonNull final IEventBus eventBus, @NonNull final Event event)
 	{
-		final ShipmentScheduleId scheduleId = ShipmentScheduleId.ofRepoId(event.getPropertyAsInt(
-				DDOrderReplenishmentEventPublisher.PROPERTY_shipmentScheduleId, -1));
+		final ShipmentScheduleId scheduleId = extractShipmentScheduleId(event);
 
-		// EventBus pool threads carry no Env client — restore it; see docs/coding-rules/event-bus.md
+		try (final IAutoCloseable ignored = switchCtx(event))
+		{
+			eventLogUserService.invokeHandlerAndLog(EventLogUserService.InvokeHandlerAndLogRequest.builder()
+					.handlerClass(DDOrderReplenishmentEventHandler.class)
+					.invokaction(() -> trxManager.runInThreadInheritedTrx(() -> replenishmentService.reconcile(scheduleId)))
+					.build());
+		}
+	}
+
+	private static @NonNull ShipmentScheduleId extractShipmentScheduleId(final @NonNull Event event)
+	{
+		return ShipmentScheduleId.ofRepoId(event.getPropertyAsInt(DDOrderReplenishmentEventPublisher.PROPERTY_shipmentScheduleId, -1));
+	}
+
+	private static ClientAndOrgId extractClientAndOrgId(final @NonNull Event event)
+	{
 		final int adClientId = event.getPropertyAsInt(DDOrderReplenishmentEventPublisher.PROPERTY_AD_Client_ID, -1);
 		final int adOrgId = event.getPropertyAsInt(DDOrderReplenishmentEventPublisher.PROPERTY_AD_Org_ID, -1);
 		if (adClientId <= 0 || adOrgId < 0)
@@ -54,15 +68,13 @@ public class DDOrderReplenishmentEventHandler implements IEventListener
 					"DD_Order replenishment event is missing AD_Client_ID/AD_Org_ID (old publisher?): clientId={0}, orgId={1}",
 					adClientId, adOrgId));
 		}
-		final ClientAndOrgId clientAndOrgId = ClientAndOrgId.ofClientAndOrg(adClientId, adOrgId);
 
-		try (final IAutoCloseable ignored = switchCtx(clientAndOrgId))
-		{
-			eventLogUserService.invokeHandlerAndLog(EventLogUserService.InvokeHandlerAndLogRequest.builder()
-					.handlerClass(DDOrderReplenishmentEventHandler.class)
-					.invokaction(() -> trxManager.runInThreadInheritedTrx(() -> replenishmentService.reconcile(scheduleId)))
-					.build());
-		}
+		return ClientAndOrgId.ofClientAndOrg(adClientId, adOrgId);
+	}
+
+	private IAutoCloseable switchCtx(final @NonNull Event event)
+	{
+		return switchCtx(extractClientAndOrgId(event));
 	}
 
 	private IAutoCloseable switchCtx(@NonNull final ClientAndOrgId clientAndOrgId)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/event/DDOrderReplenishmentEventHandler.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/event/DDOrderReplenishmentEventHandler.java
@@ -58,7 +58,7 @@ public class DDOrderReplenishmentEventHandler implements IEventListener
 		return ShipmentScheduleId.ofRepoId(event.getPropertyAsInt(DDOrderReplenishmentEventPublisher.PROPERTY_shipmentScheduleId, -1));
 	}
 
-	private static ClientAndOrgId extractClientAndOrgId(final @NonNull Event event)
+	private static @NonNull ClientAndOrgId extractClientAndOrgId(final @NonNull Event event)
 	{
 		final int adClientId = event.getPropertyAsInt(DDOrderReplenishmentEventPublisher.PROPERTY_AD_Client_ID, -1);
 		final int adOrgId = event.getPropertyAsInt(DDOrderReplenishmentEventPublisher.PROPERTY_AD_Org_ID, -1);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/event/DDOrderReplenishmentEventHandler.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/event/DDOrderReplenishmentEventHandler.java
@@ -8,14 +8,18 @@ import de.metas.event.IEventListener;
 import de.metas.event.log.EventLogUserService;
 import de.metas.distribution.ddorder.replenishment.DDOrderPickingReplenishmentService;
 import de.metas.inout.ShipmentScheduleId;
+import de.metas.organization.ClientAndOrgId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.trx.api.ITrxManager;
+import org.adempiere.util.lang.IAutoCloseable;
+import org.compiere.util.Env;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
+import java.util.Properties;
 
 @Component
 @Profile(Profiles.PROFILE_App)
@@ -39,9 +43,26 @@ public class DDOrderReplenishmentEventHandler implements IEventListener
 		final ShipmentScheduleId scheduleId = ShipmentScheduleId.ofRepoId(event.getPropertyAsInt(
 				DDOrderReplenishmentEventPublisher.PROPERTY_shipmentScheduleId, -1));
 
-		eventLogUserService.invokeHandlerAndLog(EventLogUserService.InvokeHandlerAndLogRequest.builder()
-				.handlerClass(DDOrderReplenishmentEventHandler.class)
-				.invokaction(() -> trxManager.runInThreadInheritedTrx(() -> replenishmentService.reconcile(scheduleId)))
-				.build());
+		// This handler runs on an EventBus pool thread where Env has no AD_Client_ID/AD_Org_ID.
+		// Restore the originating AD context (carried in the event) so downstream model creation
+		// (e.g. newInstance(I_DD_Order.class)) inherits the right client/org instead of AD_Client_ID=0.
+		final ClientAndOrgId clientAndOrgId = ClientAndOrgId.ofClientAndOrg(
+				event.getPropertyAsInt(DDOrderReplenishmentEventPublisher.PROPERTY_AD_Client_ID, -1),
+				event.getPropertyAsInt(DDOrderReplenishmentEventPublisher.PROPERTY_AD_Org_ID, -1));
+
+		try (final IAutoCloseable ignored = switchCtx(clientAndOrgId))
+		{
+			eventLogUserService.invokeHandlerAndLog(EventLogUserService.InvokeHandlerAndLogRequest.builder()
+					.handlerClass(DDOrderReplenishmentEventHandler.class)
+					.invokaction(() -> trxManager.runInThreadInheritedTrx(() -> replenishmentService.reconcile(scheduleId)))
+					.build());
+		}
+	}
+
+	private IAutoCloseable switchCtx(@NonNull final ClientAndOrgId clientAndOrgId)
+	{
+		final Properties ctx = Env.newTemporaryCtx();
+		Env.setClientAndOrgId(ctx, clientAndOrgId);
+		return Env.switchContext(ctx);
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/event/DDOrderReplenishmentEventPublisher.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/event/DDOrderReplenishmentEventPublisher.java
@@ -3,10 +3,11 @@ package de.metas.distribution.ddorder.replenishment.event;
 import de.metas.event.Event;
 import de.metas.event.IEventBusFactory;
 import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.springframework.stereotype.Component;
 
@@ -23,12 +24,12 @@ public class DDOrderReplenishmentEventPublisher
 	private static final String EVENT_NAME = "DDOrderPickingReconcile";
 
 	@NonNull private final IEventBusFactory eventBusFactory;
+	@NonNull private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
 
 	public void publishOne(@NonNull final ShipmentScheduleId shipmentScheduleId)
 	{
-		// publishOne runs in the originating sync (after-commit) context, so the schedule's AD_Client_ID/AD_Org_ID
-		// are the right ones to carry into the async handler (which runs on an EventBus pool thread with no AD context).
-		final I_M_ShipmentSchedule schedule = InterfaceWrapperHelper.load(shipmentScheduleId.getRepoId(), I_M_ShipmentSchedule.class);
+		// The schedule's AD_Client_ID/AD_Org_ID are carried into the async handler (which runs on an EventBus pool thread with no AD context).
+		final I_M_ShipmentSchedule schedule = shipmentScheduleBL.getById(shipmentScheduleId);
 
 		// shallBeLogged() is required: without it the event-bus never sets up the EventLogEntryCollector
 		// thread-local, the handler throws "Missing thread-local EventLogEntryCollector", and no AD_EventLog is recorded.

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/event/DDOrderReplenishmentEventPublisher.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/event/DDOrderReplenishmentEventPublisher.java
@@ -6,6 +6,7 @@ import de.metas.inout.ShipmentScheduleId;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.springframework.stereotype.Component;
 
@@ -17,17 +18,25 @@ import java.util.LinkedHashSet;
 public class DDOrderReplenishmentEventPublisher
 {
 	public static final String PROPERTY_shipmentScheduleId = "shipmentScheduleId";
+	public static final String PROPERTY_AD_Client_ID = "AD_Client_ID";
+	public static final String PROPERTY_AD_Org_ID = "AD_Org_ID";
 	private static final String EVENT_NAME = "DDOrderPickingReconcile";
 
 	@NonNull private final IEventBusFactory eventBusFactory;
 
 	public void publishOne(@NonNull final ShipmentScheduleId shipmentScheduleId)
 	{
+		// publishOne runs in the originating sync (after-commit) context, so the schedule's AD_Client_ID/AD_Org_ID
+		// are the right ones to carry into the async handler (which runs on an EventBus pool thread with no AD context).
+		final I_M_ShipmentSchedule schedule = InterfaceWrapperHelper.load(shipmentScheduleId.getRepoId(), I_M_ShipmentSchedule.class);
+
 		// shallBeLogged() is required: without it the event-bus never sets up the EventLogEntryCollector
 		// thread-local, the handler throws "Missing thread-local EventLogEntryCollector", and no AD_EventLog is recorded.
 		final Event event = Event.builder()
 				.setEventName(EVENT_NAME)
 				.putProperty(PROPERTY_shipmentScheduleId, shipmentScheduleId.getRepoId())
+				.putProperty(PROPERTY_AD_Client_ID, schedule.getAD_Client_ID())
+				.putProperty(PROPERTY_AD_Org_ID, schedule.getAD_Org_ID())
 				// Tie the resulting AD_EventLog (and thus its AD_EventLog_Entry rows) to the schedule that
 				// triggered the reconcile. EventLogService.saveEvent copies this into AD_EventLog.AD_Table_ID /
 				// Record_ID, which lets callers (incl. tests) pin a log entry to its originating schedule

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5806490_sys_DD_NetworkDistribution_DocumentNo_field_not_mandatory.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5806490_sys_DD_NetworkDistribution_DocumentNo_field_not_mandatory.sql
@@ -1,0 +1,18 @@
+-- DD_NetworkDistribution (window 53018, "Distributionsnetzwerk"): make the DocumentNo field non-mandatory.
+--
+-- Why: the DocumentNo field (AD_Field 54371) is field-level IsMandatory='Y' + IsReadOnly='Y', but the WebUI
+-- has no way to pre-fill it for this table: DD_NetworkDistribution has no C_DocType, and the WebUI auto-sequence
+-- default-value path requires AD_Field.AD_Sequence_ID (GridTabVOBasedDocumentEntityDescriptorFactory ->
+-- DefaultValueExpressionsFactory.extractDefaultValueExpression), which is never populated. So a new record's
+-- DocumentNo stays NULL, DocumentField.checkValid flags invalidFieldMandatoryNotFilled (readonly is NOT exempt),
+-- the record is not saveable -> "cannot create a new distribution network" with no error and an empty field.
+-- The underlying AD_Column.DocumentNo is already IsMandatory='N'; only the field-level override blocks it.
+--
+-- Fix: drop the field-level mandatory. On save, PO.saveNew populates DocumentNo from the
+-- DocumentNo_DD_NetworkDistribution sequence (forTableName lookup), so the number is still assigned automatically.
+
+UPDATE AD_Field
+SET IsMandatory = 'N',
+    Updated     = TO_TIMESTAMP('2026-06-05 10:00:00','YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy   = 100
+WHERE AD_Field_ID = 54371;


### PR DESCRIPTION
Follow-up fixes discovered during manual testing of https://github.com/metasfresh/me03/issues/29966 on danthermuat.

### Fixes
1. **DD_Order picking replenishment — async event handler AD context.** The reconcile event handler ran on an EventBus pool thread with no `AD_Client_ID`/`AD_Org_ID` in `Env`, so `newInstance(I_DD_Order.class)` produced `AD_Client_ID=0` → `MDDOrder.beforeSave` threw `FillMandatoryException` (Mandant). The publisher now carries the originating client/org in the event and the handler wraps the dispatch in `Env.switchContext` (mirrors `DocumentPostingBusService.DocumentPostRequestHandlerAsEventListener#switchCtx`). No `setAD_Client_ID` on models.
2. **`WarehouseBL.computeIsIgnoreInMaterialDispo`** returns `true` when `IsAutoDistributionOrder='Y'`, so an auto-distribution warehouse is excluded from material disposition (the new flow owns its replenishment; no double DD_Orders) without manually toggling `MRP_Exclude`.
3. **`DD_NetworkDistribution` DocumentNo field non-mandatory** (window 53018, migration `5806490`). The field was field-level mandatory + readonly with no WebUI way to pre-fill it (no `C_DocType`), blocking creation of a Distribution Network; `PO.saveNew` still assigns the number from the sequence on save.

### Validation
- Java changes: targeted JDK8 javac green; full module compile + reconcile cucumber to be validated by CI (the reconcile bug only manifests in real async dispatch — cucumber threads carry a client context).
- Migration applied + verified on the deep_tundra_uat local DB.