### PR TITLE
Workplace user assignment: reuse existing row on re-assign instead of inserting a duplicate

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceUserAssignRepository.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceUserAssignRepository.java
@@ -67,10 +67,8 @@ public class WorkplaceUserAssignRepository
 	}
 
 	@NonNull
-	private Optional<I_C_Workplace_User_Assign> retrieveRecordByUserId(final @NonNull UserId userId)
+	private Optional<I_C_Workplace_User_Assign> retrieveRecordByUserIdIncludingInactive(final @NonNull UserId userId)
 	{
-		// Like retrieveActiveRecordByUserId but without the active filter, so an upsert also reuses a
-		// deactivated row (one assignment per user, as in UserWorkstationAssignmentRepository).
 		return queryBL.createQueryBuilder(I_C_Workplace_User_Assign.class)
 				.addEqualsFilter(I_C_Workplace_User_Assign.COLUMNNAME_AD_User_ID, userId)
 				.create()
@@ -85,7 +83,7 @@ public class WorkplaceUserAssignRepository
 		// Reuse the user's existing row regardless of IsActive: the unique index
 		// One_User_Per_Org (AD_User_ID, AD_Org_ID) spans inactive rows too, so inserting a
 		// second row for a user who has a deactivated assignment would violate it.
-		final I_C_Workplace_User_Assign record = retrieveRecordByUserId(userId)
+		final I_C_Workplace_User_Assign record = retrieveRecordByUserIdIncludingInactive(userId)
 				.orElseGet(() -> InterfaceWrapperHelper.newInstance(I_C_Workplace_User_Assign.class));
 
 		record.setIsActive(true);

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceUserAssignRepository.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceUserAssignRepository.java
@@ -29,7 +29,6 @@ import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_Workplace_User_Assign;
-import org.compiere.util.Env;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -70,11 +69,10 @@ public class WorkplaceUserAssignRepository
 	@NonNull
 	private Optional<I_C_Workplace_User_Assign> retrieveRecordByUserId(final @NonNull UserId userId)
 	{
-		// Scope to (AD_User_ID, AD_Org_ID) — the columns of the unique index One_User_Per_Org — so the
-		// lookup matches the org the new row would be created in and can return at most one row.
+		// Like retrieveActiveRecordByUserId but without the active filter, so an upsert also reuses a
+		// deactivated row (one assignment per user, as in UserWorkstationAssignmentRepository).
 		return queryBL.createQueryBuilder(I_C_Workplace_User_Assign.class)
 				.addEqualsFilter(I_C_Workplace_User_Assign.COLUMNNAME_AD_User_ID, userId)
-				.addEqualsFilter(I_C_Workplace_User_Assign.COLUMNNAME_AD_Org_ID, Env.getAD_Org_ID(Env.getCtx()))
 				.create()
 				.firstOnlyOptional(I_C_Workplace_User_Assign.class);
 	}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceUserAssignRepository.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceUserAssignRepository.java
@@ -29,6 +29,7 @@ import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_Workplace_User_Assign;
+import org.compiere.util.Env;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -69,8 +70,11 @@ public class WorkplaceUserAssignRepository
 	@NonNull
 	private Optional<I_C_Workplace_User_Assign> retrieveRecordByUserId(final @NonNull UserId userId)
 	{
+		// Scope to (AD_User_ID, AD_Org_ID) — the columns of the unique index One_User_Per_Org — so the
+		// lookup matches the org the new row would be created in and can return at most one row.
 		return queryBL.createQueryBuilder(I_C_Workplace_User_Assign.class)
 				.addEqualsFilter(I_C_Workplace_User_Assign.COLUMNNAME_AD_User_ID, userId)
+				.addEqualsFilter(I_C_Workplace_User_Assign.COLUMNNAME_AD_Org_ID, Env.getAD_Org_ID(Env.getCtx()))
 				.create()
 				.firstOnlyOptional(I_C_Workplace_User_Assign.class);
 	}
@@ -82,8 +86,7 @@ public class WorkplaceUserAssignRepository
 
 		// Reuse the user's existing row regardless of IsActive: the unique index
 		// One_User_Per_Org (AD_User_ID, AD_Org_ID) spans inactive rows too, so inserting a
-		// second row for a user who has a deactivated assignment violates it. Reactivate and
-		// repoint the existing row instead (same approach as UserWorkstationAssignmentRepository).
+		// second row for a user who has a deactivated assignment would violate it.
 		final I_C_Workplace_User_Assign record = retrieveRecordByUserId(userId)
 				.orElseGet(() -> InterfaceWrapperHelper.newInstance(I_C_Workplace_User_Assign.class));
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceUserAssignRepository.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceUserAssignRepository.java
@@ -66,12 +66,25 @@ public class WorkplaceUserAssignRepository
 				.firstOnlyOptional(I_C_Workplace_User_Assign.class);
 	}
 
