### PR TITLE
Outbound Documents — add printed filter on doc outbound

### DIFF
--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java-gen/de/metas/document/archive/model/I_C_Doc_Outbound_Log.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java-gen/de/metas/document/archive/model/I_C_Doc_Outbound_Log.java
@@ -1,8 +1,7 @@
 package de.metas.document.archive.model;
 
-import org.adempiere.model.ModelColumn;
-
 import javax.annotation.Nullable;
+import org.adempiere.model.ModelColumn;
 
 /** Generated Interface for C_Doc_Outbound_Log
  *  @author metasfresh (generated) 
@@ -95,6 +94,26 @@ public interface I_C_Doc_Outbound_Log
 	String COLUMNNAME_C_Async_Batch_ID = "C_Async_Batch_ID";
 
 	/**
+	 * Set Business Partner.
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setC_BPartner_ID (int C_BPartner_ID);
+
+	/**
+	 * Get Business Partner.
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getC_BPartner_ID();
+
+	String COLUMNNAME_C_BPartner_ID = "C_BPartner_ID";
+
+	/**
 	 * Set Business Partner Group.
 	 * Business Partner Group
 	 *
@@ -126,26 +145,6 @@ public interface I_C_Doc_Outbound_Log
 
 	ModelColumn<I_C_Doc_Outbound_Log, org.compiere.model.I_C_BP_Group> COLUMN_C_BP_Group_ID = new ModelColumn<>(I_C_Doc_Outbound_Log.class, "C_BP_Group_ID", org.compiere.model.I_C_BP_Group.class);
 	String COLUMNNAME_C_BP_Group_ID = "C_BP_Group_ID";
-
-	/**
-	 * Set Business Partner.
-	 *
-	 * <br>Type: Search
-	 * <br>Mandatory: false
-	 * <br>Virtual Column: false
-	 */
-	void setC_BPartner_ID (int C_BPartner_ID);
-
-	/**
-	 * Get Business Partner.
-	 *
-	 * <br>Type: Search
-	 * <br>Mandatory: false
-	 * <br>Virtual Column: false
-	 */
-	int getC_BPartner_ID();
-
-	String COLUMNNAME_C_BPartner_ID = "C_BPartner_ID";
 
 	/**
 	 * Set Outbound Document Log ID.
@@ -222,7 +221,7 @@ public interface I_C_Doc_Outbound_Log
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	void setCurrentEMailAddress (@Nullable String CurrentEMailAddress);
+	void setCurrentEMailAddress (@Nullable java.lang.String CurrentEMailAddress);
 
 	/**
 	 * Get eMail.
@@ -231,11 +230,10 @@ public interface I_C_Doc_Outbound_Log
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	@Nullable String getCurrentEMailAddress();
+	@Nullable java.lang.String getCurrentEMailAddress();
 
 	ModelColumn<I_C_Doc_Outbound_Log, Object> COLUMN_CurrentEMailAddress = new ModelColumn<>(I_C_Doc_Outbound_Log.class, "CurrentEMailAddress", null);
 	String COLUMNNAME_CurrentEMailAddress = "CurrentEMailAddress";
-
 
 	/**
 	 * Set EMail Address CC.
@@ -383,13 +381,40 @@ public interface I_C_Doc_Outbound_Log
 	String COLUMNNAME_DateLastStore = "DateLastStore";
 
 	/**
+	 * Set Date Promised.
+	 * Date Order was promised
+	 *
+	 * <br>Type: Date
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true (lazy loading)
+	 * @deprecated Please don't use it because this is a virtual column
+	 */
+	@Deprecated
+	void setDatePromised (@Nullable java.sql.Timestamp DatePromised);
+
+	/**
+	 * Get Date Promised.
+	 * Date Order was promised
+	 *
+	 * <br>Type: Date
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true (lazy loading)
+	 * @deprecated Please don't use it because this is a lazy loading column and it might affect the performances
+	 */
+	@Deprecated
+	@Nullable java.sql.Timestamp getDatePromised();
+
+	ModelColumn<I_C_Doc_Outbound_Log, Object> COLUMN_DatePromised = new ModelColumn<>(I_C_Doc_Outbound_Log.class, "DatePromised", null);
+	String COLUMNNAME_DatePromised = "DatePromised";
+
+	/**
 	 * Set Status.
 	 *
 	 * <br>Type: List
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	void setDocStatus (@Nullable String DocStatus);
+	void setDocStatus (@Nullable java.lang.String DocStatus);
 
 	/**
 	 * Get Status.
@@ -398,7 +423,7 @@ public interface I_C_Doc_Outbound_Log
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	@Nullable String getDocStatus();
+	@Nullable java.lang.String getDocStatus();
 
 	ModelColumn<I_C_Doc_Outbound_Log, Object> COLUMN_DocStatus = new ModelColumn<>(I_C_Doc_Outbound_Log.class, "DocStatus", null);
 	String COLUMNNAME_DocStatus = "DocStatus";
@@ -411,7 +436,7 @@ public interface I_C_Doc_Outbound_Log
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	void setDocumentNo (@Nullable String DocumentNo);
+	void setDocumentNo (@Nullable java.lang.String DocumentNo);
 
 	/**
 	 * Get Document No.
@@ -421,7 +446,7 @@ public interface I_C_Doc_Outbound_Log
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	@Nullable String getDocumentNo();
+	@Nullable java.lang.String getDocumentNo();
 
 	ModelColumn<I_C_Doc_Outbound_Log, Object> COLUMN_DocumentNo = new ModelColumn<>(I_C_Doc_Outbound_Log.class, "DocumentNo", null);
 	String COLUMNNAME_DocumentNo = "DocumentNo";
@@ -433,7 +458,7 @@ public interface I_C_Doc_Outbound_Log
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	void setEDI_ExportStatus (@Nullable String EDI_ExportStatus);
+	void setEDI_ExportStatus (@Nullable java.lang.String EDI_ExportStatus);
 
 	/**
 	 * Get EDI export status.
@@ -442,7 +467,7 @@ public interface I_C_Doc_Outbound_Log
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	@Nullable String getEDI_ExportStatus();
+	@Nullable java.lang.String getEDI_ExportStatus();
 
 	ModelColumn<I_C_Doc_Outbound_Log, Object> COLUMN_EDI_ExportStatus = new ModelColumn<>(I_C_Doc_Outbound_Log.class, "EDI_ExportStatus", null);
 	String COLUMNNAME_EDI_ExportStatus = "EDI_ExportStatus";
@@ -480,7 +505,7 @@ public interface I_C_Doc_Outbound_Log
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	void setFileName (@Nullable String FileName);
+	void setFileName (@Nullable java.lang.String FileName);
 
 	/**
 	 * Get File Name.
@@ -490,7 +515,7 @@ public interface I_C_Doc_Outbound_Log
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	@Nullable String getFileName();
+	@Nullable java.lang.String getFileName();
 
 	ModelColumn<I_C_Doc_Outbound_Log, Object> COLUMN_FileName = new ModelColumn<>(I_C_Doc_Outbound_Log.class, "FileName", null);
 	String COLUMNNAME_FileName = "FileName";
@@ -517,6 +542,31 @@ public interface I_C_Doc_Outbound_Log
 
 	ModelColumn<I_C_Doc_Outbound_Log, Object> COLUMN_IsActive = new ModelColumn<>(I_C_Doc_Outbound_Log.class, "IsActive", null);
 	String COLUMNNAME_IsActive = "IsActive";
+
+	/**
+	 * Set Printed.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true (lazy loading)
+	 * @deprecated Please don't use it because this is a virtual column
+	 */
+	@Deprecated
+	void setIsAlreadyPrinted (boolean IsAlreadyPrinted);
+
+	/**
+	 * Get Printed.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true (lazy loading)
+	 * @deprecated Please don't use it because this is a lazy loading column and it might affect the performances
+	 */
+	@Deprecated
+	boolean isAlreadyPrinted();
+
+	ModelColumn<I_C_Doc_Outbound_Log, Object> COLUMN_IsAlreadyPrinted = new ModelColumn<>(I_C_Doc_Outbound_Log.class, "IsAlreadyPrinted", null);
+	String COLUMNNAME_IsAlreadyPrinted = "IsAlreadyPrinted";
 
 	/**
 	 * Set Invoice Email Enabled.
@@ -568,21 +618,21 @@ public interface I_C_Doc_Outbound_Log
 	 * Set Order Reference.
 	 * Transaction Reference Number (Sales Order, Purchase Order) of your Business Partner
 	 *
-	 * <br>Type: Text
+	 * <br>Type: String
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	void setPOReference (@Nullable String POReference);
+	void setPOReference (@Nullable java.lang.String POReference);
 
 	/**
 	 * Get Order Reference.
 	 * Transaction Reference Number (Sales Order, Purchase Order) of your Business Partner
 	 *
-	 * <br>Type: Text
+	 * <br>Type: String
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	@Nullable String getPOReference();
+	@Nullable java.lang.String getPOReference();
 
 	ModelColumn<I_C_Doc_Outbound_Log, Object> COLUMN_POReference = new ModelColumn<>(I_C_Doc_Outbound_Log.class, "POReference", null);
 	String COLUMNNAME_POReference = "POReference";

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java-gen/de/metas/document/archive/model/X_C_Doc_Outbound_Log.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java-gen/de/metas/document/archive/model/X_C_Doc_Outbound_Log.java
@@ -1,9 +1,9 @@
 // Generated Model - DO NOT CHANGE
 package de.metas.document.archive.model;
 
-import javax.annotation.Nullable;
 import java.sql.ResultSet;
 import java.util.Properties;
+import javax.annotation.Nullable;
 
 /** Generated Model for C_Doc_Outbound_Log
  *  @author metasfresh (generated) 
@@ -12,7 +12,7 @@ import java.util.Properties;
 public class X_C_Doc_Outbound_Log extends org.compiere.model.PO implements I_C_Doc_Outbound_Log, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = -1911580358L;
+	private static final long serialVersionUID = -1088534133L;
 
     /** Standard Constructor */
     public X_C_Doc_Outbound_Log (final Properties ctx, final int C_Doc_Outbound_Log_ID, @Nullable final String trxName)
