### PR TITLE
Mobile Packing unpick: keep panel open on transient submit error; trust backend unpickable flag

### DIFF
--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 7 | 12 | 58% |
-| Picking | 68 | 72 | 94% |
+| Picking | 69 | 73 | 95% |
 | Distribution | 40 | 41 | 98% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
@@ -88,6 +88,7 @@
 | Partial unpack: scan product not in the package → one error toast, nothing removed | `picking/picking_partial_unpack.spec.js` |
 | Partial unpack: partial-unpick then complete the job → shipment carries the net packed qty in exactly one line, no negative counter-row | `picking/picking_partial_unpack.spec.js` |
 | Partial unpack: remove item to the floor by canceling/skipping the target-HU scan → removed qty leaves the pick, rest stays packed | `picking/picking_partial_unpack.spec.js` |
+| Partial unpack: transient network failure on submit → error toast, panel stays on SCAN_TARGET; retry succeeds, net qty moved into target HU | `picking/picking_partial_unpack.spec.js` |
 | Scan invalid picking slot QR code → error shown | `picking/picking.spec.js` |
 | Line status indicator transitions draft → in-progress → complete as HUs are picked | `picking/picking.spec.js` |
 | Partial pick, allowCompletingPartialPickingJob = N → complete blocked | `picking/picking.spec.js` |
@@ -98,7 +99,7 @@
 | completeJobAutomatically=true, scan drop-to locator after pick → job auto-completed, removed from list | `picking/completeJobAutomatically.spec.js` |
 | ❌ Scan HU from wrong warehouse/locator → error shown | — |
 
-**14/15 — 93%**
+**15/16 — 94%**
 
 ### Order-based picking — filtering and facets
 

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 7 | 12 | 58% |
-| Picking | 69 | 73 | 95% |
+| Picking | 70 | 74 | 95% |
 | Distribution | 40 | 41 | 98% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
@@ -89,6 +89,7 @@
 | Partial unpack: partial-unpick then complete the job → shipment carries the net packed qty in exactly one line, no negative counter-row | `picking/picking_partial_unpack.spec.js` |
 | Partial unpack: remove item to the floor by canceling/skipping the target-HU scan → removed qty leaves the pick, rest stays packed | `picking/picking_partial_unpack.spec.js` |
 | Partial unpack: transient network failure on submit → error toast, panel stays on SCAN_TARGET; retry succeeds, net qty moved into target HU | `picking/picking_partial_unpack.spec.js` |
+| Partial unpack: mis-scan the product GTIN as the target HU → backend rejects (4xx), error toast, panel stays on SCAN_TARGET; scanning the correct target HU then commits | `picking/picking_partial_unpack.spec.js` |
 | Scan invalid picking slot QR code → error shown | `picking/picking.spec.js` |
 | Line status indicator transitions draft → in-progress → complete as HUs are picked | `picking/picking.spec.js` |
 | Partial pick, allowCompletingPartialPickingJob = N → complete blocked | `picking/picking.spec.js` |
@@ -99,7 +100,7 @@
 | completeJobAutomatically=true, scan drop-to locator after pick → job auto-completed, removed from list | `picking/completeJobAutomatically.spec.js` |
 | ❌ Scan HU from wrong warehouse/locator → error shown | — |
 
-**15/16 — 94%**
+**16/17 — 94%**
 
 ### Order-based picking — filtering and facets
 

