### PR TITLE
Auto Distribution Order — decouple packing close-out from picking

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/I_DD_Order.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/I_DD_Order.java
@@ -917,6 +917,27 @@ public interface I_DD_Order
 	String COLUMNNAME_IsInTransit = "IsInTransit";
 
 	/**
+	 * Set Is Picking Disconnected.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsPickingDisconnected (boolean IsPickingDisconnected);
+
+	/**
+	 * Get Is Picking Disconnected.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isPickingDisconnected();
+
+	ModelColumn<I_DD_Order, Object> COLUMN_IsPickingDisconnected = new ModelColumn<>(I_DD_Order.class, "IsPickingDisconnected", null);
+	String COLUMNNAME_IsPickingDisconnected = "IsPickingDisconnected";
+
+	/**
 	 * Set Printed.
 	 * Indicates if this document / line is printed
 	 *

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/X_DD_Order.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/X_DD_Order.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 public class X_DD_Order extends org.compiere.model.PO implements I_DD_Order, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = -1108292797L;
+	private static final long serialVersionUID = 988399147L;
 
     /** Standard Constructor */
     public X_DD_Order (final Properties ctx, final int DD_Order_ID, @Nullable final String trxName)
@@ -685,6 +685,18 @@ public class X_DD_Order extends org.compiere.model.PO implements I_DD_Order, org
 	public boolean isInTransit() 
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsInTransit);
+	}
+
+	@Override
+	public void setIsPickingDisconnected (final boolean IsPickingDisconnected)
+	{
+		set_Value (COLUMNNAME_IsPickingDisconnected, IsPickingDisconnected);
+	}
+
+	@Override
+	public boolean isPickingDisconnected() 
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsPickingDisconnected);
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807600_DD_Order_IsPickingDisconnected.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807600_DD_Order_IsPickingDisconnected.sql
@@ -1,0 +1,77 @@
+-- DD_Order picking replenishment — add DD_Order.IsPickingDisconnected flag.
+-- Technical, non-UI boolean: marks a replenishment DD_Order as detached from its
+-- M_Picking_Job_Schedule assignment when the shipment was closed-out independently
+-- (in-progress move). Set programmatically by the close-out reconcile; the guard /
+-- reconcile lookup filter on it. No AD_Field / AD_UI_Element — never surfaced on a window.
+--
+-- IDs allocated from idserver.metas.de on 2026-06-12:
+--   AD_MigrationScript  5807600 (this script)
+--   AD_Element          584990  (IsPickingDisconnected)
+--   AD_Column           592806  (DD_Order.IsPickingDisconnected)
+
+-- =============================================================================
+-- 1. AD_Element (new) — German base text; en_US via Trl
+-- =============================================================================
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                        ColumnName, EntityType, Name, PrintName)
+VALUES (584990 /*From ID Server*/, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-06-12 12:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+        TO_TIMESTAMP('2026-06-12 12:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+        'IsPickingDisconnected', 'D', 'Kommissionierung entkoppelt', 'Kommissionierung entkoppelt');
+
+-- Skeleton Trl rows (system languages; copy base, IsTranslated='N')
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Name, PrintName, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.Name, t.PrintName, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y') AND t.AD_Element_ID = 584990
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID);
+
+-- English translation
+UPDATE AD_Element_Trl
+   SET Name = 'Is Picking Disconnected', PrintName = 'Is Picking Disconnected', IsTranslated = 'Y',
+       Updated = TO_TIMESTAMP('2026-06-12 12:00:01','YYYY-MM-DD HH24:MI:SS')
+ WHERE AD_Element_ID = 584990 AND AD_Language = 'en_US';
+
+-- =============================================================================
+-- 2. AD_Column (DD_Order — lookup AD_Table_ID / AD_Element_ID by name)
+-- =============================================================================
+INSERT INTO AD_Column (AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                       Version, AD_Table_ID, AD_Element_ID, AD_Reference_ID,
+                       ColumnName, Name,
+                       FieldLength, IsMandatory, IsUpdateable, IsAlwaysUpdateable,
+                       DefaultValue, EntityType, IsKey, IsParent, IsSelectionColumn,
+                       IsTranslated, IsIdentifier, IsEncrypted, IsAllowLogging,
+                       IsExcludeFromZoomTargets, CloningStrategy,
+                       PersonalDataCategory)
+VALUES (592806 /*From ID Server*/, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-06-12 12:00:02','YYYY-MM-DD HH24:MI:SS'), 100,
+        TO_TIMESTAMP('2026-06-12 12:00:02','YYYY-MM-DD HH24:MI:SS'), 100,
+        0,
+        (SELECT AD_Table_ID FROM AD_Table WHERE TableName = 'DD_Order'),
+        (SELECT AD_Element_ID FROM AD_Element WHERE ColumnName = 'IsPickingDisconnected'),
+        20 /*Yes-No*/,
+        'IsPickingDisconnected', 'Kommissionierung entkoppelt',
+        1, 'Y', 'Y', 'N',
+        'N', 'D', 'N', 'N', 'N',
+        'N', 'N', 'N', 'Y',
+        'Y', 'XX',
+        'NP');
+
+-- Skeleton Trl rows
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND t.AD_Column_ID = 592806
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+-- =============================================================================
+-- 3. Physical DDL — mandatory boolean, backfilled to 'N'
+-- =============================================================================
+SELECT public.db_alter_table('DD_Order','ALTER TABLE public.DD_Order ADD COLUMN IsPickingDisconnected CHAR(1) DEFAULT ''N'' CHECK (IsPickingDisconnected IN (''Y'',''N'')) NOT NULL');
+
+-- =============================================================================
+-- 4. Propagate translations from AD_Element to AD_Column_Trl
+-- =============================================================================
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(
+  (SELECT AD_Element_ID FROM AD_Element WHERE ColumnName = 'IsPickingDisconnected')
+);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DDOrderPickingReplenishment_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DDOrderPickingReplenishment_StepDef.java
@@ -22,12 +22,18 @@
 
 package de.metas.cucumber.stepdefs.distributionorder;
 
+import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.StepDefUtil;
+import de.metas.cucumber.stepdefs.hu.M_HU_StepDefData;
 import de.metas.cucumber.stepdefs.shipmentschedule.M_ShipmentSchedule_StepDefData;
+import de.metas.distribution.ddorder.movement.schedule.DDOrderMoveScheduleStatus;
 import de.metas.event.model.I_AD_EventLog;
 import de.metas.event.model.I_AD_EventLog_Entry;
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.model.I_DD_Order_MoveSchedule;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.warehouse.api.IWarehouseDAO;
 import org.eevolution.model.I_DD_OrderLine;
 import de.metas.distribution.ddorder.replenishment.DDOrderPickingReplenishmentService;
 import de.metas.distribution.ddorder.replenishment.event.DDOrderReplenishmentEventHandler;
@@ -93,6 +99,7 @@ public class DDOrderPickingReplenishment_StepDef
 
 	@NonNull private final M_ShipmentSchedule_StepDefData shipmentScheduleTable;
 	@NonNull private final de.metas.cucumber.stepdefs.picking.M_Picking_Job_Schedule_StepDefData pickingJobScheduleTable;
+	@NonNull private final M_HU_StepDefData huTable;
 
 	/**
 	 * Directly invokes {@link DDOrderPickingReplenishmentService#reconcile(PickingJobScheduleId)} in
@@ -176,6 +183,66 @@ public class DDOrderPickingReplenishment_StepDef
 		{
 			line.setQtyInTransit(BigDecimal.ONE);
 			InterfaceWrapperHelper.save(line);
+		}
+	}
+
+	/**
+	 * Test seam: directly creates an IN-PROGRESS {@code DD_Order_MoveSchedule} (Status='IP') for the (single) line of
+	 * the DD_Order linked to the given picking job schedule, simulating a picker who has started moving the
+	 * replenishment stock — WITHOUT running the full mobile move-schedule flow. This is what
+	 * {@code DDOrderMoveScheduleService.hasInProgressSchedules(ddOrderId)} checks, and it drives the close-out
+	 * disposition down the DISCONNECT branch instead of CLOSE (AC5).
+	 *
+	 * <p>The move-schedule's mandatory columns (product/UOM/locators/warehouses) are copied from the DD_OrderLine; the
+	 * {@code PickFrom_HU_ID} is the given source HU.</p>
+	 *
+	 * <p>Required columns:</p>
+	 * <ul>
+	 *   <li>{@code M_Picking_Job_Schedule_ID} — identifier of the assignment whose DD_Order move is "in progress"</li>
+	 *   <li>{@code PickFrom_HU_ID} — identifier of the source HU being moved (any active HU in the scenario)</li>
+	 * </ul>
+	 */
+	@When("^simulate an in-progress replenishment move on DD_Order linked to picking job schedule:$")
+	public void simulate_in_progress_move(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::simulate_in_progress_move);
+	}
+
+	private void simulate_in_progress_move(@NonNull final DataTableRow row)
+	{
+		final PickingJobScheduleId jobScheduleId = pickingJobScheduleTable.getId(
+				row.getAsIdentifier(de.metas.inoutcandidate.model.I_M_Picking_Job_Schedule.COLUMNNAME_M_Picking_Job_Schedule_ID).getAsString());
+		final HuId pickFromHuId = row.getAsIdentifier("PickFrom_HU_ID").lookupNotNullIdIn(huTable);
+
+		final List<I_DD_OrderLine> lines = queryBL.createQueryBuilder(I_DD_OrderLine.class)
+				.addEqualsFilter(I_DD_OrderLine.COLUMNNAME_M_Picking_Job_Schedule_ID, jobScheduleId)
+				.addOnlyActiveRecordsFilter()
+				.create()
+				.list(I_DD_OrderLine.class);
+
+		assertThat(lines)
+				.as("DD_OrderLines for picking job schedule %s (must exist before simulating an in-progress move)", jobScheduleId.getRepoId())
+				.isNotEmpty();
+
+		final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
+		for (final I_DD_OrderLine line : lines)
+		{
+			final I_DD_Order_MoveSchedule moveSchedule = InterfaceWrapperHelper.newInstance(I_DD_Order_MoveSchedule.class);
+			moveSchedule.setAD_Org_ID(line.getAD_Org_ID());
+			moveSchedule.setDD_Order_ID(line.getDD_Order_ID());
+			moveSchedule.setDD_OrderLine_ID(line.getDD_OrderLine_ID());
+			moveSchedule.setM_Product_ID(line.getM_Product_ID());
+			moveSchedule.setC_UOM_ID(line.getC_UOM_ID());
+			moveSchedule.setQtyToPick(line.getQtyOrdered());
+			moveSchedule.setQtyPicked(BigDecimal.ZERO);
+			moveSchedule.setIsPickWholeHU(true);
+			moveSchedule.setPickFrom_HU_ID(pickFromHuId.getRepoId());
+			moveSchedule.setPickFrom_Locator_ID(line.getM_Locator_ID());
+			moveSchedule.setPickFrom_Warehouse_ID(warehouseDAO.getWarehouseIdByLocatorRepoId(line.getM_Locator_ID()).getRepoId());
+			moveSchedule.setDropTo_Locator_ID(line.getM_LocatorTo_ID());
+			moveSchedule.setDropTo_Warehouse_ID(warehouseDAO.getWarehouseIdByLocatorRepoId(line.getM_LocatorTo_ID()).getRepoId());
+			moveSchedule.setStatus(DDOrderMoveScheduleStatus.IN_PROGRESS.getCode());
+			InterfaceWrapperHelper.save(moveSchedule);
 		}
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DDOrderPickingReplenishment_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DDOrderPickingReplenishment_StepDef.java
@@ -25,15 +25,10 @@ package de.metas.cucumber.stepdefs.distributionorder;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.StepDefUtil;
-import de.metas.cucumber.stepdefs.hu.M_HU_StepDefData;
 import de.metas.cucumber.stepdefs.shipmentschedule.M_ShipmentSchedule_StepDefData;
-import de.metas.distribution.ddorder.movement.schedule.DDOrderMoveScheduleStatus;
 import de.metas.event.model.I_AD_EventLog;
 import de.metas.event.model.I_AD_EventLog_Entry;
-import de.metas.handlingunits.HuId;
-import de.metas.handlingunits.model.I_DD_Order_MoveSchedule;
 import org.adempiere.model.InterfaceWrapperHelper;
-import org.adempiere.warehouse.api.IWarehouseDAO;
 import org.eevolution.model.I_DD_OrderLine;
 import de.metas.distribution.ddorder.replenishment.DDOrderPickingReplenishmentService;
 import de.metas.distribution.ddorder.replenishment.event.DDOrderReplenishmentEventHandler;
@@ -99,7 +94,6 @@ public class DDOrderPickingReplenishment_StepDef
 
 	@NonNull private final M_ShipmentSchedule_StepDefData shipmentScheduleTable;
 	@NonNull private final de.metas.cucumber.stepdefs.picking.M_Picking_Job_Schedule_StepDefData pickingJobScheduleTable;
-	@NonNull private final M_HU_StepDefData huTable;
 
 	/**
 	 * Directly invokes {@link DDOrderPickingReplenishmentService#reconcile(PickingJobScheduleId)} in
@@ -183,66 +177,6 @@ public class DDOrderPickingReplenishment_StepDef
 		{
 			line.setQtyInTransit(BigDecimal.ONE);
 			InterfaceWrapperHelper.save(line);
-		}
-	}
-
-	/**
-	 * Test seam: directly creates an IN-PROGRESS {@code DD_Order_MoveSchedule} (Status='IP') for the (single) line of
-	 * the DD_Order linked to the given picking job schedule, simulating a picker who has started moving the
-	 * replenishment stock — WITHOUT running the full mobile move-schedule flow. This is what
-	 * {@code DDOrderMoveScheduleService.hasInProgressSchedules(ddOrderId)} checks, and it drives the close-out
-	 * disposition down the DISCONNECT branch instead of CLOSE.
-	 *
-	 * <p>The move-schedule's mandatory columns (product/UOM/locators/warehouses) are copied from the DD_OrderLine; the
-	 * {@code PickFrom_HU_ID} is the given source HU.</p>
-	 *
-	 * <p>Required columns:</p>
-	 * <ul>
-	 *   <li>{@code M_Picking_Job_Schedule_ID} — identifier of the assignment whose DD_Order move is "in progress"</li>
-	 *   <li>{@code PickFrom_HU_ID} — identifier of the source HU being moved (any active HU in the scenario)</li>
-	 * </ul>
-	 */
-	@When("^simulate an in-progress replenishment move on DD_Order linked to picking job schedule:$")
-	public void simulate_in_progress_move(@NonNull final DataTable dataTable)
-	{
-		DataTableRows.of(dataTable).forEach(this::simulate_in_progress_move);
-	}
-
-	private void simulate_in_progress_move(@NonNull final DataTableRow row)
-	{
-		final PickingJobScheduleId jobScheduleId = pickingJobScheduleTable.getId(
-				row.getAsIdentifier(de.metas.inoutcandidate.model.I_M_Picking_Job_Schedule.COLUMNNAME_M_Picking_Job_Schedule_ID).getAsString());
-		final HuId pickFromHuId = row.getAsIdentifier("PickFrom_HU_ID").lookupNotNullIdIn(huTable);
-
-		final List<I_DD_OrderLine> lines = queryBL.createQueryBuilder(I_DD_OrderLine.class)
-				.addEqualsFilter(I_DD_OrderLine.COLUMNNAME_M_Picking_Job_Schedule_ID, jobScheduleId)
-				.addOnlyActiveRecordsFilter()
-				.create()
-				.list(I_DD_OrderLine.class);
-
-		assertThat(lines)
-				.as("DD_OrderLines for picking job schedule %s (must exist before simulating an in-progress move)", jobScheduleId.getRepoId())
-				.isNotEmpty();
-
-		final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
-		for (final I_DD_OrderLine line : lines)
-		{
-			final I_DD_Order_MoveSchedule moveSchedule = InterfaceWrapperHelper.newInstance(I_DD_Order_MoveSchedule.class);
-			moveSchedule.setAD_Org_ID(line.getAD_Org_ID());
-			moveSchedule.setDD_Order_ID(line.getDD_Order_ID());
-			moveSchedule.setDD_OrderLine_ID(line.getDD_OrderLine_ID());
-			moveSchedule.setM_Product_ID(line.getM_Product_ID());
-			moveSchedule.setC_UOM_ID(line.getC_UOM_ID());
-			moveSchedule.setQtyToPick(line.getQtyOrdered());
-			moveSchedule.setQtyPicked(BigDecimal.ZERO);
-			moveSchedule.setIsPickWholeHU(true);
-			moveSchedule.setPickFrom_HU_ID(pickFromHuId.getRepoId());
-			moveSchedule.setPickFrom_Locator_ID(line.getM_Locator_ID());
-			moveSchedule.setPickFrom_Warehouse_ID(warehouseDAO.getWarehouseIdByLocatorRepoId(line.getM_Locator_ID()).getRepoId());
-			moveSchedule.setDropTo_Locator_ID(line.getM_LocatorTo_ID());
-			moveSchedule.setDropTo_Warehouse_ID(warehouseDAO.getWarehouseIdByLocatorRepoId(line.getM_LocatorTo_ID()).getRepoId());
-			moveSchedule.setStatus(DDOrderMoveScheduleStatus.IN_PROGRESS.getCode());
-			InterfaceWrapperHelper.save(moveSchedule);
 		}
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DDOrderPickingReplenishment_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DDOrderPickingReplenishment_StepDef.java
@@ -191,7 +191,7 @@ public class DDOrderPickingReplenishment_StepDef
 	 * the DD_Order linked to the given picking job schedule, simulating a picker who has started moving the
 	 * replenishment stock — WITHOUT running the full mobile move-schedule flow. This is what
 	 * {@code DDOrderMoveScheduleService.hasInProgressSchedules(ddOrderId)} checks, and it drives the close-out
-	 * disposition down the DISCONNECT branch instead of CLOSE (AC5).
+	 * disposition down the DISCONNECT branch instead of CLOSE.
 	 *
 	 * <p>The move-schedule's mandatory columns (product/UOM/locators/warehouses) are copied from the DD_OrderLine; the
 	 * {@code PickFrom_HU_ID} is the given source HU.</p>

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DD_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DD_Order_StepDef.java
@@ -56,6 +56,7 @@ import de.metas.distribution.ddorder.movement.schedule.commands.pick_from.DDOrde
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantitys;
 import de.metas.uom.UomId;
+import de.metas.user.UserId;
 import de.metas.document.DocBaseType;
 import de.metas.document.DocTypeId;
 import de.metas.document.DocTypeQuery;
@@ -656,8 +657,7 @@ public class DD_Order_StepDef
 			final PickingJobScheduleId jobScheduleId = row.getAsIdentifier(I_DD_Order.COLUMNNAME_M_Picking_Job_Schedule_ID).lookupNotNullIdIn(pickingJobScheduleTable);
 			final I_DD_Order ddOrder = liveDDOrderForPickingJobScheduleQuery(jobScheduleId).firstOnlyNotNull(I_DD_Order.class);
 			// UpdatedBy is always a valid AD_User_ID (> 0) — use it as the "worker who picked up the job".
-			ddOrder.setAD_User_Responsible_ID(ddOrder.getUpdatedBy());
-			InterfaceWrapperHelper.saveRecord(ddOrder);
+			ddOrderService.assignToResponsible(ddOrder, UserId.ofRepoId(ddOrder.getUpdatedBy()));
 		});
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DD_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DD_Order_StepDef.java
@@ -327,7 +327,7 @@ public class DD_Order_StepDef
 			softly.assertThat(actualOrderId).as("C_Order_ID").isEqualTo(expectedOrderId);
 		}
 
