### PR TITLE
EDI #30308: restore DESADV recipient GLN on the legacy replication export

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_StepDef.java
@@ -163,6 +163,35 @@ public class EDI_Desadv_StepDef
 		}
 	}
 
+	/**
+	 * Asserts that a replication-interface-exported DESADV XML (captured earlier via
+	 * "RabbitMQ receives a EDI_Exp_Desadv") still carries an expected set of business-critical
+	 * elements — a superset check that catches a whole class of regressions where an export
+	 * {@code EXP_FormatLine} is silently lost (e.g. cascade-deleted by a {@code DROP COLUMN}),
+	 * not just a single field. Tolerant of newly-added elements.
+	 * <p>
+	 * DataTable columns:
+	 * <ul>
+	 *   <li>{@code EDI_Exp_Desadv_ID.Identifier} (required) — the captured DESADV document.</li>
+	 *   <li>{@code TagName} (required) — XML element that MUST be present.</li>
+	 *   <li>{@code OPT.UnderTag} (optional) — restrict the search to the first occurrence of this
+	 *       ancestor element (e.g. {@code C_BPartner_ID}); empty = search the whole document.</li>
+	 *   <li>{@code OPT.Value} (optional) — when set, the element's text content must equal it.</li>
+	 * </ul>
+	 * Example:
+	 * <pre>
+	 * Then the following EDI_Exp_Desadv XML carries the expected elements:
+	 *   | EDI_Exp_Desadv_ID.Identifier | OPT.UnderTag  | TagName         | OPT.Value     |
+	 *   | e_d_1                        | C_BPartner_ID | EdiRecipientGLN | 1234567890123 |
+	 *   | e_d_1                        |               | MovementDate    |               |
+	 * </pre>
+	 */
+	@Then("the following EDI_Exp_Desadv XML carries the expected elements:")
+	public void validate_EDI_Exp_Desadv_elements(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::validateEDIExpDesadvElement);
+	}
+
 	@Then("^after not more than (.*)s, EDI_Desadv records have the following export status$")
 	public void validate_export_status(final int timeoutSec, @NonNull final DataTable table) throws InterruptedException
 	{
@@ -276,6 +305,38 @@ public class EDI_Desadv_StepDef
 			final Element qtyTu = getElement(desadvPackElement, QTY_TU_TAGNAME);
 			assertThat(qtyTu).as(QTY_TU_TAGNAME).isNotNull();
 			assertThat(qtyTu.getTextContent()).as(QTY_TU_TAGNAME).isEqualTo(qtyTuExpected);
+		}
+	}
+
+	private void validateEDIExpDesadvElement(@NonNull final DataTableRow row)
+	{
+		final Document ediExpDesadv = row.getAsIdentifier("EDI_Exp_Desadv_ID").lookupNotNullIn(ediExpDesadvTable);
+
+		final String tagName = row.getAsString("TagName");
+		final String underTag = row.getAsOptionalString("UnderTag").orElse(null);
+		final String expectedValue = row.getAsOptionalString("Value").orElse(null);
+
+		final Node scope;
+		if (Check.isNotBlank(underTag))
+		{
+			final Element parent = getElement(ediExpDesadv, underTag);
+			assertThat(parent).as("the exported DESADV XML must contain element <%s>", underTag).isNotNull();
+			scope = parent;
+		}
+		else
+		{
+			scope = ediExpDesadv;
+		}
+
+		final Element element = getElement(scope, tagName);
+		assertThat(element)
+				.as("the exported DESADV XML must carry element <%s>%s",
+						tagName, Check.isNotBlank(underTag) ? " under <" + underTag + ">" : "")
+				.isNotNull();
+
+		if (Check.isNotBlank(expectedValue))
+		{
+			assertThat(element.getTextContent()).as("<%s> value", tagName).isEqualTo(expectedValue);
 		}
 	}
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediExport.feature
@@ -250,6 +250,19 @@ Feature: EDI_cctop_invoic_v export format
       | EDI_Exp_Desadv_ID.Identifier | OPT.EDI_Exp_Desadv_Pack_Item.QtyCUsPerTU | OPT.EDI_Exp_Desadv_Pack_Item.QtyCUsPerLU | OPT.EDI_Exp_Desadv_Pack_Item.QtyTU |
       | e_d_1                        | 10                                       | 100                                      | 10                                 |
 