+	@NonNull
+	private Optional<I_C_Workplace_User_Assign> retrieveRecordByUserId(final @NonNull UserId userId)
+	{
+		return queryBL.createQueryBuilder(I_C_Workplace_User_Assign.class)
+				.addEqualsFilter(I_C_Workplace_User_Assign.COLUMNNAME_AD_User_ID, userId)
+				.create()
+				.firstOnlyOptional(I_C_Workplace_User_Assign.class);
+	}
+
 	public void create(@NonNull final WorkplaceAssignmentCreateRequest request)
 	{
 		final UserId userId = request.getUserId();
 		final WorkplaceId workplaceId = request.getWorkplaceId();
 
-		final I_C_Workplace_User_Assign record = retrieveActiveRecordByUserId(userId)
+		// Reuse the user's existing row regardless of IsActive: the unique index
+		// One_User_Per_Org (AD_User_ID, AD_Org_ID) spans inactive rows too, so inserting a
+		// second row for a user who has a deactivated assignment violates it. Reactivate and
+		// repoint the existing row instead (same approach as UserWorkstationAssignmentRepository).
+		final I_C_Workplace_User_Assign record = retrieveRecordByUserId(userId)
 				.orElseGet(() -> InterfaceWrapperHelper.newInstance(I_C_Workplace_User_Assign.class));
 
 		record.setIsActive(true);

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceUserAssignRepositoryTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceUserAssignRepositoryTest.java
@@ -1,0 +1,110 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.workplace;
+
+import de.metas.user.UserId;
+import de.metas.util.Services;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_Workplace_User_Assign;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WorkplaceUserAssignRepositoryTest
+{
+	private static final UserId userId = UserId.ofRepoId(1234567);
+	private static final WorkplaceId workplaceA = WorkplaceId.ofRepoId(100);
+	private static final WorkplaceId workplaceB = WorkplaceId.ofRepoId(200);
+
+	private WorkplaceUserAssignRepository repository;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		repository = new WorkplaceUserAssignRepository();
+	}
+
+	private List<I_C_Workplace_User_Assign> retrieveAllForUser()
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_C_Workplace_User_Assign.class)
+				.addEqualsFilter(I_C_Workplace_User_Assign.COLUMNNAME_AD_User_ID, userId)
+				.create()
+				.list(I_C_Workplace_User_Assign.class);
+	}
+
+	private void createRow(final WorkplaceId workplaceId, final boolean active)
+	{
+		final I_C_Workplace_User_Assign record = InterfaceWrapperHelper.newInstance(I_C_Workplace_User_Assign.class);
+		record.setAD_User_ID(userId.getRepoId());
+		record.setC_Workplace_ID(workplaceId.getRepoId());
+		record.setIsActive(active);
+		InterfaceWrapperHelper.saveRecord(record);
+	}
+
+	@Test
+	void reassign_reuses_existing_inactive_row_instead_of_inserting_a_duplicate()
+	{
+		// the user has a leftover INACTIVE assignment on another workplace (same user+org)
+		createRow(workplaceA, false);
+
+		// scanning the workstation re-asserts the workplace -> now workplaceB
+		repository.create(WorkplaceAssignmentCreateRequest.builder()
+				.userId(userId)
+				.workplaceId(workplaceB)
+				.build());
+
+		// must REUSE the single row (reactivate + repoint), not insert a duplicate
+		// (a duplicate would violate the unique index One_User_Per_Org (AD_User_ID, AD_Org_ID) in the DB)
+		final List<I_C_Workplace_User_Assign> rows = retrieveAllForUser();
+		assertThat(rows).hasSize(1);
+		assertThat(rows.get(0).isActive()).isTrue();
+		assertThat(rows.get(0).getC_Workplace_ID()).isEqualTo(workplaceB.getRepoId());
+
+		assertThat(repository.getWorkplaceIdByUserId(userId)).contains(workplaceB);
+	}
+
+	@Test
+	void scanning_a_different_workplace_repoints_the_single_active_row()
+	{
+		// the user is actively assigned to workplaceA (e.g. from the workstation)
+		createRow(workplaceA, true);
+
+		// the user deliberately scans a different workplace -> must switch to workplaceB
+		repository.create(WorkplaceAssignmentCreateRequest.builder()
+				.userId(userId)
+				.workplaceId(workplaceB)
+				.build());
+
+		final List<I_C_Workplace_User_Assign> rows = retrieveAllForUser();
+		assertThat(rows).hasSize(1);
+		assertThat(rows.get(0).getC_Workplace_ID()).isEqualTo(workplaceB.getRepoId());
+		assertThat(repository.getWorkplaceIdByUserId(userId)).contains(workplaceB);
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceUserAssignRepositoryTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceUserAssignRepositoryTest.java
@@ -80,8 +80,8 @@ class WorkplaceUserAssignRepositoryTest
 				.workplaceId(workplaceB)
 				.build());
 
