### PR TITLE
DocuWare export observability — port scripted-export status/log/error machinery (Stage 1)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_M_InOut.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_M_InOut.java
@@ -913,6 +913,29 @@ public interface I_M_InOut
 	String COLUMNNAME_EMail = "EMail";
 
 	/**
+	 * Set EPCIS Export Status.
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true
+	 * @deprecated Please don't use it because this is a virtual column
+	 */
+	@Deprecated
+	void setEPCIS_ExportStatus (@Nullable java.lang.String EPCIS_ExportStatus);
+
+	/**
+	 * Get EPCIS Export Status.
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true
+	 */
+	@Nullable java.lang.String getEPCIS_ExportStatus();
+
+	ModelColumn<I_M_InOut, Object> COLUMN_EPCIS_ExportStatus = new ModelColumn<>(I_M_InOut.class, "EPCIS_ExportStatus", null);
+	String COLUMNNAME_EPCIS_ExportStatus = "EPCIS_ExportStatus";
+
+	/**
 	 * Set External ID.
 	 *
 	 * <br>Type: String

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_M_InOut.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_M_InOut.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 public class X_M_InOut extends org.compiere.model.PO implements I_M_InOut, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = -893759826L;
+	private static final long serialVersionUID = -1997047345L;
 
     /** Standard Constructor */
     public X_M_InOut (final Properties ctx, final int M_InOut_ID, @Nullable final String trxName)
@@ -704,6 +704,36 @@ public class X_M_InOut extends org.compiere.model.PO implements I_M_InOut, org.c
 	public java.lang.String getEMail() 
 	{
 		return get_ValueAsString(COLUMNNAME_EMail);
+	}
+
+	/** 
+	 * EPCIS_ExportStatus AD_Reference_ID=542104
+	 * Reference name: ExternalSystem_ExportStatus
+	 */
+	public static final int EPCIS_EXPORTSTATUS_AD_Reference_ID=542104;
+	/** Pending = P */
+	public static final String EPCIS_EXPORTSTATUS_Pending = "P";
+	/** Enqueued = U */
+	public static final String EPCIS_EXPORTSTATUS_Enqueued = "U";
+	/** SendingStarted = D */
+	public static final String EPCIS_EXPORTSTATUS_SendingStarted = "D";
+	/** Sent = S */
+	public static final String EPCIS_EXPORTSTATUS_Sent = "S";
+	/** Error = E */
+	public static final String EPCIS_EXPORTSTATUS_Error = "E";
+	/** Invalid = I */
+	public static final String EPCIS_EXPORTSTATUS_Invalid = "I";
+	/** DontSend = N */
+	public static final String EPCIS_EXPORTSTATUS_DontSend = "N";
+	@Override
+	public void setEPCIS_ExportStatus (final @Nullable java.lang.String EPCIS_ExportStatus)
+	{
+		throw new IllegalArgumentException ("EPCIS_ExportStatus is virtual column");	}
+
+	@Override
+	public java.lang.String getEPCIS_ExportStatus() 
+	{
+		return get_ValueAsString(COLUMNNAME_EPCIS_ExportStatus);
 	}
 
 	@Override

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/externlasystem/ExternalSystemRestController.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/externlasystem/ExternalSystemRestController.java
@@ -60,6 +60,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.annotation.Nullable;
@@ -137,10 +138,27 @@ public class ExternalSystemRestController
 	@PostMapping(path = "/externalstatus/{AD_PInstance_ID}/error", consumes = "application/json", produces = "application/json")
 	public ResponseEntity<JsonCreateIssueResponse> handleError(
 			@RequestBody @NonNull final JsonError request,
-			@PathVariable final Integer AD_PInstance_ID)
+			@PathVariable final int AD_PInstance_ID)
 	{
 		final JsonCreateIssueResponse issueResponse = externalSystemService.createIssue(request, PInstanceId.ofRepoId(AD_PInstance_ID));
 		return ResponseEntity.ok(issueResponse);
+	}
+
+	@ApiOperation("Notify metasfresh that an external system invocation completed successfully. "
+			+ "\nThe `AD_PInstance_ID` is the one the external system was invoked with.")
+	@ApiResponses(value = {
+			@ApiResponse(code = 200, message = "Successfully recorded invocation success"),
+			@ApiResponse(code = 401, message = "You are not authorized to record invocation success"),
+			@ApiResponse(code = 403, message = "Accessing a related resource is forbidden"),
+			@ApiResponse(code = 422, message = "The request could not be processed")
+	})
+	@PostMapping(path = "/externalstatus/{AD_PInstance_ID}/ok")
+	public ResponseEntity<?> handleSuccess(
+			@PathVariable final int AD_PInstance_ID,
+			@RequestParam(required = false, defaultValue = "200") final int httpResponseCode)
+	{
+		externalSystemService.handleExportSuccess(PInstanceId.ofRepoId(AD_PInstance_ID), httpResponseCode);
+		return ResponseEntity.ok().build();
 	}
 
 	@ApiOperation("Upsert external system runtime parameter")

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/externlasystem/ExternalSystemService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/externlasystem/ExternalSystemService.java
@@ -43,8 +43,9 @@ import de.metas.error.IErrorManager;
 import de.metas.error.InsertRemoteIssueRequest;
 import de.metas.externalsystem.ExternalSystem;
 import de.metas.externalsystem.ExternalSystemConfigRepo;
-import de.metas.externalsystem.ExternalSystemErrorContext;
+import de.metas.externalsystem.ExternalSystemInvocationContext;
 import de.metas.externalsystem.IExternalSystemInvocationErrorListener;
+import de.metas.externalsystem.IExternalSystemInvocationSuccessListener;
 import de.metas.externalsystem.ExternalSystemParentConfig;
 import de.metas.externalsystem.ExternalSystemParentConfigId;
 import de.metas.externalsystem.ExternalSystemProcesses;
@@ -75,6 +76,7 @@ import lombok.RequiredArgsConstructor;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.slf4j.Logger;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -107,6 +109,7 @@ public class ExternalSystemService
 	@NonNull private final JsonExternalSystemRetriever jsonRetriever;
 	@NonNull private final ExternalSystemRepository externalSystemRepository;
 	@NonNull private final List<IExternalSystemInvocationErrorListener> externalSystemInvocationErrorListeners;
+	@NonNull private final List<IExternalSystemInvocationSuccessListener> externalSystemInvocationSuccessListeners;
 
 	@VisibleForTesting
 	public static ExternalSystemService newInstanceForUnitTesting()
@@ -120,6 +123,7 @@ public class ExternalSystemService
 				ExternalServices.newInstanceForUnitTesting(),
 				new JsonExternalSystemRetriever(),
 				new ExternalSystemRepository(),
+				Collections.emptyList(),
 				Collections.emptyList()));
 	}
 
@@ -181,7 +185,7 @@ public class ExternalSystemService
 				.findFirst()
 				.ifPresent(error -> {
 					final String errorMessage = buildAggregatedErrorMessage(jsonError);
-					final ExternalSystemErrorContext errorContext = ExternalSystemErrorContext.ofCodeOrUnknown(error.getErrorContext());
+					final ExternalSystemInvocationContext errorContext = ExternalSystemInvocationContext.ofCodeOrUnknown(error.getErrorContext());
 					notifyExternalSystemErrorListeners(pInstanceId, errorContext, errorMessage);
 				});
 
@@ -220,7 +224,7 @@ public class ExternalSystemService
 
 	private void notifyExternalSystemErrorListeners(
 			@NonNull final PInstanceId pInstanceId,
-			@NonNull final ExternalSystemErrorContext errorContext,
+			@NonNull final ExternalSystemInvocationContext errorContext,
 			@NonNull final String errorMessage)
 	{
 		try
@@ -238,7 +242,7 @@ public class ExternalSystemService
 				}
 				catch (final Exception e)
 				{
-					logger.error("Error listener {} threw exception while handling error for PInstance {}",
+					logger.warn("Error listener {} threw exception while handling error for PInstance {}",
 							listener.getClass().getSimpleName(), pInstanceId, e);
 				}
 			}
@@ -246,6 +250,42 @@ public class ExternalSystemService
 		catch (final Exception e)
 		{
 			logger.error("Failed to notify error listeners for PInstance {}", pInstanceId, e);
+		}
+	}
+
+	public void handleExportSuccess(@NonNull final PInstanceId pInstanceId, final int httpResponseCode)
+	{
+		notifyExternalSystemSuccessListeners(pInstanceId, ExternalSystemInvocationContext.UNKNOWN, HttpStatus.valueOf(httpResponseCode));
+	}
+
+	private void notifyExternalSystemSuccessListeners(
+			@NonNull final PInstanceId pInstanceId,
+			@NonNull final ExternalSystemInvocationContext context,
+			@NonNull final HttpStatus httpStatus)
+	{
+		try
+		{
+			for (final IExternalSystemInvocationSuccessListener listener : externalSystemInvocationSuccessListeners)
+			{
+				if (!listener.applies(context))
+				{
+					continue;
+				}
+
+				try
+				{
+					listener.onInvocationSuccess(pInstanceId, context, httpStatus);
+				}
+				catch (final Exception e)
+				{
+					logger.warn("Success listener {} threw exception while handling success for PInstance {}",
+							listener.getClass().getSimpleName(), pInstanceId, e);
+				}
+			}
+		}
+		catch (final Exception e)
+		{
+			logger.error("Failed to notify success listeners for PInstance {}", pInstanceId, e);
 		}
 	}
 

--- a/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v2/externlasystem/ExternalSystemServiceSuccessTest.java
+++ b/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v2/externlasystem/ExternalSystemServiceSuccessTest.java
@@ -1,0 +1,124 @@
+/*
+ * #%L
+ * de.metas.business.rest-api-impl
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.rest_api.v2.externlasystem;
+
+import de.metas.externalsystem.ExternalSystemConfigRepo;
+import de.metas.externalsystem.ExternalSystemInvocationContext;
+import de.metas.externalsystem.ExternalSystemRepository;
+import de.metas.externalsystem.IExternalSystemInvocationSuccessListener;
+import de.metas.externalsystem.audit.ExternalSystemExportAuditRepo;
+import de.metas.externalsystem.externalservice.ExternalServices;
+import de.metas.externalsystem.process.runtimeparameters.RuntimeParametersRepository;
+import de.metas.process.PInstanceId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.springframework.http.HttpStatus;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the success-listener wiring in {@link ExternalSystemService}.
+ * <p>
+ * Covers {@link ExternalSystemService#handleExportSuccess(PInstanceId, int)} at the service seam:
+ * verifies that each registered success listener is invoked with the correct arguments.
+ */
+public class ExternalSystemServiceSuccessTest
+{
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+	}
+
+	@Test
+	void handleExportSuccess_invokesAllApplicableSuccessListeners()
+	{
+		final IExternalSystemInvocationSuccessListener listener = mock(IExternalSystemInvocationSuccessListener.class);
+		when(listener.applies(Mockito.any())).thenReturn(true);
+
+		final ExternalSystemService service = buildService(Collections.singletonList(listener));
+
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(3001);
+		service.handleExportSuccess(pInstanceId, 200);
+
+		verify(listener).onInvocationSuccess(pInstanceId, ExternalSystemInvocationContext.UNKNOWN, HttpStatus.OK);
+	}
+
+	@Test
+	void handleExportSuccess_skipsListeners_whenAppliesReturnsFalse()
+	{
+		final IExternalSystemInvocationSuccessListener listener = mock(IExternalSystemInvocationSuccessListener.class);
+		when(listener.applies(Mockito.any())).thenReturn(false);
+
+		final ExternalSystemService service = buildService(Collections.singletonList(listener));
+
+		service.handleExportSuccess(PInstanceId.ofRepoId(3002), 201);
+
+		verify(listener).applies(ExternalSystemInvocationContext.UNKNOWN);
+		// onInvocationSuccess must NOT have been called
+		verify(listener, Mockito.never()).onInvocationSuccess(
+				Mockito.any(), Mockito.any(), Mockito.any(HttpStatus.class));
+	}
+
+	@Test
+	void handleExportSuccess_doesNotThrow_whenListenerThrows()
+	{
+		final IExternalSystemInvocationSuccessListener failingListener = mock(IExternalSystemInvocationSuccessListener.class);
+		when(failingListener.applies(Mockito.any())).thenReturn(true);
+		Mockito.doThrow(new RuntimeException("listener failure"))
+				.when(failingListener).onInvocationSuccess(Mockito.any(), Mockito.any(), Mockito.any(HttpStatus.class));
+
+		final ExternalSystemService service = buildService(Collections.singletonList(failingListener));
+
+		// must not propagate listener exception
+		Assertions.assertThatCode(
+				() -> service.handleExportSuccess(PInstanceId.ofRepoId(3003), 202))
+				.doesNotThrowAnyException();
+	}
+
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	private static ExternalSystemService buildService(
+			final List<IExternalSystemInvocationSuccessListener> successListeners)
+	{
+		return new ExternalSystemService(
+				ExternalSystemConfigRepo.newInstanceForUnitTesting(),
+				ExternalSystemExportAuditRepo.newInstanceForUnitTesting(),
+				new RuntimeParametersRepository(),
+				ExternalServices.newInstanceForUnitTesting(),
+				new JsonExternalSystemRetriever(),
+				new ExternalSystemRepository(),
+				Collections.emptyList(),
+				successListeners);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_Config_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_Config_StepDef.java
@@ -353,10 +353,39 @@ public class ExternalSystem_Config_StepDef
 	@And("metasfresh contains ExternalSystem_Config with ScriptedExportConversion")
 	public void add_externalSystemConfigWithScriptedExportConversion(@NonNull final DataTable dataTable)
 	{
-		DataTableRows.of(dataTable).forEach(this::saveExternalSystemConfigWithScriptedExportConversion);
+		DataTableRows.of(dataTable).forEach(row -> saveExternalSystemConfigWithScriptedExportConversion(row));
+	}
+
+	/**
+	 * Variant of {@code metasfresh contains ExternalSystem_Config with ScriptedExportConversion} that also
+	 * enables {@code IsTriggerOnComplete} on the scripted-export config, so completing a document of the
+	 * configured table records an {@code ExternalSystem_ScriptedExportConversion_Status} row. Use this when
+	 * the scenario verifies the status-table lifecycle (Pending/DontSend/Sent/Error/Invalid).
+	 *
+	 * <p>Accepts the same columns as the base step:
+	 * <b>ExternalSystem_Config_ID</b> (identifier), <b>ExternalSystem_Config_ScriptedExportConversion_ID</b> (identifier),
+	 * <b>AD_Process_OutboundData_ID.Value</b> (the outbound data process producing the export payload),
+	 * <b>TableName</b> (the document table the config triggers on).
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * And metasfresh contains ExternalSystem_Config with ScriptedExportConversion and StatusColumn:
+	 *   | ExternalSystem_Config_ID | ExternalSystem_Config_ScriptedExportConversion_ID | AD_Process_OutboundData_ID.Value | TableName |
+	 *   | esConfig_es              | scriptedCfg_es                                    | M_InOut_EDI_Export_JSON          | M_InOut   |
+	 * </pre>
+	 */
+	@And("metasfresh contains ExternalSystem_Config with ScriptedExportConversion and StatusColumn:")
+	public void add_externalSystemConfigWithScriptedExportConversionAndStatusColumn(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> saveExternalSystemConfigWithScriptedExportConversion(row, true));
 	}
 
 	private void saveExternalSystemConfigWithScriptedExportConversion(@NonNull final DataTableRow row)
+	{
+		saveExternalSystemConfigWithScriptedExportConversion(row, false);
+	}
+
+	private void saveExternalSystemConfigWithScriptedExportConversion(@NonNull final DataTableRow row, final boolean readStatusColumn)
 	{
 		final StepDefDataIdentifier parentConfigIdentifier = row.getAsIdentifier(COLUMNNAME_ExternalSystem_Config_ID);
 		final StepDefDataIdentifier scriptedConfigIdentifier = row.getAsIdentifier(I_ExternalSystem_Config_ScriptedExportConversion.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID);
@@ -397,6 +426,34 @@ public class ExternalSystem_Config_StepDef
 
 		scriptedExportConversionConfig.setExternalSystemValue(valueAndName.getValue());
 
+		if (readStatusColumn)
+		{
+			// Status_AD_Column_ID was removed from the model when the per-record status design was
+			// consolidated into ExternalSystem_ScriptedExportConversion_Status (a single-row-upsert table
+			// that carries the export lifecycle).  IsTriggerOnComplete is still required to tell the
+			// complete-interceptor to start the export.
+			scriptedExportConversionConfig.setIsTriggerOnComplete(true);
+
+			// Deactivate any pre-existing IsTriggerOnComplete configs for the same AD_Table_ID
+			// to avoid roll-up interference between test runs.
+			queryBL
+					.createQueryBuilder(I_ExternalSystem_Config_ScriptedExportConversion.class)
+					.addEqualsFilter(I_ExternalSystem_Config_ScriptedExportConversion.COLUMNNAME_AD_Table_ID, tableId.getRepoId())
+					.addEqualsFilter(I_ExternalSystem_Config_ScriptedExportConversion.COLUMNNAME_IsTriggerOnComplete, true)
+					.addEqualsFilter(I_ExternalSystem_Config_ScriptedExportConversion.COLUMNNAME_IsActive, true)
+					.create()
+					.list()
+					.forEach(existing -> {
+						existing.setIsActive(false);
+						InterfaceWrapperHelper.save(existing);
+					});
+		}
+
+		// The DDL default "IsActive=Y" is not valid PostgreSQL SQL (Y is treated as a column name by
+		// the JDBC driver). Overwrite with the syntactically correct form so that
+		// ExternalSystemScriptedExportConversionService.isConfigMatchingRecord() can run the WHERE
+		// clause successfully.
+		scriptedExportConversionConfig.setWhereClause("IsActive='Y'");
 
 		InterfaceWrapperHelper.save(scriptedExportConversionConfig);
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_Error_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_Error_StepDef.java
@@ -35,12 +35,16 @@ import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
 import de.metas.edi.model.I_C_Invoice;
 import de.metas.edi.model.I_M_InOut;
-import de.metas.externalsystem.ExternalSystemErrorContext;
+import de.metas.externalsystem.ExternalSystemInvocationContext;
+import de.metas.externalsystem.model.I_ExternalSystem_ScriptedExportConversion_Status;
 import de.metas.process.PInstanceId;
+import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.model.InterfaceWrapperHelper;
 
 import java.io.IOException;
@@ -57,6 +61,9 @@ public class ExternalSystem_Error_StepDef
 	@NonNull private final M_InOut_StepDefData inoutTable;
 	@NonNull private final C_Invoice_StepDefData invoiceTable;
 
+	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	private final IADTableDAO tableDAO = Services.get(IADTableDAO.class);
+
 	@And("the external system sends an error response for the shipment")
 	public void sendErrorResponseForShipments(@NonNull final DataTable dataTable)
 	{
@@ -67,17 +74,36 @@ public class ExternalSystem_Error_StepDef
 	{
 		final StepDefDataIdentifier inoutIdentifier = row.getAsIdentifier(I_M_InOut.COLUMNNAME_M_InOut_ID);
 
-
 		final org.compiere.model.I_M_InOut inout = inoutTable.get(inoutIdentifier);
 		assertThat(inout).isNotNull();
 
 		// Refresh from DB — EDI_AD_PInstance_ID is set asynchronously by the export process
 		InterfaceWrapperHelper.refresh(inout);
 		final I_M_InOut ediInout = InterfaceWrapperHelper.create(inout, I_M_InOut.class);
-		final PInstanceId pInstanceId = PInstanceId.ofRepoIdOrNull(ediInout.getEDI_AD_PInstance_ID());
+		PInstanceId pInstanceId = PInstanceId.ofRepoIdOrNull(ediInout.getEDI_AD_PInstance_ID());
+
+		if (pInstanceId == null)
+		{
+			// Scripted-export conversion does not set EDI_AD_PInstance_ID on M_InOut.
+			// Instead, the pInstance is stored in ExternalSystem_ScriptedExportConversion_Status.
+			final int m_inout_table_id = tableDAO.retrieveTableId(org.compiere.model.I_M_InOut.Table_Name);
+			final I_ExternalSystem_ScriptedExportConversion_Status statusRow = queryBL
+					.createQueryBuilder(I_ExternalSystem_ScriptedExportConversion_Status.class)
+					.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_Table_ID, m_inout_table_id)
+					.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_Record_ID, inout.getM_InOut_ID())
+					.addNotEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_PInstance_ID, 0)
+					.orderByDescending(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID)
+					.create()
+					.first(I_ExternalSystem_ScriptedExportConversion_Status.class);
+
+			if (statusRow != null)
+			{
+				pInstanceId = PInstanceId.ofRepoIdOrNull(statusRow.getAD_PInstance_ID());
+			}
+		}
 
 		assertThat(pInstanceId)
-				.as("EDI_AD_PInstance_ID should be set on M_InOut %s", inoutIdentifier)
+				.as("No pInstance found for M_InOut %s (checked EDI_AD_PInstance_ID and ExternalSystem_ScriptedExportConversion_Status)", inoutIdentifier)
 				.isNotNull();
 
 		sendErrorResponse(row, pInstanceId);