--- a/e2e/mobile-webui/tests/spec/picking/picking_partial_unpack.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_partial_unpack.spec.js
@@ -406,7 +406,7 @@ test('Partial unpack - transient network failure on submit keeps the panel open 
 
     await test.step('Scan the target HU under the network fault -> error toast, panel stays on SCAN_TARGET', async () => {
         await expectErrorToast('Unpick submit network failure', async () => {
-            await PickingJobScreen.scanTargetHUNoCommit({ qrCode: targetHUQRCode });
+            await PickingJobScreen.scanCodeAtTargetStageNoCommit({ scannedCode: targetHUQRCode });
         });
         // The panel did NOT close: the target-HU scanner is still armed (a transient failure is
         // recoverable, so the operator can simply scan again).
@@ -432,6 +432,80 @@ test('Partial unpack - transient network failure on submit keeps the panel open 
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '2 TU' });
     await Backend.expect({
         title: 'after retry: 8 PCE stays packed on lu1, unpicked 4 PCE moved into target HU2 (80 + 4 = 84)',
+        hus: {
+            lu1: { huStatus: 'S', storages: { P1: '8 PCE' } },
+            [targetHUQRCode]: { storages: { P1: '84 PCE' } },
+        }
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Partial unpack - mis-scanning the product GTIN as the target HU is rejected by the backend; the panel stays open so the operator can scan the correct target', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Partial unpack by scanning a product GTIN');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata({ packedGtin: uniqueGtin14(), otherGtin: uniqueGtin14() });
+    const packedScan = gs1GtinScan(masterdata.products.P1.gtin);
+    const targetHUQRCode = masterdata.handlingUnits.HU2.qrCode;
+
+    const { pickingJobId } = await loginAndStartJob({ masterdata });
+
+    await test.step('Pick all 3 TU (12 PCE) from HU1', async () => {
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '3' });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU' });
+        // Registers the dynamically-created `lu1` HU in the backend test context so the assertions
+        // below can refer to it by identifier.
+        await Backend.expect({
+            title: 'baseline: 12 PCE packed on lu1',
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: "12 PCE", qtyTUs: 3, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }] }
+                    }
+                }
+            },
+            hus: { lu1: { huStatus: 'S', storages: { P1: '12 PCE' } } }
+        });
+    });
+
+    // Drive the unpick panel up to the target-HU scan (the SCAN_TARGET stage).
+    await PickingJobScreen.unpickAdvanceToTargetStage({ scannedCode: packedScan, expectDefaultQty: '12', qty: '4' });
+
+    // The operator mis-scans: at the "scan the target HU" step they re-scan the product GTIN they are
+    // holding instead of an actual target HU. The code IS submitted (postStepPartiallyUnPicked -> the
+    // picking/event POST); the backend rejects it (a product GTIN is not a valid target HU) with a 4xx,
+    // so axiosError.response is present. Unlike the transient-network case (no response), this is a real
+    // server rejection — the panel must STILL stay on SCAN_TARGET so the operator can correct the scan.
+    await test.step('Mis-scan the product GTIN as the target HU -> backend 4xx, error toast, panel stays on SCAN_TARGET', async () => {
+        await expectErrorToast('Unpick target server rejection', async () => {
+            await PickingJobScreen.scanCodeAtTargetStageNoCommit({ scannedCode: packedScan });
+        });
+        // The panel did NOT close: the target-HU scanner is still armed so the operator can scan the
+        // correct target HU (or Cancel to abort).
+        await PickingJobScreen.expectOnTargetScanStage();
+    });
+
+    // Nothing was committed: the 12 PCE are still fully packed on lu1, the target HU2 is untouched.
+    await Backend.expect({
+        title: 'after rejected mis-scan: nothing unpicked, 12 PCE still packed on lu1, target HU2 untouched',
+        hus: {
+            lu1: { huStatus: 'S', storages: { P1: '12 PCE' } },
+            [targetHUQRCode]: { storages: { P1: '80 PCE' } },
+        }
+    });
+
+    await test.step('Scan the correct target HU -> the unpick commits and the panel closes', async () => {
+        await PickingJobScreen.scanTargetHUAndCommit({ qrCode: targetHUQRCode });
+    });
+
+    // The corrected scan succeeded: the panel closed back to the job screen, 4 PCE were unpicked (line
+    // drops to 2 TU), and the unpicked 4 PCE landed in target HU2 (80 start + 4 = 84).
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '2 TU' });
+    await Backend.expect({
+        title: 'after corrected scan: 8 PCE stays packed on lu1, unpicked 4 PCE moved into target HU2 (80 + 4 = 84)',
         hus: {
             lu1: { huStatus: 'S', storages: { P1: '8 PCE' } },
             [targetHUQRCode]: { storages: { P1: '84 PCE' } },

--- a/e2e/mobile-webui/tests/spec/picking/picking_partial_unpack.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_partial_unpack.spec.js
@@ -402,10 +402,7 @@ test('Partial unpack - transient network failure on submit keeps the panel open 
     // Same network-fault technique as picking.spec.js "Network failure on complete": abort the submit
     // at the network layer (no HTTP response). With no `axiosError.response`, the panel treats this as
     // a transient failure -> toasts the error AND stays on SCAN_TARGET (does NOT close).
-    const unpickEventRoute = '**/picking/event';
-    await test.step('Block picking/event to simulate a network failure on the unpick submit', async () => {
-        await page.route(unpickEventRoute, route => route.abort('failed'));
-    });
+    await PickingJobScreen.blockUnpickSubmit();
 
     await test.step('Scan the target HU under the network fault -> error toast, panel stays on SCAN_TARGET', async () => {
         await expectErrorToast('Unpick submit network failure', async () => {
@@ -426,7 +423,7 @@ test('Partial unpack - transient network failure on submit keeps the panel open 
     });
 
     await test.step('Release the network fault and retry the same target-HU scan', async () => {
-        await page.unroute(unpickEventRoute);
+        await PickingJobScreen.unblockUnpickSubmit();
         await PickingJobScreen.scanTargetHUAndCommit({ qrCode: targetHUQRCode });
     });
 

--- a/e2e/mobile-webui/tests/spec/picking/picking_partial_unpack.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_partial_unpack.spec.js
@@ -361,3 +361,83 @@ test('Partial unpack - unpick item to the floor by canceling the target-HU scan'
         });
     });
 });
+
+// noinspection JSUnusedLocalSymbols
+test('Partial unpack - transient network failure on submit keeps the panel open and shows an error; retry succeeds', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Partial unpack by scanning a product GTIN');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata({ packedGtin: uniqueGtin14(), otherGtin: uniqueGtin14() });
+    const packedScan = gs1GtinScan(masterdata.products.P1.gtin);
+    const targetHUQRCode = masterdata.handlingUnits.HU2.qrCode;
+
+    const { pickingJobId } = await loginAndStartJob({ masterdata });
+
+    await test.step('Pick all 3 TU (12 PCE) from HU1', async () => {
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '3' });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU' });
+        // Registers the dynamically-created `lu1` HU in the backend test context so the assertions
+        // below can refer to it by identifier.
+        await Backend.expect({
+            title: 'baseline: 12 PCE packed on lu1',
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: "12 PCE", qtyTUs: 3, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }] }
+                    }
+                }
+            },
+            hus: { lu1: { huStatus: 'S', storages: { P1: '12 PCE' } } }
+        });
+    });
+
+    // Drive the unpick panel up to the target-HU scan (the SCAN_TARGET stage). The submit fires only
+    // once the target HU is scanned (UnpickTargetScanDialog -> onSubmit -> postStepPartiallyUnPicked,
+    // i.e. the POST to picking/event).
+    await PickingJobScreen.unpickAdvanceToTargetStage({ scannedCode: packedScan, expectDefaultQty: '12', qty: '4' });
+
+    // Same network-fault technique as picking.spec.js "Network failure on complete": abort the submit
+    // at the network layer (no HTTP response). With no `axiosError.response`, the panel treats this as
+    // a transient failure -> toasts the error AND stays on SCAN_TARGET (does NOT close).
+    const unpickEventRoute = '**/picking/event';
+    await test.step('Block picking/event to simulate a network failure on the unpick submit', async () => {
+        await page.route(unpickEventRoute, route => route.abort('failed'));
+    });
+
+    await test.step('Scan the target HU under the network fault -> error toast, panel stays on SCAN_TARGET', async () => {
+        await expectErrorToast('Unpick submit network failure', async () => {
+            await PickingJobScreen.scanTargetHUNoCommit({ qrCode: targetHUQRCode });
+        });
+        // The panel did NOT close: the target-HU scanner is still armed (a transient failure is
+        // recoverable, so the operator can simply scan again).
+        await PickingJobScreen.expectOnTargetScanStage();
+    });
+
+    // Nothing was committed: the 12 PCE are still fully packed on lu1, the target HU2 is untouched.
+    await Backend.expect({
+        title: 'after aborted submit: nothing unpicked, 12 PCE still packed on lu1, target HU2 untouched',
+        hus: {
+            lu1: { huStatus: 'S', storages: { P1: '12 PCE' } },
+            [targetHUQRCode]: { storages: { P1: '80 PCE' } },
+        }
+    });
+
+    await test.step('Release the network fault and retry the same target-HU scan', async () => {
+        await page.unroute(unpickEventRoute);
+        await PickingJobScreen.scanTargetHUAndCommit({ qrCode: targetHUQRCode });
+    });
+
+    // The retry succeeded: the panel closed back to the job screen, 4 PCE were unpicked (line drops to
+    // 2 TU), and the unpicked 4 PCE landed in target HU2 (80 start + 4 = 84).
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '2 TU' });
+    await Backend.expect({
+        title: 'after retry: 8 PCE stays packed on lu1, unpicked 4 PCE moved into target HU2 (80 + 4 = 84)',
+        hus: {
+            lu1: { huStatus: 'S', storages: { P1: '8 PCE' } },
+            [targetHUQRCode]: { storages: { P1: '84 PCE' } },
+        }
+    });
+});

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
@@ -353,14 +353,29 @@ export const PickingJobScreen = {
 
     expectOnProductScanStage: async () => await step(`${NAME} - Expect still on product-scan stage`, async () => {
         await BarcodeScannerComponent.expectAttached({ testId: 'unpick-product-scanner', timeout: SLOW_ACTION_TIMEOUT });
-        await expect(page.locator('.get-qty-dialog')).toHaveCount(0);
+        await expect(page.locator('.get-qty-dialog')).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
     }),
 
     closeUnpickItem: async () => await step(`${NAME} - Close "Unpack item"`, async () => {
         await page.getByTestId('unpick-close-button').tap();
         await PickingJobScreen.waitForScreen();
     }),
+
+    // Simulates a transient network failure on the unpick submit by aborting the picking/event POST at
+    // the network layer (no HTTP response). With no axiosError.response, the unpick panel treats this as
+    // a recoverable failure -> toasts the error and stays on the SCAN_TARGET stage. Pair with
+    // unblockUnpickSubmit() to release the fault before the retry.
+    blockUnpickSubmit: async () => await step(`${NAME} - Block picking/event (simulate network fault on unpick submit)`, async () => {
+        await page.route(UNPICK_SUBMIT_ROUTE, route => route.abort('failed'));
+    }),
+
+    unblockUnpickSubmit: async () => await step(`${NAME} - Unblock picking/event (release network fault)`, async () => {
+        await page.unroute(UNPICK_SUBMIT_ROUTE);
+    }),
 };
