### PR TITLE
MobileUI Distribution: fix stale header bar when auto-advancing between orders

### DIFF
--- a/e2e/mobile-webui/tests/spec/distribution/header.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/header.spec.js
@@ -69,7 +69,7 @@ test('Header reflects the configured caption items (incl. Product Value and Name
 
     await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
     await DistributionJobScreen.expectHeaderProperty({ caption: 'From Locator', value: 'wh1_l1' });
-    await DistributionJobScreen.expectHeaderProperty({ caption: 'To Locator', value: 'wh2_l1' });
+    await DistributionJobScreen.expectHeaderProperty({ caption: 'Drop to locator', value: 'wh2_l1' });
     await DistributionJobScreen.expectHeaderProperty({
         caption: 'Product Value and Name',
         value: masterdata.products.P1.productCode + "_" + masterdata.products.P1.productName,

--- a/e2e/mobile-webui/tests/spec/distribution/packingTable_navigateToNextOrder.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/packingTable_navigateToNextOrder.spec.js
@@ -91,8 +91,11 @@ const createMasterdata = async () => {
                     maxLaunchers: 20,
                     maxStartedLaunchers: 3,
                     orderBys: 'Priority, LocatorPriority',
-                    // Show source locator + product in the job-detail header (assert P/L per order).
-                    captionFormat: 'LocatorFrom,LocatorTo,ProductValueAndName',
+                    // Show source locator + product + qty in the JOB header (asserted per order).
+                    // Qty is a job-level caption token, so the qty-to-move appears in the header on
+                    // EVERY order — including auto-advanced orders, where no single line is yet
+                    // selected and the line-level header is therefore absent.
+                    captionFormat: 'LocatorFrom,LocatorTo,ProductValueAndName,Qty',
                 },
             },
             // The workplace is the packing table: a single warehouse, pick-from = packingTable.
@@ -138,46 +141,67 @@ test('Packing-table operator: orders sorted by priority then locator priority an
         );
     });
 
-    await test.step('Start the first offered order → it is DD1 (product P1, from locator L1)', async () => {
+    // Assert THIS order's full job header. The header carries the job-level caption-format fields
+    // (From Locator, Product Value and Name, Quantity) for the CURRENT order. This is the regression
+    // guard: the bug left these showing the PREVIOUS order's values (or undefined) after the
+    // operator auto-advanced order→order — so the header is asserted on EVERY order, on whichever
+    // screen renders it (the job screen for the first order, the pick-from screen for the rest).
+    //
+    // From Locator + Product Value and Name: exact value match — catches a stale/leftover header
+    // and avoids the L1 ⊂ L10 substring trap. Quantity (server-rendered "<qty> <uomSymbol>"):
+    // substring on THIS order's qty number (i*10), robust to the UOM symbol while still proving the
+    // qty advanced with the order.
+    const assertJobHeader = async (screen, i) => {
+        await screen.expectHeaderProperty({ caption: 'From Locator', value: `L${i}` });
+        await screen.expectHeaderProperty({
+            caption: 'Product Value and Name',
+            value: masterdata.products[`P${i}`].productCode + "_" + masterdata.products[`P${i}`].productName,
+        });
+        await screen.expectHeaderProperty({ caption: 'Quantity', value: `${i * 10}`, exact: false });
+    };
+    const assertHeaderOnJobScreen = (i) => assertJobHeader(DistributionJobScreen, i);
+    const assertHeaderOnPickFromScreen = (i) => assertJobHeader(DistributionLinePickFromScreen, i);
+
+    await test.step('Start the first offered order → it is DD1 (product P1, from locator L1, qty 10)', async () => {
         await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
         await DistributionJobScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD1.jobId });
-        await DistributionJobScreen.expectHeaderProperty({ caption: 'From Locator', value: 'L1' });
-        await DistributionJobScreen.expectHeaderProperty({
-            caption: 'Product Value and Name',
-            value: masterdata.products.P1.productCode + "_" + masterdata.products.P1.productName,
-        });
+        await assertHeaderOnJobScreen(1);
     });
 
