### PR TITLE
MobileUI Distribution: IsPackingPlace workplace filter (me03 30429)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_Workplace.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_Workplace.java
@@ -77,7 +77,7 @@ public interface I_C_Workplace
 
 	/**
 	 * Set Workplace.
-	 * The assignment applies to all users assigned to this workstation
+	 * Logical area within a warehouse, to which one or more Workstations can be assigned. An operator logs into exactly one Workplace per shift. The associated warehouse (M_Warehouse_ID) drives the storage location of the work performed there.
 	 *
 	 * <br>Type: ID
 	 * <br>Mandatory: true
@@ -87,7 +87,7 @@ public interface I_C_Workplace
 
 	/**
 	 * Get Workplace.
-	 * The assignment applies to all users assigned to this workstation
+	 * Logical area within a warehouse, to which one or more Workstations can be assigned. An operator logs into exactly one Workplace per shift. The associated warehouse (M_Warehouse_ID) drives the storage location of the work performed there.
 	 *
 	 * <br>Type: ID
 	 * <br>Mandatory: true
@@ -141,6 +141,27 @@ public interface I_C_Workplace
 
 	ModelColumn<I_C_Workplace, Object> COLUMN_IsActive = new ModelColumn<>(I_C_Workplace.class, "IsActive", null);
 	String COLUMNNAME_IsActive = "IsActive";
+
+	/**
+	 * Set Is Packing Place.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsPackingPlace (boolean IsPackingPlace);
+
+	/**
+	 * Get Is Packing Place.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isPackingPlace();
+
+	ModelColumn<I_C_Workplace, Object> COLUMN_IsPackingPlace = new ModelColumn<>(I_C_Workplace.class, "IsPackingPlace", null);
+	String COLUMNNAME_IsPackingPlace = "IsPackingPlace";
 
 	/**
 	 * Set Max. Picking Jobs.

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_Workplace.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_Workplace.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class X_C_Workplace extends org.compiere.model.PO implements I_C_Workplace, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = -991045398L;
+	private static final long serialVersionUID = -1988281162L;
 
     /** Standard Constructor */
     public X_C_Workplace (final Properties ctx, final int C_Workplace_ID, @Nullable final String trxName)
@@ -59,6 +59,18 @@ public class X_C_Workplace extends org.compiere.model.PO implements I_C_Workplac
 	public java.lang.String getDescription() 
 	{
 		return get_ValueAsString(COLUMNNAME_Description);
+	}
+
+	@Override
+	public void setIsPackingPlace (final boolean IsPackingPlace)
+	{
+		set_Value (COLUMNNAME_IsPackingPlace, IsPackingPlace);
+	}
+
+	@Override
+	public boolean isPackingPlace() 
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsPackingPlace);
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/Workplace.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/Workplace.java
@@ -53,6 +53,7 @@ public class Workplace
 	@Nullable PriorityRule priorityRule;
 	@Nullable OrderPickingType orderPickingType;
 	int maxPickingJobs;
+	boolean isPackingPlace;
 
 	@NonNull ImmutableSet<ProductId> productIds;
 	@NonNull ImmutableSet<ProductCategoryId> productCategoryIds;
@@ -72,6 +73,7 @@ public class Workplace
 			@Nullable final PriorityRule priorityRule,
 			@Nullable final OrderPickingType orderPickingType,
 			final int maxPickingJobs,
+			final boolean isPackingPlace,
 			@Nullable final ImmutableSet<ProductId> productIds,
 			@Nullable final ImmutableSet<ProductCategoryId> productCategoryIds,
 			@Nullable final ImmutableSet<CarrierProductId> carrierProductIds,
@@ -93,6 +95,7 @@ public class Workplace
 		this.priorityRule = priorityRule;
 		this.orderPickingType = orderPickingType;
 		this.maxPickingJobs = maxPickingJobs;
+		this.isPackingPlace = isPackingPlace;
 
 		this.productIds = productIds != null ? productIds : ImmutableSet.of();
 		this.productCategoryIds = productCategoryIds != null ? productCategoryIds : ImmutableSet.of();

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceCreateRequest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceCreateRequest.java
@@ -30,7 +30,7 @@ public class WorkplaceCreateRequest
 	@Nullable SeqNo seqNo;
 	@Nullable OrderPickingType orderPickingType;
 	int maxPickingJobs;
-	/** Defaults to {@code true} to match the {@code C_Workplace.IsPackingPlace} DB column default ('Y'): a workplace created without an explicit role is a packing place, preserving the pre-existing launcher behaviour (me03 #30429 AC2). */
+	/** Defaults to {@code true} to match the {@code C_Workplace.IsPackingPlace} DB column default ('Y'): a workplace created without an explicit role is a packing place, preserving the pre-existing launcher behaviour. */
 	@Builder.Default boolean isPackingPlace = true;
 
 	@NonNull @Singular ImmutableSet<ProductCategoryId> productCategoryIds;

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceCreateRequest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceCreateRequest.java
@@ -30,6 +30,7 @@ public class WorkplaceCreateRequest
 	@Nullable SeqNo seqNo;
 	@Nullable OrderPickingType orderPickingType;
 	int maxPickingJobs;
+	boolean isPackingPlace;
 
 	@NonNull @Singular ImmutableSet<ProductCategoryId> productCategoryIds;
 	@NonNull @Singular ImmutableSet<ProductId> productIds;

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceCreateRequest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceCreateRequest.java
@@ -30,7 +30,8 @@ public class WorkplaceCreateRequest
 	@Nullable SeqNo seqNo;
 	@Nullable OrderPickingType orderPickingType;
 	int maxPickingJobs;
