### PR TITLE
EDI/EPCIS: per-crate order references (order-pure packing) + scripted-export eligibility timing fix

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
@@ -39,7 +39,9 @@ import org.compiere.util.DB;
 import org.compiere.util.Trx;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -200,6 +202,8 @@ public class EPCIS_JSON_Export_StepDef
 	 *   <b>lotNumber</b> — (optional) expected lot number<br>
 	 *   <b>bestBeforeDate</b> — (optional) expected best-before date<br>
 	 *   <b>itemCount</b> — (optional) expected number of items in this crate<br>
+	 *   <b>poReference</b> — (optional) expected per-crate source-order POReference (order-pure crate, me03 #30279)<br>
+	 *   <b>shipmentDocumentNo</b> — (optional) expected per-crate delivery note = crate-shipment M_InOut.DocumentNo<br>
 	 * @cucumber.example
 	 * <pre>
 	 * Then the EPCIS JSON crate has:
@@ -234,7 +238,62 @@ public class EPCIS_JSON_Export_StepDef
 			row.getAsOptionalInt("itemCount")
 					.ifPresent(expected -> assertThat(crate.path("items").size())
 							.as("crate itemCount").isEqualTo(expected));
+
+			row.getAsOptionalString("poReference")
+					.ifPresent(expected -> assertThat(crate.path("poReference").asText())
+							.as("crate poReference").isEqualTo(expected));
+
+			row.getAsOptionalString("shipmentDocumentNo")
+					.ifPresent(expected -> assertThat(crate.path("shipmentDocumentNo").asText())
+							.as("crate shipmentDocumentNo").isEqualTo(expected));
 		});
