### PR TITLE
AD_SysConfig: document picking auto-assign QueryLimit + addToDailyShipperTransportationOrder

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807320_sys_picking_sysconfig_descriptions.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807320_sys_picking_sysconfig_descriptions.sql
@@ -1,0 +1,9 @@
+-- me03 #30326: document the two picking sysconfigs used by the Workplace auto-assign rollout.
+-- AD_SysConfig has no _Trl companion -> description text directly in German (base-language rule).
+
+-- 541788: de.metas.handlingunits.picking.job_schedule.service.commands.PickingJobScheduleAutoAssignCommand.QueryLimit
+UPDATE AD_SysConfig SET Description='Maximale Anzahl Lieferdispositionen, die ein Lauf der automatischen Arbeitsplatz-Zuordnung (Traffic Management) lädt und zuordnet. Standard: 1000.', Updated=TO_TIMESTAMP('2026-06-11 14:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_SysConfig_ID=541788
+;
+-- 541740: de.metas.handlingunits.picking.addToDailyShipperTransportationOrder
+UPDATE AD_SysConfig SET Description='Wenn gesetzt (Y), werden nach Fertigstellung einer Kommissionier-Lieferung automatisch Packstücke erzeugt und dem täglichen Speditionsauftrag hinzugefügt. Standard: N.', Updated=TO_TIMESTAMP('2026-06-11 14:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_SysConfig_ID=541740
+;


### PR DESCRIPTION
Adds German descriptions to two previously undocumented picking sysconfigs:

- `de.metas.handlingunits.picking.job_schedule.service.commands.PickingJobScheduleAutoAssignCommand.QueryLimit` (AD_SysConfig_ID=541788): maximum number of shipment schedules one automatic workplace-assignment run loads and assigns (default 1000).
- `de.metas.handlingunits.picking.addToDailyShipperTransportationOrder` (AD_SysConfig_ID=541740): when set to Y, completing a picking shipment automatically creates packages and adds them to the daily shipper transportation order (default N).

Migration script `5807320` only sets `AD_SysConfig.Description` (no value/behaviour change). AD_SysConfig has no _Trl companion, so the description is written in German per the base-language convention.