### PR TITLE
GRAI — validate dummy-GRAI PO reference at sales-order change & completion (translated message)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809480_sys_DummyGRAIPOReference_AD_Messages.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809480_sys_DummyGRAIPOReference_AD_Messages.sql
@@ -8,7 +8,7 @@
 -- AD_Message: DummyGRAISerialPrefixTooLong
 INSERT INTO AD_Message (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
                         MsgType, Value, MsgText, EntityType, AD_Message_ID)
-VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:00','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:00','YYYY-MM-DD HH24:MI:SS'), 0,
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:00','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
         'E', 'de.metas.handlingunits.grai.DummyGRAISerialPrefixTooLong',
         'Die Bestellreferenz "{0}" ist zu lang für die GRAI-Erzeugung (max. 10 Zeichen). Bitte die Bestellreferenz im Auftrag entsprechend kürzen.',
         'de.metas.handlingunits', 545765 /*From ID Server*/);
@@ -16,24 +16,24 @@ VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:00','YYYY-MM-DD HH24:MI:SS'), 
 UPDATE AD_Message SET ErrorCode = 'GRAI_POREFERENCE_TOO_LONG' WHERE AD_Message_ID = 545765;
 
 INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
-VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:01','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:01','YYYY-MM-DD HH24:MI:SS'), 0,
+VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:01','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:01','YYYY-MM-DD HH24:MI:SS'), 100,
         545765 /*From ID Server*/,
         'Die Bestellreferenz "{0}" ist zu lang für die GRAI-Erzeugung (max. 10 Zeichen). Bitte die Bestellreferenz im Auftrag entsprechend kürzen.', NULL, 'N');
 
 INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
-VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:02','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:02','YYYY-MM-DD HH24:MI:SS'), 0,
+VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:02','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:02','YYYY-MM-DD HH24:MI:SS'), 100,
         545765 /*From ID Server*/,
         'Die Bestellreferenz "{0}" ist zu lang für die GRAI-Erzeugung (max. 10 Zeichen). Bitte die Bestellreferenz im Auftrag entsprechend kürzen.', NULL, 'N');
 
 INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
-VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:03','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:03','YYYY-MM-DD HH24:MI:SS'), 0,
+VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:03','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:03','YYYY-MM-DD HH24:MI:SS'), 100,
         545765 /*From ID Server*/,
         'The PO reference "{0}" is too long for GRAI generation (max. 10 characters). Please shorten the PO reference on the order.', NULL, 'Y');
 
 -- AD_Message: DummyGRAIPOReferenceMissing
 INSERT INTO AD_Message (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
                         MsgType, Value, MsgText, EntityType, AD_Message_ID)
-VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:04','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:04','YYYY-MM-DD HH24:MI:SS'), 0,
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:04','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:04','YYYY-MM-DD HH24:MI:SS'), 100,
         'E', 'de.metas.handlingunits.grai.DummyGRAIPOReferenceMissing',
         'Auftrag {0}: Es ist keine Bestellreferenz hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.',
         'de.metas.handlingunits', 545766 /*From ID Server*/);
@@ -41,16 +41,16 @@ VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:04','YYYY-MM-DD HH24:MI:SS'), 
 UPDATE AD_Message SET ErrorCode = 'GRAI_POREFERENCE_MISSING' WHERE AD_Message_ID = 545766;
 
 INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
-VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:05','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:05','YYYY-MM-DD HH24:MI:SS'), 0,
+VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:05','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:05','YYYY-MM-DD HH24:MI:SS'), 100,
         545766 /*From ID Server*/,
         'Auftrag {0}: Es ist keine Bestellreferenz hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.', NULL, 'N');
 
 INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
-VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:06','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:06','YYYY-MM-DD HH24:MI:SS'), 0,
+VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:06','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:06','YYYY-MM-DD HH24:MI:SS'), 100,
         545766 /*From ID Server*/,
         'Auftrag {0}: Es ist keine Bestellreferenz hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.', NULL, 'N');
 
 INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
-VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:07','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:07','YYYY-MM-DD HH24:MI:SS'), 0,
+VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:07','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:07','YYYY-MM-DD HH24:MI:SS'), 100,
         545766 /*From ID Server*/,
         'Order {0}: no PO reference is set. GRAI generation requires a PO reference (max. 10 characters).', NULL, 'Y');

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809480_sys_DummyGRAIPOReference_AD_Messages.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809480_sys_DummyGRAIPOReference_AD_Messages.sql
@@ -1,0 +1,56 @@
+-- 2026-06-24
+-- AD_Messages for the dummy-GRAI PO-reference prerequisite validation.
+-- Surfaced when a sales order's customer requires dummy GRAIs (GRAIRequired = YesWithDummyGRAIs) but the
+-- order's PO reference cannot form a valid dummy-GRAI serial prefix (missing after trim, or longer than 10
+-- characters). Used by the sales-order change/completion interceptors, the picking job-open check, and the
+-- picking-completion backstop, so the same operator-facing text shows everywhere.
+
+-- AD_Message: DummyGRAISerialPrefixTooLong
+INSERT INTO AD_Message (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                        MsgType, Value, MsgText, EntityType, AD_Message_ID)
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:00','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:00','YYYY-MM-DD HH24:MI:SS'), 0,
+        'E', 'de.metas.handlingunits.grai.DummyGRAISerialPrefixTooLong',
+        'Die Bestellreferenz "{0}" ist zu lang für die GRAI-Erzeugung (max. 10 Zeichen). Bitte die Bestellreferenz im Auftrag entsprechend kürzen.',
+        'de.metas.handlingunits', 545765 /*From ID Server*/);
+
+UPDATE AD_Message SET ErrorCode = 'GRAI_POREFERENCE_TOO_LONG' WHERE AD_Message_ID = 545765;
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
+VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:01','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:01','YYYY-MM-DD HH24:MI:SS'), 0,
+        545765 /*From ID Server*/,
+        'Die Bestellreferenz "{0}" ist zu lang für die GRAI-Erzeugung (max. 10 Zeichen). Bitte die Bestellreferenz im Auftrag entsprechend kürzen.', NULL, 'N');
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
+VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:02','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:02','YYYY-MM-DD HH24:MI:SS'), 0,
+        545765 /*From ID Server*/,
+        'Die Bestellreferenz "{0}" ist zu lang für die GRAI-Erzeugung (max. 10 Zeichen). Bitte die Bestellreferenz im Auftrag entsprechend kürzen.', NULL, 'N');
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
+VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:03','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:03','YYYY-MM-DD HH24:MI:SS'), 0,
+        545765 /*From ID Server*/,
+        'The PO reference "{0}" is too long for GRAI generation (max. 10 characters). Please shorten the PO reference on the order.', NULL, 'Y');
+
+-- AD_Message: DummyGRAIPOReferenceMissing
+INSERT INTO AD_Message (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                        MsgType, Value, MsgText, EntityType, AD_Message_ID)
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:04','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:04','YYYY-MM-DD HH24:MI:SS'), 0,
+        'E', 'de.metas.handlingunits.grai.DummyGRAIPOReferenceMissing',
+        'Es ist keine Bestellreferenz im Auftrag hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.',
+        'de.metas.handlingunits', 545766 /*From ID Server*/);
+
+UPDATE AD_Message SET ErrorCode = 'GRAI_POREFERENCE_MISSING' WHERE AD_Message_ID = 545766;
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
+VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:05','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:05','YYYY-MM-DD HH24:MI:SS'), 0,
+        545766 /*From ID Server*/,
+        'Es ist keine Bestellreferenz im Auftrag hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.', NULL, 'N');
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
+VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:06','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:06','YYYY-MM-DD HH24:MI:SS'), 0,
+        545766 /*From ID Server*/,
+        'Es ist keine Bestellreferenz im Auftrag hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.', NULL, 'N');
+
+INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
+VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:07','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:07','YYYY-MM-DD HH24:MI:SS'), 0,
+        545766 /*From ID Server*/,
+        'No PO reference is set on the order. GRAI generation requires a PO reference (max. 10 characters).', NULL, 'Y');

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809480_sys_DummyGRAIPOReference_AD_Messages.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809480_sys_DummyGRAIPOReference_AD_Messages.sql
@@ -12,45 +12,29 @@ VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:00','YYYY-MM-DD HH24:MI:SS'), 
         'E', 'de.metas.handlingunits.grai.DummyGRAISerialPrefixTooLong',
         'Die Bestellreferenz "{0}" ist zu lang für die GRAI-Erzeugung (max. 10 Zeichen). Bitte die Bestellreferenz im Auftrag entsprechend kürzen.',
         'de.metas.handlingunits', 545765 /*From ID Server*/);
