### PR TITLE
Mass Printing — search demand via picking-launcher eligibility + validate LU picking group

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/CreateWarehousePickingGroupRequest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/CreateWarehousePickingGroupRequest.java
@@ -1,0 +1,36 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.adempiere.warehouse.api;
+
+import de.metas.organization.OrgId;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+@Value
+@Builder
+public class CreateWarehousePickingGroupRequest
+{
+	@NonNull OrgId orgId;
+	@NonNull String name;
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/CreateWarehousePickingGroupRequest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/CreateWarehousePickingGroupRequest.java
@@ -22,10 +22,13 @@
 
 package org.adempiere.warehouse.api;
 
+import com.google.common.collect.ImmutableSet;
 import de.metas.organization.OrgId;
 import lombok.Builder;
 import lombok.NonNull;
+import lombok.Singular;
 import lombok.Value;
+import org.adempiere.warehouse.WarehouseId;
 
 @Value
 @Builder
@@ -33,4 +36,10 @@ public class CreateWarehousePickingGroupRequest
 {
 	@NonNull OrgId orgId;
 	@NonNull String name;
+
+	/**
+	 * Warehouses to assign to the newly-created picking group (each warehouse's
+	 * {@code M_Warehouse_PickingGroup_ID} is set to the new group). May be empty.
+	 */
+	@Singular @NonNull ImmutableSet<WarehouseId> warehouseIds;
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/IWarehouseBL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/IWarehouseBL.java
@@ -34,6 +34,7 @@ import de.metas.util.ISingletonService;
 import lombok.NonNull;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
+import org.adempiere.warehouse.groups.picking.WarehousePickingGroupId;
 import org.adempiere.warehouse.qrcode.LocatorQRCode;
 import org.compiere.model.I_M_Locator;
 import org.compiere.model.I_M_Warehouse;
@@ -121,6 +122,9 @@ public interface IWarehouseBL extends ISingletonService
 
 	@NonNull
 	Warehouse createWarehouse(@NonNull CreateWarehouseRequest request);
+
+	@NonNull
+	WarehousePickingGroupId createWarehousePickingGroup(@NonNull CreateWarehousePickingGroupRequest request);
 
 	@NonNull
 	ImmutableSet<LocatorId> getLocatorIdsOfTheSamePickingGroup(@NonNull WarehouseId warehouseId);

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/IWarehouseDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/IWarehouseDAO.java
@@ -236,4 +236,10 @@ public interface IWarehouseDAO extends ISingletonService
 	@NonNull
 	Warehouse createWarehouse(@NonNull CreateWarehouseRequest request);
 
+	/**
+	 * Create a new {@code M_Warehouse_PickingGroup} and return its id.
+	 */
+	@NonNull
+	WarehousePickingGroupId createWarehousePickingGroup(@NonNull CreateWarehousePickingGroupRequest request);
+
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/impl/WarehouseBL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/impl/WarehouseBL.java
@@ -47,7 +47,9 @@ import org.adempiere.service.ClientId;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.CreateOrUpdateLocatorRequest;
+import org.adempiere.warehouse.api.CreateWarehousePickingGroupRequest;
 import org.adempiere.warehouse.api.CreateWarehouseRequest;
+import org.adempiere.warehouse.groups.picking.WarehousePickingGroupId;
 import org.adempiere.warehouse.api.IWarehouseBL;
 import org.adempiere.warehouse.api.IWarehouseDAO;
 import org.adempiere.warehouse.api.Warehouse;
@@ -344,6 +346,13 @@ public class WarehouseBL implements IWarehouseBL
 	public Warehouse createWarehouse(@NonNull final CreateWarehouseRequest request)
 	{
 		return warehouseDAO.createWarehouse(request);
+	}
+
+	@Override
+	@NonNull
+	public WarehousePickingGroupId createWarehousePickingGroup(@NonNull final CreateWarehousePickingGroupRequest request)
+	{
+		return warehouseDAO.createWarehousePickingGroup(request);
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/impl/WarehouseDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/impl/WarehouseDAO.java
@@ -926,7 +926,19 @@ public class WarehouseDAO implements IWarehouseDAO
 		record.setName(request.getName());
 		saveRecord(record);
 
-		return WarehousePickingGroupId.ofRepoId(record.getM_Warehouse_PickingGroup_ID());
+		final WarehousePickingGroupId pickingGroupId = WarehousePickingGroupId.ofRepoId(record.getM_Warehouse_PickingGroup_ID());
+
+		// Assign each requested warehouse to the freshly-created picking group.
+		// The saves auto-invalidate the allWarehousePickingGroups CCache (it declares
+		// additionalTableNameToResetFor(M_Warehouse_PickingGroup) and M_Warehouse), so no manual reset is needed.
+		for (final WarehouseId warehouseId : request.getWarehouseIds())
+		{
+			final I_M_Warehouse warehouseRecord = load(warehouseId, I_M_Warehouse.class);
+			warehouseRecord.setM_Warehouse_PickingGroup_ID(pickingGroupId.getRepoId());
+			saveRecord(warehouseRecord);
+		}
+
+		return pickingGroupId;
 	}
 
 	@NonNull

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/impl/WarehouseDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/impl/WarehouseDAO.java
@@ -33,6 +33,7 @@ import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.WarehouseType;
 import org.adempiere.warehouse.WarehouseTypeId;
 import org.adempiere.warehouse.api.CreateOrUpdateLocatorRequest;
+import org.adempiere.warehouse.api.CreateWarehousePickingGroupRequest;
 import org.adempiere.warehouse.api.CreateWarehouseRequest;
 import org.adempiere.warehouse.api.IWarehouseDAO;
 import org.adempiere.warehouse.api.Warehouse;
@@ -120,6 +121,9 @@ public class WarehouseDAO implements IWarehouseDAO
 	private final CCache<Integer, WarehousePickingGroupsIndex> allWarehousePickingGroups = CCache.<Integer, WarehousePickingGroupsIndex>builder()
 			.tableName(I_M_Warehouse_Group.Table_Name)
 			.additionalTableNameToResetFor(I_M_Warehouse.Table_Name)
+			// Also reset when a M_Warehouse_PickingGroup is created/changed (e.g. createWarehousePickingGroup),
+			// so the index does not return a stale picking-group set to the next caller.
+			.additionalTableNameToResetFor(I_M_Warehouse_PickingGroup.Table_Name)
 			.build();
 	private final CCache<Integer, WarehouseGroupsIndex> allWarehouseGroups = CCache.<Integer, WarehouseGroupsIndex>builder()
 			.tableName(I_M_Warehouse_Group.Table_Name)
@@ -911,6 +915,18 @@ public class WarehouseDAO implements IWarehouseDAO
 		createDefaultLocator(WarehouseId.ofRepoId(warehouseRecord.getM_Warehouse_ID()));
 
 		return ofRecord(warehouseRecord);
+	}
+
+	@Override
+	@NonNull
+	public WarehousePickingGroupId createWarehousePickingGroup(@NonNull final CreateWarehousePickingGroupRequest request)
+	{
+		final I_M_Warehouse_PickingGroup record = newInstance(I_M_Warehouse_PickingGroup.class);
+		record.setAD_Org_ID(request.getOrgId().getRepoId());
+		record.setName(request.getName());
+		saveRecord(record);
+
+		return WarehousePickingGroupId.ofRepoId(record.getM_Warehouse_PickingGroup_ID());
 	}
 
 	@NonNull

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/mobileui/picking/MobileUI_MassPrinting_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/mobileui/picking/MobileUI_MassPrinting_StepDef.java
@@ -29,6 +29,8 @@ import de.metas.handlingunits.picking.job.massprinting.MassPrintingResult;
 import de.metas.handlingunits.picking.job.massprinting.MassPrintingResult.ProductResult;
 import de.metas.handlingunits.picking.job.massprinting.MassPrintingScanRequest;
 import de.metas.handlingunits.picking.job.massprinting.MassPrintingService;
+import de.metas.i18n.AdMessageKey;
+import de.metas.i18n.IMsgBL;
 import de.metas.user.UserId;
 import de.metas.user.api.IUserDAO;
 import de.metas.util.Services;
@@ -37,13 +39,16 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.adempiere.exceptions.AdempiereException;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_AD_User;
+import org.compiere.util.Env;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Step definitions for the MobileUI mass-printing flow.
@@ -57,6 +62,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MobileUI_MassPrinting_StepDef
 {
 	private final IUserDAO userDAO = Services.get(IUserDAO.class);
+	private final IMsgBL msgBL = Services.get(IMsgBL.class);
 	private final MassPrintingService massPrintingService = SpringContextHolder.instance.getBean(MassPrintingService.class);
 
 	@NonNull private final M_HU_StepDefData huTable;
@@ -97,6 +103,53 @@ public class MobileUI_MassPrinting_StepDef
 							.build());
 
 			resultsByLuIdentifier.put(row.getAsIdentifier("M_HU_ID").getAsString(), result);
+		});
+	}
+
+	/**
+	 * Triggers a mass-printing scan that is expected to be rejected, and asserts the rejection carries the
+	 * given {@code AD_Message}. Used for the case where the scanned LU is located outside the picking-warehouse
+	 * group of the picker's workplace, which the scan must refuse rather than silently pack nothing.
+	 *
+	 * <p>The expected message is the {@code AD_Message} value (key). The thrown {@link AdempiereException}'s
+	 * resolved text is matched against the message resolved via {@link IMsgBL}, so the assertion is robust to
+	 * the actual translation in the DB.
+	 *
+	 * <p>Required columns:
+	 * <ul>
+	 *   <li>{@code M_HU_ID} — identifier of the LU to scan</li>
+	 *   <li>{@code Login} — login of the user performing the scan (resolves to picker ID)</li>
+	 *   <li>{@code AD_Message} — the AD_Message value (key) the rejection must carry</li>
+	 * </ul>
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * Then mass printing scan is rejected:
+	 *   | M_HU_ID | Login      | AD_Message                                                              |
+	 *   | lu      | metasfresh | de.metas.handlingunits.picking.massprinting.LUNotInWorkplacePickingGroup |
+	 * </pre>
+	 */
+	@Then("mass printing scan is rejected:")
+	public void massPrintingScanIsRejected(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final HuId luId = huTable.getId(row.getAsIdentifier("M_HU_ID"));
+			final String login = row.getAsString(I_AD_User.COLUMNNAME_Login);
+			final UserId pickerId = userDAO.retrieveUserIdByLogin(login);
+			assertThat(pickerId).as("User exists for login=" + login).isNotNull();
+
+			final AdMessageKey expectedMessage = AdMessageKey.of(row.getAsString("AD_Message"));
+			final String expectedMessageText = msgBL.getMsg(Env.getCtx(), expectedMessage);
+
+			assertThatThrownBy(() -> massPrintingService.scan(
+					MassPrintingScanRequest.builder()
+							.luId(luId)
+							.pickerId(pickerId)
+							.build()))
+					.as("Mass printing scan for LU=%s located outside the workplace's picking group must be rejected with AD_Message %s",
+							row.getAsIdentifier("M_HU_ID").getAsString(), expectedMessage.toAD_Message())
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining(expectedMessageText);
 		});
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/MobileUIPickingUserProfile_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/MobileUIPickingUserProfile_StepDef.java
@@ -80,6 +80,7 @@ public class MobileUIPickingUserProfile_StepDef
 	 *   <li>{@code IsAllowCompletingPartialPickingJob} — boolean</li>
 	 *   <li>{@code IsCatchWeightTUPickingEnabled} — boolean</li>
 	 *   <li>{@code IsMassPrinting} — boolean</li>
+	 *   <li>{@code IsConsideredOnlyScheduledJobs} — boolean (job-scheduled-to-workplace mode: only demand scheduled to the picker's workplace via a {@code M_Picking_Job_Schedule} is eligible)</li>
 	 * </ul>
 	 *
 	 * <p>Example:
@@ -114,6 +115,7 @@ public class MobileUIPickingUserProfile_StepDef
 					.defaultPickingJobOptions(defaultPickingJobOptionsBuilder.build());
 
 			row.getAsOptionalBoolean(I_MobileUI_UserProfile_Picking.COLUMNNAME_IsMassPrinting).ifPresent(profileBuilder::isMassPrinting);
+			row.getAsOptionalBoolean(I_MobileUI_UserProfile_Picking.COLUMNNAME_IsConsideredOnlyScheduledJobs).ifPresent(profileBuilder::isConsiderOnlyJobScheduledToWorkplace);
 
 			return profileBuilder.build();
 		});

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/warehouse/M_Warehouse_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/warehouse/M_Warehouse_StepDef.java
@@ -49,7 +49,9 @@ import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.warehouse.WarehouseId;
+import org.adempiere.warehouse.api.CreateWarehousePickingGroupRequest;
 import org.adempiere.warehouse.api.IWarehouseBL;
+import org.adempiere.warehouse.groups.picking.WarehousePickingGroupId;
 import org.compiere.model.I_C_BPartner_Location;
 import org.compiere.model.I_M_Locator;
 import org.compiere.model.I_M_Warehouse_PickingGroup;
