### PR TITLE
Manufacturing BOM Costs — fix percent line cost UOM conversion

### DIFF
--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/ddl/functions/computeCurrentBOMProductCost.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/ddl/functions/computeCurrentBOMProductCost.sql
@@ -43,22 +43,33 @@ BEGIN
                     AND cas.C_AcctSchema_ID = v_acctschema_id)
     LIMIT 1;
 
-    -- Sum each direct BOM line: quantity for one finished good x component current cost.
-    -- The component current cost is taken in the BOM line UOM (getCurrentCost converts from
-    -- the component stock UOM), and a percentage line's quantity is scaled by the finished
-    -- good -> line UOM conversion (see computeCurrentBOMLineProductCost).
-    SELECT ROUND(SUM(
-                         CASE WHEN bom.IsQtyPercentage = 'Y'
-                                  THEN bom.Percentage / 100 * uomConvert(v_parent_product_id, v_parent_uom_id, bom.c_uom_id, 1) * bom.unit_cost
-                                  ELSE bom.QtyBOM * bom.unit_cost
-                         END
-                 ), 6)
+    -- Sum each direct BOM line (depth=2; depth=1 is the finished good itself): quantity for
+    -- one finished good x component current cost. The component current cost (bom.unit_cost) is
+    -- taken in the BOM line UOM (getCurrentCost converts from the component stock UOM, and for a
+    -- sub-assembly component returns its own already-rolled-up current cost). A percentage line's
+    -- quantity is scaled by bom.uom_mult = the finished good -> line UOM conversion. bom.Percentage
+    -- is PP_Product_BOMLine.QtyBatch as exposed by pp_product_bom_recursive for percentage lines.
+    --
+    -- A percentage line whose finished good / line UOMs cannot be converted has uom_mult = NULL;
+    -- that is a configuration gap, so the whole BOM cost is returned NULL to surface it (mirrors
+    -- computeCurrentBOMLineProductCost, which returns NULL for that line). The guard targets only
+    -- percentage lines, so a line that is legitimately NULL for other reasons (e.g. a by-product
+    -- with no QtyBOM) is still skipped by SUM without nulling the whole total.
+    SELECT CASE
+               WHEN bool_or(bom.IsQtyPercentage = 'Y' AND bom.uom_mult IS NULL) THEN NULL
+               ELSE ROUND(SUM(
+                                  CASE WHEN bom.IsQtyPercentage = 'Y'
+                                           THEN bom.Percentage / 100 * bom.uom_mult * bom.unit_cost
+                                           ELSE bom.QtyBOM * bom.unit_cost
+                                  END
+                          ), 6)
+           END
     INTO cost
     FROM (
              SELECT b.IsQtyPercentage,
                     b.QtyBOM,
                     b.Percentage,
-                    b.c_uom_id,
+                    uomConvert(v_parent_product_id, v_parent_uom_id, b.c_uom_id, 1) AS uom_mult,
                     COALESCE(getCurrentCost(
                                      b.m_product_id,
                                      b.c_uom_id,

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5809450_sys_gh29024_fix_computeCurrentBOMLineProductCost.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5809450_sys_gh29024_fix_computeCurrentBOMLineProductCost.sql
@@ -1,3 +1,4 @@
+-- Source DDL: backend/de.metas.manufacturing/src/main/sql/postgresql/ddl/functions/computeCurrentBOMLineProductCost.sql
 DROP FUNCTION IF EXISTS computeCurrentBOMLineProductCost(
     p_pp_product_bomline_id numeric,
     p_date                  date

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5809460_sys_gh29024_fix_computeCurrentBOMProductCost.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5809460_sys_gh29024_fix_computeCurrentBOMProductCost.sql
@@ -1,3 +1,4 @@
+-- Source DDL: backend/de.metas.manufacturing/src/main/sql/postgresql/ddl/functions/computeCurrentBOMProductCost.sql
 DROP FUNCTION IF EXISTS computeCurrentBOMProductCost(p_pp_product_bom_id numeric,
                                                     p_date              date)
 ;

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5809460_sys_gh29024_fix_computeCurrentBOMProductCost.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5809460_sys_gh29024_fix_computeCurrentBOMProductCost.sql
@@ -44,22 +44,33 @@ BEGIN
                     AND cas.C_AcctSchema_ID = v_acctschema_id)
     LIMIT 1;
 
-    -- Sum each direct BOM line: quantity for one finished good x component current cost.
-    -- The component current cost is taken in the BOM line UOM (getCurrentCost converts from
-    -- the component stock UOM), and a percentage line's quantity is scaled by the finished
-    -- good -> line UOM conversion (see computeCurrentBOMLineProductCost).
-    SELECT ROUND(SUM(
-                         CASE WHEN bom.IsQtyPercentage = 'Y'
-                                  THEN bom.Percentage / 100 * uomConvert(v_parent_product_id, v_parent_uom_id, bom.c_uom_id, 1) * bom.unit_cost
-                                  ELSE bom.QtyBOM * bom.unit_cost
-                         END
-                 ), 6)
+    -- Sum each direct BOM line (depth=2; depth=1 is the finished good itself): quantity for
+    -- one finished good x component current cost. The component current cost (bom.unit_cost) is
+    -- taken in the BOM line UOM (getCurrentCost converts from the component stock UOM, and for a
+    -- sub-assembly component returns its own already-rolled-up current cost). A percentage line's
+    -- quantity is scaled by bom.uom_mult = the finished good -> line UOM conversion. bom.Percentage
+    -- is PP_Product_BOMLine.QtyBatch as exposed by pp_product_bom_recursive for percentage lines.
+    --
+    -- A percentage line whose finished good / line UOMs cannot be converted has uom_mult = NULL;
+    -- that is a configuration gap, so the whole BOM cost is returned NULL to surface it (mirrors
+    -- computeCurrentBOMLineProductCost, which returns NULL for that line). The guard targets only
+    -- percentage lines, so a line that is legitimately NULL for other reasons (e.g. a by-product
+    -- with no QtyBOM) is still skipped by SUM without nulling the whole total.
+    SELECT CASE
+               WHEN bool_or(bom.IsQtyPercentage = 'Y' AND bom.uom_mult IS NULL) THEN NULL
+               ELSE ROUND(SUM(
+                                  CASE WHEN bom.IsQtyPercentage = 'Y'
+                                           THEN bom.Percentage / 100 * bom.uom_mult * bom.unit_cost
+                                           ELSE bom.QtyBOM * bom.unit_cost
+                                  END
+                          ), 6)
+           END
     INTO cost
     FROM (
              SELECT b.IsQtyPercentage,
                     b.QtyBOM,
                     b.Percentage,
-                    b.c_uom_id,
+                    uomConvert(v_parent_product_id, v_parent_uom_id, b.c_uom_id, 1) AS uom_mult,
                     COALESCE(getCurrentCost(
                                      b.m_product_id,
                                      b.c_uom_id,


### PR DESCRIPTION
## What

Fixes the calculation of **percentage** BOM line costs shown on the BOM window (`Komponentenkosten` per line, `Stücklistenkosten` in the header).

For a percentage line, the cost ignored the finished product's portion size and the UOM relationship between the finished good and the component. Example: a 200 g portion of a product (sold as "Stück") made from a bulk raw material measured in kg — the portion needs `200 g + 15 % = 230 g` of raw material, but the BOM cost was computed as if the percentage applied to a full unit and the raw-material cost was taken per whole bulk unit (~34 kg) — overstating the cost ~5× (then ~34× when the component is a sub-assembly).

## Root cause

Both `computeCurrentBOMLineProductCost` and `computeCurrentBOMProductCost` computed a percentage line as `Percentage/100 × component-unit-cost`, with two UOM problems:
1. the percentage was not scaled from the finished-good UOM into the line UOM;
2. the component cost was taken in the component's own stock UOM (and, for a sub-assembly component, via the per-batch rollup) rather than in the BOM line UOM.

## Fix (SQL only)

In both functions:
- scale a percentage line by `uomConvert(finishedGood, finishedGoodStockUOM → lineUOM, 1)` — mirrors the production-order quantity explosion (`org.eevolution.api.impl.ProductBOMBL.computeQtyMultiplier`);
- take the component current cost **in the BOM line UOM** via `getCurrentCost(component, lineUOM, …)`, so cost and quantity share the same UOM basis.

Same-UOM lines are unchanged (conversion factor 1); non-percentage lines are untouched.

## Verified

Against a real percentage BOM (200 g portion in "Stück"; raw material in kg; 1 bulk unit = 34 kg; raw-material cost 494.28/unit = 14.54/kg):
- before: line `16.74` / header `16.73`
- after: line `≈ 3.34` / header `3.357905` (consistent with the finished product's current cost price `3.379`)
- packaging (non-percentage) line unchanged (`0.01428`).

## Files
- `ddl/functions/computeCurrentBOMLineProductCost.sql`
- `ddl/functions/computeCurrentBOMProductCost.sql`
- migrations `5809450_…`, `5809460_…`
