### PR TITLE
Qty reservation — cap reserved CU at remaining ordered qty (OH+PS)

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/MakeQtyReservationCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/MakeQtyReservationCommand.java
@@ -1,6 +1,7 @@
 package de.metas.inoutcandidate.qty_reservation;
 
 import de.metas.handlingunits.QtyTU;
+import de.metas.i18n.AdMessageKey;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.order.IOrderLineBL;
 import de.metas.order.OrderAndLineId;
@@ -29,6 +30,9 @@ import java.math.BigDecimal;
 @Builder
 public class MakeQtyReservationCommand
 {
+	private static final AdMessageKey MSG_LineFullyReserved = AdMessageKey.of("ERR_QTY_RESERVATION_LINE_FULLY_RESERVED");
+	private static final AdMessageKey MSG_NoPackingCapacity = AdMessageKey.of("ERR_QTY_RESERVATION_NO_PACKING_CAPACITY");
+
 	@NonNull IOrderLineBL orderLineBL;
 	@NonNull IProductBL productBL;
 	@NonNull QtyReservationService qtyReservationService;
@@ -107,8 +111,7 @@ public class MakeQtyReservationCommand
 		final Quantity remainingOrdered = qtyReservationService.computeRemainingOrderedQty(salesOrderAndLineId, stockUomId);
 		if (remainingOrdered.signum() <= 0)
 		{
-			throw new AdempiereException("Cannot reserve: the sales order line is already fully reserved")
-					.markAsUserValidationError();
+			throw new AdempiereException(MSG_LineFullyReserved);
 		}
 		qty = qty.min(remainingOrdered);
 
@@ -141,8 +144,7 @@ public class MakeQtyReservationCommand
 			return capacityPerTUFallback;
 		}
 
-		throw new AdempiereException("Cannot reserve in TUs: order line has no packing-item capacity")
-				.markAsUserValidationError();
+		throw new AdempiereException(MSG_NoPackingCapacity);
 	}
 
 	@Nullable

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/MakeQtyReservationCommand.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/MakeQtyReservationCommand.java
@@ -73,8 +73,15 @@ public class MakeQtyReservationCommand
 	 * row's on-hand stock -- is what lets a planned-supply row (which has zero on-hand stock)
 	 * reserve a non-zero CU quantity.
 	 * <p>
