### PR TITLE
EPCIS: one merged order-pure SSCC event for two orders sharing one LU (close-gate + closer-emits)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
@@ -107,6 +107,7 @@ import static org.compiere.model.I_C_BPartner.COLUMNNAME_M_PricingSystem_ID;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PO_DiscountSchema_ID;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PO_InvoiceRule;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PO_PricingSystem_ID;
+import static org.compiere.model.I_C_BPartner.COLUMNNAME_AllowConsolidateInOut;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PaymentRule;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PaymentRulePO;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_Value;
@@ -320,6 +321,8 @@ public class C_BPartner_StepDef
 		row.getAsOptionalEnum(COLUMNNAME_PaymentRulePO, PaymentRule.class).ifPresent(paymentRulePO -> bPartnerRecord.setPaymentRulePO(paymentRulePO.getCode()));
 		row.getAsOptionalEnum(COLUMNNAME_PO_InvoiceRule, InvoiceRule.class).ifPresent(poInvoiceRule -> bPartnerRecord.setPO_InvoiceRule(poInvoiceRule.getCode()));
 		row.getAsOptionalBoolean(COLUMNNAME_IsAllowActionPrice).ifPresent(bPartnerRecord::setIsAllowActionPrice);
+
+		row.getAsOptionalBoolean(COLUMNNAME_AllowConsolidateInOut).ifPresent(bPartnerRecord::setAllowConsolidateInOut);
 
 		row.getAsOptionalIdentifier(I_C_BPartner.COLUMNNAME_AD_OrgBP_ID)
 				.map(orgTable::getIdAsInt)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
@@ -90,6 +90,7 @@ import static de.metas.cucumber.stepdefs.StepDefConstants.TABLECOLUMN_IDENTIFIER
 import static de.metas.invoicecandidate.model.I_C_BPartner.COLUMNNAME_SO_Invoice_Aggregation_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_AD_Language;
+import static org.compiere.model.I_C_BPartner.COLUMNNAME_AllowConsolidateInOut;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_C_BP_Group_ID;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_C_BPartner_ID;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_C_BPartner_SalesRep_ID;
@@ -107,7 +108,6 @@ import static org.compiere.model.I_C_BPartner.COLUMNNAME_M_PricingSystem_ID;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PO_DiscountSchema_ID;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PO_InvoiceRule;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PO_PricingSystem_ID;
-import static org.compiere.model.I_C_BPartner.COLUMNNAME_AllowConsolidateInOut;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PaymentRule;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_PaymentRulePO;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_Value;

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -728,6 +728,7 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | Order_Identifier | ExpectedQtyDelivered |
       | oB_S29231_170    | 100                  |
 
+  @from:cucumber
   @Id:S30558_010
   @allure.label.epic:E0292_EDI
   @allure.label.feature:F00353_EDI_DESADV_InOut_Link

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -737,7 +737,7 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
   ## by a draft shipment (not CO/CL). The RED gate assertion fires after completing ioA:
   ## the current (un-gated) function emits a non-empty partial event, so the
   ## 'returns empty object' assertion FAILS (intended RED). After ioB is also completed,
-  ## ioA (lower M_InOut_ID = owner) returns the merged full event; ioB returns {}.
+  ## both ioA and ioB then return the full merged event — no fixed owner under the close-gate model.
     And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
     And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
 
@@ -939,7 +939,7 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
   ## the LU are covered only by a draft shipment (not CO/CL). The RED gate assertion fires
   ## after completing ioB: the current (un-gated) function emits a non-empty partial event,
   ## so the 'returns empty object' assertion FAILS (intended RED). After ioA is also completed,
-  ## ioA (lower M_InOut_ID = owner) returns the merged full event; ioB returns {}.
+  ## both ioA and ioB then return the full merged event — no fixed owner under the close-gate model.
     And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
     And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -727,3 +727,382 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
     Then verify DESADV JSON export response has exactly 1 element matching:
       | Order_Identifier | ExpectedQtyDelivered |
       | oB_S29231_170    | 100                  |
