### PR TITLE
MD_Stock: re-key qty between AttributesKey buckets on HU attribute change

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/attribute/M_Attribute_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/attribute/M_Attribute_StepDef.java
@@ -68,31 +68,6 @@
 				 });
 	 }
 
-	 /**
-	  * Creates or updates M_Attribute records.
-	  *
-	  * <p>Required columns:
-	  * <ul>
-	  *   <li>{@code Identifier} — step-def identifier for subsequent references</li>
-	  *   <li>{@code Value} — attribute value/code (used as upsert key)</li>
-	  *   <li>{@code Name} — attribute display name</li>
-	  * </ul>
-	  * Optional columns:
-	  * <ul>
-	  *   <li>{@code OPT.AttributeValueType} — e.g. {@code L} for list, {@code N} for number</li>
-	  *   <li>{@code OPT.DefaultValueSQL} — SQL expression for the default value</li>
-	  *   <li>{@code OPT.IsStorageRelevant} — {@code Y}/{@code N}; when {@code Y}, this attribute
-	  *       participates in the {@link de.metas.material.event.commons.AttributesKey} used for
-	  *       {@code MD_Stock} segregation</li>
-	  * </ul>
-	  *
-	  * <p>Example:
-	  * <pre>
-	  * And metasfresh contains M_Attributes:
-	  *   | Identifier | Value           | Name            | OPT.AttributeValueType | OPT.IsStorageRelevant |
-	  *   | attr       | stock_attr_test | Stock Attr Test | L                      | Y                     |
-	  * </pre>
-	  */
 	 @And("metasfresh contains M_Attributes:")
 	 public void metasfresh_contains_M_Attributes(@NonNull final DataTable dataTable)
 	 {
@@ -118,9 +93,6 @@
 
 					 row.getAsOptionalString(I_M_Attribute.COLUMNNAME_DefaultValueSQL)
 							 .ifPresent(attributeRecord::setDefaultValueSQL);
-
-					 row.getAsOptionalBoolean(I_M_Attribute.COLUMNNAME_IsStorageRelevant)
-							 .ifPresent(attributeRecord::setIsStorageRelevant);
 
 					 InterfaceWrapperHelper.saveRecord(attributeRecord);
 					 final Attribute attribute = AttributeDAO.fromRecord(attributeRecord);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/attribute/M_Attribute_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/attribute/M_Attribute_StepDef.java
@@ -68,6 +68,31 @@
 				 });
 	 }
 
+	 /**
+	  * Creates or updates M_Attribute records.
+	  *
+	  * <p>Required columns:
+	  * <ul>
+	  *   <li>{@code Identifier} — step-def identifier for subsequent references</li>
+	  *   <li>{@code Value} — attribute value/code (used as upsert key)</li>
+	  *   <li>{@code Name} — attribute display name</li>
+	  * </ul>
+	  * Optional columns:
+	  * <ul>
+	  *   <li>{@code OPT.AttributeValueType} — e.g. {@code L} for list, {@code N} for number</li>
+	  *   <li>{@code OPT.DefaultValueSQL} — SQL expression for the default value</li>
+	  *   <li>{@code OPT.IsStorageRelevant} — {@code Y}/{@code N}; when {@code Y}, this attribute
+	  *       participates in the {@link de.metas.material.event.commons.AttributesKey} used for
+	  *       {@code MD_Stock} segregation</li>
+	  * </ul>
+	  *
+	  * <p>Example:
+	  * <pre>
+	  * And metasfresh contains M_Attributes:
+	  *   | Identifier | Value           | Name            | OPT.AttributeValueType | OPT.IsStorageRelevant |
+	  *   | attr       | stock_attr_test | Stock Attr Test | L                      | Y                     |
+	  * </pre>
+	  */
 	 @And("metasfresh contains M_Attributes:")
 	 public void metasfresh_contains_M_Attributes(@NonNull final DataTable dataTable)
 	 {
@@ -93,6 +118,9 @@
 
 					 row.getAsOptionalString(I_M_Attribute.COLUMNNAME_DefaultValueSQL)
 							 .ifPresent(attributeRecord::setDefaultValueSQL);
+
+					 row.getAsOptionalBoolean(I_M_Attribute.COLUMNNAME_IsStorageRelevant)
+							 .ifPresent(attributeRecord::setIsStorageRelevant);
 
 					 InterfaceWrapperHelper.saveRecord(attributeRecord);
 					 final Attribute attribute = AttributeDAO.fromRecord(attributeRecord);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Attribute_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Attribute_StepDef.java
@@ -252,16 +252,18 @@ public class M_HU_Attribute_StepDef
 		row.getAsOptionalBigDecimal(I_M_HU_Attribute.COLUMNNAME_ValueNumber)
 				.ifPresent(valueNumber -> attributesStorage.setValue(attributeRecord, valueNumber));
 
-		// OPT.Value: try numeric first (existing behaviour), fall back to string for list/string-type attributes
+		// OPT.Value: dispatch on the attribute's declared value type, not on whether the string
+		// parses as a number — otherwise a list attribute with a numeric-looking value code
+		// (e.g. "1") would be silently sent down the numeric path.
 		row.getAsOptionalString(I_M_HU_Attribute.COLUMNNAME_Value).ifPresent(valueStr -> {
-			try
+			final AttributeValueType attributeValueType = AttributeValueType.ofCode(attributeRecord.getAttributeValueType());
+			if (attributeValueType == AttributeValueType.NUMBER)
 			{
-				final BigDecimal numericValue = new BigDecimal(valueStr);
-				attributesStorage.setValue(attributeRecord, numericValue);
+				attributesStorage.setValue(attributeRecord, new BigDecimal(valueStr));
 			}
-			catch (final NumberFormatException ignored)
+			else
 			{
-				// Not a number — treat as a list/string attribute value code
+				// STRING / LIST / DATE: set as the string value (list = the attribute-value code)
 				attributesStorage.setValue(attributeRecord, valueStr);
 			}
 		});

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Attribute_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_Attribute_StepDef.java
@@ -206,6 +206,28 @@ public class M_HU_Attribute_StepDef
 				+ ", ValueDate=" + huAttribute.getValueDate();
 	}
 
+	/**
+	 * Changes an HU attribute via the attribute storage service, which triggers propagation and event firing.
+	 *
+	 * <p>Required columns:
+	 * <ul>
+	 *   <li>{@code M_HU_ID.Identifier} — HU whose attribute is to be changed</li>
+	 *   <li>{@code M_Attribute_ID.Value} — attribute code (e.g. "WeightGross", "Lot-Nummer")</li>
+	 * </ul>
+	 * Optional columns (at least one value column should be present):
+	 * <ul>
+	 *   <li>{@code OPT.ValueNumber} — numeric value (BigDecimal); used for number-type attributes</li>
+	 *   <li>{@code OPT.Value} — value as string; for list/string-type attributes pass the attribute-value
+	 *       code (e.g. "A", "B"); for numeric attributes a parseable number string also works</li>
+	 * </ul>
+	 *
+	 * <p>Example (list attribute):
+	 * <pre>
+	 * And M_HU_Attribute is changed
+	 *   | M_HU_ID.Identifier | M_Attribute_ID.Value    | OPT.Value |
+	 *   | vhu1               | stock_attr_rekey_test   | B         |
+	 * </pre>
+	 */
 	private void changeHUAttribute(@NonNull final DataTableRow row)
 	{
 		final StepDefDataIdentifier huIdentifier = row.getAsIdentifier(I_M_HU_Attribute.COLUMNNAME_M_HU_ID);
@@ -230,8 +252,18 @@ public class M_HU_Attribute_StepDef
 		row.getAsOptionalBigDecimal(I_M_HU_Attribute.COLUMNNAME_ValueNumber)
 				.ifPresent(valueNumber -> attributesStorage.setValue(attributeRecord, valueNumber));
 
-		row.getAsOptionalBigDecimal(I_M_HU_Attribute.COLUMNNAME_Value)
-				.ifPresent(value -> attributesStorage.setValue(attributeRecord, value));
-
+		// OPT.Value: try numeric first (existing behaviour), fall back to string for list/string-type attributes
+		row.getAsOptionalString(I_M_HU_Attribute.COLUMNNAME_Value).ifPresent(valueStr -> {
+			try
+			{
+				final BigDecimal numericValue = new BigDecimal(valueStr);
+				attributesStorage.setValue(attributeRecord, numericValue);
+			}
+			catch (final NumberFormatException ignored)
+			{
+				// Not a number — treat as a list/string attribute value code
+				attributesStorage.setValue(attributeRecord, valueStr);
+			}
+		});
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/stock/MD_Stock_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/stock/MD_Stock_StepDef.java
@@ -25,16 +25,26 @@ package de.metas.cucumber.stepdefs.stock;
 import de.metas.cucumber.stepdefs.DataTableUtil;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.StepDefUtil;
+import de.metas.cucumber.stepdefs.attribute.M_AttributeSetInstance_StepDefData;
+import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
 import de.metas.logging.LogManager;
 import de.metas.material.cockpit.model.I_MD_Stock;
+import de.metas.material.event.commons.AttributesKey;
+import org.adempiere.mm.attributes.keys.AttributesKeys;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
+import org.adempiere.ad.dao.IQuery;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.IQueryBuilder;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
+import org.compiere.model.I_M_AttributeSetInstance;
 import org.compiere.model.I_M_Product;
+import org.compiere.model.I_M_Warehouse;
 import org.slf4j.Logger;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
@@ -49,14 +59,47 @@ public class MD_Stock_StepDef
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 	private final M_Product_StepDefData productTable;
+	private final M_Warehouse_StepDefData warehouseTable;
+	private final M_AttributeSetInstance_StepDefData asiTable;
 
-	public MD_Stock_StepDef(final M_Product_StepDefData productTable)
+	public MD_Stock_StepDef(
+			final M_Product_StepDefData productTable,
+			final M_Warehouse_StepDefData warehouseTable,
+			final M_AttributeSetInstance_StepDefData asiTable)
 	{
 		this.productTable = productTable;
+		this.warehouseTable = warehouseTable;
+		this.asiTable = asiTable;
 	}
 
+	/**
+	 * Waits up to {@code timeoutSeconds} for all rows in the DataTable to match MD_Stock records,
+	 * then validates each row exactly.
+	 *
+	 * <p>Required columns:
+	 * <ul>
+	 *   <li>{@code M_Product_ID.Identifier} — product identifier registered in the step-def data store</li>
+	 *   <li>{@code QtyOnHand} — expected quantity on hand</li>
+	 * </ul>
+	 * Optional columns:
+	 * <ul>
+	 *   <li>{@code OPT.M_Warehouse_ID.Identifier} — narrows the filter to a specific warehouse</li>
+	 *   <li>{@code OPT.M_AttributeSetInstance_ID.Identifier} — ASI identifier whose storage-relevant
+	 *       attributes are used to compute the {@link AttributesKey} filter applied on
+	 *       {@code MD_Stock.AttributesKey}; resolves via
+	 *       {@link AttributesKeys#createAttributesKeyFromASIStorageAttributes}</li>
+	 * </ul>
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * And after not more than 30 seconds metasfresh has MD_Stock data
+	 *   | M_Product_ID.Identifier | QtyOnHand | OPT.M_Warehouse_ID.Identifier | OPT.M_AttributeSetInstance_ID.Identifier |
+	 *   | product                 | 10        | warehouseStd                  | asiA                                     |
+	 *   | product                 | 0         | warehouseStd                  | asiB                                     |
+	 * </pre>
+	 */
 	@And("after not more than {int} seconds metasfresh has MD_Stock data")
-	public void verify_MD_Stock_Data( final int timeoutSeconds, @NonNull final DataTable dataTable) throws InterruptedException
+	public void verify_MD_Stock_Data(final int timeoutSeconds, @NonNull final DataTable dataTable) throws InterruptedException
 	{
 		final List<Map<String, String>> rows = dataTable.asMaps();
 
@@ -77,10 +120,7 @@ public class MD_Stock_StepDef
 
 		final BigDecimal qtyOnHand = DataTableUtil.extractBigDecimalForColumnName(row, "QtyOnHand");
 
-		final I_MD_Stock mdStock = queryBL.createQueryBuilder(I_MD_Stock.class)
-				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, productId)
-				.create()
-				.firstOnly(I_MD_Stock.class);
+		final I_MD_Stock mdStock = buildStockQuery(productId, row).firstOnly(I_MD_Stock.class);
 		return mdStock != null && mdStock.getQtyOnHand().compareTo(qtyOnHand) == 0;
 	}
 
