### PR TITLE
EDI DESADV: skip Qty-0 pack items (export-gate WhereClause + prevent SSCC-generated orphan)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_DesadvLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_DesadvLine_StepDef.java
@@ -22,22 +22,31 @@
 
 package de.metas.cucumber.stepdefs.edi;
 
+import de.metas.bpartner.BPartnerId;
+import de.metas.common.util.CoalesceUtil;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.edi.api.impl.DesadvBL;
+import de.metas.edi.api.impl.pack.EDIDesadvPackService;
+import de.metas.edi.sscc18.DesadvLineSSCC18Generator;
+import de.metas.edi.sscc18.PrintableDesadvLineSSCC18Labels;
 import de.metas.esb.edi.model.I_EDI_Desadv;
 import de.metas.esb.edi.model.I_EDI_DesadvLine;
+import de.metas.sscc18.impl.SSCC18CodeBL;
 import de.metas.uom.IUOMDAO;
 import de.metas.uom.UomId;
 import de.metas.uom.X12DE355;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
+import org.compiere.SpringContextHolder;
 import org.compiere.model.I_M_Product;
 
 import java.math.BigDecimal;
@@ -51,6 +60,10 @@ public class EDI_DesadvLine_StepDef
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
+
+	private final DesadvBL desadvBL = SpringContextHolder.instance.getBean(DesadvBL.class);
+	private final SSCC18CodeBL sscc18CodeBL = SpringContextHolder.instance.getBean(SSCC18CodeBL.class);
+	private final EDIDesadvPackService ediDesadvPackService = SpringContextHolder.instance.getBean(EDIDesadvPackService.class);
 
 	private final EDI_DesadvLine_StepDefData desadvLineTable;
 	private final EDI_Desadv_StepDefData desadvTable;
@@ -131,6 +144,73 @@ public class EDI_DesadvLine_StepDef
 
 		final StepDefDataIdentifier lineIdentifier = row.getAsIdentifier(I_EDI_DesadvLine.COLUMNNAME_EDI_DesadvLine_ID);
 		desadvLineTable.put(lineIdentifier, desadvLine);
+	}
+
+	/**
+	 * Generates SSCC labels for a single EDI_DesadvLine by invoking the real
+	 * {@link DesadvLineSSCC18Generator} with an explicit label count.
+	 *
+	 * <p>This reproduces the production path of {@code EDI_Desadv_GenerateSSCCLabels}:
+	 * it calls {@link PrintableDesadvLineSSCC18Labels} which internally builds a
+	 * {@link de.metas.handlingunits.allocation.impl.TotalQtyCUBreakdownCalculator}.
+	 * When the desadv line has no proper LU/TU configuration (e.g. the order-line uses
+	 * "No Packing Item" / M_HU_PI_Item_Product_ID=101), the calculator falls back to
+	 * {@link de.metas.handlingunits.allocation.impl.TotalQtyCUBreakdownCalculator#NULL},
+	 * and every {@code subtractOneLU()} call returns {@code LUQtys.NULL} (qtyCUsPerLU=0).
+	 * Requesting more labels than the breakdown supports is the birth mechanism of an
+	 * orphan Qty-0/NULL-M_InOutLine pack item (me03 #29278).
+	 * After the fix, the generator skips Qty-0 LUs so no orphan is ever created.
+	 *
+	 * <p>Required columns:
+	 * <ul>
+	 *   <li>{@code EDI_DesadvLine_ID} – identifier of the desadv line (registered via
+	 *       {@link #edi_desadv_line_records_are_found})</li>
+	 *   <li>{@code LabelCount} – explicit number of SSCC labels (i.e. LUs) to generate</li>
+	 * </ul>
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * When SSCC labels are generated for EDI_DesadvLine:
+	 *   | EDI_DesadvLine_ID | LabelCount |
+	 *   | desadvLine        | 2          |
+	 * </pre>
+	 */
+	@When("SSCC labels are generated for EDI_DesadvLine:")
+	public void generate_sscc_labels_for_desadv_line(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::generateSSCCLabelsForDesadvLine);
+	}
+
+	private void generateSSCCLabelsForDesadvLine(@NonNull final DataTableRow row)
+	{
+		final I_EDI_DesadvLine desadvLine = row.getAsIdentifier(I_EDI_DesadvLine.COLUMNNAME_EDI_DesadvLine_ID).lookupNotNullIn(desadvLineTable);
+		final int labelCount = row.getAsInt("LabelCount");
+
+		final I_EDI_Desadv desadvRecord = desadvLine.getEDI_Desadv();
+		final int bpartnerRepoId = CoalesceUtil.firstGreaterThanZero(
+				desadvRecord.getDropShip_BPartner_ID(),
+				desadvRecord.getC_BPartner_ID());
+		final BPartnerId bpartnerId = BPartnerId.ofRepoId(bpartnerRepoId);
+
+		final DesadvLineSSCC18Generator generator = DesadvLineSSCC18Generator.builder()
+				.sscc18CodeService(sscc18CodeBL)
+				.desadvBL(desadvBL)
+				.ediDesadvPackService(ediDesadvPackService)
+				.printExistingLabels(false)
+				.bpartnerId(bpartnerId)
+				.build();
+
+		// PrintableDesadvLineSSCC18Labels uses the real shipment-schedule / LU-TU config lookup.
+		// When the order-line has no proper packing instructions (e.g. "No Packing Item" / 101),
+		// the builder falls back to TotalQtyCUBreakdownCalculator.NULL, so every subtractOneLU()
+		// returns LUQtys.NULL (qtyCUsPerLU=0).  With labelCount > available LUs the generator
+		// exhausts the calculator — this is the orphan birth mechanism (me03 #29278).
+		final PrintableDesadvLineSSCC18Labels labelsSpec = PrintableDesadvLineSSCC18Labels.builder()
+				.setEDI_DesadvLine(desadvLine)
+				.setRequiredSSCC18Count(labelCount)
+				.build();
+
+		generator.generateAndEnqueuePrinting(labelsSpec);
 	}
 
 	@Then("validate created edi desadv line")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_DesadvLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_DesadvLine_StepDef.java
@@ -22,8 +22,11 @@
 
 package de.metas.cucumber.stepdefs.edi;
 
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.esb.edi.model.I_EDI_Desadv;
 import de.metas.esb.edi.model.I_EDI_DesadvLine;
 import de.metas.uom.IUOMDAO;
@@ -60,6 +63,45 @@ public class EDI_DesadvLine_StepDef
 		this.desadvLineTable = desadvLineTable;
 		this.desadvTable = desadvTable;
 		this.productTable = productTable;
+	}
+
+	/**
+	 * Finds an EDI_DesadvLine record by EDI_Desadv_ID and registers it under the given identifier.
+	 * Useful when a test needs to reference the auto-created DESADV line by identifier,
+	 * e.g. to inject pack items referencing that line.
+	 *
+	 * <p>Required columns:
+	 * <ul>
+	 *   <li>{@code EDI_DesadvLine_ID} – identifier under which the found record is registered</li>
+	 *   <li>{@code EDI_Desadv_ID} – identifier of the parent DESADV (must be registered in {@link EDI_Desadv_StepDefData})</li>
+	 * </ul>
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * Then EDI_DesadvLine records are found:
+	 *   | EDI_DesadvLine_ID | EDI_Desadv_ID |
+	 *   | desadvLine        | myDesadv      |
+	 * </pre>
+	 */
+	@Then("EDI_DesadvLine records are found:")
+	public void edi_desadv_line_records_are_found(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::findAndRegisterDesadvLine);
+	}
+
+	private void findAndRegisterDesadvLine(@NonNull final DataTableRow row)
+	{
+		final StepDefDataIdentifier desadvIdentifier = row.getAsIdentifier(I_EDI_DesadvLine.COLUMNNAME_EDI_Desadv_ID);
+		final I_EDI_Desadv desadvRecord = desadvTable.get(desadvIdentifier);
+
+		final I_EDI_DesadvLine desadvLine = queryBL.createQueryBuilder(I_EDI_DesadvLine.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_EDI_DesadvLine.COLUMNNAME_EDI_Desadv_ID, desadvRecord.getEDI_Desadv_ID())
+				.create()
+				.firstOnlyNotNull(I_EDI_DesadvLine.class);
+
+		final StepDefDataIdentifier lineIdentifier = row.getAsIdentifier(I_EDI_DesadvLine.COLUMNNAME_EDI_DesadvLine_ID);
+		desadvLineTable.put(lineIdentifier, desadvLine);
 	}
 
 	@Then("validate created edi desadv line")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_DesadvLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_DesadvLine_StepDef.java
@@ -44,6 +44,7 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.compiere.SpringContextHolder;
@@ -56,6 +57,7 @@ import java.util.Map;
 import static de.metas.cucumber.stepdefs.StepDefConstants.TABLECOLUMN_IDENTIFIER;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RequiredArgsConstructor
 public class EDI_DesadvLine_StepDef
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
@@ -65,19 +67,9 @@ public class EDI_DesadvLine_StepDef
 	private final SSCC18CodeBL sscc18CodeBL = SpringContextHolder.instance.getBean(SSCC18CodeBL.class);
 	private final EDIDesadvPackService ediDesadvPackService = SpringContextHolder.instance.getBean(EDIDesadvPackService.class);
 
-	private final EDI_DesadvLine_StepDefData desadvLineTable;
-	private final EDI_Desadv_StepDefData desadvTable;
-	private final M_Product_StepDefData productTable;
-
-	public EDI_DesadvLine_StepDef(
-			@NonNull final EDI_DesadvLine_StepDefData desadvLineTable,
-			@NonNull final EDI_Desadv_StepDefData desadvTable,
-			@NonNull final M_Product_StepDefData productTable)
-	{
-		this.desadvLineTable = desadvLineTable;
-		this.desadvTable = desadvTable;
-		this.productTable = productTable;
-	}
+	@NonNull private final EDI_DesadvLine_StepDefData desadvLineTable;
+	@NonNull private final EDI_Desadv_StepDefData desadvTable;
+	@NonNull private final M_Product_StepDefData productTable;
 
 	/**
 	 * Finds EDI_DesadvLine records by EDI_Desadv_ID and registers each under the given identifier.
@@ -158,7 +150,7 @@ public class EDI_DesadvLine_StepDef
 	 * {@link de.metas.handlingunits.allocation.impl.TotalQtyCUBreakdownCalculator#NULL},
 	 * and every {@code subtractOneLU()} call returns {@code LUQtys.NULL} (qtyCUsPerLU=0).
 	 * Requesting more labels than the breakdown supports is the birth mechanism of an
-	 * orphan Qty-0/NULL-M_InOutLine pack item (me03 #29278).
+	 * orphan Qty-0/NULL-M_InOutLine pack item.
 	 * After the fix, the generator skips Qty-0 LUs so no orphan is ever created.
 	 *
 	 * <p>Required columns:
@@ -204,7 +196,7 @@ public class EDI_DesadvLine_StepDef
 		// When the order-line has no proper packing instructions (e.g. "No Packing Item" / 101),
 		// the builder falls back to TotalQtyCUBreakdownCalculator.NULL, so every subtractOneLU()
 		// returns LUQtys.NULL (qtyCUsPerLU=0).  With labelCount > available LUs the generator
-		// exhausts the calculator — this is the orphan birth mechanism (me03 #29278).
+		// exhausts the calculator — this is the orphan birth mechanism.
 		final PrintableDesadvLineSSCC18Labels labelsSpec = PrintableDesadvLineSSCC18Labels.builder()
 				.setEDI_DesadvLine(desadvLine)
 				.setRequiredSSCC18Count(labelCount)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_DesadvLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_DesadvLine_StepDef.java
@@ -135,7 +135,7 @@ public class EDI_DesadvLine_StepDef
 		final I_EDI_DesadvLine desadvLine = queryBuilder.create().firstOnlyNotNull(I_EDI_DesadvLine.class);
 
 		final StepDefDataIdentifier lineIdentifier = row.getAsIdentifier(I_EDI_DesadvLine.COLUMNNAME_EDI_DesadvLine_ID);
-		desadvLineTable.put(lineIdentifier, desadvLine);
+		desadvLineTable.putOrReplace(lineIdentifier, desadvLine);
 	}
 
 	/**

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_DesadvLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_DesadvLine_StepDef.java
@@ -37,6 +37,7 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Then;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.IQueryBuilder;
 import org.compiere.model.I_M_Product;
 
 import java.math.BigDecimal;
@@ -66,8 +67,8 @@ public class EDI_DesadvLine_StepDef
 	}
 
 	/**
-	 * Finds an EDI_DesadvLine record by EDI_Desadv_ID and registers it under the given identifier.
-	 * Useful when a test needs to reference the auto-created DESADV line by identifier,
+	 * Finds EDI_DesadvLine records by EDI_Desadv_ID and registers each under the given identifier.
+	 * Useful when a test needs to reference an auto-created DESADV line by identifier,
 	 * e.g. to inject pack items referencing that line.
 	 *
 	 * <p>Required columns:
@@ -76,11 +77,28 @@ public class EDI_DesadvLine_StepDef
 	 *   <li>{@code EDI_Desadv_ID} – identifier of the parent DESADV (must be registered in {@link EDI_Desadv_StepDefData})</li>
 	 * </ul>
 	 *
-	 * <p>Example:
+	 * <p>Optional disambiguator columns (use when the DESADV has more than one line):
+	 * <ul>
+	 *   <li>{@code OPT.M_Product_ID.Identifier} – narrows the match to the line with this product</li>
+	 *   <li>{@code OPT.Line} – narrows the match to the line with this line number</li>
+	 * </ul>
+	 * When no disambiguator is provided the query must return exactly one result
+	 * ({@code firstOnlyNotNull} throws if the DESADV has more than one line).
+	 * Use a disambiguator column whenever the DESADV has multiple lines.
+	 *
+	 * <p>Example (single-line DESADV):
 	 * <pre>
 	 * Then EDI_DesadvLine records are found:
 	 *   | EDI_DesadvLine_ID | EDI_Desadv_ID |
 	 *   | desadvLine        | myDesadv      |
+	 * </pre>
+	 *
+	 * <p>Example (multi-line DESADV, disambiguated by product):
+	 * <pre>
+	 * Then EDI_DesadvLine records are found:
+	 *   | EDI_DesadvLine_ID | EDI_Desadv_ID | OPT.M_Product_ID.Identifier |
+	 *   | lineA             | myDesadv      | productA                    |
+	 *   | lineB             | myDesadv      | productB                    |
 	 * </pre>
 	 */
 	@Then("EDI_DesadvLine records are found:")
@@ -94,11 +112,22 @@ public class EDI_DesadvLine_StepDef
 		final StepDefDataIdentifier desadvIdentifier = row.getAsIdentifier(I_EDI_DesadvLine.COLUMNNAME_EDI_Desadv_ID);
 		final I_EDI_Desadv desadvRecord = desadvTable.get(desadvIdentifier);
 
-		final I_EDI_DesadvLine desadvLine = queryBL.createQueryBuilder(I_EDI_DesadvLine.class)
+		final IQueryBuilder<I_EDI_DesadvLine> queryBuilder = queryBL.createQueryBuilder(I_EDI_DesadvLine.class)
 				.addOnlyActiveRecordsFilter()
-				.addEqualsFilter(I_EDI_DesadvLine.COLUMNNAME_EDI_Desadv_ID, desadvRecord.getEDI_Desadv_ID())
-				.create()
-				.firstOnlyNotNull(I_EDI_DesadvLine.class);
+				.addEqualsFilter(I_EDI_DesadvLine.COLUMNNAME_EDI_Desadv_ID, desadvRecord.getEDI_Desadv_ID());
+
+		// Optional disambiguator: filter by product identifier when provided
+		row.getAsOptionalIdentifier(I_EDI_DesadvLine.COLUMNNAME_M_Product_ID)
+				.ifPresent(productIdentifier -> {
+					final I_M_Product productRecord = productTable.get(productIdentifier);
+					queryBuilder.addEqualsFilter(I_EDI_DesadvLine.COLUMNNAME_M_Product_ID, productRecord.getM_Product_ID());
+				});
+
+		// Optional disambiguator: filter by line number when provided
+		row.getAsOptionalInt(I_EDI_DesadvLine.COLUMNNAME_Line)
+				.ifPresent(line -> queryBuilder.addEqualsFilter(I_EDI_DesadvLine.COLUMNNAME_Line, line));
+
+		final I_EDI_DesadvLine desadvLine = queryBuilder.create().firstOnlyNotNull(I_EDI_DesadvLine.class);
 
 		final StepDefDataIdentifier lineIdentifier = row.getAsIdentifier(I_EDI_DesadvLine.COLUMNNAME_EDI_DesadvLine_ID);
 		desadvLineTable.put(lineIdentifier, desadvLine);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Export_Format_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Export_Format_StepDef.java
