### PR TITLE
DD_Order_Candidate: add DB column defaults for SQL-authored inserts

### DIFF
--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5807740_DD_Order_Candidate_column_defaults.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5807740_DD_Order_Candidate_column_defaults.sql
@@ -1,0 +1,15 @@
+-- DD_Order_Candidate: add DB column defaults so SQL-authored inserts (e.g. scheduled
+-- DD_Order_Candidate generator functions) can omit the audit/flag boilerplate.
+-- App-path (PO framework) inserts always set these explicitly, so the defaults only take
+-- effect for bare SQL INSERTs. QtyProcessed / Processed / IsSimulated already have defaults.
+
+ALTER TABLE dd_order_candidate ALTER COLUMN isactive  SET DEFAULT 'Y'
+;
+ALTER TABLE dd_order_candidate ALTER COLUMN created   SET DEFAULT now()
+;
+ALTER TABLE dd_order_candidate ALTER COLUMN createdby SET DEFAULT 100
+;
+ALTER TABLE dd_order_candidate ALTER COLUMN updated   SET DEFAULT now()
+;
+ALTER TABLE dd_order_candidate ALTER COLUMN updatedby SET DEFAULT 100
+;


### PR DESCRIPTION
Adds DB column defaults on `DD_Order_Candidate` so bare-SQL inserts can omit the audit/flag boilerplate:

- `IsActive='Y'`, `Created=now()`, `CreatedBy=100`, `Updated=now()`, `UpdatedBy=100`
- (`QtyProcessed`, `Processed`, `IsSimulated` already have DB defaults.)

App-path (PO framework) inserts always set these explicitly, so the defaults only take effect for **direct SQL inserts** — e.g. scheduled `DD_Order_Candidate` generator functions, whose INSERT can then be trimmed.

Migration: a plain `ALTER … SET DEFAULT` (verified it applies and the defaults take effect).
