### PR TITLE
infra: add deep_tundra_release.env dev-stack env file

### DIFF
--- a/misc/dev-support/docker/infrastructure/env-files/deep_tundra_release.env
+++ b/misc/dev-support/docker/infrastructure/env-files/deep_tundra_release.env
@@ -1,0 +1,68 @@
+#
+# environment file for docker-compose.yml
+#
+# Dedicated stack for the deep_tundra_release base branch (dt204 release line).
+# Distinct 22xxx port band so it runs alongside deep_tundra_uat (21xxx) without conflict.
+#
+# In docker-compose, this env-file is used via the "--env-file" cmdline parameter
+#
+# If you want to use these variables as environment-variables in the git-bash shell, you can do
+# set -a
+# source <this file>
+# set +a
+#
+
+BRANCH_NAME=deep_tundra_release
+
+DB_PORT=22432
+DB_DOCKER_IMG=docker.io/metasfresh/metas-db:5.175-new-dawn-uat-preloaded
+
+RABBITMQ_PORT=22672
+RABBITMQ_MGMT_PORT=22673
+RABBITMQ_USER=guest
+RABBITMQ_PASS=guest
+
+SEARCH_PORT=22300
+
+POSTGREST_PORT=22001
+
+MAILPIT_SMTP_PORT=22587
+
+# SMTP test variables (used by Cucumber send_mail.feature)
+TEST_SMTP_HOST=localhost
+TEST_SMTP_PORT=22587
+TEST_SMTP_STARTTLS=false
+TEST_SMTP_FROM=test@localhost
+TEST_SMTP_USER=test
+TEST_SMTP_PASSWORD=test
+MAILPIT_MGMT_PORT=22408
+WIREMOCK_PORT=22080
+
+#
+# Migration-Tool (de.metas.migration.cli.workspace_migrate.Main)
+#
+db_url="jdbc:postgresql://localhost:${DB_PORT}/metasfresh"
+
+#
+# For Cucumber (de.metas.cucumber.InfrastructureSupport)
+#
+CUCUMBER_IS_USING_PROVIDED_INFRASTRUCTURE=true
+
+CUCUMBER_EXTERNALLY_RUNNING_RABBITMQ_HOST=localhost
+CUCUMBER_EXTERNALLY_RUNNING_RABBITMQ_PORT=${RABBITMQ_PORT}
+CUCUMBER_EXTERNALLY_RUNNING_RABBITMQ_USER=${RABBITMQ_USER}
+CUCUMBER_EXTERNALLY_RUNNING_RABBITMQ_PASS=${RABBITMQ_PASS}
+
+CUCUMBER_EXTERNALLY_RUNNING_POSTGRESQL_HOST=localhost
+CUCUMBER_EXTERNALLY_RUNNING_POSTGRESQL_PORT=${DB_PORT}
+
+CUCUMBER_EXTERNALLY_RUNNING_POSTGREST_HOST=localhost
+CUCUMBER_EXTERNALLY_RUNNING_POSTGREST_PORT=${POSTGREST_PORT}
+
+#
+# For IntelliJ run-configs
+#
+# for app and webapi:
+SPRING_RABBITMQ_PORT=${RABBITMQ_PORT}
+# for camel-edi and camel-externalsystems
+CAMEL_COMPONENT_RABBITMQ_PORT_NUMBER=${RABBITMQ_PORT}

--- a/misc/dev-support/docker/infrastructure/env-files/deep_tundra_release.env
+++ b/misc/dev-support/docker/infrastructure/env-files/deep_tundra_release.env
@@ -1,7 +1,7 @@
 #
 # environment file for docker-compose.yml
 #
-# Dedicated stack for the deep_tundra_release base branch (dt204 release line).
+# Dedicated stack for the deep_tundra_release base branch (deep_tundra release line).
 # Distinct 22xxx port band so it runs alongside deep_tundra_uat (21xxx) without conflict.
 #
 # In docker-compose, this env-file is used via the "--env-file" cmdline parameter
@@ -15,7 +15,7 @@
 BRANCH_NAME=deep_tundra_release
 
 DB_PORT=22432
-DB_DOCKER_IMG=docker.io/metasfresh/metas-db:5.175-new-dawn-uat-preloaded
+DB_DOCKER_IMG=docker.io/metasfresh/metas-db:5.175-deep-tundra-release-preloaded
 
 RABBITMQ_PORT=22672
 RABBITMQ_MGMT_PORT=22673


### PR DESCRIPTION
Adds a dedicated docker-infrastructure env file for the `deep_tundra_release` line, mirroring `deep_tundra_uat.env` on a distinct **22xxx** port band (DB 22432, rabbitmq 22672, postgrest 22001, search 22300, mailpit 22587, wiremock 22080).

Why: lets a `deep_tundra_release` stack run alongside `deep_tundra_uat` (21xxx) without port conflict, and makes the cucumber / migration wrapper scripts auto-detect the right stack for `deep_tundra_release*` branches (longest-prefix env-file match). Same preloaded DB image as `deep_tundra_uat.env`. No code change.