### PR TITLE
DD_Order picking-replenishment — order source locators by M_Locator.PriorityNo then Value

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderPickingReplenishmentService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/distribution/ddorder/replenishment/DDOrderPickingReplenishmentService.java
@@ -1,6 +1,7 @@
 package de.metas.distribution.ddorder.replenishment;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import de.metas.bpartner.BPartnerId;
@@ -49,6 +50,7 @@ import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.IWarehouseBL;
 import org.adempiere.warehouse.api.IWarehouseDAO;
+import org.compiere.model.I_M_Locator;
 import org.compiere.model.I_M_Warehouse;
 import org.compiere.model.X_C_DocType;
 import org.compiere.util.TimeUtil;
@@ -271,8 +273,8 @@ public class DDOrderPickingReplenishmentService
 	/**
 	 * Reconciles the required per-locator stock-aware split against the assignment's existing live DD_Orders.
 	 *
-	 * <p>Computes the required {@code (source locator -> qty)} allocation from current on-hand stock (greedy by
-	 * {@code M_Locator.Value}), then for each locator:</p>
+	 * <p>Computes the required {@code (source locator -> qty)} allocation from current on-hand stock (greedy, in
+	 * the locator pick order defined by {@link #buildLocatorSortKey}), then for each locator:</p>
 	 * <ul>
 	 *   <li>in BOTH required and existing → <b>update the existing DD_Order line qty in place</b> (no void/recreate);</li>
 	 *   <li>in EXISTING only (no longer contributes) → <b>void</b> that DD_Order (+ unlink back-ref);</li>
@@ -318,7 +320,7 @@ public class DDOrderPickingReplenishmentService
 		// up in #reconcile, so this code path is never reached with a non-positive qty.
 		final Quantity demandQty = jobSchedule.getQtyToPick();
 
-		// Stock-aware split: required (source locator -> qty), greedy by M_Locator.Value, partial coverage allowed.
+		// Stock-aware split: required (source locator -> qty), greedy in the locator pick order, partial coverage allowed.
 		final Map<LocatorId, Quantity> requiredByLocator = computeRequiredAllocation(jobScheduleId, sourceWarehouseId, productId, demandQty);
 
 		// Picker-busy guard: refuse the whole reconcile before mutating anything if any existing DD_Order is busy.
@@ -396,11 +398,11 @@ public class DDOrderPickingReplenishmentService
 	 * Computes the stock-aware per-locator allocation of {@code demandQty}.
 	 *
 	 * <p>Gets the source warehouse's locators, queries Active on-hand per locator via the shared
-	 * {@link ProductAvailableStockPerLocator} helper, keeps the contributing locators (qty &gt; 0) ordered by
-	 * {@code M_Locator.Value} ascending, and greedily allocates the demand across them. Returns an insertion-ordered
-	 * map {@code (source locator -> allocated qty)}. Partial coverage is allowed: if total on-hand &lt; demand, the
-	 * uncovered remainder is logged and left unfulfilled (no fallback default-locator line). Empty map if no locator
-	 * has stock.</p>
+	 * {@link ProductAvailableStockPerLocator} helper, keeps the contributing locators (qty &gt; 0) in the locator
+	 * pick order (see {@link #buildLocatorSortKey}), and greedily allocates the demand across them. Returns an
+	 * insertion-ordered map {@code (source locator -> allocated qty)}. Partial coverage is allowed: if total on-hand
+	 * &lt; demand, the uncovered remainder is logged and left unfulfilled (no fallback default-locator line). Empty
+	 * map if no locator has stock.</p>
 	 *
 	 * <p>The on-hand quantities returned by {@link ProductAvailableStockPerLocator} are in the product's stocking UOM,
 	 * whereas {@code demandQty} is in the assignment's UOM. Each locator's available qty is therefore converted into
@@ -424,7 +426,6 @@ public class DDOrderPickingReplenishmentService
 		final AllocationResult result = greedyAllocate(
 				demandQty,
 				qtyOnHandByLocator,
-				this::getLocatorValue,
 				availableStockingUom -> uomConversionBL.convertQuantityTo(availableStockingUom, conversionCtx, demandQty.getUomId()),
 				(locatorId, availableStockingUom) -> Loggables.addLog(
 						"DD_Order picking replenishment: skipping source M_Locator_ID={0} for M_Product_ID={1}:"
@@ -452,28 +453,28 @@ public class DDOrderPickingReplenishmentService
 	}
 
 	/**
-	 * Pure greedy allocation of {@code demandQty} across the contributing locators of {@code qtyOnHandByLocator}.
+	 * Greedy allocation of {@code demandQty} across the contributing locators of {@code qtyOnHandByLocator}.
 	 *
-	 * <p>Keeps the positive-on-hand locators ordered by their {@code M_Locator.Value} (ascending, nulls last),
-	 * converts each locator's on-hand qty (in the product stocking UOM) into the demand UOM via {@code convertToDemandUom}
-	 * (a no-op when the UOMs already match), and greedily fills the demand. A locator whose qty cannot be converted
-	 * ({@link NoUOMConversionException}) is skipped (reported via {@code onSkippedLocator}, treated as non-contributing).
-	 * Returns the insertion-ordered allocation and the uncovered remainder. Pure: no DB / service access — the conversion
-	 * and the locator-Value lookup are injected so this can be unit-tested deterministically.</p>
+	 * <p>Orders the positive-on-hand locators in the locator pick order ({@link #buildLocatorSortKey}, via
+	 * {@link #getLocatorSortKey}), converts each locator's on-hand qty (in the product stocking UOM) into the
+	 * demand UOM via {@code convertToDemandUom} (a no-op when the UOMs already match), and greedily fills the
+	 * demand. A locator whose qty cannot be converted ({@link NoUOMConversionException}) is skipped (reported via
+	 * {@code onSkippedLocator}, treated as non-contributing). Returns the insertion-ordered allocation and the
+	 * uncovered remainder. Only the UOM conversion is injected — so a contrived cross-UOM case the real warehouse
+	 * workflow could not produce can be unit-tested deterministically; locator ordering uses the real warehouse data.</p>
 	 */
 	@VisibleForTesting