+
+// The picking/event POST that the unpick submit (postStepPartiallyUnPicked) fires.
+const UNPICK_SUBMIT_ROUTE = '**/picking/event';
 
 //
 //

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
@@ -318,6 +318,33 @@ export const PickingJobScreen = {
         await PickingJobScreen.skipTargetHUAndCommit();
     }),
 
+    // Drives the unpick panel up to (but not through) the target-HU scan: open the panel, scan the
+    // product GTIN, enter the qty -> the panel is now on the SCAN_TARGET stage (the target-HU scanner
+    // is armed). Stops here so the caller can drive the target-HU submit itself (e.g. under a network
+    // fault) and assert on the in-between state.
+    unpickAdvanceToTargetStage: async ({ scannedCode, qty, expectDefaultQty }) => await step(`${NAME} - Unpack ${qty} of '${scannedCode}', advance to target-HU scan stage`, async () => {
+        await PickingJobScreen.clickUnpickItem();
+        await PickingJobScreen.scanProductToUnpick({ scannedCode });
+        if (expectDefaultQty != null) {
+            await PickingJobScreen.expectDefaultQtyToUnpick({ qty: expectDefaultQty });
+        }
+        await PickingJobScreen.enterQtyToUnpick({ qty });
+    }),
+
+    // Scans the target HU while the submit (the picking/event POST) is expected to fail at the network
+    // layer. The scan fires but the unpick does NOT commit; the panel must NOT close. Only commits the
+    // scan — the caller asserts the error toast and the still-open panel via expectOnTargetScanStage().
+    scanTargetHUNoCommit: async ({ qrCode }) => await step(`${NAME} - Scan target HU '${qrCode}' (no commit expected)`, async () => {
+        await BarcodeScannerComponent.type({ scannedCode: qrCode, testId: 'unpick-target-hu-scanner' });
+    }),
+
+    // Asserts the unpick panel is still on the SCAN_TARGET stage: the target-HU scanner is still armed
+    // (the panel did not close back to the job screen). This is the network-failure invariant — a
+    // transient submit failure keeps the panel open so the operator can simply scan again.
+    expectOnTargetScanStage: async () => await step(`${NAME} - Expect still on target-HU scan stage`, async () => {
+        await BarcodeScannerComponent.expectAttached({ testId: 'unpick-target-hu-scanner', timeout: SLOW_ACTION_TIMEOUT });
+    }),
+
     // Negative path: scans a code that does not resolve to a product packed in this job. The single
     // error surface is the scanner's toast; wrap the call site in expectErrorToast(...) to assert it.
     scanProductCodeToUnpick: async ({ scannedCode }) => await step(`${NAME} - Scan product code '${scannedCode}' (no advance expected)`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
@@ -331,16 +331,20 @@ export const PickingJobScreen = {
         await PickingJobScreen.enterQtyToUnpick({ qty });
     }),
 