+    # me03 #30308 — the replication-interface DESADV XML must carry the recipient GLN (resolved from
+    # the partner-default C_BPartner_EDI_Setting row, edi_setting_export_sc2) AND its other
+    # business-critical recipient/header elements. Superset check: catches a future silently-dropped
+    # export element (e.g. an EXP_FormatLine cascade-deleted by a column drop — the #30238 failure mode).
+    And the following EDI_Exp_Desadv XML carries the expected elements:
+      | EDI_Exp_Desadv_ID.Identifier | OPT.UnderTag  | TagName                | OPT.Value     |
+      | e_d_1                        | C_BPartner_ID | EdiRecipientGLN        | 1234567890123 |
+      | e_d_1                        |               | C_BPartner_ID          |               |
+      | e_d_1                        |               | C_BPartner_Location_ID |               |
+      | e_d_1                        |               | ShipmentDocumentNo     |               |
+      | e_d_1                        |               | MovementDate           |               |
+      | e_d_1                        |               | EDI_Exp_Desadv_Pack    |               |
+
      #  Test Kunde 1
     And the following c_bpartner is changed
       | C_BPartner_ID.Identifier | OPT.DeliveryRule |
@@ -437,3 +450,13 @@ Feature: EDI_cctop_invoic_v export format
     And EDI_Exp_Desadv_Pack of the following EDI_Exp_Desadv is validated
       | EDI_Exp_Desadv_ID.Identifier | OPT.EDI_Exp_Desadv_Pack_Item.QtyCUsPerTU | OPT.EDI_Exp_Desadv_Pack_Item.QtyCUsPerLU | OPT.EDI_Exp_Desadv_Pack_Item.QtyTU |
       | e_dB_150                     | 20                                       | 100                                      | 5                                  |