+
+  @Id:S30558_010
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00353_EDI_DESADV_InOut_Link
+  Scenario: S30558_010 — Two orders share one LU, sibling shipment not yet generated: function returns {} for ioA until ioB is also completed
+  ## Completion-ordering gate (me03 #30558): when two sales orders are picked onto ONE shared
+  ## physical pallet (ONE SSCC18), the function must return {} for the first-completed shipment
+  ## until ALL TUs on the LU are covered by a CO/CL shipment.
+  ## This scenario uses DO_NOT_CREATE: both picking jobs complete FIRST (so the LU physically
+  ## holds all 15 TUs), then shipments are generated individually. ioA is completed while ioB
+  ## has no shipment yet (its 10 TUs are on the LU but uncovered). The RED gate assertion fires
+  ## after completing ioA: the current (un-gated) function emits a non-empty partial event
+  ## for ioA because it sees no sibling M_InOut, so the 'returns empty object' assertion FAILS.
+    And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
+    And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
+
+    And metasfresh contains M_PickingSlot:
+      | Identifier | PickingSlot | IsDynamic |
+      | 200.0      | 200.0       | Y         |
+
+    Given metasfresh contains M_Products:
+      | Identifier   | GTIN          |
+      | p_S30558_010 | 4060000000185 |
+    And metasfresh contains M_PricingSystems
+      | Identifier    |
+      | ps_S30558_010 |
+    And metasfresh contains M_PriceLists
+      | Identifier    | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_S30558_010 | ps_S30558_010      | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier     | M_PriceList_ID |
+      | plv_S30558_010 | pl_S30558_010  |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | plv_S30558_010         | p_S30558_010 | 5.0      | PCE      | Normal           |
+
+    And metasfresh contains C_BPartners without locations:
+      | Identifier    | IsCustomer | M_PricingSystem_ID | GLN           |
+      | bp_S30558_010 | Y          | ps_S30558_010      | 9900000305580 |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier       | GLN           | C_BPartner_ID | OPT.IsBillToDefault | OPT.IsShipTo |
+      | bpLoc_S30558_010 | 2900000305580 | bp_S30558_010 | true                | true         |
+    And metasfresh contains C_BPartner_EDI_Setting:
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN | Identifier                |
+      | bp_S30558_010 | true                 | 9900000305580         | edi_setting_S30558_010_bp |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID |
+      | bp_S30558_010 | p_S30558_010 |
+
+    # HU PI: LU holds up to 20 TUs, each TU holds 10 PCE
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID       |
+      | pi_LU_S30558_010 |
+      | pi_TU_S30558_010 |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID       | HU_UnitType | IsCurrent |
+      | piv_LU_S30558_010  | pi_LU_S30558_010 | LU          | Y         |
+      | piv_TU_S30558_010  | pi_TU_S30558_010 | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID   | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID |
+      | pii_LU_S30558_010 | piv_LU_S30558_010  | 20  | HU       | pi_TU_S30558_010  |
+      | pii_TU_S30558_010 | piv_TU_S30558_010  | 0   | MI       |                   |
+    And metasfresh contains M_HU_PI_Attribute:
+      | M_HU_PI_Version_ID | M_Attribute.Value |
+      | piv_LU_S30558_010  | SSCC18            |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID   | M_Product_ID | Qty | ValidFrom  |
+      | pip_S30558_010          | pii_TU_S30558_010 | p_S30558_010 | 10  | 2020-01-01 |
+
+    # Mobile UI picking profile — DO_NOT_CREATE: no shipment is auto-created on job completion;
+    # both jobs finish first so the LU holds all 15 TUs before any shipment is generated.
+    And set mobile UI picking profile
+      | IsAllowPickingAnyHU | CreateShipmentPolicy | IsAllowCompletingPartialPickingJob | IsAlwaysSplitHUsEnabled |
+      | Y                   | DO_NOT_CREATE        | Y                                  | N                       |
+
+    # Source: aggregated LU with 150 PCE (5 TUs for order A + 10 TUs for order B)
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID | MovementDate | M_Warehouse_ID |
+      | inv_S30558_010 | 2026-05-25   | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | M_InventoryLine_ID  | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_S30558_010 | invLine_S30558_010  | p_S30558_010 | 0       | 150      | PCE          |
+    And complete inventory with inventoryIdentifier 'inv_S30558_010'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID  | M_HU_ID               |
+      | invLine_S30558_010  | pickFromCU_S30558_010 |
+
+    And transform CU to new LU
+      | sourceCU              | newLU                        | TU_PI_ID          | QtyCUsPerTU | QtyTUsPerLU |
+      | pickFromCU_S30558_010 | pickFromAggregatedLU_S30558  | pi_TU_S30558_010  | 10          | 15          |
+
+    # Order A — 50 PCE → 5 TUs. POReference is 10 digits so LPAD is a no-op.
+    And metasfresh contains C_Orders:
+      | Identifier    | IsSOTrx | C_BPartner_ID | DateOrdered | POReference |
+      | oA_S30558_010 | true    | bp_S30558_010 | 2026-05-25  | 1170000001  |
+    And metasfresh contains C_OrderLines:
+      | Identifier     | C_Order_ID    | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | olA_S30558_010 | oA_S30558_010 | p_S30558_010 | 50         | pip_S30558_010          |
+
+    When the order identified by oA_S30558_010 is completed
+
+    # Order B — 100 PCE → 10 TUs. Distinct POReference.
+    And metasfresh contains C_Orders:
+      | Identifier    | IsSOTrx | C_BPartner_ID | DateOrdered | POReference |
+      | oB_S30558_010 | true    | bp_S30558_010 | 2026-05-25  | 1170000002  |
+    And metasfresh contains C_OrderLines:
+      | Identifier     | C_Order_ID    | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | olB_S30558_010 | oB_S30558_010 | p_S30558_010 | 100        | pip_S30558_010          |
+
+    When the order identified by oB_S30558_010 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier     | C_OrderLine_ID | IsToRecompute |
+      | ssA_S30558_010 | olA_S30558_010 | N             |
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier     | C_OrderLine_ID | IsToRecompute |
+      | ssB_S30558_010 | olB_S30558_010 | N             |
+
+    # ─── Picking job 1: order A → new LU 'sharedLu_S30558_010' ──────────────────────
+    And start picking job for sales order identified by oA_S30558_010
+    And scan picking slot identified by 200.0
+    And set picking target as new LU identified by pi_LU_S30558_010
+    And pick lines
+      | PickingLine.byProduct | PickFromHU                  | QtyPicked |
+      | p_S30558_010          | pickFromAggregatedLU_S30558 | 5         |
+    And expect current picking target
+      | Existing_LU         |
+      | sharedLu_S30558_010 |
+    And complete picking job
+
+    # ─── Picking job 2: order B targets the SAME LU (LUPickingTarget.ofExistingHU) ──
+    # Both jobs done — the LU now physically holds all 15 TUs.
+    And start picking job for sales order identified by oB_S30558_010
+    And scan picking slot identified by 200.0
+    And set picking target as existing LU identified by sharedLu_S30558_010
+    And pick lines
+      | PickingLine.byProduct | PickFromHU                  | QtyPicked |
+      | p_S30558_010          | pickFromAggregatedLU_S30558 | 10        |
+    And complete picking job
+
+    # ─── Stamp SSCC18 on the shared LU ───────────────────────────────────────────────
+    And M_HU_Attribute is changed
+      | M_HU_ID             | M_Attribute_ID.Value | Value              |
+      | sharedLu_S30558_010 | SSCC18               | 987654321000003058 |
+
+    # ─── Generate and complete ioA only ──────────────────────────────────────────────
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ssA_S30558_010        | PD           | false               | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID     |
+      | ssA_S30558_010        | ioA_S30558_010 |
+    And the shipment identified by ioA_S30558_010 is completed
+
+    # RED gate — ioB has no shipment yet (its 10 TUs are on the LU but uncovered by any CO/CL M_InOut):
+    # Correct post-fix behaviour: {} (LU not fully covered → gate blocks emission).
+    # This assertion MUST FAIL on the current (un-gated) code.
+    Then the EPCIS JSON export function returns empty object for M_InOut identified by ioA_S30558_010
+
+    # ─── Generate and complete ioB — now all 15 TUs on the LU are covered ────────────
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ssB_S30558_010        | PD           | false               | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID     |
+      | ssB_S30558_010        | ioB_S30558_010 |
+    And the shipment identified by ioB_S30558_010 is completed
+
+    # ─── After both completions: ioA (lower ID = owner) returns the merged pallet ────
+    When the EPCIS JSON export function is called for M_InOut identified by ioA_S30558_010
+    Then the EPCIS JSON pallets contain SSCC18 values in any order:
+      | sscc18             |
+      | 987654321000003058 |
+    And the EPCIS JSON pallet has:
+      | palletIndex | sscc               | crateCount |
+      | 0           | 987654321000003058 | 15         |
+    And the EPCIS JSON array field has:
+      | field            | expectedSize |
+      | desadvReferences | 2            |
+      | poReferences     | 2            |
+    Then the EPCIS JSON pallet 0 crates are order-pure with POReferences:
+      | poReference |
+      | 1170000001  |
+      | 1170000002  |
+
+    # ─── ioB (sibling) must return {} ────────────────────────────────────────────────
+    Then the EPCIS JSON export function returns empty object for M_InOut identified by ioB_S30558_010
+
+  @Id:S30558_020
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00353_EDI_DESADV_InOut_Link
+  Scenario: S30558_020 — Two orders share one LU, sibling shipment generated but still draft: function returns {} for ioA until ioB is also completed
+  ## Completion-ordering gate (me03 #30558): same shared-pallet setup as S30558_010.
+  ## Uses DO_NOT_CREATE: both picking jobs finish, then BOTH shipment schedules are
+  ## individually generated as DRAFT. Only ioA is completed; ioB remains DRAFT (IP).
+  ## State: ioA=CO, ioB=IP — order B's TUs on the LU are covered only by a draft shipment.
+  ## The RED gate assertion fires after completing ioA: the current (un-gated) function
+  ## emits a non-empty partial event because it does not check that the sibling is CO/CL,
+  ## so the 'returns empty object' assertion FAILS on current code (expected RED).
+  ## After ioB is completed, ioA returns the merged pallet; ioB returns {}.
+    And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
+    And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
+
+    And metasfresh contains M_PickingSlot:
+      | Identifier | PickingSlot | IsDynamic |
+      | 200.0      | 200.0       | Y         |
+
+    Given metasfresh contains M_Products:
+      | Identifier   | GTIN          |
+      | p_S30558_020 | 4060000000192 |
+    And metasfresh contains M_PricingSystems
+      | Identifier    |
+      | ps_S30558_020 |
+    And metasfresh contains M_PriceLists
+      | Identifier    | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_S30558_020 | ps_S30558_020      | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier     | M_PriceList_ID |
+      | plv_S30558_020 | pl_S30558_020  |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | plv_S30558_020         | p_S30558_020 | 5.0      | PCE      | Normal           |
+
+    And metasfresh contains C_BPartners without locations:
+      | Identifier    | IsCustomer | M_PricingSystem_ID | GLN           |
+      | bp_S30558_020 | Y          | ps_S30558_020      | 9900000305582 |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier       | GLN           | C_BPartner_ID | OPT.IsBillToDefault | OPT.IsShipTo |
+      | bpLoc_S30558_020 | 2900000305582 | bp_S30558_020 | true                | true         |
+    And metasfresh contains C_BPartner_EDI_Setting:
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN | Identifier                |
+      | bp_S30558_020 | true                 | 9900000305582         | edi_setting_S30558_020_bp |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID |
+      | bp_S30558_020 | p_S30558_020 |
+
+    # HU PI: LU holds up to 20 TUs, each TU holds 10 PCE
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID       |
+      | pi_LU_S30558_020 |
+      | pi_TU_S30558_020 |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID       | HU_UnitType | IsCurrent |
+      | piv_LU_S30558_020  | pi_LU_S30558_020 | LU          | Y         |
+      | piv_TU_S30558_020  | pi_TU_S30558_020 | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID   | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID |
+      | pii_LU_S30558_020 | piv_LU_S30558_020  | 20  | HU       | pi_TU_S30558_020  |
+      | pii_TU_S30558_020 | piv_TU_S30558_020  | 0   | MI       |                   |
+    And metasfresh contains M_HU_PI_Attribute:
+      | M_HU_PI_Version_ID | M_Attribute.Value |
+      | piv_LU_S30558_020  | SSCC18            |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID   | M_Product_ID | Qty | ValidFrom  |
+      | pip_S30558_020          | pii_TU_S30558_020 | p_S30558_020 | 10  | 2020-01-01 |
+
+    # Mobile UI picking profile — DO_NOT_CREATE: no shipment is auto-created on job completion;
+    # both jobs finish first so the LU holds all 15 TUs before any shipment is generated.
+    And set mobile UI picking profile
+      | IsAllowPickingAnyHU | CreateShipmentPolicy | IsAllowCompletingPartialPickingJob | IsAlwaysSplitHUsEnabled |
+      | Y                   | DO_NOT_CREATE        | Y                                  | N                       |
+
+    # Source: aggregated LU with 150 PCE (5 TUs for order A + 10 TUs for order B)
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID | MovementDate | M_Warehouse_ID |
+      | inv_S30558_020 | 2026-05-26   | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | M_InventoryLine_ID  | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_S30558_020 | invLine_S30558_020  | p_S30558_020 | 0       | 150      | PCE          |
+    And complete inventory with inventoryIdentifier 'inv_S30558_020'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID  | M_HU_ID               |
+      | invLine_S30558_020  | pickFromCU_S30558_020 |
+
+    And transform CU to new LU
+      | sourceCU              | newLU                        | TU_PI_ID          | QtyCUsPerTU | QtyTUsPerLU |
+      | pickFromCU_S30558_020 | pickFromAggregatedLU_S30558b | pi_TU_S30558_020  | 10          | 15          |
+
+    # Order A — 50 PCE → 5 TUs.
+    And metasfresh contains C_Orders:
+      | Identifier    | IsSOTrx | C_BPartner_ID | DateOrdered | POReference |
+      | oA_S30558_020 | true    | bp_S30558_020 | 2026-05-26  | 1170000003  |
+    And metasfresh contains C_OrderLines:
+      | Identifier     | C_Order_ID    | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | olA_S30558_020 | oA_S30558_020 | p_S30558_020 | 50         | pip_S30558_020          |
+
+    When the order identified by oA_S30558_020 is completed
+
+    # Order B — 100 PCE → 10 TUs. Distinct POReference.
+    And metasfresh contains C_Orders:
+      | Identifier    | IsSOTrx | C_BPartner_ID | DateOrdered | POReference |
+      | oB_S30558_020 | true    | bp_S30558_020 | 2026-05-26  | 1170000004  |
+    And metasfresh contains C_OrderLines:
+      | Identifier     | C_Order_ID    | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | olB_S30558_020 | oB_S30558_020 | p_S30558_020 | 100        | pip_S30558_020          |
+
+    When the order identified by oB_S30558_020 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier     | C_OrderLine_ID | IsToRecompute |
+      | ssA_S30558_020 | olA_S30558_020 | N             |
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier     | C_OrderLine_ID | IsToRecompute |
+      | ssB_S30558_020 | olB_S30558_020 | N             |
+
+    # ─── Picking job 1: order A → new LU 'sharedLu_S30558_020' ──────────────────────
+    And start picking job for sales order identified by oA_S30558_020
+    And scan picking slot identified by 200.0
+    And set picking target as new LU identified by pi_LU_S30558_020
+    And pick lines
+      | PickingLine.byProduct | PickFromHU                   | QtyPicked |
+      | p_S30558_020          | pickFromAggregatedLU_S30558b | 5         |
+    And expect current picking target
+      | Existing_LU         |
+      | sharedLu_S30558_020 |
+    And complete picking job
+
+    # ─── Picking job 2: order B targets the SAME LU (LUPickingTarget.ofExistingHU) ──
+    # Both jobs done — the LU now physically holds all 15 TUs.
+    And start picking job for sales order identified by oB_S30558_020
+    And scan picking slot identified by 200.0
+    And set picking target as existing LU identified by sharedLu_S30558_020
+    And pick lines
+      | PickingLine.byProduct | PickFromHU                   | QtyPicked |
+      | p_S30558_020          | pickFromAggregatedLU_S30558b | 10        |
+    And complete picking job
+
+    # ─── Stamp SSCC18 on the shared LU ───────────────────────────────────────────────
+    And M_HU_Attribute is changed
+      | M_HU_ID             | M_Attribute_ID.Value | Value              |
+      | sharedLu_S30558_020 | SSCC18               | 987654321000003059 |
+
+    # ─── Generate DRAFT shipments for BOTH schedules, then complete ioA only ─────────
+    # State after: ioA=CO, ioB=IP (draft) — order B's TUs on the LU are covered only by a draft shipment.
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ssA_S30558_020        | PD           | false               | false       |
+      | ssB_S30558_020        | PD           | false               | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID     |
+      | ssA_S30558_020        | ioA_S30558_020 |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID     |
+      | ssB_S30558_020        | ioB_S30558_020 |
+    And the shipment identified by ioA_S30558_020 is completed
+
+    # RED gate: ioA=CO, ioB=IP — order B's TUs are covered only by a DRAFT shipment (not CO/CL).
+    # Correct post-fix behaviour: {} (sibling draft → LU not fully covered by completed shipments).
+    # This assertion MUST FAIL on the current (un-gated) code.
+    Then the EPCIS JSON export function returns empty object for M_InOut identified by ioA_S30558_020
+
+    # ─── Complete ioB — now all 15 TUs on the LU are covered by CO shipments ─────────
+    And the shipment identified by ioB_S30558_020 is completed
+
+    # ─── After both completions: ioA (lower ID = owner) returns the merged pallet ────
+    When the EPCIS JSON export function is called for M_InOut identified by ioA_S30558_020
+    Then the EPCIS JSON pallets contain SSCC18 values in any order:
+      | sscc18             |
+      | 987654321000003059 |
+    And the EPCIS JSON pallet has:
+      | palletIndex | sscc               | crateCount |
+      | 0           | 987654321000003059 | 15         |
+    And the EPCIS JSON array field has:
+      | field            | expectedSize |
+      | desadvReferences | 2            |
+      | poReferences     | 2            |
+    Then the EPCIS JSON pallet 0 crates are order-pure with POReferences:
+      | poReference |
+      | 1170000003  |
+      | 1170000004  |
+
+    # ─── ioB (sibling) must return {} ────────────────────────────────────────────────
+    Then the EPCIS JSON export function returns empty object for M_InOut identified by ioB_S30558_020

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -763,9 +763,10 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
       | plv_S30558_010         | p_S30558_010 | 5.0      | PCE      | Normal           |
 