@@ -91,11 +131,48 @@ public class MD_Stock_StepDef
 
 		final I_M_Product product = productTable.get(productIdentifier);
 
-		final I_MD_Stock mdStock = queryBL.createQueryBuilder(I_MD_Stock.class)
-				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, product.getM_Product_ID())
-				.create()
-				.firstOnly(I_MD_Stock.class);
+		final I_MD_Stock mdStock = buildStockQuery(product.getM_Product_ID(), row).firstOnly(I_MD_Stock.class);
 		assertThat(mdStock).isNotNull();
 		assertThat(mdStock.getQtyOnHand()).isEqualTo(qtyOnHand);
+	}
+
+	/**
+	 * Builds a query for MD_Stock, applying a mandatory product filter plus optional warehouse
+	 * and {@code AttributesKey} filters derived from the DataTable row.
+	 */
+	@NonNull
+	private IQuery<I_MD_Stock> buildStockQuery(final int productId, @NonNull final Map<String, String> row)
+	{
+		final IQueryBuilder<I_MD_Stock> builder = queryBL.createQueryBuilder(I_MD_Stock.class)
+				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, productId);
+
+		final String warehouseIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_MD_Stock.COLUMNNAME_M_Warehouse_ID + ".Identifier");
+		if (warehouseIdentifier != null)
+		{
+			final I_M_Warehouse warehouse = warehouseTable.get(warehouseIdentifier);
+			assertThat(warehouse).isNotNull();
+			builder.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Warehouse_ID, warehouse.getM_Warehouse_ID());
+		}
+
+		final String asiIdentifier = DataTableUtil.extractStringOrNullForColumnName(row, "OPT.M_AttributeSetInstance_ID.Identifier");
+		if (asiIdentifier != null)
+		{
+			final AttributesKey attributesKey = resolveAttributesKey(asiIdentifier);
+			builder.addEqualsFilter(I_MD_Stock.COLUMNNAME_AttributesKey, attributesKey.getAsString());
+		}
+
+		return builder.create();
+	}
+
+	@NonNull
+	private AttributesKey resolveAttributesKey(@Nullable final String asiIdentifier)
+	{
+		if (asiIdentifier == null)
+		{
+			return AttributesKey.NONE;
+		}
+		final I_M_AttributeSetInstance asi = asiTable.get(asiIdentifier);
+		final AttributeSetInstanceId asiId = AttributeSetInstanceId.ofRepoIdOrNone(asi.getM_AttributeSetInstance_ID());
+		return AttributesKeys.createAttributesKeyFromASIStorageAttributes(asiId).orElse(AttributesKey.NONE);
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/stock/MD_Stock_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/stock/MD_Stock_StepDef.java
@@ -35,7 +35,6 @@ import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
-import org.adempiere.ad.dao.IQuery;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
@@ -120,7 +119,7 @@ public class MD_Stock_StepDef
 
 		final BigDecimal qtyOnHand = DataTableUtil.extractBigDecimalForColumnName(row, "QtyOnHand");
 
-		final I_MD_Stock mdStock = buildStockQuery(productId, row).firstOnly(I_MD_Stock.class);
+		final I_MD_Stock mdStock = buildStockQuery(productId, row).create().firstOnly(I_MD_Stock.class);
 		return mdStock != null && mdStock.getQtyOnHand().compareTo(qtyOnHand) == 0;
 	}
 
@@ -131,7 +130,7 @@ public class MD_Stock_StepDef
 
 		final I_M_Product product = productTable.get(productIdentifier);
 
-		final I_MD_Stock mdStock = buildStockQuery(product.getM_Product_ID(), row).firstOnly(I_MD_Stock.class);
+		final I_MD_Stock mdStock = buildStockQuery(product.getM_Product_ID(), row).create().firstOnly(I_MD_Stock.class);
 		assertThat(mdStock).isNotNull();
 		assertThat(mdStock.getQtyOnHand()).isEqualTo(qtyOnHand);
 	}
@@ -141,7 +140,7 @@ public class MD_Stock_StepDef
 	 * and {@code AttributesKey} filters derived from the DataTable row.
 	 */
 	@NonNull
-	private IQuery<I_MD_Stock> buildStockQuery(final int productId, @NonNull final Map<String, String> row)
+	private IQueryBuilder<I_MD_Stock> buildStockQuery(final int productId, @NonNull final Map<String, String> row)
 	{
 		final IQueryBuilder<I_MD_Stock> builder = queryBL.createQueryBuilder(I_MD_Stock.class)
 				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, productId);
@@ -161,7 +160,7 @@ public class MD_Stock_StepDef
 			builder.addEqualsFilter(I_MD_Stock.COLUMNNAME_AttributesKey, attributesKey.getAsString());
 		}
 
-		return builder.create();
+		return builder;
 	}
 
 	@NonNull

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/stock/mdStock_AttributeChange_ReKey.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/stock/mdStock_AttributeChange_ReKey.feature
@@ -2,6 +2,7 @@
 @allure.label.epic:E0350_Warehouse_Managment
 @allure.label.feature:F5020
 @ghActions:run_on_executor7
+@Id:S24821_TC1
 Feature: MD_Stock is re-keyed when a storage-relevant HU attribute changes
   ## F5020: Stock
   Proves the full chain:
@@ -9,6 +10,12 @@ Feature: MD_Stock is re-keyed when a storage-relevant HU attribute changes
     -> AttributesChangedEvent fired
     -> AttributesChangedEventHandlerForStockRecords re-keys MD_Stock
        from the old AttributesKey to the new.
+
+  # Uses the standard, storage-relevant "Article_Flavor" attribute, which is part
+  # of the default HU attribute set. Only an attribute the VHU actually carries can
+  # be changed via the HU attribute path, and that change is what fires the
+  # AttributesChangedEvent. (A custom attribute assigned only to the product's
+  # M_AttributeSet does NOT reach the VHU's attribute storage, so it cannot be used.)
 
   Background:
     Given infrastructure and metasfresh are running
@@ -20,21 +27,12 @@ Feature: MD_Stock is re-keyed when a storage-relevant HU attribute changes
       | M_Warehouse_ID.Identifier | Value        |
       | warehouseStd              | StdWarehouse |
 
-    And metasfresh contains M_Attributes:
-      | Identifier | Value                     | Name                          | OPT.AttributeValueType | OPT.IsStorageRelevant |
-      | attr_rekey | stock_attr_rekey_20260628 | Stock Attr ReKey Test 20260628 | L                      | Y                     |
-
-    And metasfresh contains M_AttributeValues:
-      | Identifier | M_Attribute_ID.Identifier | Value | Name    | IsNullFieldValue |
-      | attrVal_A  | attr_rekey                | A     | Value-A | N                |
-      | attrVal_B  | attr_rekey                | B     | Value-B | N                |
-
     And metasfresh contains M_AttributeSetInstance with identifier "asiA":
     """
     {
       "attributeInstances":[
         {
-          "attributeCode":"stock_attr_rekey_20260628",
+          "attributeCode":"Article_Flavor",
           "valueStr":"A"
         }
       ]
@@ -46,16 +44,18 @@ Feature: MD_Stock is re-keyed when a storage-relevant HU attribute changes
     {
       "attributeInstances":[
         {
-          "attributeCode":"stock_attr_rekey_20260628",
+          "attributeCode":"Article_Flavor",
           "valueStr":"B"
         }
       ]
     }
     """
 
+    # No fixed Value/Name: each scenario gets a distinct product so MD_Stock rows
+    # (keyed by product) never leak between scenarios sharing the executor's DB.
     And metasfresh contains M_Products:
