### PR TITLE
Mobile Manufacturing: finished-goods labelling uses M_HU_Label_Config instead of hardcoded global QR process

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -189,6 +189,17 @@ public class HUQRCodesService
 		print(createPDF(qrCodes), copies);
 	}
 
+	public void print(@NonNull final List<HUQRCode> qrCodes, @Nullable final AdProcessId qrCodeProcessId, @NonNull final PrintCopies copies)
+	{
+		final QRCodePDFResource pdf = globalQRCodeService.createPDF(
+				qrCodes.stream()
+						.map(HUQRCode::toPrintableQRCode)
+						.collect(ImmutableList.toImmutableList()),
+				null,
+				qrCodeProcessId);
+		print(pdf, copies);
+	}
+
 	public void print(@NonNull final QRCodePDFResource pdf)
 	{
 		print(pdf, PrintCopies.ONE);

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/ManufacturingMobileApplication.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/ManufacturingMobileApplication.java
@@ -2,9 +2,14 @@ package de.metas.manufacturing.workflows_api;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import de.metas.handlingunits.HuUnitType;
+import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.service.HUQRCodeGenerateRequest;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
+import de.metas.handlingunits.report.labels.HULabelConfigQuery;
+import de.metas.handlingunits.report.labels.HULabelConfigRepository;
+import de.metas.handlingunits.report.labels.HULabelSourceDocType;
 import de.metas.i18n.TranslatableStrings;
 import de.metas.manufacturing.config.MobileUIManufacturingConfig;
 import de.metas.manufacturing.config.MobileUIManufacturingConfigRepository;
@@ -15,12 +20,14 @@ import de.metas.manufacturing.workflows_api.rest_api.json.JsonFinishGoodsReceive
 import de.metas.manufacturing.workflows_api.rest_api.json.JsonManufacturingOrderEvent;
 import de.metas.mobile.application.MobileApplicationId;
 import de.metas.mobile.application.MobileApplicationInfo;
+import de.metas.process.AdProcessId;
 import de.metas.product.ResourceId;
 import de.metas.report.PrintCopies;
 import de.metas.resource.UserWorkstationService;
 import de.metas.rest_workflows.facets.WorkflowLaunchersFacetGroupList;
 import de.metas.rest_workflows.facets.WorkflowLaunchersFacetQuery;
 import de.metas.user.UserId;
+import de.metas.util.Services;
 import de.metas.workflow.rest_api.model.WFProcess;
 import de.metas.workflow.rest_api.model.WFProcessHeaderProperties;
 import de.metas.workflow.rest_api.model.WFProcessHeaderProperty;
@@ -55,18 +62,21 @@ public class ManufacturingMobileApplication implements WorkflowBasedMobileApplic
 	private final ManufacturingWorkflowLaunchersProvider wfLaunchersProvider;
 	private final HUQRCodesService huQRCodesService;
 	private final UserWorkstationService userWorkstationService;
+	private final HULabelConfigRepository huLabelConfigRepository;
 
 	public ManufacturingMobileApplication(
 			@NonNull final MobileUIManufacturingConfigRepository userProfileRepository,
 			@NonNull final ManufacturingRestService manufacturingRestService,
 			@NonNull final HUQRCodesService huQRCodesService,
-			@NonNull final UserWorkstationService userWorkstationService)
+			@NonNull final UserWorkstationService userWorkstationService,
+			@NonNull final HULabelConfigRepository huLabelConfigRepository)
 	{
 		this.userProfileRepository = userProfileRepository;
 		this.manufacturingRestService = manufacturingRestService;
 		this.wfLaunchersProvider = new ManufacturingWorkflowLaunchersProvider(manufacturingRestService);
 		this.huQRCodesService = huQRCodesService;
 		this.userWorkstationService = userWorkstationService;
+		this.huLabelConfigRepository = huLabelConfigRepository;
 	}
 
 	@Override
@@ -241,7 +251,18 @@ public class ManufacturingMobileApplication implements WorkflowBasedMobileApplic
 				? PrintCopies.ofInt(request.getNumberOfCopies()).minimumOne()
 				: PrintCopies.ONE;
 
