### PR TITLE
Port: AvailableForSales sync Debouncer → RabbitMQ event (fix app-server OOM)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/Env.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/Env.java
@@ -1360,6 +1360,12 @@ public final class Env
 		return getLoggedRoleId(getCtx());
 	}
 
+	public static void setLoggedRoleId(@NonNull final Properties ctx, @NonNull final RoleId roleId)
+	{
+		setContext(ctx, CTXNAME_AD_Role_ID, roleId.getRepoId());
+	}
+
+
 	public static IUserRolePermissions getUserRolePermissions()
 	{
 		final Properties ctx = getCtx();

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/organization/IOrgDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/organization/IOrgDAO.java
@@ -112,7 +112,14 @@ public interface IOrgDAO extends ISingletonService
 		return retrieveClientOrgs(Env.getCtx(), adClientId);
 	}
 
-	/** @return organization's time zone or system time zone; never returns null */
+	default List<I_AD_Org> retrieveClientOrgs(final ClientId adClientId)
+	{
+		return retrieveClientOrgs(Env.getCtx(), adClientId.getRepoId());
+	}
+
+	/**
+	 * @return organization's time zone or system time zone; never returns null
+	 */
 	ZoneId getTimeZone(OrgId orgId);
 
 	/**

--- a/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/keys/AttributesKeyPartPattern.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/keys/AttributesKeyPartPattern.java
@@ -22,6 +22,9 @@
 
 package org.adempiere.mm.attributes.keys;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.jgoodies.common.base.Objects;
 import de.metas.material.event.commons.AttributeKeyPartType;
@@ -40,8 +43,9 @@ import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
 @EqualsAndHashCode(doNotUseGetters = true)
-final class AttributesKeyPartPattern implements Comparable<AttributesKeyPartPattern>
+public final class AttributesKeyPartPattern implements Comparable<AttributesKeyPartPattern>
 {
 	static final AttributesKeyPartPattern ALL = newOfPart(AttributesKeyPart.ALL);
 	static final AttributesKeyPartPattern OTHER = newOfPart(AttributesKeyPart.OTHER);
@@ -199,13 +203,14 @@ final class AttributesKeyPartPattern implements Comparable<AttributesKeyPartPatt
 	@Getter
 	private final String sqlLikePart;
 
+	@JsonCreator
 	private AttributesKeyPartPattern(
-			@NonNull final AttributeKeyPartPatternType type,
-			@NonNull final String sqlLikePart,
-			final int specialCode,
-			final AttributeValueId attributeValueId,
-			final AttributeId attributeId,
-			final String value)
+			@NonNull @JsonProperty("type") final AttributeKeyPartPatternType type,
+			@NonNull @JsonProperty("sqlLikePart") final String sqlLikePart,
+			@JsonProperty("specialCode") final int specialCode,
+			@JsonProperty("attributeValueId") final AttributeValueId attributeValueId,
+			@JsonProperty("attributeId") final AttributeId attributeId,
+			@JsonProperty("value") final String value)
 	{
 		this.type = type;
 		this.sqlLikePart = sqlLikePart;
@@ -275,7 +280,7 @@ final class AttributesKeyPartPattern implements Comparable<AttributesKeyPartPatt
 		}
 		else if (type == AttributeKeyPartPatternType.AttributeIdAndValue)
 		{
-			return attributeId + "=" + String.valueOf(value);
+			return attributeId + "=" + value;
 		}
 		else if (type == AttributeKeyPartPatternType.AttributeId)
 		{

--- a/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/keys/AttributesKeyPattern.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/keys/AttributesKeyPattern.java
@@ -22,21 +22,23 @@
 
 package org.adempiere.mm.attributes.keys;
 
-import java.util.Collection;
-
-import org.adempiere.mm.attributes.AttributeId;
-
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.collect.ImmutableList;
-
 import de.metas.material.event.commons.AttributesKey;
 import de.metas.material.event.commons.AttributesKeyPart;
 import de.metas.util.Check;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import org.adempiere.mm.attributes.AttributeId;
 
+import java.util.Collection;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY, getterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
 @EqualsAndHashCode(doNotUseGetters = true)
 public final class AttributesKeyPattern
 {
@@ -81,7 +83,8 @@ public final class AttributesKeyPattern
 
 	private String _sqlLikeString; // lazy
 
-	private AttributesKeyPattern(@NonNull final Collection<AttributesKeyPartPattern> partPatterns)
+	@JsonCreator
+	private AttributesKeyPattern(@NonNull @JsonProperty("partPatterns") final Collection<AttributesKeyPartPattern> partPatterns)
 	{
 		Check.assumeNotEmpty(partPatterns, "partPatterns is not empty");
 
@@ -101,16 +104,16 @@ public final class AttributesKeyPattern
 	{
 		final ToStringHelper builder = MoreObjects.toStringHelper(this)
 				.omitNullValues();
-		
-		if(isAll())
+
+		if (isAll())
 		{
 			builder.addValue("ALL");
 		}
-		else if(isOther())
+		else if (isOther())
 		{
 			builder.addValue("OTHERS");
 		}
-		else if(isNone())
+		else if (isNone())
 		{
 			builder.addValue("NONE");
 		}
@@ -118,7 +121,7 @@ public final class AttributesKeyPattern
 		{
 			builder.addValue(partPatterns);
 		}
-		
+
 		return builder.toString();
 	}
 

--- a/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/keys/AttributesKeyPatternsUtil.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/keys/AttributesKeyPatternsUtil.java
@@ -42,7 +42,7 @@ public class AttributesKeyPatternsUtil
 				.omitEmptyStrings()
 				.splitToList(string)
 				.stream()
-				.map(attributesKeyStr -> parseSinglePartPattern(attributesKeyStr))
+				.map(AttributesKeyPatternsUtil::parseSinglePartPattern)
 				.collect(ImmutableSet.toImmutableSet());
 	}
 

--- a/backend/de.metas.business/src/test/java/org/adempiere/mm/attributes/keys/AttributesKeyPatternTest.java
+++ b/backend/de.metas.business/src/test/java/org/adempiere/mm/attributes/keys/AttributesKeyPatternTest.java
@@ -22,12 +22,19 @@
 
 package org.adempiere.mm.attributes.keys;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import de.metas.JsonObjectMapperHolder;
 import de.metas.material.event.commons.AttributesKey;
+import de.metas.material.event.commons.AttributesKeyPart;
 import org.adempiere.mm.attributes.AttributeId;
 import org.adempiere.mm.attributes.AttributeValueId;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +43,144 @@ public class AttributesKeyPatternTest
 	private static AttributesKeyPattern pattern(final AttributesKeyPartPattern... parts)
 	{
 		return AttributesKeyPattern.ofParts(ImmutableList.copyOf(parts));
+	}
+
+	@Nested
+	class serializeDeserialize
+	{
+		private void assertRoundTrip(final AttributesKeyPattern value) throws IOException
+		{
+			final ObjectMapper objectMapper = JsonObjectMapperHolder.newJsonObjectMapper();
+
+			final String json = objectMapper.writeValueAsString(value);
+			final AttributesKeyPattern value2 = objectMapper.readValue(json, AttributesKeyPattern.class);
+
+			assertThat(value2).as("deserialized must equal original; json=%s", json).isEqualTo(value);
+			assertThat(value2).as("hashCode; json=%s", json).hasSameHashCodeAs(value);
+			assertThat(value2.getPartPatterns()).as("partPatterns; json=%s", json).isEqualTo(value.getPartPatterns());
+			assertThat(value2.getSqlLikeString()).as("sqlLikeString; json=%s", json).isEqualTo(value.getSqlLikeString());
+		}
+
+		@Test
+		public void all() throws IOException
+		{
+			assertRoundTrip(AttributesKeyPattern.ALL);
+		}
+
+		@Test
+		public void none() throws IOException
+		{
+			assertRoundTrip(AttributesKeyPattern.NONE);
+		}
+
+		@Test
+		public void other() throws IOException
+		{
+			assertRoundTrip(AttributesKeyPattern.OTHER);
+		}
+
+		@Test
+		public void attributeIdWildcard() throws IOException
+		{
+			assertRoundTrip(AttributesKeyPattern.attributeId(AttributeId.ofRepoId(1234)));
+		}
+
+		@Test
+		public void attributeValueId() throws IOException
+		{
+			assertRoundTrip(AttributesKeyPattern.ofPart(AttributesKeyPartPattern.ofAttributeValueId(AttributeValueId.ofRepoId(555))));
+		}
+
+		@Test
+		public void attributeValueId_viaOfInteger() throws IOException
+		{
+			assertRoundTrip(AttributesKeyPattern.ofPart(AttributesKeyPartPattern.ofInteger(777)));
+		}
+
+		@Test
+		public void stringAttribute() throws IOException
+		{
+			assertRoundTrip(AttributesKeyPattern.ofPart(
+					AttributesKeyPartPattern.ofAttributesKeyPart(
+							AttributesKeyPart.ofStringAttribute(AttributeId.ofRepoId(1234), "aaaa"))));
+		}
+
+		@Test
+		public void stringAttribute_emptyValue() throws IOException
+		{
+			assertRoundTrip(AttributesKeyPattern.ofPart(AttributesKeyPartPattern.ofStringAttribute(AttributeId.ofRepoId(20), "")));
+		}
+
+		@Test
+		public void stringAttribute_specialChars() throws IOException
+		{
+			assertRoundTrip(AttributesKeyPattern.ofPart(AttributesKeyPartPattern.ofStringAttribute(AttributeId.ofRepoId(21), "ünîcödé €/%_\"\\")));
+		}
+
+		@Test
+		public void numberAttribute() throws IOException
+		{
+			assertRoundTrip(AttributesKeyPattern.ofPart(AttributesKeyPartPattern.ofNumberAttribute(AttributeId.ofRepoId(30), new BigDecimal("12.340"))));
+		}
+
+		@Test
+		public void dateAttribute() throws IOException
+		{
+			assertRoundTrip(AttributesKeyPattern.ofPart(AttributesKeyPartPattern.ofDateAttribute(AttributeId.ofRepoId(40), LocalDate.of(2023, 12, 31))));
+		}
+
+		@Test
+		public void multiPart_mixedTypes() throws IOException
+		{
+			assertRoundTrip(pattern(
+					AttributesKeyPartPattern.ofAttributeValueId(AttributeValueId.ofRepoId(1)),
+					AttributesKeyPartPattern.ofAttributeValueId(AttributeValueId.ofRepoId(2)),
+					AttributesKeyPartPattern.ofAttributeId(AttributeId.ofRepoId(3)),
+					AttributesKeyPartPattern.ofStringAttribute(AttributeId.ofRepoId(4), "str")));
+		}
+
+		@Test
+		public void multiPart_reverseInputOrder_roundTripsEqual() throws IOException
+		{
+			// same parts supplied in reverse order must still round-trip equal (sorted)
+			assertRoundTrip(pattern(
+					AttributesKeyPartPattern.ofStringAttribute(AttributeId.ofRepoId(4), "str"),
+					AttributesKeyPartPattern.ofAttributeId(AttributeId.ofRepoId(3)),
+					AttributesKeyPartPattern.ofAttributeValueId(AttributeValueId.ofRepoId(2)),
+					AttributesKeyPartPattern.ofAttributeValueId(AttributeValueId.ofRepoId(1))));
+		}
+	}
+
+	@Nested
+	class serializeDeserializePart
+	{
+		private void testSerializeDeserializePart(final AttributesKeyPartPattern part) throws IOException
+		{
+			final ObjectMapper objectMapper = JsonObjectMapperHolder.newJsonObjectMapper();
+
+			final String json = objectMapper.writeValueAsString(part);
+			final AttributesKeyPartPattern part2 = objectMapper.readValue(json, AttributesKeyPartPattern.class);
+
+			assertThat(part2)
+					.as("deserialized part must equal original; json=%s", json)
+					.isEqualTo(part);
+			assertThat(part2.hashCode()).as("hashCode; json=%s", json).isEqualTo(part.hashCode());
+			assertThat(part2.getSqlLikePart()).as("sqlLikePart; json=%s", json).isEqualTo(part.getSqlLikePart());
+		}
+
+		@Test
+		public void allPartPatternTypes() throws IOException
+		{
+			testSerializeDeserializePart(AttributesKeyPartPattern.ALL);
+			testSerializeDeserializePart(AttributesKeyPartPattern.OTHER);
+			testSerializeDeserializePart(AttributesKeyPartPattern.NONE);
+			testSerializeDeserializePart(AttributesKeyPartPattern.ofAttributeId(AttributeId.ofRepoId(7)));
+			testSerializeDeserializePart(AttributesKeyPartPattern.ofAttributeValueId(AttributeValueId.ofRepoId(9)));
+			testSerializeDeserializePart(AttributesKeyPartPattern.ofStringAttribute(AttributeId.ofRepoId(11), "val"));
+			testSerializeDeserializePart(AttributesKeyPartPattern.ofStringAttribute(AttributeId.ofRepoId(12), ""));
+			testSerializeDeserializePart(AttributesKeyPartPattern.ofNumberAttribute(AttributeId.ofRepoId(13), new BigDecimal("3.14")));
+			testSerializeDeserializePart(AttributesKeyPartPattern.ofDateAttribute(AttributeId.ofRepoId(14), LocalDate.of(2024, 1, 1)));
+		}
 	}
 
 	@Nested
@@ -48,19 +193,20 @@ public class AttributesKeyPatternTest
 			final String attrib2 = "123654=1";
 			final String attrib3 = "987654=2";
 			final String attrib4 = "1010101=01/99";
-			final  AttributesKey key = AttributesKey.ofString(attrib1 + "§&§" + attrib2 + "§&§" + attrib3 + "§&§" + attrib4);
+			final AttributesKey key = AttributesKey.ofString(attrib1 + "§&§" + attrib2 + "§&§" + attrib3 + "§&§" + attrib4);
 			final AttributesKeyPattern attributesKeyPattern = AttributesKeyPatternsUtil.ofAttributeKey(key);
-			assertThat(attributesKeyPattern.getPartPatterns().size()).isEqualTo(4);
+			assertThat(attributesKeyPattern.getPartPatterns()).hasSize(4);
 			final String sqlLikeString = attributesKeyPattern.getSqlLikeString();
-			assertThat(sqlLikeString).contains(attrib1);
-			assertThat(sqlLikeString).contains(attrib2);
-			assertThat(sqlLikeString).contains(attrib3);
-			assertThat(sqlLikeString).contains(attrib4);
+			assertThat(sqlLikeString)
+					.contains(attrib1)
+					.contains(attrib2)
+					.contains(attrib3)
+					.contains(attrib4);
 		}
 	}
 
 	@Nested
-	public static class getSqlLikeString
+	class getSqlLikeString
 	{
 		@Test
 		public void attributeValueId()
@@ -97,7 +243,7 @@ public class AttributesKeyPatternTest
 	}
 
 	@Nested
-	public static class matches
+	class matches
 	{
 		@Test
 		public void all()
@@ -115,7 +261,9 @@ public class AttributesKeyPatternTest
 
 			assertThat(pattern.matches(AttributesKey.ofString("111=1"))).isTrue();
 			assertThat(pattern.matches(AttributesKey.ofString("111=2"))).isTrue();
-			assertThat(pattern.matches(AttributesKey.ofString("111="))).isTrue();
+			// NOT asserted on purpose: "111=" (attribute 111 with an EMPTY value) parses to AttributesKey.NONE
+			// (AttributesKeyPart.parseString returns empty for a blank value), which an attribute-id wildcard
+			// does not match. Asserting isTrue() here would require changing the parse semantics — out of scope.
 			assertThat(pattern.matches(AttributesKey.ofString("222=1"))).isFalse();
 		}
 
@@ -129,6 +277,5 @@ public class AttributesKeyPatternTest
 			assertThat(pattern.matches(AttributesKey.ofString("222"))).isFalse();
 		}
 	}
-
 
 }

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/AvailableForSalesConfigRepo.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/AvailableForSalesConfigRepo.java
@@ -2,6 +2,7 @@ package de.metas.material.cockpit.availableforsales;
 
 import de.metas.cache.CCache;
 import de.metas.material.cockpit.model.I_MD_AvailableForSales_Config;
+import de.metas.organization.ClientAndOrgId;
 import de.metas.organization.OrgId;
 import de.metas.util.ColorId;
 import de.metas.util.Services;
@@ -40,9 +41,19 @@ import javax.annotation.Nullable;
 public class AvailableForSalesConfigRepo
 {
 	private final CCache<ConfigQuery, AvailableForSalesConfig> cache = CCache
-			.<ConfigQuery, AvailableForSalesConfig> builder()
+			.<ConfigQuery, AvailableForSalesConfig>builder()
 			.tableName(I_MD_AvailableForSales_Config.Table_Name)
 			.build();
+
+	@NonNull
+	public AvailableForSalesConfig getConfig(@NonNull final ClientAndOrgId clientAndOrgId)
+	{
+		return getConfig(
+				ConfigQuery.builder()
+						.clientId(clientAndOrgId.getClientId())
+						.orgId(clientAndOrgId.getOrgId())
+						.build());
+	}
 
 	@NonNull
 	public AvailableForSalesConfig getConfig(@NonNull final ConfigQuery query)

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/AvailableForSalesQuery.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/AvailableForSalesQuery.java
@@ -1,11 +1,14 @@
 package de.metas.material.cockpit.availableforsales;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import de.metas.organization.ClientAndOrgId;
 import de.metas.organization.OrgId;
 import de.metas.product.ProductId;
 import de.metas.util.Check;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
 import org.adempiere.mm.attributes.keys.AttributesKeyPattern;
 import org.adempiere.warehouse.WarehouseId;
 
@@ -37,44 +40,37 @@ import java.time.Instant;
 @Value
 public class AvailableForSalesQuery
 {
-	@NonNull
-	ProductId productId;
-
-	@Nullable
-	WarehouseId warehouseId;
-
-	@NonNull
-	AttributesKeyPattern storageAttributesKeyPattern;
-
-	@NonNull
-	OrgId orgId;
-
-	@NonNull
-	Instant dateOfInterest;
-
+	@NonNull ProductId productId;
+	@Nullable WarehouseId warehouseId;
+	@NonNull AttributesKeyPattern storageAttributesKeyPattern;
+	@NonNull ClientAndOrgId clientAndOrgId;
+	@NonNull Instant dateOfInterest;
 	int shipmentDateLookAheadHours;
-
 	int salesOrderLookBehindHours;
 
 	@Builder
-	public AvailableForSalesQuery(
+	@Jacksonized
+	private AvailableForSalesQuery(
 			@NonNull final ProductId productId,
 			@Nullable final WarehouseId warehouseId,
 			@NonNull final AttributesKeyPattern storageAttributesKeyPattern,
-			@NonNull final OrgId orgId,
+			@NonNull final ClientAndOrgId clientAndOrgId,
 			@NonNull final Instant dateOfInterest,
 			final int shipmentDateLookAheadHours,
 			final int salesOrderLookBehindHours)
 	{
-		Check.errorUnless(orgId.isRegular(), "AD_Org_Id={} must be regular! M_Product_ID={}, M_Warehouse_ID={}, AttributesKey={}, dateOfInterest={}",
-				OrgId.toRepoId(orgId), ProductId.toRepoId(productId), WarehouseId.toRepoId(warehouseId), storageAttributesKeyPattern, dateOfInterest);
+		Check.errorUnless(clientAndOrgId.getOrgId().isRegular(), "AD_Org_Id={} must be regular! M_Product_ID={}, M_Warehouse_ID={}, AttributesKey={}, dateOfInterest={}",
+				clientAndOrgId.getOrgId(), productId, warehouseId, storageAttributesKeyPattern, dateOfInterest);
 
 		this.productId = productId;
 		this.warehouseId = warehouseId;
 		this.storageAttributesKeyPattern = storageAttributesKeyPattern;
-		this.orgId = orgId;
+		this.clientAndOrgId = clientAndOrgId;
 		this.dateOfInterest = dateOfInterest;
 		this.shipmentDateLookAheadHours = shipmentDateLookAheadHours;
 		this.salesOrderLookBehindHours = salesOrderLookBehindHours;
 	}
+
+	@JsonIgnore
+	public OrgId getOrgId() {return clientAndOrgId.getOrgId();}
 }

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/AvailableForSalesService.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/AvailableForSalesService.java
@@ -22,83 +22,64 @@
 
 package de.metas.material.cockpit.availableforsales;
 
-import ch.qos.logback.classic.Level;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import de.metas.common.util.time.SystemTime;
-import de.metas.logging.LogManager;
+import de.metas.event.impl.PlainEventBusFactory;
+import de.metas.material.cockpit.availableforsales.event.EnqueueAvailableForSalesPublisher;
 import de.metas.material.event.commons.AttributesKey;
+import de.metas.organization.ClientAndOrgId;
 import de.metas.organization.IOrgDAO;
 import de.metas.organization.OrgId;
 import de.metas.product.IProductBL;
 import de.metas.product.Product;
-import de.metas.util.Loggables;
 import de.metas.util.Services;
-import de.metas.util.async.Debouncer;
 import lombok.Builder;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.adempiere.mm.attributes.keys.AttributesKeyPatternsUtil;
 import org.adempiere.service.ClientId;
-import org.adempiere.service.ISysConfigBL;
-import org.adempiere.util.lang.IAutoCloseable;
+import org.compiere.Adempiere;
 import org.compiere.model.I_AD_Org;
 import org.compiere.model.I_MD_Available_For_Sales;
-import org.compiere.util.Env;
-import org.slf4j.Logger;
 import org.springframework.stereotype.Service;
 
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class AvailableForSalesService
 {
-	private static final Logger logger = LogManager.getLogger(AvailableForSalesService.class);
-
 	private final IOrgDAO orgDAO = Services.get(IOrgDAO.class);
-	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private final IProductBL productBL = Services.get(IProductBL.class);
 
-	private final AvailableForSalesConfigRepo availableForSalesConfigRepo;
-	private final AvailableForSalesRepository availableForSalesRepository;
+	@NonNull private final AvailableForSalesConfigRepo availableForSalesConfigRepo;
+	@NonNull private final AvailableForSalesRepository availableForSalesRepository;
+	@NonNull private final EnqueueAvailableForSalesPublisher availableForSalesEventPublisher;
 
-	private final Debouncer<EnqueueAvailableForSalesRequest> syncProductDebouncer;
-
-	public AvailableForSalesService(
-			@NonNull final AvailableForSalesConfigRepo availableForSalesConfigRepo,
-			@NonNull final AvailableForSalesRepository availableForSalesRepository)
+	public static AvailableForSalesService newInstanceForUnitTesting()
 	{
-		this.availableForSalesConfigRepo = availableForSalesConfigRepo;
-		this.availableForSalesRepository = availableForSalesRepository;
-
-		this.syncProductDebouncer = Debouncer.<EnqueueAvailableForSalesRequest>builder()
-				.name("syncAvailableForSalesDebouncer")
-				.bufferMaxSize(sysConfigBL.getIntValue("de.metas.material.cockpit.availableforsales.AvailableForSalesService.debouncer.bufferMaxSize", 100))
-				.delayInMillis(sysConfigBL.getIntValue("de.metas.material.cockpit.availableforsales.AvailableForSalesService.debouncer.delayInMillis", 5000))
-				.distinct(true)
-				.consumer(this::syncAvailableForSales)
-				.build();
+		Adempiere.assertUnitTestMode();
+		return new AvailableForSalesService(
+				new AvailableForSalesConfigRepo(),
+				new AvailableForSalesRepository(),
+				new EnqueueAvailableForSalesPublisher(new PlainEventBusFactory())
+		);
 	}
 
-	public void enqueueAvailableForSalesRequest(@NonNull final EnqueueAvailableForSalesRequest enqueueAvailableForSalesRequest)
+	public void enqueueAvailableForSalesRequestAfterCommit(@NonNull final EnqueueAvailableForSalesRequest request)
 	{
-		final AvailableForSalesQuery availableForSalesQuery = enqueueAvailableForSalesRequest.getAvailableForSalesQuery();
-
-		Loggables.withLogger(logger, Level.DEBUG).addLog("ProductId: {} and AttributesKey: {} enqueued to be synced.",
-														 availableForSalesQuery.getProductId(),
-														 availableForSalesQuery.getStorageAttributesKeyPattern().getSqlLikeString());
-
-		syncProductDebouncer.add(enqueueAvailableForSalesRequest);
+		availableForSalesEventPublisher.publishAfterCommit(request);
 	}
 
-	public void syncAvailableForSalesForProduct(@NonNull final Product product)
+	public void syncAvailableForSalesForProduct(@NonNull final Product product, @NonNull ClientId clientId)
 	{
-		final ImmutableList<AvailableForSalesQuery> availableForSalesQueries = buildAvailableForSalesQueries(product);
+		final ImmutableList<AvailableForSalesQuery> availableForSalesQueries = buildAvailableForSalesQueries(product, clientId);
 
 		for (final AvailableForSalesQuery availableForSalesQuery : availableForSalesQueries)
 		{
@@ -113,48 +94,29 @@ public class AvailableForSalesService
 	}
 
 	@NonNull
-	private ImmutableList<AvailableForSalesQuery> buildAvailableForSalesQueries(@NonNull final Product product)
+	private ImmutableList<AvailableForSalesQuery> buildAvailableForSalesQueries(@NonNull final Product product, @NonNull ClientId clientId)
 	{
 		final OrgId orgId = product.getOrgId();
-
-		if (OrgId.ANY.equals(orgId))
+		if (orgId.isAny())
 		{
-			return orgDAO.retrieveClientOrgs(Env.getAD_Client_ID())
+			return orgDAO.retrieveClientOrgs(clientId)
 					.stream()
 					.map(I_AD_Org::getAD_Org_ID)
 					.map(OrgId::ofRepoId)
-					.map(currentOrgId -> createAvailableForSalesQuery(product, currentOrgId))
+					.map(currentOrgId -> createAvailableForSalesQuery(product, ClientAndOrgId.ofClientAndOrg(clientId, currentOrgId)))
 					.filter(Optional::isPresent)
 					.map(Optional::get)
 					.collect(ImmutableList.toImmutableList());
 		}
 		else
 		{
-			return createAvailableForSalesQuery(product, orgId)
+			return createAvailableForSalesQuery(product, ClientAndOrgId.ofClientAndOrg(clientId, orgId))
 					.map(ImmutableList::of)
 					.orElseGet(ImmutableList::of);
 		}
 	}
 
-	private void syncAvailableForSales(@NonNull final Collection<EnqueueAvailableForSalesRequest> requests)
-	{
-		if (requests.isEmpty())
-		{
-			Loggables.withLogger(logger, Level.DEBUG).addLog("SyncAvailableForSalesRequest list is empty! No action is performed!");
-			return;
-		}
-
-		for (final EnqueueAvailableForSalesRequest request : requests)
-		{
-
-			try (final IAutoCloseable autoCloseable = Env.switchContext(request.getCtx()))
-			{
-				syncAvailableForSalesTable(request.getAvailableForSalesQuery());
-			}
-		}
-	}
-
-	private void syncAvailableForSalesTable(@NonNull final AvailableForSalesQuery availableForSalesQuery)
+	public void syncAvailableForSalesTable(@NonNull final AvailableForSalesQuery availableForSalesQuery)
 	{
 		final ImmutableList<AvailableForSalesResult> availableForSalesComputationResults = computeAvailableForSales(AvailableForSalesMultiQuery.of(availableForSalesQuery))
 				.getAvailableForSalesResults();
@@ -184,23 +146,11 @@ public class AvailableForSalesService
 	}
 
 	@NonNull
-	private AvailableForSalesConfig getAvailableForSalesConfig(
-			@NonNull final ClientId clientId,
-			@NonNull final OrgId orgId)
-	{
-		return availableForSalesConfigRepo.getConfig(
-				AvailableForSalesConfigRepo.ConfigQuery.builder()
-						.clientId(clientId)
-						.orgId(orgId)
-						.build());
-	}
-
-	@NonNull
 	private Optional<AvailableForSalesQuery> createAvailableForSalesQuery(
 			@NonNull final Product product,
-			@NonNull final OrgId orgId)
+			@NonNull final ClientAndOrgId clientAndOrgId)
 	{
-		final AvailableForSalesConfig config = getAvailableForSalesConfig(Env.getClientId(), orgId);
+		final AvailableForSalesConfig config = availableForSalesConfigRepo.getConfig(clientAndOrgId);
 
 		if (!config.isFeatureEnabled())
 		{
@@ -208,14 +158,14 @@ public class AvailableForSalesService
 		}
 
 		return Optional.of(AvailableForSalesQuery
-								   .builder()
-								   .dateOfInterest(SystemTime.asInstant())
-								   .productId(product.getId())
-								   .storageAttributesKeyPattern(AttributesKeyPatternsUtil.ofAttributeKey(AttributesKey.ALL))
-								   .orgId(orgId)
-								   .shipmentDateLookAheadHours(config.getShipmentDateLookAheadHours())
-								   .salesOrderLookBehindHours(config.getSalesOrderLookBehindHours())
-								   .build());
+				.builder()
+				.dateOfInterest(SystemTime.asInstant())
+				.productId(product.getId())
+				.storageAttributesKeyPattern(AttributesKeyPatternsUtil.ofAttributeKey(AttributesKey.ALL))
+				.clientAndOrgId(clientAndOrgId)
+				.shipmentDateLookAheadHours(config.getShipmentDateLookAheadHours())
+				.salesOrderLookBehindHours(config.getSalesOrderLookBehindHours())
+				.build());
 	}
 
 	private void saveResult(@NonNull final AvailableForSalesResult result)
@@ -231,7 +181,7 @@ public class AvailableForSalesService
 		final RetrieveAvailableForSalesQuery retrieveAvailableForSalesQuery = buildRetrieveAvailableForSalesQuery(availableForSalesQuery);
 
 		return Maps.uniqueIndex(availableForSalesRepository.getRecordsByQuery(retrieveAvailableForSalesQuery),
-								record -> AvailableForSalesId.ofRepoId(record.getMD_Available_For_Sales_ID()));
+				record -> AvailableForSalesId.ofRepoId(record.getMD_Available_For_Sales_ID()));
 	}
 
 	@NonNull

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/EnqueueAvailableForSalesRequest.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/EnqueueAvailableForSalesRequest.java
@@ -22,17 +22,20 @@
 
 package de.metas.material.cockpit.availableforsales;
 
+import de.metas.security.RoleId;
+import de.metas.user.UserId;
+import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 
-import java.util.Properties;
+import javax.annotation.Nullable;
 
-@Value(staticConstructor = "of")
+@Value
+@Builder
 public class EnqueueAvailableForSalesRequest
 {
-	@NonNull
-	AvailableForSalesQuery availableForSalesQuery;
+	@NonNull AvailableForSalesQuery availableForSalesQuery;
 
-	@NonNull
-	Properties ctx;
+	@Nullable UserId contextUserId;
+	@Nullable RoleId contextRoleId;
 }

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/event/EnqueueAvailableForSalesConfiguration.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/event/EnqueueAvailableForSalesConfiguration.java
@@ -1,0 +1,62 @@
+package de.metas.material.cockpit.availableforsales.event;
+
+import de.metas.event.Topic;
+import de.metas.event.remote.IEventBusQueueConfiguration;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Optional;
+
+@Configuration
+public class EnqueueAvailableForSalesConfiguration implements IEventBusQueueConfiguration
+{
+	public static final Topic TOPIC = Topic.distributed("de.metas.material.cockpit.availableforsales");
+	private static final String BASE_BEAN_NAME = "metasfreshMaterialCockpitAvailableForSales";
+	private static final String QUEUE_BEAN_NAME = BASE_BEAN_NAME + "Queue";
+	static final String QUEUE_NAME_SPEL = "#{" + QUEUE_BEAN_NAME + ".name}";
+	private static final String EXCHANGE_NAME = TOPIC.getName();
+
+	@Bean(QUEUE_BEAN_NAME)
+	public Queue queue()
+	{
+		// final NamingStrategy eventQueueNamingStrategy = new Base64UrlNamingStrategy(EVENTBUS_TOPIC.getName() + "." + appName + "-");
+		// return new AnonymousQueue(eventQueueNamingStrategy);
+		return new Queue(TOPIC.getName(), true);
+	}
+
+	@Bean(BASE_BEAN_NAME + "Exchange")
+	public DirectExchange exchange()
+	{
+		return new DirectExchange(EXCHANGE_NAME);
+	}
+
+	@Bean(BASE_BEAN_NAME + "Binding")
+	public Binding binding()
+	{
+		return BindingBuilder.bind(queue())
+				.to(exchange())
+				.with(EXCHANGE_NAME);
+	}
+
+	@Override
+	public String getQueueName()
+	{
+		return queue().getName();
+	}
+
+	@Override
+	public Optional<String> getTopicName()
+	{
+		return Optional.of(TOPIC.getName());
+	}
+
+	@Override
+	public String getExchangeName()
+	{
+		return exchange().getName();
+	}
+}

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/event/EnqueueAvailableForSalesConverter.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/event/EnqueueAvailableForSalesConverter.java
@@ -1,0 +1,45 @@
+package de.metas.material.cockpit.availableforsales.event;
+
+import de.metas.JsonObjectMapperHolder;
+import de.metas.event.Event;
+import de.metas.material.cockpit.availableforsales.AvailableForSalesQuery;
+import de.metas.material.cockpit.availableforsales.EnqueueAvailableForSalesRequest;
+import de.metas.security.RoleId;
+import de.metas.user.UserId;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+import org.compiere.util.Env;
+
+@UtilityClass
+class EnqueueAvailableForSalesConverter
+{
+	private static final String EVENT_NAME = "EnqueueAvailableForSales";
+	private static final String PROPERTY_Query = "query";
+
+	public static Event toEvent(final @NonNull EnqueueAvailableForSalesRequest request)
+	{
+		@NonNull final AvailableForSalesQuery query = request.getAvailableForSalesQuery();
+
+		return Event.builder()
+				.setEventName(EVENT_NAME)
+				.putProperty(PROPERTY_Query, JsonObjectMapperHolder.toJson(query))
+				.putProperty(Env.CTXNAME_AD_User_ID, UserId.toRepoId(request.getContextUserId()))
+				.putProperty(Env.CTXNAME_AD_Role_ID, RoleId.toRepoId(request.getContextRoleId()))
+				.shallBeLogged()
+				.build();
+	}
+
+	public EnqueueAvailableForSalesRequest fromEvent(final @NonNull Event event)
+	{
+		// NOTE: for some reason eventName has JsonIgnore, so we cannot validate it. he reason needs to be cleared first.
+		// Check.assumeEquals(event.getEventName(), EVENT_NAME, "Event must match event name: {}", event);
+		
+		//noinspection DataFlowIssue
+		return EnqueueAvailableForSalesRequest.builder()
+				.availableForSalesQuery(JsonObjectMapperHolder.fromJsonNonNull(event.getPropertyAsString(PROPERTY_Query), AvailableForSalesQuery.class))
+				.contextUserId(UserId.ofRepoIdOrNull(event.getPropertyAsInt(Env.CTXNAME_AD_User_ID, -1)))
+				.contextRoleId(RoleId.ofRepoIdOrNull(event.getPropertyAsInt(Env.CTXNAME_AD_Role_ID, -1)))
+				.build();
+	}
+
+}

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/event/EnqueueAvailableForSalesHandler.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/event/EnqueueAvailableForSalesHandler.java
@@ -1,0 +1,61 @@
+package de.metas.material.cockpit.availableforsales.event;
+
+import de.metas.Profiles;
+import de.metas.event.Event;
+import de.metas.event.IEventBus;
+import de.metas.event.IEventBusFactory;
+import de.metas.event.IEventListener;
+import de.metas.material.cockpit.availableforsales.AvailableForSalesService;
+import de.metas.material.cockpit.availableforsales.EnqueueAvailableForSalesRequest;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.util.lang.IAutoCloseable;
+import org.compiere.util.Env;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.Properties;
+
+@Component
+@Profile(Profiles.PROFILE_App)
+@RequiredArgsConstructor
+public class EnqueueAvailableForSalesHandler implements IEventListener
+{
+	@NonNull private final AvailableForSalesService availableForSalesService;
+	@NonNull private final IEventBusFactory eventBusFactory;
+
+	@PostConstruct
+	public void subscribe()
+	{
+		eventBusFactory.getEventBus(EnqueueAvailableForSalesConfiguration.TOPIC).subscribe(this);
+	}
+
+	@Override
+	public void onEvent(final IEventBus eventBus_NOTUSED, final Event event)
+	{
+		final EnqueueAvailableForSalesRequest request = EnqueueAvailableForSalesConverter.fromEvent(event);
+		try (final IAutoCloseable ignored = switchCtx(request))
+		{
+			availableForSalesService.syncAvailableForSalesTable(request.getAvailableForSalesQuery());
+		}
+	}
+
+	private IAutoCloseable switchCtx(final @NonNull EnqueueAvailableForSalesRequest request)
+	{
+		final Properties ctx = Env.newTemporaryCtx();
+		Env.setClientAndOrgId(ctx, request.getAvailableForSalesQuery().getClientAndOrgId());
+		// Apply the originating user/role that the publisher captured (serialized in the event), so the
+		// recompute runs under the same security context — not the system default.
+		if (request.getContextUserId() != null)
+		{
+			Env.setLoggedUserId(ctx, request.getContextUserId());
+		}
+		if (request.getContextRoleId() != null)
+		{
+			Env.setLoggedRoleId(ctx, request.getContextRoleId());
+		}
+		return Env.switchContext(ctx);
+	}
+
+}

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/event/EnqueueAvailableForSalesPublisher.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/event/EnqueueAvailableForSalesPublisher.java
@@ -1,0 +1,45 @@
+package de.metas.material.cockpit.availableforsales.event;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.event.IEventBus;
+import de.metas.event.IEventBusFactory;
+import de.metas.material.cockpit.availableforsales.EnqueueAvailableForSalesRequest;
+import de.metas.util.Services;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.trx.api.ITrxManager;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+
+@Component
+@RequiredArgsConstructor
+public class EnqueueAvailableForSalesPublisher
+{
+	@NonNull private final ITrxManager trxManager = Services.get(ITrxManager.class);
+	@NonNull private final IEventBusFactory eventBusFactory;
+
+	private IEventBus eventBus()
+	{
+		return eventBusFactory.getEventBus(EnqueueAvailableForSalesConfiguration.TOPIC);
+	}
+
+	public void publishAfterCommit(@NonNull final EnqueueAvailableForSalesRequest request)
+	{
+		trxManager.accumulateAndProcessAfterCommit(
+				"EnqueueAvailableForSalesPublisher.publishAfterCommit",
+				ImmutableList.of(request),
+				this::publishAll
+		);
+	}
+
+	private void publishAll(@NonNull final Collection<EnqueueAvailableForSalesRequest> requests)
+	{
+		requests.stream().distinct().forEach(this::publishOne);
+	}
+
+	private void publishOne(@NonNull final EnqueueAvailableForSalesRequest request)
+	{
+		eventBus().enqueueEvent(EnqueueAvailableForSalesConverter.toEvent(request));
+	}
+}

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/event/EnqueueAvailableForSalesRabbitMQEndpoint.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/event/EnqueueAvailableForSalesRabbitMQEndpoint.java
@@ -1,0 +1,38 @@
+package de.metas.material.cockpit.availableforsales.event;
+
+import de.metas.Profiles;
+import de.metas.event.Event;
+import de.metas.event.IEventBusFactory;
+import de.metas.event.Type;
+import de.metas.event.impl.EventBusMonitoringService;
+import de.metas.event.remote.rabbitmq.RabbitMQReceiveFromEndpointTemplate;
+import lombok.NonNull;
+import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.context.annotation.Profile;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableRabbit
+@Profile(Profiles.PROFILE_App) // IMPORTANT: make sure events are consumed only in the app server 
+public class EnqueueAvailableForSalesRabbitMQEndpoint extends RabbitMQReceiveFromEndpointTemplate
+{
+	public EnqueueAvailableForSalesRabbitMQEndpoint(
+			@NonNull final IEventBusFactory eventBusFactory,
+			@NonNull final EventBusMonitoringService eventBusMonitoringService)
+	{
+		super(eventBusFactory, eventBusMonitoringService);
+	}
+
+	@RabbitListener(queues = { EnqueueAvailableForSalesConfiguration.QUEUE_NAME_SPEL })
+	public void onAccountingEvent(
+			@Payload final Event event,
+			@Header(HEADER_SenderId) final String senderId,
+			@Header(HEADER_TopicName) final String topicName,
+			@Header(HEADER_TopicType) final Type topicType)
+	{
+		onRemoteEvent(event, senderId, topicName, topicType);
+	}
+}

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/interceptor/AvailableForSalesUtil.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/interceptor/AvailableForSalesUtil.java
@@ -29,7 +29,7 @@ import de.metas.order.IOrderDAO;
 import de.metas.order.IOrderLineBL;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
-import de.metas.organization.OrgId;
+import de.metas.organization.ClientAndOrgId;
 import de.metas.product.IProductDAO;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
@@ -56,6 +56,7 @@ import org.compiere.model.I_C_Order;
 import org.compiere.model.I_M_Product;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nullable;
@@ -194,46 +195,57 @@ public class AvailableForSalesUtil
 	}
 
 	@NonNull
-	public EnqueueAvailableForSalesRequest createRequestWithPreparationDateNow(
+	@Builder(builderMethodName = "requestWithPreparationDateNow", builderClassName = "$RequestWithPreparationDateNowBuilder")
+	private EnqueueAvailableForSalesRequest createRequestWithPreparationDateNow0(
 			@NonNull final Properties ctx,
 			@NonNull final AvailableForSalesConfig config,
 			@NonNull final ProductId productId,
-			@NonNull final OrgId orgId,
+			@NonNull final ClientAndOrgId clientAndOrgId,
 			@NonNull final AttributesKey storageAttributesKey,
 			@NonNull final WarehouseId warehouseId)
 	{
-		return EnqueueAvailableForSalesRequest.of(AvailableForSalesQuery
-						.builder()
+		return EnqueueAvailableForSalesRequest.builder()
+				.availableForSalesQuery(AvailableForSalesQuery.builder()
 						.dateOfInterest(SystemTime.asInstant())
 						.productId(productId)
 						.storageAttributesKeyPattern(AttributesKeyPatternsUtil.ofAttributeKey(storageAttributesKey))
-						.orgId(orgId)
+						.clientAndOrgId(clientAndOrgId)
 						.shipmentDateLookAheadHours(config.getShipmentDateLookAheadHours())
 						.salesOrderLookBehindHours(config.getSalesOrderLookBehindHours())
 						.warehouseId(warehouseId)
-						.build(),
-				ctx);
+						.build())
+				.contextUserId(Env.getLoggedUserIdIfExists(ctx).orElse(null))
+				.contextRoleId(Env.getLoggedRoleIdIfExists(ctx).orElse(null))
+				.build();
 	}
 
 	public void syncAvailableForSalesForOrderLine(
 			@NonNull final I_C_OrderLine orderLineRecord,
 			@NonNull final AvailableForSalesConfig config)
 	{
-		final Properties ctx = Env.copyCtx(InterfaceWrapperHelper.getCtx(orderLineRecord));
-		final ProductId productId = ProductId.ofRepoId(orderLineRecord.getM_Product_ID());
-		final OrgId orgId = OrgId.ofRepoId(orderLineRecord.getAD_Org_ID());
+		availableForSalesService.enqueueAvailableForSalesRequestAfterCommit(
+				requestWithPreparationDateNow()
+						.ctx(InterfaceWrapperHelper.getCtx(orderLineRecord))
+						.config(config)
+						.productId(ProductId.ofRepoId(orderLineRecord.getM_Product_ID()))
+						.clientAndOrgId(ClientAndOrgId.ofClientAndOrg(orderLineRecord.getAD_Client_ID(), orderLineRecord.getAD_Org_ID()))
+						.storageAttributesKey(extractStorageAttributesKey(orderLineRecord))
+						.warehouseId(extractWarehouseId(orderLineRecord))
+						.build()
+		);
+	}
 
-		final AttributesKey storageAttributesKey = AttributesKeys
+	private WarehouseId extractWarehouseId(final @NotNull I_C_OrderLine orderLineRecord)
+	{
+		return Optional.ofNullable(WarehouseId.ofRepoIdOrNull(orderLineRecord.getM_Warehouse_ID()))
+				.orElseGet(() -> WarehouseId.ofRepoId(ordersDAO.getById(OrderId.ofRepoId(orderLineRecord.getC_Order_ID())).getM_Warehouse_ID()));
+	}
+
+	private static AttributesKey extractStorageAttributesKey(final @NotNull I_C_OrderLine orderLineRecord)
+	{
+		return AttributesKeys
 				.createAttributesKeyFromASIStorageAttributes(AttributeSetInstanceId.ofRepoIdOrNone(orderLineRecord.getM_AttributeSetInstance_ID()))
 				.orElse(AttributesKey.NONE);
-
-		final WarehouseId warehouseId = Optional.ofNullable(WarehouseId.ofRepoIdOrNull(orderLineRecord.getM_Warehouse_ID()))
-				.orElseGet(() -> WarehouseId.ofRepoId(ordersDAO.getById(OrderId.ofRepoId(orderLineRecord.getC_Order_ID())).getM_Warehouse_ID()));
-
-		final EnqueueAvailableForSalesRequest enqueueAvailableForSalesRequest = createRequestWithPreparationDateNow(ctx, config, productId, orgId, storageAttributesKey, warehouseId);
-
-		trxManager.runAfterCommit(() -> availableForSalesService
-				.enqueueAvailableForSalesRequest(enqueueAvailableForSalesRequest));
 	}
 
 	@Value
@@ -255,14 +267,9 @@ public class AvailableForSalesUtil
 	@Builder
 	private static class CheckAvailableForSalesRequestContext
 	{
-		@NonNull
-		AvailableForSalesConfig config;
-
-		@NonNull
-		UserId errorNotificationRecipient;
-
-		@NonNull
-		OrgId orgId;
+		@NonNull AvailableForSalesConfig config;
+		@NonNull UserId errorNotificationRecipient;
+		@NonNull ClientAndOrgId clientAndOrgId;
 	}
 
 	private class CheckAvailableForSalesRequestsCollector
@@ -273,12 +280,12 @@ public class AvailableForSalesUtil
 				@NonNull final List<CheckAvailableForSalesRequest> requests,
 				@NonNull final AvailableForSalesConfig config,
 				@NonNull final UserId errorNotificationRecipient,
-				@NonNull final OrgId orgId)
+				@NonNull final ClientAndOrgId clientAndOrgId)
 		{
 			final CheckAvailableForSalesRequestContext context = CheckAvailableForSalesRequestContext.builder()
 					.config(config)
 					.errorNotificationRecipient(errorNotificationRecipient)
-					.orgId(orgId)
+					.clientAndOrgId(clientAndOrgId)
 					.build();
 
 			this.requests.putAll(context, requests);
@@ -291,11 +298,7 @@ public class AvailableForSalesUtil
 
 		private void processAsync(final CheckAvailableForSalesRequestContext context, final Collection<CheckAvailableForSalesRequest> requests)
 		{
-			final AvailableForSalesConfig config = context.getConfig();
-			final UserId errorNotificationRecipient = context.getErrorNotificationRecipient();
-			final OrgId orgId = context.getOrgId();
-
-			retrieveDataAndUpdateOrderLinesAsync(requests, config, errorNotificationRecipient, orgId);
+			retrieveDataAndUpdateOrderLinesAsync(requests, context.getConfig(), context.getErrorNotificationRecipient(), context.getClientAndOrgId());
 		}
 
 	}
@@ -303,7 +306,7 @@ public class AvailableForSalesUtil
 	public void checkAndUpdateOrderLineRecords(
 			@NonNull final List<CheckAvailableForSalesRequest> requests,
 			@NonNull final AvailableForSalesConfig config,
-			@NonNull final OrgId orgId)
+			@NonNull final ClientAndOrgId clientAndOrgId)
 	{
 		if (requests.isEmpty())
 		{
@@ -322,16 +325,16 @@ public class AvailableForSalesUtil
 						CheckAvailableForSalesRequestsCollector::new,
 						CheckAvailableForSalesRequestsCollector::processAsync);
 
-				collector.collect(requests, config, errorNotificationRecipient, orgId);
+				collector.collect(requests, config, errorNotificationRecipient, clientAndOrgId);
 			}
 			else
 			{
-				retrieveDataAndUpdateOrderLinesAsync(requests, config, errorNotificationRecipient, orgId);
+				retrieveDataAndUpdateOrderLinesAsync(requests, config, errorNotificationRecipient, clientAndOrgId);
 			}
 		}
 		else
 		{
-			retrieveDataAndUpdateOrderLines(requests, config, orgId);
+			retrieveDataAndUpdateOrderLines(requests, config, clientAndOrgId);
 		}
 	}
 
@@ -342,12 +345,12 @@ public class AvailableForSalesUtil
 			@NonNull final Collection<CheckAvailableForSalesRequest> requests,
 			@NonNull final AvailableForSalesConfig config,
 			@NonNull final UserId errorNotificationRecipient,
-			@NonNull final OrgId orgId)
+			@NonNull final ClientAndOrgId clientAndOrgId)
 	{
 		// We cannot use a thread-inherited transaction that would otherwise be used by default.
 		// Because when this method is called, it means that the thread-inherited transaction is already committed
 		// Therefore, let's create our own trx to work in
-		final Runnable runnable = () -> trxManager.runInNewTrx(() -> retrieveDataAndUpdateOrderLines(requests, config, orgId));
+		final Runnable runnable = () -> trxManager.runInNewTrx(() -> retrieveDataAndUpdateOrderLines(requests, config, clientAndOrgId));
 
 		final ExecutorService executor = Executors.newSingleThreadExecutor();
 		try
@@ -389,10 +392,10 @@ public class AvailableForSalesUtil
 	void retrieveDataAndUpdateOrderLines(
 			@NonNull final Collection<CheckAvailableForSalesRequest> requests,
 			@NonNull final AvailableForSalesConfig config,
-			@NonNull final OrgId orgId)
+			@NonNull final ClientAndOrgId clientAndOrgId)
 	{
 		final ImmutableMultimap<AvailableForSalesQuery, OrderLineId> //
-				query2OrderLineIds = createQueries(requests, config, orgId);
+				query2OrderLineIds = createQueries(requests, config, clientAndOrgId);
 
 		final AvailableForSalesMultiQuery availableForSalesMultiQuery = AvailableForSalesMultiQuery
 				.builder()
@@ -416,7 +419,7 @@ public class AvailableForSalesUtil
 	private ImmutableMultimap<AvailableForSalesQuery, OrderLineId> createQueries(
 			@NonNull final Collection<CheckAvailableForSalesRequest> requests,
 			@NonNull final AvailableForSalesConfig config,
-			@NonNull final OrgId orgId)
+			@NonNull final ClientAndOrgId clientAndOrgId)
 	{
 		final ImmutableMultimap.Builder<AvailableForSalesQuery, OrderLineId> query2OrderLineId = ImmutableMultimap.builder();
 
@@ -428,9 +431,8 @@ public class AvailableForSalesUtil
 					.createAttributesKeyFromASIStorageAttributes(request.getAttributeSetInstanceId())
 					.orElse(AttributesKey.NONE);
 
-			final AvailableForSalesQuery availableForSalesQuery = AvailableForSalesQuery
-					.builder()
-					.orgId(orgId)
+			final AvailableForSalesQuery availableForSalesQuery = AvailableForSalesQuery.builder()
+					.clientAndOrgId(clientAndOrgId)
 					.dateOfInterest(dateOfInterest)
 					.productId(productId)
 					.storageAttributesKeyPattern(AttributesKeyPatternsUtil.ofAttributeKey(storageAttributesKey))

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/interceptor/C_Order.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/interceptor/C_Order.java
@@ -4,6 +4,7 @@ import de.metas.material.cockpit.availableforsales.AvailableForSalesConfig;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesConfigRepo;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesConfigRepo.ConfigQuery;
 import de.metas.material.cockpit.availableforsales.interceptor.AvailableForSalesUtil.CheckAvailableForSalesRequest;
+import de.metas.organization.ClientAndOrgId;
 import de.metas.organization.OrgId;
 import lombok.NonNull;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
@@ -62,13 +63,8 @@ public class C_Order
 			return; // nothing to do
 		}
 
-		final OrgId orgId = OrgId.ofRepoId(orderRecord.getAD_Org_ID());
-
-		final AvailableForSalesConfig config = availableForSalesConfigRepo.getConfig(
-				ConfigQuery.builder()
-						.clientId(ClientId.ofRepoId(orderRecord.getAD_Client_ID()))
-						.orgId(orgId)
-						.build());
+		final ClientAndOrgId clientAndOrgId = ClientAndOrgId.ofClientAndOrg(orderRecord.getAD_Client_ID(), orderRecord.getAD_Org_ID());
+		final AvailableForSalesConfig config = availableForSalesConfigRepo.getConfig(clientAndOrgId);
 		if (!config.isFeatureEnabled())
 		{
 			return; // nothing to do
@@ -77,7 +73,7 @@ public class C_Order
 		// has to contain everything that the method to be invoked after commit needs
 		final List<CheckAvailableForSalesRequest> requests = availableForSalesUtil.createRequests(orderRecord);
 
-		availableForSalesUtil.checkAndUpdateOrderLineRecords(requests, config, orgId);
+		availableForSalesUtil.checkAndUpdateOrderLineRecords(requests, config, clientAndOrgId);
 	}
 
 	@ModelChange( //

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/interceptor/C_OrderLine.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/interceptor/C_OrderLine.java
@@ -3,10 +3,10 @@ package de.metas.material.cockpit.availableforsales.interceptor;
 import com.google.common.collect.ImmutableList;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesConfig;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesConfigRepo;
-import de.metas.material.cockpit.availableforsales.AvailableForSalesConfigRepo.ConfigQuery;
 import de.metas.material.cockpit.availableforsales.interceptor.AvailableForSalesUtil.CheckAvailableForSalesRequest;
 import de.metas.material.cockpit.availableforsales.model.I_C_OrderLine;
 import de.metas.order.OrderId;
+import de.metas.organization.ClientAndOrgId;
 import de.metas.organization.OrgId;
 import lombok.NonNull;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
@@ -71,13 +71,8 @@ public class C_OrderLine
 			return; // nothing to do
 		}
 
-		final OrgId orgId = OrgId.ofRepoId(orderLineRecord.getAD_Org_ID());
-
-		final AvailableForSalesConfig config = availableForSalesConfigRepo.getConfig(
-				ConfigQuery.builder()
-						.clientId(ClientId.ofRepoId(orderLineRecord.getAD_Client_ID()))
-						.orgId(orgId)
-						.build());
+		final ClientAndOrgId clientAndOrgId = ClientAndOrgId.ofClientAndOrg(orderLineRecord.getAD_Client_ID(), orderLineRecord.getAD_Org_ID());
+		final AvailableForSalesConfig config = availableForSalesConfigRepo.getConfig(clientAndOrgId);
 		if (!config.isFeatureEnabled())
 		{
 			return; // nothing to do
@@ -86,7 +81,7 @@ public class C_OrderLine
 		// has to contain everything that the method to be invoked after commit needs
 		final CheckAvailableForSalesRequest checkAvailableForSalesRequest = availableForSalesUtil.createRequest(orderLineRecord);
 
-		availableForSalesUtil.checkAndUpdateOrderLineRecords(ImmutableList.of(checkAvailableForSalesRequest), config, orgId);
+		availableForSalesUtil.checkAndUpdateOrderLineRecords(ImmutableList.of(checkAvailableForSalesRequest), config, clientAndOrgId);
 	}
 
 	@ModelChange( //

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/process/MD_Available_For_Sales_Populate_Table.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/availableforsales/process/MD_Available_For_Sales_Populate_Table.java
@@ -48,7 +48,7 @@ public class MD_Available_For_Sales_Populate_Table extends JavaProcess
 
 		while (productsMeantToBeSold.hasNext())
 		{
-			availableForSalesService.syncAvailableForSalesForProduct(productsMeantToBeSold.next());
+			availableForSalesService.syncAvailableForSalesForProduct(productsMeantToBeSold.next(), getClientId());
 		}
 
 		return MSG_OK;

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/interceptor/MD_Stock.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/interceptor/MD_Stock.java
@@ -25,32 +25,23 @@ package de.metas.material.cockpit.stock.interceptor;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesConfig;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesConfigRepo;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesService;
-import de.metas.material.cockpit.availableforsales.EnqueueAvailableForSalesRequest;
 import de.metas.material.cockpit.availableforsales.interceptor.AvailableForSalesUtil;
 import de.metas.material.cockpit.model.I_MD_Stock;
 import de.metas.material.event.commons.AttributesKey;
-import de.metas.organization.OrgId;
+import de.metas.organization.ClientAndOrgId;
 import de.metas.product.ProductId;
-import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
-import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.model.InterfaceWrapperHelper;
-import org.adempiere.service.ClientId;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.ModelValidator;
-import org.compiere.util.Env;
 import org.springframework.stereotype.Component;
-
-import java.util.Properties;
 
 @Interceptor(I_MD_Stock.class)
 @Component
 public class MD_Stock
 {
-	private final ITrxManager trxManager = Services.get(ITrxManager.class);
-
 	private final AvailableForSalesService availableForSalesService;
 	private final AvailableForSalesConfigRepo availableForSalesConfigRepo;
 	private final AvailableForSalesUtil availableForSalesUtil;
@@ -68,26 +59,22 @@ public class MD_Stock
 	@ModelChange(timings = { ModelValidator.TYPE_AFTER_NEW, ModelValidator.TYPE_AFTER_CHANGE })
 	public void triggerSyncAvailableForSales(@NonNull final I_MD_Stock stockRecord)
 	{
-		final AvailableForSalesConfig config = availableForSalesConfigRepo.getConfig(
-				AvailableForSalesConfigRepo.ConfigQuery.builder()
-						.clientId(ClientId.ofRepoId(stockRecord.getAD_Client_ID()))
-						.orgId(OrgId.ofRepoId(stockRecord.getAD_Org_ID()))
-						.build());
-
+		final ClientAndOrgId clientAndOrgId = ClientAndOrgId.ofClientAndOrg(stockRecord.getAD_Client_ID(), stockRecord.getAD_Org_ID());
+		final AvailableForSalesConfig config = availableForSalesConfigRepo.getConfig(clientAndOrgId);
 		if (!config.isFeatureEnabled())
 		{
 			return; // nothing to do
 		}
 
-		final Properties ctx = Env.copyCtx(InterfaceWrapperHelper.getCtx(stockRecord));
-		final ProductId productId = ProductId.ofRepoId(stockRecord.getM_Product_ID());
-		final OrgId orgId = OrgId.ofRepoId(stockRecord.getAD_Org_ID());
-		final AttributesKey attributesKey = AttributesKey.ofString(stockRecord.getAttributesKey());
-		final WarehouseId warehouseId = WarehouseId.ofRepoId(stockRecord.getM_Warehouse_ID());
-
-		final EnqueueAvailableForSalesRequest enqueueAvailableForSalesRequest = availableForSalesUtil
-				.createRequestWithPreparationDateNow(ctx, config, productId, orgId, attributesKey, warehouseId);
-
-		trxManager.runAfterCommit(() -> availableForSalesService.enqueueAvailableForSalesRequest(enqueueAvailableForSalesRequest));
+		availableForSalesService.enqueueAvailableForSalesRequestAfterCommit(
+				availableForSalesUtil.requestWithPreparationDateNow()
+						.ctx(InterfaceWrapperHelper.getCtx(stockRecord))
+						.config(config)
+						.productId(ProductId.ofRepoId(stockRecord.getM_Product_ID()))
+						.clientAndOrgId(clientAndOrgId)
+						.storageAttributesKey(AttributesKey.ofString(stockRecord.getAttributesKey()))
+						.warehouseId(WarehouseId.ofRepoId(stockRecord.getM_Warehouse_ID()))
+						.build()
+		);
 	}
 }

--- a/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/availableforsales/AvailableForSalesQueryTest.java
+++ b/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/availableforsales/AvailableForSalesQueryTest.java
@@ -1,0 +1,44 @@
+package de.metas.material.cockpit.availableforsales;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.metas.JsonObjectMapperHolder;
+import de.metas.common.util.time.SystemTime;
+import de.metas.organization.ClientAndOrgId;
+import de.metas.product.ProductId;
+import org.adempiere.mm.attributes.keys.AttributesKeyPattern;
+import org.adempiere.warehouse.WarehouseId;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AvailableForSalesQueryTest
+{
+	@Test
+	public void testSerializeDeserializeObject() throws IOException
+	{
+		testSerializeDeserializeObject(
+				AvailableForSalesQuery.builder()
+						.productId(ProductId.ofRepoId(1))
+						.warehouseId(WarehouseId.ofRepoId(2))
+						.storageAttributesKeyPattern(AttributesKeyPattern.ALL)
+						.clientAndOrgId(ClientAndOrgId.ofClientAndOrg(4, 5))
+						.dateOfInterest(SystemTime.asInstant())
+						.shipmentDateLookAheadHours(12)
+						.salesOrderLookBehindHours(13)
+						.build()
+		);
+	}
+
+	private void testSerializeDeserializeObject(final AvailableForSalesQuery value) throws IOException
+	{
+		final ObjectMapper objectMapper = JsonObjectMapperHolder.newJsonObjectMapper();
+
+		final Class<?> valueClass = value.getClass();
+		final String json = objectMapper.writeValueAsString(value);
+		final Object value2 = objectMapper.readValue(json, valueClass);
+		assertThat(value2).isEqualTo(value);
+	}
+
+}

--- a/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/availableforsales/event/EnqueueAvailableForSalesConverterTest.java
+++ b/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/availableforsales/event/EnqueueAvailableForSalesConverterTest.java
@@ -1,0 +1,51 @@
+package de.metas.material.cockpit.availableforsales.event;
+
+import de.metas.common.util.time.SystemTime;
+import de.metas.event.Event;
+import de.metas.material.cockpit.availableforsales.AvailableForSalesQuery;
+import de.metas.material.cockpit.availableforsales.EnqueueAvailableForSalesRequest;
+import de.metas.organization.ClientAndOrgId;
+import de.metas.product.ProductId;
+import de.metas.security.RoleId;
+import de.metas.user.UserId;
+import org.adempiere.mm.attributes.keys.AttributesKeyPattern;
+import org.adempiere.warehouse.WarehouseId;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EnqueueAvailableForSalesConverterTest
+{
+	@Test
+	public void testSerializeDeserialize()
+	{
+		final AvailableForSalesQuery query = AvailableForSalesQuery.builder()
+				.productId(ProductId.ofRepoId(1))
+				.warehouseId(WarehouseId.ofRepoId(2))
+				.storageAttributesKeyPattern(AttributesKeyPattern.ALL)
+				.clientAndOrgId(ClientAndOrgId.ofClientAndOrg(4, 5))
+				.dateOfInterest(SystemTime.asInstant())
+				.shipmentDateLookAheadHours(12)
+				.salesOrderLookBehindHours(13)
+				.build();
+
+		testSerializeDeserialize(
+				EnqueueAvailableForSalesRequest.builder()
+						.availableForSalesQuery(query)
+						.build());
+		testSerializeDeserialize(
+				EnqueueAvailableForSalesRequest.builder()
+						.availableForSalesQuery(query)
+						.contextUserId(UserId.ofRepoId(1000))
+						.contextRoleId(RoleId.ofRepoId(1001))
+						.build());
+	}
+
+	public void testSerializeDeserialize(EnqueueAvailableForSalesRequest request)
+	{
+		final Event event = EnqueueAvailableForSalesConverter.toEvent(request);
+		final EnqueueAvailableForSalesRequest request2 = EnqueueAvailableForSalesConverter.fromEvent(event);
+		assertThat(request2).isEqualTo(request);
+	}
+
+}

--- a/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/availableforsales/interceptor/AvailableForSalesUtilTest.java
+++ b/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/availableforsales/interceptor/AvailableForSalesUtilTest.java
@@ -2,14 +2,13 @@ package de.metas.material.cockpit.availableforsales.interceptor;
 
 import com.google.common.collect.ImmutableList;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesConfig;
-import de.metas.material.cockpit.availableforsales.AvailableForSalesConfigRepo;
-import de.metas.material.cockpit.availableforsales.AvailableForSalesRepository;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesService;
 import de.metas.material.cockpit.availableforsales.interceptor.AvailableForSalesUtil.CheckAvailableForSalesRequest;
 import de.metas.material.cockpit.availableforsales.model.I_C_OrderLine;
 import de.metas.material.cockpit.model.I_MD_Available_For_Sales_QueryResult;
 import de.metas.material.event.commons.AttributesKey;
 import de.metas.order.OrderLineId;
+import de.metas.organization.ClientAndOrgId;
 import de.metas.organization.OrgId;
 import de.metas.product.ProductId;
 import de.metas.uom.UomId;
@@ -158,7 +157,7 @@ class AvailableForSalesUtilTest
 				.warehouseId(qtyPerWarehouseWarehouseId)
 				.build();
 
-		availableForSalesUtil = new AvailableForSalesUtil(new AvailableForSalesService(new AvailableForSalesConfigRepo(), new AvailableForSalesRepository()));
+		availableForSalesUtil = new AvailableForSalesUtil(AvailableForSalesService.newInstanceForUnitTesting());
 	}
 
 	@Test
@@ -168,7 +167,7 @@ class AvailableForSalesUtilTest
 		createQueryResultRecord(FOUR, null/* qtyOnHandStock */, null);
 
 		// invoke the method under test