+    # AllowConsolidateInOut=N so the two orders' shipments stay separate M_InOuts (no consolidation)
     And metasfresh contains C_BPartners without locations:
-      | Identifier    | IsCustomer | M_PricingSystem_ID | GLN           |
-      | bp_S30558_010 | Y          | ps_S30558_010      | 9900000305580 |
+      | Identifier    | IsCustomer | M_PricingSystem_ID | GLN           | AllowConsolidateInOut |
+      | bp_S30558_010 | Y          | ps_S30558_010      | 9900000305580 | N                     |
     And metasfresh contains C_BPartner_Locations:
       | Identifier       | GLN           | C_BPartner_ID | OPT.IsBillToDefault | OPT.IsShipTo |
       | bpLoc_S30558_010 | 2900000305580 | bp_S30558_010 | true                | true         |
@@ -963,9 +964,10 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
       | plv_S30558_020         | p_S30558_020 | 5.0      | PCE      | Normal           |
 
+    # AllowConsolidateInOut=N so the two orders' shipments stay separate M_InOuts (no consolidation)
     And metasfresh contains C_BPartners without locations:
-      | Identifier    | IsCustomer | M_PricingSystem_ID | GLN           |
-      | bp_S30558_020 | Y          | ps_S30558_020      | 9900000305582 |
+      | Identifier    | IsCustomer | M_PricingSystem_ID | GLN           | AllowConsolidateInOut |
+      | bp_S30558_020 | Y          | ps_S30558_020      | 9900000305582 | N                     |
     And metasfresh contains C_BPartner_Locations:
       | Identifier       | GLN           | C_BPartner_ID | OPT.IsBillToDefault | OPT.IsShipTo |
       | bpLoc_S30558_020 | 2900000305582 | bp_S30558_020 | true                | true         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -904,7 +904,7 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
     # ─── Complete ioB — now all 15 TUs on the LU are covered by CO shipments ─────────
     And the shipment identified by ioB_S30558_010 is completed
 
-    # ─── After both completions: ioA (lower M_InOut_ID = owner) returns the merged pallet ─
+    # ─── After both completions (pallet fully shipped): the merged order-pure event is emitted ─
     When the EPCIS JSON export function is called for M_InOut identified by ioA_S30558_010
     Then the EPCIS JSON pallets contain SSCC18 values in any order:
       | sscc18             |
@@ -922,8 +922,11 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | 1170000001  |
       | 1170000002  |
 
-    # ─── ioB (sibling) must return {} ────────────────────────────────────────────────
-    Then the EPCIS JSON export function returns empty object for M_InOut identified by ioB_S30558_010
+    # ─── Post-fix the sibling (ioB) ALSO returns the merged pallet — no fixed owner ───
+    When the EPCIS JSON export function is called for M_InOut identified by ioB_S30558_010
+    And the EPCIS JSON pallet has:
+      | palletIndex | sscc               | crateCount |
+      | 0           | 987654321000003058 | 15         |
 
   @Id:S30558_020
   @allure.label.epic:E0292_EDI
