### PR TITLE
OLCand warehouse resolution: add BP picking warehouse level

### DIFF
--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/IOLCandBL.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/IOLCandBL.java
@@ -122,9 +122,14 @@ public interface IOLCandBL extends ISingletonService
 	 * Return the warehouse to use for the given {@code olCand}.
 	 * <ul>
 	 * <li>if C_OLCand.M_Warehouse_ID > 0, then return that</li>
-	 * <li>else if the effective business partner is a customer with a picking warehouse set, then return that</li>
-	 * <li>else, if the processor has a warehouse set, then return that</li>
+	 * <li>else if the effective business partner is a customer ({@code isCustomer=true}) with a picking warehouse set ({@code isPickingWarehouse=true}), then return that</li>
+	 * <li>else return the warehouse from {@code orderDefaults} (typically the processor's default), or {@code null} if not set</li>
 	 * </ul>
+	 * <p>
+	 * Note: unlike most peer methods in this interface, this method does not accept a {@link BPartnerOrderParams} parameter
+	 * because {@link BPartnerOrderParams} does not currently carry a warehouse field.
+	 * The BP picking warehouse is resolved internally from the effective BP record.
+	 * </p>
 	 */
 	@Nullable
 	WarehouseId getWarehouseId(@NonNull I_C_OLCand olCand, @Nullable OLCandOrderDefaults orderDefaults);

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/IOLCandBL.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/IOLCandBL.java
@@ -126,8 +126,8 @@ public interface IOLCandBL extends ISingletonService
 	 * <li>else return the warehouse from {@code orderDefaults} (typically the processor's default), or {@code null} if not set</li>
 	 * </ul>
 	 * <p>
-	 * Note: unlike most peer methods in this interface, this method does not accept a {@link BPartnerOrderParams} parameter
-	 * because {@link BPartnerOrderParams} does not currently carry a warehouse field.
+	 * Note: unlike most peer methods in this interface, this method does not accept a {@link de.metas.order.BPartnerOrderParams} parameter
+	 * because {@link de.metas.order.BPartnerOrderParams} does not currently carry a warehouse field.
 	 * The BP picking warehouse is resolved internally from the effective BP record.
 	 * </p>
 	 */

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/IOLCandBL.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/IOLCandBL.java
@@ -45,6 +45,7 @@ import de.metas.util.ISingletonService;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
+import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.PO;
 
 import javax.annotation.Nullable;
@@ -116,6 +117,17 @@ public interface IOLCandBL extends ISingletonService
 	 * </ul>
 	 */
 	PricingSystemId getPricingSystemId(@NonNull I_C_OLCand olCand, @Nullable BPartnerOrderParams bPartnerOrderParams, @Nullable OLCandOrderDefaults orderDefaults);
+
+	/**
+	 * Return the warehouse to use for the given {@code olCand}.
+	 * <ul>
+	 * <li>if C_OLCand.M_Warehouse_ID > 0, then return that</li>
+	 * <li>else if the effective business partner is a customer with a picking warehouse set, then return that</li>
+	 * <li>else, if the processor has a warehouse set, then return that</li>
+	 * </ul>
+	 */
+	@Nullable
+	WarehouseId getWarehouseId(@NonNull I_C_OLCand olCand, @Nullable OLCandOrderDefaults orderDefaults);
 
 	ShipperId getShipperId(@Nullable BPartnerOrderParams bPartnerOrderParams, @Nullable OLCandOrderDefaults orderDefaults, @Nullable I_C_OLCand olCandRecord);
 

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
@@ -216,7 +216,7 @@ class OLCandOrderFactory
 		// use values from orderDefaults when the order candidate doesn't have such values
 		order.setC_DocTypeTarget_ID(DocTypeId.toRepoId(orderDefaults.getDocTypeTargetId()));
 
-		order.setM_Warehouse_ID(WarehouseId.toRepoId(CoalesceUtil.coalesce(candidateOfGroup.getWarehouseId(), orderDefaults.getWarehouseId())));
+		order.setM_Warehouse_ID(WarehouseId.toRepoId(olcandBL.getWarehouseId(candidateOfGroup.unbox(), orderDefaults)));
 
 		// use the values from 'olCand'
 		order.setAD_Org_ID(candidateOfGroup.getAD_Org_ID());

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
@@ -121,13 +121,6 @@ public class OLCandBL implements IOLCandBL
 
 	public OLCandBL(
 			@NonNull final IBPartnerBL bpartnerBL,
-			@NonNull final BPartnerOrderParamsRepository bPartnerOrderParamsRepository)
-	{
-		this(bpartnerBL, bPartnerOrderParamsRepository, Services.get(IWarehouseDAO.class));
-	}
-
-	public OLCandBL(
-			@NonNull final IBPartnerBL bpartnerBL,
 			@NonNull final BPartnerOrderParamsRepository bPartnerOrderParamsRepository,
 			@NonNull final IWarehouseDAO warehouseDAO)
 	{

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
@@ -114,17 +114,26 @@ public class OLCandBL implements IOLCandBL
 	private final IPriceListDAO priceListDAO = Services.get(IPriceListDAO.class);
 	private final IUserDAO userDAO = Services.get(IUserDAO.class);
 	private final IErrorManager errorManager = Services.get(IErrorManager.class);
-	private final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
 
 	private final IBPartnerBL bpartnerBL;
 	private final BPartnerOrderParamsRepository bPartnerOrderParamsRepository;
+	private final IWarehouseDAO warehouseDAO;
 
 	public OLCandBL(
 			@NonNull final IBPartnerBL bpartnerBL,
 			@NonNull final BPartnerOrderParamsRepository bPartnerOrderParamsRepository)
 	{
+		this(bpartnerBL, bPartnerOrderParamsRepository, Services.get(IWarehouseDAO.class));
+	}
+
+	public OLCandBL(
+			@NonNull final IBPartnerBL bpartnerBL,
+			@NonNull final BPartnerOrderParamsRepository bPartnerOrderParamsRepository,
+			@NonNull final IWarehouseDAO warehouseDAO)
+	{
 		this.bpartnerBL = bpartnerBL;
 		this.bPartnerOrderParamsRepository = bPartnerOrderParamsRepository;
+		this.warehouseDAO = warehouseDAO;
 	}
 
 	@Override

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
@@ -78,9 +78,13 @@ import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.impl.TableRecordReference;
+import org.adempiere.warehouse.WarehouseId;
+import org.adempiere.warehouse.api.IWarehouseDAO;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_AD_Note;
 import org.compiere.model.I_AD_User;
+import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_M_Warehouse;
 import org.compiere.model.MNote;
 import org.compiere.model.PO;
 import org.compiere.util.Env;
@@ -315,6 +319,35 @@ public class OLCandBL implements IOLCandBL
 				locationShipperId,
 				bpartnerOrderParamsShipperId,
 				orderDefaultsShipperId);
+	}
+
+	@Nullable
+	@Override
+	public WarehouseId getWarehouseId(
+			@NonNull final I_C_OLCand olCand,
+			@Nullable final OLCandOrderDefaults orderDefaults)
+	{
+		final WarehouseId olCandWarehouseId = WarehouseId.ofRepoIdOrNull(olCand.getM_Warehouse_ID());
+		if (olCandWarehouseId != null)
+		{
+			return olCandWarehouseId;
+		}
+
+		final I_C_BPartner bp = effectiveValuesBL.getC_BPartner_Effective(olCand);
+		if (bp != null && bp.isCustomer())
+		{
+			final WarehouseId bpWarehouseId = WarehouseId.ofRepoIdOrNull(bp.getM_Warehouse_ID());
+			if (bpWarehouseId != null)
+			{
+				final I_M_Warehouse warehouse = Services.get(IWarehouseDAO.class).getById(bpWarehouseId);
+				if (warehouse.isPickingWarehouse())
+				{
+					return bpWarehouseId;
+				}
+			}
+		}
+
+		return orderDefaults != null ? orderDefaults.getWarehouseId() : null;
 	}
 
 	@Override

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
@@ -114,6 +114,7 @@ public class OLCandBL implements IOLCandBL
 	private final IPriceListDAO priceListDAO = Services.get(IPriceListDAO.class);
 	private final IUserDAO userDAO = Services.get(IUserDAO.class);
 	private final IErrorManager errorManager = Services.get(IErrorManager.class);
+	private final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
 
 	private final IBPartnerBL bpartnerBL;
 	private final BPartnerOrderParamsRepository bPartnerOrderParamsRepository;
@@ -339,7 +340,7 @@ public class OLCandBL implements IOLCandBL
 			final WarehouseId bpWarehouseId = WarehouseId.ofRepoIdOrNull(bp.getM_Warehouse_ID());
 			if (bpWarehouseId != null)
 			{
-				final I_M_Warehouse warehouse = Services.get(IWarehouseDAO.class).getById(bpWarehouseId);
+				final I_M_Warehouse warehouse = warehouseDAO.getById(bpWarehouseId);
 				if (warehouse.isPickingWarehouse())
 				{
 					return bpWarehouseId;

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
@@ -114,19 +114,17 @@ public class OLCandBL implements IOLCandBL
 	private final IPriceListDAO priceListDAO = Services.get(IPriceListDAO.class);
 	private final IUserDAO userDAO = Services.get(IUserDAO.class);
 	private final IErrorManager errorManager = Services.get(IErrorManager.class);
+	private final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
 
 	private final IBPartnerBL bpartnerBL;
 	private final BPartnerOrderParamsRepository bPartnerOrderParamsRepository;
-	private final IWarehouseDAO warehouseDAO;
 
 	public OLCandBL(
 			@NonNull final IBPartnerBL bpartnerBL,
-			@NonNull final BPartnerOrderParamsRepository bPartnerOrderParamsRepository,
-			@NonNull final IWarehouseDAO warehouseDAO)
+			@NonNull final BPartnerOrderParamsRepository bPartnerOrderParamsRepository)
 	{
 		this.bpartnerBL = bpartnerBL;
 		this.bPartnerOrderParamsRepository = bPartnerOrderParamsRepository;
-		this.warehouseDAO = warehouseDAO;
 	}
 
 	@Override

--- a/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
+++ b/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
@@ -27,10 +27,8 @@ import de.metas.order.BPartnerOrderParamsRepository;
 import de.metas.ordercandidate.api.impl.OLCandBL;
 import de.metas.ordercandidate.model.I_C_OLCand;
 import de.metas.user.UserRepository;
-import de.metas.util.Services;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.warehouse.WarehouseId;
-import org.adempiere.warehouse.api.IWarehouseDAO;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_M_Warehouse;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,8 +54,7 @@ class OLCandBLGetWarehouseIdTest
 		AdempiereTestHelper.get().init();
 		olCandBL = new OLCandBL(
 				new BPartnerBL(new UserRepository()),
-				BPartnerOrderParamsRepository.newInstanceForUnitTesting(),
-				Services.get(IWarehouseDAO.class)
+				BPartnerOrderParamsRepository.newInstanceForUnitTesting()
 		);
 	}
 

--- a/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
+++ b/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
@@ -27,8 +27,10 @@ import de.metas.order.BPartnerOrderParamsRepository;
 import de.metas.ordercandidate.api.impl.OLCandBL;
 import de.metas.ordercandidate.model.I_C_OLCand;
 import de.metas.user.UserRepository;
+import de.metas.util.Services;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.warehouse.WarehouseId;
+import org.adempiere.warehouse.api.IWarehouseDAO;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_M_Warehouse;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,7 +56,8 @@ class OLCandBLGetWarehouseIdTest
 		AdempiereTestHelper.get().init();
 		olCandBL = new OLCandBL(
 				new BPartnerBL(new UserRepository()),
-				BPartnerOrderParamsRepository.newInstanceForUnitTesting()
+				BPartnerOrderParamsRepository.newInstanceForUnitTesting(),
+				Services.get(IWarehouseDAO.class)
 		);
 	}
 