-		// Close-out disposition assertions (me03 30383): the in-progress disconnect marker, and the close-out
+		// Close-out disposition assertions: the in-progress disconnect marker, and the close-out
 		// picker release (AD_User_Responsible_ID cleared). Use `-` in the feature to assert the responsible is unset.
 		expected.getAsOptionalBoolean(I_DD_Order.COLUMNNAME_IsPickingDisconnected)
 				.ifPresent(expectedDisconnected -> softly.assertThat(actual.isPickingDisconnected())
@@ -636,7 +636,7 @@ public class DD_Order_StepDef
 	 * @cucumber.stepdef Test seam: assigns a responsible user ({@code AD_User_Responsible_ID}) to the live DD_Order
 	 * linked to the given workstation assignment, simulating a worker who has picked up the DD_Order-backed mobile
 	 * DistributionJob (the launcher keys on {@code AD_User_Responsible_ID}). Used so the close-out CLOSE path's picker
-	 * release ({@code AD_User_Responsible_ID} cleared — AC3) can be asserted as a state transition.
+	 * release ({@code AD_User_Responsible_ID} cleared) can be asserted as a state transition.
 	 * <p>
 	 * Required columns:
 	 * <ul>

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DD_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DD_Order_StepDef.java
@@ -54,6 +54,7 @@ import de.metas.document.engine.DocStatus;
 import de.metas.document.engine.IDocument;
 import de.metas.document.engine.IDocumentBL;
 import de.metas.order.OrderId;
+import de.metas.util.StringUtils;
 import de.metas.organization.OrgId;
 import de.metas.picking.api.PickingJobScheduleId;
 import de.metas.product.ResourceId;
@@ -311,6 +312,23 @@ public class DD_Order_StepDef
 			final OrderId actualOrderId = OrderId.ofRepoIdOrNull(actual.getC_Order_ID());
 			softly.assertThat(actualOrderId).as("C_Order_ID").isEqualTo(expectedOrderId);
 		}
+
+		// Close-out disposition assertions (me03 30383): the in-progress disconnect marker, and the close-out
+		// picker release (AD_User_Responsible_ID cleared). Use `-` in the feature to assert the responsible is unset.
+		expected.getAsOptionalBoolean(I_DD_Order.COLUMNNAME_IsPickingDisconnected)
+				.ifPresent(expectedDisconnected -> softly.assertThat(actual.isPickingDisconnected())
+						.as("IsPickingDisconnected")
+						.isEqualTo(expectedDisconnected));
+
+		// AD_User_Responsible_ID: a `-` cell asserts the responsible is unset (the CLOSE path releases the picker).
+		// Any other (numeric) value asserts that exact AD_User_ID.
+		expected.getAsOptionalString(I_DD_Order.COLUMNNAME_AD_User_Responsible_ID)
+				.map(StringUtils::trimBlankToNull)
+				.ifPresent(responsibleStr -> {
+					final int expectedResponsibleId = "-".equals(responsibleStr) ? -1 : Integer.parseInt(responsibleStr);
+					final int actualResponsibleId = actual.getAD_User_Responsible_ID() > 0 ? actual.getAD_User_Responsible_ID() : -1;
+					softly.assertThat(actualResponsibleId).as("AD_User_Responsible_ID").isEqualTo(expectedResponsibleId);
+				});
 
 		softly.assertAll();
 	}
@@ -598,6 +616,35 @@ public class DD_Order_StepDef
 				.addEqualsFilter(I_DD_Order.COLUMNNAME_M_Picking_Job_Schedule_ID, jobScheduleId)
 				.addNotEqualsFilter(I_DD_Order.COLUMNNAME_DocStatus, X_DD_Order.DOCSTATUS_Voided)
 				.create();