-      | Identifier     | Value                        | Name                         |
-      | rekeyProduct   | rekey_product_test_20260628  | Rekey Product Test 20260628  |
+      | Identifier   |
+      | rekeyProduct |
 
   Scenario: Whole-VHU attribute change re-keys MD_Stock
     # Setup: one inventory line with attribute A, qty 10 -> VHU gets attribute A
@@ -78,10 +78,10 @@ Feature: MD_Stock is re-keyed when a storage-relevant HU attribute changes
 
     # Act: change attribute on VHU from A to B
     And M_HU_Attribute is changed
-      | M_HU_ID.Identifier | M_Attribute_ID.Value              | OPT.Value |
-      | vhu1               | stock_attr_rekey_20260628         | B         |
+      | M_HU_ID.Identifier | M_Attribute_ID.Value | OPT.Value |
+      | vhu1               | Article_Flavor       | B         |
 
-    # Assert: old key A -> 0, new key B -> 10
+    # Assert: old key A -> 0, new key B -> 10 (total 10 preserved)
     Then after not more than 60 seconds metasfresh has MD_Stock data
       | M_Product_ID.Identifier | QtyOnHand | OPT.M_Warehouse_ID.Identifier | OPT.M_AttributeSetInstance_ID.Identifier |
       | rekeyProduct            | 0         | warehouseStd                  | asiA                                     |
@@ -110,8 +110,8 @@ Feature: MD_Stock is re-keyed when a storage-relevant HU attribute changes
 
     # Act: change attribute on ONE of the two VHUs from A to B
     And M_HU_Attribute is changed
-      | M_HU_ID.Identifier | M_Attribute_ID.Value              | OPT.Value |
-      | vhu2a              | stock_attr_rekey_20260628         | B         |
+      | M_HU_ID.Identifier | M_Attribute_ID.Value | OPT.Value |
+      | vhu2a              | Article_Flavor       | B         |
 
     # Assert: key A = 10 (unchanged VHU remains), key B = 10 (changed VHU)
     # This proves the handler moves only the changed VHU's qty, not the whole key.

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/stock/mdStock_AttributeChange_ReKey.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/stock/mdStock_AttributeChange_ReKey.feature
@@ -1,0 +1,121 @@
+@from:cucumber
+@allure.label.epic:E0350_Warehouse_Managment
+@allure.label.feature:F5020
+@ghActions:run_on_executor7
+Feature: MD_Stock is re-keyed when a storage-relevant HU attribute changes
+  ## F5020: Stock
+  Proves the full chain:
+  storage-relevant attribute change on a VHU
+    -> AttributesChangedEvent fired
+    -> AttributesChangedEventHandlerForStockRecords re-keys MD_Stock
+       from the old AttributesKey to the new.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And AD_Scheduler for classname 'de.metas.material.cockpit.stock.process.MD_Stock_Update_From_M_HUs' is disabled
+
+    And load M_Warehouse:
+      | M_Warehouse_ID.Identifier | Value        |
+      | warehouseStd              | StdWarehouse |
+
+    And metasfresh contains M_Attributes:
+      | Identifier | Value                     | Name                          | OPT.AttributeValueType | OPT.IsStorageRelevant |
+      | attr_rekey | stock_attr_rekey_20260628 | Stock Attr ReKey Test 20260628 | L                      | Y                     |
+
+    And metasfresh contains M_AttributeValues:
+      | Identifier | M_Attribute_ID.Identifier | Value | Name    | IsNullFieldValue |
+      | attrVal_A  | attr_rekey                | A     | Value-A | N                |
+      | attrVal_B  | attr_rekey                | B     | Value-B | N                |
+
+    And metasfresh contains M_AttributeSetInstance with identifier "asiA":
+    """
+    {
+      "attributeInstances":[
+        {
+          "attributeCode":"stock_attr_rekey_20260628",
+          "valueStr":"A"
+        }
+      ]
+    }
+    """
+
+    And metasfresh contains M_AttributeSetInstance with identifier "asiB":
+    """
+    {
+      "attributeInstances":[
+        {
+          "attributeCode":"stock_attr_rekey_20260628",
+          "valueStr":"B"
+        }
+      ]
+    }
+    """
+
+    And metasfresh contains M_Products:
+      | Identifier     | Value                        | Name                         |
+      | rekeyProduct   | rekey_product_test_20260628  | Rekey Product Test 20260628  |
+
+  Scenario: Whole-VHU attribute change re-keys MD_Stock
+    # Setup: one inventory line with attribute A, qty 10 -> VHU gets attribute A
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | M_Warehouse_ID | MovementDate |
+      | inv1                      | warehouseStd   | 2026-06-28   |
+    And metasfresh contains M_InventoriesLines:
+      | M_InventoryLine_ID.Identifier | M_Inventory_ID.Identifier | M_Product_ID.Identifier | UOM.X12DE355 | QtyCount | QtyBook | OPT.M_AttributeSetInstance_ID.Identifier |
+      | invLine1                      | inv1                      | rekeyProduct            | PCE          | 10       | 0       | asiA                                     |
+    When the inventory identified by inv1 is completed
+
+    Then after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | invLine1                      | vhu1               |
+
+    # Assert initial MD_Stock under key A
+    Then after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand | OPT.M_Warehouse_ID.Identifier | OPT.M_AttributeSetInstance_ID.Identifier |
+      | rekeyProduct            | 10        | warehouseStd                  | asiA                                     |
+
+    # Act: change attribute on VHU from A to B
+    And M_HU_Attribute is changed
+      | M_HU_ID.Identifier | M_Attribute_ID.Value              | OPT.Value |
+      | vhu1               | stock_attr_rekey_20260628         | B         |
+
+    # Assert: old key A -> 0, new key B -> 10
+    Then after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand | OPT.M_Warehouse_ID.Identifier | OPT.M_AttributeSetInstance_ID.Identifier |
+      | rekeyProduct            | 0         | warehouseStd                  | asiA                                     |
+      | rekeyProduct            | 10        | warehouseStd                  | asiB                                     |
+
+  Scenario: Partial attribute change - only changed VHU qty moves, remainder stays on old key
+    # Setup: TWO inventory lines with attribute A, 10 PCE each -> two VHUs, both key A, total 20
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID.Identifier | M_Warehouse_ID | MovementDate |
+      | inv2                      | warehouseStd   | 2026-06-28   |
+    And metasfresh contains M_InventoriesLines:
+      | M_InventoryLine_ID.Identifier | M_Inventory_ID.Identifier | M_Product_ID.Identifier | UOM.X12DE355 | QtyCount | QtyBook | OPT.M_AttributeSetInstance_ID.Identifier |
+      | invLine2a                     | inv2                      | rekeyProduct            | PCE          | 10       | 0       | asiA                                     |
+      | invLine2b                     | inv2                      | rekeyProduct            | PCE          | 10       | 0       | asiA                                     |
+    When the inventory identified by inv2 is completed
+
+    Then after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID.Identifier | M_HU_ID.Identifier |
+      | invLine2a                     | vhu2a              |
+      | invLine2b                     | vhu2b              |
+
+    # Assert initial MD_Stock: key A = 20 (two VHUs combined)
+    Then after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand | OPT.M_Warehouse_ID.Identifier | OPT.M_AttributeSetInstance_ID.Identifier |
+      | rekeyProduct            | 20        | warehouseStd                  | asiA                                     |
+
+    # Act: change attribute on ONE of the two VHUs from A to B
+    And M_HU_Attribute is changed
+      | M_HU_ID.Identifier | M_Attribute_ID.Value              | OPT.Value |
+      | vhu2a              | stock_attr_rekey_20260628         | B         |
+
+    # Assert: key A = 10 (unchanged VHU remains), key B = 10 (changed VHU)
+    # This proves the handler moves only the changed VHU's qty, not the whole key.
+    Then after not more than 60 seconds metasfresh has MD_Stock data
+      | M_Product_ID.Identifier | QtyOnHand | OPT.M_Warehouse_ID.Identifier | OPT.M_AttributeSetInstance_ID.Identifier |
+      | rekeyProduct            | 10        | warehouseStd                  | asiA                                     |
+      | rekeyProduct            | 10        | warehouseStd                  | asiB                                     |

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/StockChangeSourceInfo.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/StockChangeSourceInfo.java
@@ -5,8 +5,6 @@ import de.metas.util.Check;
 import lombok.NonNull;
 import lombok.Value;
 
-import javax.annotation.Nullable;
-
 /*
  * #%L
  * metasfresh-material-cockpit
@@ -36,47 +34,36 @@ public class StockChangeSourceInfo
 	{
 		return new StockChangeSourceInfo(
 				resetStockAdPinstanceId,
-				-1,
-				null);
+				-1);
 	}
 
 	public static StockChangeSourceInfo ofTransactionId(final int transactionId)
 	{
 		return new StockChangeSourceInfo(
 				(ResetStockPInstanceId)null,
-				Check.assumeGreaterThanZero(transactionId, "transactionId"),
-				null);
+				Check.assumeGreaterThanZero(transactionId, "transactionId"));
 	}
 
 	/**
 	 * Source info for an MD_Stock qty re-key triggered by an HU attribute change.
 	 * transactionId is -1 (no M_Transaction involved), resetStockPInstanceId is null.
-	 * The huId is retained for provenance.
 	 */
-	public static StockChangeSourceInfo ofHuAttributeChange(final int huId)
+	public static StockChangeSourceInfo ofHuAttributeChange()
 	{
-		Check.assumeGreaterThanZero(huId, "huId");
 		return new StockChangeSourceInfo(
 				(ResetStockPInstanceId)null,
-				-1,
-				huId);
+				-1);
 	}
 
 	ResetStockPInstanceId resetStockAdPinstanceId;
 	int transactionId;
 
