### PR TITLE
ci: move internal build images to GHCR (fix Docker Hub push stall) — game_time_hotfix

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/.github/workflows/CLAUDE.md

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -114,6 +114,11 @@ jobs:
         with:
           username: metasfresh
           password: ${{ secrets.DOCKERHUB_METASFRESH_RW_TOKEN }}
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: prepare-settings
         env:
           METASFRESH_PACKAGES_READ_TOKEN: ${{ secrets.METASFRESH_PACKAGES_READ_TOKEN }}
@@ -125,10 +130,10 @@ jobs:
           --progress=plain \
           --file docker-builds/Dockerfile.common \
           --cache-to type=inline \
-          --cache-from metasfresh/metas-mvn-common:${{ needs.init.outputs.tag-floating }} \
+          --cache-from ghcr.io/metasfresh/metas-mvn-common:${{ needs.init.outputs.tag-floating }} \
           --secret id=mvn-settings,src=docker-builds/mvn/local-settings.xml \
-          --tag metasfresh/metas-mvn-common:${{ needs.init.outputs.tag-floating }} \
-          --tag metasfresh/metas-mvn-common:${{ needs.init.outputs.tag-fixed }} \
+          --tag ghcr.io/metasfresh/metas-mvn-common:${{ needs.init.outputs.tag-floating }} \
+          --tag ghcr.io/metasfresh/metas-mvn-common:${{ needs.init.outputs.tag-fixed }} \
           .
       - name: build-backend
         run: |
@@ -136,11 +141,11 @@ jobs:
           --progress=plain \
           --file docker-builds/Dockerfile.backend \
           --cache-to type=inline \
-          --cache-from metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-floating }} \
+          --cache-from ghcr.io/metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-floating }} \
           --secret id=mvn-settings,src=docker-builds/mvn/local-settings.xml \
           --build-arg REFNAME=${{ needs.init.outputs.tag-floating }} \
-          --tag metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-floating }} \
-          --tag metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-fixed }} \
+          --tag ghcr.io/metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-floating }} \
+          --tag ghcr.io/metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-fixed }} \
           .
       - name: build-backend-dist
         run: |
@@ -148,11 +153,11 @@ jobs:
           --progress=plain \
           --file docker-builds/Dockerfile.backend.dist \
           --cache-to type=inline \
-          --cache-from metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-floating }} \
+          --cache-from ghcr.io/metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-floating }} \
           --build-arg REFNAME=${{ needs.init.outputs.tag-floating }} \
           --build-arg VERSION=${{ needs.init.outputs.tag-fixed }} \
-          --tag metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-floating }} \
-          --tag metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-fixed }} \
+          --tag ghcr.io/metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-floating }} \
+          --tag ghcr.io/metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-fixed }} \
           .
       - name: build-camel
         run: |
@@ -160,11 +165,11 @@ jobs:
           --progress=plain \
           --file docker-builds/Dockerfile.camel \
           --cache-to type=inline \
-          --cache-from metasfresh/metas-mvn-camel:${{ needs.init.outputs.tag-floating }} \
+          --cache-from ghcr.io/metasfresh/metas-mvn-camel:${{ needs.init.outputs.tag-floating }} \
           --secret id=mvn-settings,src=docker-builds/mvn/local-settings.xml \
           --build-arg REFNAME=${{ needs.init.outputs.tag-floating }} \
-          --tag metasfresh/metas-mvn-camel:${{ needs.init.outputs.tag-floating }} \
-          --tag metasfresh/metas-mvn-camel:${{ needs.init.outputs.tag-fixed }} \
+          --tag ghcr.io/metasfresh/metas-mvn-camel:${{ needs.init.outputs.tag-floating }} \
+          --tag ghcr.io/metasfresh/metas-mvn-camel:${{ needs.init.outputs.tag-fixed }} \
           .
       - name: build-camel-dist
         run: |
@@ -172,97 +177,97 @@ jobs:
           --progress=plain \
           --file docker-builds/Dockerfile.camel.dist \
           --cache-to type=inline \
-          --cache-from metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }} \
+          --cache-from ghcr.io/metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }} \
           --build-arg REFNAME=${{ needs.init.outputs.tag-floating }} \
           --build-arg VERSION=${{ needs.init.outputs.tag-fixed }} \
-          --tag metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }} \
-          --tag metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-fixed }} \
+          --tag ghcr.io/metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }} \
+          --tag ghcr.io/metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-fixed }} \
           .
-      - name: push-image metasfresh/metas-mvn-common:${{ needs.init.outputs.tag-fixed }}
+      - name: push-image ghcr.io/metasfresh/metas-mvn-common:${{ needs.init.outputs.tag-fixed }}
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-mvn-common:${{ needs.init.outputs.tag-fixed }}
-      - name: push-image metasfresh/metas-mvn-common:${{ needs.init.outputs.tag-floating }}
+          command: docker push ghcr.io/metasfresh/metas-mvn-common:${{ needs.init.outputs.tag-fixed }}
+      - name: push-image ghcr.io/metasfresh/metas-mvn-common:${{ needs.init.outputs.tag-floating }}
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-mvn-common:${{ needs.init.outputs.tag-floating }}
-      - name: push-image metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-fixed }}
+          command: docker push ghcr.io/metasfresh/metas-mvn-common:${{ needs.init.outputs.tag-floating }}
+      - name: push-image ghcr.io/metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-fixed }}
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-fixed }}
-      - name: push-image metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-floating }}
+          command: docker push ghcr.io/metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-fixed }}
+      - name: push-image ghcr.io/metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-floating }}
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-floating }}
-      - name: push-image metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-fixed }}
+          command: docker push ghcr.io/metasfresh/metas-mvn-backend:${{ needs.init.outputs.tag-floating }}
+      - name: push-image ghcr.io/metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-fixed }}
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-fixed }}
-      - name: push-image metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-floating }}
+          command: docker push ghcr.io/metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-fixed }}
+      - name: push-image ghcr.io/metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-floating }}
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-floating }}
-      - name: push-image metasfresh/metas-mvn-camel:${{ needs.init.outputs.tag-fixed }}
+          command: docker push ghcr.io/metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-floating }}
+      - name: push-image ghcr.io/metasfresh/metas-mvn-camel:${{ needs.init.outputs.tag-fixed }}
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-mvn-camel:${{ needs.init.outputs.tag-fixed }}
-      - name: push-image metasfresh/metas-mvn-camel:${{ needs.init.outputs.tag-floating }}
+          command: docker push ghcr.io/metasfresh/metas-mvn-camel:${{ needs.init.outputs.tag-fixed }}
+      - name: push-image ghcr.io/metasfresh/metas-mvn-camel:${{ needs.init.outputs.tag-floating }}
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-mvn-camel:${{ needs.init.outputs.tag-floating }}
-      - name: push-image metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-fixed }}
+          command: docker push ghcr.io/metasfresh/metas-mvn-camel:${{ needs.init.outputs.tag-floating }}
+      - name: push-image ghcr.io/metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-fixed }}
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-fixed }}
-      - name: push-image metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }}
+          command: docker push ghcr.io/metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-fixed }}
+      - name: push-image ghcr.io/metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }}
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }}
-      - name: push-image metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }}
+          command: docker push ghcr.io/metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }}
+      - name: push-image ghcr.io/metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }}
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }}
+          command: docker push ghcr.io/metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-floating }}
   #      # only needed for agent/hub