+	}
+
+	/**
+	 * Asserts that every crate of a pallet is order-pure: it carries a non-null per-crate
+	 * {@code poReference} and {@code shipmentDocumentNo}, and the DISTINCT set of {@code poReference}
+	 * values across all crates equals exactly the expected set. This is the EPCIS PACKING order-purity
+	 * contract (me03 #30279): a crate belongs to one order, so each crate's packing event references
+	 * only that order — even when several orders share one physical pallet/SSCC.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>poReference</b> — (required) one row per DISTINCT source-order POReference expected across the pallet's crates<br>
+	 * @cucumber.example
+	 * <pre>
+	 * Then the EPCIS JSON pallet 0 crates are order-pure with POReferences:
+	 *   | poReference |
+	 *   | 1170000001  |
+	 *   | 1170000002  |
+	 * </pre>
+	 */
+	@Then("the EPCIS JSON pallet {int} crates are order-pure with POReferences:")
+	public void validateCratesOrderPure(final int palletIndex, @NonNull final DataTable dataTable)
+	{
+		assertThat(lastEpcisResult).as("EPCIS JSON result must exist (call the export function first)").isNotNull();
+
+		final JsonNode crates = lastEpcisResult.path("pallets").get(palletIndex).path("crates");
+		assertThat(crates.isArray()).as("pallet[%d].crates must be a JSON array", palletIndex).isTrue();
+		assertThat(crates.size()).as("pallet[%d] must have crates", palletIndex).isGreaterThan(0);
+
+		final Set<String> distinctPoRefs = new HashSet<>();
+		crates.forEach(crate -> {
+			// order-pure: every crate must be tagged with exactly one (non-null) order + its delivery note
+			assertThat(crate.path("poReference").isTextual())
+					.as("every crate must carry a non-null poReference, got: %s", crate)
+					.isTrue();
+			assertThat(crate.path("shipmentDocumentNo").isTextual())
+					.as("every crate must carry a non-null shipmentDocumentNo, got: %s", crate)
+					.isTrue();
+			distinctPoRefs.add(crate.path("poReference").asText());
+		});
+
+		final Set<String> expectedPoRefs = new HashSet<>();
+		dataTable.asMaps().forEach(rowMap -> expectedPoRefs.add(rowMap.get("poReference")));
+
+		assertThat(distinctPoRefs)
+				.as("distinct per-crate poReferences on pallet[%d]", palletIndex)
+				.isEqualTo(expectedPoRefs);
 	}
 
 	/**

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EPCIS_JSON_Export_StepDef.java
@@ -289,7 +289,7 @@ public class EPCIS_JSON_Export_StepDef
 		});
 
 		final Set<String> expectedPoRefs = new HashSet<>();
-		dataTable.asMaps().forEach(rowMap -> expectedPoRefs.add(rowMap.get("poReference")));
+		DataTableRows.of(dataTable).forEach(row -> expectedPoRefs.add(row.getAsString("poReference")));
 
 		assertThat(distinctPoRefs)
 				.as("distinct per-crate poReferences on pallet[%d]", palletIndex)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_Config_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_Config_StepDef.java
@@ -365,7 +365,10 @@ public class ExternalSystem_Config_StepDef
 	 * <p>Accepts the same columns as the base step:
 	 * <b>ExternalSystem_Config_ID</b> (identifier), <b>ExternalSystem_Config_ScriptedExportConversion_ID</b> (identifier),
 	 * <b>AD_Process_OutboundData_ID.Value</b> (the outbound data process producing the export payload),
-	 * <b>TableName</b> (the document table the config triggers on).
+	 * <b>TableName</b> (the document table the config triggers on),
+	 * <b>WhereClause</b> (optional — the config's match clause; defaults to {@code IsActive='Y'}. Override with a
+	 * clause that only matches once the document is committed-complete, e.g. {@code docstatus IN ('CO','CL')},
+	 * to mirror the production EPCIS clause {@code "de.metas.edi".epcis_has_events(m_inout_id)}).
 	 *
 	 * <p>Example:
 	 * <pre>
@@ -450,10 +453,13 @@ public class ExternalSystem_Config_StepDef
 		}
 
 		// The DDL default "IsActive=Y" is not valid PostgreSQL SQL (Y is treated as a column name by
-		// the JDBC driver). Overwrite with the syntactically correct form so that
+		// the JDBC driver). Default to the syntactically correct always-true form so that
 		// ExternalSystemScriptedExportConversionService.isConfigMatchingRecord() can run the WHERE
-		// clause successfully.
-		scriptedExportConversionConfig.setWhereClause("IsActive='Y'");
+		// clause successfully. A scenario may override it via the optional WhereClause column — e.g.
+		// a clause that only matches once the document is committed-complete (docstatus IN ('CO','CL')),
+		// mirroring the production EPCIS clause "de.metas.edi".epcis_has_events(m_inout_id).
+		final String whereClause = row.getAsOptionalString("WhereClause").orElse("IsActive='Y'");
+		scriptedExportConversionConfig.setWhereClause(whereClause);
 
 		InterfaceWrapperHelper.save(scriptedExportConversionConfig);
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -662,6 +662,15 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | desadvReferences    | 2            |
       | poReferences        | 2            |
       | shipmentDocumentNos | 2            |
+    # ─── Order-pure crates (me03 #30279) ─────────────────────────────────────────────
+    # Even though both orders share ONE physical pallet, each crate (Gebinde) belongs to
+    # exactly one order, so each crate must carry its own poReference + delivery note. The
+    # scripted adapter uses these to emit one po + one desadv bizTransaction per PACKING event.
+    # 15 crates total: 5 from order A (PO 1170000001) + 10 from order B (PO 1170000002).
+    Then the EPCIS JSON pallet 0 crates are order-pure with POReferences:
+      | poReference |
+      | 1170000001  |
+      | 1170000002  |
 
     # ─── Sibling shipment B must return {} (no duplicate event for the same SSCC) ──────
     Then the EPCIS JSON export function returns empty object for M_InOut identified by ioB_S29231_170

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
@@ -212,3 +212,51 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
     And after not more than 10s, M_InOut EPCIS_ExportStatus is:
       | M_InOut_ID | EPCIS_ExportStatus |
       | io_030     | S                  |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00353_EDI_DESADV_InOut_Link
+  @Id:S30279_040
+  Scenario: S30279_040 — a WhereClause that depends on the committed-complete state still matches at trigger time
+    ## RED reproduction for the complete-time eligibility timing bug.
+    ## The production EPCIS config gates sending on "de.metas.edi".epcis_has_events(m_inout_id), which
+    ## internally requires the shipment's DocStatus IN ('CO','CL'). This scenario uses the minimal
+    ## equivalent clause `docstatus IN ('CO','CL')` to isolate the timing without LU/SSCC pallet setup.
+    ##
+    ## Today the eligibility WhereClause is evaluated synchronously inside docValidate(AFTER_COMPLETE)
+    ## — fired by MInOut.completeIt() BEFORE the engine sets+saves DocStatus='CO' — so the in-trx SQL
+    ## sees the not-yet-completed row, the clause is false, and the row is recorded DontSend (N): the
+    ## export is never enqueued. Expected once the matching is moved to after-commit: the row reaches
+    ## Enqueued (U). This assertion FAILS on current code (RED) and passes after the fix (GREEN).
+
+    # Override the Background config with one whose match clause only holds once the shipment is committed-complete.
+    # Creating it deactivates the Background's always-true scriptedCfg_es for M_InOut (table-scoped takeover).
+    And metasfresh contains ExternalSystem_Config with ScriptedExportConversion and StatusColumn:
+      | ExternalSystem_Config_ID | ExternalSystem_Config_ScriptedExportConversion_ID | AD_Process_OutboundData_ID.Value | TableName | WhereClause            |
+      | esConfig_gated           | scriptedCfg_gated                                 | M_InOut_EDI_Export_JSON          | M_InOut   | docstatus IN ('CO','CL') |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference           |
+      | o_040      | true    | bp_es         | 2026-06-09  | PO_S30279_040_@Date@  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | ol_040     | o_040      | product_es   | 10         | pip_es                  |
+    When the order identified by o_040 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ss_040     | ol_040         | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_040                | D            | true                | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | ss_040                | io_040     |
+
+    # Drain async material/DESADV workpackages from shipment generation (avoid spilling into sibling executor tests).
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # The completed shipment matches the WhereClause (docstatus is now CO) → must be Enqueued, not DontSend.
+    Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus |
+      | io_040     | scriptedCfg_gated                                 | U            |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
@@ -219,16 +219,16 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
   @allure.label.feature:F00353_EDI_DESADV_InOut_Link
   @Id:S30279_040
   Scenario: S30279_040 — a WhereClause that depends on the committed-complete state still matches at trigger time
-    ## RED reproduction for the complete-time eligibility timing bug.
+    ## Reproduces the complete-time eligibility timing bug fixed in this change.
     ## The production EPCIS config gates sending on "de.metas.edi".epcis_has_events(m_inout_id), which
     ## internally requires the shipment's DocStatus IN ('CO','CL'). This scenario uses the minimal
     ## equivalent clause `docstatus IN ('CO','CL')` to isolate the timing without LU/SSCC pallet setup.
     ##
-    ## Today the eligibility WhereClause is evaluated synchronously inside docValidate(AFTER_COMPLETE)
-    ## — fired by MInOut.completeIt() BEFORE the engine sets+saves DocStatus='CO' — so the in-trx SQL
-    ## sees the not-yet-completed row, the clause is false, and the row is recorded DontSend (N): the
-    ## export is never enqueued. Expected once the matching is moved to after-commit: the row reaches
-    ## Enqueued (U). This assertion FAILS on current code (RED) and passes after the fix (GREEN).
+    ## Before the fix, the eligibility WhereClause was evaluated synchronously inside
+    ## docValidate(AFTER_COMPLETE) — fired by MInOut.completeIt() BEFORE the engine sets+saves
+    ## DocStatus='CO' — so the in-trx SQL saw the not-yet-completed row, the clause was false, and the
+    ## row was recorded DontSend (N): the export never enqueued. With the matching moved to
+    ## after-commit, DocStatus is committed and the row reaches Enqueued (U) (was DontSend (N) before).
 
     # Override the Background config with one whose match clause only holds once the shipment is committed-complete.
     # Creating it deactivates the Background's always-true scriptedCfg_es for M_InOut (table-scoped takeover).

--- a/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
@@ -354,7 +354,7 @@ BEGIN
                           WHERE ha.ad_table_id = v_m_inoutline_table_id
                             AND ha.isactive = 'Y'
                             AND ha.m_tu_hu_id IN (SELECT tu_hu_id FROM individual_tu_ids
-                                                  UNION
+                                                  UNION ALL
                                                   SELECT vtu_hu_id FROM ha_items_with_vtu)
                           UNION ALL
                           SELECT ha.record_id, ha.vhu_id AS hu_id
@@ -362,7 +362,7 @@ BEGIN
                           WHERE ha.ad_table_id = v_m_inoutline_table_id
                             AND ha.isactive = 'Y'
                             AND ha.vhu_id IN (SELECT tu_hu_id FROM individual_tu_ids
-                                              UNION
+                                              UNION ALL
                                               SELECT vtu_hu_id FROM ha_items_with_vtu)
                       ) asg
                           JOIN m_inoutline iol ON iol.m_inoutline_id = asg.record_id

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5809070_sys_me03_30279_epcis_per_crate_order_ref.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5809070_sys_me03_30279_epcis_per_crate_order_ref.sql
@@ -1,3 +1,15 @@
+-- Source DDL: backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
+-- me03 #30279: per-crate source-order references for order-pure EPCIS PACKING events.
+--
+-- A crate (Gebinde) in the FT process is order-pure: it belongs to exactly one order. The EPCIS
+-- PACKING event for a crate must therefore carry only that crate's order (one po + one desadv
+-- bizTransaction), not the merged pallet-level set of all orders sharing the SSCC. The export JSON
+-- previously exposed order refs only at the top level, so the scripted adapter emitted every order
+-- on every crate. This adds 'poReference' (the crate's order POReference) and 'shipmentDocumentNo'
+-- (the crate-shipment's M_InOut.DocumentNo = delivery note) to each crate object, resolved per TU
+-- via m_hu_assignment -> m_inoutline -> c_order / m_inout. Picking/commissioning stay pallet-level
+-- (the scripted adapter keeps using the top-level arrays there). Pure CREATE OR REPLACE.
+
 /*
  * #%L
  * de.metas.edi

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5809070_sys_me03_30279_epcis_per_crate_order_ref.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5809070_sys_me03_30279_epcis_per_crate_order_ref.sql
@@ -366,7 +366,7 @@ BEGIN
                           WHERE ha.ad_table_id = v_m_inoutline_table_id
                             AND ha.isactive = 'Y'
                             AND ha.m_tu_hu_id IN (SELECT tu_hu_id FROM individual_tu_ids
-                                                  UNION
+                                                  UNION ALL
                                                   SELECT vtu_hu_id FROM ha_items_with_vtu)
                           UNION ALL
                           SELECT ha.record_id, ha.vhu_id AS hu_id
@@ -374,7 +374,7 @@ BEGIN
                           WHERE ha.ad_table_id = v_m_inoutline_table_id
                             AND ha.isactive = 'Y'
                             AND ha.vhu_id IN (SELECT tu_hu_id FROM individual_tu_ids
-                                              UNION
+                                              UNION ALL
                                               SELECT vtu_hu_id FROM ha_items_with_vtu)
                       ) asg
                           JOIN m_inoutline iol ON iol.m_inoutline_id = asg.record_id

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
@@ -336,36 +336,23 @@ public class ExternalSystemScriptedExportConversionService
 	}
 
 	/**
-	 * Called from the document's AFTER_COMPLETE interceptor: records an eligibility status for EVERY
-	 * trigger-on-complete config of the record's table and invokes the export for matching configs.
+	 * Records eligibility (matching WhereClause → {@link de.metas.externalsystem.ExternalSystemExportStatus#Pending},
+	 * else {@link de.metas.externalsystem.ExternalSystemExportStatus#DontSend}) for every
+	 * trigger-on-complete config of the record's table, then invokes the export for the matching ones.
 	 *
-	 * <ul>
-	 *   <li>WhereClause MATCHES → {@link de.metas.externalsystem.ExternalSystemExportStatus#Pending}
-	 *       + invokes the export.</li>
-	 *   <li>WhereClause does NOT match → {@link de.metas.externalsystem.ExternalSystemExportStatus#DontSend}
-	 *       (EDI-consistency: DontSend is always persisted).</li>
-	 * </ul>
-	 *
-	 * <p><b>Runs entirely after-commit.</b> The eligibility WhereClause may read COMMITTED document
-	 * state — e.g. the EPCIS {@code "de.metas.edi".epcis_has_events(m_inout_id)} clause requires
-	 * {@code M_InOut.DocStatus IN ('CO','CL')}. At AFTER_COMPLETE the document engine has NOT yet
-	 * set+saved {@code DocStatus='CO'} ({@code MInOut.completeIt} fires AFTER_COMPLETE <i>before</i>
-	 * {@code DocumentEngine} assigns the status), so matching in the completing transaction would read
-	 * the pre-complete row and wrongly record DontSend — the export would never fire. Deferring the
-	 * whole match → status-write → invoke step to after-commit makes the clause evaluate against the
-	 * committed state. (The invocation itself was already after-commit; this moves the decision that
-	 * gates it to the same point, removing the in-trx-vs-committed mismatch.)
-	 *
-	 * <p>A status-write failure for one config is logged and swallowed so completion is never aborted.
+	 * <p>After-commit because the WhereClause may read committed document state — e.g. the EPCIS
+	 * {@code epcis_has_events(m_inout_id)} clause requires {@code DocStatus IN ('CO','CL')}, which the
+	 * AFTER_COMPLETE interceptor fires before the engine saves. A per-config status-write failure is
+	 * swallowed so document completion is never aborted.
 	 */
