### PR TITLE
C_Invoice scripted-export status surfacing + generic export-status naming + re-send process

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_Invoice.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_Invoice.java
@@ -30,7 +30,7 @@ public interface I_C_Invoice
 	String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
 
 	/**
-	 * Set Inputsource.
+	 * Set Input Source.
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: false
@@ -39,7 +39,7 @@ public interface I_C_Invoice
 	void setAD_InputDataSource_ID (int AD_InputDataSource_ID);
 
 	/**
-	 * Get Inputsource.
+	 * Get Input Source.
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: false
@@ -1449,8 +1449,8 @@ public interface I_C_Invoice
 	String COLUMNNAME_IsPaid = "IsPaid";
 
 	/**
-	 * Set Teilrechnung.
-	 * Wenn aktiviert, ist diese Rechnung eine Teilrechnung.
+	 * Set Partial invoice.
+	 * When checked, this invoice is a partial invoice.
 	 *
 	 * <br>Type: List
 	 * <br>Mandatory: false
@@ -1459,8 +1459,8 @@ public interface I_C_Invoice
 	void setIsPartialInvoice (@Nullable java.lang.String IsPartialInvoice);
 
 	/**
-	 * Get Teilrechnung.
-	 * Wenn aktiviert, ist diese Rechnung eine Teilrechnung.
+	 * Get Partial invoice.
+	 * When checked, this invoice is a partial invoice.
 	 *
 	 * <br>Type: List
 	 * <br>Mandatory: false
@@ -2041,6 +2041,29 @@ public interface I_C_Invoice
 	int getSalesRep_ID();
 
 	String COLUMNNAME_SalesRep_ID = "SalesRep_ID";
+
+	/**
+	 * Set Export Status.
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true
+	 * @deprecated Please don't use it because this is a virtual column
+	 */
+	@Deprecated
+	void setScriptedExport_Status (@Nullable java.lang.String ScriptedExport_Status);
+
+	/**
+	 * Get Export Status.
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true
+	 */
+	@Nullable java.lang.String getScriptedExport_Status();
+
+	ModelColumn<I_C_Invoice, Object> COLUMN_ScriptedExport_Status = new ModelColumn<>(I_C_Invoice.class, "ScriptedExport_Status", null);
+	String COLUMNNAME_ScriptedExport_Status = "ScriptedExport_Status";
 
 	/**
 	 * Set Send EMail.

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_Invoice.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_Invoice.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 public class X_C_Invoice extends org.compiere.model.PO implements I_C_Invoice, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = -1413846951L;
+	private static final long serialVersionUID = -391288279L;
 
     /** Standard Constructor */
     public X_C_Invoice (final Properties ctx, final int C_Invoice_ID, @Nullable final String trxName)