-		huQRCodesService.print(qrCodes, copies);
+		final HuUnitType huUnitType = HuUnitType.ofCode(
+				Services.get(IHandlingUnitsBL.class).getHU_UnitType(request.getHuPackingInstructionsId()));
+		final HULabelConfigQuery labelConfigQuery = HULabelConfigQuery.builder()
+				.sourceDocType(HULabelSourceDocType.Manufacturing)
+				.huUnitType(huUnitType)
+				.bpartnerId(null)
+				.build();
+		final AdProcessId labelProcessId = huLabelConfigRepository.getFirstMatching(labelConfigQuery)
+				.map(config -> config.getPrintFormatProcessId())
+				.orElse(null);
+
+		huQRCodesService.print(qrCodes, labelProcessId, copies);
 
 		return JsonFinishGoodsReceiveQRCodesGenerateResponse.builder()
 				.qrCodes(qrCodes.stream()

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/ManufacturingMobileApplication.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/ManufacturingMobileApplication.java
@@ -7,6 +7,7 @@ import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.service.HUQRCodeGenerateRequest;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
+import de.metas.handlingunits.report.labels.HULabelConfig;
 import de.metas.handlingunits.report.labels.HULabelConfigQuery;
 import de.metas.handlingunits.report.labels.HULabelConfigRepository;
 import de.metas.handlingunits.report.labels.HULabelSourceDocType;
@@ -63,6 +64,7 @@ public class ManufacturingMobileApplication implements WorkflowBasedMobileApplic
 	private final HUQRCodesService huQRCodesService;
 	private final UserWorkstationService userWorkstationService;
 	private final HULabelConfigRepository huLabelConfigRepository;
+	@NonNull private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
 
 	public ManufacturingMobileApplication(
 			@NonNull final MobileUIManufacturingConfigRepository userProfileRepository,
@@ -252,14 +254,14 @@ public class ManufacturingMobileApplication implements WorkflowBasedMobileApplic
 				: PrintCopies.ONE;
 
 		final HuUnitType huUnitType = HuUnitType.ofCode(
-				Services.get(IHandlingUnitsBL.class).getHU_UnitType(request.getHuPackingInstructionsId()));
-		final HULabelConfigQuery labelConfigQuery = HULabelConfigQuery.builder()
-				.sourceDocType(HULabelSourceDocType.Manufacturing)
-				.huUnitType(huUnitType)
-				.bpartnerId(null)
-				.build();
-		final AdProcessId labelProcessId = huLabelConfigRepository.getFirstMatching(labelConfigQuery)
-				.map(config -> config.getPrintFormatProcessId())
+				handlingUnitsBL.getHU_UnitType(request.getHuPackingInstructionsId()));
+		final AdProcessId labelProcessId = huLabelConfigRepository.getFirstMatching(
+						HULabelConfigQuery.builder()
+								.sourceDocType(HULabelSourceDocType.Manufacturing)
+								.huUnitType(huUnitType)
+								.bpartnerId(null)
+								.build())
+				.map(HULabelConfig::getPrintFormatProcessId)
 				.orElse(null);
 
 		huQRCodesService.print(qrCodes, labelProcessId, copies);

--- a/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/workflows_api/FinishedGoodsLabelConfigTest.java
+++ b/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/workflows_api/FinishedGoodsLabelConfigTest.java
@@ -1,0 +1,191 @@
+package de.metas.manufacturing.workflows_api;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import de.metas.handlingunits.HuPackingInstructionsId;
+import de.metas.handlingunits.qrcodes.service.HUQRCodeGenerateRequest;
+import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
+import de.metas.handlingunits.report.labels.HULabelConfigQuery;
+import de.metas.handlingunits.report.labels.HULabelConfigService;
+import de.metas.handlingunits.report.labels.HULabelSourceDocType;
+import de.metas.i18n.TranslatableStrings;
+import de.metas.manufacturing.config.MobileUIManufacturingConfigRepository;
+import de.metas.manufacturing.job.model.FinishedGoodsReceive;
+import de.metas.manufacturing.job.model.FinishedGoodsReceiveLine;
+import de.metas.manufacturing.job.model.FinishedGoodsReceiveLineId;
+import de.metas.manufacturing.job.model.ManufacturingJob;
+import de.metas.manufacturing.job.model.ManufacturingJobActivity;
+import de.metas.manufacturing.job.model.ManufacturingJobActivityId;
+import de.metas.manufacturing.workflows_api.rest_api.json.JsonFinishGoodsReceiveQRCodesGenerateRequest;
+import de.metas.material.planning.pporder.PPAlwaysAvailableToUser;
+import de.metas.material.planning.pporder.PPRoutingActivityType;
+import de.metas.product.ProductId;
+import de.metas.business.BusinessTestHelper;
+import de.metas.quantity.Quantity;
+import de.metas.report.PrintCopies;
+import de.metas.resource.UserWorkstationService;
+import de.metas.workflow.rest_api.model.WFProcessId;
+import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_C_UOM;
+import org.eevolution.api.PPOrderId;
+import org.eevolution.api.PPOrderRoutingActivityId;
+import org.eevolution.api.PPOrderRoutingActivityStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * RED test — proves that {@code generateFinishGoodsReceiveQRCodes} (Auszeichnung Fertigware)
+ * ignores {@code M_HU_Label_Config}: the label-config service is never consulted on current code.
+ *
+ * <p>AC1 (RED — must FAIL until the fix lands):
+ * When {@code generateFinishGoodsReceiveQRCodes} is invoked, it MUST call
+ * {@code HULabelConfigService.getFirstMatching} with a query whose
+ * {@code sourceDocType == HULabelSourceDocType.Manufacturing}.
+ * On current code that call never happens → the verify below FAILS → RED.
+ */
+class FinishedGoodsLabelConfigTest
+{
+	// ── mocks ───────────────────────────────────────────────────────────────
+	private MobileUIManufacturingConfigRepository configRepository;
+	private ManufacturingRestService manufacturingRestService;
+	private UserWorkstationService userWorkstationService;
+
+	/**
+	 * Fully mocked — no real print / Jasper / DB call happens.
+	 */
+	private HUQRCodesService huQRCodesService;
+
+	/**
+	 * The service that SHOULD be consulted when selecting which label process to use.
+	 * Currently it is NOT injected into {@link ManufacturingMobileApplication} — that
+	 * is the root of the bug this test documents.
+	 */
+	private HULabelConfigService huLabelConfigService;
+
+	// ── system under test ────────────────────────────────────────────────────
+	private ManufacturingMobileApplication app;
+
+	@BeforeEach
+	void setUp()
+	{
+		// Required so that AdempiereTestHelper-managed Services.get() initialisers succeed.
+		AdempiereTestHelper.get().init();
+
+		// Create mocks (Mockito 2.x — use Mockito.mock(), no annotation processor available).
+		configRepository = mock(MobileUIManufacturingConfigRepository.class);
+		manufacturingRestService = mock(ManufacturingRestService.class);
+		userWorkstationService = mock(UserWorkstationService.class);
+		huQRCodesService = mock(HUQRCodesService.class);
+		huLabelConfigService = mock(HULabelConfigService.class);
+
+		// Construct the app.
+		// Note: HULabelConfigService is NOT a constructor parameter today — that is the bug.
+		app = new ManufacturingMobileApplication(
+				configRepository,
+				manufacturingRestService,
+				huQRCodesService,
+				userWorkstationService);
+
+		// Wire up manufacturingRestService to return a canned job so the method can
+		// reach the print call without a NullPointerException.
+		final ManufacturingJob cannedJob = buildCannedManufacturingJob();
+		doReturn(cannedJob).when(manufacturingRestService).getJobById(any(PPOrderId.class));
+
+		// Stub generate() — return an empty list (the exact content does not matter for this test).
+		doReturn(ImmutableList.of()).when(huQRCodesService).generate(any(HUQRCodeGenerateRequest.class));
+	}
+
+	// ─── AC1 — RED: HULabelConfigService must be consulted ──────────────────
+
+	/**
+	 * AC1 (RED): When {@code generateFinishGoodsReceiveQRCodes} runs, it MUST consult
+	 * {@code HULabelConfigService.getFirstMatching} with a query that has
+	 * {@code sourceDocType == Manufacturing}.
+	 *
+	 * <p>On current code this verify FAILS with
+	 * "Wanted but not invoked: huLabelConfigService.getFirstMatching(…)" because
+	 * {@code ManufacturingMobileApplication} never calls {@code HULabelConfigService} at all.
+	 * That is the RED signal.
+	 */
+	@Test
+	void generateFinishGoodsQRCodes_mustConsultHULabelConfigService()
+	{
+		// when
+		app.generateFinishGoodsReceiveQRCodes(buildRequest());
+
+		// then — HULabelConfigService.getFirstMatching MUST have been called with
+		//        a query whose sourceDocType is Manufacturing.
+		//        On current code it is NEVER called → this verify FAILS → RED.
+		final ArgumentCaptor<HULabelConfigQuery> queryCaptor = ArgumentCaptor.forClass(HULabelConfigQuery.class);
+		verify(huLabelConfigService).getFirstMatching(queryCaptor.capture());
+
+		assertThat(queryCaptor.getValue().getSourceDocType())
+				.as("HULabelConfigQuery.sourceDocType must be Manufacturing")
+				.isEqualTo(HULabelSourceDocType.Manufacturing);
+	}
+
+	// ─── helpers ────────────────────────────────────────────────────────────────
+
+	private static JsonFinishGoodsReceiveQRCodesGenerateRequest buildRequest()
+	{
+		final PPOrderId ppOrderId = PPOrderId.ofRepoId(1001);
+		return JsonFinishGoodsReceiveQRCodesGenerateRequest.builder()
+				.wfProcessId(WFProcessId.ofIdPart(ManufacturingMobileApplication.APPLICATION_ID, ppOrderId))
+				.finishedGoodsReceiveLineId(FinishedGoodsReceiveLineId.FINISHED_GOODS)
+				.huPackingInstructionsId(HuPackingInstructionsId.ofRepoId(100))
+				.numberOfHUs(1)
+				.build();
+	}
+
+	private static ManufacturingJob buildCannedManufacturingJob()
+	{
+		final ProductId productId = ProductId.ofRepoId(501);
+		final I_C_UOM uomKg = BusinessTestHelper.createUomKg();
+
+		final FinishedGoodsReceiveLine receiveLine = FinishedGoodsReceiveLine.builder()
+				.productId(productId)
+				.productName(TranslatableStrings.anyLanguage("Finished Good"))
+				.productValue("FG001")
+				.attributes(ImmutableAttributeSet.EMPTY)
+				.qtyToReceive(new Quantity(BigDecimal.TEN, uomKg))
+				.qtyReceived(new Quantity(BigDecimal.ZERO, uomKg))
+				.build();
+
+		final FinishedGoodsReceive finishedGoodsReceive = FinishedGoodsReceive.builder()
+				.linesById(ImmutableMap.of(FinishedGoodsReceiveLineId.FINISHED_GOODS, receiveLine))
+				.build();
+
+		final PPOrderRoutingActivityId routingActivityId = PPOrderRoutingActivityId.ofRepoId(
+				PPOrderId.ofRepoId(1001), 1);
+
+		final ManufacturingJobActivity activity = ManufacturingJobActivity.builder()
+				.id(ManufacturingJobActivityId.ofRepoId(1))
+				.name("Auszeichnung Fertigware")
+				.type(PPRoutingActivityType.GenerateHUQRCodes)
+				.finishedGoodsReceive(finishedGoodsReceive)
+				.orderRoutingActivityId(routingActivityId)
+				.routingActivityStatus(PPOrderRoutingActivityStatus.NOT_STARTED)
+				.alwaysAvailableToUser(PPAlwaysAvailableToUser.YES)
+				.build();
+
+		return ManufacturingJob.builder()
+				.ppOrderId(PPOrderId.ofRepoId(1001))
+				.documentNo("MO-TEST-001")
+				.dateStartSchedule(ZonedDateTime.now())
+				.warehouseId(WarehouseId.ofRepoId(1))
+				.activities(ImmutableList.of(activity))
+				.build();
+	}
+}

--- a/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/workflows_api/FinishedGoodsLabelConfigTest.java
+++ b/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/workflows_api/FinishedGoodsLabelConfigTest.java
@@ -55,8 +55,8 @@ import static org.mockito.Mockito.verify;
  * GREEN test — proves that {@code generateFinishGoodsReceiveQRCodes} (Auszeichnung Fertigware)
  * consults {@code M_HU_Label_Config} and uses the configured process when one matches.
  *
- * <p>AC1: when a matching rule exists, the print call uses the rule's process id.
- * <p>AC2: when no rule matches, the print call passes {@code null} process id → the
+ * <p>When a matching rule exists, the print call uses the rule's process id.
+ * <p>When no rule matches, the print call passes {@code null} process id → the
  * existing global default (584977) path in {@code GlobalQRCodeService} runs unchanged.
  */
 class FinishedGoodsLabelConfigTest
@@ -74,7 +74,7 @@ class FinishedGoodsLabelConfigTest
 	private HUQRCodesService huQRCodesService;
 
 	/**
-	 * Repository-level label config lookup (no sysconfig fallback — AC2 requirement).
+	 * Repository-level label config lookup (no sysconfig fallback).
 	 */
 	private HULabelConfigRepository huLabelConfigRepository;
 
@@ -121,7 +121,7 @@ class FinishedGoodsLabelConfigTest
 		doReturn(ImmutableList.of()).when(huQRCodesService).generate(any(HUQRCodeGenerateRequest.class));
 	}
 
