### PR TITLE
e-Invoicing — fix CII seller/buyer VAT-ID & tax-number mapping (VATaxID→BT-31, TaxID→BT-32) + buyer BT-49 via doc-outbound resolver + expose seller tax fields

### DIFF
--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5809330_sys_me03_30508_BPartner_TaxID_CommercialRegNo_window_540676.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5809330_sys_me03_30508_BPartner_TaxID_CommercialRegNo_window_540676.sql
@@ -1,0 +1,133 @@
+-- Run mode: SWING_CLIENT
+
+-- IDs fetched from ID server (http://idserver.metas.de):
+-- AD_MigrationScript  -> 5809330  (×10 = not appended here; filename prefix = 5809330)
+-- AD_UI_Element       -> 652361   /*From ID Server*/  (TaxID field in group 542729)
+-- AD_Field            -> 781243   /*From ID Server*/  (CommercialRegisterNumber on tab 541852)
+-- AD_UI_Element       -> 652362   /*From ID Server*/  (CommercialRegisterNumber in group 542729)
+
+-- Context (pre-resolved, no re-query needed):
+-- Window 540676 "Geschäftspartner (Org)" / Tab 541852 (C_BPartner, TabLevel=0)
+-- AD_UI_ElementGroup 542729: Value/Name/CompanyName/AD_OrgBP_ID/URL/VATaxID
+--   VATaxID (AD_Field 583134) is SeqNo 120 (last in group) — already displayed, no change
+-- TaxID:                AD_Field 583087 exists, IsDisplayed='N', no AD_UI_Element on this tab
+-- CommercialRegisterNumber: AD_Column 583367, AD_Element 581038, no AD_Field on this tab
+-- EntityType 'U' (matches sibling fields 583087, 583134 on this tab)
+
+-- ===========================================================================
+-- 1. TaxID (Steuernummer) — make AD_Field 583087 visible
+-- ===========================================================================
+-- 2026-06-22 10:00:00
+UPDATE AD_Field
+SET    IsDisplayed = 'Y',
+       Updated     = TO_TIMESTAMP('2026-06-22 10:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy   = 100
+WHERE  AD_Field_ID = 583087
+;
+
+-- ===========================================================================
+-- 2. TaxID — insert AD_UI_Element in group 542729, SeqNo 130
+-- ===========================================================================
+-- 2026-06-22 10:00:01
+INSERT INTO AD_UI_Element
+    (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID,
+     AD_Tab_ID, AD_Field_ID, AD_UI_ElementGroup_ID,
+     AD_UI_ElementType,
+     Name, SeqNo, SeqNo_SideList, SeqNoGrid,
+     IsActive, IsAdvancedField, IsAllowFiltering,
+     IsDisplayed, IsDisplayed_SideList, IsDisplayedGrid, IsMultiLine, MultiLine_LinesCount,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (652361 /*From ID Server*/, 0, 0,
+     541852, 583087, 542729,
+     'F',
+     'Steuernummer', 130, 0, 0,
+     'Y', 'N', 'N',
+     'Y', 'N', 'N', 'N', 0,
+     TO_TIMESTAMP('2026-06-22 10:00:01','YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-22 10:00:01','YYYY-MM-DD HH24:MI:SS'), 100)
+;
+
+-- ===========================================================================
+-- 3. CommercialRegisterNumber (Handelsregisternr) — insert AD_Field on tab 541852
+--    AD_Column 583367, AD_Element 581038
+-- ===========================================================================
+-- 2026-06-22 10:00:02
+INSERT INTO AD_Field
+    (AD_Field_ID, AD_Client_ID, AD_Org_ID,
+     AD_Tab_ID, AD_Column_ID,
+     Name, EntityType,
+     IsActive, IsDisplayed, IsDisplayedGrid, IsEncrypted,
+     IsFieldOnly, IsHeading, IsReadOnly, IsSameLine,
+     SeqNo, SeqNoGrid,
+     ColumnDisplayLength, DisplayLength,
+     IncludedTabHeight, SortNo, SpanX, SpanY,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (781243 /*From ID Server*/, 0, 0,
+     541852, 583367,
+     'Handelsregisternr', 'U',
+     'Y', 'Y', 'N', 'N',
+     'N', 'N', 'N', 'N',
+     325, 0,
+     0, 0,
+     0, 0, 1, 1,
+     TO_TIMESTAMP('2026-06-22 10:00:02','YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-22 10:00:02','YYYY-MM-DD HH24:MI:SS'), 100)
+;
+
+-- AD_Field_Trl (seed for all non-base system languages)
+INSERT INTO AD_Field_Trl
+    (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated,
+     AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N',
+       t.AD_Client_ID, t.AD_Org_ID,
+       TO_TIMESTAMP('2026-06-22 10:00:02','YYYY-MM-DD HH24:MI:SS'), 100,
+       TO_TIMESTAMP('2026-06-22 10:00:02','YYYY-MM-DD HH24:MI:SS'), 100
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y' AND l.IsBaseLanguage = 'N'
+  AND t.AD_Field_ID = 781243 /*From ID Server*/
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language
+                    AND tt.AD_Field_ID = t.AD_Field_ID)
+;
+
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(581038);
+
+/* DDL */ DELETE FROM AD_Element_Link WHERE AD_Field_ID = 781243 /*From ID Server*/;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781243 /*From ID Server*/);
+
+-- Fix IsTranslated='Y' for CommercialRegisterNumber AD_Field_Trl rows
+-- (update_FieldTranslation_From_AD_Name_Element seeds the text but leaves IsTranslated='N')
+-- 2026-06-22 10:00:04
+UPDATE AD_Field_Trl
+SET    IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-06-22 10:00:04','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+WHERE  AD_Field_ID = 781243 /*From ID Server*/
+  AND  AD_Language IN ('de_DE','de_CH','en_US')
+;
+
+-- ===========================================================================
+-- 4. CommercialRegisterNumber — insert AD_UI_Element in group 542729, SeqNo 140
+-- ===========================================================================
+-- 2026-06-22 10:00:03
+INSERT INTO AD_UI_Element
+    (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID,
+     AD_Tab_ID, AD_Field_ID, AD_UI_ElementGroup_ID,
+     AD_UI_ElementType,
+     Name, SeqNo, SeqNo_SideList, SeqNoGrid,
+     IsActive, IsAdvancedField, IsAllowFiltering,
+     IsDisplayed, IsDisplayed_SideList, IsDisplayedGrid, IsMultiLine, MultiLine_LinesCount,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (652362 /*From ID Server*/, 0, 0,
+     541852, 781243 /*From ID Server*/, 542729,
+     'F',
+     'Handelsregisternr', 140, 0, 0,
+     'Y', 'N', 'N',
+     'Y', 'N', 'N', 'N', 0,
+     TO_TIMESTAMP('2026-06-22 10:00:03','YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-06-22 10:00:03','YYYY-MM-DD HH24:MI:SS'), 100)
+;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
@@ -149,7 +149,8 @@ public class C_BPartner_StepDef
 	 * <p>
 	 * E-invoicing columns (all optional):
 	 * <ul>
-	 *   <li>{@code TaxID} — the partner's VAT id (BT-31 seller / BT-48 buyer)</li>
+	 *   <li>{@code VATaxID} — the partner's USt-IdNr / VAT identifier (BT-31 seller / BT-48 buyer)</li>
+	 *   <li>{@code TaxID} — the partner's Steuernummer / tax registration number (BT-32 seller)</li>
 	 *   <li>{@code IsEInvoiceRecipeint} — {@code Y}/{@code N}; marks the partner as an e-invoice recipient (note: column name is misspelled in the DB)</li>
 	 *   <li>{@code EInvoiceType} — the e-invoice format code (e.g. {@code X} for XRechnung)</li>
 	 *   <li>{@code EInvoice_BuyerReference} — the buyer reference / Leitweg-ID (BT-10)</li>

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
@@ -319,6 +319,7 @@ public class C_BPartner_StepDef
 		}
 
 		row.getAsOptionalString(I_C_BPartner.COLUMNNAME_TaxID).ifPresent(bPartnerRecord::setTaxID);
+		row.getAsOptionalString(I_C_BPartner.COLUMNNAME_VATaxID).ifPresent(vaTaxId -> bPartnerRecord.setVATaxID(DataTableUtil.nullToken2Null(vaTaxId))); // USt-IdNr (BT-31/48)
 
 		// e-invoice recipient configuration (resolved by EInvoiceConfigService.resolveForInvoice)
 		row.getAsOptionalBoolean(I_C_BPartner.COLUMNNAME_IsEInvoiceRecipeint).ifPresent(bPartnerRecord::setIsEInvoiceRecipeint);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/einvoice/eInvoiceXRechnungEmail.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/einvoice/eInvoiceXRechnungEmail.feature
@@ -53,7 +53,7 @@ Feature: XRechnung e-invoice generated, attached and emailed on sales-invoice co
     # AD_OrgBP_ID links this bpartner to sellerOrg — bPartnerDAO.retrieveOrgBPartner() (used by the CII
     # mapper for the seller) resolves the org-bpartner via C_BPartner.AD_OrgBP_ID, not AD_OrgInfo.
     And metasfresh contains C_BPartners without locations:
-      | Identifier    | Value | Name        | CompanyName | M_PricingSystem_ID | TaxID       | AD_OrgBP_ID.Identifier |
+      | Identifier    | Value | Name        | CompanyName | M_PricingSystem_ID | VATaxID     | AD_OrgBP_ID.Identifier |
       | seller_org_bp | dt    | Muster GmbH | Muster GmbH | ps_1               | DE123456789 | sellerOrg              |
     And metasfresh contains C_BPartner_Locations:
       | Identifier      | GLN           | C_BPartner_ID.Identifier | OPT.IsShipTo | OPT.IsBillTo | C_Country_ID | City   | Postal | Address1       |

--- a/backend/de.metas.einvoice.base/pom.xml
+++ b/backend/de.metas.einvoice.base/pom.xml
@@ -23,6 +23,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>de.metas.document.archive</groupId>
+			<artifactId>de.metas.document.archive.base</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
 			<groupId>de.metas.util</groupId>
 			<artifactId>de.metas.util</artifactId>
 			<version>${project.version}</version>

--- a/backend/de.metas.einvoice.base/src/main/java/de/metas/einvoice/EInvoiceCiiService.java
+++ b/backend/de.metas.einvoice.base/src/main/java/de/metas/einvoice/EInvoiceCiiService.java
@@ -1,5 +1,6 @@
 package de.metas.einvoice;
 
+import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRegistry;
 import de.metas.einvoice.cii.CiiMapper;
 import de.metas.einvoice.cii.CiiValidationResult;
 import de.metas.einvoice.cii.CiiValidator;
@@ -10,7 +11,6 @@ import de.metas.invoice.service.IInvoiceDAO;
 import de.metas.util.Services;
 import lombok.Builder;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.I_C_Invoice;
@@ -44,7 +44,6 @@ import java.util.Optional;
  * so callers do not need to check eligibility themselves.
  */
 @Service
-@RequiredArgsConstructor
 public class EInvoiceCiiService
 {
 	private static final Logger log = LoggerFactory.getLogger(EInvoiceCiiService.class);
@@ -68,7 +67,22 @@ public class EInvoiceCiiService
 	}
 
 	@NonNull private final EInvoiceConfigService configService;
+	@Nullable private final DocOutboundLogMailRecipientRegistry mailRecipientRegistry;
 	@NonNull private final IInvoiceDAO invoiceDAO = Services.get(IInvoiceDAO.class);
+
+	/**
+	 * Constructor used by Spring DI and directly in tests.
+	 * {@code mailRecipientRegistry} is nullable so that existing tests that do not exercise
+	 * the BT-49 resolver can pass {@code null} without a NPE from a {@code @NonNull} guard.
+	 * In a live Spring context {@code DocOutboundLogMailRecipientRegistry} is always present.
+	 */
+	public EInvoiceCiiService(
+			@NonNull final EInvoiceConfigService configService,
+			@Nullable final DocOutboundLogMailRecipientRegistry mailRecipientRegistry)
+	{
+		this.configService = configService;
+		this.mailRecipientRegistry = mailRecipientRegistry;
+	}
 
 	/**
 	 * Generates a CII XML e-invoice for the given invoice and validates it against EN16931 rules.
@@ -91,7 +105,7 @@ public class EInvoiceCiiService
 		}
 
 		// Map invoice to CII domain object
-		final CrossIndustryInvoiceType cii = new CiiMapper().map(invoice, config);
+		final CrossIndustryInvoiceType cii = new CiiMapper(mailRecipientRegistry).map(invoice, config);
 
 		// Marshal to XML
 		final String ciiXml = marshalToXml(cii);

--- a/backend/de.metas.einvoice.base/src/main/java/de/metas/einvoice/EInvoiceCiiService.java
+++ b/backend/de.metas.einvoice.base/src/main/java/de/metas/einvoice/EInvoiceCiiService.java
@@ -71,7 +71,6 @@ public class EInvoiceCiiService
 	@NonNull private final IInvoiceDAO invoiceDAO = Services.get(IInvoiceDAO.class);
 
 	/**
-	 * Constructor used by Spring DI and directly in tests.
 	 * {@code mailRecipientRegistry} is nullable so that existing tests that do not exercise
 	 * the BT-49 resolver can pass {@code null} without a NPE from a {@code @NonNull} guard.
 	 * In a live Spring context {@code DocOutboundLogMailRecipientRegistry} is always present.

--- a/backend/de.metas.einvoice.base/src/main/java/de/metas/einvoice/EInvoiceCiiService.java
+++ b/backend/de.metas.einvoice.base/src/main/java/de/metas/einvoice/EInvoiceCiiService.java
@@ -1,6 +1,7 @@
 package de.metas.einvoice;
 
 import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRegistry;
+import de.metas.email.MailService;
 import de.metas.einvoice.cii.CiiMapper;
 import de.metas.einvoice.cii.CiiValidationResult;
 import de.metas.einvoice.cii.CiiValidator;
@@ -68,19 +69,22 @@ public class EInvoiceCiiService
 
 	@NonNull private final EInvoiceConfigService configService;
 	@Nullable private final DocOutboundLogMailRecipientRegistry mailRecipientRegistry;
+	@Nullable private final MailService mailService;
 	@NonNull private final IInvoiceDAO invoiceDAO = Services.get(IInvoiceDAO.class);
 
 	/**
-	 * {@code mailRecipientRegistry} is nullable so that existing tests that do not exercise
-	 * the BT-49 resolver can pass {@code null} without a NPE from a {@code @NonNull} guard.
-	 * In a live Spring context {@code DocOutboundLogMailRecipientRegistry} is always present.
+	 * {@code mailRecipientRegistry} and {@code mailService} are nullable so that existing tests
+	 * that do not exercise the BT-49/BT-34 resolvers can pass {@code null} without a NPE from a
+	 * {@code @NonNull} guard. In a live Spring context both beans are always present.
 	 */
 	public EInvoiceCiiService(
 			@NonNull final EInvoiceConfigService configService,
-			@Nullable final DocOutboundLogMailRecipientRegistry mailRecipientRegistry)
+			@Nullable final DocOutboundLogMailRecipientRegistry mailRecipientRegistry,
+			@Nullable final MailService mailService)
 	{
 		this.configService = configService;
 		this.mailRecipientRegistry = mailRecipientRegistry;
+		this.mailService = mailService;
 	}
 
 	/**
@@ -104,7 +108,7 @@ public class EInvoiceCiiService
 		}
 
 		// Map invoice to CII domain object
-		final CrossIndustryInvoiceType cii = new CiiMapper(mailRecipientRegistry).map(invoice, config);
+		final CrossIndustryInvoiceType cii = new CiiMapper(mailRecipientRegistry, mailService).map(invoice, config);
 
 		// Marshal to XML
 		final String ciiXml = marshalToXml(cii);

--- a/backend/de.metas.einvoice.base/src/main/java/de/metas/einvoice/cii/CiiMapper.java
+++ b/backend/de.metas.einvoice.base/src/main/java/de/metas/einvoice/cii/CiiMapper.java
@@ -59,6 +59,7 @@ import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientReques
 import de.metas.document.DocTypeId;
 import de.metas.document.IDocTypeDAO;
 import de.metas.email.MailService;
+import de.metas.email.mailboxes.Mailbox;
 import de.metas.email.mailboxes.MailboxQuery;
 import de.metas.invoice.InvoiceId;
 import de.metas.invoice.service.IInvoiceDAO;
@@ -668,7 +669,7 @@ public class CiiMapper
 			try
 			{
 				final DocBaseAndSubType docBaseAndSubType = resolveDocBaseAndSubType(invoice);
-				final de.metas.email.mailboxes.Mailbox mailbox = mailService.findMailbox(
+				final Mailbox mailbox = mailService.findMailbox(
 						MailboxQuery.builder()
 								.clientId(ClientId.ofRepoId(invoice.getAD_Client_ID()))
 								.orgId(OrgId.ofRepoId(invoice.getAD_Org_ID()))

--- a/backend/de.metas.einvoice.base/src/main/java/de/metas/einvoice/cii/CiiMapper.java
+++ b/backend/de.metas.einvoice.base/src/main/java/de/metas/einvoice/cii/CiiMapper.java
@@ -51,10 +51,15 @@ import de.metas.einvoice.cii.model.TradeSettlementLineMonetarySummationType;
 import de.metas.einvoice.cii.model.TradeSettlementPaymentMeansType;
 import de.metas.einvoice.cii.model.TradeTaxType;
 import de.metas.einvoice.cii.model.UniversalCommunicationType;
+import de.metas.document.DocBaseAndSubType;
 import de.metas.document.archive.mailrecipient.DocOutBoundRecipient;
 import de.metas.document.archive.mailrecipient.DocOutBoundRecipients;
 import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRegistry;
 import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRequest;
+import de.metas.document.DocTypeId;
+import de.metas.document.IDocTypeDAO;
+import de.metas.email.MailService;
+import de.metas.email.mailboxes.MailboxQuery;
 import de.metas.invoice.InvoiceId;
 import de.metas.invoice.service.IInvoiceDAO;
 import de.metas.organization.OrgId;
@@ -100,15 +105,20 @@ public class CiiMapper
 	private static final Logger log = LoggerFactory.getLogger(CiiMapper.class);
 
 	@Nullable private final DocOutboundLogMailRecipientRegistry mailRecipientRegistry;
+	@Nullable private final MailService mailService;
 
 	public CiiMapper()
 	{
 		this.mailRecipientRegistry = null;
+		this.mailService = null;
 	}
 
-	public CiiMapper(@Nullable final DocOutboundLogMailRecipientRegistry mailRecipientRegistry)
+	public CiiMapper(
+			@Nullable final DocOutboundLogMailRecipientRegistry mailRecipientRegistry,
+			@Nullable final MailService mailService)
 	{
 		this.mailRecipientRegistry = mailRecipientRegistry;
+		this.mailService = mailService;
 	}
 
 	/** EN 16931 guideline IDs per invoice format. */
@@ -447,11 +457,13 @@ public class CiiMapper
 			seller.getSpecifiedTaxRegistration().add(fcReg);
 		}
 
-		// BT-34 Seller electronic address (email, scheme EM — GAP-4 default)
-		final String email = sellerBP.getEMail();
-		if (email != null && !email.isEmpty())
+		// BT-34 Seller electronic address (scheme EM).
+		// Primary source: resolved outbound mailbox "From" address (same address the e-invoice email is sent from).
+		// Fallback: sellerBP.getEMail(). Omit when both are blank.
+		final String bt34Email = resolveSellerEmail(invoice, sellerBP.getEMail());
+		if (bt34Email != null && !bt34Email.isEmpty())
 		{
-			seller.setURIUniversalCommunication(uriCommunication(email));
+			seller.setURIUniversalCommunication(uriCommunication(bt34Email));
 		}
 
 		// BG-6 Seller contact (BT-41 name, BT-42 phone, BT-43 email)
@@ -627,6 +639,71 @@ public class CiiMapper
 		}
 
 		return buyer;