@@ -1428,6 +1428,36 @@ public class X_C_Invoice extends org.compiere.model.PO implements I_C_Invoice, o
 	public int getSalesRep_ID() 
 	{
 		return get_ValueAsInt(COLUMNNAME_SalesRep_ID);
+	}
+
+	/** 
+	 * ScriptedExport_Status AD_Reference_ID=542104
+	 * Reference name: ExternalSystem_ExportStatus
+	 */
+	public static final int SCRIPTEDEXPORT_STATUS_AD_Reference_ID=542104;
+	/** Pending = P */
+	public static final String SCRIPTEDEXPORT_STATUS_Pending = "P";
+	/** Enqueued = U */
+	public static final String SCRIPTEDEXPORT_STATUS_Enqueued = "U";
+	/** SendingStarted = D */
+	public static final String SCRIPTEDEXPORT_STATUS_SendingStarted = "D";
+	/** Sent = S */
+	public static final String SCRIPTEDEXPORT_STATUS_Sent = "S";
+	/** Error = E */
+	public static final String SCRIPTEDEXPORT_STATUS_Error = "E";
+	/** Invalid = I */
+	public static final String SCRIPTEDEXPORT_STATUS_Invalid = "I";
+	/** DontSend = N */
+	public static final String SCRIPTEDEXPORT_STATUS_DontSend = "N";
+	@Override
+	public void setScriptedExport_Status (final @Nullable java.lang.String ScriptedExport_Status)
+	{
+		throw new IllegalArgumentException ("ScriptedExport_Status is virtual column");	}
+
+	@Override
+	public java.lang.String getScriptedExport_Status() 
+	{
+		return get_ValueAsString(COLUMNNAME_ScriptedExport_Status);
 	}
 
 	@Override

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
@@ -140,7 +140,10 @@ public class ExternalSystemExportStatusService
 
 	/**
 	 * Returns all config IDs that have any export-status row for the given source record,
-	 * regardless of the current status (no terminal-failure filter).
+	 * excluding {@link ExternalSystemExportStatus#DontSend} rows — those represent configs
+	 * whose WhereClause explicitly excluded the record and must not be re-triggered.
+	 * Use this when re-sending should cover all previously-triggered configs (both succeeded
+	 * and failed), not only those in terminal-failure state.
 	 */
 	@NonNull
 	public List<ExternalSystemScriptedExportConversionConfigId> getMatchingConfigIdsBySourceRecord(
@@ -148,6 +151,7 @@ public class ExternalSystemExportStatusService
 	{
 		return repo.getLatestBySourceRecord(sourceRecord)
 				.stream()
+				.filter(s -> !s.getStatus().isDontSend())
 				.map(ScriptedExportConversionStatus::getConfigId)
 				.distinct()
 				.collect(ImmutableList.toImmutableList());

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
@@ -139,6 +139,21 @@ public class ExternalSystemExportStatusService
 	}
 
 	/**
+	 * Returns all config IDs that have any export-status row for the given source record,
+	 * regardless of the current status (no terminal-failure filter).
+	 */
+	@NonNull
+	public List<ExternalSystemScriptedExportConversionConfigId> getMatchingConfigIdsBySourceRecord(
+			@NonNull final TableRecordReference sourceRecord)
+	{
+		return repo.getLatestBySourceRecord(sourceRecord)
+				.stream()
+				.map(ScriptedExportConversionStatus::getConfigId)
+				.distinct()
+				.collect(ImmutableList.toImmutableList());
+	}
+
+	/**
 	 * Binds the PInstance to the (config, record) status row and transitions it to the in-flight
 	 * {@link ExternalSystemExportStatus#Enqueued} state.
 	 *

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
@@ -139,11 +139,15 @@ public class ExternalSystemExportStatusService
 	}
 
 	/**
-	 * Returns all config IDs that have any export-status row for the given source record,
-	 * excluding {@link ExternalSystemExportStatus#DontSend} rows — those represent configs
-	 * whose WhereClause explicitly excluded the record and must not be re-triggered.
-	 * Use this when re-sending should cover all previously-triggered configs (both succeeded
-	 * and failed), not only those in terminal-failure state.
+	 * Returns all config IDs in a re-triggerable terminal state for the given source record.
+	 * Excluded:
+	 * <ul>
+	 *   <li>{@link ExternalSystemExportStatus#DontSend} — WhereClause explicitly excluded this record; must not be re-triggered.</li>
+	 *   <li>In-flight rows ({@link ExternalSystemExportStatus#Pending}, {@link ExternalSystemExportStatus#Enqueued},
+	 *       {@link ExternalSystemExportStatus#SendingStarted}) — already being processed; re-triggering would cause a duplicate send.</li>
+	 * </ul>
+	 * {@link ExternalSystemExportStatus#Sent} rows <em>are</em> included: re-triggering a successfully-sent record is
+	 * intentional (e.g. the external system lost its data).
 	 */
 	@NonNull
 	public List<ExternalSystemScriptedExportConversionConfigId> getMatchingConfigIdsBySourceRecord(
@@ -151,7 +155,7 @@ public class ExternalSystemExportStatusService
 	{
 		return repo.getLatestBySourceRecord(sourceRecord)
 				.stream()
-				.filter(s -> !s.getStatus().isDontSend())
+				.filter(s -> !s.getStatus().isDontSend() && !s.getStatus().isPending() && !s.getStatus().isProcessing())
 				.map(ScriptedExportConversionStatus::getConfigId)
 				.distinct()
 				.collect(ImmutableList.toImmutableList());

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
@@ -327,9 +327,12 @@ public class ExternalSystemScriptedExportConversionService
 	}
 
 	/**
-	 * Returns all config IDs that have any export-status row for the given source record,
-	 * regardless of the current status (i.e. no terminal-failure filter).
-	 * Use this when re-sending should apply to ALL known configs, not only those in error/invalid state.
+	 * Returns all config IDs in a re-triggerable terminal state for the given source record.
+	 * Includes {@link de.metas.externalsystem.ExternalSystemExportStatus#Sent} (re-send even when previously
+	 * successful); excludes {@link de.metas.externalsystem.ExternalSystemExportStatus#DontSend} and in-flight
+	 * states (Pending, Enqueued, SendingStarted) to avoid duplicate concurrent sends.
+	 *
+	 * @see ExternalSystemExportStatusService#getMatchingConfigIdsBySourceRecord(TableRecordReference)
 	 */
 	@NonNull
 	public List<ExternalSystemScriptedExportConversionConfigId> getMatchingConfigIdsBySourceRecord(

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
@@ -327,6 +327,18 @@ public class ExternalSystemScriptedExportConversionService
 	}
 
 	/**
+	 * Returns all config IDs that have any export-status row for the given source record,
+	 * regardless of the current status (i.e. no terminal-failure filter).
+	 * Use this when re-sending should apply to ALL known configs, not only those in error/invalid state.
+	 */
+	@NonNull
+	public List<ExternalSystemScriptedExportConversionConfigId> getMatchingConfigIdsBySourceRecord(
+			@NonNull final TableRecordReference sourceRecord)
+	{
+		return exportStatusService.getMatchingConfigIdsBySourceRecord(sourceRecord);
+	}
+
+	/**
 	 * Records a {@link ExternalSystemExportStatus#Pending} log entry for the given config and source record.
 	 * Called by the interceptor's AFTER_COMPLETE branch for each matching config, before scheduling
 	 * the after-commit execution.

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/C_Invoice_ReSend_ScriptedExportConversion.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/C_Invoice_ReSend_ScriptedExportConversion.java
@@ -1,0 +1,83 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion.process;
+
+import de.metas.externalsystem.ExternalSystemInvocationContext;
+import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionConfig;
+import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionConfigId;
+import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionService;
+import de.metas.process.JavaProcess;
+import de.metas.process.ProcessPreconditionsResolution;
+import de.metas.process.IProcessPrecondition;
+import de.metas.process.IProcessPreconditionsContext;
+import lombok.NonNull;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_C_Invoice;
+
+import java.util.List;
+
+/**
+ * Re-triggers the scripted-export-conversion for any config with a non-Sent attempt for this C_Invoice.
+ */
+public class C_Invoice_ReSend_ScriptedExportConversion extends JavaProcess implements IProcessPrecondition
+{
+	private final ExternalSystemScriptedExportConversionService scriptedExportService =
+			SpringContextHolder.instance.getBean(ExternalSystemScriptedExportConversionService.class);
+
+	@Override
+	public ProcessPreconditionsResolution checkPreconditionsApplicable(@NonNull final IProcessPreconditionsContext context)
+	{
+		if (context.getSelectedIncludedRecords().size() > 1)
+		{
+			return ProcessPreconditionsResolution.rejectBecauseNotSingleSelection();
+		}
+		return ProcessPreconditionsResolution.accept();
+	}
+
+	@Override
+	protected String doIt()
+	{
+		final int c_invoice_id = getRecord_ID();
+		final TableRecordReference sourceRecord = TableRecordReference.of(I_C_Invoice.Table_Name, c_invoice_id);
+
+		final List<ExternalSystemScriptedExportConversionConfigId> configIds =
+				scriptedExportService.getResendableConfigsBySourceRecord(sourceRecord);
+
+		int triggered = 0;
+		for (final ExternalSystemScriptedExportConversionConfigId configId : configIds)
+		{
+			final ExternalSystemScriptedExportConversionConfig config =
+					scriptedExportService.resolveConfigAndRecordPendingAsResend(configId, sourceRecord);
+
+			scriptedExportService.executeInvokeScriptedExportConversionActionAndGetResult(
+					config,
+					c_invoice_id,
+					ExternalSystemInvocationContext.RESEND);
+
+			triggered++;
+		}
+
+		return "@Processed@ #" + triggered;
+	}
+}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/C_Invoice_ReSend_ScriptedExportConversion.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/C_Invoice_ReSend_ScriptedExportConversion.java
@@ -27,6 +27,7 @@ import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedEx
 import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionConfigId;
 import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionService;
 import de.metas.process.JavaProcess;
+import de.metas.process.Param;
 import de.metas.process.ProcessPreconditionsResolution;
 import de.metas.process.IProcessPrecondition;
 import de.metas.process.IProcessPreconditionsContext;
@@ -35,22 +36,28 @@ import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_Invoice;
 
+import java.util.Iterator;
 import java.util.List;
 
 /**
- * Re-triggers the scripted-export-conversion for any config with a non-Sent attempt for this C_Invoice.
+ * Re-triggers the scripted-export-conversion for a selection of C_Invoice records.
+ * When {@code IsOnlyNotSentSuccessfully=Y} only configs whose last attempt is in error/invalid
+ * state are re-sent; otherwise all known configs for each record are triggered.
  */
 public class C_Invoice_ReSend_ScriptedExportConversion extends JavaProcess implements IProcessPrecondition
 {
 	private final ExternalSystemScriptedExportConversionService scriptedExportService =
 			SpringContextHolder.instance.getBean(ExternalSystemScriptedExportConversionService.class);
 
+	@Param(parameterName = "IsOnlyNotSentSuccessfully")
+	private boolean isOnlyNotSentSuccessfully;
+
 	@Override
 	public ProcessPreconditionsResolution checkPreconditionsApplicable(@NonNull final IProcessPreconditionsContext context)
 	{
-		if (context.getSelectedIncludedRecords().size() > 1)
+		if (context.getSelectionSize().isNoSelection())
 		{
-			return ProcessPreconditionsResolution.rejectBecauseNotSingleSelection();
+			return ProcessPreconditionsResolution.rejectBecauseNoSelection();
 		}
 		return ProcessPreconditionsResolution.accept();
 	}
@@ -58,24 +65,31 @@ public class C_Invoice_ReSend_ScriptedExportConversion extends JavaProcess imple
 	@Override
 	protected String doIt()
 	{
-		final int c_invoice_id = getRecord_ID();
-		final TableRecordReference sourceRecord = TableRecordReference.of(I_C_Invoice.Table_Name, c_invoice_id);
-
-		final List<ExternalSystemScriptedExportConversionConfigId> configIds =
-				scriptedExportService.getResendableConfigsBySourceRecord(sourceRecord);
-
 		int triggered = 0;
-		for (final ExternalSystemScriptedExportConversionConfigId configId : configIds)
+
+		final Iterator<I_C_Invoice> it = retrieveSelectedRecordsQueryBuilder(I_C_Invoice.class).create().iterate(I_C_Invoice.class);
+		while (it.hasNext())
 		{
-			final ExternalSystemScriptedExportConversionConfig config =
-					scriptedExportService.resolveConfigAndRecordPendingAsResend(configId, sourceRecord);
+			final I_C_Invoice record = it.next();
+			final int c_invoice_id = record.getC_Invoice_ID();
+			final TableRecordReference sourceRecord = TableRecordReference.of(I_C_Invoice.Table_Name, c_invoice_id);
 
-			scriptedExportService.executeInvokeScriptedExportConversionActionAndGetResult(
-					config,
-					c_invoice_id,
-					ExternalSystemInvocationContext.RESEND);
+			final List<ExternalSystemScriptedExportConversionConfigId> configIds = isOnlyNotSentSuccessfully
+					? scriptedExportService.getResendableConfigsBySourceRecord(sourceRecord)
+					: scriptedExportService.getMatchingConfigIdsBySourceRecord(sourceRecord);
 
-			triggered++;
+			for (final ExternalSystemScriptedExportConversionConfigId configId : configIds)
+			{
+				final ExternalSystemScriptedExportConversionConfig config =
+						scriptedExportService.resolveConfigAndRecordPendingAsResend(configId, sourceRecord);
+
+				scriptedExportService.executeInvokeScriptedExportConversionActionAndGetResult(
+						config,
+						c_invoice_id,
+						ExternalSystemInvocationContext.RESEND);
+
+				triggered++;
+			}
 		}
 
 		return "@Processed@ #" + triggered;

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/C_Invoice_ReSend_ScriptedExportConversion.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/C_Invoice_ReSend_ScriptedExportConversion.java
@@ -40,8 +40,9 @@ import java.util.List;
 
 /**
  * Re-triggers the scripted-export-conversion for a selection of C_Invoice records.
- * When {@code IsOnlyNotSentSuccessfully=Y} only configs whose last attempt is in error/invalid
- * state are re-sent; otherwise all known configs for each record are triggered.
+ * When {@code IsOnlyNotSentSuccessfully=Y} only configs in error/invalid state are re-sent.
+ * When {@code IsOnlyNotSentSuccessfully=N} configs in any terminal state (including already-Sent)
+ * are re-triggered; in-flight and DontSend configs are always skipped.
  */
 public class C_Invoice_ReSend_ScriptedExportConversion extends JavaProcess implements IProcessPrecondition
 {

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/C_Invoice_ReSend_ScriptedExportConversion.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/C_Invoice_ReSend_ScriptedExportConversion.java
@@ -36,7 +36,6 @@ import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_Invoice;
 
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -65,13 +64,12 @@ public class C_Invoice_ReSend_ScriptedExportConversion extends JavaProcess imple
 	@Override
 	protected String doIt()
 	{
-		int triggered = 0;
+		// Collect IDs first to close the DB cursor before making external-service calls.
+		final List<Integer> invoiceIds = retrieveSelectedRecordsQueryBuilder(I_C_Invoice.class).create().listIds();
 
-		final Iterator<I_C_Invoice> it = retrieveSelectedRecordsQueryBuilder(I_C_Invoice.class).create().iterate(I_C_Invoice.class);
-		while (it.hasNext())
+		int triggered = 0;
+		for (final int c_invoice_id : invoiceIds)
 		{
-			final I_C_Invoice record = it.next();
-			final int c_invoice_id = record.getC_Invoice_ID();
 			final TableRecordReference sourceRecord = TableRecordReference.of(I_C_Invoice.Table_Name, c_invoice_id);
 
 			final List<ExternalSystemScriptedExportConversionConfigId> configIds = isOnlyNotSentSuccessfully

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/M_InOut_ReSend_ScriptedExportConversion.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/M_InOut_ReSend_ScriptedExportConversion.java
@@ -27,6 +27,7 @@ import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedEx
 import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionConfigId;
 import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionService;
 import de.metas.process.JavaProcess;
+import de.metas.process.Param;
 import de.metas.process.ProcessPreconditionsResolution;
 import de.metas.process.IProcessPrecondition;
 import de.metas.process.IProcessPreconditionsContext;
@@ -35,22 +36,28 @@ import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_M_InOut;
 
+import java.util.Iterator;
 import java.util.List;
 
 /**
- * Re-triggers the scripted-export-conversion for any config with a non-Sent attempt for this M_InOut.
+ * Re-triggers the scripted-export-conversion for a selection of M_InOut records.
+ * When {@code IsOnlyNotSentSuccessfully=Y} only configs whose last attempt is in error/invalid
+ * state are re-sent; otherwise all known configs for each record are triggered.
  */
 public class M_InOut_ReSend_ScriptedExportConversion extends JavaProcess implements IProcessPrecondition
 {
 	private final ExternalSystemScriptedExportConversionService scriptedExportService =
 			SpringContextHolder.instance.getBean(ExternalSystemScriptedExportConversionService.class);
 
+	@Param(parameterName = "IsOnlyNotSentSuccessfully")
+	private boolean isOnlyNotSentSuccessfully;
+
 	@Override
 	public ProcessPreconditionsResolution checkPreconditionsApplicable(@NonNull final IProcessPreconditionsContext context)
 	{
-		if (context.getSelectedIncludedRecords().size() > 1)
+		if (context.getSelectionSize().isNoSelection())
 		{
-			return ProcessPreconditionsResolution.rejectBecauseNotSingleSelection();
+			return ProcessPreconditionsResolution.rejectBecauseNoSelection();
 		}
 		return ProcessPreconditionsResolution.accept();
 	}
@@ -58,24 +65,31 @@ public class M_InOut_ReSend_ScriptedExportConversion extends JavaProcess impleme
 	@Override
 	protected String doIt()
 	{
-		final int m_inout_id = getRecord_ID();
-		final TableRecordReference sourceRecord = TableRecordReference.of(I_M_InOut.Table_Name, m_inout_id);
-
-		final List<ExternalSystemScriptedExportConversionConfigId> configIds =
-				scriptedExportService.getResendableConfigsBySourceRecord(sourceRecord);
-
 		int triggered = 0;
-		for (final ExternalSystemScriptedExportConversionConfigId configId : configIds)
+
+		final Iterator<I_M_InOut> it = retrieveSelectedRecordsQueryBuilder(I_M_InOut.class).create().iterate(I_M_InOut.class);
+		while (it.hasNext())
 		{
-			final ExternalSystemScriptedExportConversionConfig config =
-					scriptedExportService.resolveConfigAndRecordPendingAsResend(configId, sourceRecord);
+			final I_M_InOut record = it.next();
+			final int m_inout_id = record.getM_InOut_ID();
+			final TableRecordReference sourceRecord = TableRecordReference.of(I_M_InOut.Table_Name, m_inout_id);
 
-			scriptedExportService.executeInvokeScriptedExportConversionActionAndGetResult(
-					config,
-					m_inout_id,
-					ExternalSystemInvocationContext.RESEND);
+			final List<ExternalSystemScriptedExportConversionConfigId> configIds = isOnlyNotSentSuccessfully
+					? scriptedExportService.getResendableConfigsBySourceRecord(sourceRecord)
+					: scriptedExportService.getMatchingConfigIdsBySourceRecord(sourceRecord);
 
-			triggered++;
+			for (final ExternalSystemScriptedExportConversionConfigId configId : configIds)
+			{
+				final ExternalSystemScriptedExportConversionConfig config =
+						scriptedExportService.resolveConfigAndRecordPendingAsResend(configId, sourceRecord);
+
+				scriptedExportService.executeInvokeScriptedExportConversionActionAndGetResult(
+						config,
+						m_inout_id,
+						ExternalSystemInvocationContext.RESEND);
+
+				triggered++;
+			}
 		}
 
 		return "@Processed@ #" + triggered;

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/M_InOut_ReSend_ScriptedExportConversion.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/M_InOut_ReSend_ScriptedExportConversion.java
@@ -36,7 +36,6 @@ import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_M_InOut;
 
-import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -65,13 +64,12 @@ public class M_InOut_ReSend_ScriptedExportConversion extends JavaProcess impleme
 	@Override
 	protected String doIt()
 	{
-		int triggered = 0;
+		// Collect IDs first to close the DB cursor before making external-service calls.
+		final List<Integer> inoutIds = retrieveSelectedRecordsQueryBuilder(I_M_InOut.class).create().listIds();
 
-		final Iterator<I_M_InOut> it = retrieveSelectedRecordsQueryBuilder(I_M_InOut.class).create().iterate(I_M_InOut.class);
-		while (it.hasNext())
+		int triggered = 0;
+		for (final int m_inout_id : inoutIds)
 		{
-			final I_M_InOut record = it.next();
-			final int m_inout_id = record.getM_InOut_ID();
 			final TableRecordReference sourceRecord = TableRecordReference.of(I_M_InOut.Table_Name, m_inout_id);
 
 			final List<ExternalSystemScriptedExportConversionConfigId> configIds = isOnlyNotSentSuccessfully

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/M_InOut_ReSend_ScriptedExportConversion.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/process/M_InOut_ReSend_ScriptedExportConversion.java
@@ -40,8 +40,9 @@ import java.util.List;
 
 /**
  * Re-triggers the scripted-export-conversion for a selection of M_InOut records.
- * When {@code IsOnlyNotSentSuccessfully=Y} only configs whose last attempt is in error/invalid
- * state are re-sent; otherwise all known configs for each record are triggered.
+ * When {@code IsOnlyNotSentSuccessfully=Y} only configs in error/invalid state are re-sent.
+ * When {@code IsOnlyNotSentSuccessfully=N} configs in any terminal state (including already-Sent)
+ * are re-triggered; in-flight and DontSend configs are always skipped.
  */
 public class M_InOut_ReSend_ScriptedExportConversion extends JavaProcess implements IProcessPrecondition
 {

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807880_sys_ExternalSystem_ExportStatus_generic_labels.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807880_sys_ExternalSystem_ExportStatus_generic_labels.sql
@@ -1,0 +1,114 @@
+-- Generic-naming: rename M_InOut export-status tab caption + column label from EPCIS-specific to generic 'Exportstatus'/'Export Status'. Labels only; column identifiers unchanged.
+
+-- ===========================================================================
+-- AD_Element 584966 (ColumnName=EPCIS_ExportStatus_Tab, tab caption)
+-- AD_Element 584959 (ColumnName=EPCIS_ExportStatus, header virtual column label)
+-- Both: Name/PrintName DE base -> 'Exportstatus'; en_US -> 'Export Status'.
+-- ColumnName identifiers are NOT changed.
+-- ===========================================================================
+
+-- 1) Update AD_Element base rows (German base language)
+UPDATE AD_Element
+SET Name      = 'Exportstatus',
+    PrintName = 'Exportstatus',
+    Updated   = TO_TIMESTAMP('2026-06-15 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Element_ID = 584966
+;
+
+UPDATE AD_Element
+SET Name      = 'Exportstatus',
+    PrintName = 'Exportstatus',
+    Updated   = TO_TIMESTAMP('2026-06-15 10:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Element_ID = 584959
+;
+
+-- 2) Update AD_Element_Trl rows for 584966
+-- en_US
+UPDATE AD_Element_Trl
+SET Name         = 'Export Status',
+    PrintName    = 'Export Status',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-15 10:00:10', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 584966
+  AND AD_Language = 'en_US'
+;
+
+-- de_DE / de_CH (German is the base language → mark actively translated, per convention
+-- and matching the Stage-1 state these rows had before this rename)
+UPDATE AD_Element_Trl
+SET Name         = 'Exportstatus',
+    PrintName    = 'Exportstatus',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-15 10:00:11', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 584966
+  AND AD_Language IN ('de_DE', 'de_CH')
+;
+
+-- 3) Update AD_Element_Trl rows for 584959
+-- en_US
+UPDATE AD_Element_Trl
+SET Name         = 'Export Status',
+    PrintName    = 'Export Status',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-15 10:00:20', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 584959
+  AND AD_Language = 'en_US'
+;
+
+-- de_DE / de_CH (German is the base language → mark actively translated, per convention
+-- and matching the Stage-1 state these rows had before this rename)
+UPDATE AD_Element_Trl
+SET Name         = 'Exportstatus',
+    PrintName    = 'Exportstatus',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-15 10:00:21', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 584959
+  AND AD_Language IN ('de_DE', 'de_CH')
+;
+
+-- fr_CH (adopts German word verbatim; IsTranslated='N' — no language-specific override)
+UPDATE AD_Element_Trl
+SET Name         = 'Exportstatus',
+    PrintName    = 'Exportstatus',
+    IsTranslated = 'N',
+    Updated      = TO_TIMESTAMP('2026-06-15 10:00:25', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 584966
+  AND AD_Language = 'fr_CH'
+;
+
+UPDATE AD_Element_Trl
+SET Name         = 'Exportstatus',
+    PrintName    = 'Exportstatus',
+    IsTranslated = 'N',
+    Updated      = TO_TIMESTAMP('2026-06-15 10:00:26', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 584959
+  AND AD_Language = 'fr_CH'
+;
+
+-- 4) Propagate element translations -> AD_Tab_Trl / AD_Tab.Name (549295),
+--    AD_Field_Trl / AD_Field.Name (780740), AD_Column_Trl / AD_Column.Name.
+--    update_TRL_Tables_On_AD_Element_TRL_Update already delegates internally to
+--    update_FieldTranslation_From_AD_Name_Element, so no separate call is needed.
+--    The guard `updated <> e_trl.updated` passes because element timestamps
+--    above (10:00:10/11, 10:00:20/21, 10:00:25/26) differ from the field/tab
+--    timestamps set in the Stage-1 migration (2026-06-09).
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584966);
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584959);
+
+-- 5) AD_UI_Element.Name is not covered by any propagation function.
+--    Set directly for the one UI element that carries the EPCIS label.
+--    652035 = M_InOut header tab UI element for EPCIS_ExportStatus field (780740)
+UPDATE AD_UI_Element
+SET Name      = 'Exportstatus',
+    Updated   = TO_TIMESTAMP('2026-06-15 10:00:30', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_UI_Element_ID = 652035
+;

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807900_sys_C_Invoice_ScriptedExport_Status_virtual.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807900_sys_C_Invoice_ScriptedExport_Status_virtual.sql
@@ -3,6 +3,8 @@
 -- The ColumnSql is a ranked-aggregate over ExternalSystem_ScriptedExportConversion_Status:
 --   Rank {E,I}→1 (error/invalid), {P,U,D}→2 (in-flight), {S,N}→3 (sent/skip);
 --   tie-break by latest Updated; LIMIT 1.
+-- No AD_Field/AD_UI_Element added here: window placement is a separate task
+-- (the DocuWare Invoice Status Tab) that places this column in the tab layout.
 -- AD_SQLColumn_SourceTableColumn ties this column to source table 542617
 -- so the WebUI virtual-column cache is invalidated when a status row changes.
 --

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807900_sys_C_Invoice_ScriptedExport_Status_virtual.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807900_sys_C_Invoice_ScriptedExport_Status_virtual.sql
@@ -1,0 +1,111 @@
+-- Adds C_Invoice.ScriptedExport_Status as a VIRTUAL (ColumnSQL) AD_Column.
+-- No physical column — IsSyncDatabase='N' makes it virtual.
+-- The ColumnSql is a ranked-aggregate over ExternalSystem_ScriptedExportConversion_Status:
+--   Rank {E,I}→1 (error/invalid), {P,U,D}→2 (in-flight), {S,N}→3 (sent/skip);
+--   tie-break by latest Updated; LIMIT 1.
+-- AD_SQLColumn_SourceTableColumn ties this column to source table 542617
+-- so the WebUI virtual-column cache is invalidated when a status row changes.
+--
+-- IDs allocated from idserver.metas.de on 2026-06-15:
+--   AD_Element                    584995  (ScriptedExport_Status)
+--   AD_Column                     592812  (C_Invoice.ScriptedExport_Status virtual)
+--   AD_SQLColumn_SourceTableColumn 540206 (cache-link to ExternalSystem_ScriptedExportConversion_Status)
+--   AD_MigrationScript            5807900 (this script)
+
+-- ============================================================================
+-- 1) AD_Element — generic name, reusable across host tables
+-- ============================================================================
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy,
+  Updated, UpdatedBy, ColumnName, EntityType, Name, PrintName)
+VALUES (584995 /*From ID Server*/, 0, 0, 'Y',
+  TO_TIMESTAMP('2026-06-15 10:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+  TO_TIMESTAMP('2026-06-15 10:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+  'ScriptedExport_Status', 'de.metas.externalsystem', 'Exportstatus', 'Exportstatus')
+ON CONFLICT (AD_Element_ID) DO NOTHING;
+
+-- Seed _Trl rows for all active system languages (copies base DE text)
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Name, PrintName, Description, Help,
+  IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.Name, t.PrintName, t.Description, t.Help,
+  'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y')
+  AND t.AD_Element_ID=584995
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt
+    WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID);
+
+-- en_US override
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Export Status', PrintName='Export Status',
+  Updated=TO_TIMESTAMP('2026-06-15 10:00:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language='en_US' AND AD_Element_ID=584995;
+
+-- de_DE and de_CH — same text as base, mark as translated
+UPDATE AD_Element_Trl SET IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-06-15 10:00:13','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+  WHERE AD_Language IN ('de_DE','de_CH') AND AD_Element_ID=584995;
+
+-- fr_CH — base text already copied (IsTranslated='N') — leave as-is
+
+-- ============================================================================
+-- 2) AD_Column — virtual List(17) column on C_Invoice (AD_Table_ID=318),
+--    IsSyncDatabase='N', ColumnSql set
+-- ============================================================================
+INSERT INTO AD_Column (AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy,
+  Updated, UpdatedBy, AD_Element_ID, AD_Table_ID, ColumnName, Name, Version,
+  AD_Reference_ID, AD_Reference_Value_ID, AD_Val_Rule_ID, EntityType, IsKey, IsParent,
+  IsMandatory, IsUpdateable, IsIdentifier, IsTranslated, IsEncrypted, IsSelectionColumn,
+  SeqNo, IsAllowLogging, IsAutocomplete, IsCalculated, PersonalDataCategory, FieldLength,
+  IsGenericZoomKeyColumn, IsGenericZoomOrigin, IsForceIncludeInGeneratedModel,
+  IsLazyLoading, IsUseDocSequence, ColumnSql, IsStaleable, IsSyncDatabase)
+VALUES (592812 /*From ID Server*/, 0, 0, 'Y',
+  TO_TIMESTAMP('2026-06-15 10:01:00','YYYY-MM-DD HH24:MI:SS'), 100,
+  TO_TIMESTAMP('2026-06-15 10:01:00','YYYY-MM-DD HH24:MI:SS'), 100,
+  584995 /*AD_Element ScriptedExport_Status*/, 318 /*C_Invoice*/, 'ScriptedExport_Status', 'Exportstatus', 0,
+  17 /*List*/, 542104 /*ExternalSystem_ExportStatus*/, NULL,
+  'de.metas.externalsystem', 'N', 'N',
+  'N', 'N' /*read-only virtual column*/,
+  'N', 'N', 'N', 'N',
+  0, 'Y',
+  'N', 'N', 'NP', 1 /*FieldLength=1*/,
+  'N', 'N', 'Y' /*IsForceIncludeInGeneratedModel: forces inclusion of this non-D entity-type column in I_C_Invoice*/,
+  'N', 'N',
+  '(select s.ExportStatus from ExternalSystem_ScriptedExportConversion_Status s
+ where s.AD_Table_ID=318 and s.Record_ID=C_Invoice.C_Invoice_ID and s.IsActive=''Y''
+ order by case s.ExportStatus when ''E'' then 1 when ''I'' then 1 when ''P'' then 2 when ''U'' then 2 when ''D'' then 2 when ''S'' then 3 when ''N'' then 3 else 4 end, s.Updated desc
+ limit 1)',
+  'N', 'N' /*IsSyncDatabase=N → virtual, no physical column sync*/)
+ON CONFLICT (AD_Column_ID) DO NOTHING;
+
+-- Seed AD_Column_Trl rows
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, Description, IsTranslated,
+  AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, NULL, 'N',
+  t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y'
+  AND t.AD_Column_ID=592812
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt
+    WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID);
+
+-- Propagate element translations → column
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584995);
+
+-- ============================================================================
+-- 3) AD_SQLColumn_SourceTableColumn — cache-invalidation link
+-- ============================================================================
+INSERT INTO AD_SQLColumn_SourceTableColumn (
+  AD_SQLColumn_SourceTableColumn_ID, AD_Client_ID, AD_Org_ID, IsActive,
+  Created, CreatedBy, Updated, UpdatedBy,
+  AD_Column_ID, AD_Table_ID, Source_Table_ID,
+  FetchTargetRecordsMethod,
+  SQL_GetTargetRecordIdBySourceRecordId)
+VALUES (
+  540206 /*From ID Server*/, 0, 0, 'Y',
+  TO_TIMESTAMP('2026-06-15 10:02:00','YYYY-MM-DD HH24:MI:SS'), 100,
+  TO_TIMESTAMP('2026-06-15 10:02:00','YYYY-MM-DD HH24:MI:SS'), 100,
+  592812 /*AD_Column ScriptedExport_Status on C_Invoice*/,
+  318    /*C_Invoice — host table*/,
+  542617 /*ExternalSystem_ScriptedExportConversion_Status — source table*/,
+  'S',
+  'select Record_ID from ExternalSystem_ScriptedExportConversion_Status where ExternalSystem_ScriptedExportConversion_Status_ID=@Record_ID/-1@ and AD_Table_ID=318')
+ON CONFLICT (AD_SQLColumn_SourceTableColumn_ID) DO NOTHING;

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807910_sys_C_Invoice_ScriptedExport_StatusTab.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807910_sys_C_Invoice_ScriptedExport_StatusTab.sql
@@ -269,9 +269,14 @@ VALUES
 --                          StatusMessage, IsResend, AD_PInstance_ID, Updated
 -- ===========================================================================
 
--- 4.1 ExportStatus (AD_Column 592784, AD_Element 577791)
+-- 4.1 ExportStatus (AD_Column 592784, shared AD_Element 577791)
+--     The column's AD_Element 577791 is shared across 8 host tables and carries English
+--     'Export Status' base text (its de_DE/de_CH trl is untranslated system-wide). To show the
+--     German caption on this tab WITHOUT a system-wide shared-element mutation, pin the field
+--     label via AD_Name_ID=584995 (the ScriptedExport_Status element, 'Exportstatus'/'Export Status').
 INSERT INTO AD_Field
     (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     AD_Name_ID,
      Created, CreatedBy, Description, DisplayLength, EntityType,
      Help, IsActive, IsDisplayed, IsDisplayedGrid,
      IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
@@ -279,11 +284,12 @@ INSERT INTO AD_Field
      SortNo, SpanX, SpanY, Updated, UpdatedBy)
 VALUES
     (0, 592784, 781120 /*From ID Server*/, 0, 549313,
+     584995 /*ScriptedExport_Status label element — 'Exportstatus'/'Export Status'*/,
      TO_TIMESTAMP('2026-06-15 09:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
      NULL, 14, 'de.metas.externalsystem',
      NULL, 'Y', 'Y', 'Y',
      'N', 'N', 'N', 'N', 'Y',
-     'N', 'Export Status', 10, 10,
+     'N', 'Exportstatus', 10, 10,
      0, 1, 1,
      TO_TIMESTAMP('2026-06-15 09:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100)
 ;
@@ -291,13 +297,13 @@ INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsT
 SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
 FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781120
 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
-/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(577791);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584995);
 DELETE FROM AD_Element_Link WHERE AD_Field_ID=781120;
 /* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781120);
 UPDATE AD_Field_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-15 09:02:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Field_ID=781120 AND AD_Language IN ('de_DE','de_CH','en_US');
 INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
-VALUES (0, 781120, 0, 549313, 555450, 652266 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-15 09:02:02','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'Export Status', 10, 10, 0, TO_TIMESTAMP('2026-06-15 09:02:02','YYYY-MM-DD HH24:MI:SS'), 100);
+VALUES (0, 781120, 0, 549313, 555450, 652266 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-15 09:02:02','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'Exportstatus', 10, 10, 0, TO_TIMESTAMP('2026-06-15 09:02:02','YYYY-MM-DD HH24:MI:SS'), 100);
 
 -- 4.2 ExternalSystem_Config_ScriptedExportConversion_ID (AD_Column 592781, AD_Element 584101)
 --     AD_Name_ID=584997 (ScriptedExport_Config) pins the label to 'Exportkonfiguration'/

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807910_sys_C_Invoice_ScriptedExport_StatusTab.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807910_sys_C_Invoice_ScriptedExport_StatusTab.sql
@@ -1,0 +1,553 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+-- Surfaces scripted-export status on the standard Sales-Invoice window (AD_Window_ID=167):
+--   1. ScriptedExport_Status rollup field (AD_Column 592812, virtual aggregate) on header
+--      tab 263 (Rechnung), placed in group 540027 ('dates') at seqno=36, adjacent to
+--      Externes System (34) and Eingabequelle (35). Read-only — value is system-computed.
+--   2. Read-only child tab over ExternalSystem_ScriptedExportConversion_Status (AD_Table 542617)
+--      showing per-config status rows for the current invoice. WhereClause filters by
+--      AD_Table_ID=318 + Record_ID=@C_Invoice_ID@. Ordered newest-first (Updated DESC).
+--      Columns: ExportStatus, Exportkonfiguration, HttpResponseCode, StatusMessage, IsResend,
+--               AD_PInstance_ID, Updated.
+--   3. AD_SQLColumn_SourceTableColumn: NOT needed — already created for column 592812 by
+--      the prior task.
+--
+-- IDs allocated from idserver.metas.de on 2026-06-15:
+--   AD_Element        584996  (generic tab caption: ScriptedExport_Status_Tab)
+--   AD_Element        584997  (dedicated field label: ScriptedExport_Config -- 'Exportkonfiguration'/'Export Configuration')
+--   AD_Tab            549313  (Status child tab on window 167)
+--   AD_UI_Section     547822  (Status tab section)
+--   AD_UI_Column      549556  (Status tab column)
+--   AD_UI_ElementGroup 555450 (Status tab element group)
+--   AD_Field          781120  (status tab: ExportStatus)
+--   AD_UI_Element     652266  (status tab: ExportStatus)
+--   AD_Field          781121  (status tab: ExternalSystem_Config_ScriptedExportConversion_ID)
+--   AD_UI_Element     652267  (status tab: ExternalSystem_Config_ScriptedExportConversion_ID)
+--   AD_Field          781122  (status tab: HttpResponseCode)
+--   AD_UI_Element     652268  (status tab: HttpResponseCode)
+--   AD_Field          781123  (status tab: StatusMessage)
+--   AD_UI_Element     652269  (status tab: StatusMessage)
+--   AD_Field          781124  (status tab: IsResend)
+--   AD_UI_Element     652270  (status tab: IsResend)
+--   AD_Field          781125  (status tab: AD_PInstance_ID)
+--   AD_UI_Element     652271  (status tab: AD_PInstance_ID)
+--   AD_Field          781126  (status tab: Updated)
+--   AD_UI_Element     652272  (status tab: Updated)
+--   AD_Field          781127  (header tab 263: ScriptedExport_Status rollup)
+--   AD_UI_Element     652273  (header tab 263: ScriptedExport_Status rollup)
+
+-- ===========================================================================
+-- PART 1: Generic tab caption AD_Element (window-agnostic, reusable)
+-- ===========================================================================
+
+-- 1a) AD_Element for tab caption — generic ColumnName so it can be reused by other windows
+INSERT INTO AD_Element
+    (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive,
+     Created, CreatedBy, Updated, UpdatedBy,
+     ColumnName, EntityType, Name, PrintName)
+VALUES
+    (584996 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-06-15 09:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-15 09:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'ScriptedExport_Status_Tab', 'de.metas.externalsystem',
+     'Exportstatus', 'Exportstatus')
+;
+
+-- 1b) Seed _Trl rows for all active system languages (DE base text in every row)
+INSERT INTO AD_Element_Trl
+    (AD_Language, AD_Element_ID, Name, PrintName, Description, Help,
+     IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.Name, t.PrintName, t.Description, t.Help,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Element_ID = 584996
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID)
+;
+
+-- 1c) en_US override: English translation
+UPDATE AD_Element_Trl
+SET Name         = 'Export Status',
+    PrintName    = 'Export Status',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-15 09:00:12', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'en_US' AND AD_Element_ID = 584996
+;
+
+-- 1d) de_DE / de_CH: mark as actively translated (text matches base German)
+UPDATE AD_Element_Trl
+SET IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-15 09:00:13', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language IN ('de_DE', 'de_CH') AND AD_Element_ID = 584996
+;
+
+-- 1e) fr_CH: base text, IsTranslated='N' (no French translation provided)
+-- Already seeded by 1b with IsTranslated='N' — no additional UPDATE needed.
+
+-- ===========================================================================
+-- PART 1b: Dedicated AD_Element for 'Exportkonfiguration' field label (AD_Element 584997)
+-- Shared element 584101 (ExternalSystem_Config_ScriptedExportConversion_ID) carries the raw
+-- technical column name and is used elsewhere. AD_Name_ID on field 781121 pins the label to
+-- this dedicated element, surviving after_migration_sync_translations.
+-- ===========================================================================
+
+INSERT INTO AD_Element
+    (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive,
+     Created, CreatedBy, Updated, UpdatedBy,
+     ColumnName, EntityType, Name, PrintName)
+VALUES
+    (584997 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-06-15 09:03:30', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-15 09:03:30', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'ScriptedExport_Config', 'de.metas.externalsystem',
+     'Exportkonfiguration', 'Exportkonfiguration')
+;
+
+-- Seed _Trl rows for all active system languages (DE base text)
+INSERT INTO AD_Element_Trl
+    (AD_Language, AD_Element_ID, Name, PrintName, Description, Help,
+     IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Element_ID, t.Name, t.PrintName, t.Description, t.Help,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Element_ID = 584997
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID)
+;
+
+-- en_US override
+UPDATE AD_Element_Trl
+SET Name         = 'Export Configuration',
+    PrintName    = 'Export Configuration',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-15 09:03:31', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'en_US' AND AD_Element_ID = 584997
+;
+
+-- de_DE / de_CH: mark as actively translated (text matches base German)
+UPDATE AD_Element_Trl
+SET IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-15 09:03:32', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language IN ('de_DE', 'de_CH') AND AD_Element_ID = 584997
+;
+
+-- ===========================================================================
+-- PART 2: Read-only child tab over ExternalSystem_ScriptedExportConversion_Status
+-- ===========================================================================
+
+-- 2a) AD_Tab on window 167, TabLevel=1, read-only, no insert, newest-first
+--     Parent_Column_ID = 592783 (Record_ID in the _Status table)
+--     WhereClause filters rows for the current C_Invoice record
+--     SeqNo=70 — placed after the existing tabs (max existing SeqNo=50 for Zuordnung)
+INSERT INTO AD_Tab
+    (AD_Client_ID, AD_Org_ID, AD_Tab_ID, AD_Table_ID, AD_Window_ID,
+     AD_Element_ID,
+     Created, CreatedBy, Description, EntityType,
+     HasTree, IsActive, IsAdvancedTab, IsCheckParentsChanged,
+     IsInfoTab, IsInsertRecord, IsReadOnly, IsRefreshAllOnActivate,
+     IsSearchActive, IsSingleRow, IsSortTab, IsTranslationTab,
+     Name, OrderByClause, SeqNo, TabLevel,
+     Parent_Column_ID,
+     Updated, UpdatedBy,
+     WhereClause)
+VALUES
+    (0, 0, 549313 /*From ID Server*/, 542617 /*ExternalSystem_ScriptedExportConversion_Status*/, 167 /*Rechnung window*/,
+     584996 /*From ID Server — generic tab caption element*/,
+     TO_TIMESTAMP('2026-06-15 09:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 'de.metas.externalsystem',
+     'N', 'Y', 'N', 'N',
+     'N', 'N' /*no insert — status rows are system-written*/, 'Y' /*read-only*/, 'N',
+     'N', 'N', 'N', 'N',
+     'Exportstatus', 'Updated DESC', 70, 1,
+     592783 /*Record_ID column in _Status table — polymorphic FK*/,
+     TO_TIMESTAMP('2026-06-15 09:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'ExternalSystem_ScriptedExportConversion_Status.AD_Table_ID = 318 AND ExternalSystem_ScriptedExportConversion_Status.Record_ID = @C_Invoice_ID/0@')
+;
+
+-- 2b) AD_Tab_Trl skeleton rows
+INSERT INTO AD_Tab_Trl
+    (AD_Language, AD_Tab_ID, CommitWarning, Description, Help, Name,
+     IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Tab_ID, t.CommitWarning, t.Description, t.Help, t.Name,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Tab t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Tab_ID = 549313
+  AND NOT EXISTS (SELECT 1 FROM AD_Tab_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Tab_ID = t.AD_Tab_ID)
+;
+
+-- 2c) en_US translation
+UPDATE AD_Tab_Trl
+SET Name         = 'Export Status',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-15 09:01:12', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'en_US'
+  AND AD_Tab_ID = 549313
+;
+
+-- 2d) de_DE / de_CH
+UPDATE AD_Tab_Trl
+SET Name         = 'Exportstatus',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-15 09:01:13', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language IN ('de_DE', 'de_CH')
+  AND AD_Tab_ID = 549313
+;
+
+-- ===========================================================================
+-- PART 3: UI layout for the status child tab (included tab — single section/column/group)
+-- ===========================================================================
+
+-- 3a) AD_UI_Section
+INSERT INTO AD_UI_Section
+    (AD_UI_Section_ID, AD_Client_ID, AD_Org_ID, IsActive,
+     Created, CreatedBy, Updated, UpdatedBy, AD_Tab_ID, SeqNo, Value)
+VALUES
+    (547822 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-06-15 09:01:20', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-15 09:01:20', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     549313, 10, 'default')
+;
+
+-- 3b) Single UI column (included tabs use a single column)
+INSERT INTO AD_UI_Column
+    (AD_UI_Column_ID, AD_Client_ID, AD_Org_ID, IsActive,
+     Created, CreatedBy, Updated, UpdatedBy, AD_UI_Section_ID, SeqNo)
+VALUES
+    (549556 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-06-15 09:01:21', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-15 09:01:21', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     547822, 10)
+;
+
+-- 3c) Single element group (UIStyle=NULL — included tabs must have exactly 1 element group)
+INSERT INTO AD_UI_ElementGroup
+    (AD_UI_ElementGroup_ID, AD_Client_ID, AD_Org_ID, IsActive,
+     Created, CreatedBy, Updated, UpdatedBy, AD_UI_Column_ID, SeqNo, UIStyle, Name)
+VALUES
+    (555450 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-06-15 09:01:22', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-15 09:01:22', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     549556, 10, NULL, 'default')
+;
+
+-- ===========================================================================
+-- PART 4: AD_Field + AD_UI_Element rows for each status column (7 fields)
+-- Order matches reference: ExportStatus, Exportkonfiguration, HttpResponseCode,
+--                          StatusMessage, IsResend, AD_PInstance_ID, Updated
+-- ===========================================================================
+
+-- 4.1 ExportStatus (AD_Column 592784, AD_Element 577791)
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592784, 781120 /*From ID Server*/, 0, 549313,
+     TO_TIMESTAMP('2026-06-15 09:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 14, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y',
+     'N', 'Export Status', 10, 10,
+     0, 1, 1,
+     TO_TIMESTAMP('2026-06-15 09:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781120
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(577791);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781120;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781120);
+UPDATE AD_Field_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-15 09:02:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=781120 AND AD_Language IN ('de_DE','de_CH','en_US');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 781120, 0, 549313, 555450, 652266 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-15 09:02:02','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'Export Status', 10, 10, 0, TO_TIMESTAMP('2026-06-15 09:02:02','YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- 4.2 ExternalSystem_Config_ScriptedExportConversion_ID (AD_Column 592781, AD_Element 584101)
+--     AD_Name_ID=584997 (ScriptedExport_Config) pins the label to 'Exportkonfiguration'/
+--     'Export Configuration', surviving after_migration_sync_translations which would
+--     otherwise overwrite AD_Field_Trl from the shared element 584101 (raw technical name).
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     AD_Name_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592781, 781121 /*From ID Server*/, 0, 549313,
+     584997 /*ScriptedExport_Config dedicated label element*/,
+     TO_TIMESTAMP('2026-06-15 09:02:03', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 14, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y',
+     'N', 'Exportkonfiguration', 20, 20,
+     0, 1, 1,
+     TO_TIMESTAMP('2026-06-15 09:03:33', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781121
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584997);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781121;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781121);
+UPDATE AD_Field_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-15 09:03:34','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=781121 AND AD_Language IN ('de_DE','de_CH','en_US');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 781121, 0, 549313, 555450, 652267 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-15 09:02:06','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'Exportkonfiguration', 20, 20, 0, TO_TIMESTAMP('2026-06-15 09:02:06','YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- 4.3 HttpResponseCode (AD_Column 592787, AD_Element 584956)
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592787, 781122 /*From ID Server*/, 0, 549313,
+     TO_TIMESTAMP('2026-06-15 09:02:07', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 10, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y',
+     'N', 'HTTP-Antwortcode', 30, 30,
+     0, 1, 1,
+     TO_TIMESTAMP('2026-06-15 09:02:07', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781122
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584956);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781122;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781122);
+UPDATE AD_Field_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-15 09:02:08','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=781122 AND AD_Language IN ('de_DE','de_CH','en_US');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 781122, 0, 549313, 555450, 652268 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-15 09:02:09','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'HTTP-Antwortcode', 30, 30, 0, TO_TIMESTAMP('2026-06-15 09:02:09','YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- 4.4 StatusMessage (AD_Column 592788, AD_Element 584955)
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592788, 781123 /*From ID Server*/, 0, 549313,
+     TO_TIMESTAMP('2026-06-15 09:02:10', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 255, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y',
+     'N', 'Status-Meldung', 40, 40,
+     0, 1, 1,
+     TO_TIMESTAMP('2026-06-15 09:02:10', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781123
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584955);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781123;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781123);
+UPDATE AD_Field_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-15 09:02:11','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=781123 AND AD_Language IN ('de_DE','de_CH','en_US');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 781123, 0, 549313, 555450, 652269 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-15 09:02:12','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'Status-Meldung', 40, 40, 0, TO_TIMESTAMP('2026-06-15 09:02:12','YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- 4.5 IsResend (AD_Column 592789, AD_Element 584957)
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592789, 781124 /*From ID Server*/, 0, 549313,
+     TO_TIMESTAMP('2026-06-15 09:02:13', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 1, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y',
+     'N', 'Erneut gesendet', 50, 50,
+     0, 1, 1,
+     TO_TIMESTAMP('2026-06-15 09:02:13', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781124
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584957);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781124;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781124);
+UPDATE AD_Field_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-15 09:02:14','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=781124 AND AD_Language IN ('de_DE','de_CH','en_US');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 781124, 0, 549313, 555450, 652270 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-15 09:02:15','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'Erneut gesendet', 50, 50, 0, TO_TIMESTAMP('2026-06-15 09:02:15','YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- 4.6 AD_PInstance_ID (AD_Column 592785, AD_Element 114)
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592785, 781125 /*From ID Server*/, 0, 549313,
+     TO_TIMESTAMP('2026-06-15 09:02:16', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 14, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y',
+     'N', 'Prozess-Instanz', 60, 60,
+     0, 1, 1,
+     TO_TIMESTAMP('2026-06-15 09:02:16', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781125
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(114);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781125;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781125);
+UPDATE AD_Field_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-15 09:02:17','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=781125 AND AD_Language IN ('de_DE','de_CH','en_US');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 781125, 0, 549313, 555450, 652271 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-15 09:02:18','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'Prozess-Instanz', 60, 60, 0, TO_TIMESTAMP('2026-06-15 09:02:18','YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- 4.7 Updated (AD_Column 592779, AD_Element 607)
+--     SortNo=-1: grid sort indicator matches OrderByClause='Updated DESC' on the tab
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592779, 781126 /*From ID Server*/, 0, 549313,
+     TO_TIMESTAMP('2026-06-15 09:02:19', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 29, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'Y',
+     'N', 'N', 'N', 'N', 'Y',
+     'N', 'Aktualisiert', 70, 70,
+     -1 /*DESC sort indicator — matches OrderByClause='Updated DESC' on the tab*/, 1, 1,
+     TO_TIMESTAMP('2026-06-15 09:02:19', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781126
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(607);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781126;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781126);
+UPDATE AD_Field_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-15 09:02:20','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=781126 AND AD_Language IN ('de_DE','de_CH','en_US');
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType, Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 781126, 0, 549313, 555450, 652272 /*From ID Server*/, 'F', TO_TIMESTAMP('2026-06-15 09:02:21','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N', 'Aktualisiert', 70, 70, 0, TO_TIMESTAMP('2026-06-15 09:02:21','YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- ===========================================================================
+-- PART 5: Rollup field on C_Invoice header tab 263
+-- AD_Column 592812 (ScriptedExport_Status virtual), AD_Element 584995
+-- Placement: group 540027 ('dates', section seqno=10), seqno=36 (free slot between
+--   Eingabequelle=35 and Belegstatus=40), adjacent to Externes System (seqno=34).
+-- Not in grid (seqnogrid=0) — summary status field, not a grid column
+-- ===========================================================================
+
+-- 5a) AD_Field on tab 263 (Rechnung header)
+INSERT INTO AD_Field
+    (AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     Created, CreatedBy, Description, DisplayLength, EntityType,
+     Help, IsActive, IsDisplayed, IsDisplayedGrid,
+     IsEncrypted, IsFieldOnly, IsHeading, IsMandatory, IsReadOnly,
+     IsSameLine, Name, SeqNo, SeqNoGrid,
+     SortNo, SpanX, SpanY, Updated, UpdatedBy)
+VALUES
+    (0, 592812 /*ScriptedExport_Status virtual column*/, 781127 /*From ID Server*/, 0, 263 /*Rechnung header tab*/,
+     TO_TIMESTAMP('2026-06-15 09:03:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     NULL, 14, 'de.metas.externalsystem',
+     NULL, 'Y', 'Y', 'N' /*not in grid — summary rollup*/,
+     'N', 'N', 'N', 'N', 'Y' /*read-only — system-computed virtual column*/,
+     'N', 'Exportstatus', 560, 0,
+     0, 1, 1,
+     TO_TIMESTAMP('2026-06-15 09:03:00', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+
+-- 5b) AD_Field_Trl skeleton rows
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781127
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID);
+
+-- 5c) Propagate element translations → field (pass AD_Element_ID 584995 = ScriptedExport_Status)
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(584995);
+
+-- 5d) Rebuild element links
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781127;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781127);
+
+-- 5e) AD_UI_Element — placed in group 540027 ('dates', section seqno=10) on tab 263
+--     Adjacent to Externes System (seqno=34) and Eingabequelle (seqno=35); free slot seqno=36.
+--     IsAdvancedField='N' so it is visible on the normal form (not hidden behind Alt+E).
+--     seqnogrid=0 — not in grid (summary rollup, not a grid column)
+INSERT INTO AD_UI_Element
+    (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID,
+     AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+     Created, CreatedBy, IsActive, IsAdvancedField,
+     IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+     Name, SeqNo, SeqNoGrid, SeqNo_SideList,
+     Updated, UpdatedBy)
+VALUES
+    (0, 781127 /*ScriptedExport_Status rollup field*/, 0, 263 /*Rechnung header tab*/,
+     540027 /*dates group — contains Externes System (34), Eingabequelle (35), Belegstatus (40)*/,
+     652273 /*From ID Server*/, 'F',
+     TO_TIMESTAMP('2026-06-15 09:03:10', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'Y', 'N' /*IsAdvancedField=N — visible on normal form*/,
+     'Y', 'N' /*not in grid — summary rollup*/, 'N',
+     'Exportstatus', 36, 0, 0,
+     TO_TIMESTAMP('2026-06-15 09:03:20', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;
+
+-- 5f) Mark field translations as actively translated (element 584995 already has correct DE+EN translations)
+UPDATE AD_Field_Trl SET IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-06-15 09:03:11','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=781127 AND AD_Language IN ('de_DE','de_CH','en_US');

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807920_sys_C_Invoice_ReSend_ScriptedExportConversion.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807920_sys_C_Invoice_ReSend_ScriptedExportConversion.sql
@@ -1,0 +1,112 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+-- Per-record "Export erneut senden (Scripted Export Conversion)" AD process on C_Invoice.
+-- Re-triggers the scripted-export-conversion for any config with a non-Sent latest attempt.
+--
+-- IDs allocated from idserver.metas.de:
+--   AD_Process_ID     585637   (C_Invoice_ReSend_ScriptedExportConversion)
+--   AD_Table_Process  541651   (C_Invoice table binding, AD_Table_ID=318)
+
+-- 1) AD_Process -----------------------------------------------------------------------
+INSERT INTO AD_Process
+    (AD_Process_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     Value, Name,
+     Classname,
+     IsReport, IsFormatExcelFile, EntityType,
+     AccessLevel, Type, ShowHelp, IsBetaFunctionality)
+VALUES
+    (585637 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-06-15 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-15 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'C_Invoice_ReSend_ScriptedExportConversion',
+     'Export erneut senden (Scripted Export Conversion)',
+     'de.metas.externalsystem.scriptedexportconversion.process.C_Invoice_ReSend_ScriptedExportConversion',
+     'N', 'Y', 'de.metas.externalsystem',
+     '3', 'Java', 'Y', 'N')
+;
+
+-- 2) AD_Process_Trl skeleton -----------------------------------------------------------
+INSERT INTO AD_Process_Trl
+    (AD_Language, AD_Process_ID, Description, Help, Name,
+     IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language,
+       t.AD_Process_ID,
+       t.Description,
+       t.Help,
+       t.Name,
+       'N',
+       t.AD_Client_ID,
+       t.AD_Org_ID,
+       t.Created,
+       t.CreatedBy,
+       t.Updated,
+       t.UpdatedBy,
+       'Y'
+FROM AD_Language l,
+     AD_Process t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Process_ID = 585637
+  AND NOT EXISTS (SELECT 1
+                  FROM AD_Process_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language
+                    AND tt.AD_Process_ID = t.AD_Process_ID)
+;
+
+-- 3) AD_Process_Trl: set en_US and German translations --------------------------------
+UPDATE AD_Process_Trl
+SET Name         = 'Re-send export (Scripted Export Conversion)',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-15 10:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'en_US'
+  AND AD_Process_ID = 585637
+;
+
+UPDATE AD_Process_Trl
+SET Name         = 'Export erneut senden (Scripted Export Conversion)',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-15 10:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language IN ('de_CH', 'de_DE')
+  AND AD_Process_ID = 585637
+;
+
+-- 4) AD_Table_Process: bind to C_Invoice (AD_Table_ID=318) as a document action ------
+INSERT INTO AD_Table_Process
+    (AD_Client_ID, AD_Org_ID,
+     AD_Process_ID, AD_Table_ID, AD_Table_Process_ID,
+     Created, CreatedBy,
+     EntityType, IsActive,
+     Updated, UpdatedBy,
+     WEBUI_DocumentAction, WEBUI_IncludedTabTopAction, WEBUI_ViewAction,
+     WEBUI_ViewQuickAction, WEBUI_ViewQuickAction_Default)
+VALUES
+    (0, 0,
+     585637 /*From ID Server*/, 318 /*C_Invoice*/, 541651 /*From ID Server*/,
+     TO_TIMESTAMP('2026-06-15 10:00:03', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'de.metas.externalsystem', 'Y',
+     TO_TIMESTAMP('2026-06-15 10:00:03', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'Y', 'N', 'Y',
+     'N', 'N')
+;

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807920_sys_C_Invoice_ReSend_ScriptedExportConversion.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807920_sys_C_Invoice_ReSend_ScriptedExportConversion.sql
@@ -41,7 +41,7 @@ VALUES
      'C_Invoice_ReSend_ScriptedExportConversion',
      'Export erneut senden (Scripted Export Conversion)',
      'de.metas.externalsystem.scriptedexportconversion.process.C_Invoice_ReSend_ScriptedExportConversion',
-     'N', 'Y', 'de.metas.externalsystem',
+     'N', 'N' /*IsReport=N, IsFormatExcelFile=N — this is a Java action process, not a spreadsheet report*/, 'de.metas.externalsystem',
      '3', 'Java', 'Y', 'N')
 ;
 

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807930_sys_ReSend_ScriptedExport_OnlyNotSent_param.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807930_sys_ReSend_ScriptedExport_OnlyNotSent_param.sql
@@ -99,7 +99,7 @@ VALUES
      585004,
      'IsOnlyNotSentSuccessfully',
      'Only not yet successfully sent',
-     20 /*YesNo*/, 1, 'N', 'N', 10,
+     20 /*YesNo*/, 1, 'N', 'Y' /*DefaultValue=Y: default to re-sending ONLY the not-yet-successfully-sent records (safe default; uncheck to force-resend all selected)*/, 10,
      'de.metas.externalsystem')
 ;
 
@@ -159,7 +159,7 @@ VALUES
      585004,
      'IsOnlyNotSentSuccessfully',
      'Only not yet successfully sent',
-     20 /*YesNo*/, 1, 'N', 'N', 10,
+     20 /*YesNo*/, 1, 'N', 'Y' /*DefaultValue=Y: default to re-sending ONLY the not-yet-successfully-sent records (safe default; uncheck to force-resend all selected)*/, 10,
      'de.metas.externalsystem')
 ;
 

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807930_sys_ReSend_ScriptedExport_OnlyNotSent_param.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807930_sys_ReSend_ScriptedExport_OnlyNotSent_param.sql
@@ -20,7 +20,7 @@
  * #L%
  */
 
--- me03 #30104: ReSend scripted export — add IsOnlyNotSentSuccessfully parameter
+-- ReSend scripted export — add the IsOnlyNotSentSuccessfully parameter
 -- to both M_InOut_ReSend_ScriptedExportConversion (585633) and
 -- C_Invoice_ReSend_ScriptedExportConversion (585637).
 --

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807930_sys_me03_30104_IsOnlyNotSentSuccessfully_param.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807930_sys_me03_30104_IsOnlyNotSentSuccessfully_param.sql
@@ -1,0 +1,178 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+-- me03 #30104: ReSend scripted export — add IsOnlyNotSentSuccessfully parameter
+-- to both M_InOut_ReSend_ScriptedExportConversion (585633) and
+-- C_Invoice_ReSend_ScriptedExportConversion (585637).
+--
+-- IDs allocated from idserver.metas.de on 2026-06-16:
+--   AD_Element_ID          585004   (IsOnlyNotSentSuccessfully)
+--   AD_Process_Para_ID     543252   (M_InOut process, AD_Process_ID=585633)
+--   AD_Process_Para_ID     543253   (C_Invoice process, AD_Process_ID=585637)
+
+-- 1) AD_Element ----------------------------------------------------------------------
+INSERT INTO AD_Element
+    (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     ColumnName, EntityType, Name, PrintName)
+VALUES
+    (585004 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-06-16 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-16 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'IsOnlyNotSentSuccessfully',
+     'de.metas.externalsystem',
+     'Only not yet successfully sent',
+     'Only not yet successfully sent')
+;
+
+-- 2) AD_Element_Trl: German translations --------------------------------------------
+INSERT INTO AD_Element_Trl
+    (AD_Language, AD_Element_ID, Name, PrintName,
+     IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language,
+       585004,
+       CASE l.AD_Language
+           WHEN 'de_DE' THEN 'Nur noch nicht erfolgreich gesendete'
+           WHEN 'de_CH' THEN 'Nur noch nicht erfolgreich gesendete'
+           ELSE e.Name
+       END,
+       CASE l.AD_Language
+           WHEN 'de_DE' THEN 'Nur noch nicht erfolgreich gesendete'
+           WHEN 'de_CH' THEN 'Nur noch nicht erfolgreich gesendete'
+           ELSE e.PrintName
+       END,
+       CASE WHEN l.AD_Language IN ('de_DE', 'de_CH') THEN 'Y' ELSE 'N' END,
+       0, 0,
+       TO_TIMESTAMP('2026-06-16 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       TO_TIMESTAMP('2026-06-16 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       'Y'
+FROM AD_Language l,
+     AD_Element e
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND e.AD_Element_ID = 585004
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = 585004)
+;
+
+-- 3) AD_Process_Para for M_InOut_ReSend_ScriptedExportConversion (AD_Process_ID=585633) --------
+INSERT INTO AD_Process_Para
+    (AD_Process_Para_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     AD_Process_ID, AD_Element_ID,
+     ColumnName, Name,
+     AD_Reference_ID, FieldLength, IsMandatory, DefaultValue, SeqNo,
+     EntityType)
+VALUES
+    (543252 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-06-16 10:00:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-16 10:00:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     585633,
+     585004,
+     'IsOnlyNotSentSuccessfully',
+     'Only not yet successfully sent',
+     20 /*YesNo*/, 0, 'N', 'N', 10,
+     'de.metas.externalsystem')
+;
+
+-- AD_Process_Para_Trl skeleton for 543252
+INSERT INTO AD_Process_Para_Trl
+    (AD_Language, AD_Process_Para_ID, Name, Description, Help,
+     IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language,
+       543252,
+       p.Name,
+       p.Description,
+       p.Help,
+       'N',
+       0, 0,
+       TO_TIMESTAMP('2026-06-16 10:00:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       TO_TIMESTAMP('2026-06-16 10:00:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       'Y'
+FROM AD_Language l,
+     AD_Process_Para p
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND p.AD_Process_Para_ID = 543252
+  AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Process_Para_ID = 543252)
+;
+
+-- German translation for 543252
+UPDATE AD_Process_Para_Trl
+SET Name         = 'Nur noch nicht erfolgreich gesendete',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-16 10:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language IN ('de_DE', 'de_CH')
+  AND AD_Process_Para_ID = 543252
+;
+
+-- 4) AD_Process_Para for C_Invoice_ReSend_ScriptedExportConversion (AD_Process_ID=585637) -------
+INSERT INTO AD_Process_Para
+    (AD_Process_Para_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     AD_Process_ID, AD_Element_ID,
+     ColumnName, Name,
+     AD_Reference_ID, FieldLength, IsMandatory, DefaultValue, SeqNo,
+     EntityType)
+VALUES
+    (543253 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-06-16 10:00:03', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-16 10:00:03', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     585637,
+     585004,
+     'IsOnlyNotSentSuccessfully',
+     'Only not yet successfully sent',
+     20 /*YesNo*/, 0, 'N', 'N', 10,
+     'de.metas.externalsystem')
+;
+
+-- AD_Process_Para_Trl skeleton for 543253
+INSERT INTO AD_Process_Para_Trl
+    (AD_Language, AD_Process_Para_ID, Name, Description, Help,
+     IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language,
+       543253,
+       p.Name,
+       p.Description,
+       p.Help,
+       'N',
+       0, 0,
+       TO_TIMESTAMP('2026-06-16 10:00:03', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       TO_TIMESTAMP('2026-06-16 10:00:03', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       'Y'
+FROM AD_Language l,
+     AD_Process_Para p
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND p.AD_Process_Para_ID = 543253
+  AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Process_Para_ID = 543253)
+;
+
+-- German translation for 543253
+UPDATE AD_Process_Para_Trl
+SET Name         = 'Nur noch nicht erfolgreich gesendete',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-16 10:00:04', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language IN ('de_DE', 'de_CH')
+  AND AD_Process_Para_ID = 543253
+;

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807930_sys_me03_30104_IsOnlyNotSentSuccessfully_param.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807930_sys_me03_30104_IsOnlyNotSentSuccessfully_param.sql
@@ -39,8 +39,8 @@ VALUES
      TO_TIMESTAMP('2026-06-16 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
      'IsOnlyNotSentSuccessfully',
      'de.metas.externalsystem',
-     'Only not yet successfully sent',
-     'Only not yet successfully sent')
+     'Nur noch nicht erfolgreich gesendete',
+     'Nur noch nicht erfolgreich gesendete')
 ;
 
 -- 2) AD_Element_Trl: German translations --------------------------------------------
@@ -73,6 +73,17 @@ WHERE l.IsActive = 'Y'
                   WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = 585004)
 ;
 
+-- AD_Element_Trl: en_US translation
+UPDATE AD_Element_Trl
+SET Name         = 'Only not yet successfully sent',
+    PrintName    = 'Only not yet successfully sent',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-06-16 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'en_US'
+  AND AD_Element_ID = 585004
+;
+
 -- 3) AD_Process_Para for M_InOut_ReSend_ScriptedExportConversion (AD_Process_ID=585633) --------
 INSERT INTO AD_Process_Para
     (AD_Process_Para_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
@@ -88,7 +99,7 @@ VALUES
      585004,
      'IsOnlyNotSentSuccessfully',
      'Only not yet successfully sent',
-     20 /*YesNo*/, 0, 'N', 'N', 10,
+     20 /*YesNo*/, 1, 'N', 'N', 10,
      'de.metas.externalsystem')
 ;
 
@@ -140,7 +151,7 @@ VALUES
      585004,
      'IsOnlyNotSentSuccessfully',
      'Only not yet successfully sent',
-     20 /*YesNo*/, 0, 'N', 'N', 10,
+     20 /*YesNo*/, 1, 'N', 'N', 10,
      'de.metas.externalsystem')
 ;
 

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807930_sys_me03_30104_IsOnlyNotSentSuccessfully_param.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5807930_sys_me03_30104_IsOnlyNotSentSuccessfully_param.sql
@@ -126,13 +126,21 @@ WHERE l.IsActive = 'Y'
                   WHERE tt.AD_Language = l.AD_Language AND tt.AD_Process_Para_ID = 543252)
 ;
 
--- German translation for 543252
+-- German translation for 543252 (fr_CH adopts German text verbatim with IsTranslated='N')
 UPDATE AD_Process_Para_Trl
 SET Name         = 'Nur noch nicht erfolgreich gesendete',
     IsTranslated = 'Y',
     Updated      = TO_TIMESTAMP('2026-06-16 10:00:02', 'YYYY-MM-DD HH24:MI:SS'),
     UpdatedBy    = 100
 WHERE AD_Language IN ('de_DE', 'de_CH')
+  AND AD_Process_Para_ID = 543252
+;
+UPDATE AD_Process_Para_Trl
+SET Name         = 'Nur noch nicht erfolgreich gesendete',
+    IsTranslated = 'N',
+    Updated      = TO_TIMESTAMP('2026-06-16 10:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'fr_CH'
   AND AD_Process_Para_ID = 543252
 ;
 
@@ -178,7 +186,7 @@ WHERE l.IsActive = 'Y'
                   WHERE tt.AD_Language = l.AD_Language AND tt.AD_Process_Para_ID = 543253)
 ;
 
--- German translation for 543253
+-- German translation for 543253 (fr_CH adopts German text verbatim with IsTranslated='N')
 UPDATE AD_Process_Para_Trl
 SET Name         = 'Nur noch nicht erfolgreich gesendete',
     IsTranslated = 'Y',
@@ -187,3 +195,14 @@ SET Name         = 'Nur noch nicht erfolgreich gesendete',
 WHERE AD_Language IN ('de_DE', 'de_CH')
   AND AD_Process_Para_ID = 543253
 ;
+UPDATE AD_Process_Para_Trl
+SET Name         = 'Nur noch nicht erfolgreich gesendete',
+    IsTranslated = 'N',
+    Updated      = TO_TIMESTAMP('2026-06-16 10:00:04', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'fr_CH'
+  AND AD_Process_Para_ID = 543253
+;
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585004);
+

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/C_Invoice_ReSend_ScriptedExportConversionProcessTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/C_Invoice_ReSend_ScriptedExportConversionProcessTest.java
@@ -120,8 +120,8 @@ public class C_Invoice_ReSend_ScriptedExportConversionProcessTest
 		final ExternalSystemScriptedExportConversionConfig configA = buildDummyConfig(configIdA, tableId);
 		final ExternalSystemScriptedExportConversionConfig configB = buildDummyConfig(configIdB, tableId);
 
-		// Service returns two qualifying configs
-		when(scriptedExportServiceMock.getResendableConfigsBySourceRecord(sourceRecord))
+		// Service returns two qualifying configs (isOnlyNotSentSuccessfully=false by default → getMatchingConfigIdsBySourceRecord)
+		when(scriptedExportServiceMock.getMatchingConfigIdsBySourceRecord(sourceRecord))
 				.thenReturn(qualifyingConfigIds);
 
 		// resolveConfigAndRecordPendingAsResend returns the resolved config for each
@@ -161,7 +161,7 @@ public class C_Invoice_ReSend_ScriptedExportConversionProcessTest
 		final int invoiceId = invoice.getC_Invoice_ID();
 		final int tableId = Services.get(IADTableDAO.class).retrieveTableId(I_C_Invoice.Table_Name);
 
-		when(scriptedExportServiceMock.getResendableConfigsBySourceRecord(any()))
+		when(scriptedExportServiceMock.getMatchingConfigIdsBySourceRecord(any()))
 				.thenReturn(Collections.emptyList());
 
 		final String result = runProcess(invoiceId, tableId);

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/C_Invoice_ReSend_ScriptedExportConversionProcessTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/C_Invoice_ReSend_ScriptedExportConversionProcessTest.java
@@ -200,7 +200,7 @@ public class C_Invoice_ReSend_ScriptedExportConversionProcessTest
 		verify(scriptedExportServiceMock, times(1)).getResendableConfigsBySourceRecord(sourceRecord);
 		verify(scriptedExportServiceMock, times(0)).getMatchingConfigIdsBySourceRecord(any());
 		verify(scriptedExportServiceMock, times(1)).resolveConfigAndRecordPendingAsResend(eq(configIdA), any());
-		assertThat(result).contains("1");
+		assertThat(result).contains("#1");
 	}
 
 	// -----------------------------------------------------------------------

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/C_Invoice_ReSend_ScriptedExportConversionProcessTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/C_Invoice_ReSend_ScriptedExportConversionProcessTest.java
@@ -134,8 +134,8 @@ public class C_Invoice_ReSend_ScriptedExportConversionProcessTest
 		when(scriptedExportServiceMock.executeInvokeScriptedExportConversionActionAndGetResult(any(), any(Integer.class), eq(ExternalSystemInvocationContext.RESEND)))
 				.thenReturn(ExternalSystemInvocationResult.error(new RuntimeException("mocked")));
 
