### PR TITLE
Manufacturing — fix inverted component-issue cost-collector Fact_Acct posting direction

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Cost_Collector_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Cost_Collector_StepDef.java
@@ -31,6 +31,7 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.IQueryBuilder;
 import org.compiere.model.I_M_Product;
 import org.eevolution.model.I_PP_Cost_Collector;
 import org.eevolution.model.I_PP_Order;
@@ -69,6 +70,41 @@ public class PP_Cost_Collector_StepDef
 		this.bomLineTable = bomLineTable;
 	}
 
+	/**
+	 * Loads PP_Cost_Collector records from the database by matching the given DataTable rows,
+	 * with a timeout to account for asynchronous cost collector creation.
+	 *
+	 * <p>Each DataTable row describes one PP_Cost_Collector to load and assert. The step waits up to
+	 * {@code timeoutSec} for the record to appear in the database, then verifies its properties match
+	 * the expected values.
+	 *
+	 * <p>Required columns:
+	 * <ul>
+	 *   <li>{@code PP_Cost_Collector_ID.Identifier} — identifier to store the loaded record (for later reference)</li>
+	 *   <li>{@code PP_Order_ID.Identifier} — identifier of the parent production order</li>
+	 *   <li>{@code MovementQty} — expected movement quantity (must match the loaded record)</li>
+	 *   <li>{@code DocStatus} — expected document status, e.g. "Drafted" or "Completed" (must match the loaded record)</li>
+	 * </ul>
+	 *
+	 * <p>Optional columns:
+	 * <ul>
+	 *   <li>{@code M_Product_ID.Identifier} — identifier of the product; used to disambiguate when a single PP_Order
+	 *   has multiple cost collectors with the same DocStatus (e.g., one for component issue and one for finished-good
+	 *   receipt). If omitted, only PP_Order_ID and DocStatus are used to match the record.</li>
+	 * </ul>
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * And after not more than 5s, PP_Cost_Collector are found:
+	 *   | PP_Cost_Collector_ID.Identifier | PP_Order_ID.Identifier | M_Product_ID.Identifier | MovementQty | DocStatus |
+	 *   | cc_1                            | order_1                | product_fg              | 100         | Completed |
+	 *   | cc_2                            | order_1                | product_comp            | -50         | Drafted   |
+	 * </pre>
+	 *
+	 * @param timeoutSec maximum seconds to wait for each PP_Cost_Collector record to appear
+	 * @param dataTable the table defining PP_Cost_Collector records to load and assert
+	 * @throws InterruptedException if the wait is interrupted
+	 */
 	@And("^after not more than (.*)s, PP_Cost_Collector are found:$")
 	public void load_PP_Cost_Collector(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
 	{
@@ -93,6 +129,18 @@ public class PP_Cost_Collector_StepDef
 		}
 	}
 