-  #      - name: push-maven-dist metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-fixed }}
+  #      - name: push-maven-dist ghcr.io/metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-fixed }}
   #        run: |
-  #          docker run --rm --env GITHUB_ACTOR=${{ github.actor }} --env GITHUB_TOKEN=${{ github.token }} metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-fixed }}
+  #          docker run --rm --env GITHUB_ACTOR=${{ github.actor }} --env GITHUB_TOKEN=${{ github.token }} ghcr.io/metasfresh/metas-mvn-backend-dist:${{ needs.init.outputs.tag-fixed }}
   #      # only needed for custom external/edi
-  #      - name: push-maven-dist metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-fixed }}
+  #      - name: push-maven-dist ghcr.io/metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-fixed }}
   #        run: |
-  #          docker run --rm --env GITHUB_ACTOR=${{ github.actor }} --env GITHUB_TOKEN=${{ github.token }} metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-fixed }}
+  #          docker run --rm --env GITHUB_ACTOR=${{ github.actor }} --env GITHUB_TOKEN=${{ github.token }} ghcr.io/metasfresh/metas-mvn-camel-dist:${{ needs.init.outputs.tag-fixed }}
 
   frontend:
     runs-on: ${{ vars.RUNNER_HEAVY }}
@@ -273,6 +278,11 @@ jobs:
         with:
           username: metasfresh
           password: ${{ secrets.DOCKERHUB_METASFRESH_RW_TOKEN }}
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: build-frontend
         run: |
           docker buildx build \
@@ -396,6 +406,11 @@ jobs:
         with:
           username: metasfresh
           password: ${{ secrets.DOCKERHUB_METASFRESH_RW_TOKEN }}
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: prepare
         env:
           INIT_BUILD_PROPS: ${{ needs.init.outputs.build-info-properties }}
@@ -627,6 +642,11 @@ jobs:
         with:
           username: metasfresh
           password: ${{ secrets.DOCKERHUB_METASFRESH_RW_TOKEN }}
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: prepare-settings
         env:
           METASFRESH_PACKAGES_READ_TOKEN: ${{ secrets.METASFRESH_PACKAGES_READ_TOKEN }}
@@ -748,6 +768,11 @@ jobs:
         with:
           username: metasfresh
           password: ${{ secrets.DOCKERHUB_METASFRESH_RW_TOKEN }}
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: prepare
         env:
           INIT_BUILD_PROPS: ${{ needs.init.outputs.build-info-properties }}
@@ -944,6 +969,11 @@ jobs:
         with:
           username: metasfresh
           password: ${{ secrets.DOCKERHUB_METASFRESH_RW_TOKEN }}
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: testspace-com/setup-testspace@v1
         if: needs.init.outputs.skip-testspace != 'true'
         with:
@@ -1013,12 +1043,19 @@ jobs:
     name: build (cucumber)
     runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: [ init, java ]
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v4
         with:
           username: metasfresh
           password: ${{ secrets.DOCKERHUB_METASFRESH_RW_TOKEN }}
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: prepare-settings
         env:
           METASFRESH_PACKAGES_READ_TOKEN: ${{ secrets.METASFRESH_PACKAGES_READ_TOKEN }}
@@ -1031,28 +1068,28 @@ jobs:
           --file docker-builds/Dockerfile.cucumber \
           --secret id=mvn-settings,src=docker-builds/mvn/local-settings.xml \
           --build-arg REFNAME=${{ needs.init.outputs.tag-fixed }} \
-          --tag metasfresh/metas-cucumber:${{ needs.init.outputs.tag-floating }} \
-          --tag metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }} \
+          --tag ghcr.io/metasfresh/metas-cucumber:${{ needs.init.outputs.tag-floating }} \
+          --tag ghcr.io/metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }} \
           .
-      - name: push-image metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }}
+      - name: push-image ghcr.io/metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }}
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }}
-      - name: push-image metasfresh/metas-cucumber:${{ needs.init.outputs.tag-floating }}
+          command: docker push ghcr.io/metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }}
+      - name: push-image ghcr.io/metasfresh/metas-cucumber:${{ needs.init.outputs.tag-floating }}
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-cucumber:${{ needs.init.outputs.tag-floating }}
+          command: docker push ghcr.io/metasfresh/metas-cucumber:${{ needs.init.outputs.tag-floating }}
       - name: produce-summary
         run: |
           echo '#### images' >> $GITHUB_STEP_SUMMARY
-          echo '* metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
-          echo '* metasfresh/metas-cucumber:${{ needs.init.outputs.tag-floating }}' >> $GITHUB_STEP_SUMMARY   
+          echo '* ghcr.io/metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
+          echo '* ghcr.io/metasfresh/metas-cucumber:${{ needs.init.outputs.tag-floating }}' >> $GITHUB_STEP_SUMMARY   
 
   cucumber-run:
     name: test (cucumber)
@@ -1090,6 +1127,11 @@ jobs:
         with:
           username: metasfresh
           password: ${{ secrets.DOCKERHUB_METASFRESH_RW_TOKEN }}
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: testspace-com/setup-testspace@v1
         if: needs.init.outputs.skip-testspace != 'true'
         with:
@@ -1110,8 +1152,12 @@ jobs:
         timeout-minutes: 120
         run: |
           mkdir -p cucumber
-          docker pull metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }} --quiet
-          docker cp "$(docker create --name tempcopytainer metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }}):/compose.yml" . && docker rm tempcopytainer
+          docker pull ghcr.io/metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }} --quiet
+          docker cp "$(docker create --name tempcopytainer ghcr.io/metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }}):/compose.yml" . && docker rm tempcopytainer
+          # compose.yml references ${mfregistry:-metasfresh}/metas-cucumber (i.e. the Docker Hub name) for the cucumber
+          # service, but the image now lives on GHCR. Retag the pulled ghcr image under that name so compose uses the
+          # local image (metas-db still resolves to Docker Hub via mfregistry).
+          docker tag ghcr.io/metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }} metasfresh/metas-cucumber:${{ needs.init.outputs.tag-fixed }}
           docker compose up --abort-on-container-exit --exit-code-from cucumber 2>&1 | tee cucumber.log && echo "${PIPESTATUS[0]}" > cucumber.exit-code
           docker commit metasfresh-db-1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postcucumber-${{ matrix.profile }}
           docker compose down
@@ -1201,6 +1247,11 @@ jobs:
         with:
           username: metasfresh
           password: ${{ secrets.DOCKERHUB_METASFRESH_RW_TOKEN }}
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: start docker compose
         working-directory: docker-builds/compose/
         env:
@@ -1295,6 +1346,11 @@ jobs:
         with:
           username: metasfresh
           password: ${{ secrets.DOCKERHUB_METASFRESH_RW_TOKEN }}
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: testspace-com/setup-testspace@v1
         if: needs.init.outputs.skip-testspace != 'true'
         with:

--- a/.github/workflows/claude-docs
+++ b/.github/workflows/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/.github/workflows/claude-docs

