### PR TITLE
EDI export cucumber: drop racy push-consumer for a synchronous basicGet pull-loop

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/MetasfreshToEDIRabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/MetasfreshToEDIRabbitMQ_StepDef.java
@@ -27,7 +27,7 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.DefaultConsumer;
-import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.GetResponse;
 import de.metas.CommandLineParser;
 import de.metas.ServerBoot;
 import de.metas.cucumber.stepdefs.DataTableUtil;
@@ -55,7 +55,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -207,70 +206,73 @@ public class MetasfreshToEDIRabbitMQ_StepDef
 		ediExpDesadvTable.put(ediExpDesadvIdentifier, export);
 	}
 
+	/**
+	 * Polls one EDI-export message off the given queue and parses it into an XML {@link Document}.
+	 * <p>
+	 * Implemented with a <b>synchronous {@code basicGet} pull-loop</b> rather than an asynchronous push
+	 * consumer ({@code basicConsume} + {@link DefaultConsumer#handleDelivery}). The push-consumer
+	 * approach is racy here: with no prefetch limit the broker dispatches <i>every</i> queued message at
+	 * once to the consumer; after we ack the first one and let the poll method's {@code finally} close
+	 * the channel, the broker's still-pending extra deliveries re-enter {@code handleDelivery} and call
+	 * {@code basicAck}/{@code basicNack} on the now-closed channel — which throws inside the consumer
+	 * callback and makes the RabbitMQ client tear the channel down with
+	 * {@code ShutdownSignalException: ... Closed due to exception from Consumer ... handleDelivery}
+	 * (the observed CI flake). A pull-loop fetches exactly one message per {@code basicGet}, on the
+	 * test thread, so there is no consumer callback to throw and no extra-delivery/close race.
+	 * <p>
+	 * The loop is also tolerant of a foreign or unparseable message left on the (shared, durable) queue:
+	 * any message that does not parse as XML is acked-and-skipped (removed) and polling continues, so a
+	 * cross-scenario/cross-feature leftover can neither be returned as the wrong document nor crash the
+	 * consumer. Combined with the Background queue-purge isolation step
+	 * ({@link #edi_export_queue_is_purged(String)}), this eliminates the bleed class entirely.
+	 */
 	@NonNull
 	private Document pollDocumentFromQueue(@NonNull final String queueName) throws IOException, TimeoutException, InterruptedException, ParserConfigurationException, SAXException
 	{
 		final Connection connection = metasfreshToRabbitMQFactory.newConnection();
 		final Channel channel = connection.createChannel();
 
-		final CountDownLatch countDownLatch = new CountDownLatch(1);
-
-		final String[] messages = new String[1];
-
-		final DefaultConsumer consumer = new DefaultConsumer(channel)
+		try
 		{
-			@Override
-			public void handleDelivery(final String consumerTag, final Envelope envelope, final AMQP.BasicProperties properties, final byte[] body) throws IOException
+			final long deadlineMillis = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(60);
+
+			while (System.currentTimeMillis() < deadlineMillis)
 			{
-				// Only accept the first delivery and ack it; cancel the consumer immediately so the
-				// broker requeues / leaves any remaining messages (e.g. a second DESADV pre-queued
-				// before this poll) for the next pollDocumentFromQueue call.
-				if (countDownLatch.getCount() == 0)
+				// autoAck=false: pull exactly one message at a time on the test thread, then ack it
+				// explicitly once we have read its body. No prefetch storm, no consumer-callback thread.
+				final GetResponse getResponse = channel.basicGet(queueName, false);
+				if (getResponse == null)
 				{
-					// Reject without requeue is wrong (would lose the message); nack with requeue=true
-					// keeps it in the queue for the next caller. With basicCancel below, this path is
-					// only hit if the broker dispatched extra messages before cancellation took effect.
-					channel.basicNack(envelope.getDeliveryTag(), false, true);
-					return;
+					// Queue currently empty (the export workpackage may not have published yet) -> wait
+					// briefly and retry until the deadline.
+					Thread.sleep(250);
+					continue;
 				}
 
-				messages[0] = new String(body, StandardCharsets.UTF_8);
-
-				logger.info("*** Queue: {}, received message: {}", queueName, messages[0]);
-
-				countDownLatch.countDown();
-
-				channel.basicAck(envelope.getDeliveryTag(), false);
+				final String message = new String(getResponse.getBody(), StandardCharsets.UTF_8);
+				channel.basicAck(getResponse.getEnvelope().getDeliveryTag(), false);
 
 				try
 				{
-					channel.basicCancel(consumerTag);
+					final Document document = parseXmlStringToDocument(message);
+					logger.info("*** Queue: {}, received message: {}", queueName, message);
+					return document;
 				}
-				catch (final Exception e)
+				catch (final SAXException | IOException foreignMessage)
 				{
-					// best-effort cancel; channel may already be in the process of closing
-					logger.warn("basicCancel failed (ignored): {}", e.getMessage());
+					// A leftover / foreign message that is not the expected EDI XML: it is already acked
+					// (removed) above, so just skip it and keep polling for the message we expect.
+					logger.warn("*** Queue: {}, skipping non-XML/foreign message: {}", queueName, foreignMessage.getMessage());
 				}
 			}
-		};
 
-		try
-		{
-			// autoAck=false: we manually ack the first message and nack-with-requeue any extras the
-			// broker dispatched before basicCancel took effect, so a follow-up pollDocumentFromQueue
-			// call still finds those messages in the queue.
-			channel.basicConsume(queueName, false, consumer);
-
-			final boolean messageReceivedWithinTimeout = countDownLatch.await(60, TimeUnit.SECONDS);
-
-			assertThat(messageReceivedWithinTimeout).isTrue();
+			throw new AssertionError("No EDI-export message received on queue '" + queueName + "' within 60s");
 		}
 		finally
 		{
 			channel.close();
+			connection.close();
 		}
-
-		return parseXmlStringToDocument(messages[0]);
 	}
 
 	@NonNull

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/MetasfreshToEDIRabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/MetasfreshToEDIRabbitMQ_StepDef.java
@@ -26,7 +26,6 @@ import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
-import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.GetResponse;
 import de.metas.CommandLineParser;
 import de.metas.ServerBoot;