+	}
+
+	/**
+	 * Resolves the seller email for BT-34.
+	 *
+	 * <p>Resolution chain:
+	 * <ol>
+	 *   <li>If {@link #mailService} is non-null, query the mailbox routing table using
+	 *       client-id, org-id, and doc-base+sub-type from the invoice's DocType.
+	 *       Use the resolved mailbox's {@code From} address when non-blank.</li>
+	 *   <li>Fall back to {@code bpEmail} (the org BPartner's {@code EMail} column).</li>
+	 *   <li>Return {@code null} when both are blank — caller omits BT-34.</li>
+	 * </ol>
+	 *
+	 * <p>A {@code null} / "no mailbox" result from {@link MailService#findMailbox} falls back
+	 * gracefully via the {@code orElseGet} in the repository; when it can't find any mailbox
+	 * the service falls back to the client's default email config, so a non-null {@link de.metas.email.mailboxes.Mailbox}
+	 * is always returned (or an exception is thrown if the client has no email config at all).
+	 * We catch {@link AdempiereException} — the documented failure mode when no client email
+	 * config exists — and log a warning rather than aborting CII generation.
+	 */
+	@Nullable
+	private String resolveSellerEmail(@NonNull final I_C_Invoice invoice, @Nullable final String bpEmail)
+	{
+		if (mailService != null)
+		{
+			try
+			{
+				final DocBaseAndSubType docBaseAndSubType = resolveDocBaseAndSubType(invoice);
+				final de.metas.email.mailboxes.Mailbox mailbox = mailService.findMailbox(
+						MailboxQuery.builder()
+								.clientId(ClientId.ofRepoId(invoice.getAD_Client_ID()))
+								.orgId(OrgId.ofRepoId(invoice.getAD_Org_ID()))
+								.adProcessId(null)
+								.docBaseAndSubType(docBaseAndSubType)
+								.build());
+				final String resolvedEmail = mailbox.getEmail().getAsString();
+				if (resolvedEmail != null && !resolvedEmail.isEmpty())
+				{
+					return resolvedEmail;
+				}
+			}
+			catch (final AdempiereException ex)
+			{
+				log.warn("BT-34: could not resolve outbound mailbox for invoice {} — falling back to BPartner email. Reason: {}",
+						invoice.getC_Invoice_ID(), ex.getMessage());
+			}
+		}
+		return bpEmail;
+	}
+
+	/**
+	 * Resolves the {@link DocBaseAndSubType} for the given invoice's C_DocType_ID.
+	 * Returns {@code null} when the invoice has no DocType set.
+	 */
+	@Nullable
+	private DocBaseAndSubType resolveDocBaseAndSubType(@NonNull final I_C_Invoice invoice)
+	{
+		final DocTypeId docTypeId = DocTypeId.ofRepoIdOrNull(invoice.getC_DocType_ID());
+		if (docTypeId == null)
+		{
+			return null;
+		}
+		final I_C_DocType docType = Services.get(IDocTypeDAO.class).getById(docTypeId);
+		return DocBaseAndSubType.of(docType.getDocBaseType(), docType.getDocSubType());
 	}
 
 	/**

--- a/backend/de.metas.einvoice.base/src/main/java/de/metas/einvoice/cii/CiiMapper.java
+++ b/backend/de.metas.einvoice.base/src/main/java/de/metas/einvoice/cii/CiiMapper.java
@@ -51,13 +51,21 @@ import de.metas.einvoice.cii.model.TradeSettlementLineMonetarySummationType;
 import de.metas.einvoice.cii.model.TradeSettlementPaymentMeansType;
 import de.metas.einvoice.cii.model.TradeTaxType;
 import de.metas.einvoice.cii.model.UniversalCommunicationType;
+import de.metas.document.archive.mailrecipient.DocOutBoundRecipient;
+import de.metas.document.archive.mailrecipient.DocOutBoundRecipients;
+import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRegistry;
+import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRequest;
 import de.metas.invoice.InvoiceId;
 import de.metas.invoice.service.IInvoiceDAO;
+import de.metas.organization.OrgId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.service.ClientId;
+import org.adempiere.util.lang.impl.TableRecordReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.compiere.SpringContextHolder;
 import org.compiere.model.I_AD_User;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_BPartner_Location;
@@ -404,16 +412,28 @@ public class CiiMapper
 			seller.setSpecifiedLegalOrganization(legalOrg);
 		}
 
-		// BT-31 VAT id (scheme VA)
-		final String taxId = sellerBP.getTaxID();
-		if (taxId != null && !taxId.isEmpty())
+		// BT-31 VAT identifier (Umsatzsteuer-ID, scheme VA) — source: VATaxID
+		final String vataxId = sellerBP.getVATaxID();
+		if (vataxId != null && !vataxId.isEmpty())
 		{
 			final TaxRegistrationType vatReg = new TaxRegistrationType();
 			final IDType vatId = new IDType();
-			vatId.setValue(taxId);
+			vatId.setValue(vataxId);
 			vatId.setSchemeID("VA");
 			vatReg.setID(vatId);
 			seller.getSpecifiedTaxRegistration().add(vatReg);
+		}
+
+		// BT-32 Tax registration (Steuernummer, scheme FC) — source: TaxID
+		final String steuernummer = sellerBP.getTaxID();
+		if (steuernummer != null && !steuernummer.isEmpty())
+		{
+			final TaxRegistrationType fcReg = new TaxRegistrationType();
+			final IDType fcId = new IDType();
+			fcId.setValue(steuernummer);
+			fcId.setSchemeID("FC");
+			fcReg.setID(fcId);
+			seller.getSpecifiedTaxRegistration().add(fcReg);
 		}
 
 		// BT-34 Seller electronic address (email, scheme EM — GAP-4 default)
@@ -562,13 +582,13 @@ public class CiiMapper
 					? companyName
 					: buyerBP.getName()));
 
-			// BT-48 Buyer VAT id
-			final String taxId = buyerBP.getTaxID();
-			if (taxId != null && !taxId.isEmpty())
+			// BT-48 Buyer VAT identifier (Umsatzsteuer-ID, scheme VA) — source: VATaxID
+			final String buyerVataxId = buyerBP.getVATaxID();
+			if (buyerVataxId != null && !buyerVataxId.isEmpty())
 			{
 				final TaxRegistrationType vatReg = new TaxRegistrationType();
 				final IDType vatId = new IDType();
-				vatId.setValue(taxId);
+				vatId.setValue(buyerVataxId);
 				vatId.setSchemeID("VA");
 				vatReg.setID(vatId);
 				buyer.getSpecifiedTaxRegistration().add(vatReg);
@@ -577,11 +597,17 @@ public class CiiMapper
 
 		if (buyerBPLoc != null)
 		{
-			// BT-49 Buyer electronic address (BPartnerLocation email, scheme EM — GAP default)
-			final String email = buyerBPLoc.getEMail();
-			if (email != null && !email.isEmpty())
+			// BT-49 Buyer electronic address (scheme EM).
+			// Primary source: doc-outbound recipient resolver (same resolution that sets
+			// C_Doc_Outbound_Log.CurrentEMailAddress). Fallback: BPartnerLocation.EMail.
+			final String resolvedEmail = resolveBuyerEmail(invoice);
+			final String locationEmail = buyerBPLoc.getEMail();
+			final String bt49Email = (resolvedEmail != null && !resolvedEmail.isEmpty())
+					? resolvedEmail
+					: locationEmail;
+			if (bt49Email != null && !bt49Email.isEmpty())
 			{
-				buyer.setURIUniversalCommunication(uriCommunication(email));
+				buyer.setURIUniversalCommunication(uriCommunication(bt49Email));
 			}
 
 			// BG-8 Buyer postal address
@@ -590,6 +616,37 @@ public class CiiMapper
 		}
 
 		return buyer;
+	}
+
+	/**
+	 * Resolves the buyer email for BT-49 via the doc-outbound recipient registry
+	 * (same logic that populates C_Doc_Outbound_Log.CurrentEMailAddress).
+	 * Returns {@code null} if the registry is unavailable or returns no address —
+	 * the caller falls back to the BPartnerLocation email in that case.
+	 */
+	@Nullable
+	private String resolveBuyerEmail(@NonNull final I_C_Invoice invoice)
+	{
+		try
+		{
+			final DocOutboundLogMailRecipientRegistry registry =
+					SpringContextHolder.instance.getBean(DocOutboundLogMailRecipientRegistry.class);
+			final DocOutboundLogMailRecipientRequest req = DocOutboundLogMailRecipientRequest.builder()
+					.recordRef(TableRecordReference.of(I_C_Invoice.Table_Name, invoice.getC_Invoice_ID()))
+					.clientId(ClientId.ofRepoId(invoice.getAD_Client_ID()))
+					.orgId(OrgId.ofRepoId(invoice.getAD_Org_ID()))
+					.build();
+			return registry.getRecipient(req)
+					.map(DocOutBoundRecipients::getTo)
+					.map(DocOutBoundRecipient::getEmailAddress)
+					.orElse(null);
+		}
+		catch (final Exception ex)
+		{
+			log.debug("Doc-outbound recipient resolver unavailable for invoice {} — falling back to BPartnerLocation email",
+					invoice.getC_Invoice_ID(), ex);
+			return null;
+		}
 	}
 
 	// ===== HeaderTradeSettlement =====

