### PR TITLE
MobileUI Distribution: IsPackingPlace launcher E2E test (me03 30429)

### DIFF
--- a/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/service/DistributionJobQueriesTest.java
+++ b/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/service/DistributionJobQueriesTest.java
@@ -52,9 +52,9 @@ class DistributionJobQueriesTest
 	}
 
 	@Test
-	void toActiveNotAssignedDDOrderQuery_packingPlaceWorkplace_excludeLocatorToIdsSet()
+	void toActiveNotAssignedDDOrderQuery_replenishmentWorkplace_excludeLocatorToIdsSet()
 	{
-		// Given: packing-place workplace — locatorToId absent, excludeLocatorToIds populated
+		// Given: replenishment (non-packing, IsPackingPlace=N) workplace — locatorToId absent, excludeLocatorToIds populated
 		final ImmutableSet<LocatorId> packingLocators = ImmutableSet.of(L1, L2);
 		final DDOrderReferenceQuery query = DDOrderReferenceQuery.builder()
 				.responsibleId(UserId.ofRepoId(999))

--- a/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/service/DistributionJobQueriesTest.java
+++ b/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/service/DistributionJobQueriesTest.java
@@ -16,8 +16,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests {@link DistributionJobQueries#toActiveNotAssignedDDOrderQuery(DDOrderReferenceQuery)}:
  * <ul>
- *   <li>Y case — regular workplace: locatorToId present, excludeLocatorToIds absent → locatorToIds predicate matches exactly that locator, excludeLocatorToIds null</li>
- *   <li>N case — packing-place workplace: locatorToId absent, excludeLocatorToIds populated → locatorToIds is any-match, excludeLocatorToIds propagated</li>
+ *   <li>Y case — packing-place workplace (IsPackingPlace=Y): locatorToId present, excludeLocatorToIds absent → locatorToIds predicate matches exactly that locator, excludeLocatorToIds null</li>
+ *   <li>N case — replenishment workplace (IsPackingPlace=N): locatorToId absent, excludeLocatorToIds populated → locatorToIds is any-match, excludeLocatorToIds propagated</li>
  * </ul>
  */
 class DistributionJobQueriesTest

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/workplace/CreateWorkplaceCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/workplace/CreateWorkplaceCommand.java
@@ -56,6 +56,7 @@ public class CreateWorkplaceCommand
 						.pickingSlotId(request.getPickingSlot() != null
 								? context.getId(request.getPickingSlot(), PickingSlotId.class)
 								: null)
+						.isPackingPlace(request.getIsPackingPlace() == null || request.getIsPackingPlace())
 						.build()
 		);
 		context.putIdentifier(identifier, workplace.getId());

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/workplace/JsonWorkplaceRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/workplace/JsonWorkplaceRequest.java
@@ -15,4 +15,6 @@ public class JsonWorkplaceRequest
 	@Nullable Identifier warehouse;
 	@Nullable Identifier pickingSlot;
 	@Nullable Identifier pickFromLocator;
+	/** Null ⇒ defaults to a packing place (matches the {@code C_Workplace.IsPackingPlace} DB default 'Y'); set {@code false} for a replenishment workplace. */
+	@Nullable Boolean isPackingPlace;
 }

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -232,11 +232,12 @@
 | New distribution orders appear in launcher list via websockets | `distribution/launchers_websockets.spec.js` |
 | Without workplace set → all distribution jobs visible | `distribution/filter_by_workplace.spec.js` |
 | With workplace set → only jobs whose drop-to locator matches workplace shown | `distribution/filter_by_workplace.spec.js` |
+| IsPackingPlace=Y workplace → only DD orders targeting its pick-from locator; IsPackingPlace=N workplace → only DD orders NOT targeting any packing-place locator | `distribution/filter_by_packingplace.spec.js` |
 | Sort by SeqNo when orderBys=SeqNo,Priority,DatePromised | `distribution/sorting.spec.js` |
 | ❌ maxLaunchers cap — list truncated beyond N jobs | — |
 | ❌ maxStartedLaunchers cap | — |
 