-
-UPDATE AD_Message SET ErrorCode = 'GRAI_POREFERENCE_TOO_LONG' WHERE AD_Message_ID = 545765;
-
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
-VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:01','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:01','YYYY-MM-DD HH24:MI:SS'), 100,
-        545765 /*From ID Server*/,
-        'Die Bestellreferenz "{0}" ist zu lang für die GRAI-Erzeugung (max. 10 Zeichen). Bitte die Bestellreferenz im Auftrag entsprechend kürzen.', NULL, 'N');
-
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
-VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:02','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:02','YYYY-MM-DD HH24:MI:SS'), 100,
-        545765 /*From ID Server*/,
-        'Die Bestellreferenz "{0}" ist zu lang für die GRAI-Erzeugung (max. 10 Zeichen). Bitte die Bestellreferenz im Auftrag entsprechend kürzen.', NULL, 'N');
-
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
-VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:03','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:03','YYYY-MM-DD HH24:MI:SS'), 100,
-        545765 /*From ID Server*/,
-        'The PO reference "{0}" is too long for GRAI generation (max. 10 characters). Please shorten the PO reference on the order.', NULL, 'Y');
+UPDATE AD_Message SET ErrorCode='GRAI_POREFERENCE_TOO_LONG', Updated=TO_TIMESTAMP('2026-06-24 12:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545765;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545765
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID);
+UPDATE AD_Message_Trl SET MsgText='The PO reference "{0}" is too long for GRAI generation (max. 10 characters). Please shorten the PO reference on the order.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-24 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545765;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-24 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545765;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-24 12:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545765;
 
 -- AD_Message: DummyGRAIPOReferenceMissing
 INSERT INTO AD_Message (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
                         MsgType, Value, MsgText, EntityType, AD_Message_ID)
-VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:04','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:04','YYYY-MM-DD HH24:MI:SS'), 100,
+VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:01','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:01','YYYY-MM-DD HH24:MI:SS'), 100,
         'E', 'de.metas.handlingunits.grai.DummyGRAIPOReferenceMissing',
         'Auftrag {0}: Es ist keine Bestellreferenz hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.',
         'de.metas.handlingunits', 545766 /*From ID Server*/);
-
-UPDATE AD_Message SET ErrorCode = 'GRAI_POREFERENCE_MISSING' WHERE AD_Message_ID = 545766;
-
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
-VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:05','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:05','YYYY-MM-DD HH24:MI:SS'), 100,
-        545766 /*From ID Server*/,
-        'Auftrag {0}: Es ist keine Bestellreferenz hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.', NULL, 'N');
-
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
-VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:06','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:06','YYYY-MM-DD HH24:MI:SS'), 100,
-        545766 /*From ID Server*/,
-        'Auftrag {0}: Es ist keine Bestellreferenz hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.', NULL, 'N');
-
-INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
-VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:07','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-06-24 12:00:07','YYYY-MM-DD HH24:MI:SS'), 100,
-        545766 /*From ID Server*/,
-        'Order {0}: no PO reference is set. GRAI generation requires a PO reference (max. 10 characters).', NULL, 'Y');
+UPDATE AD_Message SET ErrorCode='GRAI_POREFERENCE_MISSING', Updated=TO_TIMESTAMP('2026-06-24 12:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545766;
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545766
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID);
+UPDATE AD_Message_Trl SET MsgText='Order {0}: no PO reference is set. GRAI generation requires a PO reference (max. 10 characters).',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-24 12:00:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545766;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-24 12:00:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545766;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-06-24 12:00:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545766;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809480_sys_DummyGRAIPOReference_AD_Messages.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809480_sys_DummyGRAIPOReference_AD_Messages.sql
@@ -35,7 +35,7 @@ INSERT INTO AD_Message (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, U
                         MsgType, Value, MsgText, EntityType, AD_Message_ID)
 VALUES (0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:04','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:04','YYYY-MM-DD HH24:MI:SS'), 0,
         'E', 'de.metas.handlingunits.grai.DummyGRAIPOReferenceMissing',
-        'Es ist keine Bestellreferenz im Auftrag hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.',
+        'Auftrag {0}: Es ist keine Bestellreferenz hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.',
         'de.metas.handlingunits', 545766 /*From ID Server*/);
 
 UPDATE AD_Message SET ErrorCode = 'GRAI_POREFERENCE_MISSING' WHERE AD_Message_ID = 545766;
