### PR TITLE
Purchase Order: Allow DatePromised for pricing via SysConfig

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5808400_sys_30274_PurchaseOrder_PriceDateUseDatePromised.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5808400_sys_30274_PurchaseOrder_PriceDateUseDatePromised.sql
@@ -1,7 +1,7 @@
 -- SysConfig Name: de.metas.order.PurchaseOrder.UseDatePromisedForPricing
--- SysConfig Value: Y
+-- SysConfig Value: N (system default; override per client to Y to enable DatePromised)
 -- 2026-06-17T14:24:46.414Z
-INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541822,'C',TO_TIMESTAMP('2026-06-17 14:24:46.222000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','de.metas.order.PurchaseOrder.UseDatePromisedForPricing',TO_TIMESTAMP('2026-06-17 14:24:46.222000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y')
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541822 /*From ID Server*/,'C',TO_TIMESTAMP('2026-06-17 14:24:46.222000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','de.metas.order.PurchaseOrder.UseDatePromisedForPricing',TO_TIMESTAMP('2026-06-17 14:24:46.222000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y')
 ;
 
 -- SysConfig Name: de.metas.order.PurchaseOrder.UseDatePromisedForPricing

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5808400_sys_30274_PurchaseOrder_PriceDateUseDatePromised.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5808400_sys_30274_PurchaseOrder_PriceDateUseDatePromised.sql
@@ -6,6 +6,5 @@ INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLe
 
 -- SysConfig Name: de.metas.order.PurchaseOrder.UseDatePromisedForPricing
 -- 2026-06-17T14:26:39.346Z
-UPDATE AD_SysConfig SET ConfigurationLevel='C', Description='Controls which date is used to select the price list version on purchase orders. Y = DatePromised (Zugesagter Te
-rmin); N = DateOrdered (Auftragsdatum, default).', Value='N',Updated=TO_TIMESTAMP('2026-06-17 14:26:39.261000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_SysConfig_ID=541822
+UPDATE AD_SysConfig SET ConfigurationLevel='C', Description='Controls which date is used to select the price list version on purchase orders. Y = DatePromised (Zugesagter Termin); N = DateOrdered (Auftragsdatum, default).', Value='N',Updated=TO_TIMESTAMP('2026-06-17 14:26:39.261000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_SysConfig_ID=541822
 ;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5808400_sys_30274_PurchaseOrder_PriceDateUseDatePromised.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5808400_sys_30274_PurchaseOrder_PriceDateUseDatePromised.sql
@@ -1,0 +1,11 @@
+-- SysConfig Name: de.metas.order.PurchaseOrder.UseDatePromisedForPricing
+-- SysConfig Value: Y
+-- 2026-06-17T14:24:46.414Z
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541822,'C',TO_TIMESTAMP('2026-06-17 14:24:46.222000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','de.metas.order.PurchaseOrder.UseDatePromisedForPricing',TO_TIMESTAMP('2026-06-17 14:24:46.222000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y')
+;
+
+-- SysConfig Name: de.metas.order.PurchaseOrder.UseDatePromisedForPricing
+-- 2026-06-17T14:26:39.346Z
+UPDATE AD_SysConfig SET ConfigurationLevel='C', Description='Controls which date is used to select the price list version on purchase orders. Y = DatePromised (Zugesagter Te
+rmin); N = DateOrdered (Auftragsdatum, default).', Value='N',Updated=TO_TIMESTAMP('2026-06-17 14:26:39.261000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_SysConfig_ID=541822
+;

--- a/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderLineBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderLineBL.java
@@ -135,6 +135,7 @@ public class OrderLineBL implements IOrderLineBL
 {
 	@NonNull private static final AdMessageKey MSG_COUNTER_DOC_MISSING_MAPPED_PRODUCT = AdMessageKey.of("de.metas.order.CounterDocMissingMappedProduct");
 	@NonNull private static final String SYSCONFIG_SetBOMDescription = "de.metas.order.sales.line.SetBOMDescription";
+	@NonNull static final String SYSCONFIG_PO_PRICE_DATE_USE_DATE_PROMISED = "de.metas.order.PurchaseOrder.UseDatePromisedForPricing";
 
 	@NonNull private static final Logger logger = LogManager.getLogger(OrderLineBL.class);
 
@@ -150,7 +151,7 @@ public class OrderLineBL implements IOrderLineBL
 	@NonNull private final IPriceListDAO priceListDAO = Services.get(IPriceListDAO.class);
 	@NonNull private final IOrgDAO orgDAO = Services.get(IOrgDAO.class);
 	@NonNull private final IProductBOMBL productBOMBL = Services.get(IProductBOMBL.class);
-	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+	@NonNull private static final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	@NonNull private final ILocationDAO locationDAO = Services.get(ILocationDAO.class);
 	@NonNull private final ICurrencyDAO currencyDAO = Services.get(ICurrencyDAO.class);
 	@NonNull private final ITaxDAO taxDAO = Services.get(ITaxDAO.class);
@@ -569,9 +570,19 @@ public class OrderLineBL implements IOrderLineBL
 		final IOrgDAO orgDAO = Services.get(IOrgDAO.class); // as long as this is a static method, we can't use the orgDAO field. 
 		final ZoneId timeZone = orgDAO.getTimeZone(OrgId.ofRepoId(order.getAD_Org_ID()));
 
-		return order.isSOTrx()
+		if (order.isSOTrx())
+		{
+			return getPriceDateFromDatePromised(orderLine, order, timeZone);
+		}
+
+		return isUseDatePromised()
 				? getPriceDateFromDatePromised(orderLine, order, timeZone)
 				: asZonedDateTimeNonNull(orderLine.getDateOrdered(), timeZone);
+	}
+
+	private static boolean isUseDatePromised()
+	{
+		return sysConfigBL.getBooleanValue(SYSCONFIG_PO_PRICE_DATE_USE_DATE_PROMISED, false);
 	}
 
 	@NonNull

--- a/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderLineBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/impl/OrderLineBL.java
@@ -86,6 +86,7 @@ import de.metas.uom.UomId;
 import de.metas.util.Check;
 import de.metas.util.GuavaCollectors;
 import de.metas.util.Services;
+import com.google.common.annotations.VisibleForTesting;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
@@ -135,6 +136,7 @@ public class OrderLineBL implements IOrderLineBL
 {
 	@NonNull private static final AdMessageKey MSG_COUNTER_DOC_MISSING_MAPPED_PRODUCT = AdMessageKey.of("de.metas.order.CounterDocMissingMappedProduct");
 	@NonNull private static final String SYSCONFIG_SetBOMDescription = "de.metas.order.sales.line.SetBOMDescription";
+	@VisibleForTesting
 	@NonNull static final String SYSCONFIG_PO_PRICE_DATE_USE_DATE_PROMISED = "de.metas.order.PurchaseOrder.UseDatePromisedForPricing";
 
 	@NonNull private static final Logger logger = LogManager.getLogger(OrderLineBL.class);
@@ -151,7 +153,7 @@ public class OrderLineBL implements IOrderLineBL
 	@NonNull private final IPriceListDAO priceListDAO = Services.get(IPriceListDAO.class);
 	@NonNull private final IOrgDAO orgDAO = Services.get(IOrgDAO.class);
 	@NonNull private final IProductBOMBL productBOMBL = Services.get(IProductBOMBL.class);
-	@NonNull private static final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	@NonNull private final ILocationDAO locationDAO = Services.get(ILocationDAO.class);
 	@NonNull private final ICurrencyDAO currencyDAO = Services.get(ICurrencyDAO.class);
 	@NonNull private final ITaxDAO taxDAO = Services.get(ITaxDAO.class);
@@ -567,7 +569,7 @@ public class OrderLineBL implements IOrderLineBL
 			final org.compiere.model.I_C_OrderLine orderLine,
 			final I_C_Order order)
 	{
-		final IOrgDAO orgDAO = Services.get(IOrgDAO.class); // as long as this is a static method, we can't use the orgDAO field. 
+		final IOrgDAO orgDAO = Services.get(IOrgDAO.class); // static method — cannot use instance fields; use Services.get() directly
 		final ZoneId timeZone = orgDAO.getTimeZone(OrgId.ofRepoId(order.getAD_Org_ID()));
 
 		if (order.isSOTrx())
@@ -575,14 +577,15 @@ public class OrderLineBL implements IOrderLineBL
 			return getPriceDateFromDatePromised(orderLine, order, timeZone);
 		}
 
-		return isUseDatePromised()
+		return isUseDatePromised(order)
 				? getPriceDateFromDatePromised(orderLine, order, timeZone)
 				: asZonedDateTimeNonNull(orderLine.getDateOrdered(), timeZone);
 	}
 
-	private static boolean isUseDatePromised()
+	private static boolean isUseDatePromised(final I_C_Order order)
 	{
-		return sysConfigBL.getBooleanValue(SYSCONFIG_PO_PRICE_DATE_USE_DATE_PROMISED, false);
+		return Services.get(ISysConfigBL.class)
+				.getBooleanValue(SYSCONFIG_PO_PRICE_DATE_USE_DATE_PROMISED, false, order.getAD_Client_ID(), order.getAD_Org_ID());
 	}
 
 	@NonNull

--- a/backend/de.metas.business/src/test/java/de/metas/order/impl/OrderLineBLGetPriceDateTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/impl/OrderLineBLGetPriceDateTest.java
@@ -74,6 +74,32 @@ class OrderLineBLGetPriceDateTest
 				.isEqualTo(dateOrdered);
 	}
 