+
+    # ─── RECIPIENT-GLN ASSERTION (me03 #30308) ────────────────────────────────
+    # Both replication-interface DESADV XMLs must carry the recipient GLN under <C_BPartner_ID>,
+    # resolved from bp_150's partner-default C_BPartner_EDI_Setting row (edi_setting_S150_bp1).
+    # Regression: the element vanished when #30238 dropped the C_BPartner GLN column without
+    # repointing the replication (EXP_Format) export path.
+    And the following EDI_Exp_Desadv XML carries the expected elements:
+      | EDI_Exp_Desadv_ID.Identifier | OPT.UnderTag  | TagName         | OPT.Value     |
+      | e_dA_150                     | C_BPartner_ID | EdiRecipientGLN | 1234567890123 |
+      | e_dB_150                     | C_BPartner_ID | EdiRecipientGLN | 1234567890123 |

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5806710_sys_me03_30308_restore_edi_desadv_recipient_gln.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5806710_sys_me03_30308_restore_edi_desadv_recipient_gln.sql
@@ -1,0 +1,142 @@
+-- me03 #30308 — restore the DESADV recipient GLN on the legacy replication-interface export
+-- https://github.com/metasfresh/me03/issues/30308
+--
+-- Regression introduced by https://github.com/metasfresh/me03/issues/30238
+-- (PR https://github.com/metasfresh/metasfresh/pull/24423): the EDI recipient-GLN config was
+-- moved from C_BPartner columns into the new child table C_BPartner_EDI_Setting, and migration
+-- 5806040 DROPPed C_BPartner.EdiDesadvRecipientGLN. Dropping that physical column cascade-deleted
+-- the EXP_FormatLine in the legacy replication export format EDI_Exp_C_BPartner that produced the
+-- XML element /EDI_Exp_Desadv/C_BPartner_ID/EdiRecipientGLN. PR 24423 repointed the JSON + cctop
+-- export VIEWS to C_BPartner_EDI_Setting, but NOT the legacy replication (EXP_Format) export path,
+-- so DESADV XML files generated via the replication interface no longer carry the recipient GLN
+-- ("no receiver provided" on the customer side).
+--
+-- Fix (the "SQL-Column" approach): recreate a virtual ColumnSQL column EdiDesadvRecipientGLN on
+-- C_BPartner that resolves the GLN from the partner-default row of C_BPartner_EDI_Setting, and
+-- recreate the cascade-deleted EXP_FormatLine (XML element name 'EdiRecipientGLN', preserving the
+-- exact prior XML path) referencing that virtual column.
+--
+-- Resolution is partner-level (partner-default row, C_BPartner_Location_ID IS NULL) because the
+-- legacy export's recipient GLN is emitted under the partner node (C_BPartner_ID), which is
+-- partner-keyed. For partners migrated by 5806030 this is exactly the prior behaviour (each got a
+-- single partner-default row). The XML tag is driven by EXP_FormatLine.Value (ExportHelper:
+-- outDocument.createElement(formatLine.getValue())), not by the column name.
+--
+-- IDs allocated from idserver.metas.de on 2026-06-08:
+--   AD_Column      592733 (C_BPartner.EdiDesadvRecipientGLN, virtual ColumnSQL)
+--   EXP_FormatLine 550960 (EDI_Exp_C_BPartner -> EdiRecipientGLN)
+-- Reused: AD_Element 542001 (EdiRecipientGLN / "EDI-ID des DESADV-Empfängers").
+--
+-- NOTE: no AD_SQLColumn_SourceTableColumn (cache-invalidation) entry is created for this virtual
+-- column. That mechanism only matters for columns rendered in a WebUI grid (so the grid refreshes
+-- when the source table changes); this column has NO AD_Field and is read ONLY by the replication
+-- EXP_Format export, which re-evaluates the ColumnSQL fresh on every export — there is no cached
+-- grid value to invalidate, so an entry would guard against no real failure.
+-- Reused: EXP_Format 540385 (EDI_Exp_C_BPartner), AD_Table 291 (C_BPartner),
+--         AD_Table 542610 (C_BPartner_EDI_Setting), AD_Column 592678 (C_BPartner_EDI_Setting.C_BPartner_ID).
+
+-- ---------------------------------------------------------------------------------------------
+-- Step 1: recreate the virtual ColumnSQL column on C_BPartner.
+-- Clone an existing C_BPartner virtual string column (City, AD_Column 557178) so every standard /
+-- NOT NULL column is carried over, then override the fields that differ. IsSyncDatabase='N' keeps
+-- it virtual (no physical DDL). Keywords lowercased per the Convert_PostgreSQL rule.
+--
+-- The own-table key is referenced as the RAW name `C_BPartner.C_BPartner_ID`, NOT the
+-- @JoinTableNameOrAliasIncludingDot@ placeholder: this column is read ONLY by the legacy
+-- replication EXP_Format export (ExportHelper), which loads the C_BPartner PO under its raw table
+-- name and does NOT perform the placeholder substitution (that substitution is a WebUI/ColumnSql
+-- step). The placeholder would reach PostgreSQL verbatim -> "column jointablenameoraliasincludingdot
+-- does not exist". This matches the sibling EDI-export virtual columns on C_BPartner (City,
+-- Address1, EMail, Invoice_Email), which all use the raw `C_BPartner.C_BPartner_ID` form. The
+-- column has no AD_Field and never appears in a WebUI grid, so the master-alias concern behind the
+-- placeholder rule does not apply here.
+-- ---------------------------------------------------------------------------------------------
+INSERT INTO AD_Column (
+    ad_column_id, ad_client_id, ad_org_id, isactive, created, updated, createdby, updatedby,
+    name, description, help, version, entitytype, columnname, ad_table_id, ad_reference_id,
+    ad_reference_value_id, ad_val_rule_id, fieldlength, defaultvalue, iskey, isparent, ismandatory,
+    isupdateable, readonlylogic, isidentifier, seqno, istranslated, isencrypted, callout, vformat,
+    valuemin, valuemax, isselectioncolumn, ad_element_id, ad_process_id, issyncdatabase,
+    isalwaysupdateable, columnsql, mandatorylogic, infofactoryclass, isautocomplete, isallowlogging,
+    formatpattern, isadvancedtext, islazyloading, iscalculated, isgenericzoomorigin,
+    isgenericzoomkeycolumn, isusedocsequence, isstaleable, ddl_noforeignkey, isdimension,
+    isdlmpartitionboundary, cacheinvalidateparent, selectioncolumnseqno, israngefilter,
+    isshowfilterincrementbuttons, filterdefaultvalue, isforceincludeingeneratedmodel, technicalnote,
+    personaldatacategory, allowzoomto, isautoapplyvalidationrule, isfacetfilter, maxfacetstofetch,
+    facetfilterseqno, isshowfilterinline, filteroperator, isexcludefromzoomtargets,
+    isrestapicustomcolumn, cloningstrategy, isshowfilterinactivevalues
+)
+SELECT
+    592733 /*From ID Server*/, 0, 0, 'Y',
+    TO_TIMESTAMP('2026-06-08 12:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    TO_TIMESTAMP('2026-06-08 12:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100, 100,
+    (SELECT Name        FROM AD_Element WHERE AD_Element_ID=542001),  -- name
+    (SELECT Description FROM AD_Element WHERE AD_Element_ID=542001),  -- description
+    (SELECT Help        FROM AD_Element WHERE AD_Element_ID=542001),  -- help
+    0, 'de.metas.esb.edi',
+    'EdiDesadvRecipientGLN',                                   -- columnname
+    291,                                                       -- ad_table_id (C_BPartner)
+    10,                                                        -- ad_reference_id (String)
+    ad_reference_value_id, ad_val_rule_id,
+    255,                                                       -- fieldlength
+    defaultvalue, 'N', 'N', 'N',
+    'N',                                                       -- isupdateable
+    readonlylogic, 'N', seqno, 'N', 'N', callout, vformat,
+    valuemin, valuemax, isselectioncolumn,
+    542001,                                                    -- ad_element_id
+    ad_process_id,
+    'N',                                                       -- issyncdatabase (virtual)
+    isalwaysupdateable,
+    '(select s.edidesadvrecipientgln from c_bpartner_edi_setting s'
+    || ' where s.c_bpartner_id = C_BPartner.C_BPartner_ID'
+    || ' and s.c_bpartner_location_id is null and s.isactive = ''Y'''
+    || ' order by s.c_bpartner_edi_setting_id limit 1)',       -- columnsql
+    mandatorylogic, infofactoryclass, isautocomplete, isallowlogging,
+    formatpattern, isadvancedtext, islazyloading, iscalculated, isgenericzoomorigin,
+    isgenericzoomkeycolumn, isusedocsequence, isstaleable, ddl_noforeignkey, isdimension,
+    isdlmpartitionboundary, cacheinvalidateparent, selectioncolumnseqno, israngefilter,
+    isshowfilterincrementbuttons, filterdefaultvalue, isforceincludeingeneratedmodel, technicalnote,
+    personaldatacategory, allowzoomto, isautoapplyvalidationrule, isfacetfilter, maxfacetstofetch,
+    facetfilterseqno, isshowfilterinline, filteroperator, isexcludefromzoomtargets,
+    isrestapicustomcolumn, cloningstrategy, isshowfilterinactivevalues
+FROM AD_Column
+WHERE AD_Column_ID=557178   -- C_BPartner.City (template virtual ColumnSQL column)
+;
+
+-- Step 1b: skeleton AD_Column_Trl rows for all system languages, then propagate from AD_Element.
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=592733
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+/* DDL */ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(542001);
+
+-- ---------------------------------------------------------------------------------------------
+-- Step 2: recreate the cascade-deleted EXP_FormatLine in EDI_Exp_C_BPartner (EXP_Format 540385).
+-- Clone an existing scalar (type 'E') line of the same format (CreditorId / Kreditoren-Nr,
+-- EXP_FormatLine 549319) to carry every standard column, then override Value (= XML element name),
+-- Name, the referenced AD_Column, Position and activate it.
+-- ---------------------------------------------------------------------------------------------
+INSERT INTO EXP_FormatLine (
+    exp_formatline_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby,
+    value, name, description, help, exp_format_id, position, ismandatory, type, ad_column_id,
+    exp_embeddedformat_id, ispartuniqueindex, dateformat, entitytype, defaultvalue,
+    ad_reference_override_id, filteroperator
+)
+SELECT
+    550960 /*From ID Server*/, 0, 0, 'Y',
+    TO_TIMESTAMP('2026-06-08 12:00:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
+    TO_TIMESTAMP('2026-06-08 12:00:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
+    'EdiRecipientGLN',                                          -- value (drives the XML tag)
+    'EdiRecipientGLN',                                          -- name
+    description, help, exp_format_id,
+    1120,                                                       -- position (after current max 1110)
+    ismandatory, type,
+    592733,                                                     -- ad_column_id (new virtual column)
+    exp_embeddedformat_id, ispartuniqueindex, dateformat, entitytype, defaultvalue,
+    ad_reference_override_id, filteroperator
+FROM EXP_FormatLine
+WHERE EXP_FormatLine_ID=549319   -- EDI_Exp_C_BPartner / CreditorId (template scalar 'E' line)
+;


### PR DESCRIPTION
## Problem (regression from https://github.com/metasfresh/me03/issues/30238 / PR https://github.com/metasfresh/metasfresh/pull/24423)

PR #24423 moved the EDI recipient-GLN config from `C_BPartner` columns into the new
`C_BPartner_EDI_Setting` table and dropped `C_BPartner.EdiDesadvRecipientGLN`. Dropping that
physical column **cascade-deleted** the `EXP_FormatLine` in the legacy replication export format
`EDI_Exp_C_BPartner` that produced the XML element `/EDI_Exp_Desadv/C_BPartner_ID/EdiRecipientGLN`.
PR #24423 repointed the JSON and cctop export **views** but not the **legacy replication
(EXP_Format)** export path, so DESADV XMLs sent via the replication interface lost the recipient
GLN — the customer's downstream system rejects them ("no receiver provided").

## Fix — migration `5806710`

- Recreate a virtual `ColumnSQL` column `C_BPartner.EdiDesadvRecipientGLN` (reusing `AD_Element`
  542001) that resolves the GLN from the **partner-default** `C_BPartner_EDI_Setting` row
  (`C_BPartner_Location_ID IS NULL`) — exactly the pre-#30238 behaviour for migrated partners.
- Recreate the cascade-deleted `EXP_FormatLine` (`EdiRecipientGLN`) in `EDI_Exp_C_BPartner`,
  preserving the exact prior XML path so the downstream parser is unchanged.
- `ColumnSQL` uses the raw `C_BPartner.C_BPartner_ID` correlation (the replication `ExportHelper`
  does **not** substitute `@JoinTableNameOrAliasIncludingDot@`), matching the sibling EDI-export
  virtual columns (`City`, `Address1`, `EMail`). The column has no `AD_Field`/grid, so no
  `AD_SQLColumn_SourceTableColumn` cache-invalidation entry is needed.

The location-specific JSON/cctop export paths are unaffected (handled by #30238); the legacy XML
recipient GLN is partner-keyed by its structure, so partner-default resolution is the correct,
behaviour-preserving repair.

## Test

`ediExport.feature` + `EDI_Desadv_StepDef`: generalised the DESADV-export XML assertion to a
**superset element check** (`the following EDI_Exp_Desadv XML carries the expected elements:`) —
asserts the recipient GLN value **and** a baseline of recipient/header elements, so a *future*
silently-dropped export element is caught too. Verified RED (without the migration the
`<EdiRecipientGLN>` element is absent) → GREEN (with it, the element is emitted and all assertions
pass), locally against soft_panda_uat infra.

Closes after rollout: https://github.com/metasfresh/me03/issues/30308
