### PR TITLE
MobileUI manufacturing receipt: guidance when no receiving Gebinde is available

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807870_sys_AD_Message_MaterialReceipt_NoReceivingGebinde.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5807870_sys_AD_Message_MaterialReceipt_NoReceivingGebinde.sql
@@ -1,0 +1,26 @@
+-- me03 30334: guidance shown on the mobile manufacturing goods-receipt step when no
+-- receiving Gebinde (HU/TU/LU target) can be offered for the finished product, instead of
+-- an empty target area. {0} = product name. Info message (not thrown) — the backend puts
+-- the localized text into the receive line's emptyReason.
+
+-- 1. the message (base text = German)
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545757/*From ID Server*/,0,TO_TIMESTAMP('2026-06-15 21:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y',
+        'Für {0} ist keine passende Verpackungsvorschrift hinterlegt – es kann kein Gebinde zum Vereinnahmen angeboten werden. Bitte eine passende Verpackungsvorschrift für dieses Produkt konfigurieren.',
+        'I',TO_TIMESTAMP('2026-06-15 21:00:00','YYYY-MM-DD HH24:MI:SS'),100,'MaterialReceipt_NoReceivingGebinde');
+
+-- 2. seed AD_Message_Trl for ALL active system languages with the base (DE) text, IsTranslated='N'
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545757
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID);
+
+-- 3. en_US override (the real English text) + IsTranslated='Y'
+UPDATE AD_Message_Trl SET MsgText='No suitable packing instruction is configured for {0} – no receiving HU can be offered. Please configure a packing instruction for this product.',
+       IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-15 21:00:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545757;
+
+-- 4. flip de_DE + de_CH to IsTranslated='Y' (their text already equals the DE base)
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-15 21:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545757;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-15 21:00:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545757;

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/activity_handlers/receive/MaterialReceiptActivityHandler.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/activity_handlers/receive/MaterialReceiptActivityHandler.java
@@ -2,7 +2,6 @@ package de.metas.manufacturing.workflows_api.activity_handlers.receive;
 
 import com.google.common.collect.ImmutableList;
 import de.metas.bpartner.BPartnerId;
-import de.metas.bpartner.service.IBPartnerBL;
 import de.metas.frontend_testing.JsonTestId;
 import de.metas.handlingunits.HUPIItemProduct;
 import de.metas.handlingunits.HUPIItemProductId;
@@ -15,6 +14,8 @@ import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
+import de.metas.i18n.AdMessageKey;
+import de.metas.i18n.IMsgBL;
 import de.metas.manufacturing.config.MobileUIManufacturingConfig;
 import de.metas.manufacturing.config.MobileUIManufacturingConfigRepository;
 import de.metas.manufacturing.config.ReceiveUnitType;
@@ -65,11 +66,14 @@ public class MaterialReceiptActivityHandler implements WFActivityHandler
 	public static final WFActivityType HANDLED_ACTIVITY_TYPE = WFActivityType.ofString("manufacturing.materialReceipt");
 	private static final UIComponentType COMPONENT_TYPE = UIComponentType.ofString("manufacturing/materialReceipt");
 
+	// Guidance shown when no receiving Gebinde (TU/LU target) can be offered for the product. {0}=product name.
+	private static final AdMessageKey MSG_NoReceivingGebinde = AdMessageKey.of("MaterialReceipt_NoReceivingGebinde");
+
 	@NonNull private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
 	@NonNull private final IHUPIItemProductDAO huPIItemProductDAO = Services.get(IHUPIItemProductDAO.class);
+	@NonNull private final IMsgBL msgBL = Services.get(IMsgBL.class);
 	@NonNull private final IProductBL productBL = Services.get(IProductBL.class);
 	@NonNull private final IUOMDAO uomDao = Services.get(IUOMDAO.class);
-	@NonNull private final IBPartnerBL bpartnerBL;
 	@NonNull private final HUQRCodesService huQRCodeService;
 	@NonNull private final ProductHazardSymbolService productHazardSymbolService;
 	@NonNull private final ProductAllergensService productAllergensService;