-	// ─── AC1 — matching rule → configured process id is passed to print ─────────────
+	// ─── matching rule → configured process id is passed to print ─────────────
 
 	@Test
 	void generateFinishGoodsQRCodes_withMatchingLabelConfig_printsConfiguredProcess()
@@ -157,7 +157,7 @@ class FinishedGoodsLabelConfigTest
 				.isEqualTo(configuredProcessId);
 	}
 
-	// ─── AC2 — no matching rule → null processId → existing global default path ────
+	// ─── no matching rule → null processId → existing global default path ────
 
 	@Test
 	void generateFinishGoodsQRCodes_withNoMatchingLabelConfig_printsWithNullProcess()

--- a/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/workflows_api/FinishedGoodsLabelConfigTest.java
+++ b/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/workflows_api/FinishedGoodsLabelConfigTest.java
@@ -22,7 +22,6 @@ import de.metas.material.planning.pporder.PPRoutingActivityType;
 import de.metas.product.ProductId;
 import de.metas.business.BusinessTestHelper;
 import de.metas.quantity.Quantity;
-import de.metas.report.PrintCopies;
 import de.metas.resource.UserWorkstationService;
 import de.metas.workflow.rest_api.model.WFProcessId;
 import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
@@ -90,8 +89,15 @@ class FinishedGoodsLabelConfigTest
 		huQRCodesService = mock(HUQRCodesService.class);
 		huLabelConfigService = mock(HULabelConfigService.class);
 