@@ -43,14 +43,14 @@ UPDATE AD_Message SET ErrorCode = 'GRAI_POREFERENCE_MISSING' WHERE AD_Message_ID
 INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
 VALUES ('de_DE', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:05','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:05','YYYY-MM-DD HH24:MI:SS'), 0,
         545766 /*From ID Server*/,
-        'Es ist keine Bestellreferenz im Auftrag hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.', NULL, 'N');
+        'Auftrag {0}: Es ist keine Bestellreferenz hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.', NULL, 'N');
 
 INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
 VALUES ('de_CH', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:06','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:06','YYYY-MM-DD HH24:MI:SS'), 0,
         545766 /*From ID Server*/,
-        'Es ist keine Bestellreferenz im Auftrag hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.', NULL, 'N');
+        'Auftrag {0}: Es ist keine Bestellreferenz hinterlegt. Für die GRAI-Erzeugung wird eine Bestellreferenz (max. 10 Zeichen) benötigt.', NULL, 'N');
 
 INSERT INTO AD_Message_Trl (AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, AD_Message_ID, MsgText, MsgTip, IsTranslated)
 VALUES ('en_US', 0, 0, 'Y', TO_TIMESTAMP('2026-06-24 12:00:07','YYYY-MM-DD HH24:MI:SS'), 0, TO_TIMESTAMP('2026-06-24 12:00:07','YYYY-MM-DD HH24:MI:SS'), 0,
         545766 /*From ID Server*/,
-        'No PO reference is set on the order. GRAI generation requires a PO reference (max. 10 characters).', NULL, 'Y');
+        'Order {0}: no PO reference is set. GRAI generation requires a PO reference (max. 10 characters).', NULL, 'Y');

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
@@ -240,6 +240,51 @@ public class C_Order_StepDef
 				.forEach(this::createOrder);
 	}
 