-		availableForSalesUtil.retrieveDataAndUpdateOrderLines(ImmutableList.of(request), config, OrgId.MAIN);
+		availableForSalesUtil.retrieveDataAndUpdateOrderLines(ImmutableList.of(request), config, ClientAndOrgId.MAIN);
 
 		final I_C_OrderLine updatedOrderRecord = load(orderLineId, I_C_OrderLine.class);
 
@@ -183,7 +182,7 @@ class AvailableForSalesUtilTest
 		createQueryResultRecord(THREE, null/* qtyOnHandStock */, null);
 
 		// invoke the method under test
-		availableForSalesUtil.retrieveDataAndUpdateOrderLines(ImmutableList.of(request), config, OrgId.MAIN);
+		availableForSalesUtil.retrieveDataAndUpdateOrderLines(ImmutableList.of(request), config, ClientAndOrgId.MAIN);
 
 		final I_C_OrderLine updatedOrderRecord = load(orderLineId, I_C_OrderLine.class);
 
@@ -199,7 +198,7 @@ class AvailableForSalesUtilTest
 		createQueryResultRecord(THREE/* qtyToBeShipped */, FOUR/* qtyOnHandStock */, null);
 
 		// invoke the method under test
-		availableForSalesUtil.retrieveDataAndUpdateOrderLines(ImmutableList.of(request), config, OrgId.MAIN);
+		availableForSalesUtil.retrieveDataAndUpdateOrderLines(ImmutableList.of(request), config, ClientAndOrgId.MAIN);
 
 		final I_C_OrderLine updatedOrderRecord = load(orderLineId, I_C_OrderLine.class);
 