-		// Construct the app.
-		// Note: HULabelConfigService is NOT a constructor parameter today — that is the bug.
+		// HULabelConfigService is NOT a constructor parameter today — that is the bug.
+		// TODO FIX (GREEN phase): two steps are required to turn this test GREEN —
+		//   (1) production code must call huLabelConfigService.getFirstMatching(...), AND
+		//   (2) huLabelConfigService must be passed here as a new constructor argument:
+		//         app = new ManufacturingMobileApplication(
+		//                 configRepository, manufacturingRestService,
+		//                 huQRCodesService, userWorkstationService, huLabelConfigService);
+		//   If only (1) is done, this test stays RED because the verified mock is not the
+		//   one the SUT holds.
 		app = new ManufacturingMobileApplication(
 				configRepository,
 				manufacturingRestService,

--- a/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/workflows_api/FinishedGoodsLabelConfigTest.java
+++ b/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/workflows_api/FinishedGoodsLabelConfigTest.java
@@ -3,11 +3,15 @@ package de.metas.manufacturing.workflows_api;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import de.metas.handlingunits.HuPackingInstructionsId;
+import de.metas.handlingunits.HuUnitType;
+import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.qrcodes.service.HUQRCodeGenerateRequest;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
+import de.metas.handlingunits.report.labels.HULabelConfig;
 import de.metas.handlingunits.report.labels.HULabelConfigQuery;
-import de.metas.handlingunits.report.labels.HULabelConfigService;
+import de.metas.handlingunits.report.labels.HULabelConfigRepository;
 import de.metas.handlingunits.report.labels.HULabelSourceDocType;
+import de.metas.i18n.ExplainedOptional;
 import de.metas.i18n.TranslatableStrings;
 import de.metas.manufacturing.config.MobileUIManufacturingConfigRepository;
 import de.metas.manufacturing.job.model.FinishedGoodsReceive;
@@ -19,10 +23,13 @@ import de.metas.manufacturing.job.model.ManufacturingJobActivityId;
 import de.metas.manufacturing.workflows_api.rest_api.json.JsonFinishGoodsReceiveQRCodesGenerateRequest;
 import de.metas.material.planning.pporder.PPAlwaysAvailableToUser;
 import de.metas.material.planning.pporder.PPRoutingActivityType;
+import de.metas.process.AdProcessId;
 import de.metas.product.ProductId;
 import de.metas.business.BusinessTestHelper;
 import de.metas.quantity.Quantity;
+import de.metas.report.PrintCopies;
 import de.metas.resource.UserWorkstationService;
+import de.metas.util.Services;
 import de.metas.workflow.rest_api.model.WFProcessId;
 import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
 import org.adempiere.test.AdempiereTestHelper;
@@ -45,17 +52,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 /**
- * RED test — proves that {@code generateFinishGoodsReceiveQRCodes} (Auszeichnung Fertigware)
- * ignores {@code M_HU_Label_Config}: the label-config service is never consulted on current code.
+ * GREEN test — proves that {@code generateFinishGoodsReceiveQRCodes} (Auszeichnung Fertigware)
+ * consults {@code M_HU_Label_Config} and uses the configured process when one matches.
  *
- * <p>AC1 (RED — must FAIL until the fix lands):
- * When {@code generateFinishGoodsReceiveQRCodes} is invoked, it MUST call
- * {@code HULabelConfigService.getFirstMatching} with a query whose
- * {@code sourceDocType == HULabelSourceDocType.Manufacturing}.
- * On current code that call never happens → the verify below FAILS → RED.
+ * <p>AC1: when a matching rule exists, the print call uses the rule's process id.
+ * <p>AC2: when no rule matches, the print call passes {@code null} process id → the
+ * existing global default (584977) path in {@code GlobalQRCodeService} runs unchanged.
  */
 class FinishedGoodsLabelConfigTest
 {
+	private static final HuPackingInstructionsId TEST_PI_ID = HuPackingInstructionsId.ofRepoId(100);
+
 	// ── mocks ───────────────────────────────────────────────────────────────
 	private MobileUIManufacturingConfigRepository configRepository;
 	private ManufacturingRestService manufacturingRestService;
@@ -67,11 +74,14 @@ class FinishedGoodsLabelConfigTest
 	private HUQRCodesService huQRCodesService;
 
 	/**
-	 * The service that SHOULD be consulted when selecting which label process to use.
-	 * Currently it is NOT injected into {@link ManufacturingMobileApplication} — that
-	 * is the root of the bug this test documents.
+	 * Repository-level label config lookup (no sysconfig fallback — AC2 requirement).
 	 */
-	private HULabelConfigService huLabelConfigService;
+	private HULabelConfigRepository huLabelConfigRepository;
+
+	/**
+	 * Mocked so getHU_UnitType(piId) does not hit the DB.
+	 */
+	private IHandlingUnitsBL handlingUnitsBL;
 
 	// ── system under test ────────────────────────────────────────────────────
 	private ManufacturingMobileApplication app;
@@ -87,22 +97,20 @@ class FinishedGoodsLabelConfigTest
 		manufacturingRestService = mock(ManufacturingRestService.class);
 		userWorkstationService = mock(UserWorkstationService.class);
 		huQRCodesService = mock(HUQRCodesService.class);
-		huLabelConfigService = mock(HULabelConfigService.class);
+		huLabelConfigRepository = mock(HULabelConfigRepository.class);
+		handlingUnitsBL = mock(IHandlingUnitsBL.class);
 
-		// HULabelConfigService is NOT a constructor parameter today — that is the bug.
-		// TODO FIX (GREEN phase): two steps are required to turn this test GREEN —
-		//   (1) production code must call huLabelConfigService.getFirstMatching(...), AND
-		//   (2) huLabelConfigService must be passed here as a new constructor argument:
-		//         app = new ManufacturingMobileApplication(
-		//                 configRepository, manufacturingRestService,
-		//                 huQRCodesService, userWorkstationService, huLabelConfigService);
-		//   If only (1) is done, this test stays RED because the verified mock is not the
-		//   one the SUT holds.
+		// Register handlingUnitsBL mock so Services.get(IHandlingUnitsBL.class) returns it.
+		Services.registerService(IHandlingUnitsBL.class, handlingUnitsBL);
+		// Stub getHU_UnitType for the test PI id (no DB access needed).
+		doReturn(HuUnitType.TU.getCode()).when(handlingUnitsBL).getHU_UnitType(TEST_PI_ID);
+
 		app = new ManufacturingMobileApplication(
 				configRepository,
 				manufacturingRestService,
 				huQRCodesService,
-				userWorkstationService);
+				userWorkstationService,
+				huLabelConfigRepository);
 
 		// Wire up manufacturingRestService to return a canned job so the method can
 		// reach the print call without a NullPointerException.
@@ -113,33 +121,63 @@ class FinishedGoodsLabelConfigTest
 		doReturn(ImmutableList.of()).when(huQRCodesService).generate(any(HUQRCodeGenerateRequest.class));
 	}
 
