### PR TITLE
Traffic Manager Picking List: fix compound key + sum QtyToPick per product

### DIFF
--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/docs/sales/picking_traffic_mgr/report.jrxml
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/docs/sales/picking_traffic_mgr/report.jrxml
@@ -66,6 +66,9 @@
 	<variable name="prep_date_header" class="java.sql.Timestamp" resetType="None" calculation="First">
 		<variableExpression><![CDATA[$F{prep_date}]]></variableExpression>
 	</variable>
+	<variable name="product_qty_sum" class="java.math.BigDecimal" resetType="Group" resetGroup="product" calculation="Sum">
+		<variableExpression><![CDATA[$F{qtytopick}]]></variableExpression>
+	</variable>
 	<group name="picklist_section" isReprintHeaderOnEachPage="true">
 		<groupExpression><![CDATA[$F{picklist_group}]]></groupExpression>
 		<groupHeader>
@@ -122,12 +125,12 @@
 					</textElement>
 					<text><![CDATA[zu packen:]]></text>
 				</staticText>
-				<textField pattern="#,##0.##" isBlankWhenNull="true">
+				<textField pattern="#,##0.##" isBlankWhenNull="true" evaluationTime="Group" evaluationGroup="product">
 					<reportElement x="483" y="2" width="72" height="14" uuid="11111111-1111-1111-1111-111111111107"/>
 					<textElement textAlignment="Right">
 						<font fontName="Arial" size="9" isBold="true"/>
 					</textElement>
-					<textFieldExpression><![CDATA[$F{qtytopick}]]></textFieldExpression>
+					<textFieldExpression><![CDATA[$V{product_qty_sum}]]></textFieldExpression>
 				</textField>
 			</band>
 		</groupHeader>

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/docs/sales/picking_traffic_mgr/report.jrxml
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/docs/sales/picking_traffic_mgr/report.jrxml
@@ -20,34 +20,44 @@
 	<queryString>
 		<![CDATA[SELECT * FROM report.TrafficMgr_PickingList($P{p_m_shipmentschedule_ids}, $P{p_view_id})]]>
 	</queryString>
-	<field name="artikel" class="java.lang.String">
-		<property name="com.jaspersoft.studio.field.label" value="artikel"/>
+	<field name="productvalue" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="productvalue"/>
+		<property name="com.jaspersoft.studio.field.label" value="productvalue"/>
 	</field>
-	<field name="kz" class="java.lang.String">
-		<property name="com.jaspersoft.studio.field.label" value="kz"/>
+	<field name="productname" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="productname"/>
+		<property name="com.jaspersoft.studio.field.label" value="productname"/>
 	</field>
-	<field name="zu_packen" class="java.math.BigDecimal">
-		<property name="com.jaspersoft.studio.field.label" value="zu_packen"/>
+	<field name="qtytopick" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="qtytopick"/>
+		<property name="com.jaspersoft.studio.field.label" value="qtytopick"/>
 	</field>
 	<field name="status" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="status"/>
 		<property name="com.jaspersoft.studio.field.label" value="status"/>
 	</field>
 	<field name="workplace" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="workplace"/>
 		<property name="com.jaspersoft.studio.field.label" value="workplace"/>
 	</field>
 	<field name="prep_date" class="java.sql.Timestamp">
+		<property name="com.jaspersoft.studio.field.name" value="prep_date"/>
 		<property name="com.jaspersoft.studio.field.label" value="prep_date"/>
 	</field>
 	<field name="lagernr" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="lagernr"/>
 		<property name="com.jaspersoft.studio.field.label" value="lagernr"/>
 	</field>
 	<field name="menge_at_locator" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="menge_at_locator"/>
 		<property name="com.jaspersoft.studio.field.label" value="menge_at_locator"/>
 	</field>
 	<field name="m_product_id" class="java.math.BigDecimal">
+		<property name="com.jaspersoft.studio.field.name" value="m_product_id"/>
 		<property name="com.jaspersoft.studio.field.label" value="m_product_id"/>
 	</field>
 	<field name="picklist_group" class="java.lang.String">
+		<property name="com.jaspersoft.studio.field.name" value="picklist_group"/>
 		<property name="com.jaspersoft.studio.field.label" value="picklist_group"/>
 	</field>
 	<variable name="workplace_header" class="java.lang.String" resetType="None" calculation="First">
@@ -89,7 +99,7 @@
 					<textElement>
 						<font fontName="Arial" size="9" isBold="true"/>
 					</textElement>
