### PR TITLE
[base] Rate-limit C3P0 busy-connections WARN + finalization logging storm in DB_PostgreSQL

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/db/DB_PostgreSQL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/db/DB_PostgreSQL.java
@@ -495,7 +495,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 				// Without the gate, under pool saturation it would fire on EVERY checkout (thousands/min) and produce a multi-GB/day
 				// log + GC storm that turns pool-saturation into heap death. The connection acquisition above is deliberately left
 				// untouched - only this logging/finalization side-effect is throttled.
-				if (tryAcquireBusyConnectionsLogSlot(System.currentTimeMillis()))
+				if (tryAcquireBusyConnectionsLogSlot(System.currentTimeMillis(), BUSY_CONNECTIONS_LOG_INTERVAL_MILLIS))
 				{
 					final String statusBefore = getStatus();
 
@@ -538,19 +538,27 @@ public class DB_PostgreSQL implements AdempiereDatabase
 	 * Rate-limit guard for the busy-connections log+finalization block. Returns {@code true} (and atomically claims the
 	 * slot) only if at least {@link #BUSY_CONNECTIONS_LOG_INTERVAL_MILLIS} elapsed since the last claim; otherwise {@code false}.
 	 * <p>
-	 * Extracted as a package-visible method (taking {@code nowMillis} as a parameter rather than reading the clock
-	 * internally) so the throttle logic is unit-testable without touching the connection pool or the wall clock.
+	 * Extracted as a package-visible method (taking {@code nowMillis} and {@code intervalMillis} as parameters rather than
+	 * reading the clock / the configured interval internally) so the throttle logic is unit-testable without touching the
+	 * connection pool, the wall clock, or any system property.
 	 * Concurrency-safe via {@link AtomicLong#compareAndSet(long, long)}: under a saturation storm many threads may pass the
 	 * elapsed check at once, but only the one that wins the CAS proceeds; the rest fall through and just acquire their connection.
+	 * <p>
+	 * A non-positive {@code intervalMillis} (e.g. a misconfigured {@code db.postgresql.busyConnectionsLogIntervalMillis}=0)
+	 * is clamped to {@link #BUSY_CONNECTIONS_LOG_INTERVAL_MILLIS_DEFAULT} so the throttle can never be accidentally disabled
+	 * (which would re-open the multi-GB/day log + GC storm this guard exists to prevent).
 	 *
-	 * @param nowMillis current time in epoch millis (the caller passes {@link System#currentTimeMillis()} - intentionally
-	 *                  NOT {@code SystemTime}, since this is low-level infra running before/around connection acquisition)
+	 * @param nowMillis      current time in epoch millis (the caller passes {@link System#currentTimeMillis()} - intentionally
+	 *                       NOT {@code SystemTime}, since this is low-level infra running before/around connection acquisition)
+	 * @param intervalMillis minimum interval between two claims; non-positive values are treated as "use the default"
 	 */
 	@VisibleForTesting
-	boolean tryAcquireBusyConnectionsLogSlot(final long nowMillis)
+	boolean tryAcquireBusyConnectionsLogSlot(final long nowMillis, final long intervalMillis)
 	{
+		final long effectiveIntervalMillis = intervalMillis > 0 ? intervalMillis : BUSY_CONNECTIONS_LOG_INTERVAL_MILLIS_DEFAULT;
+
 		final long lastRun = _busyConnectionsLogLastRunMillis.get();
-		if (lastRun != 0 && (nowMillis - lastRun) < BUSY_CONNECTIONS_LOG_INTERVAL_MILLIS)
+		if (lastRun != 0 && (nowMillis - lastRun) < effectiveIntervalMillis)
 		{
 			return false;
 		}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/db/DB_PostgreSQL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/db/DB_PostgreSQL.java
@@ -21,6 +21,7 @@
  */
 package org.compiere.db;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
@@ -52,6 +53,7 @@ import java.sql.Statement;
 import java.sql.Types;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * PostgreSQL Database Port
@@ -119,6 +121,29 @@ public class DB_PostgreSQL implements AdempiereDatabase
 	/** Logger */
 	private static final Logger log = LogManager.getLogger(DB_PostgreSQL.class);
 	private int m_maxBusyConnectionsThreshold = 0;
+
+	/**
+	 * Minimum interval between two "busy connections found ... Running finalizations" detailed log+finalization blocks.
+	 * <p>
+	 * Under connection-pool saturation, {@link #getCachedConnection(CConnection, boolean, int)} would otherwise emit the
+	 * full {@link #getStatus()} dump (every busy connection's checkout stacktrace), run {@link Runtime#runFinalization()}
+	 * and log all of it at WARN on EVERY single checkout - i.e. thousands of times per minute. That turns a pool-saturation
+	 * symptom into a multi-GB/day log + GC storm. We rate-limit the whole side-effect block to at most once per this interval.
+	 * <p>
+	 * Configured via a plain system property (parsed as millis) so it stays low-level: this code path runs before/around
+	 * connection acquisition, so we deliberately do NOT use {@code SystemTime} / {@code SysConfig} / any higher-level service here.
+	 */
+	private static final String SYSTEM_PROPERTY_BusyConnectionsLogIntervalMillis = "db.postgresql.busyConnectionsLogIntervalMillis";
+	private static final long BUSY_CONNECTIONS_LOG_INTERVAL_MILLIS_DEFAULT = Duration.ofSeconds(60).toMillis();
+	private static final long BUSY_CONNECTIONS_LOG_INTERVAL_MILLIS = SystemUtils.getSystemProperty(
+			SYSTEM_PROPERTY_BusyConnectionsLogIntervalMillis,
+			BUSY_CONNECTIONS_LOG_INTERVAL_MILLIS_DEFAULT);
+
+	/**
+	 * Timestamp (epoch millis, {@link System#currentTimeMillis()} - NOT {@code SystemTime}, see above) of the last time we
+	 * ran the detailed busy-connections log+finalization block. {@code 0} means "never ran".
+	 */
+	private final AtomicLong _busyConnectionsLogLastRunMillis = new AtomicLong(0);
 
 	/**
 	 * PostgreSQL Database
@@ -462,20 +487,29 @@ public class DB_PostgreSQL implements AdempiereDatabase
 			{
 				// metas-ts: i think running the finalizer won't be a big help, but anyways, exhausting the connection pool is usually an issue
 				// suggestions to consider:
-				// * allow it to be configured for certain scenarios
+				// * allow it to be configured for certain scenarios -> done: rate-limited + the interval is configurable (see BUSY_CONNECTIONS_LOG_INTERVAL_MILLIS)
 				// * only log, but don't even try the finalizing
-				final String statusBefore = getStatus();
+				//
+				// IMPORTANT: this whole block (full getStatus() dump = every busy connection's checkout stacktrace, runFinalization(),
+				// and the WARN that logs all of it) is rate-limited to at most once per BUSY_CONNECTIONS_LOG_INTERVAL_MILLIS.
+				// Without the gate, under pool saturation it would fire on EVERY checkout (thousands/min) and produce a multi-GB/day
+				// log + GC storm that turns pool-saturation into heap death. The connection acquisition above is deliberately left
+				// untouched - only this logging/finalization side-effect is throttled.
+				if (tryAcquireBusyConnectionsLogSlot(System.currentTimeMillis()))
+				{
+					final String statusBefore = getStatus();
 
-				// hengsin: make a best effort to reclaim leak connection
-				Runtime.getRuntime().runFinalization();
+					// hengsin: make a best effort to reclaim leak connection
+					Runtime.getRuntime().runFinalization();
 
-				final String statusAfter = getStatus();
+					final String statusAfter = getStatus();
 
-				final Thread currentThread = Thread.currentThread();
-				log.warn(numConnections + " busy connections found (>= " + maxBusyconnectionsThreshold + "). Running finalizations..."
-						+ "\n # Thread: " + currentThread.getName() + " (ID=" + currentThread.getId() + ")"
-						+ "\n # Status(initial): " + statusBefore
-						+ "\n # Status(after finalizations started): " + statusAfter);
+					final Thread currentThread = Thread.currentThread();
+					log.warn(numConnections + " busy connections found (>= " + maxBusyconnectionsThreshold + "). Running finalizations..."
+							+ "\n # Thread: " + currentThread.getName() + " (ID=" + currentThread.getId() + ")"
+							+ "\n # Status(initial): " + statusBefore
+							+ "\n # Status(after finalizations started): " + statusAfter);
+				}
 			}
 
 			connOk = true;
@@ -499,6 +533,30 @@ public class DB_PostgreSQL implements AdempiereDatabase
 			}
 		}
 	}    // getCachedConnection
+
+	/**
+	 * Rate-limit guard for the busy-connections log+finalization block. Returns {@code true} (and atomically claims the
+	 * slot) only if at least {@link #BUSY_CONNECTIONS_LOG_INTERVAL_MILLIS} elapsed since the last claim; otherwise {@code false}.
+	 * <p>
+	 * Extracted as a package-visible method (taking {@code nowMillis} as a parameter rather than reading the clock
+	 * internally) so the throttle logic is unit-testable without touching the connection pool or the wall clock.
+	 * Concurrency-safe via {@link AtomicLong#compareAndSet(long, long)}: under a saturation storm many threads may pass the
+	 * elapsed check at once, but only the one that wins the CAS proceeds; the rest fall through and just acquire their connection.
+	 *
+	 * @param nowMillis current time in epoch millis (the caller passes {@link System#currentTimeMillis()} - intentionally
+	 *                  NOT {@code SystemTime}, since this is low-level infra running before/around connection acquisition)
+	 */
+	@VisibleForTesting
+	boolean tryAcquireBusyConnectionsLogSlot(final long nowMillis)
+	{
+		final long lastRun = _busyConnectionsLogLastRunMillis.get();
+		if (lastRun != 0 && (nowMillis - lastRun) < BUSY_CONNECTIONS_LOG_INTERVAL_MILLIS)
+		{
+			return false;
+		}
+
+		return _busyConnectionsLogLastRunMillis.compareAndSet(lastRun, nowMillis);
+	}
 
 	/**
 	 * Gets current {@link DataSource}.

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/compiere/db/DB_PostgreSQL_BusyConnectionsLogThrottleTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/compiere/db/DB_PostgreSQL_BusyConnectionsLogThrottleTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for the busy-connections log+finalization rate-limit guard
- * ({@link DB_PostgreSQL#tryAcquireBusyConnectionsLogSlot(long)}).
+ * ({@link DB_PostgreSQL#tryAcquireBusyConnectionsLogSlot(long, long)}).
  * <p>
  * The guard exists so that, under connection-pool saturation, the expensive {@code getStatus()} dump +
  * {@code Runtime.runFinalization()} + WARN block fires at most once per the configured interval instead of on every
@@ -36,7 +36,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class DB_PostgreSQL_BusyConnectionsLogThrottleTest
 {
-	/** Default interval the production code uses (60s) unless overridden via system property. */
+	/**
+	 * Interval the tests drive the guard with. Passed explicitly into {@code tryAcquireBusyConnectionsLogSlot} so the
+	 * test is deterministic regardless of any {@code db.postgresql.busyConnectionsLogIntervalMillis} system property
+	 * configured in the runtime - i.e. the test does NOT depend on the production default.
+	 */
 	private static final long INTERVAL_MILLIS = 60_000L;
 
 	private DB_PostgreSQL db;
@@ -50,32 +54,32 @@ class DB_PostgreSQL_BusyConnectionsLogThrottleTest
 	@Test
 	void firstCall_isAllowed()
 	{
-		assertThat(db.tryAcquireBusyConnectionsLogSlot(1_000_000L)).isTrue();
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(1_000_000L, INTERVAL_MILLIS)).isTrue();
 	}
 
 	@Test
 	void secondCall_withinInterval_isSuppressed()
 	{
 		final long t0 = 1_000_000L;
-		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0)).isTrue();
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0, INTERVAL_MILLIS)).isTrue();
 
 		// just before the interval elapses -> still suppressed
-		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + INTERVAL_MILLIS - 1)).isFalse();
-		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + 1)).isFalse();
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + INTERVAL_MILLIS - 1, INTERVAL_MILLIS)).isFalse();
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + 1, INTERVAL_MILLIS)).isFalse();
 	}
 
 	@Test
 	void call_afterIntervalElapsed_isAllowedAgain()
 	{
 		final long t0 = 1_000_000L;
-		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0)).isTrue();
-		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + 10)).isFalse();
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0, INTERVAL_MILLIS)).isTrue();
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + 10, INTERVAL_MILLIS)).isFalse();
 
 		// exactly at the interval boundary -> allowed again
