### PR TITLE
Shipment schedule: reactivation and reopen-processed handle processed-but-not-closed schedules

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentSchedule.feature
@@ -103,3 +103,40 @@ Feature: Shipment schedule updating
       | M_ShipmentSchedule_ID.Identifier | OPT.QtyToDeliver | OPT.QtyDelivered | OPT.QtyOrdered | OPT.QtyOnHand | OPT.Processed |
       | schedule_1_S0271                 | 10               | 0                | 10             | 11            | false         |
       | schedule_2_S0271                 | 1                | 0                | 10             | 1             | false         |
+
+
+  @ghActions:run_on_executor7
+  @allure.label.epic:E0100_Sales
+  @allure.label.feature:F00105_Sales_Order_Document
+  @Id:S0271_29118
+  Scenario: Sales order can be reactivated after a 0-qty line processed its shipment schedule
+    # Zeroing an order line (instead of deleting it) and re-completing auto-processes that line's
+    # shipment schedule (Processed=Y, IsClosed=N), which previously blocked any further reactivation
+    # with "ShipmentScheduleAlreadyProcessed".
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | o_29118    | true    | customer_so_S0271        | 2023-05-31  |
+    And metasfresh contains C_OrderLines:
+      | Identifier    | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_zero_29118 | o_29118               | product_S0271           | 10         |
+      | ol_keep_29118 | o_29118               | product_S0271           | 10         |
+    And the order identified by o_29118 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier       | C_OrderLine_ID.Identifier | IsToRecompute |
+      | sched_zero_29118 | ol_zero_29118             | N             |
+
+    # reactivate, zero one line's qty, re-complete -> that line's schedule auto-processes
+    When the order identified by o_29118 is reactivated
+    And update C_OrderLine:
+      | C_OrderLine_ID.Identifier | OPT.QtyEntered | OPT.QtyOrdered |
+      | ol_zero_29118             | 0              | 0              |
+    And the order identified by o_29118 is completed
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.QtyOrdered | OPT.Processed |
+      | sched_zero_29118                 | 0              | true          |
+
+    # the bug: this reactivation was blocked by the processed-but-not-closed schedule
+    Then the order identified by o_29118 is reactivated
+    # full customer recovery: drop the offending line and re-complete cleanly
+    And delete C_OrderLine identified by ol_zero_29118, but keep its id into identifierIds table
+    And the order identified by o_29118 is completed

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentSchedule.feature
@@ -107,7 +107,7 @@ Feature: Shipment schedule updating
 
   @ghActions:run_on_executor7
   @allure.label.epic:E0100_Sales
