### PR TITLE
Manufacturing — make raw-material issue UOM-safe so picking a Stk-stocked HU against a kg BOM line no longer crashes

### DIFF
--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/model/RawMaterialsIssueLine.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/model/RawMaterialsIssueLine.java
@@ -9,6 +9,9 @@ import de.metas.i18n.TranslatableStrings;
 import de.metas.product.IssuingToleranceSpec;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
+import de.metas.uom.IUOMConversionBL;
+import de.metas.uom.UomId;
+import de.metas.util.Services;
 import de.metas.util.collections.CollectionUtils;
 import de.metas.workflow.rest_api.model.WFActivityStatus;
 import lombok.Builder;
@@ -62,17 +65,31 @@ public class RawMaterialsIssueLine
 		this.issuingToleranceSpec = issuingToleranceSpec;
 		this.steps = steps;
 
-		this.qtyIssued = computeQtyIssued(this.steps).orElseGet(qtyToIssue::toZero);
+		this.qtyIssued = computeQtyIssued(this.steps, this.productId, this.qtyToIssue.getUomId())
+				.orElseGet(qtyToIssue::toZero);
 		this.seqNo = seqNo;
 		this.status = computeStatus(this.qtyToIssue, this.qtyIssued, this.steps);
 	}
 
-	private static Optional<Quantity> computeQtyIssued(final @NonNull ImmutableList<RawMaterialsIssueStep> steps)
+	/**
+	 * Sums the quantities issued by the steps, expressed in {@code targetUomId} (the BOM line's UOM).
+	 * <p>
+	 * A step's issued qty comes back in the picked HU's UOM, which may differ from the BOM line's UOM
+	 * (e.g. a kg BOM line picked from a piece-stocked HU). Each step's issued qty is therefore converted
+	 * to {@code targetUomId} via the product's UOM conversion before being summed, so that the resulting
+	 * {@code qtyIssued} is comparable to {@code qtyToIssue}.
+	 */
+	private static Optional<Quantity> computeQtyIssued(
+			final @NonNull ImmutableList<RawMaterialsIssueStep> steps,
+			final @NonNull ProductId productId,
+			final @NonNull UomId targetUomId)
 	{
+		final IUOMConversionBL uomConversionBL = Services.get(IUOMConversionBL.class);
 		return steps.stream()
 				.map(RawMaterialsIssueStep::getIssued)
 				.filter(Objects::nonNull)
 				.map(PPOrderIssueSchedule.Issued::getQtyIssued)
+				.map(qtyIssued -> uomConversionBL.convertQuantityTo(qtyIssued, productId, targetUomId))
 				.reduce(Quantity::add);
 	}
 

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/model/RawMaterialsIssueLine.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/model/RawMaterialsIssueLine.java
@@ -11,11 +11,12 @@ import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
 import de.metas.uom.IUOMConversionBL;
 import de.metas.uom.UomId;
-import de.metas.util.Services;
 import de.metas.util.collections.CollectionUtils;
 import de.metas.workflow.rest_api.model.WFActivityStatus;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.NonNull;
+import lombok.ToString;
 import lombok.Value;
 import org.eevolution.api.BOMComponentIssueMethod;
 import org.eevolution.api.PPOrderBOMLineId;
@@ -38,6 +39,11 @@ public class RawMaterialsIssueLine
 	@Nullable IssuingToleranceSpec issuingToleranceSpec;
 	@NonNull ImmutableList<RawMaterialsIssueStep> steps;
 
+	// Provided by the caller so qtyIssued can be expressed in the BOM line's UOM (see computeQtyIssued).
+	// Not part of the line's identity, hence excluded from equals/hashCode/toString.
+	@EqualsAndHashCode.Exclude @ToString.Exclude
+	@NonNull IUOMConversionBL uomConversionBL;
+
 	@NonNull Quantity qtyIssued; // computed
 	@NonNull WFActivityStatus status;
 	int seqNo;
@@ -53,6 +59,7 @@ public class RawMaterialsIssueLine
 			@NonNull final Quantity qtyToIssue,
 			@Nullable final IssuingToleranceSpec issuingToleranceSpec,
 			@NonNull final ImmutableList<RawMaterialsIssueStep> steps,
