### PR TITLE
MobileUI: friendly message for a split (truncated) HU QR code scan

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/adempiere/exceptions/AdempiereException.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/adempiere/exceptions/AdempiereException.java
@@ -363,6 +363,20 @@ public class AdempiereException extends RuntimeException
 		this(Env.getAD_Language(), adMessage, params);
 	}
 
+	/** Like {@link #AdempiereException(AdMessageKey, Object...)} but also keeps the underlying {@code cause}. */
+	public AdempiereException(@Nullable final Throwable cause, @NonNull final AdMessageKey adMessage, final Object... params)
+	{
+		super(cause);
+		this.adLanguage = captureLanguageOnConstructionTime ? Env.getAD_Language() : null;
+		this.messageTrl = TranslatableStrings.adMessage(adMessage, params);
+		this.userValidationError = true;
+		this.mdcContextMap = captureMDCContextMap();
+		this.errorCode = coalesce(msgBL.getErrorCode(adMessage), adMessage.toAD_Message());
+
+		setParameter("AD_Language", this.adLanguage);
+		setParameter("AD_Message", adMessage);
+	}
+
 	public AdempiereException(@Nullable final Throwable cause)
 	{
 		super(cause);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/mobile/MobileQRCodeMessages.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/mobile/MobileQRCodeMessages.java
@@ -2,7 +2,6 @@ package de.metas.handlingunits.qrcodes.mobile;
 
 import de.metas.global_qrcodes.GlobalQRCode;
 import de.metas.i18n.AdMessageKey;
-import de.metas.i18n.TranslatableStrings;
 import de.metas.scannable_code.ScannedCode;
 import de.metas.util.StringUtils;
 import lombok.NonNull;
@@ -72,9 +71,6 @@ public class MobileQRCodeMessages
 	@NonNull
 	public static AdempiereException newNotRecognizedException(@NonNull final ScannedCode scannedCode, @Nullable final Throwable cause)
 	{
-		return new AdempiereException(
-				TranslatableStrings.adMessage(NOT_RECOGNIZED, StringUtils.trunc(scannedCode.getAsString(), 40)),
-				cause)
-				.setErrorCode(NOT_RECOGNIZED.toAD_Message());
+		return new AdempiereException(cause, NOT_RECOGNIZED, StringUtils.trunc(scannedCode.getAsString(), 40));
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/mobile/MobileQRCodeMessages.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/mobile/MobileQRCodeMessages.java
@@ -2,6 +2,7 @@ package de.metas.handlingunits.qrcodes.mobile;
 
 import de.metas.global_qrcodes.GlobalQRCode;
 import de.metas.i18n.AdMessageKey;
+import de.metas.i18n.TranslatableStrings;
 import de.metas.scannable_code.ScannedCode;
 import de.metas.util.StringUtils;
 import lombok.NonNull;
@@ -9,6 +10,8 @@ import lombok.experimental.UtilityClass;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.warehouse.qrcode.LocatorQRCode;
 import org.adempiere.warehouse.qrcode.LocatorQRCodeJsonConverter;
+
+import javax.annotation.Nullable;
 
 @UtilityClass
 public class MobileQRCodeMessages
@@ -59,5 +62,19 @@ public class MobileQRCodeMessages
 	public static AdempiereException newNotRecognizedException(@NonNull final ScannedCode scannedCode)
 	{
 		return new AdempiereException(NOT_RECOGNIZED, StringUtils.trunc(scannedCode.getAsString(), 40));
+	}
+
+	/**
+	 * Same as {@link #newNotRecognizedException(ScannedCode)} but keeps the original {@code cause} for diagnostics
+	 * (e.g. the raw payload-conversion failure of a truncated QR code). The cause is wired at construction time,
+	 * so we never risk {@link Throwable#initCause(Throwable)} on an already-initialized exception.
+	 */
+	@NonNull
+	public static AdempiereException newNotRecognizedException(@NonNull final ScannedCode scannedCode, @Nullable final Throwable cause)
+	{
+		return new AdempiereException(
+				TranslatableStrings.adMessage(NOT_RECOGNIZED, StringUtils.trunc(scannedCode.getAsString(), 40)),
+				cause)
+				.setErrorCode(NOT_RECOGNIZED.toAD_Message());
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/mobile/MobileQRCodeMessages.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/mobile/MobileQRCodeMessages.java
@@ -65,8 +65,7 @@ public class MobileQRCodeMessages
 
 	/**
 	 * Same as {@link #newNotRecognizedException(ScannedCode)} but keeps the original {@code cause} for diagnostics
-	 * (e.g. the raw payload-conversion failure of a truncated QR code). The cause is wired at construction time,
-	 * so we never risk {@link Throwable#initCause(Throwable)} on an already-initialized exception.
+	 * (e.g. the raw payload-conversion failure of a truncated QR code).
 	 */
 	@NonNull
 	public static AdempiereException newNotRecognizedException(@NonNull final ScannedCode scannedCode, @Nullable final Throwable cause)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -403,13 +403,26 @@ public class HUQRCodesService
 		final GlobalQRCode globalQRCode = scannedCode.toGlobalQRCodeIfMatching().orNullIfError();
 		if (globalQRCode != null)
 		{
-			if (HUQRCode.isHandled(globalQRCode))
+			try
 			{
-				return HUQRCode.fromGlobalQRCode(globalQRCode);
+				if (HUQRCode.isHandled(globalQRCode))
+				{
+					return HUQRCode.fromGlobalQRCode(globalQRCode);
+				}
+				else if (LMQRCode.isHandled(globalQRCode))
+				{
+					return LMQRCode.fromGlobalQRCode(globalQRCode);
+				}
 			}
-			else if (LMQRCode.isHandled(globalQRCode))
+			catch (final Exception ex)
 			{
-				return LMQRCode.fromGlobalQRCode(globalQRCode);
+				// The type prefix (HU#/LM#) is handled, but the payload could not be converted into a QR code.
+				// This happens when a long QR code is split mid-stream on a slow scanner device (me03 #30625): the
+				// head fragment keeps the valid prefix but carries truncated JSON. Surface the same user-friendly
+				// "not recognized" message as any other bad code instead of leaking the raw conversion error.
+				final AdempiereException friendlyEx = MobileQRCodeMessages.newNotRecognizedException(scannedCode);
+				friendlyEx.initCause(ex);
+				throw friendlyEx;
 			}
 		}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -416,13 +416,12 @@ public class HUQRCodesService
 			}
 			catch (final Exception ex)
 			{
-				// The type prefix (HU#/LM#) is handled, but the payload could not be converted into a QR code.
-				// This happens when a long QR code is split mid-stream on a slow scanner device (me03 #30625): the
-				// head fragment keeps the valid prefix but carries truncated JSON. Surface the same user-friendly
-				// "not recognized" message as any other bad code instead of leaking the raw conversion error.
-				final AdempiereException friendlyEx = MobileQRCodeMessages.newNotRecognizedException(scannedCode);
-				friendlyEx.initCause(ex);
-				throw friendlyEx;
+				// The type prefix (HU#/LM#) matched but the payload could not be converted into a QR code. This
+				// covers a long QR code split mid-stream on a slow scanner device (the head fragment keeps the valid
+				// prefix but carries truncated JSON) as well as an incompatible version field - the user can fix
+				// neither in the field. Surface the same user-friendly "not recognized" message as any other bad
+				// code instead of leaking the raw conversion error.
+				throw MobileQRCodeMessages.newNotRecognizedException(scannedCode, ex);
 			}
 		}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -414,7 +414,7 @@ public class HUQRCodesService
 					return LMQRCode.fromGlobalQRCode(globalQRCode);
 				}
 			}
