### PR TITLE
Shipment reverse: restore picked qty when no completed picking job to reopen

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/FrontendTestingRestController.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/FrontendTestingRestController.java
@@ -11,6 +11,9 @@ import de.metas.frontend_testing.masterdata.CreateMasterdataCommand;
 import de.metas.frontend_testing.masterdata.CreateMasterdataCommandSupportingServices;
 import de.metas.frontend_testing.masterdata.JsonCreateMasterdataRequest;
 import de.metas.frontend_testing.masterdata.JsonCreateMasterdataResponse;
+import de.metas.frontend_testing.masterdata.shipment.JsonGenerateShipmentsRequest;
+import de.metas.frontend_testing.masterdata.shipment.JsonGenerateShipmentsResponse;
+import de.metas.frontend_testing.masterdata.shipment.GenerateShipmentsCommand;
 import de.metas.frontend_testing.masterdata.shipment.JsonReverseShipmentRequest;
 import de.metas.frontend_testing.masterdata.shipment.JsonReverseShipmentResponse;
 import de.metas.frontend_testing.masterdata.shipment.ReverseShipmentCommand;
@@ -149,6 +152,15 @@ public class FrontendTestingRestController
 	public JsonReverseShipmentResponse reverseShipment(@RequestBody @NonNull final JsonReverseShipmentRequest request)
 	{
 		return callInContext(() -> ReverseShipmentCommand.builder()
+				.request(request)
+				.build()
+				.execute());
+	}
+
+	@PostMapping("generateShipments")
+	public JsonGenerateShipmentsResponse generateShipments(@RequestBody @NonNull final JsonGenerateShipmentsRequest request)
+	{
+		return callInContext(() -> GenerateShipmentsCommand.builder()
 				.request(request)
 				.build()
 				.execute());

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/GenerateShipmentsCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/GenerateShipmentsCommand.java
@@ -1,0 +1,103 @@
+package de.metas.frontend_testing.masterdata.shipment;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import de.metas.handlingunits.shipmentschedule.api.GenerateShipmentsForSchedulesRequest;
+import de.metas.handlingunits.shipmentschedule.api.M_ShipmentSchedule_QuantityTypeToUse;
+import de.metas.handlingunits.shipmentschedule.api.ShipmentService;
+import de.metas.inoutcandidate.api.IShipmentSchedulePA;
+import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.interfaces.I_C_OrderLine;
+import de.metas.order.IOrderDAO;
+import de.metas.order.OrderId;
+import de.metas.order.OrderLineId;
+import de.metas.util.Services;
+import lombok.Builder;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.trx.api.ITrxManager;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Generates shipments from a sales order's shipment schedules via the REAL
+ * {@code ShipmentService.generateShipmentsForScheduleIds} path — the faithful equivalent of the
+ * desktop "Generate Shipments" process. With quantity type Picked it runs the
+ * {@code GenerateInOutFromShipmentSchedules} workpackage over the schedule's already-picked qty; when
+ * no picked qty survives it generates no shipment (the "can't recreate shipment after void" symptom).
+ *
+ * <p>Newly-created shipments are detected via a before/after snapshot of the order's {@code M_InOut}
+ * ids, so the response reports exactly the shipments this call produced (empty == nothing recreatable).
+ */
+@Builder
+public class GenerateShipmentsCommand
+{
+	@NonNull private final ITrxManager trxManager = Services.get(ITrxManager.class);
+	@NonNull private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
+	@NonNull private final IShipmentSchedulePA shipmentSchedulePA = Services.get(IShipmentSchedulePA.class);
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@NonNull private final JsonGenerateShipmentsRequest request;
+
+	public JsonGenerateShipmentsResponse execute()
+	{
+		return trxManager.callInThreadInheritedTrx(this::execute0);
+	}
+
+	private JsonGenerateShipmentsResponse execute0()
+	{
+		final OrderId orderId = OrderId.ofRepoId(Integer.parseInt(request.getSalesOrderId()));
+
+		final ImmutableSet<ShipmentScheduleId> scheduleIds = retrieveScheduleIds(orderId);
+
+		final M_ShipmentSchedule_QuantityTypeToUse quantityType = request.getQuantityType() != null
+				? M_ShipmentSchedule_QuantityTypeToUse.ofCode(request.getQuantityType())
+				: M_ShipmentSchedule_QuantityTypeToUse.TYPE_PICKED_QTY;
+		final boolean complete = request.getComplete() == null || request.getComplete();
+
+		final Set<Integer> inOutIdsBefore = retrieveInOutIds(orderId);
+
+		ShipmentService.getInstance().generateShipmentsForScheduleIds(
+				GenerateShipmentsForSchedulesRequest.builder()
+						.shipmentScheduleIds(scheduleIds)
+						.quantityTypeToUse(quantityType)
+						.isCompleteShipment(complete)
+						.waitForShipments(true)
+						.build());
+
+		final Set<Integer> inOutIdsAfter = retrieveInOutIds(orderId);
+
+		final ImmutableList<String> newShipmentIds = inOutIdsAfter.stream()
+				.filter(id -> !inOutIdsBefore.contains(id))
+				.map(String::valueOf)
+				.collect(ImmutableList.toImmutableList());
+
+		return JsonGenerateShipmentsResponse.builder()
+				.newShipmentIds(newShipmentIds)
+				.newShipmentCount(newShipmentIds.size())
+				.build();
+	}
+
+	private ImmutableSet<ShipmentScheduleId> retrieveScheduleIds(@NonNull final OrderId orderId)
+	{
+		final Set<OrderLineId> orderLineIds = orderDAO.retrieveOrderLines(orderId).stream()
+				.map(I_C_OrderLine::getC_OrderLine_ID)
+				.map(OrderLineId::ofRepoId)
+				.collect(Collectors.toSet());
+
+		return shipmentSchedulePA.getByOrderLineIds(orderLineIds).stream()
+				.map(I_M_ShipmentSchedule::getM_ShipmentSchedule_ID)
+				.map(ShipmentScheduleId::ofRepoId)
+				.collect(ImmutableSet.toImmutableSet());
+	}
+
+	private Set<Integer> retrieveInOutIds(@NonNull final OrderId orderId)
+	{
+		return ImmutableSet.copyOf(queryBL.createQueryBuilder(org.compiere.model.I_M_InOut.class)
+				.addEqualsFilter(org.compiere.model.I_M_InOut.COLUMNNAME_C_Order_ID, orderId)
+				.create()
+				.listIds());
+	}
+}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/JsonGenerateShipmentsRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/JsonGenerateShipmentsRequest.java
@@ -1,0 +1,32 @@
+package de.metas.frontend_testing.masterdata.shipment;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Request to generate shipments from a sales order's shipment schedules via the REAL
+ * {@code ShipmentService.generateShipmentsForScheduleIds} path — the faithful equivalent of the
+ * desktop "Generate Shipments" process (NOT the {@code ShipmentCreateCommand} shortcut, which calls
+ * {@code prepareShipmentSchedulesWithHU} directly and diverges after a reverse).
+ *
+ * <p>With {@code quantityType = "P"} (Picked) this ships the schedule's already-picked qty through the
+ * {@code GenerateInOutFromShipmentSchedules} workpackage; when no picked qty survives (e.g. the customer
+ * "can't recreate shipment after void" defect) it generates NO shipment.
+ */
+@Value
+@Builder
+@Jacksonized
+public class JsonGenerateShipmentsRequest
+{
+	/** The {@code C_Order_ID} (sales order) whose shipment schedules shall be shipped (as a string). */
+	@NonNull String salesOrderId;
+
+	/** Quantity type to use: {@code "P"} = Picked qty (default), {@code "D"} = QtyToDeliver. */
+	@Nullable String quantityType;
+
+	/** Whether to complete the generated shipment. Defaults to {@code true}. */
+	@Nullable Boolean complete;
+}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/JsonGenerateShipmentsResponse.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/shipment/JsonGenerateShipmentsResponse.java
@@ -1,0 +1,23 @@
+package de.metas.frontend_testing.masterdata.shipment;
+
+import com.google.common.collect.ImmutableList;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+public class JsonGenerateShipmentsResponse
+{
+	/**
+	 * The {@code M_InOut_ID}s of the shipments NEWLY created by this call (as strings) — i.e. the order's
+	 * shipments that did not exist before generation. Empty when nothing could be shipped (e.g. the picked
+	 * qty did not survive a prior reverse — the "can't recreate shipment after void" defect).
+	 */
+	@NonNull ImmutableList<String> newShipmentIds;
+
+	/** Convenience: {@code newShipmentIds.size()}. {@code 0} == no shipment could be recreated. */
+	int newShipmentCount;
+}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_InOut.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_InOut.java
@@ -83,6 +83,7 @@ public class M_InOut
 	private final IHUInOutBL huInOutBL = Services.get(IHUInOutBL.class);
 	private final IInOutBL inOutBL = Services.get(IInOutBL.class);
 	private final IHUShipmentAssignmentBL huShipmentAssignmentBL = Services.get(IHUShipmentAssignmentBL.class);
+	private final de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleBL huShipmentScheduleBL = Services.get(de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleBL.class);
 	private final IHUPickingSlotBL huPickingSlotBL = Services.get(IHUPickingSlotBL.class);
 	private final IHUEmptiesService huEmptiesService = Services.get(IHUEmptiesService.class);
 	private final IHUPackageBL huPackageBL = Services.get(IHUPackageBL.class);
@@ -291,6 +292,12 @@ public class M_InOut
 				.build();
 
 		pickingJobService.reopenPickingJobs(request);
+
+		// Safety net: the reopen above only restores picked qty for a *Completed* picking job. When the shipment
+		// was recreated via "Generate Shipments" the job is left Drafted, so a subsequent reverse restores nothing
+		// and the shipment can no longer be recreated (me03#29561). Re-create the picked rows directly from the
+		// just-reversed allocations for any (schedule, VHU) the reopen did not restore.
+		huShipmentScheduleBL.restoreUnshippedQtyPickedIfMissing(assignedQuantities);
 	}
 
 	@DocValidate(timings = ModelValidator.TIMING_BEFORE_REACTIVATE)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_InOut.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_InOut.java