-  @allure.label.feature:F00105_Sales_Order_Document
+  @allure.label.feature:F00130_Shipment_Schedule
   @Id:S0271_29118
   Scenario: Sales order can be reactivated after a 0-qty line processed its shipment schedule
     # Zeroing an order line (instead of deleting it) and re-completing auto-processes that line's

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
@@ -161,7 +161,6 @@ import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 @Service
 public class ShipmentScheduleBL implements IShipmentScheduleBL
 {
-	private static final AdMessageKey MSG_SHIPMENT_SCHEDULE_ALREADY_PROCESSED = AdMessageKey.of("ShipmentScheduleAlreadyProcessed");
 	static final AdMessageKey MSG_REACTIVATION_VOID_NOT_ALLOWED_BECAUSE_ALREADY_EXPORTED = AdMessageKey.of("salesorder.shipmentschedule.exported");
 	static final AdMessageKey MSG_REACTIVATION_VOID_NOT_ALLOWED_BECAUSE_SCHEDULED_FOR_PICKING = AdMessageKey.of("salesorder.shipmentschedule.cannotReactivateBecauseScheduledForPicking");
 
@@ -344,9 +343,13 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 	@Override
 	public void openShipmentSchedule(@NonNull final I_M_ShipmentSchedule shipmentScheduleRecord)
 	{
-		Check.errorUnless(shipmentScheduleRecord.isClosed(), "The given shipmentSchedule is not closed; shipmentSchedule={}", shipmentScheduleRecord);
-
-		shipmentScheduleRecord.setIsClosed(false);
+		// Tolerate a processed-but-not-closed schedule: "open" means active + not-processed,
+		// independent of the close flag. Un-close only if closed; always un-process and flag for recompute.
+		if (shipmentScheduleRecord.isClosed())
+		{
+			shipmentScheduleRecord.setIsClosed(false);
+		}
+		shipmentScheduleRecord.setProcessed(false);
 		save(shipmentScheduleRecord);
 
 		final IShipmentScheduleInvalidateBL invalidSchedulesService = Services.get(IShipmentScheduleInvalidateBL.class);
@@ -652,12 +655,10 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 			{
 				continue;
 			}
-			if (record.isProcessed())
-			{
-				throw new AdempiereException(
-						MSG_SHIPMENT_SCHEDULE_ALREADY_PROCESSED, record.getM_ShipmentSchedule_ID())
-						.markAsUserValidationError();
-			}
+			// A processed-but-not-closed schedule reaches here only on order reactivation, where the
+			// BEFORE_REACTIVATE guard (reactivateIfNoActiveShipment) already ensured there are no active
+			// shipments — so it has no real delivery work (e.g. auto-processed from a 0-qty line). Close it
+			// so the subsequent re-completion can reopen + recompute it.
 			closeShipmentSchedule(record);
 		}
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBLTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBLTest.java
@@ -1,16 +1,21 @@
 package de.metas.inoutcandidate.api.impl;
 
+import com.google.common.collect.ImmutableList;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
+import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.inoutcandidate.model.X_M_ShipmentSchedule;
+import de.metas.interfaces.I_C_OrderLine;
 import de.metas.order.OrderId;
 import de.metas.util.Services;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.I_C_Order;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.math.BigDecimal;
 
@@ -29,6 +34,9 @@ public class ShipmentScheduleBLTest
 	public void init()
 	{
 		AdempiereTestHelper.get().init();
+		// openShipmentSchedule flags the schedule for recompute; in the unit context the real
+		// invalidation BL has no default constructor, so register a no-op mock.
+		Services.registerService(IShipmentScheduleInvalidateBL.class, Mockito.mock(IShipmentScheduleInvalidateBL.class));
 		shipmentScheduleBL = (ShipmentScheduleBL)Services.get(IShipmentScheduleBL.class);
 	}
 
@@ -52,6 +60,44 @@ public class ShipmentScheduleBLTest
 		assertThat(schedule.getQtyToDeliver_Override())
 				.as("closing a shipment schedule may not fiddle with its QtyToDeliver_Override value")
 				.isEqualByComparingTo("24");
+	}
+
+	@Test
+	public void openShipmentSchedule_processedNotClosed_unprocessesWithoutError()
+	{
+		final I_M_ShipmentSchedule schedule = newInstance(I_M_ShipmentSchedule.class);
+		schedule.setProcessed(true);
+		schedule.setIsClosed(false);
+		saveRecord(schedule);
+
+		shipmentScheduleBL.openShipmentSchedule(schedule);
+
+		refresh(schedule);
+		assertThat(schedule.isProcessed()).as("reopening must un-process the schedule").isFalse();
+		assertThat(schedule.isClosed()).as("an already-open schedule stays open").isFalse();
+	}
+
+	@Test
+	public void closeShipmentSchedulesFor_processedNotClosed_closesInsteadOfThrowing()
+	{
+		// On order reactivation, a schedule that auto-processed from a 0-qty line (Processed=Y, IsClosed=N)
+		// must be closed, not rejected with ShipmentScheduleAlreadyProcessed. The reactivation interceptor
+		// passes C_OrderLine references, so mirror that here (matches ShipmentSchedulePA.getByReferences).
+		final I_C_OrderLine orderLine = newInstance(I_C_OrderLine.class);
+		saveRecord(orderLine);
+		final TableRecordReference sourceRef = TableRecordReference.of(I_C_OrderLine.Table_Name, orderLine.getC_OrderLine_ID());
+
+		final I_M_ShipmentSchedule schedule = newInstance(I_M_ShipmentSchedule.class);
+		schedule.setAD_Table_ID(sourceRef.getAD_Table_ID());
+		schedule.setRecord_ID(sourceRef.getRecord_ID());
+		schedule.setProcessed(true);
+		schedule.setIsClosed(false);
+		saveRecord(schedule);
+
+		shipmentScheduleBL.closeShipmentSchedulesFor(ImmutableList.of(sourceRef));
+
+		refresh(schedule);
+		assertThat(schedule.isClosed()).as("a processed-but-not-closed schedule must be closed, not rejected").isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
## Problem
A sales-order line set to `QtyOrdered=0` (instead of being deleted) and re-completed makes its
`M_ShipmentSchedule` auto-flag `Processed=Y` while `IsClosed=N`. The order can then no longer be
reactivated (`ShipmentScheduleAlreadyProcessed`), and neither the reopen-processed process nor the close
process can recover it — the only escape was a manual database update.

## Fix
- `ShipmentScheduleBL.closeShipmentSchedulesFor` (order reactivation): close a processed-but-not-closed
  schedule instead of throwing. Safe because the `BEFORE_REACTIVATE` guard (`reactivateIfNoActiveShipment`)
  already guarantees the order has no active shipments, so such a schedule carries no real delivery work;
  the subsequent re-completion reopens and recomputes it.
- `ShipmentScheduleBL.openShipmentSchedule`: no longer asserts `IsClosed`; un-closes only if closed and
  always un-processes the schedule + flags for recompute. This also repairs the
  `M_ShipmentSchedule_OpenProcessed` recovery process, which previously failed on a not-closed schedule.

## Tests
- Unit (`ShipmentScheduleBLTest`): both methods on a processed-but-not-closed schedule; red→green, all green.
- Cucumber (`shipmentSchedule.feature`): regression — complete order → reactivate → zero a line →
  re-complete (schedule auto-processes) → reactivate (previously blocked) → delete the line → re-complete.