-	 * For an {@link SupplyType#ON_HAND} row the result is capped at the row's on-hand stock
-	 * ({@code qtyStock}); for {@link SupplyType#PLANNED_SUPPLY} it is not capped.
+	 * The result is then capped by up to two upper bounds:
+	 * <ul>
+	 *   <li>on-hand stock — for an {@link SupplyType#ON_HAND} row the result is capped at the row's
+	 *       on-hand {@code qtyStock}; a {@link SupplyType#PLANNED_SUPPLY} row is not stock-capped;</li>
+	 *   <li>remaining ordered qty (OH + PS) — the result is capped at the order line's remaining
+	 *       unreserved ordered qty ({@code QtyOrdered − already-reserved}), so the line's total reserved
+	 *       CU never exceeds {@code QtyOrdered}. If nothing remains, the reservation is rejected with a
+	 *       user-validation error rather than minting a {@code Qty = 0} reservation.</li>
+	 * </ul>
 	 */
 	private Quantity computeQtyCUToReserve()
 	{
@@ -91,6 +98,19 @@ public class MakeQtyReservationCommand
 		{
 			qty = qty.min(rowVO.getQtyStock());
 		}
+
+		// Order-need cap (OH + PS): never reserve more CU than the order line still needs, so the
+		// line's TOTAL reserved CU never exceeds its QtyOrdered. The bound is the line's REMAINING
+		// unreserved ordered qty (QtyOrdered − already-reserved), which supports multiple reservations
+		// per line. The cockpit's reservable-TU count is bounded only by available stock, not by the
+		// order's need, so this bound must be enforced here at creation.
+		final Quantity remainingOrdered = qtyReservationService.computeRemainingOrderedQty(salesOrderAndLineId, stockUomId);
+		if (remainingOrdered.signum() <= 0)
+		{
+			throw new AdempiereException("Cannot reserve: the sales order line is already fully reserved")
+					.markAsUserValidationError();
+		}
+		qty = qty.min(remainingOrdered);
 
 		return qty;
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
@@ -135,10 +135,12 @@ public class QtyReservationService
 			@NonNull final OrderAndLineId orderAndLineId,
 			@NonNull final UomId targetUomId)
 	{
-		final I_C_OrderLine orderLine = orderLineBL.getOrderLineById(orderAndLineId);
+		// de.metas.interfaces.I_C_OrderLine (the richer type getOrderLineById returns) so the already-loaded
+		// record can be passed to getQtyOrdered(I_C_OrderLine) — the OrderAndLineId overload would re-fetch it.
+		final de.metas.interfaces.I_C_OrderLine orderLine = orderLineBL.getOrderLineById(orderAndLineId);
 		final ProductId productId = ProductId.ofRepoId(orderLine.getM_Product_ID());
 
-		final Quantity qtyOrdered = orderLineBL.getQtyOrdered(orderAndLineId);
+		final Quantity qtyOrdered = orderLineBL.getQtyOrdered(orderLine);
 		Quantity remaining = uomConversionBL.convertQuantityTo(qtyOrdered, productId, targetUomId);
 
 		for (final QtyReservation reservation : repository.getActiveByOrderLineId(orderAndLineId.getOrderLineId()))
@@ -149,7 +151,7 @@ public class QtyReservationService
 		}
 
 		// floor at 0: a fully/over-reserved line has no remaining ordered qty
-		return remaining.signum() < 0 ? remaining.toZero() : remaining;
+		return remaining.toZeroIfNegative();
 	}
 
 	/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/QtyReservationService.java
@@ -9,6 +9,9 @@ import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
 import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.uom.IUOMConversionBL;
+import de.metas.uom.UomId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +31,7 @@ public class QtyReservationService
 	private static final String SYSCONFIG_COPY_STORAGE_RELEVANT_ATTRS_TO_ORDER_LINE_ASI = "de.metas.handlingunits.order.CopyStorageRelevantAttributesToOrderLineASI";
 	@NonNull private final IOrderLineBL orderLineBL = Services.get(IOrderLineBL.class);
 	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+	@NonNull private final IUOMConversionBL uomConversionBL = Services.get(IUOMConversionBL.class);
 	@NonNull private final IShipmentScheduleInvalidateBL shipmentScheduleInvalidateBL;
 	@NonNull private final QtyReservationRepository repository;
 
@@ -111,6 +115,41 @@ public class QtyReservationService
 	public QtyTU getReservedQtyTU(@NonNull final OrderAndLineId orderLineId)
 	{
 		return repository.getReservedQtyTU(orderLineId);
+	}
+
+	/**
+	 * The sales-order line's <b>remaining unreserved ordered qty</b>, expressed in {@code targetUomId}:
+	 * {@code QtyOrdered − Σ(active, unprocessed reservations' Qty on the line)}, floored at 0.
+	 * <p>
+	 * Used as the order-need upper bound when creating a new reservation (REQUIREMENTS AC3a), so the
+	 * line's TOTAL reserved CU never exceeds its {@code QtyOrdered}. The bound is the <i>remaining</i>
+	 * qty (not the full {@code QtyOrdered}) so multiple reservations on one line are supported without
+	 * over-counting. All arithmetic is performed in {@code targetUomId}; each reservation's Qty and the
+	 * line's QtyOrdered are converted into it.
+	 *
+	 * @param orderAndLineId the sales order line
+	 * @param targetUomId    the UOM the result is expressed in (typically the new reservation's stock UOM)
+	 * @return the remaining ordered qty in {@code targetUomId}; never negative
+	 */
+	public Quantity computeRemainingOrderedQty(
+			@NonNull final OrderAndLineId orderAndLineId,
+			@NonNull final UomId targetUomId)
+	{
+		final I_C_OrderLine orderLine = orderLineBL.getOrderLineById(orderAndLineId);
+		final ProductId productId = ProductId.ofRepoId(orderLine.getM_Product_ID());
+
+		final Quantity qtyOrdered = orderLineBL.getQtyOrdered(orderAndLineId);
+		Quantity remaining = uomConversionBL.convertQuantityTo(qtyOrdered, productId, targetUomId);
+
+		for (final QtyReservation reservation : repository.getActiveByOrderLineId(orderAndLineId.getOrderLineId()))
+		{
+			final Quantity reservedInTarget = uomConversionBL.convertQuantityTo(
+					reservation.getQty(), reservation.getProductId(), targetUomId);
+			remaining = remaining.subtract(reservedInTarget);
+		}
+
+		// floor at 0: a fully/over-reserved line has no remaining ordered qty
+		return remaining.signum() < 0 ? remaining.toZero() : remaining;
 	}
 
 	/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/40-sw01_swat/5807100_sys_AD_Message_QtyReservation_validation.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/40-sw01_swat/5807100_sys_AD_Message_QtyReservation_validation.sql
@@ -5,41 +5,41 @@
 -- =====================================================================================
 -- Message 1: order line already fully reserved (remaining ordered qty <= 0)
 -- =====================================================================================
-INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,545749,0,TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Reservierung nicht möglich: Die Auftragsposition ist bereits vollständig reserviert.','E',TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'ERR_QTY_RESERVATION_LINE_FULLY_RESERVED')
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,545749 /*From ID Server*/,0,TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Reservierung nicht möglich: Die Auftragsposition ist bereits vollständig reserviert.','E',TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'ERR_QTY_RESERVATION_LINE_FULLY_RESERVED')
 ;
 
-UPDATE AD_Message SET ErrorCode='QTY_RESERVATION_LINE_FULLY_RESERVED', Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545749
+UPDATE AD_Message SET ErrorCode='QTY_RESERVATION_LINE_FULLY_RESERVED', Updated=TO_TIMESTAMP('2026-06-10 12:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545749
 ;
 
 INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Message t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545749 AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
 ;
 
-UPDATE AD_Message_Trl SET MsgText='Cannot reserve: the sales order line is already fully reserved.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545749
+UPDATE AD_Message_Trl SET MsgText='Cannot reserve: the sales order line is already fully reserved.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545749
 ;
 
-UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545749
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545749
 ;
 
-UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545749
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545749
 ;
 
 -- =====================================================================================
 -- Message 2: order line has no packing-item capacity (cannot derive CU per TU)
 -- =====================================================================================
-INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,545750,0,TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Reservierung in Transporteinheiten nicht möglich: Für die Auftragsposition ist keine Gebinde-Kapazität hinterlegt.','E',TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'ERR_QTY_RESERVATION_NO_PACKING_CAPACITY')
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,545750 /*From ID Server*/,0,TO_TIMESTAMP('2026-06-10 12:00:05','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Reservierung in Transporteinheiten nicht möglich: Für die Auftragsposition ist keine Gebinde-Kapazität hinterlegt.','E',TO_TIMESTAMP('2026-06-10 12:00:05','YYYY-MM-DD HH24:MI:SS'),100,'ERR_QTY_RESERVATION_NO_PACKING_CAPACITY')
 ;
 
-UPDATE AD_Message SET ErrorCode='QTY_RESERVATION_NO_PACKING_CAPACITY', Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545750
+UPDATE AD_Message SET ErrorCode='QTY_RESERVATION_NO_PACKING_CAPACITY', Updated=TO_TIMESTAMP('2026-06-10 12:00:06','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545750
 ;
 
 INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Message t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545750 AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
 ;
 
-UPDATE AD_Message_Trl SET MsgText='Cannot reserve in TUs: the order line has no packing-item capacity.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545750
+UPDATE AD_Message_Trl SET MsgText='Cannot reserve in TUs: the order line has no packing-item capacity.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545750
 ;
 
-UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545750
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:08','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545750
 ;
 
-UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545750
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545750
 ;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/40-sw01_swat/5807100_sys_AD_Message_QtyReservation_validation.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/40-sw01_swat/5807100_sys_AD_Message_QtyReservation_validation.sql
@@ -1,0 +1,45 @@
+-- Qty reservation — translatable user-validation messages for MakeQtyReservationCommand.
+-- Base text is German (fallback language); en_US carries the English override.
+-- Used via AdMessageKey from de.metas.inoutcandidate.qty_reservation.MakeQtyReservationCommand.
+
+-- =====================================================================================
+-- Message 1: order line already fully reserved (remaining ordered qty <= 0)
+-- =====================================================================================
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,545749,0,TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Reservierung nicht möglich: Die Auftragsposition ist bereits vollständig reserviert.','E',TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'ERR_QTY_RESERVATION_LINE_FULLY_RESERVED')
+;
+
+UPDATE AD_Message SET ErrorCode='QTY_RESERVATION_LINE_FULLY_RESERVED', Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545749
+;
+
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Message t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545749 AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+UPDATE AD_Message_Trl SET MsgText='Cannot reserve: the sales order line is already fully reserved.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545749
+;
+
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545749
+;
+
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545749
+;
+
+-- =====================================================================================
+-- Message 2: order line has no packing-item capacity (cannot derive CU per TU)
+-- =====================================================================================
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,545750,0,TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Reservierung in Transporteinheiten nicht möglich: Für die Auftragsposition ist keine Gebinde-Kapazität hinterlegt.','E',TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'ERR_QTY_RESERVATION_NO_PACKING_CAPACITY')
+;
+
+UPDATE AD_Message SET ErrorCode='QTY_RESERVATION_NO_PACKING_CAPACITY', Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545750
+;
+
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Message t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545750 AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+UPDATE AD_Message_Trl SET MsgText='Cannot reserve in TUs: the order line has no packing-item capacity.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545750
+;
+
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545750
+;
+
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-10 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545750
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/MakeQtyReservationCommandTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/MakeQtyReservationCommandTest.java
@@ -296,6 +296,8 @@ class MakeQtyReservationCommandTest
 		final IOrderLineBL orderLineBL = mock(IOrderLineBL.class);
 		when(orderLineBL.getOrderLineById(salesOrderAndLineId)).thenReturn(orderLineRecord);
 
+		// computeRemainingOrderedQty is intentionally NOT stubbed — the capacity error fires first,
+		// before the order-need cap is consulted, so the mock is never reached here.
 		final QtyReservationService qtyReservationService = mock(QtyReservationService.class);
 
 		final MakeQtyReservationCommand command = MakeQtyReservationCommand.builder()
@@ -413,6 +415,58 @@ class MakeQtyReservationCommandTest
 		final CreateQtyReservationRequest request = requestCaptor.getValue();
 
 		// min(10x11=110, stock 50, remaining 30) = 30
+		assertThat(request.getQty().toBigDecimal()).isEqualByComparingTo(new BigDecimal("30"));
+		assertThat(request.getQtyTU().toInt()).isEqualTo(10);
+	}
+
+	/**
+	 * Order-need cap (AC3a) is slack, on-hand stock cap binds: {@code qtyToReserveTU x capacity}
+	 * (10 x 11 = 110) is capped at on-hand stock (30); the remaining ordered qty (50) is larger, so it
+	 * does not reduce further. Result = 30. Exercises the interaction direction where the stock cap is
+	 * tighter than the order-need cap.
+	 */
+	@Test
+	void onHand_cappedAtStock_whenStockCapTighterThanOrderNeed()
+	{
+		final Quantity qtyStock = Quantitys.of(new BigDecimal("30"), uomId);
+		final MaterialCockpitV2RowVO rowVO = MaterialCockpitV2RowVO.builder()
+				.productId(productId)
+				.warehouseId(warehouseId)
+				.supplyType(SupplyType.ON_HAND)
+				.availabilityType(AvailabilityType.AVAILABLE)
+				.qtyTU(QtyTU.ofInt(10))
+				.qtyStock(qtyStock)
+				.build();
+
+		final OrderAndLineId salesOrderAndLineId = OrderAndLineId.ofRepoIds(1, 1);
+
+		final I_C_OrderLine orderLineRecord = mock(I_C_OrderLine.class);
+		when(orderLineRecord.getQtyItemCapacity()).thenReturn(new BigDecimal("11"));
+		when(orderLineRecord.getC_UOM_ID()).thenReturn(uomId.getRepoId());
+
+		final IOrderLineBL orderLineBL = mock(IOrderLineBL.class);
+		when(orderLineBL.getOrderLineById(salesOrderAndLineId)).thenReturn(orderLineRecord);
+
+		final QtyReservationService qtyReservationService = mock(QtyReservationService.class);
+		// order line still needs 50 CU — larger than the 30 stock cap, so the order-need cap does not bite
+		stubRemainingOrderedQty(qtyReservationService, salesOrderAndLineId, new BigDecimal("50"));
+		final ArgumentCaptor<CreateQtyReservationRequest> requestCaptor =
+				ArgumentCaptor.forClass(CreateQtyReservationRequest.class);
+
+		MakeQtyReservationCommand.builder()
+				.orderLineBL(orderLineBL)
+				.productBL(productBL)
+				.qtyReservationService(qtyReservationService)
+				.rowVO(rowVO)
+				.salesOrderAndLineId(salesOrderAndLineId)
+				.qtyToReserveTU(QtyTU.ofInt(10))
+				.build()
+				.execute();
+
+		verify(qtyReservationService).makeReservation(requestCaptor.capture());
+		final CreateQtyReservationRequest request = requestCaptor.getValue();
+
+		// min(10x11=110, stock 30, remaining 50) = 30 (stock cap binds)
 		assertThat(request.getQty().toBigDecimal()).isEqualByComparingTo(new BigDecimal("30"));
 		assertThat(request.getQtyTU().toInt()).isEqualTo(10);
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/MakeQtyReservationCommandTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/MakeQtyReservationCommandTest.java
@@ -28,6 +28,9 @@ import static org.mockito.Mockito.when;
 
 class MakeQtyReservationCommandTest
 {
+	/** A remaining-ordered qty large enough that the order-need cap (AC3a) never bites in a given test. */
+	private static final BigDecimal REMAINING_UNBOUNDED = new BigDecimal("100000");
+
 	private I_C_UOM uom;
 	private UomId uomId;
 	private ProductId productId;
@@ -46,6 +49,16 @@ class MakeQtyReservationCommandTest
 		// the product's stock UOM is the same "Each" UOM used for the rowVO qty and the capacity
 		productBL = mock(IProductBL.class);
 		when(productBL.getStockUOMId(productId)).thenReturn(uomId);
+	}
+
+	/** Stubs the order-need remaining-qty (AC3a) on the mocked service for the standard order line/UOM. */
+	private void stubRemainingOrderedQty(
+			final QtyReservationService qtyReservationService,
+			final OrderAndLineId salesOrderAndLineId,
+			final BigDecimal remaining)
+	{
+		when(qtyReservationService.computeRemainingOrderedQty(salesOrderAndLineId, uomId))
+				.thenReturn(Quantitys.of(remaining, uomId));
 	}
 
 	/**
@@ -82,6 +95,7 @@ class MakeQtyReservationCommandTest
 
 		// --- mock QtyReservationService: no-op makeReservation, capture the request ---
 		final QtyReservationService qtyReservationService = mock(QtyReservationService.class);
+		stubRemainingOrderedQty(qtyReservationService, salesOrderAndLineId, REMAINING_UNBOUNDED);
 		final ArgumentCaptor<CreateQtyReservationRequest> requestCaptor =
 				ArgumentCaptor.forClass(CreateQtyReservationRequest.class);
 
@@ -130,6 +144,7 @@ class MakeQtyReservationCommandTest
 		when(orderLineBL.getOrderLineById(salesOrderAndLineId)).thenReturn(orderLineRecord);
 
 		final QtyReservationService qtyReservationService = mock(QtyReservationService.class);
+		stubRemainingOrderedQty(qtyReservationService, salesOrderAndLineId, REMAINING_UNBOUNDED);
 		final ArgumentCaptor<CreateQtyReservationRequest> requestCaptor =
 				ArgumentCaptor.forClass(CreateQtyReservationRequest.class);
 
@@ -178,6 +193,7 @@ class MakeQtyReservationCommandTest
 		when(orderLineBL.getOrderLineById(salesOrderAndLineId)).thenReturn(orderLineRecord);
 
 		final QtyReservationService qtyReservationService = mock(QtyReservationService.class);
+		stubRemainingOrderedQty(qtyReservationService, salesOrderAndLineId, REMAINING_UNBOUNDED);
 		final ArgumentCaptor<CreateQtyReservationRequest> requestCaptor =
 				ArgumentCaptor.forClass(CreateQtyReservationRequest.class);
 
@@ -202,7 +218,7 @@ class MakeQtyReservationCommandTest
 	/**
 	 * Planned-supply reservation with NO order-line {@code QtyItemCapacity}: the command falls back to
 	 * the caller-supplied {@code capacityPerTUFallback} (13 CU/TU). 10 TU x 13 CU/TU = 130 CU, not
-	 * capped (planned supply).
+	 * capped (planned supply, and the order line still needs more than 130).
 	 */
 	@Test
 	void plannedSupply_usesFallbackCapacity_whenNoQtyItemCapacity()
@@ -227,6 +243,7 @@ class MakeQtyReservationCommandTest
 		when(orderLineBL.getOrderLineById(salesOrderAndLineId)).thenReturn(orderLineRecord);
 
 		final QtyReservationService qtyReservationService = mock(QtyReservationService.class);
+		stubRemainingOrderedQty(qtyReservationService, salesOrderAndLineId, REMAINING_UNBOUNDED);
 		final ArgumentCaptor<CreateQtyReservationRequest> requestCaptor =
 				ArgumentCaptor.forClass(CreateQtyReservationRequest.class);
 
@@ -254,7 +271,8 @@ class MakeQtyReservationCommandTest
 
 	/**
 	 * Neither the order line's {@code QtyItemCapacity} nor a {@code capacityPerTUFallback} yields a
-	 * positive capacity: the command cannot derive a CU qty and raises a user-validation error.
+	 * positive capacity: the command cannot derive a CU qty and raises a user-validation error
+	 * (before the order-need cap is even consulted).
 	 */
 	@Test
 	void noCapacity_throwsUserError()
@@ -296,12 +314,13 @@ class MakeQtyReservationCommandTest
 	}
 
 	/**
-	 * Whole-TU reservation is intentional: for a planned-supply row the reserved CU qty is
-	 * {@code qtyToReserveTU x capacity} and is NOT capped at the order line's QtyOrdered (the TU count
-	 * is already bounded upstream). 10 TU x 10 CU/TU = 100 CU even though the order line's CU is 95.
+	 * Order-need cap (AC3a), planned supply: {@code qtyToReserveTU x capacity} (10 x 10 = 100) exceeds
+	 * the order line's remaining unreserved ordered qty (95), so the reserved CU qty is capped at 95.
+	 * The TU count is unchanged (10) — TU reconciliation happens later at SO completion. PS is NOT
+	 * exempt from the order-need cap (only from the on-hand stock cap).
 	 */
 	@Test
-	void plannedSupply_reservesWholeTUs_evenWhenExceedingQtyOrdered()
+	void plannedSupply_cappedAtRemainingOrderedQty()
 	{
 		final Quantity qtyStockZero = Quantitys.of(BigDecimal.ZERO, uomId);
 		final MaterialCockpitV2RowVO rowVO = MaterialCockpitV2RowVO.builder()
@@ -315,7 +334,7 @@ class MakeQtyReservationCommandTest
 
 		final OrderAndLineId salesOrderAndLineId = OrderAndLineId.ofRepoIds(1, 1);
 
-		// capacity = 10 CU/TU; order line's CU (QtyOrdered) = 95 -> 10 x 10 = 100 > 95
+		// capacity = 10 CU/TU; raw = 10 x 10 = 100
 		final I_C_OrderLine orderLineRecord = mock(I_C_OrderLine.class);
 		when(orderLineRecord.getQtyItemCapacity()).thenReturn(new BigDecimal("10"));
 		when(orderLineRecord.getC_UOM_ID()).thenReturn(uomId.getRepoId());
@@ -324,6 +343,8 @@ class MakeQtyReservationCommandTest
 		when(orderLineBL.getOrderLineById(salesOrderAndLineId)).thenReturn(orderLineRecord);
 
 		final QtyReservationService qtyReservationService = mock(QtyReservationService.class);
+		// order line still needs only 95 CU (e.g. QtyOrdered 95, nothing reserved yet)
+		stubRemainingOrderedQty(qtyReservationService, salesOrderAndLineId, new BigDecimal("95"));
 		final ArgumentCaptor<CreateQtyReservationRequest> requestCaptor =
 				ArgumentCaptor.forClass(CreateQtyReservationRequest.class);
 
@@ -340,8 +361,104 @@ class MakeQtyReservationCommandTest
 		verify(qtyReservationService).makeReservation(requestCaptor.capture());
 		final CreateQtyReservationRequest request = requestCaptor.getValue();
 
-		// 10 TU x 10 CU/TU = 100 CU; intentionally NOT capped at the order line's CU of 95
-		assertThat(request.getQty().toBigDecimal()).isEqualByComparingTo(new BigDecimal("100"));
+		// 10 TU x 10 CU/TU = 100, capped at the remaining ordered qty of 95
+		assertThat(request.getQty().toBigDecimal()).isEqualByComparingTo(new BigDecimal("95"));
 		assertThat(request.getQtyTU().toInt()).isEqualTo(10);
+	}
+
+	/**
+	 * Order-need cap (AC3a), on-hand, below the stock cap: {@code qtyToReserveTU x capacity}
+	 * (10 x 11 = 110) is first capped at on-hand stock (50), then further capped at the order line's
+	 * remaining ordered qty (30) — the order-need cap can bite below the stock cap. Result = 30.
+	 */
+	@Test
+	void onHand_cappedAtRemainingOrderedQty()
+	{
+		final Quantity qtyStock = Quantitys.of(new BigDecimal("50"), uomId);
+		final MaterialCockpitV2RowVO rowVO = MaterialCockpitV2RowVO.builder()
+				.productId(productId)
+				.warehouseId(warehouseId)
+				.supplyType(SupplyType.ON_HAND)
+				.availabilityType(AvailabilityType.AVAILABLE)
+				.qtyTU(QtyTU.ofInt(10))
+				.qtyStock(qtyStock)
+				.build();
+
+		final OrderAndLineId salesOrderAndLineId = OrderAndLineId.ofRepoIds(1, 1);
+
+		final I_C_OrderLine orderLineRecord = mock(I_C_OrderLine.class);
+		when(orderLineRecord.getQtyItemCapacity()).thenReturn(new BigDecimal("11"));
+		when(orderLineRecord.getC_UOM_ID()).thenReturn(uomId.getRepoId());
+
+		final IOrderLineBL orderLineBL = mock(IOrderLineBL.class);
+		when(orderLineBL.getOrderLineById(salesOrderAndLineId)).thenReturn(orderLineRecord);
+
+		final QtyReservationService qtyReservationService = mock(QtyReservationService.class);
+		// order line still needs only 30 CU (less than both 110 and the 50 stock cap)
+		stubRemainingOrderedQty(qtyReservationService, salesOrderAndLineId, new BigDecimal("30"));
+		final ArgumentCaptor<CreateQtyReservationRequest> requestCaptor =
+				ArgumentCaptor.forClass(CreateQtyReservationRequest.class);
+
+		MakeQtyReservationCommand.builder()
+				.orderLineBL(orderLineBL)
+				.productBL(productBL)
+				.qtyReservationService(qtyReservationService)
+				.rowVO(rowVO)
+				.salesOrderAndLineId(salesOrderAndLineId)
+				.qtyToReserveTU(QtyTU.ofInt(10))
+				.build()
+				.execute();
+
+		verify(qtyReservationService).makeReservation(requestCaptor.capture());
+		final CreateQtyReservationRequest request = requestCaptor.getValue();
+
+		// min(10x11=110, stock 50, remaining 30) = 30
+		assertThat(request.getQty().toBigDecimal()).isEqualByComparingTo(new BigDecimal("30"));
+		assertThat(request.getQtyTU().toInt()).isEqualTo(10);
+	}
+
+	/**
+	 * Order-need cap (AC3b): when the order line is already fully reserved (remaining ordered qty = 0),
+	 * the command rejects the reservation with a user-validation error rather than minting a
+	 * {@code Qty = 0} reservation (the original defect this feature fixes).
+	 */
+	@Test
+	void rejectsWhenLineFullyReserved()
+	{
+		final Quantity qtyStockZero = Quantitys.of(BigDecimal.ZERO, uomId);
+		final MaterialCockpitV2RowVO rowVO = MaterialCockpitV2RowVO.builder()
+				.productId(productId)
+				.warehouseId(warehouseId)
+				.supplyType(SupplyType.PLANNED_SUPPLY)
+				.availabilityType(AvailabilityType.AVAILABLE)
+				.qtyTU(QtyTU.ofInt(10))
+				.qtyStock(qtyStockZero)
+				.build();
+
+		final OrderAndLineId salesOrderAndLineId = OrderAndLineId.ofRepoIds(1, 1);
+
+		final I_C_OrderLine orderLineRecord = mock(I_C_OrderLine.class);
+		when(orderLineRecord.getQtyItemCapacity()).thenReturn(new BigDecimal("10"));
+		when(orderLineRecord.getC_UOM_ID()).thenReturn(uomId.getRepoId());
+
+		final IOrderLineBL orderLineBL = mock(IOrderLineBL.class);
+		when(orderLineBL.getOrderLineById(salesOrderAndLineId)).thenReturn(orderLineRecord);
+
+		final QtyReservationService qtyReservationService = mock(QtyReservationService.class);
+		// the line is already fully reserved -> remaining = 0
+		stubRemainingOrderedQty(qtyReservationService, salesOrderAndLineId, BigDecimal.ZERO);
+
+		final MakeQtyReservationCommand command = MakeQtyReservationCommand.builder()
+				.orderLineBL(orderLineBL)
+				.productBL(productBL)
+				.qtyReservationService(qtyReservationService)
+				.rowVO(rowVO)
+				.salesOrderAndLineId(salesOrderAndLineId)
+				.qtyToReserveTU(QtyTU.ofInt(10))
+				.build();
+
+		assertThatThrownBy(command::execute)
+				.isInstanceOf(AdempiereException.class)
+				.satisfies(e -> assertThat(((AdempiereException)e).isUserValidationError()).isTrue());
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/QtyReservationServiceTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/QtyReservationServiceTest.java
@@ -1,0 +1,170 @@
+package de.metas.inoutcandidate.qty_reservation;
+
+import de.metas.business.BusinessTestHelper;
+import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
+import de.metas.order.OrderAndLineId;
+import de.metas.order.OrderId;
+import de.metas.order.OrderLineId;
+import de.metas.quantity.Quantity;
+import de.metas.uom.CreateUOMConversionRequest;
+import de.metas.uom.IUOMConversionDAO;
+import de.metas.uom.UomId;
+import de.metas.util.Services;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_OrderLine;
+import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_M_QtyReservation;
+import org.compiere.model.I_M_Warehouse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for {@link QtyReservationService#computeRemainingOrderedQty(OrderAndLineId, UomId)} — the
+ * order-need cap bound (REQUIREMENTS AC3a): {@code QtyOrdered - Σ(active, unprocessed reservations' Qty)},
+ * floored at 0, expressed in the requested (stock) UOM.
+ */
+class QtyReservationServiceTest
+{
+	private QtyReservationService service;
+	private I_C_UOM uom;
+	private UomId uomId;
+	private int productId;
+	private int warehouseId;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		uom = BusinessTestHelper.createUOM("Kg");
+		uomId = UomId.ofRepoId(uom.getC_UOM_ID());
+		productId = BusinessTestHelper.createProductId("P1", uom).getRepoId();
+		warehouseId = createWarehouseId();
+
+		final QtyReservationRepository repository = new QtyReservationRepository();
+		service = new QtyReservationService(mock(IShipmentScheduleInvalidateBL.class), repository);
+	}
+
+	@Test
+	void remainingEqualsOrdered_whenNoReservations()
+	{
+		final OrderAndLineId orderLineId = createOrderLine(new BigDecimal("20"));
+
+		final Quantity remaining = service.computeRemainingOrderedQty(orderLineId, uomId);
+
+		assertThat(remaining.getUomId()).isEqualTo(uomId);
+		assertThat(remaining.toBigDecimal()).isEqualByComparingTo(new BigDecimal("20"));
+	}
+
+	@Test
+	void remainingIsOrderedMinusReserved_singleReservation()
+	{
+		final OrderAndLineId orderLineId = createOrderLine(new BigDecimal("75"));
+		createReservationRecord(orderLineId.getOrderLineId(), SupplyType.ON_HAND, new BigDecimal("30"));
+
+		final Quantity remaining = service.computeRemainingOrderedQty(orderLineId, uomId);
+
+		assertThat(remaining.toBigDecimal()).isEqualByComparingTo(new BigDecimal("45"));
+	}
+
+	@Test
+	void remainingSubtractsAllReservations_multiReservation()
+	{
+		final OrderAndLineId orderLineId = createOrderLine(new BigDecimal("100"));
+		createReservationRecord(orderLineId.getOrderLineId(), SupplyType.ON_HAND, new BigDecimal("30"));
+		createReservationRecord(orderLineId.getOrderLineId(), SupplyType.PLANNED_SUPPLY, new BigDecimal("40"));
+
+		final Quantity remaining = service.computeRemainingOrderedQty(orderLineId, uomId);
+
+		// 100 - (30 + 40) = 30
+		assertThat(remaining.toBigDecimal()).isEqualByComparingTo(new BigDecimal("30"));
+	}
+
+	@Test
+	void remainingFlooredAtZero_whenOverReserved()
+	{
+		final OrderAndLineId orderLineId = createOrderLine(new BigDecimal("20"));
+		createReservationRecord(orderLineId.getOrderLineId(), SupplyType.ON_HAND, new BigDecimal("30"));
+
+		final Quantity remaining = service.computeRemainingOrderedQty(orderLineId, uomId);
+
+		// 20 - 30 = -10 -> floored to 0
+		assertThat(remaining.toBigDecimal()).isEqualByComparingTo(BigDecimal.ZERO);
+	}
+
+	@Test
+	void convertsReservationUomToTargetUom()
+	{
+		// reservation held in "Box", 1 Box = 5 Kg; order line / target UOM = Kg
+		final I_C_UOM boxUom = BusinessTestHelper.createUOM("Box");
+		Services.get(IUOMConversionDAO.class).createUOMConversion(CreateUOMConversionRequest.builder()
+				.fromUomId(UomId.ofRepoId(boxUom.getC_UOM_ID()))
+				.toUomId(uomId)
+				.fromToMultiplier(new BigDecimal("5"))
+				.build());
+
+		final OrderAndLineId orderLineId = createOrderLine(new BigDecimal("50")); // 50 Kg
+		final I_M_QtyReservation record = createReservationRecord(orderLineId.getOrderLineId(), SupplyType.ON_HAND, new BigDecimal("6"));
+		record.setC_UOM_ID(boxUom.getC_UOM_ID()); // 6 Box = 30 Kg
+		InterfaceWrapperHelper.save(record);
+
+		final Quantity remaining = service.computeRemainingOrderedQty(orderLineId, uomId);
+
+		// 50 Kg - 30 Kg = 20 Kg
+		assertThat(remaining.getUomId()).isEqualTo(uomId);
+		assertThat(remaining.toBigDecimal()).isEqualByComparingTo(new BigDecimal("20"));
+	}
+
+	// --- helpers ---
+
+	private int createWarehouseId()
+	{
+		final I_M_Warehouse warehouse = InterfaceWrapperHelper.newInstance(I_M_Warehouse.class);
+		warehouse.setValue("WH");
+		warehouse.setName("WH");
+		InterfaceWrapperHelper.save(warehouse);
+		return warehouse.getM_Warehouse_ID();
+	}
+
+	private OrderAndLineId createOrderLine(final BigDecimal qtyOrdered)
+	{
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setIsSOTrx(true);
+		InterfaceWrapperHelper.save(order);
+
+		final I_C_OrderLine orderLine = InterfaceWrapperHelper.newInstance(I_C_OrderLine.class);
+		orderLine.setC_Order_ID(order.getC_Order_ID());
+		orderLine.setM_Product_ID(productId);
+		orderLine.setM_Warehouse_ID(warehouseId);
+		orderLine.setC_UOM_ID(uom.getC_UOM_ID());
+		orderLine.setQtyOrdered(qtyOrdered);
+		orderLine.setQtyEntered(qtyOrdered);
+		InterfaceWrapperHelper.save(orderLine);
+
+		return OrderAndLineId.ofRepoIds(order.getC_Order_ID(), orderLine.getC_OrderLine_ID());
+	}
+
+	private I_M_QtyReservation createReservationRecord(
+			final OrderLineId orderLineId,
+			final SupplyType supplyType,
+			final BigDecimal qty)
+	{
+		final I_M_QtyReservation record = InterfaceWrapperHelper.newInstance(I_M_QtyReservation.class);
+		record.setC_OrderLine_ID(orderLineId.getRepoId());
+		record.setM_Product_ID(productId);
+		record.setM_Warehouse_ID(warehouseId);
+		record.setC_UOM_ID(uom.getC_UOM_ID());
+		record.setSupplyType(supplyType.getCode());
+		record.setQty(qty);
+		record.setQtyDelivered(BigDecimal.ZERO);
+		record.setQtyTU(qty);
+		InterfaceWrapperHelper.save(record);
+		return record;
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/QtyReservationServiceTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/qty_reservation/QtyReservationServiceTest.java
@@ -3,7 +3,6 @@ package de.metas.inoutcandidate.qty_reservation;
 import de.metas.business.BusinessTestHelper;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
 import de.metas.order.OrderAndLineId;
-import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
 import de.metas.quantity.Quantity;
 import de.metas.uom.CreateUOMConversionRequest;


### PR DESCRIPTION
## What

When creating a quantity reservation from the Material Cockpit, the reserved CU qty is now capped at the order line's **remaining** unreserved ordered qty, in addition to the existing on-hand-stock cap:

```
Qty = min( qtyTU × packing-capacity , [on-hand qtyStock for OH] , QtyOrdered − already-reserved )
```

## Why

The reserved CU qty (`qtyTU × packing-capacity`) was capped only at on-hand stock, never at the order line's `QtyOrdered`. The cockpit's reservable-TU count is bounded by available **stock** (the material-cockpit availability view computes available qty as `stock − reserved`, with no `QtyOrdered` term), not by the order's remaining need — so a reservation could exceed what the order actually needs. This is most visible for planned-supply rows, which have no on-hand-stock cap at all. A previous change had removed the QtyOrdered cap on the assumption that the TU count was already order-bounded upstream; it is not.

## How

- New `QtyReservationService.computeRemainingOrderedQty(orderAndLineId, uom)` = `QtyOrdered − Σ(active, unprocessed reservations' Qty on the line)`, floored at 0, UOM-converted — reuses the same `getQtyOrdered` + active-reservations + UOM-conversion building blocks as `ReconcileQtyReservationsCommand`.
- `MakeQtyReservationCommand` applies `.min(remaining)` for **both** OH and PS reservations; rejects with a user-validation error when the line is already fully reserved (never mints a `Qty = 0` reservation).
- Using the **remaining** (not full) `QtyOrdered` bounds the line's TOTAL reserved CU at `QtyOrdered` while still supporting multiple reservations per line. `QtyTU` is left as requested; TU-count reconciliation continues to happen at SO completion (`reconcileToOrderedQty`).

## Tests

- `MakeQtyReservationCommandTest` (8 methods): OH/PS capped at remaining ordered qty, order-need cap biting below the stock cap, already-fully-reserved → user error; existing capacity/stock-cap behaviour preserved.
- `QtyReservationServiceTest` (5 methods, new): remaining = ordered − Σ reserved, multi-reservation, floor-at-0 when over-reserved, cross-UOM conversion.
- `ReconcileQtyReservationsCommandTest` unchanged — 14 methods still green.
