### PR TITLE
gh#29844 Bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/flaky-metric.yaml
+++ b/.github/workflows/flaky-metric.yaml
@@ -56,7 +56,7 @@ jobs:
       ${{ github.repository == 'metasfresh/metasfresh'
           && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'failure') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Ports the Node-24 GitHub Actions migration from `new_dawn_uat` (https://github.com/metasfresh/metasfresh/pull/24247) to `galaxy_hero_hotfix`.

GitHub forced the Node-24 default on Actions runners on 2026-06-02 (Node 20 removal 2026-09-16), so CI on this branch needs the bumped action versions to keep running.

Method on this branch: **semantic-bump**. Bumped: `actions/checkout@v6`, `actions/upload-artifact@v6`, `actions/download-artifact@v8`, `docker/login-action@v4`, `nick-fields/retry@v4`, `dawidd6/action-download-artifact@v21` (the same package set new_dawn_uat migrated).

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/