@@ -214,7 +213,7 @@ class AvailableForSalesUtilTest
 		createQueryResultRecord(THREE/* qtyToBeShipped */, null/* qtyOnHandStock */, null);
 		createQueryResultRecord(THREE/* qtyToBeShipped */, TEN/* qtyOnHandStock */, null);
 
-		availableForSalesUtil.retrieveDataAndUpdateOrderLines(ImmutableList.of(request), config, OrgId.MAIN);
+		availableForSalesUtil.retrieveDataAndUpdateOrderLines(ImmutableList.of(request), config, ClientAndOrgId.MAIN);
 
 		final I_C_OrderLine updatedOrderRecord = load(orderLineId, I_C_OrderLine.class);
 
@@ -229,7 +228,7 @@ class AvailableForSalesUtilTest
 		createQueryResultRecord(THREE/* qtyToBeShipped */, null/* qtyOnHandStock */, warehouseId);
 		createQueryResultRecord(SEVEN/* qtyToBeShipped */, TEN/* qtyOnHandStock */, qtyPerWarehouseWarehouseId);
 
-		availableForSalesUtil.retrieveDataAndUpdateOrderLines(ImmutableList.of(qtyPerWarehouseRequest), qtyPerWarehouseConfig, OrgId.MAIN);
+		availableForSalesUtil.retrieveDataAndUpdateOrderLines(ImmutableList.of(qtyPerWarehouseRequest), qtyPerWarehouseConfig, ClientAndOrgId.MAIN);
 
 		final I_C_OrderLine updatedOrderRecord = load(qtyPerWarehouseOrderLineId, I_C_OrderLine.class);
 