@@ -128,16 +130,20 @@ public class M_Warehouse_StepDef
 				.findFirst()
 				.orElseThrow(() -> new AdempiereException("At least one row with a Name is required"));
 
-		final I_M_Warehouse_PickingGroup pickingGroup = InterfaceWrapperHelper.newInstance(I_M_Warehouse_PickingGroup.class);
-		pickingGroup.setName(groupName);
-		saveRecord(pickingGroup);
+		// Create the group via the BL (which owns the DAO), with a per-run-unique Name so reusing the same
+		// group label across tests in the shared DB does not collide.
+		final WarehousePickingGroupId pickingGroupId = warehouseBL.createWarehousePickingGroup(
+				CreateWarehousePickingGroupRequest.builder()
+						.orgId(StepDefConstants.ORG_ID)
+						.name(groupName + "_" + System.currentTimeMillis())
+						.build());
 
 		rows.forEach(row -> {
 			final WarehouseId warehouseId = warehouseTable.getId(row.getAsIdentifier(COLUMNNAME_M_Warehouse_ID));
 
 			final org.compiere.model.I_M_Warehouse warehouseRecord = InterfaceWrapperHelper.load(
 					warehouseId.getRepoId(), org.compiere.model.I_M_Warehouse.class);
-			warehouseRecord.setM_Warehouse_PickingGroup_ID(pickingGroup.getM_Warehouse_PickingGroup_ID());
+			warehouseRecord.setM_Warehouse_PickingGroup_ID(pickingGroupId.getRepoId());
 			saveRecord(warehouseRecord);
 		});
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/warehouse/M_Warehouse_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/warehouse/M_Warehouse_StepDef.java
@@ -24,6 +24,7 @@ package de.metas.cucumber.stepdefs.warehouse;
 
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationId;
+import de.metas.cache.CacheMgt;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.cucumber.stepdefs.C_BPartner_Location_StepDefData;
 import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
@@ -51,6 +52,7 @@ import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.IWarehouseBL;
 import org.compiere.model.I_C_BPartner_Location;
 import org.compiere.model.I_M_Locator;
+import org.compiere.model.I_M_Warehouse_PickingGroup;
 
 import static org.adempiere.model.InterfaceWrapperHelper.COLUMNNAME_IsActive;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
@@ -89,6 +91,62 @@ public class M_Warehouse_StepDef
 
 					row.getAsIdentifier().put(warehouseTable, warehouseRecord);
 				});