--- a/.github/workflows/pipeline-timing/CLAUDE.md
+++ b/.github/workflows/pipeline-timing/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/.github/workflows/pipeline-timing/CLAUDE.md

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/.mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/CLAUDE.md

--- a/backend/de-metas-salesorder/CLAUDE.md
+++ b/backend/de-metas-salesorder/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de-metas-salesorder/CLAUDE.md

--- a/backend/de.metas.acct.base/CLAUDE.md
+++ b/backend/de.metas.acct.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.acct.base/CLAUDE.md

--- a/backend/de.metas.acct.base/claude-docs
+++ b/backend/de.metas.acct.base/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.acct.base/claude-docs

--- a/backend/de.metas.acct.webui/CLAUDE.md
+++ b/backend/de.metas.acct.webui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.acct.webui/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/CLAUDE.md
+++ b/backend/de.metas.adempiere.adempiere/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/base/CLAUDE.md
+++ b/backend/de.metas.adempiere.adempiere/base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/base/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/base/claude-docs
+++ b/backend/de.metas.adempiere.adempiere/base/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/base/claude-docs

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/attachments/CLAUDE.md
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/attachments/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/attachments/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/CLAUDE.md
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/email/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/error/CLAUDE.md
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/error/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/error/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/CLAUDE.md
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/i18n/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/CLAUDE.md
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/logging/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/payment/CLAUDE.md
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/payment/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/payment/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/service/CLAUDE.md
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/service/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/service/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/client/CLAUDE.md
+++ b/backend/de.metas.adempiere.adempiere/client/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/client/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/migration/CLAUDE.md
+++ b/backend/de.metas.adempiere.adempiere/migration/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/migration/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/serverRoot/CLAUDE.md
+++ b/backend/de.metas.adempiere.adempiere/serverRoot/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/serverRoot/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/serverRoot/de.metas.adempiere.adempiere.serverRoot.base/CLAUDE.md
+++ b/backend/de.metas.adempiere.adempiere/serverRoot/de.metas.adempiere.adempiere.serverRoot.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/serverRoot/de.metas.adempiere.adempiere.serverRoot.base/CLAUDE.md

--- a/backend/de.metas.adempiere.adempiere/tools/CLAUDE.md
+++ b/backend/de.metas.adempiere.adempiere/tools/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.adempiere/tools/CLAUDE.md

--- a/backend/de.metas.adempiere.libero.liberoHR/CLAUDE.md
+++ b/backend/de.metas.adempiere.libero.liberoHR/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.adempiere.libero.liberoHR/CLAUDE.md

--- a/backend/de.metas.aggregation/CLAUDE.md
+++ b/backend/de.metas.aggregation/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.aggregation/CLAUDE.md

--- a/backend/de.metas.assemblies/CLAUDE.md
+++ b/backend/de.metas.assemblies/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.assemblies/CLAUDE.md

--- a/backend/de.metas.async/CLAUDE.md
+++ b/backend/de.metas.async/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.async/CLAUDE.md

--- a/backend/de.metas.async/src/main/java/de/metas/async/CLAUDE.md
+++ b/backend/de.metas.async/src/main/java/de/metas/async/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.async/src/main/java/de/metas/async/CLAUDE.md

--- a/backend/de.metas.banking/CLAUDE.md
+++ b/backend/de.metas.banking/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.banking/CLAUDE.md

--- a/backend/de.metas.banking/de.metas.banking.base/CLAUDE.md
+++ b/backend/de.metas.banking/de.metas.banking.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.banking/de.metas.banking.base/CLAUDE.md

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/CLAUDE.md
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/payment/paymentallocation/CLAUDE.md

--- a/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/service/CLAUDE.md
+++ b/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/service/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.banking/de.metas.banking.base/src/main/java/de/metas/banking/service/CLAUDE.md

--- a/backend/de.metas.banking/de.metas.banking.camt53/CLAUDE.md
+++ b/backend/de.metas.banking/de.metas.banking.camt53/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.banking/de.metas.banking.camt53/CLAUDE.md

--- a/backend/de.metas.banking/de.metas.banking.swingui/CLAUDE.md
+++ b/backend/de.metas.banking/de.metas.banking.swingui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.banking/de.metas.banking.swingui/CLAUDE.md

--- a/backend/de.metas.business.rest-api-impl/CLAUDE.md
+++ b/backend/de.metas.business.rest-api-impl/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.business.rest-api-impl/CLAUDE.md

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/remittanceadvice/CLAUDE.md
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/remittanceadvice/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/remittanceadvice/CLAUDE.md

--- a/backend/de.metas.business.rest-api/CLAUDE.md
+++ b/backend/de.metas.business.rest-api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.business.rest-api/CLAUDE.md

--- a/backend/de.metas.business/CLAUDE.md
+++ b/backend/de.metas.business/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.business/CLAUDE.md

--- a/backend/de.metas.business/src/main/java/de/metas/remittanceadvice/CLAUDE.md
+++ b/backend/de.metas.business/src/main/java/de/metas/remittanceadvice/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.business/src/main/java/de/metas/remittanceadvice/CLAUDE.md

--- a/backend/de.metas.contracts/CLAUDE.md
+++ b/backend/de.metas.contracts/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.contracts/CLAUDE.md

--- a/backend/de.metas.cucumber/CLAUDE.md
+++ b/backend/de.metas.cucumber/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.cucumber/CLAUDE.md

--- a/backend/de.metas.cucumber/claude-docs
+++ b/backend/de.metas.cucumber/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.cucumber/claude-docs

--- a/backend/de.metas.datev/CLAUDE.md
+++ b/backend/de.metas.datev/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.datev/CLAUDE.md

--- a/backend/de.metas.device.adempiere/CLAUDE.md
+++ b/backend/de.metas.device.adempiere/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.device.adempiere/CLAUDE.md

--- a/backend/de.metas.device.api/CLAUDE.md
+++ b/backend/de.metas.device.api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.device.api/CLAUDE.md

--- a/backend/de.metas.device.scales/CLAUDE.md
+++ b/backend/de.metas.device.scales/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.device.scales/CLAUDE.md

--- a/backend/de.metas.device.webui/CLAUDE.md
+++ b/backend/de.metas.device.webui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.device.webui/CLAUDE.md

--- a/backend/de.metas.dimension/CLAUDE.md
+++ b/backend/de.metas.dimension/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.dimension/CLAUDE.md

--- a/backend/de.metas.distribution.rest-api/CLAUDE.md
+++ b/backend/de.metas.distribution.rest-api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.distribution.rest-api/CLAUDE.md

--- a/backend/de.metas.dlm/CLAUDE.md
+++ b/backend/de.metas.dlm/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.dlm/CLAUDE.md

--- a/backend/de.metas.dlm/base/CLAUDE.md
+++ b/backend/de.metas.dlm/base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.dlm/base/CLAUDE.md

--- a/backend/de.metas.dlm/swingui/CLAUDE.md
+++ b/backend/de.metas.dlm/swingui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.dlm/swingui/CLAUDE.md

--- a/backend/de.metas.document.archive.api/CLAUDE.md
+++ b/backend/de.metas.document.archive.api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.document.archive.api/CLAUDE.md