@@ -181,6 +184,23 @@ class OLCandBLGetWarehouseIdTest
 		saveRecord(olCand);
 
 		assertThat(olCandBL.getWarehouseId(olCand, null)).isNull();
+	}
+
+	@Test
+	void olCandNoWarehouse_bpCustomerWithPickingWarehouse_nullOrderDefaults_returnsBPPickingWarehouse()
+	{
+		final WarehouseId bpPickingId = createWarehouse("Ind9", true);
+
+		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+		bp.setIsCustomer(true);
+		bp.setM_Warehouse_ID(bpPickingId.getRepoId());
+		saveRecord(bp);
+
+		final I_C_OLCand olCand = newInstanceOutOfTrx(I_C_OLCand.class);
+		olCand.setC_BPartner_ID(bp.getC_BPartner_ID());
+		saveRecord(olCand);
+
+		assertThat(olCandBL.getWarehouseId(olCand, null)).isEqualTo(bpPickingId);
 	}
 
 	private WarehouseId createWarehouse(final String name, final boolean isPickingWarehouse)

--- a/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
+++ b/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
@@ -1,0 +1,167 @@
+/*
+ * #%L
+ * de.metas.salescandidate.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ordercandidate.api;
+
+import de.metas.bpartner.service.impl.BPartnerBL;
+import de.metas.order.BPartnerOrderParamsRepository;
+import de.metas.ordercandidate.api.impl.OLCandBL;
+import de.metas.ordercandidate.model.I_C_OLCand;
+import de.metas.user.UserRepository;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_M_Warehouse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstanceOutOfTrx;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the 3-level warehouse priority: OLCand record → BP picking warehouse → processor default.
+ * Regression: before the fix, the BP picking warehouse level was missing,
+ * so orders with no OLCand-level warehouse always fell through to the processor default (Stö2)
+ * instead of picking up the customer BP's picking warehouse (Ind9).
+ */
+class OLCandBLGetWarehouseIdTest
+{
+	private OLCandBL olCandBL;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		olCandBL = new OLCandBL(
+				new BPartnerBL(new UserRepository()),
+				BPartnerOrderParamsRepository.newInstanceForUnitTesting()
+		);
+	}
+
+	@Test
+	void olCandHasExplicitWarehouse_returnsOLCandWarehouse()
+	{
+		final WarehouseId processorDefaultId = createWarehouse("Stoe2", false);
+		final WarehouseId bpPickingId = createWarehouse("Ind9", true);
+		final WarehouseId olCandSpecificId = createWarehouse("Specific", false);
+
+		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+		bp.setIsCustomer(true);
+		bp.setM_Warehouse_ID(bpPickingId.getRepoId());
+		saveRecord(bp);
+
+		final I_C_OLCand olCand = newInstanceOutOfTrx(I_C_OLCand.class);
+		olCand.setC_BPartner_ID(bp.getC_BPartner_ID());
+		olCand.setM_Warehouse_ID(olCandSpecificId.getRepoId());
+		saveRecord(olCand);
+
+		final OLCandOrderDefaults orderDefaults = OLCandOrderDefaults.builder().warehouseId(processorDefaultId).build();
+
+		assertThat(olCandBL.getWarehouseId(olCand, orderDefaults)).isEqualTo(olCandSpecificId);
+	}
+
+	@Test
+	void olCandNoWarehouse_bpCustomerWithPickingWarehouse_returnsBPPickingWarehouse()
+	{
+		final WarehouseId processorDefaultId = createWarehouse("Stoe2", false);
+		final WarehouseId bpPickingId = createWarehouse("Ind9", true);
+
+		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+		bp.setIsCustomer(true);
+		bp.setM_Warehouse_ID(bpPickingId.getRepoId());
+		saveRecord(bp);
+
+		final I_C_OLCand olCand = newInstanceOutOfTrx(I_C_OLCand.class);
+		olCand.setC_BPartner_ID(bp.getC_BPartner_ID());
+		// M_Warehouse_ID deliberately not set
+		saveRecord(olCand);
+
+		final OLCandOrderDefaults orderDefaults = OLCandOrderDefaults.builder().warehouseId(processorDefaultId).build();
+
+		assertThat(olCandBL.getWarehouseId(olCand, orderDefaults)).isEqualTo(bpPickingId);
+	}
+
+	@Test
+	void olCandNoWarehouse_bpWarehouseNotPicking_returnsProcessorDefault()
+	{
+		final WarehouseId processorDefaultId = createWarehouse("Stoe2", false);
+		final WarehouseId nonPickingBpWarehouseId = createWarehouse("NonPicking", false);
+
+		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+		bp.setIsCustomer(true);
+		bp.setM_Warehouse_ID(nonPickingBpWarehouseId.getRepoId());
+		saveRecord(bp);
+
+		final I_C_OLCand olCand = newInstanceOutOfTrx(I_C_OLCand.class);
+		olCand.setC_BPartner_ID(bp.getC_BPartner_ID());
+		saveRecord(olCand);
+
+		final OLCandOrderDefaults orderDefaults = OLCandOrderDefaults.builder().warehouseId(processorDefaultId).build();
+
+		assertThat(olCandBL.getWarehouseId(olCand, orderDefaults)).isEqualTo(processorDefaultId);
+	}
+
+	@Test
+	void olCandNoWarehouse_bpNotCustomer_returnsProcessorDefault()
+	{
+		final WarehouseId processorDefaultId = createWarehouse("Stoe2", false);
+		final WarehouseId bpPickingId = createWarehouse("Ind9", true);
+
+		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+		bp.setIsCustomer(false);
+		bp.setM_Warehouse_ID(bpPickingId.getRepoId());
+		saveRecord(bp);
+
+		final I_C_OLCand olCand = newInstanceOutOfTrx(I_C_OLCand.class);
+		olCand.setC_BPartner_ID(bp.getC_BPartner_ID());
+		saveRecord(olCand);
+
+		final OLCandOrderDefaults orderDefaults = OLCandOrderDefaults.builder().warehouseId(processorDefaultId).build();
+
+		assertThat(olCandBL.getWarehouseId(olCand, orderDefaults)).isEqualTo(processorDefaultId);
+	}
+
+	@Test
+	void olCandNoWarehouse_noBP_returnsProcessorDefault()
+	{
+		final WarehouseId processorDefaultId = createWarehouse("Stoe2", false);
+
+		final I_C_OLCand olCand = newInstanceOutOfTrx(I_C_OLCand.class);
+		// C_BPartner_ID deliberately not set
+		saveRecord(olCand);
+
+		final OLCandOrderDefaults orderDefaults = OLCandOrderDefaults.builder().warehouseId(processorDefaultId).build();
+
+		assertThat(olCandBL.getWarehouseId(olCand, orderDefaults)).isEqualTo(processorDefaultId);
+	}
+
+	private WarehouseId createWarehouse(final String name, final boolean isPickingWarehouse)
+	{
+		final I_M_Warehouse warehouse = newInstanceOutOfTrx(I_M_Warehouse.class);
+		warehouse.setName(name);
+		warehouse.setValue(name);
+		warehouse.setIsPickingWarehouse(isPickingWarehouse);
+		saveRecord(warehouse);
+		return WarehouseId.ofRepoId(warehouse.getM_Warehouse_ID());
+	}
+}

