### PR TITLE
MobileUI Picking — enforce GRAI scan on the close-LU (OK und LU schließen) path

### DIFF
--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 7 | 12 | 58% |
-| Picking | 59 | 62 | 95% |
+| Picking | 60 | 63 | 95% |
 | Distribution | 34 | 37 | 92% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
@@ -203,8 +203,9 @@
 | Pick 10 crates onto one LU; confirming the quantity auto-invokes the inline GRAI capture; capture all 10 GRAIs (one typed via manual entry, the rest scanned) → save enabled, the atomic pick is sent and the job completes | `picking/picking-grai-flowthrough.spec.js` |
 | Pick 10 crates onto one LU; capture fewer than 10 GRAIs in the inline capture → save stays disabled (and the backend completion guard blocks completing with a GRAI-less crate) | `picking/picking-grai-flowthrough.spec.js` |
 | Pick two products onto one shared LU; each pick auto-invokes its own inline GRAI capture for that pick's crates (an RFID re-read of a crate within the burst is deduped) → each product's VHU carries exactly its own GRAIs and the job completes | `picking/picking-grai-flowthrough-mixed-product.spec.js` |
+| "OK und LU schließen" still demands one GRAI per picked crate → GRAIs stamped, LU closed, job completes | `picking/picking-grai-flowthrough.spec.js` |
 
-**3/3 — 100%**
+**4/4 — 100%**
 
 ---
 