+	/**
+	 * Loads a single PP_Cost_Collector record from the database by matching the given table row.
+	 *
+	 * <p>Queries for a PP_Cost_Collector matching the PP_Order_ID and DocStatus from the row.
+	 * If a product identifier is provided, further filters by product to disambiguate when one order
+	 * has multiple cost collectors with the same status. Stores the found record in the
+	 * {@code ppCostCollectorTable} for later reference.
+	 *
+	 * @param tableRow a single DataTable row with required columns:
+	 *        {@code PP_Order_ID.Identifier}, {@code DocStatus}, and optional {@code M_Product_ID.Identifier}
+	 * @return {@code true} if the record was found and stored; {@code false} if not found (caller will retry)
+	 */
 	@NonNull
 	private Boolean loadPPCostCollector(@NonNull final Map<String, String> tableRow)
 	{
@@ -100,9 +148,19 @@ public class PP_Cost_Collector_StepDef
 		final I_PP_Order ppOrder = ppOrderTable.get(ppOrderIdentifier);
 		final String status = DataTableUtil.extractStringForColumnName(tableRow, COLUMNNAME_DocStatus);
 
-		final Optional<I_PP_Cost_Collector> ppCostCollector = queryBL.createQueryBuilder(I_PP_Cost_Collector.class)
+		final IQueryBuilder<I_PP_Cost_Collector> queryBuilder = queryBL.createQueryBuilder(I_PP_Cost_Collector.class)
 				.addEqualsFilter(I_PP_Cost_Collector.COLUMNNAME_PP_Order_ID, ppOrder.getPP_Order_ID())
-				.addEqualsFilter(COLUMNNAME_DocStatus, status)
+				.addEqualsFilter(COLUMNNAME_DocStatus, status);
+
+		// When a single order has several cost collectors with the same DocStatus (e.g. a component issue
+		// and a finished-good receipt), disambiguate by the product so each row matches exactly one record.
+		final String productIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, COLUMNNAME_M_Product_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (productIdentifier != null)
+		{
+			queryBuilder.addEqualsFilter(COLUMNNAME_M_Product_ID, productTable.get(productIdentifier).getM_Product_ID());
+		}
+
+		final Optional<I_PP_Cost_Collector> ppCostCollector = queryBuilder
 				.create()
 				.firstOnlyOptional(I_PP_Cost_Collector.class);
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Cost_Collector_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Cost_Collector_StepDef.java
@@ -116,14 +116,17 @@ public class PP_Cost_Collector_StepDef
 			final I_PP_Cost_Collector ppCostCollector = ppCostCollectorTable.get(ppCostCollectorIdentifier);
 			assertThat(ppCostCollector).isNotNull();
 
-			final String productIdentifier = DataTableUtil.extractStringForColumnName(tableRow, COLUMNNAME_M_Product_ID + "." + TABLECOLUMN_IDENTIFIER);
-			final I_M_Product product = productTable.get(productIdentifier);
-			assertThat(product).isNotNull();
+			final String productIdentifier = DataTableUtil.extractStringOrNullForColumnName(tableRow, COLUMNNAME_M_Product_ID + "." + TABLECOLUMN_IDENTIFIER);
+			if (productIdentifier != null)
+			{
+				final I_M_Product product = productTable.get(productIdentifier);
+				assertThat(product).isNotNull();
+				assertThat(ppCostCollector.getM_Product_ID()).isEqualTo(product.getM_Product_ID());
+			}
 
 			final BigDecimal movementQty = DataTableUtil.extractBigDecimalForColumnName(tableRow, COLUMNNAME_MovementQty);
 			final String status = DataTableUtil.extractStringForColumnName(tableRow, COLUMNNAME_DocStatus);
 
-			assertThat(ppCostCollector.getM_Product_ID()).isEqualTo(product.getM_Product_ID());
 			assertThat(ppCostCollector.getMovementQty()).isEqualTo(movementQty);
 			assertThat(ppCostCollector.getDocStatus()).isEqualTo(status);
 		}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/util/IdentifiersResolver.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/util/IdentifiersResolver.java
@@ -31,6 +31,7 @@ import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.match_inv.M_MatchInv_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
 import de.metas.cucumber.stepdefs.payment.C_Payment_StepDefData;
+import de.metas.cucumber.stepdefs.pporder.PP_Cost_Collector_StepDefData;
 import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
 import de.metas.dunning.DunningDocId;
 import de.metas.inout.InOutId;
@@ -49,6 +50,7 @@ import org.compiere.model.I_C_Invoice;
 import org.compiere.model.I_C_Payment;
 import org.compiere.model.I_M_InOut;
 import org.compiere.model.I_M_MatchInv;
+import org.eevolution.model.I_PP_Cost_Collector;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -66,6 +68,7 @@ public class IdentifiersResolver
 	@NonNull private final M_InOut_StepDefData inOutTable;
 	@NonNull private final C_Order_StepDefData orderTable;
 	@NonNull private final C_DunningDoc_StepDefData dunningDocTable;
+	@NonNull private final PP_Cost_Collector_StepDefData ppCostCollectorTable;
 
 	@NonNull
 	public ImmutableSet<TableRecordReference> getTableRecordReferencesOfCommaSeparatedIdentifiers(@Nullable final String commaSeparatedIdentifiers)
@@ -111,6 +114,9 @@ public class IdentifiersResolver
 				.ifPresent(result::add);
 		dunningDocTable.getIdOptional(identifier)
 				.map(DunningDocId::toRecordRef)
