### PR TITLE
gh29437: mobileUI picking — exclude orders with nothing left to pick (QtyToDeliver<=0)

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobQuery.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobQuery.java
@@ -110,7 +110,7 @@ public class PickingJobQuery
 				.includeNotLocked(true)
 				.excludeLockedForProcessing(true)
 				.excludeShipmentScheduleIds(excludeScheduleIds.getShipmentScheduleIdsWithoutJobSchedules())
-				.excludeFullyOnDraftShipment(true)
+				.excludeNothingToPick(true)
 				.scannedProductCodes(this.getScannedProductCodes())
 				.maximumFixedPreparationDate(currentTime)
 				.orderBys(ImmutableSet.of(

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/api/PackageableQuery.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/api/PackageableQuery.java
@@ -84,11 +84,11 @@ public class PackageableQuery
 	@Builder.Default boolean excludeLockedForProcessing = false; // false by default to be backward-compatibile
 
 	/**
-	 * Excludes records whose whole remaining quantity is already bound to a (draft) shipment, i.e.
-	 * {@code QtyToDeliver <= 0} AND there is at least one not-yet-processed picked qty linked to a shipment line
-	 * ({@code M_Packageable_V.IsPickQtyOnDraftShipment = 'Y'}). Such records have nothing left to pick.
+	 * Excludes records that have nothing left to pick, i.e. {@code QtyToDeliver <= 0} (the qty is already
+	 * fully picked - completed, shipped, or bound to a draft shipment - so there is nothing for the picker
+	 * to do). Records with {@code QtyToDeliver > 0} are kept.
 	 */
-	@Builder.Default boolean excludeFullyOnDraftShipment = false; // false by default to be backward-compatible
+	@Builder.Default boolean excludeNothingToPick = false; // false by default to be backward-compatible
 
 	@Nullable Set<ShipmentScheduleId> onlyShipmentScheduleIds;
 	@Nullable Set<ShipmentScheduleId> excludeShipmentScheduleIds;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/api/impl/PackagingDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/api/impl/PackagingDAO.java
@@ -230,14 +230,11 @@ public class PackagingDAO implements IPackagingDAO
 		}
 
 		//
-		// Exclude schedules fully covered by a draft shipment (QtyToDeliver<=0 AND IsPickQtyOnDraftShipment='Y').
-		if (query.isExcludeFullyOnDraftShipment())
+		// Exclude schedules that have nothing left to pick (QtyToDeliver<=0): the qty is already fully
+		// picked (completed/shipped/on a draft shipment), so there is nothing for the picker to do.
+		if (query.isExcludeNothingToPick())
 		{
-			queryBuilder.addFilter(queryBL.createCompositeQueryFilter(I_M_Packageable_V.class)
-					.setJoinOr()
-					.addCompareFilter(I_M_Packageable_V.COLUMNNAME_QtyToDeliver, CompareQueryFilter.Operator.GREATER, BigDecimal.ZERO)
-					.addEqualsFilter(I_M_Packageable_V.COLUMNNAME_IsPickQtyOnDraftShipment, false)
-			);
+			queryBuilder.addCompareFilter(I_M_Packageable_V.COLUMNNAME_QtyToDeliver, CompareQueryFilter.Operator.GREATER, BigDecimal.ZERO);
 		}
 
 		// Filter: Handover Location

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/api/impl/PackagingDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/api/impl/PackagingDAO.java
@@ -230,8 +230,7 @@ public class PackagingDAO implements IPackagingDAO
 		}
 
 		//