-	/** HU that triggered the attribute change; {@code null} if not applicable. */
-	@Nullable
-	Integer huId;
-
 	private StockChangeSourceInfo(
 			final ResetStockPInstanceId resetStockAdPinstanceId,
-			final int transactionId,
-			@Nullable final Integer huId)
+			final int transactionId)
 	{
 		this.resetStockAdPinstanceId = resetStockAdPinstanceId;
 		this.transactionId = transactionId;
-		this.huId = huId;
 	}
 
 }

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/StockChangeSourceInfo.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/StockChangeSourceInfo.java
@@ -45,7 +45,7 @@ public class StockChangeSourceInfo
 		return new StockChangeSourceInfo(
 				(ResetStockPInstanceId)null,
 				Check.assumeGreaterThanZero(transactionId, "transactionId"),
-				-1);
+				null);
 	}
 
 	/**
@@ -65,7 +65,7 @@ public class StockChangeSourceInfo
 	ResetStockPInstanceId resetStockAdPinstanceId;
 	int transactionId;
 
-	/** HU that triggered the attribute change; -1 if not applicable. */
+	/** HU that triggered the attribute change; {@code null} if not applicable. */
 	@Nullable
 	Integer huId;
 

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/StockChangeSourceInfo.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/StockChangeSourceInfo.java
@@ -5,6 +5,8 @@ import de.metas.util.Check;
 import lombok.NonNull;
 import lombok.Value;
 
+import javax.annotation.Nullable;
+
 /*
  * #%L
  * metasfresh-material-cockpit
@@ -34,25 +36,47 @@ public class StockChangeSourceInfo
 	{
 		return new StockChangeSourceInfo(
 				resetStockAdPinstanceId,
-				-1);
+				-1,
+				null);
 	}
 
 	public static StockChangeSourceInfo ofTransactionId(final int transactionId)
 	{
 		return new StockChangeSourceInfo(
 				(ResetStockPInstanceId)null,
-				Check.assumeGreaterThanZero(transactionId, "transactionId"));
+				Check.assumeGreaterThanZero(transactionId, "transactionId"),
+				-1);
+	}
+
+	/**
+	 * Source info for an MD_Stock qty re-key triggered by an HU attribute change.
+	 * transactionId is -1 (no M_Transaction involved), resetStockPInstanceId is null.
+	 * The huId is retained for provenance.
+	 */
+	public static StockChangeSourceInfo ofHuAttributeChange(final int huId)
+	{
+		Check.assumeGreaterThanZero(huId, "huId");
+		return new StockChangeSourceInfo(
+				(ResetStockPInstanceId)null,
+				-1,
+				huId);
 	}
 
 	ResetStockPInstanceId resetStockAdPinstanceId;
 	int transactionId;
 
+	/** HU that triggered the attribute change; -1 if not applicable. */
+	@Nullable
+	Integer huId;
+
 	private StockChangeSourceInfo(
 			final ResetStockPInstanceId resetStockAdPinstanceId,
-			final int transactionId)
+			final int transactionId,
+			@Nullable final Integer huId)
 	{
 		this.resetStockAdPinstanceId = resetStockAdPinstanceId;
 		this.transactionId = transactionId;
+		this.huId = huId;
 	}
 
 }

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecords.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecords.java
@@ -1,0 +1,56 @@
+package de.metas.material.cockpit.stock.eventhandler;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.Profiles;
+import de.metas.material.event.MaterialEventHandler;
+import de.metas.material.event.attributes.AttributesChangedEvent;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+
+/*
+ * #%L
+ * metasfresh-material-cockpit
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * Handles {@link AttributesChangedEvent} for MD_Stock records.
+ * Re-keys the MD_Stock qty from the old AttributesKey bucket to the new one.
+ *
+ * <p>NOTE: Task 2 stub — logic not yet implemented (see Task 3).</p>
+ */
+@Service
+@Profile(Profiles.PROFILE_App)
+public class AttributesChangedEventHandlerForStockRecords
+		implements MaterialEventHandler<AttributesChangedEvent>
+{
+	@Override
+	public Collection<Class<? extends AttributesChangedEvent>> getHandledEventType()
+	{
+		return ImmutableList.of(AttributesChangedEvent.class);
+	}
+
+	@Override
+	public void handleEvent(final AttributesChangedEvent event)
+	{
+		// no-op stub — Task 3 will implement the re-key logic
+	}
+}

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecords.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecords.java
@@ -69,12 +69,21 @@ public class AttributesChangedEventHandlerForStockRecords
 	@Override
 	public void handleEvent(@NonNull final AttributesChangedEvent event)
 	{
+		final AttributesKey oldAttributesKey = event.getOldStorageAttributes().getAttributesKey();
+		final AttributesKey newAttributesKey = event.getNewStorageAttributes().getAttributesKey();
+
+		// The event fires on ANY attribute change, including non-storage-relevant ones,
+		// which leave the storage AttributesKey unchanged (old == new, often both NONE).
+		// Nothing moves between buckets, so skip — otherwise we'd issue two offsetting
+		// MD_Stock deltas and fire spurious StockChangedEvents on every attribute change.
+		if (oldAttributesKey.equals(newAttributesKey))
+		{
+			return;
+		}
+
 		final ProductId productId = ProductId.ofRepoId(event.getProductId());
 		final BigDecimal qtyBD = event.getQty();
 		final StockChangeSourceInfo sourceInfo = StockChangeSourceInfo.ofHuAttributeChange(event.getHuId());
-
-		final AttributesKey oldAttributesKey = event.getOldStorageAttributes().getAttributesKey();
-		final AttributesKey newAttributesKey = event.getNewStorageAttributes().getAttributesKey();
 
 		// FROM leg: subtract qty from old bucket
 		final StockDataRecordIdentifier fromIdentifier = StockDataRecordIdentifier.builder()

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecords.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecords.java
@@ -11,7 +11,6 @@ import de.metas.material.event.attributes.AttributesChangedEvent;
 import de.metas.material.event.commons.AttributesKey;
 import de.metas.product.ProductId;
 import lombok.NonNull;
-import org.compiere.SpringContextHolder;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -55,17 +54,10 @@ public class AttributesChangedEventHandlerForStockRecords
 {
 	private final StockDataUpdateRequestHandler dataUpdateRequestHandler;
 
-	/** Spring-managed constructor (production). */
 	public AttributesChangedEventHandlerForStockRecords(
 			@NonNull final StockDataUpdateRequestHandler dataUpdateRequestHandler)
 	{
 		this.dataUpdateRequestHandler = dataUpdateRequestHandler;
-	}
-
-	/** Test constructor: obtains the handler from the SpringContextHolder JUnit bean registry. */
-	AttributesChangedEventHandlerForStockRecords()
-	{
-		this(SpringContextHolder.instance.getBean(StockDataUpdateRequestHandler.class));
 	}
 
 	@Override
@@ -78,7 +70,7 @@ public class AttributesChangedEventHandlerForStockRecords
 	public void handleEvent(@NonNull final AttributesChangedEvent event)
 	{
 		final ProductId productId = ProductId.ofRepoId(event.getProductId());
-		final BigDecimal qty = event.getQty();
+		final BigDecimal qtyBD = event.getQty();
 		final StockChangeSourceInfo sourceInfo = StockChangeSourceInfo.ofHuAttributeChange(event.getHuId());
 
 		final AttributesKey oldAttributesKey = event.getOldStorageAttributes().getAttributesKey();
@@ -95,7 +87,7 @@ public class AttributesChangedEventHandlerForStockRecords
 
 		dataUpdateRequestHandler.handleDataUpdateRequest(StockDataUpdateRequest.builder()
 				.identifier(fromIdentifier)
-				.onHandQtyChange(qty.negate())
+				.onHandQtyChange(qtyBD.negate())
 				.sourceInfo(sourceInfo)
 				.build());
 
@@ -110,7 +102,7 @@ public class AttributesChangedEventHandlerForStockRecords
 
 		dataUpdateRequestHandler.handleDataUpdateRequest(StockDataUpdateRequest.builder()
 				.identifier(toIdentifier)
-				.onHandQtyChange(qty)
+				.onHandQtyChange(qtyBD)
 				.sourceInfo(sourceInfo)
 				.build());
 	}

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecords.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecords.java
@@ -2,11 +2,20 @@ package de.metas.material.cockpit.stock.eventhandler;
 
 import com.google.common.collect.ImmutableList;
 import de.metas.Profiles;
+import de.metas.material.cockpit.stock.StockChangeSourceInfo;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.cockpit.stock.StockDataUpdateRequest;
+import de.metas.material.cockpit.stock.StockDataUpdateRequestHandler;
 import de.metas.material.event.MaterialEventHandler;
 import de.metas.material.event.attributes.AttributesChangedEvent;
+import de.metas.material.event.commons.AttributesKey;
+import de.metas.product.ProductId;
+import lombok.NonNull;
+import org.compiere.SpringContextHolder;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.util.Collection;
 
 /*
@@ -33,15 +42,32 @@ import java.util.Collection;
 
 /**
  * Handles {@link AttributesChangedEvent} for MD_Stock records.
- * Re-keys the MD_Stock qty from the old AttributesKey bucket to the new one.
+ * Re-keys the MD_Stock qty from the old AttributesKey bucket to the new one
+ * by issuing a FROM leg (subtract) and a TO leg (add).
  *
- * <p>NOTE: Task 2 stub — logic not yet implemented (see Task 3).</p>
+ * <p>No MRP-exclusion guard: MD_Stock tracks real on-hand qty regardless of
+ * warehouse exclusion (see cockpit/CLAUDE.md "Warehouse exclusion").</p>
  */
 @Service
 @Profile(Profiles.PROFILE_App)
 public class AttributesChangedEventHandlerForStockRecords
 		implements MaterialEventHandler<AttributesChangedEvent>
 {
+	private final StockDataUpdateRequestHandler dataUpdateRequestHandler;
+
+	/** Spring-managed constructor (production). */
+	public AttributesChangedEventHandlerForStockRecords(
+			@NonNull final StockDataUpdateRequestHandler dataUpdateRequestHandler)
+	{
+		this.dataUpdateRequestHandler = dataUpdateRequestHandler;
+	}
+
+	/** Test constructor: obtains the handler from the SpringContextHolder JUnit bean registry. */
+	AttributesChangedEventHandlerForStockRecords()
+	{
+		this(SpringContextHolder.instance.getBean(StockDataUpdateRequestHandler.class));
+	}
+
 	@Override
 	public Collection<Class<? extends AttributesChangedEvent>> getHandledEventType()
 	{
@@ -49,8 +75,43 @@ public class AttributesChangedEventHandlerForStockRecords
 	}
 
 	@Override
-	public void handleEvent(final AttributesChangedEvent event)
+	public void handleEvent(@NonNull final AttributesChangedEvent event)
 	{
-		// no-op stub — Task 3 will implement the re-key logic
+		final ProductId productId = ProductId.ofRepoId(event.getProductId());
+		final BigDecimal qty = event.getQty();
+		final StockChangeSourceInfo sourceInfo = StockChangeSourceInfo.ofHuAttributeChange(event.getHuId());
+
+		final AttributesKey oldAttributesKey = event.getOldStorageAttributes().getAttributesKey();
+		final AttributesKey newAttributesKey = event.getNewStorageAttributes().getAttributesKey();
+
+		// FROM leg: subtract qty from old bucket
+		final StockDataRecordIdentifier fromIdentifier = StockDataRecordIdentifier.builder()
+				.clientId(event.getEventDescriptor().getClientId())
+				.orgId(event.getEventDescriptor().getOrgId())
+				.warehouseId(event.getWarehouseId())
+				.productId(productId)
+				.storageAttributesKey(oldAttributesKey)
+				.build();
+
+		dataUpdateRequestHandler.handleDataUpdateRequest(StockDataUpdateRequest.builder()
+				.identifier(fromIdentifier)
+				.onHandQtyChange(qty.negate())
+				.sourceInfo(sourceInfo)
+				.build());
+
+		// TO leg: add qty to new bucket
+		final StockDataRecordIdentifier toIdentifier = StockDataRecordIdentifier.builder()
+				.clientId(event.getEventDescriptor().getClientId())
+				.orgId(event.getEventDescriptor().getOrgId())
+				.warehouseId(event.getWarehouseId())
+				.productId(productId)
+				.storageAttributesKey(newAttributesKey)
+				.build();
+
+		dataUpdateRequestHandler.handleDataUpdateRequest(StockDataUpdateRequest.builder()
+				.identifier(toIdentifier)
+				.onHandQtyChange(qty)
+				.sourceInfo(sourceInfo)
+				.build());
 	}
 }

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecords.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecords.java
@@ -76,6 +76,9 @@ public class AttributesChangedEventHandlerForStockRecords
 		// which leave the storage AttributesKey unchanged (old == new, often both NONE).
 		// Nothing moves between buckets, so skip — otherwise we'd issue two offsetting
 		// MD_Stock deltas and fire spurious StockChangedEvents on every attribute change.
+		// Note: the dispo-service sibling handler for this same event deliberately does NOT
+		// skip old==new (it always creates FROM/TO candidates); here skipping is safe because
+		// an old==new re-key nets to zero on a single MD_Stock row and only wastes two saves.
 		if (oldAttributesKey.equals(newAttributesKey))
 		{
 			return;
@@ -83,7 +86,7 @@ public class AttributesChangedEventHandlerForStockRecords
 
 		final ProductId productId = ProductId.ofRepoId(event.getProductId());
 		final BigDecimal qtyBD = event.getQty();
-		final StockChangeSourceInfo sourceInfo = StockChangeSourceInfo.ofHuAttributeChange(event.getHuId());
+		final StockChangeSourceInfo sourceInfo = StockChangeSourceInfo.ofHuAttributeChange();
 
 		// FROM leg: subtract qty from old bucket
 		final StockDataRecordIdentifier fromIdentifier = StockDataRecordIdentifier.builder()

--- a/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecords.java
+++ b/backend/de.metas.material/cockpit/src/main/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecords.java
@@ -45,7 +45,7 @@ import java.util.Collection;
  * by issuing a FROM leg (subtract) and a TO leg (add).
  *
  * <p>No MRP-exclusion guard: MD_Stock tracks real on-hand qty regardless of
- * warehouse exclusion (see cockpit/CLAUDE.md "Warehouse exclusion").</p>
+ * warehouse exclusion, consistent with the transaction-driven MD_Stock handler.</p>
  */
 @Service
 @Profile(Profiles.PROFILE_App)

--- a/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecordsTest.java
+++ b/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecordsTest.java
@@ -229,9 +229,8 @@ public class AttributesChangedEventHandlerForStockRecordsTest
 	}
 
 	/**
-	 * U1 — no-op event: old and new storage attributes are identical.
-	 * The handler currently has no short-circuit, so this test is expected to FAIL (RED) until the guard is added.
-	 * The assertion is written with passing intent: if old == new, no MD_Stock row should be created.
+	 * A change that does not alter the storage AttributesKey (old == new — e.g. a non-storage
+	 * attribute changed) must be a no-op: no MD_Stock row created, no offsetting deltas.
 	 */
 	@Test
 	public void ignoresChangeThatDoesNotAlterAttributesKey()
@@ -364,7 +363,7 @@ public class AttributesChangedEventHandlerForStockRecordsTest
 		final AttributesKey keyB = attributesKey(2600);
 
 		// Seed stock under the MRP-excluded warehouse
-		seedStockForWarehouse(mrpExcludedWarehouseId, keyA, new BigDecimal("13"));
+		seedStockForWarehouse(mrpExcludedWarehouseIdObj, keyA, new BigDecimal("13"));
 
 		// Fire re-key event on the MRP-excluded warehouse
 		final AttributesChangedEventHandlerForStockRecords handler = new AttributesChangedEventHandlerForStockRecords(stockDataUpdateRequestHandler);
@@ -380,7 +379,7 @@ public class AttributesChangedEventHandlerForStockRecordsTest
 				.build());
 
 		// Re-key must have happened: keyA zeroed, keyB has qty — no MRP-exclusion guard suppresses this
-		final I_MD_Stock keyARow = getMDStockRecordForWarehouse(mrpExcludedWarehouseId, PRODUCT_ID, keyA);
+		final I_MD_Stock keyARow = getMDStockRecordForWarehouse(mrpExcludedWarehouseIdObj, PRODUCT_ID, keyA);
 		assertThat(keyARow)
 				.as("MD_Stock(keyA, mrpExcludedWarehouse) must exist (genuinely zeroed)")
 				.isNotNull();
@@ -388,7 +387,7 @@ public class AttributesChangedEventHandlerForStockRecordsTest
 				.as("MD_Stock(keyA).QtyOnHand must be 0 after re-key (MRP-excluded warehouse still tracked)")
 				.isEqualByComparingTo(BigDecimal.ZERO);
 
-		final I_MD_Stock keyBRow = getMDStockRecordForWarehouse(mrpExcludedWarehouseId, PRODUCT_ID, keyB);
+		final I_MD_Stock keyBRow = getMDStockRecordForWarehouse(mrpExcludedWarehouseIdObj, PRODUCT_ID, keyB);
 		assertThat(keyBRow)
 				.as("MD_Stock(keyB, mrpExcludedWarehouse) must exist after re-key")
 				.isNotNull();
@@ -458,13 +457,13 @@ public class AttributesChangedEventHandlerForStockRecordsTest
 		return AttributesKey.ofAttributeValueIds(AttributeValueId.ofRepoId(attributeValueRepoId));
 	}
 