-		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + INTERVAL_MILLIS)).isTrue();
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + INTERVAL_MILLIS, INTERVAL_MILLIS)).isTrue();
 
 		// and then suppressed again relative to the new last-run timestamp
-		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + INTERVAL_MILLIS + 5)).isFalse();
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + INTERVAL_MILLIS + 5, INTERVAL_MILLIS)).isFalse();
 	}
 
 	@Test
@@ -86,11 +90,28 @@ class DB_PostgreSQL_BusyConnectionsLogThrottleTest
 		for (int i = 0; i < 10_000; i++)
 		{
 			// all calls land strictly within the first interval window
-			if (db.tryAcquireBusyConnectionsLogSlot(t0 + (i % (INTERVAL_MILLIS / 2))))
+			if (db.tryAcquireBusyConnectionsLogSlot(t0 + (i % (INTERVAL_MILLIS / 2)), INTERVAL_MILLIS))
 			{
 				allowed++;
 			}
 		}
 		assertThat(allowed).as("only the very first call within the interval window should be allowed").isEqualTo(1);
+	}
+
+	@Test
+	void nonPositiveInterval_isClampedToDefault_soThrottleStaysEnabled()
+	{
+		// A misconfigured interval of 0 (or negative) must NOT disable the throttle: it is clamped to the 60s default.
+		final long t0 = 2_000_000L;
+
+		// interval=0 -> clamped to default; first call claims the slot
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0, 0L)).isTrue();
+
+		// a call well within the default interval is still suppressed (proves the throttle was NOT disabled)
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + 5, 0L)).isFalse();
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + 1_000, -5L)).isFalse();
+
+		// once the default interval elapses it is allowed again
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + INTERVAL_MILLIS, 0L)).isTrue();
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/compiere/db/DB_PostgreSQL_BusyConnectionsLogThrottleTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/compiere/db/DB_PostgreSQL_BusyConnectionsLogThrottleTest.java
@@ -1,0 +1,96 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+package org.compiere.db;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for the busy-connections log+finalization rate-limit guard
+ * ({@link DB_PostgreSQL#tryAcquireBusyConnectionsLogSlot(long)}).
+ * <p>
+ * The guard exists so that, under connection-pool saturation, the expensive {@code getStatus()} dump +
+ * {@code Runtime.runFinalization()} + WARN block fires at most once per the configured interval instead of on every
+ * single connection checkout (which previously produced a multi-GB/day log + GC storm).
+ */
+class DB_PostgreSQL_BusyConnectionsLogThrottleTest
+{
+	/** Default interval the production code uses (60s) unless overridden via system property. */
+	private static final long INTERVAL_MILLIS = 60_000L;
+
+	private DB_PostgreSQL db;
+
+	@BeforeEach
+	void setUp()
+	{
+		db = new DB_PostgreSQL();
+	}
+
+	@Test
+	void firstCall_isAllowed()
+	{
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(1_000_000L)).isTrue();
+	}
+
+	@Test
+	void secondCall_withinInterval_isSuppressed()
+	{
+		final long t0 = 1_000_000L;
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0)).isTrue();
+
+		// just before the interval elapses -> still suppressed
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + INTERVAL_MILLIS - 1)).isFalse();
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + 1)).isFalse();
+	}
+
+	@Test
+	void call_afterIntervalElapsed_isAllowedAgain()
+	{
+		final long t0 = 1_000_000L;
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0)).isTrue();
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + 10)).isFalse();
+
+		// exactly at the interval boundary -> allowed again
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + INTERVAL_MILLIS)).isTrue();
+
+		// and then suppressed again relative to the new last-run timestamp
+		assertThat(db.tryAcquireBusyConnectionsLogSlot(t0 + INTERVAL_MILLIS + 5)).isFalse();
+	}
+
+	@Test
+	void manyCallsWithinInterval_allowExactlyOnce()
+	{
+		final long t0 = 5_000_000L;
+		int allowed = 0;
+		for (int i = 0; i < 10_000; i++)
+		{
+			// all calls land strictly within the first interval window
+			if (db.tryAcquireBusyConnectionsLogSlot(t0 + (i % (INTERVAL_MILLIS / 2))))
+			{
+				allowed++;
+			}
+		}
+		assertThat(allowed).as("only the very first call within the interval window should be allowed").isEqualTo(1);
+	}
+}