-	boolean isPackingPlace;
+	/** Defaults to {@code true} to match the {@code C_Workplace.IsPackingPlace} DB column default ('Y'): a workplace created without an explicit role is a packing place, preserving the pre-existing launcher behaviour (me03 #30429 AC2). */
+	@Builder.Default boolean isPackingPlace = true;
 
 	@NonNull @Singular ImmutableSet<ProductCategoryId> productCategoryIds;
 	@NonNull @Singular ImmutableSet<ProductId> productIds;

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceRepository.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceRepository.java
@@ -109,7 +109,7 @@ public class WorkplaceRepository
 
 	public List<Workplace> getAllActive() {return getMap().getAllActive();}
 
-	public ImmutableSet<LocatorId> getPackingPlacePickFromLocatorIds() {return getMap().getPackingPlacePickFromLocatorIds();}
+	public ImmutableSet<LocatorId> getPackingPlacePickFromLocatorIds(@NonNull final WarehouseId warehouseId) {return getMap().getPackingPlacePickFromLocatorIds(warehouseId);}
 
 	public Workplace create(@NonNull final WorkplaceCreateRequest request)
 	{
@@ -439,10 +439,11 @@ public class WorkplaceRepository
 			return workplace != null ? workplace.getSeqNo().next() : SeqNo.ofInt(10);
 		}
 
-		public ImmutableSet<LocatorId> getPackingPlacePickFromLocatorIds()
+		public ImmutableSet<LocatorId> getPackingPlacePickFromLocatorIds(@NonNull final WarehouseId warehouseId)
 		{
 			return allActive.stream()
 					.filter(Workplace::isPackingPlace)
+					.filter(workplace -> WarehouseId.equals(workplace.getWarehouseId(), warehouseId))
 					.map(Workplace::getPickFromLocatorId)
 					.filter(Objects::nonNull)
 					.collect(ImmutableSet.toImmutableSet());

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceRepository.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceRepository.java
@@ -108,6 +108,8 @@ public class WorkplaceRepository
 
 	public List<Workplace> getAllActive() {return getMap().getAllActive();}
 
+	public ImmutableSet<LocatorId> getPackingPlacePickFromLocatorIds() {return getMap().getPackingPlacePickFromLocatorIds();}
+
 	public Workplace create(@NonNull final WorkplaceCreateRequest request)
 	{
 		if (request.getPickFromLocatorId() != null && !WarehouseId.equals(request.getWarehouseId(), request.getPickFromLocatorId().getWarehouseId()))
@@ -373,6 +375,7 @@ public class WorkplaceRepository
 				.priorityRule(PriorityRule.ofNullableCode(record.getPriorityRule()))
 				.orderPickingType(OrderPickingType.ofNullableCode(record.getOrderPickingType()))
 				.maxPickingJobs(record.getMaxPickingJobs())
+				.isPackingPlace(record.isPackingPlace())
 				// Add child collections
 				.productIds(ImmutableSet.copyOf(productsByWorkplace.get(workplaceId)))
 				.productCategoryIds(ImmutableSet.copyOf(categoriesByWorkplace.get(workplaceId)))
@@ -432,6 +435,15 @@ public class WorkplaceRepository
 		{
 			final Workplace workplace = getAllActive().stream().max(Comparator.comparing(v -> v.getSeqNo().toInt())).orElse(null);
 			return workplace != null ? workplace.getSeqNo().next() : SeqNo.ofInt(10);
+		}
+
+		public ImmutableSet<LocatorId> getPackingPlacePickFromLocatorIds()
+		{
+			return allActive.stream()
+					.filter(Workplace::isPackingPlace)
+					.map(Workplace::getPickFromLocatorId)
+					.filter(java.util.Objects::nonNull)
+					.collect(ImmutableSet.toImmutableSet());
 		}
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceRepository.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceRepository.java
@@ -62,6 +62,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -124,6 +125,7 @@ public class WorkplaceRepository
 		record.setPickFrom_Locator_ID(LocatorId.toRepoId(request.getPickFromLocatorId()));
 		record.setM_PickingSlot_ID(PickingSlotId.toRepoId(request.getPickingSlotId()));
 		record.setMaxPickingJobs(request.getMaxPickingJobs());
+		record.setIsPackingPlace(request.isPackingPlace());
 
 		final SeqNo seqNo = request.getSeqNo() != null ? request.getSeqNo() : getMap().getNextSeqNo();
 		record.setSeqNo(seqNo.toInt());
@@ -442,7 +444,7 @@ public class WorkplaceRepository
 			return allActive.stream()
 					.filter(Workplace::isPackingPlace)
 					.map(Workplace::getPickFromLocatorId)
-					.filter(java.util.Objects::nonNull)
+					.filter(Objects::nonNull)
 					.collect(ImmutableSet.toImmutableSet());
 		}
 	}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceService.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceService.java
@@ -94,7 +94,7 @@ public class WorkplaceService
 		return workplaceRepository.isAnyWorkplaceActive();
 	}
 
-	public Set<LocatorId> getPackingPlacePickFromLocatorIds()
+	public ImmutableSet<LocatorId> getPackingPlacePickFromLocatorIds()
 	{
 		return workplaceRepository.getPackingPlacePickFromLocatorIds();
 	}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceService.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceService.java
@@ -94,6 +94,11 @@ public class WorkplaceService
 		return workplaceRepository.isAnyWorkplaceActive();
 	}
 
+	public Set<LocatorId> getPackingPlacePickFromLocatorIds()
+	{
+		return workplaceRepository.getPackingPlacePickFromLocatorIds();
+	}
+
 	public Set<LocatorId> getPickFromLocatorIds(final Workplace workplace)
 	{
 		if (workplace.getPickFromLocatorId() != null)

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceService.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceService.java
@@ -94,9 +94,9 @@ public class WorkplaceService
 		return workplaceRepository.isAnyWorkplaceActive();
 	}
 