@@ -65,6 +65,21 @@ public class X_C_Doc_Outbound_Log extends org.compiere.model.PO implements I_C_D
 	}
 
 	@Override
+	public void setC_BPartner_ID (final int C_BPartner_ID)
+	{
+		if (C_BPartner_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_C_BPartner_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_C_BPartner_ID, C_BPartner_ID);
+	}
+
+	@Override
+	public int getC_BPartner_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_C_BPartner_ID);
+	}
+
+	@Override
 	public org.compiere.model.I_C_BP_Group getC_BP_Group()
 	{
 		return get_ValueAsPO(COLUMNNAME_C_BP_Group_ID, org.compiere.model.I_C_BP_Group.class);
@@ -85,21 +100,6 @@ public class X_C_Doc_Outbound_Log extends org.compiere.model.PO implements I_C_D
 	public int getC_BP_Group_ID() 
 	{
 		return get_ValueAsInt(COLUMNNAME_C_BP_Group_ID);
-	}
-
-	@Override
-	public void setC_BPartner_ID (final int C_BPartner_ID)
-	{
-		if (C_BPartner_ID < 1) 
-			set_ValueNoCheck (COLUMNNAME_C_BPartner_ID, null);
-		else 
-			set_ValueNoCheck (COLUMNNAME_C_BPartner_ID, C_BPartner_ID);
-	}
-
-	@Override
-	public int getC_BPartner_ID() 
-	{
-		return get_ValueAsInt(COLUMNNAME_C_BPartner_ID);
 	}
 
 	@Override
@@ -133,13 +133,13 @@ public class X_C_Doc_Outbound_Log extends org.compiere.model.PO implements I_C_D
 	}
 
 	@Override