@@ -1101,7 +1104,7 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
     # ─── Complete ioA — now all 15 TUs on the LU are covered by CO shipments ─────────
     And the shipment identified by ioA_S30558_020 is completed
 
-    # ─── After both completions: ioA (lower M_InOut_ID = owner) returns the merged pallet ─
+    # ─── After both completions (pallet fully shipped): the merged order-pure event is emitted ─
     When the EPCIS JSON export function is called for M_InOut identified by ioA_S30558_020
     Then the EPCIS JSON pallets contain SSCC18 values in any order:
       | sscc18             |
@@ -1119,5 +1122,8 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | 1170000003  |
       | 1170000004  |
 
-    # ─── ioB (sibling) must return {} ────────────────────────────────────────────────
-    Then the EPCIS JSON export function returns empty object for M_InOut identified by ioB_S30558_020
+    # ─── Post-fix the sibling (ioB) ALSO returns the merged pallet — no fixed owner ───
+    When the EPCIS JSON export function is called for M_InOut identified by ioB_S30558_020
+    And the EPCIS JSON pallet has:
+      | palletIndex | sscc               | crateCount |
+      | 0           | 987654321000003059 | 15         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -732,19 +732,14 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
   @Id:S30558_010
   @allure.label.epic:E0292_EDI
   @allure.label.feature:F00353_EDI_DESADV_InOut_Link
-  Scenario: S30558_010 — Two orders share one LU, sibling shipment not yet generated: function returns {} for ioA until ioB is also completed
-  ## Completion-ordering gate (me03 #30558): when two sales orders are picked onto ONE shared
-  ## physical pallet (ONE SSCC18), the function must return {} for the first-completed shipment
-  ## until ALL TUs on the LU are covered by a CO/CL shipment.
-  ## This scenario uses DO_NOT_CREATE + QuantityType=P (picked-only): both picking jobs
-  ## complete FIRST (so the LU physically holds all 15 TUs from both orders), then shipments
-  ## are generated sequentially. ioA is generated+completed alone (QuantityType=P restricts it
-  ## to order A's 5 picked TUs = 50 PCE). At that point ioB has no shipment yet — order B's
-  ## 10 TUs are physically on the shared LU but uncovered by any CO/CL shipment. The RED gate
-  ## assertion fires after completing ioA: the current (un-gated) function emits a non-empty
-  ## partial event for ioA because it sees no sibling M_InOut, so the 'returns empty object'
-  ## assertion FAILS. ioB is then generated+completed, closing the pallet; ioA then returns
-  ## the merged full event and ioB returns {}.
+  Scenario: S30558_010 — Both draft shipments generated first, then ioA completed first: gate returns {} for ioA until ioB is also completed
+  ## Completion-ordering gate (me03 #30558): both-drafts flow — generate BOTH shipments as
+  ## drafts FIRST (each claims its own picked TUs, QuantityType=P), then complete in order.
+  ## Completing ioA first while ioB is only a draft means order B's 10 TUs are covered only
+  ## by a draft shipment (not CO/CL). The RED gate assertion fires after completing ioA:
+  ## the current (un-gated) function emits a non-empty partial event, so the
+  ## 'returns empty object' assertion FAILS (intended RED). After ioB is also completed,
+  ## ioA (lower M_InOut_ID = owner) returns the merged full event; ioB returns {}.
     And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
     And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
 
@@ -880,29 +875,36 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | M_HU_ID             | M_Attribute_ID.Value | Value              |
       | sharedLu_S30558_010 | SSCC18               | 987654321000003058 |
 
-    # ─── Generate + complete ioA alone (QuantityType=P = picked-only → 5 TUs = 50 PCE) ─
-    # ioB has no shipment yet; its 10 TUs are physically on the LU but uncovered.
+    # ─── Both-drafts flow: generate DRAFT for ssA, then separately for ssB ─────────────
+    # Each schedule claims its own picked TUs (QuantityType=P); generating both as drafts
+    # before completing either ensures no schedule sweeps the whole LU on its own.
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
-      | ssA_S30558_010        | P            | true                | false       |
+      | ssA_S30558_010        | P            | false               | false       |
     Then after not more than 60s, M_InOut is found:
-      | M_ShipmentSchedule_ID | M_InOut_ID     | OPT.DocStatus |
-      | ssA_S30558_010        | ioA_S30558_010 | CO            |
+      | M_ShipmentSchedule_ID | M_InOut_ID     |
+      | ssA_S30558_010        | ioA_S30558_010 |
 
-    # RED gate — ioB has no shipment yet (its 10 TUs are on the LU but uncovered by any CO/CL M_InOut):
-    # Correct post-fix behaviour: {} (LU not fully covered → gate blocks emission).
-    # This assertion MUST FAIL on the current (un-gated) code.
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ssB_S30558_010        | P            | false               | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID     |
+      | ssB_S30558_010        | ioB_S30558_010 |
+
+    # ─── Complete ioA first ───────────────────────────────────────────────────────────
+    And the shipment identified by ioA_S30558_010 is completed
+
+    # RED gate — ioB is still a draft (IP): order B's 10 TUs on the LU are covered only
+    # by a draft shipment, not a CO/CL. Correct post-fix behaviour: {} (LU not fully covered
+    # by completed shipments → gate blocks emission).
+    # This assertion MUST FAIL on the current (un-gated) code (intended RED).
     Then the EPCIS JSON export function returns empty object for M_InOut identified by ioA_S30558_010
 
-    # ─── Generate + complete ioB — now all 15 TUs on the LU are covered ─────────────
-    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
-      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
-      | ssB_S30558_010        | P            | true                | false       |
-    Then after not more than 60s, M_InOut is found:
-      | M_ShipmentSchedule_ID | M_InOut_ID     | OPT.DocStatus |
-      | ssB_S30558_010        | ioB_S30558_010 | CO            |
+    # ─── Complete ioB — now all 15 TUs on the LU are covered by CO shipments ─────────
+    And the shipment identified by ioB_S30558_010 is completed
 
-    # ─── After both completions: ioA (lower ID = owner) returns the merged pallet ────
+    # ─── After both completions: ioA (lower M_InOut_ID = owner) returns the merged pallet ─
     When the EPCIS JSON export function is called for M_InOut identified by ioA_S30558_010
     Then the EPCIS JSON pallets contain SSCC18 values in any order:
       | sscc18             |
@@ -926,15 +928,15 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
   @Id:S30558_020
   @allure.label.epic:E0292_EDI
   @allure.label.feature:F00353_EDI_DESADV_InOut_Link
-  Scenario: S30558_020 — Two orders share one LU, sibling shipment generated but still draft: function returns {} for ioA until ioB is also completed
-  ## Completion-ordering gate (me03 #30558): same shared-pallet setup as S30558_010.
-  ## Uses DO_NOT_CREATE: both picking jobs finish, then BOTH shipment schedules are
-  ## individually generated as DRAFT. Only ioA is completed; ioB remains DRAFT (IP).
-  ## State: ioA=CO, ioB=IP — order B's TUs on the LU are covered only by a draft shipment.
-  ## The RED gate assertion fires after completing ioA: the current (un-gated) function
-  ## emits a non-empty partial event because it does not check that the sibling is CO/CL,
-  ## so the 'returns empty object' assertion FAILS on current code (expected RED).
-  ## After ioB is completed, ioA returns the merged pallet; ioB returns {}.
+  Scenario: S30558_020 — Both draft shipments generated first, then ioB completed first: gate returns {} for ioB until ioA is also completed
+  ## Completion-ordering gate (me03 #30558): both-drafts flow — symmetric to S30558_010 but
+  ## completion order is reversed: ioB is completed first.
+  ## Generate BOTH shipments as drafts FIRST (each claims its own picked TUs, QuantityType=P),
+  ## then complete ioB first. At that point ioA is still a draft (IP) — order A's 5 TUs on
+  ## the LU are covered only by a draft shipment (not CO/CL). The RED gate assertion fires
+  ## after completing ioB: the current (un-gated) function emits a non-empty partial event,
+  ## so the 'returns empty object' assertion FAILS (intended RED). After ioA is also completed,
+  ## ioA (lower M_InOut_ID = owner) returns the merged full event; ioB returns {}.
     And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
     And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
 