@@ -210,12 +209,12 @@ public class MetasfreshToEDIRabbitMQ_StepDef
 	 * Polls one EDI-export message off the given queue and parses it into an XML {@link Document}.
 	 * <p>
 	 * Implemented with a <b>synchronous {@code basicGet} pull-loop</b> rather than an asynchronous push
-	 * consumer ({@code basicConsume} + {@link DefaultConsumer#handleDelivery}). The push-consumer
-	 * approach is racy here: with no prefetch limit the broker dispatches <i>every</i> queued message at
-	 * once to the consumer; after we ack the first one and let the poll method's {@code finally} close
-	 * the channel, the broker's still-pending extra deliveries re-enter {@code handleDelivery} and call
-	 * {@code basicAck}/{@code basicNack} on the now-closed channel — which throws inside the consumer
-	 * callback and makes the RabbitMQ client tear the channel down with
+	 * consumer ({@code basicConsume} + a {@code DefaultConsumer.handleDelivery} callback). The
+	 * push-consumer approach is racy here: with no prefetch limit the broker dispatches <i>every</i>
+	 * queued message at once to the consumer; after we ack the first one and let the poll method's
+	 * {@code finally} close the channel, the broker's still-pending extra deliveries re-enter the
+	 * callback and call {@code basicAck}/{@code basicNack} on the now-closed channel — which throws
+	 * inside the callback and makes the RabbitMQ client tear the channel down with
 	 * {@code ShutdownSignalException: ... Closed due to exception from Consumer ... handleDelivery}
 	 * (the observed CI flake). A pull-loop fetches exactly one message per {@code basicGet}, on the
 	 * test thread, so there is no consumer callback to throw and no extra-delivery/close race.
@@ -223,54 +222,72 @@ public class MetasfreshToEDIRabbitMQ_StepDef
 	 * The loop is also tolerant of a foreign or unparseable message left on the (shared, durable) queue:
 	 * any message that does not parse as XML is acked-and-skipped (removed) and polling continues, so a
 	 * cross-scenario/cross-feature leftover can neither be returned as the wrong document nor crash the
-	 * consumer. Combined with the Background queue-purge isolation step
-	 * ({@link #edi_export_queue_is_purged(String)}), this eliminates the bleed class entirely.
+	 * poll. See also the Background queue-purge step {@link #edi_export_queue_is_purged(String)}.
 	 */
 	@NonNull
 	private Document pollDocumentFromQueue(@NonNull final String queueName) throws IOException, TimeoutException, InterruptedException, ParserConfigurationException, SAXException
 	{
 		final Connection connection = metasfreshToRabbitMQFactory.newConnection();
-		final Channel channel = connection.createChannel();
-
 		try
 		{
-			final long deadlineMillis = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(60);
-
-			while (System.currentTimeMillis() < deadlineMillis)
+			// createChannel() is inside the outer try so the connection is still closed if it throws.
+			final Channel channel = connection.createChannel();
+			try
 			{
-				// autoAck=false: pull exactly one message at a time on the test thread, then ack it
-				// explicitly once we have read its body. No prefetch storm, no consumer-callback thread.
-				final GetResponse getResponse = channel.basicGet(queueName, false);
-				if (getResponse == null)
+				final long deadlineMillis = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(60);
+
+				while (System.currentTimeMillis() < deadlineMillis)
 				{
-					// Queue currently empty (the export workpackage may not have published yet) -> wait
-					// briefly and retry until the deadline.
-					Thread.sleep(250);
-					continue;
+					// autoAck=false: pull exactly one message at a time on the test thread, then ack it
+					// explicitly once we have read its body. No prefetch storm, no consumer-callback thread.
+					final GetResponse getResponse = channel.basicGet(queueName, false);
+					if (getResponse == null)
+					{
+						// Queue currently empty (the export workpackage may not have published yet) -> wait
+						// briefly and retry until the deadline.
+						try
+						{
+							Thread.sleep(250);
+						}
+						catch (final InterruptedException interrupted)
+						{
+							Thread.currentThread().interrupt();
+							throw interrupted;
+						}
+						continue;
+					}
+
+					final String message = new String(getResponse.getBody(), StandardCharsets.UTF_8);
+					channel.basicAck(getResponse.getEnvelope().getDeliveryTag(), false);
+
+					try
+					{
+						final Document document = parseXmlStringToDocument(message);
+						logger.info("*** Queue: {}, received message: {}", queueName, message);
+						return document;
+					}
+					catch (final SAXException | IOException foreignMessage)
+					{
+						// A leftover / foreign message that is not the expected EDI XML: it is already acked
+						// (removed) above, so just skip it and keep polling for the message we expect.
+						logger.warn("*** Queue: {}, skipping non-XML/foreign message: {}", queueName, foreignMessage.getMessage());
+					}
 				}
 
-				final String message = new String(getResponse.getBody(), StandardCharsets.UTF_8);
-				channel.basicAck(getResponse.getEnvelope().getDeliveryTag(), false);
-
-				try
+				throw new AssertionError("No EDI-export message received on queue '" + queueName + "' within 60s");
+			}
+			finally
+			{
+				// guard with isOpen(): if the broker already force-closed the channel, an unconditional
+				// close() would throw AlreadyClosedException in finally and suppress the real failure.
+				if (channel.isOpen())
 				{
-					final Document document = parseXmlStringToDocument(message);
-					logger.info("*** Queue: {}, received message: {}", queueName, message);
-					return document;
-				}
-				catch (final SAXException | IOException foreignMessage)
-				{
-					// A leftover / foreign message that is not the expected EDI XML: it is already acked
-					// (removed) above, so just skip it and keep polling for the message we expect.
-					logger.warn("*** Queue: {}, skipping non-XML/foreign message: {}", queueName, foreignMessage.getMessage());
+					channel.close();
 				}
 			}
-
-			throw new AssertionError("No EDI-export message received on queue '" + queueName + "' within 60s");
 		}
 		finally
 		{
-			channel.close();
 			connection.close();
 		}
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/MetasfreshToEDIRabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/MetasfreshToEDIRabbitMQ_StepDef.java
@@ -37,6 +37,7 @@ import de.metas.esb.edi.model.I_EDI_cctop_invoic_v;
 import de.metas.logging.LogManager;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
@@ -91,6 +92,67 @@ public class MetasfreshToEDIRabbitMQ_StepDef
 		metasfreshToRabbitMQFactory.setPort(commandLineOptions.getRabbitPort());
 		metasfreshToRabbitMQFactory.setUsername(commandLineOptions.getRabbitUser());
 		metasfreshToRabbitMQFactory.setPassword(commandLineOptions.getRabbitPassword());
+	}
+
+	/**
+	 * Purges the given durable EDI-export RabbitMQ queue so the scenario starts from a known-empty
+	 * state, regardless of what an earlier scenario (or an earlier feature on the same CI executor)
+	 * left behind.
+	 * <p>
+	 * Why this is needed: the EDI export queues (e.g. {@code ediExport}) are <b>durable</b> and
+	 * <b>shared</b> by every scenario in a feature and by every feature that exports through the same
+	 * routing key on one CI executor (all run sequentially against one RabbitMQ broker). The consumer
+	 * in {@link #pollDocumentFromQueue(String)} returns the message at the head of the queue, so a
+	 * single leftover message (a foreign DESADV/INVOIC from a sibling scenario, or a message re-queued
+	 * by the consumer's {@code basicNack(requeue=true)} extra-message path) makes the next scenario
+	 * consume the <i>wrong</i> document. That manifests as the flaky
+	 * {@code [EDI_Exp_Desadv_Pack] Expecting actual not to be null} (a foreign INVOIC has no pack
+	 * element) and the sibling {@code ShutdownSignalException}. Purging in the Background (per the
+	 * setUp-isolation convention) removes the bleed at its source.
+	 * <p>
+	 * The purge is a no-op when the queue does not exist yet (first run on a fresh broker): we
+	 * passively check existence first and skip silently, because "no queue" already means "nothing to
+	 * bleed".
+	 * <p>
+	 * DataTable-free step. Example:
+	 * <pre>
+	 * Given the EDI export RabbitMQ queue 'ediExport' is purged
+	 * </pre>
+	 */
+	@Given("the EDI export RabbitMQ queue {string} is purged")
+	public void edi_export_queue_is_purged(@NonNull final String queueName) throws IOException, TimeoutException
+	{
+		final Connection connection = metasfreshToRabbitMQFactory.newConnection();
+		try
+		{
+			final Channel channel = connection.createChannel();
+			try
+			{
+				// queueDeclarePassive throws (and closes the channel) when the queue does not exist yet;
+				// in that case there is nothing to purge, so we treat it as a no-op and return. The dead
+				// channel needs no explicit close (the broker already closed it; the finally below guards
+				// it via isOpen()), and the outer finally closes the connection.
+				channel.queueDeclarePassive(queueName);
+
+				final AMQP.Queue.PurgeOk purgeOk = channel.queuePurge(queueName);
+				logger.info("Purged {} message(s) from EDI export queue {}", purgeOk.getMessageCount(), queueName);
+			}
+			catch (final IOException queueAbsent)
+			{
+				logger.info("EDI export queue {} does not exist yet -> nothing to purge", queueName);
+			}
+			finally
+			{
+				if (channel.isOpen())
+				{
+					channel.close();
+				}
+			}
+		}
+		finally
+		{
+			connection.close();
+		}
 	}
 
 	@Then("RabbitMQ receives a EDI_cctop_invoic_v")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/MetasfreshToEDIRabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/MetasfreshToEDIRabbitMQ_StepDef.java
@@ -270,6 +270,10 @@ public class MetasfreshToEDIRabbitMQ_StepDef
 					{
 						// A leftover / foreign message that is not the expected EDI XML: it is already acked
 						// (removed) above, so just skip it and keep polling for the message we expect.
+						// ParserConfigurationException is intentionally NOT caught here: it signals a broken
+						// JAXP/JVM configuration (the DocumentBuilderFactory is created once at construction),
+						// not a per-message condition, so it must propagate and fail the run loudly rather
+						// than be swallowed as a "foreign message" and masked by the 60s-timeout AssertionError.
 						logger.warn("*** Queue: {}, skipping non-XML/foreign message: {}", queueName, foreignMessage.getMessage());
 					}
 				}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/MetasfreshToEDIRabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/MetasfreshToEDIRabbitMQ_StepDef.java
@@ -126,18 +126,25 @@ public class MetasfreshToEDIRabbitMQ_StepDef
 			final Channel channel = connection.createChannel();
 			try
 			{
-				// queueDeclarePassive throws (and closes the channel) when the queue does not exist yet;
-				// in that case there is nothing to purge, so we treat it as a no-op and return. The dead
-				// channel needs no explicit close (the broker already closed it; the finally below guards
-				// it via isOpen()), and the outer finally closes the connection.
-				channel.queueDeclarePassive(queueName);
+				try
+				{
+					// queueDeclarePassive throws (and closes the channel) when the queue does not exist yet;
+					// in that case there is nothing to purge, so we treat it as a no-op and return. The dead
+					// channel needs no explicit close (the broker already closed it; the finally below guards
+					// it via isOpen()), and the outer finally closes the connection.
+					channel.queueDeclarePassive(queueName);
+				}
+				catch (final IOException queueAbsent)
+				{
+					logger.info("EDI export queue {} does not exist yet -> nothing to purge", queueName);
+					return;
+				}
 
+				// queuePurge is OUTSIDE the queueAbsent catch on purpose: the queue exists here, so a purge
+				// failure (e.g. ACCESS_REFUSED, or a protocol error) is a real problem and must propagate
+				// rather than be mislogged as "does not exist yet" and silently leave the queue unpurged.
 				final AMQP.Queue.PurgeOk purgeOk = channel.queuePurge(queueName);
 				logger.info("Purged {} message(s) from EDI export queue {}", purgeOk.getMessageCount(), queueName);
-			}
-			catch (final IOException queueAbsent)
-			{
-				logger.info("EDI export queue {} does not exist yet -> nothing to purge", queueName);
 			}
 			finally
 			{
@@ -274,7 +281,11 @@ public class MetasfreshToEDIRabbitMQ_StepDef
 						// JAXP/JVM configuration (the DocumentBuilderFactory is created once at construction),
 						// not a per-message condition, so it must propagate and fail the run loudly rather
 						// than be swallowed as a "foreign message" and masked by the 60s-timeout AssertionError.
-						logger.warn("*** Queue: {}, skipping non-XML/foreign message: {}", queueName, foreignMessage.getMessage());
+						// The full body is logged on purpose: after the Background queue-purge, a non-parseable
+						// message most likely means the system under test published malformed XML, and the only
+						// other symptom is the generic 60s-timeout AssertionError below — the body is what makes
+						// that root cause diagnosable from the CI log.
+						logger.warn("*** Queue: {}, skipping non-XML/foreign message (body={}): {}", queueName, message, foreignMessage.getMessage());
 					}
 				}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/MetasfreshToExternalSystemRabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/MetasfreshToExternalSystemRabbitMQ_StepDef.java
@@ -307,9 +307,12 @@ public class MetasfreshToExternalSystemRabbitMQ_StepDef
 					}
 				}
 
+				// the while-loop exits at collected == numberOfMessages (success) or on the deadline
+				// (collected < numberOfMessages); collected can never exceed numberOfMessages, so assert
+				// exact equality rather than >= which would disguise the loop's invariant.
 				assertThat(collected)
 						.as("Expected %s qualifying message(s) on queue '%s' within 60s, but got %s", numberOfMessages, QUEUE_NAME_MF_TO_ES, collected)
-						.isGreaterThanOrEqualTo(numberOfMessages);
+						.isEqualTo(numberOfMessages);
 
 				return collector.build();
 			}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/MetasfreshToExternalSystemRabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/MetasfreshToExternalSystemRabbitMQ_StepDef.java