--- a/backend/de.metas.document.archive/CLAUDE.md
+++ b/backend/de.metas.document.archive/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.document.archive/CLAUDE.md

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/CLAUDE.md
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.document.archive/de.metas.document.archive.base/CLAUDE.md

--- a/backend/de.metas.document.refid/CLAUDE.md
+++ b/backend/de.metas.document.refid/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.document.refid/CLAUDE.md

--- a/backend/de.metas.documentation/CLAUDE.md
+++ b/backend/de.metas.documentation/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.documentation/CLAUDE.md

--- a/backend/de.metas.dunning/CLAUDE.md
+++ b/backend/de.metas.dunning/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.dunning/CLAUDE.md

--- a/backend/de.metas.dunning_gateway.api/CLAUDE.md
+++ b/backend/de.metas.dunning_gateway.api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.dunning_gateway.api/CLAUDE.md

--- a/backend/de.metas.dunning_gateway.spi/CLAUDE.md
+++ b/backend/de.metas.dunning_gateway.spi/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.dunning_gateway.spi/CLAUDE.md

--- a/backend/de.metas.edi/CLAUDE.md
+++ b/backend/de.metas.edi/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.edi/CLAUDE.md

--- a/backend/de.metas.elasticsearch/CLAUDE.md
+++ b/backend/de.metas.elasticsearch/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.elasticsearch/CLAUDE.md

--- a/backend/de.metas.externalreference/CLAUDE.md
+++ b/backend/de.metas.externalreference/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.externalreference/CLAUDE.md

--- a/backend/de.metas.externalsystem/CLAUDE.md
+++ b/backend/de.metas.externalsystem/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.externalsystem/CLAUDE.md

--- a/backend/de.metas.fresh/CLAUDE.md
+++ b/backend/de.metas.fresh/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.fresh/CLAUDE.md

--- a/backend/de.metas.fresh/de.metas.fresh.base/CLAUDE.md
+++ b/backend/de.metas.fresh/de.metas.fresh.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.fresh/de.metas.fresh.base/CLAUDE.md

--- a/backend/de.metas.fresh/de.metas.fresh.base/claude-docs
+++ b/backend/de.metas.fresh/de.metas.fresh.base/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.fresh/de.metas.fresh.base/claude-docs

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/docs/purchase/inout/CLAUDE.md
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/docs/purchase/inout/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/docs/purchase/inout/CLAUDE.md

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/CLAUDE.md
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/CLAUDE.md

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/CLAUDE.md
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/ddl/functions/CLAUDE.md

--- a/backend/de.metas.fresh/de.metas.fresh.swingui/CLAUDE.md
+++ b/backend/de.metas.fresh/de.metas.fresh.swingui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.fresh/de.metas.fresh.swingui/CLAUDE.md

--- a/backend/de.metas.frontend-testing/CLAUDE.md
+++ b/backend/de.metas.frontend-testing/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.frontend-testing/CLAUDE.md

--- a/backend/de.metas.global_qrcode.api/CLAUDE.md
+++ b/backend/de.metas.global_qrcode.api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.global_qrcode.api/CLAUDE.md

--- a/backend/de.metas.global_qrcode.services/CLAUDE.md
+++ b/backend/de.metas.global_qrcode.services/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.global_qrcode.services/CLAUDE.md

--- a/backend/de.metas.handlingunits.base/CLAUDE.md
+++ b/backend/de.metas.handlingunits.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.handlingunits.base/CLAUDE.md

--- a/backend/de.metas.handlingunits.base/claude-docs
+++ b/backend/de.metas.handlingunits.base/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.handlingunits.base/claude-docs

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/hutransaction/CLAUDE.md
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/hutransaction/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/hutransaction/CLAUDE.md

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inventory/CLAUDE.md
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inventory/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/inventory/CLAUDE.md

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/material/interceptor/transactionevent/CLAUDE.md
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/material/interceptor/transactionevent/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/material/interceptor/transactionevent/CLAUDE.md

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/CLAUDE.md
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/CLAUDE.md

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/CLAUDE.md
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/CLAUDE.md

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/async/CLAUDE.md
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/async/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/async/CLAUDE.md

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/trace/CLAUDE.md
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/trace/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/trace/CLAUDE.md

--- a/backend/de.metas.handlingunits.mobileui/CLAUDE.md
+++ b/backend/de.metas.handlingunits.mobileui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.handlingunits.mobileui/CLAUDE.md

--- a/backend/de.metas.handlingunits.webui/CLAUDE.md
+++ b/backend/de.metas.handlingunits.webui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.handlingunits.webui/CLAUDE.md

--- a/backend/de.metas.hu_consolidation.mobile/CLAUDE.md
+++ b/backend/de.metas.hu_consolidation.mobile/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.hu_consolidation.mobile/CLAUDE.md

--- a/backend/de.metas.inbound.mail/CLAUDE.md
+++ b/backend/de.metas.inbound.mail/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.inbound.mail/CLAUDE.md

--- a/backend/de.metas.inventory.mobileui/CLAUDE.md
+++ b/backend/de.metas.inventory.mobileui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.inventory.mobileui/CLAUDE.md

--- a/backend/de.metas.invoice_gateway.api/CLAUDE.md
+++ b/backend/de.metas.invoice_gateway.api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.invoice_gateway.api/CLAUDE.md

--- a/backend/de.metas.invoice_gateway.spi/CLAUDE.md
+++ b/backend/de.metas.invoice_gateway.spi/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.invoice_gateway.spi/CLAUDE.md

--- a/backend/de.metas.issue.tracking.everhour/CLAUDE.md
+++ b/backend/de.metas.issue.tracking.everhour/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.issue.tracking.everhour/CLAUDE.md

--- a/backend/de.metas.issue.tracking.github/CLAUDE.md
+++ b/backend/de.metas.issue.tracking.github/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.issue.tracking.github/CLAUDE.md

--- a/backend/de.metas.manufacturing.rest-api/CLAUDE.md
+++ b/backend/de.metas.manufacturing.rest-api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.manufacturing.rest-api/CLAUDE.md

--- a/backend/de.metas.manufacturing.webui/CLAUDE.md
+++ b/backend/de.metas.manufacturing.webui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.manufacturing.webui/CLAUDE.md

--- a/backend/de.metas.manufacturing/CLAUDE.md
+++ b/backend/de.metas.manufacturing/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.manufacturing/CLAUDE.md

--- a/backend/de.metas.marketing/CLAUDE.md
+++ b/backend/de.metas.marketing/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.marketing/CLAUDE.md

--- a/backend/de.metas.marketing/base/CLAUDE.md
+++ b/backend/de.metas.marketing/base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.marketing/base/CLAUDE.md

--- a/backend/de.metas.marketing/cleverreach/CLAUDE.md
+++ b/backend/de.metas.marketing/cleverreach/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.marketing/cleverreach/CLAUDE.md

--- a/backend/de.metas.marketing/serialletter/CLAUDE.md
+++ b/backend/de.metas.marketing/serialletter/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.marketing/serialletter/CLAUDE.md

--- a/backend/de.metas.material/CLAUDE.md
+++ b/backend/de.metas.material/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.material/CLAUDE.md

--- a/backend/de.metas.material/cockpit/CLAUDE.md
+++ b/backend/de.metas.material/cockpit/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.material/cockpit/CLAUDE.md