-			catch (final Exception ex)
+			catch (final RuntimeException ex)
 			{
 				// The type prefix (HU#/LM#) matched but the payload could not be converted into a QR code. This
 				// covers a long QR code split mid-stream on a slow scanner device (the head fragment keeps the valid

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
@@ -378,5 +378,27 @@ class HUQRCodesServiceTest
 					.isInstanceOf(AdempiereException.class)
 					.satisfies(ex -> assertThat(((AdempiereException)ex).isUserValidationError()).isTrue());
 		}
+
+		@Test
+		void truncatedHuQRCodeHead_throwsUserFriendlyError()
+		{
+			// A long HU QR code can be split mid-stream on a slow scanner device (me03 #30625): the head
+			// fragment keeps the valid "HU#<version>#" prefix but carries truncated JSON payload. It must
+			// surface the SAME friendly "not recognized" message as any other bad code, not leak the raw
+			// "Failed converting payload" developer error.
+			final HuId tuId = createTU();
+			final String fullHuQRCode = huQRCodesService.generateForExistingHU(tuId).getSingleQRCode(tuId).getAsString();
+
+			// sanity: the full code is a valid, parseable HU QR code
+			assertThat(huQRCodesService.parse(fullHuQRCode)).isInstanceOf(HUQRCode.class);
+
+			// simulate the device split: keep the HU#<version># prefix, drop the tail so the JSON payload is incomplete
+			final String truncatedHead = fullHuQRCode.substring(0, fullHuQRCode.length() / 2);
+			assertThat(truncatedHead).startsWith("HU#");
+
+			assertThatThrownBy(() -> huQRCodesService.parse(truncatedHead))
+					.isInstanceOf(AdempiereException.class)
+					.satisfies(ex -> assertThat(((AdempiereException)ex).isUserValidationError()).isTrue());
+		}
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
@@ -37,6 +37,7 @@ import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
 import de.metas.handlingunits.qrcodes.ean13.EAN13HUQRCode;
 import de.metas.handlingunits.qrcodes.gs1.GS1HUQRCode;