+			@NonNull final IUOMConversionBL uomConversionBL,
 			final int seqNo)
 	{
 		this.orderBOMLineId = orderBOMLineId;
@@ -64,27 +71,26 @@ public class RawMaterialsIssueLine
 		this.qtyToIssue = qtyToIssue;
 		this.issuingToleranceSpec = issuingToleranceSpec;
 		this.steps = steps;
+		this.uomConversionBL = uomConversionBL;
 
-		this.qtyIssued = computeQtyIssued(this.steps, this.productId, this.qtyToIssue.getUomId())
+		this.qtyIssued = computeQtyIssued(this.steps, this.productId, this.qtyToIssue.getUomId(), this.uomConversionBL)
 				.orElseGet(qtyToIssue::toZero);
 		this.seqNo = seqNo;
 		this.status = computeStatus(this.qtyToIssue, this.qtyIssued, this.steps);
 	}
 
 	/**
-	 * Sums the quantities issued by the steps, expressed in {@code targetUomId} (the BOM line's UOM).
-	 * <p>
-	 * A step's issued qty comes back in the picked HU's UOM, which may differ from the BOM line's UOM
-	 * (e.g. a kg BOM line picked from a piece-stocked HU). Each step's issued qty is therefore converted
-	 * to {@code targetUomId} via the product's UOM conversion before being summed, so that the resulting
-	 * {@code qtyIssued} is comparable to {@code qtyToIssue}.
+	 * Sums the steps' issued quantities, expressed in {@code targetUomId} (the BOM line's UOM). A step's
+	 * issued qty comes back in the picked HU's UOM (e.g. Stk for a kg BOM line), so each is converted to
+	 * {@code targetUomId} via the product's UOM conversion before summing — keeping {@code qtyIssued}
+	 * comparable to {@code qtyToIssue}.
 	 */
 	private static Optional<Quantity> computeQtyIssued(
 			final @NonNull ImmutableList<RawMaterialsIssueStep> steps,
 			final @NonNull ProductId productId,
-			final @NonNull UomId targetUomId)
+			final @NonNull UomId targetUomId,
+			final @NonNull IUOMConversionBL uomConversionBL)
 	{
-		final IUOMConversionBL uomConversionBL = Services.get(IUOMConversionBL.class);
 		return steps.stream()
 				.map(RawMaterialsIssueStep::getIssued)
 				.filter(Objects::nonNull)

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobLoaderAndSaver.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobLoaderAndSaver.java
@@ -225,6 +225,7 @@ public class ManufacturingJobLoaderAndSaver
 		final boolean isWeightable = !orderBOMLine.isManualQtyInput() && qtyToIssue.isWeightable();
 
 		return RawMaterialsIssueLine.builder()
+				.uomConversionBL(supportingServices.getUOMConversionBL())
 				.orderBOMLineId(ppOrderBOMLineId)
 				.productId(productId)
 				.productName(supportingServices.getProductName(productId))

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobLoaderAndSaverSupportingServices.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobLoaderAndSaverSupportingServices.java
@@ -33,6 +33,7 @@ import de.metas.organization.OrgId;
 import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
+import de.metas.uom.IUOMConversionBL;
 import de.metas.uom.UomId;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -69,6 +70,7 @@ public class ManufacturingJobLoaderAndSaverSupportingServices
 	@NonNull private final IHUPPOrderBL ppOrderBL = Services.get(IHUPPOrderBL.class);
 	@NonNull private final IPPOrderBOMBL ppOrderBOMBL = Services.get(IPPOrderBOMBL.class);
 	@NonNull private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
+	@NonNull private final IUOMConversionBL uomConversionBL = Services.get(IUOMConversionBL.class);
 	@NonNull private final IHUPIItemProductDAO huPIItemProductDAO = Services.get(IHUPIItemProductDAO.class);
 	@NonNull private final IPPOrderRoutingRepository ppOrderRoutingRepository = Services.get(IPPOrderRoutingRepository.class);
 	@NonNull private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
@@ -97,6 +99,8 @@ public class ManufacturingJobLoaderAndSaverSupportingServices
 
 	@NonNull
 	public String getProductValue(@NonNull final ProductId productId) {return productBL.getProductValue(productId);}
+
+	public IUOMConversionBL getUOMConversionBL() {return uomConversionBL;}
 
 	public I_PP_Order getPPOrderRecordById(@NonNull final PPOrderId ppOrderId) {return ppOrderBL.getById(ppOrderId);}
 

--- a/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/job/model/RawMaterialsIssueLineTest.java
+++ b/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/job/model/RawMaterialsIssueLineTest.java
@@ -9,7 +9,9 @@ import de.metas.i18n.TranslatableStrings;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
 import de.metas.uom.CreateUOMConversionRequest;
+import de.metas.uom.IUOMConversionBL;
 import de.metas.uom.UomId;
+import de.metas.util.Services;
 import de.metas.workflow.rest_api.model.WFActivityStatus;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
@@ -67,16 +69,15 @@ class RawMaterialsIssueLineTest
 				.build());
 	}
 