-    // Scans the target HU while the submit (the picking/event POST) is expected to fail at the network
-    // layer. The scan fires but the unpick does NOT commit; the panel must NOT close. Only commits the
-    // scan — the caller asserts the error toast and the still-open panel via expectOnTargetScanStage().
-    scanTargetHUNoCommit: async ({ qrCode }) => await step(`${NAME} - Scan target HU '${qrCode}' (no commit expected)`, async () => {
-        await BarcodeScannerComponent.type({ scannedCode: qrCode, testId: 'unpick-target-hu-scanner' });
+    // Scans a code at the target-HU stage when the submit (the picking/event POST) is expected to FAIL:
+    // either a transient network failure (no HTTP response) or a server rejection (4xx/5xx, e.g. the
+    // operator mis-scans the product GTIN they are holding instead of a target HU). The scan fires and is
+    // submitted, but the unpick does NOT commit and the panel must NOT close. Only commits the scan — the
+    // caller asserts the error toast and the still-open panel via expectOnTargetScanStage(); the caller's
+    // test.step / expectErrorToast label carries which failure mode is under test.
+    scanCodeAtTargetStageNoCommit: async ({ scannedCode }) => await step(`${NAME} - Scan '${scannedCode}' at target-HU stage (submit failure expected, no commit)`, async () => {
+        await BarcodeScannerComponent.type({ scannedCode, testId: 'unpick-target-hu-scanner' });
     }),
 
     // Asserts the unpick panel is still on the SCAN_TARGET stage: the target-HU scanner is still armed
-    // (the panel did not close back to the job screen). This is the network-failure invariant — a
-    // transient submit failure keeps the panel open so the operator can simply scan again.
+    // (the panel did not close back to the job screen). This is the submit-failure invariant — a failed
+    // submit (transient network OR a server rejection) keeps the panel open so the operator can simply
+    // scan again.
     expectOnTargetScanStage: async () => await step(`${NAME} - Expect still on target-HU scan stage`, async () => {
         await BarcodeScannerComponent.expectAttached({ testId: 'unpick-target-hu-scanner', timeout: SLOW_ACTION_TIMEOUT });
     }),

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/picking/UnpickPanel.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/picking/UnpickPanel.test.js
@@ -90,15 +90,18 @@ describe('UnpickPanel — onTargetSubmitted', () => {
     expect(screen.getByTestId('mock-target-submit')).toBeInTheDocument();
   });
 
-  it('SERVER rejection (response present): toasts and closes so the operator starts over', async () => {
+  it('SERVER rejection (response present): toasts but does NOT close — panel stays on SCAN_TARGET for a corrected scan', async () => {
     mockDispatch.mockReturnValue(Promise.reject({ response: { status: 422 } }));
     const onClose = jest.fn();
     render(<UnpickPanel {...baseProps} onClose={onClose} />);
 
     driveToTargetSubmit();
 
-    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
-    expect(mockToastError).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledTimes(1));
+    // A server rejection (e.g. a mis-scanned/incompatible target HU) is correctable in place, so the
+    // panel must stay open — same as the network-failure case — and let the operator re-scan or Cancel.
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId('mock-target-submit')).toBeInTheDocument();
   });
 
   it('closes exactly once on a successful submit', async () => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/picking/UnpickPanel.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/picking/UnpickPanel.test.js
@@ -27,7 +27,9 @@ jest.mock('../../../../containers/activities/picking/unpick/UnpickProductScanDia
   const Mock = ({ onResolved }) => (
     <button
       data-testid="mock-product-resolved"
-      onClick={() => onResolved({ productId: 1, scannedCode: 'x', packedQty: 5, packedQtyUom: 'PCE' })}
+      onClick={() =>
+        onResolved({ productId: 1, scannedCode: 'x', packedQty: 5, packedQtyUom: 'PCE', unpickable: true })
+      }
     >
       resolve-product
     </button>
@@ -75,7 +77,7 @@ describe('UnpickPanel — onTargetSubmitted', () => {
     mockToastError.mockClear();
   });
 
-  it('stays on SCAN_TARGET and does NOT close on a transient submit error (allow retry)', async () => {
+  it('NETWORK failure (no response): stays on SCAN_TARGET and does NOT close (allow retry)', async () => {
     mockDispatch.mockReturnValue(Promise.reject(new Error('network blip')));
     const onClose = jest.fn();
     render(<UnpickPanel {...baseProps} onClose={onClose} />);
@@ -86,6 +88,17 @@ describe('UnpickPanel — onTargetSubmitted', () => {
     expect(onClose).not.toHaveBeenCalled();
     // Still on the target stage so the operator can retry.
     expect(screen.getByTestId('mock-target-submit')).toBeInTheDocument();
+  });
+
+  it('SERVER rejection (response present): toasts and closes so the operator starts over', async () => {
+    mockDispatch.mockReturnValue(Promise.reject({ response: { status: 422 } }));
+    const onClose = jest.fn();
+    render(<UnpickPanel {...baseProps} onClose={onClose} />);
+
+    driveToTargetSubmit();
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(mockToastError).toHaveBeenCalledTimes(1);
   });
 
   it('closes exactly once on a successful submit', async () => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/picking/UnpickPanel.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/picking/UnpickPanel.test.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import UnpickPanel from '../../../../containers/activities/picking/unpick/UnpickPanel';
+
+// Controllable dispatch: each test sets its return value to a resolving / rejecting promise.
+const mockDispatch = jest.fn();
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: () => mockDispatch,
+}));
+
+// The thunk action-creator is irrelevant here — dispatch is mocked to return our promise.
+jest.mock('../../../../apps/picking/redux/postStepPartiallyUnPickedThunk', () => ({
+  postStepPartiallyUnPickedThunk: jest.fn(() => ({ type: 'MOCK_THUNK' })),
+}));
+
+const mockToastError = jest.fn();
+jest.mock('../../../../utils/toast', () => ({
+  toastError: (...args) => mockToastError(...args),
+}));
+
+// Stage 1: product scan dialog → one button that fires onResolved with a canned resolved product.
+jest.mock('../../../../containers/activities/picking/unpick/UnpickProductScanDialog', () => {
+  // eslint-disable-next-line react/prop-types
+  const Mock = ({ onResolved }) => (
+    <button
+      data-testid="mock-product-resolved"
+      onClick={() => onResolved({ productId: 1, scannedCode: 'x', packedQty: 5, packedQtyUom: 'PCE' })}
+    >
+      resolve-product
+    </button>
+  );
+  return Mock;
+});
+
+// Stage 2: qty dialog → one button that fires onQtyChange.
+jest.mock('../../../../components/dialogs/GetQuantityDialog', () => {
+  // eslint-disable-next-line react/prop-types
+  const Mock = ({ onQtyChange }) => (
+    <button data-testid="mock-qty-change" onClick={() => onQtyChange({ qtyEnteredAndValidated: 2 })}>
+      change-qty
+    </button>
+  );
+  return Mock;
+});
+
+// Stage 3: target scan dialog → one button that fires onSubmit; rendered iff we are on SCAN_TARGET.
+jest.mock('../../../../containers/activities/picking/unpick/UnpickTargetScanDialog', () => {
+  // eslint-disable-next-line react/prop-types
+  const Mock = ({ onSubmit }) => (
+    <button data-testid="mock-target-submit" onClick={() => onSubmit({ unpickToTargetQRCode: { code: 'HU#1' } })}>
+      submit-target
+    </button>
+  );
+  return Mock;
+});
+
+const baseProps = {
+  wfProcessId: 'wf-1',
+  activityId: 'act-1',
+  lineId: 'line-1',
+};
+
+const driveToTargetSubmit = () => {
+  fireEvent.click(screen.getByTestId('mock-product-resolved'));
+  fireEvent.click(screen.getByTestId('mock-qty-change'));
+  fireEvent.click(screen.getByTestId('mock-target-submit'));
+};
+
+describe('UnpickPanel — onTargetSubmitted', () => {
+  beforeEach(() => {
+    mockDispatch.mockReset();
+    mockToastError.mockClear();
+  });
+
+  it('stays on SCAN_TARGET and does NOT close on a transient submit error (allow retry)', async () => {
+    mockDispatch.mockReturnValue(Promise.reject(new Error('network blip')));
+    const onClose = jest.fn();
+    render(<UnpickPanel {...baseProps} onClose={onClose} />);
+
+    driveToTargetSubmit();
+
+    await waitFor(() => expect(mockToastError).toHaveBeenCalledTimes(1));
+    expect(onClose).not.toHaveBeenCalled();
+    // Still on the target stage so the operator can retry.
+    expect(screen.getByTestId('mock-target-submit')).toBeInTheDocument();
+  });
+
+  it('closes exactly once on a successful submit', async () => {
+    mockDispatch.mockReturnValue(Promise.resolve());
+    const onClose = jest.fn();
+    render(<UnpickPanel {...baseProps} onClose={onClose} />);
+
+    driveToTargetSubmit();
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/picking/UnpickProductScanDialog.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/picking/UnpickProductScanDialog.test.js
@@ -1,0 +1,21 @@
+import { isResolvedProductUnpickable } from '../../../../containers/activities/picking/unpick/UnpickProductScanDialog';
+
+describe('UnpickProductScanDialog — isResolvedProductUnpickable', () => {
+  it('is true when productId present and backend says unpickable', () => {
+    expect(isResolvedProductUnpickable({ productId: 1, unpickable: true, packedQty: 5 })).toBe(true);
+  });
+
+  it('honors the backend flag, NOT packedQty (drift case)', () => {
+    // packedQty > 0 but the backend says NOT unpickable → must be false.
+    // The old reimplementation (isPacked = packedQty > 0) would have proceeded here.
+    expect(isResolvedProductUnpickable({ productId: 1, unpickable: false, packedQty: 5 })).toBe(false);
+  });
+
+  it('is false when productId is missing even if unpickable', () => {
+    expect(isResolvedProductUnpickable({ productId: undefined, unpickable: true })).toBe(false);
+  });
+
+  it('is false for a null response', () => {
+    expect(isResolvedProductUnpickable(null)).toBe(false);
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/unpick/UnpickPanel.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/unpick/UnpickPanel.jsx
@@ -53,11 +53,7 @@ const UnpickPanel = ({ wfProcessId, activityId, lineId, onClose }) => {
         onClose();
       })
       .catch((axiosError) => {
-        // Any submit failure — a server rejection (4xx/5xx, e.g. a mis-scanned/incompatible target HU) OR a
-        // transient network failure — keeps the panel on SCAN_TARGET: toast the error and let the operator
-        // correct and re-scan, or Cancel to abort. A server rejection is recoverable in place (rescan the
-        // right target), so it should NOT kick the operator out of the flow any more than a network blip does;
-        // closing only on success keeps both failure modes consistent. onClose() runs on the success (.then) path.
+        // Any failure keeps the panel on SCAN_TARGET so the operator can re-scan or Cancel; only success closes.
         toastError({ axiosError });
       });
   };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/unpick/UnpickPanel.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/unpick/UnpickPanel.jsx
@@ -53,8 +53,13 @@ const UnpickPanel = ({ wfProcessId, activityId, lineId, onClose }) => {
         onClose();
       })
       .catch((axiosError) => {
-        // Stay on SCAN_TARGET (don't onClose) so the operator can retry after a transient submit error.
         toastError({ axiosError });
+        // Discriminate per mobile-webui CLAUDE.md § "API Error Surfacing": a server rejection (4xx/5xx, response
+        // present) won't succeed on retry → close so the operator can start over; a network failure (no response)
+        // may succeed on retry → stay on SCAN_TARGET. onClose() also still runs on the success (.then) path.
+        if (axiosError?.response) {
+          onClose();
+        }
       });
   };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/unpick/UnpickPanel.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/unpick/UnpickPanel.jsx
@@ -53,13 +53,12 @@ const UnpickPanel = ({ wfProcessId, activityId, lineId, onClose }) => {
         onClose();
       })
       .catch((axiosError) => {
+        // Any submit failure — a server rejection (4xx/5xx, e.g. a mis-scanned/incompatible target HU) OR a
+        // transient network failure — keeps the panel on SCAN_TARGET: toast the error and let the operator
+        // correct and re-scan, or Cancel to abort. A server rejection is recoverable in place (rescan the
+        // right target), so it should NOT kick the operator out of the flow any more than a network blip does;
+        // closing only on success keeps both failure modes consistent. onClose() runs on the success (.then) path.
         toastError({ axiosError });
-        // Discriminate per mobile-webui CLAUDE.md § "API Error Surfacing": a server rejection (4xx/5xx, response
-        // present) won't succeed on retry → close so the operator can start over; a network failure (no response)
-        // may succeed on retry → stay on SCAN_TARGET. onClose() also still runs on the success (.then) path.
-        if (axiosError?.response) {
-          onClose();
-        }
       });
   };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/unpick/UnpickPanel.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/unpick/UnpickPanel.jsx
@@ -53,8 +53,8 @@ const UnpickPanel = ({ wfProcessId, activityId, lineId, onClose }) => {
         onClose();
       })
       .catch((axiosError) => {
+        // Stay on SCAN_TARGET (don't onClose) so the operator can retry after a transient submit error.
         toastError({ axiosError });
-        onClose();
       });
   };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/unpick/UnpickProductScanDialog.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/unpick/UnpickProductScanDialog.jsx
@@ -7,6 +7,11 @@ import BarcodeScannerComponent from '../../../../components/BarcodeScannerCompon
 import DialogButton from '../../../../components/dialogs/DialogButton';
 import Dialog from '../../../../components/dialogs/Dialog';
 
+// Trust the backend's single source of truth: JsonUnpickResolveResponse.unpickable (true when
+// packedQty>0). Don't recompute "is there something to unpick" from packedQty on the FE — that would
+// drift from the backend rule.
+export const isResolvedProductUnpickable = (response) => Boolean(response?.productId && response?.unpickable);
+
 // Stage 1 of UnpickPanel: scans a product GTIN and resolves it against the picking job; surfaces an
 // inline error when the scanned product is not packed in this job (the qty/target stages live in
 // UnpickPanel).
@@ -29,8 +34,7 @@ const UnpickProductScanDialog = ({ wfProcessId, onResolved, onCloseDialog }) => 
   const onResolvedResult = useCallback(
     (result) => {
       const response = result?.resolved;
-      const isPacked = response?.packedQty != null && Number(response.packedQty) > 0;
-      if (!response?.productId || !isPacked) {
+      if (!isResolvedProductUnpickable(response)) {
         setErrorMessage(trl('activities.picking.unpick.productNotInPackage'));
         return;
       }


### PR DESCRIPTION
Follow-on quality fixes to the Mobile Packing partial-unpack flow (two defects in code introduced by #24772), with test coverage.

### H1 — keep the panel open on a transient submit error (allow retry)
`UnpickPanel.onTargetSubmitted` called `onClose()` in its `.catch`, so a network/backend blip on the final commit dropped the operator out of the 3-step flow (re-scan product, re-enter qty, re-scan target). It was the only catch-with-`onClose()` in the picking containers; the rest toast-and-stay. Fix: `onClose()` is removed from the `.catch` (the error is still toasted) and stays only in the `.then` success path, so the operator remains on `SCAN_TARGET` and can retry.

### H2 — trust the backend `unpickable` flag (single source of truth)
`UnpickProductScanDialog` recomputed "is there something to unpick" on the frontend as `packedQty != null && packedQty > 0`. The backend response (`JsonUnpickResolveResponse`) already serializes `boolean unpickable` (true when `packedQty > 0`). The frontend now consumes that flag via a new exported `isResolvedProductUnpickable` helper instead of recomputing it, so the FE cannot silently drift if the backend's unpickability rule changes.

### Tests
- `UnpickProductScanDialog.test.js` — pure-function test of `isResolvedProductUnpickable`, including the drift case (backend `unpickable: false` while `packedQty: 5` ⇒ rejected; the old reimplementation would have proceeded).
- `UnpickPanel.test.js` — RTL test driving all three stages: asserts the panel does NOT close and stays on `SCAN_TARGET` on a rejected submit (retry), and closes exactly once on a successful submit.

Both verified RED→GREEN; `yarn lint` clean.
