### PR TITLE
nShift service levels: fix non-ID-server IDs for AD_Org field + UI element on Service Level Konfiguration tab

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804799_ShipperServiceLevelConfig_tab_remove_org_conflicts.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804799_ShipperServiceLevelConfig_tab_remove_org_conflicts.sql
@@ -1,0 +1,52 @@
+-- Fixes failure of: 5804800_ShipperServiceLevelConfig_tab.sql
+-- nShift service levels: remove the AD_Org field + UI element that 5804800 created with stale,
+-- non-ID-server IDs (AD_Field 580485 / AD_UI_Element 580486). Those low values collide with
+-- pre-existing rows in downstream instances. 5804801 re-adds the field + element with fresh IDs.
+--
+-- Every delete is scoped to our new tab (AD_Tab_ID = 549282), so on instances where 580485/580486
+-- belong to a DIFFERENT (private-repo) record those rows are left untouched - only the rows that
+-- 5804800 created on this tab are removed. On instances where 5804800 never created them (fresh
+-- install, or the insert failed on the duplicate), these deletes are harmless no-ops.
+
+-- UI element first (it references the field via AD_Field_ID)
+DELETE FROM AD_UI_Element
+WHERE AD_UI_Element_ID = 580486
+  AND AD_Tab_ID = 549282
+  AND AD_UI_ElementGroup_ID = 555400
+  AND AD_Field_ID = 580485;
+
+-- Labels-selector reference (rare; guarded no-op for a plain AD_Org field)
+DELETE FROM AD_UI_Element
+WHERE Labels_Selector_Field_ID = 580485
+  AND EXISTS (SELECT 1 FROM AD_Field f WHERE f.AD_Field_ID = 580485 AND f.AD_Tab_ID = 549282);
+
+-- field children, only while the field still belongs to our tab
+DELETE FROM AD_Element_Link
+WHERE AD_Field_ID = 580485
+  AND EXISTS (SELECT 1 FROM AD_Field f WHERE f.AD_Field_ID = 580485 AND f.AD_Tab_ID = 549282);
+
+DELETE FROM AD_Field_Trl
+WHERE AD_Field_ID = 580485
+  AND EXISTS (SELECT 1 FROM AD_Field f WHERE f.AD_Field_ID = 580485 AND f.AD_Tab_ID = 549282);
+
+-- remaining FK-chain tables (guarded no-ops for this brand-new field, included for completeness)
+DELETE FROM AD_Field_ContextMenu
+WHERE AD_Field_ID = 580485
+  AND EXISTS (SELECT 1 FROM AD_Field f WHERE f.AD_Field_ID = 580485 AND f.AD_Tab_ID = 549282);
+
+DELETE FROM AD_UI_ElementField
+WHERE AD_Field_ID = 580485
+  AND EXISTS (SELECT 1 FROM AD_Field f WHERE f.AD_Field_ID = 580485 AND f.AD_Tab_ID = 549282);
+
+DELETE FROM AD_UserDef_Field
+WHERE AD_Field_ID = 580485
+  AND EXISTS (SELECT 1 FROM AD_Field f WHERE f.AD_Field_ID = 580485 AND f.AD_Tab_ID = 549282);
+
+DELETE FROM AD_User_SortPref_Line
+WHERE AD_Field_ID = 580485
+  AND EXISTS (SELECT 1 FROM AD_Field f WHERE f.AD_Field_ID = 580485 AND f.AD_Tab_ID = 549282);
+
+-- the field itself
+DELETE FROM AD_Field
+WHERE AD_Field_ID = 580485
+  AND AD_Tab_ID = 549282;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804800_ShipperServiceLevelConfig_tab.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804800_ShipperServiceLevelConfig_tab.sql
@@ -165,11 +165,19 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID = 780492;
 SELECT AD_Element_Link_Create_Missing_Field(780492);
 
 -- Field: AD_Org_ID
