### PR TITLE
HU Manager bulk-move E2E — scan target locator until the move fires

### DIFF
--- a/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
@@ -27,17 +27,13 @@ export const HUBulkActionsScreen = {
         // Wait for button text to change to "Close scanner" - ensures React re-render complete
         await page.getByTestId('toggle-target-scanner-button').getByText('Close scanner').waitFor({ timeout: SLOW_ACTION_TIMEOUT });
 
-        // Scan the target locator until the move fires (the screen navigates away).
-        // The keyboard-scanner hook attaches its window listener in a useEffect that runs
-        // AFTER the React commit that shows "Close scanner", so a single instantaneous scan
-        // can race ahead of the listener and be dropped — the move never fires and the
-        // bulk-actions screen stays open. A real operator who sees nothing happen just scans
-        // again; we do the same: re-scan while the bulk-actions screen is still present.
+        // The keyboard-scanner hook's window listener attaches asynchronously (useEffect after
+        // the React commit), so a single instantaneous scan can be dropped; re-scan until the
+        // screen navigates away — mirroring an operator who scans again when nothing happens.
         for (let attempt = 1; attempt <= SCAN_TARGET_MAX_ATTEMPTS; attempt++) {
             await BarcodeScannerComponent.type(targetLocator);
 
-            // Scan consumed => the bulk-actions screen navigates away. Check with a short
-            // bounded wait; if it's gone we're done, otherwise re-scan.
+            // Scan accepted → screen navigates away; verify with a bounded wait.
             try {
                 await containerElement().waitFor({ state: 'detached', timeout: FAST_ACTION_TIMEOUT });
                 break;

--- a/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page, SLOW_ACTION_TIMEOUT } from '../../common';
+import { page, FAST_ACTION_TIMEOUT, SLOW_ACTION_TIMEOUT } from '../../common';
 import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
@@ -7,6 +7,11 @@ import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponen
 const NAME = 'HUBulkActionsScreen';
 /** @returns {import('@playwright/test').Locator} */
 const containerElement = () => page.locator('#HUBulkActionsScreen');
+
+// A real operator scans the target locator and, if nothing happens, simply scans again.
+// We mirror that: scan the target, and if the bulk-actions screen is still open shortly
+// after, scan once more, up to this many attempts.
+const SCAN_TARGET_MAX_ATTEMPTS = 5;
 
 export const HUBulkActionsScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
@@ -20,9 +25,29 @@ export const HUBulkActionsScreen = {
     move: async ({ targetLocator }) => await test.step(`${NAME} - Move HU`, async () => {
         await page.getByTestId('toggle-target-scanner-button').tap();
         // Wait for button text to change to "Close scanner" - ensures React re-render complete
-        // and useKeyboardBarcodeReader hook has attached its event listener
         await page.getByTestId('toggle-target-scanner-button').getByText('Close scanner').waitFor({ timeout: SLOW_ACTION_TIMEOUT });
-        await BarcodeScannerComponent.type(targetLocator);
+
+        // Scan the target locator until the move fires (the screen navigates away).
+        // The keyboard-scanner hook attaches its window listener in a useEffect that runs
+        // AFTER the React commit that shows "Close scanner", so a single instantaneous scan
+        // can race ahead of the listener and be dropped — the move never fires and the
+        // bulk-actions screen stays open. A real operator who sees nothing happen just scans
+        // again; we do the same: re-scan while the bulk-actions screen is still present.
+        for (let attempt = 1; attempt <= SCAN_TARGET_MAX_ATTEMPTS; attempt++) {
+            await BarcodeScannerComponent.type(targetLocator);
+
+            // Scan consumed => the bulk-actions screen navigates away. Check with a short
+            // bounded wait; if it's gone we're done, otherwise re-scan.
+            try {
+                await containerElement().waitFor({ state: 'detached', timeout: FAST_ACTION_TIMEOUT });
+                break;
+            } catch (e) {
+                if (attempt === SCAN_TARGET_MAX_ATTEMPTS) {
+                    throw e;
+                }
+                // still on the bulk-actions screen — the scan was dropped; scan again
+            }
+        }
 
         await ApplicationsListScreen.waitForScreen();
     }),


### PR DESCRIPTION
The two mobile-webui "Bulk actions - Move" E2E specs flake/fail deterministically when run against the stack.

## Root cause (test-side)
`HUBulkActionsScreen.move()` opens the target scanner, waits for the "Close scanner" caption, then dispatches a single programmatic barcode scan. The keyboard-scanner hook attaches its `window` keydown listener in a `useEffect` that runs **after** the React commit which shows "Close scanner". The instantaneous programmatic scan races ahead of that listener and is dropped, so the move never fires and `ApplicationsListScreen.waitForScreen()` times out at 20s. A real operator scans long after the effect has attached, so this is purely a test-timing artifact — no production behaviour is involved.

## Fix
`move()` now scans the target locator and, if the bulk-actions screen is still open after a short bounded check (`FAST_ACTION_TIMEOUT`), re-scans — up to 5 attempts. This mirrors a real operator who simply scans again when nothing happens. Success is asserted by the `#HUBulkActionsScreen` container detaching (navigation away), not by any fixed delay. Encapsulated in the screen object; no `page.*` in specs; explicit timeout on the wait.

## Scope
Test-side only. No production frontend code changed.

## Verification (local, against running stack)
- RED on pre-fix code: both `tests/spec/humanager/huManager.spec.js` and `tests/spec/humanager/by_ExternalBarcode_attribute.spec.js` "Bulk actions - Move" FAIL at the 20s `waitForScreen` timeout.
- After fix: both specs pass on 3 consecutive runs (8.6s / 13.6s / 13.5s).