-	/** Variant of {@link #seedStock} that seeds against an arbitrary warehouse ID (for MRP-exclusion tests). */
-	private void seedStockForWarehouse(final int warehouseId, @NonNull final AttributesKey attributesKey, @NonNull final BigDecimal qty)
+	/** Variant of {@link #seedStock} that seeds against an arbitrary warehouse (for MRP-exclusion tests). */
+	private void seedStockForWarehouse(@NonNull final WarehouseId warehouseId, @NonNull final AttributesKey attributesKey, @NonNull final BigDecimal qty)
 	{
 		final StockDataRecordIdentifier identifier = StockDataRecordIdentifier.builder()
 				.clientId(ClientId.ofRepoId(CLIENT_ID))
 				.orgId(OrgId.ofRepoId(ORG_ID))
-				.warehouseId(WarehouseId.ofRepoId(warehouseId))
+				.warehouseId(warehouseId)
 				.productId(ProductId.ofRepoId(PRODUCT_ID))
 				.storageAttributesKey(attributesKey)
 				.build();
@@ -476,13 +475,13 @@ public class AttributesChangedEventHandlerForStockRecordsTest
 				.build());
 	}
 
-	/** Variant of {@link #getMDStockRecord} that queries against an arbitrary warehouse ID. */
-	private I_MD_Stock getMDStockRecordForWarehouse(final int warehouseId, final int productId, @NonNull final AttributesKey attributesKey)
+	/** Variant of {@link #getMDStockRecord} that queries against an arbitrary warehouse. */
+	private I_MD_Stock getMDStockRecordForWarehouse(@NonNull final WarehouseId warehouseId, final int productId, @NonNull final AttributesKey attributesKey)
 	{
 		return Services.get(IQueryBL.class)
 				.createQueryBuilder(I_MD_Stock.class)
 				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, productId)
-				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Warehouse_ID, warehouseId)
+				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Warehouse_ID, warehouseId.getRepoId())
 				.addEqualsFilter(I_MD_Stock.COLUMN_AttributesKey, attributesKey.getAsString())
 				.create()
 				.firstOnly(I_MD_Stock.class);