+import de.metas.handlingunits.qrcodes.mobile.MobileQRCodeMessages;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.model.HUQRCodeUnitType;
 import de.metas.handlingunits.qrcodes.model.IHUQRCode;
@@ -382,10 +383,9 @@ class HUQRCodesServiceTest
 		@Test
 		void truncatedHuQRCodeHead_throwsUserFriendlyError()
 		{
-			// A long HU QR code can be split mid-stream on a slow scanner device (me03 #30625): the head
-			// fragment keeps the valid "HU#<version>#" prefix but carries truncated JSON payload. It must
-			// surface the SAME friendly "not recognized" message as any other bad code, not leak the raw
-			// "Failed converting payload" developer error.
+			// A long HU QR code can be split mid-stream on a slow scanner device: the head fragment keeps the
+			// valid "HU#<version>#" prefix but carries a truncated JSON payload. It must surface the SAME friendly
+			// "not recognized" message as any other bad code, not leak the raw "Failed converting payload" error.
 			final HuId tuId = createTU();
 			final String fullHuQRCode = huQRCodesService.generateForExistingHU(tuId).getSingleQRCode(tuId).getAsString();
 
@@ -398,7 +398,11 @@ class HUQRCodesServiceTest
 
 			assertThatThrownBy(() -> huQRCodesService.parse(truncatedHead))
 					.isInstanceOf(AdempiereException.class)
-					.satisfies(ex -> assertThat(((AdempiereException)ex).isUserValidationError()).isTrue());
+					.satisfies(ex -> {
+						final AdempiereException ae = (AdempiereException)ex;
+						assertThat(ae.isUserValidationError()).isTrue();
+						assertThat(ae.getErrorCode()).isEqualTo(MobileQRCodeMessages.NOT_RECOGNIZED.toAD_Message());
+					});
 		}
 	}
 }

