### PR TITLE
MobileUI E2E: assert camera-mode-active via panel wrapper, not transient <video>

### DIFF
--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -68,7 +68,7 @@
 | ❌ Mode B — Camera (ZXing/BrowserMultiFormatReader): getUserMedia() decode → barcode forwarded | — (not testable in CI, requires real camera) |
 | ❌ `scanDuplicatesIntervalMillis` — duplicate barcode within interval suppressed, outside interval forwarded | — |
 | ❌ `triggerOnChangeIfLengthGreaterThan` — onChange fires only once input length exceeds threshold | — |
-| Footer — hardware/camera toggle: renders only when both hw + camera enabled; clicking toggle switches to camera mode and renders `<video>` (feed validation requires physical hardware) | `barcode_scanner_modes.spec.js` |
+| Footer — hardware/camera toggle: renders only when both hw + camera enabled; clicking toggle switches to camera mode (camera panel shown; live `<video>` feed validation requires physical hardware) | `barcode_scanner_modes.spec.js` |
 | ❌ Footer — "Enter manually": shows only when manual mode enabled and activeMode ≠ MANUAL; clicking sets activeMode to MANUAL | — |
 | ❌ Footer — "Back to scanner": shows when activeMode=MANUAL and at least one of hw/camera enabled; clicking returns to HARDWARE (or CAMERA if only camera enabled) | — |
 

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -140,7 +140,7 @@ test('Honeywell CT60 keystroke-wedge mode — input is off-screen + readOnly, no
 
     await BarcodeScannerComponent.expectAttributes({ type: 'text', inputmode: 'none', readonly: true });
     await BarcodeScannerComponent.expectCssClass({ present: 'input-text-offscreen' });
-    await BarcodeScannerComponent.expectCameraVideoAbsent();
+    await BarcodeScannerComponent.expectCameraModeInactive();
 });
 
 // Each test drives one real-world way a barcode reaches the app, end to end:
@@ -330,7 +330,7 @@ test.describe('Modes', () => {
         // readonly PRESENT — hard suppression for Android 11 firmware that ignores inputMode="none".
         await BarcodeScannerComponent.expectAttributes({ type: 'text', inputmode: 'none', readonly: true });
         await BarcodeScannerComponent.expectCssClass({ present: 'input-text-offscreen' });
-        await BarcodeScannerComponent.expectCameraVideoAbsent();
+        await BarcodeScannerComponent.expectCameraModeInactive();
     });
 
     // invisible=true (ApplicationsListScreen / BarcodeScannerButton callers):
@@ -353,7 +353,7 @@ test.describe('Modes', () => {
         // invisible=true → useBarcodeScannerModes returns hardware-only, no camera, no manual.
         // The component renders ONLY the off-screen #input-text and the keyboard listener.
         await BarcodeScannerComponent.expectAttached({});
-        await BarcodeScannerComponent.expectCameraVideoAbsent();
+        await BarcodeScannerComponent.expectCameraModeInactive();
         await BarcodeScannerComponent.expectFooterAbsent();
     });
 