-	// ─── AC1 — RED: HULabelConfigService must be consulted ──────────────────
+	// ─── AC1 — matching rule → configured process id is passed to print ─────────────
 
-	/**
-	 * AC1 (RED): When {@code generateFinishGoodsReceiveQRCodes} runs, it MUST consult
-	 * {@code HULabelConfigService.getFirstMatching} with a query that has
-	 * {@code sourceDocType == Manufacturing}.
-	 *
-	 * <p>On current code this verify FAILS with
-	 * "Wanted but not invoked: huLabelConfigService.getFirstMatching(…)" because
-	 * {@code ManufacturingMobileApplication} never calls {@code HULabelConfigService} at all.
-	 * That is the RED signal.
-	 */
 	@Test
-	void generateFinishGoodsQRCodes_mustConsultHULabelConfigService()
+	void generateFinishGoodsQRCodes_withMatchingLabelConfig_printsConfiguredProcess()
 	{
+		// given — a matching M_HU_Label_Config rule returns process 999001
+		final AdProcessId configuredProcessId = AdProcessId.ofRepoId(999001);
+		final HULabelConfig matchingConfig = HULabelConfig.builder()
+				.printFormatProcessId(configuredProcessId)
+				.autoPrint(true)
+				.autoPrintCopies(PrintCopies.ONE)
+				.build();
+		doReturn(ExplainedOptional.of(matchingConfig))
+				.when(huLabelConfigRepository).getFirstMatching(any(HULabelConfigQuery.class));
+
 		// when
 		app.generateFinishGoodsReceiveQRCodes(buildRequest());
 
-		// then — HULabelConfigService.getFirstMatching MUST have been called with
-		//        a query whose sourceDocType is Manufacturing.
-		//        On current code it is NEVER called → this verify FAILS → RED.
+		// then — repository must be called with sourceDocType == Manufacturing
 		final ArgumentCaptor<HULabelConfigQuery> queryCaptor = ArgumentCaptor.forClass(HULabelConfigQuery.class);
-		verify(huLabelConfigService).getFirstMatching(queryCaptor.capture());
-
+		verify(huLabelConfigRepository).getFirstMatching(queryCaptor.capture());
 		assertThat(queryCaptor.getValue().getSourceDocType())
 				.as("HULabelConfigQuery.sourceDocType must be Manufacturing")
 				.isEqualTo(HULabelSourceDocType.Manufacturing);
+
+		// and — print must be called with the configured process id
+		final ArgumentCaptor<AdProcessId> processCaptor = ArgumentCaptor.forClass(AdProcessId.class);
+		verify(huQRCodesService).print(
+				any(),
+				processCaptor.capture(),
+				any(PrintCopies.class));
+		assertThat(processCaptor.getValue())
+				.as("print must use the configured LabelReport_Process_ID=999001")
+				.isEqualTo(configuredProcessId);
+	}
+
+	// ─── AC2 — no matching rule → null processId → existing global default path ────
+
+	@Test
+	void generateFinishGoodsQRCodes_withNoMatchingLabelConfig_printsWithNullProcess()
+	{
+		// given — no M_HU_Label_Config rule matches
+		doReturn(ExplainedOptional.emptyBecause("no rule"))
+				.when(huLabelConfigRepository).getFirstMatching(any(HULabelConfigQuery.class));
+
+		// when
+		app.generateFinishGoodsReceiveQRCodes(buildRequest());
+
+		// then — print must be called with null processId (→ GlobalQRCodeService default 584977)
+		final ArgumentCaptor<AdProcessId> processCaptor = ArgumentCaptor.forClass(AdProcessId.class);
+		verify(huQRCodesService).print(
+				any(),
+				processCaptor.capture(),
+				any(PrintCopies.class));
+		assertThat(processCaptor.getValue())
+				.as("print must pass null processId when no label config rule matches (→ global default path)")
+				.isNull();
 	}
 
 	// ─── helpers ────────────────────────────────────────────────────────────────