+	@Test
+	void salesOrder_alwaysUsesDatePromised_regardlessOfSysConfig()
+	{
+		final LocalDate dateOrdered = LocalDate.of(2024, 1, 1);
+		final LocalDate datePromised = LocalDate.of(2024, 3, 1);
+
+		// SysConfig deliberately NOT set — SO must use DatePromised unconditionally
+
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setIsSOTrx(true); // sales order
+		order.setDateOrdered(TimeUtil.asTimestamp(dateOrdered));
+		order.setDatePromised(TimeUtil.asTimestamp(datePromised));
+		InterfaceWrapperHelper.save(order);
+
+		final I_C_OrderLine orderLine = InterfaceWrapperHelper.newInstance(I_C_OrderLine.class);
+		orderLine.setDateOrdered(TimeUtil.asTimestamp(dateOrdered));
+		orderLine.setDatePromised(TimeUtil.asTimestamp(datePromised));
+		InterfaceWrapperHelper.save(orderLine);
+
+		final ZonedDateTime priceDate = OrderLineBL.getPriceDate(orderLine, order);
+
+		assertThat(priceDate.toLocalDate())
+				.as("sales order must always use DatePromised regardless of SysConfig")
+				.isEqualTo(datePromised);
+	}
+
 	private static void setSysConfig(final String name, final String value)
 	{
 		final I_AD_SysConfig sysConfig = InterfaceWrapperHelper.newInstance(I_AD_SysConfig.class);

--- a/backend/de.metas.business/src/test/java/de/metas/order/impl/OrderLineBLGetPriceDateTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/impl/OrderLineBLGetPriceDateTest.java
@@ -1,0 +1,84 @@
+package de.metas.order.impl;
+
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_AD_SysConfig;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_OrderLine;
+import org.compiere.util.TimeUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrderLineBLGetPriceDateTest
+{
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+	}
+
+	@Test
+	void purchaseOrder_usesDatePromised_whenSysConfigEnabled()
+	{
+		final LocalDate dateOrdered = LocalDate.of(2024, 1, 1);
+		final LocalDate datePromised = LocalDate.of(2024, 3, 1);
+
+		setSysConfig(OrderLineBL.SYSCONFIG_PO_PRICE_DATE_USE_DATE_PROMISED, "Y");
+
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setIsSOTrx(false); // purchase order
+		order.setDateOrdered(TimeUtil.asTimestamp(dateOrdered));
+		order.setDatePromised(TimeUtil.asTimestamp(datePromised));
+		InterfaceWrapperHelper.save(order);
+
+		final I_C_OrderLine orderLine = InterfaceWrapperHelper.newInstance(I_C_OrderLine.class);
+		orderLine.setDateOrdered(TimeUtil.asTimestamp(dateOrdered));
+		orderLine.setDatePromised(TimeUtil.asTimestamp(datePromised));
+		InterfaceWrapperHelper.save(orderLine);
+
+		final ZonedDateTime priceDate = OrderLineBL.getPriceDate(orderLine, order);
+
+		assertThat(priceDate.toLocalDate())
+				.as("purchase order with SysConfig=Y must use DatePromised for price list version selection")
+				.isEqualTo(datePromised);
+	}
+
+	@Test
+	void purchaseOrder_usesDateOrdered_whenSysConfigDisabled()
+	{
+		final LocalDate dateOrdered = LocalDate.of(2024, 1, 1);
+		final LocalDate datePromised = LocalDate.of(2024, 3, 1);
+
+		// SysConfig not set → default false → DateOrdered
+
+		final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+		order.setIsSOTrx(false); // purchase order
+		order.setDateOrdered(TimeUtil.asTimestamp(dateOrdered));
+		order.setDatePromised(TimeUtil.asTimestamp(datePromised));
+		InterfaceWrapperHelper.save(order);
+
+		final I_C_OrderLine orderLine = InterfaceWrapperHelper.newInstance(I_C_OrderLine.class);
+		orderLine.setDateOrdered(TimeUtil.asTimestamp(dateOrdered));
+		orderLine.setDatePromised(TimeUtil.asTimestamp(datePromised));
+		InterfaceWrapperHelper.save(orderLine);
+
+		final ZonedDateTime priceDate = OrderLineBL.getPriceDate(orderLine, order);
+
+		assertThat(priceDate.toLocalDate())
+				.as("purchase order without SysConfig must use DateOrdered (default behavior)")
+				.isEqualTo(dateOrdered);
+	}
+
+	private static void setSysConfig(final String name, final String value)
+	{
+		final I_AD_SysConfig sysConfig = InterfaceWrapperHelper.newInstance(I_AD_SysConfig.class);
+		sysConfig.setName(name);
+		sysConfig.setValue(value);
+		InterfaceWrapperHelper.save(sysConfig);
+	}
+}


### PR DESCRIPTION
Add a SysConfig to control whether DatePromised is used to select the price list version for purchase orders and update pricing logic and tests accordingly.