-	public ImmutableSet<LocatorId> getPackingPlacePickFromLocatorIds()
+	public ImmutableSet<LocatorId> getPackingPlacePickFromLocatorIds(@NonNull final WarehouseId warehouseId)
 	{
-		return workplaceRepository.getPackingPlacePickFromLocatorIds();
+		return workplaceRepository.getPackingPlacePickFromLocatorIds(warehouseId);
 	}
 
 	public Set<LocatorId> getPickFromLocatorIds(final Workplace workplace)

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceRepositoryTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceRepositoryTest.java
@@ -58,6 +58,27 @@ public class WorkplaceRepositoryTest
 	}
 
 	@Test
+	public void create_defaultsToPackingPlace()
+	{
+		// A workplace created without an explicit IsPackingPlace must default to a packing place ('Y'),
+		// matching the C_Workplace.IsPackingPlace DB column default and preserving the pre-change launcher
+		// behaviour (me03 #30429 AC2). A 'N' default would silently flip every request-created workplace
+		// into the replenishment role.
+		final Workplace workplace = WorkplaceRepository.newInstanceForUnitTesting().create(WorkplaceCreateRequest.builder()
+				.name("default-role")
+				.warehouseId(WarehouseId.ofRepoId(1))
+				.build());
+		assertThat(workplace.isPackingPlace()).isTrue();
+
+		final Workplace replenishment = WorkplaceRepository.newInstanceForUnitTesting().create(WorkplaceCreateRequest.builder()
+				.name("explicit-replenishment")
+				.warehouseId(WarehouseId.ofRepoId(1))
+				.isPackingPlace(false)
+				.build());
+		assertThat(replenishment.isPackingPlace()).isFalse();
+	}
+
+	@Test
 	public void getPackingPlacePickFromLocatorIds_returnsOnlyPackingPlacesWithLocator()
 	{
 		final WarehouseId warehouseId = WarehouseId.ofRepoId(1);

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceRepositoryTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceRepositoryTest.java
@@ -22,11 +22,16 @@
 
 package de.metas.workplace;
 
+import com.google.common.collect.ImmutableSet;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_C_Workplace;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class WorkplaceRepositoryTest
@@ -51,5 +56,51 @@ public class WorkplaceRepositoryTest
 				.warehouseId(WarehouseId.ofRepoId(1))
 				.build());
 		assertNotNull(workplace2);
+	}
+
+	@Test
+	public void getPackingPlacePickFromLocatorIds_returnsOnlyPackingPlacesWithLocator()
+	{
+		final WarehouseId warehouseId = WarehouseId.ofRepoId(1);
+		final LocatorId L1 = LocatorId.ofRepoId(warehouseId, 101);
+		final LocatorId L2 = LocatorId.ofRepoId(warehouseId, 102);
+		final LocatorId L3 = LocatorId.ofRepoId(warehouseId, 103);
+
+		// WP-A: isPackingPlace=Y, locator L1
+		final I_C_Workplace wpA = InterfaceWrapperHelper.newInstance(I_C_Workplace.class);
+		wpA.setName("WP-A");
+		wpA.setM_Warehouse_ID(warehouseId.getRepoId());
+		wpA.setIsPackingPlace(true);
+		wpA.setPickFrom_Locator_ID(L1.getRepoId());
+		InterfaceWrapperHelper.saveRecord(wpA);
+
+		// WP-B: isPackingPlace=Y, locator L2
+		final I_C_Workplace wpB = InterfaceWrapperHelper.newInstance(I_C_Workplace.class);
+		wpB.setName("WP-B");
+		wpB.setM_Warehouse_ID(warehouseId.getRepoId());
+		wpB.setIsPackingPlace(true);
+		wpB.setPickFrom_Locator_ID(L2.getRepoId());
+		InterfaceWrapperHelper.saveRecord(wpB);
+
+		// WP-C: isPackingPlace=N, locator L3 — must NOT appear in result
+		final I_C_Workplace wpC = InterfaceWrapperHelper.newInstance(I_C_Workplace.class);
+		wpC.setName("WP-C");
+		wpC.setM_Warehouse_ID(warehouseId.getRepoId());
+		wpC.setIsPackingPlace(false);
+		wpC.setPickFrom_Locator_ID(L3.getRepoId());
+		InterfaceWrapperHelper.saveRecord(wpC);
+
+		// WP-D: isPackingPlace=Y but NO locator — contributes nothing
+		final I_C_Workplace wpD = InterfaceWrapperHelper.newInstance(I_C_Workplace.class);
+		wpD.setName("WP-D");
+		wpD.setM_Warehouse_ID(warehouseId.getRepoId());
+		wpD.setIsPackingPlace(true);
+		// PickFrom_Locator_ID intentionally not set (defaults to 0 = null)
+		InterfaceWrapperHelper.saveRecord(wpD);
+
+		final WorkplaceRepository repo = WorkplaceRepository.newInstanceForUnitTesting();
+		final ImmutableSet<LocatorId> result = repo.getPackingPlacePickFromLocatorIds();
+
+		assertThat(result).containsExactlyInAnyOrder(L1, L2);
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceRepositoryTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceRepositoryTest.java
@@ -82,9 +82,11 @@ public class WorkplaceRepositoryTest
 	public void getPackingPlacePickFromLocatorIds_returnsOnlyPackingPlacesWithLocator()
 	{
 		final WarehouseId warehouseId = WarehouseId.ofRepoId(1);
+		final WarehouseId otherWarehouseId = WarehouseId.ofRepoId(2);
 		final LocatorId L1 = LocatorId.ofRepoId(warehouseId, 101);
 		final LocatorId L2 = LocatorId.ofRepoId(warehouseId, 102);
 		final LocatorId L3 = LocatorId.ofRepoId(warehouseId, 103);
+		final LocatorId L4 = LocatorId.ofRepoId(otherWarehouseId, 104);
 
 		// WP-A: isPackingPlace=Y, locator L1
 		saveWorkplace("WP-A", warehouseId, true, L1.getRepoId());
@@ -94,8 +96,10 @@ public class WorkplaceRepositoryTest
 		saveWorkplace("WP-C", warehouseId, false, L3.getRepoId());
 		// WP-D: isPackingPlace=Y but NO locator — contributes nothing
 		saveWorkplace("WP-D", warehouseId, true, 0);
+		// WP-E: isPackingPlace=Y, locator L4 but in ANOTHER warehouse — must NOT appear when querying warehouseId
+		saveWorkplace("WP-E", otherWarehouseId, true, L4.getRepoId());
 
-		final ImmutableSet<LocatorId> result = WorkplaceRepository.newInstanceForUnitTesting().getPackingPlacePickFromLocatorIds();
+		final ImmutableSet<LocatorId> result = WorkplaceRepository.newInstanceForUnitTesting().getPackingPlacePickFromLocatorIds(warehouseId);
 
 		assertThat(result).containsExactlyInAnyOrder(L1, L2);
 	}

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceRepositoryTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceRepositoryTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class WorkplaceRepositoryTest
 {
@@ -49,13 +48,13 @@ public class WorkplaceRepositoryTest
 						.name("Test")
 						.warehouseId(WarehouseId.ofRepoId(1))
 				.build());
-		assertNotNull(workplace);
+		assertThat(workplace).isNotNull();
 
 		final Workplace workplace2 = WorkplaceRepository.newInstanceForUnitTesting().create(WorkplaceCreateRequest.builder()
 				.name("Test2")
 				.warehouseId(WarehouseId.ofRepoId(1))
 				.build());
-		assertNotNull(workplace2);
+		assertThat(workplace2).isNotNull();
 	}
 
 	@Test