--- a/e2e/mobile-webui/tests/spec/picking/picking-grai-flowthrough.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking-grai-flowthrough.spec.js
@@ -123,6 +123,10 @@ const buildDistinctGrais = (baseGrai, count) => {
  * Postcondition: the inline GRAI capture panel is showing and reports the picked crate count as the
  * required number of GRAIs (count label 0 / TU_COUNT).
  *
+ * @param {{ closeTarget?: boolean }} [options]
+ * @param {boolean} [options.closeTarget=false]  when true, confirms the pick quantity with the
+ *   "OK und LU schließen" button instead of plain "OK" — asserts the GRAI capture is demanded on
+ *   both completion paths (the close-LU path must not bypass it).
  * @returns {Promise<{ masterdata: any, grais: string[], pickingJobId: any }>}
  */
 const pickAllTUsAndOpenGraiScreen = async ({ closeTarget = false } = {}) => {

--- a/e2e/mobile-webui/tests/spec/picking/picking-grai-flowthrough.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking-grai-flowthrough.spec.js
@@ -125,7 +125,7 @@ const buildDistinctGrais = (baseGrai, count) => {
  *
  * @returns {Promise<{ masterdata: any, grais: string[], pickingJobId: any }>}
  */
-const pickAllTUsAndOpenGraiScreen = async () => {
+const pickAllTUsAndOpenGraiScreen = async ({ closeTarget = false } = {}) => {
     const masterdata = await createMasterdataForGraiFlowThrough();
     const grais = buildDistinctGrais(masterdata.packingInstructions.PI_MAIN.grai, TU_COUNT);
 
@@ -143,10 +143,12 @@ const pickAllTUsAndOpenGraiScreen = async () => {
     await PickingJobLineScreen.waitForScreen();
 
     // Pick all TU_COUNT crates from the line scan screen (one source HU, qty = TU_COUNT TUs).
+    // closeTarget=true finishes with the "OK und LU schließen" button instead of plain "OK"; the GRAI
+    // capture must be demanded for BOTH buttons (the close-LU path must not bypass it).
     await PickingJobLineScreen.clickScanButton();
     await PickLineScanScreen.waitForScreen();
     await PickLineScanScreen.typeQRCode(masterdata.handlingUnits.HU_SOURCE.qrCode);
-    await GetQuantityDialog.fillAndPressDone({ expectQtyEntered: String(TU_COUNT) });
+    await GetQuantityDialog.fillAndPressDone({ expectQtyEntered: String(TU_COUNT), closeTarget });
 
     // Confirming the quantity auto-invokes the inline GRAI capture (GRAIRequired=Y); the pick is NOT
     // sent yet. The panel shows the picked crate count as the required GRAI count: 0 / TU_COUNT.
@@ -241,4 +243,59 @@ test('Flow Through: capturing fewer GRAIs than crates keeps save disabled and bl
     // (the completion guard is the backend enforcement of the same invariant).
     await PickGraiScreen.expectCount({ scanned: TU_COUNT - 1, total: TU_COUNT });
     await PickGraiScreen.expectSaveDisabled();
+});
+
+// --- Close-LU must NOT bypass GRAI — finish with "OK und LU schließen" ---------------------------
+//
+// Regression: the GRAI capture was demanded after the plain "OK" button but skipped after
+// "OK und LU schließen", so a picker could ship returnable crates for a GRAI-required customer
+// without recording any GRAI. The close-LU path must demand exactly the same inline GRAI capture, then
+// stamp the captured GRAIs onto the picked crates and close the LU in one atomic pick.
+
+// noinspection JSUnusedLocalSymbols
+test('Flow Through: "OK und LU schließen" still demands one GRAI per picked crate, then completes', async ({ page }) => {
+    await allure.epic('E0105: Picking');
+    await allure.feature('F00230: MobileUI Picking');
+    await allure.story('GRAI Flow Through — closing the LU does not bypass the GRAI capture');
+    await allure.severity('critical');
+
+    // Finish the pick with the "OK und LU schließen" button. The inline GRAI capture must still appear
+    // (this is the bug: before the fix the close-LU button skipped it and completed the pick directly).
+    const { grais, pickingJobId } = await pickAllTUsAndOpenGraiScreen({ closeTarget: true });
+
+    // Capture exactly one GRAI per picked crate, then save: the pick (qty + GRAIs + close-LU) goes out
+    // as one atomic event — the GRAIs are stamped and the LU is closed in the same transaction.
+    await PickGraiScreen.expectSaveDisabled();
+    await PickGraiScreen.scanGraiBatch({ graiStrings: grais });
+    await PickGraiScreen.expectGraiChipCount({ expectedCount: TU_COUNT });
+    await PickGraiScreen.expectCount({ scanned: TU_COUNT, total: TU_COUNT });
+    await PickGraiScreen.expectSaveEnabled();
+    await PickGraiScreen.clickSave();
+    await PickingJobLineScreen.waitForScreen();
+
+    // The picked (and now closed) LU must carry exactly the 10 captured GRAIs — proves the close-LU
+    // path stamps GRAIs just like the plain-OK path.
+    await Backend.expect({
+        title: 'After close-LU pick: the LU carries all 10 captured GRAIs',
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: { qtyPicked: [{ vhu: 'vhu1', tu: 'tu1', lu: 'lu1' }] },
+                },
+            },
+        },
+        hus: {
+            vhu1: { attributes: { GRAI: grais.join(',') } },
+        },
+    });
+
+    // Complete the job: succeeds because every picked crate has a GRAI -> shipment created.
+    await PickingJobLineScreen.goBack();
+    await PickingJobScreen.waitForScreen();
+    await PickingJobScreen.complete();
+
+    await Backend.expect({
+        title: 'Close-LU Flow Through: order picked & shipped (every crate has a GRAI)',
+        salesOrders: { SO1: { status: 'Completed' } },
+    });
 });

--- a/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
@@ -116,6 +116,21 @@ export const GetQuantityDialog = {
         );
     }),
 