+				.ifPresent(result::add);
+		ppCostCollectorTable.getOptional(identifier)
+				.map(cc -> TableRecordReference.of(I_PP_Cost_Collector.Table_Name, cc.getPP_Cost_Collector_ID()))
 				.ifPresent(result::add);
 
 		if (result.isEmpty())

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
@@ -1,0 +1,123 @@
+@from:cucumber
+@allure.label.epic:E0226_Costing
+@allure.label.feature:F1500_Costing
+@F1500
+@ghActions:run_on_executor6
+Feature: Manufacturing cost collector posting - component issue vs material receipt signs
+## F1500: Costing
+
+  # A manufacturing order backflushes one BOM component and receives the finished good.
+  # The component-issue cost collector must post DR P_WIP_Acct / CR P_Asset_Acct (inventory down, WIP up).
+  # The finished-good material-receipt cost collector must post DR P_Asset_Acct / CR P_WIP_Acct (inventory up, WIP down).
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-03-26T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And documents are accounted immediately
+    And load and update C_AcctSchema:
+      | C_AcctSchema_ID | Name                  | CostingMethod |
+      | acctSchema      | metas fresh UN/34 CHF | A             |
+    And cost elements for material costing methods AveragePO are active
+
+    And metasfresh contains M_Products:
+      | Identifier | X12DE355 |
+      | finProd    | PCE      |
+      | compProd   | PCE      |
+
+    # Seed the component with a non-zero AveragePO current cost (10 CHF/PCE) and create its stock HU.
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 | CostPrice | M_HU_ID |
+      | compInventory  | compInventoryLine  | 2024-03-20   | 540008         | compProd     | 0       | 100      | PCE          | 10        | compHU  |
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
+      | acctSchema      | compProd     | AveragePO        | 10 CHF           | 100 PCE    |
+
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID.Identifier | Name        |
+      | finPackLU             | finPackLU   |
+      | finPackTU             | finPackTU   |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID.Identifier | M_HU_PI_ID.Identifier | Name             | HU_UnitType | IsCurrent |
+      | finPackLUVersion              | finPackLU             | finPackLUVersion | LU          | Y         |
+      | finPackTUVersion              | finPackTU             | finPackTUVersion | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType | OPT.Included_HU_PI_ID.Identifier |
+      | finPackLUItem              | finPackLUVersion              | 1   | HU       | finPackTU                        |
+      | finPackTUItem              | finPackTUVersion              | 1   | MI       |                                  |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | finProdItem                        | finPackTUItem              | finProd                 | 1   | 2022-01-01 |
+
+    And metasfresh contains PP_Product_BOM
+      | Identifier | M_Product_ID.Identifier | ValidFrom  | PP_Product_BOMVersions_ID.Identifier |
+      | bom        | finProd                 | 2021-01-02 | bomVersion                           |
+    And metasfresh contains PP_Product_BOMLines
+      | Identifier | PP_Product_BOM_ID.Identifier | M_Product_ID.Identifier | ValidFrom  | QtyBatch |
+      | bomLine    | bom                          | compProd                | 2021-01-02 | 1        |
+    And the PP_Product_BOM identified by bom is completed
+
+    And load AD_Workflow:
+      | AD_Workflow_ID.Identifier | Name                   |
+      | mobileWorkflow            | mobileUI_workflow_test |
+    And metasfresh contains PP_Product_Plannings
+      | Identifier | OPT.AD_Workflow_ID.Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan |
+      | prodPlan   | mobileWorkflow                | finProd                 | bomVersion                               | false        |
+
+    And load S_Resource:
+      | S_Resource_ID.Identifier | S_Resource_ID |
+      | testResource             | 540011        |
+
+  @from:cucumber
+  Scenario: Issue a component and receive the finished good, then check Fact_Acct signs
+    And create PP_Order:
+      | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument | OPT.PP_Product_Planning_ID.Identifier |
+      | ppOrder                | MOP         | finProd                 | 1          | testResource             | 2024-03-26T23:59:00.00Z | 2024-03-26T23:59:00.00Z | 2024-03-26T23:59:00.00Z | Y                | prodPlan                              |
+    And after not more than 60s, PP_Order_BomLines are found
+      | PP_Order_BOMLine_ID.Identifier | PP_Order_ID.Identifier | M_Product_ID.Identifier | QtyRequiered | IsQtyPercentage | C_UOM_ID.X12DE355 | ComponentType |
+      | ppOrderBomLine                 | ppOrder                | compProd                | 1            | false           | PCE               | CO            |
+    When complete planning for PP_Order:
+      | PP_Order_ID.Identifier |
+      | ppOrder                |
+
+    And create JsonWFProcessStartRequest for manufacturing and store it in context as request payload:
+      | PP_Order_ID.Identifier |
+      | ppOrder                |
+    And the metasfresh REST-API endpoint path 'api/v2/userWorkflows/wfProcess/start' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    And process response and extract manufacturing step and issueTo HU manufacturing candidate:
+      | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowStep.Identifier | WorkflowStepQRCode.Identifier |
+      | mfgWorkflow                | issueActivity               | issueStep               | issueQRCode                   |
+    And process response and extract manufacturing line and receiving target values:
+      | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowLine.Identifier | WorkflowReceivingTargetValues.Identifier |
+      | mfgWorkflow                | receiptActivity             | receiptLine             | receivingTargetValues                    |
+
+    # Issue the component to the production order
+    And create JsonManufacturingOrderEvent and store it in context as request payload:
+      | Event   | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowStep.Identifier | WorkflowStepQRCode.Identifier |
+      | IssueTo | mfgWorkflow                | issueActivity               | issueStep               | issueQRCode                   |
+    And the metasfresh REST-API endpoint path 'api/v2/manufacturing/event' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    # Receive the finished good
+    And create JsonManufacturingOrderEvent and store it in context as request payload:
+      | Event       | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowLine.Identifier | WorkflowReceivingTargetValues.Identifier |
+      | ReceiveFrom | mfgWorkflow                | receiptActivity             | receiptLine             | receivingTargetValues                    |
+    And the metasfresh REST-API endpoint path 'api/v2/manufacturing/event' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    # Load both cost collectors so they can be referenced as Fact_Acct Record_ID
+    And after not more than 60s, PP_Cost_Collector are found:
+      | PP_Cost_Collector_ID.Identifier | PP_Order_ID.Identifier | M_Product_ID.Identifier | MovementQty | DocStatus |
+      | issueCostCollector              | ppOrder                | compProd                | 1           | CO        |
+      | receiptCostCollector            | ppOrder                | finProd                 | 1           | CO        |
+
+    And Wait until documents issueCostCollector, receiptCostCollector are posted
+
+    # Component issue: DR P_WIP_Acct / CR P_Asset_Acct (inventory down, WIP up).
+    # Material receipt of finished good: DR P_Asset_Acct / CR P_WIP_Acct (inventory up, WIP down).
+    And Fact_Acct records are matching
+      | Record_ID            | AccountConceptualName | M_Product_ID | AmtAcctDr | AmtAcctCr |
+      | issueCostCollector   | P_WIP_Acct            | compProd     | 10        | 0         |
+      | issueCostCollector   | P_Asset_Acct          | compProd     | 0         | 10        |
+      | receiptCostCollector | P_Asset_Acct          | finProd      | 10        | 0         |
+      | receiptCostCollector | P_WIP_Acct            | finProd      | 0         | 10        |

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/manufacturing/acct/Doc_PPCostCollector.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/manufacturing/acct/Doc_PPCostCollector.java
@@ -295,7 +295,11 @@ public class Doc_PPCostCollector extends Doc<DocLine_CostCollector>
 			}
 
 			final CostAmount costs = costResult.getCostAmountForCostElement(element).getMainAmt();
