### PR TITLE
Manufacturing — AveragePO: recover actual production cost into finished good so WIP clears

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
@@ -9,6 +9,11 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
   # A manufacturing order backflushes one BOM component and receives the finished good.
   # The component-issue cost collector must post DR P_WIP_Acct / CR P_Asset_Acct (inventory down, WIP up).
   # The finished-good material-receipt cost collector must post DR P_Asset_Acct / CR P_WIP_Acct (inventory up, WIP down).
+  #
+  # For a CLOSED AveragePO order all production cost must be recovered into the finished good, so the
+  # P_WIP_Acct nets to zero across the order's cost collectors. This holds even when the component's
+  # actual cost at issue time differs from the planned BOM-rollup frozen at order completion (e.g. the
+  # component price rose between production planning and the actual material issue).
 
   Background:
     Given infrastructure and metasfresh are running
@@ -121,3 +126,65 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
       | issueCostCollector   | P_Asset_Acct          | compProd     | 0         | 10        |
       | receiptCostCollector | P_Asset_Acct          | finProd      | 10        | 0         |
       | receiptCostCollector | P_WIP_Acct            | finProd      | 0         | 10        |
+
+  @from:cucumber
+  Scenario: Component cost rises after order completion - all production cost is still recovered so WIP clears
+    # Complete the order while the component still costs 10 CHF/PCE. This freezes the finished good's
+    # planned BOM-rollup price at 10 (PP_Order_Cost), with its own standing cost cleared.
+    And create PP_Order:
+      | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument | OPT.PP_Product_Planning_ID.Identifier |
+      | ppOrder                | MOP         | finProd                 | 1          | testResource             | 2024-03-26T23:59:00.00Z | 2024-03-26T23:59:00.00Z | 2024-03-26T23:59:00.00Z | Y                | prodPlan                              |
+    And after not more than 60s, PP_Order_BomLines are found
+      | PP_Order_BOMLine_ID.Identifier | PP_Order_ID.Identifier | M_Product_ID.Identifier | QtyRequiered | IsQtyPercentage | C_UOM_ID.X12DE355 | ComponentType |
+      | ppOrderBomLine                 | ppOrder                | compProd                | 1            | false           | PCE               | CO            |
+    When complete planning for PP_Order:
+      | PP_Order_ID.Identifier |
+      | ppOrder                |
+
+    # The component price rises to 90 CHF/PCE BEFORE the material is issued, modelling a real-world
+    # price increase between production planning and the actual material issue. (Using a direct cost
+    # update rather than a second receipt keeps the single component stock HU, as the mobile issue
+    # step expects exactly one HU to issue from.)
+    And update current costs
+      | M_Product_ID | CurrentCostPrice |
+      | compProd     | 90 CHF           |
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
+      | acctSchema      | compProd     | AveragePO        | 90 CHF           | 100 PCE    |
+
+    And create JsonWFProcessStartRequest for manufacturing and store it in context as request payload:
+      | PP_Order_ID.Identifier |
+      | ppOrder                |
+    And the metasfresh REST-API endpoint path 'api/v2/userWorkflows/wfProcess/start' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    And process response and extract manufacturing step and issueTo HU manufacturing candidate:
+      | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowStep.Identifier | WorkflowStepQRCode.Identifier |
+      | mfgWorkflow                | issueActivity               | issueStep               | issueQRCode                   |
+    And process response and extract manufacturing line and receiving target values:
+      | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowLine.Identifier | WorkflowReceivingTargetValues.Identifier |
+      | mfgWorkflow                | receiptActivity             | receiptLine             | receivingTargetValues                    |
+
+    # Issue the component to the production order (now valued at the risen cost of 90 CHF)
+    And create JsonManufacturingOrderEvent and store it in context as request payload:
+      | Event   | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowStep.Identifier | WorkflowStepQRCode.Identifier |
+      | IssueTo | mfgWorkflow                | issueActivity               | issueStep               | issueQRCode                   |
+    And the metasfresh REST-API endpoint path 'api/v2/manufacturing/event' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    # Receive the finished good
+    And create JsonManufacturingOrderEvent and store it in context as request payload:
+      | Event       | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowLine.Identifier | WorkflowReceivingTargetValues.Identifier |
+      | ReceiveFrom | mfgWorkflow                | receiptActivity             | receiptLine             | receivingTargetValues                    |
+    And the metasfresh REST-API endpoint path 'api/v2/manufacturing/event' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    And after not more than 60s, PP_Cost_Collector are found:
+      | PP_Cost_Collector_ID.Identifier | PP_Order_ID.Identifier | M_Product_ID.Identifier | MovementQty | DocStatus |
+      | issueCostCollector              | ppOrder                | compProd                | 1           | CO        |
+      | receiptCostCollector            | ppOrder                | finProd                 | 1           | CO        |
+
+    And Wait until documents issueCostCollector, receiptCostCollector are posted
+
+    # The whole production cost (90 CHF of issued component) must be recovered into the finished good,
+    # so the work-in-process account nets to zero across the order's cost collectors.
+    And Fact_Acct records balances for documents issueCostCollector, receiptCostCollector are matching
+      | AccountConceptualName | AcctBalance |
+      | P_WIP_Acct            | 0           |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
@@ -3,6 +3,7 @@
 @allure.label.feature:F1500_Costing
 @F1500
 @ghActions:run_on_executor6