-					<textFieldExpression><![CDATA[$F{artikel} != null ? $F{artikel} : ""]]></textFieldExpression>
+					<textFieldExpression><![CDATA[$F{productvalue}!= null ?$F{productvalue} : ""]]></textFieldExpression>
 				</textField>
 				<staticText>
 					<reportElement x="165" y="2" width="30" height="14" uuid="11111111-1111-1111-1111-111111111104"/>
@@ -103,7 +113,7 @@
 					<textElement>
 						<font fontName="Arial" size="9" isBold="true"/>
 					</textElement>
-					<textFieldExpression><![CDATA[$F{kz} != null ? $F{kz} : ""]]></textFieldExpression>
+					<textFieldExpression><![CDATA[$F{productname}!= null ?$F{productname}: ""]]></textFieldExpression>
 				</textField>
 				<staticText>
 					<reportElement x="420" y="2" width="60" height="14" uuid="11111111-1111-1111-1111-111111111106"/>
@@ -117,7 +127,7 @@
 					<textElement textAlignment="Right">
 						<font fontName="Arial" size="9" isBold="true"/>
 					</textElement>
-					<textFieldExpression><![CDATA[$F{zu_packen}]]></textFieldExpression>
+					<textFieldExpression><![CDATA[$F{qtytopick}]]></textFieldExpression>
 				</textField>
 			</band>
 		</groupHeader>
@@ -220,7 +230,7 @@
 				<textElement textAlignment="Right">
 					<font fontName="Arial" size="8"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{zu_packen}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{qtytopick}]]></textFieldExpression>
 			</textField>
 			<textField pattern="#,##0.##" isBlankWhenNull="true">
 				<reportElement x="200" y="0" width="70" height="12" uuid="44444444-4444-4444-4444-444444444402"/>

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5809890_sys_Adjust_TrafficMgr_PickingList_fix_compound_key.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5809890_sys_Adjust_TrafficMgr_PickingList_fix_compound_key.sql
@@ -48,13 +48,13 @@ BEGIN
                  LEFT JOIN M_Locator loc ON loc.M_Warehouse_ID = pjs.M_Warehouse_ID AND loc.IsDefault = 'Y'
         WHERE p_m_shipmentschedule_ids IS NOT NULL
           AND (
-                (p_m_shipmentschedule_ids = 'all'
-                    AND pjs.M_ShipmentSchedule_ID IN (SELECT vs.IntKey1
-                                                      FROM T_WEBUI_ViewSelection vs
-                                                      WHERE vs.UUID = p_view_id))
+            (p_m_shipmentschedule_ids = 'all'
+                AND pjs.M_ShipmentSchedule_ID IN (SELECT vs.IntKey1
+                                                  FROM T_WEBUI_ViewSelection vs
+                                                  WHERE vs.UUID = p_view_id))
                 OR
-                (p_m_shipmentschedule_ids <> 'all'
-                    AND pjs.M_ShipmentSchedule_ID = ANY (REGEXP_SPLIT_TO_ARRAY(p_m_shipmentschedule_ids, ',')::INT[]))
+            (p_m_shipmentschedule_ids <> 'all'
+                AND pjs.M_ShipmentSchedule_ID = ANY (REGEXP_SPLIT_TO_ARRAY(p_m_shipmentschedule_ids, ',')::INT[]))
             )
         ORDER BY (CASE WHEN pjs.qtypicked > 0 THEN 2 ELSE 1 END), p.Value, wh.Name;
 END;


### PR DESCRIPTION
## Summary

- Fixes `report.TrafficMgr_PickingList` crashing with a cast error when WebUI passes compound keys like `1002746$0` (from `M_Picking_Job_Schedule_view` which has a compound primary key). Strips the `$<suffix>` before casting to `INT[]`.
- Renames SQL function return columns (`artikel`→`productValue`, `kz`→`productname`, `zu_packen`→`QtyToPick`) and updates JRXML field names accordingly.
- Adds migration script `5809890_sys_Adjust_TrafficMgr_PickingList_fix_compound_key.sql` to apply the fix to existing databases.
- Fixes the product group header showing `QtyToPick` from the first locator row only — now uses a Sum variable with `evaluationTime="Group"` so it shows the total quantity across all locator rows for that product.

## Test plan

- [x] Run the "Paper Picking List" report from the Traffic Manager window with rows selected
- [x] Verify the report renders without error
- [x] Verify the product group header "zu packen" shows the sum of quantities across all locator rows for that product
- [x] Verify detail rows still show the individual locator quantities