### PR TITLE
ArchUnit: route WarehouseCommand locator persistence through WarehouseDAO

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/CreateOrUpdateLocatorRequest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/CreateOrUpdateLocatorRequest.java
@@ -49,5 +49,7 @@ public class CreateOrUpdateLocatorRequest
 	String y;
 	String z;
 	String x1;
+	@Nullable Integer priorityNo;
+	@Nullable Boolean isGroundLocator;
 	ZonedDateTime dateLastInventory;
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/impl/WarehouseDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/warehouse/api/impl/WarehouseDAO.java
@@ -674,6 +674,14 @@ public class WarehouseDAO implements IWarehouseDAO
 		locator.setY(request.getY());
 		locator.setZ(request.getZ());
 		locator.setX1(request.getX1());
+		if (request.getPriorityNo() != null)
+		{
+			locator.setPriorityNo(request.getPriorityNo());
+		}
+		if (request.getIsGroundLocator() != null)
+		{
+			locator.setIsGroundLocator(request.getIsGroundLocator());
+		}
 		locator.setDateLastInventory(TimeUtil.asTimestamp(request.getDateLastInventory()));
 		InterfaceWrapperHelper.saveRecord(locator);
 

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/warehouse/WarehouseCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/warehouse/WarehouseCommand.java
@@ -169,27 +169,13 @@ public class WarehouseCommand
 						.y(StringUtils.trimBlankToOptional(locatorRequest.getY()).orElse(identifierStr))
 						.z(StringUtils.trimBlankToOptional(locatorRequest.getZ()).orElse(identifierStr))
 						.x1(StringUtils.trimBlankToOptional(locatorRequest.getX1()).orElse(identifierStr))
+						.priorityNo(locatorRequest.getPriorityNo())
+						.isGroundLocator(locatorRequest.getIsGroundLocator())
 						.build()
 		);
 		context.putIdentifier(identifier, locatorId);
 
 		final I_M_Locator locatorRecord = warehouseBL.getLocatorById(locatorId);
-
-		boolean needsSave = false;
-		if (locatorRequest.getPriorityNo() != null)
-		{
-			locatorRecord.setPriorityNo(locatorRequest.getPriorityNo());
-			needsSave = true;
-		}
-		if (locatorRequest.getIsGroundLocator() != null)
-		{
-			locatorRecord.setIsGroundLocator(locatorRequest.getIsGroundLocator());
-			needsSave = true;
-		}
-		if (needsSave)
-		{
-			saveRecord(locatorRecord);
-		}
 
 		return toJson(locatorRecord);
 	}


### PR DESCRIPTION
## What

Fixes the ArchUnit failure on `new_dawn_uat` (e.g. CI run https://github.com/metasfresh/metasfresh/actions/runs/27728518313, job *test (java)* → `ModuleArchitectureTest`):

> `[de.metas.frontend-testing] InterfaceWrapperHelper.save/saveRecord/load must only be called from *Repository / *DAO classes` — `WarehouseCommand.createLocator` calls `saveRecord(...)`

`WarehouseCommand.createLocator` set `PriorityNo` / `IsGroundLocator` on the locator and called `InterfaceWrapperHelper.saveRecord(...)` directly — a persistence primitive in a masterdata `*Command`, which the rule forbids. This is a genuinely new violation (the frozen baseline covers the other three `WarehouseCommand` saves, not `createLocator`).

## How

- Add `priorityNo` + `isGroundLocator` to `CreateOrUpdateLocatorRequest`.
- Set both (when provided) in `WarehouseDAO.createOrUpdateLocator`, before its existing single `saveRecord`.
- `WarehouseCommand.createLocator` now passes both via the request and no longer saves the record itself.

Behaviour-preserving: the fields are still set only when present, before one save; net DB result is identical. The persistence primitive now lives in the DAO, where the rule requires it (matches `de.metas.frontend-testing/CLAUDE.md` § "Masterdata *Command conventions").

## Verification

`ModuleArchitectureTest` (`de.metas.architecture-tests`) run locally against the full backend closure on this branch's HEAD: `Tests run: 1, Failures: 0, Errors: 0` — BUILD SUCCESS.