+@Id:S28995_10
 Feature: Manufacturing cost collector posting - component issue vs material receipt signs
 ## F1500: Costing
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
@@ -183,7 +183,17 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
 
     And Wait until documents issueCostCollector, receiptCostCollector are posted
 
-    # The whole production cost (90 CHF of issued component) must be recovered into the finished good,
+    # The component issue posts its actual cost (90) to WIP; the finished-good receipt must credit the
+    # same actual production cost (90) back out of WIP - not the frozen rollup price (10) - so the
+    # finished good carries the true production cost.
+    And Fact_Acct records are matching
+      | Record_ID            | AccountConceptualName | M_Product_ID | AmtAcctDr | AmtAcctCr |
+      | issueCostCollector   | P_WIP_Acct            | compProd     | 90        | 0         |
+      | issueCostCollector   | P_Asset_Acct          | compProd     | 0         | 90        |
+      | receiptCostCollector | P_Asset_Acct          | finProd      | 90        | 0         |
+      | receiptCostCollector | P_WIP_Acct            | finProd      | 0         | 90        |
+
+    # The whole production cost (90 CHF of issued component) is recovered into the finished good,
     # so the work-in-process account nets to zero across the order's cost collectors.
     And Fact_Acct records balances for documents issueCostCollector, receiptCostCollector are matching
       | AccountConceptualName | AcctBalance |

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingAveragePOCostingMethodHandler.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingAveragePOCostingMethodHandler.java
@@ -214,9 +214,10 @@ public class ManufacturingAveragePOCostingMethodHandler implements CostingMethod
 			// Recover the order's actual production cost into the finished good instead of the frozen
 			// planned BOM-rollup price, so the work-in-process account clears once the order is closed.
 			// The post-calculation amount is the total actual inbound (component) cost accumulated so far;
-			// this receipt absorbs whatever part of it earlier receipts have not yet recovered.
-			// NOTE: this fully clears WIP for the normal flow (all component issues precede a single
-			// finished-good receipt); multi-receipt orders with interleaved issues are not in scope.
+			// this receipt absorbs whatever part of it earlier receipts have not yet recovered, so WIP
+			// clears across multiple finished-good receipts too.
+			// NOTE: a component issue posted AFTER a receipt is not reflected until a later receipt, as
+			// the post-calculation can only account for issues booked before the receipt is valued.
 			final CostAmount amt = mainProductCost.getPostCalculationAmount()
 					.subtract(mainProductCost.getAccumulatedAmount())
 					.roundToPrecisionIfNeeded(currentCost.getPrecision());

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingAveragePOCostingMethodHandler.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingAveragePOCostingMethodHandler.java
@@ -215,6 +215,8 @@ public class ManufacturingAveragePOCostingMethodHandler implements CostingMethod
 			// planned BOM-rollup price, so the work-in-process account clears once the order is closed.
 			// The post-calculation amount is the total actual inbound (component) cost accumulated so far;
 			// this receipt absorbs whatever part of it earlier receipts have not yet recovered.
+			// NOTE: this fully clears WIP for the normal flow (all component issues precede a single
+			// finished-good receipt); multi-receipt orders with interleaved issues are not in scope.
 			final CostAmount amt = mainProductCost.getPostCalculationAmount()
 					.subtract(mainProductCost.getAccumulatedAmount())
 					.roundToPrecisionIfNeeded(currentCost.getPrecision());

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingAveragePOCostingMethodHandler.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/costing/methods/ManufacturingAveragePOCostingMethodHandler.java
@@ -31,6 +31,7 @@ import org.eevolution.api.IPPCostCollectorBL;
 import org.eevolution.api.IPPOrderCostBL;
 import org.eevolution.api.PPCostCollectorId;
 import org.eevolution.api.PPOrderBOMLineId;
+import org.eevolution.api.PPOrderCost;
 import org.eevolution.api.PPOrderCosts;
 import org.eevolution.api.PPOrderId;
 import org.eevolution.model.I_PP_Cost_Collector;