-		// must REUSE the single row (reactivate + repoint), not insert a duplicate
-		// (a duplicate would violate the unique index One_User_Per_Org (AD_User_ID, AD_Org_ID) in the DB)
+		// the unique index One_User_Per_Org (AD_User_ID, AD_Org_ID) spans inactive rows,
+		// so the row must be reused, not re-inserted
 		final List<I_C_Workplace_User_Assign> rows = retrieveAllForUser();
 		assertThat(rows).hasSize(1);
 		assertThat(rows.get(0).isActive()).isTrue();
@@ -105,6 +105,22 @@ class WorkplaceUserAssignRepositoryTest
 		final List<I_C_Workplace_User_Assign> rows = retrieveAllForUser();
 		assertThat(rows).hasSize(1);
 		assertThat(rows.get(0).getC_Workplace_ID()).isEqualTo(workplaceB.getRepoId());
+		assertThat(repository.getWorkplaceIdByUserId(userId)).contains(workplaceB);
+	}
+
+	@Test
+	void reassign_invalidates_the_cached_workplace_lookup()
+	{
+		createRow(workplaceA, true);
+		// warm the byUserId CCache with the old value
+		assertThat(repository.getWorkplaceIdByUserId(userId)).contains(workplaceA);
+
+		repository.create(WorkplaceAssignmentCreateRequest.builder()
+				.userId(userId)
+				.workplaceId(workplaceB)
+				.build());
+
+		// the save must invalidate the cache so the next read returns the new workplace
 		assertThat(repository.getWorkplaceIdByUserId(userId)).contains(workplaceB);
 	}
 }


### PR DESCRIPTION
## Problem

`WorkplaceUserAssignRepository.create()` looked up the row to reuse with an **active-only** filter (`addOnlyActiveRecordsFilter`). A user who had a *deactivated* workplace assignment therefore got a **brand-new row inserted** on re-assignment.

That violates the unique index `One_User_Per_Org (AD_User_ID, AD_Org_ID)`, which is **not partial** and spans inactive rows too. So the (re)assignment failed and the user was left without an active workplace — and any workplace-keyed lookup that depends on the active assignment (e.g. printer-config resolution via `getWorkplaceByUserId`) could not resolve.

## Fix

Look up the existing row by `AD_User_ID` **regardless of `IsActive`** and reactivate + repoint it, instead of inserting a duplicate. This mirrors the sibling `UserWorkstationAssignmentRepository.assign()`, which already reuses by user without an active filter.

- The **read** path (`getWorkplaceByUserId` → `retrieveActiveRecordByUserId`) is unchanged — it still returns only the active assignment.
- The workplace **value** written is unchanged — it still comes from the caller (the scanned/derived workplace), so a deliberately scanned different workplace is honored, not clobbered.

## Tests

`WorkplaceUserAssignRepositoryTest`:
- re-assign over a leftover **inactive** row → exactly one active row pointing to the new workplace (no duplicate).
- switching to a deliberately scanned **different** workplace over an active row → single active row repointed.