@@ -90,7 +116,7 @@ public class ExternalSystem_Error_StepDef
 		final JsonError jsonError = JsonError.builder()
 				.error(JsonErrorItem.builder()
 						.message(errorMessage)
-						.errorContext(ExternalSystemErrorContext.EDI.getCode())
+						.errorContext(ExternalSystemInvocationContext.EDI.getCode())
 						.build())
 				.build();
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_ScriptedExportConversion_Status_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_ScriptedExportConversion_Status_StepDef.java
@@ -1,0 +1,290 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.externalsystem;
+
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.cucumber.stepdefs.StepDefUtil;
+import de.metas.cucumber.stepdefs.api.APIRequest;
+import de.metas.cucumber.stepdefs.api.RESTUtil;
+import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
+import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion;
+import de.metas.externalsystem.model.I_ExternalSystem_ScriptedExportConversion_Status;
+import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionConfig;
+import de.metas.externalsystem.scriptedexportconversion.process.M_InOut_ReSend_ScriptedExportConversion;
+import de.metas.process.AdProcessId;
+import de.metas.process.IADProcessDAO;
+import de.metas.process.PInstanceId;
+import de.metas.process.ProcessExecutor;
+import de.metas.process.ProcessInfo;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.table.api.IADTableDAO;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Step definitions for {@code ExternalSystem_ScriptedExportConversion_Status} assertions,
+ * scripted-export /ok callback simulation, {@code M_InOut.EPCIS_ExportStatus} roll-up checks,
+ * and the {@code M_InOut_ReSend_ScriptedExportConversion} process invocation.
+ *
+ * <p>The status table holds one row per (config, source-record) pair that is updated in place
+ * as the export lifecycle progresses (Pending → Enqueued → Sent / Error / Invalid / DontSend).
+ */
+@RequiredArgsConstructor
+public class ExternalSystem_ScriptedExportConversion_Status_StepDef
+{
+	@NonNull private final M_InOut_StepDefData inoutTable;
+	@NonNull private final ExternalSystem_Config_ScriptedExportConversion_StepDefData scriptedCfgTable;
+
+	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	private final IADProcessDAO adProcessDAO = Services.get(IADProcessDAO.class);
+	private final IADTableDAO tableDAO = Services.get(IADTableDAO.class);
+
+	// ------------------------------------------------------------------
+	// Status-row assertion (polling)
+	// ------------------------------------------------------------------
+
+	/**
+	 * Polls until the single {@code ExternalSystem_ScriptedExportConversion_Status} row for the given
+	 * shipment + config combination reaches the expected {@code ExportStatus}, optionally asserting
+	 * {@code IsResend} and the presence of an {@code AD_Issue_ID}.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_InOut_ID</b> — (required, identifier-ref) shipment identifier<br>
+	 *   <b>ExternalSystem_Config_ScriptedExportConversion_ID</b> — (required, identifier-ref) config identifier<br>
+	 *   <b>ExportStatus</b> — (required) expected status code (P/U/D/S/E/I/N)<br>
+	 *   <b>IsResend</b> — (optional) expected IsResend flag (Y/N)<br>
+	 *   <b>HasAD_Issue</b> — (optional) Y if AD_Issue_ID must be &gt; 0<br>
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData, ExternalSystem_Config_ScriptedExportConversion_StepDefData
+	 * @cucumber.example <pre>
+	 * Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+	 *   | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | IsResend |
+	 *   | io_010     | scriptedCfg_es                                    | S            | N        |
+	 * </pre>
+	 */
+	@And("^after not more than (.*)s, ExternalSystem_ScriptedExportConversion_Status is found:$")
+	public void scriptedExportConversionStatusIsFound(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
+	{
+		final DataTableRow firstRow = DataTableRows.of(dataTable).getFirstRow();
+
+		final org.compiere.model.I_M_InOut inoutRecord = inoutTable.get(
+				firstRow.getAsIdentifier(org.compiere.model.I_M_InOut.COLUMNNAME_M_InOut_ID));
+		assertThat(inoutRecord).isNotNull();
+		final int inoutId = inoutRecord.getM_InOut_ID();
+
+		final ExternalSystemScriptedExportConversionConfig cfg = scriptedCfgTable.get(
+				firstRow.getAsIdentifier(I_ExternalSystem_Config_ScriptedExportConversion.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID));
+		assertThat(cfg).isNotNull();
+		final int cfgId = cfg.getId().getRepoId();
+
+		final String expectedStatus = firstRow.getAsString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExportStatus);
+		final String expectedIsResend = firstRow.getAsOptionalString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_IsResend).orElse(null);
+		final String expectedHasIssue = firstRow.getAsOptionalString("HasAD_Issue").orElse(null);
+
+		final int m_inout_table_id = tableDAO.retrieveTableId(org.compiere.model.I_M_InOut.Table_Name);
+
+		StepDefUtil.<I_ExternalSystem_ScriptedExportConversion_Status>tryAndWaitForItem()
+				.maxWaitSeconds(timeoutSec)
+				.checkingIntervalMs(500L)
+				.workerFromOptionalSupplier(() -> {
+					final I_ExternalSystem_ScriptedExportConversion_Status statusRow = queryBL
+							.createQueryBuilder(I_ExternalSystem_ScriptedExportConversion_Status.class)
+							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_Table_ID, m_inout_table_id)
+							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_Record_ID, inoutId)
+							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID, cfgId)
+							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExportStatus, expectedStatus)
+							.orderByDescending(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID)
+							.create()
+							.first(I_ExternalSystem_ScriptedExportConversion_Status.class);
+
+					if (statusRow == null)
+					{
+						return Optional.empty();
+					}
+
+					// optional IsResend assertion
+					if (expectedIsResend != null)
+					{
+						final boolean expectedIsResendBool = "Y".equals(expectedIsResend);
+						if (statusRow.isResend() != expectedIsResendBool)
+						{
+							return Optional.empty();
+						}
+					}
+
+					// optional HasAD_Issue assertion
+					if ("Y".equals(expectedHasIssue) && statusRow.getAD_Issue_ID() <= 0)
+					{
+						return Optional.empty();
+					}
+
+					return Optional.of(statusRow);
+				})
+				.execute();
+	}
+
+	// ------------------------------------------------------------------
+	// M_InOut.EPCIS_ExportStatus roll-up assertion (polling)
+	// ------------------------------------------------------------------
+
+	/**
+	 * Polls until {@code M_InOut.EPCIS_ExportStatus} matches the expected value.
+	 * This column is a virtual roll-up derived from the status table.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_InOut_ID</b> — (required, identifier-ref) shipment identifier<br>
+	 *   <b>EPCIS_ExportStatus</b> — (required) expected status code (S/E/P/U etc.)<br>
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData
+	 * @cucumber.example <pre>
+	 * And after not more than 10s, M_InOut EPCIS_ExportStatus is:
+	 *   | M_InOut_ID | EPCIS_ExportStatus |
+	 *   | io_010     | S                  |
+	 * </pre>
+	 */
+	@And("^after not more than (.*)s, M_InOut EPCIS_ExportStatus is:$")
+	public void m_inout_epcis_export_status_is(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
+	{
+		final DataTableRow firstRow = DataTableRows.of(dataTable).getFirstRow();
+
+		final org.compiere.model.I_M_InOut inout = inoutTable.get(
+				firstRow.getAsIdentifier(org.compiere.model.I_M_InOut.COLUMNNAME_M_InOut_ID));
+		assertThat(inout).isNotNull();
+		final int inoutId = inout.getM_InOut_ID();
+
+		final String expectedStatus = firstRow.getAsString(org.compiere.model.I_M_InOut.COLUMNNAME_EPCIS_ExportStatus);
+
+		StepDefUtil.<org.compiere.model.I_M_InOut>tryAndWaitForItem()
+				.maxWaitSeconds(timeoutSec)
+				.checkingIntervalMs(500L)
+				.workerFromOptionalSupplier(() -> {
+					final org.compiere.model.I_M_InOut fresh = queryBL
+							.createQueryBuilder(org.compiere.model.I_M_InOut.class)
+							.addEqualsFilter(org.compiere.model.I_M_InOut.COLUMNNAME_M_InOut_ID, inoutId)
+							.create()
+							.firstOnlyNotNull(org.compiere.model.I_M_InOut.class);
+
+					final String actualStatus = fresh.getEPCIS_ExportStatus();
+					return expectedStatus.equals(actualStatus)
+							? Optional.of(fresh)
+							: Optional.empty();
+				})
+				.execute();
+	}
+
+	// ------------------------------------------------------------------
+	// /ok callback simulation
+	// ------------------------------------------------------------------
+
+	/**
+	 * Posts the scripted-export success (/ok) callback for the given shipment.
+	 * Reads the most-recent status row for the shipment to determine the pInstance for the callback URL.
+	 *
+	 * <p>In production this fires when the external system responds with a 2xx HTTP status to the
+	 * scripted-export HTTP endpoint. The direct REST call here provides deterministic timing:
+	 * the test controls exactly when the callback arrives, avoiding race conditions with the real
+	 * async delivery path.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example <pre>
+	 * When the scripted-export /ok callback is posted for shipment io_010 with HTTP code 200
+	 * </pre>
+	 */
+	@When("^the scripted-export /ok callback is posted for shipment (.*) with HTTP code (\\d+)$")
+	public void scriptedExportOkCallback(final String inoutIdentifierStr, final int httpCode) throws IOException
+	{
+		final org.compiere.model.I_M_InOut inout = inoutTable.get(StepDefDataIdentifier.ofString(inoutIdentifierStr));
+		assertThat(inout).isNotNull();
+		final int inoutId = inout.getM_InOut_ID();
+		final int m_inout_table_id = tableDAO.retrieveTableId(org.compiere.model.I_M_InOut.Table_Name);
+
+		// Retrieve the most-recent status row that has an AD_PInstance_ID set (i.e. Enqueued or later)
+		final I_ExternalSystem_ScriptedExportConversion_Status statusRow = queryBL
+				.createQueryBuilder(I_ExternalSystem_ScriptedExportConversion_Status.class)
+				.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_Table_ID, m_inout_table_id)
+				.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_Record_ID, inoutId)
+				.addNotEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_PInstance_ID, 0)
+				.orderByDescending(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID)
+				.create()
+				.first(I_ExternalSystem_ScriptedExportConversion_Status.class);
+
+		assertThat(statusRow)
+				.as("No scripted-export status row with AD_PInstance_ID found for M_InOut %s", inoutIdentifierStr)
+				.isNotNull();
+
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(statusRow.getAD_PInstance_ID());
+
+		final String endpointPath = "/api/v2/externalsystem/externalstatus/" + pInstanceId.getRepoId() + "/ok?httpResponseCode=" + httpCode;
+		final String authToken = RESTUtil.getAuthToken("metasfresh", "WebUI");
+
+		RESTUtil.performHTTPRequest(
+				APIRequest.builder()
+						.authToken(authToken)
+						.endpointPath(endpointPath)
+						.method("POST")
+						.expectedStatusCode(200)
+						.build()
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// Re-send process invocation
+	// ------------------------------------------------------------------
+
+	/**
+	 * Invokes the {@code M_InOut_ReSend_ScriptedExportConversion} AD_Process for the given shipment identifier.
+	 * In production this corresponds to a user clicking "Re-send" on the shipment action menu.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example <pre>
+	 * When M_InOut_ReSend_ScriptedExportConversion process is run for shipment io_030
+	 * </pre>
+	 */
+	@When("^M_InOut_ReSend_ScriptedExportConversion process is run for shipment (.*)$")
+	public void runResendProcess(final String inoutIdentifierStr)
+	{
+		final org.compiere.model.I_M_InOut inout = inoutTable.get(StepDefDataIdentifier.ofString(inoutIdentifierStr));
+		assertThat(inout).isNotNull();
+
+		final AdProcessId processId = adProcessDAO.retrieveProcessIdByClass(M_InOut_ReSend_ScriptedExportConversion.class);
+		assertThat(processId).as("AD_Process not found for M_InOut_ReSend_ScriptedExportConversion").isNotNull();
+
+		final ProcessExecutor executor = ProcessInfo.builder()
+				.setAD_Process_ID(processId.getRepoId())
+				.setRecord(org.compiere.model.I_M_InOut.Table_Name, inout.getM_InOut_ID())
+				.buildAndPrepareExecution()
+				.executeSync();
+		executor.getResult().propagateErrorIfAny();
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
@@ -1,0 +1,214 @@
+@from:cucumber
+@allure.label.epic:E0292_EDI
+@allure.label.feature:F00353_EDI_DESADV_InOut_Link
+@ghActions:run_on_executor7
+Feature: EPCIS scripted-export status — success, error and re-send flows
+## Verifies the ExternalSystem_ScriptedExportConversion_Status lifecycle for the EPCIS export config:
+## (a) shipment completed → invocation enqueued → /ok callback → status row Sent + roll-up M_InOut.EPCIS_ExportStatus=Sent
+## (b) same path but /error callback → status row Error + AD_Issue_ID linked + roll-up Error
+## (c) re-send of an errored shipment → status row flipped to Pending+IsResend=Y (single-row upsert) → Sent via /ok
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2026-06-09T10:00:00+02:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value true for sys config de.metas.report.jasper.IsMockReportService
+    And metasfresh is configured for One-DESADV-Per-ORDERS
+
+    # Process the /ok and /error scripted-export callbacks SYNCHRONOUSLY (HTTP 200, not async 202) so the
+    # status row is visible right after the POST. Self-contained — do not rely on a sibling feature having
+    # created this config on the shared executor (SeqNo=9 takes precedence).
+    And the following API_Audit_Config records are created:
+      | Identifier  | SeqNo | OPT.Method | OPT.PathPrefix                       | IsForceProcessedAsync | IsSynchronousAuditLoggingEnabled | IsWrapApiResponse |
+      | wait4result | 9     | POST       | api/v2/externalsystem/externalstatus | N                     | Y                                | N                 |
+
+    And load M_Warehouse:
+      | M_Warehouse_ID | Value        |
+      | warehouseStd   | StdWarehouse |
+
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_es      |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_es      | ps_es              | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_es     | pl_es          |
+
+    And metasfresh contains M_Products:
+      | Identifier | GTIN          |
+      | product_es | 4060000000550 |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | plv_es                 | product_es   | 10.00    | PCE      | Normal           |
+
+    And metasfresh contains C_BPartners:
+      | Identifier | IsCustomer | M_PricingSystem_ID | GLN           |
+      | bp_es      | Y          | ps_es              | 9900000550001 |
+
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID |
+      | pi_TU_es   |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType | IsCurrent |
+      | piv_TU_es          | pi_TU_es   | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID | M_HU_PI_Version_ID | Qty | ItemType |
+      | pii_TU_es       | piv_TU_es          | 0   | PM       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID | Qty | ValidFrom  |
+      | pip_es                  | pii_TU_es       | product_es   | 10  | 2020-01-01 |
+
+    # Scripted-export config with IsTriggerOnComplete=Y (triggers export when shipment is completed)
+    And metasfresh contains ExternalSystem_Config with ScriptedExportConversion and StatusColumn:
+      | ExternalSystem_Config_ID | ExternalSystem_Config_ScriptedExportConversion_ID | AD_Process_OutboundData_ID.Value | TableName |
+      | esConfig_es              | scriptedCfg_es                                    | M_InOut_EDI_Export_JSON          | M_InOut   |
+    And metasfresh contains C_BPartner_EDI_Setting:
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN | EdiDESADVSendingMode | EdiDESADV_ExternalSystem_Config_ID | Identifier        |
+      | bp_es         | true                 | 9900000550001         | E                    | esConfig_es                        | edi_setting_es_bp |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00353_EDI_DESADV_InOut_Link
+  @Id:S30088_010
+  Scenario: S30088_010 — shipment completed, invocation enqueued, /ok callback: status row Sent + roll-up Sent
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference                |
+      | o_010      | true    | bp_es         | 2026-06-09  | PO_S30088_010_@Date@       |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | ol_010     | o_010      | product_es   | 10         | pip_es                  |
+    When the order identified by o_010 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ss_010     | ol_010         | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_010                | D            | true                | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | ss_010                | io_010     |
+
+    # Drain async material/DESADV workpackages from shipment generation so they don't spill into
+    # the next scenario in this executor (would de-calibrate sibling DESADV-aggregation tests).
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # After invocation the status row reaches Enqueued; simulate /ok success callback
+    Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus |
+      | io_010     | scriptedCfg_es                                    | U            |
+
+    When the scripted-export /ok callback is posted for shipment io_010 with HTTP code 200
+
+    Then after not more than 10s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | IsResend |
+      | io_010     | scriptedCfg_es                                    | S            | N        |
+    And after not more than 10s, M_InOut EPCIS_ExportStatus is:
+      | M_InOut_ID | EPCIS_ExportStatus |
+      | io_010     | S                  |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00353_EDI_DESADV_InOut_Link
+  @Id:S30088_020
+  Scenario: S30088_020 — /error callback: status row Error + AD_Issue_ID linked + roll-up Error
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference                |
+      | o_020      | true    | bp_es         | 2026-06-09  | PO_S30088_020_@Date@       |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | ol_020     | o_020      | product_es   | 10         | pip_es                  |
+    When the order identified by o_020 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ss_020     | ol_020         | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_020                | D            | true                | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | ss_020                | io_020     |
+
+    # Drain async material/DESADV workpackages from shipment generation (avoid spilling into sibling executor tests).
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # Wait for invocation to be Enqueued (AD_PInstance_ID is set) before sending error callback
+    Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus |
+      | io_020     | scriptedCfg_es                                    | U            |
+
+    # Simulate /error callback (reuses ExternalSystem_Error_StepDef.sendErrorResponseForShipment)
+    And the external system sends an error response for the shipment
+      | M_InOut_ID | ErrorMessage          |
+      | io_020     | EPCIS_rejected_test   |
+
+    Then after not more than 10s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | HasAD_Issue |
+      | io_020     | scriptedCfg_es                                    | E            | Y           |
+    And after not more than 10s, M_InOut EPCIS_ExportStatus is:
+      | M_InOut_ID | EPCIS_ExportStatus |
+      | io_020     | E                  |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00353_EDI_DESADV_InOut_Link
+  @Id:S30088_030
+  Scenario: S30088_030 — re-send of an errored shipment flips the single status row to Pending+IsResend=Y
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference                |
+      | o_030      | true    | bp_es         | 2026-06-09  | PO_S30088_030_@Date@       |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | ol_030     | o_030      | product_es   | 10         | pip_es                  |
+    When the order identified by o_030 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ss_030     | ol_030         | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_030                | D            | true                | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | ss_030                | io_030     |
+
+    # Drain async material/DESADV workpackages from shipment generation (avoid spilling into sibling executor tests).
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # Wait for invocation to be Enqueued before sending error callback
+    Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus |
+      | io_030     | scriptedCfg_es                                    | U            |
+
+    # First attempt ends in Error
+    And the external system sends an error response for the shipment
+      | M_InOut_ID | ErrorMessage        |
+      | io_030     | EPCIS_error_resend  |
+    Then after not more than 10s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus |
+      | io_030     | scriptedCfg_es                                    | E            |
+
+    # Run re-send process on the errored shipment
+    When M_InOut_ReSend_ScriptedExportConversion process is run for shipment io_030
+
+    # The single status row is flipped to IsResend=Y (single-row upsert), reaching at minimum Enqueued
+    Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | IsResend |
+      | io_030     | scriptedCfg_es                                    | U            | Y        |
+
+    # Simulate /ok to confirm the resend attempt reaches Sent
+    When the scripted-export /ok callback is posted for shipment io_030 with HTTP code 200
+
+    Then after not more than 10s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | IsResend |
+      | io_030     | scriptedCfg_es                                    | S            | Y        |
+    And after not more than 10s, M_InOut EPCIS_ExportStatus is:
+      | M_InOut_ID | EPCIS_ExportStatus |
+      | io_030     | S                  |

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/EDIExternalSystemErrorListener.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/EDIExternalSystemErrorListener.java
@@ -23,7 +23,7 @@
 package de.metas.edi.api.impl;
 
 import de.metas.edi.api.EDIExportStatus;
-import de.metas.externalsystem.ExternalSystemErrorContext;
+import de.metas.externalsystem.ExternalSystemInvocationContext;
 import de.metas.externalsystem.IExternalSystemInvocationErrorListener;
 import de.metas.logging.LogManager;
 import de.metas.process.PInstanceId;
@@ -48,7 +48,7 @@ public class EDIExternalSystemErrorListener implements IExternalSystemInvocation
 	@NonNull private final EDIInvoiceDAO ediInvoiceDAO;
 
 	@Override
-	public boolean applies(@NonNull final ExternalSystemErrorContext errorContext)
+	public boolean applies(@NonNull final ExternalSystemInvocationContext errorContext)
 	{
 		return errorContext.isEDI();
 	}
@@ -56,7 +56,7 @@ public class EDIExternalSystemErrorListener implements IExternalSystemInvocation
 	@Override
 	public void onInvocationError(
 			@NonNull final PInstanceId pInstanceId,
-			@NonNull final ExternalSystemErrorContext errorContext,
+			@NonNull final ExternalSystemInvocationContext errorContext,
 			@NonNull final String errorMessage)
 	{
 		//safety check

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/async/spi/impl/EDIWorkpackageProcessor.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/async/spi/impl/EDIWorkpackageProcessor.java
@@ -42,7 +42,7 @@ import de.metas.edi.model.I_EDI_Document;
 import de.metas.edi.model.I_M_InOut;
 import de.metas.edi.process.export.IExport;
 import de.metas.esb.edi.model.I_EDI_Desadv;
-import de.metas.externalsystem.ExternalSystemErrorContext;
+import de.metas.externalsystem.ExternalSystemInvocationContext;
 import de.metas.externalsystem.ExternalSystemParentConfigId;
 import de.metas.externalsystem.scriptedexportconversion.ExternalSystemInvocationResult;
 import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionConfig;
@@ -297,7 +297,7 @@ public class EDIWorkpackageProcessor implements IWorkpackageProcessor
 		return externalSystemScriptedExportConversionService.executeInvokeScriptedExportConversionActionAndGetResult(
 				configs.get(0),
 				documentRecordId,
-				ExternalSystemErrorContext.EDI);
+				ExternalSystemInvocationContext.EDI);
 	}
 
 	@Getter

--- a/backend/de.metas.externalsystem/src/main/java-gen/de/metas/externalsystem/model/I_ExternalSystem_Config_ScriptedExportConversion.java
+++ b/backend/de.metas.externalsystem/src/main/java-gen/de/metas/externalsystem/model/I_ExternalSystem_Config_ScriptedExportConversion.java
@@ -207,7 +207,7 @@ public interface I_ExternalSystem_Config_ScriptedExportConversion
 	String COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID = "ExternalSystem_Config_ScriptedExportConversion_ID";
 
 	/**
-	 * Set External System Endpoint.
+	 * Set External System Outbound Endpoint.
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: true
@@ -216,7 +216,7 @@ public interface I_ExternalSystem_Config_ScriptedExportConversion
 	void setExternalSystem_Endpoint_ID (int ExternalSystem_Endpoint_ID);
 
 	/**
-	 * Get External System Endpoint.
+	 * Get External System Outbound Endpoint.
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: true

--- a/backend/de.metas.externalsystem/src/main/java-gen/de/metas/externalsystem/model/I_ExternalSystem_ScriptedExportConversion_Status.java
+++ b/backend/de.metas.externalsystem/src/main/java-gen/de/metas/externalsystem/model/I_ExternalSystem_ScriptedExportConversion_Status.java
@@ -1,0 +1,339 @@
+package de.metas.externalsystem.model;
+
+import javax.annotation.Nullable;
+import org.adempiere.model.ModelColumn;
+
+/** Generated Interface for ExternalSystem_ScriptedExportConversion_Status
+ *  @author metasfresh (generated) 
+ */
+@SuppressWarnings("unused")
+public interface I_ExternalSystem_ScriptedExportConversion_Status 
+{
+
+	String Table_Name = "ExternalSystem_ScriptedExportConversion_Status";
+
+//	/** AD_Table_ID=542617 */
+//	int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
+
+
+	/**
+	 * Get Client.
+	 * Client/Tenant for this installation.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Client_ID();
+
+	String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+
+	/**
+	 * Set Issues.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setAD_Issue_ID (int AD_Issue_ID);
+
+	/**
+	 * Get Issues.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Issue_ID();
+
+	String COLUMNNAME_AD_Issue_ID = "AD_Issue_ID";
+
+	/**
+	 * Set Organisation.
+	 * Organisational entity within client
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setAD_Org_ID (int AD_Org_ID);
+
+	/**
+	 * Get Organisation.
+	 * Organisational entity within client
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Org_ID();
+
+	String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/**
+	 * Set Process Instance.
+	 * Instance of a Process
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setAD_PInstance_ID (int AD_PInstance_ID);
+
+	/**
+	 * Get Process Instance.
+	 * Instance of a Process
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getAD_PInstance_ID();
+
+	ModelColumn<I_ExternalSystem_ScriptedExportConversion_Status, org.compiere.model.I_AD_PInstance> COLUMN_AD_PInstance_ID = new ModelColumn<>(I_ExternalSystem_ScriptedExportConversion_Status.class, "AD_PInstance_ID", org.compiere.model.I_AD_PInstance.class);
+	String COLUMNNAME_AD_PInstance_ID = "AD_PInstance_ID";
+
+	/**
+	 * Set Table.
+	 * Database Table information
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setAD_Table_ID (int AD_Table_ID);
+
+	/**
+	 * Get Table.
+	 * Database Table information
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Table_ID();
+
+	String COLUMNNAME_AD_Table_ID = "AD_Table_ID";
+
+	/**
+	 * Get Created.
+	 * Date this record was created
+	 *
+	 * <br>Type: DateTime
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.sql.Timestamp getCreated();
+
+	ModelColumn<I_ExternalSystem_ScriptedExportConversion_Status, Object> COLUMN_Created = new ModelColumn<>(I_ExternalSystem_ScriptedExportConversion_Status.class, "Created", null);
+	String COLUMNNAME_Created = "Created";
+
+	/**
+	 * Get Created By.
+	 * User who created this records
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getCreatedBy();
+
+	String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/**
+	 * Set Export Status.
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setExportStatus (java.lang.String ExportStatus);
+
+	/**
+	 * Get Export Status.
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.lang.String getExportStatus();
+
+	ModelColumn<I_ExternalSystem_ScriptedExportConversion_Status, Object> COLUMN_ExportStatus = new ModelColumn<>(I_ExternalSystem_ScriptedExportConversion_Status.class, "ExportStatus", null);
+	String COLUMNNAME_ExportStatus = "ExportStatus";
+
+	/**
+	 * Set ExternalSystem_Config_ScriptedExportConversion.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setExternalSystem_Config_ScriptedExportConversion_ID (int ExternalSystem_Config_ScriptedExportConversion_ID);
+
+	/**
+	 * Get ExternalSystem_Config_ScriptedExportConversion.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getExternalSystem_Config_ScriptedExportConversion_ID();
+
+	ModelColumn<I_ExternalSystem_ScriptedExportConversion_Status, de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion> COLUMN_ExternalSystem_Config_ScriptedExportConversion_ID = new ModelColumn<>(I_ExternalSystem_ScriptedExportConversion_Status.class, "ExternalSystem_Config_ScriptedExportConversion_ID", de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion.class);
+	String COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID = "ExternalSystem_Config_ScriptedExportConversion_ID";
+
+	/**
+	 * Set ExternalSystem Scripted Export Conversion Status.
+	 *
+	 * <br>Type: ID
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setExternalSystem_ScriptedExportConversion_Status_ID (int ExternalSystem_ScriptedExportConversion_Status_ID);
+
+	/**
+	 * Get ExternalSystem Scripted Export Conversion Status.
+	 *
+	 * <br>Type: ID
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getExternalSystem_ScriptedExportConversion_Status_ID();
+
+	ModelColumn<I_ExternalSystem_ScriptedExportConversion_Status, Object> COLUMN_ExternalSystem_ScriptedExportConversion_Status_ID = new ModelColumn<>(I_ExternalSystem_ScriptedExportConversion_Status.class, "ExternalSystem_ScriptedExportConversion_Status_ID", null);
+	String COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID = "ExternalSystem_ScriptedExportConversion_Status_ID";
+
+	/**
+	 * Set HTTP Response Code.
+	 *
+	 * <br>Type: Integer
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setHttpResponseCode (int HttpResponseCode);
+
+	/**
+	 * Get HTTP Response Code.
+	 *
+	 * <br>Type: Integer
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getHttpResponseCode();
+
+	ModelColumn<I_ExternalSystem_ScriptedExportConversion_Status, Object> COLUMN_HttpResponseCode = new ModelColumn<>(I_ExternalSystem_ScriptedExportConversion_Status.class, "HttpResponseCode", null);
+	String COLUMNNAME_HttpResponseCode = "HttpResponseCode";
+
+	/**
+	 * Set Active.
+	 * The record is active in the system
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsActive (boolean IsActive);
+
+	/**
+	 * Get Active.
+	 * The record is active in the system
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isActive();
+
+	ModelColumn<I_ExternalSystem_ScriptedExportConversion_Status, Object> COLUMN_IsActive = new ModelColumn<>(I_ExternalSystem_ScriptedExportConversion_Status.class, "IsActive", null);
+	String COLUMNNAME_IsActive = "IsActive";
+
+	/**
+	 * Set Resend.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsResend (boolean IsResend);
+
+	/**
+	 * Get Resend.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isResend();
+
+	ModelColumn<I_ExternalSystem_ScriptedExportConversion_Status, Object> COLUMN_IsResend = new ModelColumn<>(I_ExternalSystem_ScriptedExportConversion_Status.class, "IsResend", null);
+	String COLUMNNAME_IsResend = "IsResend";
+
+	/**
+	 * Set Record ID.
+	 * Direct internal record ID
+	 *
+	 * <br>Type: Integer
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setRecord_ID (int Record_ID);
+
+	/**
+	 * Get Record ID.
+	 * Direct internal record ID
+	 *
+	 * <br>Type: Integer
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getRecord_ID();
+
+	ModelColumn<I_ExternalSystem_ScriptedExportConversion_Status, Object> COLUMN_Record_ID = new ModelColumn<>(I_ExternalSystem_ScriptedExportConversion_Status.class, "Record_ID", null);
+	String COLUMNNAME_Record_ID = "Record_ID";
+
+	/**
+	 * Set Status Message.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setStatusMessage (@Nullable java.lang.String StatusMessage);
+
+	/**
+	 * Get Status Message.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	@Nullable java.lang.String getStatusMessage();
+
+	ModelColumn<I_ExternalSystem_ScriptedExportConversion_Status, Object> COLUMN_StatusMessage = new ModelColumn<>(I_ExternalSystem_ScriptedExportConversion_Status.class, "StatusMessage", null);
+	String COLUMNNAME_StatusMessage = "StatusMessage";
+
+	/**
+	 * Get Updated.
+	 * Date this record was updated
+	 *
+	 * <br>Type: DateTime
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.sql.Timestamp getUpdated();
+
+	ModelColumn<I_ExternalSystem_ScriptedExportConversion_Status, Object> COLUMN_Updated = new ModelColumn<>(I_ExternalSystem_ScriptedExportConversion_Status.class, "Updated", null);
+	String COLUMNNAME_Updated = "Updated";
+
+	/**
+	 * Get Updated By.
+	 * User who updated this records
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getUpdatedBy();
+
+	String COLUMNNAME_UpdatedBy = "UpdatedBy";
+}

--- a/backend/de.metas.externalsystem/src/main/java-gen/de/metas/externalsystem/model/X_ExternalSystem_Config_ScriptedExportConversion.java
+++ b/backend/de.metas.externalsystem/src/main/java-gen/de/metas/externalsystem/model/X_ExternalSystem_Config_ScriptedExportConversion.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class X_ExternalSystem_Config_ScriptedExportConversion extends org.compiere.model.PO implements I_ExternalSystem_Config_ScriptedExportConversion, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 2016930087L;
+	private static final long serialVersionUID = 1101468659L;
 
     /** Standard Constructor */
     public X_ExternalSystem_Config_ScriptedExportConversion (final Properties ctx, final int ExternalSystem_Config_ScriptedExportConversion_ID, @Nullable final String trxName)
@@ -141,8 +141,8 @@ public class X_ExternalSystem_Config_ScriptedExportConversion extends org.compie
 	public static final String DOCBASETYPE_GehaltsrechnungAngestellter = "AEI";
 	/** Interne Rechnung (Lieferant) = AVI */
 	public static final String DOCBASETYPE_InterneRechnungLieferant = "AVI";
-	/** Speditionsauftrag/Ladeliste = MST */
-	public static final String DOCBASETYPE_SpeditionsauftragLadeliste = "MST";
+	/** ShipperTransportation = MST */
+	public static final String DOCBASETYPE_ShipperTransportation = "MST";
 	/** CustomerContract = CON */
 	public static final String DOCBASETYPE_CustomerContract = "CON";
 	/** DunningDoc = DUN */
@@ -163,6 +163,8 @@ public class X_ExternalSystem_Config_ScriptedExportConversion extends org.compie
 	public static final String DOCBASETYPE_CostRevaluation = "CRD";
 	/** AnalysisReport = QMA */
 	public static final String DOCBASETYPE_AnalysisReport = "QMA";
+	/** APProFormaInvoice = APF */
+	public static final String DOCBASETYPE_APProFormaInvoice = "APF";
 	@Override
 	public void setDocBaseType (final @Nullable java.lang.String DocBaseType)
 	{
@@ -208,14 +210,14 @@ public class X_ExternalSystem_Config_ScriptedExportConversion extends org.compie
 	@Override
 	public void setExternalSystem_Endpoint_ID (final int ExternalSystem_Endpoint_ID)
 	{
-		if (ExternalSystem_Endpoint_ID < 1)
+		if (ExternalSystem_Endpoint_ID < 1) 
 			set_Value (COLUMNNAME_ExternalSystem_Endpoint_ID, null);
-		else
+		else 
 			set_Value (COLUMNNAME_ExternalSystem_Endpoint_ID, ExternalSystem_Endpoint_ID);
 	}
 
 	@Override
-	public int getExternalSystem_Endpoint_ID()
+	public int getExternalSystem_Endpoint_ID() 
 	{
 		return get_ValueAsInt(COLUMNNAME_ExternalSystem_Endpoint_ID);
 	}

--- a/backend/de.metas.externalsystem/src/main/java-gen/de/metas/externalsystem/model/X_ExternalSystem_ScriptedExportConversion_Status.java
+++ b/backend/de.metas.externalsystem/src/main/java-gen/de/metas/externalsystem/model/X_ExternalSystem_ScriptedExportConversion_Status.java
@@ -1,0 +1,193 @@
+// Generated Model - DO NOT CHANGE
+package de.metas.externalsystem.model;
+
+import java.sql.ResultSet;
+import java.util.Properties;
+import javax.annotation.Nullable;
+
+/** Generated Model for ExternalSystem_ScriptedExportConversion_Status
+ *  @author metasfresh (generated) 
+ */
+@SuppressWarnings("unused")
+public class X_ExternalSystem_ScriptedExportConversion_Status extends org.compiere.model.PO implements I_ExternalSystem_ScriptedExportConversion_Status, org.compiere.model.I_Persistent 
+{
+
+	private static final long serialVersionUID = -106460927L;
+
+    /** Standard Constructor */
+    public X_ExternalSystem_ScriptedExportConversion_Status (final Properties ctx, final int ExternalSystem_ScriptedExportConversion_Status_ID, @Nullable final String trxName)
+    {
+      super (ctx, ExternalSystem_ScriptedExportConversion_Status_ID, trxName);
+    }
+
+    /** Load Constructor */
+    public X_ExternalSystem_ScriptedExportConversion_Status (final Properties ctx, final ResultSet rs, @Nullable final String trxName)
+    {
+      super (ctx, rs, trxName);
+    }
+
+
+	/** Load Meta Data */
+	@Override
+	protected org.compiere.model.POInfo initPO(final Properties ctx)
+	{
+		return org.compiere.model.POInfo.getPOInfo(Table_Name);
+	}
+
+	@Override
+	public void setAD_Issue_ID (final int AD_Issue_ID)
+	{
+		if (AD_Issue_ID < 1) 
+			set_Value (COLUMNNAME_AD_Issue_ID, null);
+		else 
+			set_Value (COLUMNNAME_AD_Issue_ID, AD_Issue_ID);
+	}
+
+	@Override
+	public int getAD_Issue_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_AD_Issue_ID);
+	}
+
+	@Override
+	public void setAD_PInstance_ID (final int AD_PInstance_ID)
+	{
+		if (AD_PInstance_ID < 1) 
+			set_Value (COLUMNNAME_AD_PInstance_ID, null);
+		else 
+			set_Value (COLUMNNAME_AD_PInstance_ID, AD_PInstance_ID);
+	}
+
+	@Override
+	public int getAD_PInstance_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_AD_PInstance_ID);
+	}
+
+	@Override
+	public void setAD_Table_ID (final int AD_Table_ID)
+	{
+		if (AD_Table_ID < 1) 
+			set_Value (COLUMNNAME_AD_Table_ID, null);
+		else 
+			set_Value (COLUMNNAME_AD_Table_ID, AD_Table_ID);
+	}
+
+	@Override
+	public int getAD_Table_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_AD_Table_ID);
+	}
+
+	/** 
+	 * ExportStatus AD_Reference_ID=542104
+	 * Reference name: ExternalSystem_ExportStatus
+	 */
+	public static final int EXPORTSTATUS_AD_Reference_ID=542104;
+	/** Pending = P */
+	public static final String EXPORTSTATUS_Pending = "P";
+	/** Enqueued = U */
+	public static final String EXPORTSTATUS_Enqueued = "U";
+	/** SendingStarted = D */
+	public static final String EXPORTSTATUS_SendingStarted = "D";
+	/** Sent = S */
+	public static final String EXPORTSTATUS_Sent = "S";
+	/** Error = E */
+	public static final String EXPORTSTATUS_Error = "E";
+	/** Invalid = I */
+	public static final String EXPORTSTATUS_Invalid = "I";
+	/** DontSend = N */
+	public static final String EXPORTSTATUS_DontSend = "N";
+	@Override
+	public void setExportStatus (final java.lang.String ExportStatus)
+	{
+		set_Value (COLUMNNAME_ExportStatus, ExportStatus);
+	}
+
+	@Override
+	public java.lang.String getExportStatus() 
+	{
+		return get_ValueAsString(COLUMNNAME_ExportStatus);
+	}
+
+	@Override
+	public void setExternalSystem_Config_ScriptedExportConversion_ID (final int ExternalSystem_Config_ScriptedExportConversion_ID)
+	{
+		if (ExternalSystem_Config_ScriptedExportConversion_ID < 1) 
+			set_Value (COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID, null);
+		else 
+			set_Value (COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID, ExternalSystem_Config_ScriptedExportConversion_ID);
+	}
+
+	@Override
+	public int getExternalSystem_Config_ScriptedExportConversion_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID);
+	}
+
+	@Override
+	public void setExternalSystem_ScriptedExportConversion_Status_ID (final int ExternalSystem_ScriptedExportConversion_Status_ID)
+	{
+		if (ExternalSystem_ScriptedExportConversion_Status_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID, ExternalSystem_ScriptedExportConversion_Status_ID);
+	}
+
+	@Override
+	public int getExternalSystem_ScriptedExportConversion_Status_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID);
+	}
+
+	@Override
+	public void setHttpResponseCode (final int HttpResponseCode)
+	{
+		set_Value (COLUMNNAME_HttpResponseCode, HttpResponseCode);
+	}
+
+	@Override
+	public int getHttpResponseCode() 
+	{
+		return get_ValueAsInt(COLUMNNAME_HttpResponseCode);
+	}
+
+	@Override
+	public void setIsResend (final boolean IsResend)
+	{
+		set_Value (COLUMNNAME_IsResend, IsResend);
+	}
+
+	@Override
+	public boolean isResend() 
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsResend);
+	}
+
+	@Override
+	public void setRecord_ID (final int Record_ID)
+	{
+		if (Record_ID < 0) 
+			set_Value (COLUMNNAME_Record_ID, null);
+		else 
+			set_Value (COLUMNNAME_Record_ID, Record_ID);
+	}
+
+	@Override
+	public int getRecord_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_Record_ID);
+	}
+
+	@Override
+	public void setStatusMessage (final @Nullable java.lang.String StatusMessage)
+	{
+		set_Value (COLUMNNAME_StatusMessage, StatusMessage);
+	}
+
+	@Override
+	public java.lang.String getStatusMessage() 
+	{
+		return get_ValueAsString(COLUMNNAME_StatusMessage);
+	}
+}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemExportStatus.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemExportStatus.java
@@ -1,0 +1,92 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2024 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import de.metas.externalsystem.model.X_ExternalSystem_ScriptedExportConversion_Status;
+import de.metas.util.lang.ReferenceListAwareEnum;
+import de.metas.util.lang.ReferenceListAwareEnums;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Getter
+public enum ExternalSystemExportStatus implements ReferenceListAwareEnum
+{
+	Pending(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Pending),
+	Enqueued(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Enqueued),
+	SendingStarted(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_SendingStarted),
+	Sent(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Sent),
+	Error(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Error),
+	Invalid(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Invalid),
+	DontSend(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_DontSend),
+	;
+
+	@NonNull private static final ReferenceListAwareEnums.ValuesIndex<ExternalSystemExportStatus> index = ReferenceListAwareEnums.index(values());
+
+	public static final int AD_Reference_ID = X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_AD_Reference_ID;
+
+	@NonNull private final String code;
+
+	@JsonCreator
+	@NonNull
+	public static ExternalSystemExportStatus ofCode(@NonNull final String code) {return index.ofCode(code);}
+
+	@Nullable
+	public static ExternalSystemExportStatus ofNullableCode(@Nullable final String code) {return index.ofNullableCode(code);}
+
+	public static Optional<ExternalSystemExportStatus> optionalOfNullableCode(@Nullable final String code) {return index.optionalOfNullableCode(code);}
+
+	@JsonValue
+	public String toJson() {return code;}
+
+	// ---- single-value predicates ----
+	public boolean isPending() {return Pending == this;}
+	public boolean isEnqueued() {return Enqueued == this;}
+	public boolean isSendingStarted() {return SendingStarted == this;}
+	public boolean isSent() {return Sent == this;}
+	public boolean isError() {return Error == this;}
+	public boolean isInvalid() {return Invalid == this;}
+	public boolean isDontSend() {return DontSend == this;}
+
+	// ---- compound predicates (mirrors EDIExportStatus) ----
+	/** Enqueued OR SendingStarted */
+	public boolean isProcessing() {return isEnqueued() || isSendingStarted();}
+
+	/** Sent OR DontSend */
+	public boolean isProcessed() {return isSent() || isDontSend();}
+
+	/** Pending OR Error */
+	public boolean isPendingOrError() {return isPending() || isError();}
+
+	/** Error OR Invalid */
+	public boolean isErrorOrInvalid() {return isError() || isInvalid();}
+
+	/** Enqueued OR SendingStarted OR Sent */
+	public boolean isInProgressOrSend() {return isEnqueued() || isSendingStarted() || isSent();}
+}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemInvocationContext.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemInvocationContext.java
@@ -30,10 +30,10 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 
 /**
- * Identifies the functional context of an external system invocation for error handling purposes.
- * Error listeners can filter errors based on this context.
+ * Identifies the functional context of an external system invocation.
+ * Both success and error listeners can filter invocations based on this context.
  */
-public enum ExternalSystemErrorContext
+public enum ExternalSystemInvocationContext
 {
 	/**
 	 * Unknown or unspecified context.
@@ -45,11 +45,18 @@ public enum ExternalSystemErrorContext
 	 * EDI (Electronic Data Interchange) export context.
 	 * Used for DESADV and INVOIC exports via external system.
 	 */
-	EDI("EDI");
+	EDI("EDI"),
+
+	/**
+	 * Re-send context.
+	 * Used when a record's non-Sent attempt is being re-triggered via the
+	 * M_InOut_ReSend_ScriptedExportConversion AD process.
+	 */
+	RESEND("Resend");
 
 	private final String code;
 
-	ExternalSystemErrorContext(@NonNull final String code)
+	ExternalSystemInvocationContext(@NonNull final String code)
 	{
 		this.code = code;
 	}
@@ -61,7 +68,7 @@ public enum ExternalSystemErrorContext
 	}
 
 	@JsonCreator
