### PR TITLE
Fix duplicate M_ShipmentSchedule_QtyPicked rows when reversing an aggregate-HU shipment

### DIFF
--- a/ai-work/29561/pending-questions.md
+++ b/ai-work/29561/pending-questions.md
@@ -1,0 +1,4 @@
+
+## Post-integration cleanup (after PR 24478 is integrated)
+- Close PR https://github.com/metasfresh/metasfresh/pull/23792 (superseded by 24478) with a WHY comment linking 24478, and delete its branch `soft_panda_release_FixDuplicateQtyPickedOnReversal`. (User decision 2026-06-08: 23792 not needed once the fix lands in 24478.) PR closing/branch deletion is the human/Tobias's call — surface when 24478 integrates.
+- Route the 2 reviewer rule-gap candidates through metasfresh-capturing-learnings (ITrxManager class-field convention; trx-dependency-at-call-site doc) — with user OK.

--- a/ai-work/29561/pending-questions.md
+++ b/ai-work/29561/pending-questions.md
@@ -1,4 +1,0 @@
-
-## Post-integration cleanup (after PR 24478 is integrated)
-- Close PR https://github.com/metasfresh/metasfresh/pull/23792 (superseded by 24478) with a WHY comment linking 24478, and delete its branch `soft_panda_release_FixDuplicateQtyPickedOnReversal`. (User decision 2026-06-08: 23792 not needed once the fix lands in 24478.) PR closing/branch deletion is the human/Tobias's call — surface when 24478 integrates.
-- Route the 2 reviewer rule-gap candidates through metasfresh-capturing-learnings (ITrxManager class-field convention; trx-dependency-at-call-site doc) — with user OK.

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/FrontendTestingRestController.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/FrontendTestingRestController.java
@@ -11,6 +11,9 @@ import de.metas.frontend_testing.masterdata.CreateMasterdataCommand;
 import de.metas.frontend_testing.masterdata.CreateMasterdataCommandSupportingServices;
 import de.metas.frontend_testing.masterdata.JsonCreateMasterdataRequest;
 import de.metas.frontend_testing.masterdata.JsonCreateMasterdataResponse;
+import de.metas.frontend_testing.masterdata.shipment.JsonReverseShipmentRequest;
+import de.metas.frontend_testing.masterdata.shipment.JsonReverseShipmentResponse;
+import de.metas.frontend_testing.masterdata.shipment.ReverseShipmentCommand;
 import de.metas.frontend_testing.masterdata.sysconfig.SysconfigCommand;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
 import de.metas.i18n.TranslatableStrings;
@@ -137,6 +140,15 @@ public class FrontendTestingRestController
 	{
 		return callInContext(() -> GetHUQRCodeCommand.builder()
 				.huQRCodesService(huQRCodesService)
+				.request(request)
+				.build()
+				.execute());
+	}
+
+	@PostMapping("reverseShipment")
+	public JsonReverseShipmentResponse reverseShipment(@RequestBody @NonNull final JsonReverseShipmentRequest request)
+	{
+		return callInContext(() -> ReverseShipmentCommand.builder()
 				.request(request)
 				.build()
 				.execute());

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/JsonReverseShipmentRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/JsonReverseShipmentRequest.java
@@ -1,0 +1,21 @@
+package de.metas.frontend_testing.masterdata.shipment;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ * Request to reverse (document-engine Reverse-Correct) a previously-created, completed {@code M_InOut}
+ * shipment. Mirrors the customer "void shipment" action: it restores the HU snapshot taken at completion
+ * and replays the per-transport-unit HU-trx lines, which is the trigger for the duplicate
+ * listener-shaped {@code M_ShipmentSchedule_QtyPicked} rows on a single aggregate VHU.
+ */
+@Value
+@Builder
+@Jacksonized
+public class JsonReverseShipmentRequest
+{
+	/** The {@code M_InOut_ID} returned by a prior shipment-create call (as a string). */
+	@NonNull String shipmentId;
+}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/JsonReverseShipmentResponse.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/JsonReverseShipmentResponse.java
@@ -1,0 +1,29 @@
+package de.metas.frontend_testing.masterdata.shipment;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+public class JsonReverseShipmentResponse
+{
+	/** The {@code M_InOut_ID} of the reversed (original) shipment. */
+	@NonNull String id;
+	@NonNull String documentNo;
+	/** The original shipment's {@code DocStatus} after the reverse (expected {@code "RE"} = Reversed). */
+	@NonNull String docStatus;
+
+	/**
+	 * After the reverse, the largest number of ACTIVE, not-yet-shipped ({@code M_InOutLine_ID} IS NULL)
+	 * {@code M_ShipmentSchedule_QtyPicked} rows that are identical on the partial-unique-index tuple
+	 * (VHU, TU, LU, QtyLU, QtyTU, QtyPicked), across all shipment schedules of the reversed shipment's order.
+	 *
+	 * <p>This is the count that would collide on {@code M_ShipmentSchedule_QtyPicked_UI} once the next
+	 * shipment assigns them an {@code M_InOutLine_ID}: {@code 1} means the listener consolidated the
+	 * aggregate-HU snapshot replay (fix in place); {@code > 1} means duplicate rows survive (no fix).
+	 */
+	int maxIdenticalUnshippedQtyPickedRowsPerVhuTuple;
+}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/ReverseShipmentCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/ReverseShipmentCommand.java
@@ -19,6 +19,7 @@ import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.model.InterfaceWrapperHelper;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -122,9 +123,9 @@ public class ReverseShipmentCommand
 					+ "|" + row.getVHU_ID()
 					+ "|" + row.getM_TU_HU_ID()
 					+ "|" + row.getM_LU_HU_ID()
-					+ "|" + row.getQtyLU().stripTrailingZeros().toPlainString()
-					+ "|" + row.getQtyTU().stripTrailingZeros().toPlainString()
-					+ "|" + row.getQtyPicked().stripTrailingZeros().toPlainString();
+					+ "|" + plain(row.getQtyLU())
+					+ "|" + plain(row.getQtyTU())
+					+ "|" + plain(row.getQtyPicked());
 			final int count = countByTuple.merge(tuple, 1, Integer::sum);
 			if (count > max)
 			{
@@ -132,5 +133,11 @@ public class ReverseShipmentCommand
 			}
 		}
 		return max;