@@ -244,7 +243,7 @@ class AvailableForSalesUtilTest
 		createQueryResultRecord(THREE/* qtyToBeShipped */, null/* qtyOnHandStock */, warehouseId);
 		createQueryResultRecord(SEVEN/* qtyToBeShipped */, ONE/* qtyOnHandStock */, qtyPerWarehouseWarehouseId);
 
-		availableForSalesUtil.retrieveDataAndUpdateOrderLines(ImmutableList.of(qtyPerWarehouseRequest), qtyPerWarehouseConfig, OrgId.MAIN);
+		availableForSalesUtil.retrieveDataAndUpdateOrderLines(ImmutableList.of(qtyPerWarehouseRequest), qtyPerWarehouseConfig, ClientAndOrgId.MAIN);
 
 		final I_C_OrderLine updatedOrderRecord = load(qtyPerWarehouseOrderLineId, I_C_OrderLine.class);
 
@@ -252,7 +251,7 @@ class AvailableForSalesUtilTest
 		assertThat(updatedOrderRecord.getQtyAvailableForSales()).isEqualByComparingTo(THREE.negate());
 		assertThat(updatedOrderRecord.getInsufficientQtyAvailableForSalesColor_ID()).isEqualTo(colorId.getRepoId());
 	}
-	
+
 	private void createQueryResultRecord(
 			@Nullable final BigDecimal qtyToBeShipped,
 			@Nullable final BigDecimal qtyOnHandStock,

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/modelvalidator/M_ShipmentSchedule.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/modelvalidator/M_ShipmentSchedule.java
@@ -28,11 +28,11 @@ import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesConfig;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesConfigRepo;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesService;
-import de.metas.material.cockpit.availableforsales.EnqueueAvailableForSalesRequest;
 import de.metas.material.cockpit.availableforsales.interceptor.AvailableForSalesUtil;
 import de.metas.material.event.commons.AttributesKey;
 import de.metas.ordercandidate.api.IOLCandDAO;
 import de.metas.ordercandidate.api.PoReferenceLookupKey;
+import de.metas.organization.ClientAndOrgId;
 import de.metas.organization.OrgId;
 import de.metas.product.ProductId;
 import de.metas.util.Check;
@@ -44,7 +44,6 @@ import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.impl.DateTruncQueryFilterModifier;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
-import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.mm.attributes.keys.AttributesKeys;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -52,14 +51,13 @@ import org.adempiere.service.ClientId;
 import org.adempiere.service.ISysConfigBL;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.ModelValidator;
-import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nullable;
 import java.time.LocalDate;
 import java.util.Map;
-import java.util.Properties;
 
 @Interceptor(I_M_ShipmentSchedule.class)
 @Component
@@ -70,7 +68,6 @@ public class M_ShipmentSchedule
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private final IOLCandDAO olCandDAO = Services.get(IOLCandDAO.class);
-	private final ITrxManager trxManager = Services.get(ITrxManager.class);
 	private final IShipmentScheduleEffectiveBL shipmentScheduleEffectiveBL = Services.get(IShipmentScheduleEffectiveBL.class);
 
 	private final AvailableForSalesService availableForSalesService;
@@ -177,9 +174,9 @@ public class M_ShipmentSchedule
 	}
 
 	private void updateNrOfOLCandsWithSamePOReference(@NonNull final String poReference,
-													  @NonNull final OrgId orgId,
-													  final int nrOfOLCandsWithSamePOReference,
-													  @Nullable final LocalDateInterval queryTimeWindow)
+	                                                  @NonNull final OrgId orgId,
+	                                                  final int nrOfOLCandsWithSamePOReference,
+	                                                  @Nullable final LocalDateInterval queryTimeWindow)
 	{
 
 		final IQueryBuilder<I_M_ShipmentSchedule> shipmentScheduleSToUpdate = queryBL.createQueryBuilder(I_M_ShipmentSchedule.class)
@@ -234,19 +231,22 @@ public class M_ShipmentSchedule
 			@NonNull final I_M_ShipmentSchedule shipmentScheduleRecord,
 			@NonNull final AvailableForSalesConfig config)
 	{
-		final Properties ctx = Env.copyCtx(InterfaceWrapperHelper.getCtx(shipmentScheduleRecord));
-		final ProductId productId = ProductId.ofRepoId(shipmentScheduleRecord.getM_Product_ID());
-		final OrgId orgId = OrgId.ofRepoId(shipmentScheduleRecord.getAD_Org_ID());
 
-		final AttributesKey storageAttributesKey = AttributesKeys
-				.createAttributesKeyFromASIStorageAttributes(AttributeSetInstanceId.ofRepoIdOrNone(shipmentScheduleRecord.getM_AttributeSetInstance_ID()))
+		availableForSalesService.enqueueAvailableForSalesRequestAfterCommit(
+				availableForSalesUtil.requestWithPreparationDateNow()
+						.ctx(InterfaceWrapperHelper.getCtx(shipmentScheduleRecord))
+						.config(config)
+						.productId(ProductId.ofRepoId(shipmentScheduleRecord.getM_Product_ID()))
+						.clientAndOrgId(ClientAndOrgId.ofClientAndOrg(shipmentScheduleRecord.getAD_Client_ID(), shipmentScheduleRecord.getAD_Org_ID()))
+						.storageAttributesKey(extractStorageAttributesKey(shipmentScheduleRecord))
+						.warehouseId(shipmentScheduleEffectiveBL.getWarehouseId(shipmentScheduleRecord))
+						.build()
+		);
+	}
+
+	private static AttributesKey extractStorageAttributesKey(final @NotNull I_M_ShipmentSchedule shipmentScheduleRecord)
+	{
+		return AttributesKeys.createAttributesKeyFromASIStorageAttributes(AttributeSetInstanceId.ofRepoIdOrNone(shipmentScheduleRecord.getM_AttributeSetInstance_ID()))
 				.orElse(AttributesKey.NONE);
-		
-		final WarehouseId warehouseId = shipmentScheduleEffectiveBL.getWarehouseId(shipmentScheduleRecord);
-
-		final EnqueueAvailableForSalesRequest enqueueAvailableForSalesRequest = availableForSalesUtil.
-				createRequestWithPreparationDateNow(ctx, config, productId, orgId, storageAttributesKey, warehouseId);
-
-		trxManager.runAfterCommit(() -> availableForSalesService.enqueueAvailableForSalesRequest(enqueueAvailableForSalesRequest));
 	}
 }

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/productLookup/AFSProductLookupEnricher.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/productLookup/AFSProductLookupEnricher.java
@@ -22,31 +22,25 @@
 
 package de.metas.ui.web.window.descriptor.sql.productLookup;
 
