### PR TITLE
Add ESR/QR Referenznummer to BusinessPartnerAccountSheetReport

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/BusinessPartnerAccountSheetReport.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/BusinessPartnerAccountSheetReport.sql
@@ -36,6 +36,7 @@ BEGIN
         endingBalance          NUMERIC,
         dateacct               date,
         description            TEXT,
+        referenceno            TEXT,
         c_doctype_id           NUMERIC,
         documentno             TEXT,
         created                TIMESTAMP,
@@ -58,12 +59,21 @@ BEGIN
                         0                                      endingBalance,
                         i.dateacct                             dateacct,
                         COALESCE(i.poreference, i.description) description,
+                        rn.referenceno,
                         i.c_doctype_id                         c_doctype_id,
                         i.documentno                           documentno,
                         i.created                              created,
                         i.c_currency_id                        c_currency_id,
                         i.ad_org_id                            ad_org_id
                  FROM c_invoice i
+                  --- refno
+                  LEFT JOIN (SELECT rn.referenceNo, rnd.Record_ID
+                             FROM C_ReferenceNo_Doc rnd
+                                      LEFT JOIN C_ReferenceNo rn ON rnd.C_ReferenceNo_ID = rn.C_ReferenceNo_ID AND rn.isActive = 'Y'
+                             WHERE AD_Table_ID = (SELECT AD_Table_ID FROM AD_Table WHERE TableName = 'C_Invoice' AND isActive = 'Y')
+                               AND rn.C_ReferenceNo_Type_ID =
+                                   (SELECT C_ReferenceNo_Type_ID FROM C_ReferenceNo_Type WHERE name = 'InvoiceReference' AND isActive = 'Y')
+                               AND rnd.isActive = 'Y') rn ON i.C_Invoice_ID = rn.Record_ID
                  WHERE TRUE
                    AND i.c_bpartner_id = p_c_bpartner_id
                    AND i.dateacct >= p_dateFrom
@@ -78,6 +88,7 @@ BEGIN
                         0               endingBalance,
                         p.dateacct      dateacct,
                         p.description   description,
+                        NULL as referenceno,
                         p.c_doctype_id  c_doctype_id,
                         p.documentno    documentno,
                         p.created       created,
@@ -98,6 +109,7 @@ BEGIN
                         0                          endingBalance,
                         hal.dateacct               dateacct,
                         hal.description            description,