-	public void recordCompleteTimeEligibilityAndScheduleInvocation(
+	public void recordEligibilityAndInvokeAfterCommit(
 			@NonNull final AdTableAndClientId tableAndClientId,
 			final int recordId)
 	{
-		trxManager.runAfterCommit(() -> recordEligibilityAndInvokeAfterCommit(tableAndClientId, recordId));
+		trxManager.runAfterCommit(() -> recordEligibilityAndInvoke(tableAndClientId, recordId));
 	}
 
-	private void recordEligibilityAndInvokeAfterCommit(
+	private void recordEligibilityAndInvoke(
 			@NonNull final AdTableAndClientId tableAndClientId,
 			final int recordId)
 	{

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemScriptedExportConversionService.java
@@ -336,21 +336,36 @@ public class ExternalSystemScriptedExportConversionService
 	}
 
 	/**
-	 * At document complete-time, records an eligibility status for EVERY trigger-on-complete config
-	 * of the record's table, then schedules the after-commit invocation for matching configs only.
+	 * Called from the document's AFTER_COMPLETE interceptor: records an eligibility status for EVERY
+	 * trigger-on-complete config of the record's table and invokes the export for matching configs.
 	 *
 	 * <ul>
 	 *   <li>WhereClause MATCHES → {@link de.metas.externalsystem.ExternalSystemExportStatus#Pending}
-	 *       + schedules the after-commit invocation (existing behaviour).</li>
+	 *       + invokes the export.</li>
 	 *   <li>WhereClause does NOT match → {@link de.metas.externalsystem.ExternalSystemExportStatus#DontSend}
 	 *       (EDI-consistency: DontSend is always persisted).</li>
 	 * </ul>
 	 *
-	 * <p>Status writes run in the same transaction (no InNewTrx). The invocation scheduling
-	 * stays after-commit. A status-write failure for one config is logged and swallowed so that
-	 * document completion is never aborted.
+	 * <p><b>Runs entirely after-commit.</b> The eligibility WhereClause may read COMMITTED document
+	 * state — e.g. the EPCIS {@code "de.metas.edi".epcis_has_events(m_inout_id)} clause requires
+	 * {@code M_InOut.DocStatus IN ('CO','CL')}. At AFTER_COMPLETE the document engine has NOT yet
+	 * set+saved {@code DocStatus='CO'} ({@code MInOut.completeIt} fires AFTER_COMPLETE <i>before</i>
+	 * {@code DocumentEngine} assigns the status), so matching in the completing transaction would read
+	 * the pre-complete row and wrongly record DontSend — the export would never fire. Deferring the
+	 * whole match → status-write → invoke step to after-commit makes the clause evaluate against the
+	 * committed state. (The invocation itself was already after-commit; this moves the decision that
+	 * gates it to the same point, removing the in-trx-vs-committed mismatch.)
+	 *
+	 * <p>A status-write failure for one config is logged and swallowed so completion is never aborted.
 	 */
 	public void recordCompleteTimeEligibilityAndScheduleInvocation(
+			@NonNull final AdTableAndClientId tableAndClientId,
+			final int recordId)
+	{
+		trxManager.runAfterCommit(() -> recordEligibilityAndInvokeAfterCommit(tableAndClientId, recordId));
+	}
+
+	private void recordEligibilityAndInvokeAfterCommit(
 			@NonNull final AdTableAndClientId tableAndClientId,
 			final int recordId)
 	{
@@ -369,7 +384,8 @@ public class ExternalSystemScriptedExportConversionService
 
 		recordCompleteTimeEligibilityStatusesOnly(matchingConfigs, nonMatchingConfigs, recordId);
 
-		matchingConfigs.forEach(config -> executeInvokeScriptedExportConversionActionAfterCommit(config, recordId));
+		// Already running after-commit — invoke synchronously rather than re-scheduling after-commit.
+		matchingConfigs.forEach(config -> executeInvokeScriptedExportConversionAction(config, recordId));
 	}
 
 	/**

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/interceptor/ExternalSystemScriptedExportConversionInterceptor.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/interceptor/ExternalSystemScriptedExportConversionInterceptor.java
@@ -140,10 +140,11 @@ import org.jetbrains.annotations.Nullable;
 		if (timing == ModelValidator.TIMING_AFTER_COMPLETE
 				&& !documentBL.isReversalDocument(po))
 		{
-			// Eligibility status writes run in the current transaction; the export invocation is scheduled
-			// after-commit (a postgrest process may run it, so the completed record must be visible in the db).
+			// Eligibility matching, status writes, and the export invocation all run after-commit: the
+			// eligibility WhereClause reads committed DocStatus, which isn't set yet at AFTER_COMPLETE
+			// (and a postgrest process may run the export, so the completed record must be visible in the db).
 			final int recordId = po.get_ID();
-			externalSystemScriptedExportConversionService.recordCompleteTimeEligibilityAndScheduleInvocation(
+			externalSystemScriptedExportConversionService.recordEligibilityAndInvokeAfterCommit(
 					AdTableAndClientId.of(AdTableId.ofRepoId(po.get_Table_ID()), ClientId.ofRepoId(getAD_Client_ID())),
 					recordId);
 		}


### PR DESCRIPTION
Two related fixes in the EDI/EPCIS export path.

## 1) EPCIS per-crate source-order references (order-pure packing)
`get_epcis_events_json_fn` exposed order references only at the top level, so when two orders share one physical pallet/SSCC the downstream EPCIS transform emitted every order's `po`+`desadv` on every crate's PACKING event. A crate (Gebinde) is order-pure, so the function now resolves each crate's source order — per TU via `m_hu_assignment → m_inoutline → c_order / m_inout` (CTE `tu_order_ref`, bounded to the already-discovered TUs) — and adds `poReference` (order POReference) and `shipmentDocumentNo` (crate-shipment `M_InOut.DocumentNo` = delivery note) to each crate JSON object. Picking/commissioning stay pallet-level.

Shipped as migration `5809070_sys_..._epcis_per_crate_order_ref.sql` (CREATE OR REPLACE; DDL + migration kept in sync).

## 2) Scripted-export eligibility timing fix
`ExternalSystemScriptedExportConversionInterceptor` fires `docValidate` at `AFTER_COMPLETE`, but `MInOut.completeIt()` fires that timing **before** `DocumentEngine` sets+saves `DocStatus='CO'`. So a complete-time eligibility WhereClause that reads committed `DocStatus` (e.g. the EPCIS `"de.metas.edi".epcis_has_events(m_inout_id)` clause, which requires `DocStatus IN ('CO','CL')`) read the pre-complete row, was recorded `DontSend`, and the export never fired. `recordCompleteTimeEligibilityAndScheduleInvocation` now defers its whole body (match → status-write → invoke) to `trxManager.runAfterCommit(...)`, where `DocStatus` is committed and the clause evaluates correctly. The invocation was already after-commit; this moves the gating decision to the same point.

## Verification
- **EPCIS** (`epcisExport.feature`, provided-infra): **5/5 green** — `S29231_170` asserts a shared-pallet owner event's 15 crates are order-pure across two orders; `EPCIS_010/020/030` + `S29231_130` guard the existing JSON against regression.
- **Eligibility timing**: new RED test `S30279_040` in `epcisScriptedExportStatus.feature` (a config whose WhereClause only matches once committed-complete must reach `Enqueued`, not `DontSend`) + an optional `WhereClause` column on the scripted-export-config step def.

Pairs with the customer-side EPCIS FT scripted-adapter change that consumes the new per-crate fields.