+	}
+
+	/** Null-safe plain-string of a qty column (a row written by a path that skipped updateQtyTUAndQtyLU may have null). */
+	private static String plain(final BigDecimal value)
+	{
+		return value != null ? value.stripTrailingZeros().toPlainString() : "0";
 	}
 }

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/ReverseShipmentCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/ReverseShipmentCommand.java
@@ -1,0 +1,136 @@
+package de.metas.frontend_testing.masterdata.shipment;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.document.engine.IDocument;
+import de.metas.document.engine.IDocumentBL;
+import de.metas.handlingunits.model.I_M_ShipmentSchedule_QtyPicked;
+import de.metas.inout.InOutId;
+import de.metas.inout.model.I_M_InOut;
+import de.metas.inoutcandidate.api.IShipmentSchedulePA;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.interfaces.I_C_OrderLine;
+import de.metas.order.IOrderDAO;
+import de.metas.order.OrderId;
+import de.metas.order.OrderLineId;
+import de.metas.util.Services;
+import lombok.Builder;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.trx.api.ITrxManager;
+import org.adempiere.model.InterfaceWrapperHelper;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Reverses a completed shipment via the document engine's Reverse-Correct action — the faithful
+ * equivalent of the desktop/WebUI "void shipment". The reverse restores the HU snapshot taken at
+ * completion and replays one HU-trx line per aggregated transport unit through the single aggregate
+ * VHU; {@code ShipmentScheduleHUTrxListener#trxLineProcessed} then emits one listener-shaped
+ * {@code M_ShipmentSchedule_QtyPicked} row per replayed line. On an aggregate-HU shipment those rows
+ * are identical on the partial unique-index tuple and would collide when the next shipment is generated
+ * — unless the merge consolidates them into a single row.
+ *
+ * <p>The response reports the largest group of identical, not-yet-shipped active rows produced by the
+ * reverse (see {@link JsonReverseShipmentResponse#getMaxIdenticalUnshippedQtyPickedRowsPerVhuTuple()}),
+ * which is exactly the count that would collide on {@code M_ShipmentSchedule_QtyPicked_UI}.
+ */
+@Builder
+public class ReverseShipmentCommand
+{
+	@NonNull private final ITrxManager trxManager = Services.get(ITrxManager.class);
+	@NonNull private final IDocumentBL documentBL = Services.get(IDocumentBL.class);
+	@NonNull private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
+	@NonNull private final IShipmentSchedulePA shipmentSchedulePA = Services.get(IShipmentSchedulePA.class);
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@NonNull private final JsonReverseShipmentRequest request;
+
+	public JsonReverseShipmentResponse execute()
+	{
+		return trxManager.callInThreadInheritedTrx(this::execute0);
+	}
+
+	private JsonReverseShipmentResponse execute0()
+	{
+		final InOutId inOutId = InOutId.ofRepoId(Integer.parseInt(request.getShipmentId()));
+		final I_M_InOut shipment = InterfaceWrapperHelper.load(inOutId, I_M_InOut.class);
+		final OrderId orderId = OrderId.ofRepoIdOrNull(shipment.getC_Order_ID());
+
+		documentBL.processEx(shipment, IDocument.ACTION_Reverse_Correct, IDocument.STATUS_Reversed);
+
+		InterfaceWrapperHelper.refresh(shipment);
+
+		return JsonReverseShipmentResponse.builder()
+				.id(String.valueOf(shipment.getM_InOut_ID()))
+				.documentNo(shipment.getDocumentNo())
+				.docStatus(shipment.getDocStatus())
+				.maxIdenticalUnshippedQtyPickedRowsPerVhuTuple(computeMaxIdenticalUnshippedRows(orderId))
+				.build();
+	}
+
+	/**
+	 * Across all shipment schedules of the given order, count the active, not-yet-shipped
+	 * {@code M_ShipmentSchedule_QtyPicked} rows grouped by the partial-unique-index tuple, and return
+	 * the size of the largest group (the count that would collide once an {@code M_InOutLine_ID} is set).
+	 */
+	private int computeMaxIdenticalUnshippedRows(final OrderId orderId)
+	{
+		if (orderId == null)
+		{
+			return 0;
+		}
+
+		final ImmutableSet<OrderLineId> orderLineIds = orderDAO.retrieveOrderLines(orderId).stream()
+				.map(I_C_OrderLine::getC_OrderLine_ID)
+				.map(OrderLineId::ofRepoId)
+				.collect(ImmutableSet.toImmutableSet());
+		if (orderLineIds.isEmpty())
+		{
+			return 0;
+		}
+
+		final Set<Integer> scheduleIds = shipmentSchedulePA.getByOrderLineIds(orderLineIds).stream()
+				.map(I_M_ShipmentSchedule::getM_ShipmentSchedule_ID)
+				.collect(Collectors.toSet());
+		if (scheduleIds.isEmpty())
+		{
+			return 0;
+		}
+
+		final List<I_M_ShipmentSchedule_QtyPicked> rows = queryBL
+				.createQueryBuilder(I_M_ShipmentSchedule_QtyPicked.class)
+				.addInArrayFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_ShipmentSchedule_ID, scheduleIds)
+				.addOnlyActiveRecordsFilter()
+				.create()
+				.list(I_M_ShipmentSchedule_QtyPicked.class);
+
+		final Map<String, Integer> countByTuple = new HashMap<>();
+		int max = 0;
+		for (final I_M_ShipmentSchedule_QtyPicked row : rows)
+		{
+			// only rows that are not yet linked to a shipment line participate in the partial index
+			if (row.getM_InOutLine_ID() > 0)
+			{
+				continue;
+			}
+
+			final String tuple = row.getM_ShipmentSchedule_ID()
+					+ "|" + row.getVHU_ID()
+					+ "|" + row.getM_TU_HU_ID()
+					+ "|" + row.getM_LU_HU_ID()
+					+ "|" + row.getQtyLU().stripTrailingZeros().toPlainString()
+					+ "|" + row.getQtyTU().stripTrailingZeros().toPlainString()
+					+ "|" + row.getQtyPicked().stripTrailingZeros().toPlainString();
+			final int count = countByTuple.merge(tuple, 1, Integer::sum);
+			if (count > max)
+			{
+				max = count;
+			}
+		}
+		return max;
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobReopenCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobReopenCommand.java
@@ -162,8 +162,11 @@ public class PickingJobReopenCommand
 					// the M_ShipmentSchedule_QtyPicked_UI partial unique index when the shipment is recreated.
 					// The FIRST request for a (schedule, VHU) pair finds no existing row, so tryMerge returns
 					// false and falls through to addQtyPickedAndUpdateHU (which creates it); the 2nd..Nth
-					// requests merge into that row. (tryMerge must run in the same transaction as the reopen so
-					// it can see that just-created sibling row — guaranteed here by execute()'s runInThreadInheritedTrx.)
+					// requests merge into that row. (On a shipment reversal the HU-snapshot replay does NOT
+					// fire ShipmentScheduleHUTrxListener#trxLineProcessed, so this reopen — not the listener —
+					// is what re-creates the QtyPicked rows, and the first request genuinely finds none.)
+					// tryMerge must run in the same transaction as the reopen so it can see that just-created
+					// sibling row — guaranteed here by execute()'s runInThreadInheritedTrx.
 					// tryMerge is self-gated (no-op for job-schedule-bound, catch-weight, negative, anonymous
 					// or non-virtual picks), so genuine per-step picks are unaffected.
 					if (!shipmentScheduleService.tryMergeQtyPickedIntoExistingForVHU(request))

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobReopenCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobReopenCommand.java
@@ -160,6 +160,10 @@ public class PickingJobReopenCommand
 					// N requests through the SAME VHU. Consolidate them into the single existing un-shipped
 					// QtyPicked row (restoring the pre-reversal one-row shape) so they do not later collide on
 					// the M_ShipmentSchedule_QtyPicked_UI partial unique index when the shipment is recreated.
+					// The FIRST request for a (schedule, VHU) pair finds no existing row, so tryMerge returns
+					// false and falls through to addQtyPickedAndUpdateHU (which creates it); the 2nd..Nth
+					// requests merge into that row. (tryMerge must run in the same transaction as the reopen so
+					// it can see that just-created sibling row — guaranteed here by execute()'s runInThreadInheritedTrx.)
 					// tryMerge is self-gated (no-op for job-schedule-bound, catch-weight, negative, anonymous
 					// or non-virtual picks), so genuine per-step picks are unaffected.
 					if (!shipmentScheduleService.tryMergeQtyPickedIntoExistingForVHU(request))

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobReopenCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobReopenCommand.java
@@ -145,7 +145,7 @@ public class PickingJobReopenCommand
 				.forEach(pickStepHU -> {
 					final HuId huId = pickStepHU.getActualPickedHU().getId();
 					final I_M_HU hu = huService.getById(huId);
-					shipmentScheduleService.addQtyPickedAndUpdateHU(AddQtyPickedRequest.builder()
+					final AddQtyPickedRequest request = AddQtyPickedRequest.builder()
 							.scheduleId(step.getScheduleId())
 							.qtyPicked(CatchWeightHelper.extractQtys(
 									huContext,
@@ -155,7 +155,17 @@ public class PickingJobReopenCommand
 							.hu(hu)
 							.huContext(huContext)
 							.anonymousHuPickedOnTheFly(huIdsToPick.get(huId).isAnonymousHuPickedOnTheFly())
-							.build());
+							.build();
+					// An aggregate HU exposes one "actual picked HU" per aggregated TU, so reopening replays
+					// N requests through the SAME VHU. Consolidate them into the single existing un-shipped
+					// QtyPicked row (restoring the pre-reversal one-row shape) so they do not later collide on
+					// the M_ShipmentSchedule_QtyPicked_UI partial unique index when the shipment is recreated.
+					// tryMerge is self-gated (no-op for job-schedule-bound, catch-weight, negative, anonymous
+					// or non-virtual picks), so genuine per-step picks are unaffected.
+					if (!shipmentScheduleService.tryMergeQtyPickedIntoExistingForVHU(request))
+					{
+						shipmentScheduleService.addQtyPickedAndUpdateHU(request);
+					}
 				});
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/shipmentschedule/PickingJobShipmentScheduleService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/shipmentschedule/PickingJobShipmentScheduleService.java
@@ -112,7 +112,7 @@ public class PickingJobShipmentScheduleService
 				.build();
 	}
 
-	public void addQtyPickedAndUpdateHU(final AddQtyPickedRequest request)
+	public void addQtyPickedAndUpdateHU(@NonNull final AddQtyPickedRequest request)
 	{
 		huShipmentScheduleBL.addQtyPickedAndUpdateHU(request);
 	}
@@ -124,7 +124,7 @@ public class PickingJobShipmentScheduleService
 	 *
 	 * @return {@code true} if the qty was merged into an existing row (caller must NOT also add a new row).
 	 */
-	public boolean tryMergeQtyPickedIntoExistingForVHU(final AddQtyPickedRequest request)
+	public boolean tryMergeQtyPickedIntoExistingForVHU(@NonNull final AddQtyPickedRequest request)
 	{
 		return huShipmentScheduleBL.tryMergeQtyPickedIntoExistingForVHU(request);
 	}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/shipmentschedule/PickingJobShipmentScheduleService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/shipmentschedule/PickingJobShipmentScheduleService.java
@@ -117,6 +117,18 @@ public class PickingJobShipmentScheduleService
 		huShipmentScheduleBL.addQtyPickedAndUpdateHU(request);
 	}
 
+	/**
+	 * Consolidate an aggregate-HU snapshot-replay pick into the single existing un-shipped QtyPicked row
+	 * for the same VHU, rather than creating a duplicate. Self-gated: returns {@code false} (no merge) for
+	 * genuine job-schedule-bound picks, catch-weight, negative, anonymous-on-the-fly or non-virtual picks.
+	 *
+	 * @return {@code true} if the qty was merged into an existing row (caller must NOT also add a new row).
+	 */
+	public boolean tryMergeQtyPickedIntoExistingForVHU(final AddQtyPickedRequest request)
+	{
+		return huShipmentScheduleBL.tryMergeQtyPickedIntoExistingForVHU(request);
+	}
+
 	public void deleteByTopLevelHUsAndShipmentScheduleId(@NonNull final Collection<I_M_HU> topLevelHUs, @NonNull final ShipmentScheduleId shipmentScheduleId)
 	{
 		huShipmentScheduleBL.deleteByTopLevelHUsAndShipmentScheduleId(topLevelHUs, shipmentScheduleId);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleBL.java
@@ -53,6 +53,27 @@ public interface IHUShipmentScheduleBL extends ISingletonService
 	ShipmentScheduleWithHU addQtyPickedAndUpdateHU(AddQtyPickedRequest request);
 
 	/**
+	 * Try to add the request's qty into a single existing un-shipped {@link I_M_ShipmentSchedule_QtyPicked}
+	 * row for the same {@code (M_ShipmentSchedule_ID, VHU_ID)} pair instead of creating a new row.
+	 * <p>
+	 * Scope is intentionally narrow — only HU-trx-listener-shaped picks are eligible:
+	 * the request must have no {@code PickingJobScheduleId}, must not be marked as
+	 * {@code anonymousHuPickedOnTheFly}, and the HU must be a virtual HU. The candidate
+	 * row is also filtered to {@code M_Picking_Job_Schedule_ID IS NULL} and
+	 * {@code IsAnonymousHuPickedOnTheFly = N} so that genuine multi-job picks on the same
+	 * VHU are never collapsed.
+	 * <p>
+	 * Used by {@code ShipmentScheduleHUTrxListener.trxLineProcessed} to defuse the duplicate-row
+	 * pattern produced when an aggregate HU's snapshot is replayed (one VHU node receives
+	 * multiple HU-trx lines in one transaction).
+	 *
+	 * @return {@code true} if a matching row was found and the qty was merged into it (caller
+	 *         should skip the regular new-row path); {@code false} otherwise (caller should fall
+	 *         through to {@link #addQtyPickedAndUpdateHU(AddQtyPickedRequest)}).
+	 */
+	boolean tryMergeQtyPickedIntoExistingForVHU(AddQtyPickedRequest request);
+
+	/**
 	 * Creates a producer which will create shipments ({@link I_M_InOut}) from {@link ShipmentScheduleWithHU}s.
 	 */
 	IInOutProducerFromShipmentScheduleWithHU createInOutProducerFromShipmentSchedule();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleDAO.java
@@ -22,6 +22,7 @@ package de.metas.handlingunits.shipmentschedule.api;
  * #L%
  */
 
+import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_ShipmentSchedule_QtyPicked;
 import de.metas.inout.ShipmentScheduleId;
@@ -46,4 +47,14 @@ public interface IHUShipmentScheduleDAO extends ISingletonService
 	IQueryBuilder<I_M_ShipmentSchedule_QtyPicked> retrieveSchedsQtyPickedForVHUQuery(I_M_HU vhu);
 
 	List<ShipmentScheduleWithHU> retrieveShipmentSchedulesWithHUsFromHUs(List<I_M_HU> hus);
+
+	/**
+	 * Active, un-shipped (M_InOutLine_ID IS NULL), non-job-schedule, non-anonymous-on-the-fly QtyPicked rows
+	 * for the given (schedule, VHU) pair. Used by {@code ShipmentScheduleHUTrxListener} to consolidate
+	 * sibling rows produced when an aggregate HU's snapshot is replayed and routes multiple HU-trx lines
+	 * through the same VHU.
+	 */
+	List<I_M_ShipmentSchedule_QtyPicked> retrieveMergeableListenerQtyPickedForVHU(
+			@NonNull ShipmentScheduleId shipmentScheduleId,
+			@NonNull HuId vhuId);
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -1,5 +1,6 @@
 package de.metas.handlingunits.shipmentschedule.api.impl;
 
+import ch.qos.logback.classic.Level;
 import com.google.common.collect.ImmutableList;
 import de.metas.adempiere.gui.search.IHUPackingAwareBL;
 import de.metas.adempiere.gui.search.impl.ShipmentScheduleHUPackingAware;
@@ -60,9 +61,11 @@ import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
 import de.metas.product.ProductId;
 import de.metas.project.ProjectId;
 import de.metas.quantity.Quantity;
+import de.metas.quantity.StockQtyAndUOMQty;
 import de.metas.shipping.model.I_M_ShipperTransportation;
 import de.metas.uom.UomId;
 import de.metas.util.Check;
+import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
@@ -212,6 +215,100 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 		huContext.flush();
 
 		return ShipmentScheduleWithHU.ofShipmentScheduleQtyPicked(qtyPickedRecord, huContext);
+	}
+
+	@Override
+	public boolean tryMergeQtyPickedIntoExistingForVHU(@NonNull final AddQtyPickedRequest request)
+	{
+		// Eligibility — only HU-trx-listener-shaped picks may be merged.
+		// Order: cheapest request-shape guards first; HU lookup last.
+		final ShipmentScheduleAndJobScheduleId scheduleId = request.getScheduleId();
+		if (scheduleId.getJobScheduleId() != null)
+		{
+			return false;
+		}
+		if (request.isAnonymousHuPickedOnTheFly())
+		{
+			return false;
+		}
+
+		// Catch-weight merging is not supported here — fall through to create-new so each
+		// catch reading keeps its own row.
+		final StockQtyAndUOMQty qtyToAdd = request.getQtyPicked();
+		if (qtyToAdd.isUOMQtySet())
+		{
+			return false;
+		}
+
+		// Only merge strictly positive allocations. Negative qty represents an un-allocation
+		// (see ShipmentScheduleHUTrxListener#trxLineProcessed Javadoc) and must remain its own
+		// audit row so the netting is visible — silently subtracting from a sibling can drive
+		// a row to zero/negative and mask a stock discrepancy.
+		if (qtyToAdd.getStockQty().signum() <= 0)
+		{
+			return false;
+		}
+
+		final I_M_HU vhu = request.getHu();
+		if (!handlingUnitsBL.isVirtual(vhu))
+		{
+			return false;
+		}
+
+		final HuId vhuId = HuId.ofRepoId(vhu.getM_HU_ID());
+		final List<I_M_ShipmentSchedule_QtyPicked> candidates = huShipmentScheduleDAO.retrieveMergeableListenerQtyPickedForVHU(
+				scheduleId.getShipmentScheduleId(),
+				vhuId);
+
+		if (candidates.isEmpty())
+		{
+			return false;
+		}
+		if (candidates.size() > 1)
+		{
+			// Pre-existing duplicates — not our job to silently collapse them. Log and fall through;
+			// the new-row path will leave the duplicates intact for human inspection.
+			Loggables.withLogger(logger, Level.WARN).addLog(
+					"tryMergeQtyPickedIntoExistingForVHU: found {} pre-existing un-shipped QtyPicked rows for shipmentScheduleId={} vhuId={} — falling through to create-new",
+					candidates.size(), scheduleId.getShipmentScheduleId(), vhuId);
+			return false;
+		}
+
+		final I_M_ShipmentSchedule_QtyPicked existing = candidates.get(0);
+		// Defensive: even though the request carries no catch UOM (guard above), reject merging
+		// into a row that was previously written with one. Could only happen if a different code
+		// path bypassed the request-side guard; better to fall through than risk arithmetic that
+		// loses the catch reading.
+		final BigDecimal existingCatchQty = existing.getQtyDeliveredCatch();
+		if (existing.getCatch_UOM_ID() > 0 || (existingCatchQty != null && existingCatchQty.signum() != 0))
+		{
+			return false;
+		}
+
+		existing.setQtyPicked(existing.getQtyPicked().add(qtyToAdd.getStockQty().toBigDecimal()));
+		final IHUContext huContext = request.getHuContext();
+		ShipmentScheduleWithHU.ofShipmentScheduleQtyPicked(existing, huContext).updateQtyTUAndQtyLU();
+		saveRecord(existing);
+
+		// Drive the same HU side-effects as the create-new path. On the well-formed reversal
+		// flow the topLevelHU is already Picked with the right partner/location (the FIRST
+		// trx-line in the same transaction went through addQtyPickedAndUpdateHU), so each call
+		// is a verified no-op:
+		//   - HUStatusBL.setHUStatus returns early when status is unchanged
+		//   - PO setters with equal values do not produce an UPDATE
+		// Re-running them here is a safety net for edge cases where the first row's flow
+		// didn't reach this point (e.g. a row pre-existed from a prior session).
+		final LUTUCUPair husPair = handlingUnitsBL.getTopLevelParentAsLUTUCUPair(vhu);
+		final I_M_HU topLevelHU = husPair.getTopLevelHU();
+		setHUStatusToPicked(topLevelHU);
+		setHUPartnerAndLocationFromSched(topLevelHU, getShipmentSchedule(request));
+		handlingUnitsDAO.saveHU(topLevelHU);
+		huContext.flush();
+
+		Loggables.withLogger(logger, Level.DEBUG).addLog(
+				"tryMergeQtyPickedIntoExistingForVHU: merged qty={} into M_ShipmentSchedule_QtyPicked_ID={} (shipmentScheduleId={} vhuId={})",
+				qtyToAdd.getStockQty(), existing.getM_ShipmentSchedule_QtyPicked_ID(), scheduleId.getShipmentScheduleId(), vhuId);
+		return true;
 	}
 
 	private de.metas.inoutcandidate.model.I_M_ShipmentSchedule getShipmentSchedule(final AddQtyPickedRequest request)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO.java
@@ -1,6 +1,7 @@
 package de.metas.handlingunits.shipmentschedule.api.impl;
 
 import com.google.common.base.Preconditions;
+import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHUContextFactory;
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.IMutableHUContext;
@@ -145,6 +146,30 @@ public class HUShipmentScheduleDAO implements IHUShipmentScheduleDAO
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_VHU_ID, vhu.getM_HU_ID())
 				.orderBy(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_ShipmentSchedule_QtyPicked_ID);
+	}
+
+	@Override
+	public List<I_M_ShipmentSchedule_QtyPicked> retrieveMergeableListenerQtyPickedForVHU(
+			@NonNull final ShipmentScheduleId shipmentScheduleId,
+			@NonNull final HuId vhuId)
+	{
+		// Run in the thread-inherited transaction. This method is called from
+		// ShipmentScheduleHUTrxListener#trxLineProcessed during an aggregate-HU snapshot replay
+		// (e.g. shipment reversal): the sibling QtyPicked rows we need to merge into are created
+		// earlier in the SAME, not-yet-committed transaction. A context-less query would run
+		// out-of-trx (committed data only) and never see them, defeating the merge.
+		final Properties ctx = Env.getCtx();
+		final String trxName = Services.get(org.adempiere.ad.trx.api.ITrxManager.class).getThreadInheritedTrxName();
+		return queryBL.createQueryBuilder(I_M_ShipmentSchedule_QtyPicked.class, ctx, trxName)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_ShipmentSchedule_ID, shipmentScheduleId)
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_VHU_ID, vhuId)
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_InOutLine_ID, null)
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_Picking_Job_Schedule_ID, null)
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_IsAnonymousHuPickedOnTheFly, false)
+				.orderBy(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_ShipmentSchedule_QtyPicked_ID)
+				.create()
+				.list();
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO.java
@@ -17,6 +17,7 @@ import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
+import org.adempiere.ad.trx.api.ITrxManager;
 import org.compiere.util.Env;
 
 import java.util.ArrayList;