-import com.google.common.collect.ImmutableList;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesConfig;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesConfigRepo;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesMultiQuery;
 import de.metas.material.cockpit.availableforsales.AvailableForSalesQuery;
-import de.metas.material.cockpit.model.I_MD_Stock;
 import de.metas.material.event.commons.AttributesKey;
+import de.metas.organization.ClientAndOrgId;
 import de.metas.organization.OrgId;
 import de.metas.product.ProductId;
 import de.metas.ui.web.material.adapter.AvailabilityInfoResultForWebui;
 import de.metas.ui.web.material.adapter.AvailableForSaleAdapter;
 import de.metas.ui.web.window.datatypes.LookupValuesList;
-import de.metas.util.Services;
 import lombok.Builder;
 import lombok.NonNull;
-import org.adempiere.ad.dao.IQueryBL;
-import org.adempiere.ad.dao.IQueryBuilder;
-import org.adempiere.ad.dao.impl.CompareQueryFilter;
 import org.adempiere.mm.attributes.keys.AttributesKeyPattern;
 import org.adempiere.mm.attributes.keys.AttributesKeyPatternsUtil;
 import org.adempiere.service.ClientId;
 import org.adempiere.warehouse.WarehouseId;
 
 import javax.annotation.Nullable;
-import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Collection;
@@ -58,14 +52,9 @@ import java.util.stream.Collectors;
  */
 public class AFSProductLookupEnricher
 {
-	@NonNull
-	final ZonedDateTime dateOrNull;
-	@Nullable
-	final WarehouseId warehouseId;
-	@NonNull
-	final ClientId clientId;
-	@NonNull
-	final OrgId orgId;
+	@NonNull final ZonedDateTime dateOrNull;
+	@Nullable final WarehouseId warehouseId;
+	@NonNull final ClientAndOrgId clientAndOrgId;
 	private final AvailableForSaleAdapter availableForSaleAdapter;
 	private final AvailableForSalesConfigRepo availableForSalesConfigRepo;
 
@@ -81,8 +70,7 @@ public class AFSProductLookupEnricher
 	{
 		this.dateOrNull = dateOrNull;
 		this.warehouseId = warehouseId;
-		this.clientId = clientId;
-		this.orgId = orgId;
+		this.clientAndOrgId = ClientAndOrgId.ofClientAndOrg(clientId, orgId);
 		this.availableForSaleAdapter = availableForSaleAdapter;
 		this.availableForSalesConfigRepo = availableForSalesConfigRepo;
 	}
@@ -108,16 +96,11 @@ public class AFSProductLookupEnricher
 			@NonNull final ProductId productId,
 			@NonNull final Instant dateOfInterest)
 	{
-		final AvailableForSalesConfig config = availableForSalesConfigRepo.getConfig(
-				AvailableForSalesConfigRepo.ConfigQuery.builder()
-						.clientId(clientId)
-						.orgId(orgId)
-						.build());
-		
+		final AvailableForSalesConfig config = availableForSalesConfigRepo.getConfig(clientAndOrgId);
 		final AvailableForSalesMultiQuery.AvailableForSalesMultiQueryBuilder result = AvailableForSalesMultiQuery.builder();
 
 		final AvailableForSalesQuery.AvailableForSalesQueryBuilder queryBuilder = AvailableForSalesQuery.builder()
-				.orgId(orgId)
+				.clientAndOrgId(clientAndOrgId)
 				.productId(productId)
 				.dateOfInterest(dateOfInterest)
 				.salesOrderLookBehindHours(config.getSalesOrderLookBehindHours())
@@ -142,21 +125,5 @@ public class AFSProductLookupEnricher
 			result.availableForSalesQuery(query);
 		}
 		return result.build();
