### PR TITLE
Make Geschaeftspartner optional in BusinessPartnerAccountSheetReport (all-partners export)

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/BusinessPartnerAccountSheetReport.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/BusinessPartnerAccountSheetReport.sql
@@ -1,9 +1,9 @@
 DROP FUNCTION IF EXISTS BusinessPartnerAccountSheetReport(p_c_bpartner_id numeric, p_dateFrom date, p_dateTo date, p_ad_client_id numeric, p_ad_org_id numeric, p_isSoTrx TEXT, p_ad_language text);
 
-CREATE OR REPLACE FUNCTION BusinessPartnerAccountSheetReport(p_c_bpartner_id numeric = NULL,
-                                                             p_dateFrom      date,
+CREATE OR REPLACE FUNCTION BusinessPartnerAccountSheetReport(p_dateFrom      date,
                                                              p_dateTo        date,
                                                              p_ad_client_id  numeric,
+                                                             p_c_bpartner_id numeric = NULL,
                                                              p_ad_org_id     numeric = NULL,
                                                              p_isSoTrx       TEXT = 'Y',
                                                              p_ad_language   text = 'en_US')
@@ -322,21 +322,20 @@ $BODY$
     LANGUAGE plpgsql
     VOLATILE;
 
-COMMENT ON FUNCTION BusinessPartnerAccountSheetReport(p_c_bpartner_id numeric, p_dateFrom date, p_dateTo date, p_ad_client_id numeric, p_ad_org_id numeric, p_isSoTrx TEXT, p_ad_language text) IS
+COMMENT ON FUNCTION BusinessPartnerAccountSheetReport(p_dateFrom date, p_dateTo date, p_ad_client_id numeric, p_c_bpartner_id numeric, p_ad_org_id numeric, p_isSoTrx TEXT, p_ad_language text) IS
 'How to run (single partner):
 
 SELECT*
-FROM BusinessPartnerAccountSheetReport(2000252,
-                                       ''1111-1-1''::date,
+FROM BusinessPartnerAccountSheetReport(''1111-1-1''::date,
                                        ''3333-1-1''::date,
-                                       1000000)
+                                       1000000,
+                                       2000252)
 ;
 
 How to run (all partners):
 
 SELECT*
-FROM BusinessPartnerAccountSheetReport(NULL,
-                                       ''1111-1-1''::date,
+FROM BusinessPartnerAccountSheetReport(''1111-1-1''::date,
                                        ''3333-1-1''::date,
                                        1000000)
 ;
@@ -346,17 +345,16 @@ FROM BusinessPartnerAccountSheetReport(NULL,
 How to run (single partner):
 
 SELECT*
-FROM BusinessPartnerAccountSheetReport(2000252,
-                                       '1111-1-1'::date,
+FROM BusinessPartnerAccountSheetReport('1111-1-1'::date,
                                        '3333-1-1'::date,
-                                       1000000)
+                                       1000000,
+                                       2000252)
 ;
 
 How to run (all partners):
 
 SELECT*
-FROM BusinessPartnerAccountSheetReport(NULL,
-                                       '1111-1-1'::date,
+FROM BusinessPartnerAccountSheetReport('1111-1-1'::date,
                                        '3333-1-1'::date,
                                        1000000)
 ;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5809240_sys_me03_29895_BusinessPartnerAccountSheetReport_MultiPartner.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5809240_sys_me03_29895_BusinessPartnerAccountSheetReport_MultiPartner.sql
@@ -1,3 +1,4 @@
+-- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/BusinessPartnerAccountSheetReport.sql
 DROP FUNCTION IF EXISTS BusinessPartnerAccountSheetReport(p_c_bpartner_id numeric, p_dateFrom date, p_dateTo date, p_ad_client_id numeric, p_ad_org_id numeric, p_isSoTrx TEXT, p_ad_language text);
 
 CREATE OR REPLACE FUNCTION BusinessPartnerAccountSheetReport(p_c_bpartner_id numeric = NULL,
@@ -362,3 +363,12 @@ FROM BusinessPartnerAccountSheetReport(NULL,
 ;
 
 */
+
+-- Make Geschäftspartner parameter optional so the report can run across all partners
+-- AD_Process_Para_ID=541752 = C_BPartner_ID on process BusinessPartnerAccountSheetReport (AD_Process_ID=584661)
+UPDATE AD_Process_Para
+SET IsMandatory = 'N',
+    Updated     = now(),
+    UpdatedBy   = 100
+WHERE AD_Process_Para_ID = 541752
+;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5809240_sys_me03_29895_BusinessPartnerAccountSheetReport_MultiPartner.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5809240_sys_me03_29895_BusinessPartnerAccountSheetReport_MultiPartner.sql
@@ -372,3 +372,12 @@ SET IsMandatory = 'N',
     UpdatedBy   = 100
 WHERE AD_Process_Para_ID = 541752
 ;
+
+-- Update SQLStatement so that an empty/unset Geschäftspartner field passes NULL (all-partners mode).
+-- NULLIF(@C_BPartner_ID/0@, 0): the /0 suffix defaults to 0 when blank; NULLIF converts 0 → NULL.
+UPDATE AD_Process
+SET SQLStatement = 'SELECT * FROM BusinessPartnerAccountSheetReport(NULLIF(@C_BPartner_ID/0@, 0), ''@DateFrom@''::date, ''@DateTo@''::date, @#AD_Client_ID@, @AD_Org_ID@, ''@IsSOTrx@'')',
+    Updated      = now(),
+    UpdatedBy    = 100
+WHERE AD_Process_ID = 584661
+;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5809240_sys_me03_29895_BusinessPartnerAccountSheetReport_MultiPartner.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5809240_sys_me03_29895_BusinessPartnerAccountSheetReport_MultiPartner.sql
@@ -368,7 +368,7 @@ FROM BusinessPartnerAccountSheetReport(NULL,
 -- AD_Process_Para_ID=541752 = C_BPartner_ID on process BusinessPartnerAccountSheetReport (AD_Process_ID=584661)
 UPDATE AD_Process_Para
 SET IsMandatory = 'N',
-    Updated     = now(),
+    Updated     = TO_TIMESTAMP('2026-06-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
     UpdatedBy   = 100
 WHERE AD_Process_Para_ID = 541752
 ;
@@ -377,7 +377,7 @@ WHERE AD_Process_Para_ID = 541752
 -- NULLIF(@C_BPartner_ID/0@, 0): the /0 suffix defaults to 0 when blank; NULLIF converts 0 → NULL.
 UPDATE AD_Process
 SET SQLStatement = 'SELECT * FROM BusinessPartnerAccountSheetReport(NULLIF(@C_BPartner_ID/0@, 0), ''@DateFrom@''::date, ''@DateTo@''::date, @#AD_Client_ID@, @AD_Org_ID@, ''@IsSOTrx@'')',
-    Updated      = now(),
+    Updated      = TO_TIMESTAMP('2026-06-22 10:00:01', 'YYYY-MM-DD HH24:MI:SS'),
     UpdatedBy    = 100
 WHERE AD_Process_ID = 584661
 ;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5809240_sys_me03_29895_BusinessPartnerAccountSheetReport_MultiPartner.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5809240_sys_me03_29895_BusinessPartnerAccountSheetReport_MultiPartner.sql
@@ -1,10 +1,10 @@
 -- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/BusinessPartnerAccountSheetReport.sql
 DROP FUNCTION IF EXISTS BusinessPartnerAccountSheetReport(p_c_bpartner_id numeric, p_dateFrom date, p_dateTo date, p_ad_client_id numeric, p_ad_org_id numeric, p_isSoTrx TEXT, p_ad_language text);
 
-CREATE OR REPLACE FUNCTION BusinessPartnerAccountSheetReport(p_c_bpartner_id numeric = NULL,
-                                                             p_dateFrom      date,
+CREATE OR REPLACE FUNCTION BusinessPartnerAccountSheetReport(p_dateFrom      date,
                                                              p_dateTo        date,
                                                              p_ad_client_id  numeric,
+                                                             p_c_bpartner_id numeric = NULL,
                                                              p_ad_org_id     numeric = NULL,
                                                              p_isSoTrx       TEXT = 'Y',
                                                              p_ad_language   text = 'en_US')
@@ -323,21 +323,20 @@ $BODY$
     LANGUAGE plpgsql
     VOLATILE;
 
-COMMENT ON FUNCTION BusinessPartnerAccountSheetReport(p_c_bpartner_id numeric, p_dateFrom date, p_dateTo date, p_ad_client_id numeric, p_ad_org_id numeric, p_isSoTrx TEXT, p_ad_language text) IS
+COMMENT ON FUNCTION BusinessPartnerAccountSheetReport(p_dateFrom date, p_dateTo date, p_ad_client_id numeric, p_c_bpartner_id numeric, p_ad_org_id numeric, p_isSoTrx TEXT, p_ad_language text) IS
 'How to run (single partner):
 
 SELECT*
-FROM BusinessPartnerAccountSheetReport(2000252,
-                                       ''1111-1-1''::date,
+FROM BusinessPartnerAccountSheetReport(''1111-1-1''::date,
                                        ''3333-1-1''::date,
-                                       1000000)
+                                       1000000,
+                                       2000252)
 ;
 
 How to run (all partners):
 
 SELECT*
-FROM BusinessPartnerAccountSheetReport(NULL,
-                                       ''1111-1-1''::date,
+FROM BusinessPartnerAccountSheetReport(''1111-1-1''::date,
                                        ''3333-1-1''::date,
                                        1000000)
 ;
@@ -347,17 +346,16 @@ FROM BusinessPartnerAccountSheetReport(NULL,
 How to run (single partner):
 
 SELECT*
-FROM BusinessPartnerAccountSheetReport(2000252,
-                                       '1111-1-1'::date,
+FROM BusinessPartnerAccountSheetReport('1111-1-1'::date,
                                        '3333-1-1'::date,
-                                       1000000)
+                                       1000000,
+                                       2000252)
 ;
 
 How to run (all partners):
 
 SELECT*
-FROM BusinessPartnerAccountSheetReport(NULL,
-                                       '1111-1-1'::date,
+FROM BusinessPartnerAccountSheetReport('1111-1-1'::date,
                                        '3333-1-1'::date,
                                        1000000)
 ;
@@ -373,10 +371,10 @@ SET IsMandatory = 'N',
 WHERE AD_Process_Para_ID = 541752
 ;
 
--- Update SQLStatement so that an empty/unset Geschäftspartner field passes NULL (all-partners mode).
--- NULLIF(@C_BPartner_ID/0@, 0): the /0 suffix defaults to 0 when blank; NULLIF converts 0 → NULL.
+-- Update SQLStatement to match new parameter order (dateFrom, dateTo, client_id, bpartner_or_null, ...)
+-- and use NULLIF(@C_BPartner_ID/0@, 0) so a blank partner field passes NULL (all-partners mode).
 UPDATE AD_Process
-SET SQLStatement = 'SELECT * FROM BusinessPartnerAccountSheetReport(NULLIF(@C_BPartner_ID/0@, 0), ''@DateFrom@''::date, ''@DateTo@''::date, @#AD_Client_ID@, @AD_Org_ID@, ''@IsSOTrx@'')',
+SET SQLStatement = 'SELECT * FROM BusinessPartnerAccountSheetReport(''@DateFrom@''::date, ''@DateTo@''::date, @#AD_Client_ID@, NULLIF(@C_BPartner_ID/0@, 0), @AD_Org_ID@, ''@IsSOTrx@'')',
     Updated      = TO_TIMESTAMP('2026-06-22 10:00:01', 'YYYY-MM-DD HH24:MI:SS'),
     UpdatedBy    = 100
 WHERE AD_Process_ID = 584661


### PR DESCRIPTION
## Summary

- `BusinessPartnerAccountSheetReport`: `p_c_bpartner_id` now defaults to `NULL`; passing `NULL` returns all business partners with invoices/payments in the date range
- New output columns `c_bpartner_id` and `bpartnerName` identify the partner per row in multi-partner mode
- Per-partner opening balance: `getBPOpenAmtToDate` is called once per distinct partner in the result set
- Rolling sum uses `PARTITION BY c_bpartner_id` so each partner's balance starts from their own opening balance
- `AD_Process_Para.IsMandatory` set to `'N'` for C_BPartner_ID parameter (ID=541752)
- `AD_Process.SQLStatement` updated to use `NULLIF(@C_BPartner_ID/0@, 0)` so leaving the field blank passes `NULL` to the function (all-partners mode)

## Test plan

- [ ] Run with a specific partner: output matches previous behavior (single-partner statement, two new leading columns c_bpartner_id / bpartnerName)
- [ ] Run with partner left empty: Excel contains rows for all partners with invoices/payments in the date range, each with correct per-partner opening/ending balance
- [ ] Verify `bpartnerName` and `c_bpartner_id` columns appear in the exported Excel
- [ ] Verify per-partner rolling balance is correct (ending balance of each partner's last row matches manual check)