-			final Fact fact = createFactLines(as, element, debit, credit, costs, qtyIssued);
+			// A ComponentIssue line carries a negated qty (DocLine_CostCollector.setQty(movementQty, isSOTrx=true)),
+			// so getCreateCosts returns a negative cost. Posting it uncompensated would invert the direction
+			// (DR-WIP negative / CR-Asset negative). Compensate the sign here — mirroring createFacts_Variance —
+			// so a component issue posts DR P_WIP_Acct (positive) / CR P_Asset_Acct (positive): inventory down, WIP up.
+			final Fact fact = createFactLines(as, element, debit, credit, costs.negate(), qtyIssued.negate());
 			if (fact != null)
 			{
 				facts.add(fact);


### PR DESCRIPTION
## Problem
Manufacturing **component-issue** cost collectors post their `Fact_Acct` lines with **inverted signs**. Consuming a component ends up *raising* the component inventory (Asset) and *reducing* Work-in-Process (WIP) — the opposite of the correct economics. The books still balance overall, but the per-account distribution (Asset vs WIP) is wrong for every production order processed under this code, so manufacturing inventory and WIP balances are untrustworthy.

## Root cause
A `ComponentIssue` cost-collector line carries a **negated** quantity (`DocLine_CostCollector.setQty(movementQty, isSOTrx=true)`), so `getCreateCosts(...)` returns a **negative** cost. `Doc_PPCostCollector.createFacts_ComponentIssue` posted that negative cost **uncompensated** (`DR P_WIP_Acct / CR P_Asset_Acct`), inverting the direction. The structurally identical `createFacts_Variance` already compensates with `costs.negate(), qty.negate()`; the issue path was missing that compensation.

## Fix
Compensate the sign in `createFacts_ComponentIssue` (negate `costs` and `qtyIssued`), mirroring `createFacts_Variance`, so a component issue posts **DR `P_WIP_Acct` (positive) / CR `P_Asset_Acct` (positive)**: inventory down, WIP up. This is a **posting-direction** fix only — the costing computation (`getCreateCosts`, `setQty` semantics, `M_CostDetail`, costing values) is unchanged. Material-receipt, variance, activity-control and by/co-product postings are unaffected.

## Test
New cucumber scenario `costing/manufacturingCostCollectorPosting.feature` drives a mobile-manufacturing component issue + finished-good receipt and asserts the `Fact_Acct` DR/CR signs of both cost collectors. It fails on the inverted issue sign before the fix (RED) and passes after (GREEN); the material-receipt assertion passes throughout. Manufacturing unit tests: green.