--- a/backend/de.metas.einvoice.base/src/main/java/de/metas/einvoice/cii/CiiMapper.java
+++ b/backend/de.metas.einvoice.base/src/main/java/de/metas/einvoice/cii/CiiMapper.java
@@ -65,7 +65,6 @@ import org.adempiere.service.ClientId;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.compiere.SpringContextHolder;
 import org.compiere.model.I_AD_User;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_BPartner_Location;
@@ -99,6 +98,18 @@ import java.util.List;
 public class CiiMapper
 {
 	private static final Logger log = LoggerFactory.getLogger(CiiMapper.class);
+
+	@Nullable private final DocOutboundLogMailRecipientRegistry mailRecipientRegistry;
+
+	public CiiMapper()
+	{
+		this.mailRecipientRegistry = null;
+	}
+
+	public CiiMapper(@Nullable final DocOutboundLogMailRecipientRegistry mailRecipientRegistry)
+	{
+		this.mailRecipientRegistry = mailRecipientRegistry;
+	}
 
 	/** EN 16931 guideline IDs per invoice format. */
 	private static final String GUIDELINE_ID_ZUGFERD =
@@ -619,34 +630,27 @@ public class CiiMapper
 	}
 
 	/**
-	 * Resolves the buyer email for BT-49 via the doc-outbound recipient registry
+	 * Resolves the buyer email for BT-49 via the injected doc-outbound recipient registry
 	 * (same logic that populates C_Doc_Outbound_Log.CurrentEMailAddress).
-	 * Returns {@code null} if the registry is unavailable or returns no address —
-	 * the caller falls back to the BPartnerLocation email in that case.
+	 * Returns {@code null} when the registry was not injected (e.g. unit tests) or when
+	 * the registry returns no address — the caller falls back to the BPartnerLocation email.
 	 */
 	@Nullable
 	private String resolveBuyerEmail(@NonNull final I_C_Invoice invoice)
 	{
-		try
+		if (mailRecipientRegistry == null)
 		{
-			final DocOutboundLogMailRecipientRegistry registry =
-					SpringContextHolder.instance.getBean(DocOutboundLogMailRecipientRegistry.class);
-			final DocOutboundLogMailRecipientRequest req = DocOutboundLogMailRecipientRequest.builder()
-					.recordRef(TableRecordReference.of(I_C_Invoice.Table_Name, invoice.getC_Invoice_ID()))
-					.clientId(ClientId.ofRepoId(invoice.getAD_Client_ID()))
-					.orgId(OrgId.ofRepoId(invoice.getAD_Org_ID()))
-					.build();
-			return registry.getRecipient(req)
-					.map(DocOutBoundRecipients::getTo)
-					.map(DocOutBoundRecipient::getEmailAddress)
-					.orElse(null);
-		}
-		catch (final Exception ex)
-		{
-			log.debug("Doc-outbound recipient resolver unavailable for invoice {} — falling back to BPartnerLocation email",
-					invoice.getC_Invoice_ID(), ex);
 			return null;
 		}
+		final DocOutboundLogMailRecipientRequest req = DocOutboundLogMailRecipientRequest.builder()
+				.recordRef(TableRecordReference.of(I_C_Invoice.Table_Name, invoice.getC_Invoice_ID()))
+				.clientId(ClientId.ofRepoId(invoice.getAD_Client_ID()))
+				.orgId(OrgId.ofRepoId(invoice.getAD_Org_ID()))
+				.build();
+		return mailRecipientRegistry.getRecipient(req)
+				.map(DocOutBoundRecipients::getTo)
+				.map(DocOutBoundRecipient::getEmailAddress)
+				.orElse(null);
 	}
 
 	// ===== HeaderTradeSettlement =====

--- a/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/EInvoiceCiiServiceTest.java
+++ b/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/EInvoiceCiiServiceTest.java
@@ -46,7 +46,7 @@ public class EInvoiceCiiServiceTest
 	void setUp()
 	{
 		AdempiereTestHelper.get().init();
-		service = new EInvoiceCiiService(new EInvoiceConfigService(), null);
+		service = new EInvoiceCiiService(new EInvoiceConfigService(), null, null);
 	}
 
 	@Test

--- a/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/EInvoiceCiiServiceTest.java
+++ b/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/EInvoiceCiiServiceTest.java
@@ -46,7 +46,7 @@ public class EInvoiceCiiServiceTest
 	void setUp()
 	{
 		AdempiereTestHelper.get().init();
-		service = new EInvoiceCiiService(new EInvoiceConfigService());
+		service = new EInvoiceCiiService(new EInvoiceConfigService(), null);
 	}
 
 	@Test

--- a/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/EInvoiceCiiServiceTest.java
+++ b/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/EInvoiceCiiServiceTest.java
@@ -130,7 +130,7 @@ public class EInvoiceCiiServiceTest
 
 		final I_C_BPartner sellerBP = newInstance(I_C_BPartner.class);
 		sellerBP.setName("Muster GmbH");
-		sellerBP.setTaxID("DE123456789");
+		sellerBP.setVATaxID("DE123456789"); // USt-IdNr -> BT-31 (VAT identifier); required by BR-CO-26
 		sellerBP.setEMail("invoice@muster.de");
 		sellerBP.setAD_OrgBP_ID(org.getAD_Org_ID());
 		saveRecord(sellerBP);
@@ -342,7 +342,7 @@ public class EInvoiceCiiServiceTest
 
 		final I_C_BPartner sellerBP = newInstance(I_C_BPartner.class);
 		sellerBP.setName("Muster GmbH");
-		sellerBP.setTaxID("DE123456789");
+		sellerBP.setVATaxID("DE123456789"); // USt-IdNr -> BT-31 (VAT identifier); required by BR-CO-26
 		sellerBP.setEMail("invoice@muster.de");
 		sellerBP.setAD_OrgBP_ID(org.getAD_Org_ID());
 		saveRecord(sellerBP);

--- a/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/cii/CiiMapperTest.java
+++ b/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/cii/CiiMapperTest.java
@@ -1558,7 +1558,7 @@ public class CiiMapperTest
 		final MailService stubMailService = new MailService(
 				new MailboxRepository(),
 				new MailTemplateRepository(),
-				java.util.Collections.emptyList())
+				Collections.emptyList())
 		{
 			@Override
 			public Mailbox findMailbox(@NonNull final MailboxQuery query)

--- a/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/cii/CiiMapperTest.java
+++ b/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/cii/CiiMapperTest.java
@@ -67,7 +67,8 @@ public class CiiMapperTest
 
 		final I_C_BPartner sellerBPartner = newInstance(I_C_BPartner.class);
 		sellerBPartner.setName("Muster GmbH");
-		sellerBPartner.setTaxID("DE123456789");
+		sellerBPartner.setVATaxID("DE123456789");   // BT-31 — Umsatzsteuer-ID (VAT identifier, scheme VA)
+		sellerBPartner.setTaxID("Steuernr-0815");   // BT-32 — Steuernummer (tax registration, scheme FC)
 		sellerBPartner.setEMail("invoice@muster.de");
 		sellerBPartner.setCommercialRegisterNumber("HRB 12345");
 		saveRecord(sellerBPartner);
@@ -113,7 +114,7 @@ public class CiiMapperTest
 
 		final I_C_BPartner buyerBPartner = newInstance(I_C_BPartner.class);
 		buyerBPartner.setName("Käufer AG");
-		buyerBPartner.setTaxID("DE987654321");
+		buyerBPartner.setVATaxID("DE987654321");   // BT-48 — Buyer VAT identifier (scheme VA)
 		saveRecord(buyerBPartner);
 
 		buyerBPLocation.setC_BPartner_ID(buyerBPartner.getC_BPartner_ID());
@@ -226,13 +227,21 @@ public class CiiMapperTest
 						"//rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:SpecifiedLegalOrganization/ram:ID")
 				.isEqualTo("HRB 12345");
 
-		// Seller VAT id (BT-31) — value and scheme
+		// Seller VAT id (BT-31) — from VATaxID, scheme VA
 		xmlAssert.valueByXPath(
 						"//rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:SpecifiedTaxRegistration[1]/ram:ID")
 				.isEqualTo("DE123456789");
 		xmlAssert.valueByXPath(
 						"//rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:SpecifiedTaxRegistration[1]/ram:ID/@schemeID")
 				.isEqualTo("VA");