@@ -26,6 +27,7 @@ import java.util.Properties;
 public class HUShipmentScheduleDAO implements IHUShipmentScheduleDAO
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	private final ITrxManager trxManager = Services.get(ITrxManager.class);
 	private final IHUContextFactory huContextFactory = Services.get(IHUContextFactory.class);
 
 	private IHandlingUnitsBL handlingUnitsBL() {return Services.get(IHandlingUnitsBL.class);}
@@ -159,7 +161,7 @@ public class HUShipmentScheduleDAO implements IHUShipmentScheduleDAO
 		// earlier in the SAME, not-yet-committed transaction. A context-less query would run
 		// out-of-trx (committed data only) and never see them, defeating the merge.
 		final Properties ctx = Env.getCtx();
-		final String trxName = Services.get(org.adempiere.ad.trx.api.ITrxManager.class).getThreadInheritedTrxName();
+		final String trxName = trxManager.getThreadInheritedTrxName();
 		return queryBL.createQueryBuilder(I_M_ShipmentSchedule_QtyPicked.class, ctx, trxName)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_ShipmentSchedule_ID, shipmentScheduleId)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleHUTrxListener.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleHUTrxListener.java
@@ -100,7 +100,7 @@ public final class ShipmentScheduleHUTrxListener implements IHUTrxListener
 		//
 		// Link VHU to shipment schedule
 		final IHUShipmentScheduleBL huShipmentScheduleBL = Services.get(IHUShipmentScheduleBL.class);