+	/**
+	 * Creates a single C_Order (same columns as {@code metasfresh contains C_Orders:}) and asserts that
+	 * the creation is rejected with an {@link AdempiereException}. Use this to verify a save-time
+	 * interceptor (e.g. the dummy-GRAI PO-reference validation) blocks the order.
+	 * <p>
+	 * Single row only. Columns: every column of {@code metasfresh contains C_Orders:} plus
+	 * <ul>
+	 *     <li><b>ErrorCode</b> (optional): when given, the thrown exception's {@code ErrorCode} must equal it.</li>
+	 * </ul>
+	 * <pre>
+	 * And metasfresh contains C_Orders expecting error:
+	 *   | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.M_Warehouse_ID.Identifier | POReference    | ErrorCode                 |
+	 *   | true    | dummyGRAICustomer        | 2026-06-24  | 540008                        | TOOLONG-PO-REF | GRAI_POREFERENCE_TOO_LONG |
+	 * </pre>
+	 */
+	@Given("metasfresh contains C_Orders expecting error:")
+	public void metasfresh_contains_c_orders_expecting_error(@NonNull final DataTable dataTable)
+	{
+		final List<Map<String, String>> tableRows = dataTable.asMaps(String.class, String.class);
+		if (tableRows.size() > 1)
+		{
+			throw new IllegalArgumentException("Multiple rows are not supported!");
+		}
+
+		AdempiereException caughtException = null;
+		try
+		{
+			metasfresh_contains_c_orders(dataTable);
+		}
+		catch (final AdempiereException e)
+		{
+			caughtException = e;
+		}
+
+		assertThat(caughtException)
+				.as("An AdempiereException should have been thrown while creating the C_Order")
+				.isNotNull();
+
+		final String expectedErrorCode = DataTableUtil.extractStringOrNullForColumnName(tableRows.get(0), "ErrorCode");
+		if (expectedErrorCode != null)
+		{
+			assertThat(caughtException.getErrorCode()).isEqualTo(expectedErrorCode);
+		}
+	}
+
 	public I_C_Order createOrder(final DataTableRow tableRow)
 	{
 		final String poReference = tableRow.getAsOptionalName(I_C_Order.COLUMNNAME_POReference).orElse(null);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/dummyGRAIPOReferenceValidation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/dummyGRAIPOReferenceValidation.feature
@@ -1,0 +1,64 @@
+@from:cucumber
+@allure.label.epic:E0105_Picking
+@allure.label.feature:F00230_MobileUI_Picking
+@ghActions:run_on_executor6
+Feature: Dummy-GRAI prerequisite — validate the sales order PO reference at the source
+  # For a customer in GRAIRequired = YesWithDummyGRAIs ('D') mode, dummy GRAIs are generated at picking
+  # completion using the sales order PO reference as the serial prefix (max 10 characters). This validates
+  # that prerequisite early, when the sales order is saved by the back-office actor who can fix it — instead
+  # of failing only at picking completion with a raw technical message. A non-GRAI customer and a valid
+  # PO reference are unaffected.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
+
+    And metasfresh contains M_Products:
+      | Identifier | Name        | Value       |
+      | product    | graiProduct | graiProduct |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name           | Value          |
+      | ps         | graiPricingSys | graiPricingSys |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name   | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl         | ps                            | DE                        | EUR                 | graiPL | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name    | ValidFrom  |
+      | plv        | pl                        | graiPLV | 2026-01-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp         | plv                               | product                 | 10.0     | PCE               | Normal                        |
+
+  Scenario: A too-long PO reference is rejected when saving a sales order for a dummy-GRAI customer
+    Given metasfresh contains C_BPartners:
+      | Identifier        | Name              | OPT.IsCustomer | M_PricingSystem_ID.Identifier | GRAIRequired |
+      | dummyGRAICustomer | dummyGRAICustomer | Y              | ps                            | D            |
+    Then metasfresh contains C_Orders expecting error:
+      | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.M_Warehouse_ID.Identifier | POReference    | ErrorCode                 |
+      | true    | dummyGRAICustomer        | 2026-06-24  | 540008                        | TOOLONG-PO-REF | GRAI_POREFERENCE_TOO_LONG |
+
+  Scenario: A valid PO reference (max 10 chars) for a dummy-GRAI customer is accepted and the order completes
+    Given metasfresh contains C_BPartners:
+      | Identifier        | Name              | OPT.IsCustomer | M_PricingSystem_ID.Identifier | GRAIRequired |
+      | dummyGRAICustomer | dummyGRAICustomer | Y              | ps                            | D            |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.M_Warehouse_ID.Identifier | POReference |
+      | order      | true    | dummyGRAICustomer        | 2026-06-24  | 540008                        | PO-123456   |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine  | order                 | product                 | 10         |
+    Then the order identified by order is completed
+
+  Scenario: A too-long PO reference for a non-GRAI customer is accepted (the validation does not apply)
+    Given metasfresh contains C_BPartners:
+      | Identifier    | Name          | OPT.IsCustomer | M_PricingSystem_ID.Identifier | GRAIRequired |
+      | plainCustomer | plainCustomer | Y              | ps                            | N            |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.M_Warehouse_ID.Identifier | POReference    |
+      | order      | true    | plainCustomer            | 2026-06-24  | 540008                        | TOOLONG-PO-REF |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine  | order                 | product                 | 10         |
+    Then the order identified by order is completed

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/dummyGRAIPOReferenceValidation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/dummyGRAIPOReferenceValidation.feature
@@ -11,6 +11,7 @@ Feature: Dummy-GRAI prerequisite — validate the sales order PO reference at th
 
   Background:
     Given infrastructure and metasfresh are running
+    And metasfresh has date and time 2026-06-24T12:00:00+01:00[Europe/Berlin]
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
     And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/grai/DummyGRAITemplate.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/grai/DummyGRAITemplate.java
@@ -1,5 +1,6 @@
 package de.metas.handlingunits.grai;
 
+import de.metas.i18n.AdMessageKey;
 import de.metas.util.StringUtils;
 import lombok.NonNull;
 import lombok.Value;
@@ -13,6 +14,11 @@ public class DummyGRAITemplate
 	public static final String MIGROS_COMPANY_PREFIX = "7613204";
 	public static final String MIGROS_ASSET_TYPE = "00307";
 	public static final int MAX_COUNTER = 99;
+
+	// User-facing, translated prerequisite messages for dummy-GRAI generation. Centralised here so every
+	// validation layer (order change/completion, picking job-open, picking completion) surfaces the same text.
+	public static final AdMessageKey MSG_DUMMY_GRAI_SERIAL_PREFIX_TOO_LONG = AdMessageKey.of("de.metas.handlingunits.grai.DummyGRAISerialPrefixTooLong");
+	public static final AdMessageKey MSG_DUMMY_GRAI_POREFERENCE_MISSING = AdMessageKey.of("de.metas.handlingunits.grai.DummyGRAIPOReferenceMissing");
 
 	@NonNull String companyPrefix;
 	@NonNull String assetType;
@@ -71,7 +77,7 @@ public class DummyGRAITemplate
 	{
 		if (serialPrefix.length() > 10)
 		{
-			throw new AdempiereException("Serial prefix too long for dummy GRAI generation (max 10 chars): " + serialPrefix);
+			throw new AdempiereException(MSG_DUMMY_GRAI_SERIAL_PREFIX_TOO_LONG, serialPrefix);
 		}
 		return StringUtils.lpadZero(serialPrefix, 10, "serialPrefix");
 	}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/grai/DummyGRAITemplate.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/grai/DummyGRAITemplate.java
@@ -72,13 +72,23 @@ public class DummyGRAITemplate
 		}
 	}
 