-		// Run the process
-		final String result = runProcess(invoiceId, tableId);
+		// Run the process (isOnlyNotSentSuccessfully=false → getMatchingConfigIdsBySourceRecord)
+		final String result = runProcess(invoiceId, tableId, false);
 
 		// Assert: resolveConfigAndRecordPendingAsResend called once per config
 		verify(scriptedExportServiceMock, times(1)).resolveConfigAndRecordPendingAsResend(eq(configIdA), any());
@@ -164,11 +164,43 @@ public class C_Invoice_ReSend_ScriptedExportConversionProcessTest
 		when(scriptedExportServiceMock.getMatchingConfigIdsBySourceRecord(any()))
 				.thenReturn(Collections.emptyList());
 
-		final String result = runProcess(invoiceId, tableId);
+		final String result = runProcess(invoiceId, tableId, false);
 
 		assertThat(result).contains("#0");
 		verify(scriptedExportServiceMock, times(0)).resolveConfigAndRecordPendingAsResend(any(), any());
 		verify(scriptedExportServiceMock, times(0)).executeInvokeScriptedExportConversionActionAndGetResult(any(), any(Integer.class), any());
+	}
+
+	// -----------------------------------------------------------------------
+	// 3. isOnlyNotSentSuccessfully=true → uses getResendableConfigsBySourceRecord
+	// -----------------------------------------------------------------------
+	@Test
+	void doIt_isOnlyNotSentSuccessfully_usesResendableConfigs()
+	{
+		final I_C_Invoice invoice = InterfaceWrapperHelper.newInstance(I_C_Invoice.class);
+		InterfaceWrapperHelper.saveRecord(invoice);
+		final int invoiceId = invoice.getC_Invoice_ID();
+		final int tableId = Services.get(IADTableDAO.class).retrieveTableId(I_C_Invoice.Table_Name);
+		final TableRecordReference sourceRecord = TableRecordReference.of(I_C_Invoice.Table_Name, invoiceId);
+
+		final ExternalSystemScriptedExportConversionConfigId configIdA = ExternalSystemScriptedExportConversionConfigId.ofRepoId(201);
+		final List<ExternalSystemScriptedExportConversionConfigId> resendableConfigIds = Collections.singletonList(configIdA);
+		final ExternalSystemScriptedExportConversionConfig configA = buildDummyConfig(configIdA, tableId);
+
+		when(scriptedExportServiceMock.getResendableConfigsBySourceRecord(sourceRecord))
+				.thenReturn(resendableConfigIds);
+		when(scriptedExportServiceMock.resolveConfigAndRecordPendingAsResend(eq(configIdA), any()))
+				.thenReturn(configA);
+		when(scriptedExportServiceMock.executeInvokeScriptedExportConversionActionAndGetResult(any(), any(Integer.class), eq(ExternalSystemInvocationContext.RESEND)))
+				.thenReturn(ExternalSystemInvocationResult.error(new RuntimeException("mocked")));
+
+		final String result = runProcess(invoiceId, tableId, true /*isOnlyNotSentSuccessfully*/);
+
+		// Verify the filtered path was used, NOT the all-configs path
+		verify(scriptedExportServiceMock, times(1)).getResendableConfigsBySourceRecord(sourceRecord);
+		verify(scriptedExportServiceMock, times(0)).getMatchingConfigIdsBySourceRecord(any());
+		verify(scriptedExportServiceMock, times(1)).resolveConfigAndRecordPendingAsResend(eq(configIdA), any());
+		assertThat(result).contains("1");
 	}
 
 	// -----------------------------------------------------------------------