+
+		// Seller tax registration (BT-32) — from TaxID (Steuernummer), scheme FC
+		xmlAssert.valueByXPath(
+						"//rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:SpecifiedTaxRegistration[2]/ram:ID")
+				.isEqualTo("Steuernr-0815");
+		xmlAssert.valueByXPath(
+						"//rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty/ram:SpecifiedTaxRegistration[2]/ram:ID/@schemeID")
+				.isEqualTo("FC");
 
 		// Buyer name (BT-44)
 		xmlAssert.valueByXPath(

--- a/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/cii/CiiMapperTest.java
+++ b/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/cii/CiiMapperTest.java
@@ -7,6 +7,14 @@ import de.metas.document.archive.mailrecipient.DocOutBoundRecipients;
 import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientProvider;
 import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRegistry;
 import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRequest;
+import de.metas.email.EMailAddress;
+import de.metas.email.MailService;
+import de.metas.email.mailboxes.Mailbox;
+import de.metas.email.mailboxes.MailboxQuery;
+import de.metas.email.mailboxes.MailboxRepository;
+import de.metas.email.mailboxes.MailboxType;
+import de.metas.email.mailboxes.SMTPConfig;
+import de.metas.email.templates.MailTemplateRepository;
 import de.metas.einvoice.EInvoiceFormat;
 import de.metas.einvoice.EInvoiceRecipientConfig;
 import de.metas.einvoice.cii.model.CrossIndustryInvoiceType;
@@ -1386,7 +1394,7 @@ public class CiiMapperTest
 				.format(EInvoiceFormat.ZUGFeRD)
 				.build();
 
-		final CrossIndustryInvoiceType cii = new CiiMapper(stubRegistry).map(invoice, recipientConfig);
+		final CrossIndustryInvoiceType cii = new CiiMapper(stubRegistry, null).map(invoice, recipientConfig);
 		final XmlAssert xmlAssert = toXmlAssert(cii);
 
 		// BT-49 must use the registry-resolved email, NOT the BPartnerLocation email
@@ -1466,8 +1474,8 @@ public class CiiMapperTest
 				.format(EInvoiceFormat.ZUGFeRD)
 				.build();
 
-		// No registry injected — mapper uses the no-arg-equivalent path (null registry)
-		final CrossIndustryInvoiceType cii = new CiiMapper(/* no registry */ (DocOutboundLogMailRecipientRegistry)null)
+		// No registry and no mailService injected — mapper uses the no-arg-equivalent path (both null)
+		final CrossIndustryInvoiceType cii = new CiiMapper(/* no registry */ (DocOutboundLogMailRecipientRegistry)null, /* no mailService */ null)
 				.map(invoice, recipientConfig);
 		final XmlAssert xmlAssert = toXmlAssert(cii);
 
@@ -1478,6 +1486,197 @@ public class CiiMapperTest
 								+ "/ram:URIUniversalCommunication/ram:URIID")
 				.as("BT-49: must fall back to BPartnerLocation email when no registry is injected")
 				.isEqualTo("einkauf@buyer.de");
+	}
+
+	/**
+	 * BT-34 happy path: when a stub {@link MailService} returns a mailbox with a distinct "From"
+	 * email, the mapper must use that address (not the org BPartner email).
+	 */
+	@Test
+	void bt34_sellerElectronicAddress_usesMailboxFromAddress() throws Exception
+	{
+		// === Seller org ===
+		final I_AD_Org org = newInstance(I_AD_Org.class);
+		saveRecord(org);
+		final I_C_Country sellerCountry = newInstance(I_C_Country.class);
+		sellerCountry.setCountryCode("DE");
+		saveRecord(sellerCountry);
+		final I_C_Location sellerLocation = newInstance(I_C_Location.class);
+		sellerLocation.setC_Country_ID(sellerCountry.getC_Country_ID());
+		saveRecord(sellerLocation);
+		final I_C_BPartner sellerBP = newInstance(I_C_BPartner.class);
+		sellerBP.setName("Seller GmbH");
+		sellerBP.setVATaxID("DE123456789");
+		sellerBP.setEMail("bpartner-email@seller.de");  // must NOT appear in BT-34 when mailbox is resolved
+		sellerBP.setAD_OrgBP_ID(org.getAD_Org_ID());
+		saveRecord(sellerBP);
+		final I_C_BPartner_Location sellerBPLoc = newInstance(I_C_BPartner_Location.class);
+		sellerBPLoc.setC_BPartner_ID(sellerBP.getC_BPartner_ID());
+		sellerBPLoc.setC_Location_ID(sellerLocation.getC_Location_ID());
+		saveRecord(sellerBPLoc);
+		final I_AD_OrgInfo orgInfo = newInstance(I_AD_OrgInfo.class);
+		orgInfo.setAD_Org_ID(org.getAD_Org_ID());
+		orgInfo.setOrg_BPartner_ID(sellerBP.getC_BPartner_ID());
+		saveRecord(orgInfo);
+
+		// === Minimal buyer ===
+		final I_C_Country buyerCountry = newInstance(I_C_Country.class);
+		buyerCountry.setCountryCode("DE");
+		saveRecord(buyerCountry);
+		final I_C_Location buyerLocation = newInstance(I_C_Location.class);
+		buyerLocation.setC_Country_ID(buyerCountry.getC_Country_ID());
+		saveRecord(buyerLocation);
+		final I_C_BPartner buyerBP = newInstance(I_C_BPartner.class);
+		buyerBP.setName("Buyer AG");
+		saveRecord(buyerBP);
+		final I_C_BPartner_Location buyerBPLoc = newInstance(I_C_BPartner_Location.class);
+		buyerBPLoc.setC_BPartner_ID(buyerBP.getC_BPartner_ID());
+		buyerBPLoc.setC_Location_ID(buyerLocation.getC_Location_ID());
+		saveRecord(buyerBPLoc);
+
+		// === Currency + DocType ===
+		final I_C_Currency currency = newInstance(I_C_Currency.class);
+		currency.setISO_Code("EUR");
+		saveRecord(currency);
+		final I_C_DocType docType = newInstance(I_C_DocType.class);
+		docType.setDocBaseType("ARI");
+		saveRecord(docType);
+
+		// === Invoice ===
+		final I_C_Invoice invoice = newInstance(I_C_Invoice.class);
+		invoice.setAD_Org_ID(org.getAD_Org_ID());
+		invoice.setDocumentNo("RE-BT34-001");
+		invoice.setDateInvoiced(Timestamp.from(LocalDate.of(2024, 6, 15).atStartOfDay(ZoneOffset.UTC).toInstant()));
+		invoice.setC_Currency_ID(currency.getC_Currency_ID());
+		invoice.setC_DocType_ID(docType.getC_DocType_ID());
+		invoice.setC_BPartner_ID(buyerBP.getC_BPartner_ID());
+		invoice.setC_BPartner_Location_ID(buyerBPLoc.getC_BPartner_Location_ID());
+		saveRecord(invoice);
+
+		// === Stub MailService: always returns a fixed mailbox "From" address ===
+		final String mailboxFromEmail = "noreply@outbound-mail.seller.de";
+		final MailService stubMailService = new MailService(
+				new MailboxRepository(),
+				new MailTemplateRepository(),
+				java.util.Collections.emptyList())
+		{
+			@Override
+			public Mailbox findMailbox(@NonNull final MailboxQuery query)
+			{
+				return Mailbox.builder()
+						.type(MailboxType.SMTP)
+						.email(EMailAddress.ofString(mailboxFromEmail))
+						.smtpConfig(SMTPConfig.builder()
+								.smtpHost("smtp.example.com")
+								.smtpPort(587)
+								.smtpAuthorization(false)
+								.build())
+						.build();
+			}
+		};
+
+		final EInvoiceRecipientConfig recipientConfig = EInvoiceRecipientConfig.builder()
+				.format(EInvoiceFormat.ZUGFeRD)
+				.build();
+
+		final CrossIndustryInvoiceType cii = new CiiMapper(null, stubMailService).map(invoice, recipientConfig);
+		final XmlAssert xmlAssert = toXmlAssert(cii);
+
+		// BT-34 must use the mailbox "From" address, NOT the BPartner email
+		xmlAssert.valueByXPath(
+						"//rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction"
+								+ "/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty"
+								+ "/ram:URIUniversalCommunication/ram:URIID")
+				.as("BT-34: must use the mailbox From address, not the BPartner email")
+				.isEqualTo(mailboxFromEmail);
+
+		xmlAssert.valueByXPath(
+						"//rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction"
+								+ "/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty"
+								+ "/ram:URIUniversalCommunication/ram:URIID/@schemeID")
+				.isEqualTo("EM");
+	}
+
+	/**
+	 * BT-34 fallback: when no {@link MailService} is injected (null), the mapper must fall back
+	 * to the org BPartner email.
+	 */
+	@Test
+	void bt34_sellerElectronicAddress_fallsBackToBPartnerEmailWhenNoMailService() throws Exception
+	{
+		// === Seller org ===
+		final I_AD_Org org = newInstance(I_AD_Org.class);
+		saveRecord(org);
+		final I_C_Country sellerCountry = newInstance(I_C_Country.class);
+		sellerCountry.setCountryCode("DE");
+		saveRecord(sellerCountry);
+		final I_C_Location sellerLocation = newInstance(I_C_Location.class);
+		sellerLocation.setC_Country_ID(sellerCountry.getC_Country_ID());
+		saveRecord(sellerLocation);
+		final I_C_BPartner sellerBP = newInstance(I_C_BPartner.class);
+		sellerBP.setName("Seller GmbH");
+		sellerBP.setVATaxID("DE123456789");
+		sellerBP.setEMail("invoice@seller.de");
+		sellerBP.setAD_OrgBP_ID(org.getAD_Org_ID());
+		saveRecord(sellerBP);
+		final I_C_BPartner_Location sellerBPLoc = newInstance(I_C_BPartner_Location.class);
+		sellerBPLoc.setC_BPartner_ID(sellerBP.getC_BPartner_ID());
+		sellerBPLoc.setC_Location_ID(sellerLocation.getC_Location_ID());
+		saveRecord(sellerBPLoc);
+		final I_AD_OrgInfo orgInfo = newInstance(I_AD_OrgInfo.class);
+		orgInfo.setAD_Org_ID(org.getAD_Org_ID());
+		orgInfo.setOrg_BPartner_ID(sellerBP.getC_BPartner_ID());
+		saveRecord(orgInfo);
+
+		// === Minimal buyer ===
+		final I_C_Country buyerCountry = newInstance(I_C_Country.class);
+		buyerCountry.setCountryCode("DE");
+		saveRecord(buyerCountry);
+		final I_C_Location buyerLocation = newInstance(I_C_Location.class);
+		buyerLocation.setC_Country_ID(buyerCountry.getC_Country_ID());
+		saveRecord(buyerLocation);
+		final I_C_BPartner buyerBP = newInstance(I_C_BPartner.class);
+		buyerBP.setName("Buyer AG");
+		saveRecord(buyerBP);
+		final I_C_BPartner_Location buyerBPLoc = newInstance(I_C_BPartner_Location.class);
+		buyerBPLoc.setC_BPartner_ID(buyerBP.getC_BPartner_ID());
+		buyerBPLoc.setC_Location_ID(buyerLocation.getC_Location_ID());
+		saveRecord(buyerBPLoc);
+
+		// === Currency + DocType ===
+		final I_C_Currency currency = newInstance(I_C_Currency.class);
+		currency.setISO_Code("EUR");
+		saveRecord(currency);
+		final I_C_DocType docType = newInstance(I_C_DocType.class);
+		docType.setDocBaseType("ARI");
+		saveRecord(docType);
+
+		// === Invoice ===
+		final I_C_Invoice invoice = newInstance(I_C_Invoice.class);
+		invoice.setAD_Org_ID(org.getAD_Org_ID());
+		invoice.setDocumentNo("RE-BT34-002");
+		invoice.setDateInvoiced(Timestamp.from(LocalDate.of(2024, 6, 15).atStartOfDay(ZoneOffset.UTC).toInstant()));
+		invoice.setC_Currency_ID(currency.getC_Currency_ID());
+		invoice.setC_DocType_ID(docType.getC_DocType_ID());
+		invoice.setC_BPartner_ID(buyerBP.getC_BPartner_ID());
+		invoice.setC_BPartner_Location_ID(buyerBPLoc.getC_BPartner_Location_ID());
+		saveRecord(invoice);
+
+		final EInvoiceRecipientConfig recipientConfig = EInvoiceRecipientConfig.builder()
+				.format(EInvoiceFormat.ZUGFeRD)
+				.build();
+
+		// No MailService — must fall back to BPartner email
+		final CrossIndustryInvoiceType cii = new CiiMapper(null, null).map(invoice, recipientConfig);
+		final XmlAssert xmlAssert = toXmlAssert(cii);
+
+		// BT-34 must fall back to the BPartner email
+		xmlAssert.valueByXPath(
+						"//rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction"
+								+ "/ram:ApplicableHeaderTradeAgreement/ram:SellerTradeParty"
+								+ "/ram:URIUniversalCommunication/ram:URIID")
+				.as("BT-34: must fall back to BPartner email when no MailService is injected")
+				.isEqualTo("invoice@seller.de");
 	}
 
 	// ===== Shared helpers =====