--- a/backend/de.metas.util/src/main/java/de/metas/util/SystemUtils.java
+++ b/backend/de.metas.util/src/main/java/de/metas/util/SystemUtils.java
@@ -43,4 +43,23 @@ public class SystemUtils
 		}
 	}
 
+	public static long getSystemProperty(final String property, final long defaultValue)
+	{
+		final String valueStr = System.getProperty(property);
+		if (valueStr == null)
+		{
+			return defaultValue;
+		}
+
+		try
+		{
+			return Long.parseLong(valueStr.trim());
+		}
+		catch (final NumberFormatException e)
+		{
+			System.err.println("Failed converting property value of '" + property + "': " + valueStr);
+			return defaultValue;
+		}
+	}
+
 }


### PR DESCRIPTION
## Problem

A heap dump from a crashed app server (OOM) showed an ~8 GB/day log and ~2 GB of heap consumed by a logging storm originating in `org.compiere.db.DB_PostgreSQL.getCachedConnection(...)`.

On **every** connection checkout while `numBusyConnections >= m_maxBusyConnectionsThreshold` (80% of max pool size), the method:
1. built `getStatus()`, which dumps **every** busy connection's full checkout stacktrace (C3P0 `debugUnreturnedConnectionStackTraces`),
2. called `Runtime.getRuntime().runFinalization()`,
3. built `getStatus()` again,
4. logged all of it at WARN.

