### PR TITLE
DD_Order picking replenishment: warehouse-default locator fallback + reconcile-decision logging (me03 30333)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceService.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceService.java
@@ -105,4 +105,20 @@ public class WorkplaceService
 			return warehouseBL.getLocatorIdsByWarehouseId(workplace.getWarehouseId());
 		}
 	}
+
+	/**
+	 * The single target locator to deliver to for this workplace: the configured {@code PickFrom_Locator_ID} if set,
+	 * otherwise the workplace warehouse's default locator (always resolvable via
+	 * {@link IWarehouseBL#getOrCreateDefaultLocatorId(WarehouseId)}). Use this when exactly one delivery locator is
+	 * required (e.g. the DD_Order picking-replenishment target); {@link #getPickFromLocatorIds(Workplace)} returns the
+	 * multi-locator set used for availability/source filtering.
+	 */
+	@NonNull
+	public LocatorId getPickFromLocatorIdOrWarehouseDefault(@NonNull final Workplace workplace)
+	{
+		final LocatorId pickFromLocatorId = workplace.getPickFromLocatorId();
+		return pickFromLocatorId != null
+				? pickFromLocatorId
+				: warehouseBL.getOrCreateDefaultLocatorId(workplace.getWarehouseId());
+	}
 }

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/distributionOrder/dd_order_replenishment/DDOrderReplenishment_locator_fallback.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/distributionOrder/dd_order_replenishment/DDOrderReplenishment_locator_fallback.feature
@@ -1,0 +1,105 @@
+@from:cucumber
+@allure.label.epic:E0106_Distribution
+@allure.label.feature:F5111_DDOrder_Replenishment
+@ghActions:run_on_executor7
+Feature: DD_Order replenishment — fall back to the packing warehouse's default locator when the workplace has no pick-from locator
+  As a warehouse operator running a packing workplace ("Packtisch") whose workplace has no explicit pick-from locator,
+  I want the replenishment to still create the distribution order and deliver the goods to the packing warehouse's
+  default locator, so that the picker always gets a DD_Order to work from even when the workplace's
+  PickFrom_Locator_ID was never configured.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-05-17T13:30:13+01:00[Europe/Berlin]
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier    |
+      | pricingSystem |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | priceList  | pricingSystem      | DE           | EUR           | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier       | M_PriceList_ID |
+      | priceListVersion | priceList      |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | priceListVersion       | product      | 10.0     | PCE      | Normal           |
+    And metasfresh contains C_BPartners:
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID |
+      | customer   | N        | Y          | pricingSystem      |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier       | GLN          | C_BPartner_ID |
+      | customerLocation | bPLocation_1 | customer      |
+    And contains M_Shippers
+      | Identifier |
+      | shipper    |
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID | C_BPartner_ID | C_BPartner_Location_ID | IsInTransit |
+      | inTransitWH    | customer      | customerLocation       | true        |
+
+  @from:cucumber
+  Scenario: A workplace without a PickFrom_Locator_ID still creates a DD_Order, delivering to the packing warehouse's default locator
+    # The stocking warehouse holds the goods; the packing warehouse is where the picker delivers them.
+    Given metasfresh contains DD_NetworkDistribution
+      | DD_NetworkDistribution_ID |
+      | network                   |
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID | C_BPartner_ID | C_BPartner_Location_ID |
+      | stockWH        | customer      | customerLocation       |
+    # The packing warehouse's default locator is captured (via getOrCreateDefaultLocator) so it can be asserted as
+    # the fallback target locator — the workplace itself has NO PickFrom_Locator_ID.
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID | C_BPartner_ID | C_BPartner_Location_ID | MRP_Exclude | IsAutoDistributionOrder | DD_NetworkDistribution_ID | M_Locator_ID          |
+      | packingWH      | customer      | customerLocation       | Y           | Y                       | network                   | packingDefaultLocator |
+    And metasfresh contains DD_NetworkDistributionLine
+      | DD_NetworkDistribution_ID | M_Warehouse_ID | M_WarehouseSource_ID | M_Shipper_ID |
+      | network                   | packingWH      | stockWH              | shipper      |
+    # The picker's workstation is on the packing warehouse but has NO PickFrom_Locator_ID — the replenishment must
+    # fall back to the packing warehouse's default locator (packingDefaultLocator) as the delivery target.
+    And metasfresh contains C_Workplaces
+      | Identifier | M_Warehouse_ID |
+      | workplace  | packingWH      |
+
+    # On-hand stock in the source warehouse (single locator, qty 5).
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | stockInventory            | 2021-10-12   | stockWH        |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | stockInventory            | stockInventoryLine            | product                 | 0       | 5        | PCE          |
+    And complete inventory with inventoryIdentifier 'stockInventory'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | stockInventoryLine            | stockProductHU     |
+
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID |
+      | order      | true    | customer      | 2022-05-17  | packingWH      |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | orderLine  | order      | product      | 5          |
+    And the order identified by order is completed
+
+    Then after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier       | C_OrderLine_ID | Warehouse_ID |
+      | shipmentSchedule | orderLine      | packingWH    |
+
+    # Assigning the schedule line to the workstation (with QtyToPick=5) fires the M_Picking_Job_Schedule
+    # interceptor, which reconciles. The workplace has no PickFrom_Locator_ID — the fix must still create the
+    # DD_Order and deliver to the packing warehouse's default locator.
+    When create or update picking job schedules
+      | M_Picking_Job_Schedule_ID | M_ShipmentSchedule_ID | C_Workplace_ID | QtyToPick |
+      | jobSchedule               | shipmentSchedule      | workplace      | 5         |
+
+    # Exactly one Completed DD_Order, qty 5, source stockWH, target locator = the packing warehouse's DEFAULT
+    # locator (the fallback), with both DD_Order and DD_OrderLine referencing the assignment.
+    Then after not more than 120s, the DD_Order linked to picking job schedule is found:
+      | M_Picking_Job_Schedule_ID | DocStatus | M_Warehouse_From_ID | M_Warehouse_To_ID | M_LocatorTo_ID        | QtyEntered |
+      | jobSchedule               | CO        | stockWH             | packingWH         | packingDefaultLocator | 5          |
+    # The async reconcile event handler records a Done AD_EventLog_Entry on success.
+    And after not more than 10s, an AD_EventLog_Entry for the replenishment event handler is found:
+      | M_Picking_Job_Schedule_ID | IsError |
+      | jobSchedule               | false   |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderPickingReplenishmentService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderPickingReplenishmentService.java
@@ -36,6 +36,7 @@ import de.metas.uom.IUOMConversionBL;
 import de.metas.uom.UOMConversionContext;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