+	}
+
+	/**
+	 * @cucumber.stepdef Test seam: assigns a responsible user ({@code AD_User_Responsible_ID}) to the live DD_Order
+	 * linked to the given workstation assignment, simulating a worker who has picked up the DD_Order-backed mobile
+	 * DistributionJob (the launcher keys on {@code AD_User_Responsible_ID}). Used so the close-out CLOSE path's picker
+	 * release ({@code AD_User_Responsible_ID} cleared — AC3) can be asserted as a state transition.
+	 * <p>
+	 * Required columns:
+	 * <ul>
+	 *   <li>{@code M_Picking_Job_Schedule_ID} — identifier of the assignment whose DD_Order gets a responsible user</li>
+	 * </ul>
+	 * @cucumber.example
+	 * <pre>
+	 * When a worker takes the DD_Order linked to picking job schedule:
+	 *   | M_Picking_Job_Schedule_ID |
+	 *   | jobSchedule               |
+	 * </pre>
+	 */
+	@When("^a worker takes the DD_Order linked to picking job schedule:$")
+	public void assignResponsibleToDDOrder(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final PickingJobScheduleId jobScheduleId = row.getAsIdentifier(I_DD_Order.COLUMNNAME_M_Picking_Job_Schedule_ID).lookupNotNullIdIn(pickingJobScheduleTable);
+			final I_DD_Order ddOrder = liveDDOrderForPickingJobScheduleQuery(jobScheduleId).firstOnlyNotNull(I_DD_Order.class);
+			// UpdatedBy is always a valid AD_User_ID (> 0) — use it as the "worker who picked up the job".
+			ddOrder.setAD_User_Responsible_ID(ddOrder.getUpdatedBy());
+			InterfaceWrapperHelper.saveRecord(ddOrder);
+		});
 	}
 
 	private void validatePickingJobScheduleLine(

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DD_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DD_Order_StepDef.java
@@ -34,6 +34,7 @@ import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.StepDefDocAction;
 import de.metas.cucumber.stepdefs.StepDefUtil;
+import de.metas.cucumber.stepdefs.hu.M_HU_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
 import de.metas.cucumber.stepdefs.picking.M_Picking_Job_Schedule_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.PP_Order_BOMLine_StepDefData;
@@ -42,10 +43,19 @@ import de.metas.cucumber.stepdefs.resource.S_Resource_StepDefData;
 import de.metas.cucumber.stepdefs.shipmentschedule.M_ShipmentSchedule_StepDefData;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
 import de.metas.cucumber.stepdefs.M_Locator_StepDefData;
+import de.metas.handlingunits.HuId;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.distribution.ddorder.DDOrderId;
+import de.metas.distribution.ddorder.DDOrderLineId;
 import de.metas.distribution.ddorder.DDOrderService;
 import de.metas.distribution.ddorder.lowlevel.DDOrderLowLevelDAO;
+import de.metas.distribution.ddorder.movement.schedule.DDOrderMoveSchedule;
+import de.metas.distribution.ddorder.movement.schedule.DDOrderMoveScheduleCreateRequest;
+import de.metas.distribution.ddorder.movement.schedule.DDOrderMoveScheduleService;
+import de.metas.distribution.ddorder.movement.schedule.commands.pick_from.DDOrderPickFromRequest;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantitys;
+import de.metas.uom.UomId;
 import de.metas.document.DocBaseType;
 import de.metas.document.DocTypeId;
 import de.metas.document.DocTypeQuery;
@@ -67,6 +77,7 @@ import io.cucumber.java.en.When;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.warehouse.LocatorId;
@@ -122,7 +133,9 @@ public class DD_Order_StepDef
 	@NonNull private final IBPartnerDAO bpartnerDAO = Services.get(IBPartnerDAO.class);
 	@NonNull private final DDOrderService ddOrderService = SpringContextHolder.instance.getBean(DDOrderService.class);
 	@NonNull private final DDOrderLowLevelDAO ddOrderLowLevelDAO = SpringContextHolder.instance.getBean(DDOrderLowLevelDAO.class);
+	@NonNull private final DDOrderMoveScheduleService moveScheduleService = SpringContextHolder.instance.getBean(DDOrderMoveScheduleService.class);
 	@NonNull private final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
+	@NonNull private final ITrxManager trxManager = Services.get(ITrxManager.class);
 	@NonNull private final IDocTypeDAO docTypeDAO = Services.get(IDocTypeDAO.class);
 	@NonNull private final C_BPartner_StepDefData bPartnerTable;
 	@NonNull private final M_Warehouse_StepDefData warehouseTable;
@@ -135,6 +148,7 @@ public class DD_Order_StepDef
 	@NonNull private final DD_OrderLine_StepDefData ddOrderLineTable;
 	@NonNull private final M_Picking_Job_Schedule_StepDefData pickingJobScheduleTable;
 	@NonNull private final M_Locator_StepDefData locatorTable;
+	@NonNull private final M_HU_StepDefData huTable;
 
 	/**
 	 * @cucumber.stepdef Creates DD_Order header records.
@@ -644,6 +658,72 @@ public class DD_Order_StepDef
 			// UpdatedBy is always a valid AD_User_ID (> 0) — use it as the "worker who picked up the job".
 			ddOrder.setAD_User_Responsible_ID(ddOrder.getUpdatedBy());
 			InterfaceWrapperHelper.saveRecord(ddOrder);
+		});
+	}
+
+	/**
+	 * @cucumber.stepdef Picks the source HU from the DD_Order linked to the given picking job schedule, leaving the
+	 * move IN_PROGRESS (goods moved to in-transit, not yet dropped). For the DD_Order's single line it creates a
+	 * move-schedule via {@link DDOrderMoveScheduleService#createScheduleToMove} and then picks the HU via
+	 * {@link DDOrderMoveScheduleService#pickFromHU}.
+	 * <p>
+	 * Real-world trigger: a worker opens the DD_Order-backed mobile DistributionJob and picks the source HU, the first
+	 * leg of a warehouse move. The IN_PROGRESS state is what {@link DDOrderMoveScheduleService#hasInProgressSchedules}
+	 * checks, which drives the shipment close-out disposition down the DISCONNECT branch.
+	 * <p>
+	 * Required columns:
+	 * <ul>
+	 *   <li>{@code M_Picking_Job_Schedule_ID} — identifier of the assignment whose DD_Order is picked from</li>
+	 *   <li>{@code PickFrom_HU_ID} — identifier of the source HU being picked</li>
+	 * </ul>
+	 * @cucumber.example
+	 * <pre>
+	 * When pick from the DD_Order linked to picking job schedule:
+	 *   | M_Picking_Job_Schedule_ID | PickFrom_HU_ID |
+	 *   | jobSchedule               | stockSourceHU  |
+	 * </pre>
+	 */
+	@When("^pick from the DD_Order linked to picking job schedule:$")
+	public void pickFromDDOrderLinkedToPickingJobSchedule(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::pickFromDDOrderLinkedToPickingJobSchedule);
+	}
+
+	private void pickFromDDOrderLinkedToPickingJobSchedule(@NonNull final DataTableRow row)
+	{
+		final PickingJobScheduleId jobScheduleId = row.getAsIdentifier(I_DD_Order.COLUMNNAME_M_Picking_Job_Schedule_ID).lookupNotNullIdIn(pickingJobScheduleTable);
+		final HuId pickFromHuId = row.getAsIdentifier("PickFrom_HU_ID").lookupNotNullIdIn(huTable);
+
+		final List<I_DD_OrderLine> lines = queryBL.createQueryBuilder(I_DD_OrderLine.class)
+				.addEqualsFilter(I_DD_OrderLine.COLUMNNAME_M_Picking_Job_Schedule_ID, jobScheduleId)
+				.addOnlyActiveRecordsFilter()
+				.create()
+				.list(I_DD_OrderLine.class);
+
+		assertThat(lines)
+				.as("DD_OrderLines for picking job schedule %s (must exist before picking from the DD_Order)", jobScheduleId.getRepoId())
+				.isNotEmpty();
+
+		trxManager.runInThreadInheritedTrx(() -> {
+			for (final I_DD_OrderLine line : lines)
+			{
+				final DDOrderMoveSchedule schedule = moveScheduleService.createScheduleToMove(
+						DDOrderMoveScheduleCreateRequest.builder()
+								.ddOrderId(DDOrderId.ofRepoId(line.getDD_Order_ID()))
+								.ddOrderLineId(DDOrderLineId.ofRepoId(line.getDD_OrderLine_ID()))
+								.productId(ProductId.ofRepoId(line.getM_Product_ID()))
+								.pickFromLocatorId(LocatorId.ofRecord(warehouseDAO.getLocatorByRepoId(line.getM_Locator_ID())))
+								.pickFromHUId(pickFromHuId)
+								.qtyToPick(Quantitys.of(line.getQtyOrdered(), UomId.ofRepoId(line.getC_UOM_ID())))
+								.isPickWholeHU(true)
+								.dropToLocatorId(LocatorId.ofRecord(warehouseDAO.getLocatorByRepoId(line.getM_LocatorTo_ID())))
+								.build());
+
+				moveScheduleService.pickFromHU(DDOrderPickFromRequest.builder()
+						.scheduleId(schedule.getId())
+						.huId(pickFromHuId)
+						.build());
+			}
 		});
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/M_Picking_Job_Schedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/M_Picking_Job_Schedule_StepDef.java
@@ -196,6 +196,74 @@ public class M_Picking_Job_Schedule_StepDef
 	}
 
 	/**
+	 * @cucumber.stepdef Marks the given workstation assignments as {@code Processed=Y}, mirroring the shipment
+	 * close-out ({@code GenerateInOutFromShipmentSchedules → pickingJobScheduleService.markAsProcessed}). This fires
+	 * the {@code M_Picking_Job_Schedule.beforeChange} guard on the {@code Processed->true} transition (which must be
+	 * EXEMPT from the picker-busy refusal — AC1) and the {@code afterChange} after-commit reconcile (which disposes
+	 * the obsolete replenishment DD_Order via CLOSE/DISCONNECT — AC2/AC5). To assert the disposition deterministically,
+	 * follow this step with {@code the reconcile event for M_Picking_Job_Schedule <id> is processed}.
+	 * <p>
+	 * Required columns:
+	 * <ul>
+	 *   <li>{@code M_Picking_Job_Schedule_ID} — identifier of the existing assignment to mark processed</li>
+	 * </ul>
+	 * @cucumber.example
+	 * <pre>
+	 * When the picking job schedule is marked as processed (shipment close-out):
+	 *   | M_Picking_Job_Schedule_ID |
+	 *   | jobSchedule               |
+	 * </pre>
+	 */
+	@And("^the picking job schedule is marked as processed \\(shipment close-out\\):$")
+	public void markAsProcessed(final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::markAsProcessed);
+	}
+
+	private void markAsProcessed(final DataTableRow row)
+	{
+		final PickingJobSchedule jobSchedule = row.getAsIdentifier(I_M_Picking_Job_Schedule.COLUMNNAME_M_Picking_Job_Schedule_ID).lookupNotNullIn(jobScheduleTable);
+		pickingJobScheduleService.markAsProcessed(ImmutableSet.of(jobSchedule.getId()));
+	}
+
+	/**
+	 * @cucumber.stepdef Attempts to mark the given assignment as {@code Processed=Y} and asserts the
+	 * {@code beforeChange} interceptor REJECTS the save with the expected {@code ErrorCode}. Used as the RED
+	 * reproduction of the packing↔picking dependency: before the close-out exemption (AC1), a {@code Processed->true}
+	 * write trips the picker-busy guard and packing is blocked.
+	 * <p>
+	 * Required columns:
+	 * <ul>
+	 *   <li>{@code M_Picking_Job_Schedule_ID} — identifier of the existing assignment</li>
+	 *   <li>{@code ErrorCode} — expected {@code AdempiereException} error code (e.g. {@code DDOrderPickingReconcile_PickerBusy})</li>
+	 * </ul>
+	 * @cucumber.example
+	 * <pre>
+	 * Then marking the picking job schedule as processed is rejected:
+	 *   | M_Picking_Job_Schedule_ID | ErrorCode                          |
+	 *   | jobSchedule               | DDOrderPickingReconcile_PickerBusy |
+	 * </pre>
+	 */
+	@And("^marking the picking job schedule as processed is rejected:$")
+	public void markAsProcessedIsRejected(final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::markAsProcessedIsRejected);
+	}
+
+	private void markAsProcessedIsRejected(final DataTableRow row)
+	{
+		final PickingJobSchedule jobSchedule = row.getAsIdentifier(I_M_Picking_Job_Schedule.COLUMNNAME_M_Picking_Job_Schedule_ID).lookupNotNullIn(jobScheduleTable);
+		final String expectedErrorCode = row.getAsString("ErrorCode");
+
+		assertThatThrownBy(() -> pickingJobScheduleService.markAsProcessed(ImmutableSet.of(jobSchedule.getId())))
+				.as("Marking the assignment as processed must be rejected by the beforeChange interceptor")
+				.isInstanceOf(AdempiereException.class)
+				.satisfies(ex -> assertThat(((AdempiereException)ex).getErrorCode())
+						.as("AdempiereException.ErrorCode")
+						.isEqualTo(expectedErrorCode));
+	}
+
+	/**
 	 * @cucumber.stepdef Deletes all {@code M_Picking_Job_Schedule} records for the given shipment schedule. Triggers
 	 * the {@code afterDelete} interceptor which synchronously voids and unlinks any live DD_Orders linked to the
 	 * deleted assignments (satisfying the deferrable FK constraint within the same transaction).

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/M_Picking_Job_Schedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/M_Picking_Job_Schedule_StepDef.java
@@ -229,7 +229,7 @@ public class M_Picking_Job_Schedule_StepDef
 	/**
 	 * @cucumber.stepdef Attempts to mark the given assignment as {@code Processed=Y} and asserts the
 	 * {@code beforeChange} interceptor REJECTS the save with the expected {@code ErrorCode}. Used as the RED
-	 * reproduction of the packing↔picking dependency: before the close-out exemption (AC1), a {@code Processed->true}
+	 * reproduction of the packing↔picking dependency: before the close-out exemption, a {@code Processed->true}
 	 * write trips the picker-busy guard and packing is blocked.
 	 * <p>
 	 * Required columns:

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/M_Picking_Job_Schedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/M_Picking_Job_Schedule_StepDef.java
@@ -196,16 +196,16 @@ public class M_Picking_Job_Schedule_StepDef
 	}
 
 	/**
-	 * @cucumber.stepdef Marks the given workstation assignments as {@code Processed=Y}, mirroring the shipment
-	 * close-out ({@code GenerateInOutFromShipmentSchedules → pickingJobScheduleService.markAsProcessed}). This fires
-	 * the {@code M_Picking_Job_Schedule.beforeChange} guard on the {@code Processed->true} transition (which must be
-	 * EXEMPT from the picker-busy refusal — AC1) and the {@code afterChange} after-commit reconcile (which disposes
-	 * the obsolete replenishment DD_Order via CLOSE/DISCONNECT — AC2/AC5). To assert the disposition deterministically,
-	 * follow this step with {@code the reconcile event for M_Picking_Job_Schedule <id> is processed}.
+	 * @cucumber.stepdef Closes out the given workstation assignments ({@code Processed=Y}) via
+	 * {@code pickingJobScheduleService.markAsProcessed}.
+	 * <p>
+	 * Real-world trigger: shipment generation (Schnelldruck/Quickpack → {@code GenerateInOutFromShipmentSchedules})
+	 * sets the assignment {@code Processed=Y} when the shipment is created. The step calls the BL directly to drive
+	 * the close-out deterministically (without spinning up the full shipment-generation flow).
 	 * <p>
 	 * Required columns:
 	 * <ul>
-	 *   <li>{@code M_Picking_Job_Schedule_ID} — identifier of the existing assignment to mark processed</li>
+	 *   <li>{@code M_Picking_Job_Schedule_ID} — identifier of the existing assignment to close out</li>
 	 * </ul>
 	 * @cucumber.example
 	 * <pre>
@@ -227,10 +227,12 @@ public class M_Picking_Job_Schedule_StepDef
 	}
 
 	/**
-	 * @cucumber.stepdef Attempts to mark the given assignment as {@code Processed=Y} and asserts the
-	 * {@code beforeChange} interceptor REJECTS the save with the expected {@code ErrorCode}. Used as the RED
-	 * reproduction of the packing↔picking dependency: before the close-out exemption, a {@code Processed->true}
-	 * write trips the picker-busy guard and packing is blocked.
+	 * @cucumber.stepdef Attempts to close out the given assignment ({@code Processed=Y}) and asserts the
+	 * {@code beforeChange} interceptor REJECTS the save with the expected {@code ErrorCode}.
+	 * <p>
+	 * Real-world trigger: same shipment close-out ({@code GenerateInOutFromShipmentSchedules}) as the step above; this
+	 * one asserts the guard's rejection path (the RED reproduction of packing being blocked while a picker is busy,
+	 * before the close-out exemption was added).
 	 * <p>
 	 * Required columns:
 	 * <ul>

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/M_Picking_Job_Schedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/M_Picking_Job_Schedule_StepDef.java
@@ -226,44 +226,6 @@ public class M_Picking_Job_Schedule_StepDef
 		pickingJobScheduleService.markAsProcessed(ImmutableSet.of(jobSchedule.getId()));
 	}
 
-	/**
-	 * @cucumber.stepdef Attempts to close out the given assignment ({@code Processed=Y}) and asserts the
-	 * {@code beforeChange} interceptor REJECTS the save with the expected {@code ErrorCode}.
-	 * <p>
-	 * Real-world trigger: same shipment close-out ({@code GenerateInOutFromShipmentSchedules}) as the step above; this
-	 * one asserts the guard's rejection path — the picker-busy guard still blocks a genuine re-plan (qty / workplace
-	 * change) while a picker is active; only the {@code Processed->true} close-out transition is exempt.
-	 * <p>
-	 * Required columns:
-	 * <ul>
-	 *   <li>{@code M_Picking_Job_Schedule_ID} — identifier of the existing assignment</li>
-	 *   <li>{@code ErrorCode} — expected {@code AdempiereException} error code (e.g. {@code DDOrderPickingReconcile_PickerBusy})</li>
-	 * </ul>
-	 * @cucumber.example
-	 * <pre>
-	 * Then marking the picking job schedule as processed is rejected:
-	 *   | M_Picking_Job_Schedule_ID | ErrorCode                          |
-	 *   | jobSchedule               | DDOrderPickingReconcile_PickerBusy |
-	 * </pre>
-	 */
-	@And("^marking the picking job schedule as processed is rejected:$")
-	public void markAsProcessedIsRejected(final DataTable dataTable)
-	{
-		DataTableRows.of(dataTable).forEach(this::markAsProcessedIsRejected);
-	}
-
-	private void markAsProcessedIsRejected(final DataTableRow row)
-	{
-		final PickingJobSchedule jobSchedule = row.getAsIdentifier(I_M_Picking_Job_Schedule.COLUMNNAME_M_Picking_Job_Schedule_ID).lookupNotNullIn(jobScheduleTable);
-		final String expectedErrorCode = row.getAsString("ErrorCode");
-
-		assertThatThrownBy(() -> pickingJobScheduleService.markAsProcessed(ImmutableSet.of(jobSchedule.getId())))
-				.as("Marking the assignment as processed must be rejected by the beforeChange interceptor")
-				.isInstanceOf(AdempiereException.class)
-				.satisfies(ex -> assertThat(((AdempiereException)ex).getErrorCode())
-						.as("AdempiereException.ErrorCode")
-						.isEqualTo(expectedErrorCode));
-	}
 
 	/**
 	 * @cucumber.stepdef Deletes all {@code M_Picking_Job_Schedule} records for the given shipment schedule. Triggers

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/M_Picking_Job_Schedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/M_Picking_Job_Schedule_StepDef.java
@@ -196,38 +196,6 @@ public class M_Picking_Job_Schedule_StepDef
 	}
 
 	/**
-	 * @cucumber.stepdef Closes out the given workstation assignments ({@code Processed=Y}) via
-	 * {@code pickingJobScheduleService.markAsProcessed}.
-	 * <p>
-	 * Real-world trigger: shipment generation (Schnelldruck/Quickpack → {@code GenerateInOutFromShipmentSchedules})
-	 * sets the assignment {@code Processed=Y} when the shipment is created. The step calls the BL directly to drive
-	 * the close-out deterministically (without spinning up the full shipment-generation flow).
-	 * <p>
-	 * Required columns:
-	 * <ul>
-	 *   <li>{@code M_Picking_Job_Schedule_ID} — identifier of the existing assignment to close out</li>
-	 * </ul>
-	 * @cucumber.example
-	 * <pre>
-	 * When the picking job schedule is marked as processed (shipment close-out):
-	 *   | M_Picking_Job_Schedule_ID |
-	 *   | jobSchedule               |
-	 * </pre>
-	 */
-	@And("^the picking job schedule is marked as processed \\(shipment close-out\\):$")
-	public void markAsProcessed(final DataTable dataTable)
-	{
-		DataTableRows.of(dataTable).forEach(this::markAsProcessed);
-	}
-
-	private void markAsProcessed(final DataTableRow row)
-	{
-		final PickingJobSchedule jobSchedule = row.getAsIdentifier(I_M_Picking_Job_Schedule.COLUMNNAME_M_Picking_Job_Schedule_ID).lookupNotNullIn(jobScheduleTable);
-		pickingJobScheduleService.markAsProcessed(ImmutableSet.of(jobSchedule.getId()));
-	}
-
-
-	/**
 	 * @cucumber.stepdef Deletes all {@code M_Picking_Job_Schedule} records for the given shipment schedule. Triggers
 	 * the {@code afterDelete} interceptor which synchronously voids and unlinks any live DD_Orders linked to the
 	 * deleted assignments (satisfying the deferrable FK constraint within the same transaction).

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/M_Picking_Job_Schedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/picking/M_Picking_Job_Schedule_StepDef.java
@@ -231,8 +231,8 @@ public class M_Picking_Job_Schedule_StepDef
 	 * {@code beforeChange} interceptor REJECTS the save with the expected {@code ErrorCode}.
 	 * <p>
 	 * Real-world trigger: same shipment close-out ({@code GenerateInOutFromShipmentSchedules}) as the step above; this
-	 * one asserts the guard's rejection path (the RED reproduction of packing being blocked while a picker is busy,
-	 * before the close-out exemption was added).
+	 * one asserts the guard's rejection path — the picker-busy guard still blocks a genuine re-plan (qty / workplace
+	 * change) while a picker is active; only the {@code Processed->true} close-out transition is exempt.
 	 * <p>
 	 * Required columns:
 	 * <ul>

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -52,6 +52,7 @@ import de.metas.cucumber.stepdefs.attribute.M_AttributeSetInstance_StepDefData;
 import de.metas.cucumber.stepdefs.context.TestContext;
 import de.metas.cucumber.stepdefs.order.C_OrderLine_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
+import de.metas.cucumber.stepdefs.picking.M_Picking_Job_Schedule_StepDefData;
 import de.metas.cucumber.stepdefs.project.C_Project_StepDefData;
 import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
 import de.metas.cucumber.stepdefs.shipper.Carrier_Goods_Type_StepDefData;
@@ -70,6 +71,7 @@ import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleHandlerBL;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateRepository;
+import de.metas.inoutcandidate.model.I_M_Picking_Job_Schedule;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule_ExportAudit;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule_Recompute;
@@ -77,6 +79,9 @@ import de.metas.logging.LogManager;
 import de.metas.material.event.commons.AttributesKey;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
+import de.metas.picking.api.PickingJobScheduleId;
+import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
+import de.metas.picking.api.ShipmentScheduleAndJobScheduleIdSet;
 import de.metas.rest_api.v2.attributes.JsonAttributeService;
 import de.metas.shipper.gateway.commons.process.CarrierAdviseProcessService;
 import de.metas.shipping.ShipperId;
@@ -169,6 +174,7 @@ public class M_ShipmentSchedule_StepDef
 	@NonNull private final Carrier_Goods_Type_StepDefData carrierGoodsTypeTable;
 	@NonNull private final Carrier_Service_StepDefData carrierServiceTable;
 	@NonNull private final C_Project_StepDefData projectTable;
+	@NonNull private final M_Picking_Job_Schedule_StepDefData pickingJobScheduleTable;
 
 	private final TestContext testContext;
 
@@ -305,10 +311,13 @@ public class M_ShipmentSchedule_StepDef
 	 * @cucumber.stepdef
 	 * @cucumber.columns
 	 *   <b>M_ShipmentSchedule_ID</b> — (required, identifier-ref) schedule alias; comma-separated to combine multiple schedules into one shipment call<br>
+	 *   <b>M_Picking_Job_Schedule_ID</b> — (optional, identifier-ref) workstation assignment to ship via; when set, the shipment is
+	 *     generated for the (shipment-schedule, job-schedule) pair and the job schedule is closed out ({@code Processed=Y}),
+	 *     mirroring the production close-out where shipment generation closes the workstation assignment<br>
 	 *   <b>quantityTypeToUse</b> — (optional) D (delivery) or O (ordered); default: BOTH<br>
 	 *   <b>isCompleteShipment</b> — (optional) true/false; default: true<br>
 	 *   <b>M_InOut_ID</b> — (optional) alias to store the generated shipment; comma-separated for multiple<br>
-	 * @cucumber.depends StepDefData: M_ShipmentSchedule_StepDefData, M_InOut_StepDefData
+	 * @cucumber.depends StepDefData: M_ShipmentSchedule_StepDefData, M_Picking_Job_Schedule_StepDefData, M_InOut_StepDefData
 	 * @cucumber.example
 	 * <pre>
 	 * And shipment is generated for the following shipment schedule
@@ -668,13 +677,30 @@ public class M_ShipmentSchedule_StepDef
 
 		waitUntilValid(60, scheduleIds);
 
-		final Set<InOutId> inOutIds = shipmentService.generateShipmentsForScheduleIds(
-				GenerateShipmentsForSchedulesRequest.builder()
-						.shipmentScheduleIds(scheduleIds)
-						.quantityTypeToUse(qtyTypeToUse)
-						.isCompleteShipment(isCompleteShipment)
-						.build()
-		);
+		// When a workstation assignment is given, ship via the (shipment-schedule, job-schedule) pair and close the
+		// assignment out — this is the production close-out: GenerateInOutFromShipmentSchedules.closeSchedules() marks
+		// the linked M_Picking_Job_Schedule as Processed=Y once the shipment is generated.
+		final PickingJobScheduleId jobScheduleId = row.getAsOptionalIdentifier(I_M_Picking_Job_Schedule.COLUMNNAME_M_Picking_Job_Schedule_ID)
+				.map(identifier -> identifier.lookupNotNullIdIn(pickingJobScheduleTable))
+				.orElse(null);
+
+		final GenerateShipmentsForSchedulesRequest.GenerateShipmentsForSchedulesRequestBuilder requestBuilder = GenerateShipmentsForSchedulesRequest.builder()
+				.quantityTypeToUse(qtyTypeToUse)
+				.isCompleteShipment(isCompleteShipment);
+
+		if (jobScheduleId != null)
+		{
+			final ShipmentScheduleId shipmentScheduleId = scheduleIds.iterator().next();
+			requestBuilder
+					.scheduleIds(ShipmentScheduleAndJobScheduleIdSet.of(ShipmentScheduleAndJobScheduleId.of(shipmentScheduleId, jobScheduleId)))
+					.isCloseShipmentSchedules(true);
+		}
+		else
+		{
+			requestBuilder.shipmentScheduleIds(scheduleIds);
+		}
+
+		final Set<InOutId> inOutIds = shipmentService.generateShipmentsForScheduleIds(requestBuilder.build());
 
 		final List<StepDefDataIdentifier> shipmentIdentifiers = row.getAsOptionalIdentifier(I_M_InOut.COLUMNNAME_M_InOut_ID)
 				.map(StepDefDataIdentifier::toCommaSeparatedList)

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/distributionOrder/dd_order_replenishment/DDOrderReplenishment_close_out.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/distributionOrder/dd_order_replenishment/DDOrderReplenishment_close_out.feature
@@ -7,8 +7,9 @@ Feature: DD_Order replenishment — shipment close-out disposes the obsolete rep
   - No replenishment move in progress: the obsolete DD_Order is CLOSED and the picker is released.
   - A replenishment move in progress: the DD_Order is DISCONNECTED (IsPickingDisconnected=Y, FKs retained) so the worker finishes it.
 
-  # Test seams: the picker is made busy via the real mobile picking REST workflow; the close-out is the system's
-  # markAsProcessed; disposal is driven via the after-commit reconcile event, invoked directly for deterministic ordering.
+  # Test seams: the picker is made busy via the real mobile picking REST workflow; the close-out is real shipment
+  # generation (which marks the workstation assignment Processed=Y); disposal is driven via the after-commit reconcile
+  # event, invoked directly for deterministic ordering.
 
   Background:
     Given infrastructure and metasfresh are running
@@ -131,11 +132,13 @@ Feature: DD_Order replenishment — shipment close-out disposes the obsolete rep
       | M_Picking_Job_Schedule_ID |
       | jobSchedule               |
 
-    # Close-out (M_Picking_Job_Schedule.Processed=Y) is a fulfilment event — it must never be blocked by the
-    # picker-busy guard, even while a picker has the DD_Order job active.
-    When the picking job schedule is marked as processed (shipment close-out):
-      | M_Picking_Job_Schedule_ID |
-      | jobSchedule               |
+    # Close-out is real shipment generation: the operator brought the rest of the qty to the packing station, so the
+    # packing-warehouse stock ships and the workstation assignment is closed out (M_Picking_Job_Schedule.Processed=Y).
+    # This is a fulfilment event — it must never be blocked by the picker-busy guard, even while a picker has the
+    # DD_Order job active.
+    When shipment is generated for the following shipment schedule
+      | M_ShipmentSchedule_ID | M_Picking_Job_Schedule_ID |
+      | shipmentSchedule      | jobSchedule               |
 
     # Disposal happens in the after-commit reconcile (driven directly here for deterministic ordering). No move is
     # in progress, so the obsolete DD_Order is CLOSED (not Voided) and the picker's assignment is released.
@@ -165,10 +168,11 @@ Feature: DD_Order replenishment — shipment close-out disposes the obsolete rep
       | M_Picking_Job_Schedule_ID | PickFrom_HU_ID |
       | jobSchedule               | stockSourceHU  |
 
-    # Close-out still succeeds (packing is GOD) ...
-    When the picking job schedule is marked as processed (shipment close-out):
-      | M_Picking_Job_Schedule_ID |
-      | jobSchedule               |
+    # Close-out still succeeds (packing is GOD): real shipment generation ships the packing-station stock and marks
+    # the workstation assignment Processed=Y ...
+    When shipment is generated for the following shipment schedule
+      | M_ShipmentSchedule_ID | M_Picking_Job_Schedule_ID |
+      | shipmentSchedule      | jobSchedule               |
     And the reconcile event for M_Picking_Job_Schedule jobSchedule is processed
 
     # ... and the DD_Order is DISCONNECTED, not Closed: IsPickingDisconnected=Y, still Completed, FK to the schedule

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/distributionOrder/dd_order_replenishment/DDOrderReplenishment_close_out.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/distributionOrder/dd_order_replenishment/DDOrderReplenishment_close_out.feature
@@ -131,8 +131,8 @@ Feature: DD_Order replenishment — shipment close-out disposes the obsolete rep
       | M_Picking_Job_Schedule_ID |
       | jobSchedule               |
 
-    # THE BUG / RED: closing out the schedule (Processed=Y) must NOT be blocked by the busy picker. Before the
-    # close-out exemption this throws DDOrderPickingReconcile_PickerBusy; after the fix it succeeds.
+    # Close-out (M_Picking_Job_Schedule.Processed=Y) is a fulfilment event — it must never be blocked by the
+    # picker-busy guard, even while a picker has the DD_Order job active.
     When the picking job schedule is marked as processed (shipment close-out):
       | M_Picking_Job_Schedule_ID |
       | jobSchedule               |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/distributionOrder/dd_order_replenishment/DDOrderReplenishment_close_out.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/distributionOrder/dd_order_replenishment/DDOrderReplenishment_close_out.feature
@@ -3,18 +3,12 @@
 @allure.label.feature:F5111_DDOrder_Replenishment
 @ghActions:run_on_executor7
 Feature: DD_Order replenishment — shipment close-out disposes the obsolete replenishment (packing is GOD)
-  As a packing operator who brought stock to the packing station manually (bypassing picking) and runs
-  Schnelldruck/Quickpack, I want the shipment close-out to ALWAYS succeed even while a picking order for the
-  schedule is still open — the close-out (M_Picking_Job_Schedule.Processed=Y) must never be blocked by the
-  replenishment side. The obsolete replenishment DD_Order is disposed of through the existing event-driven
-  reconcile: CLOSED when no replenishment move is in progress (the picker is released), or DISCONNECTED
-  (IsPickingDisconnected=Y, FKs retained) when a move is already in progress so the worker can finish it.
+  - Shipment close-out (M_Picking_Job_Schedule.Processed=Y) must always succeed, even while a picking order is open.
+  - No replenishment move in progress: the obsolete DD_Order is CLOSED and the picker is released.
+  - A replenishment move in progress: the DD_Order is DISCONNECTED (IsPickingDisconnected=Y, FKs retained) so the worker finishes it.
 
-  # The picker is made busy through the REAL mobile picking workflow (REST: start the wfProcess), which creates
-  # an active (in-progress) M_Picking_Job_Line for the schedule — exactly what the busy guard checks. The
-  # close-out is the system's markAsProcessed (Processed=Y), which mirrors GenerateInOutFromShipmentSchedules.
-  # Disposal is driven deterministically via the reconcile event (the after-commit reconcile, invoked directly
-  # to keep ordering stable — same seam the picker_busy feature uses).
+  # Test seams: the picker is made busy via the real mobile picking REST workflow; the close-out is the system's
+  # markAsProcessed; disposal is driven via the after-commit reconcile event, invoked directly for deterministic ordering.
 
   Background:
     Given infrastructure and metasfresh are running
@@ -69,13 +63,14 @@ Feature: DD_Order replenishment — shipment close-out disposes the obsolete rep
       | Identifier | M_Warehouse_ID | PickFrom_Locator_ID |
       | workplace  | packingWH      | packingLocator      |
 
-    # On-hand stock in the SOURCE warehouse (single locator, qty 5) so the stock-aware split builds the DD_Order.
+    # On-hand stock in the SOURCE warehouse (single locator, qty 3 = the partial replenishment demand) so the
+    # stock-aware split builds the DD_Order and a whole-HU pick moves exactly the scheduled qty.
     And metasfresh contains M_Inventories:
       | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
       | stockInventory            | 2021-10-12   | stockWH        |
     And metasfresh contains M_InventoriesLines:
       | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
-      | stockInventory            | stockInventoryLine            | product                 | 0       | 5        | PCE          |
+      | stockInventory            | stockInventoryLine            | product                 | 0       | 3        | PCE          |
     And complete inventory with inventoryIdentifier 'stockInventory'
     And after not more than 60s, there are added M_HUs for inventory
       | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
@@ -110,13 +105,14 @@ Feature: DD_Order replenishment — shipment close-out disposes the obsolete rep
     And after not more than 120s, M_ShipmentSchedules are found:
       | Identifier       | C_OrderLine_ID | Warehouse_ID | QtyToDeliver |
       | shipmentSchedule | orderLine      | packingWH    | 5            |
-    # Assigning the schedule line to the workstation triggers the reconcile that creates the DD_Order.
+    # Assigning the schedule line to the workstation triggers the reconcile that creates the DD_Order. The assignment
+    # replenishes only PART of the shipment qty (3 of 5) — the operator brought the rest to the station manually.
     And create or update picking job schedules
       | M_Picking_Job_Schedule_ID | M_ShipmentSchedule_ID | C_Workplace_ID | QtyToPick |
-      | jobSchedule               | shipmentSchedule      | workplace      | 5         |
+      | jobSchedule               | shipmentSchedule      | workplace      | 3         |
     And after not more than 120s, the DD_Order linked to picking job schedule is found:
       | Identifier | M_Picking_Job_Schedule_ID | DocStatus | M_Warehouse_From_ID | M_Warehouse_To_ID | M_LocatorTo_ID | QtyEntered |
-      | ddOrder    | jobSchedule               | CO        | stockWH             | packingWH         | packingLocator | 5          |
+      | ddOrder    | jobSchedule               | CO        | stockWH             | packingWH         | packingLocator | 3          |
 
     # Start a REAL picking job for the order. With IsAllowPickingAnyHU=Y the start call alone creates an active
     # M_Picking_Job_Line referencing the schedule, so the busy guard now reports the picker as busy.
@@ -163,9 +159,9 @@ Feature: DD_Order replenishment — shipment close-out disposes the obsolete rep
 
   @from:cucumber
   Scenario: In-progress replenishment move at close-out → DISCONNECT (not Closed), FKs retained, still pickable
-    # A replenishment move is already in progress for the DD_Order (a half-done move must not be corrupted by a CLOSE,
-    # which would hit the BEFORE_CLOSE clearSchedules guard).
-    Given simulate an in-progress replenishment move on DD_Order linked to picking job schedule:
+    # A worker has started moving the replenishment stock (picked the source HU), so the move is in progress — a
+    # half-done move must not be corrupted by a CLOSE (which would hit the BEFORE_CLOSE clearSchedules guard).
+    Given pick from the DD_Order linked to picking job schedule:
       | M_Picking_Job_Schedule_ID | PickFrom_HU_ID |
       | jobSchedule               | stockSourceHU  |
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/distributionOrder/dd_order_replenishment/DDOrderReplenishment_close_out.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/distributionOrder/dd_order_replenishment/DDOrderReplenishment_close_out.feature
@@ -1,0 +1,189 @@
+@from:cucumber
+@allure.label.epic:E0106_Distribution
+@allure.label.feature:F5111_DDOrder_Replenishment
+@ghActions:run_on_executor7
+Feature: DD_Order replenishment — shipment close-out disposes the obsolete replenishment (packing is GOD)
+  As a packing operator who brought stock to the packing station manually (bypassing picking) and runs
+  Schnelldruck/Quickpack, I want the shipment close-out to ALWAYS succeed even while a picking order for the
+  schedule is still open — the close-out (M_Picking_Job_Schedule.Processed=Y) must never be blocked by the
+  replenishment side. The obsolete replenishment DD_Order is disposed of through the existing event-driven
+  reconcile: CLOSED when no replenishment move is in progress (the picker is released), or DISCONNECTED
+  (IsPickingDisconnected=Y, FKs retained) when a move is already in progress so the worker can finish it.
+
+  # The picker is made busy through the REAL mobile picking workflow (REST: start the wfProcess), which creates
+  # an active (in-progress) M_Picking_Job_Line for the schedule — exactly what the busy guard checks. The
+  # close-out is the system's markAsProcessed (Processed=Y), which mirrors GenerateInOutFromShipmentSchedules.
+  # Disposal is driven deterministically via the reconcile event (the after-commit reconcile, invoked directly
+  # to keep ordering stable — same seam the picker_busy feature uses).
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-05-17T13:30:13+01:00[Europe/Berlin]
+
+    # --- Pricing ---------------------------------------------------------------------------------------
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier    |
+      | pricingSystem |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | priceList  | pricingSystem      | DE           | EUR           | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier       | M_PriceList_ID |
+      | priceListVersion | priceList      |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | priceListVersion       | product      | 10.0     | PCE      | Normal           |
+
+    # --- Customer --------------------------------------------------------------------------------------
+    And metasfresh contains C_BPartners:
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID |
+      | customer   | N        | Y          | pricingSystem      |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier       | GLN          | C_BPartner_ID |
+      | customerLocation | bPLocation_1 | customer      |
+    And contains M_Shippers
+      | Identifier |
+      | shipper    |
+
+    # --- Auto-distribution network: stockWH (source) -> packingWH (target) -----------------------------
+    And metasfresh contains DD_NetworkDistribution
+      | DD_NetworkDistribution_ID |
+      | network                   |
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID | C_BPartner_ID | C_BPartner_Location_ID |
+      | stockWH        | customer      | customerLocation       |
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID | C_BPartner_ID | C_BPartner_Location_ID | IsInTransit |
+      | inTransitWH    | customer      | customerLocation       | true        |
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID | C_BPartner_ID | C_BPartner_Location_ID | MRP_Exclude | IsAutoDistributionOrder | DD_NetworkDistribution_ID | M_Locator_ID   |
+      | packingWH      | customer      | customerLocation       | Y           | Y                       | network                   | packingLocator |
+    And metasfresh contains DD_NetworkDistributionLine
+      | DD_NetworkDistribution_ID | M_Warehouse_ID | M_WarehouseSource_ID | M_Shipper_ID |
+      | network                   | packingWH      | stockWH              | shipper      |
+    And metasfresh contains C_Workplaces
+      | Identifier | M_Warehouse_ID | PickFrom_Locator_ID |
+      | workplace  | packingWH      | packingLocator      |
+
+    # On-hand stock in the SOURCE warehouse (single locator, qty 5) so the stock-aware split builds the DD_Order.
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | stockInventory            | 2021-10-12   | stockWH        |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | stockInventory            | stockInventoryLine            | product                 | 0       | 5        | PCE          |
+    And complete inventory with inventoryIdentifier 'stockInventory'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | stockInventoryLine            | stockSourceHU      |
+
+    # --- Picking prerequisites on the packing warehouse: stock via inventory -> HU + the mobile picking profile.
+    And load S_Resource:
+      | S_Resource_ID.Identifier | S_Resource_ID |
+      | testResource             | 540011        |
+    And set mobile UI picking profile
+      | IsAllowPickingAnyHU | CreateShipmentPolicy |
+      | Y                   | CREATE_AND_COMPLETE  |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | MovementDate | M_Warehouse_ID |
+      | packingInventory          | 2021-10-12   | packingWH      |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID.Identifier | M_InventoryLine_ID.Identifier | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | packingInventory          | packingInventoryLine          | product                 | 0       | 5        | PCE          |
+    And complete inventory with inventoryIdentifier 'packingInventory'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | packingInventoryLine          | packingProductHU   |
+
+    # --- One completed sales order on the packing warehouse is the starting state for every scenario ----
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | M_Warehouse_ID |
+      | order      | true    | customer      | 2022-05-17  | packingWH      |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | orderLine  | order      | product      | 5          |
+    And the order identified by order is completed
+    And after not more than 120s, M_ShipmentSchedules are found:
+      | Identifier       | C_OrderLine_ID | Warehouse_ID | QtyToDeliver |
+      | shipmentSchedule | orderLine      | packingWH    | 5            |
+    # Assigning the schedule line to the workstation triggers the reconcile that creates the DD_Order.
+    And create or update picking job schedules
+      | M_Picking_Job_Schedule_ID | M_ShipmentSchedule_ID | C_Workplace_ID | QtyToPick |
+      | jobSchedule               | shipmentSchedule      | workplace      | 5         |
+    And after not more than 120s, the DD_Order linked to picking job schedule is found:
+      | Identifier | M_Picking_Job_Schedule_ID | DocStatus | M_Warehouse_From_ID | M_Warehouse_To_ID | M_LocatorTo_ID | QtyEntered |
+      | ddOrder    | jobSchedule               | CO        | stockWH             | packingWH         | packingLocator | 5          |
+
+    # Start a REAL picking job for the order. With IsAllowPickingAnyHU=Y the start call alone creates an active
+    # M_Picking_Job_Line referencing the schedule, so the busy guard now reports the picker as busy.
+    And create JsonWFProcessStartRequest for picking and store it in context as request payload:
+      | C_Order_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier |
+      | order                 | customer                 | customerLocation                  |
+    And the metasfresh REST-API endpoint path 'api/v2/userWorkflows/wfProcess/start' receives a 'POST' request with the payload from context and responds with '200' status code
+    And process response and extract picking step and main HU picking candidate:
+      | WorkflowProcess.Identifier | WorkflowActivity.Identifier | PickingLine.Identifier |
+      | pickingWF                  | pickingActivity             | pickingLine            |
+
+  @from:cucumber
+  Scenario: Close-out succeeds while a picker is busy and CLOSES the obsolete replenishment + releases the picker
+    # A worker has the DD_Order-backed DistributionJob (AD_User_Responsible_ID set) — proving the CLOSE path releases it.
+    Given a worker takes the DD_Order linked to picking job schedule:
+      | M_Picking_Job_Schedule_ID |
+      | jobSchedule               |
+
+    # THE BUG / RED: closing out the schedule (Processed=Y) must NOT be blocked by the busy picker. Before the
+    # close-out exemption this throws DDOrderPickingReconcile_PickerBusy; after the fix it succeeds.
+    When the picking job schedule is marked as processed (shipment close-out):
+      | M_Picking_Job_Schedule_ID |
+      | jobSchedule               |
+
+    # Disposal happens in the after-commit reconcile (driven directly here for deterministic ordering). No move is
+    # in progress, so the obsolete DD_Order is CLOSED (not Voided) and the picker's assignment is released.
+    And the reconcile event for M_Picking_Job_Schedule jobSchedule is processed
+
+    Then after not more than 10s, following DD_Orders are found
+      | Identifier | DocStatus | IsPickingDisconnected | AD_User_Responsible_ID |
+      | ddOrder    | CL        | false                 | -                      |
+
+  @from:cucumber
+  Scenario: The picker-busy guard is preserved — a genuine qty re-plan while a picker is busy is still refused
+    # A qty change (NOT the Processed=Y close-out) while the picker is busy must still be refused: the guard
+    # protects genuine re-plans (AC4). The DD_Order is left untouched (still the original Completed one).
+    Then changing the picking job schedule quantity is rejected:
+      | M_Picking_Job_Schedule_ID | QtyToPick | ErrorCode                          |
+      | jobSchedule               | 8         | DDOrderPickingReconcile_PickerBusy |
+
+    And after not more than 5s, following DD_Orders are found
+      | Identifier | DocStatus | IsPickingDisconnected |
+      | ddOrder    | CO        | false                 |
+
+  @from:cucumber
+  Scenario: In-progress replenishment move at close-out → DISCONNECT (not Closed), FKs retained, still pickable
+    # A replenishment move is already in progress for the DD_Order (a half-done move must not be corrupted by a CLOSE,
+    # which would hit the BEFORE_CLOSE clearSchedules guard).
+    Given simulate an in-progress replenishment move on DD_Order linked to picking job schedule:
+      | M_Picking_Job_Schedule_ID | PickFrom_HU_ID |
+      | jobSchedule               | stockSourceHU  |
+
+    # Close-out still succeeds (packing is GOD) ...
+    When the picking job schedule is marked as processed (shipment close-out):
+      | M_Picking_Job_Schedule_ID |
+      | jobSchedule               |
+    And the reconcile event for M_Picking_Job_Schedule jobSchedule is processed
+
+    # ... and the DD_Order is DISCONNECTED, not Closed: IsPickingDisconnected=Y, still Completed, FK to the schedule
+    # retained for traceability so the worker can finish it as a standalone replenishment.
+    Then after not more than 10s, following DD_Orders are found
+      | Identifier | DocStatus | IsPickingDisconnected |
+      | ddOrder    | CO        | true                  |
+
+    # No re-trigger (AC6): the disconnected DD_Order is invisible to the reconcile lookup, so a follow-up reconcile
+    # resolves to NONE — it must not re-void, re-close, or create a fresh replenishment.
+    And the reconcile event for M_Picking_Job_Schedule jobSchedule is processed
+    And after not more than 5s, following DD_Orders are found
+      | Identifier | DocStatus | IsPickingDisconnected |
+      | ddOrder    | CO        | true                  |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/distributionOrder/dd_order_replenishment/DDOrderReplenishment_close_out.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/distributionOrder/dd_order_replenishment/DDOrderReplenishment_close_out.feature
@@ -152,7 +152,7 @@ Feature: DD_Order replenishment — shipment close-out disposes the obsolete rep
   @from:cucumber
   Scenario: The picker-busy guard is preserved — a genuine qty re-plan while a picker is busy is still refused
     # A qty change (NOT the Processed=Y close-out) while the picker is busy must still be refused: the guard
-    # protects genuine re-plans (AC4). The DD_Order is left untouched (still the original Completed one).
+    # protects genuine re-plans. The DD_Order is left untouched (still the original Completed one).
     Then changing the picking job schedule quantity is rejected:
       | M_Picking_Job_Schedule_ID | QtyToPick | ErrorCode                          |
       | jobSchedule               | 8         | DDOrderPickingReconcile_PickerBusy |
@@ -181,7 +181,7 @@ Feature: DD_Order replenishment — shipment close-out disposes the obsolete rep
       | Identifier | DocStatus | IsPickingDisconnected |
       | ddOrder    | CO        | true                  |
 
-    # No re-trigger (AC6): the disconnected DD_Order is invisible to the reconcile lookup, so a follow-up reconcile
+    # No re-trigger: the disconnected DD_Order is invisible to the reconcile lookup, so a follow-up reconcile
     # resolves to NONE — it must not re-void, re-close, or create a fresh replenishment.
     And the reconcile event for M_Picking_Job_Schedule jobSchedule is processed
     And after not more than 5s, following DD_Orders are found

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/model/DistributionJob.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/model/DistributionJob.java
@@ -99,9 +99,7 @@ public class DistributionJob
 
 	public void assertCanEdit(final UserId userId)
 	{
-		// A closed job (its DD_Order is no longer Completed — e.g. the shipment was closed-out independently and the
-		// replenishment DD_Order was Closed under the picker) can no longer be edited, even by its responsible user.
-		// Guards the in-flight-edit race: the picker still has the job open on the device when it gets closed server-side.
+		// A closed job can no longer be edited, even by its responsible user (guards the in-flight-edit race).
 		if (isClosed)
 		{
 			throw new AdempiereException("Cannot edit " + this + " because it is closed");

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/model/DistributionJob.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/model/DistributionJob.java
@@ -99,6 +99,13 @@ public class DistributionJob
 
 	public void assertCanEdit(final UserId userId)
 	{
+		// A closed job (its DD_Order is no longer Completed — e.g. the shipment was closed-out independently and the
+		// replenishment DD_Order was Closed under the picker) can no longer be edited, even by its responsible user.
+		// Guards the in-flight-edit race: the picker still has the job open on the device when it gets closed server-side.
+		if (isClosed)
+		{
+			throw new AdempiereException("Cannot edit " + this + " because it is closed");
+		}
 		if (!UserId.equals(this.responsibleId, userId))
 		{
 			throw new AdempiereException("Cannot edit " + this + " because it is not assigned to " + userId);

--- a/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/model/DistributionJobTest.java
+++ b/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/model/DistributionJobTest.java
@@ -18,9 +18,8 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Covers {@link DistributionJob#assertCanEdit(UserId)} — in particular the closed-job guard added for the
- * packing↔picking close-out: a DD_Order-backed distribution job that was closed under the picker (its DD_Order
- * is no longer Completed) must no longer be editable, even by its responsible user.
+ * Covers {@link DistributionJob#assertCanEdit(UserId)}: a DD_Order-backed distribution job that was closed under
+ * the picker (its DD_Order is no longer Completed) must no longer be editable, even by its responsible user.
  */
 class DistributionJobTest
 {

--- a/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/model/DistributionJobTest.java
+++ b/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/model/DistributionJobTest.java
@@ -1,0 +1,74 @@
+package de.metas.distribution.mobileui.job.model;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.bpartner.BPartnerId;
+import de.metas.distribution.ddorder.DDOrderId;
+import de.metas.distribution.mobileui.external_services.warehouse.WarehouseInfo;
+import de.metas.user.UserId;
+import de.metas.util.lang.SeqNo;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.warehouse.WarehouseId;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Covers {@link DistributionJob#assertCanEdit(UserId)} — in particular the closed-job guard added for the
+ * packing↔picking close-out: a DD_Order-backed distribution job that was closed under the picker (its DD_Order
+ * is no longer Completed) must no longer be editable, even by its responsible user.
+ */
+class DistributionJobTest
+{
+	private static final UserId PICKER = UserId.ofRepoId(1234);
+
+	private static DistributionJob job(final boolean isClosed, @Nullable final UserId responsibleId)
+	{
+		final WarehouseInfo wh = WarehouseInfo.builder().warehouseId(WarehouseId.ofRepoId(100)).caption("WH").build();
+		final ZonedDateTime when = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC"));
+		return DistributionJob.builder()
+				.id(DistributionJobId.ofDDOrderId(DDOrderId.ofRepoId(5555)))
+				.documentNo("DD-1")
+				.seqNo(SeqNo.ofInt(10))
+				.customerId(BPartnerId.ofRepoId(2222))
+				.dateRequired(when)
+				.pickDate(when)
+				.pickFromWarehouse(wh)
+				.dropToWarehouse(wh)
+				.priority("5")
+				.responsibleId(responsibleId)
+				.isClosed(isClosed)
+				.allowPickingAnyHU(false)
+				.lines(ImmutableList.of())
+				.build();
+	}
+
+	@Test
+	void assertCanEdit_refuses_a_closed_job_even_for_its_responsible_user()
+	{
+		final DistributionJob closed = job(true, PICKER);
+		assertThatThrownBy(() -> closed.assertCanEdit(PICKER))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("closed");
+	}
+
+	@Test
+	void assertCanEdit_allows_an_open_job_for_its_responsible_user()
+	{
+		final DistributionJob open = job(false, PICKER);
+		assertThatCode(() -> open.assertCanEdit(PICKER)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void assertCanEdit_refuses_an_open_job_not_assigned_to_the_user()
+	{
+		final DistributionJob open = job(false, UserId.ofRepoId(9999));
+		assertThatThrownBy(() -> open.assertCanEdit(PICKER))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("not assigned");
+	}
+}

--- a/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/model/DistributionJobTest.java
+++ b/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/model/DistributionJobTest.java
@@ -28,7 +28,6 @@ class DistributionJobTest
 
 	private static DistributionJob job(final boolean isClosed, @Nullable final UserId responsibleId)
 	{
-		final WarehouseInfo wh = WarehouseInfo.builder().warehouseId(WarehouseId.ofRepoId(100)).caption("WH").build();
 		final ZonedDateTime when = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC"));
 		return DistributionJob.builder()
 				.id(DistributionJobId.ofDDOrderId(DDOrderId.ofRepoId(5555)))
@@ -37,8 +36,8 @@ class DistributionJobTest
 				.customerId(BPartnerId.ofRepoId(2222))
 				.dateRequired(when)
 				.pickDate(when)
-				.pickFromWarehouse(wh)
-				.dropToWarehouse(wh)
+				.pickFromWarehouse(WarehouseInfo.builder().warehouseId(WarehouseId.ofRepoId(100)).caption("PickFromWH").build())
+				.dropToWarehouse(WarehouseInfo.builder().warehouseId(WarehouseId.ofRepoId(200)).caption("DropToWH").build())
 				.priority("5")
 				.responsibleId(responsibleId)
 				.isClosed(isClosed)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/DDOrderService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/DDOrderService.java
@@ -344,6 +344,17 @@ public class DDOrderService
 		unassignFromResponsibleAndSave(ddOrder);
 	}
 
+	/**
+	 * Marks the order as disconnected from picking ({@code IsPickingDisconnected=Y}), keeping all FKs and the
+	 * DocStatus intact. The order then becomes invisible to the picking guard/reconcile lookup while staying live.
+	 */
+	public void markAsPickingDisconnected(@NonNull final DDOrderId ddOrderId)
+	{
+		final I_DD_Order ddOrder = getById(ddOrderId);
+		ddOrder.setIsPickingDisconnected(true);
+		save(ddOrder);
+	}
+
 	public void removeAllNotStartedSchedules(final DDOrderId ddOrderId)
 	{
 		ddOrderMoveScheduleService.removeNotStarted(ddOrderId);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderPickingReplenishmentService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderPickingReplenishmentService.java
@@ -106,7 +106,7 @@ public class DDOrderPickingReplenishmentService
 			return;
 		}
 
-		// Close-out exemption (AC1/AC4): the shipment close-out (markAsProcessed) sets Processed=Y on the assignment.
+		// Close-out exemption: the shipment close-out (markAsProcessed) sets Processed=Y on the assignment.
 		// That is a fulfilment event, NOT a user re-plan — packing is GOD and must never be blocked by the
 		// replenishment side. So when this change is the Processed->true transition, skip the picker-busy /
 		// movement-started refusal entirely; the obsolete replenishment DD_Order is disposed of (CLOSE/DISCONNECT)
@@ -228,7 +228,7 @@ public class DDOrderPickingReplenishmentService
 	 * </pre>
 	 *
 	 * <p><b>Processed=Y close-out vs IsActive=N un-assignment.</b> Both make the assignment "no longer relevant",
-	 * but they are disposed of differently (AC2): the shipment close-out (Processed=Y) <b>Closes</b> the obsolete
+	 * but they are disposed of differently: the shipment close-out (Processed=Y) <b>Closes</b> the obsolete
 	 * replenishment DD_Order (delivered stock preserved, picker released), while a genuine un-assignment / cancel
 	 * (IsActive=N, or the assignment was deleted) keeps the legacy <b>Void</b>. {@link DDOrderReplenishmentAction#CLOSE}
 	 * is the close-out marker; the per-DD_Order CLOSE-vs-DISCONNECT split (move-in-progress) is resolved at execute
@@ -734,7 +734,7 @@ public class DDOrderPickingReplenishmentService
 	}
 
 	/**
-	 * Close-out disposition (AC2/AC5): for each obsolete replenishment DD_Order linked to a now-Processed assignment,
+	 * Close-out disposition: for each obsolete replenishment DD_Order linked to a now-Processed assignment,
 	 * dispose it — <b>CLOSE</b> when no replenishment move is in progress (the customer repro), or <b>DISCONNECT</b>
 	 * when a move IS in progress (closing would hit the {@code BEFORE_CLOSE clearSchedules} guard and corrupt a
 	 * half-done move). The picker-busy state is irrelevant here: packing is GOD, the close-out is never blocked.
@@ -756,7 +756,7 @@ public class DDOrderPickingReplenishmentService
 	}
 
 	/**
-	 * CLOSE branch (AC2/AC3): Closes the obsolete replenishment DD_Order (no movement reversal — {@code voidMovements}
+	 * CLOSE branch: Closes the obsolete replenishment DD_Order (no movement reversal — {@code voidMovements}
 	 * does not fire on {@code AFTER_CLOSE}, so already-moved stock is preserved; the open remainder is closed off) and
 	 * clears {@code AD_User_Responsible_ID} so the DD_Order-backed mobile DistributionJob is released from the picker.
 	 */
@@ -777,7 +777,7 @@ public class DDOrderPickingReplenishmentService
 	}
 
 	/**
-	 * DISCONNECT branch (AC5): a replenishment move is in progress, so the DD_Order must NOT be closed (a half-done
+	 * DISCONNECT branch: a replenishment move is in progress, so the DD_Order must NOT be closed (a half-done
 	 * move must not be corrupted). Instead it is disconnected — {@code IsPickingDisconnected=Y} — so the guard /
 	 * reconcile lookup stops seeing it ({@link DDOrderLowLevelDAO#findActiveDDOrdersForPickingJobSchedule}) while the
 	 * DistributionJob stays live & assigned (launcher keys on {@code AD_User_Responsible_ID}, untouched) for the worker

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderPickingReplenishmentService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderPickingReplenishmentService.java
@@ -8,9 +8,9 @@ import de.metas.common.util.time.SystemTime;
 import de.metas.distribution.ddorder.DDOrderId;
 import de.metas.distribution.ddorder.DDOrderService;
 import de.metas.distribution.ddorder.lowlevel.DDOrderLowLevelDAO;
+import de.metas.distribution.ddorder.movement.schedule.DDOrderMoveScheduleService;
 import de.metas.distribution.ddorder.replenishment.event.DDOrderReplenishmentEventPublisher;
 import de.metas.distribution.ddorder.replenishment.event.DDOrderReplenishmentRequest;
-import de.metas.distribution.ddorder.replenishment.event.DDOrderReplenishmentEventPublisher;
 import de.metas.document.DocTypeId;
 import de.metas.document.DocTypeQuery;
 import de.metas.document.IDocTypeDAO;
@@ -90,6 +90,7 @@ public class DDOrderPickingReplenishmentService
 	@NonNull private final DDOrderReplenishmentEventPublisher reconciliationEventPublisher;
 	@NonNull private final PickingJobScheduleService pickingJobScheduleService;
 	@NonNull private final WorkplaceService workplaceService;
+	@NonNull private final DDOrderMoveScheduleService ddOrderMoveScheduleService;
 	@NonNull private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
 	@NonNull private final IShipmentScheduleEffectiveBL shipmentScheduleEffectiveBL = Services.get(IShipmentScheduleEffectiveBL.class);
 	@NonNull private final IWarehouseBL warehouseBL = Services.get(IWarehouseBL.class);
@@ -101,6 +102,17 @@ public class DDOrderPickingReplenishmentService
 	public void assertCanChange(@NonNull final I_M_Picking_Job_Schedule jobSchedule)
 	{
 		if (!isOnAutoDistributionOrder(jobSchedule))
+		{
+			return;
+		}
+
+		// Close-out exemption (AC1/AC4): the shipment close-out (markAsProcessed) sets Processed=Y on the assignment.
+		// That is a fulfilment event, NOT a user re-plan — packing is GOD and must never be blocked by the
+		// replenishment side. So when this change is the Processed->true transition, skip the picker-busy /
+		// movement-started refusal entirely; the obsolete replenishment DD_Order is disposed of (CLOSE/DISCONNECT)
+		// by the after-commit reconcile. Every OTHER change (qty / workplace re-plan) keeps the guard fully in force.
+		if (InterfaceWrapperHelper.isValueChanged(jobSchedule, I_M_Picking_Job_Schedule.COLUMNNAME_Processed)
+				&& jobSchedule.isProcessed())
 		{
 			return;
 		}
@@ -185,6 +197,10 @@ public class DDOrderPickingReplenishmentService
 			case VOID:
 				voidAllDDOrders(existingDDOrders);
 				return;
+			case CLOSE:
+				// Close-out disposition: per DD_Order, CLOSE (not-in-progress) or DISCONNECT (in-progress).
+				disposeCloseOut(existingDDOrders);
+				return;
 			default:
 				throw new AdempiereException("Unexpected action: " + action);
 		}
@@ -199,19 +215,27 @@ public class DDOrderPickingReplenishmentService
 	/**
 	 * Classifies the reconcile action based on the truth-table:
 	 * <pre>
-	 * warehouseIsAutoDistributionOrder | assignmentRelevant (*) | existingDDOrderId | action
+	 * warehouseIsAutoDistributionOrder | state (*)            | existingDDOrderId | action
 	 * false              | *                    | *                 | NONE
-	 * true               | false                | null              | NONE
-	 * true               | false                | non-null          | VOID
-	 * true               | true                 | null              | CREATE
-	 * true               | true                 | non-null          | RECREATE
+	 * true               | active, not processed| null              | CREATE
+	 * true               | active, not processed| non-null          | RECREATE
+	 * true               | processed (close-out)| null              | NONE
+	 * true               | processed (close-out)| non-null          | CLOSE   (close-out disposition)
+	 * true               | inactive (un-assign) | null              | NONE
+	 * true               | inactive (un-assign) | non-null          | VOID
 	 *
-	 * (*) assignmentRelevant = assignment exists AND IsActive=Y AND Processed=N.
-	 *     A missing (deleted) or Processed=Y assignment is treated the same as IsActive=N.
+	 * (*) A missing (deleted) assignment is treated the same as inactive (un-assignment) → VOID.
 	 * </pre>
 	 *
-	 * <p>Pure decision method — no DB queries. The caller resolves {@code existingDDOrderId} exactly once
-	 * before calling this method.</p>
+	 * <p><b>Processed=Y close-out vs IsActive=N un-assignment.</b> Both make the assignment "no longer relevant",
+	 * but they are disposed of differently (AC2): the shipment close-out (Processed=Y) <b>Closes</b> the obsolete
+	 * replenishment DD_Order (delivered stock preserved, picker released), while a genuine un-assignment / cancel
+	 * (IsActive=N, or the assignment was deleted) keeps the legacy <b>Void</b>. {@link DDOrderReplenishmentAction#CLOSE}
+	 * is the close-out marker; the per-DD_Order CLOSE-vs-DISCONNECT split (move-in-progress) is resolved at execute
+	 * time ({@link #disposeCloseOut}) since it needs a DB lookup per order and an assignment can have several.</p>
+	 *
+	 * <p>Pure decision method — no DB queries. The caller resolves {@code hasExistingDDOrder} exactly once before
+	 * calling this method.</p>
 	 */
 	@VisibleForTesting
 	DDOrderReplenishmentAction classifyAction(
@@ -220,28 +244,25 @@ public class DDOrderPickingReplenishmentService
 	{
 		if (jobSchedule == null || !isOnAutoDistributionOrder(jobSchedule))
 		{
-			// Not on a packing warehouse (or assignment gone): void any existing DD_Order, else no-op.
+			// Not on a packing warehouse (or assignment deleted): void any existing DD_Order, else no-op.
 			return hasExistingDDOrder ? DDOrderReplenishmentAction.VOID : DDOrderReplenishmentAction.NONE;
 		}
 
-		final boolean assignmentRelevant = jobSchedule.isActive() && !jobSchedule.isProcessed();
+		if (jobSchedule.isProcessed())
+		{
+			// Shipment close-out: dispose the obsolete replenishment via CLOSE (or DISCONNECT if a move is in
+			// progress — resolved per-order at execute time). No DD_Order → nothing to dispose.
+			return hasExistingDDOrder ? DDOrderReplenishmentAction.CLOSE : DDOrderReplenishmentAction.NONE;
+		}
 
-		if (!assignmentRelevant && !hasExistingDDOrder)
+		if (!jobSchedule.isActive())
 		{
-			return DDOrderReplenishmentAction.NONE;
+			// Genuine un-assignment / cancel: legacy Void (unchanged).
+			return hasExistingDDOrder ? DDOrderReplenishmentAction.VOID : DDOrderReplenishmentAction.NONE;
 		}
-		else if (!assignmentRelevant)
-		{
-			return DDOrderReplenishmentAction.VOID;
-		}
-		else if (!hasExistingDDOrder)
-		{
-			return DDOrderReplenishmentAction.CREATE;
-		}
-		else
-		{
-			return DDOrderReplenishmentAction.RECREATE;
-		}
+
+		// Active, not processed → the assignment demands replenishment.
+		return hasExistingDDOrder ? DDOrderReplenishmentAction.RECREATE : DDOrderReplenishmentAction.CREATE;
 	}
 
 	private boolean isOnAutoDistributionOrder(@NonNull final PickingJobSchedule jobSchedule)
@@ -710,6 +731,68 @@ public class DDOrderPickingReplenishmentService
 		{
 			voidDDOrderFor(DDOrderId.ofRepoId(ddOrder.getDD_Order_ID()));
 		}
+	}
+
+	/**
+	 * Close-out disposition (AC2/AC5): for each obsolete replenishment DD_Order linked to a now-Processed assignment,
+	 * dispose it — <b>CLOSE</b> when no replenishment move is in progress (the customer repro), or <b>DISCONNECT</b>
+	 * when a move IS in progress (closing would hit the {@code BEFORE_CLOSE clearSchedules} guard and corrupt a
+	 * half-done move). The picker-busy state is irrelevant here: packing is GOD, the close-out is never blocked.
+	 */
+	private void disposeCloseOut(@NonNull final List<I_DD_Order> ddOrders)
+	{
+		for (final I_DD_Order ddOrder : ddOrders)
+		{
+			final DDOrderId ddOrderId = DDOrderId.ofRepoId(ddOrder.getDD_Order_ID());
+			if (ddOrderMoveScheduleService.hasInProgressSchedules(ddOrderId))
+			{
+				disconnectDDOrderFor(ddOrderId);
+			}
+			else
+			{
+				closeDDOrderFor(ddOrderId);
+			}
+		}
+	}
+
+	/**
+	 * CLOSE branch (AC2/AC3): Closes the obsolete replenishment DD_Order (no movement reversal — {@code voidMovements}
+	 * does not fire on {@code AFTER_CLOSE}, so already-moved stock is preserved; the open remainder is closed off) and
+	 * clears {@code AD_User_Responsible_ID} so the DD_Order-backed mobile DistributionJob is released from the picker.
+	 */
+	private void closeDDOrderFor(@NonNull final DDOrderId ddOrderId)
+	{
+		ddOrderService.close(ddOrderId);
+
+		// Release the picker's assignment: the DistributionJob launcher keys on AD_User_Responsible_ID, so clearing
+		// it retires the (now closed) job from the worker's launcher.
+		final I_DD_Order ddOrder = ddOrderLowLevelDAO.getById(ddOrderId);
+		ddOrder.setAD_User_Responsible_ID(-1);
+		ddOrderLowLevelDAO.save(ddOrder);
+
+		Loggables.addLog(
+				"DD_Order picking replenishment: closed obsolete replenishment DD_Order_ID={0} on shipment close-out"
+						+ " and released AD_User_Responsible_ID",
+				ddOrderId.getRepoId());
+	}
+
+	/**
+	 * DISCONNECT branch (AC5): a replenishment move is in progress, so the DD_Order must NOT be closed (a half-done
+	 * move must not be corrupted). Instead it is disconnected — {@code IsPickingDisconnected=Y} — so the guard /
+	 * reconcile lookup stops seeing it ({@link DDOrderLowLevelDAO#findActiveDDOrdersForPickingJobSchedule}) while the
+	 * DistributionJob stays live & assigned (launcher keys on {@code AD_User_Responsible_ID}, untouched) for the worker
+	 * to finish. The FKs ({@code M_Picking_Job_Schedule_ID}, {@code M_ShipmentSchedule_ID}) are retained for traceability.
+	 */
+	private void disconnectDDOrderFor(@NonNull final DDOrderId ddOrderId)
+	{
+		final I_DD_Order ddOrder = ddOrderLowLevelDAO.getById(ddOrderId);
+		ddOrder.setIsPickingDisconnected(true);
+		ddOrderLowLevelDAO.save(ddOrder);
+
+		Loggables.addLog(
+				"DD_Order picking replenishment: disconnected (IsPickingDisconnected=Y) in-progress replenishment"
+						+ " DD_Order_ID={0} on shipment close-out; FKs retained, DistributionJob stays live for the worker",
+				ddOrderId.getRepoId());
 	}
 
 	public void rebuildDrift()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderPickingReplenishmentService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderPickingReplenishmentService.java
@@ -106,11 +106,7 @@ public class DDOrderPickingReplenishmentService
 			return;
 		}
 
-		// Close-out exemption: the shipment close-out (markAsProcessed) sets Processed=Y on the assignment.
-		// That is a fulfilment event, NOT a user re-plan — packing is GOD and must never be blocked by the
-		// replenishment side. So when this change is the Processed->true transition, skip the picker-busy /
-		// movement-started refusal entirely; the obsolete replenishment DD_Order is disposed of (CLOSE/DISCONNECT)
-		// by the after-commit reconcile. Every OTHER change (qty / workplace re-plan) keeps the guard fully in force.
+		// The shipment close-out (Processed->true) is a fulfilment event, not a user re-plan: exempt it from the guard.
 		if (InterfaceWrapperHelper.isValueChanged(jobSchedule, I_M_Picking_Job_Schedule.COLUMNNAME_Processed)
 				&& jobSchedule.isProcessed())
 		{
@@ -198,7 +194,6 @@ public class DDOrderPickingReplenishmentService
 				voidAllDDOrders(existingDDOrders);
 				return;
 			case CLOSE:
-				// Close-out disposition: per DD_Order, CLOSE (not-in-progress) or DISCONNECT (in-progress).
 				disposeCloseOut(existingDDOrders);
 				return;
 			default:
@@ -227,15 +222,8 @@ public class DDOrderPickingReplenishmentService
 	 * (*) A missing (deleted) assignment is treated the same as inactive (un-assignment) → VOID.
 	 * </pre>
 	 *
-	 * <p><b>Processed=Y close-out vs IsActive=N un-assignment.</b> Both make the assignment "no longer relevant",
-	 * but they are disposed of differently: the shipment close-out (Processed=Y) <b>Closes</b> the obsolete
-	 * replenishment DD_Order (delivered stock preserved, picker released), while a genuine un-assignment / cancel
-	 * (IsActive=N, or the assignment was deleted) keeps the legacy <b>Void</b>. {@link DDOrderReplenishmentAction#CLOSE}
-	 * is the close-out marker; the per-DD_Order CLOSE-vs-DISCONNECT split (move-in-progress) is resolved at execute
-	 * time ({@link #disposeCloseOut}) since it needs a DB lookup per order and an assignment can have several.</p>
-	 *
-	 * <p>Pure decision method — no DB queries. The caller resolves {@code hasExistingDDOrder} exactly once before
-	 * calling this method.</p>
+	 * <p>Pure decision method — no DB queries. The per-DD_Order CLOSE-vs-DISCONNECT split is resolved at execute
+	 * time ({@link #disposeCloseOut}).</p>
 	 */
 	@VisibleForTesting
 	DDOrderReplenishmentAction classifyAction(
@@ -250,14 +238,13 @@ public class DDOrderPickingReplenishmentService
 
 		if (jobSchedule.isProcessed())
 		{
-			// Shipment close-out: dispose the obsolete replenishment via CLOSE (or DISCONNECT if a move is in
-			// progress — resolved per-order at execute time). No DD_Order → nothing to dispose.
+			// Shipment close-out: dispose the obsolete replenishment (CLOSE/DISCONNECT).
 			return hasExistingDDOrder ? DDOrderReplenishmentAction.CLOSE : DDOrderReplenishmentAction.NONE;
 		}
 
 		if (!jobSchedule.isActive())
 		{
-			// Genuine un-assignment / cancel: legacy Void (unchanged).
+			// Genuine un-assignment / cancel: legacy Void.
 			return hasExistingDDOrder ? DDOrderReplenishmentAction.VOID : DDOrderReplenishmentAction.NONE;
 		}
 
@@ -734,10 +721,8 @@ public class DDOrderPickingReplenishmentService
 	}
 
 	/**
-	 * Close-out disposition: for each obsolete replenishment DD_Order linked to a now-Processed assignment,
-	 * dispose it — <b>CLOSE</b> when no replenishment move is in progress (the customer repro), or <b>DISCONNECT</b>
-	 * when a move IS in progress (closing would hit the {@code BEFORE_CLOSE clearSchedules} guard and corrupt a
-	 * half-done move). The picker-busy state is irrelevant here: packing is GOD, the close-out is never blocked.
+	 * Close-out disposition: CLOSE when no replenishment move is in progress, or DISCONNECT when a move is in
+	 * progress (closing would hit the {@code BEFORE_CLOSE clearSchedules} guard and corrupt the half-done move).
 	 */
 	private void disposeCloseOut(@NonNull final List<I_DD_Order> ddOrders)
 	{
@@ -756,19 +741,13 @@ public class DDOrderPickingReplenishmentService
 	}
 
 	/**
-	 * CLOSE branch: Closes the obsolete replenishment DD_Order (no movement reversal — {@code voidMovements}
-	 * does not fire on {@code AFTER_CLOSE}, so already-moved stock is preserved; the open remainder is closed off) and
-	 * clears {@code AD_User_Responsible_ID} so the DD_Order-backed mobile DistributionJob is released from the picker.
+	 * Closes the obsolete replenishment DD_Order (moved stock preserved, open remainder closed off) and releases the
+	 * picker so the DD_Order-backed mobile DistributionJob retires from the launcher.
 	 */
 	private void closeDDOrderFor(@NonNull final DDOrderId ddOrderId)
 	{
 		ddOrderService.close(ddOrderId);
-
-		// Release the picker's assignment: the DistributionJob launcher keys on AD_User_Responsible_ID, so clearing
-		// it retires the (now closed) job from the worker's launcher.
-		final I_DD_Order ddOrder = ddOrderLowLevelDAO.getById(ddOrderId);
-		ddOrder.setAD_User_Responsible_ID(-1);
-		ddOrderLowLevelDAO.save(ddOrder);
+		ddOrderService.unassignFromResponsible(ddOrderId);
 
 		Loggables.addLog(
 				"DD_Order picking replenishment: closed obsolete replenishment DD_Order_ID={0} on shipment close-out"
@@ -777,17 +756,13 @@ public class DDOrderPickingReplenishmentService
 	}
 
 	/**
-	 * DISCONNECT branch: a replenishment move is in progress, so the DD_Order must NOT be closed (a half-done
-	 * move must not be corrupted). Instead it is disconnected — {@code IsPickingDisconnected=Y} — so the guard /
-	 * reconcile lookup stops seeing it ({@link DDOrderLowLevelDAO#findActiveDDOrdersForPickingJobSchedule}) while the
-	 * DistributionJob stays live & assigned (launcher keys on {@code AD_User_Responsible_ID}, untouched) for the worker
-	 * to finish. The FKs ({@code M_Picking_Job_Schedule_ID}, {@code M_ShipmentSchedule_ID}) are retained for traceability.
+	 * Disconnects the in-progress replenishment DD_Order ({@code IsPickingDisconnected=Y}) instead of closing it, so
+	 * the guard/reconcile lookup stops seeing it while the FKs and the DistributionJob assignment are retained for
+	 * the worker to finish.
 	 */
 	private void disconnectDDOrderFor(@NonNull final DDOrderId ddOrderId)
 	{
-		final I_DD_Order ddOrder = ddOrderLowLevelDAO.getById(ddOrderId);
-		ddOrder.setIsPickingDisconnected(true);
-		ddOrderLowLevelDAO.save(ddOrder);
+		ddOrderService.markAsPickingDisconnected(ddOrderId);
 
 		Loggables.addLog(
 				"DD_Order picking replenishment: disconnected (IsPickingDisconnected=Y) in-progress replenishment"

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderReplenishmentAction.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderReplenishmentAction.java
@@ -6,4 +6,16 @@ public enum DDOrderReplenishmentAction
 	CREATE,
 	RECREATE,
 	VOID,
+	/**
+	 * Close-out disposition (not-in-progress): the shipment schedule was closed out (Processed=Y) and the linked
+	 * replenishment DD_Order is obsolete. It is <b>Closed</b> (not Voided) — delivered/moved stock is preserved,
+	 * the open remainder is closed off — and the DD_Order-backed mobile DistributionJob is released.
+	 */
+	CLOSE,
+	/**
+	 * Close-out disposition (in-progress): same close-out trigger as {@link #CLOSE}, but a replenishment move is
+	 * already in progress (closing would corrupt a half-done move). The DD_Order is <b>disconnected</b>
+	 * (IsPickingDisconnected=Y, FKs retained) so the worker can finish it as a standalone replenishment.
+	 */
+	DISCONNECT,
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderReplenishmentAction.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderReplenishmentAction.java
@@ -12,10 +12,4 @@ public enum DDOrderReplenishmentAction
 	 * the open remainder is closed off — and the DD_Order-backed mobile DistributionJob is released.
 	 */
 	CLOSE,
-	/**
-	 * Close-out disposition (in-progress): same close-out trigger as {@link #CLOSE}, but a replenishment move is
-	 * already in progress (closing would corrupt a half-done move). The DD_Order is <b>disconnected</b>
-	 * (IsPickingDisconnected=Y, FKs retained) so the worker can finish it as a standalone replenishment.
-	 */
-	DISCONNECT,
 }

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddorder/lowlevel/DDOrderLowLevelDAO.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddorder/lowlevel/DDOrderLowLevelDAO.java
@@ -136,6 +136,11 @@ public class DDOrderLowLevelDAO
 				.createQueryBuilder(I_DD_Order.class)
 				.addEqualsFilter(I_DD_Order.COLUMNNAME_M_Picking_Job_Schedule_ID, pickingJobScheduleId)
 				.addEqualsFilter(I_DD_Order.COLUMNNAME_DocStatus, X_DD_Order.DOCSTATUS_Completed)
+				// A disconnected DD_Order (IsPickingDisconnected=Y) is the in-progress close-out disposition: the
+				// shipment schedule was already closed out, the DD_Order survives as a standalone replenishment the
+				// worker finishes. The picker-busy guard and the reconcile must NOT see it (else they would re-block
+				// the close-out / re-void the standalone job), so it is filtered out here.
+				.addEqualsFilter(I_DD_Order.COLUMNNAME_IsPickingDisconnected, false)
 				.addOnlyActiveRecordsFilter()
 				.orderBy(I_DD_Order.COLUMNNAME_DD_Order_ID)
 				.create()


### PR DESCRIPTION
## What

Decouple the packing/shipment **close-out** from the DD_Order picking-replenishment **picker-busy guard**, so generating a shipment (Schnelldruck/Quickpack) succeeds even when a picking order for the schedule is still open — while **preserving** the guard for genuine, user-initiated assignment re-plans.

Follow-up to the Auto Distribution Order feature (https://github.com/metasfresh/metasfresh/pull/24498). When the operator brings stock to the packing station manually and quick-packs, shipment generation sets the workstation assignment `Processed=Y`; that write currently trips the picker-busy guard (`DDOrderPickingReconcile_PickerBusy`) because a picking order is still open, permanently blocking packing.

## Approach

On the `Processed=Y` close-out, dispose of the now-obsolete replenishment DD_Order via the existing async reconcile:
- not-in-progress → **CLOSE** the DD_Order (preserves delivered stock, no movement reversal) + release the picker;
- in-progress replenishment move → **DISCONNECT** (set the new `DD_Order.IsPickingDisconnected` flag, keep the FKs for traceability) so the worker finishes it independently.

The guard exempts only the close-out transition; the guard/reconcile lookup ignores disconnected DD_Orders.

## Status — DRAFT / WIP

- [x] Add `DD_Order.IsPickingDisconnected` flag (non-UI technical column) + model regen
- [ ] Guard/reconcile lookup ignores disconnected DD_Orders (`IsPickingDisconnected='N'`)
- [ ] Exempt the `Processed=Y` close-out transition from the picker-busy guard
- [ ] Close-out disposal: CLOSE / DISCONNECT via the async reconcile
- [ ] `DistributionJob.assertCanEdit` refuses a closed job
- [ ] Playwright E2E + targeted backend regression

Base: `deep_tundra_release`
