### PR TITLE
Mobile picking — restore leaked sysconfig in afterEach (fix lockstep flake)

### DIFF
--- a/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
@@ -10,6 +10,16 @@ import { generateEAN13 } from '../../utils/ean13';
 
 let previousSysconfigs = null;
 
+// Restore the sysconfig in an afterEach so it runs even if the test body fails or times out.
+// An in-body restore step is skipped on failure, which would leak
+// M_ShipmentSchedule_Close_PartiallyShipped=Y to sibling picking specs (they complete partial
+// picking jobs too) and fail them in lockstep with a 120s job-launcher timeout.
+test.afterEach(async () => {
+    if (previousSysconfigs && Object.keys(previousSysconfigs).length > 0) {
+        await Backend.setSysconfigs(previousSysconfigs);
+    }
+});
+
 const createMasterdata = async () => {
     const masterdata = await Backend.createMasterdata({
       language: "en_US",
@@ -152,11 +162,5 @@ test('Sysconfig M_ShipmentSchedule_Close_PartiallyShipped: partial and unshipped
                 }
             },
         });
-    });
-
-    await test.step("Restore sysconfigs", async () => {
-        if (previousSysconfigs && Object.keys(previousSysconfigs).length > 0) {
-            await Backend.setSysconfigs(previousSysconfigs);
-        }
     });
 });


### PR DESCRIPTION
## What

In `e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js`, move the restore of the `M_ShipmentSchedule_Close_PartiallyShipped` sysconfig from a final in-body test step into a `test.afterEach` hook.

## Why

The spec sets `M_ShipmentSchedule_Close_PartiallyShipped=Y` in its masterdata and restored it only in its last in-body step — there was no `afterEach`/`afterAll`. If the test body fails or times out before that step, the restore is skipped and `Y` leaks to the sibling picking specs that also complete partial picking jobs (`pick_what_was_scheduled_to_workplace`, `productBasedPicking/standard`). Under the leaked `Y`, completing a partial pick closes the shipment schedules early, so the next job never appears in the launcher list and the job `.tap()` waits out the full 120s budget — failing those specs in **lockstep**.

Playwright runs `afterEach` on every exit path (pass, fail, timeout), so the restore is now guaranteed.

Proven via an A/B control: with `M_ShipmentSchedule_Close_PartiallyShipped=Y` forced at `(client 1000000, org 1000000)`, `pick_what_was_scheduled_to_workplace` fails with a 120s timeout; restoring `N` makes it pass in ~12s.

## Scope

Test-only: one mobile-webui Playwright spec. No production code changed.

## Follow-up (not in this PR)

A defense-in-depth option exists: reset `M_ShipmentSchedule_Close_PartiallyShipped` to its default in the frontend-testing masterdata command (alongside the scanner-sysconfig defaults), so every spec's `createMasterdata` self-heals a leaked value. That touches shared test-infra Java and needs apply-order verification, so it is deferred.