--- a/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecordsTest.java
+++ b/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecordsTest.java
@@ -20,6 +20,7 @@ import org.adempiere.mm.attributes.AttributeValueId;
 import org.adempiere.service.ClientId;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_M_Warehouse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -27,6 +28,8 @@ import org.mockito.Mockito;
 import java.math.BigDecimal;
 import java.time.Instant;
 
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /*
@@ -225,6 +228,175 @@ public class AttributesChangedEventHandlerForStockRecordsTest
 				.isEqualByComparingTo(QTY);
 	}
 
+	/**
+	 * U1 — no-op event: old and new storage attributes are identical.
+	 * The handler currently has no short-circuit, so this test is expected to FAIL (RED) until the guard is added.
+	 * The assertion is written with passing intent: if old == new, no MD_Stock row should be created.
+	 */
+	@Test
+	public void ignoresChangeThatDoesNotAlterAttributesKey()
+	{
+		// No seed — no pre-existing MD_Stock row for this key.
+		final AttributesKey sameKey = attributesKey(1000);
+
+		// Fire event where old == new (identity re-key: nothing really changed)
+		final AttributesChangedEventHandlerForStockRecords handler = new AttributesChangedEventHandlerForStockRecords(stockDataUpdateRequestHandler);
+		handler.handleEvent(AttributesChangedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientAndOrg(CLIENT_ID, ORG_ID))
+				.warehouseId(WarehouseId.ofRepoId(WAREHOUSE_ID))
+				.date(Instant.parse("2026-06-01T00:00:00.00Z"))
+				.productId(PRODUCT_ID)
+				.qty(new BigDecimal("13"))
+				.oldStorageAttributes(attributesKeyWithASI(1000))
+				.newStorageAttributes(attributesKeyWithASI(1000))
+				.huId(100)
+				.build());
+
+		// No row should exist — a no-op event must not create a phantom stock entry.
+		assertThat(getMDStockRecord(PRODUCT_ID, sameKey))
+				.as("No MD_Stock row should be created when old == new attributes key (identity re-key is a no-op)")
+				.isNull();
+	}
+
+	/**
+	 * U2 — partial re-key: two HUs share keyA (total 20). Moving qty 10 to keyB leaves 10 on keyA.
+	 */
+	@Test
+	public void reKeyMovesOnlyChangedHusQty_leavesRemainderOnOldKey()
+	{
+		final AttributesKey keyA = attributesKey(2100);
+		final AttributesKey keyB = attributesKey(2200);
+
+		// Seed two HUs worth of qty under keyA (total = 20)
+		seedStock(keyA, new BigDecimal("10"));
+		seedStock(keyA, new BigDecimal("10"));
+
+		// Fire event: move only one HU's qty (10) from keyA → keyB
+		final AttributesChangedEventHandlerForStockRecords handler = new AttributesChangedEventHandlerForStockRecords(stockDataUpdateRequestHandler);
+		handler.handleEvent(AttributesChangedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientAndOrg(CLIENT_ID, ORG_ID))
+				.warehouseId(WarehouseId.ofRepoId(WAREHOUSE_ID))
+				.date(Instant.parse("2026-06-02T00:00:00.00Z"))
+				.productId(PRODUCT_ID)
+				.qty(new BigDecimal("10"))
+				.oldStorageAttributes(attributesKeyWithASI(2100))
+				.newStorageAttributes(attributesKeyWithASI(2200))
+				.huId(201)
+				.build());
+
+		// keyA still holds the remainder (10), not zeroed
+		final I_MD_Stock keyARow = getMDStockRecord(PRODUCT_ID, keyA);
+		assertThat(keyARow)
+				.as("MD_Stock(keyA) row must exist after partial re-key")
+				.isNotNull();
+		assertThat(keyARow.getQtyOnHand())
+				.as("MD_Stock(keyA).QtyOnHand must be 10 (remainder — one HU still on old key)")
+				.isEqualByComparingTo(new BigDecimal("10"));
+
+		// keyB received exactly the moved qty
+		final I_MD_Stock keyBRow = getMDStockRecord(PRODUCT_ID, keyB);
+		assertThat(keyBRow)
+				.as("MD_Stock(keyB) row must exist after partial re-key")
+				.isNotNull();
+		assertThat(keyBRow.getQtyOnHand())
+				.as("MD_Stock(keyB).QtyOnHand must be 10 (the moved HU qty)")
+				.isEqualByComparingTo(new BigDecimal("10"));
+	}
+
+	/**
+	 * U3 — uneven split: seed 12+8=20 on keyA, move 8 → keyB. keyA must show 12, keyB must show 8.
+	 */
+	@Test
+	public void reKeyUnevenSplit_movesExactChangedQty()
+	{
+		final AttributesKey keyA = attributesKey(2300);
+		final AttributesKey keyB = attributesKey(2400);
+
+		seedStock(keyA, new BigDecimal("12"));
+		seedStock(keyA, new BigDecimal("8"));
+
+		final AttributesChangedEventHandlerForStockRecords handler = new AttributesChangedEventHandlerForStockRecords(stockDataUpdateRequestHandler);
+		handler.handleEvent(AttributesChangedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientAndOrg(CLIENT_ID, ORG_ID))
+				.warehouseId(WarehouseId.ofRepoId(WAREHOUSE_ID))
+				.date(Instant.parse("2026-06-03T00:00:00.00Z"))
+				.productId(PRODUCT_ID)
+				.qty(new BigDecimal("8"))
+				.oldStorageAttributes(attributesKeyWithASI(2300))
+				.newStorageAttributes(attributesKeyWithASI(2400))
+				.huId(230)
+				.build());
+
+		// keyA retains the untouched qty (12)
+		final I_MD_Stock keyARow = getMDStockRecord(PRODUCT_ID, keyA);
+		assertThat(keyARow)
+				.as("MD_Stock(keyA) row must exist after uneven split")
+				.isNotNull();
+		assertThat(keyARow.getQtyOnHand())
+				.as("MD_Stock(keyA).QtyOnHand must be 12 after moving 8 to keyB")
+				.isEqualByComparingTo(new BigDecimal("12"));
+
+		// keyB receives exactly the moved qty (8)
+		final I_MD_Stock keyBRow = getMDStockRecord(PRODUCT_ID, keyB);
+		assertThat(keyBRow)
+				.as("MD_Stock(keyB) row must exist after uneven split")
+				.isNotNull();
+		assertThat(keyBRow.getQtyOnHand())
+				.as("MD_Stock(keyB).QtyOnHand must be 8 (exact moved qty)")
+				.isEqualByComparingTo(new BigDecimal("8"));
+	}
+
+	/**
+	 * U4 — MRP-excluded warehouse: re-key happens regardless of MRP_Exclude flag.
+	 * MD_Stock tracks real on-hand qty even for warehouses excluded from material disposition.
+	 */
+	@Test
+	public void reKeysStockEvenForMrpExcludedWarehouse()
+	{
+		// Create a warehouse record with MRP_Exclude = "Y"
+		final I_M_Warehouse warehouseRecord = newInstance(I_M_Warehouse.class);
+		warehouseRecord.setMRP_Exclude("Y");
+		saveRecord(warehouseRecord);
+		final int mrpExcludedWarehouseId = warehouseRecord.getM_Warehouse_ID();
+		final WarehouseId mrpExcludedWarehouseIdObj = WarehouseId.ofRepoId(mrpExcludedWarehouseId);
+
+		final AttributesKey keyA = attributesKey(2500);
+		final AttributesKey keyB = attributesKey(2600);
+
+		// Seed stock under the MRP-excluded warehouse
+		seedStockForWarehouse(mrpExcludedWarehouseId, keyA, new BigDecimal("13"));
+
+		// Fire re-key event on the MRP-excluded warehouse
+		final AttributesChangedEventHandlerForStockRecords handler = new AttributesChangedEventHandlerForStockRecords(stockDataUpdateRequestHandler);
+		handler.handleEvent(AttributesChangedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientAndOrg(CLIENT_ID, ORG_ID))
+				.warehouseId(mrpExcludedWarehouseIdObj)
+				.date(Instant.parse("2026-06-04T00:00:00.00Z"))
+				.productId(PRODUCT_ID)
+				.qty(new BigDecimal("13"))
+				.oldStorageAttributes(attributesKeyWithASI(2500))
+				.newStorageAttributes(attributesKeyWithASI(2600))
+				.huId(250)
+				.build());
+
+		// Re-key must have happened: keyA zeroed, keyB has qty — no MRP-exclusion guard suppresses this
+		final I_MD_Stock keyARow = getMDStockRecordForWarehouse(mrpExcludedWarehouseId, PRODUCT_ID, keyA);
+		assertThat(keyARow)
+				.as("MD_Stock(keyA, mrpExcludedWarehouse) must exist (genuinely zeroed)")
+				.isNotNull();
+		assertThat(keyARow.getQtyOnHand())
+				.as("MD_Stock(keyA).QtyOnHand must be 0 after re-key (MRP-excluded warehouse still tracked)")
+				.isEqualByComparingTo(BigDecimal.ZERO);
+
+		final I_MD_Stock keyBRow = getMDStockRecordForWarehouse(mrpExcludedWarehouseId, PRODUCT_ID, keyB);
+		assertThat(keyBRow)
+				.as("MD_Stock(keyB, mrpExcludedWarehouse) must exist after re-key")
+				.isNotNull();
+		assertThat(keyBRow.getQtyOnHand())
+				.as("MD_Stock(keyB).QtyOnHand must be 13 after re-key (MRP-excluded warehouse still tracked)")
+				.isEqualByComparingTo(new BigDecimal("13"));
+	}
+
 	// --- helpers ---
 
 	private void seedStock(@NonNull final AttributesKey attributesKey, @NonNull final BigDecimal qty)
@@ -284,5 +456,35 @@ public class AttributesChangedEventHandlerForStockRecordsTest
 	private static AttributesKey attributesKey(final int attributeValueRepoId)
 	{
 		return AttributesKey.ofAttributeValueIds(AttributeValueId.ofRepoId(attributeValueRepoId));
+	}
+
+	/** Variant of {@link #seedStock} that seeds against an arbitrary warehouse ID (for MRP-exclusion tests). */
+	private void seedStockForWarehouse(final int warehouseId, @NonNull final AttributesKey attributesKey, @NonNull final BigDecimal qty)
+	{
+		final StockDataRecordIdentifier identifier = StockDataRecordIdentifier.builder()
+				.clientId(ClientId.ofRepoId(CLIENT_ID))
+				.orgId(OrgId.ofRepoId(ORG_ID))
+				.warehouseId(WarehouseId.ofRepoId(warehouseId))
+				.productId(ProductId.ofRepoId(PRODUCT_ID))
+				.storageAttributesKey(attributesKey)
+				.build();
+
+		stockDataUpdateRequestHandler.handleDataUpdateRequest(StockDataUpdateRequest.builder()
+				.identifier(identifier)
+				.onHandQtyChange(qty)
+				.sourceInfo(StockChangeSourceInfo.ofTransactionId(1))
+				.build());
+	}
+
+	/** Variant of {@link #getMDStockRecord} that queries against an arbitrary warehouse ID. */
+	private I_MD_Stock getMDStockRecordForWarehouse(final int warehouseId, final int productId, @NonNull final AttributesKey attributesKey)
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_MD_Stock.class)
+				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, productId)
+				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Warehouse_ID, warehouseId)
+				.addEqualsFilter(I_MD_Stock.COLUMN_AttributesKey, attributesKey.getAsString())
+				.create()
+				.firstOnly(I_MD_Stock.class);
 	}
 }