@@ -1070,29 +1072,36 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | M_HU_ID             | M_Attribute_ID.Value | Value              |
       | sharedLu_S30558_020 | SSCC18               | 987654321000003059 |
 
-    # ─── Generate DRAFT shipments for BOTH schedules, then complete ioA only ─────────
-    # State after: ioA=CO, ioB=IP (draft) — order B's TUs on the LU are covered only by a draft shipment.
+    # ─── Both-drafts flow: generate DRAFT for ssA, then separately for ssB ─────────────
+    # Each schedule claims its own picked TUs (QuantityType=P); generating both as drafts
+    # before completing either ensures no schedule sweeps the whole LU on its own.
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
-      | ssA_S30558_020        | PD           | false               | false       |
-      | ssB_S30558_020        | PD           | false               | false       |
+      | ssA_S30558_020        | P            | false               | false       |
     Then after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID     |
       | ssA_S30558_020        | ioA_S30558_020 |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ssB_S30558_020        | P            | false               | false       |
     Then after not more than 60s, M_InOut is found:
       | M_ShipmentSchedule_ID | M_InOut_ID     |
       | ssB_S30558_020        | ioB_S30558_020 |
-    And the shipment identified by ioA_S30558_020 is completed
 
-    # RED gate: ioA=CO, ioB=IP — order B's TUs are covered only by a DRAFT shipment (not CO/CL).
-    # Correct post-fix behaviour: {} (sibling draft → LU not fully covered by completed shipments).
-    # This assertion MUST FAIL on the current (un-gated) code.
-    Then the EPCIS JSON export function returns empty object for M_InOut identified by ioA_S30558_020
-
-    # ─── Complete ioB — now all 15 TUs on the LU are covered by CO shipments ─────────
+    # ─── Complete ioB first (symmetric ordering vs. S30558_010) ──────────────────────
     And the shipment identified by ioB_S30558_020 is completed
 
-    # ─── After both completions: ioA (lower ID = owner) returns the merged pallet ────
+    # RED gate — ioA is still a draft (IP): order A's 5 TUs on the LU are covered only
+    # by a draft shipment, not a CO/CL. Correct post-fix behaviour: {} (LU not fully covered
+    # by completed shipments → gate blocks emission).
+    # This assertion MUST FAIL on the current (un-gated) code (intended RED).
+    Then the EPCIS JSON export function returns empty object for M_InOut identified by ioB_S30558_020
+
+    # ─── Complete ioA — now all 15 TUs on the LU are covered by CO shipments ─────────
+    And the shipment identified by ioA_S30558_020 is completed
+
+    # ─── After both completions: ioA (lower M_InOut_ID = owner) returns the merged pallet ─
     When the EPCIS JSON export function is called for M_InOut identified by ioA_S30558_020
     Then the EPCIS JSON pallets contain SSCC18 values in any order:
       | sscc18             |
@@ -1101,9 +1110,10 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | palletIndex | sscc               | crateCount |
       | 0           | 987654321000003059 | 15         |
     And the EPCIS JSON array field has:
-      | field            | expectedSize |
-      | desadvReferences | 2            |
-      | poReferences     | 2            |
+      | field               | expectedSize |
+      | desadvReferences    | 2            |
+      | poReferences        | 2            |
+      | shipmentDocumentNos | 2            |
     Then the EPCIS JSON pallet 0 crates are order-pure with POReferences:
       | poReference |
       | 1170000003  |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -929,6 +929,7 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | palletIndex | sscc               | crateCount |
       | 0           | 987654321000003058 | 15         |
 
+  @from:cucumber
   @Id:S30558_020
   @allure.label.epic:E0292_EDI
   @allure.label.feature:F00353_EDI_DESADV_InOut_Link

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -481,16 +481,17 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
   @Id:S29231_170
   @allure.label.epic:E0292_EDI
   @allure.label.feature:F00353_EDI_DESADV_InOut_Link
-  Scenario: S29231_170 — Two mobile-picking jobs share one LU: EPCIS emits ONE event per physical SSCC (owner merges both orders, sibling returns {})
-  ## Contract per customer clarification (two orders picked onto one shared pallet):
+  Scenario: S29231_170 — Two mobile-picking jobs share one LU: EPCIS emits ONE merged event per physical SSCC on the pallet-closing completion; post-closure either sharer returns the full pallet
+  ## Close-driven semantics (two orders picked onto one shared pallet):
   ## When two sales orders are picked onto ONE shared physical pallet (ONE SSCC), the
-  ## get_epcis_events_json_fn must emit exactly ONE picking+commissioning event for that
-  ## SSCC. The owner shipment (lowest M_InOut_ID sharing the LU) returns the full event:
+  ## get_epcis_events_json_fn emits exactly ONE picking+commissioning event for that
+  ## SSCC once the pallet is fully closed (all sharers completed). The queried shipment
+  ## returns the full merged event:
   ##   - pallets[0].crates = ALL crates from both orders on that LU (15 total)
   ##   - desadvReferences[] size 2 (one per DESADV)
   ##   - poReferences[]     size 2 (one per order)
-  ## The sibling shipment (higher M_InOut_ID) must return {} (empty object) so the receiver's
-  ## system does not render a duplicate event for the same physical SSCC.
+  ## Post-closure, EITHER sharer (ioA or ioB) returns the full merged pallet — there is
+  ## no fixed owner; single-emission guarantee is covered by the Task-4 e2e scenario.
   ##
   ## The test uses two real mobile picking jobs (LUPickingTarget.ofExistingHU on the
   ## second job) to reproduce the shared-pallet shape via the production code path.
@@ -642,11 +643,10 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | dA_S29231_170            | bp_S29231_170            | oA_S29231_170         |
       | dB_S29231_170            | bp_S29231_170            | oB_S29231_170         |
 
-    # ─── Per-SSCC contract (customer clarification) ───────────────────────────────────
-    # ioA has the lower M_InOut_ID (created first) → it is the OWNER.
-    # The owner's event merges ALL crates from the shared physical LU (5 TUs from order A
-    # + 10 TUs from order B = 15 crates total) and carries both DESADV + PO references.
-    # ioB is the SIBLING → the function must return {} so no duplicate event is emitted.
+    # ─── Per-SSCC contract (close-driven semantics) ───────────────────────────────────
+    # Both shipments are completed (pallet fully closed). The queried shipment (ioA) returns
+    # the full merged event covering ALL crates from the shared physical LU (5 TUs from
+    # order A + 10 TUs from order B = 15 crates total) with both DESADV + PO references.
     When the EPCIS JSON export function is called for M_InOut identified by ioA_S29231_170
     Then the EPCIS JSON pallets contain SSCC18 values in any order:
       | sscc18             |
@@ -672,13 +672,11 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | 1170000001  |
       | 1170000002  |
 
-    # ─── Sibling shipment B must return {} (no duplicate event for the same SSCC) ──────
-    Then the EPCIS JSON export function returns empty object for M_InOut identified by ioB_S29231_170
-
-    # ─── Export-relevance predicate (drives the scripted-adapter outbound WHERE-clause, so the
-    #     sibling is never selected for export → metasfresh never emits an empty EPCIS document) ──
-    Then the EPCIS export-relevance for M_InOut identified by ioA_S29231_170 is true
-    And the EPCIS export-relevance for M_InOut identified by ioB_S29231_170 is false
+    # ─── Post-closure: sibling (ioB) ALSO returns the merged pallet — no fixed owner ───
+    When the EPCIS JSON export function is called for M_InOut identified by ioB_S29231_170
+    And the EPCIS JSON pallet has:
+      | palletIndex | sscc               | crateCount |
+      | 0           | 987654321000001700 | 15         |
 
     # ─── DESADV-JSON regression via M_InOut_EDI_Export_JSON/invoke ───────────────────
     # Exercises get_desadv_packs_json_fn's per-M_InOut filter through the production REST

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -735,11 +735,15 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
   ## Completion-ordering gate (me03 #30558): when two sales orders are picked onto ONE shared
   ## physical pallet (ONE SSCC18), the function must return {} for the first-completed shipment
   ## until ALL TUs on the LU are covered by a CO/CL shipment.
