### PR TITLE
Transport Order — packing material without dimension UOM must not abort package creation

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/impl/HUPackingMaterialDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inout/impl/HUPackingMaterialDAO.java
@@ -116,6 +116,13 @@ public class HUPackingMaterialDAO implements IHUPackingMaterialDAO
 	@Override
 	public PackageDimensions retrievePackageDimensions(@NonNull final I_M_HU_PackingMaterial packingMaterial, @NonNull final UomId toUomId)
 	{
+		if (packingMaterial.getC_UOM_Dimension_ID() <= 0)
+		{
+			// A packing material without a dimension UOM has unknown dimensions;
+			// return UNSPECIFIED rather than letting UomId.ofRepoId(0) abort package creation.
+			return PackageDimensions.UNSPECIFIED;
+		}
+
 		final UomId fromUomId = UomId.ofRepoId(packingMaterial.getC_UOM_Dimension_ID());
 
 		final IUOMConversionBL iuomConversionBL = Services.get(IUOMConversionBL.class);

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/inout/impl/HUPackingMaterialDAOTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/inout/impl/HUPackingMaterialDAOTest.java
@@ -45,7 +45,7 @@ class HUPackingMaterialDAOTest
 	}
 
 	/**
-	 * me03 30369: a packing material without a dimension UOM (C_UOM_Dimension_ID = 0) must not abort package
+	 * A packing material without a dimension UOM (C_UOM_Dimension_ID = 0) must not abort package
 	 * creation. Before the fix, {@code retrievePackageDimensions} ran {@code UomId.ofRepoId(0)} and threw
 	 * "Assumption failure: C_UOM_ID > 0 but it was 0", which aborted "Erstelle Packstücke aus Picking Slots"
 	 * and left the Transportauftrag lineless. Dimensions are optional → expect UNSPECIFIED.
@@ -55,10 +55,11 @@ class HUPackingMaterialDAOTest
 	{
 		final I_M_HU_PackingMaterial packingMaterial = newInstance(I_M_HU_PackingMaterial.class);
 		packingMaterial.setName("no dimension UOM");
-		// C_UOM_Dimension_ID intentionally left 0 — the sp80 production condition (80 of 100 packing materials).
+		// C_UOM_Dimension_ID intentionally left at 0 — the reported production condition (many packing materials had no dimension UOM set).
 		saveRecord(packingMaterial);
 
-		final PackageDimensions dimensions = huPackingMaterialDAO.retrievePackageDimensions(packingMaterial, UomId.ofRepoId(540047));
+		// toUomId is irrelevant here — the guard returns UNSPECIFIED before it is read.
+		final PackageDimensions dimensions = huPackingMaterialDAO.retrievePackageDimensions(packingMaterial, UomId.ofRepoId(1));
 
 		assertThat(dimensions).isEqualTo(PackageDimensions.UNSPECIFIED);
 	}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/inout/impl/HUPackingMaterialDAOTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/inout/impl/HUPackingMaterialDAOTest.java
@@ -1,0 +1,65 @@
+package de.metas.handlingunits.inout.impl;
+
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.handlingunits.model.I_M_HU_PackingMaterial;
+import de.metas.product.PackageDimensions;
+import de.metas.uom.UomId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HUPackingMaterialDAOTest
+{
+	private HUPackingMaterialDAO huPackingMaterialDAO;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		huPackingMaterialDAO = new HUPackingMaterialDAO();
+	}
+
+	/**
+	 * me03 30369: a packing material without a dimension UOM (C_UOM_Dimension_ID = 0) must not abort package
+	 * creation. Before the fix, {@code retrievePackageDimensions} ran {@code UomId.ofRepoId(0)} and threw
+	 * "Assumption failure: C_UOM_ID > 0 but it was 0", which aborted "Erstelle Packstücke aus Picking Slots"
+	 * and left the Transportauftrag lineless. Dimensions are optional → expect UNSPECIFIED.
+	 */
+	@Test
+	void retrievePackageDimensions_noDimensionUom_returnsUnspecified()
+	{
+		final I_M_HU_PackingMaterial packingMaterial = newInstance(I_M_HU_PackingMaterial.class);
+		packingMaterial.setName("no dimension UOM");
+		// C_UOM_Dimension_ID intentionally left 0 — the sp80 production condition (80 of 100 packing materials).
+		saveRecord(packingMaterial);
+
+		final PackageDimensions dimensions = huPackingMaterialDAO.retrievePackageDimensions(packingMaterial, UomId.ofRepoId(540047));
+
+		assertThat(dimensions).isEqualTo(PackageDimensions.UNSPECIFIED);
+	}
+}


### PR DESCRIPTION
## Problem
`HUPackingMaterialDAO.retrievePackageDimensions` resolves the source UOM with
`UomId.ofRepoId(packingMaterial.getC_UOM_Dimension_ID())`. When a packing material has no dimension UOM
(`C_UOM_Dimension_ID = 0`), this throws `Assumption failure: C_UOM_ID > 0 but it was 0`.

Since package-dimension computation was wired into `HUPackageBL.createM_Package`, that assertion now aborts
package creation from picking slots (`M_ShippingPackage_CreateFromPickingSlots`), leaving the shipper
transportation without any `M_ShippingPackage` lines.

## Fix
Package dimensions are optional metadata and must never break package creation. When `C_UOM_Dimension_ID <= 0`,
`retrievePackageDimensions` now returns `PackageDimensions.UNSPECIFIED` — the same "dimensions unknown" outcome
the sibling branches in `HUPackageBL.getPackageDimensions` already produce. The conversion path for packing
materials that DO have a dimension UOM is untouched (no behaviour change there).

## Change
- `HUPackingMaterialDAO.retrievePackageDimensions`: early-return `PackageDimensions.UNSPECIFIED` when no dimension UOM.
- Adds `HUPackingMaterialDAOTest` covering the no-dimension-UOM case (reproduces the assertion before the fix).