@@ -197,9 +229,11 @@ public class C_Invoice_ReSend_ScriptedExportConversionProcessTest
 
 	/**
 	 * Instantiates and drives the process for the given C_Invoice record.
-	 * Returns the process summary result string.
+	 *
+	 * @param isOnlyNotSentSuccessfully value for the {@code IsOnlyNotSentSuccessfully} process parameter
+	 * @return the process summary result string
 	 */
-	private String runProcess(final int invoiceId, final int tableId)
+	private String runProcess(final int invoiceId, final int tableId, final boolean isOnlyNotSentSuccessfully)
 	{
 		final I_AD_Process adProcess = newInstanceOutOfTrx(I_AD_Process.class);
 		adProcess.setValue(C_Invoice_ReSend_ScriptedExportConversion.class.getSimpleName());
@@ -216,6 +250,7 @@ public class C_Invoice_ReSend_ScriptedExportConversionProcessTest
 				.setAD_PInstance(pinstance)
 				.setRecord(tableId, invoiceId)
 				.setTitle("Test")
+				.addParameter("IsOnlyNotSentSuccessfully", isOnlyNotSentSuccessfully)
 				.build();
 
 		// Instantiate AFTER mocks are registered (fields resolved at construction via SpringContextHolder)

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/C_Invoice_ReSend_ScriptedExportConversionProcessTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/C_Invoice_ReSend_ScriptedExportConversionProcessTest.java
@@ -147,7 +147,7 @@ public class C_Invoice_ReSend_ScriptedExportConversionProcessTest
 		verify(scriptedExportServiceMock, times(1))
 				.executeInvokeScriptedExportConversionActionAndGetResult(eq(configB), eq(invoiceId), eq(ExternalSystemInvocationContext.RESEND));
 
-		assertThat(result).contains("2");
+		assertThat(result).contains("#2");
 	}
 
 	// -----------------------------------------------------------------------

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/C_Invoice_ReSend_ScriptedExportConversionProcessTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/C_Invoice_ReSend_ScriptedExportConversionProcessTest.java
@@ -1,0 +1,231 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedexportconversion;
+
+import de.metas.externalsystem.ExternalSystemInvocationContext;
+import de.metas.externalsystem.ExternalSystemParentConfigId;
+import de.metas.externalsystem.endpoint.ExternalSystemEndpointId;
+import de.metas.externalsystem.scriptedexportconversion.process.C_Invoice_ReSend_ScriptedExportConversion;
+import de.metas.process.AdProcessId;
+import de.metas.process.IADPInstanceDAO;
+import de.metas.process.JavaProcess;
+import de.metas.process.ProcessInfo;
+import de.metas.user.UserId;
+import de.metas.util.Services;
+import org.adempiere.ad.table.api.AdTableAndClientId;
+import org.adempiere.ad.table.api.AdTableId;
+import org.adempiere.ad.table.api.IADTableDAO;
+import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.util.lang.IAutoCloseable;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_AD_PInstance;
+import org.compiere.model.I_AD_Process;
+import org.compiere.model.I_C_Invoice;
+import org.compiere.model.X_AD_Process;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstanceOutOfTrx;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Process-level test for {@link C_Invoice_ReSend_ScriptedExportConversion}.
+ *
+ * <p>Verifies:
+ * <ul>
+ *   <li>When the status service returns qualifying config IDs, the process calls
+ *       {@code resolveConfigAndRecordPendingAsResend} and then
+ *       {@code executeInvokeScriptedExportConversionActionAndGetResult} with RESEND
+ *       once per config.</li>
+ *   <li>The IsResend=Y Pending row is created (via {@code resolveConfigAndRecordPendingAsResend})
+ *       before the invocation call.</li>
+ *   <li>When no qualifying configs exist the process returns a zero-count result ({@code @Processed@ #0})
+ *       and neither service method is called.</li>
+ * </ul>
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class C_Invoice_ReSend_ScriptedExportConversionProcessTest
+{
+	private ExternalSystemScriptedExportConversionService scriptedExportServiceMock;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		// ProcessInfo builder requires a valid logged-in user ID in context
+		Env.setLoggedUserId(Env.getCtx(), UserId.ofRepoId(100));
+
+		scriptedExportServiceMock = mock(ExternalSystemScriptedExportConversionService.class);
+
+		// Register mock BEFORE instantiating the process (field is resolved at construction time)
+		SpringContextHolder.registerJUnitBean(ExternalSystemScriptedExportConversionService.class, scriptedExportServiceMock);
+	}
+
+	// -----------------------------------------------------------------------
+	// 1. Happy path: two qualifying configs → each gets resolveConfig+recordPending + invoke
+	// -----------------------------------------------------------------------
+	@Test
+	void doIt_twoQualifyingConfigs_invokeCalledOncePerConfig()
+	{
+		// Set up a C_Invoice record to act as the process record
+		final I_C_Invoice invoice = InterfaceWrapperHelper.newInstance(I_C_Invoice.class);
+		InterfaceWrapperHelper.saveRecord(invoice);
+		final int invoiceId = invoice.getC_Invoice_ID();
+
+		final int tableId = Services.get(IADTableDAO.class).retrieveTableId(I_C_Invoice.Table_Name);
+		final TableRecordReference sourceRecord = TableRecordReference.of(I_C_Invoice.Table_Name, invoiceId);
+
+		final ExternalSystemScriptedExportConversionConfigId configIdA = ExternalSystemScriptedExportConversionConfigId.ofRepoId(101);
+		final ExternalSystemScriptedExportConversionConfigId configIdB = ExternalSystemScriptedExportConversionConfigId.ofRepoId(102);
+		final List<ExternalSystemScriptedExportConversionConfigId> qualifyingConfigIds = Arrays.asList(configIdA, configIdB);
+
+		final ExternalSystemScriptedExportConversionConfig configA = buildDummyConfig(configIdA, tableId);
+		final ExternalSystemScriptedExportConversionConfig configB = buildDummyConfig(configIdB, tableId);
+
+		// Service returns two qualifying configs
+		when(scriptedExportServiceMock.getResendableConfigsBySourceRecord(sourceRecord))
+				.thenReturn(qualifyingConfigIds);
+
+		// resolveConfigAndRecordPendingAsResend returns the resolved config for each
+		when(scriptedExportServiceMock.resolveConfigAndRecordPendingAsResend(eq(configIdA), any()))
+				.thenReturn(configA);
+		when(scriptedExportServiceMock.resolveConfigAndRecordPendingAsResend(eq(configIdB), any()))
+				.thenReturn(configB);
+
+		// executeInvokeScriptedExportConversionActionAndGetResult returns a result for both (process ignores the return value)
+		when(scriptedExportServiceMock.executeInvokeScriptedExportConversionActionAndGetResult(any(), any(Integer.class), eq(ExternalSystemInvocationContext.RESEND)))
+				.thenReturn(ExternalSystemInvocationResult.error(new RuntimeException("mocked")));
+
+		// Run the process
+		final String result = runProcess(invoiceId, tableId);
+
+		// Assert: resolveConfigAndRecordPendingAsResend called once per config
+		verify(scriptedExportServiceMock, times(1)).resolveConfigAndRecordPendingAsResend(eq(configIdA), any());
+		verify(scriptedExportServiceMock, times(1)).resolveConfigAndRecordPendingAsResend(eq(configIdB), any());
+
+		// Assert: executeInvokeScriptedExportConversionActionAndGetResult called once per config with RESEND
+		verify(scriptedExportServiceMock, times(1))
+				.executeInvokeScriptedExportConversionActionAndGetResult(eq(configA), eq(invoiceId), eq(ExternalSystemInvocationContext.RESEND));
+		verify(scriptedExportServiceMock, times(1))
+				.executeInvokeScriptedExportConversionActionAndGetResult(eq(configB), eq(invoiceId), eq(ExternalSystemInvocationContext.RESEND));
+
+		assertThat(result).contains("2");
+	}
+
+	// -----------------------------------------------------------------------
+	// 2. No qualifying configs → zero-count result, no invocations
+	// -----------------------------------------------------------------------
+	@Test
+	void doIt_noQualifyingConfigs_returnsZeroCount()
+	{
+		final I_C_Invoice invoice = InterfaceWrapperHelper.newInstance(I_C_Invoice.class);
+		InterfaceWrapperHelper.saveRecord(invoice);
+		final int invoiceId = invoice.getC_Invoice_ID();
+		final int tableId = Services.get(IADTableDAO.class).retrieveTableId(I_C_Invoice.Table_Name);
+
+		when(scriptedExportServiceMock.getResendableConfigsBySourceRecord(any()))
+				.thenReturn(Collections.emptyList());
+
+		final String result = runProcess(invoiceId, tableId);
+
+		assertThat(result).contains("#0");
+		verify(scriptedExportServiceMock, times(0)).resolveConfigAndRecordPendingAsResend(any(), any());
+		verify(scriptedExportServiceMock, times(0)).executeInvokeScriptedExportConversionActionAndGetResult(any(), any(Integer.class), any());
+	}
+
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Builds a minimal config stub; the process only passes it through to the invoke call.
+	 */
+	private ExternalSystemScriptedExportConversionConfig buildDummyConfig(
+			final ExternalSystemScriptedExportConversionConfigId id,
+			final int tableId)
+	{
+		return ExternalSystemScriptedExportConversionConfig.builder()
+				.id(id)
+				.parentId(ExternalSystemParentConfigId.ofRepoId(1))
+				.externalSystemEndpointId(ExternalSystemEndpointId.ofRepoId(1))
+				.value("test")
+				.scriptIdentifier("test.js")
+				.tableAndClientId(AdTableAndClientId.of(AdTableId.ofRepoId(tableId), ClientId.ofRepoId(0)))
+				.whereClause("1=1")
+				.active(true)
+				.isTriggerOnComplete(true)
+				.build();
+	}
+
+	/**
+	 * Instantiates and drives the process for the given C_Invoice record.
+	 * Returns the process summary result string.
+	 */
+	private String runProcess(final int invoiceId, final int tableId)
+	{
+		final I_AD_Process adProcess = newInstanceOutOfTrx(I_AD_Process.class);
+		adProcess.setValue(C_Invoice_ReSend_ScriptedExportConversion.class.getSimpleName());
+		adProcess.setName(C_Invoice_ReSend_ScriptedExportConversion.class.getSimpleName());
+		adProcess.setType(X_AD_Process.TYPE_Java);
+		adProcess.setClassname(C_Invoice_ReSend_ScriptedExportConversion.class.getName());
+		saveRecord(adProcess);
+		final AdProcessId adProcessId = AdProcessId.ofRepoId(adProcess.getAD_Process_ID());
+
+		final I_AD_PInstance pinstance = Services.get(IADPInstanceDAO.class).createAD_PInstance(adProcessId);
+
+		final ProcessInfo pi = ProcessInfo.builder()
+				.setCtx(Env.getCtx())
+				.setAD_PInstance(pinstance)
+				.setRecord(tableId, invoiceId)
+				.setTitle("Test")
+				.build();
+
+		// Instantiate AFTER mocks are registered (fields resolved at construction via SpringContextHolder)
+		final C_Invoice_ReSend_ScriptedExportConversion process = new C_Invoice_ReSend_ScriptedExportConversion();
+
+		try (final IAutoCloseable ignored = JavaProcess.temporaryChangeCurrentInstance(process))
+		{
+			process.startProcess(pi, ITrx.TRX_None);
+		}
+
+		return pi.getResult().getSummary();
+	}
+}

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionProcessTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionProcessTest.java
@@ -120,8 +120,8 @@ public class M_InOut_ReSend_ScriptedExportConversionProcessTest
 		final ExternalSystemScriptedExportConversionConfig configA = buildDummyConfig(configIdA, tableId);
 		final ExternalSystemScriptedExportConversionConfig configB = buildDummyConfig(configIdB, tableId);
 
-		// Service returns two qualifying configs
-		when(scriptedExportServiceMock.getResendableConfigsBySourceRecord(sourceRecord))
+		// Service returns two qualifying configs (isOnlyNotSentSuccessfully=false by default → getMatchingConfigIdsBySourceRecord)
+		when(scriptedExportServiceMock.getMatchingConfigIdsBySourceRecord(sourceRecord))
 				.thenReturn(qualifyingConfigIds);
 
 		// resolveConfigAndRecordPendingAsResend returns the resolved config for each
@@ -161,7 +161,7 @@ public class M_InOut_ReSend_ScriptedExportConversionProcessTest
 		final int inoutId = inout.getM_InOut_ID();
 		final int tableId = Services.get(IADTableDAO.class).retrieveTableId(I_M_InOut.Table_Name);
 
-		when(scriptedExportServiceMock.getResendableConfigsBySourceRecord(any()))
+		when(scriptedExportServiceMock.getMatchingConfigIdsBySourceRecord(any()))
 				.thenReturn(Collections.emptyList());
 
 		final String result = runProcess(inoutId, tableId);

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionProcessTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionProcessTest.java
@@ -134,8 +134,8 @@ public class M_InOut_ReSend_ScriptedExportConversionProcessTest
 		when(scriptedExportServiceMock.executeInvokeScriptedExportConversionActionAndGetResult(any(), any(Integer.class), eq(ExternalSystemInvocationContext.RESEND)))
 				.thenReturn(ExternalSystemInvocationResult.error(new RuntimeException("mocked")));
 
-		// Run the process
-		final String result = runProcess(inoutId, tableId);
+		// Run the process (isOnlyNotSentSuccessfully=false → getMatchingConfigIdsBySourceRecord)
+		final String result = runProcess(inoutId, tableId, false);
 
 		// Assert: resolveConfigAndRecordPendingAsResend called once per config
 		verify(scriptedExportServiceMock, times(1)).resolveConfigAndRecordPendingAsResend(eq(configIdA), any());
@@ -164,11 +164,43 @@ public class M_InOut_ReSend_ScriptedExportConversionProcessTest
 		when(scriptedExportServiceMock.getMatchingConfigIdsBySourceRecord(any()))
 				.thenReturn(Collections.emptyList());
 
-		final String result = runProcess(inoutId, tableId);
+		final String result = runProcess(inoutId, tableId, false);
 
 		assertThat(result).contains("#0");
 		verify(scriptedExportServiceMock, times(0)).resolveConfigAndRecordPendingAsResend(any(), any());
 		verify(scriptedExportServiceMock, times(0)).executeInvokeScriptedExportConversionActionAndGetResult(any(), any(Integer.class), any());
+	}
+
+	// -----------------------------------------------------------------------
+	// 3. isOnlyNotSentSuccessfully=true → uses getResendableConfigsBySourceRecord
+	// -----------------------------------------------------------------------
+	@Test
+	void doIt_isOnlyNotSentSuccessfully_usesResendableConfigs()
+	{
+		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+		InterfaceWrapperHelper.saveRecord(inout);
+		final int inoutId = inout.getM_InOut_ID();
+		final int tableId = Services.get(IADTableDAO.class).retrieveTableId(I_M_InOut.Table_Name);
+		final TableRecordReference sourceRecord = TableRecordReference.of(I_M_InOut.Table_Name, inoutId);
+
+		final ExternalSystemScriptedExportConversionConfigId configIdA = ExternalSystemScriptedExportConversionConfigId.ofRepoId(201);
+		final List<ExternalSystemScriptedExportConversionConfigId> resendableConfigIds = Collections.singletonList(configIdA);
+		final ExternalSystemScriptedExportConversionConfig configA = buildDummyConfig(configIdA, tableId);
+
+		when(scriptedExportServiceMock.getResendableConfigsBySourceRecord(sourceRecord))
+				.thenReturn(resendableConfigIds);
+		when(scriptedExportServiceMock.resolveConfigAndRecordPendingAsResend(eq(configIdA), any()))
+				.thenReturn(configA);
+		when(scriptedExportServiceMock.executeInvokeScriptedExportConversionActionAndGetResult(any(), any(Integer.class), eq(ExternalSystemInvocationContext.RESEND)))
+				.thenReturn(ExternalSystemInvocationResult.error(new RuntimeException("mocked")));
+
+		final String result = runProcess(inoutId, tableId, true /*isOnlyNotSentSuccessfully*/);
+
+		// Verify the filtered path was used, NOT the all-configs path
+		verify(scriptedExportServiceMock, times(1)).getResendableConfigsBySourceRecord(sourceRecord);
+		verify(scriptedExportServiceMock, times(0)).getMatchingConfigIdsBySourceRecord(any());
+		verify(scriptedExportServiceMock, times(1)).resolveConfigAndRecordPendingAsResend(eq(configIdA), any());
+		assertThat(result).contains("1");
 	}
 
 	// -----------------------------------------------------------------------