--- a/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
+++ b/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
@@ -155,6 +155,34 @@ class OLCandBLGetWarehouseIdTest
 		assertThat(olCandBL.getWarehouseId(olCand, orderDefaults)).isEqualTo(processorDefaultId);
 	}
 
+	@Test
+	void olCandNoWarehouse_bpCustomerWithNoWarehouseSet_returnsProcessorDefault()
+	{
+		final WarehouseId processorDefaultId = createWarehouse("Stoe2", false);
+
+		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+		bp.setIsCustomer(true);
+		// M_Warehouse_ID deliberately not set on the BP
+		saveRecord(bp);
+
+		final I_C_OLCand olCand = newInstanceOutOfTrx(I_C_OLCand.class);
+		olCand.setC_BPartner_ID(bp.getC_BPartner_ID());
+		saveRecord(olCand);
+
+		final OLCandOrderDefaults orderDefaults = OLCandOrderDefaults.builder().warehouseId(processorDefaultId).build();
+
+		assertThat(olCandBL.getWarehouseId(olCand, orderDefaults)).isEqualTo(processorDefaultId);
+	}
+
+	@Test
+	void olCandNoWarehouse_nullOrderDefaults_returnsNull()
+	{
+		final I_C_OLCand olCand = newInstanceOutOfTrx(I_C_OLCand.class);
+		saveRecord(olCand);
+
+		assertThat(olCandBL.getWarehouseId(olCand, null)).isNull();
+	}
+
 	private WarehouseId createWarehouse(final String name, final boolean isPickingWarehouse)
 	{
 		final I_M_Warehouse warehouse = newInstanceOutOfTrx(I_M_Warehouse.class);


### PR DESCRIPTION
Add a missing middle tier to the 3-level warehouse priority (OLCand record → customer BP picking warehouse → processor default). Previously, OLCands with no explicit warehouse always fell through to the processor default (Stö2), bypassing the customer BP's picking warehouse (Ind9) configured on the Migros business partner.

Adds OLCandBL.getWarehouseId() with the full priority chain and updates OLCandOrderFactory to use it.