@@ -298,7 +298,19 @@ public class M_InOut
 		// was recreated via "Generate Shipments" the job is left Drafted, so a subsequent reverse restores nothing
 		// and the shipment can no longer be recreated (me03#29561). Re-create the picked rows directly from the
 		// just-reversed allocations for any (schedule, VHU) the reopen did not restore.
-		huShipmentScheduleBL.restoreUnshippedQtyPickedIfMissing(assignedQuantities);
+		//
+		// Gate this to allocations whose VHU is covered by a picking job: a QtyToDeliver / on-the-fly shipment has
+		// NO picking job and its reverse must instead clear the HU's BPartner + return it to Active stock (so it
+		// can be shipped to a different customer) — that behaviour must stay untouched.
+		final ImmutableSet<HuId> huIdsCoveredByPickingJobs = pickingJobService.getHuIdsCoveredByPickingJobs(allShipmentSchedulesInvolved);
+		if (!huIdsCoveredByPickingJobs.isEmpty())
+		{
+			final List<I_M_ShipmentSchedule_QtyPicked> pickedJobAllocations = assignedQuantities.stream()
+					.filter(qtyPicked -> qtyPicked.getVHU_ID() > 0
+							&& huIdsCoveredByPickingJobs.contains(HuId.ofRepoId(qtyPicked.getVHU_ID())))
+					.collect(ImmutableList.toImmutableList());
+			huShipmentScheduleBL.restoreUnshippedQtyPickedIfMissing(pickedJobAllocations);
+		}
 	}
 
 	@DocValidate(timings = ModelValidator.TIMING_BEFORE_REACTIVATE)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_InOut.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_InOut.java