--- a/e2e/mobile-webui/tests/spec/distribution/scan_HU_barcodes.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/scan_HU_barcodes.spec.js
@@ -197,12 +197,16 @@ test('Scan a truncated (split) HU QR code where HU is expected → user-friendly
 
     const masterdata = await createMasterdata();
 
-    // A long HU QR code can be split mid-stream by a slow scanner device: the worker scans one HU but only
-    // the head fragment arrives — it keeps the valid "HU#<version>#" prefix yet carries a truncated, unparseable
-    // JSON payload.
+    // A long HU QR code can be split mid-stream by a slow scanner device: it arrives as TWO bad scans —
+    // the head fragment (keeps the valid "HU#<version>#" prefix but carries truncated, unparseable JSON) and
+    // the tail fragment (the remainder of the payload, without the prefix). Both must surface the same
+    // friendly QR_NOT_RECOGNIZED message, exactly as in the originally reported problem.
     const fullHuQRCode = masterdata.handlingUnits.HU1.qrCode;
-    const truncatedHead = fullHuQRCode.substring(0, Math.floor(fullHuQRCode.length / 2));
-    expect(truncatedHead).toMatch(/^HU#/); // still looks like an HU QR head, but the payload is cut off
+    const splitAt = Math.floor(fullHuQRCode.length / 2);
+    const truncatedHead = fullHuQRCode.substring(0, splitAt);
+    const truncatedTail = fullHuQRCode.substring(splitAt);
+    expect(truncatedHead).toMatch(/^HU#/);     // head keeps the HU# prefix, payload is cut off
+    expect(truncatedTail).not.toMatch(/^HU#/); // tail is the prefix-less remainder
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
@@ -213,8 +217,15 @@ test('Scan a truncated (split) HU QR code where HU is expected → user-friendly
     await DistributionJobScreen.clickLineButton({ index: 1 });
     await DistributionLineScreen.openPickFromScreen();
 
-    await expectErrorToast('Scan a truncated (split) HU QR code where HU is expected', async () => {
+    await expectErrorToast('Scan the truncated HU QR head where HU is expected', async () => {
         await DistributionLinePickFromScreen.typeHUQRCode(truncatedHead);
+        await GetQuantityDialog.waitForDialog();
+    }, ({ textContent }) => {
+        expect(textContent).toContain('QR_NOT_RECOGNIZED');
+    });
+
+    await expectErrorToast('Scan the truncated HU QR tail where HU is expected', async () => {
+        await DistributionLinePickFromScreen.typeHUQRCode(truncatedTail);
         await GetQuantityDialog.waitForDialog();
     }, ({ textContent }) => {
         expect(textContent).toContain('QR_NOT_RECOGNIZED');

--- a/e2e/mobile-webui/tests/spec/distribution/scan_HU_barcodes.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/scan_HU_barcodes.spec.js
@@ -145,7 +145,7 @@ test('Scan locator QR code where HU is expected → user-friendly error', async 
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('distribution');
     await DistributionJobsListScreen.waitForScreen();
-    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId, expectHitCount: 1 });
     await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
     await DistributionJobScreen.clickLineButton({ index: 1 });
     await DistributionLineScreen.openPickFromScreen();
@@ -173,13 +173,48 @@ test('Scan unrecognized barcode where HU is expected → user-friendly error', a
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('distribution');
     await DistributionJobsListScreen.waitForScreen();
-    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId, expectHitCount: 1 });
     await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
     await DistributionJobScreen.clickLineButton({ index: 1 });
     await DistributionLineScreen.openPickFromScreen();
 
     await expectErrorToast('Scan unrecognized barcode where HU is expected', async () => {
         await DistributionLinePickFromScreen.typeHUQRCode('TOTALLY_UNKNOWN_FORMAT_XYZ');
+        await GetQuantityDialog.waitForDialog();
+    }, ({ textContent }) => {
+        expect(textContent).toContain('QR_NOT_RECOGNIZED');
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Scan a truncated (split) HU QR code where HU is expected → user-friendly error', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
+        allure.tag('F5114');  // Standalone tag for Tags section;
+    allure.story('Scan HU barcodes');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+
+    // A long HU QR code can be split mid-stream by a slow scanner device: the worker scans one HU but only
+    // the head fragment arrives — it keeps the valid "HU#<version>#" prefix yet carries a truncated, unparseable
+    // JSON payload.
+    const fullHuQRCode = masterdata.handlingUnits.HU1.qrCode;
+    const truncatedHead = fullHuQRCode.substring(0, Math.floor(fullHuQRCode.length / 2));
+    expect(truncatedHead).toMatch(/^HU#/); // still looks like an HU QR head, but the payload is cut off
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId, expectHitCount: 1 });
+    await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+    await DistributionJobScreen.clickLineButton({ index: 1 });
+    await DistributionLineScreen.openPickFromScreen();
+
+    await expectErrorToast('Scan a truncated (split) HU QR code where HU is expected', async () => {
+        await DistributionLinePickFromScreen.typeHUQRCode(truncatedHead);
         await GetQuantityDialog.waitForDialog();
     }, ({ textContent }) => {
         expect(textContent).toContain('QR_NOT_RECOGNIZED');

--- a/e2e/mobile-webui/tests/spec/distribution/scan_HU_barcodes.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/scan_HU_barcodes.spec.js
@@ -186,27 +186,28 @@ test('Scan unrecognized barcode where HU is expected → user-friendly error', a
     });
 });
 
-// noinspection JSUnusedLocalSymbols
-test('Scan a truncated (split) HU QR code where HU is expected → user-friendly error', async ({ page }) => {
-    // === ALLURE METADATA ===
-    allure.epic('E0370: Intralogistic (HUs)');
-    allure.tag('F5114: MobileUI Distribution');
-        allure.tag('F5114');  // Standalone tag for Tags section;
-    allure.story('Scan HU barcodes');
-    allure.severity('normal');
-
+// A long HU QR code can be split mid-stream by a slow scanner device: it arrives as TWO bad scans —
+// the head fragment (keeps the valid "HU#<version>#" prefix but carries truncated, unparseable JSON) and
+// the tail fragment (the prefix-less remainder). Each fragment, scanned on its own exactly as the device
+// delivers it, must surface the friendly QR_NOT_RECOGNIZED message — never a silent failure or the raw
+// "Failed converting payload" developer error.
+//
+// The two fragments are verified in SEPARATE tests, each starting from a clean toast state. The app shows
+// exactly one error toast per scan by design (a fixed toastId — see mobile-webui CLAUDE.md "the user must
+// see exactly ONE error"), so two back-to-back scans within one test would race that de-duplication and
+// leave the second fragment's toast suppressed. Asserting a single shared toast instead would also fail to
+// catch a tail-specific regression — a raw tail error would be hidden under the head's friendly toast. One
+// scan per scenario keeps each fragment's handling independently observable.
+const expectTruncatedHuQRFragmentShowsFriendlyError = async ({ which }) => {
     const masterdata = await createMasterdata();
 
-    // A long HU QR code can be split mid-stream by a slow scanner device: it arrives as TWO bad scans —
-    // the head fragment (keeps the valid "HU#<version>#" prefix but carries truncated, unparseable JSON) and
-    // the tail fragment (the remainder of the payload, without the prefix). Both must surface the same
-    // friendly QR_NOT_RECOGNIZED message, exactly as in the originally reported problem.
     const fullHuQRCode = masterdata.handlingUnits.HU1.qrCode;
     const splitAt = Math.floor(fullHuQRCode.length / 2);
     const truncatedHead = fullHuQRCode.substring(0, splitAt);
     const truncatedTail = fullHuQRCode.substring(splitAt);
     expect(truncatedHead).toMatch(/^HU#/);     // head keeps the HU# prefix, payload is cut off
     expect(truncatedTail).not.toMatch(/^HU#/); // tail is the prefix-less remainder
+    const fragment = which === 'head' ? truncatedHead : truncatedTail;
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
@@ -217,17 +218,34 @@ test('Scan a truncated (split) HU QR code where HU is expected → user-friendly
     await DistributionJobScreen.clickLineButton({ index: 1 });
     await DistributionLineScreen.openPickFromScreen();
 
-    await expectErrorToast('Scan the truncated HU QR head where HU is expected', async () => {
-        await DistributionLinePickFromScreen.typeHUQRCode(truncatedHead);
+    await expectErrorToast(`Scan the truncated HU QR ${which} where HU is expected`, async () => {
+        await DistributionLinePickFromScreen.typeHUQRCode(fragment);
         await GetQuantityDialog.waitForDialog();
     }, ({ textContent }) => {
         expect(textContent).toContain('QR_NOT_RECOGNIZED');
     });
+};
 
-    await expectErrorToast('Scan the truncated HU QR tail where HU is expected', async () => {
-        await DistributionLinePickFromScreen.typeHUQRCode(truncatedTail);
-        await GetQuantityDialog.waitForDialog();
-    }, ({ textContent }) => {
-        expect(textContent).toContain('QR_NOT_RECOGNIZED');
-    });
+// noinspection JSUnusedLocalSymbols
+test('Scan a truncated (split) HU QR HEAD where HU is expected → user-friendly error', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
+        allure.tag('F5114');  // Standalone tag for Tags section;
+    allure.story('Scan HU barcodes');
+    allure.severity('normal');
+
+    await expectTruncatedHuQRFragmentShowsFriendlyError({ which: 'head' });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Scan a truncated (split) HU QR TAIL where HU is expected → user-friendly error', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
+        allure.tag('F5114');  // Standalone tag for Tags section;
+    allure.story('Scan HU barcodes');
+    allure.severity('normal');
+
+    await expectTruncatedHuQRFragmentShowsFriendlyError({ which: 'tail' });
 });

--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -616,12 +616,16 @@ test('Scan a truncated (split) HU QR code during picking → user-friendly error
 
     const masterdata = await createMasterdata();
 
-    // A long HU QR code can be split mid-stream by a slow scanner device: the worker scans one HU during
-    // picking but only the head fragment arrives — it keeps the valid "HU#<version>#" prefix yet carries a
-    // truncated, unparseable JSON payload.
+    // A long HU QR code can be split mid-stream by a slow scanner device: it arrives as TWO bad scans —
+    // the head fragment (keeps the valid "HU#<version>#" prefix but carries truncated, unparseable JSON) and
+    // the tail fragment (the remainder of the payload, without the prefix). Both must surface the same
+    // friendly QR_NOT_RECOGNIZED message, exactly as in the originally reported problem.
     const fullHuQRCode = masterdata.handlingUnits.HU1.qrCode;
-    const truncatedHead = fullHuQRCode.substring(0, Math.floor(fullHuQRCode.length / 2));
-    expect(truncatedHead).toMatch(/^HU#/);
+    const splitAt = Math.floor(fullHuQRCode.length / 2);
+    const truncatedHead = fullHuQRCode.substring(0, splitAt);
+    const truncatedTail = fullHuQRCode.substring(splitAt);
+    expect(truncatedHead).toMatch(/^HU#/);     // head keeps the HU# prefix, payload is cut off
+    expect(truncatedTail).not.toMatch(/^HU#/); // tail is the prefix-less remainder
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
@@ -632,9 +636,19 @@ test('Scan a truncated (split) HU QR code during picking → user-friendly error
     await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
     await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
 
-    await expectErrorToast('Scanning a truncated HU QR code during picking', async () => {
+    await expectErrorToast('Scan the truncated HU QR head during picking', async () => {
         await PickingJobScreen.pickHU({
             qrCode: truncatedHead,
+            isScanDirectly: true,
+            expectedPickDirectly: true,
+        });
+    }, ({ textContent }) => {
+        expect(textContent).toContain('QR_NOT_RECOGNIZED');
+    });
+
+    await expectErrorToast('Scan the truncated HU QR tail during picking', async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: truncatedTail,
             isScanDirectly: true,
             expectedPickDirectly: true,
         });

--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -606,26 +606,28 @@ test('Scan invalid HU QR code and recover', async ({ page }) => {
     await PickingJobScreen.complete();
 });
 
-// noinspection JSUnusedLocalSymbols
-test('Scan a truncated (split) HU QR code during picking → user-friendly error', async ({ page }) => {
-    allure.epic('E0105: Picking');
-    allure.tag('F00230: MobileUI Picking');
-    allure.tag('F00230');
-    allure.story('Error handling - invalid HU QR code');
-    allure.severity('critical');
-
+// A long HU QR code can be split mid-stream by a slow scanner device: it arrives as TWO bad scans —
+// the head fragment (keeps the valid "HU#<version>#" prefix but carries truncated, unparseable JSON) and
+// the tail fragment (the prefix-less remainder). Each fragment, scanned on its own exactly as the device
+// delivers it, must surface the friendly QR_NOT_RECOGNIZED message — never a silent failure or the raw
+// "Failed converting payload" developer error.
+//
+// The two fragments are verified in SEPARATE tests, each starting from a clean toast state. The app shows
+// exactly one error toast per scan by design (a fixed toastId — see mobile-webui CLAUDE.md "the user must
+// see exactly ONE error"), so two back-to-back scans within one test would race that de-duplication and
+// leave the second fragment's toast suppressed. Asserting a single shared toast instead would also fail to
+// catch a tail-specific regression — a raw tail error would be hidden under the head's friendly toast. One
+// scan per scenario keeps each fragment's handling independently observable.
+const expectTruncatedHuQRFragmentShowsFriendlyErrorDuringPicking = async ({ which }) => {
     const masterdata = await createMasterdata();
 
-    // A long HU QR code can be split mid-stream by a slow scanner device: it arrives as TWO bad scans —
-    // the head fragment (keeps the valid "HU#<version>#" prefix but carries truncated, unparseable JSON) and
-    // the tail fragment (the remainder of the payload, without the prefix). Both must surface the same
-    // friendly QR_NOT_RECOGNIZED message, exactly as in the originally reported problem.
     const fullHuQRCode = masterdata.handlingUnits.HU1.qrCode;
     const splitAt = Math.floor(fullHuQRCode.length / 2);
     const truncatedHead = fullHuQRCode.substring(0, splitAt);
     const truncatedTail = fullHuQRCode.substring(splitAt);
     expect(truncatedHead).toMatch(/^HU#/);     // head keeps the HU# prefix, payload is cut off
     expect(truncatedTail).not.toMatch(/^HU#/); // tail is the prefix-less remainder
+    const fragment = which === 'head' ? truncatedHead : truncatedTail;
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
@@ -636,25 +638,37 @@ test('Scan a truncated (split) HU QR code during picking → user-friendly error
     await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
     await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
 
-    await expectErrorToast('Scan the truncated HU QR head during picking', async () => {
+    await expectErrorToast(`Scan the truncated HU QR ${which} during picking`, async () => {
         await PickingJobScreen.pickHU({
-            qrCode: truncatedHead,
+            qrCode: fragment,
             isScanDirectly: true,
             expectedPickDirectly: true,
         });
     }, ({ textContent }) => {
         expect(textContent).toContain('QR_NOT_RECOGNIZED');
     });
+};
 
-    await expectErrorToast('Scan the truncated HU QR tail during picking', async () => {
-        await PickingJobScreen.pickHU({
-            qrCode: truncatedTail,
-            isScanDirectly: true,
-            expectedPickDirectly: true,
-        });
-    }, ({ textContent }) => {
-        expect(textContent).toContain('QR_NOT_RECOGNIZED');
-    });
+// noinspection JSUnusedLocalSymbols
+test('Scan a truncated (split) HU QR HEAD during picking → user-friendly error', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Error handling - invalid HU QR code');
+    allure.severity('critical');
+
+    await expectTruncatedHuQRFragmentShowsFriendlyErrorDuringPicking({ which: 'head' });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Scan a truncated (split) HU QR TAIL during picking → user-friendly error', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Error handling - invalid HU QR code');
+    allure.severity('critical');
+
+    await expectTruncatedHuQRFragmentShowsFriendlyErrorDuringPicking({ which: 'tail' });
 });
 
 //

--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -606,6 +606,43 @@ test('Scan invalid HU QR code and recover', async ({ page }) => {
     await PickingJobScreen.complete();
 });
 
+// noinspection JSUnusedLocalSymbols
+test('Scan a truncated (split) HU QR code during picking → user-friendly error', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Error handling - invalid HU QR code');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+
+    // A long HU QR code can be split mid-stream by a slow scanner device: the worker scans one HU during
+    // picking but only the head fragment arrives — it keeps the valid "HU#<version>#" prefix yet carries a
+    // truncated, unparseable JSON payload.
+    const fullHuQRCode = masterdata.handlingUnits.HU1.qrCode;
+    const truncatedHead = fullHuQRCode.substring(0, Math.floor(fullHuQRCode.length / 2));
+    expect(truncatedHead).toMatch(/^HU#/);
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+
+    await expectErrorToast('Scanning a truncated HU QR code during picking', async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: truncatedHead,
+            isScanDirectly: true,
+            expectedPickDirectly: true,
+        });
+    }, ({ textContent }) => {
+        expect(textContent).toContain('QR_NOT_RECOGNIZED');
+    });
+});
+
 //
 // Scan a Leich+Mehl QR code (LMQ format) with an empty lot-number part.
 // Format: LMQ#1#<weight>#<date>#<lot>#<product>


### PR DESCRIPTION
## What

On slow MobileUI scanner devices, a long HU QR code can be **split mid-stream** into two fragments. The **tail** fragment already produced the friendly "QR code not recognized" message, but the **head** fragment kept a valid `HU#<version>#` type prefix with truncated JSON — so `HUQRCode.fromGlobalQRCode` threw the raw `Failed converting payload to ...` developer error instead.

This unifies the head error to the **same** user-friendly message the tail already shows. The operator always sees a friendly "QR code not recognized" message — never a silent failure, never the raw developer error.

## How

In `HUQRCodesService.parse(ScannedCode)`, wrap the type-matched HU/LM conversion: when a code whose type prefix is handled (`HU#`/`LM#`) cannot be converted (truncated/corrupt payload), rethrow the existing `MobileQRCodeMessages.newNotRecognizedException`, preserving the original exception as cause for diagnostics.

- Reuses the existing `de.metas.mobile.qr.NotRecognized` message — **no new AD_Message, no migration**.

## Tests

- **JUnit** (`HUQRCodesServiceTest`): `truncatedHuQRCodeHead_throwsUserFriendlyError` generates a real HU QR code, truncates it mid-JSON to reproduce the device split, and asserts `parse()` throws the user-friendly `QR_NOT_RECOGNIZED` error; `unrecognized_throwsUserFriendlyError` covers a generic prefix-less unrecognized code.
- **Mobile Playwright E2E** — both fragments are scanned and asserted to surface the friendly `QR_NOT_RECOGNIZED` toast, in distribution pick-from and in picking:
  - `e2e/mobile-webui/tests/spec/distribution/scan_HU_barcodes.spec.js`: "truncated (split) HU QR HEAD / TAIL where HU is expected".
  - `e2e/mobile-webui/tests/spec/picking/picking.spec.js`: "truncated (split) HU QR HEAD / TAIL during picking".
  - Each fragment is scanned in its own test from a clean toast state: the scanner emits one error toast per scan with a fixed toastId (the "user sees exactly ONE error" design), so two back-to-back scans in one test would race react-toastify's de-duplication and suppress the second fragment's toast.