### PR TITLE
PrintReceivedHUQRCodes: tolerate missing M_HU_Label_Config (skip instead of fail)

### DIFF
--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/activity_handlers/printReceivedHUQRCodes/PrintReceivedHUQRCodesActivityHandler.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/activity_handlers/printReceivedHUQRCodes/PrintReceivedHUQRCodesActivityHandler.java
@@ -39,6 +39,7 @@ import org.adempiere.exceptions.AdempiereException;
 import org.eevolution.api.PPOrderId;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -170,10 +171,11 @@ public class PrintReceivedHUQRCodesActivityHandler implements WFActivityHandler,
 			this.huLabelService = huLabelService;
 		}
 
-		private HULabelConfig getLabelConfig(final @NonNull HUToReport hu)
+		@Nullable
+		private HULabelConfig getLabelConfigOrNull(final @NonNull HUToReport hu)
 		{
 			return cache.computeIfAbsent(toHULabelConfigQuery(hu), huLabelService::getFirstMatching)
-					.orElseThrow();
+					.orElse(null);
 		}
 
 		private static HULabelConfigQuery toHULabelConfigQuery(final @NonNull HUToReport hu)
@@ -202,14 +204,21 @@ public class PrintReceivedHUQRCodesActivityHandler implements WFActivityHandler,
 		{
 			for (final HUToReport hu : hus)
 			{
-				add(hu, labelConfigProvider.getLabelConfig(hu));
-
+				final HULabelConfig labelConfigOrNull = labelConfigProvider.getLabelConfigOrNull(hu);
+				if (labelConfigOrNull != null)
+				{
+					add(hu, labelConfigOrNull);
+				}
 				final HuUnitType huUnitType = hu.getHUUnitType();
 				if (huUnitType == HuUnitType.LU)
 				{
 					for (final HUToReport includedHU : hu.getIncludedHUs())
 					{
-						add(includedHU, labelConfigProvider.getLabelConfig(includedHU));
+						final HULabelConfig includedLabelConfig = labelConfigProvider.getLabelConfigOrNull(includedHU);
+						if (includedLabelConfig != null) // only attempt printing included HU if there is a matching config
+						{
+							add(includedHU, includedLabelConfig);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## What

`PrintReceivedHUQRCodesActivityHandler` no longer fails when receiving an LU or TU on production and no matching `M_HU_Label_Config` exists for that HU type.

Previously `getLabelConfig(...)` called `.orElseThrow()`, so receiving an HU (LU or its included TUs) whose unit type had no matching `M_HU_Label_Config` aborted the whole receipt with an exception.

## Change

- `getLabelConfig` → `getLabelConfigOrNull` (`.orElseThrow()` → `.orElse(null)`).
- The label-collecting loop now skips an HU (and likewise each included HU of an LU) when no matching config is found, instead of throwing. HUs that *do* have a matching config are still printed.

Net effect: a missing `M_HU_Label_Config` for LU and/or TU degrades gracefully (that label is skipped) rather than blocking the receipt.

## Scope

Single file, behaviour-only:
`backend/de.metas.manufacturing.rest-api/.../printReceivedHUQRCodes/PrintReceivedHUQRCodesActivityHandler.java`