@@ -46,6 +46,7 @@ import de.metas.handlingunits.picking.job.service.HUWithPickOnTheFlyStatus;
 import de.metas.handlingunits.picking.job.service.PickingJobService;
 import de.metas.handlingunits.picking.job.service.ReopenPickingJobRequest;
 import de.metas.handlingunits.picking.slot.IHUPickingSlotBL;
+import de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleBL;
 import de.metas.handlingunits.shipping.IHUPackageBL;
 import de.metas.handlingunits.snapshot.IHUSnapshotDAO;
 import de.metas.handlingunits.util.HUByIdComparator;
@@ -83,7 +84,7 @@ public class M_InOut
 	private final IHUInOutBL huInOutBL = Services.get(IHUInOutBL.class);
 	private final IInOutBL inOutBL = Services.get(IInOutBL.class);
 	private final IHUShipmentAssignmentBL huShipmentAssignmentBL = Services.get(IHUShipmentAssignmentBL.class);
-	private final de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleBL huShipmentScheduleBL = Services.get(de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleBL.class);
+	private final IHUShipmentScheduleBL huShipmentScheduleBL = Services.get(IHUShipmentScheduleBL.class);
 	private final IHUPickingSlotBL huPickingSlotBL = Services.get(IHUPickingSlotBL.class);
 	private final IHUEmptiesService huEmptiesService = Services.get(IHUEmptiesService.class);
 	private final IHUPackageBL huPackageBL = Services.get(IHUPackageBL.class);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
@@ -759,6 +759,29 @@ public class PickingJobService implements PickingSlotListener
 		return pickingJob.getTuPickingTarget(lineId);
 	}
 