--- a/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/cii/CiiMapperTest.java
+++ b/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/cii/CiiMapperTest.java
@@ -1,6 +1,12 @@
 package de.metas.einvoice.cii;
 
 import de.metas.adempiere.model.I_C_InvoiceLine;
+import de.metas.document.archive.mailrecipient.DocOutBoundRecipient;
+import de.metas.document.archive.mailrecipient.DocOutBoundRecipientId;
+import de.metas.document.archive.mailrecipient.DocOutBoundRecipients;
+import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientProvider;
+import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRegistry;
+import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRequest;
 import de.metas.einvoice.EInvoiceFormat;
 import de.metas.einvoice.EInvoiceRecipientConfig;
 import de.metas.einvoice.cii.model.CrossIndustryInvoiceType;
@@ -34,8 +40,10 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
@@ -1285,6 +1293,191 @@ public class CiiMapperTest
 		xmlAssert.valueByXPath(contactXPath + "/ram:EmailURIUniversalCommunication/ram:URIID")
 				.as("BT-43: EmailURIUniversalCommunication/URIID must match the seller contact email")
 				.isEqualTo("max.mustermann@muster.de");
+	}
+
+	/**
+	 * BT-49 happy path: when a {@link DocOutboundLogMailRecipientRegistry} stub returns a recipient with
+	 * a distinct email address, the mapper must use that address (not the BPartnerLocation email).
+	 */
+	@Test
+	void bt49_buyerElectronicAddress_usesRegistryEmail() throws Exception
+	{
+		// === Minimal seller org ===
+		final I_AD_Org org = newInstance(I_AD_Org.class);
+		saveRecord(org);
+		final I_C_Country sellerCountry = newInstance(I_C_Country.class);
+		sellerCountry.setCountryCode("DE");
+		saveRecord(sellerCountry);
+		final I_C_Location sellerLocation = newInstance(I_C_Location.class);
+		sellerLocation.setC_Country_ID(sellerCountry.getC_Country_ID());
+		saveRecord(sellerLocation);
+		final I_C_BPartner sellerBP = newInstance(I_C_BPartner.class);
+		sellerBP.setName("Seller GmbH");
+		sellerBP.setAD_OrgBP_ID(org.getAD_Org_ID());
+		saveRecord(sellerBP);
+		final I_C_BPartner_Location sellerBPLoc = newInstance(I_C_BPartner_Location.class);
+		sellerBPLoc.setC_BPartner_ID(sellerBP.getC_BPartner_ID());
+		sellerBPLoc.setC_Location_ID(sellerLocation.getC_Location_ID());
+		saveRecord(sellerBPLoc);
+		final I_AD_OrgInfo orgInfo = newInstance(I_AD_OrgInfo.class);
+		orgInfo.setAD_Org_ID(org.getAD_Org_ID());
+		orgInfo.setOrg_BPartner_ID(sellerBP.getC_BPartner_ID());
+		saveRecord(orgInfo);
+
+		// === Buyer ===
+		final I_C_Country buyerCountry = newInstance(I_C_Country.class);
+		buyerCountry.setCountryCode("DE");
+		saveRecord(buyerCountry);
+		final I_C_Location buyerLocation = newInstance(I_C_Location.class);
+		buyerLocation.setC_Country_ID(buyerCountry.getC_Country_ID());
+		saveRecord(buyerLocation);
+		final I_C_BPartner buyerBP = newInstance(I_C_BPartner.class);
+		buyerBP.setName("Buyer AG");
+		saveRecord(buyerBP);
+		final I_C_BPartner_Location buyerBPLoc = newInstance(I_C_BPartner_Location.class);
+		buyerBPLoc.setC_BPartner_ID(buyerBP.getC_BPartner_ID());
+		buyerBPLoc.setC_Location_ID(buyerLocation.getC_Location_ID());
+		buyerBPLoc.setEMail("location@buyer.de");   // fallback — must NOT appear in BT-49
+		saveRecord(buyerBPLoc);
+
+		// === Currency + DocType ===
+		final I_C_Currency currency = newInstance(I_C_Currency.class);
+		currency.setISO_Code("EUR");
+		saveRecord(currency);
+		final I_C_DocType docType = newInstance(I_C_DocType.class);
+		docType.setDocBaseType("ARI");
+		saveRecord(docType);
+
+		// === Invoice ===
+		final I_C_Invoice invoice = newInstance(I_C_Invoice.class);
+		invoice.setAD_Org_ID(org.getAD_Org_ID());
+		invoice.setDocumentNo("RE-2024-00800");
+		invoice.setDateInvoiced(Timestamp.from(LocalDate.of(2024, 6, 15).atStartOfDay(ZoneOffset.UTC).toInstant()));
+		invoice.setC_Currency_ID(currency.getC_Currency_ID());
+		invoice.setC_DocType_ID(docType.getC_DocType_ID());
+		invoice.setC_BPartner_ID(buyerBP.getC_BPartner_ID());
+		invoice.setC_BPartner_Location_ID(buyerBPLoc.getC_BPartner_Location_ID());
+		saveRecord(invoice);
+
+		// === Stub registry: always returns a fixed "resolver" email (distinct from the location email) ===
+		final String resolverEmail = "registry-resolved@buyer.de";
+		final DocOutboundLogMailRecipientRegistry stubRegistry = new DocOutboundLogMailRecipientRegistry(
+				Optional.of(Collections.singletonList(new DocOutboundLogMailRecipientProvider()
+				{
+					@Override
+					public boolean isDefault() { return true; }
+
+					@Override
+					public String getTableName() { return null; }
+
+					@Override
+					public Optional<DocOutBoundRecipients> provideMailRecipient(final DocOutboundLogMailRecipientRequest request)
+					{
+						return DocOutBoundRecipients.optionalOfTo(
+								DocOutBoundRecipient.builder()
+										.id(DocOutBoundRecipientId.ofRepoId(1))
+										.emailAddress(resolverEmail)
+										.invoiceAsEmail(true)
+										.build());
+					}
+				})));
+
+		final EInvoiceRecipientConfig recipientConfig = EInvoiceRecipientConfig.builder()
+				.format(EInvoiceFormat.ZUGFeRD)
+				.build();
+
+		final CrossIndustryInvoiceType cii = new CiiMapper(stubRegistry).map(invoice, recipientConfig);
+		final XmlAssert xmlAssert = toXmlAssert(cii);
+
+		// BT-49 must use the registry-resolved email, NOT the BPartnerLocation email
+		xmlAssert.valueByXPath(
+						"//rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction"
+								+ "/ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty"
+								+ "/ram:URIUniversalCommunication/ram:URIID")
+				.as("BT-49: must use the registry-resolved email, not the BPartnerLocation email")
+				.isEqualTo(resolverEmail);
+	}
+
+	/**
+	 * BT-49 fallback: when no registry is injected (null) the mapper must fall back to the
+	 * BPartnerLocation email.
+	 */
+	@Test
+	void bt49_buyerElectronicAddress_fallsBackToLocationEmailWhenNoRegistry() throws Exception
+	{
+		// === Minimal seller org ===
+		final I_AD_Org org = newInstance(I_AD_Org.class);
+		saveRecord(org);
+		final I_C_Country sellerCountry = newInstance(I_C_Country.class);
+		sellerCountry.setCountryCode("DE");
+		saveRecord(sellerCountry);
+		final I_C_Location sellerLocation = newInstance(I_C_Location.class);
+		sellerLocation.setC_Country_ID(sellerCountry.getC_Country_ID());
+		saveRecord(sellerLocation);
+		final I_C_BPartner sellerBP = newInstance(I_C_BPartner.class);
+		sellerBP.setName("Seller GmbH");
+		sellerBP.setAD_OrgBP_ID(org.getAD_Org_ID());
+		saveRecord(sellerBP);
+		final I_C_BPartner_Location sellerBPLoc = newInstance(I_C_BPartner_Location.class);
+		sellerBPLoc.setC_BPartner_ID(sellerBP.getC_BPartner_ID());
+		sellerBPLoc.setC_Location_ID(sellerLocation.getC_Location_ID());
+		saveRecord(sellerBPLoc);
+		final I_AD_OrgInfo orgInfo = newInstance(I_AD_OrgInfo.class);
+		orgInfo.setAD_Org_ID(org.getAD_Org_ID());
+		orgInfo.setOrg_BPartner_ID(sellerBP.getC_BPartner_ID());
+		saveRecord(orgInfo);
+
+		// === Buyer ===
+		final I_C_Country buyerCountry = newInstance(I_C_Country.class);
+		buyerCountry.setCountryCode("DE");
+		saveRecord(buyerCountry);
+		final I_C_Location buyerLocation = newInstance(I_C_Location.class);
+		buyerLocation.setC_Country_ID(buyerCountry.getC_Country_ID());
+		saveRecord(buyerLocation);
+		final I_C_BPartner buyerBP = newInstance(I_C_BPartner.class);
+		buyerBP.setName("Buyer AG");
+		saveRecord(buyerBP);
+		final I_C_BPartner_Location buyerBPLoc = newInstance(I_C_BPartner_Location.class);
+		buyerBPLoc.setC_BPartner_ID(buyerBP.getC_BPartner_ID());
+		buyerBPLoc.setC_Location_ID(buyerLocation.getC_Location_ID());
+		buyerBPLoc.setEMail("einkauf@buyer.de");
+		saveRecord(buyerBPLoc);
+
+		// === Currency + DocType ===
+		final I_C_Currency currency = newInstance(I_C_Currency.class);
+		currency.setISO_Code("EUR");
+		saveRecord(currency);
+		final I_C_DocType docType = newInstance(I_C_DocType.class);
+		docType.setDocBaseType("ARI");
+		saveRecord(docType);
+
+		// === Invoice ===
+		final I_C_Invoice invoice = newInstance(I_C_Invoice.class);
+		invoice.setAD_Org_ID(org.getAD_Org_ID());
+		invoice.setDocumentNo("RE-2024-00801");
+		invoice.setDateInvoiced(Timestamp.from(LocalDate.of(2024, 6, 15).atStartOfDay(ZoneOffset.UTC).toInstant()));
+		invoice.setC_Currency_ID(currency.getC_Currency_ID());
+		invoice.setC_DocType_ID(docType.getC_DocType_ID());
+		invoice.setC_BPartner_ID(buyerBP.getC_BPartner_ID());
+		invoice.setC_BPartner_Location_ID(buyerBPLoc.getC_BPartner_Location_ID());
+		saveRecord(invoice);
+
+		final EInvoiceRecipientConfig recipientConfig = EInvoiceRecipientConfig.builder()
+				.format(EInvoiceFormat.ZUGFeRD)
+				.build();
+
+		// No registry injected — mapper uses the no-arg-equivalent path (null registry)
+		final CrossIndustryInvoiceType cii = new CiiMapper(/* no registry */ (DocOutboundLogMailRecipientRegistry)null)
+				.map(invoice, recipientConfig);
+		final XmlAssert xmlAssert = toXmlAssert(cii);
+
+		// BT-49 must fall back to the BPartnerLocation email
+		xmlAssert.valueByXPath(
+						"//rsm:CrossIndustryInvoice/rsm:SupplyChainTradeTransaction"
+								+ "/ram:ApplicableHeaderTradeAgreement/ram:BuyerTradeParty"
+								+ "/ram:URIUniversalCommunication/ram:URIID")
+				.as("BT-49: must fall back to BPartnerLocation email when no registry is injected")
+				.isEqualTo("einkauf@buyer.de");
 	}
 
 	// ===== Shared helpers =====

--- a/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/cii/CiiValidatorTest.java
+++ b/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/cii/CiiValidatorTest.java
@@ -85,7 +85,7 @@ public class CiiValidatorTest
 
 		final I_C_BPartner sellerBP = newInstance(I_C_BPartner.class);
 		sellerBP.setName("Muster GmbH");
-		sellerBP.setTaxID("DE123456789");
+		sellerBP.setVATaxID("DE123456789"); // USt-IdNr -> BT-31 (VAT identifier); required by BR-CO-26
 		sellerBP.setEMail("invoice@muster.de");
 		sellerBP.setAD_OrgBP_ID(org.getAD_Org_ID());
 		saveRecord(sellerBP);

--- a/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/interceptor/C_InvoiceEInvoiceTest.java
+++ b/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/interceptor/C_InvoiceEInvoiceTest.java
@@ -78,7 +78,7 @@ public class C_InvoiceEInvoiceTest
 		final EInvoiceConfigService configService = new EInvoiceConfigService();
 		interceptor = new C_Invoice(
 				configService,
-				new EInvoiceCiiService(configService),
+				new EInvoiceCiiService(configService, null),
 				attachmentEntryService);
 	}
 