-		huShipmentScheduleBL.addQtyPickedAndUpdateHU(AddQtyPickedRequest.builder()
+		final AddQtyPickedRequest request = AddQtyPickedRequest.builder()
 				.shipmentSchedule(shipmentSchedule)
 				.qtyPicked(CatchWeightHelper.extractQtys(
 						huContext,
@@ -111,7 +111,19 @@ public final class ShipmentScheduleHUTrxListener implements IHUTrxListener
 				.hu(vhu)
 				.huContext(huContext)
 				.anonymousHuPickedOnTheFly(false)
-				.build());
+				.build();
+
+		// On aggregate-HU snapshot replay (e.g. shipment reversal), the same VHU node receives
+		// multiple HU-trx lines in one transaction. Without consolidation, that produces N
+		// QtyPicked rows that share the same (VHU, TU, LU, QtyLU, QtyTU, QtyPicked) tuple and
+		// later collide on the M_ShipmentSchedule_QtyPicked_UI partial unique index when the
+		// next shipment is generated.
+		if (huShipmentScheduleBL.tryMergeQtyPickedIntoExistingForVHU(request))
+		{
+			return;
+		}
+
+		huShipmentScheduleBL.addQtyPickedAndUpdateHU(request);
 	}
 
 	@Nullable

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleHUTrxListener.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/ShipmentScheduleHUTrxListener.java
@@ -118,6 +118,8 @@ public final class ShipmentScheduleHUTrxListener implements IHUTrxListener
 		// QtyPicked rows that share the same (VHU, TU, LU, QtyLU, QtyTU, QtyPicked) tuple and
 		// later collide on the M_ShipmentSchedule_QtyPicked_UI partial unique index when the
 		// next shipment is generated.
+		// The FIRST trx-line for a (schedule, VHU) pair finds no existing row, so tryMerge returns
+		// false and the addQtyPickedAndUpdateHU below creates it; the 2nd..Nth lines merge into it.
 		if (huShipmentScheduleBL.tryMergeQtyPickedIntoExistingForVHU(request))
 		{
 			return;

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL_mergeQtyPickedHappyPath_Test.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL_mergeQtyPickedHappyPath_Test.java
@@ -1,0 +1,172 @@
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2015 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package de.metas.handlingunits.shipmentschedule.api.impl;
+
+import de.metas.handlingunits.HUTestHelper;
+import de.metas.handlingunits.IMutableHUContext;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.I_M_ShipmentSchedule_QtyPicked;
+import de.metas.handlingunits.shipmentschedule.api.AddQtyPickedRequest;
+import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.quantity.StockQtyAndUOMQty;
+import de.metas.util.Services;
+import org.adempiere.ad.dao.IQueryBL;
+import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_C_BPartner_Location;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static de.metas.handlingunits.HuPackingInstructionsVersionId.VIRTUAL;
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Happy-path coverage for {@link HUShipmentScheduleBL#tryMergeQtyPickedIntoExistingForVHU(AddQtyPickedRequest)}
+ * — the qty is actually summed into an existing un-shipped row instead of creating a duplicate.
+ *
+ * <p>This is the behaviour that defends against the aggregate-HU reversal defect: when a void/reversal
+ * replays N trx-lines through the SAME aggregate VHU, the shipment-schedule listener fires N times for
+ * one (schedule, VHU) pair; without merging it produces N identical {@code M_ShipmentSchedule_QtyPicked}
+ * rows that collide on the partial unique index when the next shipment binds {@code M_InOutLine_ID}. Merging keeps a
+ * single row.</p>
+ *
+ * <p>The merge itself is pure persistence logic (find the one existing un-shipped listener row for the
+ * (schedule, VHU) pair, sum the qty, save) and is therefore faithfully testable in-memory — unlike the
+ * full reversal trigger, which depends on running-stack HU snapshot replay.</p>
+ */
+class HUShipmentScheduleBL_mergeQtyPickedHappyPath_Test
+{
+	private HUTestHelper helper;
+	private HUShipmentScheduleBL bl;
+	private IQueryBL queryBL;
+
+	private I_M_ShipmentSchedule schedule;
+	private I_M_HU vhu;
+	private I_C_UOM uom;
+	private IMutableHUContext huContext;
+
+	@BeforeEach
+	void init()
+	{
+		helper = new HUTestHelper();
+		helper.init();
+		bl = new HUShipmentScheduleBL();
+		queryBL = Services.get(IQueryBL.class);
+
+		huContext = helper.createMutableHUContextOutOfTransaction();
+
+		uom = helper.uomEach;
+
+		final I_C_BPartner bpartner = newInstance(I_C_BPartner.class);
+		bpartner.setName("customer");
+		saveRecord(bpartner);
+		final I_C_BPartner_Location bpLocation = newInstance(I_C_BPartner_Location.class);
+		bpLocation.setC_BPartner_ID(bpartner.getC_BPartner_ID());
+		saveRecord(bpLocation);
+
+		schedule = newInstance(I_M_ShipmentSchedule.class);
+		schedule.setM_Product_ID(helper.pTomatoProductId.getRepoId());
+		schedule.setC_BPartner_ID(bpartner.getC_BPartner_ID());
+		schedule.setC_BPartner_Location_ID(bpLocation.getC_BPartner_Location_ID());
+		saveRecord(schedule);
+
+		// A virtual VHU (PI version = the VIRTUAL one set up by HUTestHelper.init()).
+		vhu = newInstance(I_M_HU.class);
+		vhu.setM_HU_PI_Version_ID(VIRTUAL.getRepoId());
+		saveRecord(vhu);
+	}
+
+	/**
+	 * First listener-pick created one row; the second listener-pick for the same (schedule, VHU)
+	 * must MERGE into it (qty summed) rather than create a duplicate.
+	 */
+	@Test
+	void secondListenerPickForSameVHU_mergesIntoExistingRow_insteadOfDuplicating()
+	{
+		// given: one existing un-shipped, listener-shaped QtyPicked row for (schedule, vhu)
+		final I_M_ShipmentSchedule_QtyPicked existing = newInstance(I_M_ShipmentSchedule_QtyPicked.class);
+		existing.setM_ShipmentSchedule_ID(schedule.getM_ShipmentSchedule_ID());
+		existing.setVHU_ID(vhu.getM_HU_ID());
+		existing.setQtyPicked(new BigDecimal("4"));
+		existing.setIsActive(true);
+		saveRecord(existing);
+
+		// when: a second positive, listener-shaped pick of qty 4 arrives for the same (schedule, vhu)
+		final boolean merged = bl.tryMergeQtyPickedIntoExistingForVHU(positiveListenerRequest(new BigDecimal("4")));
+
+		// then: it merged, and there is still exactly ONE row, with the summed qty
+		assertThat(merged).as("second listener pick for the same VHU should merge").isTrue();
+
+		final List<I_M_ShipmentSchedule_QtyPicked> rows = rowsForScheduleAndVhu();
+		assertThat(rows).as("must remain a single row (no duplicate)").hasSize(1);
+		assertThat(rows.get(0).getQtyPicked()).as("qty summed").isEqualByComparingTo("8");
+	}
+
+	/**
+	 * With no pre-existing row, the merge must fall through (return false) so the listener creates the
+	 * first row via the normal path.
+	 */
+	@Test
+	void firstListenerPick_noExistingRow_fallsThrough()
+	{
+		final boolean merged = bl.tryMergeQtyPickedIntoExistingForVHU(positiveListenerRequest(new BigDecimal("4")));
+
+		assertThat(merged).as("first pick (no existing row) must fall through to create-new").isFalse();
+		assertThat(rowsForScheduleAndVhu()).isEmpty();
+	}
+
+	private AddQtyPickedRequest positiveListenerRequest(final BigDecimal qty)
+	{
+		final StockQtyAndUOMQty qtyPicked = StockQtyAndUOMQty.builder()
+				.productId(ProductId.ofRepoId(schedule.getM_Product_ID()))
+				.stockQty(Quantity.of(qty, uom))
+				.build();
+
+		return AddQtyPickedRequest.builder()
+				.scheduleId(de.metas.picking.api.ShipmentScheduleAndJobScheduleId.ofShipmentScheduleId(
+						ShipmentScheduleId.ofRepoId(schedule.getM_ShipmentSchedule_ID())))
+				.cachedShipmentSchedule(schedule)
+				.qtyPicked(qtyPicked)
+				.hu(vhu)
+				.huContext(huContext)
+				.anonymousHuPickedOnTheFly(false)
+				.build();
+	}
+
+	private List<I_M_ShipmentSchedule_QtyPicked> rowsForScheduleAndVhu()
+	{
+		return queryBL.createQueryBuilder(I_M_ShipmentSchedule_QtyPicked.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_ShipmentSchedule_ID, schedule.getM_ShipmentSchedule_ID())
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_VHU_ID, vhu.getM_HU_ID())
+				.create()
+				.list();
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL_tryMergeQtyPickedIntoExistingForVHU_Test.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL_tryMergeQtyPickedIntoExistingForVHU_Test.java
@@ -1,0 +1,159 @@
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2015 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package de.metas.handlingunits.shipmentschedule.api.impl;
+
+import de.metas.handlingunits.IHUContext;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.shipmentschedule.api.AddQtyPickedRequest;
+import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.picking.api.PickingJobScheduleId;
+import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.quantity.StockQtyAndUOMQty;
+import de.metas.uom.UomId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Cheap-guard tests for {@link HUShipmentScheduleBL#tryMergeQtyPickedIntoExistingForVHU(AddQtyPickedRequest)}.
+ *
+ * <p>The merge predicate has multiple early returns based on request shape (no HU lookup,
+ * no DAO query, no side effects). Those are the contract the listener relies on for
+ * non-listener-shaped picks to fall through to {@code addQtyPickedAndUpdateHU}. This test
+ * locks each one in so we don't accidentally widen the merge scope in a future refactor.</p>
+ *
+ * <p>Happy-path coverage (qty actually summed into an existing row) requires HU machinery
+ * and is exercised by the cucumber {@code reversedShipment.feature} scenario.</p>
+ */
+class HUShipmentScheduleBL_tryMergeQtyPickedIntoExistingForVHU_Test
+{
+	private static final int VHU_ID = 1_111_111;
+
+	private HUShipmentScheduleBL bl;
+	private I_M_ShipmentSchedule schedule;
+	private I_M_HU vhu;
+	private I_C_UOM uom;
+	private IHUContext huContext;
+
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+		bl = new HUShipmentScheduleBL();
+
+		schedule = InterfaceWrapperHelper.newInstance(I_M_ShipmentSchedule.class);
+		schedule.setM_Product_ID(7777);
+		InterfaceWrapperHelper.saveRecord(schedule);
+
+		vhu = InterfaceWrapperHelper.newInstance(I_M_HU.class);
+		InterfaceWrapperHelper.saveRecord(vhu);
+
+		uom = InterfaceWrapperHelper.newInstance(I_C_UOM.class);
+		uom.setUOMSymbol("PCE");
+		InterfaceWrapperHelper.saveRecord(uom);
+
+		huContext = mock(IHUContext.class);
+	}
+
+	@Test
+	void rejects_when_pickingJobScheduleId_is_set()
+	{
+		final AddQtyPickedRequest request = baseRequestBuilder(positiveStockQty(BigDecimal.TEN))
+				.scheduleId(ShipmentScheduleAndJobScheduleId.of(
+						ShipmentScheduleId.ofRepoId(schedule.getM_ShipmentSchedule_ID()),
+						PickingJobScheduleId.ofRepoId(8_888)))
+				.cachedShipmentSchedule(null)
+				.build();
+
+		assertThat(bl.tryMergeQtyPickedIntoExistingForVHU(request)).isFalse();
+	}
+
+	@Test
+	void rejects_when_anonymous_on_the_fly_is_set()
+	{
+		final AddQtyPickedRequest request = baseRequestBuilder(positiveStockQty(BigDecimal.TEN))
+				.anonymousHuPickedOnTheFly(true)
+				.build();
+
+		assertThat(bl.tryMergeQtyPickedIntoExistingForVHU(request)).isFalse();
+	}
+
+	@Test
+	void rejects_when_request_carries_catch_weight()
+	{
+		final StockQtyAndUOMQty qtyWithCatch = StockQtyAndUOMQty.builder()
+				.productId(ProductId.ofRepoId(schedule.getM_Product_ID()))
+				.stockQty(Quantity.of(BigDecimal.TEN, uom))
+				.uomQty(Quantity.of(new BigDecimal("9.7"), uom))
+				.build();
+		final AddQtyPickedRequest request = baseRequestBuilder(qtyWithCatch).build();
+
+		assertThat(bl.tryMergeQtyPickedIntoExistingForVHU(request)).isFalse();
+	}
+
+	@Test
+	void rejects_when_qty_is_zero()
+	{
+		final AddQtyPickedRequest request = baseRequestBuilder(positiveStockQty(BigDecimal.ZERO)).build();
+
+		assertThat(bl.tryMergeQtyPickedIntoExistingForVHU(request)).isFalse();
+	}
+
+	@Test
+	void rejects_when_qty_is_negative()
+	{
+		// Un-allocation (negative trx-line qty) must remain its own audit row so the netting is visible.
+		final AddQtyPickedRequest request = baseRequestBuilder(positiveStockQty(new BigDecimal("-2"))).build();
+
+		assertThat(bl.tryMergeQtyPickedIntoExistingForVHU(request)).isFalse();
+	}
+
+	private AddQtyPickedRequest.AddQtyPickedRequestBuilder baseRequestBuilder(final StockQtyAndUOMQty qty)
+	{
+		return AddQtyPickedRequest.builder()
+				.scheduleId(ShipmentScheduleAndJobScheduleId.ofShipmentScheduleId(
+						ShipmentScheduleId.ofRepoId(schedule.getM_ShipmentSchedule_ID())))
+				.cachedShipmentSchedule(schedule)
+				.qtyPicked(qty)
+				.hu(vhu)
+				.huContext(huContext)
+				.anonymousHuPickedOnTheFly(false);
+	}
+
+	private StockQtyAndUOMQty positiveStockQty(final BigDecimal amount)
+	{
+		return StockQtyAndUOMQty.builder()
+				.productId(ProductId.ofRepoId(schedule.getM_Product_ID()))
+				.stockQty(Quantity.of(amount, uom))
+				.build();
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL_tryMergeQtyPickedIntoExistingForVHU_Test.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL_tryMergeQtyPickedIntoExistingForVHU_Test.java
@@ -138,6 +138,20 @@ class HUShipmentScheduleBL_tryMergeQtyPickedIntoExistingForVHU_Test
 		assertThat(bl.tryMergeQtyPickedIntoExistingForVHU(request)).isFalse();
 	}
 
+	@Test
+	void rejects_when_hu_is_not_virtual()
+	{
+		// Give the HU a non-virtual PI version (any id but the virtual 101); isVirtual(vhu) is then false.
+		// With a clean positive, non-catch-weight, non-anonymous, no-job-schedule request, all earlier
+		// guards pass and the non-virtual guard is the one that returns false (a non-VHU pick is never
+		// listener-shaped).
+		vhu.setM_HU_PI_Version_ID(500);
+		InterfaceWrapperHelper.saveRecord(vhu);
+		final AddQtyPickedRequest request = baseRequestBuilder(positiveStockQty(BigDecimal.TEN)).build();
+
+		assertThat(bl.tryMergeQtyPickedIntoExistingForVHU(request)).isFalse();
+	}
+
 	private AddQtyPickedRequest.AddQtyPickedRequestBuilder baseRequestBuilder(final StockQtyAndUOMQty qty)
 	{
 		return AddQtyPickedRequest.builder()

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL_tryMergeQtyPickedIntoExistingForVHU_Test.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL_tryMergeQtyPickedIntoExistingForVHU_Test.java
@@ -51,8 +51,9 @@ import static org.mockito.Mockito.mock;
  * non-listener-shaped picks to fall through to {@code addQtyPickedAndUpdateHU}. This test
  * locks each one in so we don't accidentally widen the merge scope in a future refactor.</p>
  *
- * <p>Happy-path coverage (qty actually summed into an existing row) requires HU machinery
- * and is exercised by the cucumber {@code reversedShipment.feature} scenario.</p>
+ * <p>Happy-path coverage (qty actually summed into an existing row) is in
+ * {@link HUShipmentScheduleBL_mergeQtyPickedHappyPath_Test} and the mobile-webui Playwright spec
+ * {@code recreate_shipment_after_void.spec.js}.</p>
  */
 class HUShipmentScheduleBL_tryMergeQtyPickedIntoExistingForVHU_Test
 {

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO_retrieveMergeableListenerQtyPickedForVHU_Test.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO_retrieveMergeableListenerQtyPickedForVHU_Test.java
@@ -1,0 +1,151 @@
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2015 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package de.metas.handlingunits.shipmentschedule.api.impl;
+
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.model.I_M_ShipmentSchedule_QtyPicked;
+import de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleDAO;
+import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.util.Services;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link IHUShipmentScheduleDAO#retrieveMergeableListenerQtyPickedForVHU(ShipmentScheduleId, HuId)}.
+ *
+ * <p>Pinpoint the predicate filters that scope the merge to listener-shaped picks (no job schedule,
+ * not anonymous-on-the-fly, un-shipped, active).</p>
+ */
+class HUShipmentScheduleDAO_retrieveMergeableListenerQtyPickedForVHU_Test
+{
+	private static final int VHU_ID_1 = 1_111_111;
+	private static final int VHU_ID_2 = 2_222_222;
+	private static final int OTHER_INOUT_LINE_ID = 9_999;
+	private static final int OTHER_PICKING_JOB_SCHEDULE_ID = 8_888;
+
+	private IHUShipmentScheduleDAO dao;
+
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+		dao = Services.get(IHUShipmentScheduleDAO.class);
+	}
+
+	@Test
+	void empty_when_no_rows_for_schedule_and_vhu()
+	{
+		final ShipmentScheduleId scheduleId = createSchedule();
+		final HuId vhuId = HuId.ofRepoId(VHU_ID_1);
+
+		assertThat(dao.retrieveMergeableListenerQtyPickedForVHU(scheduleId, vhuId)).isEmpty();
+	}
+
+	@Test
+	void returns_only_active_unshipped_listener_rows_for_the_given_schedule_and_vhu()
+	{
+		final ShipmentScheduleId schedule = createSchedule();
+		final ShipmentScheduleId otherSchedule = createSchedule();
+		final HuId vhuId = HuId.ofRepoId(VHU_ID_1);
+		final HuId otherVhuId = HuId.ofRepoId(VHU_ID_2);
+
+		// Eligible listener row — should be returned.
+		final I_M_ShipmentSchedule_QtyPicked eligibleRow = newRow(schedule, VHU_ID_1, b -> {});
+
+		// Same VHU + schedule but bound to a shipment line → already shipped, not mergeable.
+		newRow(schedule, VHU_ID_1, b -> b.setM_InOutLine_ID(OTHER_INOUT_LINE_ID));
+
+		// Same VHU + schedule but inactive → not mergeable.
+		newRow(schedule, VHU_ID_1, b -> b.setIsActive(false));
+
+		// Same VHU + schedule but tied to a picking-job schedule → genuine mobile pick, not listener-shaped.
+		newRow(schedule, VHU_ID_1, b -> b.setM_Picking_Job_Schedule_ID(OTHER_PICKING_JOB_SCHEDULE_ID));
+
+		// Same VHU + schedule but flagged anonymous-on-the-fly → on-the-fly path, not listener-shaped.
+		newRow(schedule, VHU_ID_1, b -> b.setIsAnonymousHuPickedOnTheFly(true));
+
+		// Different schedule — not for our pair.
+		newRow(otherSchedule, VHU_ID_1, b -> {});
+
+		// Different VHU — not for our pair.
+		newRow(schedule, VHU_ID_2, b -> {});
+
+		final List<I_M_ShipmentSchedule_QtyPicked> result =
+				dao.retrieveMergeableListenerQtyPickedForVHU(schedule, vhuId);
+
+		assertThat(result).extracting(I_M_ShipmentSchedule_QtyPicked::getM_ShipmentSchedule_QtyPicked_ID)
+				.containsExactly(eligibleRow.getM_ShipmentSchedule_QtyPicked_ID());
+
+		// Sanity-check: the second VHU truly has its own row in the DB (so the filter, not absence, excludes it).
+		assertThat(dao.retrieveMergeableListenerQtyPickedForVHU(schedule, otherVhuId)).hasSize(1);
+	}
+
+	@Test
+	void returns_multiple_when_multiple_listener_rows_exist_for_same_pair()
+	{
+		// This is the pre-existing-duplicates case: the BL method will then *not* auto-merge
+		// (it logs a warning and falls through). The DAO honestly reports both.
+		final ShipmentScheduleId schedule = createSchedule();
+		final HuId vhuId = HuId.ofRepoId(VHU_ID_1);
+
+		newRow(schedule, VHU_ID_1, b -> {});
+		newRow(schedule, VHU_ID_1, b -> {});
+
+		assertThat(dao.retrieveMergeableListenerQtyPickedForVHU(schedule, vhuId)).hasSize(2);
+	}
+
+	private ShipmentScheduleId createSchedule()
+	{
+		final I_M_ShipmentSchedule sched = InterfaceWrapperHelper.newInstance(I_M_ShipmentSchedule.class);
+		InterfaceWrapperHelper.saveRecord(sched);
+		return ShipmentScheduleId.ofRepoId(sched.getM_ShipmentSchedule_ID());
+	}
+
+	@FunctionalInterface
+	private interface RowCustomizer
+	{
+		void apply(I_M_ShipmentSchedule_QtyPicked row);
+	}
+
+	private I_M_ShipmentSchedule_QtyPicked newRow(
+			final ShipmentScheduleId scheduleId,
+			final int vhuId,
+			final RowCustomizer customizer)
+	{
+		final I_M_ShipmentSchedule_QtyPicked row = InterfaceWrapperHelper.newInstance(I_M_ShipmentSchedule_QtyPicked.class);
+		row.setM_ShipmentSchedule_ID(scheduleId.getRepoId());
+		row.setVHU_ID(vhuId);
+		row.setIsActive(true);
+		// All other relevant filter columns default to NULL/false in the in-memory DB,
+		// which matches the "eligible listener row" baseline.
+		customizer.apply(row);
+		InterfaceWrapperHelper.saveRecord(row);
+		return row;
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/integrationtest/AggregateShipmentReverseReship_IntegrationTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/integrationtest/AggregateShipmentReverseReship_IntegrationTest.java
@@ -1,0 +1,192 @@
+package de.metas.handlingunits.shipmentschedule.integrationtest;
+
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.document.engine.IDocument;
+import de.metas.document.engine.IDocumentBL;
+import de.metas.document.engine.impl.PlainDocumentBL;
+import de.metas.handlingunits.model.I_M_ShipmentSchedule_QtyPicked;
+import de.metas.util.Services;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.IQueryOrderBy.Direction;
+import org.adempiere.ad.dao.IQueryOrderBy.Nulls;
+import org.compiere.model.I_M_InOut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Aggregate-HU shipment: ship the whole aggregate VHU, then reverse the M_InOut and re-generate the shipment.
+ *
+ * <p>Goal: characterise the {@code M_ShipmentSchedule_QtyPicked} rows that survive a shipment-reversal cycle for
+ * a shipment whose allocation is an aggregate VHU (one {@code M_HU} representing N transport units). When the
+ * aggregate HU's snapshot is replayed during reversal, multiple HU-trx lines route through the same VHU; without
+ * the consolidation in {@code ShipmentScheduleHUTrxListener#trxLineProcessed} that produces several identical
+ * QtyPicked rows on the same (schedule, VHU) which later collide on the partial unique index when the next
+ * shipment is generated.
+ *
+ * <p>The harness builds + ships a real aggregate HU in-memory (inherited from
+ * {@link HUShipmentProcess_2LU_1ShipTrans_1InOut_IntegrationTest}); this test then completes the shipment, drives
+ * the document engine reverse, re-generates, and dumps + asserts the QtyPicked rows per (schedule, VHU).
+ *
+ * <p>NOTE on scope: the in-memory POJO document engine ({@link PlainDocumentBL}) fires the registered
+ * {@code @DocValidate} model interceptors for reverse, but does NOT execute the legacy {@code MInOut.reverseCorrectIt()}
+ * body that restores the HU snapshot and replays the per-TU HU-trx lines. The full per-TU trx replay (the trigger
+ * that emits N identical rows) is therefore only reproducible on the real Postgres + document stack. This test
+ * proves the structural invariant the fix enforces on the in-memory reverse and dumps the resulting rows for
+ * inspection; it is honest about what the in-memory reverse does and does not replay (see the assertions and the
+ * dumped row counts).
+ */
+public class AggregateShipmentReverseReship_IntegrationTest
+		extends HUShipmentProcess_2LU_1ShipTrans_1InOut_IntegrationTest
+{
+	private static final Logger logger = LoggerFactory.getLogger(AggregateShipmentReverseReship_IntegrationTest.class);
+
+	private PlainDocumentBL docActionBL;
+
+	@Override
+	protected void initialize()
+	{
+		super.initialize();
+
+		// Configure and register a POJO-decoupled document engine so we can drive complete/reverse on the M_InOut.
+		this.docActionBL = new PlainDocumentBL();
+		PlainDocumentBL.isDocumentTableResponse = true;
+		this.docActionBL.setDefaultProcessInterceptor(PlainDocumentBL.PROCESSINTERCEPTOR_CompleteDirectly);
+		Services.registerService(IDocumentBL.class, docActionBL);
+	}
+
+	@Override
+	protected void step50_GenerateShipment()
+	{
+		// Build + ship the aggregate HU exactly as the parent does (also runs the parent's validations).
+		super.step50_GenerateShipment();
+
+		assertThat(generatedShipments).as("expected exactly one generated shipment").hasSize(1);
+		final I_M_InOut shipment = generatedShipments.get(0);
+
+		//
+		// Snapshot the QtyPicked rows immediately after the first (aggregate) shipment.
+		dumpQtyPicked("AFTER FIRST AGGREGATE SHIPMENT");
+
+		//
+		// Complete the shipment so that it can be reversed (snapshot is taken at completion on the real stack).
+		docActionBL.processEx(shipment, IDocument.ACTION_Complete, IDocument.STATUS_Completed);
+		dumpQtyPicked("AFTER SHIPMENT COMPLETE");
+
+		//
+		// Reverse the shipment. This fires the M_InOut @DocValidate(AFTER_REVERSECORRECT) interceptors (HU assignment
+		// removal + picking-job reopen). On the real stack the HU snapshot is also restored, replaying one HU-trx line
+		// per aggregated TU through the single aggregate VHU.
+		docActionBL.processEx(shipment, IDocument.ACTION_Reverse_Correct, IDocument.STATUS_Reversed);
+		dumpQtyPicked("AFTER SHIPMENT REVERSE");
+
+		//
+		// Assert the invariant the fix enforces, expressed exactly as the customer's partial unique index
+		// (M_ShipmentSchedule_QtyPicked_UI on vhu_id, m_tu_hu_id, m_lu_hu_id, qtylu, qtytu, qtypicked, m_inoutline_id):
+		// no two ACTIVE rows may share that full tuple. Without the listener-merge, an aggregate-HU snapshot replay
+		// emits several rows that are identical on this tuple -> they would collide on the index on the next shipment.
+		// (A +qty / -qty pair on the same VHU is NOT a collision: qtypicked is part of the index key, so they are
+		// distinct index entries; only genuinely identical rows collide.)
+		assertNoIndexCollidingQtyPicked();
+	}
+
+	private void assertNoIndexCollidingQtyPicked()
+	{
+		final List<I_M_ShipmentSchedule_QtyPicked> rows = queryAllQtyPicked();
+
+		final Map<String, Integer> countByIndexKey = new LinkedHashMap<>();
+		for (final I_M_ShipmentSchedule_QtyPicked row : rows)
+		{
+			if (!row.isActive())
+			{
+				continue;
+			}
+
+			// the full unique-index tuple (plus the schedule, which scopes the rows)
+			final String key = "sched=" + row.getM_ShipmentSchedule_ID()
+					+ ",vhu=" + row.getVHU_ID()
+					+ ",tu=" + row.getM_TU_HU_ID()
+					+ ",lu=" + row.getM_LU_HU_ID()
+					+ ",qtyLU=" + row.getQtyLU().stripTrailingZeros().toPlainString()
+					+ ",qtyTU=" + row.getQtyTU().stripTrailingZeros().toPlainString()
+					+ ",qtyPicked=" + row.getQtyPicked().stripTrailingZeros().toPlainString()
+					+ ",iol=" + row.getM_InOutLine_ID();
+			countByIndexKey.merge(key, 1, Integer::sum);
+		}
+
+		logger.info("Active QtyPicked count per unique-index tuple: {}", countByIndexKey);
+
+		for (final Map.Entry<String, Integer> e : countByIndexKey.entrySet())
+		{
+			assertThat(e.getValue())
+					.as("expected at most ONE active QtyPicked row per unique-index tuple for " + e.getKey()
+							+ " but found " + e.getValue() + " (identical rows collide on M_ShipmentSchedule_QtyPicked_UI on the next shipment)")
+					.isLessThanOrEqualTo(1);
+		}
+	}
+
+	private List<I_M_ShipmentSchedule_QtyPicked> queryAllQtyPicked()
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_M_ShipmentSchedule_QtyPicked.class)
+				.create()
+				.list(I_M_ShipmentSchedule_QtyPicked.class);
+	}
+
+	private void dumpQtyPicked(final String phase)
+	{
+		final List<I_M_ShipmentSchedule_QtyPicked> rows = Services.get(IQueryBL.class)
+				.createQueryBuilder(I_M_ShipmentSchedule_QtyPicked.class)
+				.orderBy().addColumn(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_ShipmentSchedule_QtyPicked_ID, Direction.Ascending, Nulls.Last).endOrderBy()
+				.create()
+				.list(I_M_ShipmentSchedule_QtyPicked.class);
+
+		final StringBuilder sb = new StringBuilder();
+		sb.append("\n========== M_ShipmentSchedule_QtyPicked dump [").append(phase).append("] (").append(rows.size()).append(" rows) ==========");
+		sb.append("\n id | sched | vhu | tu | lu | qtyTU | qtyPicked | iol | active");
+		for (final I_M_ShipmentSchedule_QtyPicked row : rows)
+		{
+			sb.append(String.format(
+					"%n %-7d | %-6d | %-7d | %-7d | %-7d | %-5s | %-9s | %-7d | %s",
+					row.getM_ShipmentSchedule_QtyPicked_ID(),
+					row.getM_ShipmentSchedule_ID(),
+					row.getVHU_ID(),
+					row.getM_TU_HU_ID(),
+					row.getM_LU_HU_ID(),
+					row.getQtyTU(),
+					row.getQtyPicked(),
+					row.getM_InOutLine_ID(),
+					row.isActive()));
+		}
+		sb.append("\n=========================================================================================");
+		logger.info(sb.toString());
+		// also to stdout so the evidence is visible in the surefire console output
+		System.out.println(sb);
+	}
+}

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 5 | 8 | 63% |
-| Picking | 54 | 57 | 95% |
+| Picking | 55 | 58 | 95% |
 | Distribution | 27 | 30 | 90% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
@@ -165,8 +165,9 @@
 | Single sales order split and picked to multiple workplaces | `picking/pick_what_was_scheduled_to_workplace.spec.js` |
 | DO_NOT_CREATE: fully-picked order on a draft shipment must NOT reappear in the picking launcher | `picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js` |
 | DO_NOT_CREATE: order with a PARTIAL draft shipment (qty still open) must STAY in the picking list | `picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js` |
+| Reverse (void) an aggregate-HU shipment → recreate must not collide on duplicate QtyPicked rows | `picking/recreate_shipment_after_void.spec.js` |
 
-**7/7 — 100%**
+**8/8 — 100%**
 
 ### Product-based picking
 

--- a/e2e/mobile-webui/tests/spec/picking/recreate_shipment_after_void.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/recreate_shipment_after_void.spec.js
@@ -1,0 +1,109 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+
+// Regression guard for the "can't recreate shipment after void" defect on aggregate-HU shipments.
+//
+// When a shipment whose allocation is an aggregate VHU (one M_HU representing N transport units) is
+// reversed, the HU-snapshot replay re-creates the picked qty one transport unit at a time. Without
+// consolidation, that leaves N identical, not-yet-shipped M_ShipmentSchedule_QtyPicked rows on the
+// SAME (VHU, TU, LU, QtyLU, QtyTU, QtyPicked) tuple; when the shipment is recreated they all take one
+// M_InOutLine_ID and collide on the partial unique index M_ShipmentSchedule_QtyPicked_UI — so the
+// shipment can no longer be recreated. The fix consolidates the replay into the single existing row.
+//
+// This drives the full stack: mobile-pick the whole aggregate, generate a completed shipment from the
+// picked qty, reverse it (document-engine Reverse-Correct = the "void"), and assert the reverse left
+// exactly ONE active un-shipped QtyPicked row per unique-index tuple (so recreation cannot collide).
+// createShipmentPolicy:'NO' keeps the mobile pick from auto-shipping; the shipment is generated via the
+// testing API so its M_InOut_ID is known and can be reversed.
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: 'sales_order',
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'NO',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                }
+            },
+            bpartners: { 'BP1': {} },
+            warehouses: { 'wh': {} },
+            pickingSlots: { slot1: {} },
+            products: { 'P1': { prices: [{ price: 1 }] } },
+            packingInstructions: {
+                'PI': { lu: 'LU', qtyTUsPerLU: 20, tu: 'TU', product: 'P1', qtyCUsPerTU: 1 },
+            },
+            handlingUnits: {
+                'HU1': { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
+            },
+            salesOrders: {
+                'SO1': {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 6, piItemProduct: 'TU' }]
+                }
+            },
+        }
+    });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('Reverse an aggregate-HU shipment then recreate it — no duplicate QtyPicked collision', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.story('Recreate shipment after void of an aggregate-HU shipment');
+    allure.severity('blocker');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+
+    await test.step('Pick the whole aggregate HU (6 TU) and complete', async () => {
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '6' });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '6 TU', qtyPicked: '6 TU', qtyPickedCatchWeight: '' });
+        await PickingJobScreen.closeTargetLU();
+        await PickingJobScreen.complete();
+    });
+
+    let shipmentId;
+    await test.step('Generate a COMPLETED shipment from the picked qty', async () => {
+        const ship = await Backend.createMasterdata({
+            request: { shipments: { FIRST_SHIPMENT: { salesOrder: 'SO1', quantityType: 'P', complete: true } } },
+        });
+        shipmentId = ship?.shipments?.FIRST_SHIPMENT?.id;
+        if (!shipmentId) {
+            throw new Error('Initial shipment was not created:\n' + JSON.stringify(ship, null, 2));
+        }
+    });
+
+    await test.step('Reverse the completed shipment (the "void") — must not leave duplicate QtyPicked rows', async () => {
+        const reversed = await Backend.reverseShipment({ shipmentId });
+        if (reversed?.docStatus !== 'RE') {
+            throw new Error('Shipment was not reversed (expected docStatus RE):\n' + JSON.stringify(reversed, null, 2));
+        }
+
+        // GREEN (fix): exactly 1 active un-shipped row survives per tuple, so recreation cannot collide.
+        // RED  (no fix): N identical rows survive (here 6) -> guaranteed unique-index collision on recreate.
+        const dup = reversed.maxIdenticalUnshippedQtyPickedRowsPerVhuTuple;
+        if (dup !== 1) {
+            throw new Error(`Expected the reverse to leave exactly ONE active un-shipped QtyPicked row per unique-index tuple, but found ${dup} identical rows — they collide on M_ShipmentSchedule_QtyPicked_UI when the shipment is recreated. Full response:\n` + JSON.stringify(reversed, null, 2));
+        }
+    });
+});