-	public static ExternalSystemErrorContext ofCodeOrUnknown(@Nullable final String code)
+	public static ExternalSystemInvocationContext ofCodeOrUnknown(@Nullable final String code)
 	{
 		if (code == null)
 		{
@@ -82,5 +89,10 @@ public enum ExternalSystemErrorContext
 	public boolean isEDI()
 	{
 		return this == EDI;
+	}
+
+	public boolean isResend()
+	{
+		return this == RESEND;
 	}
 }

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/IExternalSystemInvocationSuccessListener.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/IExternalSystemInvocationSuccessListener.java
@@ -24,39 +24,40 @@ package de.metas.externalsystem;
 
 import de.metas.process.PInstanceId;
 import lombok.NonNull;
+import org.springframework.http.HttpStatus;
 
 /**
- * Listener interface for external system invocation errors.
- * Implementations can handle errors specific to their domain (e.g., EDI export status updates).
+ * Listener interface for external system invocation successes.
+ * Implementations can handle success callbacks specific to their domain (e.g., EDI export status updates).
  * <p>
- * This listener is invoked when the external system REST API receives an error callback
- * (e.g., from Camel route processing failures).
+ * This listener is invoked when the external system REST API receives a success callback
+ * (e.g., from Camel route processing completions).
  * <p>
- * Listeners should implement {@link #applies(ExternalSystemInvocationContext)} to check if they should handle errors
- * for a given invocation context.
+ * Listeners should implement {@link #applies(ExternalSystemInvocationContext)} to check if they should handle
+ * successes for a given context.
  */
-public interface IExternalSystemInvocationErrorListener
+public interface IExternalSystemInvocationSuccessListener
 {
 	/**
 	 * Checks if this listener applies to the given invocation context.
 	 *
 	 * @param context the invocation context (EDI, Resend, etc.), never null (defaults to UNKNOWN)
-	 * @return true if this listener should handle errors for the given context
+	 * @return true if this listener should handle successes for the given context
 	 */
 	boolean applies(@NonNull ExternalSystemInvocationContext context);
 
 	/**
-	 * Called when external system invocation fails.
+	 * Called when external system invocation succeeds.
 	 * <p>
 	 * The listener queries its relevant tables (M_InOut, C_Invoice, etc.) by PInstance_ID
-	 * to find which record(s) are affected by this error.
+	 * to find which record(s) are affected by this success.
 	 *
-	 * @param pInstanceId the process instance ID of the external system invocation
-	 * @param context     the invocation context (EDI, Resend, etc.), never null (defaults to UNKNOWN)
-	 * @param errorMessage the aggregated error message from external system
+	 * @param pInstanceId    the process instance ID of the external system invocation
+	 * @param context        the invocation context (EDI, Resend, etc.), never null (defaults to UNKNOWN)
+	 * @param httpStatus     the HTTP response status returned by the external system
 	 */
-	void onInvocationError(
+	void onInvocationSuccess(
 			@NonNull PInstanceId pInstanceId,
 			@NonNull ExternalSystemInvocationContext context,
-			@NonNull String errorMessage);
+			@NonNull HttpStatus httpStatus);
 }

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusRepository.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusRepository.java
@@ -1,0 +1,304 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import de.metas.error.AdIssueId;
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.externalsystem.model.I_ExternalSystem_ScriptedExportConversion_Status;
+import de.metas.process.PInstanceId;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.Adempiere;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Repository;
+
+import javax.annotation.Nullable;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
+/**
+ * Repository for {@code ExternalSystem_ScriptedExportConversion_Status}.
+ *
+ * <p>Repository Tables: ExternalSystem_ScriptedExportConversion_Status
+ *
+ * <p>Repository Cluster: sole owner of {@code ExternalSystem_ScriptedExportConversion_Status}.
+ * Service layer: {@link ExternalSystemExportStatusService}.
+ *
+ * <p>Grain: ONE row per (ExternalSystem_Config_ScriptedExportConversion_ID, AD_Table_ID, Record_ID).
+ * All status transitions are done via in-place update on that single row (upsert).
+ */
+@Repository
+public class ExternalSystemExportStatusRepository
+{
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@VisibleForTesting
+	public static ExternalSystemExportStatusRepository newInstanceForUnitTesting()
+	{
+		Adempiere.assertUnitTestMode();
+		return new ExternalSystemExportStatusRepository();
+	}
+
+	// ------------------------------------------------------------------
+	// Upsert / insert
+	// ------------------------------------------------------------------
+
+	/**
+	 * Upserts the status row for the given (config, sourceRecord) key.
+	 * Creates the row if it does not exist yet; updates it in-place otherwise.
+	 */
+	@NonNull
+	public ScriptedExportConversionStatus upsert(@NonNull final ScriptedExportConversionStatusCreateRequest request)
+	{
+		final I_ExternalSystem_ScriptedExportConversion_Status record =
+				queryStatusRecord(request.getConfigId(), request.getSourceRecord())
+						.orElseGet(() -> InterfaceWrapperHelper.newInstance(I_ExternalSystem_ScriptedExportConversion_Status.class));
+		updateRecord(record, request);
+		InterfaceWrapperHelper.saveRecord(record);
+		return fromRecord(record);
+	}
+
+	/**
+	 * Persists the loaded status identified by its (config, sourceRecord) key.
+	 * No-op (no throw) when no row exists for that key.
+	 */
+	public void update(@NonNull final ScriptedExportConversionStatus status)
+	{
+		final I_ExternalSystem_ScriptedExportConversion_Status record =
+				queryStatusRecord(status.getConfigId(), status.getSourceRecord()).orElse(null);
+		if (record == null)
+		{
+			return;
+		}
+		updateRecord(record, status);
+		InterfaceWrapperHelper.saveRecord(record);
+	}
+
+	/**
+	 * Loads the status row bound to the given {@code pInstanceId}, applies the operator,
+	 * and saves the result. No-op (no throw) when no row is bound to the pInstance.
+	 */
+	public void updateLatestByPInstanceId(
+			@NonNull final PInstanceId pInstanceId,
+			@NonNull final UnaryOperator<ScriptedExportConversionStatus> operator)
+	{
+		final ScriptedExportConversionStatus existing = getLatestByPInstanceId(pInstanceId).orElse(null);
+		if (existing == null)
+		{
+			return;
+		}
+		update(operator.apply(existing));
+	}
+
+	// ------------------------------------------------------------------
+	// Queries
+	// ------------------------------------------------------------------
+
+	/**
+	 * Returns the status row for the given pInstance, if any.
+	 */
+	@NonNull
+	public Optional<ScriptedExportConversionStatus> getLatestByPInstanceId(@NonNull final PInstanceId pInstanceId)
+	{
+		return queryBL.createQueryBuilder(I_ExternalSystem_ScriptedExportConversion_Status.class)
+				.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_PInstance_ID, pInstanceId.getRepoId())
+				.orderByDescending(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID)
+				.create()
+				.firstOptional(I_ExternalSystem_ScriptedExportConversion_Status.class)
+				.map(ExternalSystemExportStatusRepository::fromRecord);
+	}
+
+	/**
+	 * Returns all status rows for the given config.
+	 */
+	@NonNull
+	public List<ScriptedExportConversionStatus> getByConfigId(@NonNull final ExternalSystemScriptedExportConversionConfigId configId)
+	{
+		return queryBL.createQueryBuilder(I_ExternalSystem_ScriptedExportConversion_Status.class)
+				.addEqualsFilter(
+						I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID,
+						configId.getRepoId())
+				.create()
+				.stream()
+				.map(ExternalSystemExportStatusRepository::fromRecord)
+				.collect(ImmutableList.toImmutableList());
+	}
+
+	/**
+	 * Returns the single status row for the given config + source record combination, if any.
+	 */
+	@NonNull
+	public Optional<ScriptedExportConversionStatus> getLatestByConfigAndRecord(
+			@NonNull final ExternalSystemScriptedExportConversionConfigId configId,
+			@NonNull final TableRecordReference sourceRecord)
+	{
+		return queryStatusRecord(configId, sourceRecord)
+				.map(ExternalSystemExportStatusRepository::fromRecord);
+	}
+
+	/**
+	 * Returns the distinct config IDs whose status row for the given source record is
+	 * not yet fully processed (i.e. neither {@link ExternalSystemExportStatus#Sent} nor
+	 * {@link ExternalSystemExportStatus#DontSend}).
+	 */
+	@NonNull
+	public List<ExternalSystemScriptedExportConversionConfigId> getConfigsWithNonSentAttemptBySourceRecord(
+			@NonNull final TableRecordReference sourceRecord)
+	{
+		final List<ScriptedExportConversionStatus> allEntries = getLatestBySourceRecord(sourceRecord);
+
+		final LinkedHashMap<ExternalSystemScriptedExportConversionConfigId, ScriptedExportConversionStatus> latestPerConfig =
+				new LinkedHashMap<>();
+		for (final ScriptedExportConversionStatus entry : allEntries)
+		{
+			latestPerConfig.putIfAbsent(entry.getConfigId(), entry);
+		}
+
+		return latestPerConfig.entrySet().stream()
+				.filter(e -> !e.getValue().getStatus().isProcessed())
+				.map(Map.Entry::getKey)
+				.collect(ImmutableList.toImmutableList());
+	}
+
+	/**
+	 * Returns all status rows for the given source record, ordered newest-first.
+	 */
+	@NonNull
+	public List<ScriptedExportConversionStatus> getLatestBySourceRecord(@NonNull final TableRecordReference sourceRecord)
+	{
+		return queryBL.createQueryBuilder(I_ExternalSystem_ScriptedExportConversion_Status.class)
+				.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_Table_ID, sourceRecord.getAD_Table_ID())
+				.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_Record_ID, sourceRecord.getRecord_ID())
+				.orderByDescending(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID)
+				.create()
+				.stream()
+				.map(ExternalSystemExportStatusRepository::fromRecord)
+				.collect(ImmutableList.toImmutableList());
+	}
+
+	// ------------------------------------------------------------------
+	// Internal
+	// ------------------------------------------------------------------
+
+	@NonNull
+	private Optional<I_ExternalSystem_ScriptedExportConversion_Status> queryStatusRecord(
+			@NonNull final ExternalSystemScriptedExportConversionConfigId configId,
+			@NonNull final TableRecordReference sourceRecord)
+	{
+		return queryBL.createQueryBuilder(I_ExternalSystem_ScriptedExportConversion_Status.class)
+				.addEqualsFilter(
+						I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID,
+						configId.getRepoId())
+				.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_Table_ID, sourceRecord.getAD_Table_ID())
+				.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_Record_ID, sourceRecord.getRecord_ID())
+				// the unique index guarantees at most one row per (config, table, record); the explicit
+				// orderBy satisfies the framework's "first() without ORDER BY" developer-guard (which throws otherwise)
+				.orderByDescending(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID)
+				.create()
+				.firstOptional(I_ExternalSystem_ScriptedExportConversion_Status.class);
+	}
+
+	// ------------------------------------------------------------------
+	// Mapping helpers
+	// ------------------------------------------------------------------
+
+	@NonNull
+	public static ScriptedExportConversionStatus fromRecord(
+			@NonNull final I_ExternalSystem_ScriptedExportConversion_Status record)
+	{
+		final int httpCode = record.getHttpResponseCode();
+		return ScriptedExportConversionStatus.builder()
+				.pInstanceId(PInstanceId.ofRepoIdOrNull(record.getAD_PInstance_ID()))
+				.configId(ExternalSystemScriptedExportConversionConfigId.ofRepoId(record.getExternalSystem_Config_ScriptedExportConversion_ID()))
+				.sourceRecord(TableRecordReference.of(record.getAD_Table_ID(), record.getRecord_ID()))
+				.status(ExternalSystemExportStatus.ofCode(record.getExportStatus()))
+				.httpResponseCode(httpCode > 0 ? HttpStatus.valueOf(httpCode) : null)
+				.adIssueId(AdIssueId.ofRepoIdOrNull(record.getAD_Issue_ID()))
+				.statusMessage(record.getStatusMessage())
+				.isResend(record.isResend())
+				.build();
+	}
+
+	private static void updateRecord(
+			@NonNull final I_ExternalSystem_ScriptedExportConversion_Status record,
+			@NonNull final ScriptedExportConversionStatusCreateRequest request)
+	{
+		applyFields(
+				record,
+				request.getPInstanceId(),
+				request.getConfigId(),
+				request.getSourceRecord(),
+				request.getStatus(),
+				request.getHttpResponseCode(),
+				request.getAdIssueId(),
+				request.getStatusMessage(),
+				request.isResend());
+	}
+
+	@VisibleForTesting
+	static void updateRecord(
+			@NonNull final I_ExternalSystem_ScriptedExportConversion_Status record,
+			@NonNull final ScriptedExportConversionStatus status)
+	{
+		applyFields(
+				record,
+				status.getPInstanceId(),
+				status.getConfigId(),
+				status.getSourceRecord(),
+				status.getStatus(),
+				status.getHttpResponseCode(),
+				status.getAdIssueId(),
+				status.getStatusMessage(),
+				status.isResend());
+	}
+
+	private static void applyFields(
+			@NonNull final I_ExternalSystem_ScriptedExportConversion_Status record,
+			@Nullable final PInstanceId pInstanceId,
+			@NonNull final ExternalSystemScriptedExportConversionConfigId configId,
+			@NonNull final TableRecordReference sourceRecord,
+			@NonNull final ExternalSystemExportStatus status,
+			@Nullable final HttpStatus httpResponseCode,
+			@Nullable final AdIssueId adIssueId,
+			@Nullable final String statusMessage,
+			final boolean isResend)
+	{
+		record.setExternalSystem_Config_ScriptedExportConversion_ID(configId.getRepoId());
+		record.setAD_Table_ID(sourceRecord.getAD_Table_ID());
+		record.setRecord_ID(sourceRecord.getRecord_ID());
+		record.setExportStatus(status.getCode());
+		record.setAD_PInstance_ID(pInstanceId != null ? pInstanceId.getRepoId() : 0);
+		record.setHttpResponseCode(httpResponseCode != null ? httpResponseCode.value() : 0);
+		record.setAD_Issue_ID(adIssueId != null ? adIssueId.getRepoId() : 0);
+		record.setStatusMessage(statusMessage);
+		record.setIsResend(isResend);
+	}
+}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
@@ -1,0 +1,310 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import de.metas.error.AdIssueId;
+import de.metas.error.IErrorManager;
+import de.metas.error.IssueCreateRequest;
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.logging.LogManager;
+import de.metas.process.PInstanceId;
+import de.metas.util.Services;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.Adempiere;
+import org.compiere.SpringContextHolder;
+import org.slf4j.Logger;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * State machine for the scripted-export-conversion status row.
+ *
+ * <p>States (one row per config+record): Pending → Enqueued → Sent | Error | Invalid; plus the
+ * terminal DontSend (evaluated but excluded by the config WhereClause).
+ */
+@Service
+@RequiredArgsConstructor
+public class ExternalSystemExportStatusService
+{
+	private static final Logger log = LogManager.getLogger(ExternalSystemExportStatusService.class);
+
+	@NonNull private final ExternalSystemExportStatusRepository repo;
+
+	// IErrorManager is an ISingletonService (obtained via Services.get), not a Spring bean — it must NOT be a
+	// constructor parameter, else this @Service fails to wire at context boot with NoSuchBeanDefinitionException.
+	private final IErrorManager errorManager = Services.get(IErrorManager.class);
+
+	@VisibleForTesting
+	public static ExternalSystemExportStatusService newInstanceForUnitTesting()
+	{
+		Adempiere.assertUnitTestMode();
+		return new ExternalSystemExportStatusService(
+				SpringContextHolder.getBeanOrSupply(ExternalSystemExportStatusRepository.class, ExternalSystemExportStatusRepository::newInstanceForUnitTesting));
+	}
+
+	// ------------------------------------------------------------------
+	// Entry transitions (config + record)
+	// ------------------------------------------------------------------
+
+	/**
+	 * Records that the source record was evaluated but excluded by the config WhereClause.
+	 * Terminal state {@link ExternalSystemExportStatus#DontSend}.
+	 */
+	public void recordDontSend(
+			@NonNull final ExternalSystemScriptedExportConversionConfigId configId,
+			@NonNull final TableRecordReference sourceRecord)
+	{
+		repo.upsert(ScriptedExportConversionStatusCreateRequest.builder()
+				.configId(configId)
+				.sourceRecord(sourceRecord)
+				.status(ExternalSystemExportStatus.DontSend)
+				.build());
+	}
+
+	/**
+	 * Records that the source record was included by the config WhereClause.
+	 * Status {@link ExternalSystemExportStatus#Pending}, no PInstance yet.
+	 */
+	public void recordPending(
+			@NonNull final ExternalSystemScriptedExportConversionConfigId configId,
+			@NonNull final TableRecordReference sourceRecord)
+	{
+		repo.upsert(ScriptedExportConversionStatusCreateRequest.builder()
+				.configId(configId)
+				.sourceRecord(sourceRecord)
+				.status(ExternalSystemExportStatus.Pending)
+				.build());
+	}
+
+	/**
+	 * Flips the (config, record) status row back to {@link ExternalSystemExportStatus#Pending} with
+	 * {@code IsResend=Y} using an in-place upsert — matching the single-row-per-key design.
+	 * Creates the row if somehow absent; otherwise updates the existing row so no duplicate key
+	 * can arise.
+	 */
+	public void recordPendingAsResend(
+			@NonNull final ExternalSystemScriptedExportConversionConfigId configId,
+			@NonNull final TableRecordReference sourceRecord)
+	{
+		repo.upsert(ScriptedExportConversionStatusCreateRequest.builder()
+				.configId(configId)
+				.sourceRecord(sourceRecord)
+				.status(ExternalSystemExportStatus.Pending)
+				.isResend(true)
+				.build());
+	}
+
+	/**
+	 * Returns the config IDs whose status row for the given source record is in a terminal-failure
+	 * state ({@link ExternalSystemExportStatus#Error} or {@link ExternalSystemExportStatus#Invalid}).
+	 * In-flight rows (Pending, Enqueued, SendingStarted) are excluded to prevent double-sending.
+	 */
+	@NonNull
+	public List<ExternalSystemScriptedExportConversionConfigId> getResendableConfigsBySourceRecord(
+			@NonNull final TableRecordReference sourceRecord)
+	{
+		return repo.getLatestBySourceRecord(sourceRecord)
+				.stream()
+				.filter(s -> s.getStatus().isErrorOrInvalid())
+				.map(ScriptedExportConversionStatus::getConfigId)
+				.distinct()
+				.collect(ImmutableList.toImmutableList());
+	}
+
+	/**
+	 * Binds the PInstance to the (config, record) status row and transitions it to the in-flight
+	 * {@link ExternalSystemExportStatus#Enqueued} state.
+	 *
+	 * <p>At-most-one-in-flight guard: skips the transition unless the existing row is Pending,
+	 * so a record that is already in-flight is not double-enqueued.
+	 * No-op (no throw) when no status row exists for (config, record).
+	 */
+	public void markEnqueued(
+			@NonNull final ExternalSystemScriptedExportConversionConfigId configId,
+			@NonNull final TableRecordReference sourceRecord,
+			@NonNull final PInstanceId pInstanceId)
+	{
+		final ScriptedExportConversionStatus existing = repo.getLatestByConfigAndRecord(configId, sourceRecord).orElse(null);
+		if (existing == null)
+		{
+			log.warn("No status row found for configId={}, sourceRecord={} – skipping Enqueued transition", configId, sourceRecord);
+			return;
+		}
+		if (!existing.getStatus().isPending())
+		{
+			log.warn("Skipping Enqueued transition for configId={}, sourceRecord={} — existing status is {} (expected Pending)", configId, sourceRecord, existing.getStatus());
+			return;
+		}
+
+		repo.update(existing
+				.withPInstanceId(pInstanceId)
+				.withStatus(ExternalSystemExportStatus.Enqueued)
+				.withHttpResponseCode(null)
+				.withAdIssueId(null)
+				.withStatusMessage(null));
+	}
+
+	/**
+	 * Pre-send revalidation failed — transitions the (config, record) row to the terminal
+	 * {@link ExternalSystemExportStatus#Invalid} state.
+	 * No-op (no throw) when no status row exists for (config, record).
+	 */
+	public void markInvalidByRecord(
+			@NonNull final ExternalSystemScriptedExportConversionConfigId configId,
+			@NonNull final TableRecordReference sourceRecord,
+			@Nullable final String message)
+	{
+		final ScriptedExportConversionStatus existing = repo.getLatestByConfigAndRecord(configId, sourceRecord).orElse(null);
+		if (existing == null)
+		{
+			log.warn("No status row found for configId={}, sourceRecord={} – skipping Invalid transition", configId, sourceRecord);
+			return;
+		}
+
+		repo.update(existing
+				.withStatus(ExternalSystemExportStatus.Invalid)
+				.withStatusMessage(message));
+	}
+
+	// ------------------------------------------------------------------
+	// Outcome transitions (pInstance)
+	// ------------------------------------------------------------------
+
+	/**
+	 * Scripted-adapter returned 2xx — transitions the pInstance-bound row to
+	 * {@link ExternalSystemExportStatus#Sent}.
+	 * No-op (no throw) when no status row exists for the pInstance.
+	 */
+	public void markSent(@NonNull final PInstanceId pInstanceId, @NonNull final HttpStatus httpStatus)
+	{
+		updateStatus(pInstanceId, ExternalSystemExportStatus.Sent, httpStatus, null, null);
+	}
+
+	/**
+	 * Any send failure — transitions the pInstance-bound row to the terminal
+	 * {@link ExternalSystemExportStatus#Error} state and links an {@link AdIssueId}.
+	 * When {@code adIssueId} is null, an issue is created via {@link IErrorManager}.
+	 * No-op (no throw) when no status row exists for the pInstance.
+	 */
+	public void markError(
+			@NonNull final PInstanceId pInstanceId,
+			@Nullable final AdIssueId adIssueId,
+			@Nullable final String message)
+	{
+		final ScriptedExportConversionStatus existing = repo.getLatestByPInstanceId(pInstanceId).orElse(null);
+		if (existing == null)
+		{
+			log.debug("No status row found for pInstanceId={}, status=Error – skipping", pInstanceId);
+			return;
+		}
+
+		final AdIssueId resolvedAdIssueId = adIssueId != null
+				? adIssueId
+				: errorManager.createIssue(IssueCreateRequest.builder()
+						.summary(message)
+						.sourceClassname(ExternalSystemExportStatusService.class.getName())
+						.build());
+
+		repo.update(existing
+				.withStatus(ExternalSystemExportStatus.Error)
+				.withHttpResponseCode(null)
+				.withAdIssueId(resolvedAdIssueId)
+				.withStatusMessage(message));
+	}
+
+	/**
+	 * Transitions the pInstance-bound row to the terminal {@link ExternalSystemExportStatus#Invalid} state.
+	 * No-op (no throw) when no status row exists for the pInstance.
+	 */
+	public void markInvalid(
+			@NonNull final PInstanceId pInstanceId,
+			@Nullable final String message)
+	{
+		updateStatus(pInstanceId, ExternalSystemExportStatus.Invalid, null, null, message);
+	}
+
+	// ------------------------------------------------------------------
+	// Roll-up
+	// ------------------------------------------------------------------
+
+	/**
+	 * Computes the aggregate roll-up status from the latest status per config.
+	 * Precedence: Error/Invalid ⟫ in-flight (Pending/Enqueued/SendingStarted) ⟫ Sent.
+	 * Returns {@link ExternalSystemExportStatus#Pending} when the list is empty.
+	 */
+	@NonNull
+	public ExternalSystemExportStatus computeRollUp(@NonNull final List<ScriptedExportConversionStatus> latestEntries)
+	{
+		if (latestEntries.isEmpty())
+		{
+			return ExternalSystemExportStatus.Pending;
+		}
+
+		ExternalSystemExportStatus result = ExternalSystemExportStatus.Sent;
+		for (final ScriptedExportConversionStatus entry : latestEntries)
+		{
+			final ExternalSystemExportStatus s = entry.getStatus();
+			if (s.isErrorOrInvalid())
+			{
+				return s.isError() ? ExternalSystemExportStatus.Error : ExternalSystemExportStatus.Invalid;
+			}
+			if (s.isPending() || s.isProcessing())
+			{
+				result = s;
+			}
+		}
+		return result;
+	}
+
+	// ------------------------------------------------------------------
+	// Internal helpers
+	// ------------------------------------------------------------------
+
+	private void updateStatus(
+			@NonNull final PInstanceId pInstanceId,
+			@NonNull final ExternalSystemExportStatus newStatus,
+			@Nullable final HttpStatus httpResponseCode,
+			@Nullable final AdIssueId adIssueId,
+			@Nullable final String message)
+	{
+		final ScriptedExportConversionStatus existing = repo.getLatestByPInstanceId(pInstanceId).orElse(null);
+		if (existing == null)
+		{
+			log.debug("No status row found for pInstanceId={}, status={} – skipping", pInstanceId, newStatus);
+			return;
+		}
+
+		repo.update(existing
+				.withStatus(newStatus)
+				.withHttpResponseCode(httpResponseCode)
+				.withAdIssueId(adIssueId)
+				.withStatusMessage(message));
+	}
+}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
@@ -28,17 +28,25 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import de.metas.JsonObjectMapperHolder;
 import de.metas.adempiere.service.IColumnBL;
+import de.metas.common.util.time.SystemTime;
 import de.metas.document.engine.IDocumentBL;
-import de.metas.externalsystem.ExternalSystemErrorContext;
+import de.metas.externalsystem.ExternalSystemConfigRepo;
+import de.metas.externalsystem.ExternalSystemInvocationContext;
 import de.metas.externalsystem.ExternalSystemParentConfigId;
+import de.metas.externalsystem.ExternalSystemType;
+import de.metas.externalsystem.audit.CreateExportAuditRequest;
+import de.metas.externalsystem.audit.ExternalSystemExportAuditRepo;
 import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion;
 import de.metas.externalsystem.endpoint.ExternalSystemEndpoint;
 import de.metas.externalsystem.endpoint.ExternalSystemEndpointRepository;
 import de.metas.externalsystem.process.InvokeScriptedExportConversionAction;
 import de.metas.logging.LogManager;
+import de.metas.process.PInstanceId;
 import de.metas.process.ProcessExecutionResult;
 import de.metas.process.ProcessExecutor;
 import de.metas.process.ProcessInfo;
+import de.metas.security.RoleId;
+import de.metas.user.UserId;
 import de.metas.util.Services;
 import de.metas.util.StringUtils;
 import lombok.NonNull;
@@ -49,6 +57,7 @@ import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.util.DB;
+import org.compiere.util.Env;
 import org.slf4j.Logger;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
@@ -64,6 +73,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import static de.metas.common.externalsystem.ExternalSystemConstants.COMMAND_CONVERT_MESSAGE_FROM_METASFRESH;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_ERROR_CONTEXT;
@@ -88,9 +98,12 @@ public class ExternalSystemScriptedExportConversionService
 	private final IColumnBL columnBL = Services.get(IColumnBL.class);
 	private final ObjectMapper objectMapper = JsonObjectMapperHolder.sharedJsonObjectMapper();
 	private final ITrxManager trxManager = Services.get(ITrxManager.class);
+	@NonNull private final ExternalSystemExportStatusService exportStatusService;
 
 	@NonNull private final ExternalSystemScriptedExportConversionRepository externalSystemScriptedExportConversionRepository;
 	@NonNull private final ExternalSystemEndpointRepository externalSystemEndpointRepository;
+	@NonNull private final ExternalSystemExportAuditRepo exportAuditRepo;
+	@NonNull private final ExternalSystemConfigRepo externalSystemConfigRepo;
 
 	public void addCacheResetListener(@NonNull final ExternalSystemScriptedExportConversionConfigChangedListener listener)
 	{
@@ -101,14 +114,6 @@ public class ExternalSystemScriptedExportConversionService
 	public ImmutableSet<AdTableAndClientId> getTriggerOnCompleteDistinctTableAndClientIds()
 	{
 		return externalSystemScriptedExportConversionRepository.getTriggerOnCompleteDistinctTableAndClientIds();
-	}
-
-	@NonNull
-	public ImmutableList<ExternalSystemScriptedExportConversionConfig> getMatchingTriggerOnCompleteConfigsByTableAndClientId(@NonNull final AdTableAndClientId tableAndClientId, @NonNull final Integer recordId)
-	{
-		return externalSystemScriptedExportConversionRepository.getTriggerOnCompleteConfigsByTableAndClientIds(tableAndClientId).stream()
-				.filter(config -> isConfigMatchingRecord(config, recordId))
-				.collect(ImmutableList.toImmutableList());
 	}
 
 	@NonNull
@@ -285,13 +290,142 @@ public class ExternalSystemScriptedExportConversionService
 		return executeInvokeScriptedExportConversionActionAndGetResult(config, recordId, null).getExceptions();
 	}
 
+	/**
+	 * Resolves the config by ID (fail-fast — throws for inactive/missing configs) and, only on
+	 * success, creates a new {@link ExternalSystemExportStatus#Pending} row with {@code IsResend=Y}.
+	 *
+	 * <p>The getById-before-recordPendingAsResend ordering is intentional: if the config is
+	 * inactive or missing, getById throws <em>before</em> any Pending row is created, preventing
+	 * an orphan log row with no subsequent invocation.
+	 *
+	 * @return the resolved config, ready for the follow-up
+	 *         {@link #executeInvokeScriptedExportConversionActionAndGetResult} call
+	 */
+	@NonNull
+	public ExternalSystemScriptedExportConversionConfig resolveConfigAndRecordPendingAsResend(
+			@NonNull final ExternalSystemScriptedExportConversionConfigId configId,
+			@NonNull final TableRecordReference sourceRecord)
+	{
+		// Resolve config first — throws for inactive/missing configs (fail-fast, no orphan Pending row)
+		final ExternalSystemScriptedExportConversionConfig config =
+				externalSystemScriptedExportConversionRepository.getById(configId);
+
+		exportStatusService.recordPendingAsResend(configId, sourceRecord);
+
+		return config;
+	}
+
+	@NonNull
+	public List<ExternalSystemScriptedExportConversionConfigId> getResendableConfigsBySourceRecord(
+			@NonNull final TableRecordReference sourceRecord)
+	{
+		return exportStatusService.getResendableConfigsBySourceRecord(sourceRecord);
+	}
+
+	/**
+	 * Records a {@link ExternalSystemExportStatus#Pending} log entry for the given config and source record.
+	 * Called by the interceptor's AFTER_COMPLETE branch for each matching config, before scheduling
+	 * the after-commit execution.
+	 */
+	public void recordPendingForConfig(
+			@NonNull final ExternalSystemScriptedExportConversionConfig config,
+			final int recordId)
+	{
+		final TableRecordReference sourceRecord = TableRecordReference.of(config.getTableId(), recordId);
+		exportStatusService.recordPending(config.getId(), sourceRecord);
+	}
+
+	/**
+	 * At document complete-time, records an eligibility status for EVERY trigger-on-complete config
+	 * of the record's table, then schedules the after-commit invocation for matching configs only.
+	 *
+	 * <ul>
+	 *   <li>WhereClause MATCHES → {@link de.metas.externalsystem.ExternalSystemExportStatus#Pending}
+	 *       + schedules the after-commit invocation (existing behaviour).</li>
+	 *   <li>WhereClause does NOT match → {@link de.metas.externalsystem.ExternalSystemExportStatus#DontSend}
+	 *       (EDI-consistency: DontSend is always persisted).</li>
+	 * </ul>
+	 *
+	 * <p>Status writes run in the same transaction (no InNewTrx). The invocation scheduling
+	 * stays after-commit. A status-write failure for one config is logged and swallowed so that
+	 * document completion is never aborted.
+	 */
+	public void recordCompleteTimeEligibilityAndScheduleInvocation(
+			@NonNull final AdTableAndClientId tableAndClientId,
+			final int recordId)
+	{
+		final ImmutableList<ExternalSystemScriptedExportConversionConfig> allConfigs =
+				externalSystemScriptedExportConversionRepository.getTriggerOnCompleteConfigsByTableAndClientIds(tableAndClientId);
+
+		// Partition in a single pass — isConfigMatchingRecord issues a SQL query per config,
+		// so we must not call it twice for the same config.
+		final Map<Boolean, List<ExternalSystemScriptedExportConversionConfig>> partitioned = allConfigs.stream()
+				.collect(Collectors.partitioningBy(config -> isConfigMatchingRecord(config, recordId)));
+
+		final ImmutableList<ExternalSystemScriptedExportConversionConfig> matchingConfigs =
+				ImmutableList.copyOf(partitioned.get(Boolean.TRUE));
+		final ImmutableList<ExternalSystemScriptedExportConversionConfig> nonMatchingConfigs =
+				ImmutableList.copyOf(partitioned.get(Boolean.FALSE));
+
+		recordCompleteTimeEligibilityStatusesOnly(matchingConfigs, nonMatchingConfigs, recordId);
+
+		matchingConfigs.forEach(config -> executeInvokeScriptedExportConversionActionAfterCommit(config, recordId));
+	}
+
+	/**
+	 * Pure inner method: given a pre-partitioned list of configs, writes the eligibility statuses
+	 * in the current transaction.
+	 *
+	 * <p>This method is intentionally separated from the DB-matching logic so it can be unit-tested
+	 * without a live DB.
+	 *
+	 * <p>Each status write is individually guarded: a failure for one config is logged and swallowed
+	 * so that document completion is never aborted.
+	 *
+	 * @param matchingConfigs    configs whose WhereClause matches the record → written as Pending
+	 * @param nonMatchingConfigs configs whose WhereClause does NOT match the record → written as DontSend
+	 * @param recordId           the source record ID (table is taken from each config)
+	 */
+	/* package-private for testing */ void recordCompleteTimeEligibilityStatusesOnly(
+			@NonNull final ImmutableList<ExternalSystemScriptedExportConversionConfig> matchingConfigs,
+			@NonNull final ImmutableList<ExternalSystemScriptedExportConversionConfig> nonMatchingConfigs,
+			final int recordId)
+	{
+		for (final ExternalSystemScriptedExportConversionConfig config : matchingConfigs)
+		{
+			try
+			{
+				recordPendingForConfig(config, recordId);
+			}
+			catch (final Exception e)
+			{
+				log.warn("Failed to record Pending status for config={}, recordId={} — continuing", config.getId(), recordId, e);
+			}
+		}
+
+		for (final ExternalSystemScriptedExportConversionConfig config : nonMatchingConfigs)
+		{
+			try
+			{
+				final TableRecordReference sourceRecord = TableRecordReference.of(config.getTableId(), recordId);
+				exportStatusService.recordDontSend(config.getId(), sourceRecord);
+			}
+			catch (final Exception e)
+			{
+				log.warn("Failed to record DontSend status for config={}, recordId={} — continuing", config.getId(), recordId, e);
+			}
+		}
+	}
+
 	@NonNull
 	public ExternalSystemInvocationResult executeInvokeScriptedExportConversionActionAndGetResult(
 			@NonNull final ExternalSystemScriptedExportConversionConfig config,
 			final int recordId,
-			@Nullable final ExternalSystemErrorContext errorContext)
+			@Nullable final ExternalSystemInvocationContext errorContext)
 	{
 		final int configTableId = tableDAO.retrieveTableId(I_ExternalSystem_Config_ScriptedExportConversion.Table_Name);
+		final TableRecordReference sourceRecord = TableRecordReference.of(config.getTableId(), recordId);
+
 		try
 		{
 			final ProcessInfo.ProcessInfoBuilder processInfoBuilder = ProcessInfo.builder()
@@ -308,6 +442,23 @@ public class ExternalSystemScriptedExportConversionService
 			}
 
 			final ProcessInfo processInfo = processInfoBuilder.buildAndPrepareExecution().executeSync().getProcessInfo();
+			final ProcessExecutionResult result = processInfo.getResult();
+
+			if (result.isError())
+			{
+				// (c) Invalid — the script did not produce a valid Resource (or another process error)
+				exportStatusService.markInvalidByRecord(config.getId(), sourceRecord, result.getSummary());
+			}
+			else if (processInfo.getPinstanceId() != null)
+			{
+				// (b) Enqueued — successfully dispatched to RabbitMQ
+				exportStatusService.markEnqueued(config.getId(), sourceRecord, processInfo.getPinstanceId());
+				writeExportAudit(config, sourceRecord, processInfo.getPinstanceId());
+			}
+			else
+			{
+				log.warn("Process succeeded but PInstance is null for Config ID {}, Record ID {} — skipping Enqueued status write", config.getId(), recordId);
+			}
 
 			return ExternalSystemInvocationResult.success(processInfo.getPinstanceId());
 		}
@@ -316,6 +467,15 @@ public class ExternalSystemScriptedExportConversionService
 			log.warn("{} process failed for Config ID {}, Record ID: {}",
 					InvokeScriptedExportConversionAction.class.getName(),
 					config.getId(), recordId, e);
+			// Mark invalid if the process threw before the PInstance was established
+			try
+			{
+				exportStatusService.markInvalidByRecord(config.getId(), sourceRecord, e.getMessage());
+			}
+			catch (final Exception statusEx)
+			{
+				log.warn("Failed to write Invalid status for config={}, sourceRecord={} — continuing", config.getId(), sourceRecord, statusEx);
+			}
 			return ExternalSystemInvocationResult.error(e);
 		}
 	}
@@ -326,5 +486,51 @@ public class ExternalSystemScriptedExportConversionService
 		return externalSystemScriptedExportConversionRepository.getByParentConfigId(parentConfigId).stream()
 				.filter(config -> config.isMatching(tableAndClientId))
 				.collect(ImmutableList.toImmutableList());