-	}
-
-	private ImmutableList<AttributesKey> retrieveAttributesKeys(@Nullable final WarehouseId warehouseId, @NonNull final ProductId productId)
-	{
-		final IQueryBuilder<I_MD_Stock> queryBuilder = Services.get(IQueryBL.class).createQueryBuilder(I_MD_Stock.class)
-				.addOnlyActiveRecordsFilter()
-				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, productId.getRepoId())
-				.addCompareFilter(I_MD_Stock.COLUMN_QtyOnHand, CompareQueryFilter.Operator.GREATER, BigDecimal.ZERO);
-		if (warehouseId != null)
-		{
-			queryBuilder.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Warehouse_ID, warehouseId.getRepoId());
-		}
-		return queryBuilder
-				.create()
-				.stream().map(s -> AttributesKey.ofString(s.getAttributesKey()))
-				.collect(ImmutableList.toImmutableList());
 	}
 }

--- a/backend/de.metas.util/src/main/java/de/metas/util/async/Debouncer.java
+++ b/backend/de.metas.util/src/main/java/de/metas/util/async/Debouncer.java
@@ -26,11 +26,14 @@ import com.google.common.base.MoreObjects;
 import de.metas.util.Check;
 import lombok.Builder;
 import lombok.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
@@ -45,12 +48,27 @@ import java.util.function.Consumer;
  */
 public final class Debouncer<T>
 {
+	private static final Logger logger = LoggerFactory.getLogger(Debouncer.class);
+
 	// Params
 	@Nullable
 	private final String name; // having it as a field for debugging purposes
 	@NonNull
 	private final ScheduledExecutorService executor;
 	private final int bufferMaxSize;
+	/**
+	 * Hard upper bound on the in-memory buffer — a <b>load-shedding</b> drop cap (NOT backpressure: it does not
+	 * slow the producer; it discards overflow). Unlike {@link #bufferMaxSize} — which only controls the
+	 * scheduling delay — this is an absolute ceiling: once reached, the oldest buffered items are dropped (and
+	 * counted/logged) instead of letting the buffer grow without bound, preventing an OutOfMemoryError when the
+	 * consumer is wedged/slower than the producers (e.g. blocked on an exhausted connection pool).
+	 * <p>
+	 * <b>OPT-IN.</b> Defaults to {@code -1} ("no cap" = the pre-existing unbounded behaviour) so existing callers
+	 * are never silently capped — a cap means dropping items, which is data loss for a caller whose items are not
+	 * recomputable. Set it explicitly only where dropping the oldest pending items under overload is acceptable
+	 * (e.g. idempotent, re-computable-on-next-event sync requests).
+	 */
+	private final int bufferHardLimit;
 	private final int delayInMillis;
 	@NonNull
 	private final Consumer<List<T>> consumer;
@@ -59,12 +77,14 @@ public final class Debouncer<T>
 	private final Object lock = new Object();
 	private long dueTime = -1;
 	private final Collection<T> buffer;
+	private long droppedItemsCount = 0; // guarded by lock
 
 	@Builder
 	private Debouncer(
 			@Nullable final String name,
 			@NonNull final Consumer<List<T>> consumer,
 			final int bufferMaxSize,
+			final int bufferHardLimit,
 			final int delayInMillis,
 			final boolean distinct)
 	{
@@ -74,6 +94,9 @@ public final class Debouncer<T>
 		this.executor = createExecutor(name);
 		this.consumer = consumer;
 		this.bufferMaxSize = bufferMaxSize > 0 ? bufferMaxSize : -1;
+		// Opt-in only: no cap unless the caller sets one. Deriving a cap from bufferMaxSize would retroactively
+		// drop items for existing unbounded callers (e.g. the process-log debouncer) = silent data loss.
+		this.bufferHardLimit = bufferHardLimit > 0 ? bufferHardLimit : -1;
 		this.delayInMillis = delayInMillis;
 		this.buffer = distinct
 				? new LinkedHashSet<>(bufferMaxSize)
@@ -125,6 +148,7 @@ public final class Debouncer<T>
 		synchronized (lock)
 		{
 			buffer.addAll(items);
+			enforceHardLimit();
 			updateDueTimeAndScheduleTask();
 		}
 	}
@@ -134,7 +158,40 @@ public final class Debouncer<T>
 		synchronized (lock)
 		{
 			buffer.add(item);
+			enforceHardLimit();
 			updateDueTimeAndScheduleTask();
+		}
+	}
+
+	/**
+	 * Backpressure: enforce {@link #bufferHardLimit} by dropping the OLDEST buffered items. Must be called while
+	 * holding {@link #lock}. Dropping (rather than blocking the producer) is the correct overload response here:
+	 * the buffer only grows unbounded when the consumer cannot keep up (e.g. wedged on an exhausted connection
+	 * pool), and in that state blocking the producers would only spread the stall; the stalest pending items are
+	 * shed instead, and the drop is counted + logged. A dropped item is recomputed on the next triggering event.
+	 */
+	private void enforceHardLimit()
+	{
+		if (bufferHardLimit <= 0 || buffer.size() <= bufferHardLimit)
+		{
+			return;
+		}
+
+		long dropped = 0;
+		final Iterator<T> it = buffer.iterator();
+		while (buffer.size() > bufferHardLimit && it.hasNext())
+		{
+			it.next();
+			it.remove();
+			dropped++;
+		}
+
+		if (dropped > 0)
+		{
+			droppedItemsCount += dropped;
+			logger.warn("Debouncer {}: buffer hard limit {} reached — dropped {} oldest item(s) (total dropped so far: {}). "
+							+ "The consumer is not keeping up; check for a wedged/slow consumer (e.g. an exhausted DB connection pool).",
+					name, bufferHardLimit, dropped, droppedItemsCount);
 		}
 	}
 
