### PR TITLE
Invoice candidate scenarios — drop racy queue-drain, poll committed terminal state (300s)

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/DeliveryDateAsInvoiceDate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/DeliveryDateAsInvoiceDate.feature
@@ -48,14 +48,11 @@ Feature: Invoice Date can be taken from DeliveryDate
       | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
       | s_s_1                            | s_1                   |
 
-    # Drain the material event queue so invoice-candidate async creation completes before the poll.
-    # Background sets SKIP_WP_PROCESSOR_FOR_AUTOMATION=true, forcing async via RabbitMQ. Under CI load
-    # this poll occasionally exhausts its 60 s budget, cascading to the step-def's 120 s recompute
-    # fallback, which can in turn time out and abort the runner before any test completes
-    # ("Tests run: 0").
-    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
-
-    And after not more than 60s, C_Invoice_Candidate are found:
+    # No queue-drain step: the drain checks only the queue's ready-message count and is blind to
+    # in-flight (unacked) cascade events, so it reports "empty" prematurely. The poll below waits
+    # for the committed QtyToInvoice, which only settles after the async recompute cascade completes;
+    # the `validate invoice candidate` step that follows further confirms the candidate is settled.
+    And after not more than 300s, C_Invoice_Candidate are found:
       | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
       | ic_1                              | sol_1                     | 10           |
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceAggregationWithReversal.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceAggregationWithReversal.feature
@@ -48,17 +48,18 @@ Feature: Invoice aggregation of 2 IC2 when one IC was previously invoiced and re
       | s_s_2_1    | sol_2_1        | N             |
       | s_s_2_2    | sol_2_2        | N             |
 
-    # Drain the material event queue so invoice-candidate async creation completes before the poll.
-    # Background sets SKIP_WP_PROCESSOR_FOR_AUTOMATION=true, forcing async via RabbitMQ. Under CI load
-    # this poll occasionally exhausts its 60 s budget, cascading to the step-def's 120 s recompute
-    # fallback, which can in turn time out and abort the runner before any test completes
-    # ("Tests run: 0").
-    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
-
-    And after not more than 60s, C_Invoice_Candidate are found:
+    # No queue-drain step: the drain checks only the queue's ready-message count and is blind to
+    # in-flight (unacked) cascade events, so it reports "empty" prematurely. Instead poll the
+    # committed terminal state — the candidates exist (QtyToInvoice=0 pre-shipment) AND are no
+    # longer flagged for recompute — which only holds once the async cascade has fully settled.
+    And after not more than 300s, C_Invoice_Candidate are found:
       | C_Invoice_Candidate_ID | C_OrderLine_ID | QtyToInvoice |
       | ic_2_1                 | sol_2_1        | 0            |
       | ic_2_2                 | sol_2_2        | 0            |
+    And after not more than 300s, C_Invoice_Candidates are not marked as 'to recompute'
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_2_1                            |
+      | ic_2_2                            |
 
     # Ship first order line on 2021-04-20 08:00
     And metasfresh has date and time 2021-04-20T08:00:00+01:00[Europe/Berlin]


### PR DESCRIPTION
## What

Drop the `wait until all rabbitMQ queues are empty …` step from two invoice-candidate cucumber scenarios and rely on the committed terminal state instead:

- **invoiceAggregationWithReversal**: find the candidates (300s), then assert they are no longer flagged `to recompute` (300s) before generating shipments.
- **DeliveryDateAsInvoiceDate**: poll the committed `QtyToInvoice` (300s); the existing `validate invoice candidate` step that follows further confirms the candidate is settled.

## Why

The queue-drain step polls only the queue's *ready*-message count (`QueueInformation.getMessageCount()`) and is blind to in-flight (unacked) messages. It therefore reports the queue "empty" while invoice-candidate async creation/recompute is still settling, and the 60s business-state poll that follows races and intermittently times out under CI load (the step-def's recompute fallback can then also expire and abort the runner — "Tests run: 0").

The committed-state polls used instead (`C_Invoice_Candidates are not marked as 'to recompute'`, the settled `QtyToInvoice`) only hold once the async cascade has fully settled, so they are race-free. Both use existing step definitions; no production or step-def code changed.

Same approach as the shipmentScheduleExport `IsToRecompute=N` and shipment-notification-delay flaky-test fixes.

## Scope

Test-only: two cucumber feature files. No production code changed.