@@ -97,13 +97,22 @@ public class EDI_Desadv_Export_Format_StepDef
 		final String whereClause = expFormat.getWhereClause();
 		assertThat(whereClause).as("EXP_Format '%s' WhereClause must not be blank", EXP_FORMAT_NAME_PACK_ITEM).isNotBlank();
 
-		final DataTableRow firstRow = DataTableRows.of(dataTable).getFirstRow();
+		final DataTableRows rows = DataTableRows.of(dataTable);
+		// Guard: all DataTable rows must reference the same DESADV; a caller passing rows for
+		// different DESADVs would be silently broken (only the first row's DESADV is used).
+		final Set<StepDefDataIdentifier> distinctDesadvIdentifiers = rows.stream()
+				.map(row -> row.getAsIdentifier(I_EDI_Desadv.COLUMNNAME_EDI_Desadv_ID))
+				.collect(ImmutableSet.toImmutableSet());
+		assertThat(distinctDesadvIdentifiers)
+				.as("All DataTable rows must reference the same EDI_Desadv_ID identifier, but found multiple: %s", distinctDesadvIdentifiers)
+				.hasSize(1);
+
+		final DataTableRow firstRow = rows.getFirstRow();
 		final StepDefDataIdentifier desadvIdentifier = firstRow.getAsIdentifier(I_EDI_Desadv.COLUMNNAME_EDI_Desadv_ID);
 		final I_EDI_Desadv desadvRecord = desadvTable.get(desadvIdentifier);
 		final int desadvId = desadvRecord.getEDI_Desadv_ID();
 
-		final Set<StepDefDataIdentifier> expectedIdentifiers = DataTableRows.of(dataTable)
-				.stream()
+		final Set<StepDefDataIdentifier> expectedIdentifiers = rows.stream()
 				.map(row -> row.getAsIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_Item_ID))
 				.collect(ImmutableSet.toImmutableSet());
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Export_Format_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Export_Format_StepDef.java
@@ -47,7 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * {@code EXP_Format_ID=540418} (Name: {@code EDI_Exp_Desadv_Pack_Item}) WhereClause
  * would select for a given DESADV.
  *
- * <p>This is used by the RED test for me03 #29278 to prove that the current WhereClause
+ * <p>This is used by the RED test to prove that the current WhereClause
  * (which filters on the <em>parent line's</em> QtyDeliveredInUOM>0 rather than the
  * pack item's own MovementQty>0) incorrectly includes pack items with MovementQty=0.
  */

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Export_Format_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Export_Format_StepDef.java
@@ -61,7 +61,7 @@ public class EDI_Desadv_Export_Format_StepDef
 	 */
 	private static final String EXP_FORMAT_NAME_PACK_ITEM = "EDI_Exp_Desadv_Pack_Item";
 
-	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 	@NonNull private final EDI_Desadv_StepDefData desadvTable;
 	@NonNull private final EDI_Desadv_Pack_Item_StepDefData packItemTable;
@@ -89,7 +89,6 @@ public class EDI_Desadv_Export_Format_StepDef
 	@Then("the DESADV pack-item export-format selects only:")
 	public void desadv_pack_item_export_format_selects_only(@NonNull final DataTable dataTable)
 	{
-		// Load the WhereClause from the live EXP_Format record (looked up by Name)
 		final I_EXP_Format expFormat = queryBL.createQueryBuilder(I_EXP_Format.class)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_EXP_Format.COLUMNNAME_Name, EXP_FORMAT_NAME_PACK_ITEM)
@@ -103,18 +102,15 @@ public class EDI_Desadv_Export_Format_StepDef
 		final I_EDI_Desadv desadvRecord = desadvTable.get(desadvIdentifier);
 		final int desadvId = desadvRecord.getEDI_Desadv_ID();
 
-		// Collect all expected pack-item identifiers from every row in the table
 		final Set<StepDefDataIdentifier> expectedIdentifiers = DataTableRows.of(dataTable)
 				.stream()
 				.map(row -> row.getAsIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_Item_ID))
 				.collect(ImmutableSet.toImmutableSet());
 
-		// Resolve expected IDs from the StepDefData registry
 		final Set<Integer> expectedPackItemIds = expectedIdentifiers.stream()
 				.map(id -> packItemTable.get(id).getEDI_Desadv_Pack_Item_ID())
 				.collect(ImmutableSet.toImmutableSet());
 
-		// Find all packs that belong to the given DESADV
 		final Set<Integer> packIdsForDesadv = queryBL.createQueryBuilder(I_EDI_Desadv_Pack.class)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_EDI_Desadv_Pack.COLUMNNAME_EDI_Desadv_ID, desadvId)
@@ -128,7 +124,6 @@ public class EDI_Desadv_Export_Format_StepDef
 				.as("There must be at least one EDI_Desadv_Pack for EDI_Desadv_ID=%s", desadvId)
 				.isNotEmpty();
 
-		// Apply the live WhereClause filter to pack items that are in those packs
 		final Set<Integer> actualPackItemIds = queryBL.createQueryBuilder(I_EDI_Desadv_Pack_Item.class)
 				.addOnlyActiveRecordsFilter()
 				.addInArrayFilter(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_ID, packIdsForDesadv)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Export_Format_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Export_Format_StepDef.java
@@ -1,0 +1,155 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2024 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.edi;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.esb.edi.model.I_EDI_Desadv;
+import de.metas.esb.edi.model.I_EDI_Desadv_Pack;
+import de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Then;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.impl.TypedSqlQueryFilter;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_EXP_Format;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Step definitions that verify which EDI_Desadv_Pack_Item records the live
+ * {@code EXP_Format_ID=540418} (Name: {@code EDI_Exp_Desadv_Pack_Item}) WhereClause
+ * would select for a given DESADV.
+ *
+ * <p>This is used by the RED test for me03 #29278 to prove that the current WhereClause
+ * (which filters on the <em>parent line's</em> QtyDeliveredInUOM>0 rather than the
+ * pack item's own MovementQty>0) incorrectly includes pack items with MovementQty=0.
+ */
+public class EDI_Desadv_Export_Format_StepDef
+{
+	/**
+	 * AD_ID of the EXP_Format row for pack-item export.
+	 * Name: {@code EDI_Exp_Desadv_Pack_Item}.
+	 */
+	private static final int EXP_FORMAT_ID_PACK_ITEM = 540418;
+
+	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	private final EDI_Desadv_StepDefData desadvTable;
+	private final EDI_Desadv_Pack_Item_StepDefData packItemTable;
+
+	public EDI_Desadv_Export_Format_StepDef(
+			@NonNull final EDI_Desadv_StepDefData desadvTable,
+			@NonNull final EDI_Desadv_Pack_Item_StepDefData packItemTable)
+	{
+		this.desadvTable = desadvTable;
+		this.packItemTable = packItemTable;
+	}
+
+	/**
+	 * Loads the live WhereClause from {@code EXP_Format_ID=540418}, applies it as a
+	 * {@link TypedSqlQueryFilter} on {@link I_EDI_Desadv_Pack_Item} records belonging to the
+	 * given DESADV (via the pack), and asserts that the resulting set of records equals exactly
+	 * the listed pack-item identifiers.
+	 *
+	 * <p>Required columns:
+	 * <ul>
+	 *   <li>{@code EDI_Desadv_ID} – identifier of the DESADV whose packs are examined</li>
+	 *   <li>{@code EDI_Desadv_Pack_Item_ID} – comma-separated identifiers expected to be selected (one row per item)</li>
+	 * </ul>
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * Then the DESADV pack-item export-format selects only:
+	 *   | EDI_Desadv_ID | EDI_Desadv_Pack_Item_ID |
+	 *   | myDesadv      | pi_nonzero              |
+	 * </pre>
+	 */
+	@Then("the DESADV pack-item export-format selects only:")
+	public void desadv_pack_item_export_format_selects_only(@NonNull final DataTable dataTable)
+	{
+		// Load the WhereClause from the live EXP_Format record
+		final I_EXP_Format expFormat = InterfaceWrapperHelper.load(EXP_FORMAT_ID_PACK_ITEM, I_EXP_Format.class);
+		assertThat(expFormat).as("EXP_Format with ID=%s must exist", EXP_FORMAT_ID_PACK_ITEM).isNotNull();
+		final String whereClause = expFormat.getWhereClause();
+		assertThat(whereClause).as("EXP_Format.WhereClause must not be blank").isNotBlank();
+
+		final DataTableRow firstRow = DataTableRows.of(dataTable).getFirstRow();
+		final StepDefDataIdentifier desadvIdentifier = firstRow.getAsIdentifier(I_EDI_Desadv.COLUMNNAME_EDI_Desadv_ID);
+		final I_EDI_Desadv desadvRecord = desadvTable.get(desadvIdentifier);
+		final int desadvId = desadvRecord.getEDI_Desadv_ID();
+
+		// Collect all expected pack-item identifiers from every row in the table
+		final Set<StepDefDataIdentifier> expectedIdentifiers = DataTableRows.of(dataTable)
+				.stream()
+				.map(row -> row.getAsIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_Item_ID))
+				.collect(ImmutableSet.toImmutableSet());
+
+		// Resolve expected IDs from the StepDefData registry
+		final Set<Integer> expectedPackItemIds = expectedIdentifiers.stream()
+				.map(id -> packItemTable.get(id).getEDI_Desadv_Pack_Item_ID())
+				.collect(ImmutableSet.toImmutableSet());
+
+		// Find all packs that belong to the given DESADV
+		final Set<Integer> packIdsForDesadv = queryBL.createQueryBuilder(I_EDI_Desadv_Pack.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_EDI_Desadv_Pack.COLUMNNAME_EDI_Desadv_ID, desadvId)
+				.create()
+				.list(I_EDI_Desadv_Pack.class)
+				.stream()
+				.map(I_EDI_Desadv_Pack::getEDI_Desadv_Pack_ID)
+				.collect(ImmutableSet.toImmutableSet());
+
+		assertThat(packIdsForDesadv)
+				.as("There must be at least one EDI_Desadv_Pack for EDI_Desadv_ID=%s", desadvId)
+				.isNotEmpty();
+
+		// Apply the live WhereClause filter to pack items that are in those packs
+		final Set<Integer> actualPackItemIds = queryBL.createQueryBuilder(I_EDI_Desadv_Pack_Item.class)
+				.addOnlyActiveRecordsFilter()
+				.addInArrayFilter(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_ID, packIdsForDesadv)
+				.filter(TypedSqlQueryFilter.of(whereClause))
+				.create()
+				.list(I_EDI_Desadv_Pack_Item.class)
+				.stream()
+				.map(I_EDI_Desadv_Pack_Item::getEDI_Desadv_Pack_Item_ID)
+				.collect(ImmutableSet.toImmutableSet());
+
+		assertThat(actualPackItemIds)
+				.as("Pack items selected by EXP_Format WhereClause for EDI_Desadv_ID=%s must match exactly the expected identifiers.\n"
+						+ "WhereClause used: %s\n"
+						+ "Expected pack-item IDs: %s\n"
+						+ "Actual pack-item IDs:   %s",
+						desadvId,
+						whereClause,
+						expectedPackItemIds,
+						actualPackItemIds)
+				.isEqualTo(expectedPackItemIds);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Export_Format_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Export_Format_StepDef.java
@@ -33,9 +33,9 @@ import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Then;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.impl.TypedSqlQueryFilter;
-import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_EXP_Format;
 
 import java.util.Set;
@@ -44,36 +44,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Step definitions that verify which EDI_Desadv_Pack_Item records the live
- * {@code EXP_Format_ID=540418} (Name: {@code EDI_Exp_Desadv_Pack_Item}) WhereClause
+ * {@code EXP_Format} with Name {@code EDI_Exp_Desadv_Pack_Item} WhereClause
  * would select for a given DESADV.
  *
- * <p>This is used by the RED test to prove that the current WhereClause
- * (which filters on the <em>parent line's</em> QtyDeliveredInUOM>0 rather than the
- * pack item's own MovementQty>0) incorrectly includes pack items with MovementQty=0.
+ * <p>The invariant under test: the export format must select pack items by the
+ * item's own {@code MovementQty>0}, not the parent line's {@code QtyDeliveredInUOM}.
+ * A pack item with {@code MovementQty=0} on a line whose total
+ * {@code QtyDeliveredInUOM>0} must be excluded from the export.
  */
+@RequiredArgsConstructor
 public class EDI_Desadv_Export_Format_StepDef
 {
 	/**
-	 * AD_ID of the EXP_Format row for pack-item export.
-	 * Name: {@code EDI_Exp_Desadv_Pack_Item}.
+	 * Name of the {@code EXP_Format} row for pack-item export.
+	 * Used to look up the record via IQueryBL rather than hardcoding its AD_ID.
 	 */
-	private static final int EXP_FORMAT_ID_PACK_ITEM = 540418;
+	private static final String EXP_FORMAT_NAME_PACK_ITEM = "EDI_Exp_Desadv_Pack_Item";
 
-	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
-	private final EDI_Desadv_StepDefData desadvTable;
-	private final EDI_Desadv_Pack_Item_StepDefData packItemTable;
-
-	public EDI_Desadv_Export_Format_StepDef(
-			@NonNull final EDI_Desadv_StepDefData desadvTable,
-			@NonNull final EDI_Desadv_Pack_Item_StepDefData packItemTable)
-	{
-		this.desadvTable = desadvTable;
-		this.packItemTable = packItemTable;
-	}
+	@NonNull private final EDI_Desadv_StepDefData desadvTable;
+	@NonNull private final EDI_Desadv_Pack_Item_StepDefData packItemTable;
 
 	/**
-	 * Loads the live WhereClause from {@code EXP_Format_ID=540418}, applies it as a
+	 * Loads the live WhereClause from the {@code EXP_Format} named
+	 * {@value #EXP_FORMAT_NAME_PACK_ITEM}, applies it as a
 	 * {@link TypedSqlQueryFilter} on {@link I_EDI_Desadv_Pack_Item} records belonging to the
 	 * given DESADV (via the pack), and asserts that the resulting set of records equals exactly
 	 * the listed pack-item identifiers.
@@ -81,7 +76,7 @@ public class EDI_Desadv_Export_Format_StepDef
 	 * <p>Required columns:
 	 * <ul>
 	 *   <li>{@code EDI_Desadv_ID} – identifier of the DESADV whose packs are examined</li>
-	 *   <li>{@code EDI_Desadv_Pack_Item_ID} – comma-separated identifiers expected to be selected (one row per item)</li>
+	 *   <li>{@code EDI_Desadv_Pack_Item_ID} – identifiers expected to be selected (one row per item)</li>
 	 * </ul>
 	 *
 	 * <p>Example:
@@ -94,11 +89,14 @@ public class EDI_Desadv_Export_Format_StepDef
 	@Then("the DESADV pack-item export-format selects only:")
 	public void desadv_pack_item_export_format_selects_only(@NonNull final DataTable dataTable)
 	{
-		// Load the WhereClause from the live EXP_Format record
-		final I_EXP_Format expFormat = InterfaceWrapperHelper.load(EXP_FORMAT_ID_PACK_ITEM, I_EXP_Format.class);
-		assertThat(expFormat).as("EXP_Format with ID=%s must exist", EXP_FORMAT_ID_PACK_ITEM).isNotNull();
+		// Load the WhereClause from the live EXP_Format record (looked up by Name)
+		final I_EXP_Format expFormat = queryBL.createQueryBuilder(I_EXP_Format.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_EXP_Format.COLUMNNAME_Name, EXP_FORMAT_NAME_PACK_ITEM)
+				.create()
+				.firstOnlyNotNull(I_EXP_Format.class);
 		final String whereClause = expFormat.getWhereClause();
-		assertThat(whereClause).as("EXP_Format.WhereClause must not be blank").isNotBlank();
+		assertThat(whereClause).as("EXP_Format '%s' WhereClause must not be blank", EXP_FORMAT_NAME_PACK_ITEM).isNotBlank();
 
 		final DataTableRow firstRow = DataTableRows.of(dataTable).getFirstRow();
 		final StepDefDataIdentifier desadvIdentifier = firstRow.getAsIdentifier(I_EDI_Desadv.COLUMNNAME_EDI_Desadv_ID);
@@ -142,10 +140,11 @@ public class EDI_Desadv_Export_Format_StepDef
 				.collect(ImmutableSet.toImmutableSet());
 
 		assertThat(actualPackItemIds)
-				.as("Pack items selected by EXP_Format WhereClause for EDI_Desadv_ID=%s must match exactly the expected identifiers.\n"
-						+ "WhereClause used: %s\n"
-						+ "Expected pack-item IDs: %s\n"
-						+ "Actual pack-item IDs:   %s",
+				.as("Pack items selected by EXP_Format '%s' WhereClause for EDI_Desadv_ID=%s must match exactly the expected identifiers.\n"
+								+ "WhereClause used: %s\n"
+								+ "Expected pack-item IDs: %s\n"
+								+ "Actual pack-item IDs:   %s",
+						EXP_FORMAT_NAME_PACK_ITEM,
 						desadvId,
 						whereClause,
 						expectedPackItemIds,

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Pack_Item_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Pack_Item_StepDef.java
@@ -142,6 +142,9 @@ public class EDI_Desadv_Pack_Item_StepDef
 		packItemRecord.setEDI_DesadvLine_ID(desadvLine.getEDI_DesadvLine_ID());
 		packItemRecord.setMovementQty(movementQty);
 		packItemRecord.setQtyCUsPerLU(qtyCUsPerLU);
+		// Line is mandatory (NOT NULL). The injected item only needs a non-null, distinct line value;
+		// 9999 won't collide with the generator's low sequential line numbers within the same pack.
+		packItemRecord.setLine(row.getAsOptionalInt(I_EDI_Desadv_Pack_Item.COLUMNNAME_Line).orElse(9999));
 
 		row.getAsOptionalIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_M_InOutLine_ID)
 				.filter(id -> !id.isNullPlaceholder())
@@ -333,7 +336,9 @@ public class EDI_Desadv_Pack_Item_StepDef
 		softly.assertAll();
 
 		final StepDefDataIdentifier packItemIdentifier = dataTableRow.getAsIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_Item_ID);
-		packItemTable.put(packItemIdentifier, desadvPackItemRecord);
+		// putOrReplace (not put): a scenario may assert the same pack item at multiple checkpoints
+		// (e.g. after complete, then again after re-complete) using the same identifier.
+		packItemTable.putOrReplace(packItemIdentifier, desadvPackItemRecord);
 	}
 
 	private void logCurrentContext(

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Pack_Item_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Pack_Item_StepDef.java
@@ -31,6 +31,7 @@ import de.metas.cucumber.stepdefs.hu.M_HU_PackagingCode_StepDefData;
 import de.metas.cucumber.stepdefs.shipment.M_InOutLine_StepDefData;
 import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
 import de.metas.edi.api.impl.pack.EDIDesadvPackId;
+import de.metas.esb.edi.model.I_EDI_DesadvLine;
 import de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item;
 import de.metas.inout.InOutLineId;
 import de.metas.logging.LogManager;
@@ -131,7 +132,7 @@ public class EDI_Desadv_Pack_Item_StepDef
 		final EDIDesadvPackId packId = packTable.getId(packIdentifier);
 
 		final StepDefDataIdentifier desadvLineIdentifier = row.getAsIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_DesadvLine_ID);
-		final de.metas.esb.edi.model.I_EDI_DesadvLine desadvLine = desadvLineTable.get(desadvLineIdentifier);
+		final I_EDI_DesadvLine desadvLine = desadvLineTable.get(desadvLineIdentifier);
 
 		final BigDecimal movementQty = row.getAsBigDecimal(I_EDI_Desadv_Pack_Item.COLUMNNAME_MovementQty);
 		final BigDecimal qtyCUsPerLU = row.getAsBigDecimal(I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerLU);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Pack_Item_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Pack_Item_StepDef.java
@@ -42,6 +42,7 @@ import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.assertj.core.api.SoftAssertions;
 import org.compiere.util.DB;
 import org.slf4j.Logger;
@@ -65,6 +66,7 @@ public class EDI_Desadv_Pack_Item_StepDef
 
 	private final EDI_Desadv_Pack_StepDefData packTable;
 	private final EDI_Desadv_Pack_Item_StepDefData packItemTable;
+	private final EDI_DesadvLine_StepDefData desadvLineTable;
 	private final M_InOut_StepDefData shipmentTable;
 	private final M_InOutLine_StepDefData shipmentLineTable;
 	private final M_HU_PackagingCode_StepDefData huPackagingCodeTable;
@@ -72,12 +74,14 @@ public class EDI_Desadv_Pack_Item_StepDef
 	public EDI_Desadv_Pack_Item_StepDef(
 			@NonNull final EDI_Desadv_Pack_StepDefData packTable,
 			@NonNull final EDI_Desadv_Pack_Item_StepDefData packItemTable,
+			@NonNull final EDI_DesadvLine_StepDefData desadvLineTable,
 			@NonNull final M_InOut_StepDefData shipmentTable,
 			@NonNull final M_InOutLine_StepDefData shipmentLineTable,
 			@NonNull final M_HU_PackagingCode_StepDefData huPackagingCodeTable)
 	{
 		this.packTable = packTable;
 		this.packItemTable = packItemTable;
+		this.desadvLineTable = desadvLineTable;
 		this.shipmentTable = shipmentTable;
 		this.shipmentLineTable = shipmentLineTable;
 		this.huPackagingCodeTable = huPackagingCodeTable;
@@ -87,6 +91,68 @@ public class EDI_Desadv_Pack_Item_StepDef
 	public void setupMD_Stock_Data()
 	{
 		truncateEDIDesadvPackItem();
+	}
+
+	/**
+	 * Inserts EDI_Desadv_Pack_Item records directly into the DB so that tests can inject
+	 * pack items with specific quantities (e.g. MovementQty=0) without going through the normal
+	 * shipment/DESADV creation flow.
+	 *
+	 * <p>Required columns:
+	 * <ul>
+	 *   <li>{@code EDI_Desadv_Pack_Item_ID} – identifier under which the created record is registered</li>
+	 *   <li>{@code EDI_Desadv_Pack_ID} – identifier of an existing pack (must be registered in {@link EDI_Desadv_Pack_StepDefData})</li>
+	 *   <li>{@code EDI_DesadvLine_ID} – identifier of an existing desadv line (must be registered in {@link EDI_DesadvLine_StepDefData})</li>
+	 *   <li>{@code MovementQty} – movement quantity of this pack item</li>
+	 *   <li>{@code QtyCUsPerLU} – number of CUs per LU</li>
+	 * </ul>
+	 *
+	 * <p>Optional columns:
+	 * <ul>
+	 *   <li>{@code M_InOutLine_ID} – identifier or {@code -} for null</li>
+	 * </ul>
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * Given metasfresh contains EDI_Desadv_Pack_Item:
+	 *   | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | EDI_DesadvLine_ID | MovementQty | QtyCUsPerLU | M_InOutLine_ID |
+	 *   | pi_zero_qty             | myPack             | myLine            | 0           | 0           | -              |
+	 * </pre>
+	 */
+	@Given("metasfresh contains EDI_Desadv_Pack_Item:")
+	public void metasfresh_contains_edi_desadv_pack_item(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::insertPackItem);
+	}
+
+	private void insertPackItem(@NonNull final DataTableRow row)
+	{
+		final StepDefDataIdentifier packIdentifier = row.getAsIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_ID);
+		final EDIDesadvPackId packId = packTable.getId(packIdentifier);
+
+		final StepDefDataIdentifier desadvLineIdentifier = row.getAsIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_DesadvLine_ID);
+		final de.metas.esb.edi.model.I_EDI_DesadvLine desadvLine = desadvLineTable.get(desadvLineIdentifier);
+
+		final BigDecimal movementQty = row.getAsBigDecimal(I_EDI_Desadv_Pack_Item.COLUMNNAME_MovementQty);
+		final BigDecimal qtyCUsPerLU = row.getAsBigDecimal(I_EDI_Desadv_Pack_Item.COLUMNNAME_QtyCUsPerLU);
+
+		final I_EDI_Desadv_Pack_Item packItemRecord = InterfaceWrapperHelper.newInstance(I_EDI_Desadv_Pack_Item.class);
+		packItemRecord.setEDI_Desadv_Pack_ID(packId.getRepoId());
+		packItemRecord.setEDI_DesadvLine_ID(desadvLine.getEDI_DesadvLine_ID());
+		packItemRecord.setMovementQty(movementQty);
+		packItemRecord.setQtyCUsPerLU(qtyCUsPerLU);
+
+		row.getAsOptionalIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_M_InOutLine_ID)
+				.filter(id -> !id.isNullPlaceholder())
+				.ifPresent(inOutLineIdentifier -> {
+					final InOutLineId inOutLineId = shipmentLineTable.getId(inOutLineIdentifier);
+					packItemRecord.setM_InOutLine_ID(inOutLineId.getRepoId());
+				});
+
+		InterfaceWrapperHelper.saveRecord(packItemRecord);
+
+		final StepDefDataIdentifier packItemIdentifier = row.getAsIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_Item_ID);
+		packItemTable.put(packItemIdentifier, packItemRecord);
 	}
 
 	@Then("^after not more than (.*)s, the EDI_Desadv_Pack_Item has only the following records:$")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