+-- DISABLED: AD_Field_ID 580485 and AD_UI_Element_ID 580486 below were not retrieved from the
+-- ID server (they sit far below the other freshly-allocated IDs in this script - 780489..780492
+-- for AD_Field, 651846..651849 for AD_UI_Element - and are consecutive across two tables, which
+-- the per-table ID server never produces). These low values already exist in downstream instances
+-- and cause "duplicate key value violates unique constraint ad_ui_element_key". The AD_Org field
+-- and UI element are removed by 5804799 (scoped to this tab) and re-added with fresh ID-server IDs
+-- by 5804801.
+/*
 INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
                       Created, CreatedBy, DisplayLength, EntityType,
                       IsActive, IsDisplayed, IsDisplayedGrid, IsEncrypted, IsFieldOnly,
                       IsHeading, IsReadOnly, IsSameLine, Name, Updated, UpdatedBy)
-VALUES (0, 592628, 580485 /*From ID Server*/, 0, 549282,
+VALUES (0, 592628, 580485, 0, 549282,
         TO_TIMESTAMP('2026-05-26 14:12:04.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
         100, 10, 'D',
         'Y', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'Sektion',
@@ -189,6 +197,7 @@ WHERE l.IsActive = 'Y'
 SELECT update_FieldTranslation_From_AD_Name_Element(113);
 DELETE FROM AD_Element_Link WHERE AD_Field_ID = 580485;
 SELECT AD_Element_Link_Create_Missing_Field(580485);
+*/
 
 -- UI Section
 INSERT INTO AD_UI_Section (AD_Client_ID, AD_Org_ID, AD_Tab_ID, AD_UI_Section_ID,
@@ -307,12 +316,15 @@ UPDATE AD_UI_Element SET IsDisplayedGrid = 'Y', SeqNoGrid = 40,
     UpdatedBy = 100
 WHERE AD_UI_Element_ID = 651849;
 
+-- DISABLED: see note above the AD_Org_ID field block. AD_UI_Element_ID 580486 is not from the
+-- ID server and collides downstream. Re-added with a fresh ID by 5804801.
+/*
 INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
                            AD_UI_ElementType, Created, CreatedBy,
                            IsActive, IsAdvancedField, IsAllowFiltering, IsDisplayed,
                            IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
                            Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
-VALUES (0, 580485, 0, 549282, 555400, 580486 /*From ID Server*/,
+VALUES (0, 580485, 0, 549282, 555400, 580486,
         'F',
         TO_TIMESTAMP('2026-05-26 14:14:04.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
         100,
@@ -325,3 +337,4 @@ UPDATE AD_UI_Element SET IsDisplayedGrid = 'Y', SeqNoGrid = 50,
     Updated = TO_TIMESTAMP('2026-05-26 14:15:04.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
     UpdatedBy = 100
 WHERE AD_UI_Element_ID = 580486;
+*/

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804801_ShipperServiceLevelConfig_tab_org_fresh_ids.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5804801_ShipperServiceLevelConfig_tab_org_fresh_ids.sql
@@ -1,0 +1,55 @@
+-- Fixes failure of: 5804800_ShipperServiceLevelConfig_tab.sql
+-- nShift service levels: re-add the AD_Org field + UI element to the Service Level Konfiguration
+-- tab with fresh ID-server IDs. The original IDs in 5804800 (AD_Field 580485 / AD_UI_Element
+-- 580486) were not from the ID server and collide with pre-existing rows downstream; they are
+-- disabled in 5804800 and removed by 5804799.
+--
+-- IDs allocated from idserver.metas.de on 2026-06-11:
+--   AD_Field      780756 (AD_Org_ID field on the Service Level Konfiguration tab)
+--   AD_UI_Element 652051 (its UI element)
+
+-- Field: AD_Org_ID
+INSERT INTO AD_Field (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+                      Created, CreatedBy, DisplayLength, EntityType,
+                      IsActive, IsDisplayed, IsDisplayedGrid, IsEncrypted, IsFieldOnly,
+                      IsHeading, IsReadOnly, IsSameLine, Name, Updated, UpdatedBy)
+VALUES (0, 592628, 780756 /*From ID Server*/, 0, 549282,
+        TO_TIMESTAMP('2026-06-11 14:17:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+        100, 10, 'D',
+        'Y', 'Y', 'N', 'N', 'N', 'N', 'N', 'N', 'Sektion',
+        TO_TIMESTAMP('2026-06-11 14:17:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+        100);
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name,
+                          IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Field_ID = 780756
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+
+SELECT update_FieldTranslation_From_AD_Name_Element(113);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 780756;
+SELECT AD_Element_Link_Create_Missing_Field(780756);
+
+-- UI Element: AD_Org_ID
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID,
+                           AD_UI_ElementType, Created, CreatedBy,
+                           IsActive, IsAdvancedField, IsAllowFiltering, IsDisplayed,
+                           IsDisplayedGrid, IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount,
+                           Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 780756, 0, 549282, 555400, 652051 /*From ID Server*/,
+        'F',
+        TO_TIMESTAMP('2026-06-11 14:17:01.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+        100,
+        'Y', 'N', 'N', 'Y', 'N', 'N', 'N', 0,
+        'Sektion', 50, 0, 0,
+        TO_TIMESTAMP('2026-06-11 14:17:01.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+        100);
+
+UPDATE AD_UI_Element SET IsDisplayedGrid = 'Y', SeqNoGrid = 50,
+    Updated = TO_TIMESTAMP('2026-06-11 14:17:02.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+    UpdatedBy = 100
+WHERE AD_UI_Element_ID = 652051;


### PR DESCRIPTION
The AD_Org_ID field (`AD_Field` 580485) and its UI element (`AD_UI_Element` 580486) in `5804800` were not allocated from the ID server and collide with pre-existing rows in downstream instances:

```
ERROR: duplicate key value violates unique constraint "ad_ui_element_key"
Key (ad_ui_element_id)=(580486) already exists.
```

These two IDs sit far below the freshly-allocated siblings in the same script (`AD_Field` 780489–780492, `AD_UI_Element` 651846–651849) and are consecutive across two different tables — impossible for genuine per-table ID-server output — i.e. a copy-pasted AD_Org block carrying stale low IDs.

Since `5804800` is already rolled out, the IDs cannot be changed in place. Fix is split across three scripts:

- **`5804800`** (modified): disable the AD_Org field + UI element blocks (commented out, with reason).
- **`5804799`**: remove those rows, every statement scoped to the new tab (`AD_Tab_ID = 549282`) so differently-owned downstream rows that share IDs 580485/580486 are left untouched. Full `AD_Field` FK chain cleared in order.
- **`5804801`**: re-add the field + UI element with fresh ID-server IDs (`AD_Field` 780756 / `AD_UI_Element` 652051).

End state converges for fresh installs, instances where `5804800` already succeeded, and instances where its `580486` insert failed on the duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)