@@ -29,8 +29,7 @@ import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
-import com.rabbitmq.client.DefaultConsumer;
-import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.GetResponse;
 import de.metas.CommandLineParser;
 import de.metas.JsonObjectMapperHolder;
 import de.metas.ServerBoot;
@@ -67,7 +66,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
@@ -123,9 +121,29 @@ public class MetasfreshToExternalSystemRabbitMQ_StepDef
 	public void rabbitMQs_MF_TO_ExternalSystem_queue_is_empty() throws IOException, TimeoutException
 	{
 		final Connection connection = metasfreshToRabbitMQFactory.newConnection();
-		final Channel channel = connection.createChannel();
-		final AMQP.Queue.PurgeOk purgeOk = channel.queuePurge(QUEUE_NAME_MF_TO_ES);
-		logger.info("Purged {} messages from queue {}", purgeOk.getMessageCount(), QUEUE_NAME_MF_TO_ES);
+		try
+		{
+			// createChannel() is inside the outer try so the connection is still closed if it throws.
+			final Channel channel = connection.createChannel();
+			try
+			{
+				final AMQP.Queue.PurgeOk purgeOk = channel.queuePurge(QUEUE_NAME_MF_TO_ES);
+				logger.info("Purged {} messages from queue {}", purgeOk.getMessageCount(), QUEUE_NAME_MF_TO_ES);
+			}
+			finally
+			{
+				// guard with isOpen(): if the broker already force-closed the channel, an unconditional
+				// close() would throw AlreadyClosedException in finally and suppress the real failure.
+				if (channel.isOpen())
+				{
+					channel.close();
+				}
+			}
+		}
+		finally
+		{
+			connection.close();
+		}
 	}
 
 	@Then("RabbitMQ receives a JsonExternalSystemRequest with the following external system config and bpartnerId as parameters:")
