### PR TITLE
Merge: soft_panda_hotfix → soft_panda_release

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_S_Resource.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_S_Resource.java
@@ -1,9 +1,8 @@
 package org.compiere.model;
 
-import org.adempiere.model.ModelColumn;
-
-import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import javax.annotation.Nullable;
+import org.adempiere.model.ModelColumn;
 
 /** Generated Interface for S_Resource
  *  @author metasfresh (generated) 
@@ -73,31 +72,6 @@ public interface I_S_Resource
 	int getAD_User_ID();
 
 	String COLUMNNAME_AD_User_ID = "AD_User_ID";
-
-	/**
-	 * Set Workplace.
-	 *
-	 * <br>Type: Search
-	 * <br>Mandatory: false
-	 * <br>Virtual Column: false
-	 */
-	void setC_Workplace_ID (int C_Workplace_ID);
-
-	/**
-	 * Get Workplace.
-	 *
-	 * <br>Type: Search
-	 * <br>Mandatory: false
-	 * <br>Virtual Column: false
-	 */
-	int getC_Workplace_ID();
-
-	@Nullable org.compiere.model.I_C_Workplace getC_Workplace();
-
-	void setC_Workplace(@Nullable org.compiere.model.I_C_Workplace C_Workplace);
-
-	ModelColumn<I_S_Resource, org.compiere.model.I_C_Workplace> COLUMN_C_Workplace_ID = new ModelColumn<>(I_S_Resource.class, "C_Workplace_ID", org.compiere.model.I_C_Workplace.class);
-	String COLUMNNAME_C_Workplace_ID = "C_Workplace_ID";
 
 	/**
 	 * Set Capacity Per Production Cycle.
@@ -185,6 +159,33 @@ public interface I_S_Resource
 	int getCreatedBy();
 
 	String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/**
+	 * Set Workplace.
+	 * Logical area within a warehouse, to which one or more Workstations can be assigned. An operator logs into exactly one Workplace per shift. The associated warehouse (M_Warehouse_ID) drives the storage location of the work performed there.
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setC_Workplace_ID (int C_Workplace_ID);
+
+	/**
+	 * Get Workplace.
+	 * Logical area within a warehouse, to which one or more Workstations can be assigned. An operator logs into exactly one Workplace per shift. The associated warehouse (M_Warehouse_ID) drives the storage location of the work performed there.
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getC_Workplace_ID();
+
+	@Nullable org.compiere.model.I_C_Workplace getC_Workplace();
+
+	void setC_Workplace(@Nullable org.compiere.model.I_C_Workplace C_Workplace);
+
+	ModelColumn<I_S_Resource, org.compiere.model.I_C_Workplace> COLUMN_C_Workplace_ID = new ModelColumn<>(I_S_Resource.class, "C_Workplace_ID", org.compiere.model.I_C_Workplace.class);
+	String COLUMNNAME_C_Workplace_ID = "C_Workplace_ID";
 
 	/**
 	 * Set Daily Capacity.
@@ -297,6 +298,7 @@ public interface I_S_Resource
 
 	/**
 	 * Set Manufacturing Resource.
+	 * Marks the resource as relevant for manufacturing. Only S_Resource records flagged accordingly appear in the manufacturing module's selection lists and can be scanned as a Workstation in MobileUI.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: false
@@ -306,6 +308,7 @@ public interface I_S_Resource
 
 	/**
 	 * Get Manufacturing Resource.
+	 * Marks the resource as relevant for manufacturing. Only S_Resource records flagged accordingly appear in the manufacturing module's selection lists and can be scanned as a Workstation in MobileUI.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: false
@@ -317,7 +320,29 @@ public interface I_S_Resource
 	String COLUMNNAME_IsManufacturingResource = "IsManufacturingResource";
 
 	/**
+	 * Set Lot Number Code.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setLotNumberCode (@Nullable java.lang.String LotNumberCode);
+
+	/**
+	 * Get Lot Number Code.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	@Nullable java.lang.String getLotNumberCode();
+
+	ModelColumn<I_S_Resource, Object> COLUMN_LotNumberCode = new ModelColumn<>(I_S_Resource.class, "LotNumberCode", null);
+	String COLUMNNAME_LotNumberCode = "LotNumberCode";
+
+	/**
 	 * Set Manufacturing Resource Type.
+	 * Type of manufacturing resource: Workstation (physical scannable device), Work Center (aggregate within a Plant), Plant (manufacturing site), Production Line, or External System.
 	 *
 	 * <br>Type: List
 	 * <br>Mandatory: false
@@ -327,6 +352,7 @@ public interface I_S_Resource
 
 	/**
 	 * Get Manufacturing Resource Type.
+	 * Type of manufacturing resource: Workstation (physical scannable device), Work Center (aggregate within a Plant), Plant (manufacturing site), Production Line, or External System.
 	 *
 	 * <br>Type: List
 	 * <br>Mandatory: false

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_S_Resource.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_S_Resource.java
@@ -1,10 +1,10 @@
 // Generated Model - DO NOT CHANGE
 package org.compiere.model;
 
-import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
+import javax.annotation.Nullable;
 
 /** Generated Model for S_Resource
  *  @author metasfresh (generated) 
@@ -13,7 +13,7 @@ import java.util.Properties;
 public class X_S_Resource extends org.compiere.model.PO implements I_S_Resource, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 664197132L;
+	private static final long serialVersionUID = 2055189460L;
 
     /** Standard Constructor */
     public X_S_Resource (final Properties ctx, final int S_Resource_ID, @Nullable final String trxName)
@@ -48,33 +48,6 @@ public class X_S_Resource extends org.compiere.model.PO implements I_S_Resource,
 	public int getAD_User_ID() 
 	{
 		return get_ValueAsInt(COLUMNNAME_AD_User_ID);
-	}
-
-	@Override
-	public org.compiere.model.I_C_Workplace getC_Workplace()
-	{
-		return get_ValueAsPO(COLUMNNAME_C_Workplace_ID, org.compiere.model.I_C_Workplace.class);
-	}
-
-	@Override
-	public void setC_Workplace(final org.compiere.model.I_C_Workplace C_Workplace)
-	{
-		set_ValueFromPO(COLUMNNAME_C_Workplace_ID, org.compiere.model.I_C_Workplace.class, C_Workplace);
-	}
-
-	@Override
-	public void setC_Workplace_ID (final int C_Workplace_ID)
-	{
-		if (C_Workplace_ID < 1) 
-			set_Value (COLUMNNAME_C_Workplace_ID, null);
-		else 
-			set_Value (COLUMNNAME_C_Workplace_ID, C_Workplace_ID);
-	}
-
-	@Override
-	public int getC_Workplace_ID() 
-	{
-		return get_ValueAsInt(COLUMNNAME_C_Workplace_ID);
 	}
 
 	@Override
@@ -116,6 +89,33 @@ public class X_S_Resource extends org.compiere.model.PO implements I_S_Resource,
 	{
 		final BigDecimal bd = get_ValueAsBigDecimal(COLUMNNAME_ChargeableQty);
 		return bd != null ? bd : BigDecimal.ZERO;
+	}
+
+	@Override
+	public org.compiere.model.I_C_Workplace getC_Workplace()
+	{
+		return get_ValueAsPO(COLUMNNAME_C_Workplace_ID, org.compiere.model.I_C_Workplace.class);
+	}
+
+	@Override
+	public void setC_Workplace(final org.compiere.model.I_C_Workplace C_Workplace)
+	{
+		set_ValueFromPO(COLUMNNAME_C_Workplace_ID, org.compiere.model.I_C_Workplace.class, C_Workplace);
+	}
+
+	@Override
+	public void setC_Workplace_ID (final int C_Workplace_ID)
+	{
+		if (C_Workplace_ID < 1) 
+			set_Value (COLUMNNAME_C_Workplace_ID, null);
+		else 
+			set_Value (COLUMNNAME_C_Workplace_ID, C_Workplace_ID);
+	}
+
+	@Override
+	public int getC_Workplace_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_C_Workplace_ID);
 	}
 
 	@Override