--- a/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecordsTest.java
+++ b/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecordsTest.java
@@ -1,0 +1,150 @@
+package de.metas.material.cockpit.stock.eventhandler;
+
+import de.metas.material.cockpit.model.I_MD_Stock;
+import de.metas.material.cockpit.stock.StockChangeSourceInfo;
+import de.metas.material.cockpit.stock.StockDataRecordIdentifier;
+import de.metas.material.cockpit.stock.StockDataUpdateRequest;
+import de.metas.material.cockpit.stock.StockDataUpdateRequestHandler;
+import de.metas.material.event.PostMaterialEventService;
+import de.metas.material.event.attributes.AttributesChangedEvent;
+import de.metas.material.event.attributes.AttributesKeyWithASI;
+import de.metas.material.event.commons.AttributesKey;
+import de.metas.material.event.commons.EventDescriptor;
+import de.metas.organization.OrgId;
+import de.metas.product.ProductId;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
+import org.adempiere.mm.attributes.AttributeValueId;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * #%L
+ * metasfresh-material-cockpit
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+public class AttributesChangedEventHandlerForStockRecordsTest
+{
+	private static final int CLIENT_ID = 10;
+	private static final int ORG_ID = 20;
+	private static final int PRODUCT_ID = 2;
+	private static final int WAREHOUSE_ID = 1;
+	private static final BigDecimal QTY = new BigDecimal("13");
+	private static final AttributeSetInstanceId DUMMY_ASI_ID = AttributeSetInstanceId.ofRepoId(123);
+
+	private StockDataUpdateRequestHandler stockDataUpdateRequestHandler;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+		stockDataUpdateRequestHandler = new StockDataUpdateRequestHandler(Mockito.mock(PostMaterialEventService.class));
+	}
+
+	@Test
+	public void reKeysStockFromOldToNewAttributesKey()
+	{
+		// Given: seed MD_Stock(product=2, warehouse=1, attributesKey=A) with QtyOnHand=13
+		final AttributesKey keyA = attributesKey(1000);
+		final AttributesKey keyB = attributesKey(2000);
+
+		seedStock(keyA, QTY);
+
+		// Sanity check: stock on keyA exists before handler call
+		assertThat(getQtyOnHand(keyA)).isEqualByComparingTo(QTY);
+
+		// When: call the stub handler with an AttributesChangedEvent(old=A, new=B)
+		final AttributesChangedEventHandlerForStockRecords handler = new AttributesChangedEventHandlerForStockRecords();
+		handler.handleEvent(AttributesChangedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientAndOrg(CLIENT_ID, ORG_ID))
+				.warehouseId(WarehouseId.ofRepoId(WAREHOUSE_ID))
+				.date(Instant.parse("2019-10-03T10:15:30.00Z"))
+				.productId(PRODUCT_ID)
+				.qty(QTY)
+				.oldStorageAttributes(attributesKeyWithASI(1000))
+				.newStorageAttributes(attributesKeyWithASI(2000))
+				.huId(333)
+				.build());
+
+		// Then (RED): stub no-ops, so keyA still has QTY and keyB has nothing
+		// Task 3 will implement re-key logic to make these assertions pass green.
+		assertThat(getQtyOnHand(keyA))
+				.as("MD_Stock for old attributesKey A must be 0 after re-key")
+				.isEqualByComparingTo(BigDecimal.ZERO);
+		assertThat(getQtyOnHand(keyB))
+				.as("MD_Stock for new attributesKey B must equal QTY after re-key")
+				.isEqualByComparingTo(QTY);
+	}
+
+	// --- helpers ---
+
+	private void seedStock(@NonNull final AttributesKey attributesKey, @NonNull final BigDecimal qty)
+	{
+		final StockDataRecordIdentifier identifier = StockDataRecordIdentifier.builder()
+				.clientId(ClientId.ofRepoId(CLIENT_ID))
+				.orgId(OrgId.ofRepoId(ORG_ID))
+				.warehouseId(WarehouseId.ofRepoId(WAREHOUSE_ID))
+				.productId(ProductId.ofRepoId(PRODUCT_ID))
+				.storageAttributesKey(attributesKey)
+				.build();
+
+		final StockDataUpdateRequest request = StockDataUpdateRequest.builder()
+				.identifier(identifier)
+				.onHandQtyChange(qty)
+				.sourceInfo(StockChangeSourceInfo.ofHuAttributeChange(333))
+				.build();
+
+		stockDataUpdateRequestHandler.handleDataUpdateRequest(request);
+	}
+
+	private BigDecimal getQtyOnHand(@NonNull final AttributesKey attributesKey)
+	{
+		final I_MD_Stock record = Services.get(IQueryBL.class)
+				.createQueryBuilder(I_MD_Stock.class)
+				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, PRODUCT_ID)
+				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Warehouse_ID, WAREHOUSE_ID)
+				.addEqualsFilter(I_MD_Stock.COLUMN_AttributesKey, attributesKey.getAsString())
+				.create()
+				.firstOnly(I_MD_Stock.class);
+
+		return record != null ? record.getQtyOnHand() : BigDecimal.ZERO;
+	}
+
+	private static AttributesKeyWithASI attributesKeyWithASI(final int attributeValueRepoId)
+	{
+		return AttributesKeyWithASI.of(attributesKey(attributeValueRepoId), DUMMY_ASI_ID);
+	}
+
+	private static AttributesKey attributesKey(final int attributeValueRepoId)
+	{
+		return AttributesKey.ofAttributeValueIds(AttributeValueId.ofRepoId(attributeValueRepoId));
+	}
+}

--- a/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecordsTest.java
+++ b/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecordsTest.java
@@ -20,7 +20,6 @@ import org.adempiere.mm.attributes.AttributeValueId;
 import org.adempiere.service.ClientId;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.warehouse.WarehouseId;
-import org.compiere.SpringContextHolder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -68,7 +67,6 @@ public class AttributesChangedEventHandlerForStockRecordsTest
 	{
 		AdempiereTestHelper.get().init();
 		stockDataUpdateRequestHandler = new StockDataUpdateRequestHandler(Mockito.mock(PostMaterialEventService.class));
-		SpringContextHolder.registerJUnitBean(stockDataUpdateRequestHandler);
 	}
 
 	@Test
@@ -83,8 +81,8 @@ public class AttributesChangedEventHandlerForStockRecordsTest
 		// Sanity check: stock on keyA exists before handler call
 		assertThat(getQtyOnHand(keyA)).isEqualByComparingTo(QTY);
 
-		// When: call the stub handler with an AttributesChangedEvent(old=A, new=B)
-		final AttributesChangedEventHandlerForStockRecords handler = new AttributesChangedEventHandlerForStockRecords();
+		// When: the handler processes an AttributesChangedEvent(old=A, new=B)
+		final AttributesChangedEventHandlerForStockRecords handler = new AttributesChangedEventHandlerForStockRecords(stockDataUpdateRequestHandler);
 		handler.handleEvent(AttributesChangedEvent.builder()
 				.eventDescriptor(EventDescriptor.ofClientAndOrg(CLIENT_ID, ORG_ID))
 				.warehouseId(WarehouseId.ofRepoId(WAREHOUSE_ID))
@@ -96,13 +94,134 @@ public class AttributesChangedEventHandlerForStockRecordsTest
 				.huId(333)
 				.build());
 
-		// Then (RED): stub no-ops, so keyA still has QTY and keyB has nothing
-		// Task 3 will implement re-key logic to make these assertions pass green.
+		// Then: qty has moved off the old key and onto the new key
 		assertThat(getQtyOnHand(keyA))
 				.as("MD_Stock for old attributesKey A must be 0 after re-key")
 				.isEqualByComparingTo(BigDecimal.ZERO);
 		assertThat(getQtyOnHand(keyB))
 				.as("MD_Stock for new attributesKey B must equal QTY after re-key")