-	public void setCurrentEMailAddress (final @Nullable String CurrentEMailAddress)
+	public void setCurrentEMailAddress (final @Nullable java.lang.String CurrentEMailAddress)
 	{
 		set_Value (COLUMNNAME_CurrentEMailAddress, CurrentEMailAddress);
 	}
 
 	@Override
-	public String getCurrentEMailAddress() 
+	public java.lang.String getCurrentEMailAddress() 
 	{
 		return get_ValueAsString(COLUMNNAME_CurrentEMailAddress);
 	}
@@ -151,7 +151,7 @@ public class X_C_Doc_Outbound_Log extends org.compiere.model.PO implements I_C_D
 	}
 
 	@Override
-	public java.lang.String getCurrentEMailAddressCC()
+	public java.lang.String getCurrentEMailAddressCC() 
 	{
 		return get_ValueAsString(COLUMNNAME_CurrentEMailAddressCC);
 	}
@@ -159,14 +159,14 @@ public class X_C_Doc_Outbound_Log extends org.compiere.model.PO implements I_C_D
 	@Override
 	public void setCurrentEMailCCRecipient_ID (final int CurrentEMailCCRecipient_ID)
 	{
-		if (CurrentEMailCCRecipient_ID < 1)
+		if (CurrentEMailCCRecipient_ID < 1) 
 			set_Value (COLUMNNAME_CurrentEMailCCRecipient_ID, null);
-		else
+		else 
 			set_Value (COLUMNNAME_CurrentEMailCCRecipient_ID, CurrentEMailCCRecipient_ID);
 	}
 
 	@Override
