### PR TITLE
Merge: keen_hawk_hotfix → keen_hawk_release (kh202 rollout 12)

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1128,10 +1128,14 @@ jobs:
         env:
           mfversion: ${{ needs.init.outputs.tag-fixed }}
           cucumberparams: ${{ matrix.params }}
-          TEST_SMTP_HOST: ${{ secrets.TEST_SMTP_HOST }}
-          TEST_SMTP_FROM: ${{ secrets.TEST_SMTP_FROM }}
-          TEST_SMTP_USER: ${{ secrets.TEST_SMTP_USER }}
-          TEST_SMTP_PASSWORD: ${{ secrets.TEST_SMTP_PASSWORD }}
+          # TEST_SMTP_* env vars are no longer set here: the cucumber compose
+          # now starts a local MailPit container and the SMTP defaults in
+          # docker-builds/cucumber/compose.yml point at it. The previous
+          # external SMTP relay was rejecting the secrets-stored credentials
+          # since 2026-05-21 (provider-side lockout), keeping profile4 red
+          # across every branch. Removing the secrets reference also lets
+          # forks and PR-from-fork builds run the SMTP scenario without
+          # needing the org secrets.
         timeout-minutes: 120
         run: |
           mkdir -p cucumber

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/C_Order_DeliveryStatus_Compute.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/C_Order_DeliveryStatus_Compute.sql
@@ -1,0 +1,25 @@
+DROP FUNCTION IF EXISTS c_order_deliverystatus_compute(p_order c_order) CASCADE;
+
+CREATE OR REPLACE FUNCTION c_order_deliverystatus_compute(p_order c_order) RETURNS text
+    STABLE
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    v_DeliveryStatus text;
+BEGIN
+
+    SELECT (CASE
+        WHEN p_order.QtyOrdered <= p_order.QtyMoved AND p_order.QtyOrdered > 0
+            THEN 'CD'   --completely delivered
+        WHEN p_order.QtyOrdered > p_order.QtyMoved AND p_order.QtyMoved > 0
+            THEN 'PD'   --partially delivered
+            ELSE 'O'    --open
+    END)
+
+    INTO v_DeliveryStatus;
+
+    RETURN v_DeliveryStatus;
+END;
+$$
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/C_Order_InvoiceStatus_Compute.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/C_Order_InvoiceStatus_Compute.sql
@@ -1,0 +1,23 @@
+DROP FUNCTION IF EXISTS c_order_invoicestatus_compute(p_order c_order) CASCADE;
+
+CREATE OR REPLACE FUNCTION c_order_invoicestatus_compute(p_order c_order) RETURNS text
+    STABLE
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    v_InvoiceStatus text;
+BEGIN
+
+    SELECT (CASE
+        WHEN p_order.QtyOrdered <= p_order.QtyInvoiced AND p_order.QtyOrdered > 0
+            THEN 'CI'   --completely invoiced
+        WHEN p_order.QtyOrdered > p_order.QtyInvoiced AND p_order.QtyInvoiced > 0
+            THEN 'PI'   --partially invoiced
+            ELSE 'O'    --open
+    END) INTO v_InvoiceStatus;
+
+    RETURN v_InvoiceStatus;
+END;
+$$
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/C_Order_ProcessStatus_Color_ID_Compute.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/ddl/public/functions/C_Order_ProcessStatus_Color_ID_Compute.sql
@@ -1,0 +1,32 @@
+DROP FUNCTION IF EXISTS c_order_processstatus_color_id_compute(p_order c_order) CASCADE;
+
+CREATE OR REPLACE FUNCTION c_order_processstatus_color_id_compute(p_order c_order) RETURNS numeric
+    STABLE
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    v_ColorID numeric;
+    v_Red     numeric := getColor_ID_By_SysConfig('Red_Color');
+    v_Yellow  numeric := getColor_ID_By_SysConfig('Yellow_Color');
+    v_Green   numeric := getColor_ID_By_SysConfig('Green_Color');
+BEGIN
+
+    SELECT (CASE
+        WHEN p_order.docstatus != 'CO'
+        THEN NULL
+        WHEN c_order_deliverystatus_compute(p_order) = 'CD'
+            AND c_order_invoicestatus_compute(p_order) = 'CI'
+        THEN v_Green
+        WHEN c_order_deliverystatus_compute(p_order) = 'O'
+           AND c_order_invoicestatus_compute(p_order) = 'O'
+        THEN v_Red
+        ELSE v_Yellow
+    END)
+
+    INTO v_ColorID;
+
+    RETURN v_ColorID;
+END;
+$$
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799040_sys_gh29194_OrderProcessStatusFunctions.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799040_sys_gh29194_OrderProcessStatusFunctions.sql
@@ -1,0 +1,87 @@
+DROP FUNCTION IF EXISTS c_order_deliverystatus_compute(p_order c_order) CASCADE;
+CREATE OR REPLACE FUNCTION c_order_deliverystatus_compute(p_order c_order) RETURNS text
+    STABLE
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    v_DeliveryStatus text;
+BEGIN
+
+    SELECT (CASE
+        WHEN p_order.QtyOrdered <= p_order.QtyMoved AND p_order.QtyOrdered > 0
+            THEN 'CD'   --completely delivered
+        WHEN p_order.QtyOrdered > p_order.QtyMoved AND p_order.QtyMoved > 0
+            THEN 'PD'   --partially delivered
+            ELSE 'O'    --open
+    END)
+
+    INTO v_DeliveryStatus;
+
+    RETURN v_DeliveryStatus;
+END;
+$$
+;
+ALTER FUNCTION c_order_deliverystatus_compute(c_order) OWNER TO metasfresh
+;
+
+DROP FUNCTION IF EXISTS c_order_invoicestatus_compute(p_order c_order) CASCADE;
+CREATE OR REPLACE FUNCTION c_order_invoicestatus_compute(p_order c_order) RETURNS text
+    STABLE
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    v_InvoiceStatus text;
+BEGIN
+
+    SELECT (CASE
+        WHEN p_order.QtyOrdered <= p_order.QtyInvoiced AND p_order.QtyOrdered > 0
+            THEN 'CI'   --completely invoiced
+        WHEN p_order.QtyOrdered > p_order.QtyInvoiced AND p_order.QtyInvoiced > 0
+            THEN 'PI'   --partially invoiced
+            ELSE 'O'    --open
+    END) INTO v_InvoiceStatus;
+
+    RETURN v_InvoiceStatus;
+END;
+$$
+;
+
+ALTER FUNCTION c_order_invoicestatus_compute(c_order) OWNER TO metasfresh
+;
+
+DROP FUNCTION IF EXISTS c_order_processstatus_color_id_compute(p_order c_order) CASCADE;
+CREATE OR REPLACE FUNCTION c_order_processstatus_color_id_compute(p_order c_order) RETURNS numeric
+    STABLE
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    v_ColorID numeric;
+    v_Red     numeric := getColor_ID_By_SysConfig('Red_Color');
+    v_Yellow  numeric := getColor_ID_By_SysConfig('Yellow_Color');
+    v_Green   numeric := getColor_ID_By_SysConfig('Green_Color');
+BEGIN
+
+    SELECT (CASE
+        WHEN p_order.docstatus != 'CO'
+        THEN NULL
+        WHEN c_order_deliverystatus_compute(p_order) = 'CD'
+            AND c_order_invoicestatus_compute(p_order) = 'CI'
+        THEN v_Green
+        WHEN c_order_deliverystatus_compute(p_order) = 'O'
+           AND c_order_invoicestatus_compute(p_order) = 'O'
+        THEN v_Red
+        ELSE v_Yellow
+    END)
+
+    INTO v_ColorID;
+
+    RETURN v_ColorID;
+END;
+$$
+;
+ALTER FUNCTION c_order_processstatus_color_id_compute(c_order) OWNER TO metasfresh
+;
+

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799110_sys_gh29194_OrderProcessStatusColorColumnAndField.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5799110_sys_gh29194_OrderProcessStatusColorColumnAndField.sql
@@ -1,0 +1,289 @@
+-- Run mode: SWING_CLIENT
+
+-- Column: C_Order.DeliveryStatus
+-- Column SQL (old): ( CASE WHEN C_Order.QtyOrdered <= C_Order.QtyMoved AND C_Order.QtyOrdered > 0 THEN 'CD' WHEN C_Order.QtyOrdered > C_Order.QtyMoved AND C_Order.QtyMoved > 0 THEN 'PD' ELSE 'O' END )
+-- 2026-04-22T10:22:00.807Z
+UPDATE AD_Column SET ColumnSQL='C_Order_DeliveryStatus_Compute(C_Order)',Updated=TO_TIMESTAMP('2026-04-22 10:22:00.807000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=552710
+;
+
+-- Column: C_Order.InvoiceStatus
+-- Column SQL (old): ( CASE WHEN C_Order.QtyOrdered <= C_Order.QtyInvoiced AND C_Order.QtyOrdered > 0 THEN 'CI' WHEN C_Order.QtyOrdered > C_Order.QtyInvoiced AND C_Order.QtyInvoiced > 0 THEN 'PI' ELSE 'O' END )
+-- 2026-04-22T11:24:51.323Z
+UPDATE AD_Column SET ColumnSQL='C_Order_InvoiceStatus_Compute(C_Order)',Updated=TO_TIMESTAMP('2026-04-22 11:24:51.322000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=552695
+;
+
+
+-- 2026-04-22T11:39:41.059Z
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,584777,0,'ProcessStatusColor_ID',TO_TIMESTAMP('2026-04-22 11:39:40.922000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'C','Y','Process Status','Process Status',TO_TIMESTAMP('2026-04-22 11:39:40.922000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-04-22T11:39:41.062Z
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=584777 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- Column: C_Order.ProcessStatusColor_ID
+-- 2026-04-22T11:40:44.824Z
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,CloningStrategy,ColumnName,ColumnSQL,Created,CreatedBy,DDL_NoForeignKey,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version) VALUES (0,592405,584777,0,27,259,'XX','ProcessStatusColor_ID','C_Order_ProcessStatus_Color_ID_Compute(C_Order)',TO_TIMESTAMP('2026-04-22 11:40:44.687000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N','C',0,10,'Y','N','Y','N','N','N','Y','N','N','N','Y','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','N','N','N','N',0,'Process Status',0,0,TO_TIMESTAMP('2026-04-22 11:40:44.687000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,0)
+;
+
+-- 2026-04-22T11:40:44.830Z
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=592405 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 2026-04-22T11:40:44.836Z
+/* DDL */  select update_Column_Translation_From_AD_Element(584777)
+;
+
+-- Field: Bestellung(181,D) -> Bestellung(294,D) -> Process Status
+-- Column: C_Order.ProcessStatusColor_ID
+-- 2026-04-22T11:41:38.752Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,DisplayLength,EntityType,FacetFilterSeqNo,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,592405,777223,0,294,0,TO_TIMESTAMP('2026-04-22 11:41:38.569000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,0,'C',0,0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Process Status',0,0,260,0,1,1,TO_TIMESTAMP('2026-04-22 11:41:38.569000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-04-22T11:41:38.759Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=777223 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-04-22T11:41:38.764Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(584777)
+;
+
+-- 2026-04-22T11:41:38.785Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=777223
+;
+
+-- 2026-04-22T11:41:38.789Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(777223)
+;
+
+-- UI Element: Bestellung(181,D) -> Bestellung(294,D) -> main -> 20 -> posted.Process Status
+-- Column: C_Order.ProcessStatusColor_ID
+-- 2026-04-22T11:47:33.396Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,777223,0,294,543268,649948,'F',TO_TIMESTAMP('2026-04-22 11:47:33.206000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y','N','N','N','N','N','N',0,'Process Status',30,0,0,TO_TIMESTAMP('2026-04-22 11:47:33.206000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- UI Element: Bestellung(181,D) -> Bestellung(294,D) -> main -> 20 -> posted.Process Status
+-- Column: C_Order.ProcessStatusColor_ID
+-- 2026-04-22T11:48:34.145Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=80,Updated=TO_TIMESTAMP('2026-04-22 11:48:34.145000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=649948
+;
+
+-- UI Element: Bestellung(181,D) -> Bestellung(294,D) -> main -> 10 -> main.Warenannahme
+-- Column: C_Order.M_Warehouse_ID
+-- 2026-04-22T11:48:34.154Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=90,Updated=TO_TIMESTAMP('2026-04-22 11:48:34.154000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=541802
+;
+
+-- UI Element: Bestellung(181,D) -> Bestellung(294,D) -> main -> 10 -> main.Streckengeschäft
+-- Column: C_Order.IsDropShip
+-- 2026-04-22T11:48:34.162Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=100,Updated=TO_TIMESTAMP('2026-04-22 11:48:34.162000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547189
+;
+
+-- UI Element: Bestellung(181,D) -> Bestellung(294,D) -> main -> 10 -> main.Streckengeschäft Partner
+-- Column: C_Order.DropShip_BPartner_ID
+-- 2026-04-22T11:48:34.169Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=110,Updated=TO_TIMESTAMP('2026-04-22 11:48:34.169000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547190
+;
+
+-- UI Element: Bestellung(181,D) -> Bestellung(294,D) -> main -> 10 -> main.Tour
+-- Column: C_Order.M_Tour_ID
+-- 2026-04-22T11:48:34.177Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=120,Updated=TO_TIMESTAMP('2026-04-22 11:48:34.177000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=565151
+;
+
+-- UI Element: Bestellung(181,D) -> Bestellung(294,D) -> main -> 10 -> pricing.Preissystem
+-- Column: C_Order.M_PricingSystem_ID
+-- 2026-04-22T11:48:34.185Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=130,Updated=TO_TIMESTAMP('2026-04-22 11:48:34.185000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=541288
+;
+
+-- UI Element: Bestellung(181,D) -> Bestellung(294,D) -> main -> 10 -> pricing.Währung
+-- Column: C_Order.C_Currency_ID
+-- 2026-04-22T11:48:34.193Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=140,Updated=TO_TIMESTAMP('2026-04-22 11:48:34.193000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=541289
+;
+
+-- UI Element: Bestellung(181,D) -> Bestellung(294,D) -> main -> 20 -> dates.Belegstatus
+-- Column: C_Order.DocStatus
+-- 2026-04-22T11:48:34.200Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=150,Updated=TO_TIMESTAMP('2026-04-22 11:48:34.200000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=541291
+;
+
+-- UI Element: Bestellung(181,D) -> Bestellung(294,D) -> main -> 20 -> posted.Verbucht
+-- Column: C_Order.Posted
+-- 2026-04-22T11:48:34.206Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=160,Updated=TO_TIMESTAMP('2026-04-22 11:48:34.206000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=541259
+;
+
+-- UI Element: Bestellung(181,D) -> Bestellung(294,D) -> main -> 20 -> org.Sektion
+-- Column: C_Order.AD_Org_ID
+-- 2026-04-22T11:48:34.214Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=170,Updated=TO_TIMESTAMP('2026-04-22 11:48:34.214000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=541286
+;
+
+-- Element: ProcessStatusColor_ID
+-- 2026-04-22T11:49:57.889Z
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Prozess Status', PrintName='Prozess Status', Description='Prozessstatus der Bestellung: Grün: "Abgeschlossen", Gelb: "In Bearbeitung" oder Rot: "Nicht Bearbeitet".', Help='Berechnung des Prozessstatus:
+
+- Grün "Abgeschlossen": Bestellung wurde vollständig geliefert und vollständig abgerechnet.
+- Gelb "In Bearbeitung": Bestellung wurde teilweise geliefert oder teilweise abgerechnet.
+- Rot "Nicht bearbeitet": Bestellung wurde nicht geliefert und nicht abgerechnet.',Updated=TO_TIMESTAMP('2026-04-22 11:49:57.888000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=584777 AND AD_Language='de_DE'
+;
+
+-- 2026-04-22T11:49:57.891Z
+UPDATE AD_Element base SET Name=trl.Name, PrintName=trl.PrintName, Description=trl.Description, Help=trl.Help, Updated=trl.Updated, UpdatedBy=trl.UpdatedBy FROM AD_Element_Trl trl  WHERE trl.AD_Element_ID=base.AD_Element_ID AND trl.AD_Language='de_DE' AND trl.AD_Language=getBaseLanguage()
+;
+
+-- 2026-04-22T11:50:00.046Z
+/* DDL */  select update_ad_element_on_ad_element_trl_update(584777,'de_DE')
+;
+
+-- 2026-04-22T11:50:00.051Z
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(584777,'de_DE')
+;
+
+-- Element: ProcessStatusColor_ID
+-- 2026-04-22T11:50:05.144Z
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Prozess Status', PrintName='Prozess Status', Description='Prozessstatus der Bestellung: Grün: "Abgeschlossen", Gelb: "In Bearbeitung" oder Rot: "Nicht Bearbeitet".', Help='Berechnung des Prozessstatus:
+
+- Grün "Abgeschlossen": Bestellung wurde vollständig geliefert und vollständig abgerechnet.
+- Gelb "In Bearbeitung": Bestellung wurde teilweise geliefert oder teilweise abgerechnet.
+- Rot "Nicht bearbeitet": Bestellung wurde nicht geliefert und nicht abgerechnet.',Updated=TO_TIMESTAMP('2026-04-22 11:50:05.144000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=584777 AND AD_Language='de_CH'
+;
+
+-- 2026-04-22T11:50:05.145Z
+UPDATE AD_Element base SET Name=trl.Name, PrintName=trl.PrintName, Description=trl.Description, Help=trl.Help, Updated=trl.Updated, UpdatedBy=trl.UpdatedBy FROM AD_Element_Trl trl  WHERE trl.AD_Element_ID=base.AD_Element_ID AND trl.AD_Language='de_CH' AND trl.AD_Language=getBaseLanguage()
+;
+
+-- 2026-04-22T11:50:05.747Z
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(584777,'de_CH')
+;
+
+-- Element: ProcessStatusColor_ID
+-- 2026-04-22T11:51:13.829Z
+UPDATE AD_Element_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-04-22 11:51:13.829000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=584777 AND AD_Language='en_US'
+;
+
+-- 2026-04-22T11:51:13.832Z
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(584777,'en_US')
+;
+
+-- Element: ProcessStatusColor_ID
+-- 2026-04-22T12:10:18.469Z
+UPDATE AD_Element_Trl SET Description='Process State of the Order: Green: "Completed", Yellow: "In Progress", Red: "Not Started"', Help='Calculation of the Process State:  - Green "Completed": Order is fully received and fully invoiced. - Yellow "In Progress": Order is partially received or partially invoiced. - Red "Not Started": Order is not received and not invoiced.',Updated=TO_TIMESTAMP('2026-04-22 12:10:18.469000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=584777 AND AD_Language='en_US'
+;
+
+-- 2026-04-22T12:10:18.470Z
+UPDATE AD_Element base SET Description=trl.Description, Help=trl.Help, Updated=trl.Updated, UpdatedBy=trl.UpdatedBy FROM AD_Element_Trl trl  WHERE trl.AD_Element_ID=base.AD_Element_ID AND trl.AD_Language='en_US' AND trl.AD_Language=getBaseLanguage()
+;
+
+-- 2026-04-22T12:10:18.888Z
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(584777,'en_US')
+;
+
+-- Field: Auftrag(143,D) -> Auftrag(186,D) -> Prozess Status
+-- Column: C_Order.ProcessStatusColor_ID
+-- 2026-04-22T12:16:01.369Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,FacetFilterSeqNo,Help,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,592405,777224,0,186,0,TO_TIMESTAMP('2026-04-22 12:16:01.196000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Prozessstatus der Bestellung: Grün: "Abgeschlossen", Gelb: "In Bearbeitung" oder Rot: "Nicht Bearbeitet".',0,'C',0,'Berechnung des Prozessstatus:  - Grün "Abgeschlossen": Bestellung wurde vollständig geliefert und vollständig abgerechnet. - Gelb "In Bearbeitung": Bestellung wurde teilweise geliefert oder teilweise abgerechnet. - Rot "Nicht bearbeitet": Bestellung wurde nicht geliefert und nicht abgerechnet.',0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Prozess Status',0,0,800,0,1,1,TO_TIMESTAMP('2026-04-22 12:16:01.196000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-04-22T12:16:01.371Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=777224 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-04-22T12:16:01.374Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(584777)
+;
+
+-- 2026-04-22T12:16:01.378Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=777224
+;
+
+-- 2026-04-22T12:16:01.382Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(777224)
+;
+
+-- UI Column: Auftrag(143,D) -> Auftrag(186,D) -> main view -> 20
+-- UI Element Group: posted
+-- 2026-04-22T12:17:07.523Z
+UPDATE AD_UI_ElementGroup SET IsActive='Y',Updated=TO_TIMESTAMP('2026-04-22 12:17:07.523000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_ElementGroup_ID=543272
+;
+
+-- UI Element: Auftrag(143,D) -> Auftrag(186,D) -> main view -> 20 -> posted.Prozess Status
+-- Column: C_Order.ProcessStatusColor_ID
+-- 2026-04-22T12:17:36.365Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,777224,0,186,543272,649949,'F',TO_TIMESTAMP('2026-04-22 12:17:36.245000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Prozessstatus der Bestellung: Grün: "Abgeschlossen", Gelb: "In Bearbeitung" oder Rot: "Nicht Bearbeitet".','Berechnung des Prozessstatus:  - Grün "Abgeschlossen": Bestellung wurde vollständig geliefert und vollständig abgerechnet. - Gelb "In Bearbeitung": Bestellung wurde teilweise geliefert oder teilweise abgerechnet. - Rot "Nicht bearbeitet": Bestellung wurde nicht geliefert und nicht abgerechnet.','Y','N','N','N','N','N','N',0,'Prozess Status',30,0,0,TO_TIMESTAMP('2026-04-22 12:17:36.245000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- UI Element: Auftrag(143,D) -> Auftrag(186,D) -> main view -> 20 -> posted.Prozess Status
+-- Column: C_Order.ProcessStatusColor_ID
+-- 2026-04-22T12:18:25.284Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=70,Updated=TO_TIMESTAMP('2026-04-22 12:18:25.284000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=649949
+;
+
+-- UI Element: Auftrag(143,D) -> Auftrag(186,D) -> main view -> 20 -> DocType.Referenz
+-- Column: C_Order.POReference
+-- 2026-04-22T12:18:25.311Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=80,Updated=TO_TIMESTAMP('2026-04-22 12:18:25.311000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=544768
+;
+
+-- UI Element: Auftrag(143,D) -> Auftrag(186,D) -> main view -> 20 -> Commission.C_BPartner_SalesRep_ID
+-- Column: C_Order.C_BPartner_SalesRep_ID
+-- 2026-04-22T12:18:25.320Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=90,Updated=TO_TIMESTAMP('2026-04-22 12:18:25.319000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=562100
+;
+
+-- UI Element: Auftrag(143,D) -> Auftrag(186,D) -> main view -> 10 -> main.Abw. Lieferanschrift
+-- Column: C_Order.IsDropShip
+-- 2026-04-22T12:18:25.334Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=100,Updated=TO_TIMESTAMP('2026-04-22 12:18:25.334000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=544809
+;
+
+-- UI Element: Auftrag(143,D) -> Auftrag(186,D) -> main view -> 10 -> pricing.Incoterm Standort
+-- Column: C_Order.IncotermLocation
+-- 2026-04-22T12:18:25.345Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=110,Updated=TO_TIMESTAMP('2026-04-22 12:18:25.345000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=544771
+;
+
+-- UI Element: Auftrag(143,D) -> Auftrag(186,D) -> main view -> 10 -> main.Abw. Kunde
+-- Column: C_Order.DropShip_BPartner_ID
+-- 2026-04-22T12:18:25.355Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=120,Updated=TO_TIMESTAMP('2026-04-22 12:18:25.355000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=544810
+;
+
+-- UI Element: Auftrag(143,D) -> Auftrag(186,D) -> main view -> 20 -> Org und Lager.Organisation
+-- Column: C_Order.AD_Org_ID
+-- 2026-04-22T12:18:25.362Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=130,Updated=TO_TIMESTAMP('2026-04-22 12:18:25.362000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=1000069
+;
+
+-- UI Element: Auftrag(143,D) -> Auftrag(186,D) -> main view -> 10 -> main.Abladeort
+-- Column: C_Order.HandOver_Location_ID
+-- 2026-04-22T12:18:25.369Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=140,Updated=TO_TIMESTAMP('2026-04-22 12:18:25.369000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=548025
+;
+
+-- UI Element: Auftrag(143,D) -> Auftrag(186,D) -> main view -> 10 -> pricing.Preissystem
+-- Column: C_Order.M_PricingSystem_ID
+-- 2026-04-22T12:18:25.377Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=150,Updated=TO_TIMESTAMP('2026-04-22 12:18:25.377000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=1000210
+;
+
+-- UI Element: Auftrag(143,D) -> Auftrag(186,D) -> main view -> 10 -> pricing.Währung
+-- Column: C_Order.C_Currency_ID
+-- 2026-04-22T12:18:25.384Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=160,Updated=TO_TIMESTAMP('2026-04-22 12:18:25.384000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=541299
+;
+
+-- UI Element: Auftrag(143,D) -> Auftrag(186,D) -> main view -> 20 -> Rest.Belegstatus
+-- Column: C_Order.DocStatus
+-- 2026-04-22T12:18:25.391Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=170,Updated=TO_TIMESTAMP('2026-04-22 12:18:25.391000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=1000024
+;
+
+-- UI Element: Auftrag(143,D) -> Auftrag(186,D) -> main view -> 20 -> DocType.Auf Kommission bis
+-- Column: C_Order.Commission_DateFrom
+-- 2026-04-22T12:18:25.397Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=180,Updated=TO_TIMESTAMP('2026-04-22 12:18:25.397000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=637034
+;

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5803990_sys_gh29216_Process_Revision_Window_Update.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5803990_sys_gh29216_Process_Revision_Window_Update.sql
@@ -1,0 +1,253 @@
+-- Run mode: SWING_CLIENT
+
+-- Column: AD_PInstance.CreatedBy
+-- 2026-05-21T20:11:24.757Z
+UPDATE AD_Column SET AD_Reference_ID=30, AD_Reference_Value_ID=540401, IsExcludeFromZoomTargets='Y',Updated=TO_TIMESTAMP('2026-05-21 20:11:24.757000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=8224
+;
+
+-- 2026-05-21T20:17:11.894Z
+UPDATE AD_User SET IsSystemUser='Y', Login='Migration', Value='migratio',Updated=TO_TIMESTAMP('2026-05-21 20:17:11.894000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_User_ID=99
+;
+-- Column: AD_PInstance_Log.P_Date
+-- 2026-05-21T20:23:02.585Z
+UPDATE AD_Column SET AD_Reference_ID=16, IsExcludeFromZoomTargets='Y',Updated=TO_TIMESTAMP('2026-05-21 20:23:02.585000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=8782
+;
+
+-- 2026-05-21T20:25:21.953Z
+INSERT INTO t_alter_column values('ad_pinstance_log','P_Date','TIMESTAMP WITH TIME ZONE',null,null)
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Protokoll(665,D) -> main -> 10 -> default.Process Message
+-- Column: AD_PInstance_Log.P_Msg
+-- 2026-05-21T20:29:02.936Z
+UPDATE AD_UI_Element SET IsDisplayed='Y',Updated=TO_TIMESTAMP('2026-05-21 20:29:02.936000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547987
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Protokoll(665,D) -> main -> 10 -> default.Process Number
+-- Column: AD_PInstance_Log.P_Number
+-- 2026-05-21T20:29:10.069Z
+UPDATE AD_UI_Element SET IsDisplayed='Y',Updated=TO_TIMESTAMP('2026-05-21 20:29:10.069000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547986
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Protokoll(665,D) -> main -> 10 -> default.Process Date
+-- Column: AD_PInstance_Log.P_Date
+-- 2026-05-21T20:29:33.132Z
+UPDATE AD_UI_Element SET IsDisplayed='Y',Updated=TO_TIMESTAMP('2026-05-21 20:29:33.131000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547985
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Protokoll(665,D) -> main -> 10 -> default.Eintrag-Nr
+-- Column: AD_PInstance_Log.Log_ID
+-- 2026-05-21T20:30:52.267Z
+UPDATE AD_UI_Element SET IsDisplayed='Y',Updated=TO_TIMESTAMP('2026-05-21 20:30:52.267000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547984
+;
+
+-- Column: AD_PInstance.AD_Table_ID
+-- 2026-05-22T07:34:10.878Z
+UPDATE AD_Column SET FilterOperator='E', IsSelectionColumn='Y',Updated=TO_TIMESTAMP('2026-05-22 07:34:10.878000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=551938
+;
+
+-- Column: AD_PInstance.ErrorMsg
+-- 2026-05-22T07:34:47.012Z
+UPDATE AD_Column SET FilterOperator='E', IsSelectionColumn='Y',Updated=TO_TIMESTAMP('2026-05-22 07:34:47.012000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=3433
+;
+
+-- Column: AD_PInstance.IsProcessing
+-- 2026-05-22T07:35:19.692Z
+UPDATE AD_Column SET FilterOperator='E', IsSelectionColumn='Y',Updated=TO_TIMESTAMP('2026-05-22 07:35:19.692000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=2783
+;
+
+-- Column: AD_PInstance.AD_User_ID
+-- 2026-05-22T07:35:44.563Z
+UPDATE AD_Column SET FilterOperator='E', IsSelectionColumn='Y',Updated=TO_TIMESTAMP('2026-05-22 07:35:44.563000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=5951
+;
+
+-- Field: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> Erstellt durch
+-- Column: AD_PInstance.CreatedBy
+-- 2026-05-22T08:01:44.957Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,FacetFilterSeqNo,Help,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,8224,780261,0,663,0,TO_TIMESTAMP('2026-05-22 08:01:44.043000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Nutzer, der diesen Eintrag erstellt hat',0,'D',0,'Das Feld Erstellt durch zeigt an, welcher Nutzer diesen Eintrag erstellt hat.',0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Erstellt durch',0,0,160,0,1,1,TO_TIMESTAMP('2026-05-22 08:01:44.043000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-05-22T08:01:45.024Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=780261 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-05-22T08:01:45.116Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(246)
+;
+
+-- 2026-05-22T08:01:45.232Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=780261
+;
+
+-- 2026-05-22T08:01:45.297Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(780261)
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 10 -> default.Erstellt durch
+-- Column: AD_PInstance.CreatedBy
+-- 2026-05-22T08:03:02.504Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,780261,0,663,541066,651710,'F',TO_TIMESTAMP('2026-05-22 08:03:01.962000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Nutzer, der diesen Eintrag erstellt hat','Das Feld Erstellt durch zeigt an, welcher Nutzer diesen Eintrag erstellt hat.','Y','N','N','Y','N','N','N',0,'Erstellt durch',40,0,0,TO_TIMESTAMP('2026-05-22 08:03:01.962000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 10 -> default.Erstellt durch
+-- Column: AD_PInstance.CreatedBy
+-- 2026-05-22T08:03:12.984Z
+UPDATE AD_UI_Element SET SeqNo=25,Updated=TO_TIMESTAMP('2026-05-22 08:03:12.984000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=651710
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 20 -> flags.Ablaufsteuerung
+-- Column: AD_PInstance.AD_Scheduler_ID
+-- 2026-05-22T08:04:13.833Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,691444,0,663,541068,651711,'F',TO_TIMESTAMP('2026-05-22 08:04:13.357000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Schedule Processes','Asynchrone Ausführung von Prozessen definieren','Y','N','N','Y','N','N','N',0,'Ablaufsteuerung',60,0,0,TO_TIMESTAMP('2026-05-22 08:04:13.357000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 10 -> default.Erstellt durch
+-- Column: AD_PInstance.CreatedBy
+-- 2026-05-22T08:05:08.923Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=30,Updated=TO_TIMESTAMP('2026-05-22 08:05:08.923000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=651710
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 10 -> default.Aktualisiert
+-- Column: AD_PInstance.Updated
+-- 2026-05-22T08:05:09.282Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=40,Updated=TO_TIMESTAMP('2026-05-22 08:05:09.282000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547990
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 10 -> details.Benutzer
+-- Column: AD_PInstance.AD_User_ID
+-- 2026-05-22T08:05:09.635Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=50,Updated=TO_TIMESTAMP('2026-05-22 08:05:09.635000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547992
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 10 -> details.Sprache
+-- Column: AD_PInstance.AD_Language
+-- 2026-05-22T08:05:09.992Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=60,Updated=TO_TIMESTAMP('2026-05-22 08:05:09.992000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547991
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 10 -> details.Rolle
+-- Column: AD_PInstance.AD_Role_ID
+-- 2026-05-22T08:05:10.343Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=70,Updated=TO_TIMESTAMP('2026-05-22 08:05:10.343000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547993
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 20 -> flags.In Verarbeitung
+-- Column: AD_PInstance.IsProcessing
+-- 2026-05-22T08:05:10.692Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=80,Updated=TO_TIMESTAMP('2026-05-22 08:05:10.692000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547996
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 20 -> flags.DB Tabelle
+-- Column: AD_PInstance.AD_Table_ID
+-- 2026-05-22T08:05:11.041Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=90,Updated=TO_TIMESTAMP('2026-05-22 08:05:11.041000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547997
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 20 -> flags.Datensatz
+-- Column: AD_PInstance.Record_ID
+-- 2026-05-22T08:05:11.397Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=100,Updated=TO_TIMESTAMP('2026-05-22 08:05:11.397000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547998
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 20 -> flags.Fehlermeldung
+-- Column: AD_PInstance.ErrorMsg
+-- 2026-05-22T08:05:11.742Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=110,Updated=TO_TIMESTAMP('2026-05-22 08:05:11.742000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=548001
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 20 -> flags.Ergebnis
+-- Column: AD_PInstance.Result
+-- 2026-05-22T08:05:12.095Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=120,Updated=TO_TIMESTAMP('2026-05-22 08:05:12.095000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=548002
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 20 -> org.Sektion
+-- Column: AD_PInstance.AD_Org_ID
+-- 2026-05-22T08:05:12.455Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=130,Updated=TO_TIMESTAMP('2026-05-22 08:05:12.452000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547999
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 20 -> flags.Ablaufsteuerung
+-- Column: AD_PInstance.AD_Scheduler_ID
+-- 2026-05-22T08:05:30.322Z
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=651711
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 10 -> default.Ablaufsteuerung
+-- Column: AD_PInstance.AD_Scheduler_ID
+-- 2026-05-22T08:05:47.930Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=20,Updated=TO_TIMESTAMP('2026-05-22 08:05:47.930000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=605265
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 10 -> default.Erstellt
+-- Column: AD_PInstance.Created
+-- 2026-05-22T08:05:48.272Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=30,Updated=TO_TIMESTAMP('2026-05-22 08:05:48.272000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547989
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 10 -> default.Erstellt durch
+-- Column: AD_PInstance.CreatedBy
+-- 2026-05-22T08:05:48.613Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=40,Updated=TO_TIMESTAMP('2026-05-22 08:05:48.613000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=651710
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 10 -> default.Aktualisiert
+-- Column: AD_PInstance.Updated
+-- 2026-05-22T08:05:48.962Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=50,Updated=TO_TIMESTAMP('2026-05-22 08:05:48.962000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547990
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 10 -> details.Benutzer
+-- Column: AD_PInstance.AD_User_ID
+-- 2026-05-22T08:05:49.309Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=60,Updated=TO_TIMESTAMP('2026-05-22 08:05:49.309000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547992
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 10 -> details.Sprache
+-- Column: AD_PInstance.AD_Language
+-- 2026-05-22T08:05:49.660Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=70,Updated=TO_TIMESTAMP('2026-05-22 08:05:49.660000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547991
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 10 -> details.Rolle
+-- Column: AD_PInstance.AD_Role_ID
+-- 2026-05-22T08:05:50.004Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=80,Updated=TO_TIMESTAMP('2026-05-22 08:05:50.004000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547993
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 20 -> flags.In Verarbeitung
+-- Column: AD_PInstance.IsProcessing
+-- 2026-05-22T08:05:50.367Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=90,Updated=TO_TIMESTAMP('2026-05-22 08:05:50.367000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547996
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 20 -> flags.DB Tabelle
+-- Column: AD_PInstance.AD_Table_ID
+-- 2026-05-22T08:05:50.725Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=100,Updated=TO_TIMESTAMP('2026-05-22 08:05:50.725000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547997
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 20 -> flags.Datensatz
+-- Column: AD_PInstance.Record_ID
+-- 2026-05-22T08:05:51.072Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=110,Updated=TO_TIMESTAMP('2026-05-22 08:05:51.072000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547998
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 20 -> flags.Fehlermeldung
+-- Column: AD_PInstance.ErrorMsg
+-- 2026-05-22T08:05:51.432Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=120,Updated=TO_TIMESTAMP('2026-05-22 08:05:51.432000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=548001
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 20 -> flags.Ergebnis
+-- Column: AD_PInstance.Result
+-- 2026-05-22T08:05:51.783Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=130,Updated=TO_TIMESTAMP('2026-05-22 08:05:51.783000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=548002
+;
+
+-- UI Element: Prozess-Revision(332,D) -> Prozess-Revision(663,D) -> main -> 20 -> org.Sektion
+-- Column: AD_PInstance.AD_Org_ID
+-- 2026-05-22T08:05:52.135Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=140,Updated=TO_TIMESTAMP('2026-05-22 08:05:52.135000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=547999
+;
+

--- a/docker-builds/cucumber/compose.yml
+++ b/docker-builds/cucumber/compose.yml
@@ -55,13 +55,40 @@ services:
       mode: replicated
       replicas: 1
 
+  # Local SMTP relay for cucumber's `Test sending an outbound mail` scenario.
+  # Replaces the previous external-secrets-based SMTP relay: the external
+  # provider rejected our credentials on 2026-05-21 (locked out the test
+  # account) and the cucumber profile4 job has been red since. MailPit with
+  # --smtp-auth-accept-any removes the external dependency entirely.
+  # Image pinned (no :latest) so a future upstream change can't silently
+  # re-break the test.
+  mailpit:
+    image: axllent/mailpit:v1.20.5
+    command: ["--smtp-auth-accept-any", "--smtp-auth-allow-insecure", "--smtp=0.0.0.0:587"]
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:8025 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      start_period: 10s
+      retries: 10
+    deploy:
+      mode: replicated
+      replicas: 1
+
   cucumber:
     image: ${mfregistry:-metasfresh}/metas-cucumber:$mfversion
     environment:
-      - TEST_SMTP_HOST=$TEST_SMTP_HOST
-      - TEST_SMTP_FROM=$TEST_SMTP_FROM
-      - TEST_SMTP_USER=$TEST_SMTP_USER
-      - TEST_SMTP_PASSWORD=$TEST_SMTP_PASSWORD
+      # SMTP defaults point at the local mailpit container above.
+      # The env vars are still parametrised so a future scenario that
+      # needs a real external SMTP relay can override them at the
+      # compose `up` invocation, but the default cucumber run is now
+      # self-contained.
+      - TEST_SMTP_HOST=${TEST_SMTP_HOST:-mailpit}
+      - TEST_SMTP_PORT=${TEST_SMTP_PORT:-587}
+      - TEST_SMTP_STARTTLS=${TEST_SMTP_STARTTLS:-false}
+      - TEST_SMTP_FROM=${TEST_SMTP_FROM:-noreply@cucumber.metasfresh.test}
+      - TEST_SMTP_USER=${TEST_SMTP_USER:-cucumber}
+      - TEST_SMTP_PASSWORD=${TEST_SMTP_PASSWORD:-cucumber}
       - CUCUMBER_IS_USING_PROVIDED_INFRASTRUCTURE=true
       - CUCUMBER_EXTERNALLY_RUNNING_RABBITMQ_HOST=rabbitmq
       - CUCUMBER_EXTERNALLY_RUNNING_RABBITMQ_PORT=5672
@@ -78,6 +105,8 @@ services:
         condition: service_healthy
       postgrest:
         condition: service_started
+      mailpit:
+        condition: service_healthy
     volumes:
       - ./cucumber:/reports
     deploy:


### PR DESCRIPTION
Forward-merge `keen_hawk_hotfix` → `keen_hawk_release` (merge commit — **do NOT squash**).

Brings `keen_hawk_release` up to the current `keen_hawk_hotfix` head (`ee883db`), which is the version live on PROD (kh202 rollout 12, https://github.com/metasfresh/me03/issues/29270).

### Commits carried (3)
- `ee883db` cucumber CI: replace external SMTP relay with a local MailPit container (#24093, port of #24068)
- `89c9ddad` `Prozess Revision` window update (#24069) — migration `5803990`
- `2fbc8c15` Color Column for C_Order process status (gh29194) — migrations `5799040`, `5799110` + 3 DDL functions

### ⚠️ Contains migration / DDL changes — manual review required
Per the porter's DDL gate, this merge PR must **not** be auto-merged. Affected:
- `…/system/10-de.metas.adempiere/5799040_sys_gh29194_OrderProcessStatusFunctions.sql`
- `…/system/10-de.metas.adempiere/5799110_sys_gh29194_OrderProcessStatusColorColumnAndField.sql`
- `…/system/70-de.metas.fresh/5803990_sys_gh29216_Process_Revision_Window_Update.sql`
- `…/ddl/public/functions/C_Order_{DeliveryStatus,InvoiceStatus,ProcessStatus_Color_ID}_Compute.sql`

A developer must confirm these apply correctly against `keen_hawk_release`'s schema before merging.

### Supersedes
Replaces the stale merge PR https://github.com/metasfresh/metasfresh/pull/23773 (open since 2026-04-28, missing the latest 2 commits). That PR should be closed in favour of this one.

### Note
Merge is clean (no conflicts). This is the first hop only; propagation to `new_dawn_uat` is intentionally **not** included pending a separate decision.