-	static AllocationResult greedyAllocate(
+	AllocationResult greedyAllocate(
 			@NonNull final Quantity demandQty,
 			@NonNull final Map<LocatorId, Quantity> qtyOnHandByLocator,
-			@NonNull final java.util.function.Function<LocatorId, String> locatorValueResolver,
 			@NonNull final ConvertToDemandUom convertToDemandUom,
 			@NonNull final java.util.function.BiConsumer<LocatorId, Quantity> onSkippedLocator)
 	{
-		// Contributing locators (positive on-hand) ordered by M_Locator.Value ascending.
+		// Contributing locators (positive on-hand) in the locator pick order.
 		final List<LocatorId> contributingOrdered = qtyOnHandByLocator.entrySet().stream()
 				.filter(e -> e.getValue().signum() > 0)
 				.map(Map.Entry::getKey)
-				.sorted(Comparator.comparing(locatorValueResolver, Comparator.nullsLast(String::compareTo)))
+				.sorted(Comparator.comparing(this::getLocatorSortKey))
 				.collect(ImmutableList.toImmutableList());
 
 		final LinkedHashMap<LocatorId, Quantity> allocation = new LinkedHashMap<>();
@@ -527,10 +528,27 @@ public class DDOrderPickingReplenishmentService
 		@NonNull Quantity uncovered;
 	}
 
-	@Nullable
-	private String getLocatorValue(@NonNull final LocatorId locatorId)
+	private String getLocatorSortKey(@NonNull final LocatorId locatorId)
 	{
-		return warehouseBL.getLocatorById(locatorId).getValue();
+		// org.compiere.model.I_M_Locator (base), not de.metas.handlingunits.model.I_M_Locator (HU-extended)
+		final I_M_Locator loc = warehouseBL.getLocatorById(locatorId);
+		return buildLocatorSortKey(loc.getPriorityNo(), loc.getValue());
+	}
+
+	/**
+	 * Single source of truth for the DD_Order picking-replenishment locator pick order. Builds a composite sort key
+	 * that yields PriorityNo ASC, then Value ASC under plain lexicographic order. To change the pick order, change
+	 * this method only — every caller orders by the key it returns and does not restate the order itself.
+	 *
+	 * <p>The key format is {@code zeroPad(priorityNo, 10) + "|" + value}. The pad width 10 matches
+	 * {@code M_Locator.PriorityNo numeric(10,0)}. Both inputs are NOT NULL in production
+	 * ({@code M_Locator.Value} NOT NULL; {@code PriorityNo numeric(10,0) NOT NULL DEFAULT 50}).
+	 * Non-negative PriorityNo values are assumed (negative values would sort incorrectly as strings).</p>
+	 */
+	@VisibleForTesting
+	static String buildLocatorSortKey(final int priorityNo, @NonNull final String value)
+	{
+		return Strings.padStart(Integer.toString(priorityNo), 10, '0') + "|" + value;
 	}
 
 	/**

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/distribution/ddorder/replenishment/DDOrderPickingReplenishmentServiceGreedyAllocateTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/distribution/ddorder/replenishment/DDOrderPickingReplenishmentServiceGreedyAllocateTest.java
@@ -2,14 +2,25 @@ package de.metas.distribution.ddorder.replenishment;
 
 import com.google.common.collect.ImmutableMap;
 import de.metas.business.BusinessTestHelper;
+import de.metas.distribution.ddorder.DDOrderService;
+import de.metas.distribution.ddorder.lowlevel.DDOrderLowLevelDAO;
+import de.metas.distribution.ddorder.movement.schedule.DDOrderMoveScheduleService;
 import de.metas.distribution.ddorder.replenishment.DDOrderPickingReplenishmentService.AllocationResult;
+import de.metas.distribution.ddorder.replenishment.event.DDOrderReplenishmentEventPublisher;
+import de.metas.handlingunits.picking.job.repository.PickingJobRepository;
+import de.metas.handlingunits.picking.job_schedule.service.PickingJobScheduleService;
+import de.metas.material.planning.ddorder.DistributionNetworkRepository;
 import de.metas.quantity.Quantity;
 import de.metas.uom.UomId;
+import de.metas.workplace.WorkplaceService;
+import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.NoUOMConversionException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
 import org.adempiere.warehouse.LocatorId;
 import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_M_Locator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,30 +28,35 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
- * Focused unit tests for the pure greedy per-locator allocation, with emphasis on the cross-UOM case
- * (HIGH-1): the on-hand quantities arrive in the product STOCKING UOM while the demand is in the assignment UOM,
- * so each locator's available qty must be converted into the demand UOM before it is compared/subtracted —
+ * Focused unit tests for the per-locator greedy allocation, covering both the locator pick order
+ * (by {@code M_Locator.PriorityNo} then {@code M_Locator.Value}) and the cross-UOM case: the on-hand
+ * quantities arrive in the product STOCKING UOM while the demand is in the assignment UOM, so each
+ * locator's available qty must be converted into the demand UOM before it is compared/subtracted —
  * otherwise {@link de.metas.quantity.Quantity}'s arithmetic throws because the UOMs do not match.
  *
- * <p>A focused JUnit (rather than a cross-UOM cucumber scenario) is used here because driving a non-stocking
- * assignment UOM end-to-end through the order → shipment-schedule → assignment chain requires a contrived,
- * fractional-case product setup (priced + stocked + ordered in different UOMs) that the real warehouse workflow
- * would never produce; the conversion + greedy logic is the thing under test and is proven deterministically here.
- * The existing 16 cucumber scenarios (assignment UOM == stocking UOM) continue to cover the common end-to-end path.</p>
+ * <p>Ordering is exercised against the real {@code IWarehouseBL.getLocatorById} path using real
+ * in-memory {@code M_Locator} records (it works in the {@link AdempiereTestHelper} harness — no direct
+ * SQL). The UOM conversion is injected into {@code greedyAllocate} because driving a non-stocking
+ * assignment UOM end-to-end through the order → shipment-schedule → assignment chain requires a
+ * contrived, fractional-case product setup (priced + stocked + ordered in different UOMs) that the real
+ * warehouse workflow would never produce; the conversion + greedy logic is the thing under test and is
+ * proven deterministically here. The existing 16 cucumber scenarios (assignment UOM == stocking UOM)
+ * continue to cover the common end-to-end path.</p>
  */
 @ExtendWith(AdempiereTestWatcher.class)
 class DDOrderPickingReplenishmentServiceGreedyAllocateTest
 {
+	private static final int WAREHOUSE_ID = 1;
+
+	private DDOrderPickingReplenishmentService service;
+
 	private I_C_UOM uomEach;   // product stocking UOM (e.g. PCE)
 	private I_C_UOM uomCase;   // assignment / demand UOM (e.g. a 6-pack case)
-
-	private LocatorId locatorA; // Value "10-A" -> consumed first
-	private LocatorId locatorB; // Value "20-B" -> consumed second
 
 	/** 1 case == 6 each. */
 	private static final BigDecimal CASE_TO_EACH = new BigDecimal("6");
@@ -53,17 +69,35 @@ class DDOrderPickingReplenishmentServiceGreedyAllocateTest
 		uomEach = BusinessTestHelper.createUOM("Each", 0, 0);
 		uomCase = BusinessTestHelper.createUOM("Case", 0, 0);
 
-		locatorA = LocatorId.ofRepoId(1, 11);
-		locatorB = LocatorId.ofRepoId(1, 12);
+		// greedyAllocate only uses warehouseBL + uomConversionBL (both Services.get, in-memory);
+		// the constructor-injected collaborators are unused here, so plain mocks suffice.
+		service = new DDOrderPickingReplenishmentService(
+				mock(PickingJobRepository.class),
+				mock(DDOrderLowLevelDAO.class),
+				mock(DDOrderService.class),
+				mock(DistributionNetworkRepository.class),
+				mock(ITrxManager.class),
+				mock(DDOrderReplenishmentEventPublisher.class),
+				mock(PickingJobScheduleService.class),
+				mock(WorkplaceService.class),
+				mock(DDOrderMoveScheduleService.class));
 	}
 
 	private Quantity each(final String qty) {return Quantity.of(qty, uomEach);}
 
 	private Quantity cases(final String qty) {return Quantity.of(qty, uomCase);}
 
-	private final Map<LocatorId, String> locatorValueByLocator = new HashMap<>();
-
-	private String locatorValue(final LocatorId locatorId) {return locatorValueByLocator.get(locatorId);}
+	/** Creates a real in-memory {@code M_Locator} so the production {@code warehouseBL.getLocatorById} ordering path is exercised. */
+	private LocatorId createLocator(final String value, final int priorityNo)
+	{
+		final I_M_Locator loc = InterfaceWrapperHelper.newInstance(I_M_Locator.class);
+		loc.setM_Warehouse_ID(WAREHOUSE_ID);
+		loc.setValue(value);
+		loc.setPriorityNo(priorityNo);
+		loc.setIsActive(true);
+		InterfaceWrapperHelper.saveRecord(loc);
+		return LocatorId.ofRepoId(WAREHOUSE_ID, loc.getM_Locator_ID());
+	}
 
 	/** Converts an on-hand qty in EACH into CASE (demand UOM). Throws if the source UOM is not EACH. */
 	private Quantity convertEachToCase(final Quantity availableStockingUom)
@@ -80,18 +114,17 @@ class DDOrderPickingReplenishmentServiceGreedyAllocateTest
 	void crossUom_convertsAvailableIntoDemandUom_thenSplitsGreedily()
 	{
 		// On-hand in the STOCKING UOM (each): 12 in A (=2 cases), 18 in B (=3 cases). Demand 4 cases.
-		// Greedy by locator Value: A (lower Value) gives its full 2 cases, B covers the remaining 2 cases.
-		locatorValueByLocator.put(locatorA, "10-A");
-		locatorValueByLocator.put(locatorB, "20-B");
+		// Equal priority -> ordered by Value: A (lower Value) gives its full 2 cases, B covers the remaining 2 cases.
+		final LocatorId locatorA = createLocator("10-A", 50);
+		final LocatorId locatorB = createLocator("20-B", 50);
 
 		final Map<LocatorId, Quantity> onHand = ImmutableMap.of(
 				locatorA, each("12"),
 				locatorB, each("18"));
 
-		final AllocationResult result = DDOrderPickingReplenishmentService.greedyAllocate(
+		final AllocationResult result = service.greedyAllocate(
 				cases("4"),
 				onHand,
-				(Function<LocatorId, String>) this::locatorValue,
 				this::convertEachToCase,
 				(locatorId, qty) -> {throw new AssertionError("no locator should be skipped, got " + locatorId);});
 
@@ -106,14 +139,13 @@ class DDOrderPickingReplenishmentServiceGreedyAllocateTest
 	void crossUom_partialCoverage_leavesRemainderUncovered_inDemandUom()
 	{
 		// On-hand: 12 each (=2 cases) in A only. Demand 5 cases -> only 2 covered, 3 uncovered.
-		locatorValueByLocator.put(locatorA, "10-A");
+		final LocatorId locatorA = createLocator("10-A", 50);
 
 		final Map<LocatorId, Quantity> onHand = ImmutableMap.of(locatorA, each("12"));
 
-		final AllocationResult result = DDOrderPickingReplenishmentService.greedyAllocate(
+		final AllocationResult result = service.greedyAllocate(
 				cases("5"),
 				onHand,
-				(Function<LocatorId, String>) this::locatorValue,
 				this::convertEachToCase,
 				(locatorId, qty) -> {throw new AssertionError("no locator should be skipped, got " + locatorId);});
 
@@ -126,17 +158,16 @@ class DDOrderPickingReplenishmentServiceGreedyAllocateTest
 	void sameUom_isANoOpConversion_splitsGreedily()
 	{
 		// Common case: demand UOM == stocking UOM (each). The conversion is identity.
-		locatorValueByLocator.put(locatorA, "10-A");
-		locatorValueByLocator.put(locatorB, "20-B");
+		final LocatorId locatorA = createLocator("10-A", 50);
+		final LocatorId locatorB = createLocator("20-B", 50);
 
 		final Map<LocatorId, Quantity> onHand = ImmutableMap.of(
 				locatorA, each("10"),
 				locatorB, each("7"));
 
-		final AllocationResult result = DDOrderPickingReplenishmentService.greedyAllocate(
+		final AllocationResult result = service.greedyAllocate(
 				each("15"),
 				onHand,
-				(Function<LocatorId, String>) this::locatorValue,
 				availableStockingUom -> availableStockingUom, // same UOM -> identity conversion
 				(locatorId, qty) -> {throw new AssertionError("no locator should be skipped, got " + locatorId);});
 
@@ -149,8 +180,8 @@ class DDOrderPickingReplenishmentServiceGreedyAllocateTest
 	void locatorWithUnconvertibleQty_isSkipped_andReported()
 	{
 		// locatorA's on-hand is in an UOM the conversion rejects -> skipped; locatorB covers the demand.
-		locatorValueByLocator.put(locatorA, "10-A");
-		locatorValueByLocator.put(locatorB, "20-B");
+		final LocatorId locatorA = createLocator("10-A", 50);
+		final LocatorId locatorB = createLocator("20-B", 50);
 
 		final Map<LocatorId, Quantity> onHand = ImmutableMap.of(
 				locatorA, cases("99"), // not EACH -> convertEachToCase throws -> skipped
@@ -158,10 +189,9 @@ class DDOrderPickingReplenishmentServiceGreedyAllocateTest
 
 		final Map<LocatorId, Quantity> skipped = new HashMap<>();
 
-		final AllocationResult result = DDOrderPickingReplenishmentService.greedyAllocate(
+		final AllocationResult result = service.greedyAllocate(
 				cases("2"),
 				onHand,
-				(Function<LocatorId, String>) this::locatorValue,
 				this::convertEachToCase,
 				skipped::put);
 
@@ -169,5 +199,60 @@ class DDOrderPickingReplenishmentServiceGreedyAllocateTest
 		assertThat(result.getAllocation()).containsOnlyKeys(locatorB);
 		assertThat(result.getAllocation().get(locatorB)).isEqualTo(cases("2"));
 		assertThat(result.getUncovered()).isEqualTo(cases("0"));
+	}
+
+	@Test
+	void buildLocatorSortKey_format_and_ordering()
+	{
+		// The composite key zero-pads PriorityNo to 10 digits, then appends "|" + Value.
+		assertThat(DDOrderPickingReplenishmentService.buildLocatorSortKey(50, "10-A")).isEqualTo("0000000050|10-A");
+		// A lower PriorityNo sorts first regardless of Value (the padded prefix dominates the lexicographic compare).
+		assertThat(DDOrderPickingReplenishmentService.buildLocatorSortKey(10, "20-B"))
+				.isLessThan(DDOrderPickingReplenishmentService.buildLocatorSortKey(50, "10-A"));
+	}
+
+	@Test
+	void priorityWins_lowerPriorityNoConsumedFirst_regardlessOfValue()
+	{
+		// AC2: B has the lower PriorityNo (10 < 50) but the HIGHER Value -> B must be consumed first.
+		final LocatorId locatorA = createLocator("10-A", 50);
+		final LocatorId locatorB = createLocator("20-B", 10);
+
+		final Map<LocatorId, Quantity> onHand = ImmutableMap.of(
+				locatorA, each("10"),
+				locatorB, each("10"));
+
+		// Demand 4 each is fully covered by the first-consumed locator -> only that locator is allocated.
+		final AllocationResult result = service.greedyAllocate(
+				each("4"),
+				onHand,
+				availableStockingUom -> availableStockingUom,
+				(locatorId, qty) -> {throw new AssertionError("no locator should be skipped, got " + locatorId);});
+
+		assertThat(result.getAllocation()).containsOnlyKeys(locatorB);
+		assertThat(result.getAllocation().get(locatorB)).isEqualTo(each("4"));
+		assertThat(result.getUncovered()).isEqualTo(each("0"));
+	}
+
+	@Test
+	void samePriority_tieBreaksByValue()
+	{
+		// AC3: equal PriorityNo -> the lower Value (A "10-A") is consumed first.
+		final LocatorId locatorA = createLocator("10-A", 50);
+		final LocatorId locatorB = createLocator("20-B", 50);
+
+		final Map<LocatorId, Quantity> onHand = ImmutableMap.of(
+				locatorA, each("10"),
+				locatorB, each("10"));
+
+		final AllocationResult result = service.greedyAllocate(
+				each("4"),
+				onHand,
+				availableStockingUom -> availableStockingUom,
+				(locatorId, qty) -> {throw new AssertionError("no locator should be skipped, got " + locatorId);});
+
+		assertThat(result.getAllocation()).containsOnlyKeys(locatorA);
+		assertThat(result.getAllocation().get(locatorA)).isEqualTo(each("4"));
+		assertThat(result.getUncovered()).isEqualTo(each("0"));
 	}
 }


### PR DESCRIPTION
## What

Change the order in which source locators are picked from during DD_Order picking-replenishment. Contributing source locators (positive on-hand) were ordered by `M_Locator.Value` ascending; they are now ordered by the locator's relative priority (`M_Locator.PriorityNo`) **ascending** first, then by `Value` ascending as the tie-breaker.

## Why

The customer needs to steer which physical locators are emptied first when an assignment's demand is split across multiple source locators. `M_Locator.Value` (an arbitrary search key) is not a meaningful picking order; the locator already carries a user-configurable "Relative Priorität" field (`M_Locator.PriorityNo`) and the picking order now honours it.

## How

`DDOrderPickingReplenishmentService.greedyAllocate`'s injected locator-ordering resolver now returns a composite sort key `pad(PriorityNo,10) + "|" + Value` instead of the bare `Value`. A plain lexicographic compare of that key yields PriorityNo ASC then Value ASC. `greedyAllocate`'s arity and greedy mechanics are unchanged — only what the resolver returns changes. Both inputs are NOT NULL in production (`M_Locator.Value` NOT NULL; `PriorityNo numeric(10,0)` NOT NULL, default 50); pad width 10 matches `numeric(10,0)` and assumes non-negative `PriorityNo` (documented at the seam).

No DB migration, no AD/window change (`PriorityNo` is already visible+editable to the user in the locator window), no cucumber/frontend change.

## Tests

`DDOrderPickingReplenishmentServiceGreedyAllocateTest` — added a key-builder format+ordering test, a lower-PriorityNo-consumed-first test, and a same-priority tie-break-by-Value test; the 4 existing greedy/cross-UOM tests adapted and still green (7/7).

Issue: https://github.com/metasfresh/me03/issues/30333
