### PR TITLE
distribution mobile e2e: un-skip the two switch + Complete end-to-end specs

### DIFF
--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -9,7 +9,7 @@
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 7 | 12 | 58% |
 | Picking | 58 | 62 | 94% |
-| Distribution | 37 | 40 | 93% |
+| Distribution | 39 | 40 | 98% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
 | HU Consolidation | 4 | 5 | 80% |
@@ -252,13 +252,13 @@
 | "Lagerort leer" button advances the job's pick-from locator to the next active locator | `distribution/switchPickFromLocator.spec.js` |
 | "Lagerort leer" successive presses cycle round-robin through all active locators | `distribution/switchPickFromLocator.spec.js` |
 | "Lagerort leer" button stays visible after picking has started (mid-job switch supported) | `distribution/switchPickFromLocator.spec.js` |
-| "Lagerort leer" — after round-robin wrap, pick HU + drop completes end-to-end ⏸ SKIPPED (post-switch job-Complete doesn't navigate to jobs-list; job completes server-side — me03 #30441) | `distribution/switchPickFromLocator.spec.js` |
+| "Lagerort leer" — after round-robin wrap, pick HU + drop completes end-to-end | `distribution/switchPickFromLocator.spec.js` |
 | "Lagerort leer" — after switch, scanning an HU from the original locator is rejected with "HU is not at the target trolley" | `distribution/switchPickFromLocator.spec.js` |
-| "Lagerort leer" — fulfill one line from two locators: pick from A, switch mid-job, pick from B; pick-from dialog proposes the scanned HU's qty (HU-limited then remaining-limited) ⏸ SKIPPED (same post-switch job-Complete navigation — me03 #30441) | `distribution/switchPickFromLocator.spec.js` |
+| "Lagerort leer" — fulfill one line from two locators: pick from A, switch mid-job, pick from B; pick-from dialog proposes the scanned HU's qty (HU-limited then remaining-limited) | `distribution/switchPickFromLocator.spec.js` |
 | "Lagerort leer" — ground-locator mode: skips non-ground and no-stock locators, respects priorityNo order, cycles round-robin | `distribution/switchPickFromLocator_groundLocator.spec.js` |
 | "Lagerort leer" — ground-locator mode (AC6): no eligible ground alternative → no-alternative toast, pick-from unchanged | `distribution/switchPickFromLocator_groundLocator_noAlternative.spec.js` |
 
-**11/13 active — 2 skipped (post-switch job-Complete UI navigation, tracked on me03 #30441)**
+**13/13 — 100%**
 
 ### Distribution — HU scanning
 

--- a/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js
@@ -206,11 +206,9 @@ test('Switch pick-from locator — button stays visible after picking has starte
 });
 
 // noinspection JSUnusedLocalSymbols
-// SKIPPED (me03 #30441): after a mid-job locator switch, job-Complete completes server-side
-// (DD_Order DocStatus=CL, goods moved to wh2) but the mobile UI does not navigate back to the
-// jobs-list (#WFLaunchersScreen). The switch/priority/round-robin behaviour itself is covered by the
-// other specs above; this end-to-end completion path is a separate frontend WF-navigation fix tracked on the issue.
-test.skip('Switch pick-from locator — round-robin wrap then pick + drop completes end-to-end', async ({ page }) => {
+// End-to-end: round-robin wrap back to the starting locator, then pick + drop + Complete navigates
+// back to the jobs-list and the HU lands in the target warehouse.
+test('Switch pick-from locator — round-robin wrap then pick + drop completes end-to-end', async ({ page }) => {
     allure.epic('E0370: Intralogistic (HUs)');
     allure.tag('F5114: MobileUI Distribution');
     allure.tag('F5114');
@@ -302,10 +300,9 @@ test('Switch pick-from locator — after switch, scanning an HU from the origina
 });
 
 // noinspection JSUnusedLocalSymbols
-// SKIPPED (me03 #30441): same post-switch job-Complete navigation issue as the round-robin spec above —
-// the cross-locator pick (A→switch→B) itself works and completes server-side, but the UI doesn't return
-// to the jobs-list. Tracked on the issue as a separate frontend WF-navigation fix.
-test.skip('Switch pick-from locator — pick from locator A, switch mid-job, pick from locator B, drop + complete', async ({ page }) => {
+// End-to-end: fulfill one line from two locators (pick from A, switch mid-job, pick remainder from B),
+// then drop + Complete navigates back to the jobs-list and the HU lands fully in the target warehouse.
+test('Switch pick-from locator — pick from locator A, switch mid-job, pick from locator B, drop + complete', async ({ page }) => {
     allure.epic('E0370: Intralogistic (HUs)');
     allure.tag('F5114: MobileUI Distribution');
     allure.tag('F5114');


### PR DESCRIPTION
## What

Un-skip the two distribution **switch-pick-from-locator → Complete** end-to-end mobile E2E specs in `e2e/mobile-webui/tests/spec/distribution/switchPickFromLocator.spec.js`:

- *round-robin wrap then pick + drop completes end-to-end*
- *pick from locator A, switch mid-job, pick from locator B, drop + complete*

## Why

These two were merged as `test.skip(...)` together with the `M_Locator.IsGroundLocator` feature (https://github.com/metasfresh/metasfresh/pull/24600), on the assumption that job-Complete did not navigate back to the jobs-list after a mid-job locator switch.

Re-run against the merged `deep_tundra_release` base on a clean CI-image stack, **both pass reliably** — Complete navigates to the launchers screen and the HU lands in the target warehouse:

- the 2 specs: 8/8 over a `--repeat-each=4` run (no flakiness)
- the full switch suite (all 3 `switchPickFromLocator*` specs): 8/8 sequential

The earlier failures were an artifact of the prior hand-built local stack, not a product defect — so this change is **test-only**: no production code is touched.

## Changes

- Remove `.skip` from both tests; replace the inaccurate `SKIPPED` comments with accurate end-to-end descriptions.
- `TEST-COVERAGE.md`: drop the two `⏸ SKIPPED` annotations; distribution coverage 37/40 → 39/40.

Issue: https://github.com/metasfresh/me03/issues/30441