-	public int getCurrentEMailCCRecipient_ID()
+	public int getCurrentEMailCCRecipient_ID() 
 	{
 		return get_ValueAsInt(COLUMNNAME_CurrentEMailCCRecipient_ID);
 	}
@@ -234,6 +234,17 @@ public class X_C_Doc_Outbound_Log extends org.compiere.model.PO implements I_C_D
 		return get_ValueAsTimestamp(COLUMNNAME_DateLastStore);
 	}
 
+	@Override
+	public void setDatePromised (final @Nullable java.sql.Timestamp DatePromised)
+	{
+		throw new IllegalArgumentException ("DatePromised is virtual column");	}
+
+	@Override
+	public java.sql.Timestamp getDatePromised() 
+	{
+		return get_ValueAsTimestamp(COLUMNNAME_DatePromised);
+	}
+
 	/** 
 	 * DocStatus AD_Reference_ID=131
 	 * Reference name: _Document Status
@@ -264,25 +275,25 @@ public class X_C_Doc_Outbound_Log extends org.compiere.model.PO implements I_C_D
 	/** WaitingConfirmation = WC */
 	public static final String DOCSTATUS_WaitingConfirmation = "WC";
 	@Override
-	public void setDocStatus (final @Nullable String DocStatus)
+	public void setDocStatus (final @Nullable java.lang.String DocStatus)
 	{
-		set_ValueNoCheck (COLUMNNAME_DocStatus, DocStatus);
+		set_Value (COLUMNNAME_DocStatus, DocStatus);
 	}
 
 	@Override
-	public String getDocStatus() 
+	public java.lang.String getDocStatus() 
 	{
 		return get_ValueAsString(COLUMNNAME_DocStatus);
 	}
 
 	@Override
-	public void setDocumentNo (final @Nullable String DocumentNo)
+	public void setDocumentNo (final @Nullable java.lang.String DocumentNo)
 	{
 		set_ValueNoCheck (COLUMNNAME_DocumentNo, DocumentNo);
 	}
 
 	@Override
-	public String getDocumentNo() 
+	public java.lang.String getDocumentNo() 
 	{
 		return get_ValueAsString(COLUMNNAME_DocumentNo);
 	}
@@ -307,13 +318,13 @@ public class X_C_Doc_Outbound_Log extends org.compiere.model.PO implements I_C_D
 	/** DontSend = N */
 	public static final String EDI_EXPORTSTATUS_DontSend = "N";
 	@Override
-	public void setEDI_ExportStatus (final @Nullable String EDI_ExportStatus)
+	public void setEDI_ExportStatus (final @Nullable java.lang.String EDI_ExportStatus)
 	{
 		set_ValueNoCheck (COLUMNNAME_EDI_ExportStatus, EDI_ExportStatus);
 	}
 
 	@Override
-	public String getEDI_ExportStatus() 
+	public java.lang.String getEDI_ExportStatus() 
 	{
 		return get_ValueAsString(COLUMNNAME_EDI_ExportStatus);
 	}
@@ -330,15 +341,26 @@ public class X_C_Doc_Outbound_Log extends org.compiere.model.PO implements I_C_D
 	}
 
 	@Override