@@ -197,9 +229,11 @@ public class M_InOut_ReSend_ScriptedExportConversionProcessTest
 
 	/**
 	 * Instantiates and drives the process for the given M_InOut record.
-	 * Returns the process summary result string.
+	 *
+	 * @param isOnlyNotSentSuccessfully value for the {@code IsOnlyNotSentSuccessfully} process parameter
+	 * @return the process summary result string
 	 */
-	private String runProcess(final int inoutId, final int tableId)
+	private String runProcess(final int inoutId, final int tableId, final boolean isOnlyNotSentSuccessfully)
 	{
 		final I_AD_Process adProcess = newInstanceOutOfTrx(I_AD_Process.class);
 		adProcess.setValue(M_InOut_ReSend_ScriptedExportConversion.class.getSimpleName());
@@ -216,6 +250,7 @@ public class M_InOut_ReSend_ScriptedExportConversionProcessTest
 				.setAD_PInstance(pinstance)
 				.setRecord(tableId, inoutId)
 				.setTitle("Test")
+				.addParameter("IsOnlyNotSentSuccessfully", isOnlyNotSentSuccessfully)
 				.build();
 
 		// Instantiate AFTER mocks are registered (fields resolved at construction via SpringContextHolder)

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionProcessTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionProcessTest.java
@@ -200,7 +200,7 @@ public class M_InOut_ReSend_ScriptedExportConversionProcessTest
 		verify(scriptedExportServiceMock, times(1)).getResendableConfigsBySourceRecord(sourceRecord);
 		verify(scriptedExportServiceMock, times(0)).getMatchingConfigIdsBySourceRecord(any());
 		verify(scriptedExportServiceMock, times(1)).resolveConfigAndRecordPendingAsResend(eq(configIdA), any());
-		assertThat(result).contains("1");
+		assertThat(result).contains("#1");
 	}
 
 	// -----------------------------------------------------------------------

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionProcessTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionProcessTest.java
@@ -147,7 +147,7 @@ public class M_InOut_ReSend_ScriptedExportConversionProcessTest
 		verify(scriptedExportServiceMock, times(1))
 				.executeInvokeScriptedExportConversionActionAndGetResult(eq(configB), eq(inoutId), eq(ExternalSystemInvocationContext.RESEND));
 