-	private RawMaterialsIssueLine newNotStartedLine()
+	private RawMaterialsIssueStep newStep(final PPOrderIssueScheduleId id, final String qtyToIssueKg)
 	{
 		final LocatorId locatorId = LocatorId.ofRepoId(1, 1);
-
-		final RawMaterialsIssueStep step = RawMaterialsIssueStep.builder()
-				.id(SCHEDULE_ID)
+		return RawMaterialsIssueStep.builder()
+				.id(id)
 				.isAlternativeIssue(false)
 				.productId(productId)
 				.productName(TranslatableStrings.anyLanguage("CheeseWheel35kg"))
-				.qtyToIssue(Quantity.of("35", uomKg))
+				.qtyToIssue(Quantity.of(qtyToIssueKg, uomKg))
 				.issueFromLocator(LocatorInfo.builder()
 						.id(locatorId)
 						.caption("Hauptlager")
@@ -88,31 +89,40 @@ class RawMaterialsIssueLineTest
 						.build())
 				.issued(null)
 				.build();
+	}
 
+	private RawMaterialsIssueLine newLine(final String qtyToIssueKg, final ImmutableList<RawMaterialsIssueStep> steps)
+	{
 		return RawMaterialsIssueLine.builder()
+				.uomConversionBL(Services.get(IUOMConversionBL.class))
 				.orderBOMLineId(PPOrderBOMLineId.ofRepoId(1))
 				.productId(productId)
 				.productName(TranslatableStrings.anyLanguage("CheeseWheel35kg"))
 				.productValue("CheeseWheel35kg")
 				.isWeightable(false)
-				.qtyToIssue(Quantity.of("35", uomKg))
-				.steps(ImmutableList.of(step))
+				.qtyToIssue(Quantity.of(qtyToIssueKg, uomKg))
+				.steps(steps)
 				.seqNo(10)
 				.build();
+	}
+
+	private static RawMaterialsIssueStep issueStk(final RawMaterialsIssueStep step, final String qtyStk, final I_C_UOM uomStk)
+	{
+		return step.withIssued(PPOrderIssueSchedule.Issued.builder()
+				.qtyIssued(Quantity.of(qtyStk, uomStk))
+				.build());
 	}
 
 	@Test
 	void issuingStkFromHU_againstKgBomLine_normalizesQtyIssuedToKg()
 	{
-		final RawMaterialsIssueLine line = newNotStartedLine();
+		final RawMaterialsIssueLine line = newLine("35", ImmutableList.of(newStep(SCHEDULE_ID, "35")));
 		assertThat(line.getStatus()).isEqualTo(WFActivityStatus.NOT_STARTED);
 
 		// Pick 1 Stk (= 35 kg) from the piece-stocked HU — the production path through IssueRawMaterialsCommand.
 		final RawMaterialsIssueLine issued = line.withChangedRawMaterialsIssueStep(
 				SCHEDULE_ID,
-				step -> step.withIssued(PPOrderIssueSchedule.Issued.builder()
-						.qtyIssued(Quantity.of("1", uomStk))
-						.build()));
+				step -> issueStk(step, "1", uomStk));
 
 		// qtyIssued must be expressed in the BOM line's UOM (kg), not the picked HU's UOM (Stk).
 		assertThat(issued.getQtyIssued().getUomId()).isEqualTo(uomKgId);
@@ -120,5 +130,26 @@ class RawMaterialsIssueLineTest
 		assertThat(issued.getQtyLeftToIssue().getUomId()).isEqualTo(uomKgId);
 		assertThat(issued.getQtyLeftToIssue().toBigDecimal()).isEqualByComparingTo("0");
 		assertThat(issued.getStatus()).isEqualTo(WFActivityStatus.COMPLETED);