+	}
+
+	/**
+	 * Creates one {@code M_Warehouse_PickingGroup} and assigns every listed warehouse to it
+	 * (sets {@code M_Warehouse.M_Warehouse_PickingGroup_ID}).
+	 *
+	 * <p>Warehouses sharing a picking group are treated as a single picking scope: a picker working at a
+	 * workplace in one warehouse of the group may pick demand and stock located in any warehouse of the
+	 * same group. This mirrors the real-life setup where a storage warehouse and a packing/workplace
+	 * warehouse belong to the same physical picking area.
+	 *
+	 * <p>Required columns:
+	 * <ul>
+	 *   <li>{@code Name} — the picking group's name (one group is created for the whole DataTable;
+	 *       the {@code Name} of the first row is used).</li>
+	 *   <li>{@code M_Warehouse_ID} — (identifier-ref) a previously created/loaded warehouse to assign to the
+	 *       group. One row per warehouse.</li>
+	 * </ul>
+	 *
+	 * <p>Gherkin usage:
+	 * <pre>
+	 * And the following warehouses share one M_Warehouse_PickingGroup:
+	 *   | Name        | M_Warehouse_ID |
+	 *   | pickingArea | warehouseStock |
+	 *   | pickingArea | warehouseWork  |
+	 * </pre>
+	 */
+	@And("the following warehouses share one M_Warehouse_PickingGroup:")
+	public void assign_warehouses_to_picking_group(@NonNull final DataTable dataTable)
+	{
+		final DataTableRows rows = DataTableRows.of(dataTable);
+
+		final String groupName = rows.stream()
+				.map(row -> row.getAsString(I_M_Warehouse_PickingGroup.COLUMNNAME_Name))
+				.findFirst()
+				.orElseThrow(() -> new AdempiereException("At least one row with a Name is required"));
+
+		final I_M_Warehouse_PickingGroup pickingGroup = InterfaceWrapperHelper.newInstance(I_M_Warehouse_PickingGroup.class);
+		pickingGroup.setName(groupName);
+		saveRecord(pickingGroup);
+
+		rows.forEach(row -> {
+			final WarehouseId warehouseId = warehouseTable.getId(row.getAsIdentifier(COLUMNNAME_M_Warehouse_ID));
+
+			final org.compiere.model.I_M_Warehouse warehouseRecord = InterfaceWrapperHelper.load(
+					warehouseId.getRepoId(), org.compiere.model.I_M_Warehouse.class);
+			warehouseRecord.setM_Warehouse_PickingGroup_ID(pickingGroup.getM_Warehouse_PickingGroup_ID());
+			saveRecord(warehouseRecord);
+		});
+
+		// The picking-group → warehouses index is cached (WarehouseDAO.allWarehousePickingGroups). The bulk
+		// save fires a CacheInvalidation event, but in the shared single-JVM executor that event may not be
+		// processed before the next step reads the index. Reset the relevant caches synchronously so the
+		// freshly-assigned picking group is visible immediately (same trap handled in C_Workplace_StepDef).
+		CacheMgt.get().reset(I_M_Warehouse.Table_Name);
+		CacheMgt.get().reset(I_M_Warehouse_PickingGroup.Table_Name);
 	}
 
 	/**

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/warehouse/M_Warehouse_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/warehouse/M_Warehouse_StepDef.java
@@ -22,9 +22,9 @@
 
 package de.metas.cucumber.stepdefs.warehouse;
 
+import com.google.common.collect.ImmutableSet;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationId;
-import de.metas.cache.CacheMgt;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.cucumber.stepdefs.C_BPartner_Location_StepDefData;
 import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
@@ -51,7 +51,6 @@ import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.CreateWarehousePickingGroupRequest;
 import org.adempiere.warehouse.api.IWarehouseBL;
-import org.adempiere.warehouse.groups.picking.WarehousePickingGroupId;
 import org.compiere.model.I_C_BPartner_Location;
 import org.compiere.model.I_M_Locator;
 import org.compiere.model.I_M_Warehouse_PickingGroup;
@@ -130,29 +129,18 @@ public class M_Warehouse_StepDef
 				.findFirst()
 				.orElseThrow(() -> new AdempiereException("At least one row with a Name is required"));
 
-		// Create the group via the BL (which owns the DAO), with a per-run-unique Name so reusing the same
-		// group label across tests in the shared DB does not collide.
-		final WarehousePickingGroupId pickingGroupId = warehouseBL.createWarehousePickingGroup(
+		final ImmutableSet<WarehouseId> warehouseIds = rows.stream()
+				.map(row -> warehouseTable.getId(row.getAsIdentifier(COLUMNNAME_M_Warehouse_ID)))
+				.collect(ImmutableSet.toImmutableSet());
+
+		// Create the group AND assign the warehouses to it in one BL call (the BL/DAO owns the record load+save).
+		// A per-run-unique Name keeps reusing the same group label across tests in the shared DB from colliding.
+		warehouseBL.createWarehousePickingGroup(
 				CreateWarehousePickingGroupRequest.builder()
 						.orgId(StepDefConstants.ORG_ID)
 						.name(groupName + "_" + System.currentTimeMillis())
+						.warehouseIds(warehouseIds)
 						.build());
-
-		rows.forEach(row -> {
-			final WarehouseId warehouseId = warehouseTable.getId(row.getAsIdentifier(COLUMNNAME_M_Warehouse_ID));
-
-			final org.compiere.model.I_M_Warehouse warehouseRecord = InterfaceWrapperHelper.load(
-					warehouseId.getRepoId(), org.compiere.model.I_M_Warehouse.class);
-			warehouseRecord.setM_Warehouse_PickingGroup_ID(pickingGroupId.getRepoId());
-			saveRecord(warehouseRecord);
-		});
-
-		// The picking-group → warehouses index is cached (WarehouseDAO.allWarehousePickingGroups). The bulk
-		// save fires a CacheInvalidation event, but in the shared single-JVM executor that event may not be
-		// processed before the next step reads the index. Reset the relevant caches synchronously so the
-		// freshly-assigned picking group is visible immediately (same trap handled in C_Workplace_StepDef).
-		CacheMgt.get().reset(I_M_Warehouse.Table_Name);
-		CacheMgt.get().reset(I_M_Warehouse_PickingGroup.Table_Name);
 	}
 
 	/**

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workplace/C_Workplace_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workplace/C_Workplace_StepDef.java
@@ -198,6 +198,13 @@ public class C_Workplace_StepDef
 	@Given("deactivate all C_Workplace records")
 	public void deactivate_C_Workplace()
 	{
+		// Delete the user->workplace assignments FIRST: deactivating a workplace while leaving its
+		// C_Workplace_User_Assign rows behind creates a dangling assignment — a later getWorkplaceByUserId
+		// resolves the assignment, then fails to load the now-inactive workplace ("No workplace found for
+		// WorkplaceId"). Clearing assignments here makes "deactivate all C_Workplace" a complete reset and
+		// prevents that cross-scenario/feature leak on the shared single-JVM executor.
+		delete_C_Workplace_User_Assign();
+
 		final ICompositeQueryUpdater<I_C_Workplace> updater = queryBL
 				.createCompositeQueryUpdater(I_C_Workplace.class)
 				.addSetColumnValue(I_C_Workplace.COLUMNNAME_IsActive, false);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_cross_warehouse_picking_group.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_cross_warehouse_picking_group.feature
@@ -23,9 +23,9 @@ Feature: Mass Printing - scan an LU stored in a different warehouse of the same 
     And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
     And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
 
-    # Defensive: clear any workplace / user->workplace assignment leaked from a prior scenario in the shared JVM.
+    # Defensive: clear any leaked picker->workplace assignment so getWorkplaceByUserId resolves only OUR workplace.
+    # Do NOT deactivate all C_Workplace here — that would deactivate seed workplaces other executor features depend on.
     And delete all C_Workplace_User_Assign records
-    And deactivate all C_Workplace records
 
     And metasfresh contains M_Products:
       | Identifier | X12DE355 | IsSelfPacked |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_cross_warehouse_picking_group.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_cross_warehouse_picking_group.feature
@@ -1,0 +1,216 @@
+@from:cucumber
+@allure.label.epic:E0105_Picking
+@allure.label.feature:F00230_MobileUI_Picking
+@ghActions:run_on_executor7
+Feature: Mass Printing - scan an LU stored in a different warehouse of the same picking group
+  ## F00230.21: MobileUI Product-based Picking — mass printing
+  ##
+  ## A picker works at a workplace in the packing warehouse, but the LU they scan for mass printing
+  ## physically sits in a separate storage warehouse. Both warehouses belong to ONE picking group, so
+  ## they form a single picking area: the open sales demand lives in the packing warehouse while the
+  ## stock lives in the storage warehouse.
+  ##
+  ## When the picker scans the LU, mass printing must find the open demand of the workplace's picking
+  ## group (not only the LU's own storage warehouse) and pack against it. If the scanned LU is located
+  ## in a warehouse that is NOT part of the workplace's picking group, the scan must be rejected.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-03-26T13:30:13+01:00[Europe/Berlin]
+
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
+    And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
+
+    # Defensive: clear any workplace / user->workplace assignment leaked from a prior scenario in the shared JVM.
+    And delete all C_Workplace_User_Assign records
+    And deactivate all C_Workplace records
+
+    And metasfresh contains M_Products:
+      | Identifier | X12DE355 | IsSelfPacked |
+      | product    | PCE      | Y            |
+
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID |
+      | TU         |
+      | LU         |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID.Identifier | M_HU_PI_ID.Identifier | Name | HU_UnitType | IsCurrent |
+      | TU                            | TU                    | TU   | TU          | Y         |
+      | LU                            | LU                    | LU   | LU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType | OPT.Included_HU_PI_ID.Identifier |
+      | TU                         | TU                            | 0   | MI       |                                  |
+      | LU                         | LU                            | 10  | HU       | TU                               |
+    # Capacity-1 TU PI: 1 PCE per box (mirrors the validated mass-printing E2E setup), so the pickTuLine loop
+    # materialises and closes exactly one box per unit.
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | TU1                                | TU                         | product                 | 1   | 2000-01-01 |
+
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | PS         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx |
+      | PL         | PS                 | DE                    | EUR                 | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | PLV        | PL             |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | InvoicableQtyBasedOn | C_TaxCategory_ID.InternalName |
+      | PLV                    | product      | 6.0      | PCE               | Nominal              | Normal                        |
+
+    And set mobile UI picking profile
+      | IsMassPrinting | CreateShipmentPolicy  | IsAllowPickingAnyHU | IsAllowCompletingPartialPickingJob |
+      | Y              | CREATE_COMPLETE_CLOSE | Y                   | Y                                  |
+
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | Name     | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | customer   | customer | N            | Y              | PS                            |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier       | GLN       | C_BPartner_ID.Identifier | OPT.IsBillToDefault | OPT.IsShipTo |
+      | customerLocation | Dummy_GLN | customer                 | true                | true         |
+
+    # The packing/workplace warehouse — open sales demand and the picking machinery (picking slot) live here.
+    # warehouse 540008 = WarehouseId.MAIN (Value=StdWarehouse). It is also where the picking slot is created.
+    And load M_Warehouse:
+      | M_Warehouse_ID | Value        |
+      | warehouseWork  | StdWarehouse |
+
+    # The storage warehouse — the scanned LU physically sits here, in a different warehouse than the demand.
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID | M_Locator_ID  |
+      | warehouseStock | locatorStock  |
+
+    # Picking slot lives in WarehouseId.MAIN regardless; the workplace points the picker at warehouseWork.
+    And metasfresh contains M_PickingSlot:
+      | Identifier  | PickingSlot | IsDynamic |
+      | pickingSlot | 1           | Y         |
+    And metasfresh contains C_Workplaces
+      | Identifier | M_Warehouse_ID | M_PickingSlot_ID |
+      | workplace  | warehouseWork  | pickingSlot      |
+    And assign C_Workplace to user
+      | C_Workplace_ID | AD_User_ID.Login |
+      | workplace      | metasfresh       |
+
+
+  Scenario: Mass printing packs demand of the workplace's picking group from an LU stored in another warehouse of that group
+
+    # Both warehouses form one picking area, so a picker at the workplace (warehouseWork) may pick the LU
+    # that physically sits in warehouseStock.
+    And the following warehouses share one M_Warehouse_PickingGroup:
+      | Name        | M_Warehouse_ID |
+      | pickingArea | warehouseWork  |
+      | pickingArea | warehouseStock |
+
+    # Build the LU from inventory stock located in the STORAGE warehouse (this is the LU that will be scanned).
+    # Use individual (non-aggregated) TUs — eight real 1-PCE boxes loaded onto one LU — so the picking-slot
+    # close path can extract them one at a time.
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inventory                 | 2024-03-20   | warehouseStock |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inventory                 | stockLine                     | product                 | 0       | 80       | PCE          |
+    And complete inventory with inventoryIdentifier 'inventory'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID | M_HU_ID |
+      | stockLine          | stockCU |
+
+    When transform CU to new TUs
+      | sourceCU | cuQty | M_HU_PI_Item_Product_ID | OPT.resultedNewTUs              |
+      | stockCU  | 8     | TU1                     | tu1,tu2,tu3,tu4,tu5,tu6,tu7,tu8 |
+    And aggregate TUs to new LU
+      | sourceTUs                       | newLUs |
+      | tu1,tu2,tu3,tu4,tu5,tu6,tu7,tu8 | lu     |
+    And M_HU are validated:
+      | M_HU_ID                         | HUStatus | Parent |
+      | lu                              | A        | -      |
+      | tu1,tu2,tu3,tu4,tu5,tu6,tu7,tu8 | A        | lu     |
+
+    # Open sales demand of 4 PCE, delivered from the WORKPLACE warehouse (not the LU's storage warehouse).
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | M_Warehouse_ID | DateOrdered | PreparationDate      |
+      | SO         | true    | customer                 | warehouseWork  | 2024-03-26  | 2024-03-27T05:00:00Z |
+    And metasfresh contains C_OrderLines:
+      | C_Order_ID.Identifier | Identifier | M_Product_ID.Identifier | QtyEntered | OPT.M_HU_PI_Item_Product_ID.Identifier |
+      | SO                    | OL         | product                 | 4          | TU1                                    |
+    And the order identified by SO is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | sched      | OL                        | N             |
+
+    # The picker scans the LU (located in warehouseStock) — mass printing must search the workplace's picking
+    # group, find the open demand in warehouseWork, and pack 4 units from the LU.
+    And mass printing scan:
+      | M_HU_ID | Login      |
+      | lu      | metasfresh |
+
+    Then validate mass printing result:
+      | M_HU_ID | UnitsPacked |
+      | lu      | 4           |
+
+    # The processed schedule produced a completed shipment.
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | sched                            | shipment              | CO            |
+
+    # Leak-safety teardown.
+    And delete all C_Workplace_User_Assign records
+    And deactivate all C_Workplace records
+
+
+  Scenario: Mass printing rejects an LU located in a warehouse outside the workplace's picking group
+
+    # Only the workplace warehouse is in the picking group; the storage warehouse holding the LU is NOT.
+    And the following warehouses share one M_Warehouse_PickingGroup:
+      | Name        | M_Warehouse_ID |
+      | pickingArea | warehouseWork  |
+
+    # Build the LU in the storage warehouse, which is outside the workplace's picking group.
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inventory                 | 2024-03-20   | warehouseStock |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inventory                 | stockLine                     | product                 | 0       | 80       | PCE          |
+    And complete inventory with inventoryIdentifier 'inventory'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID | M_HU_ID |
+      | stockLine          | stockCU |
+
+    When transform CU to new TUs
+      | sourceCU | cuQty | M_HU_PI_Item_Product_ID | OPT.resultedNewTUs              |
+      | stockCU  | 8     | TU1                     | tu1,tu2,tu3,tu4,tu5,tu6,tu7,tu8 |
+    And aggregate TUs to new LU
+      | sourceTUs                       | newLUs |
+      | tu1,tu2,tu3,tu4,tu5,tu6,tu7,tu8 | lu     |
+    And M_HU are validated:
+      | M_HU_ID                         | HUStatus | Parent |
+      | lu                              | A        | -      |
+      | tu1,tu2,tu3,tu4,tu5,tu6,tu7,tu8 | A        | lu     |
+
+    # Open sales demand of 4 PCE in the workplace warehouse.
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | M_Warehouse_ID | DateOrdered | PreparationDate      |
+      | SO         | true    | customer                 | warehouseWork  | 2024-03-26  | 2024-03-27T05:00:00Z |
+    And metasfresh contains C_OrderLines:
+      | C_Order_ID.Identifier | Identifier | M_Product_ID.Identifier | QtyEntered | OPT.M_HU_PI_Item_Product_ID.Identifier |
+      | SO                    | OL         | product                 | 4          | TU1                                    |
+    And the order identified by SO is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | sched      | OL                        | N             |
+
+    # Scanning an LU located outside the workplace's picking group must be rejected, not silently pack nothing.
+    Then mass printing scan is rejected:
+      | M_HU_ID | Login      | AD_Message                                                               |
+      | lu      | metasfresh | de.metas.handlingunits.picking.massprinting.LUNotInWorkplacePickingGroup |
+
+    # Leak-safety teardown.
+    And delete all C_Workplace_User_Assign records
+    And deactivate all C_Workplace records

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_cross_warehouse_picking_group.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_cross_warehouse_picking_group.feature
@@ -153,6 +153,11 @@ Feature: Mass Printing - scan an LU stored in a different warehouse of the same 
       | M_HU_ID | UnitsPacked |
       | lu      | 4           |
 
+    # The scanned LU started with 8 PCE; 4 units were packed against the demand, so 4 PCE remain on the LU.
+    And validate M_HUs:
+      | Identifier | M_Product_ID | Qty   |
+      | lu         | product      | 4 PCE |
+
     # The processed schedule produced a completed shipment.
     And after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_cross_warehouse_picking_group.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_cross_warehouse_picking_group.feature
@@ -163,10 +163,6 @@ Feature: Mass Printing - scan an LU stored in a different warehouse of the same 
       | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
       | sched                            | shipment              | CO            |
 
-    # Leak-safety teardown.
-    And delete all C_Workplace_User_Assign records
-    And deactivate all C_Workplace records
-
 
   Scenario: Mass printing rejects an LU located in a warehouse outside the workplace's picking group
 
@@ -215,7 +211,3 @@ Feature: Mass Printing - scan an LU stored in a different warehouse of the same 
     Then mass printing scan is rejected:
       | M_HU_ID | Login      | AD_Message                                                               |
       | lu      | metasfresh | de.metas.handlingunits.picking.massprinting.LUNotInWorkplacePickingGroup |
-
-    # Leak-safety teardown.
-    And delete all C_Workplace_User_Assign records
-    And deactivate all C_Workplace records

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_job_scheduled_to_workplace.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_job_scheduled_to_workplace.feature
@@ -166,7 +166,3 @@ Feature: Mass Printing - honour job-scheduled-to-workplace mode
     And after not more than 10s, validate shipment schedules:
       | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyPickList |
       | schedNotScheduled                | 4                | 0                | 0               |
-
-    # Leak-safety teardown.
-    And delete all C_Workplace_User_Assign records
-    And deactivate all C_Workplace records

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_job_scheduled_to_workplace.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_job_scheduled_to_workplace.feature
@@ -1,0 +1,168 @@
+@from:cucumber
+@allure.label.epic:E0105_Picking
+@allure.label.feature:F00230_MobileUI_Picking
+@ghActions:run_on_executor7
+Feature: Mass Printing - honour job-scheduled-to-workplace mode
+  ## F00230.21: MobileUI Product-based Picking — mass printing
+  ##
+  ## When the picking profile runs in job-scheduled-to-workplace mode (IsConsideredOnlyScheduledJobs=Y),
+  ## only demand that has been explicitly scheduled to the picker's workplace via a M_Picking_Job_Schedule
+  ## is eligible — exactly like the regular picking launcher in that mode. A scan must pack ONLY the
+  ## scheduled demand and ignore open demand that is not scheduled to the workplace, even though the
+  ## scanned LU physically holds enough stock for both.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-03-26T13:30:13+01:00[Europe/Berlin]
+
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
+    And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
+
+    # Defensive: clear any workplace / user->workplace assignment leaked from a prior scenario in the shared JVM.
+    And delete all C_Workplace_User_Assign records
+    And deactivate all C_Workplace records
+
+    And metasfresh contains M_Products:
+      | Identifier | X12DE355 | IsSelfPacked |
+      | product    | PCE      | Y            |
+
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID |
+      | TU         |
+      | LU         |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID.Identifier | M_HU_PI_ID.Identifier | Name | HU_UnitType | IsCurrent |
+      | TU                            | TU                    | TU   | TU          | Y         |
+      | LU                            | LU                    | LU   | LU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType | OPT.Included_HU_PI_ID.Identifier |
+      | TU                         | TU                            | 0   | MI       |                                  |
+      | LU                         | LU                            | 10  | HU       | TU                               |
+    # Capacity-1 TU PI: 1 PCE per box. Mass printing packs one box (and prints one label) per unit, so the
+    # TU packing instruction MUST have capacity 1 — the pickTuLine loop fires cappedQty PICK events of qty 1,
+    # each materialising and closing exactly one box. Mirrors the validated mass-printing E2E setup.
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | TU1                                | TU                         | product                 | 1   | 2000-01-01 |
+
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | PS         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx |
+      | PL         | PS                 | DE                    | EUR                 | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | PLV        | PL             |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID.X12DE355 | InvoicableQtyBasedOn | C_TaxCategory_ID.InternalName |
+      | PLV                    | product      | 6.0      | PCE               | Nominal              | Normal                        |
+
+    # IsConsideredOnlyScheduledJobs=Y → job-scheduled-to-workplace mode: only demand scheduled to the
+    # picker's workplace (a M_Picking_Job_Schedule) is eligible for mass printing.
+    And set mobile UI picking profile
+      | IsMassPrinting | CreateShipmentPolicy  | IsAllowPickingAnyHU | IsAllowCompletingPartialPickingJob | IsConsideredOnlyScheduledJobs |
+      | Y              | CREATE_COMPLETE_CLOSE | Y                   | Y                                  | Y                             |
+
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | Name     | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | customer   | customer | N            | Y              | PS                            |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier       | GLN       | C_BPartner_ID.Identifier | OPT.IsBillToDefault | OPT.IsShipTo |
+      | customerLocation | Dummy_GLN | customer                 | true                | true         |
+
+    # Create warehouse inventory to produce stock (warehouse 540008 = WarehouseId.MAIN, Value=StdWarehouse).
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | inventory                 | 2024-03-20   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | inventory                 | stockLine                     | product                 | 0       | 80       | PCE          |
+    And complete inventory with inventoryIdentifier 'inventory'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID | M_HU_ID |
+      | stockLine          | stockCU |
+
+    # Build the LU from inventory stock — eight discrete 1-PCE boxes on one LU (this is the LU that is scanned).
+    # The LU holds 8 PCE, enough for BOTH orders' demand, so the test proves the eligibility restriction is what
+    # limits packing to the scheduled demand (not a stock shortage).
+    When transform CU to new TUs
+      | sourceCU | cuQty | M_HU_PI_Item_Product_ID | OPT.resultedNewTUs              |
+      | stockCU  | 8     | TU1                     | tu1,tu2,tu3,tu4,tu5,tu6,tu7,tu8 |
+    And aggregate TUs to new LU
+      | sourceTUs                       | newLUs |
+      | tu1,tu2,tu3,tu4,tu5,tu6,tu7,tu8 | lu     |
+    And M_HU are validated:
+      | M_HU_ID                         | HUStatus | Parent |
+      | lu                              | A        | -      |
+      | tu1,tu2,tu3,tu4,tu5,tu6,tu7,tu8 | A        | lu     |
+
+    # The picker 'metasfresh' works at a workplace carrying a (dynamic) picking slot in warehouse StdWarehouse.
+    And load M_Warehouse:
+      | M_Warehouse_ID | Value        |
+      | warehouse      | StdWarehouse |
+    And metasfresh contains M_PickingSlot:
+      | Identifier  | PickingSlot | IsDynamic |
+      | pickingSlot | 1           | Y         |
+    And metasfresh contains C_Workplaces
+      | Identifier | M_Warehouse_ID | M_PickingSlot_ID |
+      | workplace  | warehouse      | pickingSlot      |
+    And assign C_Workplace to user
+      | C_Workplace_ID | AD_User_ID.Login |
+      | workplace      | metasfresh       |
+
+
+  @from:cucumber
+  Scenario: Mass printing packs only the demand scheduled to the workplace and ignores the unscheduled demand
+
+    # Two sales orders for the same product, each demanding 4 PCE. Only ONE will be scheduled to the workplace.
+    And metasfresh contains C_Orders:
+      | Identifier      | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | PreparationDate      |
+      | SO_scheduled    | true    | customer                 | 2024-03-26  | 2024-03-27T05:00:00Z |
+      | SO_notScheduled | true    | customer                 | 2024-03-26  | 2024-03-27T06:00:00Z |
+    And metasfresh contains C_OrderLines:
+      | C_Order_ID.Identifier | Identifier     | M_Product_ID.Identifier | QtyEntered | OPT.M_HU_PI_Item_Product_ID.Identifier |
+      | SO_scheduled          | OL_scheduled   | product                 | 4          | TU1                                    |
+      | SO_notScheduled       | OL_notScheduled| product                 | 4          | TU1                                    |
+    And the order identified by SO_scheduled is completed
+    And the order identified by SO_notScheduled is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier         | C_OrderLine_ID.Identifier | IsToRecompute |
+      | schedScheduled     | OL_scheduled              | N             |
+      | schedNotScheduled  | OL_notScheduled           | N             |
+
+    # Schedule ONLY schedScheduled to the picker's workplace. schedNotScheduled stays unscheduled, so in
+    # job-scheduled-to-workplace mode it is NOT eligible for this picker.
+    And create or update picking job schedules
+      | M_ShipmentSchedule_ID | C_Workplace_ID | QtyToPick |
+      | schedScheduled        | workplace      | 4         |
+    And after not more than 60s, picking job schedules are found:
+      | M_ShipmentSchedule_ID | C_Workplace_ID | QtyToPick |
+      | schedScheduled        | workplace      | 4         |
+
+    # The picker scans the LU — mass printing must pack ONLY the 4 PCE of the scheduled demand, even though
+    # the LU holds 8 PCE and there is another open (but unscheduled) order for 4 PCE.
+    And mass printing scan:
+      | M_HU_ID | Login      |
+      | lu      | metasfresh |
+
+    Then validate mass printing result:
+      | M_HU_ID | UnitsPacked |
+      | lu      | 4           |
+
+    # The scheduled schedule was processed → a completed shipment exists for it.
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
+      | schedScheduled                   | shipment              | CO            |
+
+    # The unscheduled schedule was NOT touched: still fully open (QtyToDeliver=4, nothing picked, nothing delivered).
+    And after not more than 10s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyPickList |
+      | schedNotScheduled                | 4                | 0                | 0               |
+
+    # Leak-safety teardown.
+    And delete all C_Workplace_User_Assign records
+    And deactivate all C_Workplace records

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_job_scheduled_to_workplace.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_job_scheduled_to_workplace.feature
@@ -114,7 +114,6 @@ Feature: Mass Printing - honour job-scheduled-to-workplace mode
       | workplace      | metasfresh       |
 
 
-  @from:cucumber
   Scenario: Mass printing packs only the demand scheduled to the workplace and ignores the unscheduled demand
 
     # Two sales orders for the same product, each demanding 4 PCE. Only ONE will be scheduled to the workplace.

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_job_scheduled_to_workplace.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_job_scheduled_to_workplace.feature
@@ -20,9 +20,9 @@ Feature: Mass Printing - honour job-scheduled-to-workplace mode
     And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
     And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
 
-    # Defensive: clear any workplace / user->workplace assignment leaked from a prior scenario in the shared JVM.
+    # Defensive: clear any leaked picker->workplace assignment so getWorkplaceByUserId resolves only OUR workplace.
+    # Do NOT deactivate all C_Workplace here — that would deactivate seed workplaces other executor features depend on.
     And delete all C_Workplace_User_Assign records
-    And deactivate all C_Workplace records
 
     And metasfresh contains M_Products:
       | Identifier | X12DE355 | IsSelfPacked |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_job_scheduled_to_workplace.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_job_scheduled_to_workplace.feature
@@ -123,9 +123,9 @@ Feature: Mass Printing - honour job-scheduled-to-workplace mode
       | SO_scheduled    | true    | customer                 | 2024-03-26  | 2024-03-27T05:00:00Z |
       | SO_notScheduled | true    | customer                 | 2024-03-26  | 2024-03-27T06:00:00Z |
     And metasfresh contains C_OrderLines:
-      | C_Order_ID.Identifier | Identifier     | M_Product_ID.Identifier | QtyEntered | OPT.M_HU_PI_Item_Product_ID.Identifier |
-      | SO_scheduled          | OL_scheduled   | product                 | 4          | TU1                                    |
-      | SO_notScheduled       | OL_notScheduled| product                 | 4          | TU1                                    |
+      | C_Order_ID.Identifier | Identifier      | M_Product_ID.Identifier | QtyEntered | OPT.M_HU_PI_Item_Product_ID.Identifier |
+      | SO_scheduled          | OL_scheduled    | product                 | 4          | TU1                                    |
+      | SO_notScheduled       | OL_notScheduled | product                 | 4          | TU1                                    |
     And the order identified by SO_scheduled is completed
     And the order identified by SO_notScheduled is completed
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_job_scheduled_to_workplace.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_job_scheduled_to_workplace.feature
@@ -152,6 +152,11 @@ Feature: Mass Printing - honour job-scheduled-to-workplace mode
       | M_HU_ID | UnitsPacked |
       | lu      | 4           |
 
+    # The scanned LU started with 8 PCE; only the 4 scheduled units were packed, so 4 PCE remain on the LU.
+    And validate M_HUs:
+      | Identifier | M_Product_ID | Qty   |
+      | lu         | product      | 4 PCE |
+
     # The scheduled schedule was processed → a completed shipment exists for it.
     And after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_skip_locked_schedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_skip_locked_schedule.feature
@@ -21,9 +21,9 @@ Feature: Mass Printing - Skip shipment schedule locked by another user
     And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
     And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
 
-    # Defensive: clear any workplace / user->workplace assignment leaked from a prior scenario in the shared JVM.
+    # Defensive: clear any leaked picker->workplace assignment so getWorkplaceByUserId resolves only OUR workplace.
+    # Do NOT deactivate all C_Workplace here — that would deactivate seed workplaces other executor features depend on.
     And delete all C_Workplace_User_Assign records
-    And deactivate all C_Workplace records
 
     # otherPicker simulates a SECOND warehouse worker who is already picking one of the orders on this LU:
     # below they take a picking lock on that order's shipment schedule. The scenario then asserts that mass

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_skip_locked_schedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_skip_locked_schedule.feature
@@ -176,6 +176,11 @@ Feature: Mass Printing - Skip shipment schedule locked by another user
       | M_HU_ID | UnitsPacked |
       | lu      | 4           |
 
+    # The scanned LU started with 8 PCE; only the non-locked schedule's 4 units were packed, so 4 PCE remain.
+    And validate M_HUs:
+      | Identifier | M_Product_ID | Qty   |
+      | lu         | product      | 4 PCE |
+
     # schedLocked was skipped: its lock is still held by otherPicker (mass printing did not unlock or process it)
     And validate M_ShipmentSchedule_Lock record for:
       | M_ShipmentSchedule_ID | Login       | Exists |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_skip_locked_schedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/picking/massPrinting_skip_locked_schedule.feature
@@ -190,11 +190,3 @@ Feature: Mass Printing - Skip shipment schedule locked by another user
     And after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | OPT.DocStatus |
       | schedOpen                        | shipment              | CO            |
-
-    # Leak-safety teardown: remove the metasfresh user->workplace assignment (and the workplace) so they do
-    # not leak into other features in this executor group (e.g. pickingWorkflows.feature). Without this, a
-    # later getWorkplaceByUserId('metasfresh') would resolve the stale assign row pointing at a deactivated
-    # workplace and throw "No workplace found" (HTTP 422). DELETE (not deactivate) because the unique index
-    # one_user_per_org(AD_User_ID, AD_Org_ID) ignores IsActive and would otherwise block re-assignment.
-    And delete all C_Workplace_User_Assign records
-    And deactivate all C_Workplace records

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/warehouse/JsonWarehouseRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/warehouse/JsonWarehouseRequest.java
@@ -17,6 +17,16 @@ public class JsonWarehouseRequest
 	@Nullable String locatorCode;
 	@Nullable Map<String, Locator> locators;
 
+	/**
+	 * Optional identifier of an {@code M_Warehouse_PickingGroup} this warehouse belongs to.
+	 * All warehouses in the same masterdata request that name the same {@code pickingGroup} value are
+	 * assigned to a single, shared {@code M_Warehouse_PickingGroup} (created once, looked up afterwards).
+	 * <p>
+	 * Warehouses sharing a picking group are treated as one picking scope: a picker working at a workplace in
+	 * one warehouse of the group may pick demand and stock located in any warehouse of the same group.
+	 */
+	@Nullable String pickingGroup;
+
 	//
 	//
 	//

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/warehouse/WarehouseCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/warehouse/WarehouseCommand.java
@@ -1,6 +1,7 @@
 package de.metas.frontend_testing.masterdata.warehouse;
 
 import com.google.common.collect.ImmutableMap;