-    await test.step('Pick DD1 (scan HU1 + product P1, confirm qty 10) → auto-advance to DD2 (product P2, locator L2)', async () => {
+    // Pick DD1 on the job screen, then auto-advance DD2→DD3→…→DD10, each landing directly on the
+    // next order's pick-from screen. After EACH advance, assert the new order's full header.
+    await test.step('Pick DD1 (scan HU1 + product P1, confirm qty 10) → auto-advance to DD2 pick-from', async () => {
         await DistributionJobScreen.scanHUToMove({
             huQRCode: masterdata.externalBarcodes[1],
             productScannedCode: masterdata.products.P1.gtin,
             expectedQtyToMove: 10,
             expectNextScreen: 'DistributionLinePickFromScreen',
         });
-        // The pick-from screen for DD2 uniquely identifies the order (= product P2, locator L2 by
-        // construction: DDi moves Pi from Li). The product+locator header is asserted explicitly on
-        // the initial job screen above (the header method lives on DistributionJobScreen).
         await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD2.jobId });
+        await assertHeaderOnPickFromScreen(2);
     });
 
-    await test.step('Pick DD2 (scan HU2 + product P2, confirm qty 20) → auto-advance to DD3 (product P3, locator L3)', async () => {
-        await DistributionLinePickFromScreen.scanHUToMove({
-            huQRCode: masterdata.externalBarcodes[2],
-            productScannedCode: masterdata.products.P2.gtin,
-            expectedQtyToMove: 20,
-            expectNextScreen: 'DistributionLinePickFromScreen',
+    for (let i = 2; i < N; i++) {
+        const next = i + 1;
+        await test.step(`Pick DD${i} (scan HU${i} + product P${i}, confirm qty ${i * 10}) → auto-advance to DD${next} pick-from (assert DD${next} header)`, async () => {
+            await DistributionLinePickFromScreen.scanHUToMove({
+                huQRCode: masterdata.externalBarcodes[i],
+                productScannedCode: masterdata.products[`P${i}`].gtin,
+                expectedQtyToMove: i * 10,
+                expectNextScreen: 'DistributionLinePickFromScreen',
+            });
+            await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders[`DD${next}`].jobId });
+            await assertHeaderOnPickFromScreen(next);
         });
-        await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD3.jobId });
-    });
+    }
 
-    await test.step('Pick DD3 (scan HU3 + product P3, confirm qty 30) → auto-advance to DD4 pick-from', async () => {
+    await test.step(`Pick DD${N} (scan HU${N} + product P${N}, confirm qty ${N * 10}) → no more orders, return to jobs list`, async () => {
         await DistributionLinePickFromScreen.scanHUToMove({
-            huQRCode: masterdata.externalBarcodes[3],
-            productScannedCode: masterdata.products.P3.gtin,
-            expectedQtyToMove: 30,
-            expectNextScreen: 'DistributionLinePickFromScreen',
+            huQRCode: masterdata.externalBarcodes[N],
+            productScannedCode: masterdata.products[`P${N}`].gtin,
+            expectedQtyToMove: N * 10,
+            expectNextScreen: 'DistributionJobsListScreen',
         });
-        await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD4.jobId });
+        await DistributionJobsListScreen.waitForScreen();
     });
 });

--- a/e2e/mobile-webui/tests/spec/distribution/packingTable_navigateToNextOrder.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/packingTable_navigateToNextOrder.spec.js
@@ -152,10 +152,14 @@ test('Packing-table operator: orders sorted by priority then locator priority an
     // substring on THIS order's qty number (i*10), robust to the UOM symbol while still proving the
     // qty advanced with the order.
     const assertJobHeader = async (screen, i) => {
-        await screen.expectHeaderProperty({ caption: 'From Locator', value: `L${i}` });
+        // exact:true for locator + product on BOTH screens (the job screen's method defaults to
+        // substring, so it is passed explicitly here) — so the leftover/stale-header guard and the
+        // L1 ⊂ L10 protection hold uniformly on every order.
+        await screen.expectHeaderProperty({ caption: 'From Locator', value: `L${i}`, exact: true });
         await screen.expectHeaderProperty({
             caption: 'Product Value and Name',
             value: masterdata.products[`P${i}`].productCode + "_" + masterdata.products[`P${i}`].productName,
+            exact: true,
         });
         await screen.expectHeaderProperty({ caption: 'Quantity', value: `${i * 10}`, exact: false });
     };

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobScreen.js
@@ -25,11 +25,10 @@ export const DistributionJobScreen = {
         await DistributionUtils.expectJobId({ distributionJobId });
     }),
 
