### PR TITLE
Historical Shipments JSON — add CountryOfOrigin to parcel items

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipper/nShiftShipment.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipper/nShiftShipment.feature
@@ -446,8 +446,8 @@ Feature: nShift Shipment
       | customerContact_coo | nShift Customer Contact2 | customer      | contact2@nshift-test.example | +41 79 123 45 68 |
     # One order for product (20 PCE) and product2 (8 PCE) — the system picks from both IT and DE batches
     And metasfresh contains C_Orders:
-      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | M_Shipper_ID    | AD_User_ID          |
-      | so_coo     | true    | customer      | 2025-04-01  | wh_coo         | nShift_coo_test | customerContact_coo |
+      | Identifier | REST.Context | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID | M_Shipper_ID    | AD_User_ID          |
+      | so_coo     | order_coo_ID | true    | customer      | 2025-04-01  | wh_coo         | nShift_coo_test | customerContact_coo |
     And metasfresh contains C_OrderLines:
       | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
       | so_coo_l1  | so_coo     | product      | 20         |
@@ -504,6 +504,64 @@ Feature: nShift Shipment
       | cso_coo                  | nShift Product   | DE              | 13         | 10    | 130        | 27.3            | 12345678            |
       | cso_coo                  | nShift Product 2 | IT              | 5          | 5     | 25         | 6.0             | 12345678            |
       | cso_coo                  | nShift Product 2 | DE              | 3          | 5     | 15         | 3.6             | 12345678            |
+    # gh30205 — the per-country-of-origin content lines must be distinguishable in the Historical Shipments JSON export
+    And the following API_Audit_Config records are created:
+      | Identifier | SeqNo | OPT.Method | OPT.PathPrefix   | IsForceProcessedAsync | IsSynchronousAuditLoggingEnabled | IsWrapApiResponse |
+      | c_coo      | 10    | GET        | api/v2/processes | N                     | Y                                | N                 |
+    And add HTTP headers
+      | Key          | Value                          |
+      | Content-Type | application/json;charset=UTF-8 |
+      | accept       | application/json;charset=UTF-8 |
+    When a 'POST' request with the below payload and headers from context is sent to the metasfresh REST-API 'api/v2/processes/Historical_Shipments_JSON/invoke' and fulfills with '200' status code
+    """
+{
+  "processParameters": [
+    {
+      "name": "Order_ID",
+      "value": "@order_coo_ID@"
+    }
+  ]
+}
+    """
+    Then the metasfresh REST-API responds with
+    """
+[
+  {
+    "Order_ID": @order_coo_ID@,
+    "Parcels": [
+      {
+        "Carrier": "nShift COO Test",
+        "Items": [
+          {
+            "ProductValue": "nshift_product",
+            "ProductName": "nShift Product",
+            "QtyShipped": 7,
+            "CountryOfOrigin": "IT"
+          },
+          {
+            "ProductValue": "nshift_product",
+            "ProductName": "nShift Product",
+            "QtyShipped": 13,
+            "CountryOfOrigin": "DE"
+          },
+          {
+            "ProductValue": "product2",
+            "ProductName": "nShift Product 2",
+            "QtyShipped": 5,
+            "CountryOfOrigin": "IT"
+          },
+          {
+            "ProductValue": "product2",
+            "ProductName": "nShift Product 2",
+            "QtyShipped": 3,
+            "CountryOfOrigin": "DE"
+          }
+        ]
+      }
+    ]
+  }
+]
+    """
 
 
   @Id:S0355_DeliveryOrder_120

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inout/5807440_sys_gh30205_historical_m_inout_json_v.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inout/5807440_sys_gh30205_historical_m_inout_json_v.sql
@@ -1,7 +1,14 @@
-DROP VIEW IF EXISTS historical_m_inout_json_v
+-- Source DDL: backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/views/historical_m_inout_json_v.sql
+-- gh30205: add CountryOfOrigin to the Historical Shipments JSON parcel items.
+--   * Parcels[].Items[] now emits 'CountryOfOrigin' = carrier_shipmentorder_item.CountryOfOrigin
+--     (ISO 3166-1 alpha-2), so the per-origin item rows produced by the country-of-origin split
+--     (gh30044 / PR 24363) are no longer indistinguishable duplicate products in the export.
+--   * Everything else is unchanged from 5806060_sys_gh30196 (the immediately preceding view revision).
+
+DROP VIEW IF EXISTS historical_m_inout_json_v$new
 ;
 
-CREATE OR REPLACE VIEW historical_m_inout_json_v AS
+CREATE OR REPLACE VIEW historical_m_inout_json_v$new AS
 SELECT io.m_inout_id                                      AS "Shipment_ID",
        io.documentno                                      AS "Shipment_DocumentNo",
        io.movementdate                                    AS "Shipment_Date",
@@ -119,4 +126,15 @@ FROM m_inout io
 WHERE io.isactive = 'Y'
   AND io.processed = 'Y' /*only output items where movementdate won't change */
 ORDER BY io.movementdate, io.m_inout_id
+;
+
+SELECT db_alter_view(
+    'historical_m_inout_json_v',
+    (SELECT view_definition
+     FROM information_schema.views
+     WHERE lower(views.table_name) = lower('historical_m_inout_json_v$new'))
+)
+;
+
+DROP VIEW IF EXISTS historical_m_inout_json_v$new
 ;


### PR DESCRIPTION
Emit `CountryOfOrigin` (from `carrier_shipmentorder_item.CountryOfOrigin`, ISO 3166-1 alpha-2) in the per-parcel `Items` aggregate of `historical_m_inout_json_v`.

Background: the country-of-origin split makes a single product produce multiple `Carrier_ShipmentOrder_Item` rows (one per origin). Without this field those appear as indistinguishable duplicate products in the Historical Shipments JSON export. This adds the origin so each item is distinguishable.

- Canonical DDL `historical_m_inout_json_v.sql` updated; new migration `5807440` recreates the view via `db_alter_view` (prior view migrations untouched).
- Cucumber coverage: extended the mixed-origin scenario in `nShiftShipment.feature` to invoke `Historical_Shipments_JSON` and assert the distinct per-item `CountryOfOrigin` in `Parcels[].Items[]`.
- No Java, no AD metadata change.