--- a/backend/de.metas.material/cockpit/claude-docs
+++ b/backend/de.metas.material/cockpit/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.material/cockpit/claude-docs

--- a/backend/de.metas.material/commons/CLAUDE.md
+++ b/backend/de.metas.material/commons/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.material/commons/CLAUDE.md

--- a/backend/de.metas.material/dispo-commons/CLAUDE.md
+++ b/backend/de.metas.material/dispo-commons/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.material/dispo-commons/CLAUDE.md

--- a/backend/de.metas.material/dispo-service/CLAUDE.md
+++ b/backend/de.metas.material/dispo-service/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.material/dispo-service/CLAUDE.md

--- a/backend/de.metas.material/event/CLAUDE.md
+++ b/backend/de.metas.material/event/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.material/event/CLAUDE.md

--- a/backend/de.metas.material/planning/CLAUDE.md
+++ b/backend/de.metas.material/planning/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.material/planning/CLAUDE.md

--- a/backend/de.metas.materialtracking/CLAUDE.md
+++ b/backend/de.metas.materialtracking/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.materialtracking/CLAUDE.md

--- a/backend/de.metas.migration/CLAUDE.md
+++ b/backend/de.metas.migration/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.migration/CLAUDE.md

--- a/backend/de.metas.migration/de.metas.migration.base/CLAUDE.md
+++ b/backend/de.metas.migration/de.metas.migration.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.migration/de.metas.migration.base/CLAUDE.md

--- a/backend/de.metas.migration/de.metas.migration.cli/CLAUDE.md
+++ b/backend/de.metas.migration/de.metas.migration.cli/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.migration/de.metas.migration.cli/CLAUDE.md

--- a/backend/de.metas.monitoring/CLAUDE.md
+++ b/backend/de.metas.monitoring/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.monitoring/CLAUDE.md

--- a/backend/de.metas.payment.esr/CLAUDE.md
+++ b/backend/de.metas.payment.esr/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.payment.esr/CLAUDE.md

--- a/backend/de.metas.payment.paypal/CLAUDE.md
+++ b/backend/de.metas.payment.paypal/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.payment.paypal/CLAUDE.md

--- a/backend/de.metas.payment.revolut/CLAUDE.md
+++ b/backend/de.metas.payment.revolut/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.payment.revolut/CLAUDE.md

--- a/backend/de.metas.payment.sepa/CLAUDE.md
+++ b/backend/de.metas.payment.sepa/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.payment.sepa/CLAUDE.md

--- a/backend/de.metas.payment.sepa/base/CLAUDE.md
+++ b/backend/de.metas.payment.sepa/base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.payment.sepa/base/CLAUDE.md

--- a/backend/de.metas.payment.sepa/schema-pain_001_01_03_ch_02/CLAUDE.md
+++ b/backend/de.metas.payment.sepa/schema-pain_001_01_03_ch_02/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.payment.sepa/schema-pain_001_01_03_ch_02/CLAUDE.md

--- a/backend/de.metas.payment.sepa/schema-pain_008_003_02/CLAUDE.md
+++ b/backend/de.metas.payment.sepa/schema-pain_008_003_02/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.payment.sepa/schema-pain_008_003_02/CLAUDE.md

--- a/backend/de.metas.payment.sumup.rest-api/CLAUDE.md
+++ b/backend/de.metas.payment.sumup.rest-api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.payment.sumup.rest-api/CLAUDE.md

--- a/backend/de.metas.payment.sumup.webui/CLAUDE.md
+++ b/backend/de.metas.payment.sumup.webui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.payment.sumup.webui/CLAUDE.md

--- a/backend/de.metas.payment.sumup/CLAUDE.md
+++ b/backend/de.metas.payment.sumup/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.payment.sumup/CLAUDE.md

--- a/backend/de.metas.picking.rest-api/CLAUDE.md
+++ b/backend/de.metas.picking.rest-api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.picking.rest-api/CLAUDE.md

--- a/backend/de.metas.pos.base/CLAUDE.md
+++ b/backend/de.metas.pos.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.pos.base/CLAUDE.md

--- a/backend/de.metas.pos.rest-api/CLAUDE.md
+++ b/backend/de.metas.pos.rest-api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.pos.rest-api/CLAUDE.md

--- a/backend/de.metas.printing.client/CLAUDE.md
+++ b/backend/de.metas.printing.client/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.printing.client/CLAUDE.md

--- a/backend/de.metas.printing.common/CLAUDE.md
+++ b/backend/de.metas.printing.common/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.printing.common/CLAUDE.md

--- a/backend/de.metas.printing.common/de.metas.printing.api/CLAUDE.md
+++ b/backend/de.metas.printing.common/de.metas.printing.api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.printing.common/de.metas.printing.api/CLAUDE.md

--- a/backend/de.metas.printing.common/de.metas.printing.esb.base/CLAUDE.md
+++ b/backend/de.metas.printing.common/de.metas.printing.esb.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.printing.common/de.metas.printing.esb.base/CLAUDE.md

--- a/backend/de.metas.printing.rest-api-impl/CLAUDE.md
+++ b/backend/de.metas.printing.rest-api-impl/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.printing.rest-api-impl/CLAUDE.md

--- a/backend/de.metas.printing/CLAUDE.md
+++ b/backend/de.metas.printing/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.printing/CLAUDE.md

--- a/backend/de.metas.printing/de.metas.printing.base/CLAUDE.md
+++ b/backend/de.metas.printing/de.metas.printing.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.printing/de.metas.printing.base/CLAUDE.md

--- a/backend/de.metas.printing/de.metas.printing.embedded-client/CLAUDE.md
+++ b/backend/de.metas.printing/de.metas.printing.embedded-client/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.printing/de.metas.printing.embedded-client/CLAUDE.md

--- a/backend/de.metas.procurement.base/CLAUDE.md
+++ b/backend/de.metas.procurement.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.procurement.base/CLAUDE.md

--- a/backend/de.metas.purchasecandidate.base/CLAUDE.md
+++ b/backend/de.metas.purchasecandidate.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.purchasecandidate.base/CLAUDE.md

--- a/backend/de.metas.qualitymgmt/CLAUDE.md
+++ b/backend/de.metas.qualitymgmt/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.qualitymgmt/CLAUDE.md

--- a/backend/de.metas.report/CLAUDE.md
+++ b/backend/de.metas.report/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.report/CLAUDE.md

--- a/backend/de.metas.report/de.metas.report.jasper.client/CLAUDE.md
+++ b/backend/de.metas.report/de.metas.report.jasper.client/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.report/de.metas.report.jasper.client/CLAUDE.md

--- a/backend/de.metas.report/de.metas.report.jasper.commons/CLAUDE.md
+++ b/backend/de.metas.report/de.metas.report.jasper.commons/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.report/de.metas.report.jasper.commons/CLAUDE.md

--- a/backend/de.metas.report/metasfresh-report-service-standalone/CLAUDE.md
+++ b/backend/de.metas.report/metasfresh-report-service-standalone/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.report/metasfresh-report-service-standalone/CLAUDE.md