--- a/e2e/mobile-webui/tests/spec/picking/recreate_shipment_after_void.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/recreate_shipment_after_void.spec.js
@@ -1,4 +1,5 @@
 import { test } from "../../../playwright.config";
+import { expect } from '@playwright/test';
 import { allure } from 'allure-playwright';
 import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
 import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
@@ -95,15 +96,11 @@ test('Reverse an aggregate-HU shipment then recreate it — no duplicate QtyPick
 
     await test.step('Reverse the completed shipment (the "void") — must not leave duplicate QtyPicked rows', async () => {
         const reversed = await Backend.reverseShipment({ shipmentId });
-        if (reversed?.docStatus !== 'RE') {
-            throw new Error('Shipment was not reversed (expected docStatus RE):\n' + JSON.stringify(reversed, null, 2));
-        }
+        expect(reversed?.docStatus, 'Shipment was not reversed (expected docStatus RE):\n' + JSON.stringify(reversed, null, 2)).toBe('RE');
 
         // GREEN (fix): exactly 1 active un-shipped row survives per tuple, so recreation cannot collide.
         // RED  (no fix): N identical rows survive (here 6) -> guaranteed unique-index collision on recreate.
         const dup = reversed.maxIdenticalUnshippedQtyPickedRowsPerVhuTuple;
-        if (dup !== 1) {
-            throw new Error(`Expected the reverse to leave exactly ONE active un-shipped QtyPicked row per unique-index tuple, but found ${dup} identical rows — they collide on M_ShipmentSchedule_QtyPicked_UI when the shipment is recreated. Full response:\n` + JSON.stringify(reversed, null, 2));
-        }
+        expect(dup, `Expected the reverse to leave exactly ONE active un-shipped QtyPicked row per unique-index tuple, but found ${dup} identical rows — they collide on M_ShipmentSchedule_QtyPicked_UI when the shipment is recreated. Full response:\n` + JSON.stringify(reversed, null, 2)).toBe(1);
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/recreate_shipment_after_void.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/recreate_shipment_after_void.spec.js
@@ -89,9 +89,7 @@ test('Reverse an aggregate-HU shipment then recreate it — no duplicate QtyPick
             request: { shipments: { FIRST_SHIPMENT: { salesOrder: 'SO1', quantityType: 'P', complete: true } } },
         });
         shipmentId = ship?.shipments?.FIRST_SHIPMENT?.id;
-        if (!shipmentId) {
-            throw new Error('Initial shipment was not created:\n' + JSON.stringify(ship, null, 2));
-        }
+        expect(shipmentId, 'Initial shipment was not created:\n' + JSON.stringify(ship, null, 2)).toBeTruthy();
     });
 
     await test.step('Reverse the completed shipment (the "void") — must not leave duplicate QtyPicked rows', async () => {

--- a/e2e/mobile-webui/tests/utils/screens/Backend.js
+++ b/e2e/mobile-webui/tests/utils/screens/Backend.js
@@ -133,6 +133,30 @@ export const Backend = {
         return { shipmentId: shipment.id, documentNo: shipment.documentNo };
     }),
 
+    /**
+     * Reverse (document-engine Reverse-Correct) a previously-created, completed shipment — the
+     * faithful equivalent of the customer's "void shipment". Restores the HU snapshot taken at
+     * completion and replays the per-transport-unit HU-trx lines through the aggregate VHU.
+     *
+     * @param {Object} args
+     * @param {string} args.shipmentId - the M_InOut_ID returned by a prior shipment-create call.
+     * @returns {Promise<{id: string, documentNo: string, docStatus: string}>}
+     */
+    reverseShipment: async ({ shipmentId }) => await test.step(`Backend: reverse shipment ${shipmentId}`, async () => {
+        const backendBaseUrl = await getBackendBaseUrl();
+        const response = await page.request.post(`${backendBaseUrl}/frontendTesting/reverseShipment`, {
+            data: { shipmentId: String(shipmentId) },
+            headers: {
+                'Content-Type': 'application/json',
+            }
+        });
+
+        const responseBody = await response.json();
+        assertNoErrors({ responseBody });
+
+        return responseBody;
+    }),
+
     getWFProcess: async ({ wfProcessId }) => {
         const backendBaseUrl = await getBackendBaseUrl();
         const response = await page.request.get(`${backendBaseUrl}/userWorkflows/wfProcess/${wfProcessId}`, {


### PR DESCRIPTION
## Problem

Reversing a shipment whose allocation is an **aggregate VHU** (one `M_HU` representing N transport units) leaves the shipment schedule with **N identical, not-yet-shipped `M_ShipmentSchedule_QtyPicked` rows** on the same `(VHU, TU, LU, QtyLU, QtyTU, QtyPicked)` tuple.

On reverse, the picked qty is re-created one transport unit at a time via the picking-job reopen:
`M_InOut` `AFTER_REVERSECORRECT` → `reopenPickingJobs` → `PickingJobReopenCommand`. When the shipment is then **recreated**, those rows all take one `M_InOutLine_ID` and collide on the partial unique index `M_ShipmentSchedule_QtyPicked_UI` — so the shipment can no longer be recreated after a void.

## Fix

- `PickingJobReopenCommand` now routes its per-TU re-creation through `tryMergeQtyPickedIntoExistingForVHU` (exposed via `PickingJobShipmentScheduleService`), consolidating the replay into the single existing un-shipped row for the VHU and restoring the pre-reversal one-row shape.
- The same merge is kept in `ShipmentScheduleHUTrxListener` for paths that go through the HU-trx listener.
- The merge's lookup query now runs in the **thread-inherited transaction** so it can see the sibling rows created earlier in the same reopen/replay (it previously ran out-of-transaction and could never find them).
- The merge is **self-gated**: a no-op for job-schedule-bound, catch-weight, negative, anonymous-on-the-fly or non-virtual picks — genuine per-step mobile picks are unaffected.

## Tests

- Unit tests for the merge predicate, the DAO lookup query, and the happy-path merge.
- A `reverseShipment` op in `de.metas.frontend-testing` plus a mobile-webui Playwright spec (`recreate_shipment_after_void.spec.js`) that picks an aggregate HU, generates a completed shipment, reverses it, and asserts the reverse leaves exactly **one** un-shipped `QtyPicked` row per unique-index tuple.

Verified end-to-end on a local stack: without the fix the reverse leaves 6 colliding rows (recreate fails); with the fix it leaves 1 (recreate succeeds).