+                        NULL as referenceno,
                         -1             			   c_doctype_id,
                         hal.documentno             documentno,
                         hal.created                created,

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/BusinessPartnerAccountSheetReport.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/BusinessPartnerAccountSheetReport.sql
@@ -69,11 +69,11 @@ BEGIN
                  FROM c_invoice i
                   LEFT JOIN (SELECT rn.referenceNo, rnd.Record_ID
                              FROM C_ReferenceNo_Doc rnd
-                                      LEFT JOIN C_ReferenceNo rn ON rnd.C_ReferenceNo_ID = rn.C_ReferenceNo_ID AND rn.isActive = 'Y'
-                             WHERE rnd.AD_Table_ID = (SELECT AD_Table_ID FROM AD_Table WHERE TableName = 'C_Invoice' AND isActive = 'Y')
-                               AND rn.C_ReferenceNo_Type_ID =
-                                   (SELECT C_ReferenceNo_Type_ID FROM C_ReferenceNo_Type WHERE name = 'InvoiceReference' AND isActive = 'Y')
-                               AND rnd.isActive = 'Y') rn ON i.C_Invoice_ID = rn.Record_ID
+                                      JOIN C_ReferenceNo rn ON rnd.C_ReferenceNo_ID = rn.C_ReferenceNo_ID AND rn.isActive = 'Y'
+                                      JOIN AD_Table t ON t.AD_Table_ID = rnd.AD_Table_ID AND t.TableName = 'C_Invoice' AND t.isActive = 'Y'
+                                      JOIN C_ReferenceNo_Type rt ON rt.C_ReferenceNo_Type_ID = rn.C_ReferenceNo_Type_ID
+                                          AND rt.name = 'InvoiceReference' AND rt.isActive = 'Y'
+                             WHERE rnd.isActive = 'Y') rn ON i.C_Invoice_ID = rn.Record_ID
                  WHERE TRUE
                    AND i.c_bpartner_id = p_c_bpartner_id
                    AND i.dateacct >= p_dateFrom

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5809190_sys_me03_29895_BusinessPartnerAccountSheetReport_AddReferenceNo.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5809190_sys_me03_29895_BusinessPartnerAccountSheetReport_AddReferenceNo.sql
@@ -1,3 +1,4 @@
+-- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/BusinessPartnerAccountSheetReport.sql
 DROP FUNCTION IF EXISTS BusinessPartnerAccountSheetReport(p_c_bpartner_id numeric, p_dateFrom date, p_dateTo date, p_ad_client_id numeric, p_ad_org_id numeric, p_isSoTrx TEXT, p_ad_language text);
 
 CREATE OR REPLACE FUNCTION BusinessPartnerAccountSheetReport(p_c_bpartner_id numeric,
@@ -69,11 +70,11 @@ BEGIN
                  FROM c_invoice i
                   LEFT JOIN (SELECT rn.referenceNo, rnd.Record_ID
                              FROM C_ReferenceNo_Doc rnd
-                                      LEFT JOIN C_ReferenceNo rn ON rnd.C_ReferenceNo_ID = rn.C_ReferenceNo_ID AND rn.isActive = 'Y'
-                             WHERE rnd.AD_Table_ID = (SELECT AD_Table_ID FROM AD_Table WHERE TableName = 'C_Invoice' AND isActive = 'Y')
-                               AND rn.C_ReferenceNo_Type_ID =
-                                   (SELECT C_ReferenceNo_Type_ID FROM C_ReferenceNo_Type WHERE name = 'InvoiceReference' AND isActive = 'Y')
-                               AND rnd.isActive = 'Y') rn ON i.C_Invoice_ID = rn.Record_ID
+                                      JOIN C_ReferenceNo rn ON rnd.C_ReferenceNo_ID = rn.C_ReferenceNo_ID AND rn.isActive = 'Y'
+                                      JOIN AD_Table t ON t.AD_Table_ID = rnd.AD_Table_ID AND t.TableName = 'C_Invoice' AND t.isActive = 'Y'
+                                      JOIN C_ReferenceNo_Type rt ON rt.C_ReferenceNo_Type_ID = rn.C_ReferenceNo_Type_ID
+                                          AND rt.name = 'InvoiceReference' AND rt.isActive = 'Y'
+                             WHERE rnd.isActive = 'Y') rn ON i.C_Invoice_ID = rn.Record_ID
                  WHERE TRUE
                    AND i.c_bpartner_id = p_c_bpartner_id
                    AND i.dateacct >= p_dateFrom

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5809190_sys_me03_29895_BusinessPartnerAccountSheetReport_AddReferenceNo.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5809190_sys_me03_29895_BusinessPartnerAccountSheetReport_AddReferenceNo.sql
@@ -117,7 +117,7 @@ BEGIN
                         hal.ad_org_id               ad_org_id
                  FROM c_payment p
                           join C_AllocationLine al on al.c_payment_id = p.c_payment_id and al.paymentwriteoffamt > 0
-						  join c_allocationhdr hal on al.c_allocationhdr_id= hal.c_allocationhdr_id
+					  join c_allocationhdr hal on al.c_allocationhdr_id= hal.c_allocationhdr_id
                  WHERE TRUE
                    AND p.c_bpartner_id = p_c_bpartner_id
                    AND hal.dateacct >= p_dateFrom


### PR DESCRIPTION
## Summary

- Adds the ESR/QR payment reference number (`referenceno`) column to the `BusinessPartnerAccountSheetReport` SQL function (Geschäftspartner Kontenblatt report)
- Reference number is read from `C_ReferenceNo` / `C_ReferenceNo_Doc` for invoices; payments and write-offs show `NULL`
- Migration script `5809190` recreates the function with the updated `RETURNS TABLE` signature

## Test plan

- [x] Run the Geschäftspartner Kontenblatt report for a business partner that has invoices with ESR/QR reference numbers — verify the Referenznummer column is populated
- [x] Verify invoices without a reference number show an empty column (not an error)
- [x] Verify payment and write-off rows show an empty Referenznummer (expected — no reference on payments)
- [x] Verify all existing columns (amounts, running balance, document type, description) are unchanged