@@ -206,55 +224,108 @@ public class MetasfreshToExternalSystemRabbitMQ_StepDef
 		}
 	}
 
+	/**
+	 * Polls {@code numberOfMessages} qualifying {@link JsonExternalSystemRequest}s off the
+	 * {@code MF_TO_ExternalSystem} queue.
+	 * <p>
+	 * Implemented with a <b>synchronous {@code basicGet} pull-loop</b> rather than an asynchronous push
+	 * consumer ({@code basicConsume} + a {@code DefaultConsumer.handleDelivery} callback). The
+	 * push-consumer approach is racy here: with no prefetch limit the broker dispatches <i>every</i>
+	 * queued message at once to the consumer; after the poll method's {@code finally} closes the channel,
+	 * still-pending deliveries re-enter the callback and act on the now-closed channel — which throws
+	 * inside the callback and makes the RabbitMQ client tear the channel down with
+	 * {@code ShutdownSignalException: ... Closed due to exception from Consumer ... handleDelivery}.
+	 * A pull-loop fetches exactly one message per {@code basicGet}, on the test thread, so there is no
+	 * consumer callback to throw and no extra-delivery/close race.
+	 * <p>
+	 * The loop is also tolerant of a foreign or unparseable message left on the (shared, durable) queue:
+	 * any message that does not parse as a {@link JsonExternalSystemRequest} is acked-and-skipped (removed)
+	 * and polling continues, so a cross-scenario/cross-feature leftover can neither be collected nor crash
+	 * the poll. Messages that parse but do not satisfy {@code messageQualifier} are likewise acked-and-skipped.
+	 * Closes both channel (guarded by {@code isOpen()}) and connection in {@code finally}.
+	 */
 	@NonNull
 	private List<JsonExternalSystemRequest> pollRequestFromQueue(
 			final int numberOfMessages,
 			final Function<JsonExternalSystemRequest, Boolean> messageQualifier) throws IOException, TimeoutException, InterruptedException
 	{
-		Channel channel = null;
-
+		final Connection connection = metasfreshToRabbitMQFactory.newConnection();
 		try
 		{
-			final ImmutableList.Builder<JsonExternalSystemRequest> collector = ImmutableList.builder();
-
-			final Connection connection = metasfreshToRabbitMQFactory.newConnection();
-			channel = connection.createChannel();
-
-			final CountDownLatch countDownLatch = new CountDownLatch(numberOfMessages);
-
-			final DefaultConsumer consumer = new DefaultConsumer(channel)
+			// createChannel() is inside the outer try so the connection is still closed if it throws.
+			final Channel channel = connection.createChannel();
+			try
 			{
-				@Override
-				public void handleDelivery(final String consumerTag, final Envelope envelope, final AMQP.BasicProperties properties, final byte[] body) throws JsonProcessingException
+				final ImmutableList.Builder<JsonExternalSystemRequest> collector = ImmutableList.builder();
+				int collected = 0;
+
+				final long deadlineMillis = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(60);
+
+				while (collected < numberOfMessages && System.currentTimeMillis() < deadlineMillis)
 				{
-					final String externalSystemRequest = new String(body, StandardCharsets.UTF_8);
+					// autoAck=false: pull exactly one message at a time on the test thread, then ack it
+					// explicitly once we have read its body. No prefetch storm, no consumer-callback thread.
+					final GetResponse getResponse = channel.basicGet(QUEUE_NAME_MF_TO_ES, false);
+					if (getResponse == null)
+					{
+						// Queue currently empty (the export workpackage may not have published yet) -> wait
+						// briefly and retry until the deadline.
+						try
+						{
+							Thread.sleep(250);
+						}
+						catch (final InterruptedException interrupted)
+						{
+							Thread.currentThread().interrupt();
+							throw interrupted;
+						}
+						continue;
+					}
+
+					final String externalSystemRequest = new String(getResponse.getBody(), StandardCharsets.UTF_8);
+					channel.basicAck(getResponse.getEnvelope().getDeliveryTag(), false);
+
+					final JsonExternalSystemRequest jsonExternalSystemRequest;
+					try
+					{
+						jsonExternalSystemRequest = objectMapper.readValue(externalSystemRequest, JsonExternalSystemRequest.class);
+					}
+					catch (final JsonProcessingException foreignMessage)
+					{
+						// A leftover / foreign message that is not a JsonExternalSystemRequest: it is already acked
+						// (removed) above, so just skip it and keep polling for the messages we expect.
+						logger.warn("*** {}: skipping non-JsonExternalSystemRequest/foreign message: {}", QUEUE_NAME_MF_TO_ES, foreignMessage.getMessage());
+						continue;
+					}
 
 					logger.info("*** {}: received message: {}", QUEUE_NAME_MF_TO_ES, externalSystemRequest);
-
-					final JsonExternalSystemRequest jsonExternalSystemRequest = objectMapper.readValue(externalSystemRequest, JsonExternalSystemRequest.class);
 
 					if (messageQualifier.apply(jsonExternalSystemRequest))
 					{
 						collector.add(jsonExternalSystemRequest);
-						countDownLatch.countDown();
+						collected++;
 					}
 				}
-			};
 
-			channel.basicConsume(QUEUE_NAME_MF_TO_ES, true, consumer);
+				assertThat(collected)
+						.as("Expected %s qualifying message(s) on queue '%s' within 60s, but got %s", numberOfMessages, QUEUE_NAME_MF_TO_ES, collected)
+						.isGreaterThanOrEqualTo(numberOfMessages);
 
-			final boolean messageReceivedWithinTimeout = countDownLatch.await(60, TimeUnit.SECONDS);
-
-			assertThat(messageReceivedWithinTimeout).isTrue();
-
-			return collector.build();
+				return collector.build();
+			}
+			finally
+			{
+				// guard with isOpen(): if the broker already force-closed the channel, an unconditional
+				// close() would throw AlreadyClosedException in finally and suppress the real failure.
+				if (channel.isOpen())
+				{
+					channel.close();
+				}
+			}
 		}
 		finally
 		{
-			if (channel != null)
-			{
-				channel.close();
-			}
+			connection.close();
 		}
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/MetasfreshToExternalSystemRabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/MetasfreshToExternalSystemRabbitMQ_StepDef.java
@@ -294,7 +294,11 @@ public class MetasfreshToExternalSystemRabbitMQ_StepDef
 					{
 						// A leftover / foreign message that is not a JsonExternalSystemRequest: it is already acked
 						// (removed) above, so just skip it and keep polling for the messages we expect.
-						logger.warn("*** {}: skipping non-JsonExternalSystemRequest/foreign message: {}", QUEUE_NAME_MF_TO_ES, foreignMessage.getMessage());
+						// The full body is logged on purpose: after the queue-empty isolation step, a non-parseable
+						// message most likely means the system under test published a malformed request, and the only
+						// other symptom is the generic 60s-timeout assertion below — the body is what makes that root
+						// cause diagnosable from the CI log.
+						logger.warn("*** {}: skipping non-JsonExternalSystemRequest/foreign message (body={}): {}", QUEUE_NAME_MF_TO_ES, externalSystemRequest, foreignMessage.getMessage());
 						continue;
 					}
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediExport.feature
@@ -8,6 +8,10 @@ Feature: EDI_cctop_invoic_v export format
 
   Background:
     Given infrastructure and metasfresh are running