-    expectHeaderProperty: async ({ caption, value }) => await test.step(`${NAME} - Check header property '${caption}'='${value}'`, async () => {
-        const row = await page.locator(
-            `tr:has(th:has-text("${caption}")):has(td:has-text("${value}"))`
-        );
-        await expect(row).toHaveCount(1)
+    // `exact` defaults to false (substring value match) to preserve the long-standing behaviour of
+    // this method's existing callers. The shared helper additionally requires the row to be visible.
+    expectHeaderProperty: async ({ caption, value, exact = false }) => await test.step(`${NAME} - Check header property '${caption}'='${value}'${exact ? '' : ' (substring)'}`, async () => {
+        await DistributionUtils.expectHeaderProperty({ caption, value, exact });
     }),
 
     scanHUToMove: async ({ huQRCode, productScannedCode, expectQuantityDialog = true, expectedQtyToMove, expectNextScreen }) => await test.step(`${NAME} - Scan HU to move`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLinePickFromScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLinePickFromScreen.js
@@ -5,6 +5,7 @@ import { GetQuantityDialog } from '../picking/GetQuantityDialog';
 import { DistributionUtils } from './DistributionUtils';
 import { DistributionJobsListScreen } from './DistributionJobsListScreen';
 import { DistributionJobScreen } from './DistributionJobScreen';
+import { expect } from '@playwright/test';
 
 const NAME = 'DistributionLinePickFromScreen';
 /** @returns {import('@playwright/test').Locator} */
@@ -18,6 +19,23 @@ export const DistributionLinePickFromScreen = {
         expectJobId: async ({ distributionJobId }) => await test.step(`${NAME} - Expect jobId=${distributionJobId}`, async () => {
             await DistributionLinePickFromScreen.waitForScreen();
             await DistributionUtils.expectJobId({ distributionJobId });
+        }),
+
+        // Assert a row of the (global) job header table that this screen renders after auto-advance.
+        // The header is the shared `.view-header` table — same DOM as
+        // DistributionJobScreen.expectHeaderProperty — so the same `tr/th/td` selector applies here.
+        //
+        // Caption is matched EXACTLY (`th:text-is`) so a substring caption (e.g. "Product" vs
+        // "Product Value and Name") can't hit the wrong row. `exact` (default true) likewise matches
+        // the value EXACTLY (`td:text-is`) so that e.g. locator "L1" is not satisfied by a stale
+        // "L10" value — exactly the wrong/leftover-header class of bug this test guards. Pass
+        // `exact: false` only when the rendered value legitimately carries trailing content you do
+        // not want to pin (e.g. a qty followed by its UOM symbol).
+        expectHeaderProperty: async ({ caption, value, exact = true }) => await test.step(`${NAME} - Check header property '${caption}'='${value}'${exact ? '' : ' (substring)'}`, async () => {
+            await DistributionLinePickFromScreen.waitForScreen();
+            const valueSelector = exact ? `td:text-is("${value}")` : `td:has-text("${value}")`;
+            const row = page.locator(`tr:has(th:text-is("${caption}")):has(${valueSelector})`);
+            await expect(row).toHaveCount(1);
         }),
 
         scanHUToMove: async ({ huQRCode, productScannedCode, expectQuantityDialog = true, expectedQtyToMove, expectNextScreen }) => await test.step(`${NAME} - Scan HU to move`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLinePickFromScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLinePickFromScreen.js
@@ -5,7 +5,6 @@ import { GetQuantityDialog } from '../picking/GetQuantityDialog';
 import { DistributionUtils } from './DistributionUtils';
 import { DistributionJobsListScreen } from './DistributionJobsListScreen';
 import { DistributionJobScreen } from './DistributionJobScreen';
-import { expect } from '@playwright/test';
 
 const NAME = 'DistributionLinePickFromScreen';
 /** @returns {import('@playwright/test').Locator} */
@@ -21,21 +20,15 @@ export const DistributionLinePickFromScreen = {
             await DistributionUtils.expectJobId({ distributionJobId });
         }),
 
-        // Assert a row of the (global) job header table that this screen renders after auto-advance.
-        // The header is the shared `.view-header` table — same DOM as
-        // DistributionJobScreen.expectHeaderProperty — so the same `tr/th/td` selector applies here.
-        //
-        // Caption is matched EXACTLY (`th:text-is`) so a substring caption (e.g. "Product" vs
-        // "Product Value and Name") can't hit the wrong row. `exact` (default true) likewise matches
-        // the value EXACTLY (`td:text-is`) so that e.g. locator "L1" is not satisfied by a stale
-        // "L10" value — exactly the wrong/leftover-header class of bug this test guards. Pass
+        // Assert a row of the job header table that this screen renders after auto-advance. `exact`
+        // (default true) matches the value EXACTLY so that e.g. locator "L1" is not satisfied by a
+        // stale "L10" value — exactly the wrong/leftover-header class of bug this test guards. Pass
         // `exact: false` only when the rendered value legitimately carries trailing content you do
-        // not want to pin (e.g. a qty followed by its UOM symbol).
+        // not want to pin (e.g. a qty followed by its UOM symbol). See DistributionUtils for the
+        // shared header-row assertion.
         expectHeaderProperty: async ({ caption, value, exact = true }) => await test.step(`${NAME} - Check header property '${caption}'='${value}'${exact ? '' : ' (substring)'}`, async () => {
             await DistributionLinePickFromScreen.waitForScreen();
-            const valueSelector = exact ? `td:text-is("${value}")` : `td:has-text("${value}")`;
-            const row = page.locator(`tr:has(th:text-is("${caption}")):has(${valueSelector})`);
-            await expect(row).toHaveCount(1);
+            await DistributionUtils.expectHeaderProperty({ caption, value, exact });
         }),
 
         scanHUToMove: async ({ huQRCode, productScannedCode, expectQuantityDialog = true, expectedQtyToMove, expectNextScreen }) => await test.step(`${NAME} - Scan HU to move`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionUtils.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionUtils.js
@@ -13,4 +13,18 @@ export const DistributionUtils = {
     expectJobId: async ({ distributionJobId }) => {
         await expect(await DistributionUtils.getJobIdFromPageUrl()).toEqual(distributionJobId);
     },
+
+    // Assert a row of the shared `.view-header` table (the job/line header rendered on the
+    // distribution job, line and pick-from screens — same DOM everywhere). The caption is matched
+    // EXACTLY (`th:text-is`) so a substring caption can't hit the wrong row. `exact` controls the
+    // value: true matches the cell text exactly (`td:text-is`), false matches a substring
+    // (`td:has-text`) — use false when the value carries trailing content you don't want to pin
+    // (e.g. a qty followed by its UOM symbol). The row must exist exactly once AND be visible
+    // (painted), not merely present in the DOM.
+    expectHeaderProperty: async ({ caption, value, exact }) => {
+        const valueSelector = exact ? `td:text-is("${value}")` : `td:has-text("${value}")`;
+        const row = page.locator(`tr:has(th:text-is("${caption}")):has(${valueSelector})`);
+        await expect(row).toHaveCount(1);
+        await expect(row).toBeVisible();
+    },
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/distribution/containers/DistributionJobsDropAllScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/distribution/containers/DistributionJobsDropAllScreen.jsx
@@ -4,10 +4,12 @@ import { useScreenDefinition } from '../../../hooks/useScreenDefinition';
 import { distributionJobsListScreenLocation } from '../../../routes/distribution';
 import { postDropAll } from '../../../api/distribution';
 import { toastErrorFromObj } from '../../../utils/toast';
+import { trl } from '../../../utils/translations';
 
 const DistributionJobsDropAllScreen = () => {
   const { history } = useScreenDefinition({
     screenId: 'DistributionJobsDropAllScreen',
+    captionKey: 'activities.distribution.scanDropToLocator',
     back: distributionJobsListScreenLocation(),
   });
 
@@ -17,7 +19,12 @@ const DistributionJobsDropAllScreen = () => {
       .catch(toastErrorFromObj);
   };
 
-  return <BarcodeScannerComponent onResolvedResult={onBarcodeScanned} />;
+  return (
+    <BarcodeScannerComponent
+      onResolvedResult={onBarcodeScanned}
+      inputPlaceholderText={trl('activities.distribution.scanDropToLocator')}
+    />
+  );
 };
 
 export default DistributionJobsDropAllScreen;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionLineScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionLineScreen.jsx
@@ -67,6 +67,8 @@ const DistributionLineScreen = () => {
 
 const useDistributionLineProps = ({ wfProcessId, activityId, lineId }) => {
   return useSelector((state) => {
+    if (!lineId) return {};
+
     const line = getLineById(state, wfProcessId, activityId, lineId);
     const stepsArray = getStepsArrayFromLine(line);
     return {
@@ -101,28 +103,33 @@ export const useDistributionLineHeaders = ({ wfProcessId, activityId, lineId }) 
     lineId,
   });
   const jobHeaders = useWFProcessHeaders({ wfProcessId });
-
-  return [
-    ...jobHeaders,
-    {
+  const headers = [...jobHeaders];
+  if (productName) {
+    headers.push({
       id: 'ProductValueAndName', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
       caption: trl('general.Product'),
       value: productName,
       bold: true,
-    },
-    {
+    });
+  }
+  if (qtyToMove != null) {
+    headers.push({
       id: 'Qty', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
       caption: trl('general.QtyToMove'),
       value: formatQtyToHumanReadableStr({ qty: qtyToMove, uom }),
       bold: true,
-    },
-    {
+    });
+  }
+  if (pickFromLocator?.caption) {
+    headers.push({
       id: 'LocatorFrom', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
       caption: trl('general.LocatorFrom'),
       value: pickFromLocator?.caption,
       bold: true,
-    },
-  ];
+    });
+  }
+
+  return headers;
 };
 
 //

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionLineScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionLineScreen.jsx
@@ -12,9 +12,10 @@ import { useScreenDefinition } from '../../../hooks/useScreenDefinition';
 import { getWFProcessScreenLocation } from '../../../routes/workflow_locations';
 import { useMobileLocation } from '../../../hooks/useMobileLocation';
 import { computeQtyToPickRemaining } from '../../../reducers/wfProcesses/distribution/computeQtyToPickRemaining';
+import { useWFProcessHeaders } from '../../wfProcessScreen/WFProcessScreen';
 
 const DistributionLineScreen = () => {
-  const { history, applicationId, wfProcessId, activityId, lineId } = useDistributionScreenDefinition({
+  const { history, applicationId, wfProcessId, activityId, lineId } = useDistributionLineScreenDefinition({
     screenId: 'DistributionLineScreen',
     back: getWFProcessScreenLocation,
   });
@@ -64,7 +65,7 @@ const DistributionLineScreen = () => {
 //
 //
 
-export const useDistributionLineProps = ({ wfProcessId, activityId, lineId }) => {
+const useDistributionLineProps = ({ wfProcessId, activityId, lineId }) => {
   return useSelector((state) => {
     const line = getLineById(state, wfProcessId, activityId, lineId);
     const stepsArray = getStepsArrayFromLine(line);
@@ -82,40 +83,46 @@ export const useDistributionLineProps = ({ wfProcessId, activityId, lineId }) =>
 //
 //
 
-export const useDistributionScreenDefinition = ({ screenId, captionKey, back } = {}) => {
+const useDistributionLineScreenDefinition = ({ screenId, captionKey, back } = {}) => {
   const { wfProcessId, activityId, lineId } = useMobileLocation();
+  const headers = useDistributionLineHeaders({ wfProcessId, activityId, lineId });
+  return useScreenDefinition({
+    screenId,
+    captionKey,
+    back,
+    values: headers,
+  });
+};
 
+export const useDistributionLineHeaders = ({ wfProcessId, activityId, lineId }) => {
   const { productName, uom, qtyToMove, pickFromLocator } = useDistributionLineProps({
     wfProcessId,
     activityId,
     lineId,
   });
+  const jobHeaders = useWFProcessHeaders({ wfProcessId });
 
-  return useScreenDefinition({
-    screenId,
-    captionKey,
-    back,
-    values: [
-      {
-        id: 'ProductValueAndName', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
-        caption: trl('general.Product'),
-        value: productName,
-        bold: true,
-      },
-      {
-        id: 'Qty', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
-        caption: trl('general.QtyToMove'),
-        value: formatQtyToHumanReadableStr({ qty: qtyToMove, uom }),
-        bold: true,
-      },
-      {
-        id: 'LocatorFrom', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
-        caption: trl('general.LocatorFrom'),
-        value: pickFromLocator?.caption,
-        bold: true,
-      },
-    ],
-  });
+  return [
+    ...jobHeaders,
+    {
+      id: 'ProductValueAndName', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
+      caption: trl('general.Product'),
+      value: productName,
+      bold: true,
+    },
+    {
+      id: 'Qty', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
+      caption: trl('general.QtyToMove'),
+      value: formatQtyToHumanReadableStr({ qty: qtyToMove, uom }),
+      bold: true,
+    },
+    {
+      id: 'LocatorFrom', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
+      caption: trl('general.LocatorFrom'),
+      value: pickFromLocator?.caption,
+      bold: true,
+    },
+  ];
 };
 
 //

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
@@ -7,7 +7,6 @@ import { distributionJobScreenLocation, distributionLineScreenLocation } from '.
 import ScanHUAndGetQtyComponent from '../../../components/ScanHUAndGetQtyComponent';
 import { resolveDistributionScannedBarcodeToParsedQRCode } from '../../../apps/distribution/services/barcodeResolverService';
 import { useSearchParams } from '../../../hooks/useSearchParams';
-import { formatQtyToHumanReadableStr } from '../../../utils/qtys';
 import { useMobileLocation } from '../../../hooks/useMobileLocation';
 import { getLineByIdFromActivity, useWFActivity } from '../../../reducers/wfProcesses';
 import { computeQtyToPickRemaining } from '../../../reducers/wfProcesses/distribution/computeQtyToPickRemaining';
@@ -154,39 +153,15 @@ const useDistributionScreenDefinition = () => {
   const huQRCode = urlParams.get('huQRCode');
 
   const activity = useWFActivity({ wfProcessId, activityId });
-  const { productName, uom, qtyToMove, pickFromLocator } = getLineInfo({ activity, lineId });
-  const lineHeaders = useDistributionLineHeaders({ wfProcessId, activityId, lineId });
+  const headers = useDistributionLineHeaders({ wfProcessId, activityId, lineId });
 
   const { history } = useScreenDefinition({
     screenId: 'DistributionLinePickFromScreen',
     captionKey: 'activities.distribution.scanHU',
-    back:
-      lineId != null
-        ? distributionLineScreenLocation({ applicationId, wfProcessId, activityId, lineId })
-        : distributionJobScreenLocation({ applicationId, wfProcessId, activityId }),
-    values: [
-      ...lineHeaders,
-      {
-        id: 'ProductValueAndName', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
-        caption: trl('general.Product'),
-        value: productName,
-        bold: true,
-        hidden: productName == null,
-      },
-      {
-        id: 'Qty', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
-        caption: trl('general.QtyToMove'),
-        value: qtyToMove != null ? formatQtyToHumanReadableStr({ qty: qtyToMove, uom }) : null,
-        bold: true,
-        hidden: qtyToMove == null,
-      },
-      {
-        id: 'LocatorFrom', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
-        caption: trl('general.LocatorFrom'),
-        value: pickFromLocator?.caption,
-        bold: true,
-      },
-    ],
+    back: lineId
+      ? distributionLineScreenLocation({ applicationId, wfProcessId, activityId, lineId })
+      : distributionJobScreenLocation({ applicationId, wfProcessId, activityId }),
+    values: headers,
   });
 
   return { history, applicationId, wfProcessId, activityId, activity, lineId, huQRCode };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
@@ -14,6 +14,7 @@ import { computeQtyToPickRemaining } from '../../../reducers/wfProcesses/distrib
 import { useScreenDefinition } from '../../../hooks/useScreenDefinition';
 import { isRequireScanningProductCode } from '../../../reducers/wfProcesses/distribution/getDistributionJobCompleteStatus';
 import { postDistributionPickFromThunk } from '../../../apps/distribution/redux/postDistributionPickFromThunk';
+import { useDistributionLineHeaders } from './DistributionLineScreen';
 
 const DistributionPickFromScreen = () => {
   const {
@@ -154,6 +155,7 @@ const useDistributionScreenDefinition = () => {
 
   const activity = useWFActivity({ wfProcessId, activityId });
   const { productName, uom, qtyToMove, pickFromLocator } = getLineInfo({ activity, lineId });
+  const lineHeaders = useDistributionLineHeaders({ wfProcessId, activityId, lineId });
 
   const { history } = useScreenDefinition({
     screenId: 'DistributionLinePickFromScreen',
@@ -163,6 +165,7 @@ const useDistributionScreenDefinition = () => {
         ? distributionLineScreenLocation({ applicationId, wfProcessId, activityId, lineId })
         : distributionJobScreenLocation({ applicationId, wfProcessId, activityId }),
     values: [
+      ...lineHeaders,
       {
         id: 'ProductValueAndName', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
         caption: trl('general.Product'),

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionStepScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionStepScreen.jsx
@@ -19,6 +19,7 @@ import { updateWFProcess } from '../../../actions/WorkflowActions';
 import { toastError } from '../../../utils/toast';
 import UnpickDialog from '../picking/UnpickDialog';
 import { useMobileLocation } from '../../../hooks/useMobileLocation';
+import { useDistributionLineHeaders } from './DistributionLineScreen';
 
 const HIDE_UNDO_BUTTONS = true; // hide them because they are not working
 
@@ -40,28 +41,36 @@ const DistributionStepScreen = () => {
     droppedToLocator: isDroppedToLocator,
   } = useSelector((state) => getStepById(state, wfProcessId, activityId, lineId, stepId));
 
+  const lineHeaders = useDistributionLineHeaders({ wfProcessId, activityId, lineId });
+
   const dispatch = useDispatch();
   const { history } = useScreenDefinition({
     screenId: 'DistributionStepScreen',
     back: distributionLineScreenLocation,
     values: [
+      ...lineHeaders,
       {
-        caption: trl('general.Locator'),
+        id: 'LocatorFrom', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
+        caption: trl('general.LocatorFrom'),
         value: pickFromLocator.caption,
       },
       {
+        id: 'LocatorTo',
         caption: trl('general.DropToLocator'),
         value: dropToLocator.caption,
       },
       {
+        id: 'Qty', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
         caption: trl('general.QtyToMove'),
         value: qtyToMove + ' ' + uom,
       },
       {
+        id: 'QtyPicked',
         caption: trl('general.QtyPicked'),
         value: qtyPicked + ' ' + uom,
       },
       {
+        id: 'PickFromHU',
         caption: trl('activities.distribution.scanHU'),
         value: toQRCodeDisplayable(pickFromHU.qrCode),
       },
@@ -95,10 +104,12 @@ const DistributionStepScreen = () => {
         location,
         values: [
           {
+            id: 'LocatorTo',
             caption: trl('general.DropToLocator'),
             value: dropToLocator.caption + ' (' + dropToLocator.qrCode + ')',
           },
           {
+            id: 'Qty', // shall match the de.metas.distribution.mobileui.config.DistributionJobCaptionField#getCode
             caption: trl('general.QtyToMove'),
             value: qtyToMove,
           },

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/WFLaunchersScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/WFLaunchersScreen.jsx
@@ -24,7 +24,7 @@ import { useCurrentTrolley } from '../../api/trolley';
 import { toastError } from '../../utils/toast';
 
 const WFLaunchersScreen = () => {
-  const { history } = useScreenDefinition({ screenId: 'WFLaunchersScreen', back: '/' });
+  const { history } = useScreenDefinition({ screenId: 'WFLaunchersScreen', back: '/', isHomeStop: true });
   const dispatch = useDispatch();
   const { url, applicationId } = useMobileLocation();
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfProcessScreen/WFProcessScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfProcessScreen/WFProcessScreen.jsx
@@ -195,15 +195,41 @@ const renderActivityComponent = ({ applicationId, wfProcessId, activityItem, isL
   }
 };
 
+//
+//
+//
+//
+//
+
+const getHeaderProperties = (wfProcess) => wfProcess?.headerProperties?.entries ?? [];
+
 const getPropsFromState = ({ state, wfProcessId }) => {
   const wfProcess = getWfProcess(state, wfProcessId);
-
   return {
     parentUrl: wfProcess?.parent?.url,
-    headerProperties: wfProcess?.headerProperties?.entries ?? [],
+    headerProperties: getHeaderProperties(wfProcess),
     activities: wfProcess ? getActivitiesInOrder(wfProcess) : [],
     isAllowAbort: !!wfProcess?.isAllowAbort,
   };
 };
+
+//
+//
+//
+//
+//
+
+export const useWFProcessHeaders = ({ wfProcessId }) => {
+  return useSelector((state) => {
+    const wfProcess = getWfProcess(state, wfProcessId);
+    return getHeaderProperties(wfProcess);
+  }, shallowEqual);
+};
+
+//
+//
+//
+//
+//
 
 export default WFProcessScreen;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/headers.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/headers.js
@@ -25,6 +25,8 @@ const isLaunchersPathname = (pathname) => launchersUrlRegExp.test(pathname);
 const getHeaderEntries = (state) => state.headers.entries ?? [];
 
 const getEntryItemsFromState = (state) => {
+  // console.group('getEntryItemsFromState');
+
   const headersEntries = getHeaderEntries(state);
 
   let nextUniqueId = 1;
@@ -42,6 +44,7 @@ const getEntryItemsFromState = (state) => {
       if (entryItem.hideField) {
         if (!hiddenFields.includes(key)) {
           hiddenFields.push(key);
+          // console.log(`getEntryItemsFromState - considering ${key} hidden from now on`, { entryItem, key, itemsByKey });
         }
         isFieldRemoved = true;
       } else {
@@ -50,11 +53,15 @@ const getEntryItemsFromState = (state) => {
 
       if (isFieldRemoved) {
         delete itemsByKey[key];
+        // console.log('getEntryItemsFromState - removed item', { entryItem, key, itemsByKey });
       } else {
         itemsByKey[key] = entryItem;
+        // console.log('getEntryItemsFromState - added item', { entryItem, key, itemsByKey });
       }
     });
 
+  // console.log('getEntryItemsFromState - final result', { result: Object.values(itemsByKey) });
+  // console.groupEnd();
   return Object.values(itemsByKey);
 };
 
@@ -251,37 +258,43 @@ const mergeEntries = (entry, newValues) => {
 };
 
 const mergeEntryValues = (valuesArray, newValuesArray) => {
+  // console.log('mergeEntryValues', { valuesArray, newValuesArray });
   if (!newValuesArray?.length) return valuesArray ? [...valuesArray] : [];
   if (!valuesArray?.length) return [...newValuesArray];
 
-  const newValuesByCaption = newValuesArray.reduce((accum, value) => {
+  const newValuesById = newValuesArray.reduce((accum, value) => {
     const entryId = value.id ?? value.caption;
     accum[entryId] = value;
     return accum;
   }, {});
+  // console.log('mergeEntryValues - 2', { newValuesById });
 
   const result = [];
 
   valuesArray.forEach((value) => {
     const entryId = value.id ?? value.caption;
-    const newValue = newValuesByCaption[entryId];
-    delete newValuesByCaption[entryId];
+    const newValue = newValuesById[entryId];
+    delete newValuesById[entryId];
     if (newValue) {
       result.push(newValue);
+      // console.log('mergeEntryValues - replaced current with newValue', { value, newValue, result, newValuesById });
     } else {
       result.push(value);
+      // console.log('mergeEntryValues - preserved current value', { value, result, newValuesById });
     }
   });
 
   newValuesArray.forEach((value) => {
     const entryId = value.id ?? value.caption;
-    const newValue = newValuesByCaption[entryId];
-    delete newValuesByCaption[entryId];
+    const newValue = newValuesById[entryId];
+    delete newValuesById[entryId];
     if (newValue) {
       result.push(newValue);
+      // console.log('mergeEntryValues - added newValue', { newValue, result, newValuesById });
     }
   });
 
+  // console.log('mergeEntryValues - final result', { result });
   return result;
 };
 


### PR DESCRIPTION
## Problem

In the MobileUI Distribution app, when the operator auto-advances from one order to the next (jump-to-next-order), the header bar kept showing the **previous** order's values — wrong `From Locator`, `Product` and `Qty` on every order after the first. Two smaller header glitches were also present: an undefined screen title on the drop-all screen, and the launchers "home" button navigating past the job list.

## Root cause

Header entries were deduplicated by their **caption**, so same-captioned entries from different screens/levels collided and a stale value could win. Fixed by deduplicating on a stable **id** with deterministic keep-last semantics, so the most specific (current-screen) value always wins.

## Changes

- `reducers/headers.js` — dedup header entries by `id` (keep-last) instead of by caption.
- `WFProcessScreen` / `DistributionLineScreen` / `DistributionPickFromScreen` / `DistributionStepScreen` — build headers via shared hooks (`useWFProcessHeaders`, `useDistributionLineHeaders`); each screen resolves the correct per-order header. Guards `lineId == null` on the pick-from screen.
- `DistributionJobsDropAllScreen` — add `captionKey` (fixes the undefined title).
- `WFLaunchersScreen` — `isHomeStop` so the header home button returns to the job list (not all the way to the applications list).

## Tests

- `packingTable_navigateToNextOrder.spec.js` — now asserts the header (`From Locator`, `Product`, `Qty`) on **every one of the 10 orders** through the full auto-advance flow. Verified failing before the fix (header showed the prior order) and passing after.
- `header.spec.js` — updated the `LocatorTo` caption assertion to the renamed label `Drop to locator`.
- Shared `DistributionUtils.expectHeaderProperty` (exact caption, visible row) reused by the distribution screen objects.

## Note

Emitting the same header `id` at line level and step level is intentional — the keep-last dedup makes the step-level value override, by design.