@@ -67,40 +66,30 @@ public class WorkplaceRepositoryTest
 		final LocatorId L3 = LocatorId.ofRepoId(warehouseId, 103);
 
 		// WP-A: isPackingPlace=Y, locator L1
-		final I_C_Workplace wpA = InterfaceWrapperHelper.newInstance(I_C_Workplace.class);
-		wpA.setName("WP-A");
-		wpA.setM_Warehouse_ID(warehouseId.getRepoId());
-		wpA.setIsPackingPlace(true);
-		wpA.setPickFrom_Locator_ID(L1.getRepoId());
-		InterfaceWrapperHelper.saveRecord(wpA);
-
+		saveWorkplace("WP-A", warehouseId, true, L1.getRepoId());
 		// WP-B: isPackingPlace=Y, locator L2
-		final I_C_Workplace wpB = InterfaceWrapperHelper.newInstance(I_C_Workplace.class);
-		wpB.setName("WP-B");
-		wpB.setM_Warehouse_ID(warehouseId.getRepoId());
-		wpB.setIsPackingPlace(true);
-		wpB.setPickFrom_Locator_ID(L2.getRepoId());
-		InterfaceWrapperHelper.saveRecord(wpB);
-
+		saveWorkplace("WP-B", warehouseId, true, L2.getRepoId());
 		// WP-C: isPackingPlace=N, locator L3 — must NOT appear in result
-		final I_C_Workplace wpC = InterfaceWrapperHelper.newInstance(I_C_Workplace.class);
-		wpC.setName("WP-C");
-		wpC.setM_Warehouse_ID(warehouseId.getRepoId());
-		wpC.setIsPackingPlace(false);
-		wpC.setPickFrom_Locator_ID(L3.getRepoId());
-		InterfaceWrapperHelper.saveRecord(wpC);
-
+		saveWorkplace("WP-C", warehouseId, false, L3.getRepoId());
 		// WP-D: isPackingPlace=Y but NO locator — contributes nothing
-		final I_C_Workplace wpD = InterfaceWrapperHelper.newInstance(I_C_Workplace.class);
-		wpD.setName("WP-D");
-		wpD.setM_Warehouse_ID(warehouseId.getRepoId());
-		wpD.setIsPackingPlace(true);
-		// PickFrom_Locator_ID intentionally not set (defaults to 0 = null)
-		InterfaceWrapperHelper.saveRecord(wpD);
+		saveWorkplace("WP-D", warehouseId, true, 0);
 
-		final WorkplaceRepository repo = WorkplaceRepository.newInstanceForUnitTesting();
-		final ImmutableSet<LocatorId> result = repo.getPackingPlacePickFromLocatorIds();
+		final ImmutableSet<LocatorId> result = WorkplaceRepository.newInstanceForUnitTesting().getPackingPlacePickFromLocatorIds();
 
 		assertThat(result).containsExactlyInAnyOrder(L1, L2);