+    # Isolate the shared, durable EDI export queues so a leftover message from an earlier scenario
+    # (or an earlier feature on the same CI executor) cannot be consumed by the wrong scenario.
+    And the EDI export RabbitMQ queue 'ediExport' is purged
+    And the EDI export RabbitMQ queue 'ediExport_150' is purged
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
     And metasfresh has date and time 2021-04-16T13:30:13+01:00[Europe/Berlin]


### PR DESCRIPTION
## Problem

`edi/ediExport.feature` (executor5) flaked on CI on the `EDI_cctop_invoic_v` export scenario with:

```
com.rabbitmq.client.ShutdownSignalException: clean channel shutdown ...
Closed due to exception from Consumer ... method handleDelivery
```

## Root cause (test-side, reproduced deterministically)

`MetasfreshToEDIRabbitMQ_StepDef.pollDocumentFromQueue` consumed the export message with an **asynchronous push consumer** (`basicConsume` + a `DefaultConsumer.handleDelivery` callback) and **no prefetch limit** (`basicQos`). When more than one message is on the queue, the broker dispatches them all at once to the consumer. After the first message is acked and the method's `finally` closes the channel, the broker's still-pending extra deliveries re-enter the callback and call `basicAck`/`basicNack` on the now-closed channel — which throws `AlreadyClosedException` **inside the callback**, so the RabbitMQ client tears the channel down with the `ShutdownSignalException` above.