-	@NonNull
-	private static String padSerialPrefix(@NonNull final String serialPrefix)
+	/**
+	 * Asserts that {@code serialPrefix} (the sales order's PO reference) can form a valid dummy-GRAI serial
+	 * prefix — it must be at most 10 characters. Throws the translated prerequisite message otherwise.
+	 * The single source of truth for the dummy-GRAI length rule, reused by the early validation layers.
+	 */
+	public static void assertValidSerialPrefix(@NonNull final String serialPrefix)
 	{
 		if (serialPrefix.length() > 10)
 		{
 			throw new AdempiereException(MSG_DUMMY_GRAI_SERIAL_PREFIX_TOO_LONG, serialPrefix);
 		}
+	}
+
+	@NonNull
+	private static String padSerialPrefix(@NonNull final String serialPrefix)
+	{
+		assertValidSerialPrefix(serialPrefix);
 		return StringUtils.lpadZero(serialPrefix, 10, "serialPrefix");
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/interceptor/C_Order.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/interceptor/C_Order.java
@@ -23,7 +23,15 @@ public class C_Order
 		this.pickingJobService = pickingJobService;
 	}
 
-	@ModelChange(timings = { ModelValidator.TYPE_AFTER_NEW, ModelValidator.TYPE_AFTER_CHANGE }, ifColumnsChanged = I_C_Order.COLUMNNAME_POReference)
+	// ifColumnsChanged is honoured only for CHANGE timings; on AFTER_NEW the framework ignores it. So a
+	// dedicated NEW handler validates every newly created sales order (a no-op unless it requires dummy GRAIs).
+	@ModelChange(timings = ModelValidator.TYPE_AFTER_NEW)
+	public void validateDummyGRAIPrerequisitesOnNew(@NonNull final I_C_Order order)
+	{
+		assertDummyGRAIPrerequisites(order);
+	}
+
+	@ModelChange(timings = ModelValidator.TYPE_AFTER_CHANGE, ifColumnsChanged = I_C_Order.COLUMNNAME_POReference)
 	public void validateDummyGRAIPrerequisitesOnPOReferenceChange(@NonNull final I_C_Order order)
 	{
 		assertDummyGRAIPrerequisites(order);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/interceptor/C_Order.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/interceptor/C_Order.java
@@ -31,6 +31,9 @@ public class C_Order
 		assertDummyGRAIPrerequisites(order);
 	}
 
