### PR TITLE
EPCIS export performance: scope shared_lu_inout to the input shipment's LUs

### DIFF
--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5807120_sys_epcis_perf_scope_shared_lu.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5807120_sys_epcis_perf_scope_shared_lu.sql
@@ -1,3 +1,13 @@
+-- EPCIS export performance: bound shared_lu_inout to the input shipment's LUs
+--
+-- get_epcis_events_json_fn computed shared_lu_inout (the LU<->shipment ownership map) over the
+-- WHOLE m_hu_assignment history on every call — no predicate scoping it to the input shipment.
+-- On a large dataset (~16M m_hu_assignment rows) that materialized ~1.8M rows in ~25s, dominating
+-- a >2min single-shipment call. Add a this_inout_lu CTE (the LUs the input shipment touches) and
+-- scope shared_lu_inout via `m_lu_hu_id IN (this_inout_lu)`, so the m_hu_assignment_m_lu_hu_id
+-- index drives the scan. Owner election is unchanged (MIN over all shipments sharing each LU).
+-- Output is byte-identical; this is a pure performance fix (CREATE OR REPLACE).
+
 /*
  * #%L
  * de.metas.edi


### PR DESCRIPTION
### Problem

`get_epcis_events_json_fn(p_m_inout_id)` took **>2 min** for a single shipment on a large dataset. The cause is the `shared_lu_inout` CTE (the LU↔shipment ownership map used for owner-election / the one-event-per-physical-SSCC merge): it was computed over the **entire `m_hu_assignment` history** on every call, with no predicate scoping it to the input shipment.

`EXPLAIN (ANALYZE, BUFFERS)` on the customer dataset (~16M `m_hu_assignment` rows, 9.9M matching the filter):

```
shared_lu_inout (current, unbounded):  Parallel Seq Scan → 1,796,448 rows materialized   Execution Time: 25,185 ms
```

`lu_owner` then groups that 1.8M-row set and `desadv_agg` joins it — which is what compounds to the >2 min.

### Fix

Add a `this_inout_lu` CTE — the LUs the **input shipment** physically touches (1–5 rows via `m_hu_assignment`) — and scope `shared_lu_inout` with `m_lu_hu_id IN (SELECT … FROM this_inout_lu)`. The `m_hu_assignment_m_lu_hu_id` index then drives the scan.

```
scoped to the input's LUs (this PR):  index scans, 2 rows                                 Execution Time: 0.294 ms
```

~85,000× faster on the hot CTE (25,185 ms → 0.294 ms); no new index needed.

### Correctness — output is byte-identical

Owner election is unchanged: for each of the input shipment's LUs, `shared_lu_inout` still contains **all** shipments sharing that LU (the filter is on `m_lu_hu_id`, not `m_inout_id`), so `lu_owner`'s `MIN(m_inout_id)` is exact. `pallet_list` / `desadv_agg` only ever consult the input's owned LUs anyway. The function body is otherwise unchanged — this is a pure performance refactor.

### Migration

`5807120_sys_me03_29231_epcis_perf_scope_shared_lu.sql` — `CREATE OR REPLACE FUNCTION` (idempotent), in sync with the canonical `ddl/functions/epcis_json/get_epcis_events_json_fn.sql`.

### Tests

`epcisExport.feature` (`EPCIS_010/020/030`, `S29231_130`, `S29231_170`) re-run locally as the regression gate — the per-SSCC merge, `shipmentDocumentNos`, and references behaviour are unchanged.

### Note

The unbounded `shared_lu_inout` was introduced by the per-SSCC owner-election in https://github.com/metasfresh/metasfresh/pull/24338 — this fixes that performance regression.
