### PR TITLE
mobile-webui: device Back follows screen-declared back, not the browser stack

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/hooks/useDeviceBackButton.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/hooks/useDeviceBackButton.test.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { useDeviceBackButton } from '../../hooks/useDeviceBackButton';
+import { useMobileNavigation } from '../../hooks/useMobileNavigation';
+import { useBackLocationFromHeaders } from '../../reducers/headers';
+
+jest.mock('../../hooks/useMobileNavigation', () => ({
+  useMobileNavigation: jest.fn(),
+}));
+jest.mock('../../reducers/headers', () => ({
+  useBackLocationFromHeaders: jest.fn(),
+}));
+
+const goTo = jest.fn();
+
+function renderTrap() {
+  function TestComponent() {
+    useDeviceBackButton();
+    return null;
+  }
+  return render(
+    <MemoryRouter>
+      <TestComponent />
+    </MemoryRouter>
+  );
+}
+
+function firePopState() {
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
+describe('useDeviceBackButton', () => {
+  let pushStateSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useMobileNavigation.mockReturnValue({ goTo });
+    pushStateSpy = jest.spyOn(window.history, 'pushState');
+  });
+
+  afterEach(() => {
+    pushStateSpy.mockRestore();
+  });
+
+  it('primes a sentinel history entry on mount (so Back has something to absorb)', () => {
+    useBackLocationFromHeaders.mockReturnValue('/some/back');
+    renderTrap();
+    expect(pushStateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('on device Back, re-primes the sentinel and navigates to the screen-declared back location', () => {
+    useBackLocationFromHeaders.mockReturnValue('/some/back');
+    renderTrap();
+    pushStateSpy.mockClear();
+
+    firePopState();
+
+    // sentinel re-primed (stack/URL stays put) ...
+    expect(pushStateSpy).toHaveBeenCalledTimes(1);
+    // ... and we navigate to the declared back, NOT the browser stack
+    expect(goTo).toHaveBeenCalledTimes(1);
+    expect(goTo).toHaveBeenCalledWith('/some/back');
+  });
+
+  it('on device Back at the top of the stack (no declared back), re-primes only — a deliberate no-op', () => {
+    useBackLocationFromHeaders.mockReturnValue(null);
+    renderTrap();
+    pushStateSpy.mockClear();
+
+    firePopState();
+
+    expect(pushStateSpy).toHaveBeenCalledTimes(1);
+    expect(goTo).not.toHaveBeenCalled();
+  });
+
+  it('never falls back to history.go(-1) (the browser-stack back it is neutralizing)', () => {
+    const goSpy = jest.spyOn(window.history, 'go');
+    useBackLocationFromHeaders.mockReturnValue(null);
+    renderTrap();
+
+    firePopState();
+
+    expect(goSpy).not.toHaveBeenCalled();
+    goSpy.mockRestore();
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/applicationRoot/ApplicationRoot.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/applicationRoot/ApplicationRoot.jsx
@@ -22,6 +22,7 @@ import { toastError } from '../../utils/toast';
 import { getIsLoggedInFromState } from '../../reducers/appHandler';
 import { putSettingsAction } from '../../reducers/settings';
 import { useUIEventsTracing } from '../../utils/ui_trace/useUIEventsTracing';
+import { useDeviceBackButton } from '../../hooks/useDeviceBackButton';
 
 const ApplicationRoot = () => {
   const auth = useAuth();
@@ -70,6 +71,7 @@ const ApplicationRoot = () => {
   return (
     <>
       <ConnectedRouter history={history} basename="./">
+        <DeviceBackButtonTrap />
         <Switch>
           <Route exact path="/login">
             <LoginScreen />
@@ -89,6 +91,13 @@ const ApplicationRoot = () => {
       {REGISTER_SERVICE_WORKER && <VersionChecker updateIntervalMillis={VERSION_CHECK_INTERVAL_MILLIS} />}
     </>
   );
+};
+
+// Renderless: mounted once inside ConnectedRouter so the device/browser Back button follows the
+// app's screen-declared back navigation instead of the browser history stack. See useDeviceBackButton.
+const DeviceBackButtonTrap = () => {
+  useDeviceBackButton();
+  return null;
 };
 
 export default ApplicationRoot;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useDeviceBackButton.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useDeviceBackButton.js
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useMobileNavigation } from './useMobileNavigation';
+import { useBackLocationFromHeaders } from '../reducers/headers';
+
+/**
+ * Makes the device / browser Back button follow the app's own screen-declared back navigation
+ * instead of the browser history stack.
+ *
+ * Why this is needed: the mobile app navigates with history.replace (see useMobileNavigation.goTo)
+ * and every screen declares its own back target via headers (backLocation), independent of how the
+ * operator actually arrived. The browser history stack therefore holds *arrival order*, not the
+ * app's logical back graph — so the hardware Back button pops the wrong entry and breaks the flow.
+ *
+ * Mechanism: a popstate event cannot be cancelled (the navigation already happened by the time it
+ * fires), so we keep a throwaway "sentinel" entry on top of the browser history. When Back is
+ * pressed the sentinel is popped; we immediately re-push it (so the URL / stack never actually
+ * moves) and instead navigate to the screen-declared backLocation. When a screen declares no back
+ * (home / launchers) we re-push only — a deliberate no-op so the operator can't accidentally leave
+ * the PWA mid-job.
+ *
+ * Note: this intentionally does NOT fall through to history.go(-1) the way useMobileNavigation.goBack
+ * does when no backLocation is set — that go(-1) is the browser-stack back we are neutralizing here.
+ */
+export const useDeviceBackButton = () => {
+  const { goTo } = useMobileNavigation();
+  const backLocation = useBackLocationFromHeaders();
+  const location = useLocation();
+
+  // The popstate listener is installed once; keep the latest navigation context in a ref so it
+  // always acts on the current screen's declared back target.
+  const onBackRef = useRef();
+  onBackRef.current = () => {
+    if (backLocation) {
+      goTo(backLocation);
+    }
+    // else: no declared back (top of stack) → stay put (the re-primed sentinel keeps us here).
+  };
+
+  // Re-prime the sentinel after every navigation: goTo() uses history.replace, which overwrites the
+  // previous sentinel, so each screen must lay down a fresh one for the next Back to absorb.
+  useEffect(() => {
+    primeSentinel();
+  }, [location.key]);
+
+  useEffect(() => {
+    const onPopState = () => {
+      primeSentinel();
+      onBackRef.current();
+    };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
+};
+
+// Push a throwaway history entry at the current URL. pushState never fires popstate and is invisible
+// to the router (which only syncs on popstate), so this does not trigger an app navigation.
+const primeSentinel = () => {
+  window.history.pushState(null, '', window.location.href);
+};


### PR DESCRIPTION
## Problem

The mobile app navigates with `history.replace` (`useMobileNavigation.goTo`, `useMobileNavigation.js:28`) and every screen declares its own back target via headers (`backLocation`, resolved in `reducers/headers.js:104`), **independent of how the operator arrived**. The browser history stack therefore holds *arrival order*, not the app's logical back graph — so the device / browser **Back** button pops the wrong entry and breaks the flow.

## Change

New hook `useDeviceBackButton` (mounted once inside `ConnectedRouter` as a renderless `DeviceBackButtonTrap`):

- Keeps a throwaway **sentinel** history entry. A `popstate` (Back press) cannot be cancelled, so on Back we re-push the sentinel — the URL / stack never actually moves — and instead navigate to the screen-declared `backLocation`, i.e. the exact target the on-screen footer **Back** button uses.
- **Top of the stack** (no declared back, e.g. launchers/home) → re-prime only = deliberate **no-op**, so a warehouse operator can't accidentally leave the PWA mid-job.
- Re-primes the sentinel on every navigation, because `goTo()` uses `history.replace` which overwrites the previous sentinel.

Mounted once (not per-screen): routes render as sibling `<Route exact>` without a `<Switch>` and can double-mount (see module `CLAUDE.md`), so a single stable mount point is required.

### One deliberate design decision (please confirm)

`useMobileNavigation.goBack()` falls back to `history.go(-1)` (browser-stack back) when a screen has **no** declared `backLocation` (`useMobileNavigation.js:33-34`). This hook intentionally does **NOT** reuse that fallback — `go(-1)` is exactly the browser-stack behavior being neutralized. Net effect: on a no-`backLocation` screen, device Back becomes a no-op (instead of escaping via the stack). The footer Back button's own behavior is unchanged (out of scope here).

## UX (handheld operator baseline)

Makes the hardware Back button behave identically to the on-screen footer Back — predictable, and it can't drop the operator out of the app. This satisfies the module's "Cancel/back always available" baseline better than a frozen/dead button.

## Tests

- `src/__tests__/hooks/useDeviceBackButton.test.js` — TDD (RED first): sentinel primed on mount; Back → re-prime + `goTo(backLocation)`; Back at top → re-prime only, no nav; never `history.go(-1)`.
- Local: `yarn lint` clean; the new suite green (4/4). Full Jest suite has 13 pre-existing failures on the untouched base (picking / manufacturing / qrCode suites) — unrelated to this change (verified by re-running them with this change stashed).

### ⚠️ Runtime acceptance still owed

This unit-tests the hook's contract in jsdom. The real interaction with `ConnectedRouter` + the `history` library (popstate listener ordering, no flicker) should be confirmed with a **Playwright E2E** that drives a flow, presses browser Back, and asserts it lands on the screen-declared back screen — not yet added.

## Process note

This skipped the usual me03 grooming → brainstorming flow (no issue exists). Opened as **draft** for review of the approach + the design decision above.