+import de.metas.cache.CacheMgt;
 import de.metas.frontend_testing.masterdata.Identifier;
 import de.metas.frontend_testing.masterdata.MasterdataContext;
 import de.metas.handlingunits.model.I_M_Warehouse;
@@ -129,6 +130,12 @@ public class WarehouseCommand
 
 		warehouseRecord.setM_Warehouse_PickingGroup_ID(pickingGroupId.getRepoId());
 		saveRecord(warehouseRecord);
+
+		// Reset the warehouse / picking-group caches so a later masterdata request (same JVM Spring context)
+		// sees the freshly-assigned group — mirrors M_Warehouse_StepDef. Without this the picking-group index
+		// can be read stale and MassPrintingService.getLocatorIdsOfTheSamePickingGroup misses this warehouse.
+		CacheMgt.get().reset(I_M_Warehouse.Table_Name);
+		CacheMgt.get().reset(I_M_Warehouse_PickingGroup.Table_Name);
 	}
 
 	private Map<String, JsonWarehouseResponse.Locator> createLocators()

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/warehouse/WarehouseCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/warehouse/WarehouseCommand.java
@@ -1,7 +1,6 @@
 package de.metas.frontend_testing.masterdata.warehouse;
 
 import com.google.common.collect.ImmutableMap;
-import de.metas.cache.CacheMgt;
 import de.metas.frontend_testing.masterdata.Identifier;
 import de.metas.frontend_testing.masterdata.MasterdataContext;
 import de.metas.handlingunits.model.I_M_Warehouse;
@@ -16,11 +15,9 @@ import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.CreateOrUpdateLocatorRequest;
 import org.adempiere.warehouse.api.CreateWarehousePickingGroupRequest;
 import org.adempiere.warehouse.api.IWarehouseBL;
-import org.adempiere.warehouse.api.IWarehouseDAO;
 import org.adempiere.warehouse.groups.picking.WarehousePickingGroupId;
 import org.adempiere.warehouse.qrcode.LocatorQRCode;
 import org.compiere.model.I_M_Locator;