+    clickDoneAndCloseTarget: async ({ expectedError } = {}) => await test.step(`${NAME} - Press OK und LU schließen`, async () => {
+        const doneAndCloseButton = page.getByTestId('confirmDoneAndCloseTarget-button');
+
+        await expectErrorToastIf(
+            !!expectedError,
+            `${expectedError}`,
+            async () => {
+                await doneAndCloseButton.tap();
+                await GetQuantityDialog.expectComponentsDisabled();
+                await GetQuantityDialog.waitToClose();
+            },
+            ({ textContent }) => expect(textContent).toContain(expectedError)
+        );
+    }),
+
     clickCancel: async () => await test.step(`${NAME} - Press Cancel`, async () => {
         await page.getByTestId('cancel-button').tap();
         await GetQuantityDialog.expectComponentsDisabled();
@@ -136,7 +151,7 @@ export const GetQuantityDialog = {
         await expectMissingOrDisabled(page.getByTestId('confirmDoneAndCloseTarget-button'));
     }),
 
-    fillAndPressDone: async ({ switchToManualInput, expectQtyEntered, qtyEntered, lotNo, catchWeight, catchWeightQRCode, qtyNotFoundReason, expectQtyNotFoundReason, expectedError }) => await test.step(`${NAME} - Fill dialog`, async () => {
+    fillAndPressDone: async ({ switchToManualInput, expectQtyEntered, qtyEntered, lotNo, catchWeight, catchWeightQRCode, qtyNotFoundReason, expectQtyNotFoundReason, expectedError, closeTarget = false }) => await test.step(`${NAME} - Fill dialog`, async () => {
         await GetQuantityDialog.waitForDialog();
 
         // run this first!
@@ -171,7 +186,11 @@ export const GetQuantityDialog = {
             await GetQuantityDialog.clickQtyNotFoundReason({ reason: qtyNotFoundReason });
         }
 
-        await GetQuantityDialog.clickDone({ expectedError });
+        if (closeTarget) {
+            await GetQuantityDialog.clickDoneAndCloseTarget({ expectedError });
+        } else {
+            await GetQuantityDialog.clickDone({ expectedError });
+        }
     }),
 };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
@@ -245,8 +245,12 @@ const ScanHUAndGetQtyComponent = ({
     };
 
     // GRAI Flow-Through: when GRAI scanning is required, do not report the pick yet — auto-invoke the
-    // inline GRAI capture (one GRAI per picked crate) and report qty + GRAIs together on save.
-    if (graiScanEnabled && qtyEnteredAndValidated > 0 && !isCloseTarget) {
+    // inline GRAI capture (one GRAI per picked crate) and report qty + GRAIs together on save. This
+    // applies to BOTH the plain "OK" and the "OK und LU schließen" (isCloseTarget) completion paths:
+    // the close-LU result carries isCloseTarget through pendingGraiResult, so on save the backend
+    // stamps the GRAIs and then closes the LU within the same atomic pick. Closing the LU must never
+    // be a way to skip the GRAI scan for a GRAI-required partner.
+    if (graiScanEnabled && qtyEnteredAndValidated > 0) {
       setGraiCodes([]);
       setPendingGraiResult(result);
       setProgressStatus(STATUS_READ_GRAI);


### PR DESCRIPTION
## What

In the mobile-webui picking flow (Flow-Through / LU_TU profile), GRAI scanning for GRAI-required business partners was enforced after the plain **OK** button but **bypassed** when the pick line was finished with **"OK und LU schließen"** (OK + close the loading unit). An operator could therefore complete a pick for a GRAI-required partner without recording any GRAI.

## Root cause

`ScanHUAndGetQtyComponent.onQtyEntered` gated the inline GRAI capture on
`graiScanEnabled && qtyEnteredAndValidated > 0 && !isCloseTarget`. The `!isCloseTarget` term excluded the close-LU completion path from the capture (an oversight when the inline GRAI Flow-Through capture was first added).

## Fix

Remove the `!isCloseTarget` exclusion so the close-LU path runs the same non-skippable inline GRAI capture as the plain **OK** path. The picked result already carries `isCloseTarget` through `pendingGraiResult`, so on Save the backend stamps the GRAIs and **then** closes the LU within the same atomic pick. Non-GRAI partners and the plain-OK path are unchanged.

## Tests (Playwright E2E)

- New E2E in `e2e/mobile-webui/.../picking/picking-grai-flowthrough.spec.js`: finishing a pick with **"OK und LU schließen"** now demands one GRAI per picked crate, stamps them on the picked LU, closes the LU, and completes the job. RED before the fix (the GRAI capture screen never appeared), GREEN after.
- Full GRAI Flow-Through spec: 3/3 pass (the two existing plain-OK tests unchanged).
- `TEST-COVERAGE.md` updated.