-	public void setFileName (final @Nullable String FileName)
+	public void setFileName (final @Nullable java.lang.String FileName)
 	{
 		set_Value (COLUMNNAME_FileName, FileName);
 	}
 
 	@Override
-	public String getFileName() 
+	public java.lang.String getFileName() 
 	{
 		return get_ValueAsString(COLUMNNAME_FileName);
+	}
+
+	@Override
+	public void setIsAlreadyPrinted (final boolean IsAlreadyPrinted)
+	{
+		throw new IllegalArgumentException ("IsAlreadyPrinted is virtual column");	}
+
+	@Override
+	public boolean isAlreadyPrinted() 
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsAlreadyPrinted);
 	}
 
 	@Override
@@ -365,13 +387,13 @@ public class X_C_Doc_Outbound_Log extends org.compiere.model.PO implements I_C_D
 	}
 
 	@Override
-	public void setPOReference (final @Nullable String POReference)
+	public void setPOReference (final @Nullable java.lang.String POReference)
 	{
 		set_ValueNoCheck (COLUMNNAME_POReference, POReference);
 	}
 
 	@Override
-	public String getPOReference() 
+	public java.lang.String getPOReference() 
 	{
 		return get_ValueAsString(COLUMNNAME_POReference);
 	}

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/sql/postgresql/system/5809050_sys_30504_Doc_Outbound_Log_IsAlreadyPrinted.sql
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/sql/postgresql/system/5809050_sys_30504_Doc_Outbound_Log_IsAlreadyPrinted.sql
@@ -1,5 +1,4 @@
--- me03 30504: Add a "Gedruckt"/"Printed" Yes/No filter+grid column to window "Ausgehende Belege".
--- https://github.com/metasfresh/me03/issues/30504
+-- 30504: Add a "Gedruckt"/"Printed" Yes/No filter+grid column to window "Ausgehende Belege".
 --
 -- New virtual ColumnSQL Yes/No column C_Doc_Outbound_Log.IsAlreadyPrinted:
 --   'Y' when the document has >=1 print line, 'N' otherwise. Same definition as the existing

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/sql/postgresql/system/5809050_sys_me03_30504_Doc_Outbound_Log_IsAlreadyPrinted.sql
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/sql/postgresql/system/5809050_sys_me03_30504_Doc_Outbound_Log_IsAlreadyPrinted.sql
@@ -1,0 +1,79 @@
+-- me03 30504: Add a "Gedruckt"/"Printed" Yes/No filter+grid column to window "Ausgehende Belege".
+-- https://github.com/metasfresh/me03/issues/30504
+--
+-- New virtual ColumnSQL Yes/No column C_Doc_Outbound_Log.IsAlreadyPrinted:
+--   'Y' when the document has >=1 print line, 'N' otherwise. Same definition as the existing
+--   virtual PrintCount column (col 548164) — IsAlreadyPrinted = (PrintCount > 0) expressed as Yes/No.
+-- Surfaced as a grid column right of "Anz. gedruckt" (SeqNoGrid=105, between PrintCount@100 and
+--   DateLastPrint@110) and as a default-filter selection column (IsSelectionColumn='Y').
+-- Standard core window 540170 / tab 540474 / table 540453 (de.metas.document.archive) — verified
+--   against a customer-faithful dt204 DB: no override window for 540170, so a single core script.
+-- Virtual column => no physical DDL. No AD_SQLColumn_SourceTableColumn row, matching the identical
+--   sibling PrintCount (cacheinvalidateparent='Y' handles parent cache).
+-- A NEW AD_Element is used (not the standard IsPrinted/element 399 "andrucken", which is intended in
+--   report/Jasper windows 217/218/249 + AD_PrintFormatItem).
+
+-- Element: IsAlreadyPrinted
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy)
+VALUES (0,585032 /*From ID Server*/,0,'IsAlreadyPrinted',TO_TIMESTAMP('2026-06-19 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Gedruckt','Gedruckt',TO_TIMESTAMP('2026-06-19 12:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585032
+AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- de_DE / de_CH = "Gedruckt"
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Gedruckt', PrintName='Gedruckt',Updated=TO_TIMESTAMP('2026-06-19 12:00:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585032 AND AD_Language IN ('de_DE','de_CH')
+;
+
+-- en_US = "Printed"
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Printed', PrintName='Printed',Updated=TO_TIMESTAMP('2026-06-19 12:00:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585032 AND AD_Language='en_US'
+;
+
+-- Column: C_Doc_Outbound_Log.IsAlreadyPrinted  (virtual Yes/No, selection/filter column)
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,ColumnSQL,Created,CreatedBy,DDL_NoForeignKey,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsAutocomplete,IsCalculated,IsEncrypted,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRangeFilter,IsSelectionColumn,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,Name,PersonalDataCategory,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version)
+VALUES (0,592859 /*From ID Server*/,585032,0,20,540453,'IsAlreadyPrinted','(CASE WHEN (select COUNT(*) from C_Doc_Outbound_Log_Line where C_Doc_Outbound_Log_Line.Action = ''print'' AND C_Doc_Outbound_Log_Line.C_Doc_Outbound_Log_ID = C_Doc_Outbound_Log.C_Doc_Outbound_Log_ID) > 0 THEN ''Y'' ELSE ''N'' END)',TO_TIMESTAMP('2026-06-19 12:01:00','YYYY-MM-DD HH24:MI:SS'),100,'N','de.metas.document.archive',1,'Y','Y','N','N','N','N','N','N','N','N','N','Y','N','N','N','Y','N','N','N','N','N','Gedruckt','NP',10,0,TO_TIMESTAMP('2026-06-19 12:01:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Column_ID=592859
+AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+/* DDL */  select update_Column_Translation_From_AD_Element(585032)
+;
+
+-- Field: Ausgehende Belege -> Gedruckt  (grid + filter only, not single-record form)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,DisplayLength,EntityType,IncludedTabHeight,IsActive,IsAlwaysUpdateable,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,SpanX,SpanY,Updated,UpdatedBy)
+VALUES (0,592859,781231 /*From ID Server*/,0,540474,0,TO_TIMESTAMP('2026-06-19 12:02:00','YYYY-MM-DD HH24:MI:SS'),100,1,'de.metas.document.archive',0,'Y','N','N','Y','N','N','N','Y','N','Gedruckt',55,105,1,1,TO_TIMESTAMP('2026-06-19 12:02:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y') AND t.AD_Field_ID=781231
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(585032)
+;
+
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781231
+;
+
+/* DDL */ select AD_Element_Link_Create_Missing_Field(781231)
+;
+
+-- UI Element: place in element group 540352 on tab 540474, grid right of "Anz. gedruckt"
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy,WidgetSize)
+VALUES (0,781231,0,540474,540352,652343 /*From ID Server*/,'F',TO_TIMESTAMP('2026-06-19 12:02:30','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','N','N','Y','N','N','Gedruckt',15,105,0,TO_TIMESTAMP('2026-06-19 12:02:30','YYYY-MM-DD HH24:MI:SS'),100,'S')
+;
+
+-- Propagate all element translations (incl. en_US "Printed") to the column/field _Trl rows.
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(585032)
+;


### PR DESCRIPTION
Adds a **"Gedruckt" / "Printed"** Yes/No grid + filter column to the window **"Ausgehende Belege"** (`C_Doc_Outbound_Log`, window 540170), so users can filter outbound documents by whether they have been printed.

### What
- New virtual `ColumnSQL` Yes/No column `C_Doc_Outbound_Log.IsAlreadyPrinted` — `'Y'` when the document has ≥1 `print` line, `'N'` otherwise. Same definition as the existing virtual `PrintCount` column (`IsAlreadyPrinted = PrintCount > 0`).
- Surfaced as a **grid column** right of "Anz. gedruckt" (`SeqNoGrid=105`, between PrintCount@100 and DateLastPrint@110) and as a **default-filter selection column** (`IsSelectionColumn='Y'`). Not shown in the single-record form.
- Labels: de_DE/de_CH **"Gedruckt"**, en_US **"Printed"**.

### Notes
- Standard core window — verified against a customer-faithful DB that **no override window** exists for 540170, so a single core migration (no customer-repo companion needed).
- A new dedicated `AD_Element` is used (not the standard `IsPrinted` "andrucken", which is intended in report/Jasper windows).
- Virtual column → no physical DDL.