+	// Watches POReference only — intentionally NOT C_BPartner_ID. Switching an existing order's customer
+	// to a dummy-GRAI customer (PO reference untouched) is a rare back-office action; it is not re-validated
+	// at save and is caught instead by the BEFORE_COMPLETE backstop below. (me03 30607 — deliberate scope.)
 	@ModelChange(timings = ModelValidator.TYPE_AFTER_CHANGE, ifColumnsChanged = I_C_Order.COLUMNNAME_POReference)
 	public void validateDummyGRAIPrerequisitesOnPOReferenceChange(@NonNull final I_C_Order order)
 	{

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/interceptor/C_Order.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/interceptor/C_Order.java
@@ -1,10 +1,12 @@
 package de.metas.handlingunits.picking.interceptor;
 
+import de.metas.bpartner.BPartnerId;
 import de.metas.handlingunits.picking.job.service.PickingJobService;
 import de.metas.order.OrderId;
 import lombok.NonNull;
 import org.adempiere.ad.modelvalidator.annotations.DocValidate;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.ModelValidator;
 import org.springframework.stereotype.Component;
@@ -19,6 +21,35 @@ public class C_Order
 			@NonNull final PickingJobService pickingJobService)
 	{
 		this.pickingJobService = pickingJobService;
+	}
+
+	@ModelChange(timings = { ModelValidator.TYPE_AFTER_NEW, ModelValidator.TYPE_AFTER_CHANGE }, ifColumnsChanged = I_C_Order.COLUMNNAME_POReference)
+	public void validateDummyGRAIPrerequisitesOnPOReferenceChange(@NonNull final I_C_Order order)
+	{
+		assertDummyGRAIPrerequisites(order);
+	}
+
+	@DocValidate(timings = { ModelValidator.TIMING_BEFORE_COMPLETE })
+	public void validateDummyGRAIPrerequisitesOnComplete(@NonNull final I_C_Order order)
+	{
+		assertDummyGRAIPrerequisites(order);
+	}
+
+	/**
+	 * For a sales order, fail fast when the order's customer requires dummy GRAIs but the PO reference cannot
+	 * form a valid dummy-GRAI serial prefix — so the back-office actor who can fix the PO reference gets the
+	 * feedback at data entry / completion, instead of the picker hitting it only at picking completion.
+	 */
+	private void assertDummyGRAIPrerequisites(@NonNull final I_C_Order order)
+	{
+		if (!order.isSOTrx())
+		{
+			return;
+		}
+
+		final OrderId salesOrderId = OrderId.ofRepoId(order.getC_Order_ID());
+		final BPartnerId customerId = BPartnerId.ofRepoIdOrNull(order.getC_BPartner_ID());
+		pickingJobService.assertDummyGRAIPrerequisitesForSalesOrder(salesOrderId, customerId, order.getPOReference());
 	}
 
 	@DocValidate(timings = { ModelValidator.TIMING_BEFORE_CLOSE })

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
@@ -707,8 +707,7 @@ public class PickingJobService implements PickingSlotListener
 			throw new AdempiereException(DummyGRAITemplate.MSG_DUMMY_GRAI_POREFERENCE_MISSING, salesOrderId);
 		}
 
-		// Reuse the single dummy-GRAI validity rule (throws the translated "too long" message when > 10 chars).
-		DummyGRAITemplate.migros(serialPrefix);
+		DummyGRAITemplate.assertValidSerialPrefix(serialPrefix);
 	}
 
 	public PickingJob closeLUAndTUPickingTargets(@NonNull final PickingJob pickingJob)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
@@ -12,6 +12,7 @@ import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.HuPackingInstructionsId;
 import de.metas.handlingunits.HuPackingInstructionsIdAndCaption;
 import de.metas.handlingunits.HuPackingInstructionsItemId;
+import de.metas.handlingunits.grai.DummyGRAITemplate;
 import de.metas.handlingunits.grai.GRAI;
 import de.metas.handlingunits.grai.GRAIRequired;
 import de.metas.handlingunits.model.I_M_HU_PI;
@@ -71,6 +72,7 @@ import de.metas.product.ProductId;
 import de.metas.scannable_code.ScannedCode;
 import de.metas.user.UserId;
 import de.metas.util.Services;
+import de.metas.util.StringUtils;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.trx.api.ITrxManager;
@@ -678,6 +680,35 @@ public class PickingJobService implements PickingSlotListener
 			return GRAIRequired.No;
 		}
 		return bpartnerService.getGRAIRequired(customerId);