A standalone replay against a local broker (seed N>1 messages, run the exact old consumer logic) reproduced the precise `ShutdownSignalException` consistently; the new logic never does.

## Fix (test-side only — no production code)

- Rewrite `pollDocumentFromQueue` as a **synchronous `basicGet` pull-loop** on the test thread: one message per `basicGet`, acked explicitly, no consumer-callback thread and no extra-delivery/close race — so the `ShutdownSignalException` class cannot occur.
- The loop is **tolerant of a foreign/unparseable leftover** on the shared durable queue: a message that does not parse as XML is acked-and-skipped and polling continues, so cross-scenario / cross-feature bleed can neither return the wrong document nor crash the poll.
- Keep the Background **queue-purge** isolation step (`the EDI export RabbitMQ queue '<name>' is purged`) for both `ediExport` and `ediExport_150`, so each scenario starts from a known-empty queue.
- Consistent channel/connection lifecycle: `createChannel()` inside the outer `try`, channel closed under an `isOpen()` guard, connection always closed in `finally` (the old code leaked the connection), and `Thread.sleep` restores the interrupt flag.

Together this eliminates the failure class, not just the observed instance.

## Verification

`edi/ediExport.feature` run against local infra — all 3 scenarios (`EDI_cctop_invoic_v`, `EDI_Exp_Desadv`, the two-order consolidated-shipment regression) pass, repeated 3x clean. No production code changed.