### PR TITLE
Merging after rollout soft_panda_hotfix_49 into new_dawn_uat

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
@@ -291,12 +291,12 @@ public class EPCIS_JSON_Export_StepDef
 	}
 
 	/**
-	 * Validates jsonb-array fields in the EPCIS JSON that carry arrays of string values.
-	 * Validates {@code desadvReferences[]} and {@code poReferences[]} array fields in the EPCIS JSON.
+	 * Validates jsonb-array fields in the EPCIS JSON that carry arrays of string values
+	 * (e.g. {@code desadvReferences[]}, {@code poReferences[]}, {@code shipmentDocumentNos[]}).
 	 *
 	 * @cucumber.stepdef
 	 * @cucumber.columns
-	 *   <b>field</b> — (required) name of the top-level array field (e.g. {@code desadvReferences}, {@code poReferences})<br>
+	 *   <b>field</b> — (required) name of the top-level array field (e.g. {@code desadvReferences}, {@code poReferences}, {@code shipmentDocumentNos})<br>
 	 *   <b>expectedSize</b> — (required) expected number of elements in the array<br>
 	 *   <b>containsValue</b> — (optional) a value that must appear somewhere in the array<br>
 	 * @cucumber.example

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -326,7 +326,7 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID   | M_Product_ID  | Qty | ValidFrom  |
       | pip_S29231_130          | pii_TU_S29231_130 | p_S29231_130  | 10  | 2020-01-01 |
 
-    # Order A — distinct numeric POReference (≤10 digits) → LPAD pads to '1234567893', per Migros spec
+    # Order A — distinct numeric POReference (≤10 digits) → LPAD pads to '1234567893', per the receiver's EPCIS spec
     And metasfresh contains C_Orders:
       | Identifier    | IsSOTrx | C_BPartner_ID  | DateOrdered | POReference |
       | oA_S29231_130 | true    | bp_S29231_130  | 2026-05-20  | 1234567893  |
@@ -340,7 +340,7 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | EDI_Desadv_ID.Identifier | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_ExportStatus |
       | dA_S29231_130            | bp_S29231_130            | oA_S29231_130         | P                |
 
-    # Order B — distinct numeric POReference (10 digits) → LPAD leaves '9876543210' unchanged, per Migros spec
+    # Order B — distinct numeric POReference (10 digits) → LPAD leaves '9876543210' unchanged, per the receiver's EPCIS spec
     And metasfresh contains C_Orders:
       | Identifier    | IsSOTrx | C_BPartner_ID  | DateOrdered | POReference |
       | oB_S29231_130 | true    | bp_S29231_130  | 2026-05-20  | 9876543210  |
@@ -458,14 +458,18 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | sscc18             |
       | 987654321000000016 |
       | 987654321000000023 |
+    # 2 orders / 2 DESADVs consolidated into ONE shipment (1 M_InOut):
+    # desadvReferences/poReferences are size 2, but shipmentDocumentNos is size 1
+    # — it carries the single M_InOut.DocumentNo, not one entry per order.
     And the EPCIS JSON array field has:
-      | field            | expectedSize |
-      | desadvReferences | 2            |
-      | poReferences     | 2            |
+      | field               | expectedSize |
+      | desadvReferences    | 2            |
+      | poReferences        | 2            |
+      | shipmentDocumentNos | 1            |
     # ─── Per-LU POReference in dummy GRAI ────────────────────────────────────────────
     # POReferences are '1234567893' (Order A, 10 digits → LPAD no-op → '1234567893') and
     # '9876543210' (Order B, 10 digits → LPAD no-op → '9876543210').
-    # Migros spec: urn:epc:id:grai:<GCP>.<assetType>.<10-digit Bestellnummer><2-digit counter>
+    # GRAI format: urn:epc:id:grai:<GCP>.<assetType>.<10-digit Bestellnummer><2-digit counter>
     # Each pallet's TU dummy GRAI must contain only its own source order's padded POReference.
     Then the EPCIS JSON pallets have dummy GRAIs containing the source order POReference:
       | sscc18             | ExpectedPOReferenceSanitized |
@@ -478,18 +482,18 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
   @allure.label.epic:E0292_EDI
   @allure.label.feature:F00353_EDI_DESADV_InOut_Link
   Scenario: S29231_170 — Two mobile-picking jobs share one LU: EPCIS emits ONE event per physical SSCC (owner merges both orders, sibling returns {})
-  ## Contract change per me03#29231 customer clarification (Migros/Spavetti LAF1010-3):
+  ## Contract per customer clarification (two orders picked onto one shared pallet):
   ## When two sales orders are picked onto ONE shared physical pallet (ONE SSCC), the
   ## get_epcis_events_json_fn must emit exactly ONE picking+commissioning event for that
   ## SSCC. The owner shipment (lowest M_InOut_ID sharing the LU) returns the full event:
   ##   - pallets[0].crates = ALL crates from both orders on that LU (15 total)
   ##   - desadvReferences[] size 2 (one per DESADV)
   ##   - poReferences[]     size 2 (one per order)
-  ## The sibling shipment (higher M_InOut_ID) must return {} (empty object) so Eddyson
-  ## does not render a duplicate event for the same physical SSCC.
+  ## The sibling shipment (higher M_InOut_ID) must return {} (empty object) so the receiver's
+  ## system does not render a duplicate event for the same physical SSCC.
   ##
   ## The test uses two real mobile picking jobs (LUPickingTarget.ofExistingHU on the
-  ## second job) to reproduce the LAF1010-3 shape via the production code path.
+  ## second job) to reproduce the shared-pallet shape via the production code path.
   ## With IsAlwaysSplitHUsEnabled=N the shared LU survives across both picking jobs.
     And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
     And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
@@ -638,7 +642,7 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | dA_S29231_170            | bp_S29231_170            | oA_S29231_170         |
       | dB_S29231_170            | bp_S29231_170            | oB_S29231_170         |
 
-    # ─── Per-SSCC contract (me03#29231 customer clarification) ─────────────────────────
+    # ─── Per-SSCC contract (customer clarification) ───────────────────────────────────
     # ioA has the lower M_InOut_ID (created first) → it is the OWNER.
     # The owner's event merges ALL crates from the shared physical LU (5 TUs from order A
     # + 10 TUs from order B = 15 crates total) and carries both DESADV + PO references.
@@ -650,10 +654,14 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
     And the EPCIS JSON pallet has:
       | palletIndex | sscc               | crateCount |
       | 0           | 987654321000001700 | 15         |
+    # 2 orders / 2 DESADVs delivered via TWO M_InOuts that share one SSCC:
+    # shipmentDocumentNos is size 2 — both M_InOut.DocumentNos. The owner's merged
+    # EPCIS event references both; this is the value the EPCIS desadv bizTransaction carries.
     And the EPCIS JSON array field has:
-      | field            | expectedSize |
-      | desadvReferences | 2            |
-      | poReferences     | 2            |
+      | field               | expectedSize |
+      | desadvReferences    | 2            |
+      | poReferences        | 2            |
+      | shipmentDocumentNos | 2            |
 
     # ─── Sibling shipment B must return {} (no duplicate event for the same SSCC) ──────
     Then the EPCIS JSON export function returns empty object for M_InOut identified by ioB_S29231_170

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5805650_sys_me03_29231_epcis_shipmentDocumentNos.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5805650_sys_me03_29231_epcis_shipmentDocumentNos.sql
@@ -1,3 +1,12 @@
+-- EPCIS export: add shipmentDocumentNos[] (delivery-note numbers)
+--
+-- get_epcis_events_json_fn now also emits shipmentDocumentNos[] = DISTINCT M_InOut.DocumentNo of the
+-- DESADV messages on this SSCC (via the edi_desadv_m_inout junction). This is the value the receiver's
+-- EPCIS desadv bizTransaction must carry — the delivery-note number ("Lieferschein") — NOT
+-- EDI_Desadv.DocumentNo (which is 1:1 per ORDER and not unique across a partial delivery). Cardinality
+-- falls out naturally: 2 orders on one M_InOut → one delivery note; 2 M_InOuts sharing one SSCC → two.
+-- desadvReferences[]/poReferences[] are unchanged.
+
 /*
  * #%L
  * de.metas.edi


### PR DESCRIPTION
Merging after rollout: soft_panda_hotfix_49 into new_dawn_uat