### PR TITLE
mobile-webui E2E: env-gated UAT_CAPTURE hold so entered values are recorded on UAT videos

### DIFF
--- a/e2e/mobile-webui/tests/utils/common.js
+++ b/e2e/mobile-webui/tests/utils/common.js
@@ -16,6 +16,23 @@ export const setCurrentPage = (currentPage) => {
     page = currentPage;
 }
 
+// Capture mode — OFF by default. When the env flag UAT_CAPTURE is set, the run is a deliberate
+// recording run for a UAT/documentation video; otherwise this is a no-op and the test runs at
+// full speed. The test's normal/CI speed is never affected.
+// See skill playwright-video-delivery § "Test speed vs. recording speed".
+export const UAT_CAPTURE = !!process.env.UAT_CAPTURE;
+
+// Hold the currently-painted screen on the video recorder long enough for the freshly-entered
+// values to be captured as a clear, deliberate freeze (the recorder samples ~25 fps and Playwright
+// otherwise fills + confirms within a single frame, so the values are never recorded). NO-OP unless
+// UAT_CAPTURE is set — so this can only ever slow a deliberate capture run, never a normal/CI run;
+// the value is therefore generous for legibility, not a marginal minimum.
+const CAPTURE_HOLD_MS = 500;
+export const holdForCaptureIfEnabled = async () => {
+    if (!UAT_CAPTURE || page == null) return;
+    await page.waitForTimeout(CAPTURE_HOLD_MS);
+};
+
 export const step = async (title, func) => await test.step(title, async () => await runAndWatchForErrors(func));
 
 let nextErrorWatcherId = 101;

--- a/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
@@ -1,5 +1,5 @@
 import { test } from "../../../../playwright.config";
-import { expectErrorToastIf, page, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from "../../common";
+import { expectErrorToastIf, holdForCaptureIfEnabled, page, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from "../../common";
 import { expect } from "@playwright/test";
 
 const NAME = 'GetQuantityDialog';
@@ -197,6 +197,10 @@ export const GetQuantityDialog = {
         if (qtyNotFoundReason != null) {
             await GetQuantityDialog.clickQtyNotFoundReason({ reason: qtyNotFoundReason });
         }
+
+        // Capture mode only (UAT_CAPTURE): hold the filled dialog on the recorder for a few frames
+        // so the entered values are captured before OK closes it. No-op / full speed otherwise.
+        await holdForCaptureIfEnabled();
 
         if (closeTarget) {
             await GetQuantityDialog.clickDoneAndCloseTarget({ expectedError });


### PR DESCRIPTION
## What

Adds an **env-gated capture hold** to the mobile-webui E2E suite so freshly-entered field values are actually recorded on UAT/documentation videos.

## Why

Playwright fills the last field and confirms a dialog within a single ~40 ms recorder frame, so a just-entered value (e.g. Lot, Best-Before) is **never painted in any captured frame** of the `.webm`. Post-production cannot conjure a frame that was never recorded, so the UAT video showed empty fields with only a caption — which reads as misleading.

## How

- `holdForCaptureIfEnabled()` in `tests/utils/common.js`: a **no-op unless the env flag `UAT_CAPTURE` is set**, in which case it holds the painted screen ~500 ms so the recorder captures the entered values as a clear freeze.
- Wired into `GetQuantityDialog.fillAndPressDone` just before pressing OK — invoked **only from the screen object, never from a spec**.

## Test-speed impact

**None by default.** Normal and CI runs set no flag → the helper is a no-op → tests run full speed. The hold exists only in a deliberate capture run:

```
UAT_CAPTURE=1 npx playwright test <spec>
```

Then the recording is prepared/captioned via the standard video-delivery pipeline.

## Note

This is generic mobile-webui test infrastructure (lives in the shared `GetQuantityDialog` / `common.js`); it is useful beyond this feature and can be ported to other branches / the mainline as needed.