--- a/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/interceptor/C_InvoiceEInvoiceTest.java
+++ b/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/interceptor/C_InvoiceEInvoiceTest.java
@@ -78,7 +78,7 @@ public class C_InvoiceEInvoiceTest
 		final EInvoiceConfigService configService = new EInvoiceConfigService();
 		interceptor = new C_Invoice(
 				configService,
-				new EInvoiceCiiService(configService, null),
+				new EInvoiceCiiService(configService, null, null),
 				attachmentEntryService);
 	}
 

--- a/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/interceptor/C_InvoiceEInvoiceTest.java
+++ b/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/interceptor/C_InvoiceEInvoiceTest.java
@@ -256,7 +256,7 @@ public class C_InvoiceEInvoiceTest
 
 		final I_C_BPartner sellerBP = newInstance(I_C_BPartner.class);
 		sellerBP.setName("Muster GmbH");
-		sellerBP.setTaxID("DE123456789");
+		sellerBP.setVATaxID("DE123456789"); // USt-IdNr -> BT-31 (VAT identifier); required by BR-CO-26
 		sellerBP.setEMail("invoice@muster.de");
 		sellerBP.setAD_OrgBP_ID(org.getAD_Org_ID());
 		saveRecord(sellerBP);

--- a/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/interceptor/C_InvoiceXRechnungOnCompleteTest.java
+++ b/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/interceptor/C_InvoiceXRechnungOnCompleteTest.java
@@ -94,7 +94,7 @@ public class C_InvoiceXRechnungOnCompleteTest
 		final EInvoiceConfigService configService = new EInvoiceConfigService();
 		final C_Invoice interceptor = new C_Invoice(
 				configService,
-				new EInvoiceCiiService(configService),
+				new EInvoiceCiiService(configService, null),
 				attachmentEntryService);
 		POJOLookupMap.get().addModelValidator(interceptor);
 	}

--- a/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/interceptor/C_InvoiceXRechnungOnCompleteTest.java
+++ b/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/interceptor/C_InvoiceXRechnungOnCompleteTest.java
@@ -183,7 +183,7 @@ public class C_InvoiceXRechnungOnCompleteTest
 
 		final I_C_BPartner sellerBP = newInstance(I_C_BPartner.class);
 		sellerBP.setName("Muster GmbH");
-		sellerBP.setTaxID("DE123456789");
+		sellerBP.setVATaxID("DE123456789"); // USt-IdNr -> BT-31 (VAT identifier); required by BR-CO-26
 		sellerBP.setEMail("invoice@muster.de");
 		sellerBP.setAD_OrgBP_ID(org.getAD_Org_ID());
 		saveRecord(sellerBP);

--- a/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/interceptor/C_InvoiceXRechnungOnCompleteTest.java
+++ b/backend/de.metas.einvoice.base/src/test/java/de/metas/einvoice/interceptor/C_InvoiceXRechnungOnCompleteTest.java
@@ -94,7 +94,7 @@ public class C_InvoiceXRechnungOnCompleteTest
 		final EInvoiceConfigService configService = new EInvoiceConfigService();
 		final C_Invoice interceptor = new C_Invoice(
 				configService,
-				new EInvoiceCiiService(configService, null),
+				new EInvoiceCiiService(configService, null, null),
 				attachmentEntryService);
 		POJOLookupMap.get().addModelValidator(interceptor);
 	}

--- a/e2e/frontend-webui/TEST-COVERAGE.md
+++ b/e2e/frontend-webui/TEST-COVERAGE.md
@@ -1075,6 +1075,26 @@ This suite specifically guards the `Lookup.js` / `RawLookup.js` focus management
 
 ---
 
+### 42. E-Invoicing — Seller Tax Fields in Org-Master window layout (`einvoice-seller-tax-fields.spec.js`)
+
+**Features Tested**:
+- F00751: e-Invoicing Germany
+
+**Epic**: E0340: Invoicing
+
+**Workflow** (en_US, requires port 8282):
+1. Login via `Backend.createMasterdata()` user
+2. Reset webui metadata cache (`GET /rest/api/cache/reset`) to pick up migration 5809330's field changes
+3. Fetch the window layout via WebAPI `GET /rest/api/window/540676/layout` (window 540676 "Organisation Stammdaten", tab 541852 "Geschäftspartner")
+4. Assert each of `VATaxID`, `TaxID`, `CommercialRegisterNumber` is present in the layout
+
+**Key Validations**:
+- Migration 5809330 made `TaxID` (Steuernummer) and `CommercialRegisterNumber` (Handelsregisternr) visible in tab 541852 alongside the already-shown `VATaxID` (USt-IdNr) — these back the CII seller fields BT-31/BT-32/BT-30
+- **Data-independent**: verifies pure AD_Field/AD_UI_Element layout metadata via the `/layout` endpoint — no C_BPartner records needed (window 540676 has `isinsertrecord=N` + a WhereClause `ad_orgbp_id IS NOT NULL` that excludes seed-DB rows, so `/NEW` and hardcoded record IDs are non-options)
+- **Scope — presence only**: editability is NOT asserted here. The `/layout` endpoint carries no per-record readonly flag (and defaults every text element to `viewEditorRenderMode='never'`); editability is enforced at the AD level (`AD_Field.IsReadOnly='N'` in migration 5809330) and verified by the window-designer
+
+---
+
 ## Test Architecture
 
 ### Page Objects

--- a/e2e/frontend-webui/tests/spec/einvoice-seller-tax-fields.spec.js
+++ b/e2e/frontend-webui/tests/spec/einvoice-seller-tax-fields.spec.js
@@ -1,0 +1,213 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { FRONTEND_BASE_URL, SLOW_ACTION_TIMEOUT } from '../utils/common';
+import { assertRecordIsValid, WEBAPI_BASE_URL } from '../utils/WebAPIValidation';
+
+/**
+ * E-Invoicing — Seller tax-identification fields on Organisation Stammdaten window.
+ *
+ * Window 540676 "Organisation Stammdaten", tab 541852 "Geschäftspartner" (C_BPartner).
+ * Migration 5809330 on branch deep_tundra_release_30508_EInvoiceFieldMapping made three
+ * C_BPartner columns visible in this tab:
+ *   - VATaxID             (USt-IdNr / VAT identifier)  — was already shown
+ *   - TaxID               (Steuernummer)                — newly shown
+ *   - CommercialRegisterNumber (Handelsregisternr)      — newly added field
+ *
+ * Test verifies that all three fields:
+ *   1. Are rendered in the detail form (visible)
+ *   2. Are editable (the underlying <input> is NOT disabled/readonly)
+ *
+ * me03 #30508
+ *
+ * Features tested:
+ * - F00751: e-Invoicing Germany
+ */
+
+/**
+ * Window 540676 — Organisation Stammdaten
+ * AD_Tab 541852 "Geschäftspartner" — table C_BPartner (WhereClause: ad_orgbp_id is not null)
+ */
+const ORG_MASTER_WINDOW_ID = 540676;
+
+/**
+ * C_BPartner_ID 2155894 "Muster GmbH" — an org-BPartner record (ad_orgbp_id IS NOT NULL)
+ * that already carries VATaxID and TaxID values.  CommercialRegisterNumber is empty (NULL),
+ * which makes it a good test target: we can assert the field is present even when blank.
+ * The record is NOT modified by this test.
+ */
+const TEST_BPARTNER_ID = 2155894;
+
+/**
+ * Reset the WebUI metadata cache after login.
+ * Required because migration 5809330 added/changed field visibility — a running webui
+ * may have a stale layout in its session cache.
+ */
+async function resetWebuiCache(page) {
+  console.log('[INFO] Resetting webui metadata cache...');
+  const resp = await page.request.get(`${WEBAPI_BASE_URL}/cache/reset`);
+  const status = resp.status();
+  if (status !== 200) {
+    const body = await resp.text();
+    throw new Error(`Cache reset failed: HTTP ${status} — ${body.substring(0, 200)}`);
+  }
+  console.log(`[INFO] Cache reset response: HTTP ${status}`);
+}
+
+test.describe('Organisation Stammdaten — seller tax-identification fields (E-Invoicing)', () => {
+  test(
+    'VATaxID, TaxID and CommercialRegisterNumber are visible and editable on Geschäftspartner tab',
+    async ({ page }) => {
+      // === ALLURE METADATA ===
+      allure.epic('E0340: Invoicing');
+      allure.feature('F00751: e-Invoicing Germany');
+      allure.tag('F00751: e-Invoicing Germany');
+      allure.tag('F00751');
+      allure.story('Seller tax fields visible and editable on Organisation Stammdaten window 540676');
+      allure.severity('critical');
+      allure.tag('e-Invoicing');
+      allure.tag('OrganisationStammdaten');
+      allure.description(`
+## E-Invoicing — Seller Tax Fields on Organisation Stammdaten (Window 540676)
+
+### Feature
+Migration 5809330 makes the following **C_BPartner** columns visible in window 540676
+tab "Geschäftspartner" (AD_Tab 541852):
+- **VATaxID** (USt-IdNr / VAT identifier) — already shown, now confirmed
+- **TaxID** (Steuernummer) — newly shown
+- **CommercialRegisterNumber** (Handelsregisternr) — newly added
+
+### Test Steps
+1. Create fresh test user, login
+2. Reset webui metadata cache (so new field layout is active without server restart)
+3. Navigate directly to the org-BPartner record in window 540676
+4. Assert each field container is visible in the form (.form-field-VATaxID etc.)
+5. Assert the input inside each field is enabled (NOT disabled / NOT readonly)
+      `);
+
+      test.setTimeout(120000); // 2 minutes
+
+      // === STEP 1: Create test user ===
+      const masterdata = await Backend.createMasterdata({
+        request: {
+          login: {
+            user: {
+              language: 'en_US',
+              firstname: 'E2E',
+              lastname: 'TaxFields',
+            },
+          },
+        },
+      });
+
+      allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+      console.log(`[INFO] Test user created: ${masterdata.login.user.username}`);
+
+      // === STEP 2: Login ===
+      // Use inline login pattern (avoids waitForResponse race on role-selection step).
+      // Documented in CLAUDE.md § "Default Login (metasfresh/metasfresh) — Role Selection".
+      await page.goto(`${FRONTEND_BASE_URL}/login`);
+      await page.locator('.login-container').waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await page.locator('input[name="username"]').fill(masterdata.login.user.username);
+      await page.locator('input[name="password"]').fill(masterdata.login.user.password);
+      await page.locator('.btn-meta-success').click();
+      // Handle role selection — wait briefly, then click Send again if still on login
+      await page.waitForTimeout(1000);
+      if (page.url().includes('/login')) {
+        const sendButton = page.locator('.btn-meta-success');
+        if (await sendButton.isVisible()) { await sendButton.click(); }
+      }
+      await page.waitForURL((url) => !url.toString().includes('/login'), { timeout: SLOW_ACTION_TIMEOUT });
+      // Verify dashboard loaded — content visible (skip networkidle: WebSockets keep it pending)
+      await page.locator('.app-content, .dashboard').waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      console.log('[INFO] Logged in successfully');
+
+      // === STEP 3: Reset webui metadata cache ===
+      // Must be done after login (endpoint requires authentication).
+      await resetWebuiCache(page);
+
+      // === STEP 4: Navigate directly to the org-BPartner record in window 540676 ===
+      // Window 540676 "Organisation Stammdaten" — the Geschäftspartner tab (541852)
+      // shows C_BPartner records where ad_orgbp_id IS NOT NULL.
+      // Record 2155894 "Muster GmbH" satisfies this condition.
+      await page.goto(`${FRONTEND_BASE_URL}/window/${ORG_MASTER_WINDOW_ID}/${TEST_BPARTNER_ID}`);
+
+      // Wait for the detail view to fully load
+      await page.waitForURL(/\/window\/\d+\/\d+/, { timeout: SLOW_ACTION_TIMEOUT });
+      await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+      await page
+        .locator('.rotating, .indicator-pending')
+        .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+        .catch(() => {});
+
+      console.log('[INFO] Record loaded. URL:', page.url());
+
+      const screenshotInitial = await page.screenshot();
+      allure.attachment('Geschaeftspartner Detail — Initial State', screenshotInitial, 'image/png');
+
+      // === STEP 5: Assert record is valid (MANDATORY guard per CLAUDE.md) ===
+      // If valid=false, any UI changes would not be saved.  We are not editing in this
+      // test, but the guard confirms the record loaded correctly.
+      await assertRecordIsValid(
+        String(ORG_MASTER_WINDOW_ID),
+        String(TEST_BPARTNER_ID),
+        'before asserting field visibility'
+      );
+      console.log('[INFO] Record is valid');
+
+      // === STEP 6: Assert all three fields are visible and editable ===
+      const FIELDS = [
+        {
+          columnName: 'VATaxID',
+          label: 'USt-IdNr / VAT identifier',
+          selector: '.form-field-VATaxID',
+        },
+        {
+          columnName: 'TaxID',
+          label: 'Steuernummer',
+          selector: '.form-field-TaxID',
+        },
+        {
+          columnName: 'CommercialRegisterNumber',
+          label: 'Handelsregisternr',
+          selector: '.form-field-CommercialRegisterNumber',
+        },
+      ];
+
+      for (const field of FIELDS) {
+        await test.step(`Assert field ${field.columnName} (${field.label}) is visible and editable`, async () => {
+          // 1. Field container must be visible in the form
+          const fieldContainer = page.locator(field.selector);
+          await fieldContainer.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+          await expect(fieldContainer, `Field ${field.columnName} container must be visible`).toBeVisible();
+
+          // 2. The input inside the field must be enabled (not disabled and not readonly)
+          //    String/Text fields render as <input type="text"> inside the form-field wrapper.
+          const input = fieldContainer.locator('input').first();
+          await input.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+          const isDisabled = await input.isDisabled();
+          expect(
+            isDisabled,
+            `Field ${field.columnName} input must NOT be disabled (field must be editable)`
+          ).toBe(false);
+
+          // Also check the readonly attribute (some fields are shown but not editable)
+          const isReadonly = await input.getAttribute('readonly');
+          expect(
+            isReadonly,
+            `Field ${field.columnName} input must NOT have readonly attribute`
+          ).toBeNull();
+
+          console.log(`[PASS] ${field.columnName} (${field.label}) — visible and editable`);
+        });
+      }
+
+      const screenshotFinal = await page.screenshot();
+      allure.attachment('Geschaeftspartner Detail — Fields Verified', screenshotFinal, 'image/png');
+
+      console.log('[INFO] All three seller tax fields verified — visible and editable');
+    }
+  );
+});