@@ -113,9 +117,9 @@ public class MaterialReceiptActivityHandler implements WFActivityHandler
 				customerId,
 				line.getCatchWeightUOMId() != null);
 
-		final JsonNewTUTargetList tuTargetList = getNewTUTargets(tuPIItemProducts);
-		final JsonNewLUTargetsList newLUTargets = getNewLUTargets(tuPIItemProducts, line.getProductId(), customerId);
 		final String adLanguage = jsonOpts.getAdLanguage();
+		final JsonNewTUTargetList tuTargetList = getNewTUTargets(tuPIItemProducts, line.getProductId(), adLanguage);
+		final JsonNewLUTargetsList newLUTargets = getNewLUTargets(tuPIItemProducts, line.getProductId(), customerId, adLanguage);
 
 		final String uom;
 		final java.math.BigDecimal qtyToReceive;
@@ -176,13 +180,12 @@ public class MaterialReceiptActivityHandler implements WFActivityHandler
 	private JsonNewLUTargetsList getNewLUTargets(
 			@NonNull final List<I_M_HU_PI_Item_Product> tuPIItemProducts,
 			@NonNull final ProductId productId,
-			@Nullable final BPartnerId customerId)
+			@Nullable final BPartnerId customerId,
+			@NonNull final String adLanguage)
 	{
 		if (tuPIItemProducts.isEmpty())
 		{
-			return JsonNewLUTargetsList.emptyBecause("No CU/TU associations found for "
-					+ productBL.getProductName(productId)
-					+ " and " + (customerId != null ? bpartnerBL.getBPartnerName(customerId) : "any customer"));
+			return JsonNewLUTargetsList.emptyBecause(noReceivingGebindeReason(productId, adLanguage));
 		}
 
 		final ArrayList<JsonNewLUTarget> targets = new ArrayList<>();
@@ -239,13 +242,25 @@ public class MaterialReceiptActivityHandler implements WFActivityHandler
 	}
 
 	@NonNull
-	private JsonNewTUTargetList getNewTUTargets(@NonNull final List<I_M_HU_PI_Item_Product> tuPIItemProducts)
+	private JsonNewTUTargetList getNewTUTargets(
+			@NonNull final List<I_M_HU_PI_Item_Product> tuPIItemProducts,
+			@NonNull final ProductId productId,
+			@NonNull final String adLanguage)
 	{
-		return JsonNewTUTargetList.builder()
-				.values(tuPIItemProducts.stream()
-						.map(MaterialReceiptActivityHandler::toJsonNewTUTarget)
-						.collect(ImmutableList.toImmutableList()))
-				.build();
+		if (tuPIItemProducts.isEmpty())
+		{
+			return JsonNewTUTargetList.emptyBecause(noReceivingGebindeReason(productId, adLanguage));
+		}
+
+		return JsonNewTUTargetList.ofList(tuPIItemProducts.stream()
+				.map(MaterialReceiptActivityHandler::toJsonNewTUTarget)
+				.collect(ImmutableList.toImmutableList()));
+	}
+
+	/** Localized, actionable guidance shown when no receiving Gebinde can be offered for the product. */
+	private String noReceivingGebindeReason(@NonNull final ProductId productId, @NonNull final String adLanguage)
+	{
+		return msgBL.getMsg(adLanguage, MSG_NoReceivingGebinde, new Object[]{productBL.getProductName(productId)});
 	}
 
 	private static JsonNewTUTarget toJsonNewTUTarget(final I_M_HU_PI_Item_Product target)

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/activity_handlers/receive/json/JsonNewTUTargetList.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/activity_handlers/receive/json/JsonNewTUTargetList.java
@@ -22,17 +22,40 @@
 
 package de.metas.manufacturing.workflows_api.activity_handlers.receive.json;
 