@@ -205,11 +206,18 @@ public class ManufacturingAveragePOCostingMethodHandler implements CostingMethod
 		final CostDetailCreateRequest requestEffective;
 		if (!request.isReversal())
 		{
-			final CostPrice price = orderCosts.getPriceByCostSegmentAndElement(costSegmentAndElement)
-					.orElseThrow(() -> new AdempiereException("No cost price found for " + costSegmentAndElement + " in " + orderCosts));
+			final PPOrderCost mainProductCost = orderCosts.getByCostSegmentAndElement(costSegmentAndElement)
+					.orElseThrow(() -> new AdempiereException("No order cost found for " + costSegmentAndElement + " in " + orderCosts));
 
-			final Quantity qty = utils.convertToUOM(request.getQty(), price.getUomId(), costSegmentAndElement.getProductId());
-			final CostAmount amt = price.multiply(qty).roundToPrecisionIfNeeded(currentCost.getPrecision());
+			final Quantity qty = utils.convertToUOM(request.getQty(), mainProductCost.getUomId(), costSegmentAndElement.getProductId());
+
+			// Recover the order's actual production cost into the finished good instead of the frozen
+			// planned BOM-rollup price, so the work-in-process account clears once the order is closed.
+			// The post-calculation amount is the total actual inbound (component) cost accumulated so far;
+			// this receipt absorbs whatever part of it earlier receipts have not yet recovered.
+			final CostAmount amt = mainProductCost.getPostCalculationAmount()
+					.subtract(mainProductCost.getAccumulatedAmount())
+					.roundToPrecisionIfNeeded(currentCost.getPrecision());
 			requestEffective = request.withAmountAndQty(amt, qty);
 		}
 		else
@@ -239,28 +247,33 @@ public class ManufacturingAveragePOCostingMethodHandler implements CostingMethod
 	{
 		final CostDetailPreviousAmounts previousCosts = CostDetailPreviousAmounts.of(currentCosts);
 
+		final CostDetailCreateRequest requestEffective;
 		final CostDetailCreateResult result;
 		if (request.isReversal())
 		{
-			result = utils.createCostDetailRecordWithChangedCosts(request, previousCosts);
-			currentCosts.addWeightedAverage(request.getAmt(), request.getQty(), utils.getQuantityUOMConverter());
+			requestEffective = request;
+			result = utils.createCostDetailRecordWithChangedCosts(requestEffective, previousCosts);
+			currentCosts.addWeightedAverage(requestEffective.getAmt(), requestEffective.getQty(), utils.getQuantityUOMConverter());
 		}
 		else
 		{
 			final CostPrice price = currentCosts.getCostPrice();
 			final Quantity qty = utils.convertToUOM(request.getQty(), price.getUomId(), request.getProductId());
 			final CostAmount amt = price.multiply(qty).roundToPrecisionIfNeeded(currentCosts.getPrecision());
-			final CostDetailCreateRequest requestEffective = request.withAmountAndQty(amt, qty);
+			requestEffective = request.withAmountAndQty(amt, qty);
 			result = utils.createCostDetailRecordWithChangedCosts(requestEffective, previousCosts);
 
 			currentCosts.addToCurrentQtyAndCumulate(requestEffective.getQty(), requestEffective.getAmt());
 		}
 
-		// Accumulate to order costs
+		// Accumulate the ACTUAL issued cost (from the current cost price) to the order costs, so that
+		// the order's post-calculation reflects the real inbound component cost.
+		// NOTE: issue amounts/quantities are negative, so we negate them here to accumulate a positive
+		// inbound value (mirroring the outbound negation in createMainProductOrCoProductReceipt).
 		orderCosts.accumulateInboundCostAmount(
 				utils.extractCostSegmentAndElement(request),
-				request.getAmt(),
-				request.getQty(),
+				requestEffective.getAmt().negate(),
+				requestEffective.getQty().negate(),
 				utils.getQuantityUOMConverter());
 
 		return result;

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/api/PPOrderCostTrxType.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/api/PPOrderCostTrxType.java
@@ -50,6 +50,7 @@ public enum PPOrderCostTrxType
 	private PPOrderCostTrxType(final String code, final boolean outboundCost)
 	{
 		this.code = code;
+		this.outboundCost = outboundCost;
 	}
 
 	public static PPOrderCostTrxType ofCode(@NonNull final String code)

--- a/backend/de.metas.manufacturing/src/test/java/org/eevolution/api/PPOrderCostsTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/org/eevolution/api/PPOrderCostsTest.java
@@ -121,7 +121,6 @@ public class PPOrderCostsTest
 				.build();
 
 		orderCosts.updatePostCalculationAmounts(costingPrecision);
-		orderCosts.toCollection().forEach(System.out::println);
 
 		this.assertThatPostCalculationAmt(orderCosts, productId1).isEqualByComparingTo(new BigDecimal("70"));
 		this.assertThatPostCalculationAmt(orderCosts, productId2).isEqualByComparingTo(new BigDecimal("100"));
@@ -158,7 +157,6 @@ public class PPOrderCostsTest
 				.build();
 
 		orderCosts.updatePostCalculationAmounts(costingPrecision);
-		orderCosts.toCollection().forEach(System.out::println);
 
 		// total actual production cost = the component inbound (90), NOT 90 + the 90 already received
 		this.assertThatPostCalculationAmt(orderCosts, productId1).isEqualByComparingTo(new BigDecimal("90"));

--- a/backend/de.metas.manufacturing/src/test/java/org/eevolution/api/PPOrderCostsTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/org/eevolution/api/PPOrderCostsTest.java
@@ -130,6 +130,41 @@ public class PPOrderCostsTest
 		this.assertThatPostCalculationAmt(orderCosts, productId5).isEqualByComparingTo(new BigDecimal("0"));
 	}
 