--- a/e2e/frontend-webui/tests/spec/einvoice-seller-tax-fields.spec.js
+++ b/e2e/frontend-webui/tests/spec/einvoice-seller-tax-fields.spec.js
@@ -15,9 +15,10 @@ import { WEBAPI_BASE_URL } from '../utils/WebAPIValidation';
  *   - TaxID               (Steuernummer)                — newly shown
  *   - CommercialRegisterNumber (Handelsregisternr)      — newly added field
  *
- * Test verifies that all three fields:
- *   1. Appear in the window's tab layout (visible = not excluded from layout)
- *   2. Are editable (readonly: false in the layout)
+ * Test verifies that all three fields appear (are DISPLAYED) in the window's tab layout
+ * (visible = not excluded from the layout). Form-view editability is NOT assertable from the
+ * /layout endpoint (it carries no readonly flag — see collectLayoutFields below); it is enforced
+ * at the AD level (AD_Field.IsReadOnly='N' in migration 5809330) and verified by the window-designer.
  *
  * Data-independence: this test verifies the AD_Field layout via the WebAPI
  * /rest/api/window/{windowId}/layout endpoint. Window layout is pure metadata
@@ -61,7 +62,7 @@ async function resetWebuiCache(page) {
  * Returns the parsed JSON layout for the window's root tab.
  *
  * The /window/{id}/layout endpoint is available to any authenticated session
- * and returns field visibility/readonly metadata regardless of whether records exist.
+ * and returns field visibility/layout metadata regardless of whether records exist.
  */
 async function fetchWindowLayout(page, windowId) {
   const url = `${WEBAPI_BASE_URL}/window/${windowId}/layout`;
@@ -82,11 +83,12 @@ async function fetchWindowLayout(page, windowId) {
  *
  * - Each field entry is: { field: "<ColumnName>", caption, emptyText, ... }
  *   ("field" is the column name string, NOT an object)
- * - Editability attributes (readonly, viewEditorRenderMode) live on the ELEMENT,
- *   not on the field. A missing "readonly" key means editable.
+ * - The /layout endpoint carries NO per-record editability flag: there is no "readonly" key,
+ *   and "viewEditorRenderMode" defaults to 'never' for every text element regardless of form
+ *   editability. Form-view editability lives on the per-record data endpoint, not here.
  *
  * Returns an array of { fieldName, element } objects so callers can check
- * both presence (fieldName in layout) and editability (element.readonly).
+ * presence (fieldName in layout).
  */
 function collectLayoutFields(layout) {
   const results = [];
@@ -110,7 +112,7 @@ function collectLayoutFields(layout) {
 
 test.describe('Organisation Stammdaten — seller tax-identification fields (E-Invoicing)', () => {
   test(
-    'VATaxID, TaxID and CommercialRegisterNumber are in the window layout and editable',
+    'VATaxID, TaxID and CommercialRegisterNumber are displayed in the window layout',
     async ({ page }) => {
       // === ALLURE METADATA ===
       allure.epic('E0340: Invoicing');
@@ -142,7 +144,10 @@ AD_Field metadata without requiring any records.
 2. Reset webui metadata cache (so new field layout is active without server restart)
 3. Fetch the window layout via /rest/api/window/540676/layout
 4. Assert each field is present in the layout (not excluded from the tab)
-5. Assert each field has readonly: false (editable)
+
+Editability is NOT asserted here: the /layout endpoint carries no per-record readonly flag.
+It is enforced at the AD level (\`AD_Field.IsReadOnly='N'\` in migration 5809330) and verified
+by the window-designer.
       `);
 
       test.setTimeout(120000); // 2 minutes
@@ -198,7 +203,7 @@ AD_Field metadata without requiring any records.
       const layoutFields = collectLayoutFields(layout);
       console.log(`[INFO] Layout contains ${layoutFields.length} field entries`);
 
-      // === STEP 5: Assert all three fields are in the layout and editable ===
+      // === STEP 5: Assert all three fields are displayed in the window layout ===
       const FIELDS = [
         {
           columnName: 'VATaxID',
@@ -215,7 +220,7 @@ AD_Field metadata without requiring any records.
       ];
 
       for (const field of FIELDS) {
-        await test.step(`Assert field ${field.columnName} (${field.label}) is in layout and editable`, async () => {
+        await test.step(`Assert field ${field.columnName} (${field.label}) is displayed in the window layout`, async () => {
           // Find the field in the layout by column name
           const entry = layoutFields.find((f) => f.fieldName === field.columnName);
 
@@ -224,21 +229,19 @@ AD_Field metadata without requiring any records.
             `Field ${field.columnName} must appear in the window 540676 layout (check AD_Field.IsDisplayed and AD_UI_Element visibility for tab 541852)`
           ).toBeDefined();
 
-          // Assert the field is editable.
-          // Editability is indicated by the ABSENCE of readonly:true on the element.
-          // (The layout omits the readonly key when the field is editable;
-          //  readonly:true is set explicitly only for truly read-only fields.)
-          const isReadonly = entry.element.readonly === true;
-          expect(
-            isReadonly,
-            `Field ${field.columnName} must NOT be readonly (element.readonly must not be true)`
-          ).toBe(false);
-
-          console.log(`[PASS] ${field.columnName} (${field.label}) — present in layout, element.readonly=${entry.element.readonly}`);
+          // NOTE: this asserts PRESENCE/visibility only. Form-view editability (readonlyLogic) is
+          // per-record state exposed on the per-record data endpoint
+          // (/rest/api/window/{id}/{recordId} -> JSONDocumentField.readonly), NOT on the /layout
+          // endpoint — which carries no readonly flag and defaults every text element to
+          // viewEditorRenderMode='never' regardless of form editability. Rendering a record here is
+          // not possible (tab 541852 has no org-BPartner rows on the seed DB). Editability is
+          // enforced at the AD level (AD_Field.IsReadOnly='N' in migration 5809330, verified by the
+          // window-designer). This test guards that the fields are DISPLAYED in the layout.
+          console.log(`[PASS] ${field.columnName} (${field.label}) — present in window 540676 layout`);
         });
       }
 
-      console.log('[INFO] All three seller tax fields verified — present in layout and editable');
+      console.log('[INFO] All three seller tax fields verified — displayed in the window 540676 layout');
     }
   );
 });

--- a/e2e/frontend-webui/tests/spec/einvoice-seller-tax-fields.spec.js
+++ b/e2e/frontend-webui/tests/spec/einvoice-seller-tax-fields.spec.js
@@ -3,7 +3,7 @@ import { test } from '../../playwright.config';
 import { allure } from 'allure-playwright';
 import { Backend } from '../utils/Backend';
 import { FRONTEND_BASE_URL, SLOW_ACTION_TIMEOUT } from '../utils/common';
-import { assertRecordIsValid, WEBAPI_BASE_URL } from '../utils/WebAPIValidation';
+import { WEBAPI_BASE_URL } from '../utils/WebAPIValidation';
 
 /**
  * E-Invoicing — Seller tax-identification fields on Organisation Stammdaten window.
@@ -16,8 +16,17 @@ import { assertRecordIsValid, WEBAPI_BASE_URL } from '../utils/WebAPIValidation'
  *   - CommercialRegisterNumber (Handelsregisternr)      — newly added field
  *
  * Test verifies that all three fields:
- *   1. Are rendered in the detail form (visible)
- *   2. Are editable (the underlying <input> is NOT disabled/readonly)
+ *   1. Appear in the window's tab layout (visible = not excluded from layout)
+ *   2. Are editable (readonly: false in the layout)
+ *
+ * Data-independence: this test verifies the AD_Field layout via the WebAPI
+ * /rest/api/window/{windowId}/layout endpoint. Window layout is pure metadata
+ * (AD_Field/AD_UI_Element configuration) and does not depend on any C_BPartner
+ * records being present — making this test safe on a clean CI seed DB.
+ *
+ * Window 540676 has isinsertrecord=N and a WhereClause (ad_orgbp_id IS NOT NULL)
+ * that filters to org-BPartner records not present in the CI seed DB, so
+ * /window/540676/NEW and navigating to a hardcoded record ID are both non-options.
  *
  * me03 #30508
  *
@@ -30,14 +39,6 @@ import { assertRecordIsValid, WEBAPI_BASE_URL } from '../utils/WebAPIValidation'
  * AD_Tab 541852 "Geschäftspartner" — table C_BPartner (WhereClause: ad_orgbp_id is not null)
  */
 const ORG_MASTER_WINDOW_ID = 540676;
-
-/**
- * C_BPartner_ID 2155894 "Muster GmbH" — an org-BPartner record (ad_orgbp_id IS NOT NULL)
- * that already carries VATaxID and TaxID values.  CommercialRegisterNumber is empty (NULL),
- * which makes it a good test target: we can assert the field is present even when blank.
- * The record is NOT modified by this test.
- */
-const TEST_BPARTNER_ID = 2155894;
 
 /**
  * Reset the WebUI metadata cache after login.
@@ -55,16 +56,68 @@ async function resetWebuiCache(page) {
   console.log(`[INFO] Cache reset response: HTTP ${status}`);
 }
 
+/**
+ * Fetch the window layout from the WebAPI.
+ * Returns the parsed JSON layout for the window's root tab.
+ *
+ * The /window/{id}/layout endpoint is available to any authenticated session
+ * and returns field visibility/readonly metadata regardless of whether records exist.
+ */
+async function fetchWindowLayout(page, windowId) {
+  const url = `${WEBAPI_BASE_URL}/window/${windowId}/layout`;
+  console.log(`[INFO] Fetching layout from: ${url}`);
+  const resp = await page.request.get(url);
+  if (!resp.ok()) {
+    const body = await resp.text();
+    throw new Error(`Layout fetch failed: HTTP ${resp.status()} — ${body.substring(0, 300)}`);
+  }
+  return resp.json();
+}
+
+/**
+ * Collect all {element, field} pairs from a window layout JSON.
+ *
+ * Actual structure (verified against /rest/api/window/540676/layout):
+ *   sections[] → columns[] → elementGroups[] → elementsLine[] → elements[] → fields[]
+ *
+ * - Each field entry is: { field: "<ColumnName>", caption, emptyText, ... }
+ *   ("field" is the column name string, NOT an object)
+ * - Editability attributes (readonly, viewEditorRenderMode) live on the ELEMENT,
+ *   not on the field. A missing "readonly" key means editable.
+ *
+ * Returns an array of { fieldName, element } objects so callers can check
+ * both presence (fieldName in layout) and editability (element.readonly).
+ */
+function collectLayoutFields(layout) {
+  const results = [];
+  for (const section of layout.sections || []) {
+    for (const column of section.columns || []) {
+      for (const elementGroup of column.elementGroups || []) {
+        // The actual key is "elementsLine", not "elements"
+        for (const elementsLine of elementGroup.elementsLine || []) {
+          for (const element of elementsLine.elements || []) {
+            for (const field of element.fields || []) {
+              // field.field is the ColumnName string (e.g. "VATaxID")
+              results.push({ fieldName: field.field, element });
+            }
+          }
+        }
+      }
+    }
+  }
+  return results;
+}
+
 test.describe('Organisation Stammdaten — seller tax-identification fields (E-Invoicing)', () => {
   test(
-    'VATaxID, TaxID and CommercialRegisterNumber are visible and editable on Geschäftspartner tab',
+    'VATaxID, TaxID and CommercialRegisterNumber are in the window layout and editable',
     async ({ page }) => {
       // === ALLURE METADATA ===
       allure.epic('E0340: Invoicing');
       allure.feature('F00751: e-Invoicing Germany');
       allure.tag('F00751: e-Invoicing Germany');
       allure.tag('F00751');
-      allure.story('Seller tax fields visible and editable on Organisation Stammdaten window 540676');
+      allure.story('Seller tax fields in window layout on Organisation Stammdaten window 540676');
       allure.severity('critical');
       allure.tag('e-Invoicing');
       allure.tag('OrganisationStammdaten');
@@ -78,12 +131,18 @@ tab "Geschäftspartner" (AD_Tab 541852):
 - **TaxID** (Steuernummer) — newly shown
 - **CommercialRegisterNumber** (Handelsregisternr) — newly added
 
+### Test Approach — Data-Independent Layout Verification
+Window 540676 has \`isinsertrecord=N\` and a WhereClause that filters to org-BPartner
+records not present in the CI seed DB. The test therefore verifies the field layout
+via the WebAPI \`/rest/api/window/{windowId}/layout\` endpoint, which returns
+AD_Field metadata without requiring any records.
+
 ### Test Steps
 1. Create fresh test user, login
 2. Reset webui metadata cache (so new field layout is active without server restart)
-3. Navigate directly to the org-BPartner record in window 540676
-4. Assert each field container is visible in the form (.form-field-VATaxID etc.)
-5. Assert the input inside each field is enabled (NOT disabled / NOT readonly)
+3. Fetch the window layout via /rest/api/window/540676/layout
+4. Assert each field is present in the layout (not excluded from the tab)
+5. Assert each field has readonly: false (editable)
       `);
 
       test.setTimeout(120000); // 2 minutes
@@ -127,87 +186,59 @@ tab "Geschäftspartner" (AD_Tab 541852):
       // Must be done after login (endpoint requires authentication).
       await resetWebuiCache(page);
 
-      // === STEP 4: Navigate directly to the org-BPartner record in window 540676 ===
-      // Window 540676 "Organisation Stammdaten" — the Geschäftspartner tab (541852)
-      // shows C_BPartner records where ad_orgbp_id IS NOT NULL.
-      // Record 2155894 "Muster GmbH" satisfies this condition.
-      await page.goto(`${FRONTEND_BASE_URL}/window/${ORG_MASTER_WINDOW_ID}/${TEST_BPARTNER_ID}`);
+      // === STEP 4: Fetch window layout ===
+      // The layout endpoint returns the field definitions for the tab — this is pure metadata
+      // and works regardless of whether any C_BPartner records exist in the DB.
+      const layout = await fetchWindowLayout(page, ORG_MASTER_WINDOW_ID);
 
-      // Wait for the detail view to fully load
-      await page.waitForURL(/\/window\/\d+\/\d+/, { timeout: SLOW_ACTION_TIMEOUT });
-      await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
-      await page
-        .locator('.rotating, .indicator-pending')
-        .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
-        .catch(() => {});
+      allure.attachment('Window Layout JSON', JSON.stringify(layout, null, 2), 'application/json');
+      console.log('[INFO] Window layout fetched successfully');
 
-      console.log('[INFO] Record loaded. URL:', page.url());
+      // Collect all field names from the layout structure
+      const layoutFields = collectLayoutFields(layout);
+      console.log(`[INFO] Layout contains ${layoutFields.length} field entries`);
 
-      const screenshotInitial = await page.screenshot();
-      allure.attachment('Geschaeftspartner Detail — Initial State', screenshotInitial, 'image/png');
-
-      // === STEP 5: Assert record is valid (MANDATORY guard per CLAUDE.md) ===
-      // If valid=false, any UI changes would not be saved.  We are not editing in this
-      // test, but the guard confirms the record loaded correctly.
-      await assertRecordIsValid(
-        String(ORG_MASTER_WINDOW_ID),
-        String(TEST_BPARTNER_ID),
-        'before asserting field visibility'
-      );
-      console.log('[INFO] Record is valid');
-
-      // === STEP 6: Assert all three fields are visible and editable ===
+      // === STEP 5: Assert all three fields are in the layout and editable ===
       const FIELDS = [
         {
           columnName: 'VATaxID',
           label: 'USt-IdNr / VAT identifier',
-          selector: '.form-field-VATaxID',
         },
         {
           columnName: 'TaxID',
           label: 'Steuernummer',
-          selector: '.form-field-TaxID',
         },
         {
           columnName: 'CommercialRegisterNumber',
           label: 'Handelsregisternr',
-          selector: '.form-field-CommercialRegisterNumber',
         },
       ];
 
       for (const field of FIELDS) {
-        await test.step(`Assert field ${field.columnName} (${field.label}) is visible and editable`, async () => {
-          // 1. Field container must be visible in the form
-          const fieldContainer = page.locator(field.selector);
-          await fieldContainer.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-          await expect(fieldContainer, `Field ${field.columnName} container must be visible`).toBeVisible();
+        await test.step(`Assert field ${field.columnName} (${field.label}) is in layout and editable`, async () => {
+          // Find the field in the layout by column name
+          const entry = layoutFields.find((f) => f.fieldName === field.columnName);
 
-          // 2. The input inside the field must be enabled (not disabled and not readonly)
-          //    String/Text fields render as <input type="text"> inside the form-field wrapper.
-          const input = fieldContainer.locator('input').first();
-          await input.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-
-          const isDisabled = await input.isDisabled();
           expect(
-            isDisabled,
-            `Field ${field.columnName} input must NOT be disabled (field must be editable)`
-          ).toBe(false);
+            entry,
+            `Field ${field.columnName} must appear in the window 540676 layout (check AD_Field.IsDisplayed and AD_UI_Element visibility for tab 541852)`
+          ).toBeDefined();
 
-          // Also check the readonly attribute (some fields are shown but not editable)
-          const isReadonly = await input.getAttribute('readonly');
+          // Assert the field is editable.
+          // Editability is indicated by the ABSENCE of readonly:true on the element.
+          // (The layout omits the readonly key when the field is editable;
+          //  readonly:true is set explicitly only for truly read-only fields.)
+          const isReadonly = entry.element.readonly === true;
           expect(
             isReadonly,
-            `Field ${field.columnName} input must NOT have readonly attribute`
-          ).toBeNull();
+            `Field ${field.columnName} must NOT be readonly (element.readonly must not be true)`
+          ).toBe(false);
 
-          console.log(`[PASS] ${field.columnName} (${field.label}) — visible and editable`);
+          console.log(`[PASS] ${field.columnName} (${field.label}) — present in layout, element.readonly=${entry.element.readonly}`);
         });
       }
 
-      const screenshotFinal = await page.screenshot();
-      allure.attachment('Geschaeftspartner Detail — Fields Verified', screenshotFinal, 'image/png');
-
-      console.log('[INFO] All three seller tax fields verified — visible and editable');
+      console.log('[INFO] All three seller tax fields verified — present in layout and editable');
     }
   );
 });

--- a/e2e/frontend-webui/tests/spec/einvoice-seller-tax-fields.spec.js
+++ b/e2e/frontend-webui/tests/spec/einvoice-seller-tax-fields.spec.js
@@ -76,7 +76,7 @@ async function fetchWindowLayout(page, windowId) {
 }
 
 /**
- * Collect all {element, field} pairs from a window layout JSON.
+ * Collect all field (ColumnName) names from a window layout JSON.
  *
  * Actual structure (verified against /rest/api/window/540676/layout):
  *   sections[] → columns[] → elementGroups[] → elementsLine[] → elements[] → fields[]
@@ -87,11 +87,11 @@ async function fetchWindowLayout(page, windowId) {
  *   and "viewEditorRenderMode" defaults to 'never' for every text element regardless of form
  *   editability. Form-view editability lives on the per-record data endpoint, not here.
  *
- * Returns an array of { fieldName, element } objects so callers can check
- * presence (fieldName in layout).
+ * Returns an array of the ColumnName strings present in the layout, so callers can
+ * check presence (a field name in the array == displayed in the tab).
  */
 function collectLayoutFields(layout) {
-  const results = [];
+  const fieldNames = [];
   for (const section of layout.sections || []) {
     for (const column of section.columns || []) {
       for (const elementGroup of column.elementGroups || []) {
@@ -100,14 +100,14 @@ function collectLayoutFields(layout) {
           for (const element of elementsLine.elements || []) {
             for (const field of element.fields || []) {
               // field.field is the ColumnName string (e.g. "VATaxID")
-              results.push({ fieldName: field.field, element });
+              fieldNames.push(field.field);
             }
           }
         }
       }
     }
   }
-  return results;
+  return fieldNames;
 }
 
 test.describe('Organisation Stammdaten — seller tax-identification fields (E-Invoicing)', () => {
@@ -221,13 +221,13 @@ by the window-designer.
 
       for (const field of FIELDS) {
         await test.step(`Assert field ${field.columnName} (${field.label}) is displayed in the window layout`, async () => {
-          // Find the field in the layout by column name
-          const entry = layoutFields.find((f) => f.fieldName === field.columnName);
+          // Presence = the column name appears among the layout's displayed fields
+          const isPresent = layoutFields.includes(field.columnName);
 
           expect(
-            entry,
+            isPresent,
             `Field ${field.columnName} must appear in the window 540676 layout (check AD_Field.IsDisplayed and AD_UI_Element visibility for tab 541852)`
-          ).toBeDefined();
+          ).toBe(true);
 
           // NOTE: this asserts PRESENCE/visibility only. Form-view editability (readonlyLogic) is
           // per-record state exposed on the per-record data endpoint


### PR DESCRIPTION
Fixes the EN 16931 CII seller/buyer identification mapping so XRechnung / ZUGFeRD invoices validate.

## Problem
Completing an e-invoice failed schematron validation with `BR-S-02, BR-CO-26, BR-DE-16` (seller VAT/tax identifier) and `PEPPOL-EN16931-R010` (buyer electronic address) — even with the master data maintained. Root cause: the CII mapper read the wrong `C_BPartner` columns.

- `C_BPartner.VATaxID` = USt-IdNr = **BT-31** (VAT identifier, scheme `VA`) — the mapper wrongly read `TaxID` here.
- `C_BPartner.TaxID` = Steuernummer = **BT-32** (tax registration, scheme `FC`) — was not mapped.

## Changes
- **Seller**: BT-31 ← `VATaxID` (scheme `VA`); BT-32 ← `TaxID` (scheme `FC`, new) — two distinct `SpecifiedTaxRegistration` entries. BT-30 ← `CommercialRegisterNumber` (unchanged).
- **Buyer**: BT-48 ← `VATaxID` (was `TaxID`).
- **Buyer electronic address (BT-49)**: now resolved via the doc-outbound recipient resolver (`DocOutboundLogMailRecipientRegistry`) — the same chain that sets `C_Doc_Outbound_Log.CurrentEMailAddress` (invoice email / bill-contact / location / BILL_TO_DEFAULT) — with `C_BPartner_Location.EMail` as fallback. The registry is constructor-injected into `CiiMapper` via `EInvoiceCiiService`.
- **Org-master window 540676 / tab 541852**: the seller tax-identification fields are now visible+editable — `TaxID` (Steuernummer) shown, `CommercialRegisterNumber` (Handelsregisternr) added; `VATaxID` (USt-IdNr) was already shown. (`CommercialRegisterNumber`/BT-30 is the BR-CO-26 fallback for a seller without a VAT-ID — BR-CO-26 is satisfied by BT-29/BT-30/BT-31, not BT-32.)

## Verification
- `CiiValidatorTest` (5/5) and `C_InvoiceEInvoiceTest` (6/6) validate **clean** against the EN 16931 + KoSIT/XRechnung schematron once the seller VAT-ID is in `VATaxID` (→ BT-31) — i.e. `BR-S-02/BR-CO-26/BR-DE-16` clear. `CiiMapperTest` updated and green (incl. the BT-49 resolver happy-path + fallback).
