### PR TITLE
Scripted export: auto-trigger path propagates UNKNOWN error context (not null)

### DIFF
--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
@@ -287,7 +287,11 @@ public class ExternalSystemScriptedExportConversionService
 			@NonNull final ExternalSystemScriptedExportConversionConfig config,
 			final int recordId)
 	{
-		return executeInvokeScriptedExportConversionActionAndGetResult(config, recordId, null).getExceptions();
+		// UNKNOWN (not null): the auto-trigger / archive-listener path must propagate a non-null error
+		// context so a downstream failure reaches the scripted-export error listener (createIssue only
+		// notifies it when errorContext != null) and the status row flips to Error. The EDI and Re-send
+		// paths pass EDI / RESEND; auto-trigger has no specific context, so it uses the neutral UNKNOWN.
+		return executeInvokeScriptedExportConversionActionAndGetResult(config, recordId, ExternalSystemInvocationContext.UNKNOWN).getExceptions();
 	}
 
 	/**

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
@@ -36,9 +36,9 @@ import de.metas.externalsystem.ExternalSystemParentConfigId;
 import de.metas.externalsystem.ExternalSystemType;
 import de.metas.externalsystem.audit.CreateExportAuditRequest;
 import de.metas.externalsystem.audit.ExternalSystemExportAuditRepo;
-import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion;
 import de.metas.externalsystem.endpoint.ExternalSystemEndpoint;
 import de.metas.externalsystem.endpoint.ExternalSystemEndpointRepository;
+import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion;
 import de.metas.externalsystem.process.InvokeScriptedExportConversionAction;
 import de.metas.logging.LogManager;
 import de.metas.process.PInstanceId;
@@ -79,8 +79,8 @@ import static de.metas.common.externalsystem.ExternalSystemConstants.COMMAND_CON
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_ERROR_CONTEXT;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_FROM_MF_METASFRESH_INPUT;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_JAVASCRIPT_IDENTIFIER;
-import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_OUTBOUND_ENDPOINT_PARAMETERS;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_OUTBOUND_DOCUMENT_NO;
+import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_OUTBOUND_ENDPOINT_PARAMETERS;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_OUTBOUND_RECORD_ID;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_OUTBOUND_RECORD_TABLE_NAME;
 import static de.metas.externalsystem.process.InvokeExternalSystemProcess.PARAM_CHILD_CONFIG_ID;
@@ -425,7 +425,7 @@ public class ExternalSystemScriptedExportConversionService
 	public ExternalSystemInvocationResult executeInvokeScriptedExportConversionActionAndGetResult(
 			@NonNull final ExternalSystemScriptedExportConversionConfig config,
 			final int recordId,
-			@Nullable final ExternalSystemInvocationContext errorContext)
+			@NonNull final ExternalSystemInvocationContext errorContext)
 	{
 		final int configTableId = tableDAO.retrieveTableId(I_ExternalSystem_Config_ScriptedExportConversion.Table_Name);
 		final TableRecordReference sourceRecord = TableRecordReference.of(config.getTableId(), recordId);
@@ -438,12 +438,8 @@ public class ExternalSystemScriptedExportConversionService
 					.setAD_ProcessByClassname(InvokeScriptedExportConversionAction.class.getName())
 					.addParameter(PARAM_EXTERNAL_REQUEST, COMMAND_CONVERT_MESSAGE_FROM_METASFRESH)
 					.addParameter(PARAM_CHILD_CONFIG_ID, config.getId().getRepoId())
-					.addParameter(PARAM_Record_ID, recordId);
-
-			if (errorContext != null)
-			{
-				processInfoBuilder.addParameter(PARAM_ERROR_CONTEXT, errorContext.getCode());
-			}
+					.addParameter(PARAM_Record_ID, recordId)
+					.addParameter(PARAM_ERROR_CONTEXT, errorContext.getCode());
 
 			final ProcessInfo processInfo = processInfoBuilder.buildAndPrepareExecution().executeSync().getProcessInfo();
 			final ProcessExecutionResult result = processInfo.getResult();

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionServiceErrorContextTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionServiceErrorContextTest.java
@@ -1,0 +1,104 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.externalsystem.ExternalSystemInvocationContext;
+import de.metas.externalsystem.ExternalSystemParentConfigId;
+import de.metas.externalsystem.endpoint.ExternalSystemEndpointId;
+import de.metas.process.PInstanceId;
+import org.adempiere.ad.table.api.AdTableAndClientId;
+import org.adempiere.ad.table.api.AdTableId;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+
+/**
+ * Pins the error-context the auto-trigger export path propagates.
+ *
+ * <p>{@link ExternalSystemScriptedExportConversionService#executeInvokeScriptedExportConversionAction}
+ * is the path used by the AFTER_COMPLETE interceptor and by external archive-listener callers
+ * (e.g. the DocuWare invoice export, me03 30104). It must delegate with a <b>non-null</b>
+ * {@link ExternalSystemInvocationContext} so that a downstream failure reaches the error listener:
+ * {@code ExternalSystemService.createIssue} only notifies the export-status error listener when the
+ * error item carries a non-null {@code errorContext}, and only then does the status row flip to
+ * {@code Error} + get its {@code AD_Issue} linked. Passing {@code null} silently disables error-status
+ * tracking for every auto-trigger export. {@link ExternalSystemInvocationContext#UNKNOWN} is the neutral,
+ * always-applicable context (the EDI and Re-send paths already pass {@code EDI} / {@code RESEND}).
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class ExternalSystemScriptedExportConversionServiceErrorContextTest
+{
+	private ExternalSystemScriptedExportConversionService service;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		service = new ExternalSystemScriptedExportConversionService(
+				ExternalSystemExportStatusService.newInstanceForUnitTesting(),
+				Mockito.mock(ExternalSystemScriptedExportConversionRepository.class),
+				Mockito.mock(de.metas.externalsystem.endpoint.ExternalSystemEndpointRepository.class),
+				Mockito.mock(de.metas.externalsystem.audit.ExternalSystemExportAuditRepo.class),
+				Mockito.mock(de.metas.externalsystem.ExternalSystemConfigRepo.class));
+	}
+
+	private ExternalSystemScriptedExportConversionConfig buildConfig()
+	{
+		return ExternalSystemScriptedExportConversionConfig.builder()
+				.id(ExternalSystemScriptedExportConversionConfigId.ofRepoId(1))
+				.parentId(ExternalSystemParentConfigId.ofRepoId(1))
+				.externalSystemEndpointId(ExternalSystemEndpointId.ofRepoId(1))
+				.value("test")
+				.scriptIdentifier("test.js")
+				.tableAndClientId(AdTableAndClientId.of(AdTableId.ofRepoId(540), ClientId.ofRepoId(1)))
+				.whereClause("1=1")
+				.active(true)
+				.isTriggerOnComplete(true)
+				.build();
+	}
+
+	@Test
+	void executeInvokeScriptedExportConversionAction_propagatesUnknownErrorContext_notNull()
+	{
+		final ExternalSystemScriptedExportConversionService spy = Mockito.spy(service);
+		final ExternalSystemScriptedExportConversionConfig config = buildConfig();
+		final int recordId = 100;
+
+		// Stub the heavy "execute the process" method so the test stays a pure unit test;
+		// any() matches the null arg too, so the stub is hit in both the pre-fix and post-fix cases.
+		Mockito.doReturn(ExternalSystemInvocationResult.success(PInstanceId.ofRepoId(1)))
+				.when(spy)
+				.executeInvokeScriptedExportConversionActionAndGetResult(
+						Mockito.any(), Mockito.anyInt(), Mockito.any());
+
+		spy.executeInvokeScriptedExportConversionAction(config, recordId);
+
+		// The auto-trigger path must pass UNKNOWN, not null.
+		Mockito.verify(spy).executeInvokeScriptedExportConversionActionAndGetResult(
+				config, recordId, ExternalSystemInvocationContext.UNKNOWN);
+	}
+}


### PR DESCRIPTION
## What

The scripted-export-conversion **auto-trigger** path (`ExternalSystemScriptedExportConversionService.executeInvokeScriptedExportConversionAction`) passed `errorContext = null`. As a result, a downstream export failure never flips the `ExternalSystem_ScriptedExportConversion_Status` row to `Error` and never links the `AD_Issue` — because `ExternalSystemService.createIssue` only notifies the export-status error listener when the error item carries a **non-null** `errorContext`.

This changes the default to the neutral `ExternalSystemInvocationContext.UNKNOWN`, so auto-trigger / archive-listener exports surface their failures as an `Error` status row + linked `AD_Issue`, exactly like the EDI and Re-send paths (which already pass `EDI` / `RESEND`).

## Why

Discovered during UAT of DocuWare invoice export (me03 https://github.com/metasfresh/me03/issues/30104), whose archive-listener uses this auto-trigger path: an OAuth2 token-URL 404 created an `AD_Issue` but left the status row stuck at `Enqueued`. The gap originates in https://github.com/metasfresh/metasfresh/pull/24483 (me03 https://github.com/metasfresh/me03/issues/30088) and also affects EPCIS shipment export via the AFTER_COMPLETE interceptor.

## Scope / safety

- One-line behaviour change + a focused unit test (`ExternalSystemScriptedExportConversionServiceErrorContextTest`) asserting the auto-trigger path delegates with `UNKNOWN`, not `null` (TDD: RED before the change, GREEN after).
- Full `de.metas.externalsystem` suite green locally (120 tests).
- The #24483 cucumber scenarios (`epcisScriptedExportStatus.feature`) are unaffected: they simulate the `/error` callback with their own `EDI` context (`ExternalSystem_Error_StepDef`), independent of the trigger-path context.

## Related

A sibling PR ports this identical fix to `deep_tundra_release` (https://github.com/metasfresh/metasfresh/pull/24574) so danthermuat gets it now; keeping both branches byte-identical preserves the no-op `new_dawn_uat → deep_tundra_release` merge.