-		assertThat(result).contains("2");
+		assertThat(result).contains("#2");
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## What

Surfaces scripted-export (DocuWare) status on the **sales invoice**, mirroring the existing shipment/`M_InOut` surfacing, and renames the export-status surfacing to **generic** wording (it is generic machinery, not EPCIS-specific).

### Core changes
- **Generic-naming rename (labels only):** the existing `M_InOut` export-status tab caption + column label change from EPCIS-specific text to generic `Exportstatus` / `Export Status`. Column identifiers are unchanged.
- **`C_Invoice.ScriptedExport_Status`** — a read-only virtual (`ColumnSQL`) rollup column aggregating the latest status from `ExternalSystem_ScriptedExportConversion_Status` for the invoice (same ranked-aggregate as the shipment column), with an `AD_SQLColumn_SourceTableColumn` cache link.
- **Status child tab** on the standard Sales-Invoice window (read-only, newest-first) showing per-config status rows (status, configuration, HTTP response code, message, re-sent, process instance, updated), plus the rollup field on the header tab (in the visible "dates" group next to *External System*).
- **Re-send process** `C_Invoice_ReSend_ScriptedExportConversion` bound to `C_Invoice` (table-level `AD_Table_Process`), re-triggering the scripted export for the selected invoice — the analogue of the shipment re-send process.
- **Model regen:** `I_/X_C_Invoice` regenerated for the new virtual column.

### Notes
- All new AD IDs allocated from the central id-server; migration scripts follow the standard timestamp/translation conventions; German base language with `en_US` overrides; all active system languages covered.
- The config field on the status tab uses a dedicated `AD_Name_ID` label element so the human-readable caption survives the translation sync.
- Unit test for the re-send process passes (2/2).
