### PR TITLE
Update HU label validation rule (ad_val_rule)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809790_UpdateM_HU_labelValidationRule.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809790_UpdateM_HU_labelValidationRule.sql
@@ -1,0 +1,6 @@
+-- old value SET code='(AD_Process.JasperReport IS NOT NULL AND AD_Process.Value ilike ''%HU_Labels%'') OR AD_Process.Value=''M_HU_Report_QRCode'' OR AD_Process.Value=''Picking TU Label (Jasper)'' OR AD_Process.Value=''Wareneingangsetikett LU (Jasper)'' OR AD_Process.Value=''Finishedproduct Label''', updated='2025-03-07 09:00', updatedby=99
+
+UPDATE ad_val_rule
+SET code='(AD_Process.JasperReport IS NOT NULL AND AD_Process.Value ilike ''%HU_Labels%'') OR AD_Process.Value ilike ''%M_HU_QRCode%'' OR AD_Process.Value=''M_HU_Report_QRCode'' OR AD_Process.Value=''Picking TU Label (Jasper)'' OR AD_Process.Value=''Wareneingangsetikett LU (Jasper)'' OR AD_Process.Value=''Finishedproduct Label''', updated='2025-03-07 09:00', updatedby=99
+WHERE ad_val_rule_id = 540604
+;


### PR DESCRIPTION
Add a new SQL migration that updates ad_val_rule (id 540604) to broaden the HU label validation code. The new code adds an ilike match for '%M_HU_QRCode%' alongside existing process value checks, and sets updated='2025-03-07 09:00' and updatedby=99. The previous value is retained as a comment at the top of the file.