### PR TITLE
Cucumber step-defs for ground-locator auto-replenish coverage

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/M_Locator_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/M_Locator_StepDef.java
@@ -84,6 +84,26 @@ public class M_Locator_StepDef
 				});
 	}
 
+	/**
+	 * Creates (or updates) {@code M_Locator} records. Existing locators are matched by
+	 * ({@code M_Warehouse_ID}, {@code Value}); a new one is created when none matches.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_Warehouse_ID</b> — (required, identifier-ref) the warehouse the locator belongs to<br>
+	 *   <b>Value</b> — (optional) locator Value; auto-suggested when omitted<br>
+	 *   <b>IsDefault</b> — (optional, Y/N) defaults to {@code Y} on create<br>
+	 *   <b>PriorityNo</b> — (optional) defaults to {@code 50} on create<br>
+	 *   <b>X</b> / <b>X1</b> / <b>Y</b> / <b>Z</b> — (optional) warehouse coordinates; each defaults to {@code "0"} on create<br>
+	 * @cucumber.depends StepDefData: M_Warehouse_StepDefData, M_Locator_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And metasfresh contains M_Locator:
+	 *   | M_Locator_ID | M_Warehouse_ID | Value     | X | X1 | Y | Z  |
+	 *   | groundLoc    | warehouse      | groundLoc | 1 | 1  | 1 | 0A |
+	 *   | reserveLoc   | warehouse      | reserveLoc| 1 | 1  | 1 | 0B |
+	 * </pre>
+	 */
 	@And("metasfresh contains M_Locator:")
 	public void create_M_Locator_Simple(@NonNull final DataTable dataTable)
 	{
@@ -122,7 +142,12 @@ public class M_Locator_StepDef
 					{
 						locatorRecord.setX(x.orElse("0"));
 					}
-					final Optional<String> y = row.getAsOptionalString(I_M_Locator.COLUMNNAME_X);
+					final Optional<String> x1 = row.getAsOptionalString(I_M_Locator.COLUMNNAME_X1);
+					if (isNew || x1.isPresent())
+					{
+						locatorRecord.setX1(x1.orElse("0"));
+					}
+					final Optional<String> y = row.getAsOptionalString(I_M_Locator.COLUMNNAME_Y);
 					if (isNew || y.isPresent())
 					{
 						locatorRecord.setY(y.orElse("0"));

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/ddordercandidate/DD_Order_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/ddordercandidate/DD_Order_Candidate_StepDef.java
@@ -1,6 +1,7 @@
 package de.metas.cucumber.stepdefs.ddordercandidate;
 
 import com.google.common.collect.ImmutableSet;
+import de.metas.cucumber.stepdefs.M_Locator_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_OrderLine_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
 import de.metas.cucumber.stepdefs.DataTableRow;
@@ -19,6 +20,8 @@ import de.metas.distribution.ddordercandidate.DDOrderCandidate;
 import de.metas.distribution.ddordercandidate.DDOrderCandidateId;
 import de.metas.distribution.ddordercandidate.DDOrderCandidateQuery;
 import de.metas.distribution.ddordercandidate.DDOrderCandidateService;
+import de.metas.impex.model.I_AD_InputDataSource;
+import de.metas.impexp.InputDataSourceId;
 import de.metas.material.event.pporder.PPOrderRef;
 import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderId;
@@ -31,6 +34,8 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.SpringContextHolder;
 import org.eevolution.api.PPOrderBOMLineId;
@@ -39,6 +44,7 @@ import org.eevolution.model.I_DD_Order_Candidate;
 import org.eevolution.productioncandidate.model.PPOrderCandidateId;
 import org.eevolution.productioncandidate.model.PPOrderLineCandidateId;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -49,9 +55,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DD_Order_Candidate_StepDef
 {
 	@NonNull private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	@NonNull private final DDOrderCandidateService ddOrderCandidateService = SpringContextHolder.instance.getBean(DDOrderCandidateService.class);
 	@NonNull private final DD_Order_Candidate_StepDefData ddOrderCandidateTable;
 	@NonNull private final M_Product_StepDefData productTable;
+	@NonNull private final M_Locator_StepDefData locatorTable;
 	@NonNull private final M_Warehouse_StepDefData warehouseTable;
 	@NonNull private final C_Order_StepDefData orderTable;
 	@NonNull private final C_OrderLine_StepDefData orderLineTable;
@@ -133,6 +141,22 @@ public class DD_Order_Candidate_StepDef
 		if (targetWarehouseId != null && !WarehouseId.equals(actual.getTargetWarehouseId(), targetWarehouseId))
 		{
 			return ItemProvider.ProviderResult.resultWasNotFound("targetWarehouseId not matching, expected " + targetWarehouseId + " but found " + actual.getTargetWarehouseId()
+					+ "\n\trow=" + expected
+					+ "\n\tcandidate=" + actual);
+		}
+
+		final LocatorId sourceLocatorId = expected.getAsOptionalIdentifier(I_DD_Order_Candidate.COLUMNNAME_M_LocatorFrom_ID).map(locatorTable::getId).orElse(null);
+		if (sourceLocatorId != null && !LocatorId.equals(actual.getSourceLocatorId(), sourceLocatorId))
+		{
+			return ItemProvider.ProviderResult.resultWasNotFound("M_LocatorFrom_ID not matching, expected " + sourceLocatorId + " but found " + actual.getSourceLocatorId()
+					+ "\n\trow=" + expected
+					+ "\n\tcandidate=" + actual);
+		}
+
+		final LocatorId targetLocatorId = expected.getAsOptionalIdentifier(I_DD_Order_Candidate.COLUMNNAME_M_LocatorTo_ID).map(locatorTable::getId).orElse(null);
+		if (targetLocatorId != null && !LocatorId.equals(actual.getTargetLocatorId(), targetLocatorId))
+		{
+			return ItemProvider.ProviderResult.resultWasNotFound("M_LocatorTo_ID not matching, expected " + targetLocatorId + " but found " + actual.getTargetLocatorId()
 					+ "\n\trow=" + expected
 					+ "\n\tcandidate=" + actual);
 		}
@@ -292,6 +316,98 @@ public class DD_Order_Candidate_StepDef
 				.build());
 
 		assertThat(candidates).isEmpty();
+	}
+
+	/**
+	 * Deletes all not-processed {@code DD_Order_Candidate} rows that belong to the given
+	 * {@code AD_InputDataSource} (matched by its {@code Value}). Use this in a {@code Background} to
+	 * establish a clean slate before a scenario that generates candidates from that source, so the
+	 * exhaustive assertion below is not polluted by candidates left over from a sibling scenario on the
+	 * same executor.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * And all not-processed DD_Order_Candidates for AD_InputDataSource 'DD_AutoGroundReplenish' are deleted
+	 * </pre>
+	 *
+	 * @param inputDataSourceValue the {@code AD_InputDataSource.Value}
+	 */
+	@And("all not-processed DD_Order_Candidates for AD_InputDataSource {string} are deleted")
+	public void delete_not_processed_candidates_for_source(@NonNull final String inputDataSourceValue)
+	{
+		final InputDataSourceId inputDataSourceId = getInputDataSourceIdByValue(inputDataSourceValue);
+
+		queryBL.createQueryBuilder(I_DD_Order_Candidate.class)
+				.addEqualsFilter(I_DD_Order_Candidate.COLUMNNAME_AD_InputDataSource_ID, inputDataSourceId)
+				.addEqualsFilter(I_DD_Order_Candidate.COLUMNNAME_Processed, false)
+				.create()
+				.delete();
+	}
+
+	/**
+	 * Exhaustive, data-source-scoped assertion: the not-processed {@code DD_Order_Candidate}s for the given
+	 * {@code AD_InputDataSource} (matched by {@code Value}) are EXACTLY the rows of the DataTable — no more, no
+	 * fewer. Each expected row is matched to exactly one candidate; a leftover (extra) candidate fails the step.
+	 * Column matching reuses the same logic as {@code following DD_Order_Candidates are found} (see that step's columns,
+	 * e.g. {@code M_LocatorFrom_ID}, {@code M_LocatorTo_ID}, {@code M_Product_ID}, {@code Qty}, {@code Processed}, {@code IsSimulated}).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_LocatorFrom_ID</b> / <b>M_LocatorTo_ID</b> — (optional, identifier-ref) source / target locator<br>
+	 *   <b>M_Product_ID</b> — (optional, identifier-ref)<br>
+	 *   <b>Qty</b> / <b>QtyProcessed</b> / <b>QtyToProcess</b> — (optional)<br>
+	 *   <b>Processed</b> / <b>IsSimulated</b> — (optional, Y/N)<br>
+	 * @cucumber.depends StepDefData: DD_Order_Candidate_StepDefData, M_Locator_StepDefData, M_Product_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * Then the only not-processed DD_Order_Candidates for AD_InputDataSource 'DD_AutoGroundReplenish' are:
+	 *   | M_LocatorFrom_ID | M_LocatorTo_ID | M_Product_ID | Qty | Processed | IsSimulated |
+	 *   | reserveLoc       | groundLoc      | product      | 100 | N         | N           |
+	 * </pre>
+	 *
+	 * @param inputDataSourceValue the {@code AD_InputDataSource.Value}
+	 */
+	@And("the only not-processed DD_Order_Candidates for AD_InputDataSource {string} are:")
+	public void assert_only_not_processed_candidates_for_source(@NonNull final String inputDataSourceValue, @NonNull final DataTable dataTable)
+	{
+		final InputDataSourceId inputDataSourceId = getInputDataSourceIdByValue(inputDataSourceValue);
+
+		final List<DDOrderCandidate> remaining = new ArrayList<>(ddOrderCandidateService.list(DDOrderCandidateQuery.builder()
+				.inputDataSourceId(inputDataSourceId)
+				.processed(false)
+				.build()));
+		SharedTestContext.put("candidates", remaining);
+
+		DataTableRows.of(dataTable).forEach(row -> {
+			final DDOrderCandidate match = remaining.stream()
+					.filter(candidate -> validateDDOrderLineCandidate(row, candidate).isResultFound())
+					.findFirst()
+					.orElse(null);
+
+			assertThat(match)
+					.as("No not-processed DD_Order_Candidate for AD_InputDataSource '%s' matches expected row %s\n\tunmatched candidates=%s",
+							inputDataSourceValue, row, remaining)
+					.isNotNull();
+
+			remaining.remove(match);
+			row.getAsOptionalIdentifier().ifPresent(identifier -> ddOrderCandidateTable.putOrReplace(identifier, match));
+		});
+
+		assertThat(remaining)
+				.as("Unexpected extra not-processed DD_Order_Candidate(s) for AD_InputDataSource '%s'", inputDataSourceValue)
+				.isEmpty();
+	}
+
+	private InputDataSourceId getInputDataSourceIdByValue(@NonNull final String value)
+	{
+		final I_AD_InputDataSource dataSource = queryBL.createQueryBuilder(I_AD_InputDataSource.class)
+				.addEqualsFilter(I_AD_InputDataSource.COLUMNNAME_Value, value)
+				.addOnlyActiveRecordsFilter()
+				.create()
+				.firstOnlyNotNull(I_AD_InputDataSource.class);
+
+		return InputDataSourceId.ofRepoId(dataSource.getAD_InputDataSource_ID());
 	}
 
 	@And("the following DD_Order_Candidates are enqueued for generating DD_Orders")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/process/AD_Process_Run_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/process/AD_Process_Run_StepDef.java
@@ -1,0 +1,97 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.process;
+
+import de.metas.process.AdProcessId;
+import de.metas.process.IADProcessDAO;
+import de.metas.process.ProcessInfo;
+import de.metas.security.IRoleDAO;
+import de.metas.security.Role;
+import de.metas.security.RoleId;
+import de.metas.user.UserId;
+import de.metas.util.Services;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.service.ClientId;
+import org.compiere.util.Env;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Generic step definition that runs any {@code AD_Process} by its {@code Value}, the same way the
+ * {@code Scheduler} runs it: under the test's client context and the {@code WebUI} role (the default
+ * cucumber System client/role context would match no business records). Works for SQL processes
+ * (e.g. {@code de.metas.process.ExecuteUpdateSQL}) as well as Java processes that take no parameters.
+ *
+ * <p>Rationale for direct invocation: in production this process is triggered by an {@code AD_Scheduler}
+ * at a configurable interval. Invoking it directly via {@code ProcessInfo.executeSync()} keeps the test
+ * deterministic — no dependency on scheduler timing or async queues.
+ */
+@RequiredArgsConstructor
+public class AD_Process_Run_StepDef
+{
+	@NonNull private final IADProcessDAO adProcessDAO = Services.get(IADProcessDAO.class);
+	@NonNull private final IRoleDAO roleDAO = Services.get(IRoleDAO.class);
+
+	/**
+	 * Runs the {@code AD_Process} identified by its {@code Value}, synchronously, and fails the step if the
+	 * process reports an error. The process is executed under the logged-in client and the {@code WebUI}
+	 * role, mirroring how the {@code AD_Scheduler} invokes it.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * When the AD_Process with value 'My_AD_Process_Value' is run
+	 * </pre>
+	 *
+	 * @param processValue the {@code AD_Process.Value}
+	 */
+	@When("the AD_Process with value {string} is run")
+	public void run_ad_process_by_value(@NonNull final String processValue)
+	{
+		final AdProcessId processId = adProcessDAO.retrieveProcessIdByValue(processValue);
+		assertThat(processId).as("AD_Process with Value=%s must exist", processValue).isNotNull();
+
+		final ClientId clientId = Env.getClientId();
+		final UserId loggedUserId = Env.getLoggedUserId();
+		final RoleId roleId = roleDAO.getUserRoles(loggedUserId)
+				.stream()
+				.filter(r -> "WebUI".equals(r.getName()))
+				.map(Role::getId)
+				.findFirst()
+				.orElseThrow(() -> new AdempiereException("WebUI role not found for user " + loggedUserId));
+
+		ProcessInfo.builder()
+				.setAD_Process_ID(processId.getRepoId())
+				.setClientId(clientId)
+				.setRoleId(roleId)
+				.setCreateTemporaryCtx()
+				.buildAndPrepareExecution()
+				.switchContextWhenRunning()
+				.executeSync()
+				.getResult()
+				.propagateErrorIfAny();
+	}
+}