@@ -390,7 +390,7 @@ test.describe('Modes', () => {
         await BarcodeScannerComponent.expectManualEntryInputPresent();
         // The manual-entry input must NOT be readOnly — the user must be able to type.
         await BarcodeScannerComponent.expectManualEntryInputNotReadOnly();
-        await BarcodeScannerComponent.expectCameraVideoAbsent();
+        await BarcodeScannerComponent.expectCameraModeInactive();
         // Hardware scanner is enabled → manual mode offers the "Use hardware scanner" button
         // (testId barcode-scanner-back-to-scanner) so the operator can return to the scanner.
         await BarcodeScannerComponent.expectButtonPresent('barcode-scanner-back-to-scanner');
@@ -398,9 +398,9 @@ test.describe('Modes', () => {
 
     // camera toggle: hardware + camera both enabled →
     //   • footer toggle button present
-    //   • clicking toggle → <video> renders
+    //   • clicking toggle → camera mode becomes active (camera panel shown)
     // noinspection JSUnusedLocalSymbols
-    test('camera toggle — clicking hw/camera toggle renders <video>', async ({ page }) => {
+    test('camera toggle — clicking hw/camera toggle activates camera mode', async ({ page }) => {
         await allure.epic('E0295: Frontend MobileUI');
         await allure.feature('F12000: Frontend MobileUI');
         await allure.story('Barcode scanning modes');
@@ -419,12 +419,12 @@ test.describe('Modes', () => {
         await ApplicationsListScreen.startApplication('huManager');
         await HUManagerScreen.waitForScreen();
 
-        // Starting in hardware mode — no video yet.
-        await BarcodeScannerComponent.expectCameraVideoAbsent();
+        // Starting in hardware mode — camera mode not active.
+        await BarcodeScannerComponent.expectCameraModeInactive();
         // Toggle to camera mode via footer button.
         await BarcodeScannerComponent.clickFooterButton('barcode-scanner-toggle-hw-camera');
-        // After toggle, <video> element must be rendered.
-        await BarcodeScannerComponent.expectCameraVideoPresent();
+        // After toggle, camera mode must be active (the camera panel is shown).
+        await BarcodeScannerComponent.expectCameraModeActive();
     });
 
     // THE canonical hardware-handheld deployment: hardware scanner is the default, manual typing is
@@ -456,7 +456,7 @@ test.describe('Modes', () => {
 
         // Boots in hardware mode: off-screen scan input present, device camera absent.
         await BarcodeScannerComponent.expectAttached({});
-        await BarcodeScannerComponent.expectCameraVideoAbsent();
+        await BarcodeScannerComponent.expectCameraModeInactive();
 
         // Footer contract for this deployment: manual-entry fallback shown, camera toggle hidden
         // (camera toggle needs BOTH hardware and camera enabled).

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -173,13 +173,11 @@ export const BarcodeScannerComponent = {
         }
     }),
 
-    // Asserts the device camera <video> element is NOT rendered inside .barcode-scanner.
-    // Used by the hardware-scanner-only deployments (useCamera=N) to guard against a
-    // regression that would silently re-enable the camera capture preview.
-    //
-    // Asserts camera mode is NOT active (the CameraModePanel wrapper is not mounted).
-    // We assert on the always-mounted wrapper `.camera-mode-panel` (rendered iff activeMode===CAMERA)
-    // rather than the inner <video> — see expectCameraModeActive for why the <video> is unreliable.
+    // Asserts camera mode is NOT active — the CameraModePanel wrapper (`.camera-mode-panel`,
+    // rendered iff activeMode===CAMERA) is not mounted. Used by hardware-scanner-only deployments
+    // (camera disabled) to guard against a regression that would silently re-enable camera capture.
+    // We assert on the always-mounted wrapper rather than the inner <video> — see
+    // expectCameraModeActive for why the <video> is unreliable.
     // Uses FAST_ACTION_TIMEOUT (5s): absence-of-element assertions should fail fast — falling back
     // to the 120s global assertion timeout would silently consume the test budget on a genuine regression.
     expectCameraModeInactive: async () => await test.step(`${NAME} - Expect camera mode not active`, async () => {

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -177,12 +177,13 @@ export const BarcodeScannerComponent = {
     // Used by the hardware-scanner-only deployments (useCamera=N) to guard against a
     // regression that would silently re-enable the camera capture preview.
     //
-    // Uses FAST_ACTION_TIMEOUT (5s): absence-of-element assertions should fail fast — a
-    // <video> that doesn't appear within seconds is not going to appear, and falling back
-    // to the 120s global assertion timeout would silently consume the test budget on a
-    // genuine regression.
-    expectCameraVideoAbsent: async () => await test.step(`${NAME} - Expect no camera <video> rendered`, async () => {
-        await expect(page.locator('.barcode-scanner video')).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
+    // Asserts camera mode is NOT active (the CameraModePanel wrapper is not mounted).
+    // We assert on the always-mounted wrapper `.camera-mode-panel` (rendered iff activeMode===CAMERA)
+    // rather than the inner <video> — see expectCameraModeActive for why the <video> is unreliable.
+    // Uses FAST_ACTION_TIMEOUT (5s): absence-of-element assertions should fail fast — falling back
+    // to the 120s global assertion timeout would silently consume the test budget on a genuine regression.
+    expectCameraModeInactive: async () => await test.step(`${NAME} - Expect camera mode not active`, async () => {
+        await expect(page.locator('.camera-mode-panel')).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
     }),
 
     // Simulates Ctrl+V paste: mocks navigator.clipboard.readText to return the barcode,
@@ -229,9 +230,17 @@ export const BarcodeScannerComponent = {
         await expect(page.getByTestId('manual-entry-input')).not.toHaveAttribute('readonly', { timeout: SLOW_ACTION_TIMEOUT });
     }),
 
-    // Asserts the device camera <video> element IS rendered inside .barcode-scanner.
-    expectCameraVideoPresent: async () => await test.step(`${NAME} - Expect camera <video> rendered`, async () => {
-        await expect(page.locator('.barcode-scanner video')).toHaveCount(1, { timeout: SLOW_ACTION_TIMEOUT });
+    // Asserts camera mode IS active by checking the always-mounted CameraModePanel wrapper
+    // (`.camera-mode-panel`, rendered iff activeMode===CAMERA).
+    // NOT the inner <video>: CameraModePanel renders the <video> only `{!isProcessing && <video/>}`,
+    // so it unmounts whenever a barcode is processed. In CI the synthetic fake-media stream
+    // (--use-fake-device-for-media-stream) can make ZXing false-positive a 1-D barcode → isProcessing
+    // flips → the <video> unmounts mid-assertion (and a getUserMedia error tears the panel down via
+    // onCancel). Asserting on the stable wrapper verifies the toggle switched into camera mode without
+    // depending on a transient, hardware-feed-dependent element. Real video-feed validation needs
+    // physical camera hardware and cannot be deterministic in CI.
+    expectCameraModeActive: async () => await test.step(`${NAME} - Expect camera mode active`, async () => {
+        await expect(page.locator('.camera-mode-panel')).toHaveCount(1, { timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     // Clicks a footer button by its testId (e.g. 'barcode-scanner-toggle-hw-camera',


### PR DESCRIPTION
## What

Harden the camera-toggle E2E spec (`barcode_scanner_modes.spec.js`) against an intermittent `mobile test` failure.

The spec asserted `toHaveCount(1)` on `.barcode-scanner video`. But `CameraModePanel` renders the `<video>` only `{!isProcessing && <video/>}`, so it unmounts whenever a barcode is processed. In CI the synthetic fake-media stream (`--use-fake-device-for-media-stream`) can make ZXing false-positive a 1-D barcode → `isProcessing` flips → the `<video>` unmounts mid-assertion (and a `getUserMedia` error tears the panel down via `onCancel`). With `retries: 2`, this loses all attempts in unlucky runs → flaky red `mobile test`.

## Change

- Assert the always-mounted wrapper `.camera-mode-panel` (rendered iff `activeMode === CAMERA`) — the race-free signal that the toggle switched into camera mode — instead of the transient `<video>`.
- Rename `expectCameraVideoPresent` / `expectCameraVideoAbsent` → `expectCameraModeActive` / `expectCameraModeInactive` and update call sites + the spec title/comments + the coverage note.

Test-only; no app behaviour change. Live video-feed rendering still cannot be validated in CI (needs physical camera hardware) — that is unchanged and documented in the assertion comment.