+	/**
+	 * @return the set of picked HU ids (VHU level) that are covered by a picking job for any of the given
+	 * shipment schedules — regardless of the job's doc-status. Used by the shipment-reverse restore safety net
+	 * to fire ONLY for picked-qty shipments that originated from a picking job, and never for QtyToDeliver /
+	 * on-the-fly shipments (which have no picking job and whose reverse must clear the HU's BPartner + return it
+	 * to Active stock).
+	 */
+	public ImmutableSet<HuId> getHuIdsCoveredByPickingJobs(@NonNull final Set<ShipmentScheduleId> shipmentScheduleIds)
+	{
+		if (shipmentScheduleIds.isEmpty())
+		{
+			return ImmutableSet.of();
+		}
+		return pickingJobRepository.getPickingJobIdsByScheduleId(shipmentScheduleIds)
+				.values().stream()
+				.flatMap(List::stream)
+				.collect(ImmutableSet.toImmutableSet())
+				.stream()
+				.map(this::getById)
+				.flatMap(pickingJob -> pickingJob.getAllPickedHuIds().stream())
+				.collect(ImmutableSet.toImmutableSet());
+	}
+
 	public void reopenPickingJobs(@NonNull final ReopenPickingJobRequest request)
 	{
 		final Map<ShipmentScheduleId, List<PickingJobId>> scheduleId2JobIds = pickingJobRepository

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleBL.java
@@ -74,6 +74,20 @@ public interface IHUShipmentScheduleBL extends ISingletonService
 	boolean tryMergeQtyPickedIntoExistingForVHU(AddQtyPickedRequest request);
 
 	/**
+	 * Shipment-reverse safety net. Given the (now-deactivated) consolidated {@code M_ShipmentSchedule_QtyPicked}
+	 * rows that were assigned to a just-reversed shipment, ensure each {@code (M_ShipmentSchedule_ID, VHU_ID)}
+	 * still has an active, not-yet-shipped picked row — re-creating one (a direct copy of the reversed
+	 * allocation, with the VHU set back to {@code Picked}) when none survives.
+	 * <p>
+	 * The picking-job reopen ({@code PickingJobReopenCommand}) only restores picked qty for a <b>Completed</b>
+	 * job. When a shipment was recreated via "Generate Shipments" the job is left <b>Drafted</b>, so a subsequent
+	 * reverse restores nothing and the shipment can no longer be recreated (me03#29561). This net closes that gap
+	 * without step-replay (so no {@code tryMerge} qty inflation) and only fires when nothing was restored, so the
+	 * Completed-job path and unrelated in-progress jobs are unaffected.
+	 */
+	void restoreUnshippedQtyPickedIfMissing(Collection<I_M_ShipmentSchedule_QtyPicked> reversedAllocations);
+
+	/**
 	 * Creates a producer which will create shipments ({@link I_M_InOut}) from {@link ShipmentScheduleWithHU}s.
 	 */
 	IInOutProducerFromShipmentScheduleWithHU createInOutProducerFromShipmentSchedule();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleDAO.java
@@ -57,4 +57,14 @@ public interface IHUShipmentScheduleDAO extends ISingletonService
 	List<I_M_ShipmentSchedule_QtyPicked> retrieveMergeableListenerQtyPickedForVHU(
 			@NonNull ShipmentScheduleId shipmentScheduleId,
 			@NonNull HuId vhuId);
+
+	/**
+	 * @return {@code true} if at least one active, not-yet-shipped ({@code M_InOutLine_ID IS NULL})
+	 * {@code M_ShipmentSchedule_QtyPicked} row exists for the given (shipment schedule, VHU).
+	 * Used by the shipment-reverse restore safety net to avoid re-creating a row the picking-job reopen
+	 * already restored.
+	 */
+	boolean existsActiveUnshippedQtyPickedForVHU(
+			@NonNull ShipmentScheduleId shipmentScheduleId,
+			@NonNull HuId vhuId);
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -90,6 +90,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -103,6 +104,7 @@ import static java.math.BigDecimal.ZERO;
 import static org.adempiere.model.InterfaceWrapperHelper.create;
 import static org.adempiere.model.InterfaceWrapperHelper.getContextAware;
 import static org.adempiere.model.InterfaceWrapperHelper.isNull;
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.save;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 
@@ -309,6 +311,65 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 				"tryMergeQtyPickedIntoExistingForVHU: merged qty={} into M_ShipmentSchedule_QtyPicked_ID={} (shipmentScheduleId={} vhuId={})",
 				qtyToAdd.getStockQty(), existing.getM_ShipmentSchedule_QtyPicked_ID(), scheduleId.getShipmentScheduleId(), vhuId);
 		return true;