+	}
+
+	@Test
+	void issuingStkFromHU_acrossTwoSteps_sumsConvertedQtyInKg()
+	{
+		final PPOrderIssueScheduleId id1 = PPOrderIssueScheduleId.ofRepoId(1);
+		final PPOrderIssueScheduleId id2 = PPOrderIssueScheduleId.ofRepoId(2);
+
+		RawMaterialsIssueLine line = newLine("70", ImmutableList.of(newStep(id1, "35"), newStep(id2, "35")));
+
+		// First of two steps issued: 35 kg of 70 kg -> IN_PROGRESS (and must not crash on mixed UOMs).
+		line = line.withChangedRawMaterialsIssueStep(id1, step -> issueStk(step, "1", uomStk));
+		assertThat(line.getQtyIssued().toBigDecimal()).isEqualByComparingTo("35");
+		assertThat(line.getStatus()).isEqualTo(WFActivityStatus.IN_PROGRESS);
+
+		// Second step issued: reduce(Quantity::add) sums the two converted-to-kg quantities -> 70 kg, COMPLETED.
+		line = line.withChangedRawMaterialsIssueStep(id2, step -> issueStk(step, "1", uomStk));
+		assertThat(line.getQtyIssued().getUomId()).isEqualTo(uomKgId);
+		assertThat(line.getQtyIssued().toBigDecimal()).isEqualByComparingTo("70");
+		assertThat(line.getQtyLeftToIssue().toBigDecimal()).isEqualByComparingTo("0");
+		assertThat(line.getStatus()).isEqualTo(WFActivityStatus.COMPLETED);
 	}
 }

--- a/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/job/model/RawMaterialsIssueLineTest.java
+++ b/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/job/model/RawMaterialsIssueLineTest.java
@@ -1,0 +1,124 @@
+package de.metas.manufacturing.job.model;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.business.BusinessTestHelper;
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueSchedule;
+import de.metas.handlingunits.pporder.api.issue_schedule.PPOrderIssueScheduleId;
+import de.metas.i18n.TranslatableStrings;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.uom.CreateUOMConversionRequest;
+import de.metas.uom.UomId;
+import de.metas.workflow.rest_api.model.WFActivityStatus;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.warehouse.LocatorId;
+import org.adempiere.warehouse.qrcode.LocatorQRCode;
+import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_M_Product;
+import org.eevolution.api.PPOrderBOMLineId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduces issuing from a piece-stocked HU (Stk) against a BOM line measured in kg.
+ * <p>
+ * The BOM line's {@code qtyToIssue} is in the order-line UOM (kg) while the picked step's issued qty
+ * comes back in the HU's UOM (Stk). {@code RawMaterialsIssueLine} compared/subtracted the two without
+ * converting, throwing {@code QuantitiesUOMNotMatchingException} at {@code computeStatus} /
+ * {@code getQtyLeftToIssue} when the step is marked issued via {@link RawMaterialsIssueLine#withChangedRawMaterialsIssueStep}
+ * (the exact production path: {@code IssueRawMaterialsCommand}).
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+class RawMaterialsIssueLineTest
+{
+	private static final PPOrderIssueScheduleId SCHEDULE_ID = PPOrderIssueScheduleId.ofRepoId(1);
+
+	private I_C_UOM uomKg;
+	private I_C_UOM uomStk;
+	private UomId uomKgId;
+	private ProductId productId;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		uomKg = BusinessTestHelper.createUOM("Kg", 3);
+		uomStk = BusinessTestHelper.createUOM("Stk", 4);
+		uomKgId = UomId.ofRepoId(uomKg.getC_UOM_ID());
+
+		// Product stocked in pieces (a 35kg cheese wheel = 1 Stk)
+		final I_M_Product product = BusinessTestHelper.createProduct("CheeseWheel35kg", uomStk);
+		productId = ProductId.ofRepoId(product.getM_Product_ID());
+
+		// 1 Stk = 35 kg
+		BusinessTestHelper.createUOMConversion(CreateUOMConversionRequest.builder()
+				.productId(productId)
+				.fromUomId(UomId.ofRepoId(uomStk.getC_UOM_ID()))
+				.toUomId(uomKgId)
+				.fromToMultiplier(new BigDecimal("35"))
+				.build());
+	}
+
+	private RawMaterialsIssueLine newNotStartedLine()
+	{
+		final LocatorId locatorId = LocatorId.ofRepoId(1, 1);
+
+		final RawMaterialsIssueStep step = RawMaterialsIssueStep.builder()
+				.id(SCHEDULE_ID)
+				.isAlternativeIssue(false)
+				.productId(productId)
+				.productName(TranslatableStrings.anyLanguage("CheeseWheel35kg"))
+				.qtyToIssue(Quantity.of("35", uomKg))
+				.issueFromLocator(LocatorInfo.builder()
+						.id(locatorId)
+						.caption("Hauptlager")
+						.qrCode(LocatorQRCode.builder().locatorId(locatorId).caption("Hauptlager").build())
+						.build())
+				.issueFromHU(HUInfo.builder()
+						.id(HuId.ofRepoId(1))
+						.huCapacity(Quantity.of("40", uomStk))
+						.build())
+				.issued(null)
+				.build();
+
+		return RawMaterialsIssueLine.builder()
+				.orderBOMLineId(PPOrderBOMLineId.ofRepoId(1))
+				.productId(productId)
+				.productName(TranslatableStrings.anyLanguage("CheeseWheel35kg"))
+				.productValue("CheeseWheel35kg")
+				.isWeightable(false)
+				.qtyToIssue(Quantity.of("35", uomKg))
+				.steps(ImmutableList.of(step))
+				.seqNo(10)
+				.build();
+	}
+
+	@Test
+	void issuingStkFromHU_againstKgBomLine_normalizesQtyIssuedToKg()
+	{
+		final RawMaterialsIssueLine line = newNotStartedLine();
+		assertThat(line.getStatus()).isEqualTo(WFActivityStatus.NOT_STARTED);
+
+		// Pick 1 Stk (= 35 kg) from the piece-stocked HU — the production path through IssueRawMaterialsCommand.
+		final RawMaterialsIssueLine issued = line.withChangedRawMaterialsIssueStep(
+				SCHEDULE_ID,
+				step -> step.withIssued(PPOrderIssueSchedule.Issued.builder()
+						.qtyIssued(Quantity.of("1", uomStk))
+						.build()));
+
+		// qtyIssued must be expressed in the BOM line's UOM (kg), not the picked HU's UOM (Stk).
+		assertThat(issued.getQtyIssued().getUomId()).isEqualTo(uomKgId);
+		assertThat(issued.getQtyIssued().toBigDecimal()).isEqualByComparingTo("35");
+		assertThat(issued.getQtyLeftToIssue().getUomId()).isEqualTo(uomKgId);
+		assertThat(issued.getQtyLeftToIssue().toBigDecimal()).isEqualByComparingTo("0");
+		assertThat(issued.getStatus()).isEqualTo(WFActivityStatus.COMPLETED);
+	}
+}