@@ -49,6 +49,7 @@ import de.metas.cucumber.stepdefs.message.AD_Message_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_OrderLine_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
 import de.metas.cucumber.stepdefs.shipmentschedule.M_ShipmentSchedule_StepDefData;
+import de.metas.cucumber.stepdefs.tourplanning.M_Tour_StepDefData;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
 import de.metas.document.DocBaseType;
 import de.metas.document.engine.DocStatus;
@@ -146,6 +147,7 @@ public class M_InOut_StepDef
 	private final M_Warehouse_StepDefData warehouseTable;
 	private final AD_Message_StepDefData messageTable;
 	private final C_DocType_StepDefData docTypeTable;
+	private final M_Tour_StepDefData tourTable;
 	private final TestContext restTestContext;
 
 	private final IInOutDAO inOutDAO = Services.get(IInOutDAO.class);
@@ -503,6 +505,35 @@ public class M_InOut_StepDef
 			final String shipmentIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_M_InOut_ID + "." + TABLECOLUMN_IDENTIFIER);
 			inoutTable.putOrReplace(shipmentIdentifier, shipment);
 		}
+	}
+
+	/**
+	 * Updates existing {@link I_M_InOut} records (e.g. to set a non-quantity field before reactivation).
+	 * <p>
+	 * Columns:
+	 * <ul>
+	 *     <li>M_InOut_ID (required): identifier of the shipment to update.</li>
+	 *     <li>OPT.M_Tour_ID (optional): identifier of an {@link de.metas.tourplanning.model.I_M_Tour} to set on the shipment.</li>
+	 * </ul>
+	 * Example:
+	 * <pre>
+	 * And update M_InOut:
+	 *   | M_InOut_ID | OPT.M_Tour_ID |
+	 *   | shipment   | tour          |
+	 * </pre>
+	 */
+	@And("update M_InOut:")
+	public void update_M_InOut(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_M_InOut shipment = inoutTable.get(row.getAsIdentifier(COLUMNNAME_M_InOut_ID));
+			InterfaceWrapperHelper.refresh(shipment);
+
+			row.getAsOptionalIdentifier("M_Tour_ID")
+					.ifPresent(tourIdentifier -> shipment.setM_Tour_ID(tourTable.get(tourIdentifier).getM_Tour_ID()));
+
+			InterfaceWrapperHelper.saveRecord(shipment);
+		});
 	}
 
 	@And("perform shipment document action")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_Tour_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_Tour_StepDef.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.tourplanning;