+				.isEqualByComparingTo(QTY);
+	}
+
+	/**
+	 * AC2 — full lifecycle: receipt → attribute change → shipment leaves both keys at zero.
+	 */
+	@Test
+	public void fullLifecycle_receiptThenAttrChangeThenShipment_zeroesBothKeys()
+	{
+		final AttributesKey keyA = attributesKey(5000);
+		final AttributesKey keyB = attributesKey(6000);
+
+		// Receipt: seed MD_Stock(product=2, warehouse=1, keyA) = +Q
+		seedStock(keyA, QTY);
+
+		// Attribute change: re-key from A → B
+		final AttributesChangedEventHandlerForStockRecords handler = new AttributesChangedEventHandlerForStockRecords(stockDataUpdateRequestHandler);
+		handler.handleEvent(AttributesChangedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientAndOrg(CLIENT_ID, ORG_ID))
+				.warehouseId(WarehouseId.ofRepoId(WAREHOUSE_ID))
+				.date(Instant.parse("2026-01-02T00:00:00.00Z"))
+				.productId(PRODUCT_ID)
+				.qty(QTY)
+				.oldStorageAttributes(attributesKeyWithASI(5000))
+				.newStorageAttributes(attributesKeyWithASI(6000))
+				.huId(666)
+				.build());
+
+		// Sanity: after re-key, keyB must hold QTY
+		final I_MD_Stock keyBAfterReKey = getMDStockRecord(PRODUCT_ID, keyB);
+		assertThat(keyBAfterReKey)
+				.as("MD_Stock(keyB) row must exist after re-key")
+				.isNotNull();
+		assertThat(keyBAfterReKey.getQtyOnHand())
+				.as("MD_Stock(keyB).QtyOnHand must equal QTY after re-key")
+				.isEqualByComparingTo(QTY);
+
+		// Shipment: issue −Q under keyB (simulates shipment booking under new attributes key)
+		seedStock(keyB, QTY.negate());
+
+		// Assert: both keys end at 0 — no phantom +/− pair
+		final I_MD_Stock keyAFinal = getMDStockRecord(PRODUCT_ID, keyA);
+		assertThat(keyAFinal)
+				.as("MD_Stock(keyA) row must exist after full lifecycle (genuinely zeroed)")
+				.isNotNull();
+		assertThat(keyAFinal.getQtyOnHand())
+				.as("MD_Stock(keyA).QtyOnHand must be 0 after full lifecycle")
+				.isEqualByComparingTo(BigDecimal.ZERO);
+
+		final I_MD_Stock keyBFinal = getMDStockRecord(PRODUCT_ID, keyB);
+		assertThat(keyBFinal)
+				.as("MD_Stock(keyB) row must exist after shipment (genuinely zeroed)")
+				.isNotNull();
+		assertThat(keyBFinal.getQtyOnHand())
+				.as("MD_Stock(keyB).QtyOnHand must be 0 after shipment")
+				.isEqualByComparingTo(BigDecimal.ZERO);
+	}
+
+	/**
+	 * AC4 — repeated re-keys (e.g. nightly MonthsUntilExpiry transitions) converge with no leftover on intermediate keys.
+	 */
+	@Test
+	public void repeatedRewrites_convergeNoLeftover()
+	{
+		final AttributesKey keyA = attributesKey(7000);
+		final AttributesKey keyB = attributesKey(8000);
+		final AttributesKey keyC = attributesKey(9000);
+
+		// Seed MD_Stock(product=2, warehouse=1, keyA) = +Q
+		seedStock(keyA, QTY);
+
+		final AttributesChangedEventHandlerForStockRecords handler = new AttributesChangedEventHandlerForStockRecords(stockDataUpdateRequestHandler);
+
+		// First re-key: A → B
+		handler.handleEvent(AttributesChangedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientAndOrg(CLIENT_ID, ORG_ID))
+				.warehouseId(WarehouseId.ofRepoId(WAREHOUSE_ID))
+				.date(Instant.parse("2026-01-03T00:00:00.00Z"))
+				.productId(PRODUCT_ID)
+				.qty(QTY)
+				.oldStorageAttributes(attributesKeyWithASI(7000))
+				.newStorageAttributes(attributesKeyWithASI(8000))
+				.huId(777)
+				.build());
+
+		// Second re-key: B → C
+		handler.handleEvent(AttributesChangedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientAndOrg(CLIENT_ID, ORG_ID))
+				.warehouseId(WarehouseId.ofRepoId(WAREHOUSE_ID))
+				.date(Instant.parse("2026-01-04T00:00:00.00Z"))
+				.productId(PRODUCT_ID)
+				.qty(QTY)
+				.oldStorageAttributes(attributesKeyWithASI(8000))
+				.newStorageAttributes(attributesKeyWithASI(9000))
+				.huId(777)
+				.build());
+
+		// keyA must be zeroed
+		final I_MD_Stock keyARow = getMDStockRecord(PRODUCT_ID, keyA);
+		assertThat(keyARow)
+				.as("MD_Stock(keyA) row must exist (genuinely zeroed, not absent)")
+				.isNotNull();
+		assertThat(keyARow.getQtyOnHand())
+				.as("MD_Stock(keyA).QtyOnHand must be 0 — no leftover after two re-keys")
+				.isEqualByComparingTo(BigDecimal.ZERO);
+
+		// keyB must be zeroed (no accumulation from the intermediate step)
+		final I_MD_Stock keyBRow = getMDStockRecord(PRODUCT_ID, keyB);
+		assertThat(keyBRow)
+				.as("MD_Stock(keyB) row must exist (genuinely zeroed, not absent)")
+				.isNotNull();
+		assertThat(keyBRow.getQtyOnHand())
+				.as("MD_Stock(keyB).QtyOnHand must be 0 — no leftover after second re-key")
+				.isEqualByComparingTo(BigDecimal.ZERO);
+
+		// keyC must hold +Q
+		final I_MD_Stock keyCRow = getMDStockRecord(PRODUCT_ID, keyC);
+		assertThat(keyCRow)
+				.as("MD_Stock(keyC) row must exist after second re-key")
+				.isNotNull();
+		assertThat(keyCRow.getQtyOnHand())
+				.as("MD_Stock(keyC).QtyOnHand must equal QTY after two successive re-keys")
 				.isEqualByComparingTo(QTY);
 	}
 
@@ -138,6 +257,22 @@ public class AttributesChangedEventHandlerForStockRecordsTest
 				.firstOnly(I_MD_Stock.class);
 
 		return record != null ? record.getQtyOnHand() : BigDecimal.ZERO;
+	}
+
+	/**
+	 * Returns the MD_Stock row for the given product/warehouse/attributesKey, or {@code null} if absent.
+	 * Use this for row-existence assertions before reading QtyOnHand — avoids the vacuous-zero of
+	 * {@link #getQtyOnHand} which returns ZERO for both a missing row and a genuinely-zeroed row.
+	 */
+	private I_MD_Stock getMDStockRecord(final int productId, @NonNull final AttributesKey attributesKey)
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_MD_Stock.class)
+				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Product_ID, productId)
+				.addEqualsFilter(I_MD_Stock.COLUMNNAME_M_Warehouse_ID, WAREHOUSE_ID)
+				.addEqualsFilter(I_MD_Stock.COLUMN_AttributesKey, attributesKey.getAsString())
+				.create()
+				.firstOnly(I_MD_Stock.class);
 	}
 
 	private static AttributesKeyWithASI attributesKeyWithASI(final int attributeValueRepoId)

--- a/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecordsTest.java
+++ b/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecordsTest.java
@@ -237,10 +237,11 @@ public class AttributesChangedEventHandlerForStockRecordsTest
 				.storageAttributesKey(attributesKey)
 				.build();
 
+		// seeding represents a receipt/shipment booking (transaction-driven), not an attribute change
 		final StockDataUpdateRequest request = StockDataUpdateRequest.builder()
 				.identifier(identifier)
 				.onHandQtyChange(qty)
-				.sourceInfo(StockChangeSourceInfo.ofHuAttributeChange(333))
+				.sourceInfo(StockChangeSourceInfo.ofTransactionId(1))
 				.build();
 
 		stockDataUpdateRequestHandler.handleDataUpdateRequest(request);

--- a/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecordsTest.java
+++ b/backend/de.metas.material/cockpit/src/test/java/de/metas/material/cockpit/stock/eventhandler/AttributesChangedEventHandlerForStockRecordsTest.java
@@ -20,6 +20,7 @@ import org.adempiere.mm.attributes.AttributeValueId;
 import org.adempiere.service.ClientId;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.warehouse.WarehouseId;
+import org.compiere.SpringContextHolder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -67,6 +68,7 @@ public class AttributesChangedEventHandlerForStockRecordsTest
 	{
 		AdempiereTestHelper.get().init();
 		stockDataUpdateRequestHandler = new StockDataUpdateRequestHandler(Mockito.mock(PostMaterialEventService.class));
+		SpringContextHolder.registerJUnitBean(stockDataUpdateRequestHandler);
 	}
 
 	@Test


### PR DESCRIPTION
## What

Keeps `MD_Stock` correct when a storage-relevant HU attribute changes (e.g. the nightly `MonthsUntilExpiry` rewrite). On such a change the HU's qty logically moves from one `MD_Stock` AttributesKey bucket to another. The real-time event path previously ignored this, so per-key `MD_Stock` rows drifted apart without bound (one key runs positive, its sibling negative) even though the real total is small. Until now the only thing correcting it was the heavy `MD_Stock_Update_From_M_HUs` reconciliation scheduler, whose intraday cadence caused a production picking slowdown.

## How

- New material-cockpit handler `AttributesChangedEventHandlerForStockRecords` (`MaterialEventHandler<AttributesChangedEvent>`, `@Profile(PROFILE_App)`). On the event it issues two `MD_Stock` delta legs through the existing `StockDataUpdateRequestHandler`: **FROM** leg (−qty at the old AttributesKey) and **TO** leg (+qty at the new AttributesKey). Mirrors `TransactionEventHandlerForStockRecords` (delta application) and the dispo-service `AttributesChangedEventHandler` (two-leg shape).
- **No UOM conversion**: the event's `qty` field is already stamped in the product's stock UOM by the HU-attribute-change collector (`HUAttributeChangesCollector` calls `IHUProductStorage.getQtyInStockingUOM()` at event-construction time, which converts to `M_Product.C_UOM_ID`); the receipt/shipment bookings use that same stock UOM, so the legs offset the bookings exactly.
- **No MRP-exclusion guard**, consistent with `TransactionEventHandlerForStockRecords` — `MD_Stock` tracks real on-hand qty regardless of warehouse exclusion.
- **Delivery semantics** are the same trust boundary as every real-time `MD_Stock` handler (e.g. `TransactionEventHandlerForStockRecords`): the FROM and TO legs run inside the single event-dispatch transaction (atomic with each other — a mid-dispatch failure rolls back both), and correctness relies on the material event being delivered and committed. This PR adds no new application-level idempotency key beyond that existing boundary; the occasional nightly reconciliation remains the backstop for a genuinely lost event.
- New `StockChangeSourceInfo.ofHuAttributeChange(huId)` provenance variant (`transactionId = -1`, no reset id).

Effect: the event path now keeps `MD_Stock` converged per AttributesKey, so the reconciliation scheduler is no longer needed as live medicine (only an occasional nightly backstop).

## Tests

`AttributesChangedEventHandlerForStockRecordsTest` (in-memory `AdempiereTestHelper`, TDD RED→GREEN):
- re-key moves qty from the old AttributesKey to the new one;
- full lifecycle (receipt → attribute change → shipment) leaves both keys at zero (no phantom +/− pair, real total preserved);
- repeated rewrites (A→B→C) converge with no leftover on intermediate keys;
- identity re-key (unchanged AttributesKey) is a no-op;
- partial/uneven split and MRP-excluded warehouse.

Plus a cucumber test (`mdStock_AttributeChange_ReKey.feature`, executor7) proving the end-to-end event chain against the running stack. No DB migration.