+import com.google.common.collect.ImmutableList;
+import de.metas.util.Check;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 @Value
-@Builder
-@Jacksonized
 public class JsonNewTUTargetList
 {
 	@NonNull List<JsonNewTUTarget> values;
+	@Nullable String emptyReason;
+
+	public static JsonNewTUTargetList ofList(@NonNull final List<JsonNewTUTarget> values)
+	{
+		return builder().values(values).build();
+	}
+
+	public static JsonNewTUTargetList emptyBecause(@NonNull final String emptyReason)
+	{
+		Check.assumeNotEmpty(emptyReason, "emptyReason");
+		return builder().emptyReason(emptyReason).build();
+	}
+
+	@Builder
+	@Jacksonized
+	private JsonNewTUTargetList(
+			@Nullable final List<JsonNewTUTarget> values,
+			@Nullable final String emptyReason)
+	{
+		this.values = values != null ? ImmutableList.copyOf(values) : ImmutableList.of();
+		this.emptyReason = emptyReason;
+	}
 }

--- a/e2e/mobile-webui/tests/spec/manufacturing/receiving_no_gebinde_guidance.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/receiving_no_gebinde_guidance.spec.js
@@ -1,0 +1,68 @@
+import { Backend } from '../../utils/screens/Backend';
+import { test } from '../../../playwright.config';
+import { allure } from 'allure-playwright';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/ManufacturingJobsListScreen';
+import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
+import { MaterialReceiptLineScreen } from '../../utils/screens/manufacturing/receipt/MaterialReceiptLineScreen';
+import { ReceiptReceiveTargetScreen } from '../../utils/screens/manufacturing/receipt/ReceiptReceiveTargetScreen';
+import { ReceiptNewHUScreen } from '../../utils/screens/manufacturing/receipt/ReceiptNewHUScreen';
+
+// me03/30334 — when the manufacturing goods-receipt step cannot offer a receiving Gebinde,
+// the "Neues Gebinde" screen must show a clear, actionable guidance message instead of an
+// empty target area. Verified trigger (observed 2026-06-15): the receive query
+// (retrieveTUs) returns no usable TU packing for the product — here, the finished product
+// has NO TU packing configured at all, so no receiving target can be offered.
+// Assertions key off a stable data-testid (language-independent), never the DE/EN text.
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US" } },
+            mobileConfig: { manufacturing: { receiveUnitType: 'TU' } },
+            warehouses: { "wh": {} },
+            products: {
+                "COMP1": {},
+                "BOM": { bom: { lines: [{ product: 'COMP1', qty: 1 }] } },
+            },
+            // No packingInstructions for BOM -> retrieveTUs returns nothing -> no receiving target.
+            handlingUnits: { "HU_COMP1": { product: 'COMP1', warehouse: 'wh', qty: 100 } },
+            manufacturingOrders: {
+                "PP1": { warehouse: 'wh', product: 'BOM', qty: 80, datePromised: '2025-03-01T00:00:00.000+02:00' }
+            },
+        }
+    });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('No receiving Gebinde -> guidance message instead of empty target area', async ({ page }) => {
+    allure.epic('E0160: Manufacturing Execution');
+    allure.feature('F8030: MobileUI Manufacturing');
+    allure.story('Goods receipt — no receiving Gebinde available');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('mfg');
+    await ManufacturingJobsListScreen.waitForScreen();
+    await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+
+    await ManufacturingJobScreen.clickReceiveButton({ index: 1 });
+
+    // Surface 2 (AC2): the receive-line screen shows WHY the quantity action is unavailable,
+    // instead of a silently-disabled "Produzieren" button.
+    await MaterialReceiptLineScreen.expectNoGebindeHintVisible();
+
+    await MaterialReceiptLineScreen.clickReceiveTargetButton();
+    await ReceiptReceiveTargetScreen.clickNewHUButton();
+
+    // Precondition: this really is the dead-end — no receiving target is offered.
+    await ReceiptNewHUScreen.expectNoTargetsOffered();
+
+    // Surface 1 (AC1): the operator must see an actionable guidance message
+    // (language-independent testId), not a blank target area. (RED until the fix adds it.)
+    await ReceiptNewHUScreen.expectNoGebindeGuidanceVisible();
+});

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/receipt/MaterialReceiptLineScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/receipt/MaterialReceiptLineScreen.js
@@ -79,6 +79,10 @@ export const MaterialReceiptLineScreen = {
         await ManufacturingJobScreen.waitForScreen();
     }),
 