### PR DESCRIPTION
## Problem

Issuing raw materials in the mobile manufacturing workflow crashed with `QuantitiesUOMNotMatchingException` when a BOM line is measured in one UOM (e.g. kg) but the only stock is a handling unit stocked in a different UOM (e.g. pieces, with a product-specific conversion such as 1 Stk = 35 kg).

`RawMaterialsIssueLine` summed the steps' issued quantities in the **picked HU's UOM** and then compared/subtracted that against `qtyToIssue` in the **BOM line's UOM** in `computeStatus` / `getQtyLeftToIssue`. The two UOMs are incompatible without conversion, so `Quantity.compareTo` → `subtract` → `add` threw. The crash fired on the `withChangedRawMaterialsIssueStep` rebuild that `IssueRawMaterialsCommand` performs when a step is marked issued.

## Fix

`computeQtyIssued` now converts each step's issued qty to the BOM line's UOM (via the product's UOM conversion) before summing, so `qtyIssued` is always comparable to `qtyToIssue`. This covers both construction paths — the loader and the `toBuilder()` rebuild used when a step is issued.

The `IUOMConversionBL` converter is supplied by the caller through the builder (per `docs/coding-rules/service-injection.md` for `@Value @Builder` POJOs); `toBuilder()` carries it across rebuilds. It is excluded from `equals`/`hashCode`/`toString` since it is infrastructure, not part of the line's identity.

## Tests

`RawMaterialsIssueLineTest` reproduces the crash via the real issue path and asserts `qtyIssued` normalizes to the BOM line's UOM:
- single step: pick 1 Stk against a 35 kg line → 35 kg, COMPLETED;
- two steps: each picks 1 Stk against a 70 kg line → exercises the `reduce(Quantity::add)` path, IN_PROGRESS then 70 kg COMPLETED.

Full `de.metas.manufacturing.rest-api` suite: 64/64 green.
