### PR TITLE
Lot number: generic DB-function sequence provider + S_Resource.LotNumberCode

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_S_Resource.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_S_Resource.java
@@ -1,9 +1,8 @@
 package org.compiere.model;
 
-import org.adempiere.model.ModelColumn;
-
-import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import javax.annotation.Nullable;
+import org.adempiere.model.ModelColumn;
 
 /** Generated Interface for S_Resource
  *  @author metasfresh (generated) 
@@ -73,31 +72,6 @@ public interface I_S_Resource
 	int getAD_User_ID();
 
 	String COLUMNNAME_AD_User_ID = "AD_User_ID";
-
-	/**
-	 * Set Workplace.
-	 *
-	 * <br>Type: Search
-	 * <br>Mandatory: false
-	 * <br>Virtual Column: false
-	 */
-	void setC_Workplace_ID (int C_Workplace_ID);
-
-	/**
-	 * Get Workplace.
-	 *
-	 * <br>Type: Search
-	 * <br>Mandatory: false
-	 * <br>Virtual Column: false
-	 */
-	int getC_Workplace_ID();
-
-	@Nullable org.compiere.model.I_C_Workplace getC_Workplace();
-
-	void setC_Workplace(@Nullable org.compiere.model.I_C_Workplace C_Workplace);
-
-	ModelColumn<I_S_Resource, org.compiere.model.I_C_Workplace> COLUMN_C_Workplace_ID = new ModelColumn<>(I_S_Resource.class, "C_Workplace_ID", org.compiere.model.I_C_Workplace.class);
-	String COLUMNNAME_C_Workplace_ID = "C_Workplace_ID";
 
 	/**
 	 * Set Capacity Per Production Cycle.
@@ -185,6 +159,33 @@ public interface I_S_Resource
 	int getCreatedBy();
 
 	String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/**
+	 * Set Workplace.
+	 * Logical area within a warehouse, to which one or more Workstations can be assigned. An operator logs into exactly one Workplace per shift. The associated warehouse (M_Warehouse_ID) drives the storage location of the work performed there.
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setC_Workplace_ID (int C_Workplace_ID);
+
+	/**
+	 * Get Workplace.
+	 * Logical area within a warehouse, to which one or more Workstations can be assigned. An operator logs into exactly one Workplace per shift. The associated warehouse (M_Warehouse_ID) drives the storage location of the work performed there.
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getC_Workplace_ID();
+
+	@Nullable org.compiere.model.I_C_Workplace getC_Workplace();
+
+	void setC_Workplace(@Nullable org.compiere.model.I_C_Workplace C_Workplace);
+
+	ModelColumn<I_S_Resource, org.compiere.model.I_C_Workplace> COLUMN_C_Workplace_ID = new ModelColumn<>(I_S_Resource.class, "C_Workplace_ID", org.compiere.model.I_C_Workplace.class);
+	String COLUMNNAME_C_Workplace_ID = "C_Workplace_ID";
 
 	/**
 	 * Set Daily Capacity.
@@ -297,6 +298,7 @@ public interface I_S_Resource
 
 	/**
 	 * Set Manufacturing Resource.
+	 * Marks the resource as relevant for manufacturing. Only S_Resource records flagged accordingly appear in the manufacturing module's selection lists and can be scanned as a Workstation in MobileUI.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: false
@@ -306,6 +308,7 @@ public interface I_S_Resource
 
 	/**
 	 * Get Manufacturing Resource.
+	 * Marks the resource as relevant for manufacturing. Only S_Resource records flagged accordingly appear in the manufacturing module's selection lists and can be scanned as a Workstation in MobileUI.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: false
@@ -317,7 +320,29 @@ public interface I_S_Resource
 	String COLUMNNAME_IsManufacturingResource = "IsManufacturingResource";
 
 	/**
+	 * Set Lot Number Code.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setLotNumberCode (@Nullable java.lang.String LotNumberCode);
+
+	/**
+	 * Get Lot Number Code.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	@Nullable java.lang.String getLotNumberCode();
+
+	ModelColumn<I_S_Resource, Object> COLUMN_LotNumberCode = new ModelColumn<>(I_S_Resource.class, "LotNumberCode", null);
+	String COLUMNNAME_LotNumberCode = "LotNumberCode";
+
+	/**
 	 * Set Manufacturing Resource Type.
+	 * Type of manufacturing resource: Workstation (physical scannable device), Work Center (aggregate within a Plant), Plant (manufacturing site), Production Line, or External System.
 	 *
 	 * <br>Type: List
 	 * <br>Mandatory: false
@@ -327,6 +352,7 @@ public interface I_S_Resource
 
 	/**
 	 * Get Manufacturing Resource Type.
+	 * Type of manufacturing resource: Workstation (physical scannable device), Work Center (aggregate within a Plant), Plant (manufacturing site), Production Line, or External System.
 	 *
 	 * <br>Type: List
 	 * <br>Mandatory: false

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_S_Resource.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_S_Resource.java
@@ -1,10 +1,10 @@
 // Generated Model - DO NOT CHANGE
 package org.compiere.model;
 
-import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
+import javax.annotation.Nullable;
 
 /** Generated Model for S_Resource
  *  @author metasfresh (generated) 
@@ -13,7 +13,7 @@ import java.util.Properties;
 public class X_S_Resource extends org.compiere.model.PO implements I_S_Resource, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 664197132L;
+	private static final long serialVersionUID = 2055189460L;
 
     /** Standard Constructor */
     public X_S_Resource (final Properties ctx, final int S_Resource_ID, @Nullable final String trxName)
@@ -48,33 +48,6 @@ public class X_S_Resource extends org.compiere.model.PO implements I_S_Resource,
 	public int getAD_User_ID() 
 	{
 		return get_ValueAsInt(COLUMNNAME_AD_User_ID);
-	}
-
-	@Override
-	public org.compiere.model.I_C_Workplace getC_Workplace()
-	{
-		return get_ValueAsPO(COLUMNNAME_C_Workplace_ID, org.compiere.model.I_C_Workplace.class);
-	}
-
-	@Override
-	public void setC_Workplace(final org.compiere.model.I_C_Workplace C_Workplace)
-	{
-		set_ValueFromPO(COLUMNNAME_C_Workplace_ID, org.compiere.model.I_C_Workplace.class, C_Workplace);
-	}
-
-	@Override
-	public void setC_Workplace_ID (final int C_Workplace_ID)
-	{
-		if (C_Workplace_ID < 1) 
-			set_Value (COLUMNNAME_C_Workplace_ID, null);
-		else 
-			set_Value (COLUMNNAME_C_Workplace_ID, C_Workplace_ID);
-	}
-
-	@Override
-	public int getC_Workplace_ID() 
-	{
-		return get_ValueAsInt(COLUMNNAME_C_Workplace_ID);
 	}
 
 	@Override
@@ -116,6 +89,33 @@ public class X_S_Resource extends org.compiere.model.PO implements I_S_Resource,
 	{
 		final BigDecimal bd = get_ValueAsBigDecimal(COLUMNNAME_ChargeableQty);
 		return bd != null ? bd : BigDecimal.ZERO;
+	}
+
+	@Override
+	public org.compiere.model.I_C_Workplace getC_Workplace()
+	{
+		return get_ValueAsPO(COLUMNNAME_C_Workplace_ID, org.compiere.model.I_C_Workplace.class);
+	}
+
+	@Override
+	public void setC_Workplace(final org.compiere.model.I_C_Workplace C_Workplace)
+	{
+		set_ValueFromPO(COLUMNNAME_C_Workplace_ID, org.compiere.model.I_C_Workplace.class, C_Workplace);
+	}
+
+	@Override
+	public void setC_Workplace_ID (final int C_Workplace_ID)
+	{
+		if (C_Workplace_ID < 1) 
+			set_Value (COLUMNNAME_C_Workplace_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_Workplace_ID, C_Workplace_ID);
+	}
+
+	@Override
+	public int getC_Workplace_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_C_Workplace_ID);
 	}
 
 	@Override