+	}
+
+	/**
+	 * Writes one {@code ExternalSystem_ExportAudit} row for a successfully enqueued send.
+	 *
+	 * <p>The audit row carries the pinstance that was returned by the enqueue step, the source
+	 * record reference, and the external-system type resolved from the config's parent.
+	 * Both the status row (written by {@link ExternalSystemExportStatusService#markEnqueued}) and
+	 * this audit row carry the same {@code pInstanceId}, establishing the correlation between the
+	 * two tables.
+	 *
+	 * <p>Separated into its own method so the audit write can be exercised in a unit test without
+	 * driving the full ProcessInfo/DB send path.
+	 *
+	 * <p>A failure to write the audit row is logged and swallowed so that a non-critical audit
+	 * failure never rolls back the enqueue.
+	 */
+	/* package-private for testing */ void writeExportAudit(
+			@NonNull final ExternalSystemScriptedExportConversionConfig config,
+			@NonNull final TableRecordReference sourceRecord,
+			@NonNull final PInstanceId pInstanceId)
+	{
+		try
+		{
+			final ExternalSystemType externalSystemType = ExternalSystemType.ofValue(
+					externalSystemConfigRepo.getParentTypeById(config.getParentId()));
+
+			final UserId exportUserId = Env.getLoggedUserIdIfExists(getCtx()).orElse(UserId.SYSTEM);
+			final RoleId exportRoleId = Env.getLoggedRoleIdIfExists(getCtx()).orElse(RoleId.SYSTEM);
+
+			exportAuditRepo.createESExportAudit(CreateExportAuditRequest.builder()
+					.tableRecordReference(sourceRecord)
+					.exportTime(SystemTime.asInstant())
+					.exportUserId(exportUserId)
+					.exportRoleId(exportRoleId)
+					.externalSystemType(externalSystemType)
+					.pInstanceId(pInstanceId)
+					.build());
+		}
+		catch (final Exception e)
+		{
+			// Intentional swallow: the audit row is best-effort observability; failing to write it
+			// must never roll back the already-enqueued export or the document completion.
+			log.warn("Failed to write export audit for config={}, sourceRecord={}, pInstanceId={} — continuing",
+					config.getId(), sourceRecord, pInstanceId, e);
+		}
 	}
 }

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
@@ -287,7 +287,11 @@ public class ExternalSystemScriptedExportConversionService
 			@NonNull final ExternalSystemScriptedExportConversionConfig config,
 			final int recordId)
 	{
-		return executeInvokeScriptedExportConversionActionAndGetResult(config, recordId, null).getExceptions();
+		// UNKNOWN (not null): the auto-trigger / archive-listener path must propagate a non-null error
+		// context so a downstream failure reaches the scripted-export error listener (createIssue only
+		// notifies it when errorContext != null) and the status row flips to Error. The EDI and Re-send
+		// paths pass EDI / RESEND; auto-trigger has no specific context, so it uses the neutral UNKNOWN.
+		return executeInvokeScriptedExportConversionActionAndGetResult(config, recordId, ExternalSystemInvocationContext.UNKNOWN).getExceptions();
 	}
 
 	/**

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
@@ -36,9 +36,9 @@ import de.metas.externalsystem.ExternalSystemParentConfigId;
 import de.metas.externalsystem.ExternalSystemType;
 import de.metas.externalsystem.audit.CreateExportAuditRequest;
 import de.metas.externalsystem.audit.ExternalSystemExportAuditRepo;
-import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion;
 import de.metas.externalsystem.endpoint.ExternalSystemEndpoint;
 import de.metas.externalsystem.endpoint.ExternalSystemEndpointRepository;
+import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion;
 import de.metas.externalsystem.process.InvokeScriptedExportConversionAction;
 import de.metas.logging.LogManager;
 import de.metas.process.PInstanceId;
@@ -79,8 +79,8 @@ import static de.metas.common.externalsystem.ExternalSystemConstants.COMMAND_CON
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_ERROR_CONTEXT;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_FROM_MF_METASFRESH_INPUT;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_JAVASCRIPT_IDENTIFIER;
-import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_OUTBOUND_ENDPOINT_PARAMETERS;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_OUTBOUND_DOCUMENT_NO;
+import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_OUTBOUND_ENDPOINT_PARAMETERS;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_OUTBOUND_RECORD_ID;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_OUTBOUND_RECORD_TABLE_NAME;
 import static de.metas.externalsystem.process.InvokeExternalSystemProcess.PARAM_CHILD_CONFIG_ID;
@@ -425,7 +425,7 @@ public class ExternalSystemScriptedExportConversionService
 	public ExternalSystemInvocationResult executeInvokeScriptedExportConversionActionAndGetResult(
 			@NonNull final ExternalSystemScriptedExportConversionConfig config,
 			final int recordId,
-			@Nullable final ExternalSystemInvocationContext errorContext)
+			@NonNull final ExternalSystemInvocationContext errorContext)
 	{
 		final int configTableId = tableDAO.retrieveTableId(I_ExternalSystem_Config_ScriptedExportConversion.Table_Name);
 		final TableRecordReference sourceRecord = TableRecordReference.of(config.getTableId(), recordId);
@@ -438,12 +438,8 @@ public class ExternalSystemScriptedExportConversionService
 					.setAD_ProcessByClassname(InvokeScriptedExportConversionAction.class.getName())
 					.addParameter(PARAM_EXTERNAL_REQUEST, COMMAND_CONVERT_MESSAGE_FROM_METASFRESH)
 					.addParameter(PARAM_CHILD_CONFIG_ID, config.getId().getRepoId())
-					.addParameter(PARAM_Record_ID, recordId);
-
-			if (errorContext != null)
-			{
-				processInfoBuilder.addParameter(PARAM_ERROR_CONTEXT, errorContext.getCode());
-			}
+					.addParameter(PARAM_Record_ID, recordId)
+					.addParameter(PARAM_ERROR_CONTEXT, errorContext.getCode());
 
 			final ProcessInfo processInfo = processInfoBuilder.buildAndPrepareExecution().executeSync().getProcessInfo();
 			final ProcessExecutionResult result = processInfo.getResult();

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportConversionStatus.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportConversionStatus.java
@@ -1,0 +1,56 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.error.AdIssueId;
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.process.PInstanceId;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.With;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.springframework.http.HttpStatus;
+
+import javax.annotation.Nullable;
+
+/**
+ * Loaded shape of one row of {@code ExternalSystem_ScriptedExportConversion_Status}.
+ *
+ * <p>Grain: one row per (ExternalSystem_Config_ScriptedExportConversion_ID, AD_Table_ID, Record_ID).
+ * Use {@link ScriptedExportConversionStatusCreateRequest} for inserts.
+ */
+@Value
+@Builder
+@With
+public class ScriptedExportConversionStatus
+{
+	@Nullable PInstanceId pInstanceId;
+	@NonNull ExternalSystemScriptedExportConversionConfigId configId;
+	@NonNull TableRecordReference sourceRecord;
+	@NonNull ExternalSystemExportStatus status;
+	@Nullable HttpStatus httpResponseCode;
+	@Nullable AdIssueId adIssueId;
+	@Nullable String statusMessage;
+	boolean isResend;
+}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportConversionStatusCreateRequest.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportConversionStatusCreateRequest.java
@@ -1,0 +1,52 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.error.AdIssueId;
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.process.PInstanceId;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.springframework.http.HttpStatus;
+
+import javax.annotation.Nullable;
+
+/**
+ * Insert shape for a {@code ExternalSystem_ScriptedExportConversion_Status} row.
+ * The loaded/read shape is {@link ScriptedExportConversionStatus}.
+ */
+@Value
+@Builder
+public class ScriptedExportConversionStatusCreateRequest
+{
+	@Nullable PInstanceId pInstanceId;
+	@NonNull ExternalSystemScriptedExportConversionConfigId configId;
+	@NonNull TableRecordReference sourceRecord;
+	@NonNull ExternalSystemExportStatus status;
+	@Nullable HttpStatus httpResponseCode;
+	@Nullable AdIssueId adIssueId;
+	@Nullable String statusMessage;
+	boolean isResend;
+}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportStatusErrorListener.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportStatusErrorListener.java
@@ -1,0 +1,77 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.externalsystem.IExternalSystemInvocationErrorListener;
+import de.metas.externalsystem.ExternalSystemInvocationContext;
+import de.metas.logging.LogManager;
+import de.metas.process.PInstanceId;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+/**
+ * Error listener for Scripted Export Conversion.
+ * Updates the {@code ExternalSystem_ScriptedExportConversion_Status} row to {@code Error}
+ * when an external system invocation fails, and links the {@code AD_Issue} created for
+ * this invocation.
+ *
+ * <p>This listener applies to <em>all</em> invocation contexts — it uses the {@code pInstanceId}
+ * to look up the matching log row and is a no-op (no throw) when no matching row exists
+ * (safety: the pInstanceId may belong to a different external system invocation).
+ *
+ * <p>The {@link IExternalSystemInvocationErrorListener} SPI does not provide the
+ * {@code AD_Issue_ID} directly. Instead, {@link ExternalSystemExportStatusService#markError}
+ * creates an {@code AD_Issue} via {@code IErrorManager} and links it to the status row.
+ */
+@Component
+@RequiredArgsConstructor
+public class ScriptedExportStatusErrorListener implements IExternalSystemInvocationErrorListener
+{
+	private static final Logger logger = LogManager.getLogger(ScriptedExportStatusErrorListener.class);
+
+	@NonNull private final ExternalSystemExportStatusService exportStatusService;
+
+	/**
+	 * Always returns {@code true} — this listener dispatches by {@code pInstanceId}, not by context:
+	 * it looks up the matching log row and is a no-op when no row exists, making it safe to consult
+	 * for every invocation context.
+	 */
+	@Override
+	public boolean applies(@NonNull final ExternalSystemInvocationContext context)
+	{
+		return true;
+	}
+
+	@Override
+	public void onInvocationError(
+			@NonNull final PInstanceId pInstanceId,
+			@NonNull final ExternalSystemInvocationContext context,
+			@NonNull final String errorMessage)
+	{
+		logger.debug("Handling invocation error for pInstanceId={}, context={}", pInstanceId, context);
+		// adIssueId=null: markError creates the AD_Issue via IErrorManager
+		exportStatusService.markError(pInstanceId, null, errorMessage);
+	}
+}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportStatusSuccessListener.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportStatusSuccessListener.java
@@ -1,0 +1,72 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.externalsystem.ExternalSystemInvocationContext;
+import de.metas.externalsystem.IExternalSystemInvocationSuccessListener;
+import de.metas.logging.LogManager;
+import de.metas.process.PInstanceId;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+/**
+ * Success listener for Scripted Export Conversion.
+ * Updates the {@code ExternalSystem_ScriptedExportConversion_Status} row to {@code Sent}
+ * when an external system invocation succeeds, and stores the HTTP response status.
+ *
+ * <p>This listener applies to <em>all</em> invocation contexts — it dispatches by {@code pInstanceId},
+ * not by context: it looks up the matching log row and is a no-op (no throw) when no matching row
+ * exists (safety: the pInstanceId may belong to a different external system invocation).
+ */
+@Component
+@RequiredArgsConstructor
+public class ScriptedExportStatusSuccessListener implements IExternalSystemInvocationSuccessListener
+{
+	private static final Logger logger = LogManager.getLogger(ScriptedExportStatusSuccessListener.class);
+
+	@NonNull private final ExternalSystemExportStatusService exportStatusService;
+
+	/**
+	 * Always returns {@code true} — this listener dispatches by {@code pInstanceId}, not by context:
+	 * it looks up the matching log row and is a no-op when no row exists, making it safe to consult
+	 * for every invocation context.
+	 */
+	@Override
+	public boolean applies(@NonNull final ExternalSystemInvocationContext context)
+	{
+		return true;
+	}
+
+	@Override
+	public void onInvocationSuccess(
+			@NonNull final PInstanceId pInstanceId,
+			@NonNull final ExternalSystemInvocationContext context,
+			@NonNull final HttpStatus httpStatus)
+	{
+		logger.debug("Handling invocation success for pInstanceId={}, context={}, httpStatus={}", pInstanceId, context, httpStatus);
+		exportStatusService.markSent(pInstanceId, httpStatus);
+	}
+}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/interceptor/ExternalSystemScriptedExportConversionInterceptor.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/interceptor/ExternalSystemScriptedExportConversionInterceptor.java
@@ -140,10 +140,12 @@ import org.jetbrains.annotations.Nullable;
 		if (timing == ModelValidator.TIMING_AFTER_COMPLETE
 				&& !documentBL.isReversalDocument(po))
 		{
-			// After commit because it might be a postgrest process that is executed here, so on complete changes need to be present in db
-			externalSystemScriptedExportConversionService
-					.getMatchingTriggerOnCompleteConfigsByTableAndClientId(AdTableAndClientId.of(AdTableId.ofRepoId(po.get_Table_ID()), ClientId.ofRepoId(getAD_Client_ID())), po.get_ID())
-					.forEach(config -> externalSystemScriptedExportConversionService.executeInvokeScriptedExportConversionActionAfterCommit(config, po.get_ID()));
+			// Eligibility status writes run in the current transaction; the export invocation is scheduled
+			// after-commit (a postgrest process may run it, so the completed record must be visible in the db).
+			final int recordId = po.get_ID();
+			externalSystemScriptedExportConversionService.recordCompleteTimeEligibilityAndScheduleInvocation(
+					AdTableAndClientId.of(AdTableId.ofRepoId(po.get_Table_ID()), ClientId.ofRepoId(getAD_Client_ID())),
+					recordId);
 		}
 
 		return null;

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/M_InOut_ReSend_ScriptedExportConversion.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/M_InOut_ReSend_ScriptedExportConversion.java
@@ -1,0 +1,83 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion.process;
+
+import de.metas.externalsystem.ExternalSystemInvocationContext;
+import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionConfig;
+import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionConfigId;
+import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionService;
+import de.metas.process.JavaProcess;
+import de.metas.process.ProcessPreconditionsResolution;
+import de.metas.process.IProcessPrecondition;
+import de.metas.process.IProcessPreconditionsContext;
+import lombok.NonNull;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_M_InOut;
+
+import java.util.List;
+
+/**
+ * Re-triggers the scripted-export-conversion for any config with a non-Sent attempt for this M_InOut.
+ */
+public class M_InOut_ReSend_ScriptedExportConversion extends JavaProcess implements IProcessPrecondition
+{
+	private final ExternalSystemScriptedExportConversionService scriptedExportService =
+			SpringContextHolder.instance.getBean(ExternalSystemScriptedExportConversionService.class);
+
+	@Override
+	public ProcessPreconditionsResolution checkPreconditionsApplicable(@NonNull final IProcessPreconditionsContext context)
+	{
+		if (context.getSelectedIncludedRecords().size() > 1)
+		{
+			return ProcessPreconditionsResolution.rejectBecauseNotSingleSelection();
+		}
+		return ProcessPreconditionsResolution.accept();
+	}
+
+	@Override
+	protected String doIt()
+	{
+		final int m_inout_id = getRecord_ID();
+		final TableRecordReference sourceRecord = TableRecordReference.of(I_M_InOut.Table_Name, m_inout_id);
+
+		final List<ExternalSystemScriptedExportConversionConfigId> configIds =
+				scriptedExportService.getResendableConfigsBySourceRecord(sourceRecord);
+
+		int triggered = 0;
+		for (final ExternalSystemScriptedExportConversionConfigId configId : configIds)
+		{
+			final ExternalSystemScriptedExportConversionConfig config =
+					scriptedExportService.resolveConfigAndRecordPendingAsResend(configId, sourceRecord);
+
+			scriptedExportService.executeInvokeScriptedExportConversionActionAndGetResult(
+					config,
+					m_inout_id,
+					ExternalSystemInvocationContext.RESEND);
+
+			triggered++;
+		}
+
+		return "@Processed@ #" + triggered;
+	}
+}

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5806780_sys_ExternalSystem_ExportStatus_RefList.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5806780_sys_ExternalSystem_ExportStatus_RefList.sql
@@ -1,0 +1,129 @@
+-- me03 30088: EPCIS Error-Handling & Retry
+-- Adds AD_Reference (List) 'ExternalSystem_ExportStatus' that unifies the export-status
+-- vocabulary across external-system integrations. Codes and semantics mirror EDI's
+-- EDIExportStatus (AD_Reference 540381) 1:1; EN/DE labels mirror EDI's labels so the two
+-- vocabularies stay semantically unified.
+--
+-- Vocabulary (Value -> ValueName -> meaning):
+--   P -> Pending        : not yet sent
+--   U -> Enqueued       : queued for async sending
+--   D -> SendingStarted : transmission running
+--   S -> Sent           : sent
+--   E -> Error          : transmission error
+--   I -> Invalid        : data error (master data not correctly set up)
+--   N -> DontSend       : must not be sent
+--
+-- IDs allocated from idserver.metas.de on 2026-06-08:
+--   AD_Reference 542104
+--   AD_Ref_List  544252 (P), 544253 (U), 544254 (D), 544255 (S),
+--                544256 (E), 544257 (I), 544258 (N)
+
+-- 1) AD_Reference (List container) -------------------------------------------------------
+INSERT INTO AD_Reference (AD_Client_ID, IsActive, Created, CreatedBy, IsOrderByValue,
+  Updated, UpdatedBy, AD_Reference_ID, ValidationType, Name, AD_Org_ID, EntityType)
+VALUES (0, 'Y', TO_TIMESTAMP('2026-06-08 10:00:00','YYYY-MM-DD HH24:MI:SS'), 100, 'N',
+  TO_TIMESTAMP('2026-06-08 10:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+  542104 /*From ID Server*/, 'L', 'ExternalSystem_ExportStatus', 0, 'de.metas.externalsystem');
+
+-- 2) AD_Reference_Trl (skeleton for every active system non-base language) ----------------
+INSERT INTO AD_Reference_Trl (AD_Language, AD_Reference_ID, Help, Name, Description,
+  IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Reference_ID, t.Help, t.Name, t.Description,
+  'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Reference t
+WHERE l.IsActive='Y'
+  AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y')
+  AND t.AD_Reference_ID=542104
+  AND NOT EXISTS (SELECT 1 FROM AD_Reference_Trl tt
+    WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID);
+
+-- 3) AD_Ref_List entries (German in Name; EN via _Trl below) ------------------------------
+INSERT INTO AD_Ref_List (AD_Reference_ID, AD_Client_ID, IsActive, Created, CreatedBy,
+  Name, Updated, UpdatedBy, AD_Ref_List_ID, ValueName, Value, AD_Org_ID, Description, EntityType)
+VALUES (542104, 0, 'Y', TO_TIMESTAMP('2026-06-08 10:00:01','YYYY-MM-DD HH24:MI:SS'), 100,
+  'Noch nicht gesendet', TO_TIMESTAMP('2026-06-08 10:00:01','YYYY-MM-DD HH24:MI:SS'), 100,
+  544252 /*From ID Server*/, 'Pending', 'P', 0, NULL, 'de.metas.externalsystem');
+
+INSERT INTO AD_Ref_List (AD_Reference_ID, AD_Client_ID, IsActive, Created, CreatedBy,
+  Name, Updated, UpdatedBy, AD_Ref_List_ID, ValueName, Value, AD_Org_ID, Description, EntityType)
+VALUES (542104, 0, 'Y', TO_TIMESTAMP('2026-06-08 10:00:02','YYYY-MM-DD HH24:MI:SS'), 100,
+  'Übertragung läuft', TO_TIMESTAMP('2026-06-08 10:00:02','YYYY-MM-DD HH24:MI:SS'), 100,
+  544253 /*From ID Server*/, 'Enqueued', 'U', 0,
+  'Wie "Übertragung läuft", jedoch als asynchron laufend gekennzeichnet', 'de.metas.externalsystem');
+
+INSERT INTO AD_Ref_List (AD_Reference_ID, AD_Client_ID, IsActive, Created, CreatedBy,
+  Name, Updated, UpdatedBy, AD_Ref_List_ID, ValueName, Value, AD_Org_ID, Description, EntityType)
+VALUES (542104, 0, 'Y', TO_TIMESTAMP('2026-06-08 10:00:03','YYYY-MM-DD HH24:MI:SS'), 100,
+  'Übertragung läuft', TO_TIMESTAMP('2026-06-08 10:00:03','YYYY-MM-DD HH24:MI:SS'), 100,
+  544254 /*From ID Server*/, 'SendingStarted', 'D', 0, NULL, 'de.metas.externalsystem');
+
+INSERT INTO AD_Ref_List (AD_Reference_ID, AD_Client_ID, IsActive, Created, CreatedBy,
+  Name, Updated, UpdatedBy, AD_Ref_List_ID, ValueName, Value, AD_Org_ID, Description, EntityType)
+VALUES (542104, 0, 'Y', TO_TIMESTAMP('2026-06-08 10:00:04','YYYY-MM-DD HH24:MI:SS'), 100,
+  'Gesendet', TO_TIMESTAMP('2026-06-08 10:00:04','YYYY-MM-DD HH24:MI:SS'), 100,
+  544255 /*From ID Server*/, 'Sent', 'S', 0, NULL, 'de.metas.externalsystem');
+
+INSERT INTO AD_Ref_List (AD_Reference_ID, AD_Client_ID, IsActive, Created, CreatedBy,
+  Name, Updated, UpdatedBy, AD_Ref_List_ID, ValueName, Value, AD_Org_ID, Description, EntityType)
+VALUES (542104, 0, 'Y', TO_TIMESTAMP('2026-06-08 10:00:05','YYYY-MM-DD HH24:MI:SS'), 100,
+  'Übertragungsfehler', TO_TIMESTAMP('2026-06-08 10:00:05','YYYY-MM-DD HH24:MI:SS'), 100,
+  544256 /*From ID Server*/, 'Error', 'E', 0, NULL, 'de.metas.externalsystem');
+
+INSERT INTO AD_Ref_List (AD_Reference_ID, AD_Client_ID, IsActive, Created, CreatedBy,
+  Name, Updated, UpdatedBy, AD_Ref_List_ID, ValueName, Value, AD_Org_ID, Description, EntityType)
+VALUES (542104, 0, 'Y', TO_TIMESTAMP('2026-06-08 10:00:06','YYYY-MM-DD HH24:MI:SS'), 100,
+  'Daten Fehler', TO_TIMESTAMP('2026-06-08 10:00:06','YYYY-MM-DD HH24:MI:SS'), 100,
+  544257 /*From ID Server*/, 'Invalid', 'I', 0,
+  'Einige Stammdaten sind nicht korrekt eingerichtet. Bitte die Fehlermeldung beachten', 'de.metas.externalsystem');
+
+INSERT INTO AD_Ref_List (AD_Reference_ID, AD_Client_ID, IsActive, Created, CreatedBy,
+  Name, Updated, UpdatedBy, AD_Ref_List_ID, ValueName, Value, AD_Org_ID, Description, EntityType)
+VALUES (542104, 0, 'Y', TO_TIMESTAMP('2026-06-08 10:00:07','YYYY-MM-DD HH24:MI:SS'), 100,
+  'Soll nicht gesendet werden', TO_TIMESTAMP('2026-06-08 10:00:07','YYYY-MM-DD HH24:MI:SS'), 100,
+  544258 /*From ID Server*/, 'DontSend', 'N', 0, NULL, 'de.metas.externalsystem');
+
+-- 4) AD_Ref_List_Trl skeleton for every active system non-base language --------------------
+INSERT INTO AD_Ref_List_Trl (AD_Language, AD_Ref_List_ID, Name, Description,
+  IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Ref_List_ID, t.Name, t.Description,
+  'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive='Y'
+  AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y')
+  AND t.AD_Ref_List_ID IN (544252,544253,544254,544255,544256,544257,544258)
+  AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt
+    WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID);
+
+-- 5) English (en_US) translations ---------------------------------------------------------
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Pending',
+  Updated=TO_TIMESTAMP('2026-06-08 10:00:10','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language='en_US' AND AD_Ref_List_ID=544252;
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Enqueued',
+  Updated=TO_TIMESTAMP('2026-06-08 10:00:11','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language='en_US' AND AD_Ref_List_ID=544253;
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Sending Started',
+  Updated=TO_TIMESTAMP('2026-06-08 10:00:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language='en_US' AND AD_Ref_List_ID=544254;
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Sent',
+  Updated=TO_TIMESTAMP('2026-06-08 10:00:13','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language='en_US' AND AD_Ref_List_ID=544255;
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Error',
+  Updated=TO_TIMESTAMP('2026-06-08 10:00:14','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language='en_US' AND AD_Ref_List_ID=544256;
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Invalid', Description='Data problem',
+  Updated=TO_TIMESTAMP('2026-06-08 10:00:15','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language='en_US' AND AD_Ref_List_ID=544257;
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Don''t Send',
+  Updated=TO_TIMESTAMP('2026-06-08 10:00:16','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language='en_US' AND AD_Ref_List_ID=544258;
+
+-- 6a) Mark AD_Reference_Trl de_DE / de_CH as actively translated (name already German in base) --
+UPDATE AD_Reference_Trl SET IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-06-08 10:00:20','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language IN ('de_DE','de_CH') AND AD_Reference_ID=542104;
+
+-- 6b) Mark de_DE / de_CH as actively translated (text already German in base) ---------------
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-06-08 10:00:20','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language IN ('de_DE','de_CH')
+    AND AD_Ref_List_ID IN (544252,544253,544254,544255,544256,544257,544258);

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5806830_sys_me03_30088_M_InOut_ReSend_ScriptedExportConversion.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5806830_sys_me03_30088_M_InOut_ReSend_ScriptedExportConversion.sql
@@ -1,0 +1,113 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+-- me03 30088: EPCIS Error-Handling & Retry — Phase 5.1
+-- Per-record "Re-send EPCIS export" AD process on M_InOut.
+-- Re-triggers the scripted-export-conversion for any config with a non-Sent latest attempt.
+--
+-- IDs allocated from idserver.metas.de on 2026-06-09:
+--   AD_Process_ID     585633   (M_InOut_ReSend_ScriptedExportConversion)
+--   AD_Table_Process  541648   (M_InOut table binding)
+
+-- 1) AD_Process -----------------------------------------------------------------------
+INSERT INTO AD_Process
+    (AD_Process_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     Value, Name,
+     Classname,
+     IsReport, IsFormatExcelFile, EntityType,
+     AccessLevel, Type, ShowHelp, IsBetaFunctionality)
+VALUES
+    (585633 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-06-09 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-09 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'M_InOut_ReSend_ScriptedExportConversion',
+     'EPCIS-Export erneut senden (Scripted Export Conversion)',
+     'de.metas.externalsystem.scriptedexportconversion.process.M_InOut_ReSend_ScriptedExportConversion',
+     'N', 'Y', 'de.metas.externalsystem',
+     '3', 'Java', 'Y', 'N')
+;
+
+-- 2) AD_Process_Trl skeleton -----------------------------------------------------------
+INSERT INTO AD_Process_Trl
+    (AD_Language, AD_Process_ID, Description, Help, Name,
+     IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language,
+       t.AD_Process_ID,
+       t.Description,
+       t.Help,
+       t.Name,
+       'N',
+       t.AD_Client_ID,
+       t.AD_Org_ID,
+       t.Created,
+       t.CreatedBy,
+       t.Updated,
+       t.UpdatedBy,
+       'Y'
+FROM AD_Language l,
+     AD_Process t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Process_ID = 585633
+  AND NOT EXISTS (SELECT 1
+                  FROM AD_Process_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language
+                    AND tt.AD_Process_ID = t.AD_Process_ID)
+;
+
+-- 3) AD_Process_Trl: set en_US and German translations --------------------------------
+UPDATE AD_Process_Trl
+SET Name         = 'Re-send EPCIS export (Scripted Export Conversion)',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-09 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'en_US'
+  AND AD_Process_ID = 585633
+;
+
+UPDATE AD_Process_Trl
+SET Name         = 'EPCIS-Export erneut senden (Scripted Export Conversion)',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-09 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language IN ('de_CH', 'de_DE')
+  AND AD_Process_ID = 585633
+;
+
+-- 4) AD_Table_Process: bind to M_InOut (AD_Table_ID=319) as a document action --------
+INSERT INTO AD_Table_Process
+    (AD_Client_ID, AD_Org_ID,
+     AD_Process_ID, AD_Table_ID, AD_Table_Process_ID,
+     Created, CreatedBy,
+     EntityType, IsActive,
+     Updated, UpdatedBy,
+     WEBUI_DocumentAction, WEBUI_IncludedTabTopAction, WEBUI_ViewAction,
+     WEBUI_ViewQuickAction, WEBUI_ViewQuickAction_Default)
+VALUES
+    (0, 0,
+     585633 /*From ID Server*/, 319 /*M_InOut*/, 541648 /*From ID Server*/,
+     TO_TIMESTAMP('2026-06-09 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'de.metas.externalsystem', 'Y',
+     TO_TIMESTAMP('2026-06-09 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'Y', 'N', 'Y',
+     'N', 'N')
+;

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5806850_sys_me03_30088_ExternalSystem_ScriptedExportConversion_Status.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5806850_sys_me03_30088_ExternalSystem_ScriptedExportConversion_Status.sql
@@ -1,0 +1,319 @@
+-- me03 30088: EPCIS Error-Handling & Retry
+-- Adds the physical table ExternalSystem_ScriptedExportConversion_Status plus its
+-- AD_Table / AD_Element / AD_Column metadata.
+-- One row per (config, AD_Table_ID, Record_ID) — the authoritative per-record export state.
+-- Grain is different from the Log table (one attempt per row): Status has exactly one row
+-- per source record and is upserted on every export attempt.
+--
+-- Columns:
+--   PK + 7 standard columns (AD_Client_ID, AD_Org_ID, IsActive, Created/By, Updated/By)
+--   ExternalSystem_Config_ScriptedExportConversion_ID : mandatory FK -> config
+--   AD_Table_ID                                       : mandatory FK -> AD_Table
+--   Record_ID                                         : mandatory integer
+--   ExportStatus                                      : ref-list -> AD_Reference 542104 (codes P/U/D/S/E/I/N, existing)
+--   AD_PInstance_ID                                   : nullable FK -> AD_PInstance (in-flight run / callback correlation)
+--   AD_Issue_ID                                       : nullable FK -> AD_Issue
+--   HttpResponseCode                                  : nullable integer
+--   StatusMessage                                     : nullable text
+--   IsResend                                          : boolean, default 'N', mandatory
+--
+-- UNIQUE constraint on (ExternalSystem_Config_ScriptedExportConversion_ID, AD_Table_ID, Record_ID)
+-- uses short index name ExtSysScriptedExpConv_Status_uq to stay within Postgres's 63-char limit.
+--
+-- WebUI window / child tab: intentionally deferred to phase R7 of the 30088 rework
+-- (see ai-work/30088/PLAN-REWORK.md). This table is framework-internal until then.
+--
+-- Reused system AD_Element_IDs:
+--   102  AD_Client_ID  | 113  AD_Org_ID     | 348 IsActive
+--   245  Created       | 246  CreatedBy      | 607 Updated  | 608 UpdatedBy
+--   126  AD_Table_ID   | 538  Record_ID
+--   584101 ExternalSystem_Config_ScriptedExportConversion_ID
+--   114  AD_PInstance_ID  | 2887 AD_Issue_ID
+--   577791 ExportStatus (existing element)
+--   584955 StatusMessage  | 584956 HttpResponseCode | 584957 IsResend  (created in this script, section 3.14b)
+--
+-- IDs allocated from idserver.metas.de on 2026-06-09:
+--   AD_Table   542617
+--   AD_Element 584965 (PK: ExternalSystem_ScriptedExportConversion_Status_ID)
+--   AD_Column  592773 (PK)
+--              592774 (AD_Client_ID),  592775 (AD_Org_ID),  592776 (IsActive)
+--              592777 (Created),       592778 (CreatedBy),  592779 (Updated), 592780 (UpdatedBy)
+--              592781 (ExternalSystem_Config_ScriptedExportConversion_ID)
+--              592782 (AD_Table_ID),   592783 (Record_ID)
+--              592784 (ExportStatus),  592785 (AD_PInstance_ID), 592786 (AD_Issue_ID)
+--              592787 (HttpResponseCode), 592788 (StatusMessage)
+-- (IsResend reuses AD_Column for the new table; a fresh AD_Column ID is included above via 592780..588)
+
+-- ============================================================================
+-- 1) AD_Table
+-- ============================================================================
+INSERT INTO AD_Table (AccessLevel,ACTriggerLength,AD_Client_ID,AD_Org_ID,AD_Table_ID,CopyColumnsFromTable,Created,CreatedBy,EntityType,ImportTable,IsActive,IsAutocomplete,IsChangeLog,IsDeleteable,IsDLM,IsEnableRemoteCacheInvalidation,IsHighVolume,IsSecurityEnabled,IsView,LoadSeq,Name,PersonalDataCategory,ReplicationType,TableName,TooltipType,Updated,UpdatedBy)
+VALUES ('4',0,0,0,542617 /*From ID Server*/,'N',TO_TIMESTAMP('2026-06-09 09:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.externalsystem','N','Y','N','N','Y','N','N','N','N','N',0,'ExternalSystem_ScriptedExportConversion_Status','NP','L','ExternalSystem_ScriptedExportConversion_Status','DTI',TO_TIMESTAMP('2026-06-09 09:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Table_Trl (AD_Language,AD_Table_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Table_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Table t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Table_ID=542617
+  AND NOT EXISTS (SELECT 1 FROM AD_Table_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Table_ID=t.AD_Table_ID)
+;
+
+-- ============================================================================
+-- 2) New AD_Element for the PK column (all other columns reuse existing elements)
+-- ============================================================================
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,584965 /*From ID Server*/,0,'ExternalSystem_ScriptedExportConversion_Status_ID',TO_TIMESTAMP('2026-06-09 09:00:02','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.externalsystem','Y','ExternalSystem_ScriptedExportConversion_Status','ExternalSystem_ScriptedExportConversion_Status',TO_TIMESTAMP('2026-06-09 09:00:02','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Element_ID=584965
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+-- Mark de_DE / de_CH as actively translated (base German text is correct)
+UPDATE AD_Element_Trl SET IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-06-09 09:00:15','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language IN ('de_DE','de_CH')
+    AND AD_Element_ID=584965;
+-- Set proper en_US English translation (R1-cleanup: fix missing English name)
+UPDATE AD_Element_Trl
+  SET IsTranslated='Y',
+      Name='ExternalSystem Scripted Export Conversion Status',
+      PrintName='ExternalSystem Scripted Export Conversion Status',
+      Updated=TO_TIMESTAMP('2026-06-09 09:00:20','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language='en_US'
+    AND AD_Element_ID=584965;
+-- Propagate translations to AD_Column_Trl and any other _Trl tables linked to this element
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584965);
+
+-- ============================================================================
+-- 3) AD_Columns
+-- ============================================================================
+
+-- 3.1 PK ----------------------------------------------------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592773 /*From ID Server*/,584965,0,13,542617,'ExternalSystem_ScriptedExportConversion_Status_ID',TO_TIMESTAMP('2026-06-09 09:01:00','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',10,'Y','N','N','N','N','N','N','Y','Y','N','N','Y','N','N','ExternalSystem_ScriptedExportConversion_Status','NP',0,TO_TIMESTAMP('2026-06-09 09:01:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592773 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(584965);
+
+-- 3.2 AD_Client_ID ------------------------------------------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592774 /*From ID Server*/,102,0,19,542617,'AD_Client_ID',TO_TIMESTAMP('2026-06-09 09:01:01','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',10,'Y','Y','N','N','N','N','N','N','Y','N','N','Y','N','N','Mandant','NP',0,TO_TIMESTAMP('2026-06-09 09:01:01','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592774 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(102);
+
+-- 3.3 AD_Org_ID ---------------------------------------------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592775 /*From ID Server*/,113,0,30,542617,'AD_Org_ID',TO_TIMESTAMP('2026-06-09 09:01:02','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',10,'Y','Y','N','N','N','N','N','N','Y','N','Y','Y','N','N','Sektion','NP',10,TO_TIMESTAMP('2026-06-09 09:01:02','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592775 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(113);
+
+-- 3.4 IsActive ----------------------------------------------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592776 /*From ID Server*/,348,0,20,542617,'IsActive',TO_TIMESTAMP('2026-06-09 09:01:03','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',1,'Y','Y','N','N','N','N','N','N','Y','N','N','Y','N','Y','Aktiv','NP',0,TO_TIMESTAMP('2026-06-09 09:01:03','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592776 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(348);
+
+-- 3.5 Created -----------------------------------------------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592777 /*From ID Server*/,245,0,16,542617,'Created',TO_TIMESTAMP('2026-06-09 09:01:04','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',29,'Y','N','N','N','N','N','N','N','Y','N','N','Y','N','N','Erstellt','NP',0,TO_TIMESTAMP('2026-06-09 09:01:04','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592777 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(245);
+
+-- 3.6 CreatedBy ---------------------------------------------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592778 /*From ID Server*/,246,0,18,110,542617,'CreatedBy',TO_TIMESTAMP('2026-06-09 09:01:05','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',10,'Y','N','N','N','N','N','N','N','Y','N','N','Y','N','N','Erstellt durch','NP',0,TO_TIMESTAMP('2026-06-09 09:01:05','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592778 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(246);
+
+-- 3.7 Updated -----------------------------------------------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592779 /*From ID Server*/,607,0,16,542617,'Updated',TO_TIMESTAMP('2026-06-09 09:01:06','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',29,'Y','N','N','N','N','N','N','N','Y','N','N','Y','N','N','Aktualisiert','NP',0,TO_TIMESTAMP('2026-06-09 09:01:06','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592779 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(607);
+
+-- 3.8 UpdatedBy ---------------------------------------------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592780 /*From ID Server*/,608,0,18,110,542617,'UpdatedBy',TO_TIMESTAMP('2026-06-09 09:01:07','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',10,'Y','N','N','N','N','N','N','N','Y','N','N','Y','N','N','Aktualisiert durch','NP',0,TO_TIMESTAMP('2026-06-09 09:01:07','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592780 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(608);
+
+-- 3.9 ExternalSystem_Config_ScriptedExportConversion_ID (mandatory FK -> config) --
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592781 /*From ID Server*/,584101,0,19,542617,'ExternalSystem_Config_ScriptedExportConversion_ID',TO_TIMESTAMP('2026-06-09 09:01:08','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',10,'Y','N','N','N','N','N','N','N','Y','N','N','Y','N','Y','ExternalSystem_Config_ScriptedExportConversion','NP',0,TO_TIMESTAMP('2026-06-09 09:01:08','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592781 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(584101);
+
+-- 3.10 AD_Table_ID (mandatory, part of unique grain) --------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592782 /*From ID Server*/,126,0,30,542617,'AD_Table_ID',TO_TIMESTAMP('2026-06-09 09:01:09','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',10,'Y','N','N','N','N','N','N','N','Y','N','N','Y','N','Y','DB-Tabelle','NP',0,TO_TIMESTAMP('2026-06-09 09:01:09','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592782 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(126);
+
+-- 3.11 Record_ID (mandatory, part of unique grain) ----------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592783 /*From ID Server*/,538,0,11,542617,'Record_ID',TO_TIMESTAMP('2026-06-09 09:01:10','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',10,'Y','N','N','N','N','N','N','N','Y','N','N','Y','N','Y','Datensatz-ID','NP',0,TO_TIMESTAMP('2026-06-09 09:01:10','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592783 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(538);
+
+-- 3.12 ExportStatus (ref-list -> AD_Reference 542104) -------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592784 /*From ID Server*/,577791,0,17,542104,542617,'ExportStatus',TO_TIMESTAMP('2026-06-09 09:01:11','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',1,'Y','N','N','N','N','N','N','N','Y','N','N','Y','N','Y','Export Status','NP',0,TO_TIMESTAMP('2026-06-09 09:01:11','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592784 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(577791);
+
+-- 3.13 AD_PInstance_ID (nullable FK -> AD_PInstance) --------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592785 /*From ID Server*/,114,0,19,542617,'AD_PInstance_ID',TO_TIMESTAMP('2026-06-09 09:01:12','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',10,'Y','N','N','N','N','N','N','N','N','N','N','Y','N','Y','Prozess-Instanz','NP',0,TO_TIMESTAMP('2026-06-09 09:01:12','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592785 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(114);
+
+-- 3.14 AD_Issue_ID (nullable FK -> AD_Issue) ----------------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592786 /*From ID Server*/,2887,0,19,542617,'AD_Issue_ID',TO_TIMESTAMP('2026-06-09 09:01:13','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',10,'Y','N','N','N','N','N','N','N','N','N','N','Y','N','Y','Probleme','NP',0,TO_TIMESTAMP('2026-06-09 09:01:13','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592786 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(2887);
+
+-- ============================================================================
+-- 3.14b) Relocated AD_Elements: 584955 StatusMessage, 584956 HttpResponseCode,
+--        584957 IsResend — originally in the now-deleted 5806790 Log script.
+--        Placed here (before the AD_Column inserts that reference them) to make
+--        this script self-contained on a fresh DB apply.
+-- ============================================================================
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,584955 /*From ID Server*/,0,'StatusMessage',TO_TIMESTAMP('2026-06-08 11:00:04','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.externalsystem','Y','Status-Meldung','Status-Meldung',TO_TIMESTAMP('2026-06-08 11:00:04','YYYY-MM-DD HH24:MI:SS'),100)
+ON CONFLICT (AD_Element_ID) DO NOTHING
+;
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=584955
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Status Message', PrintName='Status Message',
+  Updated=TO_TIMESTAMP('2026-06-08 11:00:15','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language='en_US' AND AD_Element_ID=584955;
+
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,584956 /*From ID Server*/,0,'HttpResponseCode',TO_TIMESTAMP('2026-06-08 11:00:05','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.externalsystem','Y','HTTP-Antwortcode','HTTP-Antwortcode',TO_TIMESTAMP('2026-06-08 11:00:05','YYYY-MM-DD HH24:MI:SS'),100)
+ON CONFLICT (AD_Element_ID) DO NOTHING
+;
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=584956
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='HTTP Response Code', PrintName='HTTP Response Code',
+  Updated=TO_TIMESTAMP('2026-06-08 11:00:16','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language='en_US' AND AD_Element_ID=584956;
+
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,584957 /*From ID Server*/,0,'IsResend',TO_TIMESTAMP('2026-06-08 11:00:06','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.externalsystem','Y','Erneut gesendet','Erneut gesendet',TO_TIMESTAMP('2026-06-08 11:00:06','YYYY-MM-DD HH24:MI:SS'),100)
+ON CONFLICT (AD_Element_ID) DO NOTHING
+;
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=584957
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Resend', PrintName='Resend',
+  Updated=TO_TIMESTAMP('2026-06-08 11:00:17','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language='en_US' AND AD_Element_ID=584957;
+
+-- Mark de_DE / de_CH as actively translated (base German text already correct)
+UPDATE AD_Element_Trl SET IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-06-08 11:00:20','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language IN ('de_DE','de_CH')
+    AND AD_Element_ID IN (584955, 584956, 584957);
+
+-- 3.15 HttpResponseCode (nullable integer) ------------------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592787 /*From ID Server*/,584956,0,11,542617,'HttpResponseCode',TO_TIMESTAMP('2026-06-09 09:01:14','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',10,'Y','N','N','N','N','N','N','N','N','N','N','Y','N','Y','HTTP-Antwortcode','NP',0,TO_TIMESTAMP('2026-06-09 09:01:14','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592787 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(584956);
+
+-- 3.16 StatusMessage (nullable text) ------------------------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592788 /*From ID Server*/,584955,0,10,542617,'StatusMessage',TO_TIMESTAMP('2026-06-09 09:01:15','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.externalsystem',255,'Y','N','N','N','N','N','N','N','N','N','N','Y','N','Y','Status-Meldung','NP',0,TO_TIMESTAMP('2026-06-09 09:01:15','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592788 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(584955);
+
+-- NOTE: IsResend column reuses AD_Element 584957 (created by the relocated block above, section 3.14b).
+-- A fresh AD_Column ID is needed for the column on THIS table; see section 4.17 below.
+
+-- ============================================================================
+-- 4) Physical table + columns
+-- ============================================================================
+/* DDL */ CREATE TABLE public.ExternalSystem_ScriptedExportConversion_Status (
+  AD_Client_ID       NUMERIC(10)  NOT NULL,
+  AD_Org_ID          NUMERIC(10)  NOT NULL,
+  Created            TIMESTAMP WITH TIME ZONE NOT NULL,
+  CreatedBy          NUMERIC(10)  NOT NULL,
+  ExternalSystem_ScriptedExportConversion_Status_ID NUMERIC(10) NOT NULL,
+  IsActive           CHAR(1)      CHECK (IsActive IN ('Y','N')) NOT NULL,
+  Updated            TIMESTAMP WITH TIME ZONE NOT NULL,
+  UpdatedBy          NUMERIC(10)  NOT NULL,
+  CONSTRAINT ExternalSystem_ScriptedExportConversion_Status_Key
+    PRIMARY KEY (ExternalSystem_ScriptedExportConversion_Status_ID)
+);
+
+/* DDL */ SELECT public.db_alter_table('ExternalSystem_ScriptedExportConversion_Status','ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ADD COLUMN ExternalSystem_Config_ScriptedExportConversion_ID NUMERIC(10) NOT NULL');
+/* DDL */ SELECT public.db_alter_table('ExternalSystem_ScriptedExportConversion_Status','ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ADD COLUMN AD_Table_ID NUMERIC(10) NOT NULL');
+/* DDL */ SELECT public.db_alter_table('ExternalSystem_ScriptedExportConversion_Status','ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ADD COLUMN Record_ID NUMERIC(10) NOT NULL');
+/* DDL */ SELECT public.db_alter_table('ExternalSystem_ScriptedExportConversion_Status','ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ADD COLUMN ExportStatus VARCHAR(1) NOT NULL');
+/* DDL */ SELECT public.db_alter_table('ExternalSystem_ScriptedExportConversion_Status','ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ADD COLUMN AD_PInstance_ID NUMERIC(10)');
+/* DDL */ SELECT public.db_alter_table('ExternalSystem_ScriptedExportConversion_Status','ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ADD COLUMN AD_Issue_ID NUMERIC(10)');
+/* DDL */ SELECT public.db_alter_table('ExternalSystem_ScriptedExportConversion_Status','ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ADD COLUMN HttpResponseCode NUMERIC(10)');
+/* DDL */ SELECT public.db_alter_table('ExternalSystem_ScriptedExportConversion_Status','ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ADD COLUMN StatusMessage VARCHAR(255)');
+/* DDL */ SELECT public.db_alter_table('ExternalSystem_ScriptedExportConversion_Status','ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ADD COLUMN IsResend CHAR(1) DEFAULT ''N'' CHECK (IsResend IN (''Y'',''N''))');
+UPDATE public.ExternalSystem_ScriptedExportConversion_Status SET IsResend='N' WHERE IsResend IS NULL;
+/* DDL */ SELECT public.db_alter_table('ExternalSystem_ScriptedExportConversion_Status','ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ALTER COLUMN IsResend SET NOT NULL');
+
+-- ============================================================================
+-- 4.17) AD_Column for IsResend — reuses AD_Element 584957 (created in section 3.14b above)
+-- ============================================================================
+-- ID 592789 allocated from idserver.metas.de on 2026-06-09
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,DefaultValue,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsCalculated,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592789 /*From ID Server*/,584957,0,20,542617,'IsResend',TO_TIMESTAMP('2026-06-09 09:01:16','YYYY-MM-DD HH24:MI:SS'),100,'N','N','de.metas.externalsystem',1,'Y','N','N','N','N','N','N','N','Y','N','N','Y','N','Y','Erneut gesendet','NP',0,TO_TIMESTAMP('2026-06-09 09:01:16','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592789 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+/* DDL */ select update_Column_Translation_From_AD_Element(584957);
+
+-- ============================================================================
+-- 5) Foreign-key constraints
+-- ============================================================================
+ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ADD CONSTRAINT ADTable_ExtSysScrExpConvStatus FOREIGN KEY (AD_Table_ID) REFERENCES public.AD_Table DEFERRABLE INITIALLY DEFERRED;
+ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ADD CONSTRAINT ExtSysCfgScrExpConv_ExtSysScrExpConvStatus FOREIGN KEY (ExternalSystem_Config_ScriptedExportConversion_ID) REFERENCES public.ExternalSystem_Config_ScriptedExportConversion DEFERRABLE INITIALLY DEFERRED;
+ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ADD CONSTRAINT ADPInstance_ExtSysScrExpConvStatus FOREIGN KEY (AD_PInstance_ID) REFERENCES public.AD_PInstance DEFERRABLE INITIALLY DEFERRED;
+ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ADD CONSTRAINT ADIssue_ExtSysScrExpConvStatus FOREIGN KEY (AD_Issue_ID) REFERENCES public.AD_Issue DEFERRABLE INITIALLY DEFERRED;
+
+-- ============================================================================
+-- 6) ExportStatus ref-list check constraint
+-- ============================================================================
+ALTER TABLE public.ExternalSystem_ScriptedExportConversion_Status ADD CONSTRAINT ExportStatus_ExtSysScrExpConvStatus_Check CHECK (ExportStatus IN ('P','U','D','S','E','I','N'));
+
+-- ============================================================================
+-- 7) UNIQUE index on (config, AD_Table_ID, Record_ID)
+--    Explicit short name to stay under Postgres's 63-char identifier limit.
+-- ============================================================================
+CREATE UNIQUE INDEX ExtSysScriptedExpConv_Status_uq
+  ON public.ExternalSystem_ScriptedExportConversion_Status
+    (ExternalSystem_Config_ScriptedExportConversion_ID, AD_Table_ID, Record_ID);

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5806870_sys_me03_30088_M_InOut_EPCIS_ExportStatus_virtual.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5806870_sys_me03_30088_M_InOut_EPCIS_ExportStatus_virtual.sql
@@ -1,0 +1,86 @@
+-- me03 30088: EPCIS Error-Handling & Retry
+-- Adds M_InOut.EPCIS_ExportStatus as a VIRTUAL (ColumnSQL) AD_Column.
+-- No physical column or CHECK constraint — IsSyncDatabase='N' makes it virtual.
+-- AD_Element 584959 (EPCIS_ExportStatus) is created here (relocated from the now-deleted
+-- 5806810 script) to make this script self-contained on a fresh DB apply.
+-- AD_Column 592752 (physical) was dropped in R1.2; this is a fresh virtual column.
+--
+-- The ColumnSql is a ranked-aggregate over ExternalSystem_ScriptedExportConversion_Status:
+--   Rank {E,I}→1 (error/invalid), {P,U,D}→2 (in-flight), {S,N}→3 (sent/skip);
+--   tie-break by latest Updated; LIMIT 1.
+--
+-- IDs allocated from idserver.metas.de on 2026-06-09:
+--   AD_Column  592790  (M_InOut.EPCIS_ExportStatus virtual)
+
+-- ============================================================================
+-- 1) AD_Element 584959 (EPCIS_ExportStatus) — relocated from deleted 5806810
+--    script; idempotency guard ensures safe re-apply on a DB that already has it.
+-- ============================================================================
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy,
+  Updated, UpdatedBy, ColumnName, EntityType, Name, PrintName)
+VALUES (584959 /*From ID Server*/, 0, 0, 'Y',
+  TO_TIMESTAMP('2026-06-08 15:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+  TO_TIMESTAMP('2026-06-08 15:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+  'EPCIS_ExportStatus', 'de.metas.externalsystem', 'EPCIS-Exportstatus', 'EPCIS-Exportstatus')
+ON CONFLICT (AD_Element_ID) DO NOTHING;
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Name, PrintName, Description, Help,
+  IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.Name, t.PrintName, t.Description, t.Help,
+  'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y')
+  AND t.AD_Element_ID=584959
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt
+    WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID);
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='EPCIS Export Status', PrintName='EPCIS Export Status',
+  Updated=TO_TIMESTAMP('2026-06-08 15:00:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language='en_US' AND AD_Element_ID=584959;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-06-08 15:00:13','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language IN ('de_DE','de_CH') AND AD_Element_ID=584959;
+
+-- ============================================================================
+-- 2) AD_Column — virtual List(17) column, IsSyncDatabase='N', ColumnSql set
+-- ============================================================================
+INSERT INTO AD_Column (AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy,
+  Updated, UpdatedBy, AD_Element_ID, AD_Table_ID, ColumnName, Name, Version,
+  AD_Reference_ID, AD_Reference_Value_ID, AD_Val_Rule_ID, EntityType, IsKey, IsParent,
+  IsMandatory, IsUpdateable, IsIdentifier, IsTranslated, IsEncrypted, IsSelectionColumn,
+  SeqNo, IsAllowLogging, IsAutocomplete, IsCalculated, PersonalDataCategory, FieldLength,
+  IsGenericZoomKeyColumn, IsGenericZoomOrigin, IsForceIncludeInGeneratedModel,
+  IsLazyLoading, IsUseDocSequence, ColumnSql, IsStaleable, IsSyncDatabase)
+VALUES (592790 /*From ID Server*/, 0, 0, 'Y',
+  TO_TIMESTAMP('2026-06-09 10:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+  TO_TIMESTAMP('2026-06-09 10:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+  584959 /*AD_Element EPCIS_ExportStatus*/, 319 /*M_InOut*/, 'EPCIS_ExportStatus', 'EPCIS-Exportstatus', 0,
+  17 /*List*/, 542104 /*ExternalSystem_ExportStatus*/, NULL,
+  'de.metas.externalsystem', 'N', 'N',
+  'N', 'N' /*read-only virtual column*/,
+  'N', 'N', 'N', 'N',
+  0, 'Y',
+  'N', 'N', 'NP', 1 /*fieldlength=1 like EDI counterpart*/,
+  'N', 'N', 'Y' /*IsForceIncludeInGeneratedModel: must be Y so the model generator includes
+                  this non-D entity-type column in the base I_M_InOut interface*/,
+  'N', 'N',
+  '(select s.ExportStatus from ExternalSystem_ScriptedExportConversion_Status s
+ where s.AD_Table_ID=319 and s.Record_ID=M_InOut.M_InOut_ID and s.IsActive=''Y''
+ order by case s.ExportStatus when ''E'' then 1 when ''I'' then 1 when ''P'' then 2 when ''U'' then 2 when ''D'' then 2 when ''S'' then 3 when ''N'' then 3 else 4 end, s.Updated desc
+ limit 1)',
+  'N', 'N' /*IsSyncDatabase=N → virtual, no physical column sync*/)
+ON CONFLICT (AD_Column_ID) DO NOTHING;
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, Description, IsTranslated,
+  AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, NULL, 'N',
+  t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y'
+  AND t.AD_Column_ID=592790
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt
+    WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+
+-- Propagate element translations → column (element id, not column id) ------------------
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584959);

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807070_sys_me03_30088_Shipment_EPCIS_StatusTab.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807070_sys_me03_30088_Shipment_EPCIS_StatusTab.sql
@@ -1,0 +1,520 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+-- me03 30088: EPCIS Error-Handling & Retry — Phase R7 (Window UI)
+-- Surfaces EPCIS export status on the Lieferung window (AD_Window_ID=169):
+--   1. EPCIS_ExportStatus field (AD_Column 592790, virtual aggregate) on header tab (AD_Tab 257),
+--      placed after EDI-Sendestatus (seqno=80, seqnogrid=100) in group 1000029, right column 1000015.
+--      Read-only — the value is system-computed.
+--   2. Read-only child tab over ExternalSystem_ScriptedExportConversion_Status (AD_Table 542617),
+--      showing per-config status rows for the current shipment. WhereClause filters by
+--      AD_Table_ID=319 + Record_ID=@M_InOut_ID@. Ordered newest-first (Updated DESC).
+--      Columns: ExportStatus, Exportkonfiguration, HttpResponseCode, StatusMessage, IsResend,
+--               AD_PInstance_ID, Updated.
+--   3. Re-send action: AD_Process 585633 is already bound to M_InOut (AD_Table_Process 541648)
+--      by migration 5806830 — confirmed present, no duplicate inserted here.
+--   4. AD_SQLColumn_SourceTableColumn entry tying the virtual column 592790 (M_InOut.EPCIS_ExportStatus)
+--      to its source table 542617 (ExternalSystem_ScriptedExportConversion_Status), so the WebUI
+--      virtual-column cache is invalidated whenever a status row changes.
+--
+-- IDs allocated from idserver.metas.de on 2026-06-09:
+--   AD_Field          780740  (M_InOut header tab: EPCIS_ExportStatus)
+--   AD_UI_Element     652035  (M_InOut header tab: EPCIS_ExportStatus)
+--   AD_Element        584966  (tab caption: EPCIS-Exportstatus)
+--   AD_Tab            549295  (Status child tab)
+--   AD_UI_Section     547812  (Status tab section)
+--   AD_UI_Column      549544  (Status tab column)
+--   AD_UI_ElementGroup 555432 (Status tab element group)
+--   AD_Field          780741  (status tab: ExportStatus)
+--   AD_UI_Element     652036  (status tab: ExportStatus)
+--   AD_Field          780742  (status tab: ExternalSystem_Config_ScriptedExportConversion_ID)
+--   AD_UI_Element     652037  (status tab: ExternalSystem_Config_ScriptedExportConversion_ID)
+--   AD_Field          780743  (status tab: HttpResponseCode)
+--   AD_UI_Element     652038  (status tab: HttpResponseCode)
+--   AD_Field          780744  (status tab: StatusMessage)
+--   AD_UI_Element     652039  (status tab: StatusMessage)
+--   AD_Field          780745  (status tab: IsResend)
+--   AD_UI_Element     652040  (status tab: IsResend)
+--   AD_Field          780746  (status tab: AD_PInstance_ID)
+--   AD_UI_Element     652041  (status tab: AD_PInstance_ID)
+--   AD_Field          780747  (status tab: Updated)
+--   AD_UI_Element     652042  (status tab: Updated)
+--   AD_SQLColumn_SourceTableColumn 540199  (cache: EPCIS_ExportStatus → _Status table)
+
+-- ===========================================================================
+-- PART 1: EPCIS_ExportStatus field on Shipment header tab
+-- ===========================================================================
+
+-- 1a) AD_Field on tab 257 (Lieferung header), pointing at AD_Column 592790 (EPCIS_ExportStatus virtual)
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592790 /*EPCIS_ExportStatus virtual column*/, 780740 /*From ID Server*/, 0, 257 /*Lieferung header tab*/,
+     TO_TIMESTAMP('2026-06-09 10:10:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 14, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y' /*read-only — value is system-computed virtual column*/,
+     'N', 'EPCIS-Exportstatus', 560, 110,
+     0, 1, 1,
+     TO_TIMESTAMP('2026-06-09 10:10:00', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+
+-- 1b) AD_Field_Trl skeleton rows
+INSERT INTO AD_Field_Trl
+    (AD_Language, AD_Field_ID, Description, Help, Name,
+     IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Field_ID = 780740
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID)
+;
+
+-- 1c) Propagate element translations → field (pass AD_Element_ID 584959 = EPCIS_ExportStatus element)
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584959);
+
+-- 1d) Rebuild element links
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 780740;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(780740);
+
+-- 1e) AD_UI_Element — placed in 'dates' element group (1000029), right column (1000015)
+--     after EDI-Sendestatus (seqno=80, seqnogrid=100); seqno=90, seqnogrid=110
+INSERT INTO AD_UI_Element
+    (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+     Created, CreatedBy, IsActive, IsAdvancedField,
+     IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+     Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+     Updated, UpdatedBy)
+VALUES
+    (0, 780740 /*EPCIS_ExportStatus field*/, 0, 257 /*Lieferung header tab*/,
+     1000029 /*dates group*/, 652035 /*From ID Server*/, 'F',
+     TO_TIMESTAMP('2026-06-09 10:10:10', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'Y', 'N',
+     'Y', 'Y', 'N',
+     'EPCIS-Exportstatus', 90, 110, 0,
+     TO_TIMESTAMP('2026-06-09 10:10:10', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+
+-- ===========================================================================
+-- PART 2: AD_Element for the child tab caption
+-- ===========================================================================
+
+-- 2a) AD_Element for the tab caption (AD_Tab.AD_Element_ID is NOT NULL in metasfresh)
+INSERT INTO AD_Element
+    (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive,
+     Created, CreatedBy, Updated, UpdatedBy,
+     ColumnName, EntityType, Name, PrintName)
+VALUES
+    (584966 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-06-09 10:10:20', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-09 10:10:20', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'EPCIS_ExportStatus_Tab', 'de.metas.externalsystem',
+     'EPCIS-Exportstatus', 'EPCIS-Exportstatus')
+;
+
+INSERT INTO AD_Element_Trl
+    (AD_Language, AD_Element_ID, Name, PrintName, Description, Help,
+     IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.Name, t.PrintName, t.Description, t.Help,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Element_ID = 584966
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID)
+;
+
+-- en_US override
+UPDATE AD_Element_Trl
+SET Name = 'EPCIS Export Status', PrintName = 'EPCIS Export Status',
+    IsTranslated = 'Y',
+    Updated = TO_TIMESTAMP('2026-06-09 10:10:32', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy = 100
+WHERE AD_Language = 'en_US' AND AD_Element_ID = 584966
+;
+
+-- de_DE / de_CH: mark as translated (name matches the base German text)
+UPDATE AD_Element_Trl
+SET IsTranslated = 'Y',
+    Updated = TO_TIMESTAMP('2026-06-09 10:10:33', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy = 100
+WHERE AD_Language IN ('de_DE', 'de_CH') AND AD_Element_ID = 584966
+;
+
+-- ===========================================================================
+-- PART 3: Read-only child tab over ExternalSystem_ScriptedExportConversion_Status
+-- ===========================================================================
+
+-- 3a) AD_Tab — read-only, TabLevel=1, no insert, ordered newest-first (Updated DESC)
+--     Parent_Column_ID = 592783 (Record_ID in the _Status table, the FK into M_InOut via polymorphic link)
+--     WhereClause filters rows for the current M_InOut record via AD_Table_ID=319 + Record_ID context
+INSERT INTO AD_Tab
+    (AD_Client_ID, AD_Org_ID, AD_Tab_ID, AD_Table_ID, AD_Window_ID,
+     AD_Element_ID,
+     Created, CreatedBy, Description, EntityType,
+     HasTree, IsActive, IsAdvancedTab, IsCheckParentsChanged,
+     IsInfoTab, IsInsertRecord, IsReadOnly, IsRefreshAllOnActivate,
+     IsSearchActive, IsSingleRow, IsSortTab, IsTranslationTab,
+     Name, OrderByClause, SeqNo, TabLevel,
+     Parent_Column_ID,
+     Updated, UpdatedBy,
+     WhereClause)
+VALUES
+    (0, 0, 549295 /*From ID Server*/, 542617 /*ExternalSystem_ScriptedExportConversion_Status*/, 169 /*Lieferung window*/,
+     584966 /*From ID Server*/,
+     TO_TIMESTAMP('2026-06-09 10:11:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 'de.metas.externalsystem',
+     'N', 'Y', 'N', 'N',
+     'N', 'N' /*no insert — status rows are system-written*/, 'Y' /*read-only*/, 'N',
+     'N', 'N', 'N', 'N',
+     'EPCIS-Exportstatus', 'Updated DESC', 60, 1,
+     592783 /*Record_ID column in _Status table — polymorphic FK to M_InOut*/,
+     TO_TIMESTAMP('2026-06-09 10:11:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'ExternalSystem_ScriptedExportConversion_Status.AD_Table_ID = 319 AND ExternalSystem_ScriptedExportConversion_Status.Record_ID = @M_InOut_ID/0@')
+;
+
+-- 3b) AD_Tab_Trl skeleton rows
+INSERT INTO AD_Tab_Trl
+    (AD_Language, AD_Tab_ID, CommitWarning, Description, Help, Name,
+     IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Tab_ID, t.CommitWarning, t.Description, t.Help, t.Name,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Tab t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Tab_ID = 549295
+  AND NOT EXISTS (SELECT 1 FROM AD_Tab_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Tab_ID = t.AD_Tab_ID)
+;
+
+-- en_US translation
+UPDATE AD_Tab_Trl
+SET Name         = 'EPCIS Export Status',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-09 10:11:12', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'en_US'
+  AND AD_Tab_ID = 549295
+;
+
+-- de_DE / de_CH
+UPDATE AD_Tab_Trl
+SET Name         = 'EPCIS-Exportstatus',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-09 10:11:13', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language IN ('de_DE', 'de_CH')
+  AND AD_Tab_ID = 549295
+;
+
+-- ===========================================================================
+-- PART 4: UI layout for the status child tab (included tab — single element group)
+-- ===========================================================================
+
+-- 4a) AD_UI_Section (one per tab)
+INSERT INTO AD_UI_Section
+    (AD_UI_Section_ID, AD_Client_ID, AD_Org_ID, IsActive,
+     Created, CreatedBy, Updated, UpdatedBy, AD_Tab_ID, SeqNo, Value)
+VALUES
+    (547812 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-06-09 10:11:20', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-09 10:11:20', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     549295, 10, 'default')
+;
+
+-- 4b) Single UI column (included tabs use a single column)
+INSERT INTO AD_UI_Column
+    (AD_UI_Column_ID, AD_Client_ID, AD_Org_ID, IsActive,
+     Created, CreatedBy, Updated, UpdatedBy, AD_UI_Section_ID, SeqNo)
+VALUES
+    (549544 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-06-09 10:11:21', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-09 10:11:21', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     547812, 10)
+;
+
+-- 4c) Single element group (included tabs must have exactly 1 element group, UIStyle=NULL)
+INSERT INTO AD_UI_ElementGroup
+    (AD_UI_ElementGroup_ID, AD_Client_ID, AD_Org_ID, IsActive,
+     Created, CreatedBy, Updated, UpdatedBy, AD_UI_Column_ID, SeqNo, UIStyle, Name)
+VALUES
+    (555432 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-06-09 10:11:22', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-09 10:11:22', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     549544, 10, NULL, 'default')
+;
+
+-- ===========================================================================
+-- PART 5: AD_Field + AD_UI_Element rows for each status column
+-- Grid + form columns: ExportStatus, Exportkonfiguration, HttpResponseCode,
+--                      StatusMessage, IsResend, AD_PInstance_ID, Updated
+-- Updated shown last; sort indicator SortNo=-1 on Updated (Updated DESC per OrderByClause)
+-- ===========================================================================
+
+-- 5.1 ExportStatus (AD_Column 592784, AD_Element 577791)
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592784, 780741 /*From ID Server*/, 0, 549295,
+     TO_TIMESTAMP('2026-06-09 10:12:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 14, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y',
+     'N', 'Export Status', 10, 10,
+     0, 1, 1,
+     TO_TIMESTAMP('2026-06-09 10:12:00', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=780741
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(577791);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=780741;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(780741);
+UPDATE AD_Field_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-09 10:12:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=780741 AND AD_Language IN ('de_DE','de_CH','en_US');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 780741, 0, 549295, 555432, 652036 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-09 10:12:02','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'Export Status', 10, 10, 0, TO_TIMESTAMP('2026-06-09 10:12:02','YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- 5.2 ExternalSystem_Config_ScriptedExportConversion_ID (AD_Column 592781, AD_Element 584101)
+--     Field-level label override: 'Exportkonfiguration' / 'Export Configuration' (shared element not touched)
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592781, 780742 /*From ID Server*/, 0, 549295,
+     TO_TIMESTAMP('2026-06-09 10:12:03', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 14, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y',
+     'N', 'Exportkonfiguration', 20, 20,
+     0, 1, 1,
+     TO_TIMESTAMP('2026-06-09 10:12:03', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=780742
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584101);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=780742;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(780742);
+-- Field-level label override (shared element has raw technical name — override per-field only)
+UPDATE AD_Field_Trl SET Name='Exportkonfiguration', IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-06-09 10:12:04','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=780742 AND AD_Language IN ('de_DE','de_CH');
+UPDATE AD_Field_Trl SET Name='Export Configuration', IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-06-09 10:12:05','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=780742 AND AD_Language='en_US';
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 780742, 0, 549295, 555432, 652037 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-09 10:12:06','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'Exportkonfiguration', 20, 20, 0, TO_TIMESTAMP('2026-06-09 10:12:06','YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- 5.3 HttpResponseCode (AD_Column 592787, AD_Element 584956)
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592787, 780743 /*From ID Server*/, 0, 549295,
+     TO_TIMESTAMP('2026-06-09 10:12:07', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 10, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y',
+     'N', 'HTTP-Antwortcode', 30, 30,
+     0, 1, 1,
+     TO_TIMESTAMP('2026-06-09 10:12:07', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=780743
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584956);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=780743;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(780743);
+UPDATE AD_Field_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-09 10:12:08','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=780743 AND AD_Language IN ('de_DE','de_CH','en_US');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 780743, 0, 549295, 555432, 652038 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-09 10:12:09','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'HTTP-Antwortcode', 30, 30, 0, TO_TIMESTAMP('2026-06-09 10:12:09','YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- 5.4 StatusMessage (AD_Column 592788, AD_Element 584955)
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592788, 780744 /*From ID Server*/, 0, 549295,
+     TO_TIMESTAMP('2026-06-09 10:12:10', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 255, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y',
+     'N', 'Status-Meldung', 40, 40,
+     0, 1, 1,
+     TO_TIMESTAMP('2026-06-09 10:12:10', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=780744
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584955);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=780744;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(780744);
+UPDATE AD_Field_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-09 10:12:11','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=780744 AND AD_Language IN ('de_DE','de_CH','en_US');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 780744, 0, 549295, 555432, 652039 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-09 10:12:12','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'Status-Meldung', 40, 40, 0, TO_TIMESTAMP('2026-06-09 10:12:12','YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- 5.5 IsResend (AD_Column 592789, AD_Element 584957)
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592789, 780745 /*From ID Server*/, 0, 549295,
+     TO_TIMESTAMP('2026-06-09 10:12:13', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 1, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y',
+     'N', 'Erneut gesendet', 50, 50,
+     0, 1, 1,
+     TO_TIMESTAMP('2026-06-09 10:12:13', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=780745
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584957);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=780745;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(780745);
+UPDATE AD_Field_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-09 10:12:14','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=780745 AND AD_Language IN ('de_DE','de_CH','en_US');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 780745, 0, 549295, 555432, 652040 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-09 10:12:15','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'Erneut gesendet', 50, 50, 0, TO_TIMESTAMP('2026-06-09 10:12:15','YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- 5.6 AD_PInstance_ID (AD_Column 592785, AD_Element 114)
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592785, 780746 /*From ID Server*/, 0, 549295,
+     TO_TIMESTAMP('2026-06-09 10:12:16', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 14, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y',
+     'N', 'Prozess-Instanz', 60, 60,
+     0, 1, 1,
+     TO_TIMESTAMP('2026-06-09 10:12:16', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=780746
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(114);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=780746;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(780746);
+UPDATE AD_Field_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-09 10:12:17','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=780746 AND AD_Language IN ('de_DE','de_CH','en_US');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 780746, 0, 549295, 555432, 652041 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-09 10:12:18','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'Prozess-Instanz', 60, 60, 0, TO_TIMESTAMP('2026-06-09 10:12:18','YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- 5.7 Updated (AD_Column 592779, AD_Element 607)
+--     SortNo=-1: grid sort indicator matches OrderByClause='Updated DESC' on the tab
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592779, 780747 /*From ID Server*/, 0, 549295,
+     TO_TIMESTAMP('2026-06-09 10:12:19', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 29, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y',
+     'N', 'Aktualisiert', 70, 70,
+     -1 /*DESC sort indicator — matches OrderByClause='Updated DESC' on the tab*/, 1, 1,
+     TO_TIMESTAMP('2026-06-09 10:12:19', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=780747
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(607);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=780747;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(780747);
+UPDATE AD_Field_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-09 10:12:20','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=780747 AND AD_Language IN ('de_DE','de_CH','en_US');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 780747, 0, 549295, 555432, 652042 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-09 10:12:21','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'Aktualisiert', 70, 70, 0, TO_TIMESTAMP('2026-06-09 10:12:21','YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- ===========================================================================
+-- PART 6: AD_SQLColumn_SourceTableColumn — cache invalidation
+-- Ties virtual column M_InOut.EPCIS_ExportStatus (592790) to its source table
+-- ExternalSystem_ScriptedExportConversion_Status (542617), so the WebUI virtual-column
+-- cache is invalidated when a status row is inserted/updated for a given M_InOut record.
+-- ===========================================================================
+INSERT INTO AD_SQLColumn_SourceTableColumn
+    (AD_Client_ID, AD_Column_ID, AD_Org_ID, AD_SQLColumn_SourceTableColumn_ID,
+     AD_Table_ID,
+     Created, CreatedBy, IsActive,
+     Source_Table_ID,
+     FetchTargetRecordsMethod, SQL_GetTargetRecordIdBySourceRecordId,
+     Updated, UpdatedBy)
+VALUES
+    (0, 592790 /*M_InOut.EPCIS_ExportStatus virtual column*/, 0, 540199 /*From ID Server*/,
+     319 /*M_InOut — host table of the virtual column*/,
+     TO_TIMESTAMP('2026-06-09 10:13:00', 'YYYY-MM-DD HH24:MI:SS'), 100, 'Y',
+     542617 /*ExternalSystem_ScriptedExportConversion_Status — source of the aggregate*/,
+     -- polymorphic link (source carries AD_Table_ID+Record_ID, no direct FK): use SQL method
+     -- to map a changed status row back to its host M_InOut_ID (its Record_ID, filtered to this table)
+     'S', 'select Record_ID from ExternalSystem_ScriptedExportConversion_Status where ExternalSystem_ScriptedExportConversion_Status_ID=@Record_ID/-1@ and AD_Table_ID=319',
+     TO_TIMESTAMP('2026-06-09 10:13:00', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemExportStatusTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemExportStatusTest.java
@@ -1,0 +1,229 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2024 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.externalsystem.model.X_ExternalSystem_ScriptedExportConversion_Status;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExternalSystemExportStatusTest
+{
+	/** Every enum value round-trips: ofCode(getCode()) == enumValue */
+	@Test
+	void testCodeRoundTrip()
+	{
+		for (final ExternalSystemExportStatus status : ExternalSystemExportStatus.values())
+		{
+			assertThat(ExternalSystemExportStatus.ofCode(status.getCode()))
+					.as("round-trip for %s", status)
+					.isSameAs(status);
+		}
+	}
+
+	/** Exactly 7 codes and they match the X_ constants 1:1 */
+	@Test
+	void testExactlySevenCodesMatchingXConstants()
+	{
+		final Set<String> expectedCodes = ImmutableSet.of(
+				X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Pending,
+				X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Enqueued,
+				X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_SendingStarted,
+				X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Sent,
+				X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Error,
+				X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Invalid,
+				X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_DontSend
+		);
+
+		final Set<String> actualCodes = Arrays.stream(ExternalSystemExportStatus.values())
+				.map(ExternalSystemExportStatus::getCode)
+				.collect(Collectors.toSet());
+
+		assertThat(actualCodes).isEqualTo(expectedCodes);
+	}
+
+	/** Verify individual code values */
+	@Test
+	void testIndividualCodes()
+	{
+		assertThat(ExternalSystemExportStatus.Pending.getCode())
+				.isEqualTo(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Pending);
+		assertThat(ExternalSystemExportStatus.Enqueued.getCode())
+				.isEqualTo(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Enqueued);
+		assertThat(ExternalSystemExportStatus.SendingStarted.getCode())
+				.isEqualTo(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_SendingStarted);
+		assertThat(ExternalSystemExportStatus.Sent.getCode())
+				.isEqualTo(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Sent);
+		assertThat(ExternalSystemExportStatus.Error.getCode())
+				.isEqualTo(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Error);
+		assertThat(ExternalSystemExportStatus.Invalid.getCode())
+				.isEqualTo(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_Invalid);
+		assertThat(ExternalSystemExportStatus.DontSend.getCode())
+				.isEqualTo(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_DontSend);
+	}
+
+	/** Predicate methods: isError() */
+	@Test
+	void testIsError()
+	{
+		assertThat(ExternalSystemExportStatus.Error.isError()).isTrue();
+		for (final ExternalSystemExportStatus status : ExternalSystemExportStatus.values())
+		{
+			if (status != ExternalSystemExportStatus.Error)
+			{
+				assertThat(status.isError()).as("%s.isError() should be false", status).isFalse();
+			}
+		}
+	}
+
+	/** Predicate methods: isSent() */
+	@Test
+	void testIsSent()
+	{
+		assertThat(ExternalSystemExportStatus.Sent.isSent()).isTrue();
+		for (final ExternalSystemExportStatus status : ExternalSystemExportStatus.values())
+		{
+			if (status != ExternalSystemExportStatus.Sent)
+			{
+				assertThat(status.isSent()).as("%s.isSent() should be false", status).isFalse();
+			}
+		}
+	}
+
+	/** Predicate methods: isPending() */
+	@Test
+	void testIsPending()
+	{
+		assertThat(ExternalSystemExportStatus.Pending.isPending()).isTrue();
+		assertThat(ExternalSystemExportStatus.Enqueued.isPending()).isFalse();
+	}
+
+	/** isProcessing() = Enqueued OR SendingStarted (mirrors EDIExportStatus) */
+	@Test
+	void testIsProcessing()
+	{
+		assertThat(ExternalSystemExportStatus.Enqueued.isProcessing()).isTrue();
+		assertThat(ExternalSystemExportStatus.SendingStarted.isProcessing()).isTrue();
+
+		assertThat(ExternalSystemExportStatus.Pending.isProcessing()).isFalse();
+		assertThat(ExternalSystemExportStatus.Sent.isProcessing()).isFalse();
+		assertThat(ExternalSystemExportStatus.Error.isProcessing()).isFalse();
+		assertThat(ExternalSystemExportStatus.Invalid.isProcessing()).isFalse();
+		assertThat(ExternalSystemExportStatus.DontSend.isProcessing()).isFalse();
+	}
+
+	/** isProcessed() = Sent OR DontSend */
+	@Test
+	void testIsProcessed()
+	{
+		assertThat(ExternalSystemExportStatus.Sent.isProcessed()).isTrue();
+		assertThat(ExternalSystemExportStatus.DontSend.isProcessed()).isTrue();
+
+		assertThat(ExternalSystemExportStatus.Pending.isProcessed()).isFalse();
+		assertThat(ExternalSystemExportStatus.Enqueued.isProcessed()).isFalse();
+		assertThat(ExternalSystemExportStatus.SendingStarted.isProcessed()).isFalse();
+		assertThat(ExternalSystemExportStatus.Error.isProcessed()).isFalse();
+		assertThat(ExternalSystemExportStatus.Invalid.isProcessed()).isFalse();
+	}
+
+	/** isPendingOrError() */
+	@Test
+	void testIsPendingOrError()
+	{
+		assertThat(ExternalSystemExportStatus.Pending.isPendingOrError()).isTrue();
+		assertThat(ExternalSystemExportStatus.Error.isPendingOrError()).isTrue();
+
+		assertThat(ExternalSystemExportStatus.Sent.isPendingOrError()).isFalse();
+		assertThat(ExternalSystemExportStatus.Invalid.isPendingOrError()).isFalse();
+	}
+
+	/** isErrorOrInvalid() */
+	@Test
+	void testIsErrorOrInvalid()
+	{
+		assertThat(ExternalSystemExportStatus.Error.isErrorOrInvalid()).isTrue();
+		assertThat(ExternalSystemExportStatus.Invalid.isErrorOrInvalid()).isTrue();
+
+		assertThat(ExternalSystemExportStatus.Pending.isErrorOrInvalid()).isFalse();
+		assertThat(ExternalSystemExportStatus.Sent.isErrorOrInvalid()).isFalse();
+	}
+
+	/** isInvalid() */
+	@Test
+	void testIsInvalid()
+	{
+		assertThat(ExternalSystemExportStatus.Invalid.isInvalid()).isTrue();
+		assertThat(ExternalSystemExportStatus.Error.isInvalid()).isFalse();
+	}
+
+	/** isDontSend() */
+	@Test
+	void testIsDontSend()
+	{
+		assertThat(ExternalSystemExportStatus.DontSend.isDontSend()).isTrue();
+		assertThat(ExternalSystemExportStatus.Sent.isDontSend()).isFalse();
+	}
+
+	/** isEnqueued() */
+	@Test
+	void testIsEnqueued()
+	{
+		assertThat(ExternalSystemExportStatus.Enqueued.isEnqueued()).isTrue();
+		assertThat(ExternalSystemExportStatus.Pending.isEnqueued()).isFalse();
+	}
+
+	/** isSendingStarted() */
+	@Test
+	void testIsSendingStarted()
+	{
+		assertThat(ExternalSystemExportStatus.SendingStarted.isSendingStarted()).isTrue();
+		assertThat(ExternalSystemExportStatus.Enqueued.isSendingStarted()).isFalse();
+	}
+
+	/** isInProgressOrSend() — Enqueued, SendingStarted, Sent */
+	@Test
+	void testIsInProgressOrSend()
+	{
+		assertThat(ExternalSystemExportStatus.Enqueued.isInProgressOrSend()).isTrue();
+		assertThat(ExternalSystemExportStatus.SendingStarted.isInProgressOrSend()).isTrue();
+		assertThat(ExternalSystemExportStatus.Sent.isInProgressOrSend()).isTrue();
+
+		assertThat(ExternalSystemExportStatus.Pending.isInProgressOrSend()).isFalse();
+		assertThat(ExternalSystemExportStatus.Error.isInProgressOrSend()).isFalse();
+		assertThat(ExternalSystemExportStatus.Invalid.isInProgressOrSend()).isFalse();
+		assertThat(ExternalSystemExportStatus.DontSend.isInProgressOrSend()).isFalse();
+	}
+
+	/** AD_Reference_ID binding is 542104 */
+	@Test
+	void testAdReferenceId()
+	{
+		assertThat(ExternalSystemExportStatus.AD_Reference_ID)
+				.isEqualTo(X_ExternalSystem_ScriptedExportConversion_Status.EXPORTSTATUS_AD_Reference_ID);
+	}
+}

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusRepositoryTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusRepositoryTest.java
@@ -1,0 +1,272 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.error.AdIssueId;
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.externalsystem.model.I_ExternalSystem_ScriptedExportConversion_Status;
+import de.metas.process.PInstanceId;
+import de.metas.util.Services;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.table.api.IADTableDAO;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_M_InOut;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TDD test for {@link ExternalSystemExportStatusRepository}.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class ExternalSystemExportStatusRepositoryTest
+{
+	private ExternalSystemExportStatusRepository repo;
+	private ExternalSystemScriptedExportConversionConfigId configId;
+	private TableRecordReference sourceRecord;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		repo = ExternalSystemExportStatusRepository.newInstanceForUnitTesting();
+
+		configId = ExternalSystemScriptedExportConversionConfigId.ofRepoId(1001);
+
+		final int tableId = Services.get(IADTableDAO.class).retrieveTableId(I_M_InOut.Table_Name);
+		sourceRecord = TableRecordReference.of(tableId, 5001);
+	}
+
+	private ScriptedExportConversionStatusCreateRequest.ScriptedExportConversionStatusCreateRequestBuilder requestBuilder()
+	{
+		return ScriptedExportConversionStatusCreateRequest.builder()
+				.configId(configId)
+				.sourceRecord(sourceRecord)
+				.status(ExternalSystemExportStatus.Pending);
+	}
+
+	// -----------------------------------------------------------------------
+	// upsert — creates one row, then updates in-place on the same key
+	// -----------------------------------------------------------------------
+
+	@Test
+	void upsert_createsOneRow()
+	{
+		repo.upsert(requestBuilder().build());
+
+		assertThat(countStatusRows(configId, sourceRecord)).isEqualTo(1);
+	}
+
+	@Test
+	void upsert_updateInPlace_onSameKey()
+	{
+		repo.upsert(requestBuilder().status(ExternalSystemExportStatus.Pending).build());
+
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(777);
+		repo.upsert(requestBuilder()
+				.pInstanceId(pInstanceId)
+				.status(ExternalSystemExportStatus.Enqueued)
+				.build());
+
+		assertThat(countStatusRows(configId, sourceRecord)).isEqualTo(1);
+
+		final Optional<ScriptedExportConversionStatus> reloaded = repo.getLatestByPInstanceId(pInstanceId);
+		assertThat(reloaded).isPresent();
+		assertThat(reloaded.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Enqueued);
+		assertThat(reloaded.get().getPInstanceId()).isEqualTo(pInstanceId);
+	}
+
+	// -----------------------------------------------------------------------
+	// updateLatestByPInstanceId — applies operator to pInstance-bound row
+	// -----------------------------------------------------------------------
+
+	@Test
+	void updateLatestByPInstanceId_appliesOperator()
+	{
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(888);
+		repo.upsert(requestBuilder()
+				.pInstanceId(pInstanceId)
+				.status(ExternalSystemExportStatus.Enqueued)
+				.build());
+
+		repo.updateLatestByPInstanceId(pInstanceId,
+				e -> e.withStatus(ExternalSystemExportStatus.Sent).withHttpResponseCode(HttpStatus.OK));
+
+		final Optional<ScriptedExportConversionStatus> result = repo.getLatestByPInstanceId(pInstanceId);
+		assertThat(result).isPresent();
+		assertThat(result.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Sent);
+		assertThat(result.get().getHttpResponseCode()).isEqualTo(HttpStatus.OK);
+	}
+
+	@Test
+	void updateLatestByPInstanceId_noopWhenNoRow()
+	{
+		repo.updateLatestByPInstanceId(PInstanceId.ofRepoId(99999),
+				e -> e.withStatus(ExternalSystemExportStatus.Sent));
+	}
+
+	// -----------------------------------------------------------------------
+	// fromRecord / updateRecord round-trip
+	// -----------------------------------------------------------------------
+
+	@Test
+	void fromRecord_updateRecord_roundTrip()
+	{
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(999);
+
+		final ScriptedExportConversionStatus original = ScriptedExportConversionStatus.builder()
+				.pInstanceId(pInstanceId)
+				.configId(configId)
+				.sourceRecord(sourceRecord)
+				.status(ExternalSystemExportStatus.Error)
+				.httpResponseCode(HttpStatus.INTERNAL_SERVER_ERROR)
+				.adIssueId(AdIssueId.ofRepoId(42))
+				.statusMessage("Something went wrong")
+				.isResend(true)
+				.build();
+
+		final I_ExternalSystem_ScriptedExportConversion_Status record =
+				InterfaceWrapperHelper.newInstance(I_ExternalSystem_ScriptedExportConversion_Status.class);
+		ExternalSystemExportStatusRepository.updateRecord(record, original);
+		InterfaceWrapperHelper.saveRecord(record);
+
+		final ScriptedExportConversionStatus reloaded = ExternalSystemExportStatusRepository.fromRecord(record);
+
+		assertThat(reloaded.getPInstanceId()).isEqualTo(pInstanceId);
+		assertThat(reloaded.getConfigId()).isEqualTo(configId);
+		assertThat(reloaded.getSourceRecord()).isEqualTo(sourceRecord);
+		assertThat(reloaded.getStatus()).isEqualTo(ExternalSystemExportStatus.Error);
+		assertThat(reloaded.getHttpResponseCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+		assertThat(reloaded.getAdIssueId()).isEqualTo(AdIssueId.ofRepoId(42));
+		assertThat(reloaded.getStatusMessage()).isEqualTo("Something went wrong");
+		assertThat(reloaded.isResend()).isTrue();
+	}
+
+	// -----------------------------------------------------------------------
+	// httpResponseCode and adIssueId persisted correctly
+	// -----------------------------------------------------------------------
+
+	@Test
+	void upsert_persists_httpResponseCode_and_adIssueId()
+	{
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(1234);
+		repo.upsert(requestBuilder()
+				.pInstanceId(pInstanceId)
+				.status(ExternalSystemExportStatus.Error)
+				.httpResponseCode(HttpStatus.SERVICE_UNAVAILABLE)
+				.adIssueId(AdIssueId.ofRepoId(77))
+				.statusMessage("service unavailable")
+				.build());
+
+		final Optional<ScriptedExportConversionStatus> loaded = repo.getLatestByPInstanceId(pInstanceId);
+		assertThat(loaded).isPresent();
+		assertThat(loaded.get().getHttpResponseCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+		assertThat(loaded.get().getAdIssueId()).isEqualTo(AdIssueId.ofRepoId(77));
+		assertThat(loaded.get().getStatusMessage()).isEqualTo("service unavailable");
+	}
+
+	// -----------------------------------------------------------------------
+	// getConfigsWithNonSentAttemptBySourceRecord — filters correctly
+	// -----------------------------------------------------------------------
+
+	@Test
+	void getConfigsWithNonSentAttempt_returnsNonSentConfig()
+	{
+		repo.upsert(ScriptedExportConversionStatusCreateRequest.builder()
+				.configId(configId)
+				.sourceRecord(sourceRecord)
+				.status(ExternalSystemExportStatus.Error)
+				.build());
+
+		final ExternalSystemScriptedExportConversionConfigId configId2 = ExternalSystemScriptedExportConversionConfigId.ofRepoId(1002);
+		repo.upsert(ScriptedExportConversionStatusCreateRequest.builder()
+				.configId(configId2)
+				.sourceRecord(sourceRecord)
+				.status(ExternalSystemExportStatus.Sent)
+				.build());
+
+		final List<ExternalSystemScriptedExportConversionConfigId> nonSent =
+				repo.getConfigsWithNonSentAttemptBySourceRecord(sourceRecord);
+
+		assertThat(nonSent).containsExactly(configId);
+		assertThat(nonSent).doesNotContain(configId2);
+	}
+
+	// -----------------------------------------------------------------------
+	// getLatestByPInstanceId
+	// -----------------------------------------------------------------------
+
+	@Test
+	void getLatestByPInstanceId_returnsRow_afterUpsert()
+	{
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(4242);
+
+		repo.upsert(requestBuilder()
+				.pInstanceId(pInstanceId)
+				.status(ExternalSystemExportStatus.Sent)
+				.httpResponseCode(HttpStatus.OK)
+				.build());
+
+		final Optional<ScriptedExportConversionStatus> result = repo.getLatestByPInstanceId(pInstanceId);
+		assertThat(result).isPresent();
+		assertThat(result.get().getPInstanceId()).isEqualTo(pInstanceId);
+		assertThat(result.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Sent);
+		assertThat(result.get().getHttpResponseCode()).isEqualTo(HttpStatus.OK);
+	}
+
+	@Test
+	void getLatestByPInstanceId_returnsEmpty_whenNoRow()
+	{
+		final Optional<ScriptedExportConversionStatus> result =
+				repo.getLatestByPInstanceId(PInstanceId.ofRepoId(88888));
+		assertThat(result).isEmpty();
+	}
+
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	private long countStatusRows(
+			final ExternalSystemScriptedExportConversionConfigId cfgId,
+			final TableRecordReference srcRecord)
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_ExternalSystem_ScriptedExportConversion_Status.class)
+				.addEqualsFilter(
+						I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID,
+						cfgId.getRepoId())
+				.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_Table_ID, srcRecord.getAD_Table_ID())
+				.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_Record_ID, srcRecord.getRecord_ID())
+				.create()
+				.count();
+	}
+}

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
@@ -1,0 +1,369 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.error.AdIssueId;
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion;
+import de.metas.process.PInstanceId;
+import de.metas.util.Services;
+import org.adempiere.ad.table.api.IADTableDAO;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_M_InOut;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@ExtendWith(AdempiereTestWatcher.class)
+public class ExternalSystemExportStatusServiceTest
+{
+	private ExternalSystemExportStatusRepository repo;
+	private ExternalSystemExportStatusService service;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+
+		repo = ExternalSystemExportStatusRepository.newInstanceForUnitTesting();
+		service = ExternalSystemExportStatusService.newInstanceForUnitTesting();
+	}
+
+	private I_ExternalSystem_Config_ScriptedExportConversion createConfig(final int adTableId)
+	{
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg =
+				InterfaceWrapperHelper.newInstance(I_ExternalSystem_Config_ScriptedExportConversion.class);
+		cfg.setAD_Table_ID(adTableId);
+		cfg.setExternalSystemValue("test");
+		cfg.setScriptIdentifier("test.js");
+		cfg.setWhereClause("1=1");
+		cfg.setIsTriggerOnComplete(true);
+		cfg.setIsActive(true);
+		InterfaceWrapperHelper.saveRecord(cfg);
+		return cfg;
+	}
+
+	private TableRecordReference newInOutRef()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		return TableRecordReference.of(I_M_InOut.Table_Name, inout.getM_InOut_ID());
+	}
+
+	private ExternalSystemScriptedExportConversionConfigId newConfigId()
+	{
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg = createConfig(getM_InOutTableId());
+		return ExternalSystemScriptedExportConversionConfigId.ofRepoId(cfg.getExternalSystem_Config_ScriptedExportConversion_ID());
+	}
+
+	// -----------------------------------------------------------------------
+	// recordDontSend → terminal DontSend
+	// -----------------------------------------------------------------------
+	@Test
+	void recordDontSend_setsDontSendStatus()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+
+		service.recordDontSend(configId, ref);
+
+		final Optional<ScriptedExportConversionStatus> entry = repo.getLatestByConfigAndRecord(configId, ref);
+		assertThat(entry).isPresent();
+		assertThat(entry.get().getStatus()).isEqualTo(ExternalSystemExportStatus.DontSend);
+	}
+
+	// -----------------------------------------------------------------------
+	// recordPending → Pending
+	// -----------------------------------------------------------------------
+	@Test
+	void recordPending_createsPendingRow()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+
+		service.recordPending(configId, ref);
+
+		final Optional<ScriptedExportConversionStatus> entry = repo.getLatestByConfigAndRecord(configId, ref);
+		assertThat(entry).isPresent();
+		assertThat(entry.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Pending);
+	}
+
+	// -----------------------------------------------------------------------
+	// Pending → Enqueued → Sent
+	// -----------------------------------------------------------------------
+	@Test
+	void transitions_Pending_Enqueued_Sent()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(201);
+
+		service.recordPending(configId, ref);
+		service.markEnqueued(configId, ref, pInstanceId);
+		service.markSent(pInstanceId, HttpStatus.OK);
+
+		final Optional<ScriptedExportConversionStatus> entry = repo.getLatestByPInstanceId(pInstanceId);
+		assertThat(entry).isPresent();
+		assertThat(entry.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Sent);
+		assertThat(entry.get().getHttpResponseCode()).isEqualTo(HttpStatus.OK);
+	}
+
+	// -----------------------------------------------------------------------
+	// markEnqueued — at-most-one-in-flight guard: second call must not re-enqueue
+	// -----------------------------------------------------------------------
+	@Test
+	void markEnqueued_atMostOneInFlight_guardsAgainstDoubleEnqueue()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+		final PInstanceId first = PInstanceId.ofRepoId(701);
+		final PInstanceId second = PInstanceId.ofRepoId(702);
+
+		service.recordPending(configId, ref);
+		service.markEnqueued(configId, ref, first);
+		// already in-flight (Enqueued, not Pending) → second markEnqueued is a no-op
+		service.markEnqueued(configId, ref, second);
+
+		final Optional<ScriptedExportConversionStatus> entry = repo.getLatestByConfigAndRecord(configId, ref);
+		assertThat(entry).isPresent();
+		assertThat(entry.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Enqueued);
+		assertThat(entry.get().getPInstanceId()).isEqualTo(first);
+	}
+
+	// -----------------------------------------------------------------------
+	// markError records Error + issue ID + message
+	// -----------------------------------------------------------------------
+	@Test
+	void markError_setsErrorStatus()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(301);
+
+		service.recordPending(configId, ref);
+		service.markEnqueued(configId, ref, pInstanceId);
+		service.markError(pInstanceId, AdIssueId.ofRepoId(42), "Something went wrong");
+
+		final Optional<ScriptedExportConversionStatus> entry = repo.getLatestByPInstanceId(pInstanceId);
+		assertThat(entry).isPresent();
+		assertThat(entry.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Error);
+		assertThat(entry.get().getAdIssueId()).isEqualTo(AdIssueId.ofRepoId(42));
+		assertThat(entry.get().getStatusMessage()).isEqualTo("Something went wrong");
+	}
+
+	// -----------------------------------------------------------------------
+	// markInvalid records Invalid
+	// -----------------------------------------------------------------------
+	@Test
+	void markInvalid_setsInvalidStatus()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(401);
+
+		service.recordPending(configId, ref);
+		service.markEnqueued(configId, ref, pInstanceId);
+		service.markInvalid(pInstanceId, "Bad data");
+
+		final Optional<ScriptedExportConversionStatus> entry = repo.getLatestByPInstanceId(pInstanceId);
+		assertThat(entry).isPresent();
+		assertThat(entry.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Invalid);
+		assertThat(entry.get().getStatusMessage()).isEqualTo("Bad data");
+	}
+
+	// -----------------------------------------------------------------------
+	// markInvalidByRecord — pre-send revalidation failure (no pInstance)
+	// -----------------------------------------------------------------------
+	@Test
+	void markInvalidByRecord_setsInvalidStatus()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+
+		service.recordPending(configId, ref);
+		service.markInvalidByRecord(configId, ref, "revalidation failed");
+
+		final Optional<ScriptedExportConversionStatus> entry = repo.getLatestByConfigAndRecord(configId, ref);
+		assertThat(entry).isPresent();
+		assertThat(entry.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Invalid);
+	}
+
+	// -----------------------------------------------------------------------
+	// Roll-up: Error beats in-flight beats Sent
+	// -----------------------------------------------------------------------
+	@Test
+	void rollUp_Error_beats_inFlight_beats_Sent()
+	{
+		final TableRecordReference ref = newInOutRef();
+
+		final ExternalSystemScriptedExportConversionConfigId idA = newConfigId();
+		final PInstanceId pA = PInstanceId.ofRepoId(501);
+		service.recordPending(idA, ref);
+		service.markEnqueued(idA, ref, pA);
+		service.markSent(pA, HttpStatus.OK);
+
+		final ExternalSystemScriptedExportConversionConfigId idB = newConfigId();
+		service.recordPending(idB, ref);
+
+		final ExternalSystemScriptedExportConversionConfigId idC = newConfigId();
+		final PInstanceId pC = PInstanceId.ofRepoId(503);
+		service.recordPending(idC, ref);
+		service.markEnqueued(idC, ref, pC);
+		service.markError(pC, AdIssueId.ofRepoId(9), "oops");
+
+		final List<ScriptedExportConversionStatus> rows = repo.getLatestBySourceRecord(ref);
+		assertThat(service.computeRollUp(rows)).isEqualTo(ExternalSystemExportStatus.Error);
+	}
+
+	@Test
+	void rollUp_inFlight_beats_Sent()
+	{
+		final TableRecordReference ref = newInOutRef();
+
+		final ExternalSystemScriptedExportConversionConfigId idA = newConfigId();
+		final PInstanceId pA = PInstanceId.ofRepoId(601);
+		service.recordPending(idA, ref);
+		service.markEnqueued(idA, ref, pA);
+		service.markSent(pA, HttpStatus.OK);
+
+		final ExternalSystemScriptedExportConversionConfigId idB = newConfigId();
+		service.recordPending(idB, ref);
+
+		final List<ScriptedExportConversionStatus> rows = repo.getLatestBySourceRecord(ref);
+		assertThat(service.computeRollUp(rows)).isEqualTo(ExternalSystemExportStatus.Pending);
+	}
+
+	// -----------------------------------------------------------------------
+	// No-op / no-throw when pInstanceId has no matching status row
+	// -----------------------------------------------------------------------
+	@Test
+	void markSent_noopAndNoThrow_whenNoMatchingLogRow()
+	{
+		final PInstanceId unknownPInstance = PInstanceId.ofRepoId(99999);
+		assertThatCode(() -> service.markSent(unknownPInstance, HttpStatus.OK))
+				.doesNotThrowAnyException();
+	}
+
+	@Test
+	void markError_noopAndNoThrow_whenNoMatchingLogRow()
+	{
+		final PInstanceId unknownPInstance = PInstanceId.ofRepoId(99998);
+		assertThatCode(() -> service.markError(unknownPInstance, null, "msg"))
+				.doesNotThrowAnyException();
+	}
+
+	// -----------------------------------------------------------------------
+	// Upsert semantics: second transition on same key keeps a single row
+	// -----------------------------------------------------------------------
+	@Test
+	void upsert_sameRow_onSecondCall()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(901);
+
+		service.recordPending(configId, ref);
+		service.markEnqueued(configId, ref, pInstanceId);
+
+		final List<ScriptedExportConversionStatus> byConfig = repo.getByConfigId(configId);
+		assertThat(byConfig).hasSize(1);
+		assertThat(byConfig.get(0).getStatus()).isEqualTo(ExternalSystemExportStatus.Enqueued);
+	}
+
+	// -----------------------------------------------------------------------
+	// getResendableConfigsBySourceRecord — Error/Invalid-only filter
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A config with an in-flight (Pending) status must NOT be returned by the re-send
+	 * selection, to prevent double-sending a record that is already queued.
+	 */
+	@Test
+	void getResendableConfigs_excludes_pendingConfig()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+
+		service.recordPending(configId, ref); // stays Pending
+
+		final List<ExternalSystemScriptedExportConversionConfigId> result =
+				service.getResendableConfigsBySourceRecord(ref);
+
+		assertThat(result).isEmpty();
+	}
+
+	/**
+	 * A config with an Error status must be returned so the re-send process can retry it.
+	 */
+	@Test
+	void getResendableConfigs_includes_errorConfig()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(1101);
+
+		service.recordPending(configId, ref);
+		service.markEnqueued(configId, ref, pInstanceId);
+		service.markError(pInstanceId, AdIssueId.ofRepoId(99), "connection refused");
+
+		final List<ExternalSystemScriptedExportConversionConfigId> result =
+				service.getResendableConfigsBySourceRecord(ref);
+
+		assertThat(result).containsExactly(configId);
+	}
+
+	/**
+	 * A config with an Invalid status must be returned so the re-send process can retry it.
+	 */
+	@Test
+	void getResendableConfigs_includes_invalidConfig()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(1201);
+
+		service.recordPending(configId, ref);
+		service.markEnqueued(configId, ref, pInstanceId);
+		service.markInvalid(pInstanceId, "bad data");
+
+		final List<ExternalSystemScriptedExportConversionConfigId> result =
+				service.getResendableConfigsBySourceRecord(ref);
+
+		assertThat(result).containsExactly(configId);
+	}
+
+	private int getM_InOutTableId()
+	{
+		return Services.get(IADTableDAO.class).retrieveTableId(I_M_InOut.Table_Name);
+	}
+}

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionAuditWriteTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionAuditWriteTest.java
@@ -1,0 +1,165 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.externalsystem.ExternalSystemConfigRepo;
+import de.metas.externalsystem.ExternalSystemParentConfigId;
+import de.metas.externalsystem.ExternalSystemTestHelper;
+import de.metas.externalsystem.ExternalSystemType;
+import de.metas.externalsystem.audit.ExternalSystemExportAudit;
+import de.metas.externalsystem.audit.ExternalSystemExportAuditRepo;
+import de.metas.externalsystem.endpoint.ExternalSystemEndpointId;
+import de.metas.process.PInstanceId;
+import org.adempiere.ad.table.api.AdTableAndClientId;
+import org.adempiere.ad.table.api.AdTableId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_M_InOut;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link ExternalSystemScriptedExportConversionService#writeExportAudit}
+ * writes exactly one {@code ExternalSystem_ExportAudit} row carrying the expected
+ * pinstance, record reference, and external-system type.
+ *
+ * <p>The full DB-driven send→audit integration is covered by the cucumber suite;
+ * this test exercises only the extracted seam method.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class ExternalSystemScriptedExportConversionAuditWriteTest
+{
+	private ExternalSystemExportAuditRepo auditRepo;
+	private ExternalSystemScriptedExportConversionService service;
+
+	private static final ExternalSystemType SCRIPTED_TYPE = ExternalSystemType.ScriptedExportConversion;
+	private static final ExternalSystemParentConfigId PARENT_ID = ExternalSystemParentConfigId.ofRepoId(1);
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+
+		ExternalSystemTestHelper.createExternalSystemIfNotExists(SCRIPTED_TYPE);
+
+		auditRepo = ExternalSystemExportAuditRepo.newInstanceForUnitTesting();
+
+		// Mock ExternalSystemConfigRepo so that getParentTypeById(PARENT_ID) returns SCRIPTED_TYPE
+		final ExternalSystemConfigRepo configRepoMock = Mockito.mock(ExternalSystemConfigRepo.class);
+		Mockito.when(configRepoMock.getParentTypeById(PARENT_ID))
+				.thenReturn(SCRIPTED_TYPE.getValue());
+
+		service = new ExternalSystemScriptedExportConversionService(
+				ExternalSystemExportStatusService.newInstanceForUnitTesting(),
+				Mockito.mock(ExternalSystemScriptedExportConversionRepository.class),
+				Mockito.mock(de.metas.externalsystem.endpoint.ExternalSystemEndpointRepository.class),
+				auditRepo,
+				configRepoMock);
+	}
+
+	// -----------------------------------------------------------------------
+	// Helper factories
+	// -----------------------------------------------------------------------
+
+	private ExternalSystemScriptedExportConversionConfig buildConfig(
+			final ExternalSystemParentConfigId parentId,
+			final AdTableId tableId)
+	{
+		return ExternalSystemScriptedExportConversionConfig.builder()
+				.id(ExternalSystemScriptedExportConversionConfigId.ofRepoId(1))
+				.parentId(parentId)
+				.externalSystemEndpointId(ExternalSystemEndpointId.ofRepoId(1))
+				.value("test")
+				.scriptIdentifier("test.js")
+				.tableAndClientId(AdTableAndClientId.of(tableId, ClientId.ofRepoId(1)))
+				.whereClause("1=1")
+				.active(true)
+				.isTriggerOnComplete(true)
+				.build();
+	}
+
+	private I_M_InOut newInOut()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		return inout;
+	}
+
+	// -----------------------------------------------------------------------
+	// Core assertion: writeExportAudit persists a row with the right pinstance
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Given a source record and a pInstanceId,
+	 * {@code writeExportAudit} must persist an audit row
+	 * that carries the given pinstance and whose table-record reference
+	 * matches the source record.
+	 *
+	 * <p>This is the {@code _Status.AD_PInstance_ID → ExportAudit} correlation assertion:
+	 * both the status row and the audit row share the same pInstanceId.
+	 */
+	@Test
+	void writeExportAudit_persistsRowWithExpectedPinstanceAndRecord()
+	{
+		// Arrange
+		final I_M_InOut inout = newInOut();
+		final TableRecordReference sourceRecord = TableRecordReference.of(I_M_InOut.Table_Name, inout.getM_InOut_ID());
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(42);
+
+		final AdTableId tableId = AdTableId.ofRepoId(sourceRecord.getAD_Table_ID());
+		final ExternalSystemScriptedExportConversionConfig config = buildConfig(PARENT_ID, tableId);
+
+		// Act
+		service.writeExportAudit(config, sourceRecord, pInstanceId);
+
+		// Assert — the row is present and carries the expected pinstance
+		final Optional<ExternalSystemExportAudit> auditOpt =
+				auditRepo.getMostRecentByTableReferenceAndSystem(sourceRecord, SCRIPTED_TYPE);
+
+		assertThat(auditOpt)
+				.as("an audit row must have been written for the source record")
+				.isPresent();
+
+		final ExternalSystemExportAudit audit = auditOpt.get();
+		assertThat(audit.getPInstanceId())
+				.as("audit row must carry the pinstance passed at enqueue — _Status and ExportAudit both share this id")
+				.isEqualTo(pInstanceId);
+
+		assertThat(audit.getTableRecordReference())
+				.as("audit row must reference the source record")
+				.isEqualTo(sourceRecord);
+
+		assertThat(audit.getExternalSystemType())
+				.as("audit row must carry the config's external-system type")
+				.isEqualTo(SCRIPTED_TYPE);
+	}
+}

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionServiceCompleteTimeTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionServiceCompleteTimeTest.java
@@ -1,0 +1,308 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.externalsystem.ExternalSystemParentConfigId;
+import de.metas.externalsystem.endpoint.ExternalSystemEndpointId;
+import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion;
+import de.metas.util.Services;
+import org.adempiere.ad.table.api.AdTableAndClientId;
+import org.adempiere.ad.table.api.AdTableId;
+import org.adempiere.ad.table.api.IADTableDAO;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_M_InOut;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * At complete-time, ALL trigger-on-complete configs for the record's table
+ * must have an eligibility status recorded — Pending for matching configs, DontSend for non-matching ones.
+ *
+ * <p>The DB-SQL matching ({@code isConfigMatchingRecord}) is sealed behind the inner method
+ * {@link ExternalSystemScriptedExportConversionService#recordCompleteTimeEligibilityStatusesOnly}
+ * which receives pre-partitioned lists and is unit-testable without a live DB.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class ExternalSystemScriptedExportConversionServiceCompleteTimeTest
+{
+	private ExternalSystemExportStatusRepository repo;
+	private ExternalSystemExportStatusService exportStatusService;
+	private ExternalSystemScriptedExportConversionService service;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		// `repo` and the repo inside `exportStatusService` are distinct instances but share the
+		// POJOLookupMap singleton in unit-test mode, so writes through the service are visible via `repo`.
+		repo = ExternalSystemExportStatusRepository.newInstanceForUnitTesting();
+		exportStatusService = ExternalSystemExportStatusService.newInstanceForUnitTesting();
+
+		// Service is constructed with the real exportStatusService; audit/config repo and endpoint
+		// dependencies are mocked because recordCompleteTimeEligibilityStatusesOnly does not call them.
+		service = new ExternalSystemScriptedExportConversionService(
+				exportStatusService,
+				Mockito.mock(ExternalSystemScriptedExportConversionRepository.class),
+				Mockito.mock(de.metas.externalsystem.endpoint.ExternalSystemEndpointRepository.class),
+				Mockito.mock(de.metas.externalsystem.audit.ExternalSystemExportAuditRepo.class),
+				Mockito.mock(de.metas.externalsystem.ExternalSystemConfigRepo.class));
+	}
+
+	// -----------------------------------------------------------------------
+	// Helper factories
+	// -----------------------------------------------------------------------
+
+	private int getM_InOutTableId()
+	{
+		return Services.get(IADTableDAO.class).retrieveTableId(I_M_InOut.Table_Name);
+	}
+
+	private ExternalSystemScriptedExportConversionConfigId newConfigId()
+	{
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg =
+				InterfaceWrapperHelper.newInstance(I_ExternalSystem_Config_ScriptedExportConversion.class);
+		cfg.setAD_Table_ID(getM_InOutTableId());
+		cfg.setExternalSystemValue("test");
+		cfg.setScriptIdentifier("test.js");
+		cfg.setWhereClause("1=1");
+		cfg.setIsTriggerOnComplete(true);
+		cfg.setIsActive(true);
+		InterfaceWrapperHelper.saveRecord(cfg);
+		return ExternalSystemScriptedExportConversionConfigId.ofRepoId(cfg.getExternalSystem_Config_ScriptedExportConversion_ID());
+	}
+
+	private ExternalSystemScriptedExportConversionConfig buildConfig(
+			AdTableId tableId,
+			ClientId clientId,
+			ExternalSystemScriptedExportConversionConfigId configId)
+	{
+		return ExternalSystemScriptedExportConversionConfig.builder()
+				.id(configId)
+				.parentId(ExternalSystemParentConfigId.ofRepoId(1))
+				.externalSystemEndpointId(ExternalSystemEndpointId.ofRepoId(1))
+				.value("test")
+				.scriptIdentifier("test.js")
+				.tableAndClientId(AdTableAndClientId.of(tableId, clientId))
+				.whereClause("1=1")
+				.active(true)
+				.isTriggerOnComplete(true)
+				.build();
+	}
+
+	private I_M_InOut newInOut()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		return inout;
+	}
+
+	// -----------------------------------------------------------------------
+	// Core behaviour: matching → Pending; non-matching → DontSend
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Given one matching and one non-matching config,
+	 * {@code recordCompleteTimeEligibilityStatusesOnly} must write Pending for the matching config
+	 * and DontSend for the non-matching config.
+	 */
+	@Test
+	void recordCompleteTimeEligibilityStatusesOnly_writesPendingForMatchAndDontSendForNonMatch()
+	{
+		// Arrange
+		final int tableId = getM_InOutTableId();
+		final ClientId clientId = ClientId.ofRepoId(1);
+		final AdTableId adTableId = AdTableId.ofRepoId(tableId);
+
+		final ExternalSystemScriptedExportConversionConfigId matchingConfigId = newConfigId();
+		final ExternalSystemScriptedExportConversionConfigId nonMatchingConfigId = newConfigId();
+
+		final ExternalSystemScriptedExportConversionConfig matchingConfig = buildConfig(adTableId, clientId, matchingConfigId);
+		final ExternalSystemScriptedExportConversionConfig nonMatchingConfig = buildConfig(adTableId, clientId, nonMatchingConfigId);
+
+		final I_M_InOut inout = newInOut();
+		final int recordId = inout.getM_InOut_ID();
+
+		// Act — call the pure inner method directly, bypassing DB matching
+		service.recordCompleteTimeEligibilityStatusesOnly(
+				ImmutableList.of(matchingConfig),
+				ImmutableList.of(nonMatchingConfig),
+				recordId);
+
+		// Assert matching config → Pending
+		final Optional<ScriptedExportConversionStatus> pendingEntry =
+				repo.getLatestByConfigAndRecord(matchingConfigId, TableRecordReference.of(I_M_InOut.Table_Name, recordId));
+		assertThat(pendingEntry).as("matching config should have a status row").isPresent();
+		assertThat(pendingEntry.get().getStatus())
+				.as("matching config WhereClause match → Pending")
+				.isEqualTo(ExternalSystemExportStatus.Pending);
+
+		// Assert non-matching config → DontSend
+		final Optional<ScriptedExportConversionStatus> dontSendEntry =
+				repo.getLatestByConfigAndRecord(nonMatchingConfigId, TableRecordReference.of(I_M_InOut.Table_Name, recordId));
+		assertThat(dontSendEntry).as("non-matching config should have a status row").isPresent();
+		assertThat(dontSendEntry.get().getStatus())
+				.as("non-matching config WhereClause miss → DontSend")
+				.isEqualTo(ExternalSystemExportStatus.DontSend);
+	}
+
+	/**
+	 * When all configs match the record (no non-matching), only Pending rows must be written.
+	 */
+	@Test
+	void recordCompleteTimeEligibilityStatusesOnly_onlyMatchingConfigs_allPending()
+	{
+		final int tableId = getM_InOutTableId();
+		final ClientId clientId = ClientId.ofRepoId(1);
+		final AdTableId adTableId = AdTableId.ofRepoId(tableId);
+
+		final ExternalSystemScriptedExportConversionConfigId configId1 = newConfigId();
+		final ExternalSystemScriptedExportConversionConfigId configId2 = newConfigId();
+
+		final ExternalSystemScriptedExportConversionConfig config1 = buildConfig(adTableId, clientId, configId1);
+		final ExternalSystemScriptedExportConversionConfig config2 = buildConfig(adTableId, clientId, configId2);
+
+		final I_M_InOut inout = newInOut();
+		final int recordId = inout.getM_InOut_ID();
+
+		service.recordCompleteTimeEligibilityStatusesOnly(
+				ImmutableList.of(config1, config2),
+				ImmutableList.of(),
+				recordId);
+
+		final Optional<ScriptedExportConversionStatus> entry1 =
+				repo.getLatestByConfigAndRecord(configId1, TableRecordReference.of(I_M_InOut.Table_Name, recordId));
+		assertThat(entry1).isPresent();
+		assertThat(entry1.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Pending);
+
+		final Optional<ScriptedExportConversionStatus> entry2 =
+				repo.getLatestByConfigAndRecord(configId2, TableRecordReference.of(I_M_InOut.Table_Name, recordId));
+		assertThat(entry2).isPresent();
+		assertThat(entry2.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Pending);
+	}
+
+	/**
+	 * When no config matches the record, all configs receive DontSend.
+	 */
+	@Test
+	void recordCompleteTimeEligibilityStatusesOnly_noMatchingConfigs_allDontSend()
+	{
+		final int tableId = getM_InOutTableId();
+		final ClientId clientId = ClientId.ofRepoId(1);
+		final AdTableId adTableId = AdTableId.ofRepoId(tableId);
+
+		final ExternalSystemScriptedExportConversionConfigId configId1 = newConfigId();
+		final ExternalSystemScriptedExportConversionConfigId configId2 = newConfigId();
+
+		final ExternalSystemScriptedExportConversionConfig config1 = buildConfig(adTableId, clientId, configId1);
+		final ExternalSystemScriptedExportConversionConfig config2 = buildConfig(adTableId, clientId, configId2);
+
+		final I_M_InOut inout = newInOut();
+		final int recordId = inout.getM_InOut_ID();
+
+		service.recordCompleteTimeEligibilityStatusesOnly(
+				ImmutableList.of(),
+				ImmutableList.of(config1, config2),
+				recordId);
+
+		final Optional<ScriptedExportConversionStatus> entry1 =
+				repo.getLatestByConfigAndRecord(configId1, TableRecordReference.of(I_M_InOut.Table_Name, recordId));
+		assertThat(entry1).isPresent();
+		assertThat(entry1.get().getStatus()).isEqualTo(ExternalSystemExportStatus.DontSend);
+
+		final Optional<ScriptedExportConversionStatus> entry2 =
+				repo.getLatestByConfigAndRecord(configId2, TableRecordReference.of(I_M_InOut.Table_Name, recordId));
+		assertThat(entry2).isPresent();
+		assertThat(entry2.get().getStatus()).isEqualTo(ExternalSystemExportStatus.DontSend);
+	}
+
+	/**
+	 * Status-write failure for one config must NOT abort the whole loop — the remaining config
+	 * must still receive its status row.
+	 * (Principle: a status-write failure must never abort document completion.)
+	 *
+	 * <p>We simulate the failure via a Mockito spy on the exportStatusService: the spy throws on
+	 * the first {@code recordDontSend} call (for the "bad" config) but delegates normally for the
+	 * second call (the "good" config). The try/catch guard in the production code must swallow the
+	 * first failure so the second call still runs.
+	 */
+	@Test
+	void recordCompleteTimeEligibilityStatusesOnly_statusWriteFailure_doesNotAbortLoop()
+	{
+		final int tableId = getM_InOutTableId();
+		final ClientId clientId = ClientId.ofRepoId(1);
+		final AdTableId adTableId = AdTableId.ofRepoId(tableId);
+
+		final ExternalSystemScriptedExportConversionConfigId badConfigId = newConfigId();
+		final ExternalSystemScriptedExportConversionConfigId goodConfigId = newConfigId();
+
+		final ExternalSystemScriptedExportConversionConfig badConfig = buildConfig(adTableId, clientId, badConfigId);
+		final ExternalSystemScriptedExportConversionConfig goodConfig = buildConfig(adTableId, clientId, goodConfigId);
+
+		final I_M_InOut inout = newInOut();
+		final int recordId = inout.getM_InOut_ID();
+
+		// Spy on the export-status service: throw on the first recordDontSend call, delegate on subsequent calls
+		final ExternalSystemExportStatusService spyExportStatusService = Mockito.spy(exportStatusService);
+		Mockito.doThrow(new RuntimeException("simulated DontSend write failure"))
+				.doCallRealMethod()
+				.when(spyExportStatusService)
+				.recordDontSend(Mockito.any(), Mockito.any());
+
+		// Build a new service instance wired with the spy
+		final ExternalSystemScriptedExportConversionService serviceWithSpy = new ExternalSystemScriptedExportConversionService(
+				spyExportStatusService,
+				Mockito.mock(ExternalSystemScriptedExportConversionRepository.class),
+				Mockito.mock(de.metas.externalsystem.endpoint.ExternalSystemEndpointRepository.class),
+				Mockito.mock(de.metas.externalsystem.audit.ExternalSystemExportAuditRepo.class),
+				Mockito.mock(de.metas.externalsystem.ExternalSystemConfigRepo.class));
+
+		// Must not throw even though the first config causes a status-write failure
+		serviceWithSpy.recordCompleteTimeEligibilityStatusesOnly(
+				ImmutableList.of(),
+				ImmutableList.of(badConfig, goodConfig),
+				recordId);
+
+		// goodConfig must still have its DontSend row even though badConfig's write threw first
+		final Optional<ScriptedExportConversionStatus> goodEntry =
+				repo.getLatestByConfigAndRecord(goodConfigId, TableRecordReference.of(I_M_InOut.Table_Name, recordId));
+		assertThat(goodEntry).as("good config must still be processed despite bad config failure").isPresent();
+		assertThat(goodEntry.get().getStatus()).isEqualTo(ExternalSystemExportStatus.DontSend);
+
+		// badConfig's write threw, so no row was persisted for it
+		final Optional<ScriptedExportConversionStatus> badEntry =
+				repo.getLatestByConfigAndRecord(badConfigId, TableRecordReference.of(I_M_InOut.Table_Name, recordId));
+		assertThat(badEntry).as("bad config's row is absent because its status write threw").isEmpty();
+	}
+}

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionServiceErrorContextTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionServiceErrorContextTest.java
@@ -1,0 +1,104 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.externalsystem.ExternalSystemInvocationContext;
+import de.metas.externalsystem.ExternalSystemParentConfigId;
+import de.metas.externalsystem.endpoint.ExternalSystemEndpointId;
+import de.metas.process.PInstanceId;
+import org.adempiere.ad.table.api.AdTableAndClientId;
+import org.adempiere.ad.table.api.AdTableId;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+/**
+ * Pins the error-context the auto-trigger export path propagates.
+ *
+ * <p>{@link ExternalSystemScriptedExportConversionService#executeInvokeScriptedExportConversionAction}
+ * is the path used by the AFTER_COMPLETE interceptor and by external archive-listener callers
+ * (e.g. the DocuWare invoice export, me03 30104). It must delegate with a <b>non-null</b>
+ * {@link ExternalSystemInvocationContext} so that a downstream failure reaches the error listener:
+ * {@code ExternalSystemService.createIssue} only notifies the export-status error listener when the
+ * error item carries a non-null {@code errorContext}, and only then does the status row flip to
+ * {@code Error} + get its {@code AD_Issue} linked. Passing {@code null} silently disables error-status
+ * tracking for every auto-trigger export. {@link ExternalSystemInvocationContext#UNKNOWN} is the neutral,
+ * always-applicable context (the EDI and Re-send paths already pass {@code EDI} / {@code RESEND}).
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class ExternalSystemScriptedExportConversionServiceErrorContextTest
+{
+	private ExternalSystemScriptedExportConversionService service;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		service = new ExternalSystemScriptedExportConversionService(
+				ExternalSystemExportStatusService.newInstanceForUnitTesting(),
+				Mockito.mock(ExternalSystemScriptedExportConversionRepository.class),
+				Mockito.mock(de.metas.externalsystem.endpoint.ExternalSystemEndpointRepository.class),
+				Mockito.mock(de.metas.externalsystem.audit.ExternalSystemExportAuditRepo.class),
+				Mockito.mock(de.metas.externalsystem.ExternalSystemConfigRepo.class));
+	}
+
+	private ExternalSystemScriptedExportConversionConfig buildConfig()
+	{
+		return ExternalSystemScriptedExportConversionConfig.builder()
+				.id(ExternalSystemScriptedExportConversionConfigId.ofRepoId(1))
+				.parentId(ExternalSystemParentConfigId.ofRepoId(1))
+				.externalSystemEndpointId(ExternalSystemEndpointId.ofRepoId(1))
+				.value("test")
+				.scriptIdentifier("test.js")
+				.tableAndClientId(AdTableAndClientId.of(AdTableId.ofRepoId(540), ClientId.ofRepoId(1)))
+				.whereClause("1=1")
+				.active(true)
+				.isTriggerOnComplete(true)
+				.build();
+	}
+
+	@Test
+	void executeInvokeScriptedExportConversionAction_propagatesUnknownErrorContext_notNull()
+	{
+		final ExternalSystemScriptedExportConversionService spy = Mockito.spy(service);
+		final ExternalSystemScriptedExportConversionConfig config = buildConfig();
+		final int recordId = 100;
+
+		// Stub the heavy "execute the process" method so the test stays a pure unit test;
+		// any() matches the null arg too, so the stub is hit in both the pre-fix and post-fix cases.
+		Mockito.doReturn(ExternalSystemInvocationResult.success(PInstanceId.ofRepoId(1)))
+				.when(spy)
+				.executeInvokeScriptedExportConversionActionAndGetResult(
+						Mockito.any(), Mockito.anyInt(), Mockito.any());
+
+		spy.executeInvokeScriptedExportConversionAction(config, recordId);
+
+		// The auto-trigger path must pass UNKNOWN, not null.
+		Mockito.verify(spy).executeInvokeScriptedExportConversionActionAndGetResult(
+				config, recordId, ExternalSystemInvocationContext.UNKNOWN);
+	}
+}

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionProcessTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionProcessTest.java
@@ -1,0 +1,231 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.externalsystem.ExternalSystemInvocationContext;
+import de.metas.externalsystem.ExternalSystemParentConfigId;
+import de.metas.externalsystem.endpoint.ExternalSystemEndpointId;
+import de.metas.externalsystem.scriptedexportconversion.process.M_InOut_ReSend_ScriptedExportConversion;
+import de.metas.process.AdProcessId;
+import de.metas.process.IADPInstanceDAO;
+import de.metas.process.JavaProcess;
+import de.metas.process.ProcessInfo;
+import de.metas.user.UserId;
+import de.metas.util.Services;
+import org.adempiere.ad.table.api.AdTableAndClientId;
+import org.adempiere.ad.table.api.AdTableId;
+import org.adempiere.ad.table.api.IADTableDAO;
+import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.util.lang.IAutoCloseable;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_AD_PInstance;
+import org.compiere.model.I_AD_Process;
+import org.compiere.model.I_M_InOut;
+import org.compiere.model.X_AD_Process;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstanceOutOfTrx;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Process-level test for {@link M_InOut_ReSend_ScriptedExportConversion}.
+ *
+ * <p>Verifies:
+ * <ul>
+ *   <li>When the status service returns qualifying config IDs, the process calls
+ *       {@code resolveConfigAndRecordPendingAsResend} and then
+ *       {@code executeInvokeScriptedExportConversionActionAndGetResult} with RESEND
+ *       once per config.</li>
+ *   <li>The IsResend=Y Pending row is created (via {@code resolveConfigAndRecordPendingAsResend})
+ *       before the invocation call.</li>
+ *   <li>When no qualifying configs exist the process returns a zero-count result ({@code @Processed@ #0})
+ *       and neither service method is called.</li>
+ * </ul>
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class M_InOut_ReSend_ScriptedExportConversionProcessTest
+{
+	private ExternalSystemScriptedExportConversionService scriptedExportServiceMock;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		// ProcessInfo builder requires a valid logged-in user ID in context
+		Env.setLoggedUserId(Env.getCtx(), UserId.ofRepoId(100));
+
+		scriptedExportServiceMock = mock(ExternalSystemScriptedExportConversionService.class);
+
+		// Register mock BEFORE instantiating the process (field is resolved at construction time)
+		SpringContextHolder.registerJUnitBean(ExternalSystemScriptedExportConversionService.class, scriptedExportServiceMock);
+	}
+
+	// -----------------------------------------------------------------------
+	// 1. Happy path: two qualifying configs → each gets resolveConfig+recordPending + invoke
+	// -----------------------------------------------------------------------
+	@Test
+	void doIt_twoQualifyingConfigs_invokeCalledOncePerConfig()
+	{
+		// Set up an M_InOut record to act as the process record
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		final int inoutId = inout.getM_InOut_ID();
+
+		final int tableId = Services.get(IADTableDAO.class).retrieveTableId(I_M_InOut.Table_Name);
+		final TableRecordReference sourceRecord = TableRecordReference.of(I_M_InOut.Table_Name, inoutId);
+
+		final ExternalSystemScriptedExportConversionConfigId configIdA = ExternalSystemScriptedExportConversionConfigId.ofRepoId(101);
+		final ExternalSystemScriptedExportConversionConfigId configIdB = ExternalSystemScriptedExportConversionConfigId.ofRepoId(102);
+		final List<ExternalSystemScriptedExportConversionConfigId> qualifyingConfigIds = Arrays.asList(configIdA, configIdB);
+
+		final ExternalSystemScriptedExportConversionConfig configA = buildDummyConfig(configIdA, tableId);
+		final ExternalSystemScriptedExportConversionConfig configB = buildDummyConfig(configIdB, tableId);
+
+		// Service returns two qualifying configs
+		when(scriptedExportServiceMock.getResendableConfigsBySourceRecord(sourceRecord))
+				.thenReturn(qualifyingConfigIds);
+
+		// resolveConfigAndRecordPendingAsResend returns the resolved config for each
+		when(scriptedExportServiceMock.resolveConfigAndRecordPendingAsResend(eq(configIdA), any()))
+				.thenReturn(configA);
+		when(scriptedExportServiceMock.resolveConfigAndRecordPendingAsResend(eq(configIdB), any()))
+				.thenReturn(configB);
+
+		// executeInvokeScriptedExportConversionActionAndGetResult returns a result for both (process ignores the return value)
+		when(scriptedExportServiceMock.executeInvokeScriptedExportConversionActionAndGetResult(any(), any(Integer.class), eq(ExternalSystemInvocationContext.RESEND)))
+				.thenReturn(ExternalSystemInvocationResult.error(new RuntimeException("mocked")));
+
+		// Run the process
+		final String result = runProcess(inoutId, tableId);
+
+		// Assert: resolveConfigAndRecordPendingAsResend called once per config
+		verify(scriptedExportServiceMock, times(1)).resolveConfigAndRecordPendingAsResend(eq(configIdA), any());
+		verify(scriptedExportServiceMock, times(1)).resolveConfigAndRecordPendingAsResend(eq(configIdB), any());
+
+		// Assert: executeInvokeScriptedExportConversionActionAndGetResult called once per config with RESEND
+		verify(scriptedExportServiceMock, times(1))
+				.executeInvokeScriptedExportConversionActionAndGetResult(eq(configA), eq(inoutId), eq(ExternalSystemInvocationContext.RESEND));
+		verify(scriptedExportServiceMock, times(1))
+				.executeInvokeScriptedExportConversionActionAndGetResult(eq(configB), eq(inoutId), eq(ExternalSystemInvocationContext.RESEND));
+
+		assertThat(result).contains("2");
+	}
+
+	// -----------------------------------------------------------------------
+	// 2. No qualifying configs → zero-count result, no invocations
+	// -----------------------------------------------------------------------
+	@Test
+	void doIt_noQualifyingConfigs_returnsZeroCount()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		final int inoutId = inout.getM_InOut_ID();
+		final int tableId = Services.get(IADTableDAO.class).retrieveTableId(I_M_InOut.Table_Name);
+
+		when(scriptedExportServiceMock.getResendableConfigsBySourceRecord(any()))
+				.thenReturn(Collections.emptyList());
+
+		final String result = runProcess(inoutId, tableId);
+
+		assertThat(result).contains("#0");
+		verify(scriptedExportServiceMock, times(0)).resolveConfigAndRecordPendingAsResend(any(), any());
+		verify(scriptedExportServiceMock, times(0)).executeInvokeScriptedExportConversionActionAndGetResult(any(), any(Integer.class), any());
+	}
+
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Builds a minimal config stub; the process only passes it through to the invoke call.
+	 */
+	private ExternalSystemScriptedExportConversionConfig buildDummyConfig(
+			final ExternalSystemScriptedExportConversionConfigId id,
+			final int tableId)
+	{
+		return ExternalSystemScriptedExportConversionConfig.builder()
+				.id(id)
+				.parentId(ExternalSystemParentConfigId.ofRepoId(1))
+				.externalSystemEndpointId(ExternalSystemEndpointId.ofRepoId(1))
+				.value("test")
+				.scriptIdentifier("test.js")
+				.tableAndClientId(AdTableAndClientId.of(AdTableId.ofRepoId(tableId), ClientId.ofRepoId(0)))
+				.whereClause("1=1")
+				.active(true)
+				.isTriggerOnComplete(true)
+				.build();
+	}
+
+	/**
+	 * Instantiates and drives the process for the given M_InOut record.
+	 * Returns the process summary result string.
+	 */
+	private String runProcess(final int inoutId, final int tableId)
+	{
+		final I_AD_Process adProcess = newInstanceOutOfTrx(I_AD_Process.class);
+		adProcess.setValue(M_InOut_ReSend_ScriptedExportConversion.class.getSimpleName());
+		adProcess.setName(M_InOut_ReSend_ScriptedExportConversion.class.getSimpleName());
+		adProcess.setType(X_AD_Process.TYPE_Java);
+		adProcess.setClassname(M_InOut_ReSend_ScriptedExportConversion.class.getName());
+		saveRecord(adProcess);
+		final AdProcessId adProcessId = AdProcessId.ofRepoId(adProcess.getAD_Process_ID());
+
+		final I_AD_PInstance pinstance = Services.get(IADPInstanceDAO.class).createAD_PInstance(adProcessId);
+
+		final ProcessInfo pi = ProcessInfo.builder()
+				.setCtx(Env.getCtx())
+				.setAD_PInstance(pinstance)
+				.setRecord(tableId, inoutId)
+				.setTitle("Test")
+				.build();
+
+		// Instantiate AFTER mocks are registered (fields resolved at construction via SpringContextHolder)
+		final M_InOut_ReSend_ScriptedExportConversion process = new M_InOut_ReSend_ScriptedExportConversion();
+
+		try (final IAutoCloseable ignored = JavaProcess.temporaryChangeCurrentInstance(process))
+		{
+			process.startProcess(pi, ITrx.TRX_None);
+		}
+
+		return pi.getResult().getSummary();
+	}
+}

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionTest.java
@@ -1,0 +1,243 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.error.AdIssueId;
+import de.metas.error.IErrorManager;
+import de.metas.error.IssueCreateRequest;
+import de.metas.externalsystem.ExternalSystemInvocationContext;
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion;
+import de.metas.process.PInstanceId;
+import de.metas.util.Services;
+import org.adempiere.ad.table.api.IADTableDAO;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_M_InOut;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * TDD tests for {@link M_InOut_ReSend_ScriptedExportConversion} process logic.
+ * <p>
+ * Covers:
+ * <ul>
+ *   <li>repo.getConfigsWithNonSentAttemptBySourceRecord: returns distinct config(s) with a non-sent attempt (status not Sent/DontSend); the Error/Invalid-only narrowing for re-send is covered at the service layer in ExternalSystemExportStatusServiceTest</li>
+ *   <li>recordPendingAsResend: flips the single row in place to Pending+IsResend=Y (no duplicate row)</li>
+ *   <li>multi-config: both configs returned when both have Error or Invalid status</li>
+ *   <li>sent-only: config not returned when latest attempt is Sent</li>
+ *   <li>RESEND error context value: exists and returns non-null code</li>
+ * </ul>
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class M_InOut_ReSend_ScriptedExportConversionTest
+{
+	private ExternalSystemExportStatusRepository repo;
+	private ExternalSystemExportStatusService service;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+
+		final IErrorManager errorManager = Mockito.mock(IErrorManager.class);
+		Mockito.when(errorManager.createIssue(Mockito.any(IssueCreateRequest.class))).thenReturn(AdIssueId.ofRepoId(8888));
+		SpringContextHolder.registerJUnitBean(IErrorManager.class, errorManager);
+
+		repo = ExternalSystemExportStatusRepository.newInstanceForUnitTesting();
+		service = ExternalSystemExportStatusService.newInstanceForUnitTesting();
+	}
+
+	// -----------------------------------------------------------------------
+	// Helper
+	// -----------------------------------------------------------------------
+
+	private I_ExternalSystem_Config_ScriptedExportConversion createConfig(final int adTableId)
+	{
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg =
+				InterfaceWrapperHelper.newInstance(I_ExternalSystem_Config_ScriptedExportConversion.class);
+		cfg.setAD_Table_ID(adTableId);
+		cfg.setExternalSystemValue("test");
+		cfg.setScriptIdentifier("test.js");
+		cfg.setWhereClause("1=1");
+		cfg.setIsTriggerOnComplete(true);
+		cfg.setIsActive(true);
+		InterfaceWrapperHelper.saveRecord(cfg);
+		return cfg;
+	}
+
+	private int getM_InOutTableId()
+	{
+		return Services.get(IADTableDAO.class).retrieveTableId(I_M_InOut.Table_Name);
+	}
+
+	// -----------------------------------------------------------------------
+	// 1. getConfigsWithNonSentAttemptBySourceRecord: returns config with Error attempt
+	// -----------------------------------------------------------------------
+	@Test
+	void getConfigsWithNonSentAttempt_returnsConfig_whenErrorAttemptExists()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		final int tableId = getM_InOutTableId();
+		final TableRecordReference ref = TableRecordReference.of(I_M_InOut.Table_Name, inout.getM_InOut_ID());
+
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg = createConfig(tableId);
+		final ExternalSystemScriptedExportConversionConfigId configId =
+				ExternalSystemScriptedExportConversionConfigId.ofRepoId(cfg.getExternalSystem_Config_ScriptedExportConversion_ID());
+
+		// Simulate: initial attempt => Error
+		final PInstanceId pInstance = PInstanceId.ofRepoId(1001);
+		service.recordPending(configId, ref);
+		service.markEnqueued(configId, ref, pInstance);
+		service.markError(pInstance, null, "Connection refused");
+
+		final List<ExternalSystemScriptedExportConversionConfigId> nonSentConfigs =
+				repo.getConfigsWithNonSentAttemptBySourceRecord(ref);
+
+		assertThat(nonSentConfigs).containsExactly(configId);
+	}
+
+	// -----------------------------------------------------------------------
+	// 2. getConfigsWithNonSentAttemptBySourceRecord: does NOT return Sent config
+	// -----------------------------------------------------------------------
+	@Test
+	void getConfigsWithNonSentAttempt_excludes_sentConfig()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		final int tableId = getM_InOutTableId();
+		final TableRecordReference ref = TableRecordReference.of(I_M_InOut.Table_Name, inout.getM_InOut_ID());
+
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg = createConfig(tableId);
+		final ExternalSystemScriptedExportConversionConfigId configId =
+				ExternalSystemScriptedExportConversionConfigId.ofRepoId(cfg.getExternalSystem_Config_ScriptedExportConversion_ID());
+
+		// Simulate: attempt => Sent
+		final PInstanceId pInstance = PInstanceId.ofRepoId(2001);
+		service.recordPending(configId, ref);
+		service.markEnqueued(configId, ref, pInstance);
+		service.markSent(pInstance, HttpStatus.OK);
+
+		final List<ExternalSystemScriptedExportConversionConfigId> nonSentConfigs =
+				repo.getConfigsWithNonSentAttemptBySourceRecord(ref);
+
+		assertThat(nonSentConfigs).isEmpty();
+	}
+
+	// -----------------------------------------------------------------------
+	// 3. getConfigsWithNonSentAttemptBySourceRecord: multi-config — both returned
+	// -----------------------------------------------------------------------
+	@Test
+	void getConfigsWithNonSentAttempt_returnsMultipleConfigs_whenBothHaveNonSentAttempts()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		final int tableId = getM_InOutTableId();
+		final TableRecordReference ref = TableRecordReference.of(I_M_InOut.Table_Name, inout.getM_InOut_ID());
+
+		final I_ExternalSystem_Config_ScriptedExportConversion cfgA = createConfig(tableId);
+		final ExternalSystemScriptedExportConversionConfigId configIdA =
+				ExternalSystemScriptedExportConversionConfigId.ofRepoId(cfgA.getExternalSystem_Config_ScriptedExportConversion_ID());
+
+		final I_ExternalSystem_Config_ScriptedExportConversion cfgB = createConfig(tableId);
+		final ExternalSystemScriptedExportConversionConfigId configIdB =
+				ExternalSystemScriptedExportConversionConfigId.ofRepoId(cfgB.getExternalSystem_Config_ScriptedExportConversion_ID());
+
+		// Config A: Error
+		final PInstanceId pA = PInstanceId.ofRepoId(3001);
+		service.recordPending(configIdA, ref);
+		service.markEnqueued(configIdA, ref, pA);
+		service.markError(pA, null, "Error A");
+
+		// Config B: Invalid (also non-Sent)
+		final PInstanceId pB = PInstanceId.ofRepoId(3002);
+		service.recordPending(configIdB, ref);
+		service.markEnqueued(configIdB, ref, pB);
+		service.markInvalid(pB, "Invalid B");
+
+		final List<ExternalSystemScriptedExportConversionConfigId> nonSentConfigs =
+				repo.getConfigsWithNonSentAttemptBySourceRecord(ref);
+
+		assertThat(nonSentConfigs).containsExactlyInAnyOrder(configIdA, configIdB);
+	}
+
+	// -----------------------------------------------------------------------
+	// 4. recordPendingAsResend: flips the single row in place to Pending+IsResend=Y (no duplicate)
+	// -----------------------------------------------------------------------
+	@Test
+	void recordPendingAsResend_flipsSingleRowToPendingResend_noDuplicate()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		final int tableId = getM_InOutTableId();
+		final TableRecordReference ref = TableRecordReference.of(I_M_InOut.Table_Name, inout.getM_InOut_ID());
+
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg = createConfig(tableId);
+		final ExternalSystemScriptedExportConversionConfigId configId =
+				ExternalSystemScriptedExportConversionConfigId.ofRepoId(cfg.getExternalSystem_Config_ScriptedExportConversion_ID());
+
+		// Prior attempt => Error
+		final PInstanceId pInstance = PInstanceId.ofRepoId(4001);
+		service.recordPending(configId, ref);
+		service.markEnqueued(configId, ref, pInstance);
+		service.markError(pInstance, null, "prior error");
+
+		// Exactly 1 row, in Error state before re-send
+		assertThat(repo.getByConfigId(configId)).hasSize(1);
+		assertThat(repo.getByConfigId(configId).get(0).getStatus()).isEqualTo(ExternalSystemExportStatus.Error);
+
+		// Call recordPendingAsResend
+		service.recordPendingAsResend(configId, ref);
+
+		// Single-row contract: STILL exactly 1 row — the row was flipped in place, not duplicated
+		final List<ScriptedExportConversionStatus> rows = repo.getByConfigId(configId);
+		assertThat(rows).hasSize(1);
+
+		// The single row is now Pending + IsResend=Y
+		final ScriptedExportConversionStatus flippedRow = rows.get(0);
+		assertThat(flippedRow.getStatus()).isEqualTo(ExternalSystemExportStatus.Pending);
+		assertThat(flippedRow.isResend()).isTrue();
+	}
+
+	// -----------------------------------------------------------------------
+	// 5. RESEND error context: value exists and has a non-null code
+	// -----------------------------------------------------------------------
+	@Test
+	void externalSystemErrorContext_hasResendValue()
+	{
+		// This will fail until RESEND is added to the enum
+		assertThat(ExternalSystemInvocationContext.RESEND).isNotNull();
+		assertThat(ExternalSystemInvocationContext.RESEND.getCode()).isNotBlank();
+	}
+}

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportStatusErrorListenerTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportStatusErrorListenerTest.java
@@ -1,0 +1,160 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.error.AdIssueId;
+import de.metas.error.IErrorManager;
+import de.metas.error.IssueCreateRequest;
+import de.metas.externalsystem.ExternalSystemInvocationContext;
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion;
+import de.metas.process.PInstanceId;
+import de.metas.util.Services;
+import org.adempiere.ad.table.api.IADTableDAO;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_M_InOut;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests for {@link ScriptedExportStatusErrorListener}.
+ * <p>
+ * The listener must be a no-op (no throw) when there is no matching log row.
+ * Main path: when a pInstanceId has a matching Enqueued log row, the listener must transition
+ * the row to Error, set the message, and link the AD_Issue created via {@link IErrorManager}.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class ScriptedExportStatusErrorListenerTest
+{
+	private static final AdIssueId STUB_AD_ISSUE_ID = AdIssueId.ofRepoId(8888);
+
+	private ExternalSystemExportStatusRepository repo;
+	private ExternalSystemExportStatusService statusService;
+	private ScriptedExportStatusErrorListener listener;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+
+		final IErrorManager errorManager = Mockito.mock(IErrorManager.class);
+		Mockito.when(errorManager.createIssue(Mockito.any(IssueCreateRequest.class))).thenReturn(STUB_AD_ISSUE_ID);
+		SpringContextHolder.registerJUnitBean(IErrorManager.class, errorManager);
+
+		repo = ExternalSystemExportStatusRepository.newInstanceForUnitTesting();
+		statusService = ExternalSystemExportStatusService.newInstanceForUnitTesting();
+		listener = new ScriptedExportStatusErrorListener(statusService);
+	}
+
+	@Test
+	void applies_trueForAllContexts()
+	{
+		for (final ExternalSystemInvocationContext ctx : ExternalSystemInvocationContext.values())
+		{
+			assertThat(listener.applies(ctx))
+					.as("applies() must return true for context %s", ctx)
+					.isTrue();
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Main path: Enqueued row → Error + message stored + AD_Issue (via IErrorManager) linked
+	// -----------------------------------------------------------------------
+	@Test
+	void onInvocationError_setsErrorStatus_andLinksAdIssue_whenMatchingLogRowExists()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		final TableRecordReference sourceRecord = TableRecordReference.of(I_M_InOut.Table_Name, inout.getM_InOut_ID());
+
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg = createConfig(getM_InOutTableId());
+		final ExternalSystemScriptedExportConversionConfigId configId =
+				ExternalSystemScriptedExportConversionConfigId.ofRepoId(cfg.getExternalSystem_Config_ScriptedExportConversion_ID());
+
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(1001);
+		statusService.recordPending(configId, sourceRecord);
+		statusService.markEnqueued(configId, sourceRecord, pInstanceId);
+
+		final Optional<ScriptedExportConversionStatus> before = repo.getLatestByPInstanceId(pInstanceId);
+		assertThat(before).isPresent();
+		assertThat(before.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Enqueued);
+
+		listener.onInvocationError(pInstanceId, ExternalSystemInvocationContext.UNKNOWN, "Something went wrong");
+
+		final Optional<ScriptedExportConversionStatus> after = repo.getLatestByPInstanceId(pInstanceId);
+		assertThat(after).isPresent();
+		assertThat(after.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Error);
+		assertThat(after.get().getStatusMessage()).isEqualTo("Something went wrong");
+		assertThat(after.get().getAdIssueId())
+				.as("Status row must be linked to the AD_Issue created via IErrorManager")
+				.isEqualTo(STUB_AD_ISSUE_ID);
+	}
+
+	// -----------------------------------------------------------------------
+	// no matching log row → no-op, no throw
+	// -----------------------------------------------------------------------
+	@Test
+	void onInvocationError_noopAndNoThrow_whenNoMatchingLogRow()
+	{
+		final PInstanceId unknownPInstance = PInstanceId.ofRepoId(99997);
+		assertThatCode(() -> listener.onInvocationError(
+				unknownPInstance,
+				ExternalSystemInvocationContext.UNKNOWN,
+				"Some error"))
+				.doesNotThrowAnyException();
+	}
+
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	private I_ExternalSystem_Config_ScriptedExportConversion createConfig(final int adTableId)
+	{
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg =
+				InterfaceWrapperHelper.newInstance(I_ExternalSystem_Config_ScriptedExportConversion.class);
+		cfg.setAD_Table_ID(adTableId);
+		cfg.setExternalSystemValue("test-error-listener");
+		cfg.setScriptIdentifier("test.js");
+		cfg.setWhereClause("1=1");
+		cfg.setIsTriggerOnComplete(true);
+		cfg.setIsActive(true);
+		InterfaceWrapperHelper.saveRecord(cfg);
+		return cfg;
+	}
+
+	private int getM_InOutTableId()
+	{
+		return Services.get(IADTableDAO.class).retrieveTableId(I_M_InOut.Table_Name);
+	}
+}

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportStatusSuccessListenerTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportStatusSuccessListenerTest.java
@@ -1,0 +1,183 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.externalsystem.ExternalSystemInvocationContext;
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion;
+import de.metas.process.PInstanceId;
+import de.metas.util.Services;
+import org.adempiere.ad.table.api.IADTableDAO;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_M_InOut;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Tests for {@link ScriptedExportStatusSuccessListener}.
+ * <p>
+ * The listener must be a no-op (no throw) when there is no matching log row.
+ * Main path: when a pInstanceId has a matching Enqueued log row,
+ * the listener must transition the row to Sent and store the httpResponseCode.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class ScriptedExportStatusSuccessListenerTest
+{
+	private ExternalSystemExportStatusRepository repo;
+	private ExternalSystemExportStatusService statusService;
+	private ScriptedExportStatusSuccessListener listener;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+
+		repo = ExternalSystemExportStatusRepository.newInstanceForUnitTesting();
+		statusService = ExternalSystemExportStatusService.newInstanceForUnitTesting();
+		listener = new ScriptedExportStatusSuccessListener(statusService);
+	}
+
+	// -----------------------------------------------------------------------
+	// applies() — the listener must apply to every context (uses pInstanceId
+	// lookup; context is not used for filtering — mirrors error listener).
+	// -----------------------------------------------------------------------
+	@Test
+	void applies_trueForAllContexts()
+	{
+		for (final ExternalSystemInvocationContext ctx : ExternalSystemInvocationContext.values())
+		{
+			assertThat(listener.applies(ctx))
+					.as("applies() must return true for context %s", ctx)
+					.isTrue();
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Main path: Enqueued log row → Sent + httpResponseCode stored
+	// -----------------------------------------------------------------------
+	@Test
+	void onInvocationSuccess_setsSentStatus_andHttpResponseCode_whenMatchingLogRowExists()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		final TableRecordReference sourceRecord = TableRecordReference.of(I_M_InOut.Table_Name, inout.getM_InOut_ID());
+
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg = createConfig(getM_InOutTableId());
+		final ExternalSystemScriptedExportConversionConfigId configId =
+				ExternalSystemScriptedExportConversionConfigId.ofRepoId(cfg.getExternalSystem_Config_ScriptedExportConversion_ID());
+
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(2001);
+		statusService.recordPending(configId, sourceRecord);
+		statusService.markEnqueued(configId, sourceRecord, pInstanceId);
+
+		// precondition: row is Enqueued
+		final Optional<ScriptedExportConversionStatus> before = repo.getLatestByPInstanceId(pInstanceId);
+		assertThat(before).isPresent();
+		assertThat(before.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Enqueued);
+
+		// act
+		listener.onInvocationSuccess(pInstanceId, ExternalSystemInvocationContext.UNKNOWN, HttpStatus.OK);
+
+		// assert: status=Sent, httpResponseCode stored
+		final Optional<ScriptedExportConversionStatus> after = repo.getLatestByPInstanceId(pInstanceId);
+		assertThat(after).isPresent();
+		assertThat(after.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Sent);
+		assertThat(after.get().getHttpResponseCode())
+				.as("HttpResponseCode must be stored on the status row")
+				.isEqualTo(HttpStatus.OK);
+	}
+
+	// -----------------------------------------------------------------------
+	// Roll-up: Sent transitions roll-up to Sent when it's the only entry
+	// -----------------------------------------------------------------------
+	@Test
+	void onInvocationSuccess_rollUpIsSent_whenOnlyOneEntry()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		final TableRecordReference sourceRecord = TableRecordReference.of(I_M_InOut.Table_Name, inout.getM_InOut_ID());
+
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg = createConfig(getM_InOutTableId());
+		final ExternalSystemScriptedExportConversionConfigId configId =
+				ExternalSystemScriptedExportConversionConfigId.ofRepoId(cfg.getExternalSystem_Config_ScriptedExportConversion_ID());
+
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(2002);
+		statusService.recordPending(configId, sourceRecord);
+		statusService.markEnqueued(configId, sourceRecord, pInstanceId);
+
+		listener.onInvocationSuccess(pInstanceId, ExternalSystemInvocationContext.UNKNOWN, HttpStatus.CREATED);
+
+		final Optional<ScriptedExportConversionStatus> after = repo.getLatestByPInstanceId(pInstanceId);
+		assertThat(after).isPresent();
+		assertThat(after.get().getStatus())
+				.as("Single-entry roll-up must be Sent after success")
+				.isEqualTo(ExternalSystemExportStatus.Sent);
+	}
+
+	// -----------------------------------------------------------------------
+	// no matching log row → no-op, no throw
+	// -----------------------------------------------------------------------
+	@Test
+	void onInvocationSuccess_noopAndNoThrow_whenNoMatchingLogRow()
+	{
+		final PInstanceId unknownPInstance = PInstanceId.ofRepoId(99998);
+		assertThatCode(() -> listener.onInvocationSuccess(
+				unknownPInstance,
+				ExternalSystemInvocationContext.UNKNOWN,
+				HttpStatus.OK))
+				.doesNotThrowAnyException();
+	}
+
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	private I_ExternalSystem_Config_ScriptedExportConversion createConfig(final int adTableId)
+	{
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg =
+				InterfaceWrapperHelper.newInstance(I_ExternalSystem_Config_ScriptedExportConversion.class);
+		cfg.setAD_Table_ID(adTableId);
+		cfg.setExternalSystemValue("test-success-listener");
+		cfg.setScriptIdentifier("test.js");
+		cfg.setWhereClause("1=1");
+		cfg.setIsTriggerOnComplete(true);
+		cfg.setIsActive(true);
+		InterfaceWrapperHelper.saveRecord(cfg);
+		return cfg;
+	}
+
+	private int getM_InOutTableId()
+	{
+		return Services.get(IADTableDAO.class).retrieveTableId(I_M_InOut.Table_Name);
+	}
+}

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportStatusWiringTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportStatusWiringTest.java
@@ -1,0 +1,166 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion;
+import de.metas.process.PInstanceId;
+import de.metas.util.Services;
+import org.adempiere.ad.table.api.IADTableDAO;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_M_InOut;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the three status-write hooks wired into the scripted-export-conversion flow:
+ * (a) Pending on AFTER_COMPLETE,
+ * (b) Enqueued after successful invocation,
+ * (c) Invalid on "no valid Resource" path.
+ *
+ * <p>We test at the service seam — the interceptor and service both delegate status writes
+ * to the methods added here; testing those methods directly proves the writes work without
+ * requiring a full process-execution stack.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class ScriptedExportStatusWiringTest
+{
+	private ExternalSystemExportStatusRepository repo;
+	private ExternalSystemExportStatusService statusService;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+
+		repo = ExternalSystemExportStatusRepository.newInstanceForUnitTesting();
+		statusService = ExternalSystemExportStatusService.newInstanceForUnitTesting();
+	}
+
+	// -----------------------------------------------------------------------
+	// (a) Pending — recordPending(configId, sourceRecord) produces a Pending
+	//     log row and roll-up = Pending.
+	// -----------------------------------------------------------------------
+	@Test
+	void recordPending_withoutPInstance_createsPendingRow()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		final TableRecordReference sourceRecord = TableRecordReference.of(I_M_InOut.Table_Name, inout.getM_InOut_ID());
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg = createConfig(getM_InOutTableId(), 0);
+		final ExternalSystemScriptedExportConversionConfigId configId =
+				ExternalSystemScriptedExportConversionConfigId.ofRepoId(cfg.getExternalSystem_Config_ScriptedExportConversion_ID());
+
+		// (a) — the interceptor hook
+		statusService.recordPending(configId, sourceRecord);
+
+		final Optional<ScriptedExportConversionStatus> entry = repo.getLatestByConfigAndRecord(configId, sourceRecord);
+		assertThat(entry).isPresent();
+		assertThat(entry.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Pending);
+		assertThat(entry.get().getPInstanceId()).isNull();
+	}
+
+	// -----------------------------------------------------------------------
+	// (b) Enqueued — markEnqueued updates the Pending row
+	//     with the PInstance and transitions status to Enqueued.
+	// -----------------------------------------------------------------------
+	@Test
+	void markEnqueued_transitionsPendingToEnqueued()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		final TableRecordReference sourceRecord = TableRecordReference.of(I_M_InOut.Table_Name, inout.getM_InOut_ID());
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg = createConfig(getM_InOutTableId(), 0);
+		final ExternalSystemScriptedExportConversionConfigId configId =
+				ExternalSystemScriptedExportConversionConfigId.ofRepoId(cfg.getExternalSystem_Config_ScriptedExportConversion_ID());
+
+		// (a) pending first
+		statusService.recordPending(configId, sourceRecord);
+
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(555);
+
+		// (b) — the invocation service hook after successful enqueue
+		statusService.markEnqueued(configId, sourceRecord, pInstanceId);
+
+		final Optional<ScriptedExportConversionStatus> entry = repo.getLatestByPInstanceId(pInstanceId);
+		assertThat(entry).isPresent();
+		assertThat(entry.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Enqueued);
+		assertThat(entry.get().getPInstanceId()).isEqualTo(pInstanceId);
+	}
+
+	// -----------------------------------------------------------------------
+	// (c) Invalid — markInvalidByRecord marks the Pending row Invalid.
+	// -----------------------------------------------------------------------
+	@Test
+	void markInvalidByRecord_transitionsPendingToInvalid()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		final TableRecordReference sourceRecord = TableRecordReference.of(I_M_InOut.Table_Name, inout.getM_InOut_ID());
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg = createConfig(getM_InOutTableId(), 0);
+		final ExternalSystemScriptedExportConversionConfigId configId =
+				ExternalSystemScriptedExportConversionConfigId.ofRepoId(cfg.getExternalSystem_Config_ScriptedExportConversion_ID());
+
+		// (a) pending first
+		statusService.recordPending(configId, sourceRecord);
+
+		// (c) — the invocation service hook on "no valid Resource" path
+		statusService.markInvalidByRecord(configId, sourceRecord, "Process did not return a valid Resource");
+
+		final Optional<ScriptedExportConversionStatus> entry = repo.getLatestByConfigAndRecord(configId, sourceRecord);
+		assertThat(entry).isPresent();
+		assertThat(entry.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Invalid);
+		assertThat(entry.get().getStatusMessage()).isEqualTo("Process did not return a valid Resource");
+	}
+
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	private I_ExternalSystem_Config_ScriptedExportConversion createConfig(final int adTableId, @SuppressWarnings("unused") final int statusAdColumnId)
+	{
+		final I_ExternalSystem_Config_ScriptedExportConversion cfg =
+				InterfaceWrapperHelper.newInstance(I_ExternalSystem_Config_ScriptedExportConversion.class);
+		cfg.setAD_Table_ID(adTableId);
+		cfg.setExternalSystemValue("test");
+		cfg.setScriptIdentifier("test.js");
+		cfg.setWhereClause("1=1");
+		cfg.setIsTriggerOnComplete(true);
+		cfg.setIsActive(true);
+		InterfaceWrapperHelper.saveRecord(cfg);
+		return cfg;
+	}
+
+	private int getM_InOutTableId()
+	{
+		return Services.get(IADTableDAO.class).retrieveTableId(I_M_InOut.Table_Name);
+	}
+}

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/main/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/from_mf/ScriptedAdapterConvertMsgFromMFRouteBuilder.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/main/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/from_mf/ScriptedAdapterConvertMsgFromMFRouteBuilder.java
@@ -68,7 +68,9 @@ import java.util.Optional;
 
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static de.metas.camel.externalsystems.common.ExternalSystemCamelConstants.HEADER_ERROR_CONTEXT;
+import static de.metas.camel.externalsystems.common.ExternalSystemCamelConstants.HEADER_PINSTANCE_ID;
 import static de.metas.camel.externalsystems.common.ExternalSystemCamelConstants.MF_ERROR_ROUTE_ID;
+import static de.metas.camel.externalsystems.common.ExternalSystemCamelConstants.MF_EXTERNAL_SYSTEM_V2_URI;
 import static de.metas.camel.externalsystems.scriptedadapter.ScriptedAdapterConstants.ATTACHMENT_FILE_NAME;
 import static de.metas.camel.externalsystems.scriptedadapter.ScriptedAdapterConstants.ROUTE_MSG_FROM_MF_CONTEXT;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_ERROR_CONTEXT;
@@ -101,6 +103,22 @@ public class ScriptedAdapterConvertMsgFromMFRouteBuilder extends RouteBuilder
 	@VisibleForTesting
 	static final String ScriptedExportConversion_ConvertMsgFromMF_OUTBOUND_HTTP_EP_ID = "ScriptedExportConversionOutboundHttpEPId";
 
+	/** Node ID for the single-send /ok success-callback toD, used by AdviceWith in tests. */
+	@VisibleForTesting
+	static final String ScriptedExportConversion_OkCallback_EP_ID = "ScriptedExportConversionOkCallbackEPId";
+
+	/** Node ID for the fan-out /ok success-callback toD, used by AdviceWith in tests. */
+	@VisibleForTesting
+	static final String ScriptedExportConversion_FanOutOkCallback_EP_ID = "ScriptedExportConversionFanOutOkCallbackEPId";
+
+	/**
+	 * Exchange property used to carry the HTTP response code received from the external system
+	 * across the {@code removeHeaders("CamelHttp*")} boundary so the success-callback URL can
+	 * include it as a query parameter.
+	 */
+	@VisibleForTesting
+	static final String EXCHANGE_PROPERTY_HTTP_RESPONSE_CODE = "savedHttpResponseCode";
+
 	/** Exchange property holding the parsed {@link ArrayNode} when fan-out mode is active; null/missing otherwise. */
 	@VisibleForTesting
 	static final String EXCHANGE_PROPERTY_FAN_OUT_ARRAY = "fanOutArray";
@@ -116,6 +134,14 @@ public class ScriptedAdapterConvertMsgFromMFRouteBuilder extends RouteBuilder
 	/** Exchange property holding the {@link FanOutResult} aggregator across all iterations of one fan-out. */
 	@VisibleForTesting
 	static final String EXCHANGE_PROPERTY_FAN_OUT_RESULT = "fanOutResult";
+
+	/**
+	 * Exchange property used to stash the raw external-system HTTP response body before the /ok success-callback
+	 * POST to metasfresh overwrites the exchange body. Restored immediately after the /ok call so that
+	 * {@link #prepareJsonAttachmentRequest} can still include the original response in the audit log.
+	 */
+	@VisibleForTesting
+	static final String EXCHANGE_PROPERTY_EXTERNAL_SYSTEM_RESPONSE = "externalSystemResponse";
 
 	private JavaScriptRepo javaScriptRepo;
 
@@ -213,6 +239,24 @@ public class ScriptedAdapterConvertMsgFromMFRouteBuilder extends RouteBuilder
 									.toD("${header." + Exchange.HTTP_URI + "}").id(ScriptedExportConversion_ConvertMsgFromMF_OUTBOUND_HTTP_EP_ID + "_OAUTH2_RETRY")
 							.end()
 
+							// Notify metasfresh that the export succeeded (2xx). Fires exactly once after the final
+							// successful response — whether from the original attempt or the 401-refresh retry.
+							// Skipped when no pInstanceId is present (fire-and-configure invocations without a process instance).
+							// Save the external-system response body to a property so the attachment log can
+							// still read it after the /ok HTTP call overwrites the exchange body.
+							.choice()
+								.when(header(HEADER_PINSTANCE_ID).isNotNull())
+									.log(LoggingLevel.DEBUG, "Reporting export success to metasfresh: pInstance=${header." + HEADER_PINSTANCE_ID + "} httpCode=${header.CamelHttpResponseCode}")
+									.setProperty(EXCHANGE_PROPERTY_EXTERNAL_SYSTEM_RESPONSE, body())
+									.setProperty(EXCHANGE_PROPERTY_HTTP_RESPONSE_CODE, header(Exchange.HTTP_RESPONSE_CODE))
+									.setBody(constant(null))
+									.removeHeaders("CamelHttp*")
+									.setHeader(Exchange.HTTP_METHOD, constant(HttpMethods.POST))
+									.setHeader(Exchange.HTTP_RESPONSE_CODE, exchangeProperty(EXCHANGE_PROPERTY_HTTP_RESPONSE_CODE))
+									.toD("{{" + MF_EXTERNAL_SYSTEM_V2_URI + "}}/externalstatus/${header." + HEADER_PINSTANCE_ID + "}/ok?httpResponseCode=${header.CamelHttpResponseCode}").id(ScriptedExportConversion_OkCallback_EP_ID)
+									.setBody(exchangeProperty(EXCHANGE_PROPERTY_EXTERNAL_SYSTEM_RESPONSE))
+							.end()
+
 							.process(this::prepareJsonAttachmentRequest)
 							.log(LoggingLevel.DEBUG, "Calling metasfresh-api to save attachment: ${body}")
 							.to(direct(ExternalSystemCamelConstants.MF_ATTACHMENT_ROUTE_ID))
@@ -264,6 +308,25 @@ public class ScriptedAdapterConvertMsgFromMFRouteBuilder extends RouteBuilder
 							.process(fileUploadProcessor::applyFileUploadBodyIfRequested)
 							.toD("${header." + Exchange.HTTP_URI + "}").id(ScriptedExportConversion_ConvertMsgFromMF_OUTBOUND_HTTP_EP_ID + "_FANOUT_OAUTH2_RETRY")
 					.end()
+
+					// Notify metasfresh that this fan-out element succeeded (2xx). Fires exactly once after
+					// the final successful response — whether from the original attempt or the 401-refresh retry.
+					// Skipped when no pInstanceId is present (fire-and-configure invocations without a process instance).
+					// Save the external-system response body to a property so the attachment log can
+					// still read it after the /ok HTTP call overwrites the exchange body.
+					.choice()
+						.when(header(HEADER_PINSTANCE_ID).isNotNull())
+							.log(LoggingLevel.DEBUG, "Reporting fan-out export success to metasfresh: pInstance=${header." + HEADER_PINSTANCE_ID + "} element=${exchangeProperty." + EXCHANGE_PROPERTY_FAN_OUT_INDEX + "} httpCode=${header.CamelHttpResponseCode}")
+							.setProperty(EXCHANGE_PROPERTY_EXTERNAL_SYSTEM_RESPONSE, body())
+							.setProperty(EXCHANGE_PROPERTY_HTTP_RESPONSE_CODE, header(Exchange.HTTP_RESPONSE_CODE))
+							.setBody(constant(null))
+							.removeHeaders("CamelHttp*")
+							.setHeader(Exchange.HTTP_METHOD, constant(HttpMethods.POST))
+							.setHeader(Exchange.HTTP_RESPONSE_CODE, exchangeProperty(EXCHANGE_PROPERTY_HTTP_RESPONSE_CODE))
+							.toD("{{" + MF_EXTERNAL_SYSTEM_V2_URI + "}}/externalstatus/${header." + HEADER_PINSTANCE_ID + "}/ok?httpResponseCode=${header.CamelHttpResponseCode}").id(ScriptedExportConversion_FanOutOkCallback_EP_ID)
+							.setBody(exchangeProperty(EXCHANGE_PROPERTY_EXTERNAL_SYSTEM_RESPONSE))
+					.end()
+
 					.process(this::prepareJsonAttachmentRequest)
 					.to(direct(ExternalSystemCamelConstants.MF_ATTACHMENT_ROUTE_ID))
 			.end();

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/test/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/from_mf/ScriptedAdapterConvertMsgFromMFRouteBuilderTests.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/test/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/from_mf/ScriptedAdapterConvertMsgFromMFRouteBuilderTests.java
@@ -54,13 +54,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static de.metas.camel.externalsystems.common.ExternalSystemCamelConstants.HEADER_PINSTANCE_ID;
 import static de.metas.camel.externalsystems.common.ExternalSystemCamelConstants.MF_ATTACHMENT_ROUTE_ID;
 import static de.metas.camel.externalsystems.common.ExternalSystemCamelConstants.MF_ERROR_ROUTE_ID;
 import static de.metas.camel.externalsystems.scriptedadapter.ScriptedAdapterConstants.ROUTE_MSG_FROM_MF_CONTEXT;
 import static de.metas.camel.externalsystems.scriptedadapter.convertmsg.from_mf.ScriptedAdapterConvertMsgFromMFRouteBuilder.PROPERTY_SCRIPTING_REPO_BASE_DIR;
 import static de.metas.camel.externalsystems.scriptedadapter.convertmsg.from_mf.ScriptedAdapterConvertMsgFromMFRouteBuilder.ScriptedExportConversion_ConvertMsgFromMF_OUTBOUND_HTTP_EP_ID;
 import static de.metas.camel.externalsystems.scriptedadapter.convertmsg.from_mf.ScriptedAdapterConvertMsgFromMFRouteBuilder.ScriptedExportConversion_ConvertMsgFromMF_ROUTE_ID;
+import static de.metas.camel.externalsystems.scriptedadapter.convertmsg.from_mf.ScriptedAdapterConvertMsgFromMFRouteBuilder.ScriptedExportConversion_FanOutIteration_ROUTE_ID;
+import static de.metas.camel.externalsystems.scriptedadapter.convertmsg.from_mf.ScriptedAdapterConvertMsgFromMFRouteBuilder.ScriptedExportConversion_FanOutOkCallback_EP_ID;
+import static de.metas.camel.externalsystems.scriptedadapter.convertmsg.from_mf.ScriptedAdapterConvertMsgFromMFRouteBuilder.ScriptedExportConversion_OkCallback_EP_ID;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_FROM_MF_METASFRESH_INPUT;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_JAVASCRIPT_IDENTIFIER;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_OUTBOUND_ENDPOINT_PARAMETERS;
@@ -661,6 +666,414 @@ public class ScriptedAdapterConvertMsgFromMFRouteBuilderTests extends CamelTestS
 								  "authType" : "Token",
 								  "clientId" : "clientId",
 								  "clientSecret" : "clientSecret",
+								  "token" : "API_TOKEN",
+								  "user" : "user",
+								  "password" : "password"%s
+								}""".formatted(arrayFanOutLine))
+						.parameter(PARAM_SCRIPTEDADAPTER_OUTBOUND_RECORD_TABLE_NAME, "TableName")
+						.parameter(PARAM_SCRIPTEDADAPTER_OUTBOUND_RECORD_ID, "123")
+						.build());
+
+		return exchange;
+	}
+
+	// ========================================================================================
+	// Success-callback wiring tests (single-send path and fan-out path)
+	// ========================================================================================
+
+	/**
+	 * Single-send, pInstance PRESENT, external system returns 201.
+	 * <p>
+	 * Asserts:
+	 * <ol>
+	 *   <li>The /ok callback fires exactly once.</li>
+	 *   <li>The /ok callback carries the HTTP response code from the external system (the exchange
+	 *       property and restored header must survive the {@code removeHeaders("CamelHttp*")} strip
+	 *       so the {@code toD} URL expression can include {@code ?httpResponseCode=201}).</li>
+	 * </ol>
+	 * The {@code httpResponseCode} assertion guards the stash/restore across the
+	 * {@code removeHeaders("CamelHttp*")} strip: it fails if the {@code setProperty}/{@code setHeader}
+	 * pair is removed and the /ok URL loses the external system's response code.
+	 */
+	@Test
+	void singleSend_withPInstanceId_okCallbackCarriesHttpResponseCode() throws Exception
+	{
+		final String jsScript = """
+				function transform(messageFromMetasfresh) {
+					return JSON.stringify({result: "ok"});
+				}
+				""";
+
+		final Exchange exchange = prepareScriptAndExchangeWithPInstance(jsScript, "{}", "42");
+
+		final MockJsonAttachmentRequestProcessor mockJsonAttachmentRequestProcessor = new MockJsonAttachmentRequestProcessor();
+
+		// Capture the state seen by the /ok callback node so we can assert on it.
+		final AtomicReference<Integer> capturedResponseCode = new AtomicReference<>();
+		final AtomicReference<String> capturedPInstanceId = new AtomicReference<>();
+		final AtomicInteger okCallbackCount = new AtomicInteger(0);
+
+		AdviceWith.adviceWith(context,
+				ScriptedExportConversion_ConvertMsgFromMF_ROUTE_ID,
+				advice -> {
+					// Replace the external-system HTTP call; return 201.
+					advice.weaveById(ScriptedExportConversion_ConvertMsgFromMF_OUTBOUND_HTTP_EP_ID)
+							.replace()
+							.process(ex -> {
+								ex.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 201);
+								ex.getIn().setBody("Created");
+							});
+
+					// Replace the /ok callback toD; capture what the route passes to it.
+					advice.weaveById(ScriptedExportConversion_OkCallback_EP_ID)
+							.replace()
+							.process(ex -> {
+								okCallbackCount.incrementAndGet();
+								capturedResponseCode.set(ex.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE, Integer.class));
+								capturedPInstanceId.set(ex.getIn().getHeader(HEADER_PINSTANCE_ID, String.class));
+								// Simulate a 200 OK reply so the route continues normally.
+								ex.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
+								ex.getIn().setBody(null);
+							});
+
+					advice.interceptSendToEndpoint("direct:" + MF_ATTACHMENT_ROUTE_ID)
+							.skipSendToOriginalEndpoint()
+							.to(MOCK_ATTACHMENT_ENDPOINT)
+							.process(mockJsonAttachmentRequestProcessor);
+				});
+
+		context.start();
+		template.send("direct:" + ScriptedExportConversion_ConvertMsgFromMF_ROUTE_ID, exchange);
+
+		// /ok callback must fire exactly once.
+		assertThat(okCallbackCount.get()).isEqualTo(1);
+
+		// The pInstanceId from the header must be passed through.
+		assertThat(capturedPInstanceId.get()).isEqualTo("42");
+
+		// The HTTP response code from the external system (201) must survive the
+		// removeHeaders("CamelHttp*") strip and arrive at the /ok callback so the toD URL
+		// expression can embed it as ?httpResponseCode=201.
+		// RED before fix (returns null / missing header); GREEN after fix.
+		assertThat(capturedResponseCode.get())
+				.as("httpResponseCode must be preserved across removeHeaders(\"CamelHttp*\") and available for the /ok callback URL")
+				.isEqualTo(201);
+	}
+
+	/**
+	 * Single-send, pInstance ABSENT (header null).
+	 * The {@code .when(header(HEADER_PINSTANCE_ID).isNotNull())} guard must suppress the /ok callback.
+	 */
+	@Test
+	void singleSend_withoutPInstanceId_okCallbackNotInvoked() throws Exception
+	{
+		final String jsScript = """
+				function transform(messageFromMetasfresh) {
+					return JSON.stringify({result: "ok"});
+				}
+				""";
+
+		// No pInstanceId set on this exchange.
+		final Exchange exchange = prepareScriptAndExchangeForFanOut(jsScript, "{}", /*arrayFanOut*/ null);
+
+		final MockJsonAttachmentRequestProcessor mockJsonAttachmentRequestProcessor = new MockJsonAttachmentRequestProcessor();
+		final AtomicInteger okCallbackCount = new AtomicInteger(0);
+
+		AdviceWith.adviceWith(context,
+				ScriptedExportConversion_ConvertMsgFromMF_ROUTE_ID,
+				advice -> {
+					advice.weaveById(ScriptedExportConversion_ConvertMsgFromMF_OUTBOUND_HTTP_EP_ID)
+							.replace()
+							.process(ex -> {
+								ex.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
+								ex.getIn().setBody("OK");
+							});
+
+					advice.weaveById(ScriptedExportConversion_OkCallback_EP_ID)
+							.replace()
+							.process(ex -> okCallbackCount.incrementAndGet());
+
+					advice.interceptSendToEndpoint("direct:" + MF_ATTACHMENT_ROUTE_ID)
+							.skipSendToOriginalEndpoint()
+							.to(MOCK_ATTACHMENT_ENDPOINT)
+							.process(mockJsonAttachmentRequestProcessor);
+				});
+
+		context.start();
+		template.send("direct:" + ScriptedExportConversion_ConvertMsgFromMF_ROUTE_ID, exchange);
+
+		// /ok callback must NOT fire when pInstanceId is absent.
+		assertThat(okCallbackCount.get()).isEqualTo(0);
+	}
+
+	/**
+	 * Single-send, OAuth, external system returns 401 on the first call.
+	 * The route retries exactly once with a refreshed token; the /ok callback fires after the retry.
+	 */
+	@Test
+	void singleSend_oauthWith401_retriesOnceAndCallsOkCallback() throws Exception
+	{
+		final String jsScript = """
+				function transform(messageFromMetasfresh) {
+					return JSON.stringify({result: "ok"});
+				}
+				""";
+
+		final Exchange exchange = prepareScriptAndExchangeWithPInstanceOAuth(jsScript, "{}", "99");
+
+		final AtomicInteger outboundCallCount = new AtomicInteger(0);
+		final AtomicInteger okCallbackCount = new AtomicInteger(0);
+
+		AdviceWith.adviceWith(context,
+				ScriptedExportConversion_ConvertMsgFromMF_ROUTE_ID,
+				advice -> {
+					// First call → 401; second call (RETRY) → 200.
+					advice.weaveById(ScriptedExportConversion_ConvertMsgFromMF_OUTBOUND_HTTP_EP_ID)
+							.replace()
+							.process(ex -> {
+								final int callNo = outboundCallCount.incrementAndGet();
+								if (callNo == 1)
+								{
+									ex.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 401);
+									ex.getIn().setBody("Unauthorized");
+								}
+								else
+								{
+									ex.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
+									ex.getIn().setBody("OK after retry");
+								}
+							});
+
+					// Also intercept the RETRY node so it goes to the same counter mock.
+					advice.weaveById(ScriptedExportConversion_ConvertMsgFromMF_OUTBOUND_HTTP_EP_ID + "_RETRY")
+							.replace()
+							.process(ex -> {
+								final int callNo = outboundCallCount.incrementAndGet();
+								if (callNo == 1)
+								{
+									ex.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 401);
+									ex.getIn().setBody("Unauthorized");
+								}
+								else
+								{
+									ex.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
+									ex.getIn().setBody("OK after retry");
+								}
+							});
+
+					advice.weaveById(ScriptedExportConversion_OkCallback_EP_ID)
+							.replace()
+							.process(ex -> {
+								okCallbackCount.incrementAndGet();
+								ex.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
+								ex.getIn().setBody(null);
+							});
+
+					advice.interceptSendToEndpoint("direct:" + MF_ATTACHMENT_ROUTE_ID)
+							.skipSendToOriginalEndpoint()
+							.to(MOCK_ATTACHMENT_ENDPOINT)
+							.process(new MockJsonAttachmentRequestProcessor());
+				});
+
+		context.start();
+		template.send("direct:" + ScriptedExportConversion_ConvertMsgFromMF_ROUTE_ID, exchange);
+
+		// Exactly two outbound calls (original + one retry).
+		assertThat(outboundCallCount.get()).isEqualTo(2);
+
+		// /ok callback fires once (after the successful retry).
+		assertThat(okCallbackCount.get()).isEqualTo(1);
+	}
+
+	/**
+	 * Fan-out path: JS returns a 2-element array, pInstance PRESENT.
+	 * The /ok callback must fire once per element (2 times total), each carrying the HTTP response
+	 * code from that element's external-system call.
+	 */
+	@Test
+	void fanOut_withPInstanceId_okCallbackFiredPerElement() throws Exception
+	{
+		final String jsScript = """
+				function transform(messageFromMetasfresh) {
+					return JSON.stringify([{a: 1}, {b: 2}]);
+				}
+				""";
+
+		final Exchange exchange = prepareScriptAndExchangeForFanOutWithPInstance(jsScript, "{}", Boolean.TRUE, "77");
+
+		final AtomicInteger fanOutOkCount = new AtomicInteger(0);
+		final List<Integer> capturedResponseCodes = new ArrayList<>();
+
+		final MockJsonAttachmentRequestProcessor mockJsonAttachmentRequestProcessor = new MockJsonAttachmentRequestProcessor();
+
+		// The FanOutIteration sub-route is advised separately (its own routeId).
+		AdviceWith.adviceWith(context,
+				ScriptedExportConversion_ConvertMsgFromMF_ROUTE_ID,
+				advice -> advice.interceptSendToEndpoint("direct:" + MF_ATTACHMENT_ROUTE_ID)
+						.skipSendToOriginalEndpoint()
+						.to(MOCK_ATTACHMENT_ENDPOINT)
+						.process(mockJsonAttachmentRequestProcessor));
+
+		AdviceWith.adviceWith(context,
+				ScriptedExportConversion_FanOutIteration_ROUTE_ID,
+				advice -> {
+					final AtomicInteger elementCallIdx = new AtomicInteger(0);
+					advice.weaveById(ScriptedExportConversion_ConvertMsgFromMF_OUTBOUND_HTTP_EP_ID + "_FANOUT")
+							.replace()
+							.process(ex -> {
+								final int code = 200 + elementCallIdx.getAndIncrement();
+								ex.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, code);
+								ex.getIn().setBody("body-" + code);
+							});
+
+					advice.weaveById(ScriptedExportConversion_FanOutOkCallback_EP_ID)
+							.replace()
+							.process(ex -> {
+								fanOutOkCount.incrementAndGet();
+								synchronized (capturedResponseCodes)
+								{
+									capturedResponseCodes.add(ex.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE, Integer.class));
+								}
+								ex.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 200);
+								ex.getIn().setBody(null);
+							});
+
+					advice.interceptSendToEndpoint("direct:" + MF_ATTACHMENT_ROUTE_ID)
+							.skipSendToOriginalEndpoint()
+							.to(MOCK_ATTACHMENT_ENDPOINT)
+							.process(mockJsonAttachmentRequestProcessor);
+				});
+
+		context.start();
+		template.send("direct:" + ScriptedExportConversion_ConvertMsgFromMF_ROUTE_ID, exchange);
+
+		// Two elements → /ok callback fired twice.
+		assertThat(fanOutOkCount.get()).isEqualTo(2);
+
+		// Each call carried the element-specific HTTP response code.
+		assertThat(capturedResponseCodes).containsExactlyInAnyOrder(200, 201);
+	}
+
+	/**
+	 * Builds an exchange with a pInstance header set, using Token auth (simpler than OAuth for
+	 * the success-path tests).
+	 */
+	@NonNull
+	private Exchange prepareScriptAndExchangeWithPInstance(
+			@NonNull final String jsScript,
+			@NonNull final String messageFromMetasfresh,
+			@NonNull final String pInstanceId)
+	{
+		final JavaScriptRepo javaScriptRepo = new JavaScriptRepo(context.resolvePropertyPlaceholders("{{" + PROPERTY_SCRIPTING_REPO_BASE_DIR + "}}"));
+		javaScriptRepo.save("testScript", jsScript);
+
+		final Exchange exchange = new DefaultExchange(template.getCamelContext());
+		exchange.getIn().setHeader(HEADER_PINSTANCE_ID, pInstanceId);
+		exchange.getIn().setBody(
+				JsonExternalSystemRequest.builder()
+						.orgCode("orgCode")
+						.externalSystemName(JsonExternalSystemName.of("externalSystemName"))
+						.command("command")
+						.externalSystemConfigId(JsonMetasfreshId.of(1))
+						.traceId("traceId")
+						.externalSystemChildConfigValue("externalSystemChildConfigValue")
+						.adPInstanceId(JsonMetasfreshId.of(Integer.parseInt(pInstanceId)))
+						.parameter(PARAM_SCRIPTEDADAPTER_FROM_MF_METASFRESH_INPUT, messageFromMetasfresh)
+						.parameter(PARAM_SCRIPTEDADAPTER_JAVASCRIPT_IDENTIFIER, "testScript")
+						.parameter(PARAM_SCRIPTEDADAPTER_OUTBOUND_ENDPOINT_PARAMETERS, """
+								{
+								  "value" : "value",
+								  "endpointUrl" : "http://localhost:8080/test",
+								  "method" : "POST",
+								  "authType" : "Token",
+								  "token" : "API_TOKEN",
+								  "user" : "user",
+								  "password" : "password"
+								}""")
+						.parameter(PARAM_SCRIPTEDADAPTER_OUTBOUND_RECORD_TABLE_NAME, "TableName")
+						.parameter(PARAM_SCRIPTEDADAPTER_OUTBOUND_RECORD_ID, "123")
+						.build());
+
+		return exchange;
+	}
+
+	/**
+	 * Builds an exchange with a pInstance header, using OAuth auth (for the 401-retry test).
+	 */
+	@NonNull
+	private Exchange prepareScriptAndExchangeWithPInstanceOAuth(
+			@NonNull final String jsScript,
+			@NonNull final String messageFromMetasfresh,
+			@NonNull final String pInstanceId)
+	{
+		final JavaScriptRepo javaScriptRepo = new JavaScriptRepo(context.resolvePropertyPlaceholders("{{" + PROPERTY_SCRIPTING_REPO_BASE_DIR + "}}"));
+		javaScriptRepo.save("testScript", jsScript);
+
+		final Exchange exchange = new DefaultExchange(template.getCamelContext());
+		exchange.getIn().setHeader(HEADER_PINSTANCE_ID, pInstanceId);
+		exchange.getIn().setBody(
+				JsonExternalSystemRequest.builder()
+						.orgCode("orgCode")
+						.externalSystemName(JsonExternalSystemName.of("externalSystemName"))
+						.command("command")
+						.externalSystemConfigId(JsonMetasfreshId.of(1))
+						.traceId("traceId")
+						.externalSystemChildConfigValue("externalSystemChildConfigValue")
+						.adPInstanceId(JsonMetasfreshId.of(Integer.parseInt(pInstanceId)))
+						.parameter(PARAM_SCRIPTEDADAPTER_FROM_MF_METASFRESH_INPUT, messageFromMetasfresh)
+						.parameter(PARAM_SCRIPTEDADAPTER_JAVASCRIPT_IDENTIFIER, "testScript")
+						.parameter(PARAM_SCRIPTEDADAPTER_OUTBOUND_ENDPOINT_PARAMETERS, """
+								{
+								  "value" : "value",
+								  "endpointUrl" : "http://localhost:8080/test",
+								  "method" : "POST",
+								  "authType" : "OAuth",
+								  "clientId" : "clientId",
+								  "clientSecret" : "clientSecret",
+								  "user" : "user",
+								  "password" : "password"
+								}""")
+						.parameter(PARAM_SCRIPTEDADAPTER_OUTBOUND_RECORD_TABLE_NAME, "TableName")
+						.parameter(PARAM_SCRIPTEDADAPTER_OUTBOUND_RECORD_ID, "123")
+						.build());
+
+		return exchange;
+	}
+
+	/**
+	 * Builds a fan-out exchange with the pInstance header set.
+	 */
+	@NonNull
+	private Exchange prepareScriptAndExchangeForFanOutWithPInstance(
+			@NonNull final String jsScript,
+			@NonNull final String messageFromMetasfresh,
+			final Boolean arrayFanOut,
+			@NonNull final String pInstanceId)
+	{
+		final JavaScriptRepo javaScriptRepo = new JavaScriptRepo(context.resolvePropertyPlaceholders("{{" + PROPERTY_SCRIPTING_REPO_BASE_DIR + "}}"));
+		javaScriptRepo.save("testScript", jsScript);
+
+		final String arrayFanOutLine = arrayFanOut == null ? "" : ",\n  \"arrayFanOut\" : " + arrayFanOut;
+
+		final Exchange exchange = new DefaultExchange(template.getCamelContext());
+		exchange.getIn().setHeader(HEADER_PINSTANCE_ID, pInstanceId);
+		exchange.getIn().setBody(
+				JsonExternalSystemRequest.builder()
+						.orgCode("orgCode")
+						.externalSystemName(JsonExternalSystemName.of("externalSystemName"))
+						.command("command")
+						.externalSystemConfigId(JsonMetasfreshId.of(1))
+						.traceId("traceId")
+						.externalSystemChildConfigValue("externalSystemChildConfigValue")
+						.adPInstanceId(JsonMetasfreshId.of(Integer.parseInt(pInstanceId)))
+						.parameter(PARAM_SCRIPTEDADAPTER_FROM_MF_METASFRESH_INPUT, messageFromMetasfresh)
+						.parameter(PARAM_SCRIPTEDADAPTER_JAVASCRIPT_IDENTIFIER, "testScript")
+						.parameter(PARAM_SCRIPTEDADAPTER_OUTBOUND_ENDPOINT_PARAMETERS, """
+								{
+								  "value" : "value",
+								  "endpointUrl" : "http://localhost:8080/test",
+								  "method" : "POST",
+								  "authType" : "Token",
 								  "token" : "API_TOKEN",
 								  "user" : "user",
 								  "password" : "password"%s

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/test/resources/application.properties
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/test/resources/application.properties
@@ -25,3 +25,4 @@ metasfresh.scriptedadapter.repo.baseDir=\\
 
 metasfresh.create-service-status-v2.camel.uri=direct:doesntmatter
 metasfresh.external-system-info-v2.camel.uri=direct:metasfresh-external-system-info-v2
+metasfresh.externalsystem.v2.api.uri=http://localhost:9999/testmfapi


### PR DESCRIPTION
## What

Verbatim port of metasfresh PR https://github.com/metasfresh/metasfresh/pull/24483 (`913c419`, me03 https://github.com/metasfresh/me03/issues/30088) onto `deep_tundra_release`, bringing the **generic scripted-export-conversion observability machinery** to the branch danthermuat (dt204) runs.

## Why

me03 https://github.com/metasfresh/me03/issues/30104 — DocuWare invoice export is live on danthermuat but a failure (e.g. the OAuth2 token-URL 404 currently blocking UAT) surfaces **only** in `AD_PInstance_Log`, with nothing on the document. #24483 adds, for every scripted-export attempt: an `ExternalSystem_ScriptedExportConversion_Status` log row (status / message / HTTP code / linked `AD_Issue`), error/success listeners, and a per-record re-send process.

## Scope — Stage 1 (the generic machinery only)

- Cherry-picked **byte-identical** to `new_dawn_uat` (verified: `git diff origin/new_dawn_uat` is empty for every one of the 47 files, incl. the camel route that combines #24483's hooks with this branch's existing OAuth2 support). This makes the eventual `new_dawn_uat → deep_tundra_release` merge a **no-op** — no future divergence.
- 5 migrations ride along: `5806780 / 5806830 / 5806850 / 5806870 / 5807070`.
- The EPCIS/`M_InOut` UI bits from #24483 ride along verbatim (harmless, unused on this branch).
- A customer-facing `C_Invoice` status tab is **Stage 2** (additive, separate PR — touches no file this PR touches).

## Known limitation (verified, fix tracked under #30104)

On the DocuWare **auto-trigger** path the export call passes `errorContext = null`, so on failure the status row stays `Enqueued` rather than flipping to `Error` (the `AD_Issue` with the error is still created + carries the process instance). The EDI and Re-send paths pass a context and flip correctly. The fix belongs on `new_dawn_uat` (core) — it is **not** adapted here, to preserve the byte-identical/no-op-merge invariant.

## Merge

Migration-bearing → **DDL human-review gate**: please review the 5 migrations before merge; do not auto-merge.