+	}
+
+	@Override
+	public void restoreUnshippedQtyPickedIfMissing(@NonNull final Collection<I_M_ShipmentSchedule_QtyPicked> reversedAllocations)
+	{
+		final Set<String> processedKeys = new HashSet<>();
+		for (final I_M_ShipmentSchedule_QtyPicked alloc : reversedAllocations)
+		{
+			final int vhuRepoId = alloc.getVHU_ID();
+			if (vhuRepoId <= 0)
+			{
+				continue; // only VHU-backed picked rows can be restored this way
+			}
+			final ShipmentScheduleId scheduleId = ShipmentScheduleId.ofRepoId(alloc.getM_ShipmentSchedule_ID());
+			final HuId vhuId = HuId.ofRepoId(vhuRepoId);
+			if (!processedKeys.add(scheduleId.getRepoId() + "|" + vhuId.getRepoId()))
+			{
+				continue; // already handled this (schedule, VHU) — allocations are consolidated to one row per VHU
+			}
+
+			// If the picking-job reopen (a Completed job) already restored an active un-shipped row, leave it.
+			if (huShipmentScheduleDAO.existsActiveUnshippedQtyPickedForVHU(scheduleId, vhuId))
+			{
+				continue;
+			}
+
+			// Nothing was restored (e.g. the shipment was recreated via "Generate Shipments", leaving the
+			// picking job Drafted, so its reopen was a no-op). Re-create an active copy of the consolidated
+			// reversed allocation so the picked qty survives this reverse. Direct copy — no step-replay, no
+			// tryMerge — so the qty is not inflated and exactly one active row per tuple is preserved.
+			// M_Picking_Job_Schedule_ID is intentionally NOT copied: the restored row is a plain picked row,
+			// matching the shape a Completed-job reopen produces.
+			final I_M_ShipmentSchedule_QtyPicked restored = newInstance(I_M_ShipmentSchedule_QtyPicked.class, alloc);
+			restored.setAD_Org_ID(alloc.getAD_Org_ID());
+			restored.setM_ShipmentSchedule_ID(alloc.getM_ShipmentSchedule_ID());
+			restored.setVHU_ID(alloc.getVHU_ID());
+			restored.setM_TU_HU_ID(alloc.getM_TU_HU_ID());
+			restored.setM_LU_HU_ID(alloc.getM_LU_HU_ID());
+			restored.setQtyPicked(alloc.getQtyPicked());
+			restored.setQtyTU(alloc.getQtyTU());
+			restored.setQtyLU(alloc.getQtyLU());
+			restored.setIsAnonymousHuPickedOnTheFly(alloc.isAnonymousHuPickedOnTheFly());
+			restored.setCatch_UOM_ID(alloc.getCatch_UOM_ID());
+			restored.setQtyDeliveredCatch(alloc.getQtyDeliveredCatch());
+			// M_InOutLine_ID stays null (un-shipped); IsActive defaults Y; Processed defaults N.
+			saveRecord(restored);
+
+			// The reverse reactivated the HU to Active; a picked row needs the HU to be Picked
+			// (retrieveNotShippedRecords keeps only Picked/Shipped HUs).
+			final I_M_HU vhu = handlingUnitsDAO.getById(vhuId);
+			final LUTUCUPair husPair = handlingUnitsBL.getTopLevelParentAsLUTUCUPair(vhu);
+			final I_M_HU topLevelHU = husPair.getTopLevelHU();
+			setHUStatusToPicked(topLevelHU);
+			handlingUnitsDAO.saveHU(topLevelHU);
+
+			Loggables.withLogger(logger, Level.INFO).addLog(
+					"restoreUnshippedQtyPickedIfMissing: re-created active QtyPicked_ID={} for shipmentScheduleId={} vhuId={} (reverse left no completed-job reopen to restore it)",
+					restored.getM_ShipmentSchedule_QtyPicked_ID(), scheduleId, vhuId);
+		}
 	}
 
 	private de.metas.inoutcandidate.model.I_M_ShipmentSchedule getShipmentSchedule(final AddQtyPickedRequest request)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -359,11 +359,14 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 			saveRecord(restored);
 
 			// The reverse reactivated the HU to Active; a picked row needs the HU to be Picked
-			// (retrieveNotShippedRecords keeps only Picked/Shipped HUs).
+			// (retrieveNotShippedRecords keeps only Picked/Shipped HUs). Also re-stamp BPartner/Location
+			// from the schedule, exactly like addQtyPickedAndUpdateHU / tryMergeQtyPickedIntoExistingForVHU —
+			// every pick-creation path must leave the top-level HU with the delivery partner/location set.
 			final I_M_HU vhu = handlingUnitsDAO.getById(vhuId);
 			final LUTUCUPair husPair = handlingUnitsBL.getTopLevelParentAsLUTUCUPair(vhu);
 			final I_M_HU topLevelHU = husPair.getTopLevelHU();
 			setHUStatusToPicked(topLevelHU);