--- a/backend/de.metas.report/metasfresh-report-service/CLAUDE.md
+++ b/backend/de.metas.report/metasfresh-report-service/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.report/metasfresh-report-service/CLAUDE.md

--- a/backend/de.metas.rfq/CLAUDE.md
+++ b/backend/de.metas.rfq/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.rfq/CLAUDE.md

--- a/backend/de.metas.salescandidate.base/CLAUDE.md
+++ b/backend/de.metas.salescandidate.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.salescandidate.base/CLAUDE.md

--- a/backend/de.metas.scripts.rollout/CLAUDE.md
+++ b/backend/de.metas.scripts.rollout/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.scripts.rollout/CLAUDE.md

--- a/backend/de.metas.serviceprovider/CLAUDE.md
+++ b/backend/de.metas.serviceprovider/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.serviceprovider/CLAUDE.md

--- a/backend/de.metas.servicerepair.base/CLAUDE.md
+++ b/backend/de.metas.servicerepair.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.servicerepair.base/CLAUDE.md

--- a/backend/de.metas.servicerepair.webui/CLAUDE.md
+++ b/backend/de.metas.servicerepair.webui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.servicerepair.webui/CLAUDE.md

--- a/backend/de.metas.shipper.client.nshift/CLAUDE.md
+++ b/backend/de.metas.shipper.client.nshift/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.shipper.client.nshift/CLAUDE.md

--- a/backend/de.metas.shipper.gateway.commons.webui/CLAUDE.md
+++ b/backend/de.metas.shipper.gateway.commons.webui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.shipper.gateway.commons.webui/CLAUDE.md

--- a/backend/de.metas.shipper.gateway.commons/CLAUDE.md
+++ b/backend/de.metas.shipper.gateway.commons/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.shipper.gateway.commons/CLAUDE.md

--- a/backend/de.metas.shipper.gateway.derkurier/CLAUDE.md
+++ b/backend/de.metas.shipper.gateway.derkurier/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.shipper.gateway.derkurier/CLAUDE.md

--- a/backend/de.metas.shipper.gateway.dhl/CLAUDE.md
+++ b/backend/de.metas.shipper.gateway.dhl/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.shipper.gateway.dhl/CLAUDE.md

--- a/backend/de.metas.shipper.gateway.dpd/CLAUDE.md
+++ b/backend/de.metas.shipper.gateway.dpd/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.shipper.gateway.dpd/CLAUDE.md

--- a/backend/de.metas.shipper.gateway.go/CLAUDE.md
+++ b/backend/de.metas.shipper.gateway.go/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.shipper.gateway.go/CLAUDE.md

--- a/backend/de.metas.shipper.gateway.nshift/CLAUDE.md
+++ b/backend/de.metas.shipper.gateway.nshift/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.shipper.gateway.nshift/CLAUDE.md

--- a/backend/de.metas.shipper.gateway.spi/CLAUDE.md
+++ b/backend/de.metas.shipper.gateway.spi/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.shipper.gateway.spi/CLAUDE.md

--- a/backend/de.metas.storage/CLAUDE.md
+++ b/backend/de.metas.storage/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.storage/CLAUDE.md

--- a/backend/de.metas.swat/CLAUDE.md
+++ b/backend/de.metas.swat/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.swat/CLAUDE.md

--- a/backend/de.metas.swat/de.metas.swat.base/CLAUDE.md
+++ b/backend/de.metas.swat/de.metas.swat.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.swat/de.metas.swat.base/CLAUDE.md

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/CLAUDE.md
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/CLAUDE.md

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/CLAUDE.md
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/qty_reservation/CLAUDE.md

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/CLAUDE.md
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/CLAUDE.md

--- a/backend/de.metas.swat/de.metas.swat.webui/CLAUDE.md
+++ b/backend/de.metas.swat/de.metas.swat.webui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.swat/de.metas.swat.webui/CLAUDE.md

--- a/backend/de.metas.ui.web.base/CLAUDE.md
+++ b/backend/de.metas.ui.web.base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.ui.web.base/CLAUDE.md

--- a/backend/de.metas.ui.web.base/claude-docs
+++ b/backend/de.metas.ui.web.base/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.ui.web.base/claude-docs

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/CLAUDE.md
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/CLAUDE.md

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/claude-docs
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/handlingunits/claude-docs

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/session/CLAUDE.md
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/session/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/session/CLAUDE.md

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/CLAUDE.md
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/CLAUDE.md

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/CLAUDE.md
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/CLAUDE.md

--- a/backend/de.metas.util.web/CLAUDE.md
+++ b/backend/de.metas.util.web/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.util.web/CLAUDE.md

--- a/backend/de.metas.util/CLAUDE.md
+++ b/backend/de.metas.util/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.util/CLAUDE.md

--- a/backend/de.metas.vendor.gateway.api/CLAUDE.md
+++ b/backend/de.metas.vendor.gateway.api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.vendor.gateway.api/CLAUDE.md

--- a/backend/de.metas.vertical.creditscore/CLAUDE.md
+++ b/backend/de.metas.vertical.creditscore/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.vertical.creditscore/CLAUDE.md

--- a/backend/de.metas.vertical.creditscore/base/CLAUDE.md
+++ b/backend/de.metas.vertical.creditscore/base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.vertical.creditscore/base/CLAUDE.md

--- a/backend/de.metas.vertical.creditscore/creditpass/CLAUDE.md
+++ b/backend/de.metas.vertical.creditscore/creditpass/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.vertical.creditscore/creditpass/CLAUDE.md

--- a/backend/de.metas.vertical.healthcare.alberta/CLAUDE.md
+++ b/backend/de.metas.vertical.healthcare.alberta/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.vertical.healthcare.alberta/CLAUDE.md

--- a/backend/de.metas.vertical.pharma.msv3.commons/CLAUDE.md
+++ b/backend/de.metas.vertical.pharma.msv3.commons/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.vertical.pharma.msv3.commons/CLAUDE.md

--- a/backend/de.metas.vertical.pharma.msv3.schema.v1/CLAUDE.md
+++ b/backend/de.metas.vertical.pharma.msv3.schema.v1/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.vertical.pharma.msv3.schema.v1/CLAUDE.md

--- a/backend/de.metas.vertical.pharma.msv3.schema.v2/CLAUDE.md
+++ b/backend/de.metas.vertical.pharma.msv3.schema.v2/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.vertical.pharma.msv3.schema.v2/CLAUDE.md

--- a/backend/de.metas.vertical.pharma.msv3.server-peer-metasfresh/CLAUDE.md
+++ b/backend/de.metas.vertical.pharma.msv3.server-peer-metasfresh/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.vertical.pharma.msv3.server-peer-metasfresh/CLAUDE.md

--- a/backend/de.metas.vertical.pharma.msv3.server-peer/CLAUDE.md
+++ b/backend/de.metas.vertical.pharma.msv3.server-peer/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.vertical.pharma.msv3.server-peer/CLAUDE.md

--- a/backend/de.metas.vertical.pharma.msv3.server/CLAUDE.md
+++ b/backend/de.metas.vertical.pharma.msv3.server/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.vertical.pharma.msv3.server/CLAUDE.md

--- a/backend/de.metas.vertical.pharma.securpharm/CLAUDE.md
+++ b/backend/de.metas.vertical.pharma.securpharm/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.vertical.pharma.securpharm/CLAUDE.md