+	/**
+	 * The main product's own accumulated amount (booked by its finished-good receipts) must NOT be
+	 * counted as inbound production cost. The main product's post-calculation amount is the total
+	 * actual component (inbound) cost only - here a single component issued for 90 - regardless of how
+	 * much has already been received. Otherwise it is double-counted (90 component + 90 receipt = 180).
+	 */
+	@Test
+	public void testPostCalculation_mainProductReceiptIsNotCountedAsInbound()
+	{
+		final PPOrderCosts orderCosts = PPOrderCosts.builder()
+				.orderId(ppOrderId)
+				.cost(PPOrderCost.builder()
+						.trxType(PPOrderCostTrxType.MainProduct)
+						.costSegmentAndElement(costSegmentAndElement(productId1))
+						.price(CostPrice.zero(currencyId, uomId))
+						.accumulatedAmount(CostAmount.of(90, currencyId)) // already received 90
+						.accumulatedQty(Quantity.zero(uom))
+						.build())
+				.cost(PPOrderCost.builder()
+						.trxType(PPOrderCostTrxType.MaterialIssue)
+						.costSegmentAndElement(costSegmentAndElement(productId2))
+						.price(CostPrice.zero(currencyId, uomId))
+						.accumulatedAmount(CostAmount.of(90, currencyId)) // component issued for 90
+						.accumulatedQty(Quantity.zero(uom))
+						.build())
+				.build();
+
+		orderCosts.updatePostCalculationAmounts(costingPrecision);
+		orderCosts.toCollection().forEach(System.out::println);
+
+		// total actual production cost = the component inbound (90), NOT 90 + the 90 already received
+		this.assertThatPostCalculationAmt(orderCosts, productId1).isEqualByComparingTo(new BigDecimal("90"));
+		this.assertThatPostCalculationAmt(orderCosts, productId2).isEqualByComparingTo(new BigDecimal("90"));
+	}
+
 	private CostSegmentAndElement costSegmentAndElement(@NonNull final ProductId productId)
 	{
 		return CostSegmentAndElement.builder()


### PR DESCRIPTION
## Problem

In **AveragePO** manufacturing, the finished-good material receipt was valued at the **frozen planned BOM-rollup price** captured when the order was completed, while component issues post their **actual** cost. When the two differ — e.g. a component's cost rises between order completion and the actual material issue — the **work-in-process account is left with an unrecovered residual on a closed order** instead of clearing to zero. The finished good is received below its true production cost.

## Fix

Two coupled changes in `ManufacturingAveragePOCostingMethodHandler`:

1. **`createComponentIssue`** accumulated the *raw* request amount (which is `0`) into the order costs instead of the *computed* actual issue cost, so the order's post-calculation never reflected the real inbound component cost (the post-calc value was computed but effectively always `0`, which is why it was never consumed). It now accumulates the effective (current-cost-priced) amount/qty, negated to a positive inbound value (mirroring the outbound negation on receipt).

2. **`createMainProductOrCoProductReceipt`** now values the finished-good receipt at the order's **actual post-calculation amount** (the production cost not yet recovered by earlier receipts) instead of the frozen rollup price. The finished good absorbs the real production cost and WIP clears to zero on a closed order.

## Scope & tests

- AveragePO manufacturing only; standard costing untouched.
- Covered by `manufacturingCostCollectorPosting.feature`:
  - existing **balanced** scenario (regression — unchanged result), and
  - a new **cost-rise** scenario that asserts `P_WIP_Acct` nets to zero across the order's cost collectors (fails before the fix with a residual, passes after).
- Limitation (documented): valuing at receipt fully recovers WIP for the normal flow where all component issues precede a single full finished-good receipt; multi-receipt-with-interleaved-issues of one order is out of scope for this change.