+			setHUPartnerAndLocationFromSched(topLevelHU, shipmentScheduleBL.getById(scheduleId));
 			handlingUnitsDAO.saveHU(topLevelHU);
 
 			Loggables.withLogger(logger, Level.INFO).addLog(

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO.java
@@ -175,6 +175,26 @@ public class HUShipmentScheduleDAO implements IHUShipmentScheduleDAO
 	}
 
 	@Override
+	public boolean existsActiveUnshippedQtyPickedForVHU(
+			@NonNull final ShipmentScheduleId shipmentScheduleId,
+			@NonNull final HuId vhuId)
+	{
+		// Thread-inherited trx (same reasoning as retrieveMergeableListenerQtyPickedForVHU): the row may have
+		// been (re)created earlier in the SAME, not-yet-committed reversal transaction (e.g. by the picking-job
+		// reopen). Broad existence check — any active, not-yet-shipped row for the (schedule, VHU); intentionally
+		// NOT filtered by picking-job / anonymous, so a row restored via any path counts.
+		final Properties ctx = Env.getCtx();
+		final String trxName = trxManager.getThreadInheritedTrxName();
+		return queryBL.createQueryBuilder(I_M_ShipmentSchedule_QtyPicked.class, ctx, trxName)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_ShipmentSchedule_ID, shipmentScheduleId)
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_VHU_ID, vhuId)
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_InOutLine_ID, null)
+				.create()
+				.anyMatch();
+	}
+
+	@Override
 	public List<ShipmentScheduleWithHU> retrieveShipmentSchedulesWithHUsFromHUs(@NonNull final List<I_M_HU> hus)
 	{
 		final IMutableHUContext huContext = huContextFactory.createMutableHUContext();

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 5 | 8 | 63% |
-| Picking | 55 | 58 | 95% |
+| Picking | 56 | 59 | 95% |
 | Distribution | 27 | 30 | 90% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
@@ -167,9 +167,10 @@
 | DO_NOT_CREATE: partially-picked order (qty still open) → must STAY in the picking launcher | `picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js` |
 | DO_NOT_CREATE: picked qty fully bound to a draft shipment → must NOT appear in the picking launcher | `picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js` |
 | Reverse (void) an aggregate-HU shipment → recreate must not collide on duplicate QtyPicked rows | `picking/recreate_shipment_after_void.spec.js` |
+| Reverse an aggregate-HU shipment TWICE (recreate via Generate Shipments between) → picked qty must survive every void so the shipment stays recreatable | `picking/recreate_shipment_after_void.spec.js` |
 
 
-**8/8 — 100%**
+**9/9 — 100%**
 
 ### Product-based picking
 

--- a/e2e/mobile-webui/tests/spec/picking/recreate_shipment_after_void.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/recreate_shipment_after_void.spec.js
@@ -148,7 +148,7 @@ test('Reverse an aggregate-HU shipment TWICE then recreate it — picked qty mus
     // The reverse restores the picked qty via an async picking-job reopen that commits a moment after the
     // reverse call returns, so we POLL Generate Shipments until it ships (or the window elapses). When the
     // picked qty is genuinely gone (after the 2nd void) the poll never ships and returns null.
-    const generateShipmentWithin = async (timeoutMs = 30000) => {
+    const generateShipmentWithin = async (timeoutMs = 60000) => {
         const intervalMs = 2000;
         const start = Date.now();
         for (;;) {

--- a/e2e/mobile-webui/tests/spec/picking/recreate_shipment_after_void.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/recreate_shipment_after_void.spec.js
@@ -102,3 +102,95 @@ test('Reverse an aggregate-HU shipment then recreate it — no duplicate QtyPick
         expect(dup, `Expected the reverse to leave exactly ONE active un-shipped QtyPicked row per unique-index tuple, but found ${dup} identical rows — they collide on M_ShipmentSchedule_QtyPicked_UI when the shipment is recreated. Full response:\n` + JSON.stringify(reversed, null, 2)).toBe(1);
     });
 });
+
+// Regression guard for the me03#29561 UAT-demo finding: a SECOND void of an aggregate-HU shipment.
+//
+// The single-reverse case above is fixed by PR 24478 (the reverse leaves exactly ONE active un-shipped
+// QtyPicked row, so the shipment can be recreated). The UAT demo then exposed the next cycle: after the
+// shipment is recreated and reversed a SECOND time, the picked qty is no longer recreatable — the
+// M_ShipmentScheduleQueue workpackage (GenerateInOutFromShipmentSchedules) aborts with MSG_NoQtyPicked
+// ("Die Auswahl enthält keine Einträge mit kommissionierten Mengen"), i.e. the second reverse left ZERO
+// active un-shipped rows (the opposite extreme of the original duplicate-row defect).
+//
+// This drives pick -> ship -> reverse -> reship -> reverse -> reship and asserts the third shipment is
+// still created. RED today: the third shipment cannot be generated after the second void.
+//
+// noinspection JSUnusedLocalSymbols
+test('Reverse an aggregate-HU shipment TWICE then recreate it — picked qty must survive the second void', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.story('Recreate shipment after a second void of an aggregate-HU shipment');
+    allure.severity('blocker');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+
+    await test.step('Pick the whole aggregate HU (6 TU) and complete', async () => {
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '6' });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '6 TU', qtyPicked: '6 TU', qtyPickedCatchWeight: '' });
+        await PickingJobScreen.closeTargetLU();
+        await PickingJobScreen.complete();
+    });
+
+    // Recreate the shipment via the REAL "Generate Shipments" process (qtyPicked) — the exact demo path,
+    // NOT the masterdata `shipments` shortcut (which diverges from the real process after a reverse).
+    // generateShipments returns the shipments NEWLY created by the call; an empty result == nothing shipped.
+    // createShipmentPolicy:'NO' keeps the mobile pick from auto-shipping.
+    //
+    // The reverse restores the picked qty via an async picking-job reopen that commits a moment after the
+    // reverse call returns, so we POLL Generate Shipments until it ships (or the window elapses). When the
+    // picked qty is genuinely gone (after the 2nd void) the poll never ships and returns null.
+    const generateShipmentWithin = async (timeoutMs = 30000) => {
+        const intervalMs = 2000;
+        const start = Date.now();
+        for (;;) {
+            const result = await Backend.generateShipments({ salesOrderId: masterdata.salesOrders.SO1.id, quantityType: 'P', complete: true });
+            if (result.newShipmentCount >= 1) {
+                return result.newShipmentIds[0];
+            }
+            if (Date.now() - start >= timeoutMs) {
+                return null;
+            }
+            await new Promise(r => setTimeout(r, intervalMs));
+        }
+    };
+
+    // Cycle 1 — Generate Shipments, then reverse. PR 24478 makes this reverse restore one active picked row.
+    let shipmentId1;
+    await test.step('Generate the first shipment (Generate Shipments, qtyPicked)', async () => {
+        shipmentId1 = await generateShipmentWithin();
+        expect(shipmentId1, 'First shipment was not created from the picked qty').toBeTruthy();
+    });
+    await test.step('Reverse the first shipment (first void)', async () => {
+        const reversed = await Backend.reverseShipment({ shipmentId: shipmentId1 });
+        expect(reversed?.docStatus, 'First reverse did not reach docStatus RE:\n' + JSON.stringify(reversed, null, 2)).toBe('RE');
+        expect(reversed.maxIdenticalUnshippedQtyPickedRowsPerVhuTuple, 'First reverse must leave exactly one active un-shipped row per tuple').toBe(1);
+    });
+
+    // Cycle 2 — recreate via Generate Shipments (this leaves the picking job in Drafted state), reverse AGAIN.
+    let shipmentId2;
+    await test.step('Recreate the shipment after the first void (Generate Shipments)', async () => {
+        shipmentId2 = await generateShipmentWithin();
+        expect(shipmentId2, 'Second shipment (recreate after the FIRST void) was not created — picked qty did not survive the first reverse').toBeTruthy();
+    });
+    await test.step('Reverse the second shipment (SECOND void)', async () => {
+        const reversed = await Backend.reverseShipment({ shipmentId: shipmentId2 });
+        expect(reversed?.docStatus, 'Second reverse did not reach docStatus RE:\n' + JSON.stringify(reversed, null, 2)).toBe('RE');
+    });
+
+    // The defect (me03#29561): after the SECOND void the picking job is already Drafted, so
+    // PickingJobReopenCommand (Completed-only) restores nothing -> zero active QtyPicked rows ->
+    // "Generate Shipments" produces no shipment (MSG_NoQtyPicked in the workpackage). This MUST still ship.
+    await test.step('Recreate the shipment after the SECOND void — must still succeed', async () => {
+        const shipmentId3 = await generateShipmentWithin();
+        expect(shipmentId3, 'Third shipment (recreate after the SECOND void) was NOT created — the picked qty did not survive the second reverse (MSG_NoQtyPicked / zero active QtyPicked rows).').toBeTruthy();
+    });
+});