-  ## This scenario uses DO_NOT_CREATE: both picking jobs complete FIRST (so the LU physically
-  ## holds all 15 TUs), then shipments are generated individually. ioA is completed while ioB
-  ## has no shipment yet (its 10 TUs are on the LU but uncovered). The RED gate assertion fires
-  ## after completing ioA: the current (un-gated) function emits a non-empty partial event
-  ## for ioA because it sees no sibling M_InOut, so the 'returns empty object' assertion FAILS.
+  ## This scenario uses DO_NOT_CREATE + QuantityType=P (picked-only): both picking jobs
+  ## complete FIRST (so the LU physically holds all 15 TUs from both orders), then shipments
+  ## are generated sequentially. ioA is generated+completed alone (QuantityType=P restricts it
+  ## to order A's 5 picked TUs = 50 PCE). At that point ioB has no shipment yet — order B's
+  ## 10 TUs are physically on the shared LU but uncovered by any CO/CL shipment. The RED gate
+  ## assertion fires after completing ioA: the current (un-gated) function emits a non-empty
+  ## partial event for ioA because it sees no sibling M_InOut, so the 'returns empty object'
+  ## assertion FAILS. ioB is then generated+completed, closing the pallet; ioA then returns
+  ## the merged full event and ioB returns {}.
     And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
     And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
 
@@ -875,28 +879,27 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | M_HU_ID             | M_Attribute_ID.Value | Value              |
       | sharedLu_S30558_010 | SSCC18               | 987654321000003058 |
 
-    # ─── Generate and complete ioA only ──────────────────────────────────────────────
+    # ─── Generate + complete ioA alone (QuantityType=P = picked-only → 5 TUs = 50 PCE) ─
+    # ioB has no shipment yet; its 10 TUs are physically on the LU but uncovered.
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
-      | ssA_S30558_010        | PD           | false               | false       |
+      | ssA_S30558_010        | P            | true                | false       |
     Then after not more than 60s, M_InOut is found:
-      | M_ShipmentSchedule_ID | M_InOut_ID     |
-      | ssA_S30558_010        | ioA_S30558_010 |
-    And the shipment identified by ioA_S30558_010 is completed
+      | M_ShipmentSchedule_ID | M_InOut_ID     | OPT.DocStatus |
+      | ssA_S30558_010        | ioA_S30558_010 | CO            |
 
     # RED gate — ioB has no shipment yet (its 10 TUs are on the LU but uncovered by any CO/CL M_InOut):
     # Correct post-fix behaviour: {} (LU not fully covered → gate blocks emission).
     # This assertion MUST FAIL on the current (un-gated) code.
     Then the EPCIS JSON export function returns empty object for M_InOut identified by ioA_S30558_010
 
-    # ─── Generate and complete ioB — now all 15 TUs on the LU are covered ────────────
+    # ─── Generate + complete ioB — now all 15 TUs on the LU are covered ─────────────
     And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
       | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
-      | ssB_S30558_010        | PD           | false               | false       |
+      | ssB_S30558_010        | P            | true                | false       |
     Then after not more than 60s, M_InOut is found:
-      | M_ShipmentSchedule_ID | M_InOut_ID     |
-      | ssB_S30558_010        | ioB_S30558_010 |
-    And the shipment identified by ioB_S30558_010 is completed
+      | M_ShipmentSchedule_ID | M_InOut_ID     | OPT.DocStatus |
+      | ssB_S30558_010        | ioB_S30558_010 | CO            |
 
     # ─── After both completions: ioA (lower ID = owner) returns the merged pallet ────
     When the EPCIS JSON export function is called for M_InOut identified by ioA_S30558_010
@@ -907,9 +910,10 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | palletIndex | sscc               | crateCount |
       | 0           | 987654321000003058 | 15         |
     And the EPCIS JSON array field has:
-      | field            | expectedSize |
-      | desadvReferences | 2            |
-      | poReferences     | 2            |
+      | field               | expectedSize |
+      | desadvReferences    | 2            |
+      | poReferences        | 2            |
+      | shipmentDocumentNos | 2            |
     Then the EPCIS JSON pallet 0 crates are order-pure with POReferences:
       | poReference |
       | 1170000001  |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
@@ -294,7 +294,7 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
       | Identifier    | GLN           | C_BPartner_ID | OPT.IsBillToDefault | OPT.IsShipTo |
       | bpLoc_040     | 2900000305584 | bp_040        | true                | true         |
     And metasfresh contains C_BPartner_EDI_Setting:
-      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN | EdiDesadvSendingMode | EdiDESADV_ExternalSystem_Config_ID | Identifier       |
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN | EdiDESADVSendingMode | EdiDESADV_ExternalSystem_Config_ID | Identifier       |
       | bp_040        | true                 | 9900000305584         | E                    | esConfig_040                       | edi_setting_040  |
 
     And metasfresh contains C_BPartner_Product

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
@@ -260,3 +260,182 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
     Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
       | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus |
       | io_040     | scriptedCfg_gated                                 | U            |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00353_EDI_DESADV_InOut_Link
+  @ghActions:run_on_executor7
+  @Id:S30558_040
+  Scenario: S30558_040 — shared-LU pallet: first completion yields DontSend, closing completion yields Enqueued
+    ## Close-gate / closer-enqueues: two orders are picked onto ONE shared physical pallet (one SSCC).
+    ## The scripted-export config is gated on "de.metas.edi".epcis_has_events(m_inout_id) — a function
+    ## that returns true only when the pallet is fully covered by completed (CO/CL) shipments.
+    ##
+    ## Flow:
+    ##   1. Both picking jobs complete onto ONE shared LU (DO_NOT_CREATE policy — no auto-shipment).
+    ##   2. Both shipments generated as drafts (QuantityType=P, IsCompleteShipments=false).
+    ##   3. ioA completed first → epcis_has_events(ioA) = false (ioB still draft) → ExportStatus = N (DontSend).
+    ##   4. ioB completed (closer) → epcis_has_events(ioB) = true (all TUs now CO) → ExportStatus = U (Enqueued).
+    ##
+    ## This proves the CLOSER — not the first completer — is the one enqueued for scripted EPCIS export.
+
+    # Gated scripted-export config: WhereClause returns true only when the shared pallet is fully
+    # covered by completed shipments. Overrides the Background's always-true config (table-scoped takeover).
+    And metasfresh contains ExternalSystem_Config with ScriptedExportConversion and StatusColumn:
+      | ExternalSystem_Config_ID | ExternalSystem_Config_ScriptedExportConversion_ID | AD_Process_OutboundData_ID.Value | TableName | WhereClause                                  |
+      | esConfig_040             | scriptedCfg_040                                   | M_InOut_EDI_Export_JSON          | M_InOut   | "de.metas.edi".epcis_has_events(m_inout_id) |
+
+    # Dedicated BPartner with AllowConsolidateInOut=N — keeps the two orders' shipments as separate M_InOuts.
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsCustomer | M_PricingSystem_ID | GLN           | AllowConsolidateInOut |
+      | bp_040     | Y          | ps_es              | 9900000305584 | N                     |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier    | GLN           | C_BPartner_ID | OPT.IsBillToDefault | OPT.IsShipTo |
+      | bpLoc_040     | 2900000305584 | bp_040        | true                | true         |
+    And metasfresh contains C_BPartner_EDI_Setting:
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN | EdiDesadvSendingMode | EdiDESADV_ExternalSystem_Config_ID | Identifier       |
+      | bp_040        | true                 | 9900000305584         | E                    | esConfig_040                       | edi_setting_040  |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID |
+      | bp_040        | product_es   |
+
+    # HU PI: LU holds up to 20 TUs
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID  |
+      | pi_LU_040   |
+      | pi_TU_040   |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType | IsCurrent |
+      | piv_LU_040         | pi_LU_040  | LU          | Y         |
+      | piv_TU_040         | pi_TU_040  | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID |
+      | pii_LU_040      | piv_LU_040         | 20  | HU       | pi_TU_040         |
+      | pii_TU_040      | piv_TU_040         | 0   | MI       |                   |
+    And metasfresh contains M_HU_PI_Attribute:
+      | M_HU_PI_Version_ID | M_Attribute.Value |
+      | piv_LU_040         | SSCC18            |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID | Qty | ValidFrom  |
+      | pip_LU_TU_040           | pii_TU_040      | product_es   | 10  | 2020-01-01 |
+
+    # DO_NOT_CREATE: no shipment is auto-created on picking job completion;
+    # both picking jobs finish before any shipment is generated.
+    And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
+    And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
+    And metasfresh contains M_PickingSlot:
+      | Identifier | PickingSlot | IsDynamic |
+      | slot_040   | 300.0       | Y         |
+    And set mobile UI picking profile
+      | IsAllowPickingAnyHU | CreateShipmentPolicy | IsAllowCompletingPartialPickingJob | IsAlwaysSplitHUsEnabled |
+      | Y                   | DO_NOT_CREATE        | Y                                  | N                       |
+
+    # Source stock: 150 PCE (5 TUs for order A + 10 TUs for order B)
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID | MovementDate | M_Warehouse_ID |
+      | inv_040        | 2026-06-09   | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | M_InventoryLine_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_040        | invLine_040        | product_es   | 0       | 150      | PCE          |
+    And complete inventory with inventoryIdentifier 'inv_040'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID | M_HU_ID      |
+      | invLine_040        | pickFromCU_040 |
+
+    And transform CU to new LU
+      | sourceCU       | newLU                    | TU_PI_ID  | QtyCUsPerTU | QtyTUsPerLU |
+      | pickFromCU_040 | pickFromAggregatedLU_040 | pi_TU_040 | 10          | 15          |
+
+    # Order A — 50 PCE → 5 TUs. Distinct POReference.
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference |
+      | oA_040     | true    | bp_040        | 2026-06-09  | 3058400001  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | olA_040    | oA_040     | product_es   | 50         | pip_LU_TU_040           |
+
+    When the order identified by oA_040 is completed
+
+    # Order B — 100 PCE → 10 TUs. Distinct POReference.
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference |
+      | oB_040     | true    | bp_040        | 2026-06-09  | 3058400002  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | olB_040    | oB_040     | product_es   | 100        | pip_LU_TU_040           |
+
+    When the order identified by oB_040 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ssA_040    | olA_040        | N             |
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ssB_040    | olB_040        | N             |
+
+    # ─── Picking job 1: order A → new shared LU ──────────────────────────────────────
+    And start picking job for sales order identified by oA_040
+    And scan picking slot identified by slot_040
+    And set picking target as new LU identified by pi_LU_040
+    And pick lines
+      | PickingLine.byProduct | PickFromHU               | QtyPicked |
+      | product_es            | pickFromAggregatedLU_040 | 5         |
+    And expect current picking target
+      | Existing_LU |
+      | sharedLu_040 |
+    And complete picking job
+
+    # ─── Picking job 2: order B → SAME LU (all 15 TUs on one physical pallet) ────────
+    And start picking job for sales order identified by oB_040
+    And scan picking slot identified by slot_040
+    And set picking target as existing LU identified by sharedLu_040
+    And pick lines
+      | PickingLine.byProduct | PickFromHU               | QtyPicked |
+      | product_es            | pickFromAggregatedLU_040 | 10        |
+    And complete picking job
+
+    # Stamp a deterministic SSCC18 on the shared LU for traceability.
+    And M_HU_Attribute is changed
+      | M_HU_ID      | M_Attribute_ID.Value | Value              |
+      | sharedLu_040 | SSCC18               | 987654321000003060 |
+
+    # ─── Both-drafts flow: generate DRAFT for ssA, then separately for ssB ──────────
+    # QuantityType=P: each schedule claims its own picked TUs without completing the shipment.
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ssA_040               | P            | false               | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | ssA_040               | ioA_040    |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ssB_040               | P            | false               | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | ssB_040               | ioB_040    |
+
+    # ─── Complete ioA first — ioB is still a draft ────────────────────────────────────
+    # epcis_has_events(ioA) = false: order B's 10 TUs are covered only by a draft shipment (not CO/CL).
+    # The gate evaluates false → scripted export records DontSend (N) for ioA.
+    And the shipment identified by ioA_040 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus |
+      | ioA_040    | scriptedCfg_040                                   | N            |
+
+    # ─── Complete ioB — closing completion; all TUs now covered by CO shipments ───────
+    # epcis_has_events(ioB) = true: pallet is fully closed → gate passes → Enqueued (U).
+    And the shipment identified by ioB_040 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus |
+      | ioB_040    | scriptedCfg_040                                   | U            |