+
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.tourplanning.model.I_M_Tour;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+
+@RequiredArgsConstructor
+public class M_Tour_StepDef
+{
+	private final M_Tour_StepDefData tourTable;
+
+	/**
+	 * Creates {@link I_M_Tour} records.
+	 * <p>
+	 * Columns:
+	 * <ul>
+	 *     <li>Identifier (required): identifier under which the created M_Tour is stored for later reference.</li>
+	 *     <li>OPT.Name (optional): the tour's name; defaults to the identifier.</li>
+	 * </ul>
+	 * Example:
+	 * <pre>
+	 * Given metasfresh contains M_Tour:
+	 *   | Identifier | OPT.Name  |
+	 *   | tour       | Tour Mon  |
+	 * </pre>
+	 */
+	@Given("metasfresh contains M_Tour:")
+	public void metasfresh_contains_M_Tour(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_M_Tour tour = newInstance(I_M_Tour.class);
+			tour.setName(row.getAsOptionalString("Name").orElseGet(() -> row.getAsIdentifier().getAsString()));
+			saveRecord(tour);
+
+			row.getAsOptionalIdentifier().ifPresent(identifier -> tourTable.putOrReplace(identifier, tour));
+		});
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_Tour_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_Tour_StepDefData.java
@@ -26,7 +26,7 @@ import de.metas.cucumber.stepdefs.StepDefData;
 import de.metas.tourplanning.model.I_M_Tour;
 
 /**
- * Having a dedicated class to help the IOC-framework injecting the right instances, if a step-def needs more than one.
+ * Having a dedicated class to help the IoC framework injecting the right instances, if a step-def needs more than one.
  */
 public class M_Tour_StepDefData extends StepDefData<I_M_Tour>
 {

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_Tour_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/tourplanning/M_Tour_StepDefData.java
@@ -1,0 +1,37 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.tourplanning;
+
+import de.metas.cucumber.stepdefs.StepDefData;
+import de.metas.tourplanning.model.I_M_Tour;
+
+/**
+ * Having a dedicated class to help the IOC-framework injecting the right instances, if a step-def needs more than one.
+ */
+public class M_Tour_StepDefData extends StepDefData<I_M_Tour>
+{
+	public M_Tour_StepDefData()
+	{
+		super(I_M_Tour.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvExportSkipsQtyZeroPackItem.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvExportSkipsQtyZeroPackItem.feature
@@ -1,0 +1,116 @@
+@from:cucumber
+@ghActions:run_on_executor5
+@allure.label.epic:E0292_EDI
+@allure.label.feature:F00353_EDI
+Feature: EDI DESADV export must not include pack items whose own MovementQty is zero
+## me03 #29278 — Fehler bei EDI Coop
+## The EXP_Format_ID=540418 WhereClause currently filters on the PARENT LINE's QtyDeliveredInUOM
+## rather than the pack item's own MovementQty. A pack item with MovementQty=0 on a line whose
+## total QtyDeliveredInUOM>0 is therefore wrongly included in the export.
+## This feature documents that bug (RED test): it must FAIL before the production fix is applied.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And set sys config boolean value true for sys config de.metas.report.jasper.IsMockReportService
+    And metasfresh has date and time 2024-06-10T13:30:13+02:00[Europe/Berlin]
+    And metasfresh is configured for One-DESADV-Per-ORDERS
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh initially has no EDI_Desadv_Pack_Item data
+    And metasfresh initially has no EDI_Desadv_Pack data
+    And destroy existing M_HUs
+    And load M_Warehouse:
+      | M_Warehouse_ID | Value        |
+      | warehouseStd   | StdWarehouse |
+
+  @from:cucumber
+  @Id:S0353_010
+  Scenario: S0353_010 - Export format must skip pack items with MovementQty=0 (RED test for me03 29278)
+  Setup: one valid DESADV with a qty>0 pack item is created via the normal flow.
+  Then a second pack item with MovementQty=0 is injected directly into the same pack.
+  The assertion checks that the EXP_Format WhereClause (EXP_Format_ID=540418) only
+  selects the qty>0 item — this FAILS before the fix because the current WhereClause
+  filters on the parent line qty, not the pack item own qty.
+
+    Given metasfresh contains M_Products:
+      | Identifier   |
+      | product_main |
+    And metasfresh contains M_PricingSystems
+      | Identifier    |
+      | ps_S0353_010  |
+    And metasfresh contains M_PriceLists
+      | Identifier    | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_S0353_010  | ps_S0353_010       | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier     | M_PriceList_ID |
+      | plv_S0353_010  | pl_S0353_010   |
+    And metasfresh contains M_ProductPrices
+      | Identifier    | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | pp_S0353_010  | plv_S0353_010          | product_main | 10.0     | PCE      | Normal           |
+    And metasfresh contains C_BPartners:
+      | Identifier  | IsCustomer | M_PricingSystem_ID | GLN          |
+      | endcustomer | Y          | ps_S0353_010       | location_gln |
+    And the following c_bpartner is changed
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN      |
+      | endcustomer   | true                 | bPartnerDesadvRecipientGLN |
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID.Identifier | M_Product_ID.Identifier |
+      | endcustomer              | product_main            |
+
+    And metasfresh contains C_Orders:
+      | Identifier   | IsSOTrx | C_BPartner_ID | DateOrdered | POReference   |
+      | order_main   | true    | endcustomer   | 2024-06-10  | po_ref_@Date@ |
+
+    And metasfresh contains C_OrderLines:
+      | Identifier      | C_Order_ID | M_Product_ID | QtyEntered |
+      | orderLine_main  | order_main | product_main | 10         |
+
+    When the order identified by order_main is completed
+
+    And after not more than 30s, M_ShipmentSchedules are found:
+      | Identifier    | C_OrderLine_ID.Identifier | IsToRecompute |
+      | shipSched     | orderLine_main            | N             |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | shipSched                         | D            | true                | false       |
+
+    Then after not more than 30s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | shipSched                         | shipment              |
+
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed | OPT.C_OrderLine_ID.Identifier |
+      | shipmentLine              | shipment              | product_main            | 10          | true      | orderLine_main                |
+
+    And after not more than 30s, EDI_Desadv_Pack records are found:
+      | EDI_Desadv_Pack_ID.Identifier | IsManual_IPA_SSCC18 | OPT.M_HU_ID.Identifier | OPT.M_HU_PackagingCode_ID.Identifier | OPT.GTIN_PackingMaterial | OPT.SeqNo |
+      | packMain                      | true                | null                   | null                                 | null                     | 1         |
+
+    And after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerTU_InInvoiceUOM | QtyCUsPerLU | QtyCUsPerLU_InInvoiceUOM | QtyItemCapacity | OPT.QtyTU | OPT.M_InOut_ID.Identifier | M_InOutLine_ID | BestBeforeDate | LotNumber | M_HU_PackagingCode_TU_ID | GTIN_TU_PackingMaterial |
+      | pi_nonzero              | packMain           | 10          | 10          | 10                       | 10          | 10                       | 0               | 1         | shipment                  | shipmentLine   | null           | null      | null                     | null                    |
+
+    # Find and register the EDI_Desadv so we can capture the desadv line
+    Then validate created edi desadv
+      | C_Order_ID.Identifier | SumDeliveredInStockingUOM | SumOrderedInStockingUOM | EDI_Desadv_ID.Identifier |
+      | order_main            | 10                        | 10                      | desadv                   |
+
+    # Capture the auto-created EDI_DesadvLine under an identifier
+    Then EDI_DesadvLine records are found:
+      | EDI_DesadvLine_ID | EDI_Desadv_ID |
+      | desadvLine        | desadv        |
+
+    # Inject an extra pack item with MovementQty=0 into the SAME pack on the same line
+    Given metasfresh contains EDI_Desadv_Pack_Item:
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | EDI_DesadvLine_ID | MovementQty | QtyCUsPerLU | M_InOutLine_ID |
+      | pi_zero                 | packMain           | desadvLine        | 0           | 0           | -              |
+
+    # This assertion MUST FAIL (RED) before the fix:
+    # The current WhereClause filters on the parent line's QtyDeliveredInUOM>0, so pi_zero
+    # is wrongly included (because its parent line has QtyDeliveredInUOM=10 > 0).
+    # After the fix the WhereClause will also require the pack item's own MovementQty>0,
+    # and only pi_nonzero will be selected.
+    Then the DESADV pack-item export-format selects only:
+      | EDI_Desadv_ID | EDI_Desadv_Pack_Item_ID |
+      | desadv        | pi_nonzero              |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvExportSkipsQtyZeroPackItem.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvExportSkipsQtyZeroPackItem.feature
@@ -101,9 +101,8 @@ Feature: EDI DESADV export must not include pack items whose own MovementQty is 
       | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | EDI_DesadvLine_ID | MovementQty | QtyCUsPerLU | M_InOutLine_ID |
       | pi_zero                 | packMain           | desadvLine        | 0           | 0           | -              |
 
-    # The export format WhereClause must select only the qty>0 item.
-    # This assertion FAILS (RED) until the EXP_Format WhereClause is fixed to require
-    # MovementQty>0 on the pack item itself.
+    # The export format WhereClause must select pack items by the item's own MovementQty>0,
+    # not by the parent line's QtyDeliveredInUOM, so only the qty>0 item is exported.
     Then the DESADV pack-item export-format selects only:
       | EDI_Desadv_ID | EDI_Desadv_Pack_Item_ID |
       | desadv        | pi_nonzero              |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvExportSkipsQtyZeroPackItem.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvExportSkipsQtyZeroPackItem.feature
@@ -85,10 +85,15 @@ Feature: EDI DESADV export must not include pack items whose own MovementQty is 
       | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerTU_InInvoiceUOM | QtyCUsPerLU | QtyCUsPerLU_InInvoiceUOM | QtyItemCapacity | OPT.QtyTU | OPT.M_InOut_ID.Identifier | M_InOutLine_ID | BestBeforeDate | LotNumber | M_HU_PackagingCode_TU_ID | GTIN_TU_PackingMaterial |
       | pi_nonzero              | packMain           | 10          | 10          | 10                       | 10          | 10                       | 0               | 1         | shipment                  | shipmentLine   | null           | null      | null                     | null                    |
 
-    # Find and register the EDI_Desadv so we can capture the desadv line
+    # Validate the auto-created EDI_Desadv sums
     Then validate created edi desadv
-      | C_Order_ID.Identifier | SumDeliveredInStockingUOM | SumOrderedInStockingUOM | EDI_Desadv_ID.Identifier |
-      | order_main            | 10                        | 10                      | desadv                   |
+      | C_Order_ID.Identifier | SumDeliveredInStockingUOM | SumOrderedInStockingUOM |
+      | order_main            | 10                        | 10                      |
+
+    # Register the EDI_Desadv under the 'desadv' identifier so subsequent steps can reference it
+    Then EDI_Desadv is found:
+      | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_Desadv_ID.Identifier |
+      | endcustomer              | order_main            | desadv                   |
 
     # Capture the auto-created EDI_DesadvLine under an identifier
     # Precondition: this DESADV has exactly one line (the scenario creates a single order line)

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvExportSkipsQtyZeroPackItem.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvExportSkipsQtyZeroPackItem.feature
@@ -3,7 +3,6 @@
 @allure.label.epic:E0292_EDI
 @allure.label.feature:F00353_EDI
 Feature: EDI DESADV export must not include pack items whose own MovementQty is zero
-## me03 #29278 — Fehler bei EDI Coop
 ## The EXP_Format_ID=540418 WhereClause currently filters on the PARENT LINE's QtyDeliveredInUOM
 ## rather than the pack item's own MovementQty. A pack item with MovementQty=0 on a line whose
 ## total QtyDeliveredInUOM>0 is therefore wrongly included in the export.
@@ -25,7 +24,7 @@ Feature: EDI DESADV export must not include pack items whose own MovementQty is 
 
   @from:cucumber
   @Id:S0353_010
-  Scenario: S0353_010 - Export format must skip pack items with MovementQty=0 (RED test for me03 29278)
+  Scenario: S0353_010 - Export format must skip pack items with MovementQty=0
   Setup: one valid DESADV with a qty>0 pack item is created via the normal flow.
   Then a second pack item with MovementQty=0 is injected directly into the same pack.
   The assertion checks that the EXP_Format WhereClause (EXP_Format_ID=540418) only

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvExportSkipsQtyZeroPackItem.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvExportSkipsQtyZeroPackItem.feature
@@ -3,10 +3,10 @@
 @allure.label.epic:E0292_EDI
 @allure.label.feature:F00353_EDI
 Feature: EDI DESADV export must not include pack items whose own MovementQty is zero
-## The EXP_Format_ID=540418 WhereClause currently filters on the PARENT LINE's QtyDeliveredInUOM
-## rather than the pack item's own MovementQty. A pack item with MovementQty=0 on a line whose
-## total QtyDeliveredInUOM>0 is therefore wrongly included in the export.
-## This feature documents that bug (RED test): it must FAIL before the production fix is applied.
+# The EXP_Format (Name: EDI_Exp_Desadv_Pack_Item) WhereClause must filter on the pack
+# item's own MovementQty>0, not the parent line's QtyDeliveredInUOM.
+# A pack item with MovementQty=0 on a line whose total QtyDeliveredInUOM>0 must be
+# excluded from the export.
 
   Background:
     Given infrastructure and metasfresh are running
@@ -24,28 +24,23 @@ Feature: EDI DESADV export must not include pack items whose own MovementQty is 
 
   @from:cucumber
   @Id:S0353_010
-  Scenario: S0353_010 - Export format must skip pack items with MovementQty=0
-  Setup: one valid DESADV with a qty>0 pack item is created via the normal flow.
-  Then a second pack item with MovementQty=0 is injected directly into the same pack.
-  The assertion checks that the EXP_Format WhereClause (EXP_Format_ID=540418) only
-  selects the qty>0 item — this FAILS before the fix because the current WhereClause
-  filters on the parent line qty, not the pack item own qty.
+  Scenario: Export format must skip pack items with MovementQty=0
 
     Given metasfresh contains M_Products:
       | Identifier   |
       | product_main |
     And metasfresh contains M_PricingSystems
-      | Identifier    |
-      | ps_S0353_010  |
+      | Identifier   |
+      | ps_S0353_010 |
     And metasfresh contains M_PriceLists
-      | Identifier    | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
-      | pl_S0353_010  | ps_S0353_010       | DE           | EUR           | true  | false         | 2              |
+      | Identifier   | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_S0353_010 | ps_S0353_010       | DE           | EUR           | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
-      | Identifier     | M_PriceList_ID |
-      | plv_S0353_010  | pl_S0353_010   |
+      | Identifier    | M_PriceList_ID |
+      | plv_S0353_010 | pl_S0353_010   |
     And metasfresh contains M_ProductPrices
-      | Identifier    | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
-      | pp_S0353_010  | plv_S0353_010          | product_main | 10.0     | PCE      | Normal           |
+      | Identifier   | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | pp_S0353_010 | plv_S0353_010          | product_main | 10.0     | PCE      | Normal           |
     And metasfresh contains C_BPartners:
       | Identifier  | IsCustomer | M_PricingSystem_ID | GLN          |
       | endcustomer | Y          | ps_S0353_010       | location_gln |
@@ -57,18 +52,18 @@ Feature: EDI DESADV export must not include pack items whose own MovementQty is 
       | endcustomer              | product_main            |
 
     And metasfresh contains C_Orders:
-      | Identifier   | IsSOTrx | C_BPartner_ID | DateOrdered | POReference   |
-      | order_main   | true    | endcustomer   | 2024-06-10  | po_ref_@Date@ |
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference   |
+      | order_main | true    | endcustomer   | 2024-06-10  | po_ref_@Date@ |
 
     And metasfresh contains C_OrderLines:
-      | Identifier      | C_Order_ID | M_Product_ID | QtyEntered |
-      | orderLine_main  | order_main | product_main | 10         |
+      | Identifier     | C_Order_ID | M_Product_ID | QtyEntered |
+      | orderLine_main | order_main | product_main | 10         |
 
     When the order identified by order_main is completed
 
     And after not more than 30s, M_ShipmentSchedules are found:
-      | Identifier    | C_OrderLine_ID.Identifier | IsToRecompute |
-      | shipSched     | orderLine_main            | N             |
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | shipSched  | orderLine_main            | N             |
 
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
@@ -96,6 +91,7 @@ Feature: EDI DESADV export must not include pack items whose own MovementQty is 
       | order_main            | 10                        | 10                      | desadv                   |
 
     # Capture the auto-created EDI_DesadvLine under an identifier
+    # Precondition: this DESADV has exactly one line (the scenario creates a single order line)
     Then EDI_DesadvLine records are found:
       | EDI_DesadvLine_ID | EDI_Desadv_ID |
       | desadvLine        | desadv        |
@@ -105,11 +101,9 @@ Feature: EDI DESADV export must not include pack items whose own MovementQty is 
       | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | EDI_DesadvLine_ID | MovementQty | QtyCUsPerLU | M_InOutLine_ID |
       | pi_zero                 | packMain           | desadvLine        | 0           | 0           | -              |
 
-    # This assertion MUST FAIL (RED) before the fix:
-    # The current WhereClause filters on the parent line's QtyDeliveredInUOM>0, so pi_zero
-    # is wrongly included (because its parent line has QtyDeliveredInUOM=10 > 0).
-    # After the fix the WhereClause will also require the pack item's own MovementQty>0,
-    # and only pi_nonzero will be selected.
+    # The export format WhereClause must select only the qty>0 item.
+    # This assertion FAILS (RED) until the EXP_Format WhereClause is fixed to require
+    # MovementQty>0 on the pack item itself.
     Then the DESADV pack-item export-format selects only:
       | EDI_Desadv_ID | EDI_Desadv_Pack_Item_ID |
       | desadv        | pi_nonzero              |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvReactivateRecompleteNoOrphanPack.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvReactivateRecompleteNoOrphanPack.feature
@@ -152,10 +152,12 @@ Feature: Reactivating and re-completing a shipment must not leave an orphan Qty-
     And the shipment identified by shipment is completed
 
     # Re-completion deletes packMain's real item (it had an M_InOutLine_ID) and re-creates the real
-    # qty>0 item in a fresh pack. packMain (SeqNo 1) survives so the fresh pack gets SeqNo 2.
+    # Reactivation removes the old pack (its item was linked by M_InOutLine_ID); re-completion
+    # creates a single fresh manual pack. We don't pin SeqNo (it is an implementation detail of
+    # the pack sequence) — we just locate the active manual pack so we can assert its item below.
     And after not more than 30s, EDI_Desadv_Pack records are found:
-      | EDI_Desadv_Pack_ID.Identifier | IsManual_IPA_SSCC18 | OPT.M_HU_ID.Identifier | OPT.SeqNo |
-      | packRecompleted               | true                | null                   | 2         |
+      | EDI_Desadv_Pack_ID.Identifier | IsManual_IPA_SSCC18 | OPT.M_HU_ID.Identifier |
+      | packRecompleted               | true                | null                   |
 
     # After the cycle, only the legitimate qty>0 pack item must remain.
     # If a Qty-0/NULL-M_InOutLine_ID orphan had been created by the SSCC generator (pre-fix),

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvReactivateRecompleteNoOrphanPack.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvReactivateRecompleteNoOrphanPack.feature
@@ -1,0 +1,132 @@
+@from:cucumber
+@ghActions:run_on_executor5
+@allure.label.epic:E0292_EDI
+@allure.label.feature:F00353_EDI
+Feature: Reactivating and re-completing a shipment must not leave an orphan Qty-0 DESADV pack item
+# me03 #29278: a shipment is COMPLETED, then REACTIVATED (only a non-quantity field such as M_Tour_ID changed),
+# then RE-COMPLETED. A pre-existing "drafted" pack item (created by SSCC-label generation, with M_InOutLine_ID=NULL)
+# whose MovementQty is 0 can never be reclaimed (no real shipment line has MovementQty 0) and is invisible to the
+# reactivation cleanup (which deletes pack items filtered by M_InOutLine_ID). It therefore survives forever as an
+# orphan Qty-0 pack item in its own phantom pack, which then breaks the EDI export.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And set sys config boolean value true for sys config de.metas.report.jasper.IsMockReportService
+    And metasfresh has date and time 2024-06-10T13:30:13+02:00[Europe/Berlin]
+    And metasfresh is configured for One-DESADV-Per-ORDERS
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh initially has no EDI_Desadv_Pack_Item data
+    And metasfresh initially has no EDI_Desadv_Pack data
+    And destroy existing M_HUs
+    And load M_Warehouse:
+      | M_Warehouse_ID | Value        |
+      | warehouseStd   | StdWarehouse |
+
+  @from:cucumber
+  @Id:S0353_020
+  Scenario: A reactivate (M_Tour_ID change) -> re-complete cycle leaves no orphan Qty-0 pack item
+
+    Given metasfresh contains M_Products:
+      | Identifier   |
+      | product_main |
+    And metasfresh contains M_PricingSystems
+      | Identifier   |
+      | ps_S0353_020 |
+    And metasfresh contains M_PriceLists
+      | Identifier   | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_S0353_020 | ps_S0353_020       | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier    | M_PriceList_ID |
+      | plv_S0353_020 | pl_S0353_020   |
+    And metasfresh contains M_ProductPrices
+      | Identifier   | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | pp_S0353_020 | plv_S0353_020          | product_main | 10.0     | PCE      | Normal           |
+    And metasfresh contains C_BPartners:
+      | Identifier  | IsCustomer | M_PricingSystem_ID | GLN          |
+      | endcustomer | Y          | ps_S0353_020       | location_gln |
+    And the following c_bpartner is changed
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN      |
+      | endcustomer   | true                 | bPartnerDesadvRecipientGLN |
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID.Identifier | M_Product_ID.Identifier |
+      | endcustomer              | product_main            |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference   |
+      | order_main | true    | endcustomer   | 2024-06-10  | po_ref_@Date@ |
+
+    And metasfresh contains C_OrderLines:
+      | Identifier     | C_Order_ID | M_Product_ID | QtyEntered |
+      | orderLine_main | order_main | product_main | 10         |
+
+    # A tour used to trigger reactivation by changing a non-quantity field on the shipment.
+    And metasfresh contains M_Tour:
+      | Identifier | OPT.Name |
+      | tour       | Tour Mon |
+
+    When the order identified by order_main is completed
+
+    And after not more than 30s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | shipSched  | orderLine_main            | N             |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | shipSched                        | D            | true                | false       |
+
+    Then after not more than 30s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | shipSched                        | shipment              |
+
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed | OPT.C_OrderLine_ID.Identifier |
+      | shipmentLine              | shipment              | product_main            | 10          | true      | orderLine_main                |
+
+    And after not more than 30s, EDI_Desadv_Pack records are found:
+      | EDI_Desadv_Pack_ID.Identifier | IsManual_IPA_SSCC18 | OPT.M_HU_ID.Identifier | OPT.M_HU_PackagingCode_ID.Identifier | OPT.GTIN_PackingMaterial | OPT.SeqNo |
+      | packMain                      | true                | null                   | null                                 | null                     | 1         |
+
+    And after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerTU_InInvoiceUOM | QtyCUsPerLU | QtyCUsPerLU_InInvoiceUOM | QtyItemCapacity | OPT.QtyTU | OPT.M_InOut_ID.Identifier | M_InOutLine_ID | BestBeforeDate | LotNumber | M_HU_PackagingCode_TU_ID | GTIN_TU_PackingMaterial |
+      | pi_nonzero              | packMain           | 10          | 10          | 10                       | 10          | 10                       | 0               | 1         | shipment                  | shipmentLine   | null           | null      | null                     | null                    |
+
+    # Capture the auto-created EDI_Desadv and its single line.
+    Then validate created edi desadv
+      | C_Order_ID.Identifier | SumDeliveredInStockingUOM | SumOrderedInStockingUOM | EDI_Desadv_ID.Identifier |
+      | order_main            | 10                        | 10                      | desadv                   |
+
+    Then EDI_DesadvLine records are found:
+      | EDI_DesadvLine_ID | EDI_Desadv_ID |
+      | desadvLine        | desadv        |
+
+    # Pre-existing "drafted" pack item from SSCC-label generation: M_InOutLine_ID=NULL and MovementQty=0.
+    # It sits in the existing pack (packMain). Because its M_InOutLine_ID is NULL it is invisible to the
+    # reactivation cleanup (which deletes pack items filtered by M_InOutLine_ID), and because its MovementQty
+    # is 0 it can never be reclaimed on re-completion (no real shipment line has MovementQty 0).
+    Given metasfresh contains EDI_Desadv_Pack_Item:
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | EDI_DesadvLine_ID | MovementQty | QtyCUsPerLU | M_InOutLine_ID |
+      | pi_orphan               | packMain           | desadvLine        | 0           | 0           | -              |
+
+    # 1) REACTIVATE the shipment (production: a non-quantity field changed)
+    When the shipment identified by shipment is reactivated
+
+    # change a non-quantity field (the tour) while the shipment is reactivated
+    And update M_InOut:
+      | M_InOut_ID | OPT.M_Tour_ID |
+      | shipment   | tour          |
+
+    # 2) RE-COMPLETE the shipment
+    And the shipment identified by shipment is completed
+
+    # Re-completion deletes packMain's real item (it had an M_InOutLine_ID) and re-creates the real
+    # qty>0 item in a fresh pack. packMain (SeqNo 1) survives so the fresh pack gets SeqNo 2.
+    And after not more than 30s, EDI_Desadv_Pack records are found:
+      | EDI_Desadv_Pack_ID.Identifier | IsManual_IPA_SSCC18 | OPT.M_HU_ID.Identifier | OPT.SeqNo |
+      | packRecompleted               | true                | null                   | 2         |
+
+    # After the cycle, only the legitimate qty>0 pack item must remain.
+    # If the orphan Qty-0 / NULL-M_InOutLine_ID item (pi_orphan) survives, the total-count assertion fails.
+    Then after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerLU | M_InOutLine_ID |
+      | pi_recompleted          | packRecompleted    | 10          | 10          | shipmentLine   |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvReactivateRecompleteNoOrphanPack.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvReactivateRecompleteNoOrphanPack.feature
@@ -3,7 +3,7 @@
 @allure.label.epic:E0292_EDI
 @allure.label.feature:F00353_EDI
 Feature: Reactivating and re-completing a shipment must not leave an orphan Qty-0 DESADV pack item
-# me03 #29278: a shipment is COMPLETED, then REACTIVATED (only a non-quantity field such as M_Tour_ID changed),
+# A shipment is COMPLETED,then REACTIVATED (only a non-quantity field such as M_Tour_ID changed),
 # then RE-COMPLETED.
 #
 # The bug (birth mechanism, DesadvLineSSCC18Generator): when the SSCC generator is invoked with more labels
@@ -24,7 +24,7 @@ Feature: Reactivating and re-completing a shipment must not leave an orphan Qty-
 # After the fix, the generator skips the 0-qty LU -> no orphan is created.
 # Then reactivate (M_Tour_ID change) -> re-complete -> assert only the 1 real qty>0 item survives.
 # This scenario is RED before the fix and GREEN after — it is the authoritative cucumber
-# reproduction of me03 #29278 (birth-prevention path).
+# reproduction of the orphan birth-prevention path.
 
   Background:
     Given infrastructure and metasfresh are running

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvReactivateRecompleteNoOrphanPack.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvReactivateRecompleteNoOrphanPack.feature
@@ -6,17 +6,25 @@ Feature: Reactivating and re-completing a shipment must not leave an orphan Qty-
 # me03 #29278: a shipment is COMPLETED, then REACTIVATED (only a non-quantity field such as M_Tour_ID changed),
 # then RE-COMPLETED.
 #
-# Birth-prevention fix (DesadvLineSSCC18Generator): the SSCC generator now skips any LU whose breakdown
-# yields qtyCUsPerLU=0 — no pack/pack-item is created for that slot. This is the primary fix and is
-# covered by the JUnit RED test DesadvBL_reactivateRecomplete_orphanPackItem_Test (rigorous unit reproduction).
+# The bug (birth mechanism, DesadvLineSSCC18Generator): when the SSCC generator is invoked with more labels
+# than the LU/TU breakdown can supply (e.g. no packing instructions configured — "No Packing Item" / 101),
+# TotalQtyCUBreakdownCalculator.NULL is used.  Every subtractOneLU() call returns LUQtys.NULL
+# (qtyCUsPerLU=0), so a pack item with MovementQty=0 and M_InOutLine_ID=NULL is created.
+# That item becomes a permanent orphan after reactivate->re-complete because:
+#   - reactivation cleanup is keyed on M_InOutLine_ID (NULL items are invisible to it)
+#   - re-completion cannot reclaim a Qty-0 item (no real shipment line has MovementQty=0)
 #
-# Defense-in-depth (this scenario): even if a Qty-0/NULL-InOutLine pack item were present in the DB
-# (e.g. from a pre-fix deployment, data migration, or another tool), the reactivate→re-complete cycle
-# must not silently strand it as a permanent orphan. The scenario below injects such an item directly and
-# asserts it does not survive the cycle.
-# NOTE: driving the REAL SSCC generator to produce a 0-qty item via cucumber is not feasible without a
-# dedicated process-invocation step definition — the generator post-fix produces no Qty-0 items. The JUnit
-# is the authoritative birth-prevention reproduction; this cucumber validates cleanup-side resilience.
+# The fix (DesadvLineSSCC18Generator.generateAndEnqueuePrinting): skip any LU whose breakdown yields
+# qtyCUsPerLU=0 — no pack/pack-item is created for that slot, so no orphan is ever born.
+#
+# This scenario reproduces the BIRTH by invoking real SSCC generation via
+# "When SSCC labels are generated for EDI_DesadvLine:" with LabelCount=2 on an order-line that uses
+# "No Packing Item" (M_HU_PI_Item_Product_ID=101).  The LU/TU config lookup falls back to
+# TotalQtyCUBreakdownCalculator.NULL -> subtractOneLU() returns LUQtys.NULL (qtyCUsPerLU=0).
+# After the fix, the generator skips the 0-qty LU -> no orphan is created.
+# Then reactivate (M_Tour_ID change) -> re-complete -> assert only the 1 real qty>0 item survives.
+# This scenario is RED before the fix and GREEN after — it is the authoritative cucumber
+# reproduction of me03 #29278 (birth-prevention path).
 
   Background:
     Given infrastructure and metasfresh are running
@@ -109,13 +117,23 @@ Feature: Reactivating and re-completing a shipment must not leave an orphan Qty-
       | EDI_DesadvLine_ID | EDI_Desadv_ID |
       | desadvLine        | desadv        |
 
-    # Pre-existing "drafted" pack item from SSCC-label generation: M_InOutLine_ID=NULL and MovementQty=0.
-    # It sits in the existing pack (packMain). Because its M_InOutLine_ID is NULL it is invisible to the
-    # reactivation cleanup (which deletes pack items filtered by M_InOutLine_ID), and because its MovementQty
-    # is 0 it can never be reclaimed on re-completion (no real shipment line has MovementQty 0).
-    Given metasfresh contains EDI_Desadv_Pack_Item:
-      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | EDI_DesadvLine_ID | MovementQty | QtyCUsPerLU | M_InOutLine_ID |
-      | pi_orphan               | packMain           | desadvLine        | 0           | 0           | -              |
+    # Invoke real SSCC label generation with LabelCount=2 on the desadv line.
+    # The order-line uses "No Packing Item" (M_HU_PI_Item_Product_ID=101), so
+    # PrintableDesadvLineSSCC18Labels falls back to TotalQtyCUBreakdownCalculator.NULL.
+    # Each subtractOneLU() returns LUQtys.NULL (qtyCUsPerLU=0).
+    # PRE-FIX: the generator would create 2 pack items with MovementQty=0, M_InOutLine_ID=NULL
+    #          (one for each requested label slot that exhausts the calculator).
+    # POST-FIX: the generator skips Qty-0 LUs — no orphan pack item is created.
+    # The total EDI_Desadv_Pack_Item count MUST remain exactly 1 (the real qty=10 item).
+    When SSCC labels are generated for EDI_DesadvLine:
+      | EDI_DesadvLine_ID | LabelCount |
+      | desadvLine        | 2          |
+
+    # After SSCC generation: the fix ensures no Qty-0 orphan was born.
+    # Still exactly 1 pack item (the real qty=10 item from shipment completion).
+    Then after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
+      | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerLU | M_InOutLine_ID |
+      | pi_nonzero              | packMain           | 10          | 10          | shipmentLine   |
 
     # 1) REACTIVATE the shipment (production: a non-quantity field changed)
     When the shipment identified by shipment is reactivated
@@ -135,7 +153,9 @@ Feature: Reactivating and re-completing a shipment must not leave an orphan Qty-
       | packRecompleted               | true                | null                   | 2         |
 
     # After the cycle, only the legitimate qty>0 pack item must remain.
-    # If the orphan Qty-0 / NULL-M_InOutLine_ID item (pi_orphan) survives, the total-count assertion fails.
+    # If a Qty-0/NULL-M_InOutLine_ID orphan had been created by the SSCC generator (pre-fix),
+    # it would survive here (it cannot be cleaned up by reactivation or reclaimed on re-complete)
+    # and the total-count assertion would fail with 2 items instead of 1.
     Then after not more than 30s, the EDI_Desadv_Pack_Item has only the following records:
       | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerLU | M_InOutLine_ID |
       | pi_recompleted          | packRecompleted    | 10          | 10          | shipmentLine   |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvReactivateRecompleteNoOrphanPack.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvReactivateRecompleteNoOrphanPack.feature
@@ -151,7 +151,6 @@ Feature: Reactivating and re-completing a shipment must not leave an orphan Qty-
     # 2) RE-COMPLETE the shipment
     And the shipment identified by shipment is completed
 
-    # Re-completion deletes packMain's real item (it had an M_InOutLine_ID) and re-creates the real
     # Reactivation removes the old pack (its item was linked by M_InOutLine_ID); re-completion
     # creates a single fresh manual pack. We don't pin SeqNo (it is an implementation detail of
     # the pack sequence) — we just locate the active manual pack so we can assert its item below.

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvReactivateRecompleteNoOrphanPack.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvReactivateRecompleteNoOrphanPack.feature
@@ -108,10 +108,15 @@ Feature: Reactivating and re-completing a shipment must not leave an orphan Qty-
       | EDI_Desadv_Pack_Item_ID | EDI_Desadv_Pack_ID | MovementQty | QtyCUsPerTU | QtyCUsPerTU_InInvoiceUOM | QtyCUsPerLU | QtyCUsPerLU_InInvoiceUOM | QtyItemCapacity | OPT.QtyTU | OPT.M_InOut_ID.Identifier | M_InOutLine_ID | BestBeforeDate | LotNumber | M_HU_PackagingCode_TU_ID | GTIN_TU_PackingMaterial |
       | pi_nonzero              | packMain           | 10          | 10          | 10                       | 10          | 10                       | 0               | 1         | shipment                  | shipmentLine   | null           | null      | null                     | null                    |
 
-    # Capture the auto-created EDI_Desadv and its single line.
+    # Validate the auto-created EDI_Desadv sums
     Then validate created edi desadv
-      | C_Order_ID.Identifier | SumDeliveredInStockingUOM | SumOrderedInStockingUOM | EDI_Desadv_ID.Identifier |
-      | order_main            | 10                        | 10                      | desadv                   |
+      | C_Order_ID.Identifier | SumDeliveredInStockingUOM | SumOrderedInStockingUOM |
+      | order_main            | 10                        | 10                      |
+
+    # Register the EDI_Desadv under the 'desadv' identifier so subsequent steps can reference it
+    Then EDI_Desadv is found:
+      | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_Desadv_ID.Identifier |
+      | endcustomer              | order_main            | desadv                   |
 
     Then EDI_DesadvLine records are found:
       | EDI_DesadvLine_ID | EDI_Desadv_ID |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvReactivateRecompleteNoOrphanPack.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvReactivateRecompleteNoOrphanPack.feature
@@ -4,10 +4,19 @@
 @allure.label.feature:F00353_EDI
 Feature: Reactivating and re-completing a shipment must not leave an orphan Qty-0 DESADV pack item
 # me03 #29278: a shipment is COMPLETED, then REACTIVATED (only a non-quantity field such as M_Tour_ID changed),
-# then RE-COMPLETED. A pre-existing "drafted" pack item (created by SSCC-label generation, with M_InOutLine_ID=NULL)
-# whose MovementQty is 0 can never be reclaimed (no real shipment line has MovementQty 0) and is invisible to the
-# reactivation cleanup (which deletes pack items filtered by M_InOutLine_ID). It therefore survives forever as an
-# orphan Qty-0 pack item in its own phantom pack, which then breaks the EDI export.
+# then RE-COMPLETED.
+#
+# Birth-prevention fix (DesadvLineSSCC18Generator): the SSCC generator now skips any LU whose breakdown
+# yields qtyCUsPerLU=0 — no pack/pack-item is created for that slot. This is the primary fix and is
+# covered by the JUnit RED test DesadvBL_reactivateRecomplete_orphanPackItem_Test (rigorous unit reproduction).
+#
+# Defense-in-depth (this scenario): even if a Qty-0/NULL-InOutLine pack item were present in the DB
+# (e.g. from a pre-fix deployment, data migration, or another tool), the reactivate→re-complete cycle
+# must not silently strand it as a permanent orphan. The scenario below injects such an item directly and
+# asserts it does not survive the cycle.
+# NOTE: driving the REAL SSCC generator to produce a 0-qty item via cucumber is not feasible without a
+# dedicated process-invocation step definition — the generator post-fix produces no Qty-0 items. The JUnit
+# is the authoritative birth-prevention reproduction; this cucumber validates cleanup-side resilience.
 
   Background:
     Given infrastructure and metasfresh are running

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/sscc18/DesadvLineSSCC18Generator.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/sscc18/DesadvLineSSCC18Generator.java
@@ -168,10 +168,11 @@ public class DesadvLineSSCC18Generator
 				// Subtract one LU from total QtyCUs remaining.
 				final LUQtys luQtys = totalQtyCUsRemaining.subtractOneLU();
 
-				// A Qty-0 LU means the calculator is exhausted or misconfigured — a pack item with
-				// MovementQty=0 is meaningless (nothing to label) and would become an orphan that
-				// can never be reclaimed after reactivate→re-complete (me03 #29278).
-				if (luQtys.isNull() || luQtys.getQtyCUsPerLU().signum() <= 0)
+				// A Qty-0 / null LU means the calculator is exhausted or misconfigured. A pack item with
+				// MovementQty=0 is meaningless (nothing to label) and would become an orphan that can
+				// never be reclaimed after reactivate/re-complete. LUQtys.NULL is the only zero-qty case
+				// (the builder collapses any qty<=0 to the NULL singleton), so isNull() covers it.
+				if (luQtys.isNull())
 				{
 					logger.warn("Skipping SSCC pack-item creation for desadvLine={} because LU breakdown returned Qty-0 (luQtys={}). "
 									+ "No pack/pack-item will be created for this label slot.",

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/sscc18/DesadvLineSSCC18Generator.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/sscc18/DesadvLineSSCC18Generator.java
@@ -168,10 +168,8 @@ public class DesadvLineSSCC18Generator
 				// Subtract one LU from total QtyCUs remaining.
 				final LUQtys luQtys = totalQtyCUsRemaining.subtractOneLU();
 
-				// A Qty-0 / null LU means the calculator is exhausted or misconfigured. A pack item with
-				// MovementQty=0 is meaningless (nothing to label) and would become an orphan that can
-				// never be reclaimed after reactivate/re-complete. LUQtys.NULL is the only zero-qty case
-				// (the builder collapses any qty<=0 to the NULL singleton), so isNull() covers it.
+				// Skip a 0-qty / null LU (exhausted or misconfigured calculator): persisting a MovementQty=0
+				// pack item would create an un-reclaimable orphan.
 				if (luQtys.isNull())
 				{
 					logger.warn("Skipping SSCC pack-item creation for desadvLine={} because LU breakdown returned Qty-0 (luQtys={}). "

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/sscc18/DesadvLineSSCC18Generator.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/sscc18/DesadvLineSSCC18Generator.java
@@ -168,6 +168,17 @@ public class DesadvLineSSCC18Generator
 				// Subtract one LU from total QtyCUs remaining.
 				final LUQtys luQtys = totalQtyCUsRemaining.subtractOneLU();
 
+				// A Qty-0 LU means the calculator is exhausted or misconfigured — a pack item with
+				// MovementQty=0 is meaningless (nothing to label) and would become an orphan that
+				// can never be reclaimed after reactivate→re-complete (me03 #29278).
+				if (luQtys.isNull() || luQtys.getQtyCUsPerLU().signum() <= 0)
+				{
+					logger.warn("Skipping SSCC pack-item creation for desadvLine={} because LU breakdown returned Qty-0 (luQtys={}). "
+									+ "No pack/pack-item will be created for this label slot.",
+							desadvLine, luQtys);
+					continue;
+				}
+
 				final EDIDesadvPack desadvPack = generateDesadvLineSSCC(desadvLine, luQtys, tuPIItemProduct);
 				enqueueToPrint(desadvPack);
 			}

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5807110_sys_me03_29278_EDI_Desadv_Exp_packitem_qty_whereclause.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5807110_sys_me03_29278_EDI_Desadv_Exp_packitem_qty_whereclause.sql
@@ -1,0 +1,20 @@
+-- Run mode: SWING_CLIENT
+
+-- DESADV export must skip pack items whose OWN delivered qty is 0.
+-- gh22804 added a parent-line qty filter (dl.QtyDeliveredInUOM>0); this adds the
+-- pack-item-level filter (pi.MovementQty>0) so an orphan/zero-qty pack item on a
+-- line that still has qty>0 is not exported as an empty line.
+
+-- EDI_Exp_Desadv_Pack_Item (540418): also require the pack item's own MovementQty>0
+UPDATE EXP_Format SET WhereClause=
+'IsActive=''Y'' and MovementQty>0 and EDI_DesadvLine_ID in (select dl.EDI_DesadvLine_ID from EDI_DesadvLine dl where dl.IsActive=''Y'' and dl.QtyDeliveredInUOM>0)',
+ Updated=now(), UpdatedBy=100
+WHERE EXP_Format_ID=540418
+;
+
+-- EDI_Exp_Desadv_Pack (540419): a pack qualifies only if it has >=1 item with MovementQty>0 on a qty>0 line
+UPDATE EXP_Format SET WhereClause=
+'IsActive=''Y'' and EDI_Desadv_Pack_ID in (select pi.EDI_Desadv_Pack_ID from EDI_Desadv_Pack_Item pi join EDI_DesadvLine dl on pi.EDI_DesadvLine_ID=dl.EDI_DesadvLine_ID where pi.IsActive=''Y'' and pi.MovementQty>0 and dl.IsActive=''Y'' and dl.QtyDeliveredInUOM>0)',
+ Updated=now(), UpdatedBy=100
+WHERE EXP_Format_ID=540419
+;

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5807110_sys_me03_29278_EDI_Desadv_Exp_packitem_qty_whereclause.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5807110_sys_me03_29278_EDI_Desadv_Exp_packitem_qty_whereclause.sql
@@ -12,7 +12,9 @@ UPDATE EXP_Format SET WhereClause=
 WHERE EXP_Format_ID=540418
 ;
 
--- EDI_Exp_Desadv_Pack (540419): a pack qualifies only if it has >=1 item with MovementQty>0 on a qty>0 line
+-- EDI_Exp_Desadv_Pack (540419): a pack qualifies only if it has >=1 item with MovementQty>0 on a qty>0 line.
+-- The pack-item subquery is deliberate: it checks individual item qty, not the pack header.
+-- A full scan is acceptable here — EDI DESADV data volumes are small (dozens to hundreds of rows).
 UPDATE EXP_Format SET WhereClause=
 'IsActive=''Y'' and EDI_Desadv_Pack_ID in (select pi.EDI_Desadv_Pack_ID from EDI_Desadv_Pack_Item pi join EDI_DesadvLine dl on pi.EDI_DesadvLine_ID=dl.EDI_DesadvLine_ID where pi.IsActive=''Y'' and pi.MovementQty>0 and dl.IsActive=''Y'' and dl.QtyDeliveredInUOM>0)',
  Updated=TO_TIMESTAMP('2026-06-10 10:10:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5807110_sys_me03_29278_EDI_Desadv_Exp_packitem_qty_whereclause.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5807110_sys_me03_29278_EDI_Desadv_Exp_packitem_qty_whereclause.sql
@@ -8,13 +8,13 @@
 -- EDI_Exp_Desadv_Pack_Item (540418): also require the pack item's own MovementQty>0
 UPDATE EXP_Format SET WhereClause=
 'IsActive=''Y'' and MovementQty>0 and EDI_DesadvLine_ID in (select dl.EDI_DesadvLine_ID from EDI_DesadvLine dl where dl.IsActive=''Y'' and dl.QtyDeliveredInUOM>0)',
- Updated=now(), UpdatedBy=100
+ Updated=TO_TIMESTAMP('2026-06-10 10:10:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE EXP_Format_ID=540418
 ;
 
 -- EDI_Exp_Desadv_Pack (540419): a pack qualifies only if it has >=1 item with MovementQty>0 on a qty>0 line
 UPDATE EXP_Format SET WhereClause=
 'IsActive=''Y'' and EDI_Desadv_Pack_ID in (select pi.EDI_Desadv_Pack_ID from EDI_Desadv_Pack_Item pi join EDI_DesadvLine dl on pi.EDI_DesadvLine_ID=dl.EDI_DesadvLine_ID where pi.IsActive=''Y'' and pi.MovementQty>0 and dl.IsActive=''Y'' and dl.QtyDeliveredInUOM>0)',
- Updated=now(), UpdatedBy=100
+ Updated=TO_TIMESTAMP('2026-06-10 10:10:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE EXP_Format_ID=540419
 ;

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_reactivateRecomplete_orphanPackItem_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_reactivateRecomplete_orphanPackItem_Test.java
@@ -94,7 +94,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.refresh;
  */
 
 /**
- * me03 #29278 — reproduce the orphan Qty-0 pack item bug.
+ * Reproduce the orphan Qty-0 pack item bug.
  * <p>
  * Models the production cycle (M_InOut validator timings):
  * BEFORE_COMPLETE -> {@link DesadvBL#addToDesadvCreateForInOutIfNotExist(I_M_InOut)}
@@ -207,7 +207,7 @@ class DesadvBL_reactivateRecomplete_orphanPackItem_Test
 	}
 
 	/**
-	 * Birth-prevention test (me03 #29278, fix part B).
+	 * Birth-prevention test (fix part B).
 	 *
 	 * <p>BEFORE the fix: {@link DesadvLineSSCC18Generator} would call
 	 * {@code buildCreateEDIDesadvPackItemRequest} even when {@link TotalQtyCUBreakdownCalculator#subtractOneLU()}
@@ -325,7 +325,7 @@ class DesadvBL_reactivateRecomplete_orphanPackItem_Test
 				.collect(Collectors.toList());
 
 		assertThat(orphans)
-				.as("orphan Qty-0 pack item with NULL M_InOutLine_ID (me03 #29278) must not exist " + context)
+				.as("orphan Qty-0 pack item with NULL M_InOutLine_ID must not exist " + context)
 				.isEmpty();
 	}
 

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_reactivateRecomplete_orphanPackItem_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_reactivateRecomplete_orphanPackItem_Test.java
@@ -3,11 +3,12 @@ package de.metas.edi.api.impl;
 import com.google.common.collect.ImmutableList;
 import de.metas.bpartner.BPartnerId;
 import de.metas.business.BusinessTestHelper;
-import de.metas.edi.api.EDIDesadvId;
-import de.metas.edi.api.EDIDesadvLineId;
-import de.metas.edi.api.impl.pack.CreateEDIDesadvPackItemRequest;
-import de.metas.edi.api.impl.pack.CreateEDIDesadvPackRequest;
+import de.metas.edi.api.impl.pack.EDIDesadvPack;
 import de.metas.edi.api.impl.pack.EDIDesadvPackService;
+import de.metas.edi.sscc18.DesadvLineSSCC18Generator;
+import de.metas.edi.sscc18.IPrintableDesadvLineSSCC18Labels;
+import de.metas.handlingunits.allocation.impl.TotalQtyCUBreakdownCalculator;
+import lombok.NonNull;
 import de.metas.edi.model.I_C_Order;
 import de.metas.edi.model.I_C_OrderLine;
 import de.metas.edi.model.I_M_InOut;
@@ -205,14 +206,36 @@ class DesadvBL_reactivateRecomplete_orphanPackItem_Test
 		setupHandlingUnit(); // HU with 49 CUs assigned to inOutLineRecord
 	}
 
+	/**
+	 * Birth-prevention test (me03 #29278, fix part B).
+	 *
+	 * <p>BEFORE the fix: {@link DesadvLineSSCC18Generator} would call
+	 * {@code buildCreateEDIDesadvPackItemRequest} even when {@link TotalQtyCUBreakdownCalculator#subtractOneLU()}
+	 * returned {@code LUQtys.NULL} (exhausted/misconfigured calculator), producing a
+	 * {@code EDI_Desadv_Pack_Item} with {@code MovementQty=0} and {@code M_InOutLine_ID=NULL}.
+	 * That item could never be reclaimed after reactivate→re-complete (exact-qty match required,
+	 * and reactivation cleanup is keyed on {@code M_InOutLine_ID}).
+	 *
+	 * <p>AFTER the fix: the generator skips any LU whose breakdown yields {@code qtyCUsPerLU=0},
+	 * so no such orphan is ever persisted.  This test drives the REAL generator with an exhausted
+	 * calculator (1 label requested, calculator returns NULL for every subtractOneLU call) and
+	 * then runs the full complete→reactivate→re-complete cycle, asserting no Qty-0/NULL-inoutline
+	 * pack item exists at any point.
+	 */
 	@Test
-	void reactivate_recomplete_doesNotLeaveOrphanQtyZeroPackItem()
+	void generatorSkipsQtyZeroLU_andCycleIsClean()
 	{
-		// 0) SSCC labels generated up-front for this DESADV line (production: EDI_Desadv_GenerateSSCCLabels).
-		//    This creates a "drafted" pack item: M_InOutLine_ID = NULL (see DesadvLineSSCC18Generator#buildCreateEDIDesadvPackItemRequest).
-		//    We model a label whose LU breakdown ended up with qtyCUsPerLU=0 (e.g. labels printed before the qty was firmed up),
-		//    so movementQty=0 and it can never be reclaimed by popFirstMatching (no real shipment line has movementQty 0).
-		seedDraftedSSCCPackItem(BigDecimal.ZERO);
+		// 0) SSCC labels "generated" via the real DesadvLineSSCC18Generator with an exhausted
+		//    TotalQtyCUBreakdownCalculator (returns LUQtys.NULL for every subtractOneLU call).
+		//    This models production: EDI_Desadv_GenerateSSCCLabels invoked when the LU breakdown
+		//    cannot supply a qty (e.g. labels printed before the shipment qty was firmed up, or
+		//    the calculator is misconfigured).
+		//    Pre-fix: one EDI_Desadv_Pack + EDI_Desadv_Pack_Item (MovementQty=0, M_InOutLine_ID=NULL) created.
+		//    Post-fix: the generator skips the 0-qty LU → no pack/pack-item created.
+		invokeGeneratorWithExhaustedCalculator();
+
+		// Assert birth-prevention: no Qty-0/NULL-inoutline pack item was born.
+		assertNoQtyZeroOrphanPackItems("after SSCC generation with exhausted calculator");
 
 		// 1) COMPLETE
 		desadvBL.addToDesadvCreateForInOutIfNotExist(inOutRecord);
@@ -227,7 +250,73 @@ class DesadvBL_reactivateRecomplete_orphanPackItem_Test
 		saveRecord(inOutRecord);
 		desadvBL.addToDesadvCreateForInOutIfNotExist(inOutRecord);
 
-		// ASSERT — no orphan pack item: (MovementQty == 0 AND M_InOutLine_ID == null)
+		// ASSERT — no orphan pack item survived the full cycle
+		assertNoQtyZeroOrphanPackItems("after reactivate→re-complete cycle");
+	}
+
+	/**
+	 * Invokes {@link DesadvLineSSCC18Generator} with an {@link IPrintableDesadvLineSSCC18Labels} that
+	 * requests 1 label but whose {@link TotalQtyCUBreakdownCalculator} is exhausted
+	 * ({@link TotalQtyCUBreakdownCalculator#NULL} always returns {@code LUQtys.NULL} from
+	 * {@code subtractOneLU}).  Before the fix this created a Qty-0 pack item; after the fix it
+	 * produces nothing.
+	 */
+	private void invokeGeneratorWithExhaustedCalculator()
+	{
+		final EDIDesadvPackService packService = EDIDesadvPackService.newInstanceForUnitTesting();
+
+		final DesadvLineSSCC18Generator generator = DesadvLineSSCC18Generator.builder()
+				.sscc18CodeService(sscc18CodeBL)
+				.desadvBL(desadvBL)
+				.ediDesadvPackService(packService)
+				.printExistingLabels(false)
+				.bpartnerId(recipientBPartnerId)
+				.build();
+
+		// IPrintableDesadvLineSSCC18Labels with 1 label requested but exhausted (NULL) calculator.
+		// subtractOneLU() on TotalQtyCUBreakdownCalculator.NULL returns LUQtys.NULL (qty=0).
+		final IPrintableDesadvLineSSCC18Labels labelsSpec = new IPrintableDesadvLineSSCC18Labels()
+		{
+			@Override
+			public I_EDI_DesadvLine getEDI_DesadvLine() { return desadvLine; }
+
+			@Override
+			public de.metas.handlingunits.model.I_M_HU_PI_Item_Product getTuPIItemProduct() { return huPIItemProductRecord; }
+
+			@Override
+			public Integer getLineNo() { return 10; }
+
+			@Override
+			public String getProductValue() { return "TESTPROD"; }
+
+			@Override
+			public String getProductName() { return "Test Product"; }
+
+			@Override
+			public Integer getExistingSSCC18sCount() { return 0; }
+
+			@Override
+			public List<EDIDesadvPack> getExistingSSCC18s() { return ImmutableList.of(); }
+
+			@Override
+			public BigDecimal getRequiredSSCC18sCount() { return BigDecimal.ONE; }
+
+			@Override
+			public void setRequiredSSCC18sCount(final BigDecimal requiredSSCC18sCount) { /* no-op */ }
+
+			@Override
+			public TotalQtyCUBreakdownCalculator breakdownTotalQtyCUsToLUs()
+			{
+				// NULL calculator: every subtractOneLU() call returns LUQtys.NULL (qtyCUsPerLU=0)
+				return TotalQtyCUBreakdownCalculator.NULL.copy();
+			}
+		};
+
+		generator.generateAndEnqueuePrinting(labelsSpec);
+	}
+
+	private void assertNoQtyZeroOrphanPackItems(@NonNull final String context)
+	{
 		final List<I_EDI_Desadv_Pack_Item> orphans = POJOLookupMap.get()
 				.getRecords(I_EDI_Desadv_Pack_Item.class)
 				.stream()
@@ -236,41 +325,8 @@ class DesadvBL_reactivateRecomplete_orphanPackItem_Test
 				.collect(Collectors.toList());
 
 		assertThat(orphans)
-				.as("orphan Qty-0 pack item with NULL M_InOutLine_ID (me03 #29278) must not exist after reactivate->re-complete")
+				.as("orphan Qty-0 pack item with NULL M_InOutLine_ID (me03 #29278) must not exist " + context)
 				.isEmpty();
-	}
-
-	/**
-	 * Models {@link de.metas.edi.sscc18.DesadvLineSSCC18Generator}: creates an EDI_Desadv_Pack with a single
-	 * "drafted" pack item that has NO M_InOutLine_ID (null) and movementQty = the given qtyCUsPerLU.
-	 */
-	private void seedDraftedSSCCPackItem(final BigDecimal qtyCUsPerLU)
-	{
-		final EDIDesadvPackService packService = EDIDesadvPackService.newInstanceForUnitTesting();
-		final EDIDesadvPackService.Sequences sequences =
-				packService.createSequences(EDIDesadvId.ofRepoId(desadvLine.getEDI_Desadv_ID()));
-
-		final CreateEDIDesadvPackItemRequest packItemRequest =
-				CreateEDIDesadvPackItemRequest.builder()
-						.ediDesadvLineId(EDIDesadvLineId.ofRepoId(desadvLine.getEDI_DesadvLine_ID()))
-						.line(sequences.getPackItemLineSequence().next())
-						.qtyTu(0)
-						.qtyCUsPerLU(qtyCUsPerLU)
-						.movementQtyInStockUOM(qtyCUsPerLU) // exactly how the generator sets it
-						// note: NO inOutId / inOutLineId -> M_InOutLine_ID stays null -> "drafted"
-						.build();
-
-		final CreateEDIDesadvPackRequest packRequest =
-				CreateEDIDesadvPackRequest.builder()
-						.orgId(OrgId.ofRepoId(desadvLine.getAD_Org_ID()))
-						.seqNo(sequences.getPackSeqNoSequence().next())
-						.ediDesadvId(EDIDesadvId.ofRepoId(desadvLine.getEDI_Desadv_ID()))
-						.sscc18("000000000000000099")
-						.isManualIpaSSCC(true)
-						.createEDIDesadvPackItemRequest(packItemRequest)
-						.build();
-
-		packService.createDesadvPack(packRequest);
 	}
 
 	private void setupHandlingUnit()

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_reactivateRecomplete_orphanPackItem_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_reactivateRecomplete_orphanPackItem_Test.java
@@ -67,9 +67,9 @@ import java.util.stream.Collectors;
 import static de.metas.handlingunits.HUTestHelper.NAME_IFCO_Product;
 import static java.math.BigDecimal.TEN;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.refresh;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.adempiere.model.InterfaceWrapperHelper.refresh;
 
 /*
  * #%L

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_reactivateRecomplete_orphanPackItem_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_reactivateRecomplete_orphanPackItem_Test.java
@@ -3,6 +3,11 @@ package de.metas.edi.api.impl;
 import com.google.common.collect.ImmutableList;
 import de.metas.bpartner.BPartnerId;
 import de.metas.business.BusinessTestHelper;
+import de.metas.edi.api.EDIDesadvId;
+import de.metas.edi.api.EDIDesadvLineId;
+import de.metas.edi.api.impl.pack.CreateEDIDesadvPackItemRequest;
+import de.metas.edi.api.impl.pack.CreateEDIDesadvPackRequest;
+import de.metas.edi.api.impl.pack.EDIDesadvPackService;
 import de.metas.edi.model.I_C_Order;
 import de.metas.edi.model.I_C_OrderLine;
 import de.metas.edi.model.I_M_InOut;
@@ -36,6 +41,7 @@ import de.metas.uom.CreateUOMConversionRequest;
 import de.metas.uom.UomId;
 import de.metas.util.Services;
 import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.ad.wrapper.POJOLookupMap;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.api.AttributeConstants;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -55,6 +61,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import static de.metas.handlingunits.HUTestHelper.NAME_IFCO_Product;
 import static java.math.BigDecimal.TEN;
@@ -221,12 +228,12 @@ class DesadvBL_reactivateRecomplete_orphanPackItem_Test
 		desadvBL.addToDesadvCreateForInOutIfNotExist(inOutRecord);
 
 		// ASSERT — no orphan pack item: (MovementQty == 0 AND M_InOutLine_ID == null)
-		final List<I_EDI_Desadv_Pack_Item> orphans = org.adempiere.ad.wrapper.POJOLookupMap.get()
+		final List<I_EDI_Desadv_Pack_Item> orphans = POJOLookupMap.get()
 				.getRecords(I_EDI_Desadv_Pack_Item.class)
 				.stream()
 				.filter(pi -> pi.getMovementQty() != null && pi.getMovementQty().signum() == 0)
 				.filter(pi -> pi.getM_InOutLine_ID() <= 0)
-				.collect(java.util.stream.Collectors.toList());
+				.collect(Collectors.toList());
 
 		assertThat(orphans)
 				.as("orphan Qty-0 pack item with NULL M_InOutLine_ID (me03 #29278) must not exist after reactivate->re-complete")
@@ -239,13 +246,13 @@ class DesadvBL_reactivateRecomplete_orphanPackItem_Test
 	 */
 	private void seedDraftedSSCCPackItem(final BigDecimal qtyCUsPerLU)
 	{
-		final de.metas.edi.api.impl.pack.EDIDesadvPackService packService = de.metas.edi.api.impl.pack.EDIDesadvPackService.newInstanceForUnitTesting();
-		final de.metas.edi.api.impl.pack.EDIDesadvPackService.Sequences sequences =
-				packService.createSequences(de.metas.edi.api.EDIDesadvId.ofRepoId(desadvLine.getEDI_Desadv_ID()));
+		final EDIDesadvPackService packService = EDIDesadvPackService.newInstanceForUnitTesting();
+		final EDIDesadvPackService.Sequences sequences =
+				packService.createSequences(EDIDesadvId.ofRepoId(desadvLine.getEDI_Desadv_ID()));
 
-		final de.metas.edi.api.impl.pack.CreateEDIDesadvPackItemRequest packItemRequest =
-				de.metas.edi.api.impl.pack.CreateEDIDesadvPackItemRequest.builder()
-						.ediDesadvLineId(de.metas.edi.api.EDIDesadvLineId.ofRepoId(desadvLine.getEDI_DesadvLine_ID()))
+		final CreateEDIDesadvPackItemRequest packItemRequest =
+				CreateEDIDesadvPackItemRequest.builder()
+						.ediDesadvLineId(EDIDesadvLineId.ofRepoId(desadvLine.getEDI_DesadvLine_ID()))
 						.line(sequences.getPackItemLineSequence().next())
 						.qtyTu(0)
 						.qtyCUsPerLU(qtyCUsPerLU)
@@ -253,11 +260,11 @@ class DesadvBL_reactivateRecomplete_orphanPackItem_Test
 						// note: NO inOutId / inOutLineId -> M_InOutLine_ID stays null -> "drafted"
 						.build();
 
-		final de.metas.edi.api.impl.pack.CreateEDIDesadvPackRequest packRequest =
-				de.metas.edi.api.impl.pack.CreateEDIDesadvPackRequest.builder()
+		final CreateEDIDesadvPackRequest packRequest =
+				CreateEDIDesadvPackRequest.builder()
 						.orgId(OrgId.ofRepoId(desadvLine.getAD_Org_ID()))
 						.seqNo(sequences.getPackSeqNoSequence().next())
-						.ediDesadvId(de.metas.edi.api.EDIDesadvId.ofRepoId(desadvLine.getEDI_Desadv_ID()))
+						.ediDesadvId(EDIDesadvId.ofRepoId(desadvLine.getEDI_Desadv_ID()))
 						.sscc18("000000000000000099")
 						.isManualIpaSSCC(true)
 						.createEDIDesadvPackItemRequest(packItemRequest)
@@ -292,7 +299,7 @@ class DesadvBL_reactivateRecomplete_orphanPackItem_Test
 		huAttrRecord.setM_HU_PI_Attribute_ID(sscc18HUPIAttributeRecord.getM_HU_PI_Attribute_ID());
 		saveRecord(huAttrRecord);
 
-		final I_M_HU_PI_Attribute bestBeforeHUPIAttributeRecord = org.adempiere.ad.wrapper.POJOLookupMap.get()
+		final I_M_HU_PI_Attribute bestBeforeHUPIAttributeRecord = POJOLookupMap.get()
 				.getRecords(I_M_HU_PI_Attribute.class,
 						record -> record.getM_Attribute_ID() == bestBeforeAttrRecord.getM_Attribute_ID())
 				.stream()

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_reactivateRecomplete_orphanPackItem_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_reactivateRecomplete_orphanPackItem_Test.java
@@ -5,14 +5,12 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.business.BusinessTestHelper;
 import de.metas.edi.api.impl.pack.EDIDesadvPack;
 import de.metas.edi.api.impl.pack.EDIDesadvPackService;
-import de.metas.edi.sscc18.DesadvLineSSCC18Generator;
-import de.metas.edi.sscc18.IPrintableDesadvLineSSCC18Labels;
-import de.metas.handlingunits.allocation.impl.TotalQtyCUBreakdownCalculator;
-import lombok.NonNull;
 import de.metas.edi.model.I_C_Order;
 import de.metas.edi.model.I_C_OrderLine;
 import de.metas.edi.model.I_M_InOut;
 import de.metas.edi.model.I_M_InOutLine;
+import de.metas.edi.sscc18.DesadvLineSSCC18Generator;
+import de.metas.edi.sscc18.IPrintableDesadvLineSSCC18Labels;
 import de.metas.esb.edi.model.I_EDI_Desadv;
 import de.metas.esb.edi.model.I_EDI_DesadvLine;
 import de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item;
@@ -21,6 +19,7 @@ import de.metas.handlingunits.IHUAssignmentBL;
 import de.metas.handlingunits.IHUContextFactory;
 import de.metas.handlingunits.IHandlingUnitsDAO;
 import de.metas.handlingunits.IMutableHUContext;
+import de.metas.handlingunits.allocation.impl.TotalQtyCUBreakdownCalculator;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_Attribute;
 import de.metas.handlingunits.model.I_M_HU_PI;
@@ -41,6 +40,7 @@ import de.metas.sscc18.impl.SSCC18CodeBL;
 import de.metas.uom.CreateUOMConversionRequest;
 import de.metas.uom.UomId;
 import de.metas.util.Services;
+import lombok.NonNull;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.wrapper.POJOLookupMap;
 import org.adempiere.exceptions.AdempiereException;
@@ -281,7 +281,7 @@ class DesadvBL_reactivateRecomplete_orphanPackItem_Test
 			public I_EDI_DesadvLine getEDI_DesadvLine() { return desadvLine; }
 
 			@Override
-			public de.metas.handlingunits.model.I_M_HU_PI_Item_Product getTuPIItemProduct() { return huPIItemProductRecord; }
+			public I_M_HU_PI_Item_Product getTuPIItemProduct() { return huPIItemProductRecord; }
 
 			@Override
 			public Integer getLineNo() { return 10; }

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_reactivateRecomplete_orphanPackItem_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_reactivateRecomplete_orphanPackItem_Test.java
@@ -1,0 +1,339 @@
+package de.metas.edi.api.impl;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.bpartner.BPartnerId;
+import de.metas.business.BusinessTestHelper;
+import de.metas.edi.model.I_C_Order;
+import de.metas.edi.model.I_C_OrderLine;
+import de.metas.edi.model.I_M_InOut;
+import de.metas.edi.model.I_M_InOutLine;
+import de.metas.esb.edi.model.I_EDI_Desadv;
+import de.metas.esb.edi.model.I_EDI_DesadvLine;
+import de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item;
+import de.metas.handlingunits.HUTestHelper;
+import de.metas.handlingunits.IHUAssignmentBL;
+import de.metas.handlingunits.IHUContextFactory;
+import de.metas.handlingunits.IHandlingUnitsDAO;
+import de.metas.handlingunits.IMutableHUContext;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.I_M_HU_Attribute;
+import de.metas.handlingunits.model.I_M_HU_PI;
+import de.metas.handlingunits.model.I_M_HU_PI_Attribute;
+import de.metas.handlingunits.model.I_M_HU_PI_Item;
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.handlingunits.model.X_M_HU_PI_Version;
+import de.metas.handlingunits.test.misc.builders.HUPIAttributeBuilder;
+import de.metas.inoutcandidate.api.IReceiptScheduleProducerFactory;
+import de.metas.inoutcandidate.api.impl.ReceiptScheduleProducerFactory;
+import de.metas.inoutcandidate.filter.GenerateReceiptScheduleForModelAggregateFilter;
+import de.metas.organization.ClientAndOrgId;
+import de.metas.organization.OrgId;
+import de.metas.pricing.InvoicableQtyBasedOn;
+import de.metas.product.ProductId;
+import de.metas.sscc18.ISSCC18CodeBL;
+import de.metas.sscc18.impl.SSCC18CodeBL;
+import de.metas.uom.CreateUOMConversionRequest;
+import de.metas.uom.UomId;
+import de.metas.util.Services;
+import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.mm.attributes.api.AttributeConstants;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.service.ISysConfigBL;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_M_Attribute;
+import org.compiere.model.I_M_Product;
+import org.compiere.model.X_M_Attribute;
+import org.compiere.util.Env;
+import org.compiere.util.TimeUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Properties;
+
+import static de.metas.handlingunits.HUTestHelper.NAME_IFCO_Product;
+import static java.math.BigDecimal.TEN;
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.adempiere.model.InterfaceWrapperHelper.refresh;
+
+/*
+ * #%L
+ * de.metas.edi
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * me03 #29278 — reproduce the orphan Qty-0 pack item bug.
+ * <p>
+ * Models the production cycle (M_InOut validator timings):
+ * BEFORE_COMPLETE -> {@link DesadvBL#addToDesadvCreateForInOutIfNotExist(I_M_InOut)}
+ * BEFORE_REACTIVATE -> {@link DesadvBL#removeInOutFromDesadv(I_M_InOut)}
+ * then re-complete.
+ * <p>
+ * After the cycle there must be NO EDI_Desadv_Pack_Item with (MovementQty==0 AND M_InOutLine_ID==null).
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+class DesadvBL_reactivateRecomplete_orphanPackItem_Test
+{
+	private int sscc18SerialNo = 0;
+	private I_M_HU_PI_Item_Product huPIItemProductRecord;
+	private UomId stockUomId;
+	private final BPartnerId recipientBPartnerId = BPartnerId.ofRepoId(20);
+	private I_M_HU_PI_Item huPIItemPallet;
+	private HUTestHelper huTestHelper;
+	private I_M_InOutLine inOutLineRecord;
+	private I_M_InOut inOutRecord;
+	private SSCC18CodeBL sscc18CodeBL;
+	private DesadvBL desadvBL;
+	private final IHUAssignmentBL huAssignmentBL = Services.get(IHUAssignmentBL.class);
+	private I_EDI_DesadvLine desadvLine;
+	private I_M_Attribute bestBeforeAttrRecord;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		final ReceiptScheduleProducerFactory receiptScheduleProducerFactory = new ReceiptScheduleProducerFactory(new GenerateReceiptScheduleForModelAggregateFilter(ImmutableList.of()));
+		Services.registerService(IReceiptScheduleProducerFactory.class, receiptScheduleProducerFactory);
+
+		huTestHelper = HUTestHelper.newInstanceOutOfTrx();
+
+		sscc18SerialNo = 0;
+		sscc18CodeBL = new SSCC18CodeBL();
+		sscc18CodeBL.setOverrideNextSerialNumberProvider(orgId -> ++sscc18SerialNo);
+		Services.registerService(ISSCC18CodeBL.class, sscc18CodeBL);
+
+		Services.get(ISysConfigBL.class).setValue(SSCC18CodeBL.SYSCONFIG_ManufacturerCode, "111111", ClientId.METASFRESH, OrgId.ANY);
+
+		final I_C_UOM stockUOMRecord = BusinessTestHelper.createUOM("stockUOM", 0, -1);
+		final I_C_UOM orderUOMRecord = BusinessTestHelper.createUOM("orderUOM", 3, -1);
+
+		final I_M_Product productRecord = BusinessTestHelper.createProduct("product", stockUOMRecord);
+		final ProductId productId = ProductId.ofRepoId(productRecord.getM_Product_ID());
+		stockUomId = UomId.ofRepoId(stockUOMRecord.getC_UOM_ID());
+
+		BusinessTestHelper.createUOMConversion(CreateUOMConversionRequest.builder()
+													   .productId(productId)
+													   .fromUomId(UomId.ofRepoId(orderUOMRecord.getC_UOM_ID()))
+													   .toUomId(stockUomId)
+													   .fromToMultiplier(new BigDecimal("2"))
+													   .build());
+
+		// setup HU packing instructions
+		final I_M_HU_PI huDefPalet = huTestHelper.createHUDefinition(HUTestHelper.NAME_Palet_Product, X_M_HU_PI_Version.HU_UNITTYPE_LoadLogistiqueUnit);
+		huTestHelper.createHU_PI_Item_PackingMaterial(huDefPalet, huTestHelper.pmPalet);
+
+		final I_M_HU_PI huDefIFCO = huTestHelper.createHUDefinition(NAME_IFCO_Product, X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit);
+		huTestHelper.createHU_PI_Item_PackingMaterial(huDefIFCO, huTestHelper.pmIFCO);
+		final I_M_HU_PI_Item maItemIFCO = huTestHelper.createHU_PI_Item_Material(huDefIFCO);
+		huPIItemPallet = huTestHelper.createHU_PI_Item_IncludedHU(huDefPalet, huDefIFCO, TEN);
+
+		huPIItemProductRecord = huTestHelper.assignProduct(maItemIFCO, productId, new BigDecimal("5"), stockUOMRecord);
+
+		final I_EDI_Desadv desadv = newInstance(I_EDI_Desadv.class);
+		saveRecord(desadv);
+
+		desadvLine = newInstance(I_EDI_DesadvLine.class);
+		desadvLine.setEDI_Desadv_ID(desadv.getEDI_Desadv_ID());
+		desadvLine.setM_Product_ID(huPIItemProductRecord.getM_Product_ID());
+		desadvLine.setC_UOM_ID(orderUOMRecord.getC_UOM_ID());
+		desadvLine.setQtyDeliveredInStockingUOM(BigDecimal.ZERO);
+		desadvLine.setInvoicableQtyBasedOn(InvoicableQtyBasedOn.NominalWeight.getCode());
+		saveRecord(desadvLine);
+
+		final I_C_Order orderRecord = newInstance(I_C_Order.class);
+		orderRecord.setC_BPartner_ID(20);
+		orderRecord.setEDI_Desadv_ID(desadv.getEDI_Desadv_ID());
+		saveRecord(orderRecord);
+
+		final I_C_OrderLine orderLineRecord = newInstance(I_C_OrderLine.class);
+		orderLineRecord.setC_Order_ID(orderRecord.getC_Order_ID());
+		orderLineRecord.setEDI_DesadvLine_ID(desadvLine.getEDI_DesadvLine_ID());
+		orderLineRecord.setM_Product_ID(huPIItemProductRecord.getM_Product_ID());
+		orderLineRecord.setM_HU_PI_Item_Product_ID(huPIItemProductRecord.getM_HU_PI_Item_Product_ID());
+		orderLineRecord.setC_UOM_ID(orderUOMRecord.getC_UOM_ID());
+		saveRecord(orderLineRecord);
+
+		inOutRecord = newInstance(I_M_InOut.class);
+		inOutRecord.setC_Order_ID(orderRecord.getC_Order_ID());
+		inOutRecord.setC_BPartner_ID(recipientBPartnerId.getRepoId());
+		inOutRecord.setEDI_Desadv_ID(desadv.getEDI_Desadv_ID());
+		saveRecord(inOutRecord);
+
+		inOutLineRecord = newInstance(I_M_InOutLine.class);
+		inOutLineRecord.setC_OrderLine_ID(orderLineRecord.getC_OrderLine_ID());
+		inOutLineRecord.setM_Product_ID(huPIItemProductRecord.getM_Product_ID());
+		inOutLineRecord.setMovementQty(new BigDecimal("84"));
+		inOutLineRecord.setQtyEntered(new BigDecimal("52"));
+		inOutLineRecord.setC_UOM_ID(stockUomId.getRepoId());
+		inOutLineRecord.setM_InOut_ID(inOutRecord.getM_InOut_ID());
+		saveRecord(inOutLineRecord);
+
+		desadvBL = DesadvBL.newInstanceForUnitTesting();
+
+		bestBeforeAttrRecord = huTestHelper.attr_BestBeforeDate;
+
+		setupHandlingUnit(); // HU with 49 CUs assigned to inOutLineRecord
+	}
+
+	@Test
+	void reactivate_recomplete_doesNotLeaveOrphanQtyZeroPackItem()
+	{
+		// 0) SSCC labels generated up-front for this DESADV line (production: EDI_Desadv_GenerateSSCCLabels).
+		//    This creates a "drafted" pack item: M_InOutLine_ID = NULL (see DesadvLineSSCC18Generator#buildCreateEDIDesadvPackItemRequest).
+		//    We model a label whose LU breakdown ended up with qtyCUsPerLU=0 (e.g. labels printed before the qty was firmed up),
+		//    so movementQty=0 and it can never be reclaimed by popFirstMatching (no real shipment line has movementQty 0).
+		seedDraftedSSCCPackItem(BigDecimal.ZERO);
+
+		// 1) COMPLETE
+		desadvBL.addToDesadvCreateForInOutIfNotExist(inOutRecord);
+
+		// 2) REACTIVATE (production: only a non-qty field such as Tour changed)
+		refresh(inOutRecord);
+		desadvBL.removeInOutFromDesadv(inOutRecord);
+
+		// 3) RE-COMPLETE
+		refresh(inOutRecord);
+		inOutRecord.setEDI_Desadv_ID(desadvLine.getEDI_Desadv_ID());
+		saveRecord(inOutRecord);
+		desadvBL.addToDesadvCreateForInOutIfNotExist(inOutRecord);
+
+		// ASSERT — no orphan pack item: (MovementQty == 0 AND M_InOutLine_ID == null)
+		final List<I_EDI_Desadv_Pack_Item> orphans = org.adempiere.ad.wrapper.POJOLookupMap.get()
+				.getRecords(I_EDI_Desadv_Pack_Item.class)
+				.stream()
+				.filter(pi -> pi.getMovementQty() != null && pi.getMovementQty().signum() == 0)
+				.filter(pi -> pi.getM_InOutLine_ID() <= 0)
+				.collect(java.util.stream.Collectors.toList());
+
+		assertThat(orphans)
+				.as("orphan Qty-0 pack item with NULL M_InOutLine_ID (me03 #29278) must not exist after reactivate->re-complete")
+				.isEmpty();
+	}
+
+	/**
+	 * Models {@link de.metas.edi.sscc18.DesadvLineSSCC18Generator}: creates an EDI_Desadv_Pack with a single
+	 * "drafted" pack item that has NO M_InOutLine_ID (null) and movementQty = the given qtyCUsPerLU.
+	 */
+	private void seedDraftedSSCCPackItem(final BigDecimal qtyCUsPerLU)
+	{
+		final de.metas.edi.api.impl.pack.EDIDesadvPackService packService = de.metas.edi.api.impl.pack.EDIDesadvPackService.newInstanceForUnitTesting();
+		final de.metas.edi.api.impl.pack.EDIDesadvPackService.Sequences sequences =
+				packService.createSequences(de.metas.edi.api.EDIDesadvId.ofRepoId(desadvLine.getEDI_Desadv_ID()));
+
+		final de.metas.edi.api.impl.pack.CreateEDIDesadvPackItemRequest packItemRequest =
+				de.metas.edi.api.impl.pack.CreateEDIDesadvPackItemRequest.builder()
+						.ediDesadvLineId(de.metas.edi.api.EDIDesadvLineId.ofRepoId(desadvLine.getEDI_DesadvLine_ID()))
+						.line(sequences.getPackItemLineSequence().next())
+						.qtyTu(0)
+						.qtyCUsPerLU(qtyCUsPerLU)
+						.movementQtyInStockUOM(qtyCUsPerLU) // exactly how the generator sets it
+						// note: NO inOutId / inOutLineId -> M_InOutLine_ID stays null -> "drafted"
+						.build();
+
+		final de.metas.edi.api.impl.pack.CreateEDIDesadvPackRequest packRequest =
+				de.metas.edi.api.impl.pack.CreateEDIDesadvPackRequest.builder()
+						.orgId(OrgId.ofRepoId(desadvLine.getAD_Org_ID()))
+						.seqNo(sequences.getPackSeqNoSequence().next())
+						.ediDesadvId(de.metas.edi.api.EDIDesadvId.ofRepoId(desadvLine.getEDI_Desadv_ID()))
+						.sscc18("000000000000000099")
+						.isManualIpaSSCC(true)
+						.createEDIDesadvPackItemRequest(packItemRequest)
+						.build();
+
+		packService.createDesadvPack(packRequest);
+	}
+
+	private void setupHandlingUnit()
+	{
+		final Properties ctx = Env.getCtx();
+		final IMutableHUContext huContext = Services.get(IHUContextFactory.class).createMutableHUContext(ctx, ClientAndOrgId.ofClientAndOrg(Env.getAD_Client_ID(), Env.getAD_Org_ID(ctx)));
+
+		final I_M_Attribute sscc18AttrRecord = newInstance(I_M_Attribute.class);
+		sscc18AttrRecord.setAttributeValueType(X_M_Attribute.ATTRIBUTEVALUETYPE_StringMax40);
+		sscc18AttrRecord.setValue(AttributeConstants.ATTR_SSCC18_Value.getCode());
+		saveRecord(sscc18AttrRecord);
+
+		final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
+		final I_M_HU_PI_Attribute sscc18HUPIAttributeRecord = huTestHelper
+				.createM_HU_PI_Attribute(HUPIAttributeBuilder.newInstance(sscc18AttrRecord)
+						.setM_HU_PI(handlingUnitsDAO.getIncludedPI(huPIItemPallet)));
+		final I_M_HU lu = huTestHelper.createLU(
+				huContext,
+				huPIItemPallet,
+				huPIItemProductRecord,
+				new BigDecimal("49"));
+		final I_M_HU_Attribute huAttrRecord = newInstance(I_M_HU_Attribute.class);
+		huAttrRecord.setM_Attribute_ID(sscc18HUPIAttributeRecord.getM_Attribute_ID());
+		huAttrRecord.setM_HU_ID(lu.getM_HU_ID());
+		huAttrRecord.setValue(sscc18CodeBL.generate(OrgId.ANY).asString());
+		huAttrRecord.setM_HU_PI_Attribute_ID(sscc18HUPIAttributeRecord.getM_HU_PI_Attribute_ID());
+		saveRecord(huAttrRecord);
+
+		final I_M_HU_PI_Attribute bestBeforeHUPIAttributeRecord = org.adempiere.ad.wrapper.POJOLookupMap.get()
+				.getRecords(I_M_HU_PI_Attribute.class,
+						record -> record.getM_Attribute_ID() == bestBeforeAttrRecord.getM_Attribute_ID())
+				.stream()
+				.findFirst()
+				.orElseThrow(() -> new AdempiereException("No M_HU_PI_Attribute found for BestBeforeDate attribute"));
+
+		for (final I_M_HU tu : handlingUnitsDAO.retrieveIncludedHUs(lu))
+		{
+			final I_M_HU_Attribute childHUAttrRecord = newInstance(I_M_HU_Attribute.class);
+			childHUAttrRecord.setM_Attribute_ID(bestBeforeHUPIAttributeRecord.getM_Attribute_ID());
+			childHUAttrRecord.setM_HU_ID(tu.getM_HU_ID());
+			childHUAttrRecord.setValueDate(TimeUtil.parseTimestamp("2026-12-02"));
+			childHUAttrRecord.setM_HU_PI_Attribute_ID(bestBeforeHUPIAttributeRecord.getM_HU_PI_Attribute_ID());
+			saveRecord(childHUAttrRecord);
+
+			huAssignmentBL.createHUAssignmentBuilder()
+					.initializeAssignment(ctx, ITrx.TRXNAME_None)
+					.setModel(inOutLineRecord)
+					.setTopLevelHU(lu)
+					.setM_LU_HU(lu)
+					.setM_TU_HU(tu)
+					.build();
+
+			for (final I_M_HU cu : handlingUnitsDAO.retrieveIncludedHUs(tu))
+			{
+				huAssignmentBL.createHUAssignmentBuilder()
+						.initializeAssignment(ctx, ITrx.TRXNAME_None)
+						.setModel(inOutLineRecord)
+						.setTopLevelHU(lu)
+						.setM_LU_HU(lu)
+						.setM_TU_HU(tu)
+						.setVHU(cu)
+						.build();
+			}
+		}
+
+		huAssignmentBL.createHUAssignmentBuilder()
+				.initializeAssignment(ctx, ITrx.TRXNAME_None)
+				.setModel(inOutLineRecord)
+				.setTopLevelHU(lu)
+				.setM_LU_HU(lu)
+				.build();
+	}
+}

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvLineSSCC18Generator_QtyZeroSkip_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvLineSSCC18Generator_QtyZeroSkip_Test.java
@@ -94,17 +94,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 /**
- * Reproduce the orphan Qty-0 pack item bug.
+ * Tests {@link DesadvLineSSCC18Generator}'s Qty-0 skip guard.
  * <p>
- * Models the production cycle (M_InOut validator timings):
- * BEFORE_COMPLETE -> {@link DesadvBL#addToDesadvCreateForInOutIfNotExist(I_M_InOut)}
- * BEFORE_REACTIVATE -> {@link DesadvBL#removeInOutFromDesadv(I_M_InOut)}
- * then re-complete.
- * <p>
- * After the cycle there must be NO EDI_Desadv_Pack_Item with (MovementQty==0 AND M_InOutLine_ID==null).
+ * Verifies that the generator skips any LU whose breakdown yields {@code qtyCUsPerLU=0}
+ * so no orphan {@code EDI_Desadv_Pack_Item} with {@code MovementQty=0} / {@code M_InOutLine_ID=null}
+ * is ever persisted, even after a complete → reactivate → re-complete cycle.
  */
 @ExtendWith(AdempiereTestWatcher.class)
-class DesadvBL_reactivateRecomplete_orphanPackItem_Test
+class DesadvLineSSCC18Generator_QtyZeroSkip_Test
 {
 	private int sscc18SerialNo = 0;
 	private I_M_HU_PI_Item_Product huPIItemProductRecord;
@@ -320,7 +317,7 @@ class DesadvBL_reactivateRecomplete_orphanPackItem_Test
 		final List<I_EDI_Desadv_Pack_Item> orphans = POJOLookupMap.get()
 				.getRecords(I_EDI_Desadv_Pack_Item.class)
 				.stream()
-				.filter(pi -> pi.getMovementQty() != null && pi.getMovementQty().signum() == 0)
+				.filter(pi -> pi.getMovementQty().signum() == 0) // MovementQty is NOT NULL in EDI_Desadv_Pack_Item
 				.filter(pi -> pi.getM_InOutLine_ID() <= 0)
 				.collect(Collectors.toList());
 


### PR DESCRIPTION
## Problem

A Coop DESADV EDI message (clearing center Compudata) fails to send when the DESADV contains a **pack item of quantity 0**. Such a pack item is exported as a null/empty line, which the clearing center rejects.

Root analysis shows two distinct layers:

1. **The 0-qty pack item is created by SSCC-label generation.** `DesadvLineSSCC18Generator` builds a "drafted" pack item (no `M_InOutLine_ID`) with `MovementQty = qtyCUsPerLU`; when the LU breakdown is exhausted/misconfigured, `TotalQtyCUBreakdownCalculator.subtractOneLU()` returns the `LUQtys.NULL` singleton (qty 0), so a `MovementQty = 0` pack item is persisted.
2. **It then survives forever** — the reactivate/re-complete cleanup deletes pack items filtered by `M_InOutLine_ID` (a `NULL`-linked drafted item is invisible to it), and it can never be reclaimed (a 0 qty never matches a real shipment-line qty). The export-format WhereClause added previously filtered on the *parent line's* qty, not the item's own, so it slipped through.

## Fix (two layers)

**A — Export gate (`EXP_Format` WhereClause migration `5807110`).** `EDI_Exp_Desadv_Pack_Item` (540418) and `EDI_Exp_Desadv_Pack` (540419) now additionally require the pack item's **own** `MovementQty > 0`. A 0-qty pack item is never exported, even when its parent line still has qty > 0. Consistent with the existing export-gate design.

**B — Prevent the orphan at its source (`DesadvLineSSCC18Generator`).** A 0-qty / null LU is no longer turned into a pack item — the generator skips that label slot (with a `warn` log) instead of persisting a meaningless `MovementQty = 0` pack/pack-item. A 0-qty LU only arises from an exhausted/misconfigured calculator; it is not a legitimate label.

## Tests

- **JUnit** `DesadvBL_reactivateRecomplete_orphanPackItem_Test` — reproduces the complete → reactivate → re-complete cycle and asserts no orphan (`MovementQty = 0`, `M_InOutLine_ID = NULL`) pack item remains. RED before the generator fix, GREEN after.
- **Cucumber** `ediDesadvExportSkipsQtyZeroPackItem.feature` — exercises the live `EXP_Format` WhereClause and asserts a 0-qty pack item is excluded from the export selection.
- **Cucumber** `ediDesadvReactivateRecompleteNoOrphanPack.feature` — drives real SSCC-label generation (label count exceeding the shipped qty) to reproduce the orphan birth, then asserts none remains after reactivate/re-complete.