+	}
+
+	/**
+	 * Validates the dummy-GRAI prerequisites for a sales order whose customer is in
+	 * {@link GRAIRequired#YesWithDummyGRAIs} mode: the order's PO reference must be able to form a valid
+	 * dummy-GRAI serial prefix (present after trim, max 10 characters). Throws the translated, operator-facing
+	 * message otherwise. No-op for any other GRAI mode.
+	 * <p>
+	 * The GRAI mode is resolved from the order's customer — the same source the picking-completion backstop
+	 * uses — so this early validation predicts (and stays consistent with) the completion-time check.
+	 */
+	public void assertDummyGRAIPrerequisitesForSalesOrder(
+			@NonNull final OrderId salesOrderId,
+			@Nullable final BPartnerId customerId,
+			@Nullable final String poReference)
+	{
+		if (getGRAIRequired(customerId) != GRAIRequired.YesWithDummyGRAIs)
+		{
+			return;
+		}
+
+		final String serialPrefix = StringUtils.trimBlankToNull(poReference);
+		if (serialPrefix == null)
+		{
+			throw new AdempiereException(DummyGRAITemplate.MSG_DUMMY_GRAI_POREFERENCE_MISSING, salesOrderId);
+		}
+
+		// Reuse the single dummy-GRAI validity rule (throws the translated "too long" message when > 10 chars).
+		DummyGRAITemplate.migros(serialPrefix);
 	}
 
 	public PickingJob closeLUAndTUPickingTargets(@NonNull final PickingJob pickingJob)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/grai/SalesOrderDummyGRAIProviders.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/grai/SalesOrderDummyGRAIProviders.java
@@ -51,7 +51,7 @@ class SalesOrderDummyGRAIProviders
 		final String poReference = StringUtils.trimBlankToNull(salesOrder.getPOReference());
 		if (poReference == null)
 		{
-			throw new AdempiereException("Cannot generate dummy GRAIs: POReference not found for " + salesOrderId);
+			throw new AdempiereException(DummyGRAITemplate.MSG_DUMMY_GRAI_POREFERENCE_MISSING, salesOrderId);
 		}
 		return poReference;
 	}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/DummyGRAITemplateTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/grai/DummyGRAITemplateTest.java
@@ -44,7 +44,8 @@ class DummyGRAITemplateTest
 	void migros_tooLongSerialPrefix_throws()
 	{
 		assertThatThrownBy(() -> DummyGRAITemplate.migros("12345678901"))
-				.isInstanceOf(AdempiereException.class);
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining(DummyGRAITemplate.MSG_DUMMY_GRAI_SERIAL_PREFIX_TOO_LONG.toAD_Message());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Customers in `C_BPartner.GRAIRequired = YesWithDummyGRAIs` mode get dummy GRAIs auto-generated at picking completion, deriving the serial prefix from the sales order's PO reference (which must be ≤ 10 characters). When the PO reference is missing or too long, generation failed **only at picking completion**, with a raw English technical message — too late, and for the wrong actor (the picker cannot fix the order's PO reference).

This validates the prerequisite earlier, at the source:

- **Translatable message** — the two hardcoded English `AdempiereException` strings ("serial prefix too long", "PO reference not found") are replaced by one pair of translatable `AdMessageKey`s (DE primary, EN), centralised on `DummyGRAITemplate`. The picking-completion path now emits the same translated message.
- **Shared check** — `PickingJobService.assertDummyGRAIPrerequisitesForSalesOrder(...)`: for a sales order whose customer requires dummy GRAIs, the PO reference must form a valid serial prefix (present after trim, ≤ 10 chars). Reuses the single existing validity rule (`DummyGRAITemplate.migros`).
- **Order-level layers** — the `C_Order` picking interceptor calls the shared check on PO-reference change (`@ModelChange`) and before completion (`@DocValidate` BEFORE_COMPLETE), so the back-office actor is informed at data entry and at order completion.
- **AD_Message migration** (DE/CH/EN) for the two keys.

GRAI mode is resolved from the order's customer — the same source the picking-completion backstop uses — so the early checks stay consistent with completion.

Follow-up on this branch: block opening a picking job whose order has an invalid PO reference (protects orders already completed before this ships).