-import org.compiere.model.I_M_Warehouse_PickingGroup;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,7 +28,6 @@ public class WarehouseCommand
 {
 	// services
 	@NonNull private final IWarehouseBL warehouseBL = Services.get(IWarehouseBL.class);
-	@NonNull private final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
 
 	// params
 	@NonNull private final MasterdataContext context;
@@ -123,7 +119,7 @@ public class WarehouseCommand
 				.orElseGet(() -> {
 					// Use a unique Name (string + datetime): the picking group lives in the shared DB and a raw
 					// pickingGroupName would collide across tests reusing the same group label.
-					final WarehousePickingGroupId newId = warehouseDAO.createWarehousePickingGroup(
+					final WarehousePickingGroupId newId = warehouseBL.createWarehousePickingGroup(
 							CreateWarehousePickingGroupRequest.builder()
 									.orgId(MasterdataContext.ORG_ID)
 									.name(pickingGroupIdentifier.toUniqueString())
@@ -134,12 +130,6 @@ public class WarehouseCommand
 
 		warehouseRecord.setM_Warehouse_PickingGroup_ID(pickingGroupId.getRepoId());
 		saveRecord(warehouseRecord);
-
-		// Reset the warehouse / picking-group caches so a later masterdata request (same JVM Spring context)
-		// sees the freshly-assigned group — mirrors M_Warehouse_StepDef. Without this the picking-group index
-		// can be read stale and MassPrintingService.getLocatorIdsOfTheSamePickingGroup misses this warehouse.
-		CacheMgt.get().reset(I_M_Warehouse.Table_Name);
-		CacheMgt.get().reset(I_M_Warehouse_PickingGroup.Table_Name);
 	}
 
 	private Map<String, JsonWarehouseResponse.Locator> createLocators()

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/warehouse/WarehouseCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/warehouse/WarehouseCommand.java
@@ -14,8 +14,10 @@ import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.CreateOrUpdateLocatorRequest;
 import org.adempiere.warehouse.api.IWarehouseBL;
+import org.adempiere.warehouse.groups.picking.WarehousePickingGroupId;
 import org.adempiere.warehouse.qrcode.LocatorQRCode;
 import org.compiere.model.I_M_Locator;
+import org.compiere.model.I_M_Warehouse_PickingGroup;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -53,6 +55,7 @@ public class WarehouseCommand
 	public JsonWarehouseResponse execute()
 	{
 		createWarehouse();
+		assignPickingGroup();
 
 		final JsonWarehouseResponse.JsonWarehouseResponseBuilder responseBuilder = JsonWarehouseResponse.builder()
 				.warehouseId(warehouseRecord.getM_Warehouse_ID())
@@ -95,6 +98,37 @@ public class WarehouseCommand
 		saveRecord(warehouseRecord);
 		final WarehouseId warehouseId = getWarehouseId();
 		context.putIdentifier(identifier, warehouseId);
+	}
+
+	/**
+	 * If the request named a {@code pickingGroup}, assign this warehouse to the shared
+	 * {@code M_Warehouse_PickingGroup} identified by that value (looked up in / created once into the
+	 * masterdata context, keyed by the group identifier). Warehouses naming the same {@code pickingGroup}
+	 * thus end up in the same picking group.
+	 */
+	private void assignPickingGroup()
+	{
+		final String pickingGroupName = StringUtils.trimBlankToNull(request.getPickingGroup());
+		if (pickingGroupName == null)
+		{
+			return;
+		}
+
+		final Identifier pickingGroupIdentifier = Identifier.ofString(pickingGroupName);
+		final WarehousePickingGroupId pickingGroupId = context.getOptionalId(pickingGroupIdentifier, WarehousePickingGroupId.class)
+				.orElseGet(() -> {
+					final I_M_Warehouse_PickingGroup pickingGroupRecord = InterfaceWrapperHelper.newInstance(I_M_Warehouse_PickingGroup.class);
+					pickingGroupRecord.setAD_Org_ID(MasterdataContext.ORG_ID.getRepoId());
+					pickingGroupRecord.setName(pickingGroupName);
+					saveRecord(pickingGroupRecord);
+
+					final WarehousePickingGroupId newId = WarehousePickingGroupId.ofRepoId(pickingGroupRecord.getM_Warehouse_PickingGroup_ID());
+					context.putIdentifier(pickingGroupIdentifier, newId);
+					return newId;
+				});
+
+		warehouseRecord.setM_Warehouse_PickingGroup_ID(pickingGroupId.getRepoId());
+		saveRecord(warehouseRecord);
 	}
 
 	private Map<String, JsonWarehouseResponse.Locator> createLocators()

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/warehouse/WarehouseCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/warehouse/WarehouseCommand.java
@@ -14,7 +14,9 @@ import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.CreateOrUpdateLocatorRequest;
+import org.adempiere.warehouse.api.CreateWarehousePickingGroupRequest;
 import org.adempiere.warehouse.api.IWarehouseBL;
+import org.adempiere.warehouse.api.IWarehouseDAO;
 import org.adempiere.warehouse.groups.picking.WarehousePickingGroupId;
 import org.adempiere.warehouse.qrcode.LocatorQRCode;
 import org.compiere.model.I_M_Locator;
@@ -29,6 +31,7 @@ public class WarehouseCommand
 {
 	// services
 	@NonNull private final IWarehouseBL warehouseBL = Services.get(IWarehouseBL.class);
+	@NonNull private final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
 
 	// params
 	@NonNull private final MasterdataContext context;
@@ -118,12 +121,13 @@ public class WarehouseCommand
 		final Identifier pickingGroupIdentifier = Identifier.ofString(pickingGroupName);
 		final WarehousePickingGroupId pickingGroupId = context.getOptionalId(pickingGroupIdentifier, WarehousePickingGroupId.class)
 				.orElseGet(() -> {
-					final I_M_Warehouse_PickingGroup pickingGroupRecord = InterfaceWrapperHelper.newInstance(I_M_Warehouse_PickingGroup.class);
-					pickingGroupRecord.setAD_Org_ID(MasterdataContext.ORG_ID.getRepoId());
-					pickingGroupRecord.setName(pickingGroupName);
-					saveRecord(pickingGroupRecord);
-
-					final WarehousePickingGroupId newId = WarehousePickingGroupId.ofRepoId(pickingGroupRecord.getM_Warehouse_PickingGroup_ID());
+					// Use a unique Name (string + datetime): the picking group lives in the shared DB and a raw
+					// pickingGroupName would collide across tests reusing the same group label.
+					final WarehousePickingGroupId newId = warehouseDAO.createWarehousePickingGroup(
+							CreateWarehousePickingGroupRequest.builder()
+									.orgId(MasterdataContext.ORG_ID)
+									.name(pickingGroupIdentifier.toUniqueString())
+									.build());
 					context.putIdentifier(pickingGroupIdentifier, newId);
 					return newId;
 				});

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/massprinting/MassPrintingService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/massprinting/MassPrintingService.java
@@ -94,7 +94,7 @@ public class MassPrintingService
 		final Workplace workplace = warehouseService.getWorkplaceByUserId(request.getPickerId()).orElse(null);
 		final LocatorId luLocatorId = huService.getLocatorId(luId);
 
-		// AC3: the operator scanned a workplace; the LU must belong to its picking group.
+		// If the picker is assigned to a workplace, the scanned LU must belong to that workplace's picking group.
 		if (workplace != null
 				&& !warehouseService.getLocatorIdsOfTheSamePickingGroup(workplace.getWarehouseId()).contains(luLocatorId))
 		{
@@ -208,8 +208,8 @@ public class MassPrintingService
 		// schedules, before creating our own job. A job that is unassigned or assigned to this mass-printing
 		// picker is a leftover from a previous failed scan and is aborted here (self-cleanup; also prevents
 		// DDOrderPickingReconcile_PickerBusy errors). A job held by a different picker is left untouched — its
-		// schedules were already dropped before selection by filterSkipLockedByOtherUser (the picking-job
-		// schedule lock), so they do not reach this point.
+		// schedules were already excluded before selection by the reused launcher query's lockedBy(pickerId) +
+		// includeNotLocked filter (PickingJobQuery.toPackageableQueryBuilder), so they do not reach this point.
 		pickingJobService.abortAbortablePickingJobsForSchedules(
 				ImmutableSet.of(productId),
 				ImmutableSet.copyOf(selection.getSelectedScheduleIds()),

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/massprinting/MassPrintingService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/massprinting/MassPrintingService.java
@@ -27,7 +27,6 @@ import de.metas.i18n.AdMessageKey;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.logging.LogManager;
 import de.metas.picking.api.Packageable;
-import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
 import de.metas.picking.api.ShipmentScheduleAndJobScheduleIdSet;
 import de.metas.picking.job_schedule.model.PickingJobSchedule;
 import de.metas.picking.job_schedule.model.PickingJobScheduleCollection;
@@ -338,13 +337,17 @@ public class MassPrintingService
 
 	/**
 	 * Resolves the {@link ShipmentScheduleAndJobScheduleIdSet} to drive a PRODUCT picking-job creation for the
-	 * selected shipment-schedule ids.
-	 * <p>
-	 * In job-scheduled-to-workplace mode (the query carries a {@code scheduledForWorkplaceId}), each selected
-	 * shipment schedule carries its picking-job-schedule id (looked up via {@link PickingJobService#listJobSchedules},
-	 * the same job-schedule resolution the launcher / {@code streamPackageable} use), so the created job is driven
-	 * by the job-schedules — consistent with how regular picking creates jobs from candidates. In warehouse mode
-	 * it falls back to a plain shipment-schedule-id set.
+	 * selected shipment-schedule ids. The resolution branches on the query MODE — never on whether job-schedules
+	 * happen to exist:
+	 * <ul>
+	 * <li><b>Warehouse mode</b> ({@code isScheduledForWorkplaceOnly() == false}): the job is driven by plain
+	 * shipment-schedule ids.</li>
+	 * <li><b>Job-scheduled-to-workplace mode</b> ({@code isScheduledForWorkplaceOnly() == true}): the job MUST be
+	 * driven by the picking-job schedules (looked up via {@link PickingJobService#listJobSchedules}, the same
+	 * job-schedule resolution the launcher / {@code streamPackageable} use). We never fall back to a plain
+	 * shipment-schedule set here — that would defeat {@code isScheduledForWorkplaceOnly}. A selected schedule with
+	 * no matching job-schedule is simply not included (we accept "no job schedules" rather than falling back).</li>
+	 * </ul>
 	 */
 	@NonNull
 	private ShipmentScheduleAndJobScheduleIdSet resolveScheduleIdsForJobCreation(
@@ -357,19 +360,20 @@ public class MassPrintingService
 			return ShipmentScheduleAndJobScheduleIdSet.EMPTY;
 		}
 
-		// listJobSchedules returns EMPTY both in warehouse mode (isScheduledForWorkplaceOnly=false) and in
-		// job-scheduled-to-workplace mode when no job-schedules exist for the query; in both cases the job is
-		// driven by plain shipment-schedule ids.
-		final PickingJobScheduleCollection jobSchedules = pickingJobService.listJobSchedules(query);
-		if (jobSchedules.isEmpty())
+		// Warehouse mode: the job is driven by plain shipment-schedule ids.
+		if (!query.isScheduledForWorkplaceOnly())
 		{
 			return ShipmentScheduleAndJobScheduleIdSet.ofShipmentScheduleIds(selectedShipmentScheduleIds);
 		}
 
+		// Scheduled-to-workplace mode: the job MUST be driven by the picking-job schedules.
+		// NEVER fall back to a plain shipment-schedule set here — that would defeat isScheduledForWorkplaceOnly.
+		final PickingJobScheduleCollection jobSchedules = pickingJobService.listJobSchedules(query);
 		return selectedShipmentScheduleIds.stream()
-				.map(shipmentScheduleId -> jobSchedules.getSingleScheduleByShipmentScheduleId(shipmentScheduleId)
+				.map(ssId -> jobSchedules.getSingleScheduleByShipmentScheduleId(ssId)
 						.map(PickingJobSchedule::getShipmentScheduleAndJobScheduleId)
-						.orElseGet(() -> ShipmentScheduleAndJobScheduleId.ofShipmentScheduleId(shipmentScheduleId)))
+						.orElse(null))
+				.filter(java.util.Objects::nonNull)
 				.collect(ShipmentScheduleAndJobScheduleIdSet.collect());
 	}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/massprinting/MassPrintingService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/massprinting/MassPrintingService.java
@@ -14,25 +14,24 @@ import de.metas.handlingunits.picking.job.model.PickingJobStepEvent;
 import de.metas.handlingunits.picking.job.model.PickingJobStepEventType;
 import de.metas.handlingunits.picking.job.model.PickingUnit;
 import de.metas.handlingunits.picking.job.model.TUPickingTarget;
-import de.metas.handlingunits.picking.job.service.PickingJobLockService;
+import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfile;
+import de.metas.handlingunits.picking.job.model.PickingJobQuery;
 import de.metas.handlingunits.picking.job.service.PickingJobService;
 import de.metas.handlingunits.picking.job.service.commands.PickingJobCreateRequest;
 import de.metas.handlingunits.picking.job.service.external.hu.PickingJobHUService;
 import de.metas.handlingunits.picking.job.service.external.product.PickingJobProductService;
-import de.metas.handlingunits.picking.job.service.external.shipmentschedule.PickingJobShipmentScheduleService;
+import de.metas.handlingunits.picking.job.service.external.warehouse.PickingJobWarehouseService;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.storage.IHUProductStorage;
 import de.metas.i18n.AdMessageKey;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.logging.LogManager;
 import de.metas.picking.api.Packageable;
-import de.metas.picking.api.PackageableQuery;
-import de.metas.picking.api.PackageableQuery.OrderBy;
 import de.metas.picking.api.ShipmentScheduleAndJobScheduleIdSet;
 import de.metas.product.Product;
 import de.metas.product.ProductId;
-import de.metas.user.UserId;
 import de.metas.util.Services;
+import de.metas.workplace.Workplace;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +39,6 @@ import lombok.Value;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.warehouse.LocatorId;
-import org.adempiere.warehouse.WarehouseId;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 
@@ -57,6 +55,7 @@ import java.util.stream.Collectors;
 public class MassPrintingService
 {
 	private static final AdMessageKey MSG_MASS_PRINTING_NOT_ENABLED = AdMessageKey.of("de.metas.handlingunits.picking.massprinting.MassPrintingNotEnabled");
+	private static final AdMessageKey MSG_LU_NOT_IN_PICKING_GROUP = AdMessageKey.of("de.metas.handlingunits.picking.massprinting.LUNotInWorkplacePickingGroup");
 
 	private static final Logger logger = LogManager.getLogger(MassPrintingService.class);
 
@@ -64,8 +63,7 @@ public class MassPrintingService
 	@NonNull private final PickingJobService pickingJobService;
 	@NonNull private final PickingJobHUService huService;
 	@NonNull private final PickingJobProductService productService;
-	@NonNull private final PickingJobShipmentScheduleService shipmentScheduleService;
-	@NonNull private final PickingJobLockService pickingJobLockService;
+	@NonNull private final PickingJobWarehouseService warehouseService;
 
 	@NonNull private final ITrxManager trxManager = Services.get(ITrxManager.class);
 
@@ -89,13 +87,39 @@ public class MassPrintingService
 		final ImmutableSet<ProductId> productIds = extractProductIds(productStorages);
 		final Map<ProductId, Product> productsById = productService.getByIdsAsMap(productIds);
 
-		final LocatorId locatorId = huService.getLocatorId(luId);
-		final WarehouseId warehouseId = locatorId.getWarehouseId();
-
 		final ImmutableSet<ProductId> selfPackedProductIds = retainSelfPackedProducts(productsById.values());
 
-		// Batch-load all packageables for self-packed products in one query (avoids N+1 per product).
-		final Map<ProductId, List<Packageable>> packageablesByProduct = loadPackageablesGroupedByProduct(warehouseId, selfPackedProductIds, request.getPickerId());
+		// Search demand exactly like the picking launcher: scope by the operator's workplace warehouse
+		// (which spans every locator of the same M_Warehouse_PickingGroup), not by the LU's own locator.
+		final Workplace workplace = warehouseService.getWorkplaceByUserId(request.getPickerId()).orElse(null);
+		final LocatorId luLocatorId = huService.getLocatorId(luId);
+
+		// AC3: the operator scanned a workplace; the LU must belong to its picking group.
+		if (workplace != null
+				&& !warehouseService.getLocatorIdsOfTheSamePickingGroup(workplace.getWarehouseId()).contains(luLocatorId))
+		{
+			throw new AdempiereException(MSG_LU_NOT_IN_PICKING_GROUP)
+					.appendParametersToMessage()
+					.setParameter("luId", luId)
+					.setParameter("luLocatorId", luLocatorId)
+					.setParameter("workplaceWarehouseId", workplace.getWarehouseId());
+		}
+
+		final MobileUIPickingUserProfile profile = profileService.getProfile();
+		final PickingJobQuery pickingJobQuery = PickingJobQuery.builder()
+				.userId(request.getPickerId())
+				.warehouseId(workplace != null ? workplace.getWarehouseId() : null)
+				.scheduledForWorkplaceId(profile.isConsiderOnlyJobScheduledToWorkplace() && workplace != null ? workplace.getId() : null)
+				.onlyCustomerIds(profile.getPickOnlyCustomerIds())
+				.build();
+
+		// Reuse the launcher's eligibility seam: streamPackageable applies the same launcher filters
+		// (workplace warehouse, job-schedule branch, lockedBy(userId)+includeNotLocked → other-user-locked
+		// schedules are excluded, excludeLockedForProcessing, etc.). Keep only the self-packed products.
+		final Map<ProductId, List<Packageable>> packageablesByProduct =
+				pickingJobService.streamPackageable(pickingJobQuery)
+						.filter(p -> selfPackedProductIds.contains(p.getProductId()))
+						.collect(Collectors.groupingBy(Packageable::getProductId));
 
 		final ImmutableList.Builder<ProductResult> productResults = ImmutableList.builder();
 		final ImmutableList.Builder<ProductId> skippedNonSelfPacked = ImmutableList.builder();
@@ -145,71 +169,6 @@ public class MassPrintingService
 				.filter(Product::isSelfPacked)
 				.map(Product::getId)
 				.collect(ImmutableSet.toImmutableSet());
-	}
-
-	/** Loads all packageables for the given products in one query, grouped by product. */
-	private Map<ProductId, List<Packageable>> loadPackageablesGroupedByProduct(
-			@NonNull final WarehouseId warehouseId,
-			@NonNull final ImmutableSet<ProductId> selfPackedProductIds,
-			@NonNull final UserId pickerId)
-	{
-		if (selfPackedProductIds.isEmpty())
-		{
-			return ImmutableMap.of();
-		}
-
-		final PackageableQuery query = PackageableQuery.builder()
-				.warehouseId(warehouseId)
-				.onlyFromSalesOrder(true)
-				.productIds(selfPackedProductIds)
-				.orderBys(ImmutableSet.of(OrderBy.PreparationDate))
-				.build();
-
-		final ImmutableList<Packageable> allPackageables = shipmentScheduleService.stream(query)
-				.collect(ImmutableList.toImmutableList());
-
-		return filterSkipLockedByOtherUser(allPackageables, pickerId)
-				.stream()
-				.collect(Collectors.groupingBy(Packageable::getProductId));
-	}
-
-	/**
-	 * Filters out packageables whose shipment schedule is already locked by a picker other than {@code pickerId}.
-	 * Logs a warning for each skipped schedule so the operator knows why demand was not processed.
-	 */
-	private ImmutableList<Packageable> filterSkipLockedByOtherUser(
-			@NonNull final ImmutableList<Packageable> packageables,
-			@NonNull final UserId pickerId)
-	{
-		if (packageables.isEmpty())
-		{
-			return packageables;
-		}
-
-		final ImmutableSet<ShipmentScheduleId> scheduleIds = packageables.stream()
-				.map(Packageable::getShipmentScheduleId)
-				.collect(ImmutableSet.toImmutableSet());
-
-		final ImmutableSet<ShipmentScheduleId> lockedByOtherUser = pickingJobLockService.getScheduleIdsLockedByOtherUser(scheduleIds, pickerId);
-		if (lockedByOtherUser.isEmpty())
-		{
-			return packageables;
-		}
-
-		final ImmutableList.Builder<Packageable> result = ImmutableList.builder();
-		for (final Packageable packageable : packageables)
-		{
-			if (lockedByOtherUser.contains(packageable.getShipmentScheduleId()))
-			{
-				logger.warn("Skipping shipment schedule {} for product {} — locked by another picker",
-						packageable.getShipmentScheduleId(), packageable.getProductId());
-			}
-			else
-			{
-				result.add(packageable);
-			}
-		}
-		return result.build();
 	}
 
 	@NonNull

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/massprinting/MassPrintingService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/massprinting/MassPrintingService.java
@@ -71,7 +71,8 @@ public class MassPrintingService
 	@NonNull
 	public MassPrintingResult scan(@NonNull final MassPrintingScanRequest request)
 	{
-		if (!profileService.getProfile().isMassPrinting())
+		final MobileUIPickingUserProfile profile = profileService.getProfile();
+		if (!profile.isMassPrinting())
 		{
 			throw new AdempiereException(MSG_MASS_PRINTING_NOT_ENABLED);
 		}
@@ -105,7 +106,6 @@ public class MassPrintingService
 					.setParameter("workplaceWarehouseId", workplace.getWarehouseId());
 		}
 
-		final MobileUIPickingUserProfile profile = profileService.getProfile();
 		final PickingJobQuery pickingJobQuery = PickingJobQuery.builder()
 				.userId(request.getPickerId())
 				.warehouseId(workplace != null ? workplace.getWarehouseId() : null)
@@ -312,9 +312,10 @@ public class MassPrintingService
 			@NonNull final ScheduleSelection selection)
 	{
 		// Resolve the schedule-id set exactly like regular picking does from a candidate: in
-		// job-scheduled-to-workplace mode (profile.isConsiderOnlyJobScheduledToWorkplace), the FIFO-selected
-		// shipment schedules carry their picking-job-schedule ids, so the created PRODUCT job is driven by the
-		// job-schedules (consistent with the launcher). In warehouse mode this yields a plain shipment-schedule set.
+		// job-scheduled-to-workplace mode (query.isScheduledForWorkplaceOnly(), set when the profile's
+		// IsConsideredOnlyScheduledJobs=Y), the FIFO-selected shipment schedules carry their picking-job-schedule
+		// ids, so the created PRODUCT job is driven by the job-schedules (consistent with the launcher). In
+		// warehouse mode this yields a plain shipment-schedule set.
 		final ShipmentScheduleAndJobScheduleIdSet scheduleIdSet =
 				pickingJobService.resolveScheduleIdsForJobCreation(pickingJobQuery, ImmutableSet.copyOf(selection.getSelectedScheduleIds()));
 		final PickingJob pickingJob = pickingJobService.createPickingJob(

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/massprinting/MassPrintingService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/massprinting/MassPrintingService.java
@@ -144,7 +144,7 @@ public class MassPrintingService
 
 			// Pack+ship inside a transaction. Labels print through the standard picking close path during the
 			// pick (the physical print job is enqueued after the transaction commits, like a regular picking job).
-			final PackAndPickResult packAndPickResult = processProductInTrx(request, luId, productId, productStorage.getQtyAsInt(), packageables);
+			final PackAndPickResult packAndPickResult = processProductInTrx(request, pickingJobQuery, luId, productId, productStorage.getQtyAsInt(), packageables);
 
 			productResults.add(buildProductResult(productId, packAndPickResult));
 		}
@@ -174,6 +174,7 @@ public class MassPrintingService
 	@NonNull
 	private PackAndPickResult processProductInTrx(
 			@NonNull final MassPrintingScanRequest request,
+			@NonNull final PickingJobQuery pickingJobQuery,
 			@NonNull final HuId luId,
 			@NonNull final ProductId productId,
 			final int unitsOnLU,
@@ -182,12 +183,13 @@ public class MassPrintingService
 		// Shipment generation inside PickingJobCompleteCommand opens its own nested transaction
 		// (callInNewTrx), so the async-batch assignment commits independently from the outer
 		// picking transaction — no M_ShipmentSchedule row-lock deadlock is possible.
-		return trxManager.callInThreadInheritedTrx(() -> processProduct(request, luId, productId, unitsOnLU, packageables));
+		return trxManager.callInThreadInheritedTrx(() -> processProduct(request, pickingJobQuery, luId, productId, unitsOnLU, packageables));
 	}
 
 	@NonNull
 	private PackAndPickResult processProduct(
 			@NonNull final MassPrintingScanRequest request,
+			@NonNull final PickingJobQuery pickingJobQuery,
 			@NonNull final HuId luId,
 			@NonNull final ProductId productId,
 			final int unitsOnLU,
@@ -218,7 +220,7 @@ public class MassPrintingService
 		// Each line is picked-and-closed through the standard picking close path (see pickTuLine / pickCuLine),
 		// so labels print exactly like a regular picking job — closeLUAndTUPickingTargets() collects every
 		// top-level TU/VHU via addTopLevelTUId() and prints its label. No bespoke side-channel print here.
-		final PickingJob pickedJob = createAndPickJob(request, luId, selection);
+		final PickingJob pickedJob = createAndPickJob(request, pickingJobQuery, luId, selection);
 		final ImmutableSet<HuId> pickedHuIds = pickedJob.getAllPickedHuIds();
 		final ImmutableSet<HuId> packedHUIds = huService.getPackedBoxHUIds(pickedHuIds);
 		pickingJobService.complete(pickedJob);
@@ -305,10 +307,16 @@ public class MassPrintingService
 	@NonNull
 	private PickingJob createAndPickJob(
 			@NonNull final MassPrintingScanRequest request,
+			@NonNull final PickingJobQuery pickingJobQuery,
 			@NonNull final HuId luId,
 			@NonNull final ScheduleSelection selection)
 	{
-		final ShipmentScheduleAndJobScheduleIdSet scheduleIdSet = ShipmentScheduleAndJobScheduleIdSet.ofShipmentScheduleIds(selection.getSelectedScheduleIds());
+		// Resolve the schedule-id set exactly like regular picking does from a candidate: in
+		// job-scheduled-to-workplace mode (profile.isConsiderOnlyJobScheduledToWorkplace), the FIFO-selected
+		// shipment schedules carry their picking-job-schedule ids, so the created PRODUCT job is driven by the
+		// job-schedules (consistent with the launcher). In warehouse mode this yields a plain shipment-schedule set.
+		final ShipmentScheduleAndJobScheduleIdSet scheduleIdSet =
+				pickingJobService.resolveScheduleIdsForJobCreation(pickingJobQuery, ImmutableSet.copyOf(selection.getSelectedScheduleIds()));
 		final PickingJob pickingJob = pickingJobService.createPickingJob(
 				PickingJobCreateRequest.builder()
 						.pickerId(request.getPickerId())

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/massprinting/MassPrintingService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/massprinting/MassPrintingService.java
@@ -27,7 +27,10 @@ import de.metas.i18n.AdMessageKey;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.logging.LogManager;
 import de.metas.picking.api.Packageable;
+import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
 import de.metas.picking.api.ShipmentScheduleAndJobScheduleIdSet;
+import de.metas.picking.job_schedule.model.PickingJobSchedule;
+import de.metas.picking.job_schedule.model.PickingJobScheduleCollection;
 import de.metas.product.Product;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
@@ -47,6 +50,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /** Orchestration service for the mass-printing flow: scan LU → pick every self-packed product → print labels. */
@@ -308,16 +312,12 @@ public class MassPrintingService
 	private PickingJob createAndPickJob(
 			@NonNull final MassPrintingScanRequest request,
 			@NonNull final PickingJobQuery pickingJobQuery,
-			@NonNull final HuId luId,
+			@NonNull final HuId pickFromLUId,
 			@NonNull final ScheduleSelection selection)
 	{
-		// Resolve the schedule-id set exactly like regular picking does from a candidate: in
-		// job-scheduled-to-workplace mode (query.isScheduledForWorkplaceOnly(), set when the profile's
-		// IsConsideredOnlyScheduledJobs=Y), the FIFO-selected shipment schedules carry their picking-job-schedule
-		// ids, so the created PRODUCT job is driven by the job-schedules (consistent with the launcher). In
-		// warehouse mode this yields a plain shipment-schedule set.
+		// Build the job's schedule-id set the same way regular picking does from a candidate.
 		final ShipmentScheduleAndJobScheduleIdSet scheduleIdSet =
-				pickingJobService.resolveScheduleIdsForJobCreation(pickingJobQuery, ImmutableSet.copyOf(selection.getSelectedScheduleIds()));
+				resolveScheduleIdsForJobCreation(pickingJobQuery, ImmutableSet.copyOf(selection.getSelectedScheduleIds()));
 		final PickingJob pickingJob = pickingJobService.createPickingJob(
 				PickingJobCreateRequest.builder()
 						.pickerId(request.getPickerId())
@@ -326,7 +326,7 @@ public class MassPrintingService
 						.scheduleIds(scheduleIdSet)
 						.build());
 
-		final HUQRCode luQRCode = huService.getQRCodeByHuId(luId);
+		final HUQRCode luQRCode = huService.getQRCodeByHuId(pickFromLUId);
 
 		PickingJob pickedJob = pickingJob;
 		for (final PickingJobLine line : pickingJob.getLines())
@@ -334,6 +334,43 @@ public class MassPrintingService
 			pickedJob = pickLine(pickedJob, line, luQRCode, selection.getSelectedScheduleQtys());
 		}
 		return pickedJob;
+	}
+
+	/**
+	 * Resolves the {@link ShipmentScheduleAndJobScheduleIdSet} to drive a PRODUCT picking-job creation for the
+	 * selected shipment-schedule ids.
+	 * <p>
+	 * In job-scheduled-to-workplace mode (the query carries a {@code scheduledForWorkplaceId}), each selected
+	 * shipment schedule carries its picking-job-schedule id (looked up via {@link PickingJobService#listJobSchedules},
+	 * the same job-schedule resolution the launcher / {@code streamPackageable} use), so the created job is driven
+	 * by the job-schedules — consistent with how regular picking creates jobs from candidates. In warehouse mode
+	 * it falls back to a plain shipment-schedule-id set.
+	 */
+	@NonNull
+	private ShipmentScheduleAndJobScheduleIdSet resolveScheduleIdsForJobCreation(
+			@NonNull final PickingJobQuery query,
+			@NonNull final Set<ShipmentScheduleId> selectedShipmentScheduleIds)
+	{
+		// Nothing selected → nothing to create or query for. Guard so we neither build an empty set nor hit the DB.
+		if (selectedShipmentScheduleIds.isEmpty())
+		{
+			return ShipmentScheduleAndJobScheduleIdSet.EMPTY;
+		}
+
+		// listJobSchedules returns EMPTY both in warehouse mode (isScheduledForWorkplaceOnly=false) and in
+		// job-scheduled-to-workplace mode when no job-schedules exist for the query; in both cases the job is
+		// driven by plain shipment-schedule ids.
+		final PickingJobScheduleCollection jobSchedules = pickingJobService.listJobSchedules(query);
+		if (jobSchedules.isEmpty())
+		{
+			return ShipmentScheduleAndJobScheduleIdSet.ofShipmentScheduleIds(selectedShipmentScheduleIds);
+		}
+
+		return selectedShipmentScheduleIds.stream()
+				.map(shipmentScheduleId -> jobSchedules.getSingleScheduleByShipmentScheduleId(shipmentScheduleId)
+						.map(PickingJobSchedule::getShipmentScheduleAndJobScheduleId)
+						.orElseGet(() -> ShipmentScheduleAndJobScheduleId.ofShipmentScheduleId(shipmentScheduleId)))
+				.collect(ShipmentScheduleAndJobScheduleIdSet.collect());
 	}
 
 	/** Fires pick events for one line from the LU, using the capped qty from the FIFO selection. */

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
@@ -66,6 +66,9 @@ import de.metas.logging.LogManager;
 import de.metas.order.OrderId;
 import de.metas.picking.api.Packageable;
 import de.metas.picking.api.PickingSlotId;
+import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
+import de.metas.picking.api.ShipmentScheduleAndJobScheduleIdSet;
+import de.metas.picking.job_schedule.model.PickingJobSchedule;
 import de.metas.picking.job_schedule.model.PickingJobScheduleCollection;
 import de.metas.picking.qrcode.PickingSlotQRCode;
 import de.metas.product.ProductId;
@@ -323,6 +326,38 @@ public class PickingJobService implements PickingSlotListener
 						.onlyShipmentScheduleIds(onlyShipmentScheduleIds)
 						.build()
 		);
+	}
+
+	/**
+	 * Resolves the {@link ShipmentScheduleAndJobScheduleIdSet} to drive a picking-job creation for the given
+	 * selected shipment-schedule ids, using the same job-schedule resolution as the picking launcher.
+	 * <p>
+	 * In job-scheduled-to-workplace mode (the query carries a {@code scheduledForWorkplaceId}), the returned set
+	 * carries the picking-job-schedule ids for the selected shipment schedules (looked up via the same
+	 * {@code toPickingJobScheduleQuery()} the launcher / {@link #streamPackageable} use), so the created job is
+	 * driven by the job-schedules — consistent with how regular picking creates jobs from candidates. In
+	 * warehouse mode (no {@code scheduledForWorkplaceId}) it falls back to a plain shipment-schedule-id set.
+	 */
+	public ShipmentScheduleAndJobScheduleIdSet resolveScheduleIdsForJobCreation(
+			@NonNull final PickingJobQuery query,
+			@NonNull final Set<ShipmentScheduleId> selectedShipmentScheduleIds)
+	{
+		if (selectedShipmentScheduleIds.isEmpty())
+		{
+			return ShipmentScheduleAndJobScheduleIdSet.EMPTY;
+		}
+
+		if (!query.isScheduledForWorkplaceOnly())
+		{
+			return ShipmentScheduleAndJobScheduleIdSet.ofShipmentScheduleIds(selectedShipmentScheduleIds);
+		}
+
+		final PickingJobScheduleCollection jobSchedules = pickingJobScheduleService.list(query.toPickingJobScheduleQuery());
+		return selectedShipmentScheduleIds.stream()
+				.map(shipmentScheduleId -> jobSchedules.getSingleScheduleByShipmentScheduleId(shipmentScheduleId)
+						.map(PickingJobSchedule::getShipmentScheduleAndJobScheduleId)
+						.orElseGet(() -> ShipmentScheduleAndJobScheduleId.ofShipmentScheduleId(shipmentScheduleId)))
+				.collect(ShipmentScheduleAndJobScheduleIdSet.collect());
 	}
 
 	public ADRefList getQtyRejectedReasons()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
@@ -66,9 +66,6 @@ import de.metas.logging.LogManager;
 import de.metas.order.OrderId;
 import de.metas.picking.api.Packageable;
 import de.metas.picking.api.PickingSlotId;
-import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
-import de.metas.picking.api.ShipmentScheduleAndJobScheduleIdSet;
-import de.metas.picking.job_schedule.model.PickingJobSchedule;
 import de.metas.picking.job_schedule.model.PickingJobScheduleCollection;
 import de.metas.picking.qrcode.PickingSlotQRCode;
 import de.metas.product.ProductId;
@@ -329,35 +326,19 @@ public class PickingJobService implements PickingSlotListener
 	}
 
 	/**
-	 * Resolves the {@link ShipmentScheduleAndJobScheduleIdSet} to drive a picking-job creation for the given
-	 * selected shipment-schedule ids, using the same job-schedule resolution as the picking launcher.
-	 * <p>
-	 * In job-scheduled-to-workplace mode (the query carries a {@code scheduledForWorkplaceId}), the returned set
-	 * carries the picking-job-schedule ids for the selected shipment schedules (looked up via the same
-	 * {@code toPickingJobScheduleQuery()} the launcher / {@link #streamPackageable} use), so the created job is
-	 * driven by the job-schedules — consistent with how regular picking creates jobs from candidates. In
-	 * warehouse mode (no {@code scheduledForWorkplaceId}) it falls back to a plain shipment-schedule-id set.
+	 * Lists the picking-job-schedules matching the query, using the same {@code toPickingJobScheduleQuery()}
+	 * resolution as the launcher / {@link #streamPackageable}. Returns {@link PickingJobScheduleCollection#EMPTY}
+	 * when the query is not in job-scheduled-to-workplace mode (no job-schedules apply in warehouse mode).
 	 */
-	public ShipmentScheduleAndJobScheduleIdSet resolveScheduleIdsForJobCreation(
-			@NonNull final PickingJobQuery query,
-			@NonNull final Set<ShipmentScheduleId> selectedShipmentScheduleIds)
+	@NonNull
+	public PickingJobScheduleCollection listJobSchedules(@NonNull final PickingJobQuery query)
 	{
-		if (selectedShipmentScheduleIds.isEmpty())
-		{
-			return ShipmentScheduleAndJobScheduleIdSet.EMPTY;
-		}
-
 		if (!query.isScheduledForWorkplaceOnly())
 		{
-			return ShipmentScheduleAndJobScheduleIdSet.ofShipmentScheduleIds(selectedShipmentScheduleIds);
+			return PickingJobScheduleCollection.EMPTY;
 		}
 
-		final PickingJobScheduleCollection jobSchedules = pickingJobScheduleService.list(query.toPickingJobScheduleQuery());
-		return selectedShipmentScheduleIds.stream()
-				.map(shipmentScheduleId -> jobSchedules.getSingleScheduleByShipmentScheduleId(shipmentScheduleId)
-						.map(PickingJobSchedule::getShipmentScheduleAndJobScheduleId)
-						.orElseGet(() -> ShipmentScheduleAndJobScheduleId.ofShipmentScheduleId(shipmentScheduleId)))
-				.collect(ShipmentScheduleAndJobScheduleIdSet.collect());
+		return pickingJobScheduleService.list(query.toPickingJobScheduleQuery());
 	}
 
 	public ADRefList getQtyRejectedReasons()

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5807480_msg_LUNotInWorkplacePickingGroup.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5807480_msg_LUNotInWorkplacePickingGroup.sql
@@ -1,0 +1,84 @@
+-- Run mode: SWING_CLIENT
+-- IDs allocated from idserver.metas.de on 2026-06-12:
+--   AD_Message  545753  (de.metas.handlingunits.picking.massprinting.LUNotInWorkplacePickingGroup)
+
+-- AD_Message: MassPrinting / picking guard — fired when a scanned LU's locator is not in the
+-- picker's workplace picking warehouse group. The server rejects any scan of an LU that does
+-- not belong to the workplace's picking group, regardless of how the request arrived.
+-- MsgType=E because this is a user-visible error that must surface in the mobile UI.
+-- 2026-06-12T12:00:00Z
+INSERT INTO AD_Message
+    (AD_Client_ID, AD_Message_ID, AD_Org_ID, Created, CreatedBy, EntityType, IsActive,
+     MsgText, MsgTip, MsgType, ErrorCode, Updated, UpdatedBy, Value)
+VALUES
+    (0, 545753 /*From ID Server*/, 0,
+     TO_TIMESTAMP('2026-06-12 12:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+     100, 'D', 'Y',
+     'Die gescannte Ladeeinheit gehört nicht zur Kommissionier-Lagergruppe des Arbeitsplatzes.',
+     NULL,
+     'E',
+     'LUNotInWorkplacePickingGroup',
+     TO_TIMESTAMP('2026-06-12 12:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+     100,
+     'de.metas.handlingunits.picking.massprinting.LUNotInWorkplacePickingGroup')
+;
+
+-- Seed translation rows for all active system languages (copies DE base text)
+-- 2026-06-12T12:00:01Z
+INSERT INTO AD_Message_Trl
+    (AD_Language, AD_Message_ID, AD_Client_ID, AD_Org_ID,
+     Created, CreatedBy, Updated, UpdatedBy,
+     IsActive, IsTranslated, MsgText, MsgTip)
+SELECT l.AD_Language,
+       t.AD_Message_ID,
+       t.AD_Client_ID,
+       t.AD_Org_ID,
+       TO_TIMESTAMP('2026-06-12 12:00:01.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+       100,
+       TO_TIMESTAMP('2026-06-12 12:00:01.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+       100,
+       'Y',
+       'N',
+       t.MsgText,
+       t.MsgTip
+FROM AD_Language l,
+     AD_Message  t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Message_ID = 545753
+  AND NOT EXISTS (SELECT 1
+                  FROM AD_Message_Trl tt
+                  WHERE tt.AD_Language    = l.AD_Language
+                    AND tt.AD_Message_ID  = t.AD_Message_ID)
+;
+
+-- Override en_US with English translation
+-- 2026-06-12T12:00:02Z
+UPDATE AD_Message_Trl
+SET    MsgText        = 'The scanned LU does not belong to the workplace''s picking warehouse group.',
+       IsTranslated   = 'Y',
+       Updated        = TO_TIMESTAMP('2026-06-12 12:00:02.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+       UpdatedBy      = 100
+WHERE  AD_Language    = 'en_US'
+  AND  AD_Message_ID  = 545753
+;
+
+-- Mark de_DE as actively translated (same text as base)
+-- 2026-06-12T12:00:03Z
+UPDATE AD_Message_Trl
+SET    IsTranslated   = 'Y',
+       Updated        = TO_TIMESTAMP('2026-06-12 12:00:03.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+       UpdatedBy      = 100
+WHERE  AD_Language    = 'de_DE'
+  AND  AD_Message_ID  = 545753
+;
+
+-- Mark de_CH as actively translated (same text as base)
+-- 2026-06-12T12:00:04Z
+UPDATE AD_Message_Trl
+SET    IsTranslated   = 'Y',
+       Updated        = TO_TIMESTAMP('2026-06-12 12:00:04.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+       UpdatedBy      = 100
+WHERE  AD_Language    = 'de_CH'
+  AND  AD_Message_ID  = 545753
+;

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 5 | 8 | 63% |
-| Picking | 56 | 60 | 93% |
+| Picking | 58 | 62 | 94% |
 | Distribution | 34 | 37 | 92% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
@@ -151,9 +151,11 @@
 | Non-self-packed-only LU: no boxes packed, skipped-products section is visible | `picking/massPrinting.spec.js` |
 | Off-mode guard: mass-printing trigger button is absent when feature is disabled in picking profile | `picking/massPrinting.spec.js` |
 | Null PackTo PI: self-packed product with no TU packing instruction packs as VHU (one label per unit, not a TU box) | `picking/massPrinting.spec.js` |
+| Cross-warehouse: LU stored in one warehouse, demand + workplace in another warehouse of the same picking group → demand is found and packed (searches by the workplace warehouse, not the LU's storage warehouse) | `picking/massPrinting.spec.js` |
+| LU outside the workplace's picking group → scan is rejected with an error, nothing packed | `picking/massPrinting.spec.js` |
 | ❌ CREATE_COMPLETE_CLOSE policy: scanning LU packs + produces a completed shipment and closes the shipment schedule — but the schedule must be closed **only on a full pick**; a partially-picked schedule must stay **open** (closing it would discard the remaining open demand) | — |
 
-**10/11 — 91%**
+**12/13 — 92%**
 
 ### Order-based picking — catch-weight
 

--- a/e2e/mobile-webui/tests/spec/picking/massPrinting.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/massPrinting.spec.js
@@ -644,7 +644,8 @@ test('Mass printing — cross-warehouse: LU in storage warehouse, demand in work
                 "whPacking": { pickingGroup: 'pickingArea' },
                 "whStorage": { pickingGroup: 'pickingArea' },
             },
-            pickingSlots: { slot1: {} },
+            // Pin the slot to the workplace warehouse — with >1 warehouse the locator is otherwise ambiguous.
+            pickingSlots: { slot1: { locator: 'whPacking' } },
             // The picker's workplace is in the PACKING warehouse (not where the LU is stored).
             workplaces: { "workplace1": { warehouse: 'whPacking', pickingSlot: 'slot1' } },
             products: {
@@ -736,7 +737,8 @@ test('Mass printing — LU outside the workplace picking group is rejected', asy
                 // The LU's warehouse — NOT in any picking group.
                 "whOutside": {},
             },
-            pickingSlots: { slot1: {} },
+            // Pin the slot to the workplace warehouse — with >1 warehouse the locator is otherwise ambiguous.
+            pickingSlots: { slot1: { locator: 'whPacking' } },
             workplaces: { "workplace1": { warehouse: 'whPacking', pickingSlot: 'slot1' } },
             products: {
                 "selfPackedPrd": { prices: [{ price: 10 }], isSelfPacked: true },

--- a/e2e/mobile-webui/tests/spec/picking/massPrinting.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/massPrinting.spec.js
@@ -5,6 +5,8 @@ import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsLi
 import { MassPrintingScanScreen } from "../../utils/screens/picking/MassPrintingScanScreen";
 import { Backend } from "../../utils/screens/Backend";
 import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { expectErrorToast } from "../../utils/common";
+import { expect } from '@playwright/test';
 
 /**
  * End-to-end coverage of the mobileUI mass-printing scan-and-pack flow.
@@ -605,4 +607,177 @@ test('Mass printing — null PackTo PI: self-packed schedule with no PI packs as
 
     await MassPrintingScanScreen.clickDone();
     await PickingJobsListScreen.waitForScreen();
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Mass printing — cross-warehouse: LU in storage warehouse, demand in workplace warehouse, same picking group', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');  // Standalone tag for Tags section;
+    allure.story('Mass printing — cross-warehouse pack within one picking group');
+    allure.severity('critical');
+
+    // Two warehouses share ONE picking group:
+    //   - whPacking: the workplace's (picker's) warehouse, where the demand is delivered from
+    //   - whStorage: where the scanned LU physically sits
+    // Mass printing must search demand by the picker's WORKPLACE warehouse (whPacking), spanning the whole
+    // picking group, and accept the LU even though it lives in a different warehouse of the same group.
+    // Before the fix this packed 0 (demand was searched only in the LU's own storage warehouse).
+    const masterdata = await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US', workplace: 'workplace1' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: 'sales_order',
+                    allowPickingAnyCustomer: true,
+                    allowPickingAnyHU: true,
+                    createShipmentPolicy: 'NO',
+                    massPrinting: true,
+                    pickTo: ['LU_TU'],
+                }
+            },
+            bpartners: { "customer": {} },
+            warehouses: {
+                // Both warehouses belong to the same picking group "pickingArea".
+                "whPacking": { pickingGroup: 'pickingArea' },
+                "whStorage": { pickingGroup: 'pickingArea' },
+            },
+            pickingSlots: { slot1: {} },
+            // The picker's workplace is in the PACKING warehouse (not where the LU is stored).
+            workplaces: { "workplace1": { warehouse: 'whPacking', pickingSlot: 'slot1' } },
+            products: {
+                "selfPackedPrd": { prices: [{ price: 10 }], isSelfPacked: true },
+            },
+            packingInstructions: {
+                "boxPI": { lu: "LU", qtyTUsPerLU: 4, tu: "TU", product: "selfPackedPrd", qtyCUsPerTU: 1 },
+            },
+            handlingUnits: {
+                // The LU of 4 single-unit boxes physically sits in the STORAGE warehouse.
+                "lu": { product: 'selfPackedPrd', warehouse: 'whStorage', packingInstructions: 'boxPI' },
+            },
+            salesOrders: {
+                // Demand is delivered from the PACKING warehouse (the picker's workplace warehouse).
+                "SO1": {
+                    bpartner: 'customer',
+                    warehouse: 'whPacking',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'selfPackedPrd', qty: 1 }],
+                },
+                "SO2": {
+                    bpartner: 'customer',
+                    warehouse: 'whPacking',
+                    datePromised: '2025-03-02T00:00:00.000+02:00',
+                    lines: [{ product: 'selfPackedPrd', qty: 1 }],
+                },
+                "SO3": {
+                    bpartner: 'customer',
+                    warehouse: 'whPacking',
+                    datePromised: '2025-03-03T00:00:00.000+02:00',
+                    lines: [{ product: 'selfPackedPrd', qty: 1 }],
+                },
+                "SO4": {
+                    bpartner: 'customer',
+                    warehouse: 'whPacking',
+                    datePromised: '2025-03-04T00:00:00.000+02:00',
+                    lines: [{ product: 'selfPackedPrd', qty: 1 }],
+                },
+            },
+        }
+    });
+
+    await openMassPrintingFromLaunchers({ masterdata });
+
+    await MassPrintingScanScreen.scanLU({ qrCode: masterdata.handlingUnits.lu.qrCode });
+    await MassPrintingScanScreen.waitForResult();
+    await MassPrintingScanScreen.expectProductResultCount({ expectedCount: 1 });
+    // LU has 4 units; 4 single-unit orders delivered from the workplace warehouse => 4 boxes packed,
+    // nothing left over, no open demand remaining. (Before the fix: 0 packed.)
+    await MassPrintingScanScreen.expectUnitsPacked({ expected: 4 });
+    await MassPrintingScanScreen.expectUnitsLeftOnLU({ expected: 0 });
+    await MassPrintingScanScreen.expectDemandRemaining({ expected: 0 });
+
+    await MassPrintingScanScreen.clickDone();
+    await PickingJobsListScreen.waitForScreen();
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Mass printing — LU outside the workplace picking group is rejected', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');  // Standalone tag for Tags section;
+    allure.story('Mass printing — reject LU not in workplace picking group');
+    allure.severity('critical');
+
+    // The workplace sits in "whPacking" (picking group "pickingArea"); the scanned LU is stored in
+    // "whOutside", which belongs to NO picking group. Scanning it must be rejected (error surfaced in the
+    // mobile UI) and nothing may be packed. Before the fix the scan was accepted regardless of the LU's
+    // warehouse.
+    const masterdata = await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US', workplace: 'workplace1' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: 'sales_order',
+                    allowPickingAnyCustomer: true,
+                    allowPickingAnyHU: true,
+                    createShipmentPolicy: 'NO',
+                    massPrinting: true,
+                    pickTo: ['LU_TU'],
+                }
+            },
+            bpartners: { "customer": {} },
+            warehouses: {
+                // Workplace warehouse, in picking group "pickingArea".
+                "whPacking": { pickingGroup: 'pickingArea' },
+                // The LU's warehouse — NOT in any picking group.
+                "whOutside": {},
+            },
+            pickingSlots: { slot1: {} },
+            workplaces: { "workplace1": { warehouse: 'whPacking', pickingSlot: 'slot1' } },
+            products: {
+                "selfPackedPrd": { prices: [{ price: 10 }], isSelfPacked: true },
+            },
+            packingInstructions: {
+                "boxPI": { lu: "LU", qtyTUsPerLU: 3, tu: "TU", product: "selfPackedPrd", qtyCUsPerTU: 1 },
+            },
+            handlingUnits: {
+                // The LU sits in a warehouse outside the workplace's picking group.
+                "lu": { product: 'selfPackedPrd', warehouse: 'whOutside', packingInstructions: 'boxPI' },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'customer',
+                    warehouse: 'whPacking',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'selfPackedPrd', qty: 1 }],
+                },
+            },
+        }
+    });
+
+    await openMassPrintingFromLaunchers({ masterdata });
+
+    // Scanning an LU outside the workplace's picking group must surface a rejection error (toast)
+    // and produce no result panel.
+    await expectErrorToast(
+        'LU not in workplace picking group',
+        async () => {
+            await MassPrintingScanScreen.scanLU({ qrCode: masterdata.handlingUnits.lu.qrCode });
+        },
+        ({ textContent }) => {
+            expect(textContent).toContain('picking warehouse group');
+        }
+    );
+
+    // Nothing was packed: confirm the order still has no shipment.
+    await Backend.expect({
+        title: 'SO1 should have no shipment after a rejected mass-printing scan',
+        salesOrders: {
+            'SO1': { shipments: [] },
+        }
+    });
 });


### PR DESCRIPTION
## What

Mobile Mass Printing (MobileUI Picking) now searches open demand the same way the picking launcher computes its candidates, instead of using the scanned LU's own storage warehouse. It also validates that the scanned LU belongs to the picker workplace's picking group.

## Why

The mass-printing scan resolved the demand-search warehouse from the scanned LU's locator. When stock is stored in one warehouse and brought to a packing workplace in another warehouse of the same picking group, the open shipment schedules live in the workplace warehouse, so the LU-warehouse-scoped search found nothing and packed 0 units.

## Changes

- `MassPrintingService.scan()` now builds a `PickingJobQuery` mirroring the picking launcher (picker, workplace warehouse, `scheduledForWorkplaceId` when `isConsiderOnlyJobScheduledToWorkplace`, `pickOnlyCustomerIds`) and resolves eligible schedules via the shared `PickingJobService.streamPackageable(...)` seam, intersected with the self-packed products on the LU. Removes the bespoke `PackageableQuery` and the now-redundant other-user-lock filter (inherited from the reused query).
- Adds a guard: if the picker is assigned to a workplace, the scanned LU's locator must belong to that workplace's picking group, else the scan is rejected with a typed message.
- New `AD_Message` for that rejection.
- Cucumber coverage: cross-warehouse pack (LU in another warehouse of the same picking group) + LU-not-in-group rejection.