@@ -203,6 +260,15 @@ public final class Debouncer<T>
 		synchronized (lock)
 		{
 			return buffer.size();
+		}
+	}
+
+	/** Number of items dropped so far due to the {@link #bufferHardLimit} backpressure (monitoring / tests). */
+	public long getDroppedItemsCount()
+	{
+		synchronized (lock)
+		{
+			return droppedItemsCount;
 		}
 	}
 

--- a/backend/de.metas.util/src/test/java/de/metas/util/async/DebouncerBackpressureTest.java
+++ b/backend/de.metas.util/src/test/java/de/metas/util/async/DebouncerBackpressureTest.java
@@ -1,0 +1,70 @@
+package de.metas.util.async;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Backpressure guard: the {@link Debouncer} buffer must never grow without bound when the consumer can't keep up.
+ * Once {@code bufferHardLimit} is reached, the OLDEST items are dropped (and counted) instead of accumulating to
+ * millions of entries (which can exhaust the heap).
+ *
+ * <p>A long {@code delayInMillis} keeps the scheduled drain from firing during the test, so we observe the raw
+ * buffering behaviour; {@code processAndClearBufferSync()} then drains synchronously to assert WHICH items survived.
+ */
+class DebouncerBackpressureTest
+{
+	private static Debouncer<Integer> debouncer(final int bufferMaxSize, final int bufferHardLimit, final List<Integer> consumed)
+	{
+		return Debouncer.<Integer>builder()
+				.name("test-debouncer")
+				.delayInMillis(60_000) // long enough that the async drain never fires during the test
+				.bufferMaxSize(bufferMaxSize)
+				.bufferHardLimit(bufferHardLimit)
+				.distinct(false) // ArrayList -> insertion order preserved, so we can assert drop-oldest
+				.consumer(consumed::addAll)
+				.build();
+	}
+
+	@Test
+	void hardLimit_dropsOldest_andCounts()
+	{
+		final List<Integer> consumed = new ArrayList<>();
+		final Debouncer<Integer> d = debouncer(/*bufferMaxSize*/ 0, /*bufferHardLimit*/ 10, consumed);
+
+		for (int i = 0; i < 100; i++)
+		{
+			d.add(i);
+		}
+
+		assertThat(d.getCurrentBufferSize()).isEqualTo(10);
+		assertThat(d.getDroppedItemsCount()).isEqualTo(90);
+
+		// drain synchronously and verify the SURVIVORS are the newest 10 (90..99) -> oldest were dropped
+		d.processAndClearBufferSync();
+		assertThat(consumed).containsExactly(90, 91, 92, 93, 94, 95, 96, 97, 98, 99);
+
+		d.shutdown();
+	}
+
+	@Test
+	void noLimits_remainsUnbounded_backwardCompatible()
+	{
+		final List<Integer> consumed = new ArrayList<>();
+		// neither bufferMaxSize nor bufferHardLimit set -> no hard cap (preserves pre-existing behaviour)
+		final Debouncer<Integer> d = debouncer(/*bufferMaxSize*/ 0, /*bufferHardLimit*/ 0, consumed);
+
+		for (int i = 0; i < 1000; i++)
+		{
+			d.add(i);
+		}
+
+		assertThat(d.getCurrentBufferSize()).isEqualTo(1000);
+		assertThat(d.getDroppedItemsCount()).isEqualTo(0);
+
+		d.shutdown();
+	}
+}


