### PR TITLE
e2e: honor openRelatedInvoiceCandidate retryDelay (fix silently-ignored bare-number arg)

### DIFF
--- a/e2e/frontend-webui/tests/spec/invoice-reversal.spec.js
+++ b/e2e/frontend-webui/tests/spec/invoice-reversal.spec.js
@@ -163,7 +163,7 @@ which is essential for handling billing errors and credit adjustments.
                 .catch(() => {});
             await page.waitForTimeout(500);
 
-            await SalesOrderPage.openRelatedInvoiceCandidate(5000);
+            await SalesOrderPage.openRelatedInvoiceCandidate({ retryDelay: 5000 });
             await InvoiceCandidatePage.expectVisibleForSalesOrder();
             await InvoiceCandidatePage.createInvoiceForSalesOrder();
             console.log(`[${language}] Invoice created from invoice candidates`);

--- a/e2e/frontend-webui/tests/spec/promotion-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/promotion-code.spec.js
@@ -225,7 +225,7 @@ Full O2C chain (IC -> Invoice) is covered by the Cucumber test.
             await page.waitForTimeout(5000);
 
             // Step 9: Navigate to invoice candidates to verify propagation
-            await SalesOrderPage.openRelatedInvoiceCandidate(5000);
+            await SalesOrderPage.openRelatedInvoiceCandidate({ retryDelay: 5000 });
             await InvoiceCandidatePage.expectVisibleForSalesOrder();
 
             const screenshotIC = await page.screenshot();

--- a/e2e/frontend-webui/tests/spec/shipment.spec.js
+++ b/e2e/frontend-webui/tests/spec/shipment.spec.js
@@ -299,7 +299,7 @@ Ensures the complete order-to-cash flow works correctly across UI languages.
 
             // Step 15: Zoom to invoice candidates from sales order (Alt+6)
             // Wait for invoice candidates to be created (5 seconds)
-            await SalesOrderPage.openRelatedInvoiceCandidate(5000);
+            await SalesOrderPage.openRelatedInvoiceCandidate({ retryDelay: 5000 });
             console.log(`[${language}] Navigated to Invoice Candidates from Sales Order`);
 
             // Step 16: Verify invoice candidate window is visible


### PR DESCRIPTION
## Problem

`SalesOrderPage.openRelatedInvoiceCandidate` has a destructured options-object signature
(`{ maxRetries = 5, retryDelay = 2000, refreshOnRetry = false } = {}`). Three specs called it with
a **bare number** — `openRelatedInvoiceCandidate(5000)` — which destructures to `undefined` for
every key, so the call silently ran with all defaults (`5×2s = 10s` budget), discarding the
intended 5s retry delay. No error, no warning.

## Fix

Pass an options object so the value is honored — `openRelatedInvoiceCandidate({ retryDelay: 5000 })` —
in the three affected specs:

- `e2e/frontend-webui/tests/spec/invoice-reversal.spec.js`
- `e2e/frontend-webui/tests/spec/promotion-code.spec.js`
- `e2e/frontend-webui/tests/spec/shipment.spec.js`

The behaviour change only **lengthens** the retry budget (10s → 25s), so it cannot regress a
passing spec — it makes the code do what it already reads as doing. No assertions changed.

## Validation

`playwright --list` parses all three (spec + imported page objects resolve). These specs pass on CI
today with the silent 10s default; this change only raises the wait budget.

Relates to https://github.com/metasfresh/metasfresh/pull/24436 (which added the `refreshOnRetry`
option to the `openRelated*` helpers).