--- a/backend/de.metas.vertical.pharma.vendor.gateway.msv3/CLAUDE.md
+++ b/backend/de.metas.vertical.pharma.vendor.gateway.msv3/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.vertical.pharma.vendor.gateway.msv3/CLAUDE.md

--- a/backend/de.metas.vertical.pharma/CLAUDE.md
+++ b/backend/de.metas.vertical.pharma/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.vertical.pharma/CLAUDE.md

--- a/backend/de.metas.workflow.rest-api/CLAUDE.md
+++ b/backend/de.metas.workflow.rest-api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/de.metas.workflow.rest-api/CLAUDE.md

--- a/backend/extensionsupport/CLAUDE.md
+++ b/backend/extensionsupport/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/extensionsupport/CLAUDE.md

--- a/backend/metasfresh-dist/CLAUDE.md
+++ b/backend/metasfresh-dist/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/metasfresh-dist/CLAUDE.md

--- a/backend/metasfresh-dist/base/CLAUDE.md
+++ b/backend/metasfresh-dist/base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/metasfresh-dist/base/CLAUDE.md

--- a/backend/metasfresh-dist/dist/CLAUDE.md
+++ b/backend/metasfresh-dist/dist/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/metasfresh-dist/dist/CLAUDE.md

--- a/backend/metasfresh-dist/serverRoot/CLAUDE.md
+++ b/backend/metasfresh-dist/serverRoot/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/metasfresh-dist/serverRoot/CLAUDE.md

--- a/backend/metasfresh-dist/swingui/CLAUDE.md
+++ b/backend/metasfresh-dist/swingui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/metasfresh-dist/swingui/CLAUDE.md

--- a/backend/metasfresh-webui-api/CLAUDE.md
+++ b/backend/metasfresh-webui-api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/metasfresh-webui-api/CLAUDE.md

--- a/backend/vertical-healthcare_ch/CLAUDE.md
+++ b/backend/vertical-healthcare_ch/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/vertical-healthcare_ch/CLAUDE.md

--- a/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_440_request/CLAUDE.md
+++ b/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_440_request/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_440_request/CLAUDE.md

--- a/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_440_response/CLAUDE.md
+++ b/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_440_response/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_440_response/CLAUDE.md

--- a/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_450_request/CLAUDE.md
+++ b/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_450_request/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_450_request/CLAUDE.md

--- a/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_450_response/CLAUDE.md
+++ b/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_450_response/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_450_response/CLAUDE.md

--- a/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_base/CLAUDE.md
+++ b/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_base/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_base/CLAUDE.md

--- a/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_commons/CLAUDE.md
+++ b/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_commons/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_commons/CLAUDE.md

--- a/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_rest-api/CLAUDE.md
+++ b/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_rest-api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_rest-api/CLAUDE.md

--- a/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_xversion/CLAUDE.md
+++ b/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_xversion/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/backend/vertical-healthcare_ch/forum_datenaustausch_ch.invoice_xversion/CLAUDE.md

--- a/docker-builds/CLAUDE.md
+++ b/docker-builds/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/docker-builds/CLAUDE.md

--- a/docker-builds/Dockerfile.backend
+++ b/docker-builds/Dockerfile.backend
@@ -1,5 +1,5 @@
 ARG REFNAME=local
-ARG REGISTRY=
+ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-common:$REFNAME AS common
 
 # first, just extract pom.xml files

--- a/docker-builds/Dockerfile.backend.api
+++ b/docker-builds/Dockerfile.backend.api
@@ -1,5 +1,5 @@
 ARG REFNAME=local
-ARG REGISTRY=
+ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
 FROM eclipse-temurin:8-jre-jammy

--- a/docker-builds/Dockerfile.backend.app
+++ b/docker-builds/Dockerfile.backend.app
@@ -1,5 +1,5 @@
 ARG REFNAME=local
-ARG REGISTRY=
+ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
 FROM eclipse-temurin:8-jre-jammy

--- a/docker-builds/Dockerfile.backend.app.compat
+++ b/docker-builds/Dockerfile.backend.app.compat
@@ -1,6 +1,6 @@
 ARG REFNAME=local
 ARG REGISTRY=
-FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
+FROM ghcr.io/metasfresh/metas-mvn-backend:$REFNAME AS backend
 FROM ${REGISTRY}metasfresh/metas-app:$REFNAME AS app
 
 # instead of: FROM ubuntu:16.04 & apt get install openjdk-8-jdk-headless

--- a/docker-builds/Dockerfile.backend.dist
+++ b/docker-builds/Dockerfile.backend.dist
@@ -1,5 +1,5 @@
 ARG REFNAME=local
-ARG REGISTRY=
+ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
 COPY docker-builds/mvn/settings.xml /root/.m2/

--- a/docker-builds/Dockerfile.camel
+++ b/docker-builds/Dockerfile.camel
@@ -1,5 +1,5 @@
 ARG REFNAME=local
-ARG REGISTRY=
+ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-common:$REFNAME AS common
 
 FROM maven:3.8.4-eclipse-temurin-17 AS build

--- a/docker-builds/Dockerfile.camel.dist
+++ b/docker-builds/Dockerfile.camel.dist
@@ -1,5 +1,5 @@
 ARG REFNAME=local
-ARG REGISTRY=
+ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-camel:$REFNAME AS camel
 
 COPY docker-builds/mvn/settings.xml /root/.m2/

--- a/docker-builds/Dockerfile.camel.edi
+++ b/docker-builds/Dockerfile.camel.edi
@@ -5,7 +5,7 @@ ARG REFNAME=local
 # thx to https://github.com/moby/moby/issues/1996#issuecomment-185872769
 ARG CACHEBUST=1
 
-ARG REGISTRY=
+ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-camel:$REFNAME AS camel
 
 FROM eclipse-temurin:17-jre-jammy

--- a/docker-builds/Dockerfile.camel.externalsystems
+++ b/docker-builds/Dockerfile.camel.externalsystems
@@ -1,5 +1,5 @@
 ARG REFNAME=local
-ARG REGISTRY=
+ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-camel:$REFNAME AS camel
 
 FROM eclipse-temurin:17.0.5_8-jdk

--- a/docker-builds/Dockerfile.camel.junit
+++ b/docker-builds/Dockerfile.camel.junit
@@ -1,5 +1,5 @@
 ARG REFNAME=local
-ARG REGISTRY=
+ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-camel:$REFNAME AS camel
 
 FROM maven:3.8.4-eclipse-temurin-17 AS junit

--- a/docker-builds/Dockerfile.cucumber
+++ b/docker-builds/Dockerfile.cucumber
@@ -1,5 +1,5 @@
 ARG REFNAME=local
-ARG REGISTRY=
+ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
 FROM maven:3.8.4-jdk-8

--- a/docker-builds/Dockerfile.db-migration-tool
+++ b/docker-builds/Dockerfile.db-migration-tool
@@ -1,5 +1,5 @@
 ARG REFNAME=local
-ARG REGISTRY=
+ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 
 FROM eclipse-temurin:17.0.7_7-jdk AS runtime

--- a/docker-builds/Dockerfile.junit
+++ b/docker-builds/Dockerfile.junit
@@ -1,5 +1,5 @@
 ARG REFNAME=local