--- a/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
@@ -92,7 +92,12 @@ BEGIN
           AND iol.m_inout_id = p_m_inout_id
     )
     AND EXISTS (
-        -- ... and there is at least one child TU on a touched LU not yet covered by a CO/CL inout
+        -- Close-gate (AC1): block emission until EVERY physical child TU on every touched LU is
+        -- covered by a CO/CL shipment. This is intentional: we emit one complete merged event only
+        -- once the entire physical pallet is shipped. A TU that belongs to a still-open (IP) or
+        -- not-yet-assigned shipment will keep the gate open. When this shipment touches multiple
+        -- LUs the gate is all-or-nothing across ALL of them — the event is emitted together for
+        -- the complete set of LUs or not at all.
         SELECT 1
         FROM m_hu_assignment ha
                  JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
@@ -113,6 +118,7 @@ BEGIN
                        JOIN m_inout io2 ON io2.m_inout_id = iol2.m_inout_id
               WHERE ha2.ad_table_id = v_m_inoutline_table_id
                 AND ha2.isactive = 'Y'
+                AND iol2.isactive = 'Y'
                 AND (ha2.m_tu_hu_id = tu.m_hu_id OR ha2.vhu_id = tu.m_hu_id)
                 AND io2.docstatus IN ('CO', 'CL')
           )
@@ -135,13 +141,12 @@ BEGIN
           AND iol.m_inout_id = p_m_inout_id
     ),
     shared_lu_inout AS MATERIALIZED (
-        -- (lu, m_inout) pairs: every active completed/closed shipment that has goods physically
-        -- assigned to an LU. Voided/reversed/in-progress shipments are excluded so they can never
-        -- be elected owner (which would otherwise silence the active shipment for that SSCC).
-        -- Scoped to the LUs THIS shipment touches (this_inout_lu): the m_lu_hu_id IN-list lets the
-        -- m_hu_assignment_m_lu_hu_id index drive the scan (a handful of LUs) instead of a full
-        -- table scan. Owner election is unchanged — for each of THIS shipment's LUs we still see
-        -- ALL shipments sharing it (the filter is on m_lu_hu_id, not m_inout_id), so MIN() is exact.
+        -- (lu, m_inout) pairs: every CO/CL shipment that has goods physically assigned to an LU
+        -- touched by THIS shipment. Voided/reversed/in-progress shipments are excluded.
+        -- Scoped to the LUs THIS shipment touches (this_inout_lu) so the m_lu_hu_id IN-list
+        -- drives the m_hu_assignment_m_lu_hu_id index (a handful of LUs) instead of a full scan.
+        -- Used to enumerate all sibling CO/CL shipments sharing an LU — feeds DESADV/PO reference
+        -- aggregation (desadv_agg, po_agg, pallet_list) and gives the full set of co-shippers.
         SELECT DISTINCT ha.m_lu_hu_id AS lu_hu_id, iol.m_inout_id
         FROM m_hu_assignment ha
                  JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
@@ -264,10 +269,10 @@ BEGIN
              -- CASE A: individual TU HU IDs across all pallets — no attribute joins yet.
              --
              -- Scoped to TUs allocated to SOME shipment via m_hu_assignment (excludes unshipped
-             -- TUs on a partial pallet). Under the one-EPCIS-event-per-physical-SSCC rule the
-             -- scope gate is the OWNED LU (pallet_list, restricted to LUs this shipment owns), NOT
-             -- the M_InOut: when two shipments share a physical LU, the owner's event intentionally
-             -- merges the individual TUs of BOTH source orders onto that one SSCC.
+             -- TUs on a partial pallet). Under the close-gate / closer-emits model, pallet_list
+             -- covers ALL LUs touched by any of the CO/CL sibling shipments (not owner-restricted).
+             -- When two shipments share a physical LU, the emitting shipment merges the individual
+             -- TUs of BOTH source orders onto that one SSCC.
              SELECT lu_hu.m_hu_id                 AS lu_hu_id,
                     pl.lu_poreference_padded,
                     tu_hu.m_hu_id                 AS tu_hu_id,
@@ -292,10 +297,10 @@ BEGIN
              --         both attribute lookup and storage item joins (avoids double m_hu scan).
              --
              -- Scoped to HA aggregates allocated to SOME shipment via m_hu_assignment; ha_item.qty