+import de.metas.workplace.Workplace;
 import de.metas.workplace.WorkplaceId;
 import de.metas.workplace.WorkplaceService;
 import lombok.NonNull;
@@ -76,8 +77,6 @@ public class DDOrderPickingReplenishmentService
 	private static final AdMessageKey MSG_DDOrderPickingReplenishment_MandatoryNetwork = AdMessageKey.of("DDOrderPickingReconcile_MandatoryNetwork");
 	@VisibleForTesting
 	static final AdMessageKey MSG_DDOrderPickingReplenishment_QtyZero = AdMessageKey.of("DDOrderPickingReconcile_QtyZero");
-	@VisibleForTesting
-	static final AdMessageKey MSG_DDOrderPickingReplenishment_NoPickFromLocator = AdMessageKey.of("DDOrderPickingReconcile_NoPickFromLocator");
 
 	// FQN trx-property key: avoids collisions with any other service that might register an
 	// after-commit accumulator under a shorter, easier-to-clash name.
@@ -287,18 +286,21 @@ public class DDOrderPickingReplenishmentService
 		final I_M_Warehouse targetWarehouse = warehouseBL.getById(targetWarehouseId);
 		final ProductId productId = ProductId.ofRepoId(schedule.getM_Product_ID());
 
-		// Target locator = the workstation's configured pick-from locator. If unset there is nowhere to deliver
-		// to → skip (informational log, no DD_Order). Mirrors the network-gap soft-fail.
+		// Target locator = the workstation's configured pick-from locator; if unset, fall back to the workplace
+		// warehouse's default locator (getOrCreateDefaultLocatorId always yields one). There is therefore no
+		// "no pick-from locator" skip — the goods always have a delivery target. The fallback is logged so an
+		// operator can see the goods were routed to the warehouse default rather than a configured pick shelf.
 		final WorkplaceId workplaceId = jobSchedule.getWorkplaceId();