-ARG REGISTRY=
+ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-common:$REFNAME AS common
 FROM ${REGISTRY}metasfresh/metas-mvn-backend:$REFNAME AS backend
 

--- a/docker-builds/Dockerfile.procurement.backend
+++ b/docker-builds/Dockerfile.procurement.backend
@@ -1,5 +1,5 @@
 ARG REFNAME=local
-ARG REGISTRY=
+ARG REGISTRY=ghcr.io/
 FROM ${REGISTRY}metasfresh/metas-mvn-common:$REFNAME AS common
 
 FROM maven:3.6.3-adoptopenjdk-14 AS build

--- a/docker-builds/claude-docs
+++ b/docker-builds/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/docker-builds/claude-docs

--- a/docker-builds/compose/CLAUDE.md
+++ b/docker-builds/compose/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/docker-builds/compose/CLAUDE.md

--- a/docker-builds/db/init-preloaded/CLAUDE.md
+++ b/docker-builds/db/init-preloaded/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/docker-builds/db/init-preloaded/CLAUDE.md

--- a/docs/coding-rules
+++ b/docs/coding-rules
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/docs/coding-rules

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/e2e/CLAUDE.md

--- a/e2e/frontend-webui/CLAUDE.md
+++ b/e2e/frontend-webui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/e2e/frontend-webui/CLAUDE.md

--- a/e2e/frontend-webui/claude-docs
+++ b/e2e/frontend-webui/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/e2e/frontend-webui/claude-docs

--- a/e2e/mobile-webui/CLAUDE.md
+++ b/e2e/mobile-webui/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/e2e/mobile-webui/CLAUDE.md

--- a/e2e/mobile-webui/claude-docs
+++ b/e2e/mobile-webui/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/e2e/mobile-webui/claude-docs

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/frontend/CLAUDE.md

--- a/frontend/claude-docs
+++ b/frontend/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/frontend/claude-docs

--- a/misc/de-metas-common/CLAUDE.md
+++ b/misc/de-metas-common/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-bpartner/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-bpartner/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-bpartner/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-changelog/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-changelog/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-changelog/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-delivery/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-delivery/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-delivery/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-externalreference/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-externalreference/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-externalreference/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-externalsystem/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-externalsystem/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-externalsystem/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-filemaker/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-filemaker/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-filemaker/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-manufacturing/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-manufacturing/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-manufacturing/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-ordercandidates/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-ordercandidates/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-ordercandidates/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-pricing/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-pricing/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-pricing/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-procurement/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-procurement/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-procurement/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-product/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-product/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-product/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-rest_api/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-rest_api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-rest_api/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-rest_api/src/main/java/de/metas/common/rest_api/v1/remittanceadvice/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-rest_api/src/main/java/de/metas/common/rest_api/v1/remittanceadvice/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-rest_api/src/main/java/de/metas/common/rest_api/v1/remittanceadvice/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-shipping/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-shipping/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-shipping/CLAUDE.md

--- a/misc/de-metas-common/de-metas-common-util/CLAUDE.md
+++ b/misc/de-metas-common/de-metas-common-util/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/de-metas-common/de-metas-common-util/CLAUDE.md

--- a/misc/dev-support/docker/infrastructure/CLAUDE.md
+++ b/misc/dev-support/docker/infrastructure/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/dev-support/docker/infrastructure/CLAUDE.md

--- a/misc/dev-support/docker/infrastructure/claude-docs
+++ b/misc/dev-support/docker/infrastructure/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/dev-support/docker/infrastructure/claude-docs

--- a/misc/parent-pom/CLAUDE.md
+++ b/misc/parent-pom/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/parent-pom/CLAUDE.md

--- a/misc/parent-pom/assemblies/CLAUDE.md
+++ b/misc/parent-pom/assemblies/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/parent-pom/assemblies/CLAUDE.md

--- a/misc/services/admin/CLAUDE.md
+++ b/misc/services/admin/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/admin/CLAUDE.md

--- a/misc/services/camel/CLAUDE.md
+++ b/misc/services/camel/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-edi/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-edi/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-edi/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/alberta/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/alberta/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/alberta/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/alberta/alberta-article-api/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/alberta/alberta-article-api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/alberta/alberta-article-api/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/alberta/alberta-document-api/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/alberta/alberta-document-api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/alberta/alberta-document-api/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/alberta/alberta-orders-api/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/alberta/alberta-orders-api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/alberta/alberta-orders-api/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/alberta/alberta-patient-api/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/alberta/alberta-patient-api/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/alberta/alberta-patient-api/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/alberta/de-metas-camel-alberta-camelroutes/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/alberta/de-metas-camel-alberta-camelroutes/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/alberta/de-metas-camel-alberta-camelroutes/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/common/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/common/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/common/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/core/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/core/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/core/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-ebay/de-metas-camel-ebay-camelroutes/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-ebay/de-metas-camel-ebay-camelroutes/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-ebay/de-metas-camel-ebay-camelroutes/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-ebay/ebay-api-client/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-ebay/ebay-api-client/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-ebay/ebay-api-client/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-grssignum/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-grssignum/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-grssignum/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-leichundmehl/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-leichundmehl/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-leichundmehl/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-pcm-file-import/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-pcm-file-import/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-pcm-file-import/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-printingclient/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-printingclient/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-printingclient/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-rabbitmq/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-rabbitmq/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-rabbitmq/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-shopware6/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-shopware6/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-shopware6/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-woocommerce/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-woocommerce/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-woocommerce/CLAUDE.md

--- a/misc/services/camel/de-metas-camel-externalsystems/dist/CLAUDE.md
+++ b/misc/services/camel/de-metas-camel-externalsystems/dist/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/camel/de-metas-camel-externalsystems/dist/CLAUDE.md

--- a/misc/services/federated-rabbitmq/CLAUDE.md
+++ b/misc/services/federated-rabbitmq/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/federated-rabbitmq/CLAUDE.md

--- a/misc/services/mobile-webui/mobile-webui-frontend/CLAUDE.md
+++ b/misc/services/mobile-webui/mobile-webui-frontend/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/mobile-webui/mobile-webui-frontend/CLAUDE.md

--- a/misc/services/mobile-webui/mobile-webui-frontend/claude-docs
+++ b/misc/services/mobile-webui/mobile-webui-frontend/claude-docs
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/mobile-webui/mobile-webui-frontend/claude-docs

--- a/misc/services/procurement-webui/procurement-webui-backend/CLAUDE.md
+++ b/misc/services/procurement-webui/procurement-webui-backend/CLAUDE.md
@@ -1,0 +1,1 @@
+/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/misc/services/procurement-webui/procurement-webui-backend/CLAUDE.md


### PR DESCRIPTION
Port of the GHCR build-image fix (from new_dawn_uat https://github.com/metasfresh/metasfresh/pull/24773) to `game_time_hotfix`. Internal build/test images → ghcr.io; ghcr login on all 10 image-handling jobs; packages: write on java + cucumber-build; cucumber-run retag bridge; Dockerfiles `ARG REGISTRY=ghcr.io/` (+ backend.app.compat hardcode). Deployable images stay on Docker Hub.