-             -- carries the crate count. Under the one-EPCIS-event-per-physical-SSCC rule the scope
-             -- gate is the OWNED LU (pallet_list), NOT the M_InOut: when two shipments share a
-             -- physical LU, the owner's event intentionally merges the HA aggregates of
-             -- BOTH source orders onto that one SSCC.
+             -- carries the crate count. Under the close-gate / closer-emits model, pallet_list
+             -- covers ALL LUs touched by any of the CO/CL sibling shipments (not owner-restricted).
+             -- When two shipments share a physical LU, the emitting shipment merges the HA
+             -- aggregates of BOTH source orders onto that one SSCC.
              SELECT lu_hu.m_hu_id                           AS lu_hu_id,
                     pl.lu_poreference_padded,
                     ha_item.m_hu_item_id                    AS tu_hu_id,

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5809860_sys_me03_30558_epcis_close_gate.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5809860_sys_me03_30558_epcis_close_gate.sql
@@ -1,3 +1,4 @@
+-- Source DDL: backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
 /*
  * #%L
  * de.metas.edi

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5809860_sys_me03_30558_epcis_close_gate.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5809860_sys_me03_30558_epcis_close_gate.sql
@@ -1,4 +1,4 @@
-﻿-- Source DDL: backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
+-- Source DDL: backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
 /*
  * #%L
  * de.metas.edi

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5809860_sys_me03_30558_epcis_close_gate.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5809860_sys_me03_30558_epcis_close_gate.sql
@@ -1,4 +1,4 @@
--- Source DDL: backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
+﻿-- Source DDL: backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
 /*
  * #%L
  * de.metas.edi
@@ -93,7 +93,12 @@ BEGIN
           AND iol.m_inout_id = p_m_inout_id
     )
     AND EXISTS (
-        -- ... and there is at least one child TU on a touched LU not yet covered by a CO/CL inout
+        -- Close-gate (AC1): block emission until EVERY physical child TU on every touched LU is
+        -- covered by a CO/CL shipment. This is intentional: we emit one complete merged event only
+        -- once the entire physical pallet is shipped. A TU that belongs to a still-open (IP) or
+        -- not-yet-assigned shipment will keep the gate open. When this shipment touches multiple
+        -- LUs the gate is all-or-nothing across ALL of them — the event is emitted together for
+        -- the complete set of LUs or not at all.
         SELECT 1
         FROM m_hu_assignment ha
                  JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
@@ -114,6 +119,7 @@ BEGIN
                        JOIN m_inout io2 ON io2.m_inout_id = iol2.m_inout_id
               WHERE ha2.ad_table_id = v_m_inoutline_table_id
                 AND ha2.isactive = 'Y'
+                AND iol2.isactive = 'Y'
                 AND (ha2.m_tu_hu_id = tu.m_hu_id OR ha2.vhu_id = tu.m_hu_id)
                 AND io2.docstatus IN ('CO', 'CL')
           )
@@ -136,13 +142,12 @@ BEGIN
           AND iol.m_inout_id = p_m_inout_id
     ),
     shared_lu_inout AS MATERIALIZED (
-        -- (lu, m_inout) pairs: every active completed/closed shipment that has goods physically
-        -- assigned to an LU. Voided/reversed/in-progress shipments are excluded so they can never
-        -- be elected owner (which would otherwise silence the active shipment for that SSCC).
-        -- Scoped to the LUs THIS shipment touches (this_inout_lu): the m_lu_hu_id IN-list lets the
-        -- m_hu_assignment_m_lu_hu_id index drive the scan (a handful of LUs) instead of a full
-        -- table scan. Owner election is unchanged — for each of THIS shipment's LUs we still see
-        -- ALL shipments sharing it (the filter is on m_lu_hu_id, not m_inout_id), so MIN() is exact.
+        -- (lu, m_inout) pairs: every CO/CL shipment that has goods physically assigned to an LU
+        -- touched by THIS shipment. Voided/reversed/in-progress shipments are excluded.
+        -- Scoped to the LUs THIS shipment touches (this_inout_lu) so the m_lu_hu_id IN-list
+        -- drives the m_hu_assignment_m_lu_hu_id index (a handful of LUs) instead of a full scan.
+        -- Used to enumerate all sibling CO/CL shipments sharing an LU — feeds DESADV/PO reference
+        -- aggregation (desadv_agg, po_agg, pallet_list) and gives the full set of co-shippers.
         SELECT DISTINCT ha.m_lu_hu_id AS lu_hu_id, iol.m_inout_id
         FROM m_hu_assignment ha
                  JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
@@ -265,10 +270,10 @@ BEGIN
              -- CASE A: individual TU HU IDs across all pallets — no attribute joins yet.
              --
              -- Scoped to TUs allocated to SOME shipment via m_hu_assignment (excludes unshipped
-             -- TUs on a partial pallet). Under the one-EPCIS-event-per-physical-SSCC rule the
-             -- scope gate is the OWNED LU (pallet_list, restricted to LUs this shipment owns), NOT
-             -- the M_InOut: when two shipments share a physical LU, the owner's event intentionally
-             -- merges the individual TUs of BOTH source orders onto that one SSCC.
+             -- TUs on a partial pallet). Under the close-gate / closer-emits model, pallet_list
+             -- covers ALL LUs touched by any of the CO/CL sibling shipments (not owner-restricted).
+             -- When two shipments share a physical LU, the emitting shipment merges the individual
+             -- TUs of BOTH source orders onto that one SSCC.
              SELECT lu_hu.m_hu_id                 AS lu_hu_id,
                     pl.lu_poreference_padded,
                     tu_hu.m_hu_id                 AS tu_hu_id,
@@ -293,10 +298,10 @@ BEGIN
              --         both attribute lookup and storage item joins (avoids double m_hu scan).
              --
              -- Scoped to HA aggregates allocated to SOME shipment via m_hu_assignment; ha_item.qty
-             -- carries the crate count. Under the one-EPCIS-event-per-physical-SSCC rule the scope
-             -- gate is the OWNED LU (pallet_list), NOT the M_InOut: when two shipments share a
-             -- physical LU, the owner's event intentionally merges the HA aggregates of
-             -- BOTH source orders onto that one SSCC.
+             -- carries the crate count. Under the close-gate / closer-emits model, pallet_list
+             -- covers ALL LUs touched by any of the CO/CL sibling shipments (not owner-restricted).
+             -- When two shipments share a physical LU, the emitting shipment merges the HA
+             -- aggregates of BOTH source orders onto that one SSCC.
              SELECT lu_hu.m_hu_id                           AS lu_hu_id,
                     pl.lu_poreference_padded,
                     ha_item.m_hu_item_id                    AS tu_hu_id,


### PR DESCRIPTION
## What

EPCIS export for two sales orders sharing **one physical LU (one SSCC)** now emits exactly **one** complete, order-pure event for that SSCC — on the completion that **closes the pallet** — instead of a premature/partial/duplicate/mis-attributed event depending on the order in which the two shipments complete.

## Why

The per-SSCC EPCIS export evaluated ownership + order references as a `DocStatus IN ('CO','CL')` snapshot at whichever shipment completion triggered it. With two orders on one pallet, any sharing shipment still open — or not yet created — at that moment corrupted the event. Surfaced on the LAF1010-3 "2 Bestellungen auf einer Palette" retest.

## How

SQL-only change to `"de.metas.edi".get_epcis_events_json_fn`, replacing the fixed lowest-`M_InOut_ID` "owner" election with:

1. **Close-gate** — the function returns `{}` while any child TU physically on an LU this shipment touches is **not** covered by a CO/CL shipment (covered = an active `M_HU_Assignment` from the TU to an inoutline of a CO/CL `M_InOut`, `isactive='Y'`). So every non-closing completion defers.
2. **Closer-emits** — `pallet_list` keeps all touched LUs and `desadv_agg` unions all CO/CL shipments sharing a touched LU (the `lu_owner` CTE is removed). Export eligibility is evaluated once per completion (the after-commit timing already in place), so the pallet-closing completion is the sole emitter; post-closure either sharer returns the full merged pallet.

Ships as the DDL file + a byte-identical migration (`5809860`).

## Tests

- `epcisExport.feature`:
  - `S30558_010` / `S30558_020` — two orders on one shared LU, both shipments created as drafts, completed in each order (A-first / B-first): the first completion's function call returns `{}` (gate), the closing completion returns the merged order-pure pallet. (Picking uses `DO_NOT_CREATE` + `AllowConsolidateInOut=N`, matching the EDI-recipient production config, so the two shipments are separate `M_InOut`s each holding only their own TUs.)
  - `S29231_170` reworked to the close-driven semantics (the old owner/sibling-`{}` assertions removed; both sharers return the merged pallet post-closure).
- `epcisScriptedExportStatus.feature`:
  - `S30558_040` — e2e proving the **closing** completion is the one enqueued for scripted export (`U`), while the first completion is `DontSend` (`N`).
- `C_BPartner_StepDef` gains optional `AllowConsolidateInOut` column support.

## Out of scope

The **sequential** flow (create+complete order 1, *then* create+complete order 2 on a shared pallet) currently fails at order-1 completion (the shipment's HU-assignment sweeps the whole LU → DESADV `validateMovementQtySum`). That is a separate, larger shipment-generation/HU-assignment fix, tracked separately. The in-scope contract here matches REQUIREMENTS AC1: emit one complete event only once the whole physical pallet is covered by completed shipments.