@@ -180,6 +180,18 @@ public class X_S_Resource extends org.compiere.model.PO implements I_S_Resource,
 	public boolean isManufacturingResource() 
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsManufacturingResource);
+	}
+
+	@Override
+	public void setLotNumberCode (final @Nullable java.lang.String LotNumberCode)
+	{
+		set_Value (COLUMNNAME_LotNumberCode, LotNumberCode);
+	}
+
+	@Override
+	public java.lang.String getLotNumberCode() 
+	{
+		return get_ValueAsString(COLUMNNAME_LotNumberCode);
 	}
 
 	/** 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/sequenceno/DBFunctionSequenceNoProvider.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/document/sequenceno/DBFunctionSequenceNoProvider.java
@@ -1,0 +1,144 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.document.sequenceno;
+
+import ch.qos.logback.classic.Level;
+import de.metas.adempiere.model.IPOReferenceAware;
+import de.metas.common.util.time.SystemTime;
+import de.metas.document.DocumentSequenceInfo;
+import de.metas.logging.LogManager;
+import de.metas.util.Check;
+import de.metas.util.ILoggable;
+import de.metas.util.Loggables;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.service.ISysConfigBL;
+import org.compiere.util.DB;
+import org.compiere.util.Evaluatee;
+import org.compiere.util.SQLValueStringResult;
+import org.slf4j.Logger;
+
+import javax.annotation.Nullable;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Generic {@link CustomSequenceNoProvider} that delegates the whole sequence-number string to a PL/pgSQL function.
+ * <p>
+ * The function name is configured <b>per sequence</b> via the SysConfig
+ * {@code de.metas.document.seqNo.DBFunctionSequenceNoProvider.<AD_Sequence.Name>.dbFunctionName},
+ * so several sequences can each name their own function with no code change. The function is called as
+ * {@code SELECT <fn>(Record_ID, generated_at)} and its result is returned verbatim as the full sequence string
+ * ({@link #isUseIncrementSeqNoAsPrefix()} is {@code false}, so no incremental counter is appended).
+ * <p>
+ * The {@code Record_ID} comes from the evaluation context (the caller puts the driving record's id there);
+ * {@code generated_at} is the generation timestamp (now).
+ */
+public class DBFunctionSequenceNoProvider implements CustomSequenceNoProvider
+{
+	private static final Logger logger = LogManager.getLogger(DBFunctionSequenceNoProvider.class);
+
+	// Per-sequence key: de.metas.document.seqNo.DBFunctionSequenceNoProvider.<AD_Sequence.Name>.dbFunctionName
+	private static final String SYSCONFIG_PREFIX = "de.metas.document.seqNo.DBFunctionSequenceNoProvider.";
+	private static final String SYSCONFIG_SUFFIX = ".dbFunctionName";
+
+	// The function name is concatenated into SQL (an identifier can't be a bind parameter), so it must be a plain,
+	// optionally single-schema-qualified SQL identifier (e.g. fn_x or myschema.fn_x) - guards against a malformed /
+	// injected SysConfig value. Matcher.matches() anchors the whole string.
+	private static final Pattern FUNCTION_NAME_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)?");
+
+	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+
+	private static String sysConfigKey(@NonNull final DocumentSequenceInfo docSeqInfo)
+	{
+		return SYSCONFIG_PREFIX + docSeqInfo.getName() + SYSCONFIG_SUFFIX;
+	}
+
+	/** @return {@code true} if the (trimmed) function name is a plain or single-schema-qualified SQL identifier. */
+	static boolean isValidFunctionName(@Nullable final String functionName)
+	{
+		return functionName != null && FUNCTION_NAME_PATTERN.matcher(functionName.trim()).matches();
+	}
+
+	/**
+	 * Applicable when this sequence has a (per-sequence) function-name SysConfig set and the context carries a
+	 * positive {@code Record_ID}. We deliberately do NOT check here that the function actually exists: a
+	 * misconfigured function name must fail <b>loud</b> in {@link #provideSequenceNo} (so the wrong lot number is
+	 * never silently replaced by a plain incremental one), not silently disable the provider.
+	 */
+	@Override
+	public boolean isApplicable(@NonNull final Evaluatee context, @NonNull final DocumentSequenceInfo docSeqInfo)
+	{
+		final String functionName = sysConfigBL.getValue(sysConfigKey(docSeqInfo), (String)null);
+		if (Check.isBlank(functionName))
+		{
+			return false;
+		}
+		return context.get_ValueAsInt(IPOReferenceAware.COLUMNNAME_Record_ID, -1) > 0;
+	}
+
+	@Override
+	public String provideSequenceNo(
+			@NonNull final Evaluatee context,
+			@NonNull final DocumentSequenceInfo docSeqInfo,
+			@Nullable final String autoIncrementedSeqNumber)
+	{
+		final String sysConfigKey = sysConfigKey(docSeqInfo);
+		final String functionName = sysConfigBL.getValue(sysConfigKey, (String)null);
+		Check.assumeNotEmpty(functionName, "{} sysconfig must be set", sysConfigKey);
+
+		Check.assume(isValidFunctionName(functionName),
+				"{}={} must be a plain or single-schema-qualified SQL function identifier", sysConfigKey, functionName);
+		final String functionNameNorm = functionName.trim();
+
+		final int recordId = context.get_ValueAsInt(IPOReferenceAware.COLUMNNAME_Record_ID, -1);
+		Check.assume(recordId > 0, "context must carry a positive {}", IPOReferenceAware.COLUMNNAME_Record_ID);
+
+		final Timestamp generatedAt = Timestamp.from(SystemTime.asInstant());
+		final SQLValueStringResult sqlResult = DB.getSQLValueStringWithWarningEx(ITrx.TRXNAME_None,
+				"SELECT " + functionNameNorm + "(?, ?)", recordId, generatedAt);
+
+		// Surface any RAISE NOTICE the DB function emitted (PostgreSQL delivers them as JDBC SQLWarnings) to the
+		// ambient Loggable, so they are visible when debugging - the same notice output SQL-type AD_Processes log.
+		final List<String> noticeMessages = sqlResult.getWarningMessages();
+		if (noticeMessages != null && !noticeMessages.isEmpty())
+		{
+			final ILoggable loggable = Loggables.withLogger(logger, Level.DEBUG);
+			noticeMessages.forEach(noticeMessage -> loggable.addLog("{}", noticeMessage));
+		}
+
+		final String result = sqlResult.getReturnedValue();
+		Check.assumeNotEmpty(result, "DB function {} returned empty for {}={}",
+				functionNameNorm, IPOReferenceAware.COLUMNNAME_Record_ID, recordId);
+		return result;
+	}
+
+	/** Standalone number - no auto-incremented counter is appended (same day+shift+line legitimately share one number). */
+	@Override
+	public boolean isUseIncrementSeqNoAsPrefix()
+	{
+		return false;
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/document/sequenceno/DBFunctionSequenceNoProviderTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/document/sequenceno/DBFunctionSequenceNoProviderTest.java
@@ -1,0 +1,121 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.document.sequenceno;
+
+import de.metas.adempiere.model.IPOReferenceAware;
+import de.metas.document.DocumentSequenceInfo;
+import de.metas.util.Services;
+import org.adempiere.service.ISysConfigBL;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.util.Evaluatee;
+import org.compiere.util.Evaluatees;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the applicability / fail-loud contract of {@link DBFunctionSequenceNoProvider}.
+ * The DB-backed {@code provideSequenceNo} (which calls the configured PL/pgSQL function) is exercised by the
+ * integration test, not here.
+ */
+class DBFunctionSequenceNoProviderTest
+{
+	private static final String SEQ_NAME = "TestLotSeq";
+	// The provider must derive exactly this per-sequence key from the sequence Name:
+	private static final String EXPECTED_SYSCONFIG_KEY =
+			"de.metas.document.seqNo.DBFunctionSequenceNoProvider." + SEQ_NAME + ".dbFunctionName";
+
+	private ISysConfigBL sysConfigBL;
+	private DBFunctionSequenceNoProvider provider;
+
+	private static DocumentSequenceInfo docSeqInfo()
+	{
+		return DocumentSequenceInfo.builder().name(SEQ_NAME).build();
+	}
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		sysConfigBL = mock(ISysConfigBL.class);
+		Services.registerService(ISysConfigBL.class, sysConfigBL);
+
+		provider = new DBFunctionSequenceNoProvider();
+	}
+
+	@Test
+	void isApplicable_true_whenPerSequenceFunctionConfiguredAndRecordIdPresent()
+	{
+		// the function-name SysConfig is set for THIS sequence's derived key:
+		when(sysConfigBL.getValue(EXPECTED_SYSCONFIG_KEY, (String)null)).thenReturn("fn_lotno_test");
+		final Evaluatee context = Evaluatees.ofSingleton(IPOReferenceAware.COLUMNNAME_Record_ID, 12345);
+
+		assertThat(provider.isApplicable(context, docSeqInfo())).isTrue();
+	}
+
+	@Test
+	void isApplicable_false_whenSysConfigBlank()
+	{
+		// no stub -> getValue returns null -> not configured for this sequence
+		final Evaluatee context = Evaluatees.ofSingleton(IPOReferenceAware.COLUMNNAME_Record_ID, 12345);
+
+		assertThat(provider.isApplicable(context, docSeqInfo())).isFalse();
+	}
+
+	@Test
+	void isApplicable_false_whenConfiguredButNoRecordId()
+	{
+		when(sysConfigBL.getValue(EXPECTED_SYSCONFIG_KEY, (String)null)).thenReturn("fn_lotno_test");
+		final Evaluatee context = Evaluatees.empty(); // no Record_ID
+
+		assertThat(provider.isApplicable(context, docSeqInfo())).isFalse();
+	}
+
+	@Test
+	void doesNotUseIncrementSeqNoAsPrefix()
+	{
+		assertThat(provider.isUseIncrementSeqNoAsPrefix()).isFalse();
+	}
+
+	@Test
+	void isValidFunctionName_acceptsPlainAndSchemaQualified()
+	{
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("fn_lotno_custom")).isTrue();
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("myschema.fn_lotno")).isTrue();
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("  fn_lotno  ")).isTrue(); // trimmed
+	}
+
+	@Test
+	void isValidFunctionName_rejectsMalformedOrInjection()
+	{
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName(null)).isFalse();
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("")).isFalse();
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("fn_lotno; DROP TABLE ad_sequence")).isFalse();
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("fn lotno")).isFalse();
+		assertThat(DBFunctionSequenceNoProvider.isValidFunctionName("schema.sub.fn")).isFalse(); // only one schema segment
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809270_sys_DBFunctionSequenceNoProvider.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809270_sys_DBFunctionSequenceNoProvider.sql
@@ -1,0 +1,7 @@
+-- Register the generic DBFunctionSequenceNoProvider as a selectable AD_Sequence.CustomSequenceNoProvider_JavaClass_ID.
+-- For a sequence whose Name is <seqName>, the provider reads the per-sequence SysConfig
+-- "de.metas.document.seqNo.DBFunctionSequenceNoProvider.<seqName>.dbFunctionName" to get a PL/pgSQL function name,
+-- then calls <fn>(Record_ID, generated_at) and returns its result as the full sequence string (no counter appended).
+INSERT INTO AD_JavaClass (AD_Client_ID,AD_JavaClass_ID,AD_JavaClass_Type_ID,AD_Org_ID,Classname,Created,CreatedBy,Description,EntityType,IsActive,IsInterface,Name,Updated,UpdatedBy)
+VALUES (0,540102 /*From ID Server*/,540040,0,'de.metas.document.sequenceno.DBFunctionSequenceNoProvider',TO_TIMESTAMP('2026-06-22 16:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Generic custom AD_Sequence number provider. For a sequence whose Name is <seqName>, reads the SysConfig ''de.metas.document.seqNo.DBFunctionSequenceNoProvider.<seqName>.dbFunctionName'' to get a PL/pgSQL function name, then calls <fn>(Record_ID, generated_at) and returns its result as the full sequence string (no incremental counter appended). Configure one SysConfig per sequence that should use it.','D','Y','N','DBFunctionSequenceNoProvider',TO_TIMESTAMP('2026-06-22 16:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809310_sys_S_Resource_LotNumberCode.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809310_sys_S_Resource_LotNumberCode.sql
@@ -1,0 +1,139 @@
+-- Add S_Resource.LotNumberCode column (String, length 10, optional)
+-- A per-resource code consumed by custom lot-number sequence providers (e.g. to embed a
+-- production-line code in a generated lot number). Not unique, not mandatory.
+
+-- ===========================================================
+-- 1. AD_Element
+-- ===========================================================
+INSERT INTO AD_Element
+(AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+ ColumnName, Name, PrintName, EntityType)
+SELECT
+ 585043 /*From ID Server*/,
+ 0, 0, 'Y',
+ TO_TIMESTAMP('2026-06-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ TO_TIMESTAMP('2026-06-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ 'LotNumberCode',
+ 'Lot-Nummer Code',
+ 'Lot-Nummer Code',
+ 'D'
+WHERE NOT EXISTS (SELECT 1 FROM AD_Element WHERE AD_Element_ID=585043)
+;
+
+-- ===========================================================
+-- 2a. Seed AD_Element_Trl skeleton rows for all active system languages
+-- ===========================================================
+INSERT INTO AD_Element_Trl
+(AD_Language, AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+ Name, PrintName, IsTranslated)
+SELECT
+ l.AD_Language, t.AD_Element_ID, t.AD_Client_ID, t.AD_Org_ID, 'Y',
+ TO_TIMESTAMP('2026-06-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ TO_TIMESTAMP('2026-06-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ t.Name, t.PrintName, 'N'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y'
+  AND t.AD_Element_ID=585043
+  AND NOT EXISTS (
+    SELECT 1 FROM AD_Element_Trl tt
+    WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID
+  )
+;
+
+-- ===========================================================
+-- 2b. Mark de_DE and de_CH as translated (same text as base)
+-- ===========================================================
+UPDATE AD_Element_Trl
+SET IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-06-22 10:00:12', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy=100
+WHERE AD_Element_ID=585043 AND AD_Language='de_DE'
+;
+
+UPDATE AD_Element_Trl
+SET IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-06-22 10:00:13', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy=100
+WHERE AD_Element_ID=585043 AND AD_Language='de_CH'
+;
+
+-- ===========================================================
+-- 2c. Override en_US with English translation
+-- ===========================================================
+UPDATE AD_Element_Trl
+SET Name='Lot Number Code',
+    PrintName='Lot Number Code',
+    IsTranslated='Y',
+    Updated=TO_TIMESTAMP('2026-06-22 10:00:18', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy=100
+WHERE AD_Element_ID=585043 AND AD_Language='en_US'
+;
+
+-- ===========================================================
+-- 3. AD_Column
+-- ===========================================================
+INSERT INTO AD_Column
+(AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+ AD_Table_ID, AD_Element_ID, AD_Reference_ID,
+ ColumnName, Name, FieldLength, IsMandatory, IsKey, IsParent, IsTranslated,
+ IsIdentifier, IsEncrypted, IsUpdateable, IsAlwaysUpdateable,
+ IsSelectionColumn, IsSyncDatabase,
+ PersonalDataCategory, Version, EntityType)
+SELECT
+ 592876 /*From ID Server*/,
+ 0, 0, 'Y',
+ TO_TIMESTAMP('2026-06-22 10:01:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ TO_TIMESTAMP('2026-06-22 10:01:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ 487,          -- AD_Table_ID for S_Resource
+ 585043,       -- AD_Element_ID
+ 10,           -- String reference
+ 'LotNumberCode',
+ 'Lot-Nummer Code',
+ 10,           -- FieldLength
+ 'N',          -- IsMandatory
+ 'N', 'N', 'N',
+ 'N', 'N', 'Y', 'N',
+ 'N', 'N',
+ 'NP',         -- PersonalDataCategory: Not Personal
+ 0,            -- Version
+ 'D'           -- EntityType: core dictionary
+WHERE NOT EXISTS (SELECT 1 FROM AD_Column WHERE AD_Column_ID=592876)
+;
+
+-- ===========================================================
+-- 4a. Seed AD_Column_Trl skeleton rows
+-- ===========================================================
+INSERT INTO AD_Column_Trl
+(AD_Language, AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+ Name, IsTranslated)
+SELECT
+ l.AD_Language, t.AD_Column_ID, t.AD_Client_ID, t.AD_Org_ID, 'Y',
+ TO_TIMESTAMP('2026-06-22 10:01:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ TO_TIMESTAMP('2026-06-22 10:01:00', 'YYYY-MM-DD HH24:MI:SS'),
+ 100,
+ t.Name, 'N'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y'
+  AND t.AD_Column_ID=592876
+  AND NOT EXISTS (
+    SELECT 1 FROM AD_Column_Trl tt
+    WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID
+  )
+;
+
+-- ===========================================================
+-- 4b. Propagate element translations into the column
+-- ===========================================================
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585043);
+
+-- ===========================================================
+-- 5. Add the physical column
+-- ===========================================================
+ALTER TABLE S_Resource ADD COLUMN IF NOT EXISTS LotNumberCode VARCHAR(10);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809380_sys_S_Resource_LotNumberCode_window.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5809380_sys_S_Resource_LotNumberCode_window.sql
@@ -1,0 +1,130 @@
+-- Add LotNumberCode field to the Resource window (AD_Window_ID=236, AD_Tab_ID=414)
+-- AD_Column_ID=592876, AD_Element_ID=585043
+-- AD_Field_ID=781245, AD_UI_Element_ID=652364  (all from ID server)
+
+-- =============================================================================
+-- Step 1: Add Description + Help to AD_Element_Trl (de_DE, de_CH, en_US)
+--         so users see a meaningful tooltip on the field.
+-- =============================================================================
+UPDATE AD_Element_Trl
+SET    Description  = 'Code dieser Ressource, der in generierte Lot-Nummern eingebettet wird.',
+       Help         = 'Code dieser Ressource, der in generierte Lot-Nummern eingebettet wird.',
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-06-23 08:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+WHERE  AD_Element_ID = 585043
+  AND  AD_Language   = 'de_DE';
+
+UPDATE AD_Element_Trl
+SET    Description  = 'Code dieser Ressource, der in generierte Lot-Nummern eingebettet wird.',
+       Help         = 'Code dieser Ressource, der in generierte Lot-Nummern eingebettet wird.',
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-06-23 08:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+WHERE  AD_Element_ID = 585043
+  AND  AD_Language   = 'de_CH';
+
+UPDATE AD_Element_Trl
+SET    Description  = 'Code of this resource, embedded into generated lot numbers.',
+       Help         = 'Code of this resource, embedded into generated lot numbers.',
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-06-23 08:00:03', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+WHERE  AD_Element_ID = 585043
+  AND  AD_Language   = 'en_US';
+
+-- Also set Description/Help on the base AD_Element (base language = de_DE)
+UPDATE AD_Element
+SET    Description  = 'Code dieser Ressource, der in generierte Lot-Nummern eingebettet wird.',
+       Help         = 'Code dieser Ressource, der in generierte Lot-Nummern eingebettet wird.',
+       Updated      = TO_TIMESTAMP('2026-06-23 08:00:04', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy    = 100
+WHERE  AD_Element_ID = 585043;
+
+-- Propagate element TRL changes to all dependent translation tables
+/* DDL */ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585043);
+
+-- =============================================================================
+-- Step 2: Create AD_Field for LotNumberCode on tab 414 (main S_Resource tab)
+-- Placement: primary group (SeqNo=80, after Arbeitsplatz at 70)
+--            visible in grid at SeqNoGrid=25 (between Name=20 and Beschreibung=70)
+-- Not mandatory, editable.
+-- =============================================================================
+INSERT INTO AD_Field
+  (AD_Field_ID, AD_Client_ID, AD_Org_ID,
+   IsActive, Created, CreatedBy, Updated, UpdatedBy,
+   Name, AD_Tab_ID, AD_Column_ID,
+   IsDisplayed, DisplayLength, SeqNo,
+   IsReadOnly, IsMandatory, IsFieldOnly, IsHeading,
+   IsDisplayedGrid, SeqNoGrid,
+   EntityType)
+VALUES
+  (781245 /*From ID Server*/, 0, 0,
+   'Y',
+   TO_TIMESTAMP('2026-06-23 08:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   TO_TIMESTAMP('2026-06-23 08:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   'Lot-Nummer Code', 414, 592876,
+   'Y', 10, 80,
+   'N', 'N', 'N', 'N',
+   'Y', 25,
+   'D');
+
+-- =============================================================================
+-- Step 3: Seed AD_Field_Trl skeleton rows for all active system languages
+-- =============================================================================
+INSERT INTO AD_Field_Trl
+  (AD_Language, AD_Field_ID, Name, IsTranslated,
+   AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Name, 'N',
+       t.AD_Client_ID, t.AD_Org_ID,
+       TO_TIMESTAMP('2026-06-23 08:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       TO_TIMESTAMP('2026-06-23 08:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       'Y'
+FROM   AD_Language l, AD_Field t
+WHERE  l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y'
+  AND  t.AD_Field_ID = 781245
+  AND  NOT EXISTS (
+         SELECT 1 FROM AD_Field_Trl tt
+         WHERE  tt.AD_Language = l.AD_Language
+           AND  tt.AD_Field_ID = t.AD_Field_ID
+       );
+
+-- =============================================================================
+-- Step 4: Propagate element translations → field translations
+--         (uses AD_Element_ID=585043, not the field ID)
+-- =============================================================================
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(585043);
+
+-- =============================================================================
+-- Step 5: Rebuild AD_Element_Link for the new field
+-- =============================================================================
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 781245;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781245);
+
+-- =============================================================================
+-- Step 6: Create AD_UI_Element — places the field in the primary group
+--         of the left column of tab 414.
+--         Group 543924 = 'default' (UIStyle='primary'), left column of section 542062.
+--         SeqNo=80 (form view, after Arbeitsplatz=70)
+--         SeqNoGrid=25 (grid view, between Name=20 and Beschreibung=70)
+-- =============================================================================
+INSERT INTO AD_UI_Element
+  (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID,
+   IsActive, Created, CreatedBy, Updated, UpdatedBy,
+   AD_Tab_ID, AD_Field_ID, AD_UI_ElementGroup_ID,
+   AD_UI_ElementType,
+   Name,
+   SeqNo, SeqNoGrid, SeqNo_SideList,
+   IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+   IsAdvancedField, WidgetSize)
+VALUES
+  (652364 /*From ID Server*/, 0, 0,
+   'Y',
+   TO_TIMESTAMP('2026-06-23 08:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   TO_TIMESTAMP('2026-06-23 08:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   414, 781245, 543924,
+   'F',
+   'LotNumberCode',
+   80, 25, 0,
+   'Y', 'Y', 'N',
+   'N', 'S');   -- narrow widget: 10-char code field

--- a/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/LotNumberBL.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/mm/attributes/api/impl/LotNumberBL.java
@@ -1,5 +1,6 @@
 package org.adempiere.mm.attributes.api.impl;
 
+import de.metas.adempiere.model.IPOReferenceAware;
 import de.metas.document.sequence.IDocumentNoBuilder;
 import de.metas.document.sequence.IDocumentNoBuilderFactory;
 import de.metas.util.Services;
@@ -12,8 +13,10 @@ import org.adempiere.mm.attributes.api.ILotNumberDateAttributeDAO;
 import org.adempiere.mm.attributes.api.LotNoContext;
 import org.compiere.model.I_M_AttributeInstance;
 import org.compiere.model.I_M_AttributeSetInstance;
+import org.compiere.util.Evaluatee;
 import org.compiere.util.Evaluatees;
 import org.compiere.util.TimeUtil;
+import org.eevolution.api.PPOrderId;
 
 import java.util.Date;
 import java.util.Objects;
@@ -70,10 +73,20 @@ public class LotNumberBL implements ILotNumberBL
 	{
 		final IDocumentNoBuilderFactory documentNoFactory = Services.get(IDocumentNoBuilderFactory.class);
 
+		// A CustomSequenceNoProvider (opt-in, configured on the sequence) may need the PP_Order behind this lot number.
+		// Expose it under the standard Record_ID context key. Without a PP_Order the context carries no Record_ID: a
+		// provider such as DBFunctionSequenceNoProvider then reports isApplicable=false, which makes
+		// DocumentNoBuilder.getSequenceNoToUse() throw unconditionally (independent of failOnError) - it does NOT
+		// silently fall back. Sequences with no provider are unaffected (empty context == today's behaviour).
+		final PPOrderId ppOrderId = context.getPpOrderId();
+		final Evaluatee evaluationContext = ppOrderId != null
+				? Evaluatees.ofSingleton(IPOReferenceAware.COLUMNNAME_Record_ID, ppOrderId.getRepoId())
+				: Evaluatees.empty();
+
 		final String lotNo = documentNoFactory.forSequenceId(context.getSequenceId())
 				.setFailOnError(true)
 				.setClientId(context.getClientId())
-				.setEvaluationContext(Evaluatees.empty())
+				.setEvaluationContext(evaluationContext)
 				.build();
 
 		return lotNo != null && !Objects.equals(lotNo, IDocumentNoBuilder.NO_DOCUMENTNO)

--- a/backend/de.metas.business/src/test/java/org/adempiere/mm/attributes/api/impl/LotNumberBLTest.java
+++ b/backend/de.metas.business/src/test/java/org/adempiere/mm/attributes/api/impl/LotNumberBLTest.java
@@ -1,0 +1,95 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.adempiere.mm.attributes.api.impl;
+
+import de.metas.adempiere.model.IPOReferenceAware;
+import de.metas.document.sequence.DocSequenceId;
+import de.metas.document.sequence.IDocumentNoBuilder;
+import de.metas.document.sequence.IDocumentNoBuilderFactory;
+import de.metas.util.Services;
+import org.adempiere.mm.attributes.api.LotNoContext;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.util.Evaluatee;
+import org.eevolution.api.PPOrderId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LotNumberBLTest
+{
+	private IDocumentNoBuilderFactory documentNoBuilderFactory;
+	private IDocumentNoBuilder documentNoBuilder;
+	private LotNumberBL lotNumberBL;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		documentNoBuilderFactory = mock(IDocumentNoBuilderFactory.class);
+		documentNoBuilder = mock(IDocumentNoBuilder.class);
+
+		// Chain the builder methods so each returns itself
+		when(documentNoBuilderFactory.forSequenceId(any())).thenReturn(documentNoBuilder);
+		when(documentNoBuilder.setFailOnError(true)).thenReturn(documentNoBuilder);
+		when(documentNoBuilder.setClientId(any())).thenReturn(documentNoBuilder);
+		when(documentNoBuilder.setEvaluationContext(any())).thenReturn(documentNoBuilder);
+		when(documentNoBuilder.build()).thenReturn("LOT-001");
+
+		Services.registerService(IDocumentNoBuilderFactory.class, documentNoBuilderFactory);
+
+		lotNumberBL = new LotNumberBL();
+	}
+
+	@Test
+	void evalContextCarriesPPOrderId()
+	{
+		// arrange
+		final int ppOrderRepoId = 12345;
+		final LotNoContext context = LotNoContext.builder()
+				.sequenceId(DocSequenceId.ofRepoId(1))
+				.clientId(ClientId.ofRepoId(1))
+				.ppOrderId(PPOrderId.ofRepoId(ppOrderRepoId))
+				.build();
+
+		// capture the Evaluatee passed to setEvaluationContext
+		final ArgumentCaptor<Evaluatee> evaluateeCaptor = ArgumentCaptor.forClass(Evaluatee.class);
+		when(documentNoBuilder.setEvaluationContext(evaluateeCaptor.capture())).thenReturn(documentNoBuilder);
+
+		// act
+		lotNumberBL.getAndIncrementLotNo(context);
+
+		// assert — the captured evaluatee must expose Record_ID = ppOrderRepoId
+		final Evaluatee capturedEvaluatee = evaluateeCaptor.getValue();
+		assertThat(capturedEvaluatee).isNotNull();
+		assertThat(capturedEvaluatee.get_ValueAsInt(IPOReferenceAware.COLUMNNAME_Record_ID, -1))
+				.as("Evaluatee must expose PP_Order repo-id under key Record_ID")
+				.isEqualTo(ppOrderRepoId);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
@@ -90,6 +90,7 @@ import static de.metas.cucumber.stepdefs.StepDefConstants.TABLECOLUMN_IDENTIFIER
 import static de.metas.invoicecandidate.model.I_C_BPartner.COLUMNNAME_SO_Invoice_Aggregation_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_AD_Language;
+import static org.compiere.model.I_C_BPartner.COLUMNNAME_AllowConsolidateInOut;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_C_BP_Group_ID;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_C_BPartner_ID;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_C_BPartner_SalesRep_ID;
@@ -320,6 +321,8 @@ public class C_BPartner_StepDef
 		row.getAsOptionalEnum(COLUMNNAME_PaymentRulePO, PaymentRule.class).ifPresent(paymentRulePO -> bPartnerRecord.setPaymentRulePO(paymentRulePO.getCode()));
 		row.getAsOptionalEnum(COLUMNNAME_PO_InvoiceRule, InvoiceRule.class).ifPresent(poInvoiceRule -> bPartnerRecord.setPO_InvoiceRule(poInvoiceRule.getCode()));
 		row.getAsOptionalBoolean(COLUMNNAME_IsAllowActionPrice).ifPresent(bPartnerRecord::setIsAllowActionPrice);
+
+		row.getAsOptionalBoolean(COLUMNNAME_AllowConsolidateInOut).ifPresent(bPartnerRecord::setAllowConsolidateInOut);
 
 		row.getAsOptionalIdentifier(I_C_BPartner.COLUMNNAME_AD_OrgBP_ID)
 				.map(orgTable::getIdAsInt)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/DB_Function_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/DB_Function_StepDef.java
@@ -1,0 +1,56 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs;
+
+import io.cucumber.java.en.And;
+import lombok.NonNull;
+import org.adempiere.ad.trx.api.ITrx;
+import org.compiere.util.DB;
+
+/**
+ * Step definitions for creating or replacing PL/pgSQL functions in the test DB.
+ * Used by scenarios that verify DB-function-driven sequence providers.
+ */
+public class DB_Function_StepDef
+{
+	/**
+	 * Creates (or replaces) a PL/pgSQL function in the test database.
+	 * The function body is supplied inline in the feature file as a docstring.
+	 * The complete {@code CREATE OR REPLACE FUNCTION …} DDL is passed verbatim to the DB.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * And the following PL/pgSQL function is created or replaced in the DB:
+	 * """
+	 * CREATE OR REPLACE FUNCTION test_lotno(p_pp_order_id numeric, p_at timestamptz)
+	 *   RETURNS text LANGUAGE sql AS $$ SELECT 'L' || to_char(p_at AT TIME ZONE 'UTC','DDD') || 'M2' $$
+	 * """
+	 * </pre>
+	 */
+	@And("the following PL\\/pgSQL function is created or replaced in the DB:")
+	public void create_or_replace_pg_function(@NonNull final String ddl)
+	{
+		DB.executeUpdateAndThrowExceptionOnFail(ddl, ITrx.TRXNAME_None);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/billofmaterial/PP_Product_Bom_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/billofmaterial/PP_Product_Bom_StepDef.java
@@ -27,6 +27,7 @@ import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.attribute.M_AttributeSetInstance_StepDefData;
+import de.metas.cucumber.stepdefs.sequence.AD_Sequence_StepDefData;
 import de.metas.document.engine.IDocument;
 import de.metas.document.engine.IDocumentBL;
 import de.metas.product.ProductId;
@@ -76,6 +77,7 @@ public class PP_Product_Bom_StepDef
 	private final PP_Product_BOMVersions_StepDefData productBomVersionsTable;
 	private final PP_Product_BOMLine_StepDefData productBOMLineTable;
 	private final M_AttributeSetInstance_StepDefData attributeSetInstanceTable;
+	private final AD_Sequence_StepDefData adSequenceTable;
 
 	private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
 
@@ -84,7 +86,8 @@ public class PP_Product_Bom_StepDef
 			@NonNull final PP_Product_BOM_StepDefData productBOMTable,
 			@NonNull final PP_Product_BOMVersions_StepDefData productBomVersionsTable,
 			@NonNull final PP_Product_BOMLine_StepDefData productBOMLineTable,
-			@NonNull final M_AttributeSetInstance_StepDefData attributeSetInstanceTable
+			@NonNull final M_AttributeSetInstance_StepDefData attributeSetInstanceTable,
+			@NonNull final AD_Sequence_StepDefData adSequenceTable
 	)
 	{
 		this.productTable = productTable;
@@ -92,6 +95,7 @@ public class PP_Product_Bom_StepDef
 		this.productBomVersionsTable = productBomVersionsTable;
 		this.productBOMLineTable = productBOMLineTable;
 		this.attributeSetInstanceTable = attributeSetInstanceTable;
+		this.adSequenceTable = adSequenceTable;
 	}
 
 	@Given("metasfresh contains PP_Product_BOM")
@@ -114,6 +118,38 @@ public class PP_Product_Bom_StepDef
 		final I_PP_Product_BOM productBOM = productBOMTable.get(productBOMIdentifier);
 		productBOM.setDocAction(IDocument.ACTION_Complete);
 		documentBL.processEx(productBOM, IDocument.ACTION_Complete, IDocument.STATUS_Completed);
+	}
+
+	/**
+	 * Updates attributes of an existing PP_Product_BOM record (identified by its identifier alias).
+	 * Currently supports setting the lot-number sequence ({@code LotNo_Sequence_ID}).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>PP_Product_BOM_ID</b> — (required, identifier-ref) BOM to update<br>
+	 *   <b>OPT.LotNo_Sequence_ID</b> — (optional, identifier-ref) AD_Sequence to use for lot-number generation<br>
+	 * @cucumber.depends StepDefData: PP_Product_BOM_StepDefData, AD_Sequence_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And update PP_Product_BOM:
+	 *   | PP_Product_BOM_ID | OPT.LotNo_Sequence_ID |
+	 *   | bom               | seq_provider          |
+	 * </pre>
+	 */
+	@And("update PP_Product_BOM:")
+	public void update_PP_Product_BOM(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_PP_Product_BOM bom = row.getAsIdentifier(I_PP_Product_BOM.COLUMNNAME_PP_Product_BOM_ID).lookupNotNullIn(productBOMTable);
+
+			// only persist when a supported column is actually present, to avoid a no-op UPDATE on the (just-completed) document
+			row.getAsOptionalIdentifier(I_PP_Product_BOM.COLUMNNAME_LotNo_Sequence_ID)
+					.map(id -> id.lookupNotNullIn(adSequenceTable))
+					.ifPresent(seq -> {
+						bom.setLotNo_Sequence_ID(seq.getAD_Sequence_ID());
+						saveRecord(bom);
+					});
+		});
 	}
 
 	private void createPP_Product_BOMLine(@NonNull final DataTableRow row)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDef.java
@@ -1,0 +1,115 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.sequence;
+
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.util.Check;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.And;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
+import de.metas.javaclasses.model.I_AD_JavaClass;
+import org.compiere.model.I_AD_Sequence;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+
+/**
+ * Step definitions for {@link I_AD_Sequence} — creates or updates lot-number sequences used in manufacturing.
+ *
+ * @cucumber.stepdef
+ * @cucumber.columns
+ *   <b>AD_Sequence_ID</b> — (required) identifier alias for cross-step reference<br>
+ *   <b>Name</b> — (required) unique sequence name; used by the provider SysConfig key<br>
+ *   <b>OPT.CustomSequenceNoProvider_JavaClass_ID.Classname</b> — (optional) fully-qualified class name of the provider;
+ *     when present the step looks up {@code AD_JavaClass} by classname and sets the FK (fails if no such class exists)<br>
+ *   <b>OPT.StartNo</b> — (optional) starting value; also seeds CurrentNext (the number actually issued), default 1,000,000<br>
+ *   <b>OPT.CurrentNext</b> — (optional) explicit next-issued number; applied after the StartNo seed, so it wins if both are present<br>
+ * @cucumber.example
+ * <pre>
+ * And metasfresh contains AD_Sequence:
+ *   | AD_Sequence_ID | Name        | OPT.CustomSequenceNoProvider_JavaClass_ID.Classname                 |
+ *   | seq_provider   | TestLotSeq  | de.metas.document.sequenceno.DBFunctionSequenceNoProvider           |
+ * </pre>
+ */
+@RequiredArgsConstructor
+public class AD_Sequence_StepDef
+{
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@NonNull private final AD_Sequence_StepDefData adSequenceTable;
+
+	@And("metasfresh contains AD_Sequence:")
+	public void createOrUpdate_AD_Sequence(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable)
+				.setAdditionalRowIdentifierColumnName(I_AD_Sequence.COLUMNNAME_AD_Sequence_ID)
+				.forEach(this::createOrUpdateAdSequence);
+	}
+
+	private void createOrUpdateAdSequence(@NonNull final DataTableRow row)
+	{
+		final String name = row.getAsString(I_AD_Sequence.COLUMNNAME_Name);
+
+		// upsert: find existing active record by name, or create new
+		final I_AD_Sequence seqRecord = queryBL.createQueryBuilder(I_AD_Sequence.class)
+				.addEqualsFilter(I_AD_Sequence.COLUMNNAME_Name, name)
+				.addOnlyActiveRecordsFilter()
+				.create()
+				.firstOnlyOptional(I_AD_Sequence.class)
+				.orElseGet(() -> newInstance(I_AD_Sequence.class));
+
+		seqRecord.setName(name);
+		seqRecord.setIsTableID(false);
+		seqRecord.setIsAutoSequence(true);
+
+		// StartNo seeds CurrentNext as well: the number actually handed out by the document-no builder is CurrentNext
+		// (a freshly created sequence defaults CurrentNext to 1,000,000), so a test that sets StartNo expects to start there.
+		row.getAsOptionalInt(I_AD_Sequence.COLUMNNAME_StartNo)
+				.ifPresent(startNo -> {
+					seqRecord.setStartNo(startNo);
+					seqRecord.setCurrentNext(startNo);
+				});
+
+		row.getAsOptionalInt(I_AD_Sequence.COLUMNNAME_CurrentNext)
+				.ifPresent(seqRecord::setCurrentNext);
+
+		row.getAsOptionalString(I_AD_Sequence.COLUMNNAME_CustomSequenceNoProvider_JavaClass_ID + ".Classname")
+				.ifPresent(classname -> {
+					final I_AD_JavaClass javaClass = queryBL.createQueryBuilder(I_AD_JavaClass.class)
+							.addEqualsFilter(I_AD_JavaClass.COLUMNNAME_Classname, classname)
+							.addOnlyActiveRecordsFilter()
+							.create()
+							.firstOnlyOrNull(I_AD_JavaClass.class);
+					Check.assumeNotNull(javaClass, "No active AD_JavaClass found for classname={}", classname);
+					seqRecord.setCustomSequenceNoProvider_JavaClass_ID(javaClass.getAD_JavaClass_ID());
+				});
+
+		saveRecord(seqRecord);
+
+		row.getAsIdentifier(I_AD_Sequence.COLUMNNAME_AD_Sequence_ID).putOrReplace(adSequenceTable, seqRecord);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/sequence/AD_Sequence_StepDefData.java
@@ -1,8 +1,8 @@
 /*
  * #%L
- * de.metas.business
+ * de.metas.cucumber
  * %%
- * Copyright (C) 2024 metas GmbH
+ * Copyright (C) 2026 metas GmbH
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as
@@ -20,29 +20,16 @@
  * #L%
  */
 
-package org.adempiere.mm.attributes.api;
+package de.metas.cucumber.stepdefs.sequence;
 
-import de.metas.document.sequence.DocSequenceId;
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.Value;
-import org.adempiere.service.ClientId;
-import org.eevolution.api.PPOrderId;
+import de.metas.cucumber.stepdefs.StepDefData;
+import org.compiere.model.I_AD_Sequence;
 
-import javax.annotation.Nullable;
-
-@Value
-@Builder
-public class LotNoContext
+/** Step-def data store for {@link I_AD_Sequence} records. */
+public class AD_Sequence_StepDefData extends StepDefData<I_AD_Sequence>
 {
-	@NonNull
-	DocSequenceId sequenceId;
-
-	@NonNull
-	ClientId clientId;
-
-	/** The PP_Order this lot number is generated for; exposed to a {@link de.metas.document.sequenceno.CustomSequenceNoProvider} via the eval-context {@code Record_ID}. */
-	@Nullable
-	PPOrderId ppOrderId;
-
+	public AD_Sequence_StepDefData()
+	{
+		super(I_AD_Sequence.class);
+	}
 }

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisExport.feature
@@ -481,16 +481,17 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
   @Id:S29231_170
   @allure.label.epic:E0292_EDI
   @allure.label.feature:F00353_EDI_DESADV_InOut_Link
-  Scenario: S29231_170 — Two mobile-picking jobs share one LU: EPCIS emits ONE event per physical SSCC (owner merges both orders, sibling returns {})
-  ## Contract per customer clarification (two orders picked onto one shared pallet):
+  Scenario: S29231_170 — Two mobile-picking jobs share one LU: EPCIS emits ONE merged event per physical SSCC on the pallet-closing completion; post-closure either sharer returns the full pallet
+  ## Close-driven semantics (two orders picked onto one shared pallet):
   ## When two sales orders are picked onto ONE shared physical pallet (ONE SSCC), the
-  ## get_epcis_events_json_fn must emit exactly ONE picking+commissioning event for that
-  ## SSCC. The owner shipment (lowest M_InOut_ID sharing the LU) returns the full event:
+  ## get_epcis_events_json_fn emits exactly ONE picking+commissioning event for that
+  ## SSCC once the pallet is fully closed (all sharers completed). The queried shipment
+  ## returns the full merged event:
   ##   - pallets[0].crates = ALL crates from both orders on that LU (15 total)
   ##   - desadvReferences[] size 2 (one per DESADV)
   ##   - poReferences[]     size 2 (one per order)
-  ## The sibling shipment (higher M_InOut_ID) must return {} (empty object) so the receiver's
-  ## system does not render a duplicate event for the same physical SSCC.
+  ## Post-closure, EITHER sharer (ioA or ioB) returns the full merged pallet — there is
+  ## no fixed owner; single-emission guarantee is covered by the Task-4 e2e scenario.
   ##
   ## The test uses two real mobile picking jobs (LUPickingTarget.ofExistingHU on the
   ## second job) to reproduce the shared-pallet shape via the production code path.
@@ -642,11 +643,10 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | dA_S29231_170            | bp_S29231_170            | oA_S29231_170         |
       | dB_S29231_170            | bp_S29231_170            | oB_S29231_170         |
 
-    # ─── Per-SSCC contract (customer clarification) ───────────────────────────────────
-    # ioA has the lower M_InOut_ID (created first) → it is the OWNER.
-    # The owner's event merges ALL crates from the shared physical LU (5 TUs from order A
-    # + 10 TUs from order B = 15 crates total) and carries both DESADV + PO references.
-    # ioB is the SIBLING → the function must return {} so no duplicate event is emitted.
+    # ─── Per-SSCC contract (close-driven semantics) ───────────────────────────────────
+    # Both shipments are completed (pallet fully closed). The queried shipment (ioA) returns
+    # the full merged event covering ALL crates from the shared physical LU (5 TUs from
+    # order A + 10 TUs from order B = 15 crates total) with both DESADV + PO references.
     When the EPCIS JSON export function is called for M_InOut identified by ioA_S29231_170
     Then the EPCIS JSON pallets contain SSCC18 values in any order:
       | sscc18             |
@@ -672,13 +672,11 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
       | 1170000001  |
       | 1170000002  |
 
-    # ─── Sibling shipment B must return {} (no duplicate event for the same SSCC) ──────
-    Then the EPCIS JSON export function returns empty object for M_InOut identified by ioB_S29231_170
-
-    # ─── Export-relevance predicate (drives the scripted-adapter outbound WHERE-clause, so the
-    #     sibling is never selected for export → metasfresh never emits an empty EPCIS document) ──
-    Then the EPCIS export-relevance for M_InOut identified by ioA_S29231_170 is true
-    And the EPCIS export-relevance for M_InOut identified by ioB_S29231_170 is false
+    # ─── Post-closure: sibling (ioB) ALSO returns the merged pallet — no fixed owner ───
+    When the EPCIS JSON export function is called for M_InOut identified by ioB_S29231_170
+    And the EPCIS JSON pallet has:
+      | palletIndex | sscc               | crateCount |
+      | 0           | 987654321000001700 | 15         |
 
     # ─── DESADV-JSON regression via M_InOut_EDI_Export_JSON/invoke ───────────────────
     # Exercises get_desadv_packs_json_fn's per-M_InOut filter through the production REST
@@ -727,3 +725,406 @@ Feature: EPCIS JSON export via get_epcis_events_json_fn
     Then verify DESADV JSON export response has exactly 1 element matching:
       | Order_Identifier | ExpectedQtyDelivered |
       | oB_S29231_170    | 100                  |
+
+  @from:cucumber
+  @Id:S30558_010
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00353_EDI_DESADV_InOut_Link
+  Scenario: S30558_010 — Both draft shipments generated first, then ioA completed first: gate returns {} for ioA until ioB is also completed
+  ## Completion-ordering gate (me03 #30558): both-drafts flow — generate BOTH shipments as
+  ## drafts FIRST (each claims its own picked TUs, QuantityType=P), then complete in order.
+  ## Completing ioA first while ioB is only a draft means order B's 10 TUs are covered only
+  ## by a draft shipment (not CO/CL). The RED gate assertion fires after completing ioA:
+  ## the current (un-gated) function emits a non-empty partial event, so the
+  ## 'returns empty object' assertion FAILS (intended RED). After ioB is also completed,
+  ## both ioA and ioB then return the full merged event — no fixed owner under the close-gate model.
+    And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
+    And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
+
+    And metasfresh contains M_PickingSlot:
+      | Identifier | PickingSlot | IsDynamic |
+      | 200.0      | 200.0       | Y         |
+
+    Given metasfresh contains M_Products:
+      | Identifier   | GTIN          |
+      | p_S30558_010 | 4060000000185 |
+    And metasfresh contains M_PricingSystems
+      | Identifier    |
+      | ps_S30558_010 |
+    And metasfresh contains M_PriceLists
+      | Identifier    | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_S30558_010 | ps_S30558_010      | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier     | M_PriceList_ID |
+      | plv_S30558_010 | pl_S30558_010  |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | plv_S30558_010         | p_S30558_010 | 5.0      | PCE      | Normal           |
+
+    # AllowConsolidateInOut=N so the two orders' shipments stay separate M_InOuts (no consolidation)
+    And metasfresh contains C_BPartners without locations:
+      | Identifier    | IsCustomer | M_PricingSystem_ID | GLN           | AllowConsolidateInOut |
+      | bp_S30558_010 | Y          | ps_S30558_010      | 9900000305580 | N                     |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier       | GLN           | C_BPartner_ID | OPT.IsBillToDefault | OPT.IsShipTo |
+      | bpLoc_S30558_010 | 2900000305580 | bp_S30558_010 | true                | true         |
+    And metasfresh contains C_BPartner_EDI_Setting:
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN | Identifier                |
+      | bp_S30558_010 | true                 | 9900000305580         | edi_setting_S30558_010_bp |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID |
+      | bp_S30558_010 | p_S30558_010 |
+
+    # HU PI: LU holds up to 20 TUs, each TU holds 10 PCE
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID       |
+      | pi_LU_S30558_010 |
+      | pi_TU_S30558_010 |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID       | HU_UnitType | IsCurrent |
+      | piv_LU_S30558_010  | pi_LU_S30558_010 | LU          | Y         |
+      | piv_TU_S30558_010  | pi_TU_S30558_010 | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID   | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID |
+      | pii_LU_S30558_010 | piv_LU_S30558_010  | 20  | HU       | pi_TU_S30558_010  |
+      | pii_TU_S30558_010 | piv_TU_S30558_010  | 0   | MI       |                   |
+    And metasfresh contains M_HU_PI_Attribute:
+      | M_HU_PI_Version_ID | M_Attribute.Value |
+      | piv_LU_S30558_010  | SSCC18            |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID   | M_Product_ID | Qty | ValidFrom  |
+      | pip_S30558_010          | pii_TU_S30558_010 | p_S30558_010 | 10  | 2020-01-01 |
+
+    # Mobile UI picking profile — DO_NOT_CREATE: no shipment is auto-created on job completion;
+    # both jobs finish first so the LU holds all 15 TUs before any shipment is generated.
+    And set mobile UI picking profile
+      | IsAllowPickingAnyHU | CreateShipmentPolicy | IsAllowCompletingPartialPickingJob | IsAlwaysSplitHUsEnabled |
+      | Y                   | DO_NOT_CREATE        | Y                                  | N                       |
+
+    # Source: aggregated LU with 150 PCE (5 TUs for order A + 10 TUs for order B)
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID | MovementDate | M_Warehouse_ID |
+      | inv_S30558_010 | 2026-05-25   | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | M_InventoryLine_ID  | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_S30558_010 | invLine_S30558_010  | p_S30558_010 | 0       | 150      | PCE          |
+    And complete inventory with inventoryIdentifier 'inv_S30558_010'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID  | M_HU_ID               |
+      | invLine_S30558_010  | pickFromCU_S30558_010 |
+
+    And transform CU to new LU
+      | sourceCU              | newLU                        | TU_PI_ID          | QtyCUsPerTU | QtyTUsPerLU |
+      | pickFromCU_S30558_010 | pickFromAggregatedLU_S30558  | pi_TU_S30558_010  | 10          | 15          |
+
+    # Order A — 50 PCE → 5 TUs. POReference is 10 digits so LPAD is a no-op.
+    And metasfresh contains C_Orders:
+      | Identifier    | IsSOTrx | C_BPartner_ID | DateOrdered | POReference |
+      | oA_S30558_010 | true    | bp_S30558_010 | 2026-05-25  | 1170000001  |
+    And metasfresh contains C_OrderLines:
+      | Identifier     | C_Order_ID    | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | olA_S30558_010 | oA_S30558_010 | p_S30558_010 | 50         | pip_S30558_010          |
+
+    When the order identified by oA_S30558_010 is completed
+
+    # Order B — 100 PCE → 10 TUs. Distinct POReference.
+    And metasfresh contains C_Orders:
+      | Identifier    | IsSOTrx | C_BPartner_ID | DateOrdered | POReference |
+      | oB_S30558_010 | true    | bp_S30558_010 | 2026-05-25  | 1170000002  |
+    And metasfresh contains C_OrderLines:
+      | Identifier     | C_Order_ID    | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | olB_S30558_010 | oB_S30558_010 | p_S30558_010 | 100        | pip_S30558_010          |
+
+    When the order identified by oB_S30558_010 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier     | C_OrderLine_ID | IsToRecompute |
+      | ssA_S30558_010 | olA_S30558_010 | N             |
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier     | C_OrderLine_ID | IsToRecompute |
+      | ssB_S30558_010 | olB_S30558_010 | N             |
+
+    # ─── Picking job 1: order A → new LU 'sharedLu_S30558_010' ──────────────────────
+    And start picking job for sales order identified by oA_S30558_010
+    And scan picking slot identified by 200.0
+    And set picking target as new LU identified by pi_LU_S30558_010
+    And pick lines
+      | PickingLine.byProduct | PickFromHU                  | QtyPicked |
+      | p_S30558_010          | pickFromAggregatedLU_S30558 | 5         |
+    And expect current picking target
+      | Existing_LU         |
+      | sharedLu_S30558_010 |
+    And complete picking job
+
+    # ─── Picking job 2: order B targets the SAME LU (LUPickingTarget.ofExistingHU) ──
+    # Both jobs done — the LU now physically holds all 15 TUs.
+    And start picking job for sales order identified by oB_S30558_010
+    And scan picking slot identified by 200.0
+    And set picking target as existing LU identified by sharedLu_S30558_010
+    And pick lines
+      | PickingLine.byProduct | PickFromHU                  | QtyPicked |
+      | p_S30558_010          | pickFromAggregatedLU_S30558 | 10        |
+    And complete picking job
+
+    # ─── Stamp SSCC18 on the shared LU ───────────────────────────────────────────────
+    And M_HU_Attribute is changed
+      | M_HU_ID             | M_Attribute_ID.Value | Value              |
+      | sharedLu_S30558_010 | SSCC18               | 987654321000003058 |
+
+    # ─── Both-drafts flow: generate DRAFT for ssA, then separately for ssB ─────────────
+    # Each schedule claims its own picked TUs (QuantityType=P); generating both as drafts
+    # before completing either ensures no schedule sweeps the whole LU on its own.
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ssA_S30558_010        | P            | false               | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID     |
+      | ssA_S30558_010        | ioA_S30558_010 |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ssB_S30558_010        | P            | false               | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID     |
+      | ssB_S30558_010        | ioB_S30558_010 |
+
+    # ─── Complete ioA first ───────────────────────────────────────────────────────────
+    And the shipment identified by ioA_S30558_010 is completed
+
+    # RED gate — ioB is still a draft (IP): order B's 10 TUs on the LU are covered only
+    # by a draft shipment, not a CO/CL. Correct post-fix behaviour: {} (LU not fully covered
+    # by completed shipments → gate blocks emission).
+    # This assertion MUST FAIL on the current (un-gated) code (intended RED).
+    Then the EPCIS JSON export function returns empty object for M_InOut identified by ioA_S30558_010
+
+    # ─── Complete ioB — now all 15 TUs on the LU are covered by CO shipments ─────────
+    And the shipment identified by ioB_S30558_010 is completed
+
+    # ─── After both completions (pallet fully shipped): the merged order-pure event is emitted ─
+    When the EPCIS JSON export function is called for M_InOut identified by ioA_S30558_010
+    Then the EPCIS JSON pallets contain SSCC18 values in any order:
+      | sscc18             |
+      | 987654321000003058 |
+    And the EPCIS JSON pallet has:
+      | palletIndex | sscc               | crateCount |
+      | 0           | 987654321000003058 | 15         |
+    And the EPCIS JSON array field has:
+      | field               | expectedSize |
+      | desadvReferences    | 2            |
+      | poReferences        | 2            |
+      | shipmentDocumentNos | 2            |
+    Then the EPCIS JSON pallet 0 crates are order-pure with POReferences:
+      | poReference |
+      | 1170000001  |
+      | 1170000002  |
+
+    # ─── Post-fix the sibling (ioB) ALSO returns the merged pallet — no fixed owner ───
+    When the EPCIS JSON export function is called for M_InOut identified by ioB_S30558_010
+    And the EPCIS JSON pallet has:
+      | palletIndex | sscc               | crateCount |
+      | 0           | 987654321000003058 | 15         |
+
+  @from:cucumber
+  @Id:S30558_020
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00353_EDI_DESADV_InOut_Link
+  Scenario: S30558_020 — Both draft shipments generated first, then ioB completed first: gate returns {} for ioB until ioA is also completed
+  ## Completion-ordering gate (me03 #30558): both-drafts flow — symmetric to S30558_010 but
+  ## completion order is reversed: ioB is completed first.
+  ## Generate BOTH shipments as drafts FIRST (each claims its own picked TUs, QuantityType=P),
+  ## then complete ioB first. At that point ioA is still a draft (IP) — order A's 5 TUs on
+  ## the LU are covered only by a draft shipment (not CO/CL). The RED gate assertion fires
+  ## after completing ioB: the current (un-gated) function emits a non-empty partial event,
+  ## so the 'returns empty object' assertion FAILS (intended RED). After ioA is also completed,
+  ## both ioA and ioB then return the full merged event — no fixed owner under the close-gate model.
+    And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
+    And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
+
+    And metasfresh contains M_PickingSlot:
+      | Identifier | PickingSlot | IsDynamic |
+      | 200.0      | 200.0       | Y         |
+
+    Given metasfresh contains M_Products:
+      | Identifier   | GTIN          |
+      | p_S30558_020 | 4060000000192 |
+    And metasfresh contains M_PricingSystems
+      | Identifier    |
+      | ps_S30558_020 |
+    And metasfresh contains M_PriceLists
+      | Identifier    | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_S30558_020 | ps_S30558_020      | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier     | M_PriceList_ID |
+      | plv_S30558_020 | pl_S30558_020  |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | plv_S30558_020         | p_S30558_020 | 5.0      | PCE      | Normal           |
+
+    # AllowConsolidateInOut=N so the two orders' shipments stay separate M_InOuts (no consolidation)
+    And metasfresh contains C_BPartners without locations:
+      | Identifier    | IsCustomer | M_PricingSystem_ID | GLN           | AllowConsolidateInOut |
+      | bp_S30558_020 | Y          | ps_S30558_020      | 9900000305582 | N                     |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier       | GLN           | C_BPartner_ID | OPT.IsBillToDefault | OPT.IsShipTo |
+      | bpLoc_S30558_020 | 2900000305582 | bp_S30558_020 | true                | true         |
+    And metasfresh contains C_BPartner_EDI_Setting:
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN | Identifier                |
+      | bp_S30558_020 | true                 | 9900000305582         | edi_setting_S30558_020_bp |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID |
+      | bp_S30558_020 | p_S30558_020 |
+
+    # HU PI: LU holds up to 20 TUs, each TU holds 10 PCE
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID       |
+      | pi_LU_S30558_020 |
+      | pi_TU_S30558_020 |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID       | HU_UnitType | IsCurrent |
+      | piv_LU_S30558_020  | pi_LU_S30558_020 | LU          | Y         |
+      | piv_TU_S30558_020  | pi_TU_S30558_020 | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID   | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID |
+      | pii_LU_S30558_020 | piv_LU_S30558_020  | 20  | HU       | pi_TU_S30558_020  |
+      | pii_TU_S30558_020 | piv_TU_S30558_020  | 0   | MI       |                   |
+    And metasfresh contains M_HU_PI_Attribute:
+      | M_HU_PI_Version_ID | M_Attribute.Value |
+      | piv_LU_S30558_020  | SSCC18            |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID   | M_Product_ID | Qty | ValidFrom  |
+      | pip_S30558_020          | pii_TU_S30558_020 | p_S30558_020 | 10  | 2020-01-01 |
+
+    # Mobile UI picking profile — DO_NOT_CREATE: no shipment is auto-created on job completion;
+    # both jobs finish first so the LU holds all 15 TUs before any shipment is generated.
+    And set mobile UI picking profile
+      | IsAllowPickingAnyHU | CreateShipmentPolicy | IsAllowCompletingPartialPickingJob | IsAlwaysSplitHUsEnabled |
+      | Y                   | DO_NOT_CREATE        | Y                                  | N                       |
+
+    # Source: aggregated LU with 150 PCE (5 TUs for order A + 10 TUs for order B)
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID | MovementDate | M_Warehouse_ID |
+      | inv_S30558_020 | 2026-05-26   | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | M_InventoryLine_ID  | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_S30558_020 | invLine_S30558_020  | p_S30558_020 | 0       | 150      | PCE          |
+    And complete inventory with inventoryIdentifier 'inv_S30558_020'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID  | M_HU_ID               |
+      | invLine_S30558_020  | pickFromCU_S30558_020 |
+
+    And transform CU to new LU
+      | sourceCU              | newLU                        | TU_PI_ID          | QtyCUsPerTU | QtyTUsPerLU |
+      | pickFromCU_S30558_020 | pickFromAggregatedLU_S30558b | pi_TU_S30558_020  | 10          | 15          |
+
+    # Order A — 50 PCE → 5 TUs.
+    And metasfresh contains C_Orders:
+      | Identifier    | IsSOTrx | C_BPartner_ID | DateOrdered | POReference |
+      | oA_S30558_020 | true    | bp_S30558_020 | 2026-05-26  | 1170000003  |
+    And metasfresh contains C_OrderLines:
+      | Identifier     | C_Order_ID    | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | olA_S30558_020 | oA_S30558_020 | p_S30558_020 | 50         | pip_S30558_020          |
+
+    When the order identified by oA_S30558_020 is completed
+
+    # Order B — 100 PCE → 10 TUs. Distinct POReference.
+    And metasfresh contains C_Orders:
+      | Identifier    | IsSOTrx | C_BPartner_ID | DateOrdered | POReference |
+      | oB_S30558_020 | true    | bp_S30558_020 | 2026-05-26  | 1170000004  |
+    And metasfresh contains C_OrderLines:
+      | Identifier     | C_Order_ID    | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | olB_S30558_020 | oB_S30558_020 | p_S30558_020 | 100        | pip_S30558_020          |
+
+    When the order identified by oB_S30558_020 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier     | C_OrderLine_ID | IsToRecompute |
+      | ssA_S30558_020 | olA_S30558_020 | N             |
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier     | C_OrderLine_ID | IsToRecompute |
+      | ssB_S30558_020 | olB_S30558_020 | N             |
+
+    # ─── Picking job 1: order A → new LU 'sharedLu_S30558_020' ──────────────────────
+    And start picking job for sales order identified by oA_S30558_020
+    And scan picking slot identified by 200.0
+    And set picking target as new LU identified by pi_LU_S30558_020
+    And pick lines
+      | PickingLine.byProduct | PickFromHU                   | QtyPicked |
+      | p_S30558_020          | pickFromAggregatedLU_S30558b | 5         |
+    And expect current picking target
+      | Existing_LU         |
+      | sharedLu_S30558_020 |
+    And complete picking job
+
+    # ─── Picking job 2: order B targets the SAME LU (LUPickingTarget.ofExistingHU) ──
+    # Both jobs done — the LU now physically holds all 15 TUs.
+    And start picking job for sales order identified by oB_S30558_020
+    And scan picking slot identified by 200.0
+    And set picking target as existing LU identified by sharedLu_S30558_020
+    And pick lines
+      | PickingLine.byProduct | PickFromHU                   | QtyPicked |
+      | p_S30558_020          | pickFromAggregatedLU_S30558b | 10        |
+    And complete picking job
+
+    # ─── Stamp SSCC18 on the shared LU ───────────────────────────────────────────────
+    And M_HU_Attribute is changed
+      | M_HU_ID             | M_Attribute_ID.Value | Value              |
+      | sharedLu_S30558_020 | SSCC18               | 987654321000003059 |
+
+    # ─── Both-drafts flow: generate DRAFT for ssA, then separately for ssB ─────────────
+    # Each schedule claims its own picked TUs (QuantityType=P); generating both as drafts
+    # before completing either ensures no schedule sweeps the whole LU on its own.
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ssA_S30558_020        | P            | false               | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID     |
+      | ssA_S30558_020        | ioA_S30558_020 |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ssB_S30558_020        | P            | false               | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID     |
+      | ssB_S30558_020        | ioB_S30558_020 |
+
+    # ─── Complete ioB first (symmetric ordering vs. S30558_010) ──────────────────────
+    And the shipment identified by ioB_S30558_020 is completed
+
+    # RED gate — ioA is still a draft (IP): order A's 5 TUs on the LU are covered only
+    # by a draft shipment, not a CO/CL. Correct post-fix behaviour: {} (LU not fully covered
+    # by completed shipments → gate blocks emission).
+    # This assertion MUST FAIL on the current (un-gated) code (intended RED).
+    Then the EPCIS JSON export function returns empty object for M_InOut identified by ioB_S30558_020
+
+    # ─── Complete ioA — now all 15 TUs on the LU are covered by CO shipments ─────────
+    And the shipment identified by ioA_S30558_020 is completed
+
+    # ─── After both completions (pallet fully shipped): the merged order-pure event is emitted ─
+    When the EPCIS JSON export function is called for M_InOut identified by ioA_S30558_020
+    Then the EPCIS JSON pallets contain SSCC18 values in any order:
+      | sscc18             |
+      | 987654321000003059 |
+    And the EPCIS JSON pallet has:
+      | palletIndex | sscc               | crateCount |
+      | 0           | 987654321000003059 | 15         |
+    And the EPCIS JSON array field has:
+      | field               | expectedSize |
+      | desadvReferences    | 2            |
+      | poReferences        | 2            |
+      | shipmentDocumentNos | 2            |
+    Then the EPCIS JSON pallet 0 crates are order-pure with POReferences:
+      | poReference |
+      | 1170000003  |
+      | 1170000004  |
+
+    # ─── Post-fix the sibling (ioB) ALSO returns the merged pallet — no fixed owner ───
+    When the EPCIS JSON export function is called for M_InOut identified by ioB_S30558_020
+    And the EPCIS JSON pallet has:
+      | palletIndex | sscc               | crateCount |
+      | 0           | 987654321000003059 | 15         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
@@ -260,3 +260,182 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
     Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
       | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus |
       | io_040     | scriptedCfg_gated                                 | U            |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00353_EDI_DESADV_InOut_Link
+  @ghActions:run_on_executor7
+  @Id:S30558_040
+  Scenario: S30558_040 — shared-LU pallet: first completion yields DontSend, closing completion yields Enqueued
+    ## Close-gate / closer-enqueues: two orders are picked onto ONE shared physical pallet (one SSCC).
+    ## The scripted-export config is gated on "de.metas.edi".epcis_has_events(m_inout_id) — a function
+    ## that returns true only when the pallet is fully covered by completed (CO/CL) shipments.
+    ##
+    ## Flow:
+    ##   1. Both picking jobs complete onto ONE shared LU (DO_NOT_CREATE policy — no auto-shipment).
+    ##   2. Both shipments generated as drafts (QuantityType=P, IsCompleteShipments=false).
+    ##   3. ioA completed first → epcis_has_events(ioA) = false (ioB still draft) → ExportStatus = N (DontSend).
+    ##   4. ioB completed (closer) → epcis_has_events(ioB) = true (all TUs now CO) → ExportStatus = U (Enqueued).
+    ##
+    ## This proves the CLOSER — not the first completer — is the one enqueued for scripted EPCIS export.
+
+    # Gated scripted-export config: WhereClause returns true only when the shared pallet is fully
+    # covered by completed shipments. Overrides the Background's always-true config (table-scoped takeover).
+    And metasfresh contains ExternalSystem_Config with ScriptedExportConversion and StatusColumn:
+      | ExternalSystem_Config_ID | ExternalSystem_Config_ScriptedExportConversion_ID | AD_Process_OutboundData_ID.Value | TableName | WhereClause                                  |
+      | esConfig_040             | scriptedCfg_040                                   | M_InOut_EDI_Export_JSON          | M_InOut   | "de.metas.edi".epcis_has_events(m_inout_id) |
+
+    # Dedicated BPartner with AllowConsolidateInOut=N — keeps the two orders' shipments as separate M_InOuts.
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsCustomer | M_PricingSystem_ID | GLN           | AllowConsolidateInOut |
+      | bp_040     | Y          | ps_es              | 9900000305584 | N                     |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier    | GLN           | C_BPartner_ID | OPT.IsBillToDefault | OPT.IsShipTo |
+      | bpLoc_040     | 2900000305584 | bp_040        | true                | true         |
+    And metasfresh contains C_BPartner_EDI_Setting:
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN | EdiDESADVSendingMode | EdiDESADV_ExternalSystem_Config_ID | Identifier       |
+      | bp_040        | true                 | 9900000305584         | E                    | esConfig_040                       | edi_setting_040  |
+
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID | M_Product_ID |
+      | bp_040        | product_es   |
+
+    # HU PI: LU holds up to 20 TUs
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID  |
+      | pi_LU_040   |
+      | pi_TU_040   |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType | IsCurrent |
+      | piv_LU_040         | pi_LU_040  | LU          | Y         |
+      | piv_TU_040         | pi_TU_040  | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID |
+      | pii_LU_040      | piv_LU_040         | 20  | HU       | pi_TU_040         |
+      | pii_TU_040      | piv_TU_040         | 0   | MI       |                   |
+    And metasfresh contains M_HU_PI_Attribute:
+      | M_HU_PI_Version_ID | M_Attribute.Value |
+      | piv_LU_040         | SSCC18            |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID | Qty | ValidFrom  |
+      | pip_LU_TU_040           | pii_TU_040      | product_es   | 10  | 2020-01-01 |
+
+    # DO_NOT_CREATE: no shipment is auto-created on picking job completion;
+    # both picking jobs finish before any shipment is generated.
+    And set sys config boolean value false for sys config de.metas.handlingunits.HUConstants.Fresh_QuickShipment
+    And set sys config boolean value true for sys config de.metas.handlingunits.shipmentschedule.api.ShipmentScheduleWithHUService.PackCUsToTU
+    And metasfresh contains M_PickingSlot:
+      | Identifier | PickingSlot | IsDynamic |
+      | slot_040   | 300.0       | Y         |
+    And set mobile UI picking profile
+      | IsAllowPickingAnyHU | CreateShipmentPolicy | IsAllowCompletingPartialPickingJob | IsAlwaysSplitHUsEnabled |
+      | Y                   | DO_NOT_CREATE        | Y                                  | N                       |
+
+    # Source stock: 150 PCE (5 TUs for order A + 10 TUs for order B)
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID | MovementDate | M_Warehouse_ID |
+      | inv_040        | 2026-06-09   | warehouseStd   |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | M_InventoryLine_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_040        | invLine_040        | product_es   | 0       | 150      | PCE          |
+    And complete inventory with inventoryIdentifier 'inv_040'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID | M_HU_ID      |
+      | invLine_040        | pickFromCU_040 |
+
+    And transform CU to new LU
+      | sourceCU       | newLU                    | TU_PI_ID  | QtyCUsPerTU | QtyTUsPerLU |
+      | pickFromCU_040 | pickFromAggregatedLU_040 | pi_TU_040 | 10          | 15          |
+
+    # Order A — 50 PCE → 5 TUs. Distinct POReference.
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference |
+      | oA_040     | true    | bp_040        | 2026-06-09  | 3058400001  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | olA_040    | oA_040     | product_es   | 50         | pip_LU_TU_040           |
+
+    When the order identified by oA_040 is completed
+
+    # Order B — 100 PCE → 10 TUs. Distinct POReference.
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference |
+      | oB_040     | true    | bp_040        | 2026-06-09  | 3058400002  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | olB_040    | oB_040     | product_es   | 100        | pip_LU_TU_040           |
+
+    When the order identified by oB_040 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ssA_040    | olA_040        | N             |
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ssB_040    | olB_040        | N             |
+
+    # ─── Picking job 1: order A → new shared LU ──────────────────────────────────────
+    And start picking job for sales order identified by oA_040
+    And scan picking slot identified by slot_040
+    And set picking target as new LU identified by pi_LU_040
+    And pick lines
+      | PickingLine.byProduct | PickFromHU               | QtyPicked |
+      | product_es            | pickFromAggregatedLU_040 | 5         |
+    And expect current picking target
+      | Existing_LU |
+      | sharedLu_040 |
+    And complete picking job
+
+    # ─── Picking job 2: order B → SAME LU (all 15 TUs on one physical pallet) ────────
+    And start picking job for sales order identified by oB_040
+    And scan picking slot identified by slot_040
+    And set picking target as existing LU identified by sharedLu_040
+    And pick lines
+      | PickingLine.byProduct | PickFromHU               | QtyPicked |
+      | product_es            | pickFromAggregatedLU_040 | 10        |
+    And complete picking job
+
+    # Stamp a deterministic SSCC18 on the shared LU for traceability.
+    And M_HU_Attribute is changed
+      | M_HU_ID      | M_Attribute_ID.Value | Value              |
+      | sharedLu_040 | SSCC18               | 987654321000003060 |
+
+    # ─── Both-drafts flow: generate DRAFT for ssA, then separately for ssB ──────────
+    # QuantityType=P: each schedule claims its own picked TUs without completing the shipment.
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ssA_040               | P            | false               | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | ssA_040               | ioA_040    |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ssB_040               | P            | false               | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | ssB_040               | ioB_040    |
+
+    # ─── Complete ioA first — ioB is still a draft ────────────────────────────────────
+    # epcis_has_events(ioA) = false: order B's 10 TUs are covered only by a draft shipment (not CO/CL).
+    # The gate evaluates false → scripted export records DontSend (N) for ioA.
+    And the shipment identified by ioA_040 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus |
+      | ioA_040    | scriptedCfg_040                                   | N            |
+
+    # ─── Complete ioB — closing completion; all TUs now covered by CO shipments ───────
+    # epcis_has_events(ioB) = true: pallet is fully closed → gate passes → Enqueued (U).
+    And the shipment identified by ioB_040 is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus |
+      | ioB_040    | scriptedCfg_040                                   | U            |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/pporder/lotNumberSequenceProvider.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/pporder/lotNumberSequenceProvider.feature
@@ -1,0 +1,118 @@
+@from:cucumber
+@ghActions:run_on_executor5
+@allure.label.epic:E3000_Manufacturing
+@allure.label.feature:F5000_Handling_Unit
+@F5000
+Feature: Lot number stamped on HU during manufacturing receipt
+## Two paths through lot-number assignment on production receipt:
+## 1. Provider-driven: AD_Sequence with DBFunctionSequenceNoProvider → lot value comes from a PL/pgSQL function
+## 2. Plain sequence (no provider): lot value is the plain incremental number (zero-regression)
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2025-04-01T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+
+    And metasfresh contains M_Products:
+      | Identifier        |
+      | finishedGoodsProd |
+      | rawMaterialProd   |
+
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID.Identifier |
+      | lotNoTU_PI            |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID.Identifier | M_HU_PI_ID.Identifier | HU_UnitType | IsCurrent |
+      | lotNoTU_PIVersion             | lotNoTU_PI            | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType |
+      | lotNoTU_PIItem             | lotNoTU_PIVersion             | 0   | MI       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | lotNoProduct_HUPI                  | lotNoTU_PIItem             | finishedGoodsProd       | 10  | 2021-01-01 |
+
+    And load S_Resource:
+      | S_Resource_ID.Identifier | S_Resource_ID |
+      | testResource             | 540006        |
+
+  @from:cucumber
+  Scenario: Provider-driven lot number — DBFunctionSequenceNoProvider stamps a PL/pgSQL-derived value on the finished-goods HU
+    ## The sequence has DBFunctionSequenceNoProvider as its provider.
+    ## The provider calls the PL/pgSQL function and returns its result as the lot number (no counter appended).
+    ## Fixed system time 2025-04-01T13:30:13+01:00 → UTC day-of-year 091 → expected lot = L091M2
+
+    And the following PL/pgSQL function is created or replaced in the DB:
+    """
+    CREATE OR REPLACE FUNCTION test_lotno_provider(p_pp_order_id numeric, p_at timestamptz)
+      RETURNS text LANGUAGE sql AS
+    $$ SELECT 'L' || to_char(p_at AT TIME ZONE 'UTC', 'DDD') || 'M2' $$
+    """
+
+    And metasfresh contains AD_Sequence:
+      | AD_Sequence_ID.Identifier | Name                      | OPT.CustomSequenceNoProvider_JavaClass_ID.Classname                   | OPT.StartNo |
+      | seq_lotno_provider        | TestLotNoProviderSequence | de.metas.document.sequenceno.DBFunctionSequenceNoProvider             | 1           |
+
+    And set sys config String value test_lotno_provider for sys config de.metas.document.seqNo.DBFunctionSequenceNoProvider.TestLotNoProviderSequence.dbFunctionName
+
+    And metasfresh contains PP_Product_BOM
+      | Identifier      | M_Product_ID.Identifier | ValidFrom  | PP_Product_BOMVersions_ID.Identifier |
+      | bom_provider    | finishedGoodsProd       | 2021-01-01 | bomVersions_provider                 |
+    And metasfresh contains PP_Product_BOMLines
+      | Identifier          | PP_Product_BOM_ID.Identifier | M_Product_ID.Identifier | ValidFrom  | QtyBatch |
+      | bomLine_provider    | bom_provider                 | rawMaterialProd         | 2021-01-01 | 10       |
+    And the PP_Product_BOM identified by bom_provider is completed
+    And update PP_Product_BOM:
+      | PP_Product_BOM_ID.Identifier | OPT.LotNo_Sequence_ID.Identifier |
+      | bom_provider                 | seq_lotno_provider               |
+
+    And create PP_Order:
+      | PP_Order_ID.Identifier  | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument |
+      | ppOrder_lotno_provider  | MOP         | finishedGoodsProd       | 10         | testResource             | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | Y                |
+
+    And receive HUs for PP_Order with M_HU_LUTU_Configuration:
+      | PP_Order_ID             | M_HU_ID.Identifier  | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier |
+      | ppOrder_lotno_provider  | hu_lotno_provider   | N               | 0     | N               | 1     | N               | 10          | lotNoProduct_HUPI                  |
+
+    When complete planning for PP_Order:
+      | PP_Order_ID.Identifier |
+      | ppOrder_lotno_provider |
+
+    Then M_HU_Attribute is validated
+      | M_HU_ID             | M_Attribute_ID.Value | Value  |
+      | hu_lotno_provider   | Lot-Nummer           | L091M2 |
+
+  @from:cucumber
+  Scenario: Plain incremental lot number — no provider configured, lot is the plain sequence counter (zero-regression)
+    ## AD_Sequence with no CustomSequenceNoProvider → DocumentNoBuilder uses the plain counter.
+
+    And metasfresh contains AD_Sequence:
+      | AD_Sequence_ID.Identifier | Name                  | OPT.StartNo |
+      | seq_lotno_plain           | TestLotNoPlainSeq     | 1           |
+
+    And metasfresh contains PP_Product_BOM
+      | Identifier   | M_Product_ID.Identifier | ValidFrom  | PP_Product_BOMVersions_ID.Identifier |
+      | bom_plain    | finishedGoodsProd       | 2021-01-01 | bomVersions_plain                    |
+    And metasfresh contains PP_Product_BOMLines
+      | Identifier       | PP_Product_BOM_ID.Identifier | M_Product_ID.Identifier | ValidFrom  | QtyBatch |
+      | bomLine_plain    | bom_plain                    | rawMaterialProd         | 2021-01-01 | 10       |
+    And the PP_Product_BOM identified by bom_plain is completed
+    And update PP_Product_BOM:
+      | PP_Product_BOM_ID.Identifier | OPT.LotNo_Sequence_ID.Identifier |
+      | bom_plain                    | seq_lotno_plain                  |
+
+    And create PP_Order:
+      | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument |
+      | ppOrder_lotno_plain    | MOP         | finishedGoodsProd       | 10         | testResource             | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | Y                |
+
+    And receive HUs for PP_Order with M_HU_LUTU_Configuration:
+      | PP_Order_ID          | M_HU_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier |
+      | ppOrder_lotno_plain  | hu_lotno_plain     | N               | 0     | N               | 1     | N               | 10          | lotNoProduct_HUPI                  |
+
+    When complete planning for PP_Order:
+      | PP_Order_ID.Identifier |
+      | ppOrder_lotno_plain    |
+
+    Then M_HU_Attribute is validated
+      | M_HU_ID        | M_Attribute_ID.Value | Value |
+      | hu_lotno_plain | Lot-Nummer           | 1     |

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5809860_sys_me03_30558_epcis_close_gate.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5809860_sys_me03_30558_epcis_close_gate.sql
@@ -1,3 +1,4 @@
+-- Source DDL: backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/epcis_json/get_epcis_events_json_fn.sql
 /*
  * #%L
  * de.metas.edi

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pporder/api/impl/AbstractPPOrderReceiptHUProducer.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pporder/api/impl/AbstractPPOrderReceiptHUProducer.java
@@ -407,6 +407,7 @@ import java.util.Optional;
 				lotNumber = lotNumberBL.getAndIncrementLotNo(LotNoContext.builder()
 						.sequenceId(sequenceId)
 						.clientId(ClientId.ofRepoId(ppOrderBom.getAD_Client_ID()))
+						.ppOrderId(ppOrderId)
 						.build());
 
 			}

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/activity_handlers/printReceivedHUQRCodes/PrintReceivedHUQRCodesActivityHandler.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/activity_handlers/printReceivedHUQRCodes/PrintReceivedHUQRCodesActivityHandler.java
@@ -39,6 +39,7 @@ import org.adempiere.exceptions.AdempiereException;
 import org.eevolution.api.PPOrderId;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -170,10 +171,11 @@ public class PrintReceivedHUQRCodesActivityHandler implements WFActivityHandler,
 			this.huLabelService = huLabelService;
 		}
 
-		private HULabelConfig getLabelConfig(final @NonNull HUToReport hu)
+		@Nullable
+		private HULabelConfig getLabelConfigOrNull(final @NonNull HUToReport hu)
 		{
 			return cache.computeIfAbsent(toHULabelConfigQuery(hu), huLabelService::getFirstMatching)
-					.orElseThrow();
+					.orElse(null);
 		}
 
 		private static HULabelConfigQuery toHULabelConfigQuery(final @NonNull HUToReport hu)
@@ -202,14 +204,21 @@ public class PrintReceivedHUQRCodesActivityHandler implements WFActivityHandler,
 		{
 			for (final HUToReport hu : hus)
 			{
-				add(hu, labelConfigProvider.getLabelConfig(hu));
-
+				final HULabelConfig labelConfigOrNull = labelConfigProvider.getLabelConfigOrNull(hu);
+				if (labelConfigOrNull != null)
+				{
+					add(hu, labelConfigOrNull);
+				}
 				final HuUnitType huUnitType = hu.getHUUnitType();
 				if (huUnitType == HuUnitType.LU)
 				{
 					for (final HUToReport includedHU : hu.getIncludedHUs())
 					{
-						add(includedHU, labelConfigProvider.getLabelConfig(includedHU));
+						final HULabelConfig includedLabelConfig = labelConfigProvider.getLabelConfigOrNull(includedHU);
+						if (includedLabelConfig != null) // only attempt printing included HU if there is a matching config
+						{
+							add(includedHU, includedLabelConfig);
+						}
 					}
 				}
 			}

--- a/e2e/frontend-webui/tests/spec/resource-lot-number-code.spec.js
+++ b/e2e/frontend-webui/tests/spec/resource-lot-number-code.spec.js
@@ -1,0 +1,177 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { LoginPage } from '../utils/pages/LoginPage';
+import {
+    FRONTEND_BASE_URL,
+    SLOW_ACTION_TIMEOUT,
+    VERY_SLOW_ACTION_TIMEOUT,
+} from '../utils/common';
+import { RESOURCE_WINDOW_ID } from '../utils/WindowIds';
+
+/**
+ * Resource LotNumberCode field E2E test.
+ *
+ * Validates the new optional `S_Resource.LotNumberCode` field that selects a
+ * per-resource lot-number sequence at manufacturing receipt:
+ *   1. Login with a test user
+ *   2. Navigate to the Resource window
+ *   3. Open an existing Resource record
+ *   4. Verify the "Lot-Nummer Code" field renders and is editable
+ *   5. Set a unique value, save (Tab), reload the page
+ *   6. Verify the value persisted after reload
+ *   7. Restore the original value (in a finally block — runs even if an
+ *      assertion above fails, so the test never leaves residue on the record)
+ *
+ * This is the WebUI-side proof that the AD metadata added for the field
+ * (AD_Field 781245 / AD_UI_Element on window 236, tab 414) renders a usable,
+ * persisting text input — complementing the backend DBFunctionSequenceNoProvider
+ * unit + cucumber coverage.
+ */
+
+const LOT_FIELD = '.form-field-LotNumberCode input';
+
+test.describe('Resource — LotNumberCode field', () => {
+    test('LotNumberCode field renders, is editable, and persists after reload', async ({ page }) => {
+        allure.epic('Manufacturing');
+        allure.story('Per-resource lot-number sequence');
+        allure.severity('normal');
+        allure.description(`
+### Scenario
+Verify the optional **Lot-Nummer Code** (\`S_Resource.LotNumberCode\`) field on the
+Resource window: it renders, accepts input, and the value survives a save + reload.
+
+### Business value
+The field lets a manufacturing resource opt into a custom lot-number sequence at
+receipt time. If it does not render or persist, the feature cannot be configured.
+        `);
+
+        test.setTimeout(90000);
+
+        // A field save is committed by Tab/blur, which fires a PATCH to THIS record's
+        // window document. Awaiting that specific response is deterministic — no blind
+        // sleeps, and no reload before the save round-trips. Scoped to /window/<win>/<rec>
+        // so a concurrent PATCH to another record can't satisfy the wait. Resolves to the
+        // response, or null if none arrived within the timeout — callers handle null.
+        const waitForSave = (recId) =>
+            page
+                .waitForResponse(
+                    (r) =>
+                        r.request().method() === 'PATCH' &&
+                        r.url().includes(`/window/${RESOURCE_WINDOW_ID}/${recId}`),
+                    { timeout: SLOW_ACTION_TIMEOUT }
+                )
+                .catch(() => null);
+
+        // Step 1: test user (Backend.createMasterdata logs the created masterdata itself)
+        const masterdata = await Backend.createMasterdata({
+            request: { login: { user: { language: 'en_US', firstname: 'first', lastname: 'last' } } },
+        });
+
+        // Step 2: login. login() already waits for the redirect off /login; the call
+        // below is a URL-only sanity assertion (not a DOM-ready signal). The real
+        // ready-to-render guard is the document-list wait in step 3. We intentionally do
+        // NOT wait for the dashboard to reach 'networkidle' — its STOMP/websocket + KPI
+        // polling keep the network active, so networkidle never settles locally.
+        await LoginPage.goto();
+        await LoginPage.login(masterdata.login.user);
+        await LoginPage.expectLoggedIn();
+
+        // Step 3: navigate to the Resource window
+        await page.goto(`${FRONTEND_BASE_URL}/window/${RESOURCE_WINDOW_ID}`);
+        await page.locator('.document-list-wrapper, .document-list').waitFor({
+            state: 'visible',
+            timeout: VERY_SLOW_ACTION_TIMEOUT,
+        });
+        await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+        await page.locator('.rotating, .panel-spaced-lg')
+            .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+            .catch(() => {});
+        await page.waitForTimeout(500);
+
+        // Step 4: open the first existing Resource record (double-click opens detail).
+        // Any resource carries the LotNumberCode field, so the first row is fine — the
+        // restore in the finally block is per-run (restores whatever record THIS run
+        // opened to its own captured baseline), so it does not depend on a stable sort.
+        const firstRow = page.locator('.table tbody tr, table tbody tr').first();
+        await firstRow.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
+        await firstRow.dblclick();
+        await page.waitForURL(/\/window\/\d+\/\d+/, { timeout: SLOW_ACTION_TIMEOUT });
+        await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+        await page.locator('.rotating, .indicator-pending')
+            .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+            .catch(() => {});
+
+        const recordUrl = page.url();
+        const recordId = recordUrl.split('/').pop();
+        console.log(`Opened Resource record: ${recordId}`);
+
+        // Step 5: the LotNumberCode field renders and is editable
+        const lotInput = page.locator(LOT_FIELD).first();
+        await lotInput.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+        await expect(lotInput).toBeEditable();
+
+        const originalValue = await lotInput.inputValue();
+        console.log(`Original LotNumberCode value: "${originalValue}"`);
+
+        try {
+            // Step 6: set a unique value and save (Tab triggers the field save).
+            // LotNumberCode is a short per-resource code — VARCHAR(10) / AD FieldLength 10
+            // (e.g. a production-line code). Keep the value within 10 chars so the field's
+            // maxLength does not truncate it.
+            const uniqueValue = `L${Date.now().toString().slice(-8)}`; // 9 chars, unique per run
+            await lotInput.click();
+            await lotInput.fill(uniqueValue);
+            const saved = waitForSave(recordId);
+            await page.keyboard.press('Tab');
+            await saved;
+            console.log(`Set LotNumberCode to: ${uniqueValue}`);
+
+            // Step 7: reload and verify persistence
+            await page.reload();
+            await page.locator(LOT_FIELD).first().waitFor({
+                state: 'visible',
+                timeout: VERY_SLOW_ACTION_TIMEOUT,
+            });
+            const reloadedValue = await page.locator(LOT_FIELD).first().inputValue();
+            expect(reloadedValue).toBe(uniqueValue);
+            console.log(`After reload, LotNumberCode = "${reloadedValue}" (persisted)`);
+
+            const screenshot = await page.screenshot();
+            allure.attachment('Resource LotNumberCode persisted', screenshot, 'image/png');
+
+            const validationHtml = `<table border="1">
+                <tr><th>Check</th><th>Status</th><th>Value</th></tr>
+                <tr><td>Field renders + editable</td><td>PASS</td><td>${LOT_FIELD}</td></tr>
+                <tr><td>Value set</td><td>PASS</td><td>${uniqueValue}</td></tr>
+                <tr><td>Persisted after reload</td><td>PASS</td><td>${reloadedValue}</td></tr>
+            </table>`;
+            allure.attachment('Validation Results', validationHtml, 'text/html');
+        } finally {
+            // Restore the original value so the test leaves no residue — runs even if the
+            // persistence assertion above threw (the record is pre-existing, not owned by
+            // this test, so teardown must be unconditional). Wrapped in try/catch so a
+            // restore error never replaces the original test failure (standard finally
+            // semantics would otherwise mask it).
+            try {
+                await page.goto(recordUrl);
+                const lotInputRestore = page.locator(LOT_FIELD).first();
+                await lotInputRestore.waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
+                await lotInputRestore.click();
+                await lotInputRestore.fill(originalValue);
+                const restored = waitForSave(recordId);
+                await page.keyboard.press('Tab');
+                if ((await restored) === null) {
+                    // Don't fail silently: a missing save round-trip means the record may
+                    // still hold the test value, which a later run would read as baseline.
+                    console.warn(`Restore save for LotNumberCode did not round-trip within timeout; record ${recordId} may still hold the test value.`);
+                } else {
+                    console.log(`Restored original LotNumberCode value: "${originalValue}"`);
+                }
+            } catch (restoreErr) {
+                console.error(`LotNumberCode restore failed (original test result preserved): ${restoreErr}`);
+            }
+        }
+    });
+});

--- a/e2e/frontend-webui/tests/utils/WindowIds.js
+++ b/e2e/frontend-webui/tests/utils/WindowIds.js
@@ -54,6 +54,15 @@ export const BUSINESS_PARTNER_WINDOW_ID = 123;
  */
 export const PRODUCT_WINDOW_ID = 140;
 
+/**
+ * Resource window (Ressource)
+ * Table: S_Resource
+ * Window ID: 236 (main tab AD_Tab_ID=414 "Ressource")
+ * Description: Manufacturing resources/work centers. Carries the optional
+ * LotNumberCode field that selects a per-resource lot-number sequence.
+ */
+export const RESOURCE_WINDOW_ID = 236;
+
 // ============================================================================
 // SALES SIDE WINDOWS
 // ============================================================================

--- a/e2e/mobile-webui/tests/utils/common.js
+++ b/e2e/mobile-webui/tests/utils/common.js
@@ -16,6 +16,23 @@ export const setCurrentPage = (currentPage) => {
     page = currentPage;
 }
 
+// Capture mode — OFF by default. When the env flag UAT_CAPTURE is set, the run is a deliberate
+// recording run for a UAT/documentation video; otherwise this is a no-op and the test runs at
+// full speed. The test's normal/CI speed is never affected.
+// See skill playwright-video-delivery § "Test speed vs. recording speed".
+export const UAT_CAPTURE = !!process.env.UAT_CAPTURE;
+
+// Hold the currently-painted screen on the video recorder long enough for the freshly-entered
+// values to be captured as a clear, deliberate freeze (the recorder samples ~25 fps and Playwright
+// otherwise fills + confirms within a single frame, so the values are never recorded). NO-OP unless
+// UAT_CAPTURE is set — so this can only ever slow a deliberate capture run, never a normal/CI run;
+// the value is therefore generous for legibility, not a marginal minimum.
+const CAPTURE_HOLD_MS = 500;
+export const holdForCaptureIfEnabled = async () => {
+    if (!UAT_CAPTURE || page == null) return;
+    await page.waitForTimeout(CAPTURE_HOLD_MS);
+};
+
 export const step = async (title, func) => await test.step(title, async () => await runAndWatchForErrors(func));
 
 let nextErrorWatcherId = 101;

--- a/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
@@ -1,5 +1,5 @@
 import { test } from "../../../../playwright.config";
-import { expectErrorToastIf, page, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from "../../common";
+import { expectErrorToastIf, holdForCaptureIfEnabled, page, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from "../../common";
 import { expect } from "@playwright/test";
 
 const NAME = 'GetQuantityDialog';
@@ -197,6 +197,10 @@ export const GetQuantityDialog = {
         if (qtyNotFoundReason != null) {
             await GetQuantityDialog.clickQtyNotFoundReason({ reason: qtyNotFoundReason });
         }
+
+        // Capture mode only (UAT_CAPTURE): hold the filled dialog on the recorder for a few frames
+        // so the entered values are captured before OK closes it. No-op / full speed otherwise.
+        await holdForCaptureIfEnabled();
 
         if (closeTarget) {
             await GetQuantityDialog.clickDoneAndCloseTarget({ expectedError });


### PR DESCRIPTION
Forward merge-through of `soft_panda_hotfix` into `soft_panda_release` to keep the release branch current (no RC ongoing; per dev request).

Carries the 4 `soft_panda_hotfix` commits not yet on `soft_panda_release`, including the EPCIS completion-ordering fix (close-gate + closer-emits, migration `5809860`) plus the DB-function sequence-no provider and S_Resource lot-number work.

**Merge-commit only (NOT squash)** — squashing a merge-through destroys the branch parent relationship.

Migrations / DDL present → DDL-regression review required before merge.