@@ -180,6 +180,18 @@ public class X_S_Resource extends org.compiere.model.PO implements I_S_Resource,
 	public boolean isManufacturingResource() 
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsManufacturingResource);
+	}
+
+	@Override
+	public void setLotNumberCode (final @Nullable java.lang.String LotNumberCode)
+	{
+		set_Value (COLUMNNAME_LotNumberCode, LotNumberCode);
+	}
+
+	@Override
+	public java.lang.String getLotNumberCode() 
+	{
+		return get_ValueAsString(COLUMNNAME_LotNumberCode);
 	}
 
 	/** 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/sequenceno/DBFunctionSequenceNoProvider.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/sequenceno/DBFunctionSequenceNoProvider.java
@@ -1,0 +1,117 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.document.sequenceno;
+
+import de.metas.common.util.time.SystemTime;
+import de.metas.document.DocumentSequenceInfo;
+import de.metas.util.Check;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.service.ISysConfigBL;
+import org.compiere.util.DB;
+import org.compiere.util.Evaluatee;
+import org.compiere.util.Trx;
+
+import javax.annotation.Nullable;
+import java.sql.Timestamp;
+import java.util.regex.Pattern;
+
+/**
+ * Generic {@link CustomSequenceNoProvider} that delegates the whole sequence-number string to a PL/pgSQL function.
+ * <p>
+ * The function name is configured <b>per sequence</b> via the SysConfig
+ * {@code de.metas.document.seqNo.DBFunctionSequenceNoProvider.<AD_Sequence.Name>.dbFunctionName},
+ * so several sequences can each name their own function with no code change. The function is called as
+ * {@code SELECT <fn>(Record_ID, generated_at)} and its result is returned verbatim as the full sequence string
+ * ({@link #isUseIncrementSeqNoAsPrefix()} is {@code false}, so no incremental counter is appended).
+ * <p>
+ * The {@code Record_ID} comes from the evaluation context (the caller puts the driving record's id there);
+ * {@code generated_at} is the generation timestamp (now).
+ */
+public class DBFunctionSequenceNoProvider implements CustomSequenceNoProvider
+{
+	// Per-sequence key: de.metas.document.seqNo.DBFunctionSequenceNoProvider.<AD_Sequence.Name>.dbFunctionName
+	private static final String SYSCONFIG_PREFIX = "de.metas.document.seqNo.DBFunctionSequenceNoProvider.";
+	private static final String SYSCONFIG_SUFFIX = ".dbFunctionName";
+
+	static final String PARAM_Record_ID = "Record_ID";
+
+	// The function name is concatenated into SQL (an identifier can't be a bind parameter), so it must be a plain
+	// SQL identifier - guards against a malformed / injected SysConfig value.
+	private static final Pattern FUNCTION_NAME_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+
+	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+
+	private static String sysConfigKey(@NonNull final DocumentSequenceInfo docSeqInfo)
+	{
+		return SYSCONFIG_PREFIX + docSeqInfo.getName() + SYSCONFIG_SUFFIX;
+	}
+
+	/**
+	 * Applicable when this sequence has a (per-sequence) function-name SysConfig set and the context carries a
+	 * positive {@code Record_ID}. We deliberately do NOT check here that the function actually exists: a
+	 * misconfigured function name must fail <b>loud</b> in {@link #provideSequenceNo} (so the wrong lot number is
+	 * never silently replaced by a plain incremental one), not silently disable the provider.
+	 */
+	@Override
+	public boolean isApplicable(@NonNull final Evaluatee context, @NonNull final DocumentSequenceInfo docSeqInfo)
+	{
+		final String functionName = sysConfigBL.getValue(sysConfigKey(docSeqInfo), (String)null);
+		if (Check.isBlank(functionName))
+		{
+			return false;
+		}
+		return context.get_ValueAsInt(PARAM_Record_ID, -1) > 0;
+	}
+
+	@Override
+	public String provideSequenceNo(
+			@NonNull final Evaluatee context,
+			@NonNull final DocumentSequenceInfo docSeqInfo,
+			@Nullable final String autoIncrementedSeqNumber)
+	{
+		final String sysConfigKey = sysConfigKey(docSeqInfo);
+		final String functionName = sysConfigBL.getValue(sysConfigKey, (String)null);
+		Check.assumeNotEmpty(functionName, "{} sysconfig must be set", sysConfigKey);
+
+		final String functionNameNorm = functionName.trim();
+		Check.assume(FUNCTION_NAME_PATTERN.matcher(functionNameNorm).matches(),
+				"{}={} must be a plain SQL function identifier", sysConfigKey, functionName);
+
+		final int recordId = context.get_ValueAsInt(PARAM_Record_ID, -1);
+		Check.assume(recordId > 0, "context must carry a positive {}", PARAM_Record_ID);
+
+		final Timestamp generatedAt = Timestamp.from(SystemTime.asInstant());
+		final String result = DB.getSQLValueStringEx(Trx.TRXNAME_None,
+				"SELECT " + functionNameNorm + "(?, ?)", recordId, generatedAt);
+		Check.assumeNotEmpty(result, "DB function {} returned empty for {}={}", functionNameNorm, PARAM_Record_ID, recordId);
+		return result;
+	}
+
+	/** Standalone number - no auto-incremented counter is appended (same day+shift+line legitimately share one number). */
+	@Override
+	public boolean isUseIncrementSeqNoAsPrefix()
+	{
+		return false;
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/sequenceno/DBFunctionSequenceNoProvider.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/sequenceno/DBFunctionSequenceNoProvider.java
@@ -22,19 +22,26 @@
 
 package de.metas.document.sequenceno;
 
+import ch.qos.logback.classic.Level;
 import de.metas.adempiere.model.IPOReferenceAware;
 import de.metas.common.util.time.SystemTime;
 import de.metas.document.DocumentSequenceInfo;
+import de.metas.logging.LogManager;
 import de.metas.util.Check;
+import de.metas.util.ILoggable;
+import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.service.ISysConfigBL;
 import org.compiere.util.DB;
 import org.compiere.util.Evaluatee;
+import org.compiere.util.SQLValueStringResult;
+import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 import java.sql.Timestamp;
+import java.util.List;
 import java.util.regex.Pattern;
 
 /**
@@ -51,6 +58,8 @@ import java.util.regex.Pattern;
  */
 public class DBFunctionSequenceNoProvider implements CustomSequenceNoProvider
 {
+	private static final Logger logger = LogManager.getLogger(DBFunctionSequenceNoProvider.class);
+
 	// Per-sequence key: de.metas.document.seqNo.DBFunctionSequenceNoProvider.<AD_Sequence.Name>.dbFunctionName
 	private static final String SYSCONFIG_PREFIX = "de.metas.document.seqNo.DBFunctionSequenceNoProvider.";
 	private static final String SYSCONFIG_SUFFIX = ".dbFunctionName";
@@ -108,8 +117,19 @@ public class DBFunctionSequenceNoProvider implements CustomSequenceNoProvider
 		Check.assume(recordId > 0, "context must carry a positive {}", IPOReferenceAware.COLUMNNAME_Record_ID);
 
 		final Timestamp generatedAt = Timestamp.from(SystemTime.asInstant());
-		final String result = DB.getSQLValueStringEx(ITrx.TRXNAME_None,
+		final SQLValueStringResult sqlResult = DB.getSQLValueStringWithWarningEx(ITrx.TRXNAME_None,
 				"SELECT " + functionNameNorm + "(?, ?)", recordId, generatedAt);
+
+		// Surface any RAISE NOTICE the DB function emitted (PostgreSQL delivers them as JDBC SQLWarnings) to the
+		// ambient Loggable, so they are visible when debugging - the same notice output SQL-type AD_Processes log.
+		final List<String> noticeMessages = sqlResult.getWarningMessages();
+		if (noticeMessages != null && !noticeMessages.isEmpty())
+		{
+			final ILoggable loggable = Loggables.withLogger(logger, Level.DEBUG);
+			noticeMessages.forEach(noticeMessage -> loggable.addLog("{}", noticeMessage));
+		}
+
+		final String result = sqlResult.getReturnedValue();
 		Check.assumeNotEmpty(result, "DB function {} returned empty for {}={}",
 				functionNameNorm, IPOReferenceAware.COLUMNNAME_Record_ID, recordId);
 		return result;

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/sequenceno/DBFunctionSequenceNoProvider.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/sequenceno/DBFunctionSequenceNoProvider.java
@@ -22,15 +22,16 @@
 
 package de.metas.document.sequenceno;
 
+import de.metas.adempiere.model.IPOReferenceAware;
 import de.metas.common.util.time.SystemTime;
 import de.metas.document.DocumentSequenceInfo;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.service.ISysConfigBL;
 import org.compiere.util.DB;
 import org.compiere.util.Evaluatee;
-import org.compiere.util.Trx;
 
 import javax.annotation.Nullable;
 import java.sql.Timestamp;
@@ -54,17 +55,22 @@ public class DBFunctionSequenceNoProvider implements CustomSequenceNoProvider
 	private static final String SYSCONFIG_PREFIX = "de.metas.document.seqNo.DBFunctionSequenceNoProvider.";
 	private static final String SYSCONFIG_SUFFIX = ".dbFunctionName";
 
-	static final String PARAM_Record_ID = "Record_ID";
-
-	// The function name is concatenated into SQL (an identifier can't be a bind parameter), so it must be a plain
-	// SQL identifier - guards against a malformed / injected SysConfig value.
-	private static final Pattern FUNCTION_NAME_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+	// The function name is concatenated into SQL (an identifier can't be a bind parameter), so it must be a plain,
+	// optionally single-schema-qualified SQL identifier (e.g. fn_x or sp80.fn_x) - guards against a malformed /
+	// injected SysConfig value. Pattern.matches() anchors the whole string.
+	private static final Pattern FUNCTION_NAME_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)?");
 
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 
 	private static String sysConfigKey(@NonNull final DocumentSequenceInfo docSeqInfo)
 	{
 		return SYSCONFIG_PREFIX + docSeqInfo.getName() + SYSCONFIG_SUFFIX;
+	}
+
+	/** @return {@code true} if the (trimmed) function name is a plain or single-schema-qualified SQL identifier. */
+	static boolean isValidFunctionName(@Nullable final String functionName)
+	{
+		return functionName != null && FUNCTION_NAME_PATTERN.matcher(functionName.trim()).matches();
 	}
 
 	/**
@@ -81,7 +87,7 @@ public class DBFunctionSequenceNoProvider implements CustomSequenceNoProvider
 		{
 			return false;
 		}
-		return context.get_ValueAsInt(PARAM_Record_ID, -1) > 0;
+		return context.get_ValueAsInt(IPOReferenceAware.COLUMNNAME_Record_ID, -1) > 0;
 	}
 
 	@Override
@@ -94,17 +100,18 @@ public class DBFunctionSequenceNoProvider implements CustomSequenceNoProvider
 		final String functionName = sysConfigBL.getValue(sysConfigKey, (String)null);
 		Check.assumeNotEmpty(functionName, "{} sysconfig must be set", sysConfigKey);
 
+		Check.assume(isValidFunctionName(functionName),
+				"{}={} must be a plain or single-schema-qualified SQL function identifier", sysConfigKey, functionName);
 		final String functionNameNorm = functionName.trim();
-		Check.assume(FUNCTION_NAME_PATTERN.matcher(functionNameNorm).matches(),
-				"{}={} must be a plain SQL function identifier", sysConfigKey, functionName);
 
-		final int recordId = context.get_ValueAsInt(PARAM_Record_ID, -1);
-		Check.assume(recordId > 0, "context must carry a positive {}", PARAM_Record_ID);
+		final int recordId = context.get_ValueAsInt(IPOReferenceAware.COLUMNNAME_Record_ID, -1);
+		Check.assume(recordId > 0, "context must carry a positive {}", IPOReferenceAware.COLUMNNAME_Record_ID);
 
 		final Timestamp generatedAt = Timestamp.from(SystemTime.asInstant());
-		final String result = DB.getSQLValueStringEx(Trx.TRXNAME_None,
+		final String result = DB.getSQLValueStringEx(ITrx.TRXNAME_None,
 				"SELECT " + functionNameNorm + "(?, ?)", recordId, generatedAt);
-		Check.assumeNotEmpty(result, "DB function {} returned empty for {}={}", functionNameNorm, PARAM_Record_ID, recordId);
+		Check.assumeNotEmpty(result, "DB function {} returned empty for {}={}",
+				functionNameNorm, IPOReferenceAware.COLUMNNAME_Record_ID, recordId);
 		return result;
 	}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/sequenceno/DBFunctionSequenceNoProvider.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/sequenceno/DBFunctionSequenceNoProvider.java
@@ -56,7 +56,7 @@ public class DBFunctionSequenceNoProvider implements CustomSequenceNoProvider
 	private static final String SYSCONFIG_SUFFIX = ".dbFunctionName";
 
 	// The function name is concatenated into SQL (an identifier can't be a bind parameter), so it must be a plain,
-	// optionally single-schema-qualified SQL identifier (e.g. fn_x or sp80.fn_x) - guards against a malformed /
+	// optionally single-schema-qualified SQL identifier (e.g. fn_x or myschema.fn_x) - guards against a malformed /
 	// injected SysConfig value. Matcher.matches() anchors the whole string.
 	private static final Pattern FUNCTION_NAME_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)?");
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/sequenceno/DBFunctionSequenceNoProvider.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/sequenceno/DBFunctionSequenceNoProvider.java
@@ -57,7 +57,7 @@ public class DBFunctionSequenceNoProvider implements CustomSequenceNoProvider
 
 	// The function name is concatenated into SQL (an identifier can't be a bind parameter), so it must be a plain,
 	// optionally single-schema-qualified SQL identifier (e.g. fn_x or sp80.fn_x) - guards against a malformed /
-	// injected SysConfig value. Pattern.matches() anchors the whole string.
+	// injected SysConfig value. Matcher.matches() anchors the whole string.
 	private static final Pattern FUNCTION_NAME_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)?");
 
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/document/sequenceno/DBFunctionSequenceNoProviderTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/document/sequenceno/DBFunctionSequenceNoProviderTest.java
@@ -104,8 +104,8 @@ class DBFunctionSequenceNoProviderTest
 	@Test
 	void isValidFunctionName_acceptsPlainAndSchemaQualified()
 	{
-		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("fn_lotno_soft_panda")).isTrue();
-		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("sp80.fn_lotno")).isTrue();
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("fn_lotno_custom")).isTrue();
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("myschema.fn_lotno")).isTrue();
 		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("  fn_lotno  ")).isTrue(); // trimmed
 	}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/document/sequenceno/DBFunctionSequenceNoProviderTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/document/sequenceno/DBFunctionSequenceNoProviderTest.java
@@ -1,0 +1,102 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.document.sequenceno;
+
+import de.metas.document.DocumentSequenceInfo;
+import de.metas.util.Services;
+import org.adempiere.service.ISysConfigBL;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.util.Evaluatee;
+import org.compiere.util.Evaluatees;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the applicability / fail-loud contract of {@link DBFunctionSequenceNoProvider}.
+ * The DB-backed {@code provideSequenceNo} (which calls the configured PL/pgSQL function) is exercised by the
+ * integration test, not here.
+ */
+class DBFunctionSequenceNoProviderTest
+{
+	private static final String SEQ_NAME = "TestLotSeq";
+	// The provider must derive exactly this per-sequence key from the sequence Name:
+	private static final String EXPECTED_SYSCONFIG_KEY =
+			"de.metas.document.seqNo.DBFunctionSequenceNoProvider." + SEQ_NAME + ".dbFunctionName";
+
+	private ISysConfigBL sysConfigBL;
+	private DBFunctionSequenceNoProvider provider;
+
+	private static DocumentSequenceInfo docSeqInfo()
+	{
+		return DocumentSequenceInfo.builder().name(SEQ_NAME).build();
+	}
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		sysConfigBL = mock(ISysConfigBL.class);
+		Services.registerService(ISysConfigBL.class, sysConfigBL);
+
+		provider = new DBFunctionSequenceNoProvider();
+	}
+
+	@Test
+	void isApplicable_true_whenPerSequenceFunctionConfiguredAndRecordIdPresent()
+	{
+		// the function-name SysConfig is set for THIS sequence's derived key:
+		when(sysConfigBL.getValue(EXPECTED_SYSCONFIG_KEY, (String)null)).thenReturn("fn_lotno_test");
+		final Evaluatee context = Evaluatees.ofSingleton(DBFunctionSequenceNoProvider.PARAM_Record_ID, 12345);
+
+		assertThat(provider.isApplicable(context, docSeqInfo())).isTrue();
+	}
+
+	@Test
+	void isApplicable_false_whenSysConfigBlank()
+	{
+		// no stub -> getValue returns null -> not configured for this sequence
+		final Evaluatee context = Evaluatees.ofSingleton(DBFunctionSequenceNoProvider.PARAM_Record_ID, 12345);
+
+		assertThat(provider.isApplicable(context, docSeqInfo())).isFalse();
+	}
+
+	@Test
+	void isApplicable_false_whenConfiguredButNoRecordId()
+	{
+		when(sysConfigBL.getValue(EXPECTED_SYSCONFIG_KEY, (String)null)).thenReturn("fn_lotno_test");
+		final Evaluatee context = Evaluatees.empty(); // no Record_ID
+
+		assertThat(provider.isApplicable(context, docSeqInfo())).isFalse();
+	}
+
+	@Test
+	void doesNotUseIncrementSeqNoAsPrefix()
+	{
+		assertThat(provider.isUseIncrementSeqNoAsPrefix()).isFalse();
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/document/sequenceno/DBFunctionSequenceNoProviderTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/document/sequenceno/DBFunctionSequenceNoProviderTest.java
@@ -22,6 +22,7 @@
 
 package de.metas.document.sequenceno;
 
+import de.metas.adempiere.model.IPOReferenceAware;
 import de.metas.document.DocumentSequenceInfo;
 import de.metas.util.Services;
 import org.adempiere.service.ISysConfigBL;
@@ -71,7 +72,7 @@ class DBFunctionSequenceNoProviderTest
 	{
 		// the function-name SysConfig is set for THIS sequence's derived key:
 		when(sysConfigBL.getValue(EXPECTED_SYSCONFIG_KEY, (String)null)).thenReturn("fn_lotno_test");
-		final Evaluatee context = Evaluatees.ofSingleton(DBFunctionSequenceNoProvider.PARAM_Record_ID, 12345);
+		final Evaluatee context = Evaluatees.ofSingleton(IPOReferenceAware.COLUMNNAME_Record_ID, 12345);
 
 		assertThat(provider.isApplicable(context, docSeqInfo())).isTrue();
 	}
@@ -80,7 +81,7 @@ class DBFunctionSequenceNoProviderTest
 	void isApplicable_false_whenSysConfigBlank()
 	{
 		// no stub -> getValue returns null -> not configured for this sequence
-		final Evaluatee context = Evaluatees.ofSingleton(DBFunctionSequenceNoProvider.PARAM_Record_ID, 12345);
+		final Evaluatee context = Evaluatees.ofSingleton(IPOReferenceAware.COLUMNNAME_Record_ID, 12345);
 
 		assertThat(provider.isApplicable(context, docSeqInfo())).isFalse();
 	}
@@ -98,5 +99,23 @@ class DBFunctionSequenceNoProviderTest
 	void doesNotUseIncrementSeqNoAsPrefix()
 	{
 		assertThat(provider.isUseIncrementSeqNoAsPrefix()).isFalse();
+	}
+
+	@Test
+	void isValidFunctionName_acceptsPlainAndSchemaQualified()
+	{
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("fn_lotno_soft_panda")).isTrue();
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("sp80.fn_lotno")).isTrue();
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("  fn_lotno  ")).isTrue(); // trimmed
+	}
+
+	@Test
+	void isValidFunctionName_rejectsMalformedOrInjection()
+	{
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName(null)).isFalse();
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("")).isFalse();
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("fn_lotno; DROP TABLE ad_sequence")).isFalse();
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("fn lotno")).isFalse();
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("schema.sub.fn")).isFalse(); // only one schema segment
 	}
 }

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809270_sys_DBFunctionSequenceNoProvider.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809270_sys_DBFunctionSequenceNoProvider.sql
@@ -1,0 +1,7 @@
+-- Register the generic DBFunctionSequenceNoProvider as a selectable AD_Sequence.CustomSequenceNoProvider_JavaClass_ID.
+-- For a sequence whose Name is <seqName>, the provider reads the per-sequence SysConfig
+-- "de.metas.document.seqNo.DBFunctionSequenceNoProvider.<seqName>.dbFunctionName" to get a PL/pgSQL function name,
+-- then calls <fn>(Record_ID, generated_at) and returns its result as the full sequence string (no counter appended).
+INSERT INTO AD_JavaClass (AD_Client_ID,AD_JavaClass_ID,AD_JavaClass_Type_ID,AD_Org_ID,Classname,Created,CreatedBy,Description,EntityType,IsActive,IsInterface,Name,Updated,UpdatedBy)
+VALUES (0,540102 /*From ID Server*/,540040,0,'de.metas.document.sequenceno.DBFunctionSequenceNoProvider',TO_TIMESTAMP('2026-06-22 16:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Generic custom AD_Sequence number provider. For a sequence whose Name is <seqName>, reads the SysConfig ''de.metas.document.seqNo.DBFunctionSequenceNoProvider.<seqName>.dbFunctionName'' to get a PL/pgSQL function name, then calls <fn>(Record_ID, generated_at) and returns its result as the full sequence string (no incremental counter appended). Configure one SysConfig per sequence that should use it.','D','Y','N','DBFunctionSequenceNoProvider',TO_TIMESTAMP('2026-06-22 16:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809310_sys_S_Resource_LotNumberCode.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809310_sys_S_Resource_LotNumberCode.sql
@@ -1,5 +1,6 @@
 -- Add S_Resource.LotNumberCode column (String, length 10, optional)
--- Used for Lot-Nummer logic (me03 #29154, customer sp80)
+-- A per-resource code consumed by custom lot-number sequence providers (e.g. to embed a
+-- production-line code in a generated lot number). Not unique, not mandatory.
 
 -- ===========================================================
 -- 1. AD_Element

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809310_sys_S_Resource_LotNumberCode.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809310_sys_S_Resource_LotNumberCode.sql
@@ -1,0 +1,138 @@
+-- Add S_Resource.LotNumberCode column (String, length 10, optional)
+-- Used for Lot-Nummer logic (me03 #29154, customer sp80)
+
+-- ===========================================================
+-- 1. AD_Element
+-- ===========================================================
+INSERT INTO AD_Element
+(AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+ ColumnName, Name, PrintName, EntityType)
+SELECT
+ 585043 /*From ID Server*/,
+ 0, 0, 'Y',
+ TO_TIMESTAMP('2026-06-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ TO_TIMESTAMP('2026-06-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ 'LotNumberCode',
+ 'Lot-Nummer Code',
+ 'Lot-Nummer Code',
+ 'D'
+WHERE NOT EXISTS (SELECT 1 FROM AD_Element WHERE AD_Element_ID=585043)
+;
+
+-- ===========================================================
+-- 2a. Seed AD_Element_Trl skeleton rows for all active system languages
+-- ===========================================================
+INSERT INTO AD_Element_Trl
+(AD_Language, AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+ Name, PrintName, IsTranslated)
+SELECT
+ l.AD_Language, t.AD_Element_ID, t.AD_Client_ID, t.AD_Org_ID, 'Y',
+ TO_TIMESTAMP('2026-06-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ TO_TIMESTAMP('2026-06-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ t.Name, t.PrintName, 'N'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y'
+  AND t.AD_Element_ID=585043
+  AND NOT EXISTS (
+    SELECT 1 FROM AD_Element_Trl tt
+    WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID
+  )
+;
+
+-- ===========================================================
+-- 2b. Mark de_DE and de_CH as translated (same text as base)
+-- ===========================================================
+UPDATE AD_Element_Trl
+SET IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-06-22 10:00:12', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy=100
+WHERE AD_Element_ID=585043 AND AD_Language='de_DE'
+;
+
+UPDATE AD_Element_Trl
+SET IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-06-22 10:00:13', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy=100
+WHERE AD_Element_ID=585043 AND AD_Language='de_CH'
+;
+
+-- ===========================================================
+-- 2c. Override en_US with English translation
+-- ===========================================================
+UPDATE AD_Element_Trl
+SET Name='Lot Number Code',
+    PrintName='Lot Number Code',
+    IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-06-22 10:00:18', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy=100
+WHERE AD_Element_ID=585043 AND AD_Language='en_US'
+;
+
+-- ===========================================================
+-- 3. AD_Column
+-- ===========================================================
+INSERT INTO AD_Column
+(AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+ AD_Table_ID, AD_Element_ID, AD_Reference_ID,
+ ColumnName, Name, FieldLength, IsMandatory, IsKey, IsParent, IsTranslated,
+ IsIdentifier, IsEncrypted, IsUpdateable, IsAlwaysUpdateable,
+ IsSelectionColumn, IsSyncDatabase,
+ PersonalDataCategory, Version, EntityType)
+SELECT
+ 592876 /*From ID Server*/,
+ 0, 0, 'Y',
+ TO_TIMESTAMP('2026-06-22 10:01:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ TO_TIMESTAMP('2026-06-22 10:01:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ 487,          -- AD_Table_ID for S_Resource
+ 585043,       -- AD_Element_ID
+ 10,           -- String reference
+ 'LotNumberCode',
+ 'Lot-Nummer Code',
+ 10,           -- FieldLength
+ 'N',          -- IsMandatory
+ 'N', 'N', 'N',
+ 'N', 'N', 'Y', 'N',
+ 'N', 'N',
+ 'NP',         -- PersonalDataCategory: Not Personal
+ 0,            -- Version
+ 'D'           -- EntityType: core dictionary
+WHERE NOT EXISTS (SELECT 1 FROM AD_Column WHERE AD_Column_ID=592876)
+;
+
+-- ===========================================================
+-- 4a. Seed AD_Column_Trl skeleton rows
+-- ===========================================================
+INSERT INTO AD_Column_Trl
+(AD_Language, AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+ Name, IsTranslated)
+SELECT
+ l.AD_Language, t.AD_Column_ID, t.AD_Client_ID, t.AD_Org_ID, 'Y',
+ TO_TIMESTAMP('2026-06-22 10:01:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ TO_TIMESTAMP('2026-06-22 10:01:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ t.Name, 'N'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y'
+  AND t.AD_Column_ID=592876
+  AND NOT EXISTS (
+    SELECT 1 FROM AD_Column_Trl tt
+    WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID
+  )
+;
+
+-- ===========================================================
+-- 4b. Propagate element translations into the column
+-- ===========================================================
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585043);
+
+-- ===========================================================
+-- 5. Add the physical column
+-- ===========================================================
+ALTER TABLE S_Resource ADD COLUMN IF NOT EXISTS LotNumberCode VARCHAR(10);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809380_sys_S_Resource_LotNumberCode_window.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809380_sys_S_Resource_LotNumberCode_window.sql
@@ -63,7 +63,7 @@ VALUES
    'Y',
    TO_TIMESTAMP('2026-06-23 08:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
    TO_TIMESTAMP('2026-06-23 08:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
-   'LotNumberCode', 414, 592876,
+   'Lot-Nummer Code', 414, 592876,
    'Y', 10, 80,
    'N', 'N', 'N', 'N',
    'Y', 25,

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809380_sys_S_Resource_LotNumberCode_window.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809380_sys_S_Resource_LotNumberCode_window.sql
@@ -1,0 +1,130 @@
+-- Add LotNumberCode field to the Resource window (AD_Window_ID=236, AD_Tab_ID=414)
+-- AD_Column_ID=592876, AD_Element_ID=585043
+-- AD_Field_ID=781245, AD_UI_Element_ID=652364  (all from ID server)
+
+-- =============================================================================
+-- Step 1: Add Description + Help to AD_Element_Trl (de_DE, de_CH, en_US)
+--         so users see a meaningful tooltip on the field.
+-- =============================================================================
+UPDATE AD_Element_Trl
+SET    Description  = 'Code dieser Ressource, der in generierte Lot-Nummern eingebettet wird.',
+       Help         = 'Code dieser Ressource, der in generierte Lot-Nummern eingebettet wird.',
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-06-23 08:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+WHERE  AD_Element_ID = 585043
+  AND  AD_Language   = 'de_DE';
+
+UPDATE AD_Element_Trl
+SET    Description  = 'Code dieser Ressource, der in generierte Lot-Nummern eingebettet wird.',
+       Help         = 'Code dieser Ressource, der in generierte Lot-Nummern eingebettet wird.',
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-06-23 08:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+WHERE  AD_Element_ID = 585043
+  AND  AD_Language   = 'de_CH';
+
+UPDATE AD_Element_Trl
+SET    Description  = 'Code of this resource, embedded into generated lot numbers.',
+       Help         = 'Code of this resource, embedded into generated lot numbers.',
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-06-23 08:00:03', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+WHERE  AD_Element_ID = 585043
+  AND  AD_Language   = 'en_US';
+
+-- Also set Description/Help on the base AD_Element (base language = de_DE)
+UPDATE AD_Element
+SET    Description  = 'Code dieser Ressource, der in generierte Lot-Nummern eingebettet wird.',
+       Help         = 'Code dieser Ressource, der in generierte Lot-Nummern eingebettet wird.',
+       Updated      = TO_TIMESTAMP('2026-06-23 08:00:04', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+WHERE  AD_Element_ID = 585043;
+
+-- Propagate element TRL changes to all dependent translation tables
+/* DDL */ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585043);
+
+-- =============================================================================
+-- Step 2: Create AD_Field for LotNumberCode on tab 414 (main S_Resource tab)
+-- Placement: primary group (SeqNo=80, after Arbeitsplatz at 70)
+--            visible in grid at SeqNoGrid=25 (between Name=20 and Beschreibung=70)
+-- Not mandatory, editable.
+-- =============================================================================
+INSERT INTO AD_Field
+  (AD_Field_ID, AD_Client_ID, AD_Org_ID,
+   IsActive, Created, CreatedBy, Updated, UpdatedBy,
+   Name, AD_Tab_ID, AD_Column_ID,
+   IsDisplayed, DisplayLength, SeqNo,
+   IsReadOnly, IsMandatory, IsFieldOnly, IsHeading,
+   IsDisplayedGrid, SeqNoGrid,
+   EntityType)
+VALUES
+  (781245 /*From ID Server*/, 0, 0,
+   'Y',
+   TO_TIMESTAMP('2026-06-23 08:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   TO_TIMESTAMP('2026-06-23 08:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   'LotNumberCode', 414, 592876,
+   'Y', 10, 80,
+   'N', 'N', 'N', 'N',
+   'Y', 25,
+   'D');
+
+-- =============================================================================
+-- Step 3: Seed AD_Field_Trl skeleton rows for all active system languages
+-- =============================================================================
+INSERT INTO AD_Field_Trl
+  (AD_Language, AD_Field_ID, Name, IsTranslated,
+   AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Name, 'N',
+       t.AD_Client_ID, t.AD_Org_ID,
+       TO_TIMESTAMP('2026-06-23 08:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       TO_TIMESTAMP('2026-06-23 08:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       'Y'
+FROM   AD_Language l, AD_Field t
+WHERE  l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y'
+  AND  t.AD_Field_ID = 781245
+  AND  NOT EXISTS (
+         SELECT 1 FROM AD_Field_Trl tt
+         WHERE  tt.AD_Language = l.AD_Language
+           AND  tt.AD_Field_ID = t.AD_Field_ID
+       );
+
+-- =============================================================================
+-- Step 4: Propagate element translations → field translations
+--         (uses AD_Element_ID=585043, not the field ID)
+-- =============================================================================
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(585043);
+
+-- =============================================================================
+-- Step 5: Rebuild AD_Element_Link for the new field
+-- =============================================================================
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 781245;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781245);
+
+-- =============================================================================
+-- Step 6: Create AD_UI_Element — places the field in the primary group
+--         of the left column of tab 414.
+--         Group 543924 = 'default' (UIStyle='primary'), left column of section 542062.
+--         SeqNo=80 (form view, after Arbeitsplatz=70)
+--         SeqNoGrid=25 (grid view, between Name=20 and Beschreibung=70)
+-- =============================================================================
+INSERT INTO AD_UI_Element
+  (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID,
+   IsActive, Created, CreatedBy, Updated, UpdatedBy,
+   AD_Tab_ID, AD_Field_ID, AD_UI_ElementGroup_ID,
+   AD_UI_ElementType,
+   Name,
+   SeqNo, SeqNoGrid, SeqNo_SideList,
+   IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+   IsAdvancedField, WidgetSize)
+VALUES
+  (652364 /*From ID Server*/, 0, 0,
+   'Y',
+   TO_TIMESTAMP('2026-06-23 08:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   TO_TIMESTAMP('2026-06-23 08:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   414, 781245, 543924,
+   'F',
+   'LotNumberCode',
+   80, 25, 0,
+   'Y', 'Y', 'N',
+   'N', 'S');   -- narrow widget: 10-char code field

--- a/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/LotNoContext.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/LotNoContext.java
@@ -23,7 +23,6 @@
 package org.adempiere.mm.attributes.api;
 
 import de.metas.document.sequence.DocSequenceId;
-import de.metas.organization.OrgId;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
@@ -31,7 +30,6 @@ import org.adempiere.service.ClientId;
 import org.eevolution.api.PPOrderId;
 
 import javax.annotation.Nullable;
-import java.time.Instant;
 
 @Value
 @Builder
@@ -43,13 +41,8 @@ public class LotNoContext
 	@NonNull
 	ClientId clientId;
 
+	/** The PP_Order this lot number is generated for; exposed to a {@link de.metas.document.sequenceno.CustomSequenceNoProvider} via the eval-context {@code Record_ID}. */
 	@Nullable
 	PPOrderId ppOrderId;
-
-	@Nullable
-	Instant generatedAt;
-
-	@Nullable
-	OrgId orgId;
 
 }

--- a/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/LotNoContext.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/LotNoContext.java
@@ -23,10 +23,15 @@
 package org.adempiere.mm.attributes.api;
 
 import de.metas.document.sequence.DocSequenceId;
+import de.metas.organization.OrgId;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 import org.adempiere.service.ClientId;
+import org.eevolution.api.PPOrderId;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
 
 @Value
 @Builder
@@ -37,5 +42,14 @@ public class LotNoContext
 
 	@NonNull
 	ClientId clientId;
+
+	@Nullable
+	PPOrderId ppOrderId;
+
+	@Nullable
+	Instant generatedAt;
+
+	@Nullable
+	OrgId orgId;
 
 }

--- a/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/LotNumberBL.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/LotNumberBL.java
@@ -1,5 +1,6 @@
 package org.adempiere.mm.attributes.api.impl;
 
+import de.metas.adempiere.model.IPOReferenceAware;
 import de.metas.document.sequence.IDocumentNoBuilder;
 import de.metas.document.sequence.IDocumentNoBuilderFactory;
 import de.metas.util.Services;
@@ -73,10 +74,13 @@ public class LotNumberBL implements ILotNumberBL
 		final IDocumentNoBuilderFactory documentNoFactory = Services.get(IDocumentNoBuilderFactory.class);
 
 		// A CustomSequenceNoProvider (opt-in, configured on the sequence) may need the PP_Order behind this lot number.
-		// Expose it under the standard "Record_ID" context key; without a PP_Order the context stays empty (= legacy behaviour).
+		// Expose it under the standard Record_ID context key. Without a PP_Order the context carries no Record_ID: a
+		// provider such as DBFunctionSequenceNoProvider then reports isApplicable=false and DocumentNoBuilder
+		// (setFailOnError) throws - it does NOT silently fall back. Sequences with no provider are unaffected
+		// (empty context == today's behaviour).
 		final PPOrderId ppOrderId = context.getPpOrderId();
 		final Evaluatee evaluationContext = ppOrderId != null
-				? Evaluatees.ofSingleton("Record_ID", ppOrderId.getRepoId())
+				? Evaluatees.ofSingleton(IPOReferenceAware.COLUMNNAME_Record_ID, ppOrderId.getRepoId())
 				: Evaluatees.empty();
 
 		final String lotNo = documentNoFactory.forSequenceId(context.getSequenceId())

--- a/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/LotNumberBL.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/LotNumberBL.java
@@ -75,9 +75,9 @@ public class LotNumberBL implements ILotNumberBL
 
 		// A CustomSequenceNoProvider (opt-in, configured on the sequence) may need the PP_Order behind this lot number.
 		// Expose it under the standard Record_ID context key. Without a PP_Order the context carries no Record_ID: a
-		// provider such as DBFunctionSequenceNoProvider then reports isApplicable=false and DocumentNoBuilder
-		// (setFailOnError) throws - it does NOT silently fall back. Sequences with no provider are unaffected
-		// (empty context == today's behaviour).
+		// provider such as DBFunctionSequenceNoProvider then reports isApplicable=false, which makes
+		// DocumentNoBuilder.getSequenceNoToUse() throw unconditionally (independent of failOnError) - it does NOT
+		// silently fall back. Sequences with no provider are unaffected (empty context == today's behaviour).
 		final PPOrderId ppOrderId = context.getPpOrderId();
 		final Evaluatee evaluationContext = ppOrderId != null
 				? Evaluatees.ofSingleton(IPOReferenceAware.COLUMNNAME_Record_ID, ppOrderId.getRepoId())

--- a/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/LotNumberBL.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/LotNumberBL.java
@@ -12,8 +12,10 @@ import org.adempiere.mm.attributes.api.ILotNumberDateAttributeDAO;
 import org.adempiere.mm.attributes.api.LotNoContext;
 import org.compiere.model.I_M_AttributeInstance;
 import org.compiere.model.I_M_AttributeSetInstance;
+import org.compiere.util.Evaluatee;
 import org.compiere.util.Evaluatees;
 import org.compiere.util.TimeUtil;
+import org.eevolution.api.PPOrderId;
 
 import java.util.Date;
 import java.util.Objects;
@@ -70,10 +72,17 @@ public class LotNumberBL implements ILotNumberBL
 	{
 		final IDocumentNoBuilderFactory documentNoFactory = Services.get(IDocumentNoBuilderFactory.class);
 
+		// A CustomSequenceNoProvider (opt-in, configured on the sequence) may need the PP_Order behind this lot number.
+		// Expose it under the standard "Record_ID" context key; without a PP_Order the context stays empty (= legacy behaviour).
+		final PPOrderId ppOrderId = context.getPpOrderId();
+		final Evaluatee evaluationContext = ppOrderId != null
+				? Evaluatees.ofSingleton("Record_ID", ppOrderId.getRepoId())
+				: Evaluatees.empty();
+
 		final String lotNo = documentNoFactory.forSequenceId(context.getSequenceId())
 				.setFailOnError(true)
 				.setClientId(context.getClientId())
-				.setEvaluationContext(Evaluatees.empty())
+				.setEvaluationContext(evaluationContext)
 				.build();
 
 		return lotNo != null && !Objects.equals(lotNo, IDocumentNoBuilder.NO_DOCUMENTNO)

--- a/backend/de.metas.business/src/test/java/org/adempiere/mm/attributes/api/impl/LotNumberBLTest.java
+++ b/backend/de.metas.business/src/test/java/org/adempiere/mm/attributes/api/impl/LotNumberBLTest.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2024 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.adempiere.mm.attributes.api.impl;
+
+import de.metas.document.sequence.DocSequenceId;
+import de.metas.document.sequence.IDocumentNoBuilder;
+import de.metas.document.sequence.IDocumentNoBuilderFactory;
+import de.metas.util.Services;
+import org.adempiere.mm.attributes.api.LotNoContext;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.util.Evaluatee;
+import org.eevolution.api.PPOrderId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LotNumberBLTest
+{
+	private IDocumentNoBuilderFactory documentNoBuilderFactory;
+	private IDocumentNoBuilder documentNoBuilder;
+	private LotNumberBL lotNumberBL;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		documentNoBuilderFactory = mock(IDocumentNoBuilderFactory.class);
+		documentNoBuilder = mock(IDocumentNoBuilder.class);
+
+		// Chain the builder methods so each returns itself
+		when(documentNoBuilderFactory.forSequenceId(any())).thenReturn(documentNoBuilder);
+		when(documentNoBuilder.setFailOnError(true)).thenReturn(documentNoBuilder);
+		when(documentNoBuilder.setClientId(any())).thenReturn(documentNoBuilder);
+		when(documentNoBuilder.setEvaluationContext(any())).thenReturn(documentNoBuilder);
+		when(documentNoBuilder.build()).thenReturn("LOT-001");
+
+		Services.registerService(IDocumentNoBuilderFactory.class, documentNoBuilderFactory);
+
+		lotNumberBL = new LotNumberBL();
+	}
+
+	@Test
+	void evalContextCarriesPPOrderId()
+	{
+		// arrange
+		final int ppOrderRepoId = 12345;
+		final LotNoContext context = LotNoContext.builder()
+				.sequenceId(DocSequenceId.ofRepoId(1))
+				.clientId(ClientId.ofRepoId(1))
+				.ppOrderId(PPOrderId.ofRepoId(ppOrderRepoId))
+				.build();
+
+		// capture the Evaluatee passed to setEvaluationContext
+		final ArgumentCaptor<Evaluatee> evaluateeCaptor = ArgumentCaptor.forClass(Evaluatee.class);
+		when(documentNoBuilder.setEvaluationContext(evaluateeCaptor.capture())).thenReturn(documentNoBuilder);
+
+		// act
+		lotNumberBL.getAndIncrementLotNo(context);
+
+		// assert — the captured evaluatee must expose Record_ID = ppOrderRepoId
+		final Evaluatee capturedEvaluatee = evaluateeCaptor.getValue();
+		assertThat(capturedEvaluatee).isNotNull();
+		assertThat(capturedEvaluatee.get_ValueAsInt("Record_ID", -1))
+				.as("Evaluatee must expose PP_Order repo-id under key Record_ID")
+				.isEqualTo(ppOrderRepoId);
+	}
+}

--- a/backend/de.metas.business/src/test/java/org/adempiere/mm/attributes/api/impl/LotNumberBLTest.java
+++ b/backend/de.metas.business/src/test/java/org/adempiere/mm/attributes/api/impl/LotNumberBLTest.java
@@ -2,7 +2,7 @@
  * #%L
  * de.metas.business
  * %%
- * Copyright (C) 2024 metas GmbH
+ * Copyright (C) 2026 metas GmbH
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -22,6 +22,7 @@
 
 package org.adempiere.mm.attributes.api.impl;
 
+import de.metas.adempiere.model.IPOReferenceAware;
 import de.metas.document.sequence.DocSequenceId;
 import de.metas.document.sequence.IDocumentNoBuilder;
 import de.metas.document.sequence.IDocumentNoBuilderFactory;
@@ -87,7 +88,7 @@ class LotNumberBLTest
 		// assert — the captured evaluatee must expose Record_ID = ppOrderRepoId
 		final Evaluatee capturedEvaluatee = evaluateeCaptor.getValue();
 		assertThat(capturedEvaluatee).isNotNull();
-		assertThat(capturedEvaluatee.get_ValueAsInt("Record_ID", -1))
+		assertThat(capturedEvaluatee.get_ValueAsInt(IPOReferenceAware.COLUMNNAME_Record_ID, -1))
 				.as("Evaluatee must expose PP_Order repo-id under key Record_ID")
 				.isEqualTo(ppOrderRepoId);
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/DB_Function_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/DB_Function_StepDef.java
@@ -48,7 +48,7 @@ public class DB_Function_StepDef
 	 * """
 	 * </pre>
 	 */
-	@And("the following PL/pgSQL function is created or replaced in the DB:")
+	@And("the following PL\\/pgSQL function is created or replaced in the DB:")
 	public void create_or_replace_pg_function(@NonNull final String ddl)
 	{
 		DB.executeUpdateAndThrowExceptionOnFail(ddl, ITrx.TRXNAME_None);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/DB_Function_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/DB_Function_StepDef.java
@@ -1,0 +1,56 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs;
+
+import io.cucumber.java.en.And;
+import lombok.NonNull;
+import org.adempiere.ad.trx.api.ITrx;
+import org.compiere.util.DB;
+
+/**
+ * Step definitions for creating or replacing PL/pgSQL functions in the test DB.
+ * Used by scenarios that verify DB-function-driven sequence providers.
+ */
+public class DB_Function_StepDef
+{
+	/**
+	 * Creates (or replaces) a PL/pgSQL function in the test database.
+	 * The function body is supplied inline in the feature file as a docstring.
+	 * The complete {@code CREATE OR REPLACE FUNCTION …} DDL is passed verbatim to the DB.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * And the following PL/pgSQL function is created or replaced in the DB:
+	 * """
+	 * CREATE OR REPLACE FUNCTION test_lotno(p_pp_order_id numeric, p_at timestamptz)
+	 *   RETURNS text LANGUAGE sql AS $$ SELECT 'L' || to_char(p_at AT TIME ZONE 'UTC','DDD') || 'M2' $$
+	 * """
+	 * </pre>
+	 */
+	@And("the following PL/pgSQL function is created or replaced in the DB:")
+	public void create_or_replace_pg_function(@NonNull final String ddl)
+	{
+		DB.executeUpdateAndThrowExceptionOnFail(ddl, ITrx.TRXNAME_None);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/billofmaterial/PP_Product_Bom_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/billofmaterial/PP_Product_Bom_StepDef.java
@@ -27,6 +27,7 @@ import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.attribute.M_AttributeSetInstance_StepDefData;
+import de.metas.cucumber.stepdefs.sequence.AD_Sequence_StepDefData;
 import de.metas.document.engine.IDocument;
 import de.metas.document.engine.IDocumentBL;
 import de.metas.product.ProductId;
@@ -76,6 +77,7 @@ public class PP_Product_Bom_StepDef
 	private final PP_Product_BOMVersions_StepDefData productBomVersionsTable;
 	private final PP_Product_BOMLine_StepDefData productBOMLineTable;
 	private final M_AttributeSetInstance_StepDefData attributeSetInstanceTable;
+	private final AD_Sequence_StepDefData adSequenceTable;
 
 	private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
 
@@ -84,7 +86,8 @@ public class PP_Product_Bom_StepDef
 			@NonNull final PP_Product_BOM_StepDefData productBOMTable,
 			@NonNull final PP_Product_BOMVersions_StepDefData productBomVersionsTable,
 			@NonNull final PP_Product_BOMLine_StepDefData productBOMLineTable,
-			@NonNull final M_AttributeSetInstance_StepDefData attributeSetInstanceTable
+			@NonNull final M_AttributeSetInstance_StepDefData attributeSetInstanceTable,
+			@NonNull final AD_Sequence_StepDefData adSequenceTable
 	)
 	{
 		this.productTable = productTable;
@@ -92,6 +95,7 @@ public class PP_Product_Bom_StepDef
 		this.productBomVersionsTable = productBomVersionsTable;
 		this.productBOMLineTable = productBOMLineTable;
 		this.attributeSetInstanceTable = attributeSetInstanceTable;
+		this.adSequenceTable = adSequenceTable;
 	}
 
 	@Given("metasfresh contains PP_Product_BOM")
@@ -114,6 +118,36 @@ public class PP_Product_Bom_StepDef
 		final I_PP_Product_BOM productBOM = productBOMTable.get(productBOMIdentifier);
 		productBOM.setDocAction(IDocument.ACTION_Complete);
 		documentBL.processEx(productBOM, IDocument.ACTION_Complete, IDocument.STATUS_Completed);
+	}
+
+	/**
+	 * Updates attributes of an existing PP_Product_BOM record (identified by its identifier alias).
+	 * Currently supports setting the lot-number sequence ({@code LotNo_Sequence_ID}).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>PP_Product_BOM_ID</b> — (required, identifier-ref) BOM to update<br>
+	 *   <b>OPT.LotNo_Sequence_ID</b> — (optional, identifier-ref) AD_Sequence to use for lot-number generation<br>
+	 * @cucumber.depends StepDefData: PP_Product_BOM_StepDefData, AD_Sequence_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And update PP_Product_BOM:
+	 *   | PP_Product_BOM_ID | OPT.LotNo_Sequence_ID |
+	 *   | bom               | seq_provider          |
+	 * </pre>
+	 */
+	@And("update PP_Product_BOM:")
+	public void update_PP_Product_BOM(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_PP_Product_BOM bom = row.getAsIdentifier(I_PP_Product_BOM.COLUMNNAME_PP_Product_BOM_ID).lookupNotNullIn(productBOMTable);
+
+			row.getAsOptionalIdentifier(I_PP_Product_BOM.COLUMNNAME_LotNo_Sequence_ID)
+					.map(adSequenceTable::get)
+					.ifPresent(seq -> bom.setLotNo_Sequence_ID(seq.getAD_Sequence_ID()));
+
+			saveRecord(bom);
+		});
 	}
 
 	private void createPP_Product_BOMLine(@NonNull final DataTableRow row)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/billofmaterial/PP_Product_Bom_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/billofmaterial/PP_Product_Bom_StepDef.java
@@ -144,7 +144,7 @@ public class PP_Product_Bom_StepDef
 
 			// only persist when a supported column is actually present, to avoid a no-op UPDATE on the (just-completed) document
 			row.getAsOptionalIdentifier(I_PP_Product_BOM.COLUMNNAME_LotNo_Sequence_ID)
-					.map(adSequenceTable::get)
+					.map(id -> id.lookupNotNullIn(adSequenceTable))
 					.ifPresent(seq -> {
 						bom.setLotNo_Sequence_ID(seq.getAD_Sequence_ID());
 						saveRecord(bom);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/billofmaterial/PP_Product_Bom_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/billofmaterial/PP_Product_Bom_StepDef.java
@@ -142,11 +142,13 @@ public class PP_Product_Bom_StepDef
 		DataTableRows.of(dataTable).forEach(row -> {
 			final I_PP_Product_BOM bom = row.getAsIdentifier(I_PP_Product_BOM.COLUMNNAME_PP_Product_BOM_ID).lookupNotNullIn(productBOMTable);
 
+			// only persist when a supported column is actually present, to avoid a no-op UPDATE on the (just-completed) document
 			row.getAsOptionalIdentifier(I_PP_Product_BOM.COLUMNNAME_LotNo_Sequence_ID)
 					.map(adSequenceTable::get)
-					.ifPresent(seq -> bom.setLotNo_Sequence_ID(seq.getAD_Sequence_ID()));
-
-			saveRecord(bom);
+					.ifPresent(seq -> {
+						bom.setLotNo_Sequence_ID(seq.getAD_Sequence_ID());
+						saveRecord(bom);
+					});
 		});
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDef.java
@@ -46,7 +46,8 @@ import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
  *   <b>Name</b> — (required) unique sequence name; used by the provider SysConfig key<br>
  *   <b>OPT.CustomSequenceNoProvider_JavaClass_ID.Classname</b> — (optional) fully-qualified class name of the provider;
  *     when present the step looks up {@code AD_JavaClass} by classname and sets the FK (fails if no such class exists)<br>
- *   <b>OPT.StartNo</b> — (optional) starting value, default 1<br>
+ *   <b>OPT.StartNo</b> — (optional) starting value; also seeds CurrentNext (the number actually issued), default 1,000,000<br>
+ *   <b>OPT.CurrentNext</b> — (optional) explicit next-issued number; applied after the StartNo seed, so it wins if both are present<br>
  * @cucumber.example
  * <pre>
  * And metasfresh contains AD_Sequence:

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDef.java
@@ -24,6 +24,7 @@ package de.metas.cucumber.stepdefs.sequence;
 
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.util.Check;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
@@ -43,13 +44,13 @@ import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
  * @cucumber.columns
  *   <b>AD_Sequence_ID</b> — (required) identifier alias for cross-step reference<br>
  *   <b>Name</b> — (required) unique sequence name; used by the provider SysConfig key<br>
- *   <b>OPT.CustomSequenceNoProvider_JavaClass_Classname</b> — (optional) fully-qualified class name of the provider;
- *     when present the step looks up {@code AD_JavaClass} by classname and sets the FK<br>
+ *   <b>OPT.CustomSequenceNoProvider_JavaClass_ID.Classname</b> — (optional) fully-qualified class name of the provider;
+ *     when present the step looks up {@code AD_JavaClass} by classname and sets the FK (fails if no such class exists)<br>
  *   <b>OPT.StartNo</b> — (optional) starting value, default 1<br>
  * @cucumber.example
  * <pre>
  * And metasfresh contains AD_Sequence:
- *   | AD_Sequence_ID | Name        | OPT.CustomSequenceNoProvider_JavaClass_Classname                    |
+ *   | AD_Sequence_ID | Name        | OPT.CustomSequenceNoProvider_JavaClass_ID.Classname                 |
  *   | seq_provider   | TestLotSeq  | de.metas.document.sequenceno.DBFunctionSequenceNoProvider           |
  * </pre>
  */
@@ -70,9 +71,10 @@ public class AD_Sequence_StepDef
 	{
 		final String name = row.getAsString(I_AD_Sequence.COLUMNNAME_Name);
 
-		// upsert: find existing by name, or create new
+		// upsert: find existing active record by name, or create new
 		final I_AD_Sequence seqRecord = queryBL.createQueryBuilder(I_AD_Sequence.class)
 				.addEqualsFilter(I_AD_Sequence.COLUMNNAME_Name, name)
+				.addOnlyActiveRecordsFilter()
 				.create()
 				.firstOnlyOptional(I_AD_Sequence.class)
 				.orElseGet(() -> newInstance(I_AD_Sequence.class));
@@ -90,11 +92,9 @@ public class AD_Sequence_StepDef
 							.addEqualsFilter(I_AD_JavaClass.COLUMNNAME_Classname, classname)
 							.addOnlyActiveRecordsFilter()
 							.create()
-							.firstOnly(I_AD_JavaClass.class);
-					if (javaClass != null)
-					{
-						seqRecord.setCustomSequenceNoProvider_JavaClass_ID(javaClass.getAD_JavaClass_ID());
-					}
+							.firstOnlyOrNull(I_AD_JavaClass.class);
+					Check.assumeNotNull(javaClass, "No active AD_JavaClass found for classname={}", classname);
+					seqRecord.setCustomSequenceNoProvider_JavaClass_ID(javaClass.getAD_JavaClass_ID());
 				});
 
 		saveRecord(seqRecord);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDef.java
@@ -1,0 +1,104 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.sequence;
+
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.And;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
+import de.metas.javaclasses.model.I_AD_JavaClass;
+import org.compiere.model.I_AD_Sequence;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+
+/**
+ * Step definitions for {@link I_AD_Sequence} — creates or updates lot-number sequences used in manufacturing.
+ *
+ * @cucumber.stepdef
+ * @cucumber.columns
+ *   <b>AD_Sequence_ID</b> — (required) identifier alias for cross-step reference<br>
+ *   <b>Name</b> — (required) unique sequence name; used by the provider SysConfig key<br>
+ *   <b>OPT.CustomSequenceNoProvider_JavaClass_Classname</b> — (optional) fully-qualified class name of the provider;
+ *     when present the step looks up {@code AD_JavaClass} by classname and sets the FK<br>
+ *   <b>OPT.StartNo</b> — (optional) starting value, default 1<br>
+ * @cucumber.example
+ * <pre>
+ * And metasfresh contains AD_Sequence:
+ *   | AD_Sequence_ID | Name        | OPT.CustomSequenceNoProvider_JavaClass_Classname                    |
+ *   | seq_provider   | TestLotSeq  | de.metas.document.sequenceno.DBFunctionSequenceNoProvider           |
+ * </pre>
+ */
+@RequiredArgsConstructor
+public class AD_Sequence_StepDef
+{
+	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@NonNull private final AD_Sequence_StepDefData adSequenceTable;
+
+	@And("metasfresh contains AD_Sequence:")
+	public void createOrUpdate_AD_Sequence(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::createOrUpdateAdSequence);
+	}
+
+	private void createOrUpdateAdSequence(@NonNull final DataTableRow row)
+	{
+		final String name = row.getAsString(I_AD_Sequence.COLUMNNAME_Name);
+
+		// upsert: find existing by name, or create new
+		final I_AD_Sequence seqRecord = queryBL.createQueryBuilder(I_AD_Sequence.class)
+				.addEqualsFilter(I_AD_Sequence.COLUMNNAME_Name, name)
+				.create()
+				.firstOnlyOptional(I_AD_Sequence.class)
+				.orElseGet(() -> newInstance(I_AD_Sequence.class));
+
+		seqRecord.setName(name);
+		seqRecord.setIsTableID(false);
+		seqRecord.setIsAutoSequence(true);
+
+		row.getAsOptionalInt(I_AD_Sequence.COLUMNNAME_StartNo)
+				.ifPresent(seqRecord::setStartNo);
+
+		row.getAsOptionalString(I_AD_Sequence.COLUMNNAME_CustomSequenceNoProvider_JavaClass_ID + ".Classname")
+				.ifPresent(classname -> {
+					final I_AD_JavaClass javaClass = queryBL.createQueryBuilder(I_AD_JavaClass.class)
+							.addEqualsFilter(I_AD_JavaClass.COLUMNNAME_Classname, classname)
+							.addOnlyActiveRecordsFilter()
+							.create()
+							.firstOnly(I_AD_JavaClass.class);
+					if (javaClass != null)
+					{
+						seqRecord.setCustomSequenceNoProvider_JavaClass_ID(javaClass.getAD_JavaClass_ID());
+					}
+				});
+
+		saveRecord(seqRecord);
+
+		row.getAsOptionalIdentifier().ifPresent(identifier -> adSequenceTable.putOrReplace(identifier, seqRecord));
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDef.java
@@ -57,7 +57,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 @RequiredArgsConstructor
 public class AD_Sequence_StepDef
 {
-	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 	@NonNull private final AD_Sequence_StepDefData adSequenceTable;
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDef.java
@@ -85,8 +85,16 @@ public class AD_Sequence_StepDef
 		seqRecord.setIsTableID(false);
 		seqRecord.setIsAutoSequence(true);
 
+		// StartNo seeds CurrentNext as well: the number actually handed out by the document-no builder is CurrentNext
+		// (a freshly created sequence defaults CurrentNext to 1,000,000), so a test that sets StartNo expects to start there.
 		row.getAsOptionalInt(I_AD_Sequence.COLUMNNAME_StartNo)
-				.ifPresent(seqRecord::setStartNo);
+				.ifPresent(startNo -> {
+					seqRecord.setStartNo(startNo);
+					seqRecord.setCurrentNext(startNo);
+				});
+
+		row.getAsOptionalInt(I_AD_Sequence.COLUMNNAME_CurrentNext)
+				.ifPresent(seqRecord::setCurrentNext);
 
 		row.getAsOptionalString(I_AD_Sequence.COLUMNNAME_CustomSequenceNoProvider_JavaClass_ID + ".Classname")
 				.ifPresent(classname -> {

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDef.java
@@ -64,7 +64,9 @@ public class AD_Sequence_StepDef
 	@And("metasfresh contains AD_Sequence:")
 	public void createOrUpdate_AD_Sequence(@NonNull final DataTable dataTable)
 	{
-		DataTableRows.of(dataTable).forEach(this::createOrUpdateAdSequence);
+		DataTableRows.of(dataTable)
+				.setAdditionalRowIdentifierColumnName(I_AD_Sequence.COLUMNNAME_AD_Sequence_ID)
+				.forEach(this::createOrUpdateAdSequence);
 	}
 
 	private void createOrUpdateAdSequence(@NonNull final DataTableRow row)
@@ -99,6 +101,6 @@ public class AD_Sequence_StepDef
 
 		saveRecord(seqRecord);
 
-		row.getAsOptionalIdentifier().ifPresent(identifier -> adSequenceTable.putOrReplace(identifier, seqRecord));
+		row.getAsIdentifier(I_AD_Sequence.COLUMNNAME_AD_Sequence_ID).putOrReplace(adSequenceTable, seqRecord);
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDefData.java
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.sequence;
+
+import de.metas.cucumber.stepdefs.StepDefData;
+import org.compiere.model.I_AD_Sequence;
+
+/** Step-def data store for {@link I_AD_Sequence} records. */
+public class AD_Sequence_StepDefData extends StepDefData<I_AD_Sequence>
+{
+	public AD_Sequence_StepDefData()
+	{
+		super(I_AD_Sequence.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/pporder/lotNumberSequenceProvider.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/pporder/lotNumberSequenceProvider.feature
@@ -1,0 +1,118 @@
+@from:cucumber
+@ghActions:run_on_executor5
+@allure.label.epic:E3000_Manufacturing
+@allure.label.feature:F5000_Handling_Unit
+@F5000
+Feature: Lot number stamped on HU during manufacturing receipt
+## Two paths through lot-number assignment on production receipt:
+## 1. Provider-driven: AD_Sequence with DBFunctionSequenceNoProvider → lot value comes from a PL/pgSQL function
+## 2. Plain sequence (no provider): lot value is the plain incremental number (zero-regression)
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2025-04-01T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+
+    And metasfresh contains M_Products:
+      | Identifier        |
+      | finishedGoodsProd |
+      | rawMaterialProd   |
+
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID.Identifier |
+      | lotNoTU_PI            |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID.Identifier | M_HU_PI_ID.Identifier | HU_UnitType | IsCurrent |
+      | lotNoTU_PIVersion             | lotNoTU_PI            | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType |
+      | lotNoTU_PIItem             | lotNoTU_PIVersion             | 0   | MI       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | lotNoProduct_HUPI                  | lotNoTU_PIItem             | finishedGoodsProd       | 10  | 2021-01-01 |
+
+    And load S_Resource:
+      | S_Resource_ID.Identifier | S_Resource_ID |
+      | testResource             | 540006        |
+
+  @from:cucumber
+  Scenario: Provider-driven lot number — DBFunctionSequenceNoProvider stamps a PL/pgSQL-derived value on the finished-goods HU
+    ## The sequence has DBFunctionSequenceNoProvider as its provider.
+    ## The provider calls the PL/pgSQL function and returns its result as the lot number (no counter appended).
+    ## Fixed system time 2025-04-01T13:30:13+01:00 → UTC day-of-year 091 → expected lot = L091M2
+
+    And the following PL/pgSQL function is created or replaced in the DB:
+    """
+    CREATE OR REPLACE FUNCTION test_lotno_provider(p_pp_order_id numeric, p_at timestamptz)
+      RETURNS text LANGUAGE sql AS
+    $$ SELECT 'L' || to_char(p_at AT TIME ZONE 'UTC', 'DDD') || 'M2' $$
+    """
+
+    And metasfresh contains AD_Sequence:
+      | AD_Sequence_ID.Identifier | Name                      | OPT.CustomSequenceNoProvider_JavaClass_ID.Classname                   | OPT.StartNo |
+      | seq_lotno_provider        | TestLotNoProviderSequence | de.metas.document.sequenceno.DBFunctionSequenceNoProvider             | 1           |
+
+    And set sys config String value test_lotno_provider for sys config de.metas.document.seqNo.DBFunctionSequenceNoProvider.TestLotNoProviderSequence.dbFunctionName
+
+    And metasfresh contains PP_Product_BOM
+      | Identifier      | M_Product_ID.Identifier | ValidFrom  | PP_Product_BOMVersions_ID.Identifier |
+      | bom_provider    | finishedGoodsProd       | 2021-01-01 | bomVersions_provider                 |
+    And metasfresh contains PP_Product_BOMLines
+      | Identifier          | PP_Product_BOM_ID.Identifier | M_Product_ID.Identifier | ValidFrom  | QtyBatch |
+      | bomLine_provider    | bom_provider                 | rawMaterialProd         | 2021-01-01 | 10       |
+    And the PP_Product_BOM identified by bom_provider is completed
+    And update PP_Product_BOM:
+      | PP_Product_BOM_ID.Identifier | OPT.LotNo_Sequence_ID.Identifier |
+      | bom_provider                 | seq_lotno_provider               |
+
+    And create PP_Order:
+      | PP_Order_ID.Identifier  | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument |
+      | ppOrder_lotno_provider  | MOP         | finishedGoodsProd       | 10         | testResource             | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | Y                |
+
+    And receive HUs for PP_Order with M_HU_LUTU_Configuration:
+      | PP_Order_ID             | M_HU_ID.Identifier  | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier |
+      | ppOrder_lotno_provider  | hu_lotno_provider   | N               | 0     | N               | 1     | N               | 10          | lotNoProduct_HUPI                  |
+
+    When complete planning for PP_Order:
+      | PP_Order_ID.Identifier |
+      | ppOrder_lotno_provider |
+
+    Then M_HU_Attribute is validated
+      | M_HU_ID             | M_Attribute_ID.Value | Value  |
+      | hu_lotno_provider   | Lot-Nummer           | L091M2 |
+
+  @from:cucumber
+  Scenario: Plain incremental lot number — no provider configured, lot is the plain sequence counter (zero-regression)
+    ## AD_Sequence with no CustomSequenceNoProvider → DocumentNoBuilder uses the plain counter.
+
+    And metasfresh contains AD_Sequence:
+      | AD_Sequence_ID.Identifier | Name                  | OPT.StartNo |
+      | seq_lotno_plain           | TestLotNoPlainSeq     | 1           |
+
+    And metasfresh contains PP_Product_BOM
+      | Identifier   | M_Product_ID.Identifier | ValidFrom  | PP_Product_BOMVersions_ID.Identifier |
+      | bom_plain    | finishedGoodsProd       | 2021-01-01 | bomVersions_plain                    |
+    And metasfresh contains PP_Product_BOMLines
+      | Identifier       | PP_Product_BOM_ID.Identifier | M_Product_ID.Identifier | ValidFrom  | QtyBatch |
+      | bomLine_plain    | bom_plain                    | rawMaterialProd         | 2021-01-01 | 10       |
+    And the PP_Product_BOM identified by bom_plain is completed
+    And update PP_Product_BOM:
+      | PP_Product_BOM_ID.Identifier | OPT.LotNo_Sequence_ID.Identifier |
+      | bom_plain                    | seq_lotno_plain                  |
+
+    And create PP_Order:
+      | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument |
+      | ppOrder_lotno_plain    | MOP         | finishedGoodsProd       | 10         | testResource             | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | Y                |
+
+    And receive HUs for PP_Order with M_HU_LUTU_Configuration:
+      | PP_Order_ID          | M_HU_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier |
+      | ppOrder_lotno_plain  | hu_lotno_plain     | N               | 0     | N               | 1     | N               | 10          | lotNoProduct_HUPI                  |
+
+    When complete planning for PP_Order:
+      | PP_Order_ID.Identifier |
+      | ppOrder_lotno_plain    |
+
+    Then M_HU_Attribute is validated
+      | M_HU_ID        | M_Attribute_ID.Value | Value |
+      | hu_lotno_plain | Lot-Nummer           | 1     |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pporder/api/impl/AbstractPPOrderReceiptHUProducer.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pporder/api/impl/AbstractPPOrderReceiptHUProducer.java
@@ -408,8 +408,6 @@ import java.util.Optional;
 						.sequenceId(sequenceId)
 						.clientId(ClientId.ofRepoId(ppOrderBom.getAD_Client_ID()))
 						.ppOrderId(ppOrderId)
-						.generatedAt(SystemTime.asInstant())
-						.orgId(OrgId.ofRepoId(ppOrderBom.getAD_Org_ID()))
 						.build());
 
 			}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pporder/api/impl/AbstractPPOrderReceiptHUProducer.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pporder/api/impl/AbstractPPOrderReceiptHUProducer.java
@@ -407,6 +407,9 @@ import java.util.Optional;
 				lotNumber = lotNumberBL.getAndIncrementLotNo(LotNoContext.builder()
 						.sequenceId(sequenceId)
 						.clientId(ClientId.ofRepoId(ppOrderBom.getAD_Client_ID()))
+						.ppOrderId(ppOrderId)
+						.generatedAt(SystemTime.asInstant())
+						.orgId(OrgId.ofRepoId(ppOrderBom.getAD_Org_ID()))
 						.build());
 
 			}

--- a/e2e/frontend-webui/tests/spec/resource-lot-number-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/resource-lot-number-code.spec.js
@@ -49,13 +49,17 @@ receipt time. If it does not render or persist, the feature cannot be configured
 
         test.setTimeout(90000);
 
-        // A field save is committed by Tab/blur, which fires a PATCH to the window
-        // document. Awaiting that response is deterministic — no blind sleeps, and no
-        // risk of reloading before the save round-trips.
-        const waitForSave = () =>
+        // A field save is committed by Tab/blur, which fires a PATCH to THIS record's
+        // window document. Awaiting that specific response is deterministic — no blind
+        // sleeps, and no reload before the save round-trips. Scoped to /window/<win>/<rec>
+        // so a concurrent PATCH to another record can't satisfy the wait. Resolves to the
+        // response, or null if none arrived within the timeout — callers handle null.
+        const waitForSave = (recId) =>
             page
                 .waitForResponse(
-                    (r) => r.request().method() === 'PATCH' && r.url().includes('/window/'),
+                    (r) =>
+                        r.request().method() === 'PATCH' &&
+                        r.url().includes(`/window/${RESOURCE_WINDOW_ID}/${recId}`),
                     { timeout: SLOW_ACTION_TIMEOUT }
                 )
                 .catch(() => null);
@@ -100,7 +104,8 @@ receipt time. If it does not render or persist, the feature cannot be configured
             .catch(() => {});
 
         const recordUrl = page.url();
-        console.log(`Opened Resource record: ${recordUrl.split('/').pop()}`);
+        const recordId = recordUrl.split('/').pop();
+        console.log(`Opened Resource record: ${recordId}`);
 
         // Step 5: the LotNumberCode field renders and is editable
         const lotInput = page.locator(LOT_FIELD).first();
@@ -118,7 +123,7 @@ receipt time. If it does not render or persist, the feature cannot be configured
             const uniqueValue = `L${Date.now().toString().slice(-8)}`; // 9 chars, unique per run
             await lotInput.click();
             await lotInput.fill(uniqueValue);
-            const saved = waitForSave();
+            const saved = waitForSave(recordId);
             await page.keyboard.press('Tab');
             await saved;
             console.log(`Set LotNumberCode to: ${uniqueValue}`);
@@ -146,16 +151,27 @@ receipt time. If it does not render or persist, the feature cannot be configured
         } finally {
             // Restore the original value so the test leaves no residue — runs even if the
             // persistence assertion above threw (the record is pre-existing, not owned by
-            // this test, so teardown must be unconditional).
-            await page.goto(recordUrl);
-            const lotInputRestore = page.locator(LOT_FIELD).first();
-            await lotInputRestore.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
-            await lotInputRestore.click();
-            await lotInputRestore.fill(originalValue);
-            const restored = waitForSave();
-            await page.keyboard.press('Tab');
-            await restored;
-            console.log(`Restored original LotNumberCode value: "${originalValue}"`);
+            // this test, so teardown must be unconditional). Wrapped in try/catch so a
+            // restore error never replaces the original test failure (standard finally
+            // semantics would otherwise mask it).
+            try {
+                await page.goto(recordUrl);
+                const lotInputRestore = page.locator(LOT_FIELD).first();
+                await lotInputRestore.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
+                await lotInputRestore.click();
+                await lotInputRestore.fill(originalValue);
+                const restored = waitForSave(recordId);
+                await page.keyboard.press('Tab');
+                if ((await restored) === null) {
+                    // Don't fail silently: a missing save round-trip means the record may
+                    // still hold the test value, which a later run would read as baseline.
+                    console.warn(`Restore save for LotNumberCode did not round-trip within timeout; record ${recordId} may still hold the test value.`);
+                } else {
+                    console.log(`Restored original LotNumberCode value: "${originalValue}"`);
+                }
+            } catch (restoreErr) {
+                console.error(`LotNumberCode restore failed (original test result preserved): ${restoreErr}`);
+            }
         }
     });
 });

--- a/e2e/frontend-webui/tests/spec/resource-lot-number-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/resource-lot-number-code.spec.js
@@ -21,7 +21,8 @@ import { RESOURCE_WINDOW_ID } from '../utils/WindowIds';
  *   4. Verify the "Lot-Nummer Code" field renders and is editable
  *   5. Set a unique value, save (Tab), reload the page
  *   6. Verify the value persisted after reload
- *   7. Restore the original value (leave no test residue)
+ *   7. Restore the original value (in a finally block — runs even if an
+ *      assertion above fails, so the test never leaves residue on the record)
  *
  * This is the WebUI-side proof that the AD metadata added for the field
  * (AD_Field 781245 / AD_UI_Element on window 236, tab 414) renders a usable,
@@ -48,20 +49,29 @@ receipt time. If it does not render or persist, the feature cannot be configured
 
         test.setTimeout(90000);
 
-        // Step 1: test user
+        // A field save is committed by Tab/blur, which fires a PATCH to the window
+        // document. Awaiting that response is deterministic — no blind sleeps, and no
+        // risk of reloading before the save round-trips.
+        const waitForSave = () =>
+            page
+                .waitForResponse(
+                    (r) => r.request().method() === 'PATCH' && r.url().includes('/window/'),
+                    { timeout: SLOW_ACTION_TIMEOUT }
+                )
+                .catch(() => null);
+
+        // Step 1: test user (Backend.createMasterdata logs the created masterdata itself)
         const masterdata = await Backend.createMasterdata({
             request: { login: { user: { language: 'en_US', firstname: 'first', lastname: 'last' } } },
         });
-        console.log(`Test user created: ${masterdata.login.user.username}`);
 
-        // Step 2: login
+        // Step 2: login. login() already waits for the redirect off /login; the call
+        // below is a URL-only sanity assertion (not a DOM-ready signal). The real
+        // ready-to-render guard is the document-list wait in step 3. We intentionally do
+        // NOT wait for the dashboard to reach 'networkidle' — its STOMP/websocket + KPI
+        // polling keep the network active, so networkidle never settles locally.
         await LoginPage.goto();
         await LoginPage.login(masterdata.login.user);
-        // login() already waits for the redirect off /login; assert it deterministically.
-        // Intentionally NOT waiting for the dashboard to reach 'networkidle' — the
-        // dashboard's STOMP/websocket + KPI polling keep the network active, so
-        // networkidle never settles locally. The Resource-window load below waits on a
-        // deterministic DOM signal (the document list) instead.
         await LoginPage.expectLoggedIn();
 
         // Step 3: navigate to the Resource window
@@ -76,7 +86,10 @@ receipt time. If it does not render or persist, the feature cannot be configured
             .catch(() => {});
         await page.waitForTimeout(500);
 
-        // Step 4: open the first existing Resource record (double-click opens detail)
+        // Step 4: open the first existing Resource record (double-click opens detail).
+        // Any resource carries the LotNumberCode field, so the first row is fine — the
+        // restore in the finally block is per-run (restores whatever record THIS run
+        // opened to its own captured baseline), so it does not depend on a stable sort.
         const firstRow = page.locator('.table tbody tr, table tbody tr').first();
         await firstRow.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
         await firstRow.dblclick();
@@ -85,10 +98,9 @@ receipt time. If it does not render or persist, the feature cannot be configured
         await page.locator('.rotating, .indicator-pending')
             .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
             .catch(() => {});
-        await page.waitForTimeout(1000);
 
-        const recordId = page.url().split('/').pop();
-        console.log(`Opened Resource record: ${recordId}`);
+        const recordUrl = page.url();
+        console.log(`Opened Resource record: ${recordUrl.split('/').pop()}`);
 
         // Step 5: the LotNumberCode field renders and is editable
         const lotInput = page.locator(LOT_FIELD).first();
@@ -98,51 +110,52 @@ receipt time. If it does not render or persist, the feature cannot be configured
         const originalValue = await lotInput.inputValue();
         console.log(`Original LotNumberCode value: "${originalValue}"`);
 
-        // Step 6: set a unique value and save (Tab triggers the field save).
-        // LotNumberCode is a short per-resource code — VARCHAR(10) / AD FieldLength 10
-        // (e.g. a production-line code). Keep the value within 10 chars so the field's
-        // maxLength does not truncate it.
-        const uniqueValue = `L${Date.now().toString().slice(-8)}`; // 9 chars, unique per run
-        await lotInput.click();
-        await lotInput.fill(uniqueValue);
-        await page.keyboard.press('Tab');
-        await page.waitForTimeout(2000);
-        await page.locator('.rotating, .indicator-pending')
-            .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
-            .catch(() => {});
-        console.log(`Set LotNumberCode to: ${uniqueValue}`);
+        try {
+            // Step 6: set a unique value and save (Tab triggers the field save).
+            // LotNumberCode is a short per-resource code — VARCHAR(10) / AD FieldLength 10
+            // (e.g. a production-line code). Keep the value within 10 chars so the field's
+            // maxLength does not truncate it.
+            const uniqueValue = `L${Date.now().toString().slice(-8)}`; // 9 chars, unique per run
+            await lotInput.click();
+            await lotInput.fill(uniqueValue);
+            const saved = waitForSave();
+            await page.keyboard.press('Tab');
+            await saved;
+            console.log(`Set LotNumberCode to: ${uniqueValue}`);
 
-        // Step 7: reload and verify persistence
-        await page.reload();
-        await page.locator(LOT_FIELD).first().waitFor({
-            state: 'visible',
-            timeout: VERY_SLOW_ACTION_TIMEOUT,
-        });
-        await page.waitForTimeout(500);
-        const reloadedValue = await page.locator(LOT_FIELD).first().inputValue();
-        expect(reloadedValue).toBe(uniqueValue);
-        console.log(`After reload, LotNumberCode = "${reloadedValue}" (persisted)`);
+            // Step 7: reload and verify persistence
+            await page.reload();
+            await page.locator(LOT_FIELD).first().waitFor({
+                state: 'visible',
+                timeout: VERY_SLOW_ACTION_TIMEOUT,
+            });
+            const reloadedValue = await page.locator(LOT_FIELD).first().inputValue();
+            expect(reloadedValue).toBe(uniqueValue);
+            console.log(`After reload, LotNumberCode = "${reloadedValue}" (persisted)`);
 
-        const screenshot = await page.screenshot();
-        allure.attachment('Resource LotNumberCode persisted', screenshot, 'image/png');
+            const screenshot = await page.screenshot();
+            allure.attachment('Resource LotNumberCode persisted', screenshot, 'image/png');
 
-        const validationHtml = `<table border="1">
-            <tr><th>Check</th><th>Status</th><th>Value</th></tr>
-            <tr><td>Field renders + editable</td><td>PASS</td><td>${LOT_FIELD}</td></tr>
-            <tr><td>Value set</td><td>PASS</td><td>${uniqueValue}</td></tr>
-            <tr><td>Persisted after reload</td><td>PASS</td><td>${reloadedValue}</td></tr>
-        </table>`;
-        allure.attachment('Validation Results', validationHtml, 'text/html');
-
-        // Step 8: restore the original value so the test leaves no residue
-        const lotInputRestore = page.locator(LOT_FIELD).first();
-        await lotInputRestore.click();
-        await lotInputRestore.fill(originalValue);
-        await page.keyboard.press('Tab');
-        await page.waitForTimeout(1500);
-        await page.locator('.rotating, .indicator-pending')
-            .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
-            .catch(() => {});
-        console.log(`Restored original LotNumberCode value: "${originalValue}"`);
+            const validationHtml = `<table border="1">
+                <tr><th>Check</th><th>Status</th><th>Value</th></tr>
+                <tr><td>Field renders + editable</td><td>PASS</td><td>${LOT_FIELD}</td></tr>
+                <tr><td>Value set</td><td>PASS</td><td>${uniqueValue}</td></tr>
+                <tr><td>Persisted after reload</td><td>PASS</td><td>${reloadedValue}</td></tr>
+            </table>`;
+            allure.attachment('Validation Results', validationHtml, 'text/html');
+        } finally {
+            // Restore the original value so the test leaves no residue — runs even if the
+            // persistence assertion above threw (the record is pre-existing, not owned by
+            // this test, so teardown must be unconditional).
+            await page.goto(recordUrl);
+            const lotInputRestore = page.locator(LOT_FIELD).first();
+            await lotInputRestore.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
+            await lotInputRestore.click();
+            await lotInputRestore.fill(originalValue);
+            const restored = waitForSave();
+            await page.keyboard.press('Tab');
+            await restored;
+            console.log(`Restored original LotNumberCode value: "${originalValue}"`);
+        }
     });
 });

--- a/e2e/frontend-webui/tests/spec/resource-lot-number-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/resource-lot-number-code.spec.js
@@ -1,0 +1,148 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { LoginPage } from '../utils/pages/LoginPage';
+import {
+    FRONTEND_BASE_URL,
+    SLOW_ACTION_TIMEOUT,
+    VERY_SLOW_ACTION_TIMEOUT,
+} from '../utils/common';
+import { RESOURCE_WINDOW_ID } from '../utils/WindowIds';
+
+/**
+ * Resource LotNumberCode field E2E test.
+ *
+ * Validates the new optional `S_Resource.LotNumberCode` field that selects a
+ * per-resource lot-number sequence at manufacturing receipt:
+ *   1. Login with a test user
+ *   2. Navigate to the Resource window
+ *   3. Open an existing Resource record
+ *   4. Verify the "Lot-Nummer Code" field renders and is editable
+ *   5. Set a unique value, save (Tab), reload the page
+ *   6. Verify the value persisted after reload
+ *   7. Restore the original value (leave no test residue)
+ *
+ * This is the WebUI-side proof that the AD metadata added for the field
+ * (AD_Field 781245 / AD_UI_Element on window 236, tab 414) renders a usable,
+ * persisting text input — complementing the backend DBFunctionSequenceNoProvider
+ * unit + cucumber coverage.
+ */
+
+const LOT_FIELD = '.form-field-LotNumberCode input';
+
+test.describe('Resource — LotNumberCode field', () => {
+    test('LotNumberCode field renders, is editable, and persists after reload', async ({ page }) => {
+        allure.epic('Manufacturing');
+        allure.story('Per-resource lot-number sequence');
+        allure.severity('normal');
+        allure.description(`
+### Scenario
+Verify the optional **Lot-Nummer Code** (\`S_Resource.LotNumberCode\`) field on the
+Resource window: it renders, accepts input, and the value survives a save + reload.
+
+### Business value
+The field lets a manufacturing resource opt into a custom lot-number sequence at
+receipt time. If it does not render or persist, the feature cannot be configured.
+        `);
+
+        test.setTimeout(90000);
+
+        // Step 1: test user
+        const masterdata = await Backend.createMasterdata({
+            request: { login: { user: { language: 'en_US', firstname: 'first', lastname: 'last' } } },
+        });
+        console.log(`Test user created: ${masterdata.login.user.username}`);
+
+        // Step 2: login
+        await LoginPage.goto();
+        await LoginPage.login(masterdata.login.user);
+        // login() already waits for the redirect off /login; assert it deterministically.
+        // Intentionally NOT waiting for the dashboard to reach 'networkidle' — the
+        // dashboard's STOMP/websocket + KPI polling keep the network active, so
+        // networkidle never settles locally. The Resource-window load below waits on a
+        // deterministic DOM signal (the document list) instead.
+        await LoginPage.expectLoggedIn();
+
+        // Step 3: navigate to the Resource window
+        await page.goto(`${FRONTEND_BASE_URL}/window/${RESOURCE_WINDOW_ID}`);
+        await page.locator('.document-list-wrapper, .document-list').waitFor({
+            state: 'visible',
+            timeout: VERY_SLOW_ACTION_TIMEOUT,
+        });
+        await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+        await page.locator('.rotating, .panel-spaced-lg')
+            .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+            .catch(() => {});
+        await page.waitForTimeout(500);
+
+        // Step 4: open the first existing Resource record (double-click opens detail)
+        const firstRow = page.locator('.table tbody tr, table tbody tr').first();
+        await firstRow.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
+        await firstRow.dblclick();
+        await page.waitForURL(/\/window\/\d+\/\d+/, { timeout: SLOW_ACTION_TIMEOUT });
+        await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+        await page.locator('.rotating, .indicator-pending')
+            .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+            .catch(() => {});
+        await page.waitForTimeout(1000);
+
+        const recordId = page.url().split('/').pop();
+        console.log(`Opened Resource record: ${recordId}`);
+
+        // Step 5: the LotNumberCode field renders and is editable
+        const lotInput = page.locator(LOT_FIELD).first();
+        await lotInput.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+        await expect(lotInput).toBeEditable();
+
+        const originalValue = await lotInput.inputValue();
+        console.log(`Original LotNumberCode value: "${originalValue}"`);
+
+        // Step 6: set a unique value and save (Tab triggers the field save).
+        // LotNumberCode is a short per-resource code — VARCHAR(10) / AD FieldLength 10
+        // (e.g. a production-line code). Keep the value within 10 chars so the field's
+        // maxLength does not truncate it.
+        const uniqueValue = `L${Date.now().toString().slice(-8)}`; // 9 chars, unique per run
+        await lotInput.click();
+        await lotInput.fill(uniqueValue);
+        await page.keyboard.press('Tab');
+        await page.waitForTimeout(2000);
+        await page.locator('.rotating, .indicator-pending')
+            .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+            .catch(() => {});
+        console.log(`Set LotNumberCode to: ${uniqueValue}`);
+
+        // Step 7: reload and verify persistence
+        await page.reload();
+        await page.locator(LOT_FIELD).first().waitFor({
+            state: 'visible',
+            timeout: VERY_SLOW_ACTION_TIMEOUT,
+        });
+        await page.waitForTimeout(500);
+        const reloadedValue = await page.locator(LOT_FIELD).first().inputValue();
+        expect(reloadedValue).toBe(uniqueValue);
+        console.log(`After reload, LotNumberCode = "${reloadedValue}" (persisted)`);
+
+        const screenshot = await page.screenshot();
+        allure.attachment('Resource LotNumberCode persisted', screenshot, 'image/png');
+
+        const validationHtml = `<table border="1">
+            <tr><th>Check</th><th>Status</th><th>Value</th></tr>
+            <tr><td>Field renders + editable</td><td>PASS</td><td>${LOT_FIELD}</td></tr>
+            <tr><td>Value set</td><td>PASS</td><td>${uniqueValue}</td></tr>
+            <tr><td>Persisted after reload</td><td>PASS</td><td>${reloadedValue}</td></tr>
+        </table>`;
+        allure.attachment('Validation Results', validationHtml, 'text/html');
+
+        // Step 8: restore the original value so the test leaves no residue
+        const lotInputRestore = page.locator(LOT_FIELD).first();
+        await lotInputRestore.click();
+        await lotInputRestore.fill(originalValue);
+        await page.keyboard.press('Tab');
+        await page.waitForTimeout(1500);
+        await page.locator('.rotating, .indicator-pending')
+            .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+            .catch(() => {});
+        console.log(`Restored original LotNumberCode value: "${originalValue}"`);
+    });
+});

--- a/e2e/frontend-webui/tests/utils/WindowIds.js
+++ b/e2e/frontend-webui/tests/utils/WindowIds.js
@@ -54,6 +54,15 @@ export const BUSINESS_PARTNER_WINDOW_ID = 123;
  */
 export const PRODUCT_WINDOW_ID = 140;
 
+/**
+ * Resource window (Ressource)
+ * Table: S_Resource
+ * Window ID: 236 (main tab AD_Tab_ID=414 "Ressource")
+ * Description: Manufacturing resources/work centers. Carries the optional
+ * LotNumberCode field that selects a per-resource lot-number sequence.
+ */
+export const RESOURCE_WINDOW_ID = 236;
+
 // ============================================================================
 // SALES SIDE WINDOWS
 // ============================================================================


### PR DESCRIPTION
## What

Adds a **generic, opt-in mechanism to produce custom lot numbers** at manufacturing receipt via metasfresh's existing pluggable sequence hook — with **zero behaviour change** for any sequence that is not explicitly configured to use it.

### Changes
- **`DBFunctionSequenceNoProvider`** (`de.metas.document.sequenceno`) — a generic `CustomSequenceNoProvider` that delegates the sequence string to a **PL/pgSQL function named per-sequence in a SysConfig** (`de.metas.document.seqNo.DBFunctionSequenceNoProvider.<AD_Sequence.Name>.dbFunctionName`). Fail-loud: applicable only when the SysConfig is set, the function exists, and the eval-context carries a `Record_ID`. Schema-qualified function-name validation guards against injection.
- **Lot-sequence eval-context** — carry the `PP_Order` behind a finished-goods receipt into the `DocumentNoBuilder` evaluation context (`Record_ID`), so a provider can pass it to its DB function. Default path (no provider) is unchanged.
- **Provider registration** — `DBFunctionSequenceNoProvider` registered in `AD_JavaClass` so it is selectable as `AD_Sequence.CustomSequenceNoProvider_JavaClass_ID`.
- **`S_Resource.LotNumberCode`** — new optional `VARCHAR(10)` column + AD metadata, shown as an editable field on the Resource window (so a per-resource code can be embedded into generated lot numbers).

### Notes
- **Opt-in by construction**: until a sequence is configured with this provider (+ its SysConfig), every code path is identical to today.
- The concrete lot-number format lives in a customer-side PL/pgSQL function + configuration (separate customer-repo change), not in core.

### Status
**Draft** — core mechanism complete and reviewed. Still in progress: an automated integration test (Cucumber, validated on CI), a Playwright UI test for the new field, and the customer-side function + configuration.