### PR DESCRIPTION
## What

Cucumber step-definitions enabling an integration test for a ground-locator auto-replenish process. All additions are generic cucumber test infrastructure (no customer-specific code).

- **`M_Locator_StepDef`** — support the `X1` coordinate column; fix a copy-paste bug where `Y` was read from `COLUMNNAME_X`. No existing `.feature` sets `X`/`X1`/`Y` on `M_Locator`, so the fix is behaviour-safe.
- **`DD_Order_Candidate_StepDef`** — match `M_LocatorFrom_ID` / `M_LocatorTo_ID`; add an exhaustive, data-source-scoped assertion (`the only not-processed DD_Order_Candidates for AD_InputDataSource '<value>' are:`) and a Background cleanup step (`all not-processed DD_Order_Candidates for AD_InputDataSource '<value>' are deleted`). The input data source is resolved by `Value`.
- **`AD_Process_Run_StepDef`** (new) — `the AD_Process with value '<value>' is run`: runs any `AD_Process` by its `Value` under the logged client + `WebUI` role (mirrors how the `AD_Scheduler` invokes a process).

## Why

Adds the missing integration-test coverage for an already-merged auto-replenish process. The consuming feature file lives in the customer repo (`custom` cucumber profile); this core PR must merge and be baked into the `-compat` cucumber image before that feature can run green (cross-repo ordering).
