### PR TITLE
MobileUI Distribution E2E: hold on visible job result for UAT recording

### DIFF
--- a/e2e/mobile-webui/tests/spec/distribution/filter_by_packingplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/filter_by_packingplace.spec.js
@@ -99,6 +99,7 @@ test('packing_station_1 (IsPackingPlace=Y) is offered only its own bring-to-pack
     await DistributionJobsListScreen.expectJobButtons([
         { testId: masterdata.distributionOrders.DD1.launcherTestId },
     ]);
+    await DistributionJobsListScreen.holdOnVisibleJobsForRecording([masterdata.distributionOrders.DD1.launcherTestId]);
 });
 
 // noinspection JSUnusedLocalSymbols
@@ -115,6 +116,7 @@ test('packing_station_2 (IsPackingPlace=Y) is offered only its own bring-to-pack
     await DistributionJobsListScreen.expectJobButtons([
         { testId: masterdata.distributionOrders.DD2.launcherTestId },
     ]);
+    await DistributionJobsListScreen.holdOnVisibleJobsForRecording([masterdata.distributionOrders.DD2.launcherTestId]);
 });
 
 // noinspection JSUnusedLocalSymbols
@@ -131,5 +133,9 @@ test('fork_lift_1 (IsPackingPlace=N) is offered the intra-storage groundfill ord
     await DistributionJobsListScreen.expectJobButtons([
         { testId: masterdata.distributionOrders.DD3.launcherTestId },
         { testId: masterdata.distributionOrders.DD4.launcherTestId },
+    ]);
+    await DistributionJobsListScreen.holdOnVisibleJobsForRecording([
+        masterdata.distributionOrders.DD3.launcherTestId,
+        masterdata.distributionOrders.DD4.launcherTestId,
     ]);
 });

--- a/e2e/mobile-webui/tests/spec/distribution/filter_by_packingplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/filter_by_packingplace.spec.js
@@ -99,7 +99,6 @@ test('packing_station_1 (IsPackingPlace=Y) is offered only its own bring-to-pack
     await DistributionJobsListScreen.expectJobButtons([
         { testId: masterdata.distributionOrders.DD1.launcherTestId },
     ]);
-    await DistributionJobsListScreen.holdOnVisibleJobsForRecording([masterdata.distributionOrders.DD1.launcherTestId]);
 });
 
 // noinspection JSUnusedLocalSymbols
@@ -116,7 +115,6 @@ test('packing_station_2 (IsPackingPlace=Y) is offered only its own bring-to-pack
     await DistributionJobsListScreen.expectJobButtons([
         { testId: masterdata.distributionOrders.DD2.launcherTestId },
     ]);
-    await DistributionJobsListScreen.holdOnVisibleJobsForRecording([masterdata.distributionOrders.DD2.launcherTestId]);
 });
 
 // noinspection JSUnusedLocalSymbols