--- a/e2e/mobile-webui/tests/utils/screens/Backend.js
+++ b/e2e/mobile-webui/tests/utils/screens/Backend.js
@@ -157,6 +157,35 @@ export const Backend = {
         return responseBody;
     }),
 
+    /**
+     * Generate shipments from a sales order's shipment schedules via the REAL "Generate Shipments"
+     * process path ({@code ShipmentService.generateShipmentsForScheduleIds}) — NOT the
+     * {@code shipments} masterdata shortcut. With quantityType 'P' (Picked) this ships the already-picked
+     * qty through the {@code GenerateInOutFromShipmentSchedules} workpackage. Returns the shipments NEWLY
+     * created by this call; an empty {@code newShipmentIds} means nothing could be shipped (e.g. the
+     * picked qty did not survive a prior reverse — the "can't recreate shipment after void" defect).
+     *
+     * @param {Object} args
+     * @param {string} args.salesOrderId - the C_Order_ID (e.g. masterdata.salesOrders.SO1.id).
+     * @param {string} [args.quantityType='P'] - 'P' = Picked qty, 'D' = QtyToDeliver.
+     * @param {boolean} [args.complete=true] - complete the generated shipment.
+     * @returns {Promise<{newShipmentIds: string[], newShipmentCount: number}>}
+     */
+    generateShipments: async ({ salesOrderId, quantityType = 'P', complete = true }) => await test.step(`Backend: generate shipments for order ${salesOrderId} (qtyType=${quantityType})`, async () => {
+        const backendBaseUrl = await getBackendBaseUrl();
+        const response = await page.request.post(`${backendBaseUrl}/frontendTesting/generateShipments`, {
+            data: { salesOrderId: String(salesOrderId), quantityType, complete },
+            headers: {
+                'Content-Type': 'application/json',
+            }
+        });
+
+        const responseBody = await response.json();
+        assertNoErrors({ responseBody });
+
+        return responseBody;
+    }),
+
     getWFProcess: async ({ wfProcessId }) => {
         const backendBaseUrl = await getBackendBaseUrl();
         const response = await page.request.get(`${backendBaseUrl}/userWorkflows/wfProcess/${wfProcessId}`, {


### PR DESCRIPTION
## Problem

A shipment generated from **picked quantities** (aggregate HU) cannot be recreated after being voided a
**second** time: the picked quantity is lost, "Generate Shipments" produces nothing, and the
`M_ShipmentScheduleQueue` workpackage aborts with `MSG_NoQtyPicked`.

## Root cause

On a shipment reverse, the picked qty is restored **only** by reopening the picking job
(`PickingJobReopenCommand.reopenPickingJob`), which bails out unless the job is **Completed**:

```java
if (!jobToReopen.getDocStatus().isCompleted()) return;
```

The `Completed`-only gate is intentional — the reopen replays the job's pick steps and `tryMerge`-adds qty
into existing rows, so replaying a mid-pick *Drafted* job would inflate the picked qty.

But after a shipment is recreated via "Generate Shipments", the picking job is left **Drafted**. The next
reverse therefore finds a Drafted job, the reopen is a no-op, and **no** active
`M_ShipmentSchedule_QtyPicked` row survives → the shipment can no longer be recreated.

## Fix

The reverse handler `M_InOut.removeHUAssignmentsForShipment` already captures the consolidated picked rows
(`retrieveAssignedQuantities`) before deactivating them. After `reopenPickingJobs`, it now calls a new
`IHUShipmentScheduleBL.restoreUnshippedQtyPickedIfMissing(...)`:

- For each reversed allocation `(M_ShipmentSchedule_ID, VHU_ID)`, if **no** active, not-yet-shipped row now
  exists (`HUShipmentScheduleDAO.existsActiveUnshippedQtyPickedForVHU`), re-create one as a **direct copy** of
  the consolidated allocation (same `VHU/TU/LU/QtyLU/QtyTU/QtyPicked`, `M_InOutLine=null`, `IsActive=Y`), set
  the VHU `HUStatus=Picked`, and stamp BPartner/Location from the schedule.

Because it copies the already-consolidated single row (no step-replay, no `tryMerge`), there is **no qty
inflation** and the exactly-one-row-per-tuple invariant is preserved. It fires **only when nothing was
restored**, so the Completed-job reopen path and unrelated in-progress picking jobs are unaffected. The
`PickingJobReopenCommand` `Completed`-only gate is left untouched.

## Testing

- New mobile-webui Playwright test (`recreate_shipment_after_void.spec.js`): pick an aggregate HU → ship →
  reverse → recreate → **reverse again** → recreate must still succeed. Confirmed RED before the fix
  (recreate after the 2nd void produced no shipment), GREEN after. The existing single-reverse test in the
  same file still passes.
- New `frontendTesting/generateShipments` endpoint drives the real
  `ShipmentService.generateShipmentsForScheduleIds` (Picked qty) path used by "Generate Shipments".
- DB invariant verified after the 2nd reverse: exactly one active un-shipped `QtyPicked` row, qty not inflated.