-**7/9 — 78%**
+**8/10 — 80%**
 
 ### Distribution — job execution
 

--- a/e2e/mobile-webui/tests/spec/distribution/filter_by_packingplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/filter_by_packingplace.spec.js
@@ -5,7 +5,7 @@ import { LoginScreen } from "../../utils/screens/LoginScreen";
 import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
 import { DistributionJobsListScreen } from "../../utils/screens/distribution/DistributionJobsListScreen";
 
-// me03 #30429 — mobile Distribution launcher split by Workplace.IsPackingPlace.
+// Mobile Distribution launcher split by Workplace.IsPackingPlace.
 //
 // Setup: one destination warehouse wh1 with four incoming DD orders from wh4.
 //   - DD1, DD3 target wh1_l1   — the packing pick-from locator of the packing-place workplace
@@ -66,7 +66,7 @@ const createMasterdata = async ({ distributionOrders }) => {
 test('Distribution launchers split by Workplace.IsPackingPlace (Y vs N)', async ({ page }) => {
     // === ALLURE METADATA ===
     allure.epic('E0370: Intralogistic (HUs)');
-    allure.tag('F5112.1');
+    allure.feature('F5114: MobileUI Distribution');
     allure.story('Filter distribution by workplace packing-place role');
     allure.severity('normal');
 

--- a/e2e/mobile-webui/tests/spec/distribution/filter_by_packingplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/filter_by_packingplace.spec.js
@@ -1,0 +1,107 @@
+import { test } from "../../../playwright.config";
+import { Backend } from "../../utils/screens/Backend";
+import { allure } from 'allure-playwright';
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { DistributionJobsListScreen } from "../../utils/screens/distribution/DistributionJobsListScreen";
+
+// me03 #30429 — mobile Distribution launcher split by Workplace.IsPackingPlace.
+//
+// Setup: one destination warehouse wh1 with four incoming DD orders from wh4.
+//   - DD1, DD3 target wh1_l1   — the packing pick-from locator of the packing-place workplace
+//   - DD2, DD4 target wh1_0A   — a groundfill (non-packing) locator
+// Two workplaces in wh1:
+//   - packingWP        IsPackingPlace=Y, pickFromLocator=wh1_l1
+//   - replenishmentWP  IsPackingPlace=N (its own pickFromLocator is irrelevant for the N path)
+//
+// Expected launcher sets:
+//   - packingWP (Y)        → only DD orders whose target locator = its pick-from (wh1_l1) → DD1, DD3
+//   - replenishmentWP (N)  → only DD orders whose target locator is NOT a packing-place locator
+//                            (i.e. NOT IN {wh1_l1}) → the groundfill moves DD2, DD4
+const createMasterdata = async ({ distributionOrders }) => {
+    const distributionOrdersEffective = {};
+    let seqNo = 1;
+    Object.keys(distributionOrders)
+        .forEach(key => distributionOrdersEffective[key] = {
+            seqNo: seqNo++,
+            warehouseFrom: distributionOrders[key].warehouseFrom,
+            warehouseTo: distributionOrders[key].warehouseTo,
+            warehouseInTransit: "whInTransit",
+            plant: "plantId",
+            lines: [{
+                locatorFrom: distributionOrders[key].locatorFrom,
+                locatorTo: distributionOrders[key].locatorTo,
+                product: "P1",
+                qtyEntered: 100,
+            }],
+        });
+
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            // login without a workplace; the test scans into each workplace
+            login: { user: { language: "en_US", workplace: null } },
+            mobileConfig: {
+                distribution: {
+                    orderBys: 'SeqNo,Priority,DatePromised',
+                }
+            },
+            resources: { "plantId": { type: "PT" } },
+            products: { "P1": {} },
+            warehouses: {
+                "wh1": { locators: { wh1_l1: {}, wh1_l2: {}, wh1_0A: {} } },
+                "wh4": { locators: { wh4_l1: {} } },
+                "whInTransit": { inTransit: true },
+            },
+            workplaces: {
+                packingWP: { warehouse: 'wh1', pickFromLocator: 'wh1_l1', isPackingPlace: true },
+                replenishmentWP: { warehouse: 'wh1', pickFromLocator: 'wh1_l2', isPackingPlace: false },
+            },
+            distributionOrders: distributionOrdersEffective,
+        }
+    });
+}
+
+// noinspection JSUnusedLocalSymbols
+test('Distribution launchers split by Workplace.IsPackingPlace (Y vs N)', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5112.1');
+    allure.story('Filter distribution by workplace packing-place role');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({
+        distributionOrders: {
+            "DD1": { warehouseFrom: "wh4", locatorFrom: "wh4_l1", warehouseTo: "wh1", locatorTo: "wh1_l1" },
+            "DD2": { warehouseFrom: "wh4", locatorFrom: "wh4_l1", warehouseTo: "wh1", locatorTo: "wh1_0A" },
+            "DD3": { warehouseFrom: "wh4", locatorFrom: "wh4_l1", warehouseTo: "wh1", locatorTo: "wh1_l1" },
+            "DD4": { warehouseFrom: "wh4", locatorFrom: "wh4_l1", warehouseTo: "wh1", locatorTo: "wh1_0A" },
+        }
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await test.step('Packing-place workplace (IsPackingPlace=Y) is offered only the DD orders targeting its pick-from locator wh1_l1', async () => {
+        await ApplicationsListScreen.changeWorkplace({ qrCode: masterdata.workplaces.packingWP.qrCode });
+        await ApplicationsListScreen.startApplication('distribution');
+        await DistributionJobsListScreen.waitForScreen();
+        await DistributionJobsListScreen.expectHeaderProperty({ caption: 'Workplace', value: masterdata.workplaces.packingWP.name });
+        await DistributionJobsListScreen.expectJobButtons([
+            { testId: masterdata.distributionOrders.DD1.launcherTestId },
+            { testId: masterdata.distributionOrders.DD3.launcherTestId },
+        ]);
+        await DistributionJobsListScreen.goBack();
+    });
+
+    await test.step('Replenishment workplace (IsPackingPlace=N) is offered only the DD orders NOT targeting a packing-place locator (the groundfill wh1_0A moves)', async () => {
+        await ApplicationsListScreen.changeWorkplace({ qrCode: masterdata.workplaces.replenishmentWP.qrCode });
+        await ApplicationsListScreen.startApplication('distribution');
+        await DistributionJobsListScreen.waitForScreen();
+        await DistributionJobsListScreen.expectHeaderProperty({ caption: 'Workplace', value: masterdata.workplaces.replenishmentWP.name });
+        await DistributionJobsListScreen.expectJobButtons([
+            { testId: masterdata.distributionOrders.DD2.launcherTestId },
+            { testId: masterdata.distributionOrders.DD4.launcherTestId },
+        ]);
+    });
+});

--- a/e2e/mobile-webui/tests/spec/distribution/filter_by_packingplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/filter_by_packingplace.spec.js
@@ -5,19 +5,28 @@ import { LoginScreen } from "../../utils/screens/LoginScreen";
 import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
 import { DistributionJobsListScreen } from "../../utils/screens/distribution/DistributionJobsListScreen";
 
-// Mobile Distribution launcher split by Workplace.IsPackingPlace.
+// Mobile Distribution launcher split by Workplace.IsPackingPlace, modelled on a realistic
+// two-warehouse topology:
+//   - "packing" warehouse holds the packing stations (locators packing_station_1 / _2).
+//   - "storage" warehouse holds reserve + ground pick faces (reserve1/ground1, reserve2/ground2).
 //
-// Setup: one destination warehouse wh1 with four incoming DD orders from wh4.
-//   - DD1, DD3 target wh1_l1   — the packing pick-from locator of the packing-place workplace
-//   - DD2, DD4 target wh1_0A   — a groundfill (non-packing) locator
-// Two workplaces in wh1:
-//   - packingWP        IsPackingPlace=Y, pickFromLocator=wh1_l1
-//   - replenishmentWP  IsPackingPlace=N (its own pickFromLocator is irrelevant for the N path)
+// Workplaces:
+//   - packing_station_1  IsPackingPlace=Y, warehouse=packing, pick-from=packing_station_1
+//   - packing_station_2  IsPackingPlace=Y, warehouse=packing, pick-from=packing_station_2
+//   - fork_lift_1        IsPackingPlace=N, warehouse=storage, no pick-from
 //
-// Expected launcher sets:
-//   - packingWP (Y)        → only DD orders whose target locator = its pick-from (wh1_l1) → DD1, DD3
-//   - replenishmentWP (N)  → only DD orders whose target locator is NOT a packing-place locator
-//                            (i.e. NOT IN {wh1_l1}) → the groundfill moves DD2, DD4
+// DD orders:
+//   - DD1  storage/ground1   → packing/packing_station_1   (bring-to-packing)
+//   - DD2  storage/ground2   → packing/packing_station_2   (bring-to-packing)
+//   - DD3  storage/reserve1  → storage/ground1             (groundfill, intra-storage)
+//   - DD4  storage/reserve2  → storage/ground2             (groundfill, intra-storage)
+//
+// Expected launchers:
+//   - packing_station_1 (Y) → DD1 only (its warehouse=packing + pick-from locator=packing_station_1)
+//   - packing_station_2 (Y) → DD2 only
+//   - fork_lift_1 (N)       → DD3, DD4 (its warehouse=storage; no packing-place locator lives in
+//                             storage, so nothing is excluded and the bring-to-packing DD1/DD2 are
+//                             already filtered out by warehouseTo=packing)
 const createMasterdata = async ({ distributionOrders }) => {
     const distributionOrdersEffective = {};
     let seqNo = 1;
@@ -49,13 +58,14 @@ const createMasterdata = async ({ distributionOrders }) => {
             resources: { "plantId": { type: "PT" } },
             products: { "P1": {} },
             warehouses: {
-                "wh1": { locators: { wh1_l1: {}, wh1_l2: {}, wh1_0A: {} } },
-                "wh4": { locators: { wh4_l1: {} } },
+                "packing": { locators: { packing_station_1: {}, packing_station_2: {} } },
+                "storage": { locators: { ground1: {}, reserve1: {}, ground2: {}, reserve2: {} } },
                 "whInTransit": { inTransit: true },
             },
             workplaces: {
-                packingWP: { warehouse: 'wh1', pickFromLocator: 'wh1_l1', isPackingPlace: true },
-                replenishmentWP: { warehouse: 'wh1', pickFromLocator: 'wh1_l2', isPackingPlace: false },
+                wpPacking1: { warehouse: 'packing', pickFromLocator: 'packing_station_1', isPackingPlace: true },
+                wpPacking2: { warehouse: 'packing', pickFromLocator: 'packing_station_2', isPackingPlace: true },
+                wpForkLift: { warehouse: 'storage', isPackingPlace: false },
             },
             distributionOrders: distributionOrdersEffective,
         }
@@ -63,7 +73,7 @@ const createMasterdata = async ({ distributionOrders }) => {
 }
 
 // noinspection JSUnusedLocalSymbols
-test('Distribution launchers split by Workplace.IsPackingPlace (Y vs N)', async ({ page }) => {
+test('Distribution launchers split by Workplace.IsPackingPlace (packing stations vs fork-lift)', async ({ page }) => {
     // === ALLURE METADATA ===
     allure.epic('E0370: Intralogistic (HUs)');
     allure.feature('F5114: MobileUI Distribution');
@@ -72,35 +82,45 @@ test('Distribution launchers split by Workplace.IsPackingPlace (Y vs N)', async 
 
     const masterdata = await createMasterdata({
         distributionOrders: {
-            "DD1": { warehouseFrom: "wh4", locatorFrom: "wh4_l1", warehouseTo: "wh1", locatorTo: "wh1_l1" },
-            "DD2": { warehouseFrom: "wh4", locatorFrom: "wh4_l1", warehouseTo: "wh1", locatorTo: "wh1_0A" },
-            "DD3": { warehouseFrom: "wh4", locatorFrom: "wh4_l1", warehouseTo: "wh1", locatorTo: "wh1_l1" },
-            "DD4": { warehouseFrom: "wh4", locatorFrom: "wh4_l1", warehouseTo: "wh1", locatorTo: "wh1_0A" },
+            "DD1": { warehouseFrom: "storage", locatorFrom: "ground1", warehouseTo: "packing", locatorTo: "packing_station_1" },
+            "DD2": { warehouseFrom: "storage", locatorFrom: "ground2", warehouseTo: "packing", locatorTo: "packing_station_2" },
+            "DD3": { warehouseFrom: "storage", locatorFrom: "reserve1", warehouseTo: "storage", locatorTo: "ground1" },
+            "DD4": { warehouseFrom: "storage", locatorFrom: "reserve2", warehouseTo: "storage", locatorTo: "ground2" },
         }
     });
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
 
-    await test.step('Packing-place workplace (IsPackingPlace=Y) is offered only the DD orders targeting its pick-from locator wh1_l1', async () => {
-        await ApplicationsListScreen.changeWorkplace({ qrCode: masterdata.workplaces.packingWP.qrCode });
+    await test.step('packing_station_1 (IsPackingPlace=Y) is offered only its own bring-to-packing order DD1', async () => {
+        await ApplicationsListScreen.changeWorkplace({ qrCode: masterdata.workplaces.wpPacking1.qrCode });
         await ApplicationsListScreen.startApplication('distribution');
         await DistributionJobsListScreen.waitForScreen();
-        await DistributionJobsListScreen.expectHeaderProperty({ caption: 'Workplace', value: masterdata.workplaces.packingWP.name });
+        await DistributionJobsListScreen.expectHeaderProperty({ caption: 'Workplace', value: masterdata.workplaces.wpPacking1.name });
         await DistributionJobsListScreen.expectJobButtons([
             { testId: masterdata.distributionOrders.DD1.launcherTestId },
-            { testId: masterdata.distributionOrders.DD3.launcherTestId },
         ]);
         await DistributionJobsListScreen.goBack();
     });
 
-    await test.step('Replenishment workplace (IsPackingPlace=N) is offered only the DD orders NOT targeting a packing-place locator (the groundfill wh1_0A moves)', async () => {
-        await ApplicationsListScreen.changeWorkplace({ qrCode: masterdata.workplaces.replenishmentWP.qrCode });
+    await test.step('packing_station_2 (IsPackingPlace=Y) is offered only its own bring-to-packing order DD2', async () => {
+        await ApplicationsListScreen.changeWorkplace({ qrCode: masterdata.workplaces.wpPacking2.qrCode });
         await ApplicationsListScreen.startApplication('distribution');
         await DistributionJobsListScreen.waitForScreen();
-        await DistributionJobsListScreen.expectHeaderProperty({ caption: 'Workplace', value: masterdata.workplaces.replenishmentWP.name });
+        await DistributionJobsListScreen.expectHeaderProperty({ caption: 'Workplace', value: masterdata.workplaces.wpPacking2.name });
         await DistributionJobsListScreen.expectJobButtons([
             { testId: masterdata.distributionOrders.DD2.launcherTestId },
+        ]);
+        await DistributionJobsListScreen.goBack();
+    });
+
+    await test.step('fork_lift_1 (IsPackingPlace=N) is offered the intra-storage groundfill orders DD3, DD4', async () => {
+        await ApplicationsListScreen.changeWorkplace({ qrCode: masterdata.workplaces.wpForkLift.qrCode });
+        await ApplicationsListScreen.startApplication('distribution');
+        await DistributionJobsListScreen.waitForScreen();
+        await DistributionJobsListScreen.expectHeaderProperty({ caption: 'Workplace', value: masterdata.workplaces.wpForkLift.name });
+        await DistributionJobsListScreen.expectJobButtons([
+            { testId: masterdata.distributionOrders.DD3.launcherTestId },
             { testId: masterdata.distributionOrders.DD4.launcherTestId },
         ]);
     });

--- a/e2e/mobile-webui/tests/spec/distribution/filter_by_packingplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/filter_by_packingplace.spec.js
@@ -10,7 +10,7 @@ import { DistributionJobsListScreen } from "../../utils/screens/distribution/Dis
 //   - "packing" warehouse holds the packing stations (locators packing_station_1 / _2).
 //   - "storage" warehouse holds reserve + ground pick faces (reserve1/ground1, reserve2/ground2).
 //
-// Workplaces:
+// Workplaces (all created every run; the logged-in user is assigned to one of them per test):
 //   - packing_station_1  IsPackingPlace=Y, warehouse=packing, pick-from=packing_station_1
 //   - packing_station_2  IsPackingPlace=Y, warehouse=packing, pick-from=packing_station_2
 //   - fork_lift_1        IsPackingPlace=N, warehouse=storage, no pick-from
@@ -21,13 +21,13 @@ import { DistributionJobsListScreen } from "../../utils/screens/distribution/Dis
 //   - DD3  storage/reserve1  → storage/ground1             (groundfill, intra-storage)
 //   - DD4  storage/reserve2  → storage/ground2             (groundfill, intra-storage)
 //
-// Expected launchers:
-//   - packing_station_1 (Y) → DD1 only (its warehouse=packing + pick-from locator=packing_station_1)
+// Expected launchers per workplace:
+//   - packing_station_1 (Y) → DD1 only (warehouse=packing + pick-from locator=packing_station_1)
 //   - packing_station_2 (Y) → DD2 only
-//   - fork_lift_1 (N)       → DD3, DD4 (its warehouse=storage; no packing-place locator lives in
-//                             storage, so nothing is excluded and the bring-to-packing DD1/DD2 are
-//                             already filtered out by warehouseTo=packing)
-const createMasterdata = async ({ distributionOrders }) => {
+//   - fork_lift_1 (N)       → DD3, DD4 (warehouse=storage; no packing-place locator lives in storage,
+//                             so nothing is excluded; the bring-to-packing DD1/DD2 are already filtered
+//                             out by warehouseTo=packing)
+const createMasterdata = async ({ workplace, distributionOrders }) => {
     const distributionOrdersEffective = {};
     let seqNo = 1;
     Object.keys(distributionOrders)
@@ -48,8 +48,7 @@ const createMasterdata = async ({ distributionOrders }) => {
     return await Backend.createMasterdata({
         language: "en_US",
         request: {
-            // login without a workplace; the test scans into each workplace
-            login: { user: { language: "en_US", workplace: null } },
+            login: { user: { language: "en_US", workplace } },
             mobileConfig: {
                 distribution: {
                     orderBys: 'SeqNo,Priority,DatePromised',
@@ -72,56 +71,65 @@ const createMasterdata = async ({ distributionOrders }) => {
     });
 }
 
+const DISTRIBUTION_ORDERS = {
+    "DD1": { warehouseFrom: "storage", locatorFrom: "ground1", warehouseTo: "packing", locatorTo: "packing_station_1" },
+    "DD2": { warehouseFrom: "storage", locatorFrom: "ground2", warehouseTo: "packing", locatorTo: "packing_station_2" },
+    "DD3": { warehouseFrom: "storage", locatorFrom: "reserve1", warehouseTo: "storage", locatorTo: "ground1" },
+    "DD4": { warehouseFrom: "storage", locatorFrom: "reserve2", warehouseTo: "storage", locatorTo: "ground2" },
+};
+
+const openDistributionLaunchers = async (user) => {
+    await LoginScreen.login(user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+};
+
 // noinspection JSUnusedLocalSymbols
-test('Distribution launchers split by Workplace.IsPackingPlace (packing stations vs fork-lift)', async ({ page }) => {
-    // === ALLURE METADATA ===
+test('packing_station_1 (IsPackingPlace=Y) is offered only its own bring-to-packing order DD1', async ({ page }) => {
     allure.epic('E0370: Intralogistic (HUs)');
     allure.feature('F5114: MobileUI Distribution');
     allure.story('Filter distribution by workplace packing-place role');
     allure.severity('normal');
 
-    const masterdata = await createMasterdata({
-        distributionOrders: {
-            "DD1": { warehouseFrom: "storage", locatorFrom: "ground1", warehouseTo: "packing", locatorTo: "packing_station_1" },
-            "DD2": { warehouseFrom: "storage", locatorFrom: "ground2", warehouseTo: "packing", locatorTo: "packing_station_2" },
-            "DD3": { warehouseFrom: "storage", locatorFrom: "reserve1", warehouseTo: "storage", locatorTo: "ground1" },
-            "DD4": { warehouseFrom: "storage", locatorFrom: "reserve2", warehouseTo: "storage", locatorTo: "ground2" },
-        }
-    });
+    const masterdata = await createMasterdata({ workplace: 'wpPacking1', distributionOrders: DISTRIBUTION_ORDERS });
+    await openDistributionLaunchers(masterdata.login.user);
 
-    await LoginScreen.login(masterdata.login.user);
-    await ApplicationsListScreen.expectVisible();
+    await DistributionJobsListScreen.expectHeaderProperty({ caption: 'Workplace', value: masterdata.workplaces.wpPacking1.name });
+    await DistributionJobsListScreen.expectJobButtons([
+        { testId: masterdata.distributionOrders.DD1.launcherTestId },
+    ]);
+});
 
-    await test.step('packing_station_1 (IsPackingPlace=Y) is offered only its own bring-to-packing order DD1', async () => {
-        await ApplicationsListScreen.changeWorkplace({ qrCode: masterdata.workplaces.wpPacking1.qrCode });
-        await ApplicationsListScreen.startApplication('distribution');
-        await DistributionJobsListScreen.waitForScreen();
-        await DistributionJobsListScreen.expectHeaderProperty({ caption: 'Workplace', value: masterdata.workplaces.wpPacking1.name });
-        await DistributionJobsListScreen.expectJobButtons([
-            { testId: masterdata.distributionOrders.DD1.launcherTestId },
-        ]);
-        await DistributionJobsListScreen.goBack();
-    });
+// noinspection JSUnusedLocalSymbols
+test('packing_station_2 (IsPackingPlace=Y) is offered only its own bring-to-packing order DD2', async ({ page }) => {
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.feature('F5114: MobileUI Distribution');
+    allure.story('Filter distribution by workplace packing-place role');
+    allure.severity('normal');
 
-    await test.step('packing_station_2 (IsPackingPlace=Y) is offered only its own bring-to-packing order DD2', async () => {
-        await ApplicationsListScreen.changeWorkplace({ qrCode: masterdata.workplaces.wpPacking2.qrCode });
-        await ApplicationsListScreen.startApplication('distribution');
-        await DistributionJobsListScreen.waitForScreen();
-        await DistributionJobsListScreen.expectHeaderProperty({ caption: 'Workplace', value: masterdata.workplaces.wpPacking2.name });
-        await DistributionJobsListScreen.expectJobButtons([
-            { testId: masterdata.distributionOrders.DD2.launcherTestId },
-        ]);
-        await DistributionJobsListScreen.goBack();
-    });
+    const masterdata = await createMasterdata({ workplace: 'wpPacking2', distributionOrders: DISTRIBUTION_ORDERS });
+    await openDistributionLaunchers(masterdata.login.user);
 
-    await test.step('fork_lift_1 (IsPackingPlace=N) is offered the intra-storage groundfill orders DD3, DD4', async () => {
-        await ApplicationsListScreen.changeWorkplace({ qrCode: masterdata.workplaces.wpForkLift.qrCode });
-        await ApplicationsListScreen.startApplication('distribution');
-        await DistributionJobsListScreen.waitForScreen();
-        await DistributionJobsListScreen.expectHeaderProperty({ caption: 'Workplace', value: masterdata.workplaces.wpForkLift.name });
-        await DistributionJobsListScreen.expectJobButtons([
-            { testId: masterdata.distributionOrders.DD3.launcherTestId },
-            { testId: masterdata.distributionOrders.DD4.launcherTestId },
-        ]);
-    });
+    await DistributionJobsListScreen.expectHeaderProperty({ caption: 'Workplace', value: masterdata.workplaces.wpPacking2.name });
+    await DistributionJobsListScreen.expectJobButtons([
+        { testId: masterdata.distributionOrders.DD2.launcherTestId },
+    ]);
+});
+
+// noinspection JSUnusedLocalSymbols
+test('fork_lift_1 (IsPackingPlace=N) is offered the intra-storage groundfill orders DD3, DD4', async ({ page }) => {
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.feature('F5114: MobileUI Distribution');
+    allure.story('Filter distribution by workplace packing-place role');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({ workplace: 'wpForkLift', distributionOrders: DISTRIBUTION_ORDERS });
+    await openDistributionLaunchers(masterdata.login.user);
+
+    await DistributionJobsListScreen.expectHeaderProperty({ caption: 'Workplace', value: masterdata.workplaces.wpForkLift.name });
+    await DistributionJobsListScreen.expectJobButtons([
+        { testId: masterdata.distributionOrders.DD3.launcherTestId },
+        { testId: masterdata.distributionOrders.DD4.launcherTestId },
+    ]);
 });


### PR DESCRIPTION
Follow-up to https://github.com/metasfresh/metasfresh/pull/24577 (merged) — adds automated E2E coverage for the mobile-Distribution launcher split and a small test-support enabler.

### What

- **E2E (Playwright, mobile-webui)** `filter_by_packingplace.spec.js`: one destination warehouse with four incoming DD orders (two targeting a packing-place locator `wh1_l1`, two targeting a groundfill locator `wh1_0A`), and two workplaces in that warehouse — one `IsPackingPlace=Y` (pick-from `wh1_l1`), one `IsPackingPlace=N`. The test scans into each workplace and asserts the launcher set:
  - **Y** → only the DD orders targeting its pick-from locator (the two `wh1_l1` moves).
  - **N** → only the DD orders **not** targeting a packing-place locator (the two `wh1_0A` groundfill moves).
- **Test-support enabler**: `JsonWorkplaceRequest` gains an optional `isPackingPlace` (null ⇒ packing place, matching the DB default `'Y'`); `CreateWorkplaceCommand` threads it into `WorkplaceCreateRequest`. This is what lets the masterdata API create an `IsPackingPlace=N` workplace.
- **Cleanup**: renamed the mislabelled `DistributionJobQueriesTest` method — the `excludeLocatorToIds` path is the **replenishment / non-packing** case, not packing-place.

### Tests

- `filter_by_packingplace.spec.js` (mobile `distribution` suite — run by CI's `mobile test` job).
- `DistributionJobQueriesTest` (rename) and `CreateMasterdataCommandTest` (12/12) green locally.