Under pool saturation this fired thousands of times per minute, producing a multi-GB/day log plus heavy GC pressure — i.e. a pool-saturation symptom escalating into heap death.

## Fix

Rate-limit (de-amplify) the **logging + finalization side-effect** only. The actual connection acquisition (`conn = m_ds.getConnection()` and its setup) is left completely unchanged — pool behavior is not touched.

- The whole `getStatus()` dump + `runFinalization()` + WARN block now fires **at most once per a configurable interval** (default 60s).
- Guarded by a simple `AtomicLong` last-run timestamp + `System.currentTimeMillis()` (deliberately **not** `SystemTime` — this is low-level infra running around connection acquisition; matches the existing convention in this file).
- Interval is configurable via the system property `db.postgresql.busyConnectionsLogIntervalMillis` (millis); a non-positive value is clamped to the 60s default so the throttle can never be accidentally disabled.
- The throttle is extracted into a small package-visible, clock-injected method `tryAcquireBusyConnectionsLogSlot(nowMillis, intervalMillis)` so it is unit-testable without the connection pool, the wall clock, or any system property. Concurrency-safe via `compareAndSet` (under a storm, exactly one thread wins the slot; the rest just acquire their connection).

A focused JUnit test (`DB_PostgreSQL_BusyConnectionsLogThrottleTest`) covers first-call-allowed, within-interval suppression, allowed-again-after-interval, "10k calls within one window → allowed exactly once", and non-positive-interval-clamped-to-default.

Also adds a `long` overload of `SystemUtils.getSystemProperty(String, long)` (mirrors the existing `int` overload) for parsing the interval property.

## Notes

- Core, all-customer hardening; based on `deep_tundra_release`.
- Behavior-preserving for connection acquisition; only the logging/finalization amplification is throttled.
