### PR TITLE
Port to soft_panda_hotfix: mobile barcode-scanner Honeywell fixes + modes redesign

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807370_sys_mobileui_barcodeScanner_offscreenInput_readOnly_default.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807370_sys_mobileui_barcodeScanner_offscreenInput_readOnly_default.sql
@@ -1,0 +1,28 @@
+-- mobileUI barcode scanner: ship the offscreenInput.readOnly capability (default OFF).
+--
+-- Creates the System-level setting mobileui.frontend.barcodeScanner.offscreenInput.readOnly with
+-- its safe default value 'N' (= unchanged behaviour) if it does not already exist. The NOT EXISTS
+-- guard keeps this forward-compatible with the wider scanner-config framework
+-- (https://github.com/metasfresh/me03/issues/29246) that may introduce the same setting in core.
+--
+-- When set to 'Y', the off-screen scan input carries the HTML readOnly attribute, which suppresses
+-- the on-screen keyboard on keystroke-mode devices (e.g. Honeywell) where inputMode=none is not
+-- honoured. The Zebra DataWedge IME path is unaffected while the setting is off.
+--
+-- This core script ships ONLY the capability + safe default. Turning the setting ON for a specific
+-- instance (and setting useCamera=N) is deployment configuration and lives in the customer
+-- repo via set_sysconfig_value(...), NOT here. See https://github.com/metasfresh/me03/issues/30363.
+
+INSERT INTO AD_SysConfig (
+    AD_Client_ID, AD_Org_ID, AD_SysConfig_ID, ConfigurationLevel, EntityType, IsActive,
+    Name, Value, Description, Created, CreatedBy, Updated, UpdatedBy
+)
+SELECT
+    0, 0, 541813 /*From ID Server*/, 'S', 'D', 'Y',
+    'mobileui.frontend.barcodeScanner.offscreenInput.readOnly', 'N',
+    'Wenn ''Y'', wird am ausgeblendeten Barcode-Scan-Eingabefeld das HTML-Attribut readOnly gesetzt, um die Bildschirmtastatur auf Geräten mit Tastatur-Modus (z. B. Honeywell) zu unterdrücken, bei denen inputMode=none nicht beachtet wird. Standard ''N''.',
+    TO_TIMESTAMP('2026-06-11 10:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+    TO_TIMESTAMP('2026-06-11 10:00:00','YYYY-MM-DD HH24:MI:SS'), 100
+WHERE NOT EXISTS (
+    SELECT 1 FROM AD_SysConfig WHERE Name = 'mobileui.frontend.barcodeScanner.offscreenInput.readOnly'
+);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807430_sys_mobileui_barcodeScanner_visibleInput_readOnly_default.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807430_sys_mobileui_barcodeScanner_visibleInput_readOnly_default.sql
@@ -1,0 +1,31 @@
+-- mobileUI barcode scanner: ship the visibleInput.readOnly capability (default OFF).
+--
+-- Creates the System-level setting mobileui.frontend.barcodeScanner.visibleInput.readOnly with
+-- its safe default value 'N' (= unchanged behaviour) if it does not already exist. The NOT EXISTS
+-- guard keeps this forward-compatible with the wider scanner-config framework
+-- (https://github.com/metasfresh/me03/issues/29246) that may introduce the same setting in core.
+--
+-- Symmetric to offscreenInput.readOnly but applies to the VISIBLE scan input (when
+-- barcodeScanner.showInputText = Y). When 'Y', the visible scan input carries the HTML readOnly
+-- attribute, which suppresses the on-screen keyboard on keystroke-mode devices (e.g. Honeywell
+-- CT60 / Android 11) where inputMode="none" is not honoured. Manual typing into the input is
+-- blocked when set; intentional opt-in for hardware-scanner-only deployments. Keystroke-wedge
+-- scans continue to work (read at window level).
+--
+-- This core script ships ONLY the capability + safe default. Turning the setting ON for a
+-- specific instance is deployment configuration and lives in the customer repo via
+-- set_sysconfig_value(...), NOT here. See https://github.com/metasfresh/me03/issues/30363.
+
+INSERT INTO AD_SysConfig (
+    AD_Client_ID, AD_Org_ID, AD_SysConfig_ID, ConfigurationLevel, EntityType, IsActive,
+    Name, Value, Description, Created, CreatedBy, Updated, UpdatedBy
+)
+SELECT
+    0, 0, 541815 /*From ID Server*/, 'S', 'D', 'Y',
+    'mobileui.frontend.barcodeScanner.visibleInput.readOnly', 'N',
+    'Wenn ''Y'', wird am sichtbaren Barcode-Scan-Eingabefeld das HTML-Attribut readOnly gesetzt, um die Bildschirmtastatur auf Geräten mit Tastatur-Modus (z. B. Honeywell) zu unterdrücken, bei denen inputMode=none nicht beachtet wird. Manuelle Eingabe wird dadurch blockiert (bewusster Opt-in nur für reinen Hardware-Scanner-Betrieb). Standard ''N''.',
+    TO_TIMESTAMP('2026-06-11 22:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+    TO_TIMESTAMP('2026-06-11 22:00:00','YYYY-MM-DD HH24:MI:SS'), 100
+WHERE NOT EXISTS (
+    SELECT 1 FROM AD_SysConfig WHERE Name = 'mobileui.frontend.barcodeScanner.visibleInput.readOnly'
+);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807640_sysconfig_barcodeScanner_modes.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807640_sysconfig_barcodeScanner_modes.sql
@@ -1,0 +1,67 @@
+-- IDs allocated from idserver.metas.de on 2026-06-12:
+--   AD_SysConfig 541816 (mobileui.frontend.barcodeScanner.defaultMode)
+--   AD_SysConfig 541817 (mobileui.frontend.barcodeScanner.mode.hardware.enabled)
+--   AD_SysConfig 541818 (mobileui.frontend.barcodeScanner.mode.camera.enabled)
+--   AD_SysConfig 541819 (mobileui.frontend.barcodeScanner.mode.manual.enabled)
+--   AD_SysConfig 541820 (mobileui.frontend.barcodeScanner.mode.hardware.input.readOnly)
+--   AD_SysConfig 541821 (mobileui.frontend.barcodeScanner.mode.hardware.input.inputMode)
+
+-- SysConfig Name: mobileui.frontend.barcodeScanner.defaultMode
+-- Default: hardware — welcher Scanner-Modus beim Start der mobilen Barcode-UI aktiv ist.
+-- Erlaubte Werte: hardware | camera | manual
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value)
+SELECT 0,0,541816 /*From ID Server*/,'S',TO_TIMESTAMP('2026-06-12 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,
+       'Scanner-Modus beim Start der mobilen Barcode-UI. Erlaubte Werte: hardware | camera | manual. Standard: hardware.',
+       'D','Y','mobileui.frontend.barcodeScanner.defaultMode',TO_TIMESTAMP('2026-06-12 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'hardware'
+WHERE NOT EXISTS (SELECT 1 FROM AD_SysConfig WHERE Name='mobileui.frontend.barcodeScanner.defaultMode')
+;
+
+-- SysConfig Name: mobileui.frontend.barcodeScanner.mode.hardware.enabled
+-- Default: Y — Hardware-Scanner-Modus (Tastatur-Wedge / HID) ist standardmäßig aktiv.
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value)
+SELECT 0,0,541817 /*From ID Server*/,'S',TO_TIMESTAMP('2026-06-12 10:00:01','YYYY-MM-DD HH24:MI:SS'),100,
+       'Hardware-Scanner-Modus (Tastatur-Wedge / HID) aktivieren. Y=aktiv, N=deaktiviert. Standard: Y.',
+       'D','Y','mobileui.frontend.barcodeScanner.mode.hardware.enabled',TO_TIMESTAMP('2026-06-12 10:00:01','YYYY-MM-DD HH24:MI:SS'),100,'Y'
+WHERE NOT EXISTS (SELECT 1 FROM AD_SysConfig WHERE Name='mobileui.frontend.barcodeScanner.mode.hardware.enabled')
+;
+
+-- SysConfig Name: mobileui.frontend.barcodeScanner.mode.camera.enabled
+-- Default: Y — Kamera-Scanner-Modus ist standardmäßig aktiv.
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value)
+SELECT 0,0,541818 /*From ID Server*/,'S',TO_TIMESTAMP('2026-06-12 10:00:02','YYYY-MM-DD HH24:MI:SS'),100,
+       'Kamera-Scanner-Modus aktivieren. Y=aktiv, N=deaktiviert. Standard: Y.',
+       'D','Y','mobileui.frontend.barcodeScanner.mode.camera.enabled',TO_TIMESTAMP('2026-06-12 10:00:02','YYYY-MM-DD HH24:MI:SS'),100,'Y'
+WHERE NOT EXISTS (SELECT 1 FROM AD_SysConfig WHERE Name='mobileui.frontend.barcodeScanner.mode.camera.enabled')
+;
+
+-- SysConfig Name: mobileui.frontend.barcodeScanner.mode.manual.enabled
+-- Default: N — manuelle Barcode-Eingabe ist standardmäßig deaktiviert.
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value)
+SELECT 0,0,541819 /*From ID Server*/,'S',TO_TIMESTAMP('2026-06-12 10:00:03','YYYY-MM-DD HH24:MI:SS'),100,
+       'Manuelle Barcode-Eingabe (getippter Text) aktivieren. Y=aktiv, N=deaktiviert. Standard: N.',
+       'D','Y','mobileui.frontend.barcodeScanner.mode.manual.enabled',TO_TIMESTAMP('2026-06-12 10:00:03','YYYY-MM-DD HH24:MI:SS'),100,'N'
+WHERE NOT EXISTS (SELECT 1 FROM AD_SysConfig WHERE Name='mobileui.frontend.barcodeScanner.mode.manual.enabled')
+;
+
+-- SysConfig Name: mobileui.frontend.barcodeScanner.mode.hardware.input.readOnly
+-- Default: N — das Eingabefeld im Hardware-Modus ist bearbeitbar.
+-- Dieses Feld steuert das HARDWARE-MODUS-Eingabefeld (mode.hardware.*).
+-- Es ist NICHT identisch mit barcodeScanner.offscreenInput.readOnly (Off-Screen-Eingabefeld, Modus A)
+-- oder barcodeScanner.visibleInput.readOnly (sichtbares Eingabefeld, Modus C3).
+-- Nur für Keystroke-Firmware-Deployments setzen, bei denen inputMode=none nicht unterdrückt (z. B. Honeywell CT60).
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value)
+SELECT 0,0,541820 /*From ID Server*/,'S',TO_TIMESTAMP('2026-06-12 10:00:04','YYYY-MM-DD HH24:MI:SS'),100,
+       'Hardware-Modus-Eingabefeld schreibschützen (Y=readOnly, N=editierbar; Standard: N). Nur für Keystroke-Firmware ohne inputMode=none-Unterstützung. Nicht verwechseln mit offscreenInput.readOnly / visibleInput.readOnly.',
+       'D','Y','mobileui.frontend.barcodeScanner.mode.hardware.input.readOnly',TO_TIMESTAMP('2026-06-12 10:00:04','YYYY-MM-DD HH24:MI:SS'),100,'N'
+WHERE NOT EXISTS (SELECT 1 FROM AD_SysConfig WHERE Name='mobileui.frontend.barcodeScanner.mode.hardware.input.readOnly')
+;
+
+-- SysConfig Name: mobileui.frontend.barcodeScanner.mode.hardware.input.inputMode
+-- Default: none — HTML-inputmode für das Hardware-Scanner-Eingabefeld. 'none' unterdrückt die
+-- Bildschirmtastatur auf Touch-Geräten, sodass nur der Hardware-Scanner in das Feld eingeben kann.
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value)
+SELECT 0,0,541821 /*From ID Server*/,'S',TO_TIMESTAMP('2026-06-12 10:00:05','YYYY-MM-DD HH24:MI:SS'),100,
+       'HTML inputmode für das Hardware-Scanner-Eingabefeld. ''none'' unterdrückt die Bildschirmtastatur auf Touch-Geräten. Standard: none.',
+       'D','Y','mobileui.frontend.barcodeScanner.mode.hardware.input.inputMode',TO_TIMESTAMP('2026-06-12 10:00:05','YYYY-MM-DD HH24:MI:SS'),100,'none'
+WHERE NOT EXISTS (SELECT 1 FROM AD_SysConfig WHERE Name='mobileui.frontend.barcodeScanner.mode.hardware.input.inputMode')
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807650_sysconfig_barcodeScanner_alias_retire.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807650_sysconfig_barcodeScanner_alias_retire.sql
@@ -1,0 +1,86 @@
+-- Barcode scanner: carry legacy knob values forward into the new mode scheme and retire dead knobs.
+-- Order: all carry-forward UPDATEs first, then DELETEs.
+-- Missing legacy rows are harmless (WHERE EXISTS guards).
+
+-- Back up AD_SysConfig before the carry-forward UPDATEs and retire DELETEs below.
+SELECT backup_table('AD_SysConfig');
+
+-- ============================================================
+-- A1. useCamera → mode.camera.enabled (alias: keep useCamera row)
+-- ============================================================
+UPDATE AD_SysConfig
+SET    Value      = COALESCE(
+                       (SELECT Value FROM AD_SysConfig WHERE Name = 'mobileui.frontend.barcodeScanner.useCamera'),
+                       Value  -- keep Task-1 default when legacy row has NULL Value
+                   ),
+       Updated    = TO_TIMESTAMP('2026-06-13 09:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy  = 99
+WHERE  Name = 'mobileui.frontend.barcodeScanner.mode.camera.enabled'
+  AND  EXISTS (SELECT 1 FROM AD_SysConfig WHERE Name = 'mobileui.frontend.barcodeScanner.useCamera')
+;
+
+-- ============================================================
+-- A2. offscreenInput.readOnly → mode.hardware.input.readOnly (alias: keep offscreenInput.readOnly row)
+-- ============================================================
+UPDATE AD_SysConfig
+SET    Value      = COALESCE(
+                       (SELECT Value FROM AD_SysConfig WHERE Name = 'mobileui.frontend.barcodeScanner.offscreenInput.readOnly'),
+                       Value  -- keep Task-1 default when legacy row has NULL Value
+                   ),
+       Updated    = TO_TIMESTAMP('2026-06-13 09:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy  = 99
+WHERE  Name = 'mobileui.frontend.barcodeScanner.mode.hardware.input.readOnly'
+  AND  EXISTS (SELECT 1 FROM AD_SysConfig WHERE Name = 'mobileui.frontend.barcodeScanner.offscreenInput.readOnly')
+;
+
+-- ============================================================
+-- B3. showInputText: if Value='Y' → set mode.manual.enabled='Y', then DELETE showInputText
+-- ============================================================
+UPDATE AD_SysConfig
+SET    Value      = 'Y',
+       Updated    = TO_TIMESTAMP('2026-06-13 09:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy  = 99
+WHERE  Name = 'mobileui.frontend.barcodeScanner.mode.manual.enabled'
+  AND  EXISTS (SELECT 1 FROM AD_SysConfig WHERE Name = 'mobileui.frontend.barcodeScanner.showInputText' AND Value = 'Y')
+;
+
+-- DELETE regardless of Value: showInputText is retired unconditionally;
+-- only the mode.manual.enabled carry-forward above is conditional on Value='Y'.
+DELETE FROM AD_SysConfig
+WHERE  Name = 'mobileui.frontend.barcodeScanner.showInputText'
+;
+
+-- ============================================================
+-- B4. showInputVideo: if exists → set mode.camera.enabled to its Value, then DELETE showInputVideo
+-- ============================================================
+-- Guard: only apply showInputVideo when useCamera (A1, the authoritative alias) did NOT already set the target.
+-- This prevents B4 from overwriting A1 on DBs that carry both legacy rows simultaneously.
+UPDATE AD_SysConfig
+SET    Value      = COALESCE(
+                       (SELECT Value FROM AD_SysConfig WHERE Name = 'mobileui.frontend.barcodeScanner.showInputVideo'),
+                       Value  -- keep current value when legacy row has NULL Value
+                   ),
+       Updated    = TO_TIMESTAMP('2026-06-13 09:00:03', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy  = 99
+WHERE  Name = 'mobileui.frontend.barcodeScanner.mode.camera.enabled'
+  AND  EXISTS     (SELECT 1 FROM AD_SysConfig WHERE Name = 'mobileui.frontend.barcodeScanner.showInputVideo')
+  AND  NOT EXISTS (SELECT 1 FROM AD_SysConfig WHERE Name = 'mobileui.frontend.barcodeScanner.useCamera')
+;
+
+DELETE FROM AD_SysConfig
+WHERE  Name = 'mobileui.frontend.barcodeScanner.showInputVideo'
+;
+
+-- ============================================================
+-- B5. isInputTextReadonly: DELETE (keyboard suppression now decided by mode)
+-- ============================================================
+DELETE FROM AD_SysConfig
+WHERE  Name = 'mobileui.frontend.barcodeScanner.isInputTextReadonly'
+;
+
+-- ============================================================
+-- B6. visibleInput.readOnly: DELETE (visible read-only input no longer exists)
+-- ============================================================
+DELETE FROM AD_SysConfig
+WHERE  Name = 'mobileui.frontend.barcodeScanner.visibleInput.readOnly'
+;

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/sysconfig/SysconfigCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/sysconfig/SysconfigCommand.java
@@ -22,9 +22,18 @@ import java.util.Map;
 @Builder
 public class SysconfigCommand
 {
-	private static final ImmutableMap<String, String> SCANNER_SYSCONFIG_DEFAULTS = ImmutableMap.of(
-			"mobileui.frontend.barcodeScanner.showInputText", "Y",
-			"mobileui.frontend.barcodeScanner.isInputTextReadonly", "Y");
+	private static final ImmutableMap<String, String> SCANNER_SYSCONFIG_DEFAULTS = ImmutableMap.<String, String>builder()
+			.put("mobileui.frontend.barcodeScanner.showInputText", "Y")
+			.put("mobileui.frontend.barcodeScanner.isInputTextReadonly", "Y")
+			// Reset the per-instance scanner-mode knobs too — a test that flips them (e.g. the
+			// Honeywell CT60 keystroke-wedge contract test) must not leak readOnly=Y or
+			// useCamera=N onto unrelated specs in the same run. Defaults match the framework
+			// fall-backs in BarcodeScannerComponent.jsx (useCamera=true, offscreen/visible
+			// readOnly=false) and the core seed migrations 5807370 / 5807430.
+			.put("mobileui.frontend.barcodeScanner.useCamera", "Y")
+			.put("mobileui.frontend.barcodeScanner.offscreenInput.readOnly", "N")
+			.put("mobileui.frontend.barcodeScanner.visibleInput.readOnly", "N")
+			.build();
 
 	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -7,9 +7,9 @@
 | Module | Covered | Total | % |
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
-| Barcode Scanner Modes | 5 | 8 | 63% |
-| Picking | 56 | 59 | 95% |
-| Distribution | 27 | 30 | 90% |
+| Barcode Scanner Modes | 6 | 9 | 67% |
+| Picking | 56 | 60 | 93% |
+| Distribution | 34 | 37 | 92% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
 | HU Consolidation | 4 | 5 | 80% |
@@ -52,9 +52,10 @@
 
 | Scenario | Test |
 |---|---|
-| `type=text`, `inputmode=none`, `readonly` absent, CSS-hidden — all four DataWedge-required HTML properties in one check | `barcode_scanner_modes.spec.js` |
+| `type=text`, `inputmode=none`, `readonly` absent, CSS-hidden — DataWedge IME contract (visible-input editable, virtual keyboard suppressed via soft hint) | `barcode_scanner_modes.spec.js` |
+| `type=text`, `inputmode=none`, `readOnly` present, CSS-hidden, no `<video>` — Honeywell CT60 / Android 11 keystroke-wedge contract (HARD keyboard suppression via `readOnly`; camera disabled) | `barcode_scanner_modes.spec.js` |
 
-**1/1 — 100%**
+**2/2 — 100%**
 
 ### Scan paths
 
@@ -163,14 +164,8 @@
 | No suggestions configured → no suggested picking slots shown | `picking/pickingSlotSuggestions.spec.js` |
 | Configured picking slot suggestions → shown and selectable | `picking/pickingSlotSuggestions.spec.js` |
 | Single sales order split and picked to multiple workplaces | `picking/pick_what_was_scheduled_to_workplace.spec.js` |
-| DO_NOT_CREATE: fully-picked order completed with no shipment → must NOT appear in the picking launcher | `picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js` |
-| DO_NOT_CREATE: partially-picked order (qty still open) → must STAY in the picking launcher | `picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js` |
-| DO_NOT_CREATE: picked qty fully bound to a draft shipment → must NOT appear in the picking launcher | `picking/picking_DO_NOT_CREATE_shipment_reappearance.spec.js` |
-| Reverse (void) an aggregate-HU shipment → recreate must not collide on duplicate QtyPicked rows | `picking/recreate_shipment_after_void.spec.js` |
-| Reverse an aggregate-HU shipment TWICE (recreate via Generate Shipments between) → picked qty must survive every void so the shipment stays recreatable | `picking/recreate_shipment_after_void.spec.js` |
 
-
-**9/9 — 100%**
+**5/5 — 100%**
 
 ### Product-based picking
 
@@ -182,21 +177,6 @@
 | Pick-from HU identified by ExternalBarcode attribute | `picking/productBasedPicking/pick_by_ExternalBarcode.spec.js` |
 
 **4/4 — 100%**
-
-### GRAI-scan picking (product aggregation)
-
-| Scenario | Test |
-|---|---|
-| Scan one GRAI → TU auto-created with GRAI attribute (TC1) | `picking/picking-grai-scan.spec.js` |
-| Scanned GRAI has no M_HU_PI_GRAI mapping → GRAINoMatchingTUType error (TC2) | `picking/picking-grai-scan.spec.js` |
-| Resolved TU not allowed on picking-target LU → GRAITUNotAllowedOnLU error (TC3) | `picking/picking-grai-scan.spec.js` |
-| Two distinct GRAIs before debounce → GRAIMultipleScanned error, no list (TC4) | `picking/picking-grai-scan.spec.js` |
-| Unparseable barcode → scanner ignores it, stays live for valid scan (TC5) | `picking/picking-grai-scan.spec.js` |
-| Resolved TU has no capacity for product → GRAINoCapacityForProduct error (TC6) | `picking/picking-grai-scan.spec.js` |
-| BPartner GRAIRequired=No → no GRAI scanner shown (TC7) | `picking/picking-grai-scan.spec.js` |
-| Scan one GRAI into a top-level TU (no LU) → GRAI stamped on the top-level TU and persists through complete (TC9) | `picking/picking-grai-scan.spec.js` |
-
-**8/8 — 100%**
 
 ---
 

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -7,8 +7,8 @@
 | Module | Covered | Total | % |
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
-| Barcode Scanner Modes | 6 | 9 | 67% |
-| Picking | 56 | 60 | 93% |
+| Barcode Scanner Modes | 7 | 12 | 58% |
+| Picking | 58 | 62 | 94% |
 | Distribution | 34 | 37 | 92% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
@@ -68,8 +68,11 @@
 | ❌ Mode B — Camera (ZXing/BrowserMultiFormatReader): getUserMedia() decode → barcode forwarded | — (not testable in CI, requires real camera) |
 | ❌ `scanDuplicatesIntervalMillis` — duplicate barcode within interval suppressed, outside interval forwarded | — |
 | ❌ `triggerOnChangeIfLengthGreaterThan` — onChange fires only once input length exceeds threshold | — |
+| Footer — hardware/camera toggle: renders only when both hw + camera enabled; clicking toggle switches to camera mode and renders `<video>` (feed validation requires physical hardware) | `barcode_scanner_modes.spec.js` |
+| ❌ Footer — "Enter manually": shows only when manual mode enabled and activeMode ≠ MANUAL; clicking sets activeMode to MANUAL | — |
+| ❌ Footer — "Back to scanner": shows when activeMode=MANUAL and at least one of hw/camera enabled; clicking returns to HARDWARE (or CAMERA if only camera enabled) | — |
 
-**4/7 — 57%** (Mode B excluded — untestable in Playwright CI; `scanDuplicatesIntervalMillis` and `triggerOnChangeIfLengthGreaterThan` not yet covered)
+**5/10 — 50%** (Mode B excluded — untestable in Playwright CI; `scanDuplicatesIntervalMillis`, `triggerOnChangeIfLengthGreaterThan`, and two footer buttons not yet covered)
 
 ---
 

--- a/e2e/mobile-webui/playwright.config.js
+++ b/e2e/mobile-webui/playwright.config.js
@@ -76,6 +76,8 @@ export default defineConfig({
                         '--allow-insecure-localhost', // Allows HTTP on local addresses
                         '--allow-running-insecure-content', // Allows mixed content (HTTP on HTTPS)
                         // '--user-data-dir=/tmp/chrome-test-profile' // Ensures fresh profile each time (prevents stored HSTS rules)
+                        '--use-fake-ui-for-media-stream', // Suppress getUserMedia permission dialog in CI (no physical camera)
+                        '--use-fake-device-for-media-stream', // Provide a synthetic camera so getUserMedia() succeeds in CI
                     ],
                 },
             },

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -422,9 +422,9 @@ test.describe('Modes', () => {
 
     // THE canonical hardware-handheld deployment: hardware scanner is the default, manual typing is
     // an available fallback, the device camera is OFF, and the off-screen input is readOnly
-    // (keyboard-suppress for firmware that ignores inputMode=none). This is the config shipped to
-    // intercheese / Dantherm handhelds. The footer must therefore offer the manual-entry fallback
-    // but NOT a camera toggle, and the manual fallback must actually forward a typed barcode.
+    // (keyboard-suppress for firmware that ignores inputMode=none). The footer must therefore offer
+    // the manual-entry fallback but NOT a camera toggle, and the manual fallback must actually
+    // forward a typed barcode.
     test('hardware default + manual fallback, camera off — footer shows manual, hides camera toggle', async ({ page }) => {
         await allure.epic('E0295: Frontend MobileUI');
         await allure.feature('F12000: Frontend MobileUI');

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -6,29 +6,32 @@ import { HUManagerScreen } from '../utils/screens/huManager/HUManagerScreen';
 import { BarcodeScannerComponent } from '../utils/components/BarcodeScannerComponent';
 import { allure } from 'allure-playwright';
 
-const scannerSysconfigs = ({ showInputText, isInputTextReadonly }) => ({
+const scannerSysconfigs = ({ showInputText, isInputTextReadonly, useCamera, offscreenInputReadOnly, visibleInputReadOnly }) => ({
     ...(showInputText != null && { 'mobileui.frontend.barcodeScanner.showInputText': showInputText }),
     ...(isInputTextReadonly != null && { 'mobileui.frontend.barcodeScanner.isInputTextReadonly': isInputTextReadonly }),
+    ...(useCamera != null && { 'mobileui.frontend.barcodeScanner.useCamera': useCamera }),
+    ...(offscreenInputReadOnly != null && { 'mobileui.frontend.barcodeScanner.offscreenInput.readOnly': offscreenInputReadOnly }),
+    ...(visibleInputReadOnly != null && { 'mobileui.frontend.barcodeScanner.visibleInput.readOnly': visibleInputReadOnly }),
 });
 
 // Minimal masterdata: login only, no HU/orders. Used by the attribute-guard tests,
 // which only need the barcode input to render — so they run in seconds.
-const createLoginMasterdata = async ({ extraSysconfigs, showInputText, isInputTextReadonly } = {}) => {
+const createLoginMasterdata = async ({ extraSysconfigs, showInputText, isInputTextReadonly, useCamera, offscreenInputReadOnly, visibleInputReadOnly } = {}) => {
     return await Backend.createMasterdata({
         language: 'en_US',
         request: {
-            sysconfigs: { ...scannerSysconfigs({ showInputText, isInputTextReadonly }), ...extraSysconfigs },
+            sysconfigs: { ...scannerSysconfigs({ showInputText, isInputTextReadonly, useCamera, offscreenInputReadOnly, visibleInputReadOnly }), ...extraSysconfigs },
             login: { user: { language: 'en_US' } },
         },
     });
 };
 
 // Full masterdata: login + a handling unit, so scanning its QR code navigates to the HU Manager.
-const createMasterdataWithHU = async ({ extraSysconfigs, showInputText, isInputTextReadonly } = {}) => {
+const createMasterdataWithHU = async ({ extraSysconfigs, showInputText, isInputTextReadonly, useCamera, offscreenInputReadOnly, visibleInputReadOnly } = {}) => {
     return await Backend.createMasterdata({
         language: 'en_US',
         request: {
-            sysconfigs: { ...scannerSysconfigs({ showInputText, isInputTextReadonly }), ...extraSysconfigs },
+            sysconfigs: { ...scannerSysconfigs({ showInputText, isInputTextReadonly, useCamera, offscreenInputReadOnly, visibleInputReadOnly }), ...extraSysconfigs },
             login: { user: { language: 'en_US' } },
             products: { P1: {} },
             warehouses: { wh1: {} },
@@ -75,6 +78,52 @@ test('#input-text HTML: type=text, inputMode=none, readOnly absent, CSS-hidden',
     // input-text-offscreen: CSS-hidden, NOT removed from DOM (type=hidden would break IME)
     await BarcodeScannerComponent.expectAttributes({ type: 'text', inputmode: 'none', readonly: null });
     await BarcodeScannerComponent.expectCssClass({ present: 'input-text-offscreen' });
+});
+
+// ⚠️ HARDWARE CONTRACT — Honeywell CT60 / Android 11 / Keyboard-wedge mode.
+// DO NOT WEAKEN THIS TEST. The five conditions below must ALL hold simultaneously — any
+// single regression silently breaks scanning on the real CT60 hardware:
+//
+//   type=text             — required for Android InputConnection (type=hidden cannot focus)
+//   inputmode=none        — soft suppression of the virtual keyboard (Android < 11 honours it)
+//   readOnly PRESENT      — HARD suppression of the virtual keyboard on Android 11+ where
+//                           inputMode="none" is IGNORED (CT60 / Honeywell Wedge keyboard mode).
+//                           This is the load-bearing flag for this device.
+//   input-text-offscreen  — the input stays in the DOM (the keystroke hook listens on document)
+//                           but is visually hidden. The scan-prompt UI provides the visual anchor.
+//   no <video> element    — useCamera=N → device camera should never render
+//
+// Asserts on HU Manager so BarcodeScannerComponent renders from SysConfig (no hardcoded prop) —
+// ApplicationsListScreen hardcodes both isShowInputText={false} and isShowVideo={false}, which
+// would short-circuit the sysconfig path and make readOnly + camera-absent checks vacuously pass.
+//
+// IF THIS TEST FAILS after a change to BarcodeScannerComponent.jsx: the CODE broke the contract.
+// Fix the code, do NOT relax these expected values. Any change to readOnly / inputMode / type /
+// the off-screen class on #input-text MUST be re-validated on a physical Honeywell CT60 (see
+// e2e/mobile-webui/CLAUDE.md → "Manual Hardware Test Rule"). Automated tests cannot prove the
+// on-device behaviour.
+// noinspection JSUnusedLocalSymbols
+test('Honeywell CT60 keystroke-wedge mode — input is off-screen + readOnly, no camera', async ({ page }) => {
+    await allure.epic('E0295: Frontend MobileUI');
+    await allure.feature('F12000: Frontend MobileUI');
+    await allure.story('Barcode scanning modes');
+    await allure.severity('critical');
+
+    // Sysconfig combo for the keystroke-wedge mode — captured from a live local stack and
+    // validated on physical CT60 hardware.
+    const masterdata = await createMasterdataWithHU({
+        showInputText: 'N',
+        useCamera: 'N',
+        offscreenInputReadOnly: 'Y',
+    });
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('huManager');
+    await HUManagerScreen.waitForScreen();
+
+    await BarcodeScannerComponent.expectAttributes({ type: 'text', inputmode: 'none', readonly: true });
+    await BarcodeScannerComponent.expectCssClass({ present: 'input-text-offscreen' });
+    await BarcodeScannerComponent.expectCameraVideoAbsent();
 });
 
 // Each test drives one real-world way a barcode reaches the app, end to end:

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -223,8 +223,9 @@ test.describe('Scan paths', () => {
         const masterdata = await createMasterdataWithHU({
             // manual mode: mode.manual.enabled=Y + defaultMode=manual renders a visible editable
             // input so Playwright can locate and fill it. inputMode attribute is absent (keyboard enabled).
+            // hardware stays enabled (the handheld's scanner is always present in real deployments).
             extraSysconfigs: modeSysconfigs({
-                hardwareEnabled: 'N',
+                hardwareEnabled: 'Y',
                 cameraEnabled: 'N',
                 manualEnabled: 'Y',
                 defaultMode: 'manual',
@@ -356,10 +357,13 @@ test.describe('Modes', () => {
         await BarcodeScannerComponent.expectFooterAbsent();
     });
 
-    // manual mode: mode.manual.enabled=Y + defaultMode=manual →
+    // manual mode: mode.manual.enabled=Y + defaultMode=manual, hardware always enabled →
     //   • visible editable input (data-testid="manual-entry-input") IS rendered
     //   • off-screen #input-text IS still present (keyboard listener stays mounted)
     //   • manual-entry-input has no readOnly attribute (keyboard must be enabled)
+    //   • the "Use hardware scanner" button IS shown (hardware is an enabled scanner mode to
+    //     return to) — this mirrors the real deployment, where the handheld's hardware scanner
+    //     is always present, so manual mode always offers a way back to it.
     // noinspection JSUnusedLocalSymbols
     test('manual mode — visible editable input rendered, off-screen input present, no readOnly', async ({ page }) => {
         await allure.epic('E0295: Frontend MobileUI');
@@ -369,7 +373,7 @@ test.describe('Modes', () => {
 
         const masterdata = await createLoginMasterdata({
             extraSysconfigs: modeSysconfigs({
-                hardwareEnabled: 'N',
+                hardwareEnabled: 'Y',
                 cameraEnabled: 'N',
                 manualEnabled: 'Y',
                 defaultMode: 'manual',
@@ -387,6 +391,9 @@ test.describe('Modes', () => {
         // The manual-entry input must NOT be readOnly — the user must be able to type.
         await BarcodeScannerComponent.expectManualEntryInputNotReadOnly();
         await BarcodeScannerComponent.expectCameraVideoAbsent();
+        // Hardware scanner is enabled → manual mode offers the "Use hardware scanner" button
+        // (testId barcode-scanner-back-to-scanner) so the operator can return to the scanner.
+        await BarcodeScannerComponent.expectFooterButtonPresent('barcode-scanner-back-to-scanner');
     });
 
     // camera toggle: hardware + camera both enabled →

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -105,8 +105,9 @@ test('#input-text HTML: type=text, inputMode=none, readOnly absent, CSS-hidden',
 //   no <video> element    — mode.camera.enabled=N → device camera should never render
 //
 // Asserts on HU Manager so BarcodeScannerComponent renders from SysConfig (no hardcoded prop) —
-// ApplicationsListScreen hardcodes both isShowInputText={false} and isShowVideo={false}, which
-// would short-circuit the sysconfig path and make readOnly + camera-absent checks vacuously pass.
+// ApplicationsListScreen hardcodes `invisible` (headless hardware variant: off-screen input only,
+// no footer, no video), which would short-circuit the sysconfig path and make readOnly +
+// camera-absent checks vacuously pass.
 //
 // IF THIS TEST FAILS after a change to BarcodeScannerComponent.jsx: the CODE broke the contract.
 // Fix the code, do NOT relax these expected values. Any change to readOnly / inputMode / type /
@@ -234,7 +235,7 @@ test.describe('Scan paths', () => {
         await ApplicationsListScreen.expectVisible();
 
         // Navigate to HU Manager so the barcode scanner renders from SysConfig (no hardcoded prop).
-        // The ApplicationsListScreen hardcodes isShowInputText={false}, which would override the
+        // The ApplicationsListScreen hardcodes `invisible`, which would override the
         // SysConfig and make the attribute assertion below meaningless.
         await ApplicationsListScreen.startApplication('huManager');
         await HUManagerScreen.waitForScreen();

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -420,4 +420,50 @@ test.describe('Modes', () => {
         await BarcodeScannerComponent.expectCameraVideoPresent();
     });
 
+    // THE canonical hardware-handheld deployment: hardware scanner is the default, manual typing is
+    // an available fallback, the device camera is OFF, and the off-screen input is readOnly
+    // (keyboard-suppress for firmware that ignores inputMode=none). This is the config shipped to
+    // intercheese / Dantherm handhelds. The footer must therefore offer the manual-entry fallback
+    // but NOT a camera toggle, and the manual fallback must actually forward a typed barcode.
+    test('hardware default + manual fallback, camera off — footer shows manual, hides camera toggle', async ({ page }) => {
+        await allure.epic('E0295: Frontend MobileUI');
+        await allure.feature('F12000: Frontend MobileUI');
+        await allure.story('Barcode scanning modes');
+        await allure.severity('critical');
+
+        const masterdata = await createMasterdataWithHU({
+            extraSysconfigs: modeSysconfigs({
+                hardwareEnabled: 'Y',
+                cameraEnabled: 'N',
+                manualEnabled: 'Y',
+                defaultMode: 'hardware',
+                hardwareInputMode: 'none',
+                hardwareInputReadOnly: 'Y',
+            }),
+        });
+
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('huManager');
+        await HUManagerScreen.waitForScreen();
+
+        // Boots in hardware mode: off-screen scan input present, device camera absent.
+        await BarcodeScannerComponent.expectAttached({});
+        await BarcodeScannerComponent.expectCameraVideoAbsent();
+
+        // Footer contract for this deployment: manual-entry fallback shown, camera toggle hidden
+        // (camera toggle needs BOTH hardware and camera enabled).
+        await BarcodeScannerComponent.expectFooterButtonPresent('barcode-scanner-enter-manually');
+        await BarcodeScannerComponent.expectFooterButtonAbsent('barcode-scanner-toggle-hw-camera');
+
+        // Manual fallback works: tap "enter manually" → visible editable input → type + Enter forwards.
+        await BarcodeScannerComponent.clickFooterButton('barcode-scanner-enter-manually');
+        await BarcodeScannerComponent.expectManualEntryInputPresent();
+        await BarcodeScannerComponent.expectManualEntryInputNotReadOnly();
+        await BarcodeScannerComponent.typeManually(masterdata.handlingUnits.HU1.qrCode);
+
+        await HUManagerScreen.waitForHUInfoPanel();
+        await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
+    });
+
 });

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -6,32 +6,43 @@ import { HUManagerScreen } from '../utils/screens/huManager/HUManagerScreen';
 import { BarcodeScannerComponent } from '../utils/components/BarcodeScannerComponent';
 import { allure } from 'allure-playwright';
 
-const scannerSysconfigs = ({ showInputText, isInputTextReadonly, useCamera, offscreenInputReadOnly, visibleInputReadOnly }) => ({
-    ...(showInputText != null && { 'mobileui.frontend.barcodeScanner.showInputText': showInputText }),
-    ...(isInputTextReadonly != null && { 'mobileui.frontend.barcodeScanner.isInputTextReadonly': isInputTextReadonly }),
-    ...(useCamera != null && { 'mobileui.frontend.barcodeScanner.useCamera': useCamera }),
-    ...(offscreenInputReadOnly != null && { 'mobileui.frontend.barcodeScanner.offscreenInput.readOnly': offscreenInputReadOnly }),
-    ...(visibleInputReadOnly != null && { 'mobileui.frontend.barcodeScanner.visibleInput.readOnly': visibleInputReadOnly }),
+
+// Mode-engine sysconfigs (new per-mode knobs introduced by the BarcodeScannerModes redesign).
+// Keys map 1:1 to AD_SysConfig names (mobileui.frontend.* prefix included).
+const modeSysconfigs = ({
+    hardwareEnabled,
+    cameraEnabled,
+    manualEnabled,
+    defaultMode,
+    hardwareInputMode,
+    hardwareInputReadOnly,
+} = {}) => ({
+    ...(hardwareEnabled != null && { 'mobileui.frontend.barcodeScanner.mode.hardware.enabled': hardwareEnabled }),
+    ...(cameraEnabled != null && { 'mobileui.frontend.barcodeScanner.mode.camera.enabled': cameraEnabled }),
+    ...(manualEnabled != null && { 'mobileui.frontend.barcodeScanner.mode.manual.enabled': manualEnabled }),
+    ...(defaultMode != null && { 'mobileui.frontend.barcodeScanner.defaultMode': defaultMode }),
+    ...(hardwareInputMode != null && { 'mobileui.frontend.barcodeScanner.mode.hardware.input.inputMode': hardwareInputMode }),
+    ...(hardwareInputReadOnly != null && { 'mobileui.frontend.barcodeScanner.mode.hardware.input.readOnly': hardwareInputReadOnly }),
 });
 
 // Minimal masterdata: login only, no HU/orders. Used by the attribute-guard tests,
 // which only need the barcode input to render — so they run in seconds.
-const createLoginMasterdata = async ({ extraSysconfigs, showInputText, isInputTextReadonly, useCamera, offscreenInputReadOnly, visibleInputReadOnly } = {}) => {
+const createLoginMasterdata = async ({ extraSysconfigs } = {}) => {
     return await Backend.createMasterdata({
         language: 'en_US',
         request: {
-            sysconfigs: { ...scannerSysconfigs({ showInputText, isInputTextReadonly, useCamera, offscreenInputReadOnly, visibleInputReadOnly }), ...extraSysconfigs },
+            sysconfigs: { ...extraSysconfigs },
             login: { user: { language: 'en_US' } },
         },
     });
 };
 
 // Full masterdata: login + a handling unit, so scanning its QR code navigates to the HU Manager.
-const createMasterdataWithHU = async ({ extraSysconfigs, showInputText, isInputTextReadonly, useCamera, offscreenInputReadOnly, visibleInputReadOnly } = {}) => {
+const createMasterdataWithHU = async ({ extraSysconfigs } = {}) => {
     return await Backend.createMasterdata({
         language: 'en_US',
         request: {
-            sysconfigs: { ...scannerSysconfigs({ showInputText, isInputTextReadonly, useCamera, offscreenInputReadOnly, visibleInputReadOnly }), ...extraSysconfigs },
+            sysconfigs: { ...extraSysconfigs },
             login: { user: { language: 'en_US' } },
             products: { P1: {} },
             warehouses: { wh1: {} },
@@ -91,7 +102,7 @@ test('#input-text HTML: type=text, inputMode=none, readOnly absent, CSS-hidden',
 //                           This is the load-bearing flag for this device.
 //   input-text-offscreen  — the input stays in the DOM (the keystroke hook listens on document)
 //                           but is visually hidden. The scan-prompt UI provides the visual anchor.
-//   no <video> element    — useCamera=N → device camera should never render
+//   no <video> element    — mode.camera.enabled=N → device camera should never render
 //
 // Asserts on HU Manager so BarcodeScannerComponent renders from SysConfig (no hardcoded prop) —
 // ApplicationsListScreen hardcodes both isShowInputText={false} and isShowVideo={false}, which
@@ -110,11 +121,16 @@ test('Honeywell CT60 keystroke-wedge mode — input is off-screen + readOnly, no
     await allure.severity('critical');
 
     // Sysconfig combo for the keystroke-wedge mode — captured from a live local stack and
-    // validated on physical CT60 hardware.
+    // validated on physical CT60 hardware. Drives the new mode-engine keys so the frontend
+    // renders hardware mode with readOnly=Y (hard keyboard suppression for Android 11+).
     const masterdata = await createMasterdataWithHU({
-        showInputText: 'N',
-        useCamera: 'N',
-        offscreenInputReadOnly: 'Y',
+        extraSysconfigs: modeSysconfigs({
+            hardwareEnabled: 'Y',
+            cameraEnabled: 'N',
+            manualEnabled: 'N',
+            defaultMode: 'hardware',
+            hardwareInputReadOnly: 'Y',
+        }),
     });
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
@@ -130,15 +146,14 @@ test('Honeywell CT60 keystroke-wedge mode — input is off-screen + readOnly, no
 // scanning the HU's QR code must navigate to the HU Manager and show the HU quantity.
 test.describe('Scan paths', () => {
 
-    // The manual-typing test flips two GLOBAL barcode-scanner sysconfigs to make the input
-    // visible + editable. A leaked isInputTextReadonly='N' would make every later spec's scanner
+    // The manual-typing test sets the mode-engine sysconfigs to manual mode to make the input
+    // visible + editable. A leaked defaultMode=manual would make every later spec's scanner
     // editable, and BarcodeScannerComponent.type() would then double-insert characters
     // (see e2e/mobile-webui/CLAUDE.md "Barcode Scanner Testing"), breaking unrelated picking scans.
     //
     // No explicit reset is needed here: SysconfigCommand resets the scanner sysconfigs to their
-    // mobile defaults (showInputText='Y', isInputTextReadonly='Y') at the start of every
-    // createMasterdata call, so each test starts from a clean scanner state regardless of what a
-    // prior test left behind.
+    // mobile defaults at the start of every createMasterdata call, so each test starts from
+    // a clean scanner state regardless of what a prior test left behind.
 
     // noinspection JSUnusedLocalSymbols
     test('DataWedge IME — InputConnection injection forwards barcode', async ({ page }) => {
@@ -205,10 +220,14 @@ test.describe('Scan paths', () => {
         await allure.severity('critical');
 
         const masterdata = await createMasterdataWithHU({
-            // showInputText='Y' makes the input visible so Playwright can locate and fill it.
-            showInputText: 'Y',
-            // isInputTextReadonly='N' makes the input editable (not inputMode="none") so fill() works.
-            isInputTextReadonly: 'N',
+            // manual mode: mode.manual.enabled=Y + defaultMode=manual renders a visible editable
+            // input so Playwright can locate and fill it. inputMode attribute is absent (keyboard enabled).
+            extraSysconfigs: modeSysconfigs({
+                hardwareEnabled: 'N',
+                cameraEnabled: 'N',
+                manualEnabled: 'Y',
+                defaultMode: 'manual',
+            }),
         });
 
         await LoginScreen.login(masterdata.login.user);
@@ -220,9 +239,13 @@ test.describe('Scan paths', () => {
         await ApplicationsListScreen.startApplication('huManager');
         await HUManagerScreen.waitForScreen();
 
-        // Regression guard: when isInputTextReadonly=N, inputmode attribute must be absent
-        // (virtual keyboard suppression is disabled to allow manual typing).
-        await BarcodeScannerComponent.expectAttributes({ inputmode: null });
+        // Regression guard: in manual mode (defaultMode=manual), the visible editable input
+        // ([data-testid="manual-entry-input"]) must be present and NOT readOnly — the user must
+        // be able to type into it (virtual keyboard suppression must be disabled on that field).
+        // NOTE: #input-text (off-screen hardware input) always has inputmode="none" in every mode
+        // (DataWedge IME suppression) — do NOT assert inputmode absence on that element here.
+        await BarcodeScannerComponent.expectManualEntryInputPresent();
+        await BarcodeScannerComponent.expectManualEntryInputNotReadOnly();
 
         // fill + Enter exercises the manual-typing path: onKeyUp → handleInputTextKeyPress →
         // validateScannedBarcodeAndForward. BarcodeScannerComponent.typeManually() encapsulates
@@ -231,6 +254,169 @@ test.describe('Scan paths', () => {
 
         await HUManagerScreen.waitForHUInfoPanel();
         await HUManagerScreen.expectValue({ name: 'qty-value', expectedValue: '80 PCE' });
+    });
+
+});
+
+// Per-mode attribute contract — guards the HTML attributes emitted by the new mode engine.
+//
+// These tests assert the DOM output of useBarcodeScannerModes + the hardware input knobs:
+//   mode.hardware.input.inputMode  → the `inputMode` HTML attribute on #input-text
+//   mode.hardware.input.readOnly   → the `readOnly` HTML attribute on #input-text (absent=N, present=Y)
+//
+// Navigation: HU Manager is used (not ApplicationsListScreen) because ApplicationsListScreen
+// hardcodes `invisible=true`, which short-circuits the sysconfig path and would make
+// mode-specific attribute/footer assertions vacuously pass.
+test.describe('Modes', () => {
+
+    // ⚠️ HARDWARE CONTRACT — mode-engine driven.
+    // Off-screen hardware input default contract: inputmode=none, readonly absent, CSS-hidden.
+    // Mirrors the top-level DataWedge guard above but exercises the NEW mode-engine path
+    // (mode.hardware.enabled=Y, mode.hardware.input.readOnly=N default).
+    // noinspection JSUnusedLocalSymbols
+    test('hardware mode — off-screen input: inputmode=none, readonly absent, CSS-hidden', async ({ page }) => {
+        await allure.epic('E0295: Frontend MobileUI');
+        await allure.feature('F12000: Frontend MobileUI');
+        await allure.story('Barcode scanning modes');
+        await allure.severity('critical');
+
+        // hardware.enabled=Y (default), readOnly=N (default) — explicit to document the contract.
+        const masterdata = await createMasterdataWithHU({
+            extraSysconfigs: modeSysconfigs({
+                hardwareEnabled: 'Y',
+                cameraEnabled: 'N',
+                manualEnabled: 'N',
+                hardwareInputReadOnly: 'N',
+            }),
+        });
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('huManager');
+        await HUManagerScreen.waitForScreen();
+
+        // Off-screen input HTML contract for DataWedge IME deployments:
+        //   type=text       — focusable, keeps InputConnection alive
+        //   inputmode=none  — suppresses virtual keyboard (soft hint)
+        //   readonly absent — readOnly kills InputConnection; must be absent for DataWedge IME
+        //   CSS-hidden      — input-text-offscreen keeps it in DOM but invisible
+        await BarcodeScannerComponent.expectAttributes({ type: 'text', inputmode: 'none', readonly: null });
+        await BarcodeScannerComponent.expectCssClass({ present: 'input-text-offscreen' });
+    });
+
+    // ⚠️ HARDWARE CONTRACT — mode-engine driven, readOnly=Y.
+    // Mirrors the CT60 keystroke-wedge guard above via the new mode-engine readOnly knob.
+    // noinspection JSUnusedLocalSymbols
+    test('hardware mode — off-screen input readOnly=Y: inputmode=none, readonly present', async ({ page }) => {
+        await allure.epic('E0295: Frontend MobileUI');
+        await allure.feature('F12000: Frontend MobileUI');
+        await allure.story('Barcode scanning modes');
+        await allure.severity('critical');
+
+        const masterdata = await createMasterdataWithHU({
+            extraSysconfigs: modeSysconfigs({
+                hardwareEnabled: 'Y',
+                cameraEnabled: 'N',
+                manualEnabled: 'N',
+                hardwareInputReadOnly: 'Y',
+            }),
+        });
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('huManager');
+        await HUManagerScreen.waitForScreen();
+
+        // readonly PRESENT — hard suppression for Android 11 firmware that ignores inputMode="none".
+        await BarcodeScannerComponent.expectAttributes({ type: 'text', inputmode: 'none', readonly: true });
+        await BarcodeScannerComponent.expectCssClass({ present: 'input-text-offscreen' });
+        await BarcodeScannerComponent.expectCameraVideoAbsent();
+    });
+
+    // invisible=true (ApplicationsListScreen / BarcodeScannerButton callers):
+    //   • off-screen #input-text IS present (keyboard listener needs it in DOM)
+    //   • NO <video> element
+    //   • NO footer (.barcode-scanner-footer)
+    // noinspection JSUnusedLocalSymbols
+    test('invisible mode — off-screen input present, no video, no footer', async ({ page }) => {
+        await allure.epic('E0295: Frontend MobileUI');
+        await allure.feature('F12000: Frontend MobileUI');
+        await allure.story('Barcode scanning modes');
+        await allure.severity('critical');
+
+        // ApplicationsListScreen always renders BarcodeScannerComponent with invisible=true,
+        // so no HU or extra sysconfig setup is needed — just login.
+        const masterdata = await createLoginMasterdata();
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+
+        // invisible=true → useBarcodeScannerModes returns hardware-only, no camera, no manual.
+        // The component renders ONLY the off-screen #input-text and the keyboard listener.
+        await BarcodeScannerComponent.expectAttached({});
+        await BarcodeScannerComponent.expectCameraVideoAbsent();
+        await BarcodeScannerComponent.expectFooterAbsent();
+    });
+
+    // manual mode: mode.manual.enabled=Y + defaultMode=manual →
+    //   • visible editable input (data-testid="manual-entry-input") IS rendered
+    //   • off-screen #input-text IS still present (keyboard listener stays mounted)
+    //   • manual-entry-input has no readOnly attribute (keyboard must be enabled)
+    // noinspection JSUnusedLocalSymbols
+    test('manual mode — visible editable input rendered, off-screen input present, no readOnly', async ({ page }) => {
+        await allure.epic('E0295: Frontend MobileUI');
+        await allure.feature('F12000: Frontend MobileUI');
+        await allure.story('Barcode scanning modes');
+        await allure.severity('critical');
+
+        const masterdata = await createLoginMasterdata({
+            extraSysconfigs: modeSysconfigs({
+                hardwareEnabled: 'N',
+                cameraEnabled: 'N',
+                manualEnabled: 'Y',
+                defaultMode: 'manual',
+            }),
+        });
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('huManager');
+        await HUManagerScreen.waitForScreen();
+
+        // Off-screen input stays mounted in MANUAL mode (DataWedge IME InputConnection preserved).
+        await BarcodeScannerComponent.expectAttached({});
+        // Visible editable input is rendered in manual mode.
+        await BarcodeScannerComponent.expectManualEntryInputPresent();
+        // The manual-entry input must NOT be readOnly — the user must be able to type.
+        await BarcodeScannerComponent.expectManualEntryInputNotReadOnly();
+        await BarcodeScannerComponent.expectCameraVideoAbsent();
+    });
+
+    // camera toggle: hardware + camera both enabled →
+    //   • footer toggle button present
+    //   • clicking toggle → <video> renders
+    // noinspection JSUnusedLocalSymbols
+    test('camera toggle — clicking hw/camera toggle renders <video>', async ({ page }) => {
+        await allure.epic('E0295: Frontend MobileUI');
+        await allure.feature('F12000: Frontend MobileUI');
+        await allure.story('Barcode scanning modes');
+        await allure.severity('critical');
+
+        const masterdata = await createLoginMasterdata({
+            extraSysconfigs: modeSysconfigs({
+                hardwareEnabled: 'Y',
+                cameraEnabled: 'Y',
+                manualEnabled: 'N',
+                defaultMode: 'hardware',
+            }),
+        });
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('huManager');
+        await HUManagerScreen.waitForScreen();
+
+        // Starting in hardware mode — no video yet.
+        await BarcodeScannerComponent.expectCameraVideoAbsent();
+        // Toggle to camera mode via footer button.
+        await BarcodeScannerComponent.clickFooterButton('barcode-scanner-toggle-hw-camera');
+        // After toggle, <video> element must be rendered.
+        await BarcodeScannerComponent.expectCameraVideoPresent();
     });
 
 });

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -141,11 +141,16 @@ export const BarcodeScannerComponent = {
 
     // Fills the visible editable input and presses Enter — exercises the manual-typing path
     // (onChange debounce / onKeyUp Enter) in BarcodeScannerComponent. Only valid when
-    // barcodeScanner.showInputText=Y and barcodeScanner.isInputTextReadonly=N.
+    // the mode-engine is in manual mode (defaultMode=manual, mode.manual.enabled=Y).
+    // NOTE: wait on the manual-entry input, NOT on `#input-text`. The hardware off-screen
+    // `#input-text` is rendered by HardwareModePanel only when activeMode === HARDWARE; in
+    // pure manual mode (`mode.hardware.enabled=N` or `defaultMode=manual`) it is not in the
+    // DOM, so `waitToAttach({})` would time out and look like a manual-entry failure.
     typeManually: async (barcode) => await test.step(`${NAME} - Type manually and press Enter`, async () => {
-        await BarcodeScannerComponent.waitToAttach({});
-        await page.locator('#input-text').fill(barcode);
-        await page.keyboard.press('Enter');
+        const input = page.locator('[data-testid="manual-entry-input"]');
+        await input.waitFor({ state: 'attached', timeout: SLOW_ACTION_TIMEOUT });
+        await input.fill(barcode);
+        await input.press('Enter');
     }),
 
     // Asserts DOM attributes on #input-text.
@@ -200,5 +205,38 @@ export const BarcodeScannerComponent = {
         await BarcodeScannerComponent.waitToAttach({});
         if (present) await expect(page.locator('#input-text')).toHaveClass(new RegExp(`(^|\\s)${present}(\\s|$)`));
         if (absent) await expect(page.locator('#input-text')).not.toHaveClass(new RegExp(`(^|\\s)${absent}(\\s|$)`));
+    }),
+
+    // Asserts the footer (.barcode-scanner-footer) is NOT rendered.
+    // Used by invisible-mode tests — invisible suppresses the footer entirely.
+    expectFooterAbsent: async () => await test.step(`${NAME} - Expect no footer rendered`, async () => {
+        await expect(page.locator('.barcode-scanner-footer')).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
+    }),
+
+    // Asserts the manual-entry visible input IS rendered (data-testid="manual-entry-input").
+    expectManualEntryInputPresent: async () => await test.step(`${NAME} - Expect manual-entry input present`, async () => {
+        await expect(page.getByTestId('manual-entry-input')).toBeAttached({ timeout: SLOW_ACTION_TIMEOUT });
+    }),
+
+    // Asserts the manual-entry visible input is NOT rendered.
+    expectManualEntryInputAbsent: async () => await test.step(`${NAME} - Expect manual-entry input absent`, async () => {
+        await expect(page.getByTestId('manual-entry-input')).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
+    }),
+
+    // Asserts the manual-entry input does NOT have the readOnly attribute — the user must be able
+    // to type into it (keyboard-enabled). Only meaningful when expectManualEntryInputPresent() passes.
+    expectManualEntryInputNotReadOnly: async () => await test.step(`${NAME} - Expect manual-entry input not readOnly`, async () => {
+        await expect(page.getByTestId('manual-entry-input')).not.toHaveAttribute('readonly', { timeout: SLOW_ACTION_TIMEOUT });
+    }),
+
+    // Asserts the device camera <video> element IS rendered inside .barcode-scanner.
+    expectCameraVideoPresent: async () => await test.step(`${NAME} - Expect camera <video> rendered`, async () => {
+        await expect(page.locator('.barcode-scanner video')).toHaveCount(1, { timeout: SLOW_ACTION_TIMEOUT });
+    }),
+
+    // Clicks a footer button by its testId (e.g. 'barcode-scanner-toggle-hw-camera',
+    // 'barcode-scanner-enter-manually', 'barcode-scanner-back-to-scanner').
+    clickFooterButton: async (testId) => await test.step(`${NAME} - Click footer button '${testId}'`, async () => {
+        await page.getByTestId(testId).tap();
     }),
 }

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -239,4 +239,14 @@ export const BarcodeScannerComponent = {
     clickFooterButton: async (testId) => await test.step(`${NAME} - Click footer button '${testId}'`, async () => {
         await page.getByTestId(testId).tap();
     }),
+
+    // Asserts a footer button (by testId) IS shown.
+    expectFooterButtonPresent: async (testId) => await test.step(`${NAME} - Expect footer button present '${testId}'`, async () => {
+        await expect(page.getByTestId(testId)).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+    }),
+
+    // Asserts a footer button (by testId) is NOT shown.
+    expectFooterButtonAbsent: async (testId) => await test.step(`${NAME} - Expect footer button absent '${testId}'`, async () => {
+        await expect(page.getByTestId(testId)).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
+    }),
 }

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -148,17 +148,36 @@ export const BarcodeScannerComponent = {
         await page.keyboard.press('Enter');
     }),
 
-    // Asserts DOM attributes on #input-text. Pass null as value to assert the attribute is ABSENT.
+    // Asserts DOM attributes on #input-text.
+    //   value === null   → attribute must be ABSENT
+    //   value === true   → attribute must be PRESENT (any value — use for HTML boolean attrs
+    //                      like readonly/disabled where React's rendered value can vary)
+    //   other            → attribute must equal that exact string
     // Example: expectAttributes({ type: 'text', inputmode: 'none', readonly: null })
+    //          expectAttributes({ type: 'text', inputmode: 'none', readonly: true })   // CT60 mode
     expectAttributes: async (expectedAttrs) => await test.step(`${NAME} - Expect attributes: ${JSON.stringify(expectedAttrs)}`, async () => {
         await BarcodeScannerComponent.waitToAttach({});
         for (const [attr, expectedValue] of Object.entries(expectedAttrs)) {
             if (expectedValue === null) {
                 await expect(page.locator('#input-text')).not.toHaveAttribute(attr);
+            } else if (expectedValue === true) {
+                await expect(page.locator('#input-text')).toHaveAttribute(attr, /.*/);
             } else {
                 await expect(page.locator('#input-text')).toHaveAttribute(attr, expectedValue);
             }
         }
+    }),
+
+    // Asserts the device camera <video> element is NOT rendered inside .barcode-scanner.
+    // Used by the hardware-scanner-only deployments (useCamera=N) to guard against a
+    // regression that would silently re-enable the camera capture preview.
+    //
+    // Uses FAST_ACTION_TIMEOUT (5s): absence-of-element assertions should fail fast — a
+    // <video> that doesn't appear within seconds is not going to appear, and falling back
+    // to the 120s global assertion timeout would silently consume the test budget on a
+    // genuine regression.
+    expectCameraVideoAbsent: async () => await test.step(`${NAME} - Expect no camera <video> rendered`, async () => {
+        await expect(page.locator('.barcode-scanner video')).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
     }),
 
     // Simulates Ctrl+V paste: mocks navigator.clipboard.readText to return the barcode,

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/useBarcodeScannerModes.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/useBarcodeScannerModes.test.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useBarcodeScannerModes, MODE } from '../components/BarcodeScanner/useBarcodeScannerModes';
+import { useBooleanSetting, useSetting } from '../reducers/settings';
+
+// Mock the settings hooks
+jest.mock('../reducers/settings', () => ({
+  useBooleanSetting: jest.fn(),
+  useSetting: jest.fn(),
+}));
+
+/**
+ * Helper: configure the mocked settings hooks for a given scenario.
+ */
+function setupMocks({ hardware = true, camera = true, manual = false, defaultMode = undefined } = {}) {
+  useBooleanSetting.mockImplementation((key, defaultValue) => {
+    if (key === 'barcodeScanner.mode.hardware.enabled') return hardware;
+    if (key === 'barcodeScanner.mode.camera.enabled') return camera;
+    if (key === 'barcodeScanner.mode.manual.enabled') return manual;
+    return defaultValue;
+  });
+  useSetting.mockReturnValue(defaultMode);
+}
+
+/**
+ * Renders the hook by calling it inside a component and capturing the result via a ref.
+ */
+function renderHookResult(options) {
+  const result = { current: null };
+  function TestComponent() {
+    result.current = useBarcodeScannerModes(options);
+    return null;
+  }
+  render(<TestComponent />);
+  return result;
+}
+
+describe('useBarcodeScannerModes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('(a) configured defaultMode is honoured when that mode is enabled', () => {
+    setupMocks({ hardware: true, camera: true, manual: true, defaultMode: 'camera' });
+    const result = renderHookResult();
+    expect(result.current.defaultMode).toBe(MODE.CAMERA);
+    expect(result.current.enabledModes.camera).toBe(true);
+  });
+
+  it('(b) configured defaultMode is DISABLED → falls back to first enabled by priority hardware→camera→manual', () => {
+    // defaultMode=hardware but hardware is disabled; camera is enabled → should fall back to camera
+    setupMocks({ hardware: false, camera: true, manual: false, defaultMode: 'hardware' });
+    const result = renderHookResult();
+    expect(result.current.defaultMode).toBe(MODE.CAMERA);
+    expect(result.current.enabledModes.hardware).toBe(false);
+  });
+
+  it('(c) none enabled → manual is force-enabled and defaultMode=manual (operator never locked out)', () => {
+    setupMocks({ hardware: false, camera: false, manual: false, defaultMode: undefined });
+    const result = renderHookResult();
+    expect(result.current.enabledModes.manual).toBe(true);
+    expect(result.current.defaultMode).toBe(MODE.MANUAL);
+  });
+
+  it('(d) invisible:true → only hardware enabled, no camera/manual, defaultMode=hardware', () => {
+    setupMocks({ hardware: true, camera: true, manual: true, defaultMode: 'camera' });
+    const result = renderHookResult({ invisible: true });
+    expect(result.current.enabledModes.hardware).toBe(true);
+    expect(result.current.enabledModes.camera).toBe(false);
+    expect(result.current.enabledModes.manual).toBe(false);
+    expect(result.current.defaultMode).toBe(MODE.HARDWARE);
+  });
+
+  it('MODE constants are exported', () => {
+    expect(MODE.HARDWARE).toBe('hardware');
+    expect(MODE.CAMERA).toBe('camera');
+    expect(MODE.MANUAL).toBe('manual');
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/huConsolidation/activities/ScanHUConsolidationTargetScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/huConsolidation/activities/ScanHUConsolidationTargetScreen.jsx
@@ -31,11 +31,7 @@ export const ScanHUConsolidationTargetScreen = () => {
 
   return (
     <div className="section pt-2">
-      <BarcodeScannerComponent
-        continuousRunning={true}
-        resolveScannedBarcode={resolveScannedBarcode}
-        onResolvedResult={onBarcodeScanned}
-      />
+      <BarcodeScannerComponent resolveScannedBarcode={resolveScannedBarcode} onResolvedResult={onBarcodeScanned} />
     </div>
   );
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/huManager/components/ChangeCurrentLocatorDialog.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/huManager/components/ChangeCurrentLocatorDialog.jsx
@@ -13,7 +13,6 @@ const ChangeCurrentLocatorDialog = ({ onOK, onClose }) => {
     <div>
       <Dialog className="screen">
         <BarcodeScannerComponent
-          continuousRunning={true}
           inputPlaceholderText={trl('huManager.locator')}
           onResolvedResult={({ scannedBarcode }) => {
             resolveLocatorQRCode({ scannedBarcode })

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/huManager/containers/GRAIScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/huManager/containers/GRAIScreen.jsx
@@ -78,7 +78,7 @@ const GRAIScreen = () => {
     <div className="grai-screen">
       <HUInfoComponent handlingUnitInfo={handlingUnitInfo} />
 
-      {!loading && <BarcodeScannerComponent onResolvedResult={onResolvedResult} continuousRunning={true} />}
+      {!loading && <BarcodeScannerComponent onResolvedResult={onResolvedResult} />}
 
       <div className="grai-count" data-testid="grai-count">
         {trl('huManager.action.scanGRAI.count', { scanned: assignedGrais.length, total: tuCount })}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/huManager/containers/HUBulkActionsScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/huManager/containers/HUBulkActionsScreen.jsx
@@ -89,7 +89,7 @@ const HUBulkActionsScreen = () => {
       {showHUScanner && (
         <BarcodeScannerComponent
           onResolvedResult={onScannedHUResolved}
-          scannerPlaceholder={'huManager.action.bulkActions.scanHUPlaceholder'}
+          inputPlaceholderText={trl('huManager.action.bulkActions.scanHUPlaceholder')}
         />
       )}
       <br />

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/huManager/containers/HUManagerScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/huManager/containers/HUManagerScreen.jsx
@@ -24,6 +24,7 @@ import { useScreenDefinition } from '../../../hooks/useScreenDefinition';
 import { trl } from '../../../utils/translations';
 import { useApplicationInfo } from '../../../reducers/applications';
 import { APPLICATION_ID } from '../constants';
+import { toast } from 'react-toastify';
 
 const MODALS = {
   CHANGE_QTY: 'CHANGE_QTY',
@@ -213,7 +214,10 @@ const useHandlingUnitInfo = () => {
   const handlingUnitInfo = useSelector((state) => getHandlingUnitInfoFromGlobalState(state));
 
   const dispatch = useDispatch();
-  const setHandlingUnitInfo = (handlingUnitInfo) => dispatch(handlingUnitLoaded({ handlingUnitInfo }));
+  const setHandlingUnitInfo = (handlingUnitInfo) => {
+    toast.dismiss();
+    return dispatch(handlingUnitLoaded({ handlingUnitInfo }));
+  };
 
   return [handlingUnitInfo, setHandlingUnitInfo];
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/inventory/activities/InventoryScanScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/inventory/activities/InventoryScanScreen.jsx
@@ -106,7 +106,6 @@ const InventoryScanScreen = () => {
           key="scanLocator"
           inputPlaceholderText={trl('inventory.scanLocatorPlaceholder')}
           onResolvedResult={onLocatorScanned}
-          continuousRunning={true}
         />
       )}
       {status === STATUS_ScanHU && (
@@ -114,7 +113,6 @@ const InventoryScanScreen = () => {
           key="scanHU"
           inputPlaceholderText={trl('inventory.scanHUPlaceholder')}
           onResolvedResult={onHUScanned}
-          continuousRunning={true}
         />
       )}
       {status === STATUS_FillData && (

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/pos/containers/order_panel/BarcodeReader.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/pos/containers/order_panel/BarcodeReader.jsx
@@ -37,7 +37,7 @@ const BarcodeReader = ({ onBarcodeScanned }) => {
   }, []);
 
   useEffect(() => {
-    videoRef?.current?.scrollIntoView({ behaviour: 'smooth', block: 'center', inline: 'end' });
+    videoRef?.current?.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'end' });
   });
 
   const fireBarcodeScanned = ({ scannedBarcode }) => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/pos/containers/order_panel/OrderLine.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/pos/containers/order_panel/OrderLine.jsx
@@ -40,7 +40,7 @@ export const OrderLine = ({
 
   useEffect(() => {
     if (selected && elementRef?.current?.scrollIntoView) {
-      elementRef.current.scrollIntoView({ behaviour: 'smooth', block: 'end', inline: 'end' });
+      elementRef.current.scrollIntoView({ behavior: 'smooth', block: 'end', inline: 'end' });
     }
   }, [selected]);
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/pos/containers/order_panel/ProductSearchBar.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/pos/containers/order_panel/ProductSearchBar.jsx
@@ -10,8 +10,8 @@ const _ = (key) => trl(`pos.products.searchBar.${key}`);
 const ProductSearchBar = ({ queryString, onQueryStringChanged, isEnabled }) => {
   const [isBarcodeScannerDisplayed, setBarcodeScannerDisplayed] = useState(false);
   // Camera scanning is hidden when the device camera is disabled (e.g. handheld hardware-scanner
-  // deployments). Shares the global barcodeScanner.useCamera switch.
-  const isCameraEnabled = useBooleanSetting('barcodeScanner.useCamera', true);
+  // deployments). Shares the global barcodeScanner.mode.camera.enabled switch.
+  const isCameraEnabled = useBooleanSetting('barcodeScanner.mode.camera.enabled', true);
   const queryStringRef = useRef();
 
   useEffect(() => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/pos/containers/order_panel/ProductSearchBar.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/pos/containers/order_panel/ProductSearchBar.jsx
@@ -2,18 +2,30 @@ import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import BarcodeReader from './BarcodeReader';
 import { trl } from '../../../../utils/translations';
+import { useBooleanSetting } from '../../../../reducers/settings';
 import './ProductSearchBar.scss';
 
 const _ = (key) => trl(`pos.products.searchBar.${key}`);
 
 const ProductSearchBar = ({ queryString, onQueryStringChanged, isEnabled }) => {
   const [isBarcodeScannerDisplayed, setBarcodeScannerDisplayed] = useState(false);
+  // Camera scanning is hidden when the device camera is disabled (e.g. handheld hardware-scanner
+  // deployments). Shares the global barcodeScanner.useCamera switch.
+  const isCameraEnabled = useBooleanSetting('barcodeScanner.useCamera', true);
   const queryStringRef = useRef();
 
   useEffect(() => {
     if (!isEnabled) return;
     queryStringRef?.current?.focus();
   }, [isEnabled]);
+
+  // If the camera gets disabled while the scanner overlay is open, close it — otherwise it would
+  // stay visible with no button to dismiss it (the toggle button is hidden when the camera is off).
+  useEffect(() => {
+    if (!isCameraEnabled && isBarcodeScannerDisplayed) {
+      setBarcodeScannerDisplayed(false);
+    }
+  }, [isCameraEnabled, isBarcodeScannerDisplayed]);
 
   const handleQueryStringFocus = () => {
     queryStringRef?.current?.select();
@@ -56,11 +68,13 @@ const ProductSearchBar = ({ queryString, onQueryStringChanged, isEnabled }) => {
           onBlur={handleQueryStringBlur}
           onChange={handleQueryStringChanged}
         />
-        <button className="button" disabled={!isEnabled} onClick={handleScannerButtonClicked}>
-          <i className="fa-solid fa-barcode"></i>
-        </button>
+        {isCameraEnabled && (
+          <button className="button" disabled={!isEnabled} onClick={handleScannerButtonClicked}>
+            <i className="fa-solid fa-barcode"></i>
+          </button>
+        )}
       </div>
-      {isBarcodeScannerDisplayed && <BarcodeReader onBarcodeScanned={handleBarcodeScanned} />}
+      {isCameraEnabled && isBarcodeScannerDisplayed && <BarcodeReader onBarcodeScanned={handleBarcodeScanned} />}
     </div>
   );
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/scanAnything/containers/AppScreen.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/scanAnything/containers/AppScreen.js
@@ -25,7 +25,7 @@ const AppScreen = () => {
     });
   };
 
-  return <BarcodeScannerComponent onResolvedResult={onResolvedResult} continuousRunning={true} />;
+  return <BarcodeScannerComponent onResolvedResult={onResolvedResult} />;
 };
 
 export default AppScreen;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workplaceManager/containers/AppScreen.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workplaceManager/containers/AppScreen.js
@@ -109,7 +109,7 @@ const AppScreen = () => {
       </div>
     );
   } else {
-    return <BarcodeScannerComponent onResolvedResult={onBarcodeScanned} continuousRunning={true} />;
+    return <BarcodeScannerComponent onResolvedResult={onBarcodeScanned} />;
   }
 };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/containers/AppScreen.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/containers/AppScreen.js
@@ -99,7 +99,7 @@ const AppScreen = () => {
       </div>
     );
   } else {
-    return <BarcodeScannerComponent onResolvedResult={onBarcodeScanned} continuousRunning={true} />;
+    return <BarcodeScannerComponent onResolvedResult={onBarcodeScanned} />;
   }
 };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/assets/BarcodeScannerComponent.scss
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/assets/BarcodeScannerComponent.scss
@@ -41,8 +41,52 @@
     border: none;
   }
 
+  // Scan prompt — rendered when there is no camera preview, the input is off-screen, and the
+  // caller did NOT explicitly request silent capture (isShowInputText={false} AND
+  // isShowVideo={false} both passed as props). Large barcode icon + inputPlaceholderText caption.
+  // See BarcodeScannerComponent.jsx for the guard (isComponentHidden / isComponentHiddenByParam).
+  .scan-prompt {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1rem 1rem;
+    color: $grey;
+
+    .scan-prompt-icon {
+      font-size: 6rem;
+      margin-bottom: 1rem;
+      color: $base-mf-green;
+
+      // Slow opacity pulse — signals "ready / waiting for scan" without competing with the
+      // hardware scanner input. Opacity-only (not scale/rotation) so the icon doesn't read as
+      // a loading spinner. Respects the user's reduced-motion preference (accessibility).
+      @media (prefers-reduced-motion: no-preference) {
+        animation: scan-prompt-pulse 1.4s ease-in-out infinite alternate;
+      }
+    }
+
+    .scan-prompt-text {
+      font-size: 1.5em;
+      text-align: center;
+      line-height: 1.3;
+
+      // Caption swap: .scan-prompt-text-idle is shown by default; .scan-prompt-text-progress
+      // takes its place while the input has content (see in-progress :has() rule below).
+      // Both occupy the same DOM slot — no layout shift on the transition.
+      .scan-prompt-text-progress {
+        display: none;
+      }
+    }
+  }
+
   .loading {
-    position: absolute;
+    // Center on the VIEWPORT (position: fixed — same as the global .loading rule in
+    // spinner.scss), not within .barcode-scanner. When isProcessing=true the prompt and
+    // input are hidden so .barcode-scanner shrinks to a short container; if the spinner
+    // were absolute-positioned to that short container its centre would land in the upper
+    // portion of the screen, partially behind the top green bar.
+    position: fixed;
     z-index: 999;
     top: 0;
     left: 0;
@@ -72,9 +116,44 @@
 // layer ignores CSS z-index and covers overlaid HTML content).
 .barcode-scanner:not(:has(video)) {
   display: flex;
+  flex-direction: column;
 
-  .input-text {
-    flex-grow: 1;
+  // .scan-prompt + .input-text stack vertically (prompt above input).
+  // flex-grow on the input would stretch it vertically — leave it at its natural height.
+}
+
+@keyframes scan-prompt-pulse {
+  from {
+    opacity: 0.25;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+// In-progress scan signal — when the visible/off-screen input has content (i.e. the hook is
+// mid-burst, chars are accumulating from the scanner), switch the prompt icon to a yellow
+// "scanning" hue and double the pulse rate. CSS-only — :placeholder-shown evaluates against
+// the input's current `value`, including imperative `inputTextRef.current.value = barcode`
+// writes from the hook's onReadInProgress. When the buffer is cleared on scan completion the
+// input falls back to placeholder-shown ⇒ icon returns to the idle green/slow pulse.
+.barcode-scanner:has(.input-text:not(:placeholder-shown)) {
+  .scan-prompt-icon {
+    color: $indicator-yellow;
+
+    @media (prefers-reduced-motion: no-preference) {
+      // Floored at 0.3s — at smaller durations the alternate-pulse crest rate approaches the
+      // WCAG 2.3.1 3Hz photosensitivity threshold (~0.17s duration). Smooth ease-in-out keeps
+      // the transition non-abrupt, but stay conservative.
+      animation-duration: 0.3s;
+    }
+  }
+
+  .scan-prompt-text-idle {
+    display: none;
+  }
+  .scan-prompt-text-progress {
+    display: inline;
   }
 }
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/assets/BarcodeScannerComponent.scss
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/assets/BarcodeScannerComponent.scss
@@ -1,13 +1,61 @@
+// Single stylesheet for the whole BarcodeScannerComponent subtree:
+//   - Root container (.barcode-scanner)
+//   - Per-mode panels (.hardware-mode-panel, .camera-mode-panel, .manual-mode-panel)
+//   - Footer (.barcode-scanner-footer)
+//   - Shared button class (.barcode-scanner-btn) used by footer buttons AND manual submit
+//   - Shared input bases (.input-text, .input-text-offscreen)
+// Imported globally via assets/index.scss; no local scss imports in the panel JSX files.
+
+// ---- Pixel-perfect layout constants ----
+// Two panel heights — sized to each mode's content so each panel is visually tight, not
+// padded out for inter-mode symmetry. Mode-switch jumps the bottom of the component up/down
+// by the height delta — acceptable; the buttons themselves never move within a given mode.
+//   - HARDWARE / CAMERA: just-fits the pulsing barcode icon + the one-line caption.
+//   - MANUAL: taller, with empty space at the bottom for the mobile virtual keyboard
+//             (input + Submit + back-to-scanner anchor at the TOP, not the bottom).
+$panel-height-scanner: 12rem;   // HARDWARE + CAMERA
+$panel-height-manual:  16rem;   // MANUAL — bottom area reserved for the soft keyboard
+$panel-padding-x: 1rem;   // horizontal margins for all panel content (manual input, submit)
+$btn-gap: 0.5rem;         // vertical gap between stacked buttons (footer + manual submit↔footer)
+// EXACT button height in rem so all panel/footer arithmetic stays single-unit (Sass refuses
+// to add px + rem). 3rem = 48px at the default 16px base — meets the touch-target floor for
+// gloved-hand warehouse use and guarantees pixel-identical buttons across panels.
+$btn-height: 3rem;
+
+// Maximum buttons the footer can show in HARDWARE/CAMERA (toggle + enter-manually). In
+// MANUAL the footer renders null entirely (the back-to-scanner button lives inside
+// ManualModePanel — see BarcodeScannerFooter.jsx). We still reserve the max-slot height in
+// HARDWARE/CAMERA so toggling between those two modes (1 button each ↔ 2 buttons depending
+// on which other mode is enabled) does not jump the footer.
+$footer-button-slots: 2;
+$footer-padding-y-top: $btn-gap;
+$footer-padding-y-bottom: 1rem;
+$footer-height: $btn-height * $footer-button-slots + $btn-gap * ($footer-button-slots - 1) +
+                $footer-padding-y-top + $footer-padding-y-bottom;
+
 .barcode-scanner {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
 
-  video {
-    position: relative;
-    width: 100%;
-    height: 100%;
-    z-index: 0;
+  // Shared button class — applied to every clickable in the scanner (footer toggle,
+  // footer back-to-scanner, footer enter-manually, manual Submit). All use ButtonWithIndicator
+  // (is-fullwidth + is-outlined + complete-btn) so they already share font/colour/border;
+  // this class adds the touch-target floor. Containers around them (.barcode-scanner-footer
+  // and .manual-mode-panel) both apply the same horizontal padding so the buttons sit at
+  // identical x-positions across all modes — visually one continuous button cluster.
+  // EXACT height (not min-height) — overrides Bulma's `.button { height: 2.5em }` and the
+  // ButtonWithIndicator inner `.full-size-btn { height: 2.5em }` so every button rendered
+  // in the scanner is pixel-identical (Submit ≡ footer back-to-scanner ≡ footer toggle).
+  .barcode-scanner-btn,
+  .barcode-scanner-btn .full-size-btn {
+    height: $btn-height;
+    min-height: $btn-height;
   }
 
+  // Base style for any text input inside the scanner subtree (manual + offscreen).
+  // Specific panels override font-size / text-align via their own modifier classes.
   .input-text {
     margin: 10px;
     padding: 8px 12px;
@@ -23,10 +71,12 @@
     }
   }
 
-  // Visually hidden but focusable input for background barcode scanning.
-  // Used by BarcodeScannerButton to capture DataWedge IME text injection
-  // without showing a visible input field. Must NOT use type="hidden" or
-  // display:none — those break Android InputConnection. (me03#28834)
+  // Visually hidden but focusable input for background barcode scanning. Used by both:
+  //   - HardwareModePanel (visible mode): captures DataWedge IME / keystroke-wedge input
+  //   - HardwareModePanel rendered with invisible=true in MANUAL/CAMERA modes: stays mounted
+  //     so DataWedge's Android InputConnection survives the mode switch (re-handshake on
+  //     every remount can drop the first scan after switching back to HARDWARE)
+  // Must NOT use type="hidden" or display:none — those break Android InputConnection. (me03#28834)
   .input-text-offscreen {
     position: absolute;
     top: 0;
@@ -41,16 +91,30 @@
     border: none;
   }
 
-  // Scan prompt — rendered when there is no camera preview, the input is off-screen, and the
-  // caller did NOT explicitly request silent capture (isShowInputText={false} AND
-  // isShowVideo={false} both passed as props). Large barcode icon + inputPlaceholderText caption.
-  // See BarcodeScannerComponent.jsx for the guard (isComponentHidden / isComponentHiddenByParam).
-  .scan-prompt {
+  // ---- Panel heights: per-mode, sized to each mode's content ----
+  // Hardware panel uses min-height so the caption stays visible when font-rendering / line-height
+  // (mobile Android, custom font-scale) makes the icon's box taller than expected. Camera and
+  // manual panels stay fixed-height because their content has a defined slot (video, input+buttons).
+  .hardware-mode-panel.scan-prompt {
+    min-height: $panel-height-scanner;
+  }
+  .camera-mode-panel {
+    height: $panel-height-scanner;
+    overflow: hidden;
+  }
+  .manual-mode-panel {
+    height: $panel-height-manual;
+    overflow: hidden;
+  }
+
+  // === HardwareModePanel — visible mode ===
+  // Large pulsing barcode icon + caption. The off-screen <input> is also a child but
+  // contributes no visible layout (position: absolute).
+  .hardware-mode-panel.scan-prompt {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 2rem 1rem 1rem;
     color: $grey;
 
     .scan-prompt-icon {
@@ -59,8 +123,8 @@
       color: $base-mf-green;
 
       // Slow opacity pulse — signals "ready / waiting for scan" without competing with the
-      // hardware scanner input. Opacity-only (not scale/rotation) so the icon doesn't read as
-      // a loading spinner. Respects the user's reduced-motion preference (accessibility).
+      // hardware scanner input. Opacity-only (not scale/rotation) so the icon doesn't read
+      // as a loading spinner. Respects the user's reduced-motion preference (accessibility).
       @media (prefers-reduced-motion: no-preference) {
         animation: scan-prompt-pulse 1.4s ease-in-out infinite alternate;
       }
@@ -70,22 +134,124 @@
       font-size: 1.5em;
       text-align: center;
       line-height: 1.3;
+      // One-line caption — never wrap. Wrapping would inflate panel height and push the
+      // footer down on long translations. text-overflow: ellipsis is the graceful-degrade
+      // fallback for an unexpectedly long string on a narrow viewport; current EN/DE
+      // translations ("Scan barcode" / "Barcode scannen") sit well within the 360px width.
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 100%;
 
-      // Caption swap: .scan-prompt-text-idle is shown by default; .scan-prompt-text-progress
-      // takes its place while the input has content (see in-progress :has() rule below).
-      // Both occupy the same DOM slot — no layout shift on the transition.
+      // Caption swap: .scan-prompt-text-idle shown by default; .scan-prompt-text-progress
+      // takes its place while the input has content (see :has() rule below). Same DOM slot,
+      // no layout shift on the transition.
       .scan-prompt-text-progress {
         display: none;
       }
     }
   }
 
+  // In-progress scan signal — when the off-screen hardware input has content (i.e. the
+  // useKeyboardBarcodeReader hook is mid-burst, chars accumulating), switch the icon to a
+  // yellow "scanning" hue and double the pulse rate. CSS-only — :placeholder-shown evaluates
+  // against the input's current `value`, including imperative `inputTextRef.current.value`
+  // writes from the hook's onReadInProgress. When the buffer is cleared on scan completion
+  // the input falls back to placeholder-shown ⇒ icon returns to the idle green/slow pulse.
+  .hardware-mode-panel.scan-prompt:has(.input-text:not(:placeholder-shown)) {
+    .scan-prompt-icon {
+      // Darker amber — $indicator-yellow (#ffd500) on white is 1.42:1, fails WCAG AA and
+      // is effectively invisible on a white scanner background. #c8900a is ~4.1:1, passes
+      // large-text AA. Global $indicator-yellow is kept for other components that use it
+      // against darker backgrounds (buttons.scss).
+      color: #c8900a;
+
+      @media (prefers-reduced-motion: no-preference) {
+        // Floored at 0.3s — at smaller durations the alternate-pulse crest rate approaches
+        // the WCAG 2.3.1 3Hz photosensitivity threshold (~0.17s duration). Smooth ease-in-out
+        // keeps the transition non-abrupt, but stay conservative.
+        animation-duration: 0.3s;
+      }
+    }
+
+    .scan-prompt-text-idle {
+      display: none;
+    }
+    .scan-prompt-text-progress {
+      display: inline;
+    }
+  }
+
+  // === CameraModePanel ===
+  // <video> fills the fixed-height slot. overflow: hidden on the shared rule above caps the
+  // intrinsic-aspect-ratio video to the panel box.
+  .camera-mode-panel {
+    video {
+      width: 100%;
+      height: 100%;
+      position: relative;
+      z-index: 0;
+      object-fit: cover;     // crop, don't letterbox — the scanner only needs the centre
+    }
+  }
+
+  // === ManualModePanel ===
+  // Visible editable text field stacked above the submit button. Both are ANCHORED AT THE
+  // TOP of the fixed-height panel so the mobile virtual keyboard, which slides up from the
+  // bottom edge of the viewport, does not overlap them. Empty space sits BELOW the submit
+  // button — that empty area is where the keyboard appears on focus. Horizontal padding
+  // matches .barcode-scanner-footer's so the submit and the back-to-scanner button still
+  // line up exactly on the x-axis. (Footer is below the empty space and may be covered by
+  // the keyboard while typing — acceptable: the user is committed to a manual submit at
+  // that moment; mode-switching is a less common action that requires dismissing the
+  // keyboard first.)
+  .manual-mode-panel {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    padding: $panel-padding-x $panel-padding-x 0;
+    gap: $btn-gap;
+
+    .manual-input {
+      // Override .input-text's font-size for the manual context — comfortable typing size,
+      // not the oversized scan-display size used by the offscreen hardware input.
+      font-size: 1.25em;
+      text-align: left;
+      // Override .input-text's outer margin (which assumed the input was a top-level child
+      // of .barcode-scanner). Here the panel owns the horizontal padding instead.
+      margin: 0;
+      width: 100%;
+    }
+  }
+
+  // === BarcodeScannerFooter ===
+  // Vertical button stack, rendered ONLY in HARDWARE / CAMERA (in MANUAL the footer returns
+  // null — see BarcodeScannerFooter.jsx). Same horizontal padding as .manual-mode-panel so
+  // a future inter-mode visual continuity check (HARDWARE footer ↔ MANUAL panel buttons)
+  // keeps button x-positions consistent.
+  //
+  // FIXED height — reserves space for $footer-button-slots buttons regardless of how many
+  // are actually shown in the current scanner mode. Without it, e.g. HARDWARE with one mode
+  // enabled (toggle hidden, only enter-manually) vs HARDWARE with both enabled (toggle +
+  // enter-manually) would change footer height and jump the bottom of the component.
+  // `justify-content: flex-start` stacks the visible buttons at the top of the reserved
+  // area; modes with fewer buttons leave empty space below them.
+  .barcode-scanner-footer {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    gap: $btn-gap;
+    padding: $footer-padding-y-top $panel-padding-x $footer-padding-y-bottom;
+    height: $footer-height;
+  }
+
+  // === Spinner overlay ===
+  // Center on the VIEWPORT (position: fixed — same as the global .loading rule in
+  // spinner.scss), not within .barcode-scanner. When isProcessing=true the visible parts
+  // shrink so .barcode-scanner is a short container; if the spinner were absolute-positioned
+  // to that short container its centre would land in the upper portion of the screen,
+  // partially behind the top green bar.
   .loading {
-    // Center on the VIEWPORT (position: fixed — same as the global .loading rule in
-    // spinner.scss), not within .barcode-scanner. When isProcessing=true the prompt and
-    // input are hidden so .barcode-scanner shrinks to a short container; if the spinner
-    // were absolute-positioned to that short container its centre would land in the upper
-    // portion of the screen, partially behind the top green bar.
     position: fixed;
     z-index: 999;
     top: 0;
@@ -110,18 +276,6 @@
   }
 }
 
-// Input is rendered ABOVE the video in normal document flow (not overlaid).
-// Overlaying with position:absolute + z-index does not work reliably on
-// Android 11 WebView due to SurfaceView video compositing (the native video
-// layer ignores CSS z-index and covers overlaid HTML content).
-.barcode-scanner:not(:has(video)) {
-  display: flex;
-  flex-direction: column;
-
-  // .scan-prompt + .input-text stack vertically (prompt above input).
-  // flex-grow on the input would stretch it vertically — leave it at its natural height.
-}
-
 @keyframes scan-prompt-pulse {
   from {
     opacity: 0.25;
@@ -130,30 +284,3 @@
     opacity: 1;
   }
 }
-
-// In-progress scan signal — when the visible/off-screen input has content (i.e. the hook is
-// mid-burst, chars are accumulating from the scanner), switch the prompt icon to a yellow
-// "scanning" hue and double the pulse rate. CSS-only — :placeholder-shown evaluates against
-// the input's current `value`, including imperative `inputTextRef.current.value = barcode`
-// writes from the hook's onReadInProgress. When the buffer is cleared on scan completion the
-// input falls back to placeholder-shown ⇒ icon returns to the idle green/slow pulse.
-.barcode-scanner:has(.input-text:not(:placeholder-shown)) {
-  .scan-prompt-icon {
-    color: $indicator-yellow;
-
-    @media (prefers-reduced-motion: no-preference) {
-      // Floored at 0.3s — at smaller durations the alternate-pulse crest rate approaches the
-      // WCAG 2.3.1 3Hz photosensitivity threshold (~0.17s duration). Smooth ease-in-out keeps
-      // the transition non-abrupt, but stay conservative.
-      animation-duration: 0.3s;
-    }
-  }
-
-  .scan-prompt-text-idle {
-    display: none;
-  }
-  .scan-prompt-text-progress {
-    display: inline;
-  }
-}
-

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/assets/applications-list.scss
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/assets/applications-list.scss
@@ -5,7 +5,7 @@
   overflow: hidden;
 
   .section {
-    padding-top: 3rem;
+    padding-top: 1rem;
     padding-bottom: 3rem;
     flex: 1;
     overflow-y: auto;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/assets/applications-list.scss
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/assets/applications-list.scss
@@ -6,7 +6,7 @@
 
   .section {
     padding-top: 1rem;
-    padding-bottom: 3rem;
+    padding-bottom: 5rem !important; /* 5rem important for small screens like 320x534 */ 
     flex: 1;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
@@ -18,8 +18,7 @@
     }
 
     .section {
-      padding-top: 1rem;
-      padding-bottom: 1rem;
+      padding-top: 0;
     }
   }
 }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/assets/login.scss
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/assets/login.scss
@@ -1,12 +1,14 @@
+@import './variables.scss';
+
 .login-view {
 
-  .login-error {
-    min-height: 3em;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  .section {
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   .button {
+    width: 100%;
     background-color: $base-mf-green;
     color: white;
 
@@ -18,18 +20,20 @@
   }
 
   .alternative-button {
+    width: 100%;
     background-color: white;
     color: $base-mf-green;
     border-color: $base-mf-green;
     font-size: 1.25rem;
+    margin-top: 0.5rem;
   }
 
   .qr-code-auth {
-    .barcode-scanner {
+    padding-top: 0;
+    padding-bottom: 0;
+
+    .barcode-scanner video {
       max-height: 50vh;
-      video {
-        max-height: 50vh;
-      }
     }
   }
 }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/BarcodeScannerFooter.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/BarcodeScannerFooter.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { MODE } from './useBarcodeScannerModes';
+import ButtonWithIndicator from '../buttons/ButtonWithIndicator';
+
+/*
+ * Footer button cluster — shown only in scanner modes (HARDWARE / CAMERA).
+ *
+ * In MANUAL mode the footer renders nothing (returns null) so the empty area below the
+ * manual input stays free for the mobile virtual keyboard. The "back to scanner" button
+ * lives inside ManualModePanel itself in that mode (stacked under Submit, anchored at the
+ * top of the panel) so it doesn't get overlapped by the keyboard.
+ *
+ * Two buttons can show here, both signal the parent via onModeSelected(targetMode):
+ *   - HW⇄CAM toggle  → opposite scanner mode of the current activeMode
+ *   - Enter manually → MODE.MANUAL
+ */
+const BarcodeScannerFooter = ({ activeMode, enabledModes, onModeSelected }) => {
+  // Both buttons are gated on activeMode !== MANUAL → in MANUAL the footer is empty and
+  // the early return below kicks in.
+  const isHardwareCameraToggleShown = !!(enabledModes?.hardware && enabledModes?.camera) && activeMode !== MODE.MANUAL;
+  const isManualButtonShown = !!enabledModes?.manual && activeMode !== MODE.MANUAL;
+
+  if (!isManualButtonShown && !isHardwareCameraToggleShown) {
+    return null;
+  }
+
+  const toggleTarget = activeMode === MODE.HARDWARE ? MODE.CAMERA : MODE.HARDWARE;
+  const toggleCaptionKey =
+    activeMode === MODE.HARDWARE
+      ? 'components.BarcodeScannerComponent.scanWithCamera'
+      : 'components.BarcodeScannerComponent.useHardwareScanner';
+  const toggleIconName = activeMode === MODE.HARDWARE ? 'fa-camera' : 'fa-barcode';
+
+  return (
+    <div className="barcode-scanner-footer">
+      {isHardwareCameraToggleShown && (
+        <ButtonWithIndicator
+          captionKey={toggleCaptionKey}
+          typeFASIconName={toggleIconName}
+          additionalCssClass="barcode-scanner-btn"
+          onClick={() => onModeSelected(toggleTarget)}
+          testId="barcode-scanner-toggle-hw-camera"
+        />
+      )}
+      {isManualButtonShown && (
+        <ButtonWithIndicator
+          captionKey="components.BarcodeScannerComponent.enterManually"
+          typeFASIconName="fa-keyboard"
+          additionalCssClass="barcode-scanner-btn"
+          onClick={() => onModeSelected(MODE.MANUAL)}
+          testId="barcode-scanner-enter-manually"
+        />
+      )}
+    </div>
+  );
+};
+
+BarcodeScannerFooter.propTypes = {
+  activeMode: PropTypes.string.isRequired,
+  enabledModes: PropTypes.shape({
+    hardware: PropTypes.bool,
+    camera: PropTypes.bool,
+    manual: PropTypes.bool,
+  }).isRequired,
+  onModeSelected: PropTypes.func.isRequired,
+};
+
+export default BarcodeScannerFooter;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/CameraModePanel.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/CameraModePanel.jsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { trl } from '../../utils/translations';
+import { BarcodeFormat, BrowserMultiFormatReader } from '@zxing/browser';
+import DecodeHintType from '@zxing/library/cjs/core/DecodeHintType';
+import { toastError } from '../../utils/toast';
+
+const READER_HINTS = new Map().set(DecodeHintType.POSSIBLE_FORMATS, [
+  BarcodeFormat.QR_CODE,
+  BarcodeFormat.CODE_128,
+  BarcodeFormat.ITF,
+]);
+
+const READER_OPTIONS = {
+  delayBetweenScanSuccess: 2000,
+  delayBetweenScanAttempts: 600,
+};
+
+const CameraModePanel = ({ isProcessing, onBarcodeScanned, onCancel }) => {
+  const videoRef = useRef();
+  const cameraControlsRef = useRef(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const startCamera = async () => {
+      const codeReader = new BrowserMultiFormatReader(READER_HINTS, READER_OPTIONS);
+      try {
+        const controls = await codeReader.decodeFromVideoDevice(undefined, videoRef.current, (result, error, ctrl) => {
+          if (cancelled) {
+            ctrl.stop();
+            return;
+          }
+          if (typeof result !== 'undefined') {
+            onBarcodeScanned({ scannedBarcode: result.text });
+          }
+        });
+        if (cancelled) {
+          controls.stop();
+          return;
+        }
+        cameraControlsRef.current = controls;
+      } catch (err) {
+        if (cancelled) return;
+        toastError({
+          plainMessage: trl('components.BarcodeScannerComponent.cameraError'),
+        });
+        onCancel();
+      }
+    };
+
+    startCamera();
+
+    return () => {
+      cancelled = true;
+      if (cameraControlsRef.current) {
+        cameraControlsRef.current.stop();
+        cameraControlsRef.current = null;
+      }
+      // Also stop any lingering MediaStream tracks on the video element.
+      if (videoRef.current && videoRef.current.srcObject) {
+        const stream = videoRef.current.srcObject;
+        stream.getTracks().forEach((track) => track.stop());
+        videoRef.current.srcObject = null;
+      }
+    };
+  }, []);
+
+  useEffect(
+    () => {
+      videoRef?.current?.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'end' });
+    } /* no deps, call it on each render */
+  );
+
+  // Wrapper is always present so the panel reserves the same vertical slot whether or not the
+  // <video> is currently mounted (during isProcessing). Keeps the footer anchored — no jump.
+  return (
+    <div className="camera-mode-panel">
+      {!isProcessing && <video key="video" ref={videoRef} width="100%" height="100%" />}
+    </div>
+  );
+};
+
+CameraModePanel.propTypes = {
+  isProcessing: PropTypes.bool,
+  onBarcodeScanned: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+export default CameraModePanel;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/HardwareModePanel.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/HardwareModePanel.jsx
@@ -1,0 +1,216 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { trl } from '../../utils/translations';
+import { useBooleanSetting, usePositiveNumberSetting, useSetting } from '../../reducers/settings';
+import { useKeyboardBarcodeReader } from '../../hooks/useKeyboardBarcodeReader';
+import { debounce } from 'lodash';
+
+const useHardwareConfigParams = () => {
+  const hardwareInputMode = useSetting('barcodeScanner.mode.hardware.input.inputMode') ?? 'none';
+  const isHardwareInputReadOnly = useBooleanSetting('barcodeScanner.mode.hardware.input.readOnly', false);
+
+  return {
+    hardwareInputMode,
+    isHardwareInputReadOnly,
+    triggerOnChangeIfLengthGreaterThan: usePositiveNumberSetting(
+      'barcodeScanner.inputText.triggerOnChangeIfLengthGreaterThan',
+      0
+    ),
+    textChangedDebounceMillis: usePositiveNumberSetting('barcodeScanner.inputText.debounceMillis', 300),
+  };
+};
+
+const HardwareModePanel = ({ invisible, inputPlaceholderText, isProcessing, disabled, onBarcodeScanned, testId }) => {
+  const { hardwareInputMode, isHardwareInputReadOnly, triggerOnChangeIfLengthGreaterThan, textChangedDebounceMillis } =
+    useHardwareConfigParams();
+  const inputTextRef = useRef();
+  // Tracks the LIVE `disabled` prop so the 2s blur-refocus setTimeout below can check the
+  // current value at fire time, not the stale closure value at schedule time. Without this,
+  // a HW→MANUAL switch right after an offscreen-blur would silently re-grab focus 2s later
+  // and yank it from the visible manual input.
+  const disabledRef = useRef(disabled);
+  useEffect(() => {
+    disabledRef.current = disabled;
+  }, [disabled]);
+
+  // Refocus the offscreen <input> after every render — necessary for IME-style configs (the
+  // input is editable, OS expects focus to route InputConnection). Skipped for keystroke-wedge
+  // configs (readOnly + inputMode=none) which capture at window level and don't need focus.
+  // Always skipped when `disabled` so the visible ManualModePanel input keeps its focus.
+  useEffect(() => {
+    if (disabled) return;
+    if (hardwareInputMode !== 'none' && !isHardwareInputReadOnly) {
+      inputTextRef?.current?.focus();
+    }
+  });
+
+  // Mount-time focus for DataWedge IME (inputMode=none) — establishes InputConnection once;
+  // the window-level hook handles subsequent scans.
+  useEffect(() => {
+    if (disabled) return;
+    if (hardwareInputMode === 'none') {
+      inputTextRef?.current?.focus();
+    }
+  }, []);
+
+  // Hardware-specific telemetry forwarded to the parent's uiTrace context on every
+  // onBarcodeScanned call. BSC owns the canonical fields (eventName, scannedBarcode,
+  // activeMode, scanDuplicatesIntervalMillis); this panel adds the hardware-input
+  // attributes + buffering knobs that the parent doesn't know (and shouldn't read).
+  const traceParams = {
+    hardwareInputMode,
+    isHardwareInputReadOnly,
+    triggerOnChangeIfLengthGreaterThan,
+    textChangedDebounceMillis,
+  };
+
+  const handleInputTextChanged = (e) => {
+    const scannedBarcode = e.target.value;
+
+    if (
+      scannedBarcode &&
+      triggerOnChangeIfLengthGreaterThan &&
+      triggerOnChangeIfLengthGreaterThan > 0 &&
+      scannedBarcode.length >= triggerOnChangeIfLengthGreaterThan
+    ) {
+      onBarcodeScanned({ scannedBarcode, traceParams });
+    }
+  };
+  const handleInputTextChangedDebounced = useMemo(() => {
+    return debounce(handleInputTextChanged, textChangedDebounceMillis);
+  }, [textChangedDebounceMillis]);
+
+  useEffect(() => {
+    return () => handleInputTextChangedDebounced.cancel();
+  }, [handleInputTextChangedDebounced]);
+
+  useKeyboardBarcodeReader({
+    onReadDone: (barcode) => {
+      // console.log('onReadDone', barcode);
+      // Clear the input BEFORE calling onBarcodeScanned.
+      // onBarcodeScanned triggers setProcessing(true) in the parent, which in React 17 legacy
+      // mode (outside a React event handler) re-renders synchronously and unmounts the input
+      // ({!isProcessing && <input/>}), nulling inputTextRef.current. Clearing AFTER the call
+      // would be silently skipped and the un-cleared value could reach handleInputTextKeyPress
+      // via the trailing keyup event, double-firing the scan.
+      if (inputTextRef?.current) {
+        inputTextRef.current.value = '';
+      }
+      onBarcodeScanned({ scannedBarcode: barcode, traceParams });
+    },
+    onReadInProgress: (barcode) => {
+      // console.log('onReadInProgress', barcode);
+      if (inputTextRef?.current) {
+        inputTextRef.current.value = barcode;
+      }
+    },
+    rateMs: textChangedDebounceMillis,
+    minLength: triggerOnChangeIfLengthGreaterThan,
+    // Parent owns the disabled decision (see BarcodeScannerComponent — combines isProcessing
+    // with `activeMode === MANUAL` so keystrokes flow to the visible manual input instead
+    // of the offscreen hardware one).
+    disabled,
+  });
+
+  const handleInputTextKeyPress = (e) => {
+    if (e.key === 'Enter') {
+      const scannedBarcode = e.target.value?.trim();
+      if (!scannedBarcode) return;
+
+      onBarcodeScanned({
+        scannedBarcode,
+        traceParams,
+        onStart: () => {
+          inputTextRef?.current?.select();
+        },
+        onFinally: () => {
+          if (inputTextRef?.current) {
+            inputTextRef.current.value = '';
+          }
+        },
+      });
+    }
+  };
+
+  const handleInputTextFocus = () => {
+    inputTextRef?.current?.select();
+  };
+
+  const handleInputTextBlur = () => {
+    setTimeout(() => {
+      // Check the LIVE `disabled` value via ref — the prop at schedule time may be stale 2s
+      // later. If the user switched into MANUAL during the window, we must NOT yank focus
+      // back from the visible manual input.
+      if (disabledRef.current) return;
+      inputTextRef?.current?.focus();
+    }, 2000);
+  };
+
+  // The off-screen input is the only DOM element needed for both the visible hardware-mode
+  // scan-prompt UI and the invisible variant (BarcodeScannerButton, ApplicationsListScreen,
+  // DistributionMoveActivity). Render it once; conditionally surround with the scan-prompt
+  // chrome when not invisible. When invisible, return ONLY the off-screen input so the
+  // component contributes zero visible layout — no padding, no background, no animated icon.
+  const offscreenInput = !isProcessing && (
+    <input
+      id="input-text"
+      key="input-text"
+      ref={inputTextRef}
+      className="input-text input-text-offscreen"
+      type="text"
+      autoComplete="off"
+      autoCorrect="off"
+      autoCapitalize="none"
+      spellCheck="false"
+      placeholder={inputPlaceholderText || trl('components.BarcodeScannerComponent.scanTextPlaceholder')}
+      inputMode={hardwareInputMode}
+      readOnly={isHardwareInputReadOnly}
+      onFocus={handleInputTextFocus}
+      onBlur={handleInputTextBlur}
+      onChange={handleInputTextChangedDebounced}
+      onKeyUp={handleInputTextKeyPress}
+      data-testid={testId ?? 'qrCode-input'}
+    />
+  );
+
+  if (invisible) {
+    return offscreenInput || null;
+  }
+
+  return (
+    <div className="hardware-mode-panel scan-prompt">
+      {/* FontAwesome SVG-with-JS (src/index.js → @fortawesome/fontawesome-free/js/all.min) mutates
+          <i className="fas …"> into <svg> in place. React's fiber keeps a stale stateNode pointer
+          to the detached <i>; if the conditional <input> below were ever a sibling needing
+          insertBefore against the icon, React would throw NotFoundError. Wrapping in <span>
+          (codebase convention — see ButtonWithIndicator.jsx) gives React a stable, React-owned
+          parent that FA never touches. */}
+      <span>
+        <i className="fas fa-barcode scan-prompt-icon" aria-hidden="true" />
+      </span>
+      {/* Caption swap — idle text by default, "Scanning in progress…" while the input has
+          content (mid-burst). CSS-only via :has() — see BarcodeScannerComponent.scss. */}
+      <div className="scan-prompt-text">
+        <span className="scan-prompt-text-idle">
+          {inputPlaceholderText || trl('components.BarcodeScannerComponent.scanPrompt')}
+        </span>
+        <span className="scan-prompt-text-progress">{trl('components.BarcodeScannerComponent.scanInProgress')}</span>
+      </div>
+      {offscreenInput}
+    </div>
+  );
+};
+HardwareModePanel.propTypes = {
+  invisible: PropTypes.bool,
+  inputPlaceholderText: PropTypes.string,
+  isProcessing: PropTypes.bool,
+  disabled: PropTypes.bool,
+  onBarcodeScanned: PropTypes.func.isRequired,
+  testId: PropTypes.string,
+};
+HardwareModePanel.defaultProps = {
+  invisible: false,
+  disabled: false,
+};
+
+export default HardwareModePanel;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/ManualModePanel.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/ManualModePanel.jsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { trl } from '../../utils/translations';
+import ButtonWithIndicator from '../buttons/ButtonWithIndicator';
+import { MODE, PRIORITY } from './useBarcodeScannerModes';
+
+// "Back to scanner" target resolution — moved here from BarcodeScannerFooter because in
+// MANUAL mode the footer is empty (so the keyboard doesn't overlap any actionable button)
+// and this button needs to sit inside the panel, under Submit. HARDWARE wins over CAMERA.
+const SCANNER_MODES = PRIORITY.filter((m) => m === MODE.HARDWARE || m === MODE.CAMERA);
+const BACK_TO_SCANNER_CAPTION_KEY = {
+  [MODE.HARDWARE]: 'components.BarcodeScannerComponent.useHardwareScanner',
+  [MODE.CAMERA]: 'components.BarcodeScannerComponent.scanWithCamera',
+};
+const BACK_TO_SCANNER_ICON = {
+  [MODE.HARDWARE]: 'fa-barcode',
+  [MODE.CAMERA]: 'fa-camera',
+};
+
+/*
+ * Focus policy — DELIBERATE NON-DECISION on blur-refocus.
+ *
+ * We focus the visible manual <input> in exactly TWO cases:
+ *   (1) Mount — when MANUAL becomes the active mode, autofocus so the user can
+ *       type immediately without an extra tap.
+ *   (2) After every submission (success OR error) — once isProcessing flips
+ *       back false, refocus (.focus() on success, .select() on error so the
+ *       rejected text is highlighted for re-edit). Implemented via
+ *       prevProcessingRef below: .focus() inside onSuccess/onError would be a
+ *       no-op because the input is still `disabled` at that moment.
+ *
+ * We DO NOT auto-refocus on every `onBlur`. Reasons:
+ *   - Fights the mobile virtual keyboard — if the user intentionally dismisses
+ *     it (back-button, tap-outside), immediate refocus would reopen it.
+ *   - Fights modals / dialogs / toasts (e.g. GetQuantityDialog, YesNo,
+ *     ErrorToast) — those legitimately steal focus and must keep it; an
+ *     auto-refocus loop would yank focus back and break expectErrorToast tests.
+ *   - The realistic "lost focus" cases on a mobile scanner are already covered:
+ *     Submit (case 2 above), mode switch (panel unmounts), screen change.
+ *
+ * If we ever need stray-tap recovery (e.g. CT60 with gloves accidentally
+ * tapping empty regions), the right pattern is a DELAYED + GATED refocus,
+ * mirroring HardwareModePanel's blur handler: setTimeout 1-2s, then refocus
+ * only if `document.activeElement` is body/null (i.e. focus is genuinely
+ * nowhere — not on a dialog/button/toast). Do NOT add a synchronous refocus
+ * inside onBlur — see reasons above.
+ */
+const ManualModePanel = ({ isProcessing, onBarcodeScanned, enabledModes, onModeSelected }) => {
+  // Resolve the back-to-scanner target: the highest-priority enabled scanner mode
+  // (HARDWARE > CAMERA). Undefined when no scanner mode is enabled → button hidden.
+  const backToScannerTarget = SCANNER_MODES.find((m) => enabledModes?.[m]);
+  const manualInputRef = useRef();
+  // Tracks whether the most recent submission failed (so the post-submit focus effect can
+  // .select() the rejected text for re-edit instead of just .focus()ing an empty field).
+  const lastSubmitErroredRef = useRef(false);
+  // Tracks the previous render's isProcessing so we can detect the true→false transition
+  // (= submission just finished, success or error) and return focus to the input.
+  const prevProcessingRef = useRef(false);
+
+  // Case (1) from the focus policy above: autofocus on mount (mode just became MANUAL).
+  useEffect(() => {
+    manualInputRef?.current?.focus();
+  }, []);
+
+  // Case (2) from the focus policy above: re-focus after every submission, regardless of
+  // outcome. The input is `disabled` while isProcessing=true, so .focus() inside
+  // onSuccess/onError would be a no-op. Instead we wait for the disabled→enabled flip via
+  // the prev-processing tracker.
+  useEffect(() => {
+    if (prevProcessingRef.current && !isProcessing) {
+      if (lastSubmitErroredRef.current) {
+        manualInputRef?.current?.select();
+        lastSubmitErroredRef.current = false;
+      } else {
+        manualInputRef?.current?.focus();
+      }
+    }
+    prevProcessingRef.current = isProcessing;
+  });
+
+  const handleManualSubmit = () => {
+    if (isProcessing) return;
+
+    const scannedBarcode = manualInputRef?.current?.value?.trim();
+    if (!scannedBarcode) return;
+
+    onBarcodeScanned({
+      scannedBarcode,
+      onSuccess: () => {
+        if (manualInputRef?.current) {
+          manualInputRef.current.value = '';
+        }
+      },
+      onError: () => {
+        lastSubmitErroredRef.current = true;
+      },
+    });
+  };
+
+  const handleManualKeyUp = (e) => {
+    if (isProcessing) return;
+    if (e.key === 'Enter') {
+      handleManualSubmit();
+    }
+  };
+
+  return (
+    <div className="manual-mode-panel">
+      <input
+        disabled={isProcessing}
+        ref={manualInputRef}
+        className="input-text manual-input"
+        type="text"
+        inputMode="text"
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="none"
+        spellCheck="false"
+        placeholder={trl('components.BarcodeScannerComponent.manualInputPlaceholder')}
+        onKeyUp={handleManualKeyUp}
+        data-testid="manual-entry-input"
+      />
+      <ButtonWithIndicator
+        captionKey="components.BarcodeScannerComponent.manualInputSubmit"
+        typeFASIconName="fa-check"
+        additionalCssClass="barcode-scanner-btn"
+        disabled={isProcessing}
+        onClick={handleManualSubmit}
+        testId="manual-entry-submit"
+      />
+      {backToScannerTarget && (
+        <ButtonWithIndicator
+          captionKey={BACK_TO_SCANNER_CAPTION_KEY[backToScannerTarget]}
+          typeFASIconName={BACK_TO_SCANNER_ICON[backToScannerTarget]}
+          additionalCssClass="barcode-scanner-btn"
+          disabled={isProcessing}
+          onClick={() => onModeSelected(backToScannerTarget)}
+          testId="barcode-scanner-back-to-scanner"
+        />
+      )}
+    </div>
+  );
+};
+ManualModePanel.propTypes = {
+  isProcessing: PropTypes.bool,
+  onBarcodeScanned: PropTypes.func.isRequired,
+  enabledModes: PropTypes.shape({
+    hardware: PropTypes.bool,
+    camera: PropTypes.bool,
+    manual: PropTypes.bool,
+  }).isRequired,
+  onModeSelected: PropTypes.func.isRequired,
+};
+
+export default ManualModePanel;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/useBarcodeScannerModes.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/useBarcodeScannerModes.js
@@ -1,0 +1,32 @@
+import { useBooleanSetting, useSetting } from '../../reducers/settings';
+
+export const MODE = { HARDWARE: 'hardware', CAMERA: 'camera', MANUAL: 'manual' };
+// Mode-preference order — used by useBarcodeScannerModes to resolve the default mode and by
+// BarcodeScannerFooter to pick the "back to scanner" target from MANUAL (HARDWARE before CAMERA).
+export const PRIORITY = [MODE.HARDWARE, MODE.CAMERA, MODE.MANUAL];
+
+export const useBarcodeScannerModes = ({ invisible = false } = {}) => {
+  const isHardwareEnabled = useBooleanSetting('barcodeScanner.mode.hardware.enabled', true);
+  const isCameraEnabled = useBooleanSetting('barcodeScanner.mode.camera.enabled', false);
+  const isManualEnabled = useBooleanSetting('barcodeScanner.mode.manual.enabled', true);
+  const configuredDefault = useSetting('barcodeScanner.defaultMode');
+
+  if (invisible) {
+    return { enabledModes: { hardware: true, camera: false, manual: false }, defaultMode: MODE.HARDWARE };
+  }
+
+  // Object keys MUST stay as MODE string values ('hardware'/'camera'/'manual') —
+  // they're looked up dynamically below via `enabled[configuredDefault]` and
+  // `enabled[m]` where m is a MODE value.
+  let enabled = { hardware: isHardwareEnabled, camera: isCameraEnabled, manual: isManualEnabled };
+  if (!PRIORITY.some((m) => enabled[m])) {
+    enabled = { ...enabled, manual: true }; // fail-safe: operator never locked out
+  }
+
+  const defaultMode =
+    (configuredDefault && enabled[configuredDefault] && configuredDefault) ||
+    PRIORITY.find((m) => enabled[m]) ||
+    MODE.MANUAL;
+
+  return { enabledModes: enabled, defaultMode };
+};

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerButton.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerButton.jsx
@@ -7,9 +7,7 @@ export const BarcodeScannerButton = ({ captionKey, enableScanning, disabled, onB
   return (
     <>
       <ButtonWithIndicator id="scanQRCode-button" captionKey={captionKey} disabled={disabled} onClick={onClick} />
-      {enableScanning && !disabled && (
-        <BarcodeScannerComponent isShowInputText={false} isShowVideo={false} onResolvedResult={onBarcodeScanned} />
-      )}
+      {enableScanning && !disabled && <BarcodeScannerComponent invisible onResolvedResult={onBarcodeScanned} />}
     </>
   );
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
@@ -1,193 +1,42 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { BarcodeFormat, BrowserMultiFormatReader } from '@zxing/browser';
-import DecodeHintType from '@zxing/library/cjs/core/DecodeHintType';
+import React, { useRef, useState } from 'react';
 import { toastError, toastErrorFromObj } from '../utils/toast';
-import { trl } from '../utils/translations';
-import { useBooleanSetting, useNumber, usePositiveNumberSetting } from '../reducers/settings';
-import { debounce } from 'lodash';
+import { useNumber, usePositiveNumberSetting } from '../reducers/settings';
 import { beep } from '../utils/audio';
 import * as uiTrace from '../utils/ui_trace';
 import Spinner from './Spinner';
-import { useKeyboardBarcodeReader } from '../hooks/useKeyboardBarcodeReader';
-import { isMobileOrTablet } from '../utils/browser';
+import { MODE, useBarcodeScannerModes } from './BarcodeScanner/useBarcodeScannerModes';
+import ManualModePanel from './BarcodeScanner/ManualModePanel';
+import CameraModePanel from './BarcodeScanner/CameraModePanel';
+import HardwareModePanel from './BarcodeScanner/HardwareModePanel';
+import BarcodeScannerFooter from './BarcodeScanner/BarcodeScannerFooter';
 
-const READER_HINTS = new Map().set(DecodeHintType.POSSIBLE_FORMATS, [
-  BarcodeFormat.QR_CODE,
-  BarcodeFormat.CODE_128,
-  BarcodeFormat.ITF,
-]);
-
-const READER_OPTIONS = {
-  delayBetweenScanSuccess: 2000,
-  delayBetweenScanAttempts: 600,
-};
-
-const useConfigParams = ({ isShowInputTextParam, isShowVideoParam, continuousRunningParam } = {}) => {
-  const isShowInputText =
-    isShowInputTextParam != null ? isShowInputTextParam : useBooleanSetting('barcodeScanner.showInputText');
-
-  // Two orthogonal keyboard-suppression knobs feed the scan <input>. They are named after their
-  // mechanism (not their UX effect) so the two cannot be confused:
-  //   • isInputModeNone  → sets `inputMode="none"` (a HINT — soft. Honoured by recent Chrome/Android,
-  //                       ignored by some firmware, e.g. Honeywell CT60 / Android 11).
-  //   • isReadOnlyAttrSet   → sets the HTML `readOnly` attribute (a HARD GUARANTEE — the browser never
-  //                       opens the soft keyboard on a readOnly input, AND manual typing is blocked).
-  // Per the scanner-framework design (https://github.com/metasfresh/me03/issues/29246), readOnly is
-  // controlled by per-mode knobs (`offscreenInput.readOnly` vs `visibleInput.readOnly`) so the two
-  // modes tune independently. Defaults OFF in both modes ⇒ byte-for-byte today's behaviour.
-  // DataWedge IME deployments MUST keep BOTH off — readOnly kills the InputConnection. Enabling
-  // visibleInput.readOnly also BLOCKS manual typing (Mode C3) — intentional opt-in for
-  // hardware-scanner-only deployments where the visible input must stay on screen (e.g. /huManager,
-  // whose only content is the scan field — hiding it leaves the screen blank).
-  const isInputModeNone = isShowInputText
-    ? useBooleanSetting('barcodeScanner.isInputTextReadonly', isMobileOrTablet)
-    : true;
-  const isOffscreenInputReadOnly = useBooleanSetting('barcodeScanner.offscreenInput.readOnly', false);
-  const isVisibleInputReadOnly = useBooleanSetting('barcodeScanner.visibleInput.readOnly', false);
-  const isReadOnlyAttrSet = isShowInputText ? isVisibleInputReadOnly : isOffscreenInputReadOnly;
-
-  const isShowVideo = isShowVideoParam != null ? isShowVideoParam : useBooleanSetting('barcodeScanner.useCamera', true);
-
-  const continuousRunning = continuousRunningParam != null ? continuousRunningParam : true;
-
-  return {
-    okBeepParams: {
-      name: 'OK',
-      beepFrequency: useNumber('barcodeScanner.onSuccess.beep.frequency', 1000),
-      beepVolume: useNumber('barcodeScanner.onSuccess.beep.volume', 0.1),
-      beepDurationMillis: useNumber('barcodeScanner.onSuccess.beep.durationMillis', 100),
-      vibrateMillis: useNumber('barcodeScanner.onSuccess.vibrate.durationMillis', 100),
-    },
-    errorBeepParams: {
-      name: 'error',
-      beepFrequency: useNumber('barcodeScanner.onError.beep.frequency', 100),
-      beepVolume: useNumber('barcodeScanner.onError.beep.volume', 0.1),
-      beepDurationMillis: useNumber('barcodeScanner.onError.beep.durationMillis', 100),
-      vibrateMillis: useNumber('barcodeScanner.onError.vibrate.durationMillis', 100),
-    },
-    isShowInputText,
-    isInputModeNone,
-    isReadOnlyAttrSet,
-    triggerOnChangeIfLengthGreaterThan: usePositiveNumberSetting(
-      'barcodeScanner.inputText.triggerOnChangeIfLengthGreaterThan',
-      0
-    ),
-    textChangedDebounceMillis: usePositiveNumberSetting('barcodeScanner.inputText.debounceMillis', 300),
-    scanDuplicatesIntervalMillis: usePositiveNumberSetting('barcodeScanner.scanDuplicatesIntervalMillis', 0),
-    isShowVideo,
-    continuousRunning,
-  };
-};
+const TOAST_ID = 'BarcodeScannerComponentError';
 
 const BarcodeScannerComponent = ({
   testId,
-  isShowInputText: isShowInputTextParam,
-  isShowVideo: isShowVideoParam,
   resolveScannedBarcode,
   onResolvedResult,
   inputPlaceholderText,
-  continuousRunning: continuousRunningParam,
+  invisible,
 }) => {
-  const {
-    okBeepParams,
-    errorBeepParams,
-    isShowInputText,
-    isInputModeNone,
-    isReadOnlyAttrSet,
-    triggerOnChangeIfLengthGreaterThan,
-    textChangedDebounceMillis,
-    scanDuplicatesIntervalMillis,
-    isShowVideo,
-    continuousRunning,
-  } = useConfigParams({ isShowInputTextParam, isShowVideoParam, continuousRunningParam });
-  const isComponentHidden = !isShowInputText && !isShowVideo;
-  const isComponentHiddenByParam = isShowInputTextParam === false && isShowVideoParam === false;
+  const { enabledModes, defaultMode, okBeepParams, errorBeepParams, scanDuplicatesIntervalMillis } = useConfigParams({
+    invisible,
+  });
 
-  const inputTextRef = useRef();
+  const [activeMode, setActiveMode] = useState(defaultMode);
+
   const scanningStatusRef = useRef({ running: false, done: false });
   const [isProcessing, setProcessing] = useState(false);
   const { trackDuplicateScan } = useDuplicateScansGuard({ scanDuplicatesIntervalMillis });
 
-  //
-  // Video
-  const mountedRef = useRef(true);
-  const videoRef = useRef();
-  useEffect(() => {
-    mountedRef.current = true;
-
-    if (isShowVideo) {
-      const codeReader = new BrowserMultiFormatReader(READER_HINTS, READER_OPTIONS);
-      codeReader.decodeFromVideoDevice(undefined, videoRef.current, (result, error, controls) => {
-        if (mountedRef.current === false) {
-          controls.stop();
-        } else if (typeof result !== 'undefined') {
-          validateScannedBarcodeAndForward({ scannedBarcode: result.text, controls });
-        }
-      });
-    }
-
-    return () => {
-      mountedRef.current = false;
-    };
-  }, [isShowVideo]);
-
-  useEffect(() => {
-    return () => handleInputTextChangedDebounced.cancel();
-  });
-
-  useEffect(
-    () => {
-      if (isShowVideo) {
-        videoRef?.current?.scrollIntoView({ behaviour: 'smooth', block: 'center', inline: 'end' });
-      }
-      if (!isInputModeNone) {
-        inputTextRef?.current?.focus();
-      }
-    } /* no deps, call it on each render */
-  );
-
-  // DataWedge IME needs a focused editable input to establish InputConnection.
-  // Focus once on mount; the window-level hook handles all subsequent scan events.
-  useEffect(() => {
-    if (isInputModeNone) {
-      inputTextRef?.current?.focus();
-    }
-  }, []);
-
-  useKeyboardBarcodeReader({
-    onReadDone: (barcode) => {
-      // console.log('onReadDone', barcode);
-      // Clear the input BEFORE calling validateScannedBarcodeAndForward.
-      // validateScannedBarcodeAndForward calls setProcessing(true), which in React 17 legacy
-      // mode (outside a React event handler) triggers a synchronous re-render that unmounts
-      // the input ({!isProcessing && <input/>}) and nulls inputTextRef.current.  If we clear
-      // after the call, inputTextRef.current is already null and the clear is silently skipped.
-      // The un-cleared input value then reaches handleInputTextKeyPress via the keyup event
-      // that follows the Enter keydown, causing a second validateScannedBarcodeAndForward
-      // invocation and a duplicate error toast.
-      if (inputTextRef?.current) {
-        inputTextRef.current.value = '';
-      }
-      validateScannedBarcodeAndForward({ scannedBarcode: barcode });
-    },
-    onReadInProgress: (barcode) => {
-      // console.log('onReadInProgress', barcode);
-      if (inputTextRef?.current) {
-        inputTextRef.current.value = barcode;
-      }
-    },
-    rateMs: textChangedDebounceMillis,
-    minLength: triggerOnChangeIfLengthGreaterThan,
-    disabled: isProcessing,
-  });
-
-  const validateScannedBarcodeAndForward0 = async ({ scannedBarcode, controls = null }) => {
+  const validateScannedBarcodeAndForward0 = async ({ scannedBarcode, onStart, onSuccess, onError, onFinally }) => {
     if (!scannedBarcode?.trim()) {
       uiTrace.traceLogWarn('Ignoring blank barcode', { scannedBarcode });
       return;
     }
-    inputTextRef?.current?.select();
+
+    onStart?.();
 
     const scanningStatus = scanningStatusRef.current;
     if (scanningStatus.running || scanningStatus.done) {
@@ -223,178 +72,133 @@ const BarcodeScannerComponent = ({
       console.debug('Got resolvedResult', resolvedResult);
 
       if (resolvedResult.error) {
-        toastError({ plainMessage: resolvedResult.error });
+        toastError({ plainMessage: resolvedResult.error, toastId: TOAST_ID });
         beep(errorBeepParams);
         scanningStatus.done = false; // not done yet
+        onError?.();
       } else {
         await onResolvedResult(resolvedResult);
-
-        if (!continuousRunning) {
-          scanningStatus.done = true;
-          controls?.stop();
-        }
-
         beep(okBeepParams);
+        onSuccess?.();
       }
     } catch (error) {
       beep(errorBeepParams);
-      toastErrorFromObj(error);
+      toastErrorFromObj(error, TOAST_ID);
+      onError?.();
     } finally {
       scanningStatus.running = false;
       setProcessing(false);
 
-      if (inputTextRef?.current) {
-        inputTextRef.current.value = '';
-      }
+      onFinally?.();
     }
   };
   const validateScannedBarcodeAndForward = uiTrace.traceFunction(
     validateScannedBarcodeAndForward0,
-    ({ scannedBarcode }) => ({
+    ({ scannedBarcode, traceParams }) => ({
+      ...traceParams,
       eventName: 'barcodeScanned',
       scannedBarcode,
-      isShowInputText,
-      isInputModeNone,
-      isReadOnlyAttrSet,
-      triggerOnChangeIfLengthGreaterThan,
-      textChangedDebounceMillis,
+      activeMode,
       scanDuplicatesIntervalMillis,
     })
   );
 
-  const handleInputTextChanged = (e) => {
-    const scannedBarcode = e.target.value;
-
-    if (
-      scannedBarcode &&
-      triggerOnChangeIfLengthGreaterThan &&
-      triggerOnChangeIfLengthGreaterThan > 0 &&
-      scannedBarcode.length >= triggerOnChangeIfLengthGreaterThan
-    ) {
-      validateScannedBarcodeAndForward({ scannedBarcode });
-    }
-  };
-  const handleInputTextChangedDebounced = useMemo(() => {
-    return debounce(handleInputTextChanged, textChangedDebounceMillis);
-  }, [textChangedDebounceMillis]);
-
-  const handleInputTextKeyPress = (e) => {
-    if (e.key === 'Enter') {
-      const scannedBarcode = e.target.value?.trim();
-      if (!scannedBarcode) return;
-
-      validateScannedBarcodeAndForward({ scannedBarcode });
-    }
-  };
-
-  const handleInputTextFocus = () => {
-    inputTextRef?.current?.select();
-  };
-
-  const handleInputTextBlur = () => {
-    setTimeout(() => {
-      inputTextRef?.current?.focus();
-    }, 2000);
-  };
-
   return (
     <div className="barcode-scanner">
-      {isProcessing && <Spinner />}
-      {/* Scan prompt — visible on hardware-scanner deployments (no camera) when the input is
-          OFF-SCREEN (the actual empty-screen case: the only thing the component otherwise renders
-          is the invisible off-screen input). When the input is on-screen (isShowInputText=Y) the
-          input itself is the visual anchor — no big prompt needed. Reuses inputPlaceholderText so
-          a caller can override the default caption (e.g. HUScanner's locator-scan branch passes
-          'Scan LU or locator…'); when the caller passes none, the default scanPrompt translation
-          is used. See https://github.com/metasfresh/me03/issues/30363. */}
-      {!isProcessing && isComponentHidden && !isComponentHiddenByParam && (
-        <div className="scan-prompt">
-          <i className="fas fa-barcode scan-prompt-icon" aria-hidden="true" />
-          {/* Caption swap — idle text by default, "Scanning in progress…" while the input
-              has content (mid-burst). CSS-only via :has() — see BarcodeScannerComponent.scss. */}
-          <div className="scan-prompt-text">
-            <span className="scan-prompt-text-idle">
-              {inputPlaceholderText || trl('components.BarcodeScannerComponent.scanPrompt')}
-            </span>
-            <span className="scan-prompt-text-progress">
-              {trl('components.BarcodeScannerComponent.scanInProgress')}
-            </span>
-          </div>
-        </div>
-      )}
-      {/* IMPORTANT: Always use type="text" — never type="hidden".
-          When isShowInputText=false, the input is visually hidden via CSS (input-text-offscreen)
-          instead of type="hidden". This is critical for Zebra MC3300x DataWedge IME mode:
-          type="hidden" inputs cannot receive focus, so Android InputConnection is never established
-          and DataWedge text injection silently fails. CSS hiding keeps the input focusable and
-          IME-compatible while remaining invisible to the user.
-          (https://github.com/metasfresh/me03/issues/28834) */}
-      {/* NOTE: Input is rendered BEFORE video to avoid Android 11 WebView SurfaceView
-          compositing issue where the native video layer covers CSS-overlaid content.
-          (https://github.com/metasfresh/me03/issues/28964) */}
-      {/* ⚠️ HARDWARE CONTRACT — TWO device classes; each has its own #input-text attribute combo.
-          Any edit to type / inputMode / readOnly / the focus useEffects MUST preserve BOTH.
-
-                                  │ DataWedge IME             │ Keystroke-wedge
-                                  │ (e.g. Zebra MC3300x)      │ (e.g. Honeywell CT60 / Android 11)
-          ────────────────────────┼───────────────────────────┼──────────────────────────────────────
-          type                    │ "text"                    │ "text"
-          inputMode               │ "none"                    │ "none" (ignored on Android 11)
-          readOnly                │ ABSENT (else kills the    │ PRESENT (load-bearing keyboard
-                                  │ InputConnection — text    │ suppression — Android 11 ignores
-                                  │ injection silently fails) │ inputMode="none")
-          Focus useEffects        │ Establish the IME         │ N/A — keystroke hook listens on document
-          ────────────────────────┼───────────────────────────┼──────────────────────────────────────
-          Sysconfig — off-screen  │ offscreenInput.readOnly=N │ offscreenInput.readOnly=Y
-          Sysconfig — visible     │ visibleInput.readOnly=N   │ visibleInput.readOnly=Y (when visible)
-
-          The `readOnly` attribute is per-mode (offscreenInput vs visibleInput) and driven by
-          sysconfigs per the framework design (https://github.com/metasfresh/me03/issues/29246).
-          DataWedge IME requires readOnly ABSENT or InputConnection breaks
-          (https://github.com/metasfresh/me03/issues/28834). Keystroke-wedge devices that ignore
-          inputMode="none" require readOnly PRESENT — first deployed for Honeywell CT60 /
-          Android 11.
-
-          Regression guards (BOTH must stay green — `e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js`):
-            • DataWedge IME:        "#input-text HTML: type=text, inputMode=none, readOnly absent, CSS-hidden"
-            • CT60 keystroke-wedge: "Honeywell CT60 keystroke-wedge mode — input is off-screen + readOnly, no camera"
-
-          Do NOT relax either test to make a change land. A red test means the CODE broke a
-          contract — fix the code, not the test. Any change here MUST be re-validated on physical
-          hardware for BOTH device classes (e2e/mobile-webui/CLAUDE.md → "Manual Hardware Test Rule"). */}
-      {!isProcessing && (
-        <input
-          id="input-text"
-          key="input-text"
-          ref={inputTextRef}
-          className={`input-text${isShowInputText ? '' : ' input-text-offscreen'}`}
-          type="text"
-          placeholder={inputPlaceholderText || trl('components.BarcodeScannerComponent.scanTextPlaceholder')}
-          inputMode={isInputModeNone ? 'none' : undefined}
-          readOnly={isReadOnlyAttrSet}
-          onFocus={handleInputTextFocus}
-          onBlur={handleInputTextBlur}
-          onChange={handleInputTextChangedDebounced}
-          onKeyUp={handleInputTextKeyPress}
-          data-testid={testId ?? 'qrCode-input'}
+      {!invisible && isProcessing && <Spinner />}
+      {/* HardwareModePanel is rendered in EVERY visible mode:
+            HARDWARE → full scan-prompt UI + off-screen <input>
+            MANUAL / CAMERA → invisible mode: off-screen <input> only, no visible chrome
+          Two reasons:
+            (1) keeps `#input-text` mounted across mode switches so DataWedge IME
+                InputConnection survives — matches the E2E contract
+                (barcode_scanner_modes.spec.js — `expectAttached({})` in MANUAL mode).
+            (2) keeps the window-level useKeyboardBarcodeReader hook attached during
+                CAMERA mode (workplaces with a plugged scanner can still scan into the
+                camera view). The hook is `disabled` in MANUAL mode so keystrokes go
+                straight to the visible manual input. */}
+      <HardwareModePanel
+        inputPlaceholderText={inputPlaceholderText}
+        invisible={invisible || activeMode !== MODE.HARDWARE}
+        isProcessing={isProcessing}
+        disabled={isProcessing || activeMode === MODE.MANUAL}
+        onBarcodeScanned={validateScannedBarcodeAndForward}
+        testId={testId}
+      />
+      {!invisible && activeMode === MODE.MANUAL && (
+        <ManualModePanel
+          isProcessing={isProcessing}
+          enabledModes={enabledModes}
+          onModeSelected={setActiveMode}
+          onBarcodeScanned={({ scannedBarcode, onSuccess, onError }) =>
+            validateScannedBarcodeAndForward({
+              scannedBarcode,
+              onSuccess: () => {
+                onSuccess?.();
+                setActiveMode(defaultMode);
+              },
+              onError,
+            })
+          }
         />
       )}
-      <video key="video" ref={videoRef} width="100%" height="100%" />
+      {!invisible && activeMode === MODE.CAMERA && (
+        <CameraModePanel
+          isProcessing={isProcessing}
+          onBarcodeScanned={validateScannedBarcodeAndForward}
+          onCancel={() => setActiveMode(defaultMode)}
+        />
+      )}
+      {!invisible && (
+        <BarcodeScannerFooter activeMode={activeMode} enabledModes={enabledModes} onModeSelected={setActiveMode} />
+      )}
     </div>
   );
 };
 
 BarcodeScannerComponent.propTypes = {
   testId: PropTypes.string,
-  isShowInputText: PropTypes.bool,
-  isShowVideo: PropTypes.bool,
   resolveScannedBarcode: PropTypes.func,
   inputPlaceholderText: PropTypes.string,
-  continuousRunning: PropTypes.bool,
   onResolvedResult: PropTypes.func.isRequired,
+  invisible: PropTypes.bool,
+};
+
+BarcodeScannerComponent.defaultProps = {
+  invisible: false,
 };
 
 export default BarcodeScannerComponent;
+
+//
+//
+//
+//
+//
+
+const useConfigParams = ({ invisible }) => {
+  const { enabledModes, defaultMode } = useBarcodeScannerModes({ invisible });
+
+  return {
+    enabledModes,
+    defaultMode,
+    okBeepParams: {
+      name: 'OK',
+      beepFrequency: useNumber('barcodeScanner.onSuccess.beep.frequency', 1000),
+      beepVolume: useNumber('barcodeScanner.onSuccess.beep.volume', 0.1),
+      beepDurationMillis: useNumber('barcodeScanner.onSuccess.beep.durationMillis', 100),
+      vibrateMillis: useNumber('barcodeScanner.onSuccess.vibrate.durationMillis', 100),
+    },
+    errorBeepParams: {
+      name: 'error',
+      beepFrequency: useNumber('barcodeScanner.onError.beep.frequency', 100),
+      beepVolume: useNumber('barcodeScanner.onError.beep.volume', 0.1),
+      beepDurationMillis: useNumber('barcodeScanner.onError.beep.durationMillis', 100),
+      vibrateMillis: useNumber('barcodeScanner.onError.vibrate.durationMillis', 100),
+    },
+    scanDuplicatesIntervalMillis: usePositiveNumberSetting('barcodeScanner.scanDuplicatesIntervalMillis', 0),
+  };
+};
 
 //
 //

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
@@ -27,9 +27,25 @@ const useConfigParams = ({ isShowInputTextParam, isShowVideoParam, continuousRun
   const isShowInputText =
     isShowInputTextParam != null ? isShowInputTextParam : useBooleanSetting('barcodeScanner.showInputText');
 
-  const isInputTextReadonly = isShowInputText
+  // Two orthogonal keyboard-suppression knobs feed the scan <input>. They are named after their
+  // mechanism (not their UX effect) so the two cannot be confused:
+  //   • isInputModeNone  → sets `inputMode="none"` (a HINT — soft. Honoured by recent Chrome/Android,
+  //                       ignored by some firmware, e.g. Honeywell CT60 / Android 11).
+  //   • isReadOnlyAttrSet   → sets the HTML `readOnly` attribute (a HARD GUARANTEE — the browser never
+  //                       opens the soft keyboard on a readOnly input, AND manual typing is blocked).
+  // Per the scanner-framework design (https://github.com/metasfresh/me03/issues/29246), readOnly is
+  // controlled by per-mode knobs (`offscreenInput.readOnly` vs `visibleInput.readOnly`) so the two
+  // modes tune independently. Defaults OFF in both modes ⇒ byte-for-byte today's behaviour.
+  // DataWedge IME deployments MUST keep BOTH off — readOnly kills the InputConnection. Enabling
+  // visibleInput.readOnly also BLOCKS manual typing (Mode C3) — intentional opt-in for
+  // hardware-scanner-only deployments where the visible input must stay on screen (e.g. /huManager,
+  // whose only content is the scan field — hiding it leaves the screen blank).
+  const isInputModeNone = isShowInputText
     ? useBooleanSetting('barcodeScanner.isInputTextReadonly', isMobileOrTablet)
     : true;
+  const isOffscreenInputReadOnly = useBooleanSetting('barcodeScanner.offscreenInput.readOnly', false);
+  const isVisibleInputReadOnly = useBooleanSetting('barcodeScanner.visibleInput.readOnly', false);
+  const isReadOnlyAttrSet = isShowInputText ? isVisibleInputReadOnly : isOffscreenInputReadOnly;
 
   const isShowVideo = isShowVideoParam != null ? isShowVideoParam : useBooleanSetting('barcodeScanner.useCamera', true);
 
@@ -51,7 +67,8 @@ const useConfigParams = ({ isShowInputTextParam, isShowVideoParam, continuousRun
       vibrateMillis: useNumber('barcodeScanner.onError.vibrate.durationMillis', 100),
     },
     isShowInputText,
-    isInputTextReadonly,
+    isInputModeNone,
+    isReadOnlyAttrSet,
     triggerOnChangeIfLengthGreaterThan: usePositiveNumberSetting(
       'barcodeScanner.inputText.triggerOnChangeIfLengthGreaterThan',
       0
@@ -76,13 +93,16 @@ const BarcodeScannerComponent = ({
     okBeepParams,
     errorBeepParams,
     isShowInputText,
-    isInputTextReadonly,
+    isInputModeNone,
+    isReadOnlyAttrSet,
     triggerOnChangeIfLengthGreaterThan,
     textChangedDebounceMillis,
     scanDuplicatesIntervalMillis,
     isShowVideo,
     continuousRunning,
   } = useConfigParams({ isShowInputTextParam, isShowVideoParam, continuousRunningParam });
+  const isComponentHidden = !isShowInputText && !isShowVideo;
+  const isComponentHiddenByParam = isShowInputTextParam === false && isShowVideoParam === false;
 
   const inputTextRef = useRef();
   const scanningStatusRef = useRef({ running: false, done: false });
@@ -121,7 +141,7 @@ const BarcodeScannerComponent = ({
       if (isShowVideo) {
         videoRef?.current?.scrollIntoView({ behaviour: 'smooth', block: 'center', inline: 'end' });
       }
-      if (!isInputTextReadonly) {
+      if (!isInputModeNone) {
         inputTextRef?.current?.focus();
       }
     } /* no deps, call it on each render */
@@ -130,7 +150,7 @@ const BarcodeScannerComponent = ({
   // DataWedge IME needs a focused editable input to establish InputConnection.
   // Focus once on mount; the window-level hook handles all subsequent scan events.
   useEffect(() => {
-    if (isInputTextReadonly) {
+    if (isInputModeNone) {
       inputTextRef?.current?.focus();
     }
   }, []);
@@ -234,7 +254,8 @@ const BarcodeScannerComponent = ({
       eventName: 'barcodeScanned',
       scannedBarcode,
       isShowInputText,
-      isInputTextReadonly,
+      isInputModeNone,
+      isReadOnlyAttrSet,
       triggerOnChangeIfLengthGreaterThan,
       textChangedDebounceMillis,
       scanDuplicatesIntervalMillis,
@@ -279,23 +300,68 @@ const BarcodeScannerComponent = ({
   return (
     <div className="barcode-scanner">
       {isProcessing && <Spinner />}
+      {/* Scan prompt — visible on hardware-scanner deployments (no camera) when the input is
+          OFF-SCREEN (the actual empty-screen case: the only thing the component otherwise renders
+          is the invisible off-screen input). When the input is on-screen (isShowInputText=Y) the
+          input itself is the visual anchor — no big prompt needed. Reuses inputPlaceholderText so
+          a caller can override the default caption (e.g. HUScanner's locator-scan branch passes
+          'Scan LU or locator…'); when the caller passes none, the default scanPrompt translation
+          is used. See https://github.com/metasfresh/me03/issues/30363. */}
+      {!isProcessing && isComponentHidden && !isComponentHiddenByParam && (
+        <div className="scan-prompt">
+          <i className="fas fa-barcode scan-prompt-icon" aria-hidden="true" />
+          {/* Caption swap — idle text by default, "Scanning in progress…" while the input
+              has content (mid-burst). CSS-only via :has() — see BarcodeScannerComponent.scss. */}
+          <div className="scan-prompt-text">
+            <span className="scan-prompt-text-idle">
+              {inputPlaceholderText || trl('components.BarcodeScannerComponent.scanPrompt')}
+            </span>
+            <span className="scan-prompt-text-progress">
+              {trl('components.BarcodeScannerComponent.scanInProgress')}
+            </span>
+          </div>
+        </div>
+      )}
       {/* IMPORTANT: Always use type="text" — never type="hidden".
           When isShowInputText=false, the input is visually hidden via CSS (input-text-offscreen)
           instead of type="hidden". This is critical for Zebra MC3300x DataWedge IME mode:
           type="hidden" inputs cannot receive focus, so Android InputConnection is never established
           and DataWedge text injection silently fails. CSS hiding keeps the input focusable and
-          IME-compatible while remaining invisible to the user. (me03#28834) */}
+          IME-compatible while remaining invisible to the user.
+          (https://github.com/metasfresh/me03/issues/28834) */}
       {/* NOTE: Input is rendered BEFORE video to avoid Android 11 WebView SurfaceView
-          compositing issue where the native video layer covers CSS-overlaid content. (me03#28964) */}
-      {/* ⚠️ HARDWARE CONTRACT — Zebra MC3300x DataWedge IME. The exact combination below lets scans
-          inject WITHOUT popping the virtual keyboard:
-            • type="text"                    — Android InputConnection (type="hidden" cannot focus)
-            • inputMode="none" when readonly — suppresses the virtual keyboard, keeps the IME alive
-            • the focus useEffects above     — establish / recover the InputConnection on the device
-          Do NOT change type / inputMode / readOnly or the focus logic to make a test pass. If the
-          regression guard (e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js) goes red, the
-          CODE broke this contract — fix the code, not the test. Any change here MUST be re-validated
-          on a physical Zebra MC3300x (e2e/mobile-webui/CLAUDE.md → "Manual Hardware Test Rule"). */}
+          compositing issue where the native video layer covers CSS-overlaid content.
+          (https://github.com/metasfresh/me03/issues/28964) */}
+      {/* ⚠️ HARDWARE CONTRACT — TWO device classes; each has its own #input-text attribute combo.
+          Any edit to type / inputMode / readOnly / the focus useEffects MUST preserve BOTH.
+
+                                  │ DataWedge IME             │ Keystroke-wedge
+                                  │ (e.g. Zebra MC3300x)      │ (e.g. Honeywell CT60 / Android 11)
+          ────────────────────────┼───────────────────────────┼──────────────────────────────────────
+          type                    │ "text"                    │ "text"
+          inputMode               │ "none"                    │ "none" (ignored on Android 11)
+          readOnly                │ ABSENT (else kills the    │ PRESENT (load-bearing keyboard
+                                  │ InputConnection — text    │ suppression — Android 11 ignores
+                                  │ injection silently fails) │ inputMode="none")
+          Focus useEffects        │ Establish the IME         │ N/A — keystroke hook listens on document
+          ────────────────────────┼───────────────────────────┼──────────────────────────────────────
+          Sysconfig — off-screen  │ offscreenInput.readOnly=N │ offscreenInput.readOnly=Y
+          Sysconfig — visible     │ visibleInput.readOnly=N   │ visibleInput.readOnly=Y (when visible)
+
+          The `readOnly` attribute is per-mode (offscreenInput vs visibleInput) and driven by
+          sysconfigs per the framework design (https://github.com/metasfresh/me03/issues/29246).
+          DataWedge IME requires readOnly ABSENT or InputConnection breaks
+          (https://github.com/metasfresh/me03/issues/28834). Keystroke-wedge devices that ignore
+          inputMode="none" require readOnly PRESENT — first deployed for Honeywell CT60 /
+          Android 11.
+
+          Regression guards (BOTH must stay green — `e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js`):
+            • DataWedge IME:        "#input-text HTML: type=text, inputMode=none, readOnly absent, CSS-hidden"
+            • CT60 keystroke-wedge: "Honeywell CT60 keystroke-wedge mode — input is off-screen + readOnly, no camera"
+
+          Do NOT relax either test to make a change land. A red test means the CODE broke a
+          contract — fix the code, not the test. Any change here MUST be re-validated on physical
+          hardware for BOTH device classes (e2e/mobile-webui/CLAUDE.md → "Manual Hardware Test Rule"). */}
       {!isProcessing && (
         <input
           id="input-text"
@@ -304,7 +370,8 @@ const BarcodeScannerComponent = ({
           className={`input-text${isShowInputText ? '' : ' input-text-offscreen'}`}
           type="text"
           placeholder={inputPlaceholderText || trl('components.BarcodeScannerComponent.scanTextPlaceholder')}
-          inputMode={isInputTextReadonly ? 'none' : undefined}
+          inputMode={isInputModeNone ? 'none' : undefined}
+          readOnly={isReadOnlyAttrSet}
           onFocus={handleInputTextFocus}
           onBlur={handleInputTextBlur}
           onChange={handleInputTextChangedDebounced}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScreenToaster.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScreenToaster.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import { ToastContainer } from 'react-toastify';
+import { ToastContainer, toast } from 'react-toastify';
+import { useLocationChange } from '../hooks/useLocationChange';
 
 const ScreenToaster = () => {
+  useLocationChange(() => toast.dismiss());
+
   return (
     <ToastContainer
       position="bottom-center"

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScreenToaster.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScreenToaster.jsx
@@ -12,6 +12,8 @@ const ScreenToaster = () => {
       rtl={false}
       pauseOnFocusLoss
       draggable
+      draggableDirection="x"
+      draggablePercent={50}
       pauseOnHover
       theme="dark"
       style={{ marginBottom: '3rem' }}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/dialogs/GetQuantityDialog.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/dialogs/GetQuantityDialog.jsx
@@ -283,7 +283,6 @@ const GetQuantityDialog = ({
             <tr>
               <td colSpan="2">
                 <BarcodeScannerComponent
-                  continuousRunning={true}
                   customQRCodeFormats={customQRCodeFormats}
                   onResolvedResult={readQtyFromQrCode}
                 />

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/LoginScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/LoginScreen.jsx
@@ -90,26 +90,20 @@ const LoginView = ({
       <LoginMethodPanel authMethod={currentAuthMethod} />
       {availableAuthMethods && availableAuthMethods.length === 2 && (
         <div className="section is-size-5" style={{ paddingTop: 0 }}>
-          <div className="container px-6">
-            <ButtonWithIndicator
-              caption={trl('login.alternativeMethods')}
-              onClick={() =>
-                onSetAuthMethodClicked(availableAuthMethods.find((method) => method !== currentAuthMethod))
-              }
-              additionalCssClass={'alternative-button'}
-            />
-          </div>
+          <ButtonWithIndicator
+            caption={trl('login.alternativeMethods')}
+            onClick={() => onSetAuthMethodClicked(availableAuthMethods.find((method) => method !== currentAuthMethod))}
+            additionalCssClass={'alternative-button'}
+          />
         </div>
       )}
       {availableAuthMethods && availableAuthMethods.length > 2 && (
         <div className="section is-size-5" style={{ paddingTop: 0 }}>
-          <div className="container px-6">
-            <ButtonWithIndicator
-              caption={trl('login.alternativeMethods')}
-              onClick={onAlternativeAuthMethodClicked}
-              additionalCssClass={'alternative-button'}
-            />
-          </div>
+          <ButtonWithIndicator
+            caption={trl('login.alternativeMethods')}
+            onClick={onAlternativeAuthMethodClicked}
+            additionalCssClass={'alternative-button'}
+          />
         </div>
       )}
     </>

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionMoveActivity.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionMoveActivity.jsx
@@ -34,7 +34,7 @@ const DistributionMoveActivity = ({ applicationId, wfProcessId, activityId, acti
 
   return (
     <div className="mt-5">
-      <BarcodeScannerComponent isShowInputText={false} isShowVideo={false} onResolvedResult={onScannedCode} />
+      <BarcodeScannerComponent invisible onResolvedResult={onScannedCode} />
       {lines.map((line, lineIdx) => {
         const lineId = line.lineId;
         return (

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/SelectPickTargetScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/SelectPickTargetScreen.jsx
@@ -175,9 +175,7 @@ const GraiScanPanel = ({ onGraiScanned }) => {
     [onGraiScanned]
   );
 
-  return (
-    <BarcodeScannerComponent onResolvedResult={onResolvedResult} continuousRunning={true} testId="grai-scan-input" />
-  );
+  return <BarcodeScannerComponent onResolvedResult={onResolvedResult} testId="grai-scan-input" />;
 };
 
 GraiScanPanel.propTypes = {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/scan/ScanScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/scan/ScanScreen.jsx
@@ -98,7 +98,7 @@ const ScanScreen = () => {
   } else {
     return (
       <>
-        <BarcodeScannerComponent onResolvedResult={onBarcodeScanned} continuousRunning={true} />
+        <BarcodeScannerComponent onResolvedResult={onBarcodeScanned} />
         {isDisplaySuggestions && (
           <ScannedBarcodeSuggestions
             isLoading={isScannedBarcodeSuggestionsLoading}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/applicationsListScreen/ApplicationsListScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/applicationsListScreen/ApplicationsListScreen.jsx
@@ -58,9 +58,7 @@ const ApplicationsListScreen = () => {
       <LogoHeader />
       <div className="section">
         {isLoading && <Spinner />}
-        {!isLoading && (
-          <BarcodeScannerComponent isShowInputText={false} isShowVideo={false} onResolvedResult={onBarcodeScanned} />
-        )}
+        {!isLoading && <BarcodeScannerComponent invisible onResolvedResult={onBarcodeScanned} />}
         {applicationsDisplayed.map((app) => (
           <ApplicationButton
             key={app.id}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/authMethods/QrCodeAuth.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/authMethods/QrCodeAuth.jsx
@@ -3,6 +3,7 @@ import { useAuth } from '../../hooks/useAuth';
 import BarcodeScannerComponent from '../../components/BarcodeScannerComponent';
 import { toastError } from '../../utils/toast';
 import { useMobileNavigation } from '../../hooks/useMobileNavigation';
+import { trl } from '../../utils/translations';
 
 const QrCodeAuth = () => {
   const history = useMobileNavigation();
@@ -19,9 +20,7 @@ const QrCodeAuth = () => {
 
   return (
     <div id="qr-code-auth" className="section is-size-5 qr-code-auth">
-      <div className="container px-6">
-        <BarcodeScannerComponent onResolvedResult={performLogin} />
-      </div>
+      <BarcodeScannerComponent onResolvedResult={performLogin} inputPlaceholderText={trl('login.qrLoginPlaceholder')} />
     </div>
   );
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/authMethods/UserAndPassAuth.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/authMethods/UserAndPassAuth.jsx
@@ -1,13 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useAuth } from '../../hooks/useAuth';
 import { trl } from '../../utils/translations';
-import { extractUserFriendlyErrorMessageFromAxiosError } from '../../utils/toast';
+import { toastError } from '../../utils/toast';
 import { useMobileNavigation } from '../../hooks/useMobileNavigation';
 
 const UserAndPassAuth = () => {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [errorMessage, setErrorMessage] = useState('');
   const [loginPending, setLoginPending] = useState(false);
 
   const history = useMobileNavigation();
@@ -23,7 +22,7 @@ const UserAndPassAuth = () => {
       .then(() => history.goToFromLocation())
       .catch((axiosError) => {
         setLoginPending(false);
-        setErrorMessage(extractUserFriendlyErrorMessageFromAxiosError({ axiosError }));
+        toastError({ axiosError });
       });
     // .finally(() => setLoginPending(false)); // don't set it here because at this point the component is already unmounted
   };
@@ -35,54 +34,55 @@ const UserAndPassAuth = () => {
 
   return (
     <div id="password-auth" className="section is-size-5">
-      <div className="container px-6">
-        <form>
-          <p className="help is-danger is-size-6 login-error">{errorMessage}</p>
-          <div className="field">
-            <p className="control has-icons-left">
-              <input
-                className="input is-medium"
-                type="text"
-                id="username"
-                name="username"
-                value={username}
-                autoComplete="username"
-                ref={usernameFieldRef}
-                disabled={loginPending}
-                onInput={(e) => setUsername(e.target.value)}
-              />
-              <span className="icon is-small is-left">
-                <i className="fas fa-user" />
-              </span>
-            </p>
+      <form>
+        <div className="field">
+          <p className="control has-icons-left">
+            <input
+              className="input is-medium"
+              type="text"
+              id="username"
+              name="username"
+              value={username}
+              autoComplete="username"
+              aria-label={trl('login.username')}
+              placeholder={trl('login.username')}
+              ref={usernameFieldRef}
+              disabled={loginPending}
+              onInput={(e) => setUsername(e.target.value)}
+            />
+            <span className="icon is-small is-left">
+              <i className="fas fa-user" />
+            </span>
+          </p>
+        </div>
+        <div className="field">
+          <p className="control has-icons-left">
+            <input
+              className="input is-medium"
+              id="current-password"
+              type="password"
+              name="password"
+              value={password}
+              autoComplete="current-password"
+              aria-label={trl('login.password')}
+              placeholder={trl('login.password')}
+              disabled={loginPending}
+              onInput={(e) => setPassword(e.target.value)}
+            />
+            <span className="icon is-small is-left">
+              <i className="fas fa-lock" />
+            </span>
+          </p>
+        </div>
+        <div className="field">
+          <div className="control">
+            <button type="submit" className="button is-medium" disabled={loginPending} onClick={submitForm}>
+              {/* eslint-disable-next-line no-undef */}
+              {trl('login.submitButton')}
+            </button>
           </div>
-          <div className="field">
-            <p className="control has-icons-left">
-              <input
-                className="input is-medium"
-                id="current-password"
-                type="password"
-                name="password"
-                value={password}
-                autoComplete="current-password"
-                disabled={loginPending}
-                onInput={(e) => setPassword(e.target.value)}
-              />
-              <span className="icon is-small is-left">
-                <i className="fas fa-lock" />
-              </span>
-            </p>
-          </div>
-          <div className="field">
-            <div className="control">
-              <button type="submit" className="button is-medium" disabled={loginPending} onClick={submitForm}>
-                {/* eslint-disable-next-line no-undef */}
-                {trl('login.submitButton')}
-              </button>
-            </div>
-          </div>
-        </form>
-      </div>
+        </div>
+      </form>
     </div>
   );
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/WFLaunchersScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/WFLaunchersScreen.jsx
@@ -81,7 +81,6 @@ const WFLaunchersScreen = () => {
         <BarcodeScannerComponent
           onResolvedResult={({ scannedBarcode }) => setWorkstationByQRCode(scannedBarcode)}
           inputPlaceholderText={trl('components.BarcodeScannerComponent.scanWorkstationPlaceholder')}
-          continuousRunning={true}
         />
       </div>
     );
@@ -101,7 +100,6 @@ const WFLaunchersScreen = () => {
         <BarcodeScannerComponent
           onResolvedResult={({ scannedBarcode }) => setWorkplaceByQRCode(scannedBarcode)}
           inputPlaceholderText={trl('components.BarcodeScannerComponent.scanWorkplacePlaceholder')}
-          continuousRunning={true}
         />
       </div>
     );
@@ -121,7 +119,6 @@ const WFLaunchersScreen = () => {
         <BarcodeScannerComponent
           onResolvedResult={({ scannedBarcode }) => setTrolleyByScannedCode(scannedBarcode)}
           inputPlaceholderText={trl('components.BarcodeScannerComponent.scanTrolleyPlaceholder')}
-          continuousRunning={true}
         />
       </div>
     );

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
@@ -13,6 +13,18 @@ export const useKeyboardBarcodeReader = ({
 
   useEffect(() => {
     const handleKeyDown = async (event) => {
+      // console.log('[scanner] keydown', {
+      //   key: event.key,
+      //   alt: event.altKey,
+      //   ctrl: event.ctrlKey,
+      //   meta: event.metaKey,
+      //   len: event.key?.length,
+      // });
+
+      if (event.key === 'Unidentified') {
+        return;
+      }
+
       //
       // Handle Ctrl+V (or Cmd+V on Mac)
       if ((event.ctrlKey || event.metaKey) && event.key === 'v') {
@@ -21,7 +33,6 @@ export const useKeyboardBarcodeReader = ({
           if (clipboardText?.length < minLength) {
             return;
           }
-          console.log('Pasted text:', clipboardText);
 
           event.preventDefault(); // Prevent default paste behavior
           onReadDone(clipboardText);

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/toast.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/toast.jsx
@@ -8,21 +8,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ContextualError } from './ContextualError';
 
-export const toastErrorFromObj = (obj) => {
+export const toastErrorFromObj = (obj, toastId) => {
   console.log('toastErrorFromObj', { obj });
   if (!obj) {
     // shall not happen
     console.error('toastErrorFromObj called without any error');
   } else if (isError(obj) || obj instanceof ContextualError) {
-    toastError({ axiosError: obj, context: obj?.context });
+    toastError({ axiosError: obj, context: obj?.context, toastId });
   } else if (typeof obj === 'object') {
     toastError(obj);
   } else {
-    toastError({ plainMessage: `${obj}` });
+    toastError({ plainMessage: `${obj}`, toastId });
   }
 };
 
-export const toastError = ({ axiosError, messageKey, fallbackMessageKey, plainMessage, context }) => {
+export const toastError = ({ axiosError, messageKey, fallbackMessageKey, plainMessage, context, toastId }) => {
   let code;
   let message;
   if (axiosError) {
@@ -45,6 +45,7 @@ export const toastError = ({ axiosError, messageKey, fallbackMessageKey, plainMe
     position: 'bottom-center',
     transition: Bounce,
     bodyStyle: { overflow: 'auto' },
+    toastId,
   });
 
   uiTrace.trace({

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -81,6 +81,8 @@ const translations = {
       scanWorkplacePlaceholder: 'Arbeitsplatz scannen...',
       scanWorkstationPlaceholder: 'Arbeitsstation scannen...',
       scanTrolleyPlaceholder: 'Wagen scannen...',
+      scanPrompt: 'Barcode scannen',
+      scanInProgress: 'Scan läuft...',
     },
   },
   activities: {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -58,6 +58,9 @@ const translations = {
   login: {
     submitButton: 'Login',
     alternativeMethods: 'Wechseln zu...',
+    qrLoginPlaceholder: 'QR-Code zum Anmelden scannen',
+    username: 'Benutzername',
+    password: 'Passwort',
     authMethod: {
       qrCode: 'QR Code',
       userAndPass: 'Passwort',
@@ -83,6 +86,12 @@ const translations = {
       scanTrolleyPlaceholder: 'Wagen scannen...',
       scanPrompt: 'Barcode scannen',
       scanInProgress: 'Scan läuft...',
+      enterManually: 'Manuell eingeben',
+      scanWithCamera: 'Mit Kamera scannen',
+      useHardwareScanner: 'Hardware-Scanner verwenden',
+      manualInputPlaceholder: 'Barcode eingeben...',
+      manualInputSubmit: 'Senden',
+      cameraError: 'Kamera konnte nicht gestartet werden. Bitte Kamerazugriff prüfen.',
     },
   },
   activities: {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -54,6 +54,9 @@ const translations = {
   login: {
     submitButton: 'Login',
     alternativeMethods: 'Switch to...',
+    qrLoginPlaceholder: 'Scan your login QR code',
+    username: 'Username',
+    password: 'Password',
     authMethod: {
       qrCode: 'QR Code',
       userAndPass: 'Password',
@@ -79,6 +82,12 @@ const translations = {
       scanTrolleyPlaceholder: 'Scan trolley...',
       scanPrompt: 'Scan barcode',
       scanInProgress: 'Scanning in progress...',
+      enterManually: 'Enter manually',
+      scanWithCamera: 'Scan with camera',
+      useHardwareScanner: 'Use hardware scanner',
+      manualInputPlaceholder: 'Enter barcode...',
+      manualInputSubmit: 'Submit',
+      cameraError: 'Camera could not be started. Please check camera permissions.',
     },
   },
   activities: {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -77,6 +77,8 @@ const translations = {
       scanWorkplacePlaceholder: 'Scan workplace...',
       scanWorkstationPlaceholder: 'Scan workstation...',
       scanTrolleyPlaceholder: 'Scan trolley...',
+      scanPrompt: 'Scan barcode',
+      scanInProgress: 'Scanning in progress...',
     },
   },
   activities: {


### PR DESCRIPTION
Ports the mobile barcode-scanner work onto `soft_panda_hotfix`, mirroring the intensive_care port (https://github.com/metasfresh/metasfresh/pull/24558).

### What this ports
- **Honeywell handheld fixes** (https://github.com/metasfresh/metasfresh/pull/24522): launcher gap, hide camera, keyboard-suppress knob.
- **Barcode-scanner modes redesign / "Track C"** (https://github.com/metasfresh/metasfresh/pull/24553): `useBarcodeScannerModes` hook + `BarcodeScannerFooter` + hardware/camera/manual mode panels; always-off-screen input; `invisible` prop; `continuousRunning` retired.
- Spec comment fix + an added coverage test for the canonical hardware-handheld config (hardware default + manual fallback, camera off).

### Migrations (4)
- `5807370` offscreen-input readOnly default
- `5807430` visible-input readOnly default
- `5807640` SysConfig `mode.*` seed
- `5807650` alias/retire of legacy knobs (backs up `AD_SysConfig` first)

### Port notes (deviations from a flat replay of the intensive_care branch)
- **`soft_panda`'s GRAI scanner feature is preserved** — the intensive_care adaptation commit that reverted `SelectPickTargetScreen.jsx` to drop `useGraiScanner`/`GraiScanPanel` was **deliberately not applied** (that feature exists on soft_panda; only the `continuousRunning` prop was removed).
- `traceLogWarn` and the restored e2e util methods were already present on `soft_panda` → those adaptation hunks were no-ops/skipped.
- All Track-C redesign component files verified byte-identical to the reviewed intensive_care state.

soft_panda already carried the keyboard-popup fix (https://github.com/metasfresh/metasfresh/pull/24366) — same baseline the intensive_care port built on.