-		// Exclude schedules that have nothing left to pick (QtyToDeliver<=0): the qty is already fully
-		// picked (completed/shipped/on a draft shipment), so there is nothing for the picker to do.
+		// Nothing left to pick: keep only QtyToDeliver > 0 (it is already net of picked/shipped/on-draft qty).
 		if (query.isExcludeNothingToPick())
 		{
 			queryBuilder.addCompareFilter(I_M_Packageable_V.COLUMNNAME_QtyToDeliver, CompareQueryFilter.Operator.GREATER, BigDecimal.ZERO);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5806850_sys_gh29437_M_Packageable_v_drop_IsPickQtyOnDraftShipment.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5806850_sys_gh29437_M_Packageable_v_drop_IsPickQtyOnDraftShipment.sql
@@ -1,24 +1,8 @@
-/*
- * #%L
- * de.metas.handlingunits.base
- * %%
- * Copyright (C) 2026 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
+-- Source DDL: backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/de_metas_inoutcandidate/M_Packageable_v.sql
+-- gh29437: recreate m_packageable_v WITHOUT the IsPickQtyOnDraftShipment column.
+-- The picking-launcher exclusion is now QtyToDeliver>0 (PackagingDAO/PackageableQuery.excludeNothingToPick),
+-- so the view-level draft-shipment flag is no longer read by anyone. The admission branch
+-- (s.QtyToDeliver > 0 OR s.qtypicklist > 0) is intentionally UNCHANGED (ship-again, 25383).
 
 DROP VIEW IF EXISTS m_packageable_v$new
 ;
@@ -195,4 +179,3 @@ SELECT db_alter_view(
 
 DROP VIEW IF EXISTS m_packageable_v$new
 ;
-

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5806860_sys_gh29437_drop_IsPickQtyOnDraftShipment_AD.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5806860_sys_gh29437_drop_IsPickQtyOnDraftShipment_AD.sql
@@ -1,0 +1,17 @@
+-- gh29437: remove the AD metadata for the now-dropped backend-only filter column
+-- M_Packageable_V.IsPickQtyOnDraftShipment (added by 5805870_sys_gh29437_..._DML.sql).
+-- The physical view column is removed in 5806850_sys_gh29437_M_Packageable_v_drop_IsPickQtyOnDraftShipment.sql.
+-- No AD_Field / AD_UI_Element / AD_Element_Link ever referenced this column (backend filter only),
+-- so the delete is limited to AD_Column(+_Trl) and AD_Element(+_Trl).
+--   AD_Column  592700  M_Packageable_V.IsPickQtyOnDraftShipment
+--   AD_Element 584934  IsPickQtyOnDraftShipment
+
+-- FK-safe order: _Trl children first, then AD_Column (FK to AD_Element), then AD_Element(+_Trl).
+DELETE FROM AD_Column_Trl WHERE AD_Column_ID=592700
+;
+DELETE FROM AD_Column WHERE AD_Column_ID=592700
+;
+DELETE FROM AD_Element_Trl WHERE AD_Element_ID=584934
+;
+DELETE FROM AD_Element WHERE AD_Element_ID=584934
+;

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 5 | 8 | 63% |
-| Picking | 54 | 57 | 95% |
+| Picking | 55 | 58 | 95% |
 | Distribution | 27 | 30 | 90% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
@@ -163,10 +163,11 @@
 | No suggestions configured → no suggested picking slots shown | `picking/pickingSlotSuggestions.spec.js` |
 | Configured picking slot suggestions → shown and selectable | `picking/pickingSlotSuggestions.spec.js` |
 | Single sales order split and picked to multiple workplaces | `picking/pick_what_was_scheduled_to_workplace.spec.js` |
-| DO_NOT_CREATE: fully-picked order on a draft shipment must NOT reappear in the picking launcher | `picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js` |
-| DO_NOT_CREATE: order with a PARTIAL draft shipment (qty still open) must STAY in the picking list | `picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js` |
+| DO_NOT_CREATE: fully-picked order completed with no shipment → must NOT appear in the picking launcher | `picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js` |
+| DO_NOT_CREATE: partially-picked order (qty still open) → must STAY in the picking launcher | `picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js` |
+| DO_NOT_CREATE: picked qty fully bound to a draft shipment → must NOT appear in the picking launcher | `picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js` |
 
-**7/7 — 100%**
+**8/8 — 100%**
 
 ### Product-based picking
 

--- a/e2e/mobile-webui/tests/spec/picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js
@@ -8,15 +8,18 @@ import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
 import { QTY_NOT_FOUND_REASON_NOT_FOUND } from "../../utils/screens/picking/GetQuantityDialog";
 
 /**
- * With picking profile "Don't create shipment" (DO_NOT_CREATE), a fully-picked order whose
- * picked qty is bound to a DRAFT shipment must NOT appear in the mobileUI picking launcher:
- * there is nothing left to pick. It re-appears only if the shipment is reversed (the picked
- * qty becomes unbound again and the order genuinely has to be picked once more).
+ * Picking profile "Don't create shipment" (DO_NOT_CREATE): once a sales order has nothing left to
+ * pick it must NOT appear in the mobileUI picking launcher — there is nothing for the picker to do.
+ * "Nothing left to pick" means QtyToDeliver <= 0, regardless of whether a shipment was ever created.
  *
- * The fix excludes a schedule from the launcher ONLY when QtyToDeliver <= 0 AND
- * IsPickQtyOnDraftShipment='Y' (fully on draft). The second test below guards the inverse:
- * a PARTIAL draft (some picked qty on a draft line, but order qty still open => QtyToDeliver > 0)
- * must STAY visible, because there is still qty left to pick.
+ * - AC1 (the reported bug, me03 29437): pick FULLY + complete the job + NO shipment => launcher empty.
+ * - AC2: a PARTIALLY-picked order (qty still open, QtyToDeliver > 0) => stays in the launcher.
+ * - AC5: picked qty fully bound to a DRAFT shipment (the previously-merged fix's case) => not listed,
+ *        subsumed by the general "nothing left to pick" rule.
+ *
+ * On the current (merged) code AC1 FAILS (RED): the merged fix only excludes the fully-on-draft case
+ * (QtyToDeliver<=0 AND IsPickQtyOnDraftShipment='Y'); a completed, never-shipped order has
+ * IsPickQtyOnDraftShipment='N' and therefore still shows. AC2 + AC5 already pass on the merged code.
  */
 
 const createMasterdata = async ({ allowCompletingPartialPickingJob = false } = {}) => {
@@ -61,24 +64,25 @@ const createMasterdata = async ({ allowCompletingPartialPickingJob = false } = {
 };
 
 // noinspection JSUnusedLocalSymbols
-test('DO_NOT_CREATE: completed order must NOT re-appear after a draft shipment is created', async ({ page }) => {
+// AC1 — the reported bug. RED on the current merged code (no shipment => IsPickQtyOnDraftShipment='N').
+test('DO_NOT_CREATE: fully-picked completed order with NO shipment must NOT appear in the picking launcher', async ({ page }) => {
     // === ALLURE METADATA ===
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
-    allure.story('DO_NOT_CREATE picking — order must stay gone after draft shipment');
+    allure.story('DO_NOT_CREATE picking — fully-picked completed order leaves the launcher (no shipment)');
     allure.severity('critical');
 
     const masterdata = await createMasterdata();
     const documentNo = masterdata.salesOrders.SO1.documentNo;
 
-    // --- Pick all qty and complete in the mobileUI ---
+    // --- Pick all qty and complete in the mobileUI (mirrors the customer's manual flow exactly). ---
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('picking');
     await PickingJobsListScreen.waitForScreen();
     await PickingJobsListScreen.filterByDocumentNo(documentNo);
-    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo });
+    await PickingJobsListScreen.startJob({ documentNo });
 
     await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
     await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
@@ -89,19 +93,10 @@ test('DO_NOT_CREATE: completed order must NOT re-appear after a draft shipment i
     await PickingJobScreen.complete();
     await PickingJobsListScreen.waitForScreen();
 
-    // After completing (createShipmentPolicy='NO' => no shipment created), the picked qty sits in
-    // M_ShipmentSchedule_QtyPicked rows with M_InOutLine_ID=NULL, Processed='N'. The order is still
-    // legitimately shown in the picking list (it still has to be shipped). We do NOT assert it gone
-    // here — that is normal and unchanged by the fix.
-
-    // --- Create a DRAFT shipment from the shipment schedule (quantityType='P', complete=false).
-    //     This binds M_ShipmentSchedule_QtyPicked.M_InOutLine_ID with Processed='N' — picked qty
-    //     fully assigned to a draft shipment line. ---
-    await Backend.createDraftShipmentForOrder({ orderIdentifier: 'SO1' });
-
-    // --- With all picked qty bound to the draft shipment line, the order has nothing left to pick
-    //     and must NOT be listed in the mobileUI picking launcher. ---
-    await test.step("After the draft shipment, the order must NOT be in the picking list", async () => {
+    // createShipmentPolicy='NO' => completing the job creates NO shipment at all. The order is now
+    // fully picked (QtyToDeliver=0) with nothing left to pick, so it MUST NOT be listed in the
+    // picking launcher — there is nothing for the picker to do.
+    await test.step("After completing the fully-picked job (no shipment), the order must NOT be in the picking list", async () => {
         await PickingJobsListScreen.goBack();
         await ApplicationsListScreen.startApplication('picking');
         await PickingJobsListScreen.waitForScreen();
@@ -111,12 +106,13 @@ test('DO_NOT_CREATE: completed order must NOT re-appear after a draft shipment i
 });
 
 // noinspection JSUnusedLocalSymbols
-test('DO_NOT_CREATE: order with a PARTIAL draft shipment (qty still open) must STAY in the picking list', async ({ page }) => {
+// AC2 — no regression: a partial pick leaves QtyToDeliver > 0, so the order stays in the launcher.
+test('DO_NOT_CREATE: a partially-picked order (qty still open) must STAY in the picking launcher', async ({ page }) => {
     // === ALLURE METADATA ===
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
-    allure.story('DO_NOT_CREATE picking — partial draft shipment keeps the order visible');
+    allure.story('DO_NOT_CREATE picking — partially-picked order stays in the launcher');
     allure.severity('critical');
 
     // allowCompletingPartialPickingJob=true so we can complete after picking a strict subset.
@@ -130,7 +126,7 @@ test('DO_NOT_CREATE: order with a PARTIAL draft shipment (qty still open) must S
     await ApplicationsListScreen.startApplication('picking');
     await PickingJobsListScreen.waitForScreen();
     await PickingJobsListScreen.filterByDocumentNo(documentNo);
-    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo });
+    await PickingJobsListScreen.startJob({ documentNo });
 
     await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
     await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
@@ -148,18 +144,59 @@ test('DO_NOT_CREATE: order with a PARTIAL draft shipment (qty still open) must S
     await PickingJobScreen.complete();
     await PickingJobsListScreen.waitForScreen();
 
-    // --- Create a DRAFT shipment for the picked subset (quantityType='P' ships the 4 PCE picked).
-    //     This binds the picked qty to a draft shipment line (IsPickQtyOnDraftShipment='Y'), but the
-    //     order still has 8 PCE open => QtyToDeliver > 0. This is the PARTIAL-draft case. ---
-    await Backend.createDraftShipmentForOrder({ orderIdentifier: 'SO1' });
-
-    // --- The order still has open qty to pick, so it MUST remain in the picking launcher.
-    //     This is the inverse of the fully-on-draft exclusion guarded by the first test. ---
-    await test.step("After the partial draft shipment, the order must STILL be in the picking list", async () => {
+    // The order still has 8 PCE open => QtyToDeliver > 0 => there is still qty left to pick, so it
+    // MUST remain in the picking launcher.
+    await test.step("The partially-picked order must STILL be in the picking list", async () => {
         await PickingJobsListScreen.goBack();
         await ApplicationsListScreen.startApplication('picking');
         await PickingJobsListScreen.waitForScreen();
         await PickingJobsListScreen.filterByDocumentNo(documentNo);
         await PickingJobsListScreen.expectJobButtons([{ salesOrderId }]);
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+// AC5 — the previously-merged fix's scenario: picked qty fully on a DRAFT shipment. Subsumed by the
+// general "nothing left to pick" rule, so it must also stay out of the launcher (passes on both
+// merged and fixed code — a regression guard, not RED).
+test('DO_NOT_CREATE: order with picked qty fully on a DRAFT shipment must NOT appear in the picking launcher', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('DO_NOT_CREATE picking — fully-on-draft-shipment order leaves the launcher');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+    const documentNo = masterdata.salesOrders.SO1.documentNo;
+
+    // --- Pick all qty and complete in the mobileUI. ---
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(documentNo);
+    await PickingJobsListScreen.startJob({ documentNo });
+
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '0 TU', qtyPickedCatchWeight: '' });
+    await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '3' });
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });
+
+    await PickingJobScreen.complete();
+    await PickingJobsListScreen.waitForScreen();
+
+    // --- Bind all picked qty to a DRAFT shipment line (quantityType='P', complete=false). ---
+    await Backend.createDraftShipmentForOrder({ orderIdentifier: 'SO1' });
+
+    // QtyToDeliver=0 and the picked qty is fully bound to a draft shipment => nothing left to pick =>
+    // the order MUST NOT be listed in the picking launcher.
+    await test.step("With the picked qty fully on a draft shipment, the order must NOT be in the picking list", async () => {
+        await PickingJobsListScreen.goBack();
+        await ApplicationsListScreen.startApplication('picking');
+        await PickingJobsListScreen.waitForScreen();
+        await PickingJobsListScreen.filterByDocumentNo(documentNo);
+        await PickingJobsListScreen.expectJobButtons([]);
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js
@@ -12,7 +12,7 @@ import { QTY_NOT_FOUND_REASON_NOT_FOUND } from "../../utils/screens/picking/GetQ
  * pick it must NOT appear in the mobileUI picking launcher — there is nothing for the picker to do.
  * "Nothing left to pick" means QtyToDeliver <= 0, regardless of whether a shipment was ever created.
  *
- * - AC1 (the reported bug, me03 29437): pick FULLY + complete the job + NO shipment => launcher empty.
+ * - AC1 (the reported bug): pick FULLY + complete the job + NO shipment => launcher empty.
  * - AC2: a PARTIALLY-picked order (qty still open, QtyToDeliver > 0) => stays in the launcher.
  * - AC5: picked qty fully bound to a DRAFT shipment (the previously-merged fix's case) => not listed,
  *        subsumed by the general "nothing left to pick" rule.
@@ -76,7 +76,7 @@ test('DO_NOT_CREATE: fully-picked completed order with NO shipment must NOT appe
     const masterdata = await createMasterdata();
     const documentNo = masterdata.salesOrders.SO1.documentNo;
 
-    // --- Pick all qty and complete in the mobileUI (mirrors the customer's manual flow exactly). ---
+    // --- Pick all qty and complete in the mobileUI (mirrors the reported manual flow exactly). ---
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('picking');


### PR DESCRIPTION
### Issue
https://github.com/metasfresh/me03/issues/29437 — Sales Order still displayed in mobileUI picking after processing.

### Problem
A fully-picked sales order with **nothing left to pick** reappears in the mobileUI picking launcher. This happens with the **"Don't create shipment" (DO_NOT_CREATE)** picking profile: the job is completed, the qty is fully picked, **no shipment exists at all**, yet `M_Packageable_V` re-admits the schedule through its `OR qtypicklist > 0` branch even though `QtyToDeliver = 0`.

The previously merged attempt (https://github.com/metasfresh/metasfresh/pull/24385 + https://github.com/metasfresh/metasfresh/pull/24390) added a `M_Packageable_V.IsPickQtyOnDraftShipment` view column and excluded only `QtyToDeliver<=0 AND IsPickQtyOnDraftShipment='Y'`. That covered only the *draft-shipment* case — which this customer never produces (DO_NOT_CREATE creates no shipment) — so it missed the real bug.

### Fix
Broaden the launcher exclusion from "fully on a draft shipment" to the general **"nothing left to pick"**:
- `PackageableQuery.excludeNothingToPick` flag → `PackagingDAO#createQuery` adds a single keep-filter **`QtyToDeliver > 0`** (excludes `QtyToDeliver <= 0`).
- `PickingJobQuery.toPackageableQueryBuilder` (mobileUI launcher) sets the flag; no other `PackageableQuery` consumer (WebUI desktop packing) sets it → launcher-scoped.

`QtyToDeliver` is already `max(0, qtyRequired − qtyPickedOrOnDraftShipmentOrShipped)`, so `QtyToDeliver <= 0` means genuinely nothing left — covering completed-no-shipment, fully-shipped, **and** fully-on-draft in one rule. A **partial draft** (open qty remaining) keeps `QtyToDeliver > 0` and stays listed. The view admission branch `(QtyToDeliver > 0 OR qtypicklist > 0)` is intentionally **unchanged** (ship-again, https://github.com/metasfresh/me03/issues/25383): a reversed shipment becomes shippable again via generate-shipments but must NOT reappear in the *picking* launcher — "ship again ≠ pick again".

The merged `IsPickQtyOnDraftShipment` column is removed cleanly (view + AD metadata).

### Changes
- `PackageableQuery` / `PackagingDAO` — `excludeNothingToPick` keep-filter.
- `PickingJobQuery` — sets the flag.
- `M_Packageable_v.sql` + migration `5806850` — recreate the view without `IsPickQtyOnDraftShipment`.
- Migration `5806860` — delete `AD_Column` 592700 + `AD_Element` 584934 (+_Trl).
- Regenerated `I_/X_M_Packageable_V` (follow-up commit).

### Tests
- E2E `picking_DO_NOT_CREATE_shipment_reappearance.spec.js`: AC1 fully-picked DO_NOT_CREATE → not listed; AC2 partial pick → stays listed; AC5 fully-on-draft → not listed.
- Reversal cucumber `hu/huClearance/cleared/pick.feature` (https://github.com/metasfresh/me03/issues/25383) — ship-again path unaffected.
