### PR TITLE
Fix C_Order(Quotation) -> C_Order(SO) relation type (restore Ref_Proposal_ID linkage)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809340_sys_Fix_C_Order_Quotation_to_SO_RelationType.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809340_sys_Fix_C_Order_Quotation_to_SO_RelationType.sql
@@ -1,0 +1,20 @@
+-- Fix the "C_Order(Quotation) -> C_Order(SO)" relation type (AD_RelationType 540260,
+-- target reference AD_Reference 541184): from a quotation/proposal, "Related Documents"
+-- must list the sales order(s) created from it, NOT the quotation itself.
+--
+-- Regression history:
+--   * gh9969  (5567990, 2020-09) created the relation with the CORRECT where-clause
+--             ( o.Ref_Proposal_ID = @C_Order_ID@ ): the created order points back to the
+--             quotation via Ref_Proposal_ID.
+--   * gh10718 (5580630, 2021-03) — an UNRELATED "Frame Agreement / Order Call doctypes"
+--             migration — collaterally overwrote it to a self/same-BPartner match
+--             ( o.C_DocType_ID=<x> AND C_Order.C_Order_ID = o.C_Order_ID AND @C_BPartner_ID@=o.C_BPartner_ID ).
+--   * gh11822 (5610770, 2021-11) changed the hard-coded doctype but kept the broken
+--             self/same-BPartner structure.
+-- Result since 2021: the relation lists the customer's other quotations (incl. the record
+-- itself) instead of the created order. The reverse direction (541185, SO -> Quotation,
+-- via Ref_Proposal_ID) was never touched and is correct; the SO<->PO relations are correct.
+-- This change restores ONLY 541184 to gh9969's linkage clause; no other relation is touched.
+
+UPDATE AD_Ref_Table SET WhereClause='exists ( select 1 from C_Order o where o.Ref_Proposal_ID=@C_Order_ID/-1@ and C_Order.C_Order_ID = o.C_Order_ID)',Updated=TO_TIMESTAMP('2026-06-23 10:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Reference_ID=541184
+;


### PR DESCRIPTION
## Problem

The relation type **`C_Order(Quotation) -> C_Order(SO)`** (`AD_RelationType` 540260, target reference `AD_Reference` 541184) is broken: from a quotation/proposal, the "Related Documents" side-list shows the customer's other quotations (and the record itself) instead of the **sales order created from the quotation**.

Current (broken) where-clause on ref 541184:
```sql
exists ( select 1 from C_Order o where o.C_DocType_ID=1000027
         and C_Order.C_Order_ID = o.C_Order_ID
         and @C_BPartner_ID/-1@=o.C_BPartner_ID )
```
`C_Order.C_Order_ID = o.C_Order_ID` makes it a self/same-BPartner match — it never follows the quotation→order link.

## Root cause

- `#gh9969` (migration `5567990`, 2020-09) created the relation with the **correct** clause (`o.Ref_Proposal_ID = @C_Order_ID@`).
- https://github.com/metasfresh/metasfresh/commit/53e03500dec29b05184b10f645066a25682add08 (`#gh10718`, migration `5580630`, 2021-03) — an **unrelated** "Frame Agreement / Order Call doctypes" change — collaterally overwrote ref 541184 with the self/same-BPartner clause.
- https://github.com/metasfresh/metasfresh/commit/6ffe72587c2a44c7fe7c64cdd4662b96f721b39c (`#gh11822`, migration `5610770`, 2021-11, https://github.com/metasfresh/metasfresh/issues/11822) changed the hard-coded doctype but kept the broken structure.

## Fix

Restore ref 541184 to the gh9969 linkage clause (the order created from the quotation points back via `Ref_Proposal_ID`):
```sql
exists ( select 1 from C_Order o where o.Ref_Proposal_ID=@C_Order_ID/-1@
         and C_Order.C_Order_ID = o.C_Order_ID )
```
One migration, one `AD_Ref_Table` row. **No other relation is touched** — verified the reverse direction `C_Order(SO) -> C_Order(Quotation)` (541185) and the SO↔PO relations (counter docs, `Link_Order_ID`/`C_PO_OrderLine_Alloc`, and `C_PurchaseCandidate` planning) are all already correct and keep working.

## Verification

Logic-proof against a `Q=quotation, O=order-created-from-Q (Ref_Proposal_ID=Q), X=other quotation same BPartner` set:
- restored clause, viewing Q → returns **only O** (the created order) ✓
- old clause, viewing Q → returns Q (self) + X ✗

Migration applies cleanly and updates exactly 1 row (ref 541184).
