### PR TITLE
autovacuum: tighten settings on hot HU/picking/shipment tables

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5809720_sys_gh30640_autovacuum_settings_hot_hu_picking_tables.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5809720_sys_gh30640_autovacuum_settings_hot_hu_picking_tables.sql
@@ -1,0 +1,44 @@
+-- Tighten autovacuum on the small-but-high-churn HU / picking / shipment tables.
+-- These tables turn over their whole row set many times a day (HUs, picking jobs,
+-- shipments) but stay physically small, so at the default scale_factor 0.2 they
+-- accumulate large dead-tuple ratios (observed up to ~300% dead) while bigger
+-- log tables monopolise the autovacuum workers. A low scale_factor + low
+-- threshold makes a worker reclaim them promptly and often.
+-- See gh30640 (picking performance). Pattern follows
+-- 5660150_sys_gh13753_adjust_autovacuum_settings_on_translation_tables.sql.
+
+ALTER TABLE public.m_hu SET (autovacuum_vacuum_scale_factor = 0.05);
+ALTER TABLE public.m_hu SET (autovacuum_vacuum_threshold = 50);
+ALTER TABLE public.m_hu SET (autovacuum_analyze_scale_factor = 0.05);
+
+ALTER TABLE public.m_hu_item SET (autovacuum_vacuum_scale_factor = 0.05);
+ALTER TABLE public.m_hu_item SET (autovacuum_vacuum_threshold = 50);
+ALTER TABLE public.m_hu_item SET (autovacuum_analyze_scale_factor = 0.05);
+
+ALTER TABLE public.m_hu_trx_line SET (autovacuum_vacuum_scale_factor = 0.05);
+ALTER TABLE public.m_hu_trx_line SET (autovacuum_vacuum_threshold = 50);
+ALTER TABLE public.m_hu_trx_line SET (autovacuum_analyze_scale_factor = 0.05);
+
+ALTER TABLE public.m_picking_job SET (autovacuum_vacuum_scale_factor = 0.05);
+ALTER TABLE public.m_picking_job SET (autovacuum_vacuum_threshold = 50);
+ALTER TABLE public.m_picking_job SET (autovacuum_analyze_scale_factor = 0.05);
+
+ALTER TABLE public.m_picking_job_line SET (autovacuum_vacuum_scale_factor = 0.05);
+ALTER TABLE public.m_picking_job_line SET (autovacuum_vacuum_threshold = 50);
+ALTER TABLE public.m_picking_job_line SET (autovacuum_analyze_scale_factor = 0.05);
+
+ALTER TABLE public.m_picking_job_step SET (autovacuum_vacuum_scale_factor = 0.05);
+ALTER TABLE public.m_picking_job_step SET (autovacuum_vacuum_threshold = 50);
+ALTER TABLE public.m_picking_job_step SET (autovacuum_analyze_scale_factor = 0.05);
+
+ALTER TABLE public.m_inout SET (autovacuum_vacuum_scale_factor = 0.05);
+ALTER TABLE public.m_inout SET (autovacuum_vacuum_threshold = 50);
+ALTER TABLE public.m_inout SET (autovacuum_analyze_scale_factor = 0.05);
+
+ALTER TABLE public.m_inoutline SET (autovacuum_vacuum_scale_factor = 0.05);
+ALTER TABLE public.m_inoutline SET (autovacuum_vacuum_threshold = 50);
+ALTER TABLE public.m_inoutline SET (autovacuum_analyze_scale_factor = 0.05);
+
+ALTER TABLE public.m_shipmentschedule_qtypicked SET (autovacuum_vacuum_scale_factor = 0.05);
+ALTER TABLE public.m_shipmentschedule_qtypicked SET (autovacuum_vacuum_threshold = 50);
+ALTER TABLE public.m_shipmentschedule_qtypicked SET (autovacuum_analyze_scale_factor = 0.05);


### PR DESCRIPTION
## What

Tightens PostgreSQL autovacuum on the small-but-high-churn HU / picking / shipment tables (`m_hu`, `m_hu_item`, `m_hu_trx_line`, `m_picking_job`, `m_picking_job_line`, `m_picking_job_step`, `m_inout`, `m_inoutline`, `m_shipmentschedule_qtypicked`).

These tables turn over their whole row set many times a day but stay physically small, so at the default `scale_factor = 0.2` they accumulate large dead-tuple ratios (observed up to ~300% dead) while the much larger log tables monopolise the autovacuum workers. A low `scale_factor` (0.05) + low `threshold` (50) makes a worker reclaim them promptly and often, reducing bloat-driven slowdowns on the picking path.

## How

Migration `5809720_sys_gh30640_autovacuum_settings_hot_hu_picking_tables.sql` — per-table `ALTER TABLE … SET (autovacuum_vacuum_scale_factor = 0.05, autovacuum_vacuum_threshold = 50, autovacuum_analyze_scale_factor = 0.05)`. Follows the established pattern of `5660150_sys_gh13753_adjust_autovacuum_settings_on_translation_tables.sql`.

Server-wide autovacuum tuning (`autovacuum_vacuum_cost_limit`, `autovacuum_max_workers`) is handled separately as an ops-managed `postgresql.conf` change, not in this migration.