@@ -150,7 +188,7 @@ class FinishedGoodsLabelConfigTest
 		return JsonFinishGoodsReceiveQRCodesGenerateRequest.builder()
 				.wfProcessId(WFProcessId.ofIdPart(ManufacturingMobileApplication.APPLICATION_ID, ppOrderId))
 				.finishedGoodsReceiveLineId(FinishedGoodsReceiveLineId.FINISHED_GOODS)
-				.huPackingInstructionsId(HuPackingInstructionsId.ofRepoId(100))
+				.huPackingInstructionsId(TEST_PI_ID)
 				.numberOfHUs(1)
 				.build();
 	}


### PR DESCRIPTION
## What
The mobile Manufacturing "Auszeichnung Fertigware" action (`POST /api/v2/manufacturing/generateHUQRCodes`)
printed its HU QR-code labels through a **hardcoded** global QR-code report process
(`GlobalQRCodeService.default_qrCodeProcessId`), ignoring the `M_HU_Label_Config` routing.

This change makes that action resolve the report process from `M_HU_Label_Config` for
`HU_SourceDocType = MO`, matched on the finished-good HU's unit type (and business partner if the rule sets one).

## How
- `HUQRCodesService`: new overload `print(List<HUQRCode>, @Nullable AdProcessId, PrintCopies)` that prints with
  an explicit report process (delegates to `GlobalQRCodeService.createPDF(..., processId)`); a `null` process id
  preserves the previous default behaviour.
- `ManufacturingMobileApplication.generateFinishGoodsReceiveQRCodes`: resolves the HU unit type from the
  packing instruction, queries `HULabelConfigRepository.getFirstMatching({Manufacturing, unitType, bpartner})`,
  and prints with the configured `LabelReport_Process_ID`. When **no** `M_HU_Label_Config` rule matches, the
  process id is `null` → the existing global-default print path is used unchanged (no regression).

## Scope / safety
- Resolution uses the `M_HU_Label_Config` repository only — the no-rule path keeps the current global default
  (does not switch to the legacy sysconfig label).
- QR-code content/generation is unchanged; only the print report process selection changes.
- `GlobalQRCodeService` and the other HU-QR-print callers (warehouse, picking-slot, device, …) are untouched.

## Tests
- `FinishedGoodsLabelConfigTest` (unit, `de.metas.manufacturing.rest-api`): a matching MO rule → the configured
  process is used; no matching rule → the default path. RED before the fix, GREEN after.