+	}
+
+	private static void saveWorkplace(
+			final String name,
+			final WarehouseId warehouseId,
+			final boolean isPackingPlace,
+			final int pickFromLocatorRepoId)
+	{
+		final I_C_Workplace record = InterfaceWrapperHelper.newInstance(I_C_Workplace.class);
+		record.setName(name);
+		record.setM_Warehouse_ID(warehouseId.getRepoId());
+		record.setIsPackingPlace(isPackingPlace);
+		record.setPickFrom_Locator_ID(pickFromLocatorRepoId);
+		InterfaceWrapperHelper.saveRecord(record);
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceRepositoryTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceRepositoryTest.java
@@ -62,8 +62,8 @@ public class WorkplaceRepositoryTest
 	{
 		// A workplace created without an explicit IsPackingPlace must default to a packing place ('Y'),
 		// matching the C_Workplace.IsPackingPlace DB column default and preserving the pre-change launcher
-		// behaviour (me03 #30429 AC2). A 'N' default would silently flip every request-created workplace
-		// into the replenishment role.
+		// behaviour. A 'N' default would silently flip every request-created workplace into the
+		// replenishment role.
 		final Workplace workplace = WorkplaceRepository.newInstanceForUnitTesting().create(WorkplaceCreateRequest.builder()
 				.name("default-role")
 				.warehouseId(WarehouseId.ofRepoId(1))

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807860_sys_C_Workplace_IsPackingPlace.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807860_sys_C_Workplace_IsPackingPlace.sql
@@ -101,9 +101,7 @@ WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND t.AD_Field_ID = 781119
   AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
 
 -- Propagate AD_Element_Trl → AD_Field_Trl (pass ELEMENT ID, not field ID)
-SELECT update_FieldTranslation_From_AD_Name_Element(
-  (SELECT AD_Element_ID FROM AD_Element WHERE ColumnName = 'IsPackingPlace')
-);
+SELECT update_FieldTranslation_From_AD_Name_Element(584993 /*IsPackingPlace, From ID Server*/);
 
 -- Rebuild element links for this field
 DELETE FROM AD_Element_Link WHERE AD_Field_ID = 781119;
@@ -134,6 +132,4 @@ VALUES (652265 /*From ID Server*/, 0, 0, 'Y',
 -- =============================================================================
 -- 6. Propagate all translations from AD_Element_Trl
 -- =============================================================================
-SELECT update_TRL_Tables_On_AD_Element_TRL_Update(
-  (SELECT AD_Element_ID FROM AD_Element WHERE ColumnName = 'IsPackingPlace')
-);
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584993 /*IsPackingPlace, From ID Server*/);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807860_sys_C_Workplace_IsPackingPlace.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807860_sys_C_Workplace_IsPackingPlace.sql
@@ -1,0 +1,139 @@
+-- C_Workplace — add IsPackingPlace boolean column and WebUI window field.
+-- Marks a workplace as a packing place (used for packing operations).
+-- Default 'Y' — all existing workplaces become packing places on migration.
+--
+-- IDs allocated from idserver.metas.de on 2026-06-15:
+--   AD_MigrationScript  5807860  (this script)
+--   AD_Element          584993   (IsPackingPlace)
+--   AD_Column           592810   (C_Workplace.IsPackingPlace)
+--   AD_Field            781119   (Arbeitsplatz tab, window 541744)
+--   AD_UI_Element       652265   (flags group 551258)
+
+-- =============================================================================
+-- 1. AD_Element — German base text; en_US via Trl
+-- =============================================================================
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                        ColumnName, EntityType, Name, PrintName)
+VALUES (584993 /*From ID Server*/, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-06-15 14:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        TO_TIMESTAMP('2026-06-15 14:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        'IsPackingPlace', 'D', 'Packplatz', 'Packplatz');
+
+-- Skeleton Trl rows (all active system languages; copy base DE, IsTranslated='N')
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Name, PrintName, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.Name, t.PrintName, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y') AND t.AD_Element_ID = 584993
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID);
+
+-- English translation (en_US — strictly later timestamp than element INSERT)
+UPDATE AD_Element_Trl
+   SET Name = 'Is Packing Place', PrintName = 'Is Packing Place', IsTranslated = 'Y',
+       Updated = TO_TIMESTAMP('2026-06-15 14:00:12', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy = 100
+ WHERE AD_Element_ID = 584993 AND AD_Language = 'en_US';
+
+-- de_DE / de_CH — same text as base, mark as translated
+UPDATE AD_Element_Trl
+   SET IsTranslated = 'Y',
+       Updated = TO_TIMESTAMP('2026-06-15 14:00:13', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy = 100
+ WHERE AD_Element_ID = 584993 AND AD_Language IN ('de_DE', 'de_CH');
+
+-- =============================================================================
+-- 2. AD_Column — C_Workplace.IsPackingPlace
+-- =============================================================================
+INSERT INTO AD_Column (AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                       Version, AD_Table_ID, AD_Element_ID, AD_Reference_ID,
+                       ColumnName, Name,
+                       FieldLength, IsMandatory, IsUpdateable, IsAlwaysUpdateable,
+                       DefaultValue, EntityType, IsKey, IsParent, IsSelectionColumn,
+                       IsTranslated, IsIdentifier, IsEncrypted, IsAllowLogging,
+                       IsExcludeFromZoomTargets, CloningStrategy,
+                       PersonalDataCategory)
+VALUES (592810 /*From ID Server*/, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-06-15 14:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        TO_TIMESTAMP('2026-06-15 14:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        0,
+        (SELECT AD_Table_ID FROM AD_Table WHERE TableName = 'C_Workplace'),
+        (SELECT AD_Element_ID FROM AD_Element WHERE ColumnName = 'IsPackingPlace'),
+        20 /*Yes-No*/,
+        'IsPackingPlace', 'Packplatz',
+        1, 'Y', 'Y', 'N',
+        'Y', 'D', 'N', 'N', 'N',
+        'N', 'N', 'N', 'Y',
+        'Y', 'XX',
+        'NP');
+
+-- Skeleton Column Trl rows
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND t.AD_Column_ID = 592810
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID);
+
+-- =============================================================================
+-- 3. Physical DDL — add column with DEFAULT 'Y', backfill, then enforce NOT NULL
+-- =============================================================================
+SELECT public.db_alter_table('C_Workplace', 'ALTER TABLE public.C_Workplace ADD COLUMN IF NOT EXISTS IsPackingPlace CHAR(1) DEFAULT ''Y'' CHECK (IsPackingPlace IN (''Y'',''N'')) NOT NULL');
+
+-- =============================================================================
+-- 4. AD_Field — place on main tab (547260) of C_Workplace window (541744)
+-- =============================================================================
+INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                      Name, AD_Tab_ID, AD_Column_ID, IsDisplayed, DisplayLength,
+                      SeqNo, SeqNoGrid, IsSameLine, IsHeading, IsFieldOnly, IsReadOnly,
+                      IsMandatory, IsEncrypted, EntityType)
+VALUES (781119 /*From ID Server*/, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-06-15 14:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        TO_TIMESTAMP('2026-06-15 14:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        'Packplatz',
+        547260 /*tab: Arbeitsplatz*/,
+        (SELECT AD_Column_ID FROM AD_Column WHERE ColumnName = 'IsPackingPlace' AND AD_Table_ID = (SELECT AD_Table_ID FROM AD_Table WHERE TableName = 'C_Workplace')),
+        'Y', 1,
+        0, 55,  -- SeqNo=0 (form governed by AD_UI_Element); SeqNoGrid=55 (before Sektion/AD_Org_ID at 60)
+        'N', 'N', 'N', 'N',
+        'N', 'N', 'D');
+
+-- Skeleton Field Trl rows
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND t.AD_Field_ID = 781119
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID);
+
+-- Propagate AD_Element_Trl → AD_Field_Trl (pass ELEMENT ID, not field ID)
+SELECT update_FieldTranslation_From_AD_Name_Element(
+  (SELECT AD_Element_ID FROM AD_Element WHERE ColumnName = 'IsPackingPlace')
+);
+
+-- Rebuild element links for this field
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 781119;
+SELECT AD_Element_Link_Create_Missing_Field(781119);
+
+-- =============================================================================
+-- 5. AD_UI_Element — place in flags group (551258) on tab 547260
+--    IsActive is at SeqNo=10, IsPackingPlace goes at SeqNo=20
+--    Grid: SeqNoGrid=55 (Aktiv=50, this=55, Sektion/AD_Org_ID=60)
+-- =============================================================================
+INSERT INTO AD_UI_Element (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                           AD_Tab_ID, AD_Field_ID, AD_UI_ElementGroup_ID,
+                           AD_UI_ElementType, Name,
+                           SeqNo, SeqNoGrid, SeqNo_SideList,
+                           IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, IsAdvancedField)
+VALUES (652265 /*From ID Server*/, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-06-15 14:02:30', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        TO_TIMESTAMP('2026-06-15 14:02:30', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        547260 /*tab: Arbeitsplatz*/,
+        781119 /*AD_Field_ID*/,
+        551258 /*group: flags*/,
+        'F', 'Packplatz',
+        20,  -- SeqNo in form: after IsActive (10)
+        55,  -- SeqNoGrid: before AD_Org_ID (60)
+        0,
+        'Y', 'Y', 'N', 'N');
+
+-- =============================================================================
+-- 6. Propagate all translations from AD_Element_Trl
+-- =============================================================================
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(
+  (SELECT AD_Element_ID FROM AD_Element WHERE ColumnName = 'IsPackingPlace')
+);

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/DistributionWarehouseService.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/DistributionWarehouseService.java
@@ -46,9 +46,9 @@ public class DistributionWarehouseService
 	}
 
 	@NonNull
-	public Set<LocatorId> getPackingPlacePickFromLocatorIds()
+	public Set<LocatorId> getPackingPlacePickFromLocatorIds(@NonNull final WarehouseId warehouseId)
 	{
-		return workplaceService.getPackingPlacePickFromLocatorIds();
+		return workplaceService.getPackingPlacePickFromLocatorIds(warehouseId);
 	}
 
 	public WarehouseInfo getWarehouseInfoByRepoId(final int warehouseRepoId)

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/DistributionWarehouseService.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/DistributionWarehouseService.java
@@ -18,6 +18,7 @@ import org.compiere.model.I_M_Locator;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -42,6 +43,11 @@ public class DistributionWarehouseService
 	public Optional<Workplace> getWorkplaceByUserId(@NonNull final UserId userId)
 	{
 		return workplaceService.getWorkplaceByUserId(userId);
+	}
+
+	public Set<LocatorId> getPackingPlacePickFromLocatorIds()
+	{
+		return workplaceService.getPackingPlacePickFromLocatorIds();
 	}
 
 	public WarehouseInfo getWarehouseInfoByRepoId(final int warehouseRepoId)

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/DistributionWarehouseService.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/DistributionWarehouseService.java
@@ -45,6 +45,7 @@ public class DistributionWarehouseService
 		return workplaceService.getWorkplaceByUserId(userId);
 	}
 
+	@NonNull
 	public Set<LocatorId> getPackingPlacePickFromLocatorIds()
 	{
 		return workplaceService.getPackingPlacePickFromLocatorIds();

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DDOrderReferenceQuery.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DDOrderReferenceQuery.java
@@ -12,6 +12,7 @@ import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 
 import javax.annotation.Nullable;
+import java.util.Set;
 
 @Value
 @Builder
@@ -24,4 +25,5 @@ public class DDOrderReferenceQuery
 	@NonNull @Default DistributionJobSorting sorting = DistributionJobSorting.DEFAULT;
 	@Nullable WarehouseId warehouseToId;
 	@Nullable LocatorId locatorToId;
+	@Nullable Set<LocatorId> excludeLocatorToIds;
 }

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DistributionJobQueries.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/service/DistributionJobQueries.java
@@ -55,6 +55,7 @@ public class DistributionJobQueries
 				.warehouseFromIds(activeFacetIds.getWarehouseFromIds())
 				.warehouseToIds(warehouseToIds)
 				.locatorToIds(InSetPredicate.onlyOrAny(query.getLocatorToId()))
+				.excludeLocatorToIds(query.getExcludeLocatorToIds())
 				.salesOrderIds(activeFacetIds.getSalesOrderIds())
 				.manufacturingOrderIds(activeFacetIds.getManufacturingOrderIds())
 				.datesPromised(activeFacetIds.getDatesPromised())

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/launchers/DistributionWorkflowLaunchersProvider.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/launchers/DistributionWorkflowLaunchersProvider.java
@@ -103,7 +103,7 @@ public class DistributionWorkflowLaunchersProvider
 
 		if (workplace != null && !workplace.isPackingPlace())
 		{
-			builder.excludeLocatorToIds(warehouseService.getPackingPlacePickFromLocatorIds());
+			builder.excludeLocatorToIds(warehouseService.getPackingPlacePickFromLocatorIds(workplace.getWarehouseId()));
 		}
 		else
 		{

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/launchers/DistributionWorkflowLaunchersProvider.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/launchers/DistributionWorkflowLaunchersProvider.java
@@ -96,11 +96,21 @@ public class DistributionWorkflowLaunchersProvider
 		final MobileUIDistributionConfig config = getConfig();
 		final Workplace workplace = warehouseService.getWorkplaceByUserId(userId).orElse(null);
 
-		return DDOrderReferenceQuery.builder()
+		final DDOrderReferenceQueryBuilder builder = DDOrderReferenceQuery.builder()
 				.sorting(config.getSorting())
 				.responsibleId(userId)
-				.warehouseToId(workplace != null ? workplace.getWarehouseId() : null)
-				.locatorToId(workplace != null ? workplace.getPickFromLocatorId() : null);
+				.warehouseToId(workplace != null ? workplace.getWarehouseId() : null);
+
+		if (workplace != null && !workplace.isPackingPlace())
+		{
+			builder.excludeLocatorToIds(warehouseService.getPackingPlacePickFromLocatorIds());
+		}
+		else
+		{
+			builder.locatorToId(workplace != null ? workplace.getPickFromLocatorId() : null);
+		}
+
+		return builder;
 	}
 
 	private WorkflowLauncher toWorkflowLauncher(@NonNull final DDOrderReference ddOrderReference)

--- a/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/service/DistributionJobQueriesTest.java
+++ b/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/service/DistributionJobQueriesTest.java
@@ -1,0 +1,76 @@
+package de.metas.distribution.mobileui.job.service;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.distribution.ddorder.DDOrderQuery;
+import de.metas.util.InSetPredicate;
+import org.adempiere.warehouse.LocatorId;
+import org.adempiere.warehouse.WarehouseId;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests {@link DistributionJobQueries#toActiveNotAssignedDDOrderQuery(DDOrderReferenceQuery)}:
+ * <ul>
+ *   <li>Y case — regular workplace: locatorToId present, excludeLocatorToIds absent → locatorToIds predicate matches exactly that locator, excludeLocatorToIds null</li>
+ *   <li>N case — packing-place workplace: locatorToId absent, excludeLocatorToIds populated → locatorToIds is any-match, excludeLocatorToIds propagated</li>
+ * </ul>
+ */
+class DistributionJobQueriesTest
+{
+	private static final WarehouseId W1 = WarehouseId.ofRepoId(1);
+	private static final LocatorId L1 = LocatorId.ofRepoId(1, 101);
+	private static final LocatorId L2 = LocatorId.ofRepoId(1, 102);
+
+	@Test
+	void toActiveNotAssignedDDOrderQuery_regularWorkplace_locatorToIdSet()
+	{
+		// Given: regular (non-packing) workplace — locatorToId set, excludeLocatorToIds absent
+		final DDOrderReferenceQuery query = DDOrderReferenceQuery.builder()
+				.responsibleId(de.metas.user.UserId.ofRepoId(999))
+				.warehouseToId(W1)
+				.locatorToId(L1)
+				.excludeLocatorToIds(null)
+				.build();
+
+		// When
+		final DDOrderQuery result = DistributionJobQueries.toActiveNotAssignedDDOrderQuery(query);
+
+		// Then: locatorToIds matches exactly L1; excludeLocatorToIds is null/empty
+		final InSetPredicate<LocatorId> locatorToIds = result.getLocatorToIds();
+		assertThat(locatorToIds).isNotNull();
+		assertThat(locatorToIds.isAny()).isFalse();
+		assertThat(locatorToIds.test(L1)).isTrue();
+		assertThat(locatorToIds.test(L2)).isFalse();
+
+		@Nullable final Set<LocatorId> excludeLocatorToIds = result.getExcludeLocatorToIds();
+		assertThat(excludeLocatorToIds).isNullOrEmpty();
+	}
+
+	@Test
+	void toActiveNotAssignedDDOrderQuery_packingPlaceWorkplace_excludeLocatorToIdsSet()
+	{
+		// Given: packing-place workplace — locatorToId absent, excludeLocatorToIds populated
+		final ImmutableSet<LocatorId> packingLocators = ImmutableSet.of(L1, L2);
+		final DDOrderReferenceQuery query = DDOrderReferenceQuery.builder()
+				.responsibleId(de.metas.user.UserId.ofRepoId(999))
+				.warehouseToId(W1)
+				.locatorToId(null)
+				.excludeLocatorToIds(packingLocators)
+				.build();
+
+		// When
+		final DDOrderQuery result = DistributionJobQueries.toActiveNotAssignedDDOrderQuery(query);
+
+		// Then: locatorToIds is any-match (null or isAny()); excludeLocatorToIds == {L1, L2}
+		final InSetPredicate<LocatorId> locatorToIds = result.getLocatorToIds();
+		// locatorToId was null → InSetPredicate.onlyOrAny(null) → isAny()
+		assertThat(locatorToIds == null || locatorToIds.isAny()).isTrue();
+
+		final Set<LocatorId> excludeLocatorToIds = result.getExcludeLocatorToIds();
+		assertThat(excludeLocatorToIds).containsExactlyInAnyOrderElementsOf(packingLocators);
+	}
+}

--- a/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/service/DistributionJobQueriesTest.java
+++ b/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/service/DistributionJobQueriesTest.java
@@ -2,6 +2,7 @@ package de.metas.distribution.mobileui.job.service;
 
 import com.google.common.collect.ImmutableSet;
 import de.metas.distribution.ddorder.DDOrderQuery;
+import de.metas.user.UserId;
 import de.metas.util.InSetPredicate;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
@@ -30,7 +31,7 @@ class DistributionJobQueriesTest
 	{
 		// Given: regular (non-packing) workplace — locatorToId set, excludeLocatorToIds absent
 		final DDOrderReferenceQuery query = DDOrderReferenceQuery.builder()
-				.responsibleId(de.metas.user.UserId.ofRepoId(999))
+				.responsibleId(UserId.ofRepoId(999))
 				.warehouseToId(W1)
 				.locatorToId(L1)
 				.excludeLocatorToIds(null)
@@ -56,7 +57,7 @@ class DistributionJobQueriesTest
 		// Given: packing-place workplace — locatorToId absent, excludeLocatorToIds populated
 		final ImmutableSet<LocatorId> packingLocators = ImmutableSet.of(L1, L2);
 		final DDOrderReferenceQuery query = DDOrderReferenceQuery.builder()
-				.responsibleId(de.metas.user.UserId.ofRepoId(999))
+				.responsibleId(UserId.ofRepoId(999))
 				.warehouseToId(W1)
 				.locatorToId(null)
 				.excludeLocatorToIds(packingLocators)

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddorder/DDOrderQuery.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddorder/DDOrderQuery.java
@@ -32,6 +32,7 @@ public class DDOrderQuery
 	@Nullable Set<WarehouseId> warehouseFromIds;
 	@Nullable InSetPredicate<WarehouseId> warehouseToIds;
 	@Nullable InSetPredicate<LocatorId> locatorToIds;
+	/** Plain {@link Set} (not {@link InSetPredicate}) because the exclude filter uses a NOT-IN subquery via {@code DD_OrderLine}; there is no meaningful "exclude all" wildcard case. */
 	@Nullable Set<LocatorId> excludeLocatorToIds;
 	@Nullable Set<OrderId> salesOrderIds;
 	@Nullable Set<PPOrderId> manufacturingOrderIds;

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddorder/DDOrderQuery.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddorder/DDOrderQuery.java
@@ -32,6 +32,7 @@ public class DDOrderQuery
 	@Nullable Set<WarehouseId> warehouseFromIds;
 	@Nullable InSetPredicate<WarehouseId> warehouseToIds;
 	@Nullable InSetPredicate<LocatorId> locatorToIds;
+	@Nullable Set<LocatorId> excludeLocatorToIds;
 	@Nullable Set<OrderId> salesOrderIds;
 	@Nullable Set<PPOrderId> manufacturingOrderIds;
 	@Nullable Set<LocalDate> datesPromised;

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddorder/lowlevel/DDOrderLowLevelDAO.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddorder/lowlevel/DDOrderLowLevelDAO.java
@@ -392,6 +392,19 @@ public class DDOrderLowLevelDAO
 		}
 
 		//
+		// Locator To — exclude (packing places)
+		if (query.getExcludeLocatorToIds() != null && !query.getExcludeLocatorToIds().isEmpty())
+		{
+			queryBuilder.addNotInSubQueryFilter(
+					I_DD_Order.COLUMNNAME_DD_Order_ID,
+					I_DD_Order.COLUMNNAME_DD_Order_ID,
+					queryBL.createQueryBuilder(I_DD_OrderLine.class)
+							.addOnlyActiveRecordsFilter()
+							.addInArrayFilter(I_DD_OrderLine.COLUMNNAME_M_LocatorTo_ID, query.getExcludeLocatorToIds())
+							.create());
+		}
+
+		//
 		// Sales Order
 		if (query.getSalesOrderIds() != null && !query.getSalesOrderIds().isEmpty())
 		{


### PR DESCRIPTION
### What

Adds a new boolean **`C_Workplace.IsPackingPlace`** (default `'Y'`) that splits the mobile-Distribution launcher into two roles:

- **`IsPackingPlace='Y'` (default)** — behaviour unchanged: the launcher offers the workplace-warehouse DD_Orders whose target locator = `workplace.PickFrom_Locator_ID` (null ⇒ whole destination warehouse), exactly as before.
- **`IsPackingPlace='N'` (replenishment)** — the launcher offers the workplace-warehouse DD_Orders whose target locator is **NOT** a packing-place locator, so groundfill target moves become visible to replenishment workers. The workplace's own `PickFrom_Locator_ID` is ignored.

The excluded set is data-driven: the `PickFrom_Locator_ID` of every `IsPackingPlace='Y'` workplace in the destination warehouse, read off the existing cached `WorkplaceRepository` map (CCache auto-invalidates on `C_Workplace` change). Empty set ⇒ no exclusion (catch-all). The already-assigned pool (responsible = user) is untouched in both roles.

### How

- Migration `5807860_sys_C_Workplace_IsPackingPlace.sql`: AD_Column (Yes-No), default `'Y'`, NOT NULL after backfill, AD_Element (DE "Packplatz" / EN "Is Packing Place"), field on the C_Workplace window (flags group).
- `Workplace` / `WorkplaceRepository` / `WorkplaceService`: new `isPackingPlace` flag + cached `getPackingPlacePickFromLocatorIds(WarehouseId)`.
- `DDOrderQuery.excludeLocatorToIds` + a NOT-IN target-locator subquery in `DDOrderLowLevelDAO`, mirroring the existing IN subquery.
- `DistributionWorkflowLaunchersProvider` branches the launcher query on `IsPackingPlace`.

### Tests

- `WorkplaceRepositoryTest`, `DistributionJobQueriesTest` — unit coverage of the cached lookup + Y/N query construction. E2E follow-up in a separate PR.