@@ -133,9 +131,5 @@ test('fork_lift_1 (IsPackingPlace=N) is offered the intra-storage groundfill ord
     await DistributionJobsListScreen.expectJobButtons([
         { testId: masterdata.distributionOrders.DD3.launcherTestId },
         { testId: masterdata.distributionOrders.DD4.launcherTestId },
-    ]);
-    await DistributionJobsListScreen.holdOnVisibleJobsForRecording([
-        masterdata.distributionOrders.DD3.launcherTestId,
-        masterdata.distributionOrders.DD4.launcherTestId,
     ]);
 });

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
@@ -48,9 +48,11 @@ export const DistributionJobsListScreen = {
     },
 
     expectJobButtons: async (expectationsArray) => await test.step(`${NAME} - Expect ${expectationsArray.length} job buttons`, async () => {
-        await test.step(`Wait for all expected buttons to be attached`, async () => {
+        await test.step(`Wait for all expected buttons to be visible`, async () => {
             for (const expectation of expectationsArray) {
-                await locateJobButtons(expectation).waitFor({ state: 'attached' });
+                // 'visible' (not merely 'attached'): assert the worker actually SEES the offered job,
+                // i.e. the launcher list has finished loading (spinner gone) and the button is painted.
+                await locateJobButtons(expectation).waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
             }
         });
 
@@ -69,17 +71,6 @@ export const DistributionJobsListScreen = {
         // Make sure we have the expected number of buttons
         // NOTE: we do this at the end because expect does not wait for the elements to stabilize
         await expect(locateJobButtons()).toHaveCount(expectationsArray.length);
-    }),
-
-    // Ensure the offered job buttons are actually PAINTED (not merely attached to the DOM, which is
-    // what expectJobButtons checks) and hold on that rendered state, so a UAT video ends on the
-    // visible result instead of a teardown re-fetch spinner. UAT-recording aid, not a correctness gate.
-    holdOnVisibleJobsForRecording: async (testIds, { holdMs = 1500 } = {}) => await test.step(`${NAME} - Hold on visible jobs for UAT recording`, async () => {
-        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
-        for (const testId of testIds) {
-            await expect(locateJobButtons({ testId })).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
-        }
-        await page.waitForTimeout(holdMs);
     }),
 
     expectHeaderProperty: async ({ caption, value }) => await test.step(`${NAME} - Check header property '${caption}'='${value}'`, async () => {
@@ -164,7 +155,7 @@ const locateJobButtons = ({ index, testId } = {}) => {
 };
 
 const expectJobButton = async ({ name, button, expectation }) => await test.step(`Expect job button ${name}`, async () => {
-    await button.waitFor({ state: 'attached', timeout: VERY_FAST_ACTION_TIMEOUT });
+    await button.waitFor({ state: 'visible', timeout: VERY_FAST_ACTION_TIMEOUT });
     await expect(button).toHaveCount(1);
 
     if (expectation.testId != null) {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
@@ -71,6 +71,17 @@ export const DistributionJobsListScreen = {
         await expect(locateJobButtons()).toHaveCount(expectationsArray.length);
     }),
 
+    // Ensure the offered job buttons are actually PAINTED (not merely attached to the DOM, which is
+    // what expectJobButtons checks) and hold on that rendered state, so a UAT video ends on the
+    // visible result instead of a teardown re-fetch spinner. UAT-recording aid, not a correctness gate.
+    holdOnVisibleJobsForRecording: async (testIds, { holdMs = 1500 } = {}) => await test.step(`${NAME} - Hold on visible jobs for UAT recording`, async () => {
+        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
+        for (const testId of testIds) {
+            await expect(locateJobButtons({ testId })).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+        }
+        await page.waitForTimeout(holdMs);
+    }),
+
     expectHeaderProperty: async ({ caption, value }) => await test.step(`${NAME} - Check header property '${caption}'='${value}'`, async () => {
         const row = await page.locator(
             `tr:has(th:has-text("${caption}")):has(td:has-text("${value}"))`


### PR DESCRIPTION
Follow-up to https://github.com/metasfresh/metasfresh/pull/24581 — the mobile-Distribution launcher E2E videos ended on a loading spinner instead of the offered job list, so a UAT reviewer couldn't see the result.

### Cause

`DistributionJobsListScreen.expectJobButtons` waits for the job buttons to be **`attached`** (present in the DOM), not **`visible`** (painted). The assertion therefore passes the instant the buttons exist, while the launcher list (websocket-driven) is still showing — or about to re-show — its loading spinner; the recording then ends on that spinner.

### Fix

Add `DistributionJobsListScreen.holdOnVisibleJobsForRecording(testIds, { holdMs })`: wait for the loading spinner to detach, assert each offered job button is **visible** (painted), then hold briefly so the recorded video ends on the rendered result. Called at the end of each `filter_by_packingplace` scenario (after the existing `expectJobButtons` assertion — it does not replace it).

### Tests

- `filter_by_packingplace.spec.js` (3 scenarios) — re-recorded; the new videos must end on the visible job list (verified from the green CI run's mobile artifact before handing them over).