+    expectNoGebindeHintVisible: async () => await test.step(`${NAME} - Expect no-Gebinde hint near disabled Produzieren`, async () => {
+        await expect(page.getByTestId('receive-no-gebinde-hint')).toBeVisible();
+    }),
+
     expectHeaderProperty:  async ({ caption, value }) => await test.step(`${NAME} - Check header property "${caption}" = "${value}"`, async () => {
         const row = await page.locator(
             `tr:has(th:text-is("${caption}")):has(td:has-text("${value}"))`

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/receipt/ReceiptNewHUScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/receipt/ReceiptNewHUScreen.js
@@ -1,9 +1,10 @@
-import { page } from '../../../common';
+import { page, SLOW_ACTION_TIMEOUT } from '../../../common';
 import { test } from '../../../../../playwright.config';
 import { expect } from '@playwright/test';
 import { MaterialReceiptLineScreen } from './MaterialReceiptLineScreen';
 
 const NAME = 'ReceiptNewHUScreen';
+const NO_GEBINDE_GUIDANCE_TESTID = 'receive-no-gebinde-guidance';
 /** @returns {import('@playwright/test').Locator} */
 const containerElement = () => page.locator('#ReceiptNewHUScreen');
 
@@ -31,5 +32,21 @@ export const ReceiptNewHUScreen = {
     expectTUTargetNotPresent: async ({ tuPIItemProductTestId }) => await test.step(`${NAME} - Expect TU target "${tuPIItemProductTestId}" not present`, async () => {
         await ReceiptNewHUScreen.expectVisible();
         await expect(page.getByTestId(tuPIItemProductTestId)).toHaveCount(0);
+    }),
+
+    // Precondition for the dead-end: no receiving target (TU or LU) is offered.
+    // Target buttons carry a data-testid; the footer Back/Home use id selectors and the
+    // guidance message is excluded, so this counts only selectable targets.
+    expectNoTargetsOffered: async () => await test.step(`${NAME} - Expect no receiving targets offered`, async () => {
+        await ReceiptNewHUScreen.expectVisible();
+        await expect(page.locator(`#ReceiptNewHUScreen [data-testid]:not([data-testid="${NO_GEBINDE_GUIDANCE_TESTID}"])`))
+            .toHaveCount(0, { timeout: SLOW_ACTION_TIMEOUT });
+    }),
+
+    // Guidance shown when no receiving Gebinde (TU or LU target) can be offered.
+    // Asserts on a stable data-testid (language-independent), never the translated text.
+    expectNoGebindeGuidanceVisible: async () => await test.step(`${NAME} - Expect no-Gebinde guidance message`, async () => {
+        await ReceiptNewHUScreen.expectVisible();
+        await expect(page.getByTestId(NO_GEBINDE_GUIDANCE_TESTID)).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
     }),
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/receipt/MaterialReceiptLineScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/receipt/MaterialReceiptLineScreen.jsx
@@ -34,6 +34,8 @@ const MaterialReceiptLineScreen = () => {
       aggregateToLU,
       aggregateToTU,
       currentReceivingHU,
+      availableReceivingTargets,
+      availableReceivingTUTargets,
       productName,
       uom,
       catchWeightUomSymbol,
@@ -146,6 +148,14 @@ const MaterialReceiptLineScreen = () => {
     allowReceivingQty = true;
   }
 
+  // When the quantity action stays disabled because no receiving Gebinde can be resolved,
+  // surface the backend's localized reason as a hint (instead of a silently-disabled button).
+  // Safe to key off emptyReason: the backend sets it ONLY when the target lists are empty
+  // (MaterialReceiptActivityHandler.getNewTU/LUTargets) — it is never present alongside targets.
+  const noGebindeReason = !allowReceivingQty
+    ? availableReceivingTargets?.emptyReason || availableReceivingTUTargets?.emptyReason
+    : null;
+
   return (
     <>
       {showSpinner && <Spinner />}
@@ -162,6 +172,11 @@ const MaterialReceiptLineScreen = () => {
           caption={trl('activities.mfg.receipts.btnReceiveProducts')}
           customQRCodeFormats={customQRCodeFormats}
         />
+        {noGebindeReason && (
+          <p className="help is-danger" data-testid="receive-no-gebinde-hint">
+            {noGebindeReason}
+          </p>
+        )}
       </div>
     </>
   );

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/receipt/ReceiptNewHUScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/receipt/ReceiptNewHUScreen.jsx
@@ -43,9 +43,21 @@ const ReceiptNewHUScreen = () => {
     history.goTo(manufacturingReceiptScreenLocation);
   };
 
+  const luTargets = availableReceivingTargets?.values ?? [];
+  const tuTargets = availableReceivingTUTargets?.values ?? [];
+  const hasTargets = luTargets.length > 0 || tuTargets.length > 0;
+  // When no receiving Gebinde can be offered, the backend supplies a localized, actionable
+  // reason on either target list. Show it instead of an empty screen.
+  const emptyReason = availableReceivingTargets?.emptyReason || availableReceivingTUTargets?.emptyReason;
+
   return (
     <div className="section pt-2">
-      {availableReceivingTargets.values.map((target) => (
+      {!hasTargets && emptyReason && (
+        <div className="notification is-warning" data-testid="receive-no-gebinde-guidance">
+          {emptyReason}
+        </div>
+      )}
+      {luTargets.map((target) => (
         <ButtonWithIndicator
           key={target.luPIItemId}
           caption={target.luCaption}
@@ -55,8 +67,8 @@ const ReceiptNewHUScreen = () => {
           <div className="row is-full is-size-7">{target.tuCaption}</div>
         </ButtonWithIndicator>
       ))}
-      {availableReceivingTUTargets?.values?.length > 0 && <br />}
-      {availableReceivingTUTargets?.values?.map((tuTarget) => (
+      {tuTargets.length > 0 && <br />}
+      {tuTargets.map((tuTarget) => (
         <ButtonWithIndicator
           key={tuTarget.tuPIItemProductId}
           caption={tuTarget.caption}


### PR DESCRIPTION
## What

When the mobile manufacturing goods-receipt step cannot offer any receiving Gebinde (the finished product has no usable TU packing instruction that the receive query returns), the operator previously reached an empty "Neues Gebinde" target area and a silently-disabled "Produzieren" button, with no explanation.

This change shows a clear, localized, product-named guidance message wherever the receive flow cannot proceed:
- on the **"Neues Gebinde"** screen, instead of an empty target area (`data-testid="receive-no-gebinde-guidance"`);
- as a **hint next to the disabled "Produzieren"** button on the receive line (`data-testid="receive-no-gebinde-hint"`).

The message names the affected product and points to the remedy (configure a suitable packing instruction).

## How

- add `emptyReason` to `JsonNewTUTargetList` (mirrors `JsonNewLUTargetsList`)
- set the localized reason (AdMessage `MaterialReceipt_NoReceivingGebinde`, `{0}`=product) on the empty TU and LU target lists in `MaterialReceiptActivityHandler`
- render the guidance message + disabled-button hint in the mobile-webui receipt screens
- AdMessage migration (German base + English translation)
- language-independent mobile-webui Playwright acceptance test (asserts on `data-testid`, never translated text), covering both surfaces

## Test

- New Playwright spec `receiving_no_gebinde_guidance.spec.js` — GREEN locally against a customer-flavored stack.
- Manufacturing-receipt happy-path specs unaffected (the change only touches the empty-target path).