-		final LocatorId locatorToId = workplaceService.getById(workplaceId).getPickFromLocatorId();
-		if (locatorToId == null)
+		final Workplace workplace = workplaceService.getById(workplaceId);
+		final LocatorId locatorToId = workplaceService.getPickFromLocatorIdOrWarehouseDefault(workplace);
+		if (workplace.getPickFromLocatorId() == null)
 		{
 			Loggables.addLog(
-					"{0}: C_Workplace_ID={1} has no PickFrom_Locator_ID for M_Picking_Job_Schedule_ID={2}; no DD_Order will be created",
-					MSG_DDOrderPickingReplenishment_NoPickFromLocator.toAD_Message(),
+					"DD_Order picking replenishment: C_Workplace_ID={0} has no PickFrom_Locator_ID for"
+							+ " M_Picking_Job_Schedule_ID={1}; falling back to the warehouse default M_Locator_ID={2}",
 					workplaceId.getRepoId(),
-					jobScheduleId.getRepoId());
-			return;
+					jobScheduleId.getRepoId(),
+					locatorToId.getRepoId());
 		}
 
 		final DistributionNetworkId networkId = DistributionNetworkId.ofRepoIdOrNull(targetWarehouse.getDD_NetworkDistribution_ID());
@@ -370,6 +372,14 @@ public class DDOrderPickingReplenishmentService
 						.bpartnerId(BPartnerId.ofRepoIdOrNull(schedule.getC_BPartner_ID()))
 						.build());
 				ddOrderService.complete(DDOrderId.ofRepoId(ddOrder.getDD_Order_ID()));
+				Loggables.addLog(
+						"DD_Order picking replenishment: created DD_Order_ID={0} qty={1} from source M_Locator_ID={2}"
+								+ " to target M_Locator_ID={3} for M_Picking_Job_Schedule_ID={4}",
+						ddOrder.getDD_Order_ID(),
+						locatorQty.toBigDecimal(),
+						sourceLocatorId.getRepoId(),
+						locatorToId.getRepoId(),
+						jobScheduleId.getRepoId());
 			}
 		}
 	}
@@ -580,6 +590,11 @@ public class DDOrderPickingReplenishmentService
 		line.setQtyOrdered(newQtyBD);
 		line.setTargetQty(newQtyBD);
 		ddOrderLowLevelDAO.save(line);
+		Loggables.addLog(
+				"DD_Order picking replenishment: updated DD_OrderLine_ID={0} (DD_Order_ID={1}) qty in place to {2}",
+				line.getDD_OrderLine_ID(),
+				line.getDD_Order_ID(),
+				newQtyBD);
 	}
 
 	/**
@@ -653,6 +668,7 @@ public class DDOrderPickingReplenishmentService
 			throw new AdempiereException(MSG_DDOrderPickingReplenishment_PickerBusy, existingDDOrderId);
 		}
 		ddOrderService.voidIt(existingDDOrderId);
+		Loggables.addLog("DD_Order picking replenishment: voided DD_Order_ID={0}", existingDDOrderId.getRepoId());
 
 		// Null the back-reference to M_Picking_Job_Schedule on the (now voided) DD_Order header and its lines.
 		// voidIt does NOT clear it, so when the void runs synchronously inside the assignment's delete transaction


### PR DESCRIPTION
Follow-up fix for the DD_Order picking-replenishment feature (me03 https://github.com/metasfresh/me03/issues/30333), found during UAT on danthermuat.

### Problem
An assignment whose workstation (`C_Workplace`) has **no `PickFrom_Locator_ID`** produced **no DD_Order** — the reconcile hit a silent `NoPickFromLocator` skip. (The whole-qty DD_Order seen on the instance was a pre-rollout, old-design leftover, unrelated.)

### Fix
- **Target-locator fallback (AC3, amended):** the DD_Order target locator is `C_Workplace.PickFrom_Locator_ID`; if unset, it now falls back to the **default locator of the workstation's warehouse** (`C_Workplace.M_Warehouse_ID`) via `WarehouseBL.getOrCreateDefaultLocatorId`, which always resolves. The `NoPickFromLocator` skip (and its now-unused `AdMessageKey`) are removed. New `WorkplaceService.getPickFromLocatorIdOrWarehouseDefault` mirrors the existing `getPickFromLocatorIds` shape.
- **Observability (AC11, new):** every meaningful reconcile decision is logged via `Loggables` → `AD_EventLog_Entry`: DD_Order created (qty + source/target locator), line updated in place, DD_Order(s) voided, and the warehouse-default fallback used. The high-frequency non-Auto-Distribution-Order no-op stays silent (no log spam).
- **Test (AC9, trigger-path gap):** `DDOrderReplenishment_locator_fallback.feature` drives a real `M_Picking_Job_Schedule` create **through the model** (interceptor → reconcile), asserting the DD_Order lands at the warehouse default locator. Confirmed RED before the fix, GREEN after (locally, against the dt204 stack).

Single core change on `deep_tundra_release`; no customer-repo override.