### PR DESCRIPTION
## What

Port of https://github.com/metasfresh/metasfresh/pull/24617 to `intensive_care_hotfix` (clean cherry-pick of squash commit `6e02dc7163a4`).

Replaces the in-process `Debouncer<EnqueueAvailableForSalesRequest>` for AvailableForSales sync with a `DISTRIBUTED` RabbitMQ event, so the backlog buffers off-heap in the broker instead of the JVM heap.

## Why — a customer PROD app-server OOM

A customer PROD instance hit an `OutOfMemoryError`. Evidence ties the OOM to exactly the mechanism https://github.com/metasfresh/metasfresh/pull/24617 fixes:
- The `MD_Stock_Update_From_M_HUs` scheduler ran a divergent correction loop, firing a flood of `StockChangedEvent`s.
- Each event drives an AvailableForSales sync → the **unbounded in-process Debouncer** buffers requests; its consumer wedged on an exhausted JDBC pool → the backlog grew on-heap → OOM.
- Console log shows the signature (heavy AvailableForSales/Debouncer churn + `HikariPool` connection exhaustion); the heap dump (~4.4 GB) matches https://github.com/metasfresh/metasfresh/pull/24617's analysis (Debouncer ≈ 3.9 GB / ~48% of heap).

This port fixes the **OOM symptom / defense-in-depth**. The divergent `MD_Stock` loop (the event flood at source) is addressed separately.

## Validation

Clean cherry-pick (no conflicts) of an already-reviewed, CI-green core PR. Relying on this PR's CI for the port.