### PR TITLE
gh#29844 Bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/actions/generate-allure-report/action.yml
+++ b/.github/actions/generate-allure-report/action.yml
@@ -43,7 +43,7 @@ runs:
     # Download previous history from last successful run on same branch
     - name: Download previous Allure history
       if: inputs.history-artifact-name != ''
-      uses: dawidd6/action-download-artifact@v9
+      uses: dawidd6/action-download-artifact@v21
       with:
         name: ${{ inputs.history-artifact-name }}
         path: ${{ inputs.results-dir }}/history

--- a/.github/actions/generate-junit-html/action.yml
+++ b/.github/actions/generate-junit-html/action.yml
@@ -33,7 +33,7 @@ runs:
     # Download previous history from last run on same branch
     - name: Download previous Allure history
       if: inputs.history-artifact-name != ''
-      uses: dawidd6/action-download-artifact@v9
+      uses: dawidd6/action-download-artifact@v21
       with:
         name: ${{ inputs.history-artifact-name }}
         path: junit-history-temp

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -696,7 +696,7 @@ jobs:
           echo -e "$INIT_BUILD_PROPS" > docker-builds/metadata/build-info.properties
           echo -e "$INIT_GIT_PROPS" > docker-builds/metadata/git.properties
       - name: download-migration-cli-jar
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: migration-cli-jar
           path: .
@@ -1638,7 +1638,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download all Cucumber Allure results
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: cucumber-allure-results-*
           path: all-cucumber-results/
@@ -2004,7 +2004,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download all shard Allure results
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: allure-results-frontend-*
           path: allure-results-merged


### PR DESCRIPTION
Ports the Node-24 GitHub Actions migration from `new_dawn_uat` (https://github.com/metasfresh/metasfresh/pull/24247) to `vernal_mousse_hotfix`.

GitHub forced the Node-24 default on Actions runners on 2026-06-02 (Node 20 removal 2026-09-16), so CI on this branch needs the bumped action versions to keep running.

Method on this branch: **semantic-bump**. Bumped: `actions/checkout@v6`, `actions/upload-artifact@v6`, `actions/download-artifact@v8`, `docker/login-action@v4`, `nick-fields/retry@v4`, `dawidd6/action-download-artifact@v21` (the same package set new_dawn_uat migrated).

Reference: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/