### PR TITLE
Delete linked M_ReceiptSchedule records when purchase order line is deleted (#30516)

### DIFF
--- a/backend/de.metas.business/pom.xml
+++ b/backend/de.metas.business/pom.xml
@@ -95,8 +95,14 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>de.metas.handlingunits</groupId>
+            <artifactId>de.metas.handlingunits.base</artifactId>
+            <version>10.0.0</version>
+            <scope>compile</scope>
+        </dependency>
 
-	</dependencies>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/backend/de.metas.business/pom.xml
+++ b/backend/de.metas.business/pom.xml
@@ -95,14 +95,8 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>de.metas.handlingunits</groupId>
-            <artifactId>de.metas.handlingunits.base</artifactId>
-            <version>10.0.0</version>
-            <scope>compile</scope>
-        </dependency>
 
-    </dependencies>
+	</dependencies>
 
 	<build>
 		<plugins>

--- a/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_OrderLine.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_OrderLine.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerSupplierApprovalService;
 import de.metas.bpartner_product.IBPartnerProductBL;
+import de.metas.handlingunits.model.I_M_ReceiptSchedule;
 import de.metas.i18n.AdMessageKey;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.lang.SOTrx;
@@ -135,6 +136,13 @@ public class C_OrderLine
 					ol.setRef_OrderLine(null);
 					return IQueryUpdater.MODEL_UPDATED;
 				});
+
+		// 30516
+		queryBL
+				.createQueryBuilder(I_M_ReceiptSchedule.class)
+				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, purchaseOrderLine.getC_OrderLine_ID())
+				.create()
+				.delete();
 
 	}
 

--- a/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_OrderLine.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_OrderLine.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerSupplierApprovalService;
 import de.metas.bpartner_product.IBPartnerProductBL;
-import de.metas.handlingunits.model.I_M_ReceiptSchedule;
 import de.metas.i18n.AdMessageKey;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.lang.SOTrx;
@@ -136,13 +135,6 @@ public class C_OrderLine
 					ol.setRef_OrderLine(null);
 					return IQueryUpdater.MODEL_UPDATED;
 				});
-
-		// 30516
-		queryBL
-				.createQueryBuilder(I_M_ReceiptSchedule.class)
-				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, purchaseOrderLine.getC_OrderLine_ID())
-				.create()
-				.delete();
 
 	}
 

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5810010_sys_gh30516_CannotDeleteOrderLine_ReceiptSchedule_Msg.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5810010_sys_gh30516_CannotDeleteOrderLine_ReceiptSchedule_Msg.sql
@@ -11,10 +11,16 @@ INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTransla
 
 -- Value: CannotDeleteOrderLine_ReceiptSchedule
 -- 2026-06-29T17:13:19.290Z
-UPDATE AD_Message_Trl SET IsTranslated='Y', MsgText='Cannot delete order line: a receipt already exists for the linked receipt schedule.',Updated=TO_TIMESTAMP('2026-06-29 17:13:19.290000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545771
+UPDATE AD_Message_Trl SET IsTranslated='Y', MsgText='Cannot delete order line: a receipt already exists for the linked receipt schedule. Please reverse the associated receipt before deleting this order line.',Updated=TO_TIMESTAMP('2026-06-29 17:13:19.290000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545771
 ;
 
 -- 2026-06-29T17:13:19.291Z
 UPDATE AD_Message base SET MsgText=trl.MsgText, Updated=trl.Updated, UpdatedBy=trl.UpdatedBy FROM AD_Message_Trl trl  WHERE trl.AD_Message_ID=base.AD_Message_ID AND trl.AD_Language='en_US' AND trl.AD_Language=getBaseLanguage()
+;
+
+-- Value: CannotDeleteOrderLine_ReceiptSchedule (DE recovery hint)
+UPDATE AD_Message SET MsgText='Auftragsposition kann nicht gelöscht werden: Für den verknüpften Belegplan existiert bereits ein Beleg. Bitte stornieren Sie den zugehörigen Beleg, bevor Sie diese Auftragsposition löschen.' WHERE AD_Message_ID=545771 AND getBaseLanguage()='de_DE'
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y', MsgText='Auftragsposition kann nicht gelöscht werden: Für den verknüpften Belegplan existiert bereits ein Beleg. Bitte stornieren Sie den zugehörigen Beleg, bevor Sie diese Auftragsposition löschen.' WHERE AD_Language='de_DE' AND AD_Message_ID=545771
 ;
 

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5810010_sys_gh30516_CannotDeleteOrderLine_ReceiptSchedule_Msg.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5810010_sys_gh30516_CannotDeleteOrderLine_ReceiptSchedule_Msg.sql
@@ -1,0 +1,20 @@
+-- Run mode: SWING_CLIENT
+
+-- Value: CannotDeleteOrderLine_ReceiptSchedule
+-- 2026-06-29T17:12:20.319Z
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value) VALUES (0,545771,0,TO_TIMESTAMP('2026-06-29 17:12:20.057000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','Auftragsposition kann nicht gelöscht werden: Für den verknüpften Belegplan existiert bereits ein Beleg.','E',TO_TIMESTAMP('2026-06-29 17:12:20.057000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'CannotDeleteOrderLine_ReceiptSchedule')
+;
+
+-- 2026-06-29T17:12:20.325Z
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Message t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545771 AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- Value: CannotDeleteOrderLine_ReceiptSchedule
+-- 2026-06-29T17:13:19.290Z
+UPDATE AD_Message_Trl SET IsTranslated='Y', MsgText='Cannot delete order line: a receipt already exists for the linked receipt schedule.',Updated=TO_TIMESTAMP('2026-06-29 17:13:19.290000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545771
+;
+
+-- 2026-06-29T17:13:19.291Z
+UPDATE AD_Message base SET MsgText=trl.MsgText, Updated=trl.Updated, UpdatedBy=trl.UpdatedBy FROM AD_Message_Trl trl  WHERE trl.AD_Message_ID=base.AD_Message_ID AND trl.AD_Language='en_US' AND trl.AD_Language=getBaseLanguage()
+;
+

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -5,8 +5,10 @@ import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.handlingunits.IHUPIItemProductDAO;
 import de.metas.handlingunits.model.I_C_Order;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.handlingunits.model.I_M_ReceiptSchedule;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
+import org.adempiere.ad.dao.IQueryBL;
 import lombok.NonNull;
 import org.adempiere.ad.callout.annotations.Callout;
 import org.adempiere.ad.callout.annotations.CalloutMethod;
@@ -51,6 +53,7 @@ import java.util.Properties;
 public class C_OrderLine
 {
 	private final IHUPIItemProductDAO hupiItemProductDAO = Services.get(IHUPIItemProductDAO.class);
+	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 	@Init
 	public void registerCallouts()
@@ -61,7 +64,11 @@ public class C_OrderLine
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_DELETE)
 	public void deleteReservation(@NonNull final I_C_OrderLine orderLineRecord)
 	{
-		// TODO
+		queryBL
+				.createQueryBuilder(I_M_ReceiptSchedule.class)
+				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineRecord.getC_OrderLine_ID())
+				.create()
+				.delete();
 	}
 
 	@ModelChange( //

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -13,6 +13,7 @@ import lombok.NonNull;
 import org.adempiere.ad.callout.annotations.Callout;
 import org.adempiere.ad.callout.annotations.CalloutMethod;
 import org.adempiere.ad.callout.spi.IProgramaticCalloutProvider;
+import org.adempiere.ad.dao.IQueryUpdater;
 import org.adempiere.ad.modelvalidator.annotations.Init;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
@@ -64,6 +65,15 @@ public class C_OrderLine
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_DELETE)
 	public void deleteReservation(@NonNull final I_C_OrderLine orderLineRecord)
 	{
+		queryBL
+				.createQueryBuilder(I_M_ReceiptSchedule.class)
+				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineRecord.getC_OrderLine_ID())
+				.create()
+				.update(rs -> {
+					rs.setIsActive(false);
+					return IQueryUpdater.MODEL_UPDATED;
+				});
+
 		queryBL
 				.createQueryBuilder(I_M_ReceiptSchedule.class)
 				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineRecord.getC_OrderLine_ID())

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -6,6 +6,8 @@ import de.metas.handlingunits.IHUPIItemProductDAO;
 import de.metas.handlingunits.model.I_C_Order;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.inoutcandidate.api.IReceiptScheduleDAO;
+import de.metas.order.IOrderBL;
+import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
@@ -53,6 +55,7 @@ import java.util.Properties;
 public class C_OrderLine
 {
 	private final IHUPIItemProductDAO hupiItemProductDAO = Services.get(IHUPIItemProductDAO.class);
+	private final IOrderBL orderBL = Services.get(IOrderBL.class);
 	private final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
 
 	@Init
@@ -69,12 +72,8 @@ public class C_OrderLine
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_DELETE)
 	public void beforeOrderLineDeleted(@NonNull final I_C_OrderLine orderLineRecord)
 	{
-		// Receipt schedules only exist for purchase order lines.
-		// Guard against null: getC_Order() returns null when C_Order_ID <= 0 (malformed data).
-		// Treat that as a no-op to avoid NPE; deleteByOrderLineId will be a no-op anyway since
-		// no receipt schedules can be linked to an order-less order line.
-		final org.compiere.model.I_C_Order order = orderLineRecord.getC_Order();
-		if (order == null || order.isSOTrx())
+		// Receipt schedules only exist for purchase order lines
+		if (orderBL.isSalesOrder(OrderId.ofRepoId(orderLineRecord.getC_Order_ID())))
 		{
 			return;
 		}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -69,7 +69,8 @@ public class C_OrderLine
 				.createQueryBuilder(I_M_ReceiptSchedule.class)
 				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineRecord.getC_OrderLine_ID())
 				.create()
-				.update(rs -> {
+				.updateDirectly(rs -> {
+					rs.setProcessed(false);
 					rs.setIsActive(false);
 					return IQueryUpdater.MODEL_UPDATED;
 				});

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -69,8 +69,12 @@ public class C_OrderLine
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_DELETE)
 	public void beforeOrderLineDeleted(@NonNull final I_C_OrderLine orderLineRecord)
 	{
-		// Receipt schedules only exist for purchase order lines
-		if (orderLineRecord.getC_Order().isSOTrx())
+		// Receipt schedules only exist for purchase order lines.
+		// Guard against null: getC_Order() returns null when C_Order_ID <= 0 (malformed data).
+		// Treat that as a no-op to avoid NPE; deleteByOrderLineId will be a no-op anyway since
+		// no receipt schedules can be linked to an order-less order line.
+		final org.compiere.model.I_C_Order order = orderLineRecord.getC_Order();
+		if (order == null || order.isSOTrx())
 		{
 			return;
 		}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -61,9 +61,19 @@ public class C_OrderLine
 		Services.get(IProgramaticCalloutProvider.class).registerAnnotatedCallout(this);
 	}
 
+	// Note: receipt schedule cleanup belongs conceptually in de.metas.business, but adding
+	// IReceiptScheduleDAO there would create a circular Maven dependency
+	// (de.metas.handlingunits.base → de.metas.swat.base → de.metas.business).
+	// This interceptor lives in de.metas.handlingunits.base, which already depends on
+	// de.metas.swat.base, making it the lowest layer where the call is possible.
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_DELETE)
 	public void beforeOrderLineDeleted(@NonNull final I_C_OrderLine orderLineRecord)
 	{
+		// Receipt schedules only exist for purchase order lines
+		if (orderLineRecord.getC_Order().isSOTrx())
+		{
+			return;
+		}
 		receiptScheduleDAO.deleteByOrderLineId(OrderLineId.ofRepoId(orderLineRecord.getC_OrderLine_ID()));
 	}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -5,15 +5,14 @@ import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.handlingunits.IHUPIItemProductDAO;
 import de.metas.handlingunits.model.I_C_Order;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
-import de.metas.handlingunits.model.I_M_ReceiptSchedule;
+import de.metas.inoutcandidate.api.IReceiptScheduleDAO;
+import de.metas.order.OrderLineId;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
-import org.adempiere.ad.dao.IQueryBL;
 import lombok.NonNull;
 import org.adempiere.ad.callout.annotations.Callout;
 import org.adempiere.ad.callout.annotations.CalloutMethod;
 import org.adempiere.ad.callout.spi.IProgramaticCalloutProvider;
-import org.adempiere.ad.dao.IQueryUpdater;
 import org.adempiere.ad.modelvalidator.annotations.Init;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
@@ -54,7 +53,7 @@ import java.util.Properties;
 public class C_OrderLine
 {
 	private final IHUPIItemProductDAO hupiItemProductDAO = Services.get(IHUPIItemProductDAO.class);
-	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	private final IReceiptScheduleDAO receiptScheduleDAO = Services.get(IReceiptScheduleDAO.class);
 
 	@Init
 	public void registerCallouts()
@@ -63,23 +62,9 @@ public class C_OrderLine
 	}
 
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_DELETE)
-	public void deleteReservation(@NonNull final I_C_OrderLine orderLineRecord)
+	public void beforeOrderLineDeleted(@NonNull final I_C_OrderLine orderLineRecord)
 	{
-		queryBL
-				.createQueryBuilder(I_M_ReceiptSchedule.class)
-				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineRecord.getC_OrderLine_ID())
-				.create()
-				.updateDirectly(rs -> {
-					rs.setProcessed(false);
-					rs.setIsActive(false);
-					return IQueryUpdater.MODEL_UPDATED;
-				});
-
-		queryBL
-				.createQueryBuilder(I_M_ReceiptSchedule.class)
-				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineRecord.getC_OrderLine_ID())
-				.create()
-				.delete();
+		receiptScheduleDAO.deleteByOrderLineId(OrderLineId.ofRepoId(orderLineRecord.getC_OrderLine_ID()));
 	}
 
 	@ModelChange( //

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IReceiptScheduleDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IReceiptScheduleDAO.java
@@ -28,6 +28,7 @@ import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule_Alloc;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.order.OrderId;
+import de.metas.order.OrderLineId;
 import de.metas.util.ISingletonService;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBuilder;
@@ -102,4 +103,10 @@ public interface IReceiptScheduleDAO extends ISingletonService
 
 	@NonNull
 	Optional<ReceiptScheduleId> getIdByQuery(@NonNull ReceiptScheduleQuery query);
+
+	/**
+	 * Delete all {@link I_M_ReceiptSchedule} records linked to the given order line.
+	 * Uses direct SQL to bypass the BEFORE_DELETE interceptor that blocks deletion of processed schedules.
+	 */
+	void deleteByOrderLineId(@NonNull OrderLineId orderLineId);
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IReceiptScheduleDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IReceiptScheduleDAO.java
@@ -106,7 +106,10 @@ public interface IReceiptScheduleDAO extends ISingletonService
 
 	/**
 	 * Delete all {@link I_M_ReceiptSchedule} records linked to the given order line.
-	 * Uses direct SQL to bypass the BEFORE_DELETE interceptor that blocks deletion of processed schedules.
+	 *
+	 * @throws org.adempiere.exceptions.AdempiereException if any linked schedule has an active
+	 *                                                      {@link I_M_ReceiptSchedule_Alloc} with {@code M_InOutLine_ID} set,
+	 *                                                      indicating that goods have already been received and deletion would corrupt receipt history.
 	 */
 	void deleteByOrderLineId(@NonNull OrderLineId orderLineId);
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IReceiptScheduleDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IReceiptScheduleDAO.java
@@ -105,7 +105,15 @@ public interface IReceiptScheduleDAO extends ISingletonService
 	Optional<ReceiptScheduleId> getIdByQuery(@NonNull ReceiptScheduleQuery query);
 
 	/**
-	 * Delete all {@link I_M_ReceiptSchedule} records linked to the given order line.
+	 * Delete all {@link I_M_ReceiptSchedule} records linked to the given order line,
+	 * including any {@code IsActive=false} schedules (to avoid orphaned rows after order line deletion).
+	 * HU destruction and alloc cleanup are delegated to the {@code M_ReceiptSchedule TYPE_BEFORE_DELETE}
+	 * interceptor in {@code de.metas.handlingunits.base}.
+	 * <p>
+	 * Callers must therefore be in a module that (transitively) depends on both {@code de.metas.swat.base}
+	 * and {@code de.metas.handlingunits.base} for the HU lifecycle to fire correctly.
+	 * The canonical call site is {@code de.metas.handlingunits.reservation.interceptor.C_OrderLine},
+	 * placed there due to the Maven dependency constraints described in that class.
 	 *
 	 * @throws org.adempiere.exceptions.AdempiereException if any linked schedule has an active
 	 *                                                      {@link I_M_ReceiptSchedule_Alloc} with {@code M_InOutLine_ID} set,

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
@@ -15,14 +15,17 @@ import de.metas.inoutcandidate.model.I_M_ReceiptSchedule_Alloc;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.order.OrderId;
+import de.metas.order.OrderLineId;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import de.metas.util.lang.ExternalHeaderIdWithExternalLineIds;
 import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.IQueryFilter;
 import org.adempiere.ad.dao.IQueryOrderBy;
+import org.adempiere.ad.dao.IQueryUpdater;
 import org.adempiere.ad.dao.impl.ASIQueryFilterModifier;
 import org.adempiere.ad.dao.impl.CompareQueryFilter;
 import org.adempiere.ad.dao.impl.EqualsQueryFilter;
@@ -385,6 +388,41 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 	{
 		return buildQuery(query)
 				.firstIdOnlyOptional(ReceiptScheduleId::ofRepoId);
+	}
+
+	@Override
+	public void deleteByOrderLineId(@NonNull final OrderLineId orderLineId)
+	{
+		final IQuery<I_M_ReceiptSchedule> receiptSchedulesForOrderLine = queryBL
+				.createQueryBuilder(I_M_ReceiptSchedule.class)
+				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineId)
+				.create();
+
+		// Guard: refuse to delete if any receipt schedule has already been received (has M_ReceiptSchedule_Alloc with M_InOutLine_ID set).
+		// Deleting such schedules would corrupt receipt and invoice-candidate history.
+		final boolean hasReceivedAllocations = queryBL
+				.createQueryBuilder(I_M_ReceiptSchedule_Alloc.class)
+				.addInSubQueryFilter(I_M_ReceiptSchedule_Alloc.COLUMNNAME_M_ReceiptSchedule_ID, I_M_ReceiptSchedule.COLUMNNAME_M_ReceiptSchedule_ID, receiptSchedulesForOrderLine)
+				.addNotNull(I_M_ReceiptSchedule_Alloc.COLUMNNAME_M_InOutLine_ID)
+				.create()
+				.anyMatch();
+		if (hasReceivedAllocations)
+		{
+			throw new AdempiereException("Cannot delete order line: a receipt already exists for the linked receipt schedule.")
+					.appendParametersToMessage()
+					.setParameter("orderLineId", orderLineId);
+		}
+
+		// updateDirectly bypasses model interceptors and goes straight to SQL.
+		// We unset Processed and IsActive here first so that the subsequent .delete() call is not blocked by that guard.
+		receiptSchedulesForOrderLine
+				.updateDirectly(rs -> {
+					rs.setProcessed(false);
+					rs.setIsActive(false);
+					return IQueryUpdater.MODEL_UPDATED;
+				});
+
+		receiptSchedulesForOrderLine.delete();
 	}
 
 	@NonNull

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
@@ -406,6 +406,11 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 		// Guard: refuse to delete if any receipt schedule has an active alloc with M_InOutLine_ID set.
 		// IsActive=false allocs indicate reversed receipts and must not block deletion.
 		// Deleting schedules with active received allocs would corrupt receipt and invoice-candidate history.
+		// Note: there is a narrow TOCTOU window between this check and the delete() below — a concurrent
+		// receipt posting could insert a received alloc after the anyMatch() returns false. This is an
+		// accepted risk: receipt confirmation is always a user-triggered, transactional operation making
+		// the window extremely unlikely, and the DEFERRABLE INITIALLY DEFERRED FK on M_ReceiptSchedule_Alloc
+		// provides a last-resort safety net at commit time.
 		final boolean hasReceivedAllocations = queryBL
 				.createQueryBuilder(I_M_ReceiptSchedule_Alloc.class)
 				.addInSubQueryFilter(I_M_ReceiptSchedule_Alloc.COLUMNNAME_M_ReceiptSchedule_ID, I_M_ReceiptSchedule.COLUMNNAME_M_ReceiptSchedule_ID, receiptSchedulesForOrderLine)
@@ -427,11 +432,15 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 		//      suppresses that spurious event entirely.
 		//   2. The Processed=true flag prevents model-based deletion (the ADempiere PO layer guards processed
 		//      records). Clearing it via SQL unblocks the subsequent delete().
+		// This also clears Processed=false on any IsActive=false schedules in scope, which is harmless
+		// since they are deleted in the very next statement.
 		// The model-based delete() below fires all TYPE_BEFORE_DELETE interceptors, which correctly handle:
 		//   - HU lifecycle: M_ReceiptSchedule validator in de.metas.handlingunits.base destroys any
-		//     Planning-status HUs pre-assigned to the schedule, then deletes all linked alloc rows
-		//     model-by-model so their own interceptors fire. The FK on M_ReceiptSchedule_Alloc is
-		//     DEFERRABLE INITIALLY DEFERRED, so alloc deletions inside TYPE_BEFORE_DELETE are safe.
+		//     Planning-status HUs pre-assigned to the schedule, then deletes ALL linked alloc rows
+		//     model-by-model (active and inactive) so their own interceptors fire. The receipt documents
+		//     (M_InOut / M_InOutLine) are NOT touched — only the alloc booking links are removed, which
+		//     is safe. The FK on M_ReceiptSchedule_Alloc is DEFERRABLE INITIALLY DEFERRED, so alloc
+		//     deletions inside TYPE_BEFORE_DELETE are valid before the parent row is removed.
 		//   - MRP: M_ReceiptSchedule_PostMaterialEvent posts ReceiptScheduleDeletedEvent → MRP removes the supply.
 		//   - Order line quantities: M_ReceiptSchedule.propagateQtysToOrderLine resets QtyOrderedOverUnder
 		//     (harmless when the order line is also being deleted immediately after).

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
@@ -24,6 +24,7 @@ import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.IQueryFilter;
 import org.adempiere.ad.dao.IQueryOrderBy;
+import org.adempiere.ad.dao.IQueryUpdater;
 import org.adempiere.ad.dao.impl.ASIQueryFilterModifier;
 import org.adempiere.ad.dao.impl.CompareQueryFilter;
 import org.adempiere.ad.dao.impl.EqualsQueryFilter;
@@ -68,7 +69,7 @@ import java.util.Set;
 public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
-	public static final String CANNOT_DELETE_ORDER_LINE_RECEIPT_SCHEDULE = "CannotDeleteOrderLine_ReceiptSchedule";
+	private static final String CANNOT_DELETE_ORDER_LINE_RECEIPT_SCHEDULE = "CannotDeleteOrderLine_ReceiptSchedule";
 
 	@Override
 	public Iterator<I_M_ReceiptSchedule> retrieve(final IQuery<I_M_ReceiptSchedule> query)
@@ -425,8 +426,20 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 				.create()
 				.deleteDirectly();
 
-		// deleteDirectly goes straight to SQL, bypassing model interceptors guard that blocks deletion of Processed=Y records.
-		receiptSchedulesForOrderLine.deleteDirectly();
+		// Clear Processed=Y via direct SQL to bypass only the M_ReceiptSchedule model-validator guard that blocks
+		// deletion of processed records. updateDirectly targets only this specific guard — it does NOT skip any
+		// other model interceptors. The subsequent model-based delete() correctly triggers all of them:
+		//   - TYPE_BEFORE_DELETE: M_ReceiptSchedule_PostMaterialEvent fires ReceiptScheduleDeletedEvent to
+		//     update material disposition (MD candidates).
+		//   - TYPE_AFTER_DELETE: M_ReceiptSchedule.propagateQtysToOrderLine resets QtyOrderedOverUnder on the
+		//     order line. This is harmless in the primary use-case (order line deletion) since the order line
+		//     is removed immediately after but fires correctly if this method is called in other contexts.
+		receiptSchedulesForOrderLine.updateDirectly(rs -> {
+			rs.setProcessed(false);
+			return IQueryUpdater.MODEL_UPDATED;
+		});
+
+		receiptSchedulesForOrderLine.delete();
 	}
 
 	@NonNull

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
@@ -395,6 +395,9 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 	@Override
 	public void deleteByOrderLineId(@NonNull final OrderLineId orderLineId)
 	{
+		// Intentionally no addOnlyActiveRecordsFilter(): when an order line is deleted, all linked receipt
+		// schedules must be cleaned up regardless of their IsActive state. Leaving IsActive=false schedules
+		// behind would leave orphaned rows tied to a non-existent order line.
 		final IQuery<I_M_ReceiptSchedule> receiptSchedulesForOrderLine = queryBL
 				.createQueryBuilder(I_M_ReceiptSchedule.class)
 				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineId)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import de.metas.document.engine.IDocument;
 import de.metas.externalsystem.ExternalSystemIdWithExternalIds;
+import de.metas.i18n.AdMessageKey;
 import de.metas.inout.model.I_M_InOutLine;
 import de.metas.inoutcandidate.ReceiptScheduleId;
 import de.metas.inoutcandidate.api.IReceiptScheduleDAO;
@@ -69,7 +70,7 @@ import java.util.Set;
 public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
-	private static final String CANNOT_DELETE_ORDER_LINE_RECEIPT_SCHEDULE = "CannotDeleteOrderLine_ReceiptSchedule";
+	private static final AdMessageKey MSG_CANNOT_DELETE_ORDER_LINE_RECEIPT_SCHEDULE = AdMessageKey.of("CannotDeleteOrderLine_ReceiptSchedule");
 
 	@Override
 	public Iterator<I_M_ReceiptSchedule> retrieve(final IQuery<I_M_ReceiptSchedule> query)
@@ -411,7 +412,7 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 				.anyMatch();
 		if (hasReceivedAllocations)
 		{
-			throw new AdempiereException("@" + CANNOT_DELETE_ORDER_LINE_RECEIPT_SCHEDULE + "@");
+			throw new AdempiereException(MSG_CANNOT_DELETE_ORDER_LINE_RECEIPT_SCHEDULE);
 		}
 
 		// Delete all alloc records first to satisfy the FK constraint
@@ -421,19 +422,34 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 		//   - Reversed-receipt allocs (IsActive=false, M_InOutLine_ID set): the receipt was reversed,
 		//     so the alloc was deactivated and the HU destroyed; safe to delete.
 		// Active allocs with M_InOutLine_ID set (real open receipts) were rejected by the guard above.
+		//
+		// deleteDirectly() is used intentionally here and is safe to bypass the M_ReceiptSchedule_Alloc
+		// model interceptor (updateQtyMovedSubtract / onReceiptScheduleDeleted), for two reasons:
+		//   1. Inactive allocs (reversed receipts) return zero qty from getQtysIfActive → the interceptor
+		//      would be a no-op anyway.
+		//   2. Active unreceived allocs (M_InOutLine_ID=null) carry no QtyMoved contribution, and the parent
+		//      receipt schedule is deleted in this same operation so any accounting adjustment is moot.
+		// INVARIANT: this safety holds only because both allocs AND their parent receipt schedules are always
+		// deleted together in this method. Do not split this operation without re-evaluating the interceptor bypass.
 		queryBL.createQueryBuilder(I_M_ReceiptSchedule_Alloc.class)
 				.addInSubQueryFilter(I_M_ReceiptSchedule_Alloc.COLUMNNAME_M_ReceiptSchedule_ID, I_M_ReceiptSchedule.COLUMNNAME_M_ReceiptSchedule_ID, receiptSchedulesForOrderLine)
 				.create()
 				.deleteDirectly();
 
-		// Clear Processed=Y via direct SQL to bypass only the M_ReceiptSchedule model-validator guard that blocks
-		// deletion of processed records. updateDirectly targets only this specific guard — it does NOT skip any
-		// other model interceptors. The subsequent model-based delete() correctly triggers all of them:
-		//   - TYPE_BEFORE_DELETE: M_ReceiptSchedule_PostMaterialEvent fires ReceiptScheduleDeletedEvent to
-		//     update material disposition (MD candidates).
-		//   - TYPE_AFTER_DELETE: M_ReceiptSchedule.propagateQtysToOrderLine resets QtyOrderedOverUnder on the
-		//     order line. This is harmless in the primary use-case (order line deletion) since the order line
-		//     is removed immediately after but fires correctly if this method is called in other contexts.
+		// updateDirectly() goes straight to SQL and bypasses ALL model interceptors — not just the processed
+		// guard, but also M_ReceiptSchedule_PostMaterialEvent. We need this for two reasons:
+		//   1. M_ReceiptSchedule_PostMaterialEvent watches COLUMNNAME_Processed in its ifColumnsChanged list.
+		//      A normal model-based update setting Processed=false would fire a spurious ReceiptScheduleUpdatedEvent
+		//      immediately before the delete, causing MRP to process a phantom "supply restored" signal that is
+		//      immediately contradicted by the ReceiptScheduleDeletedEvent that follows. Using updateDirectly()
+		//      suppresses that spurious event entirely.
+		//   2. The Processed=true flag prevents model-based deletion (the ADempiere PO layer guards processed
+		//      records). Clearing it via SQL unblocks the subsequent delete().
+		// Material disposition is handled correctly by the model-based delete() call below, which fires all
+		// TYPE_BEFORE_DELETE and TYPE_AFTER_DELETE interceptors:
+		//   - M_ReceiptSchedule_PostMaterialEvent posts ReceiptScheduleDeletedEvent → MRP removes the supply.
+		//   - M_ReceiptSchedule.propagateQtysToOrderLine resets QtyOrderedOverUnder on the order line
+		//     (harmless when the order line is also being deleted immediately after).
 		receiptSchedulesForOrderLine.updateDirectly(rs -> {
 			rs.setProcessed(false);
 			return IQueryUpdater.MODEL_UPDATED;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
@@ -20,17 +20,16 @@ import de.metas.util.Check;
 import de.metas.util.Services;
 import de.metas.util.lang.ExternalHeaderIdWithExternalLineIds;
 import lombok.NonNull;
-import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.IQueryFilter;
 import org.adempiere.ad.dao.IQueryOrderBy;
-import org.adempiere.ad.dao.IQueryUpdater;
 import org.adempiere.ad.dao.impl.ASIQueryFilterModifier;
 import org.adempiere.ad.dao.impl.CompareQueryFilter;
 import org.adempiere.ad.dao.impl.EqualsQueryFilter;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.IQuery;
 import org.compiere.model.I_M_InOut;
@@ -69,6 +68,7 @@ import java.util.Set;
 public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	public static final String CANNOT_DELETE_ORDER_LINE_RECEIPT_SCHEDULE = "CannotDeleteOrderLine_ReceiptSchedule";
 
 	@Override
 	public Iterator<I_M_ReceiptSchedule> retrieve(final IQuery<I_M_ReceiptSchedule> query)
@@ -398,31 +398,35 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineId)
 				.create();
 
-		// Guard: refuse to delete if any receipt schedule has already been received (has M_ReceiptSchedule_Alloc with M_InOutLine_ID set).
-		// Deleting such schedules would corrupt receipt and invoice-candidate history.
+		// Guard: refuse to delete if any receipt schedule has an active alloc with M_InOutLine_ID set.
+		// IsActive=false allocs indicate reversed receipts and must not block deletion.
+		// Deleting schedules with active received allocs would corrupt receipt and invoice-candidate history.
 		final boolean hasReceivedAllocations = queryBL
 				.createQueryBuilder(I_M_ReceiptSchedule_Alloc.class)
 				.addInSubQueryFilter(I_M_ReceiptSchedule_Alloc.COLUMNNAME_M_ReceiptSchedule_ID, I_M_ReceiptSchedule.COLUMNNAME_M_ReceiptSchedule_ID, receiptSchedulesForOrderLine)
 				.addNotNull(I_M_ReceiptSchedule_Alloc.COLUMNNAME_M_InOutLine_ID)
+				.addOnlyActiveRecordsFilter()
 				.create()
 				.anyMatch();
 		if (hasReceivedAllocations)
 		{
-			throw new AdempiereException("Cannot delete order line: a receipt already exists for the linked receipt schedule.")
-					.appendParametersToMessage()
-					.setParameter("orderLineId", orderLineId);
+			throw new AdempiereException("@" + CANNOT_DELETE_ORDER_LINE_RECEIPT_SCHEDULE + "@");
 		}
 
-		// updateDirectly bypasses model interceptors and goes straight to SQL.
-		// We unset Processed and IsActive here first so that the subsequent .delete() call is not blocked by that guard.
-		receiptSchedulesForOrderLine
-				.updateDirectly(rs -> {
-					rs.setProcessed(false);
-					rs.setIsActive(false);
-					return IQueryUpdater.MODEL_UPDATED;
-				});
+		// Delete all alloc records first to satisfy the FK constraint
+		// M_ReceiptSchedule_Alloc.M_ReceiptSchedule_ID → M_ReceiptSchedule before the parent rows are removed.
+		// Two alloc categories can exist here:
+		//   - Unreceived allocs (M_InOutLine_ID=null): normal unprocessed planning allocations.
+		//   - Reversed-receipt allocs (IsActive=false, M_InOutLine_ID set): the receipt was reversed,
+		//     so the alloc was deactivated and the HU destroyed; safe to delete.
+		// Active allocs with M_InOutLine_ID set (real open receipts) were rejected by the guard above.
+		queryBL.createQueryBuilder(I_M_ReceiptSchedule_Alloc.class)
+				.addInSubQueryFilter(I_M_ReceiptSchedule_Alloc.COLUMNNAME_M_ReceiptSchedule_ID, I_M_ReceiptSchedule.COLUMNNAME_M_ReceiptSchedule_ID, receiptSchedulesForOrderLine)
+				.create()
+				.deleteDirectly();
 
-		receiptSchedulesForOrderLine.delete();
+		// deleteDirectly goes straight to SQL, bypassing model interceptors guard that blocks deletion of Processed=Y records.
+		receiptSchedulesForOrderLine.deleteDirectly();
 	}
 
 	@NonNull

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
@@ -415,27 +415,6 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 			throw new AdempiereException(MSG_CANNOT_DELETE_ORDER_LINE_RECEIPT_SCHEDULE);
 		}
 
-		// Delete all alloc records first to satisfy the FK constraint
-		// M_ReceiptSchedule_Alloc.M_ReceiptSchedule_ID → M_ReceiptSchedule before the parent rows are removed.
-		// Two alloc categories can exist here:
-		//   - Unreceived allocs (M_InOutLine_ID=null): normal unprocessed planning allocations.
-		//   - Reversed-receipt allocs (IsActive=false, M_InOutLine_ID set): the receipt was reversed,
-		//     so the alloc was deactivated and the HU destroyed; safe to delete.
-		// Active allocs with M_InOutLine_ID set (real open receipts) were rejected by the guard above.
-		//
-		// deleteDirectly() is used intentionally here and is safe to bypass the M_ReceiptSchedule_Alloc
-		// model interceptor (updateQtyMovedSubtract / onReceiptScheduleDeleted), for two reasons:
-		//   1. Inactive allocs (reversed receipts) return zero qty from getQtysIfActive → the interceptor
-		//      would be a no-op anyway.
-		//   2. Active unreceived allocs (M_InOutLine_ID=null) carry no QtyMoved contribution, and the parent
-		//      receipt schedule is deleted in this same operation so any accounting adjustment is moot.
-		// INVARIANT: this safety holds only because both allocs AND their parent receipt schedules are always
-		// deleted together in this method. Do not split this operation without re-evaluating the interceptor bypass.
-		queryBL.createQueryBuilder(I_M_ReceiptSchedule_Alloc.class)
-				.addInSubQueryFilter(I_M_ReceiptSchedule_Alloc.COLUMNNAME_M_ReceiptSchedule_ID, I_M_ReceiptSchedule.COLUMNNAME_M_ReceiptSchedule_ID, receiptSchedulesForOrderLine)
-				.create()
-				.deleteDirectly();
-
 		// updateDirectly() goes straight to SQL and bypasses ALL model interceptors — not just the processed
 		// guard, but also M_ReceiptSchedule_PostMaterialEvent. We need this for two reasons:
 		//   1. M_ReceiptSchedule_PostMaterialEvent watches COLUMNNAME_Processed in its ifColumnsChanged list.
@@ -445,10 +424,13 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 		//      suppresses that spurious event entirely.
 		//   2. The Processed=true flag prevents model-based deletion (the ADempiere PO layer guards processed
 		//      records). Clearing it via SQL unblocks the subsequent delete().
-		// Material disposition is handled correctly by the model-based delete() call below, which fires all
-		// TYPE_BEFORE_DELETE and TYPE_AFTER_DELETE interceptors:
-		//   - M_ReceiptSchedule_PostMaterialEvent posts ReceiptScheduleDeletedEvent → MRP removes the supply.
-		//   - M_ReceiptSchedule.propagateQtysToOrderLine resets QtyOrderedOverUnder on the order line
+		// The model-based delete() below fires all TYPE_BEFORE_DELETE interceptors, which correctly handle:
+		//   - HU lifecycle: M_ReceiptSchedule validator in de.metas.handlingunits.base destroys any
+		//     Planning-status HUs pre-assigned to the schedule, then deletes all linked alloc rows
+		//     model-by-model so their own interceptors fire. The FK on M_ReceiptSchedule_Alloc is
+		//     DEFERRABLE INITIALLY DEFERRED, so alloc deletions inside TYPE_BEFORE_DELETE are safe.
+		//   - MRP: M_ReceiptSchedule_PostMaterialEvent posts ReceiptScheduleDeletedEvent → MRP removes the supply.
+		//   - Order line quantities: M_ReceiptSchedule.propagateQtysToOrderLine resets QtyOrderedOverUnder
 		//     (harmless when the order line is also being deleted immediately after).
 		receiptSchedulesForOrderLine.updateDirectly(rs -> {
 			rs.setProcessed(false);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAO.java
@@ -398,6 +398,16 @@ public class ReceiptScheduleDAO implements IReceiptScheduleDAO
 		// Intentionally no addOnlyActiveRecordsFilter(): when an order line is deleted, all linked receipt
 		// schedules must be cleaned up regardless of their IsActive state. Leaving IsActive=false schedules
 		// behind would leave orphaned rows tied to a non-existent order line.
+		// Note on double ReceiptScheduleDeletedEvent: for any IsActive=false schedule in the result set,
+		// the TYPE_BEFORE_DELETE fired by delete() below will post a ReceiptScheduleDeletedEvent via
+		// M_ReceiptSchedule_PostMaterialEvent. A prior event was posted when the schedule was deactivated.
+		// This double-fire is harmless: in normal application flow, inactivateReceiptSchedules() immediately
+		// follows setIsActive(false) with deleteRecord(), so IsActive=false schedules never persist as a
+		// steady state. If one does exist (e.g. after a crash), its QtyToMove will be 0 (the updateQtys
+		// interceptor zeroes it on deactivation), making the second event a no-op for MRP.
+		// Note on getQtyOrdered in the deletion event: IReceiptScheduleQtysBL.getQtyOrdered() reads the
+		// QtyOrdered column directly and is not affected by the Processed=false written by updateDirectly()
+		// below, so the event reports the correct ordered quantity.
 		final IQuery<I_M_ReceiptSchedule> receiptSchedulesForOrderLine = queryBL
 				.createQueryBuilder(I_M_ReceiptSchedule.class)
 				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineId)

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAOTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAOTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.IQuery;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -89,9 +88,12 @@ public class ReceiptScheduleDAOTest extends ReceiptScheduleTestBase
 
 		receiptScheduleDAO.deleteByOrderLineId(orderLineId);
 
-		Assertions.assertFalse(
-				InterfaceWrapperHelper.isActive(InterfaceWrapperHelper.load(rs.getM_ReceiptSchedule_ID(), I_M_ReceiptSchedule.class)),
-				"Receipt schedule should have been deleted");
+		final boolean stillExists = Services.get(IQueryBL.class)
+				.createQueryBuilder(I_M_ReceiptSchedule.class)
+				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineId)
+				.create()
+				.anyMatch();
+		Assertions.assertFalse(stillExists, "Receipt schedule should have been deleted");
 	}
 
 	@Test

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAOTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAOTest.java
@@ -27,11 +27,14 @@ import java.util.List;
 
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.IQuery;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
+import de.metas.order.OrderLineId;
 import de.metas.util.Services;
 import de.metas.util.collections.IteratorUtils;
 
@@ -59,5 +62,48 @@ public class ReceiptScheduleDAOTest extends ReceiptScheduleTestBase
 		Assertions.assertEquals(rs2, schedulesList.get(2), "Invalid receipt schedule at index 2");
 		Assertions.assertEquals(rs3, schedulesList.get(3), "Invalid receipt schedule at index 3");
 		Assertions.assertEquals(rs4, schedulesList.get(4), "Invalid receipt schedule at index 4");
+	}
+
+	@Test
+	public void deleteByOrderLineId_noAllocations_deletesSchedule()
+	{
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(createOrderLine(createOrder(warehouse1), product1_wh1).getC_OrderLine_ID());
+		createReceiptScheduleForOrderLine(bpartner1, warehouse1, date, product1_wh1, 10, orderLineId);
+
+		receiptScheduleDAO.deleteByOrderLineId(orderLineId);
+
+		final boolean stillExists = Services.get(IQueryBL.class)
+				.createQueryBuilder(I_M_ReceiptSchedule.class)
+				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineId)
+				.create()
+				.anyMatch();
+		Assertions.assertFalse(stillExists, "Receipt schedule should have been deleted");
+	}
+
+	@Test
+	public void deleteByOrderLineId_withUnreceivedAlloc_deletesSchedule()
+	{
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(createOrderLine(createOrder(warehouse1), product1_wh1).getC_OrderLine_ID());
+		final I_M_ReceiptSchedule rs = createReceiptScheduleForOrderLine(bpartner1, warehouse1, date, product1_wh1, 10, orderLineId);
+		createReceiptScheduleAlloc(rs, 0 /* no M_InOutLine_ID = not yet received */);
+
+		receiptScheduleDAO.deleteByOrderLineId(orderLineId);
+
+		Assertions.assertFalse(
+				InterfaceWrapperHelper.isActive(InterfaceWrapperHelper.load(rs.getM_ReceiptSchedule_ID(), I_M_ReceiptSchedule.class)),
+				"Receipt schedule should have been deleted");
+	}
+
+	@Test
+	public void deleteByOrderLineId_withReceivedAlloc_throws()
+	{
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(createOrderLine(createOrder(warehouse1), product1_wh1).getC_OrderLine_ID());
+		final I_M_ReceiptSchedule rs = createReceiptScheduleForOrderLine(bpartner1, warehouse1, date, product1_wh1, 10, orderLineId);
+		createReceiptScheduleAlloc(rs, 999 /* non-zero M_InOutLine_ID = goods already received */);
+
+		Assertions.assertThrows(
+				AdempiereException.class,
+				() -> receiptScheduleDAO.deleteByOrderLineId(orderLineId),
+				"Should throw when a receipt already exists for the schedule");
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAOTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAOTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
+import de.metas.inout.InOutLineId;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule_Alloc;
 import de.metas.order.OrderLineId;
 import de.metas.util.Services;
@@ -101,7 +102,7 @@ public class ReceiptScheduleDAOTest extends ReceiptScheduleTestBase
 		// in the HU module's test suite.
 		final OrderLineId orderLineId = OrderLineId.ofRepoId(createOrderLine(createOrder(warehouse1), product1_wh1).getC_OrderLine_ID());
 		final I_M_ReceiptSchedule rs = createReceiptScheduleForOrderLine(bpartner1, warehouse1, date, product1_wh1, 10, orderLineId);
-		createReceiptScheduleAlloc(rs, 0 /* no M_InOutLine_ID = not yet received */);
+		createReceiptScheduleAlloc(rs, null /* no M_InOutLine_ID = not yet received */);
 
 		receiptScheduleDAO.deleteByOrderLineId(orderLineId);
 
@@ -118,7 +119,7 @@ public class ReceiptScheduleDAOTest extends ReceiptScheduleTestBase
 	{
 		final OrderLineId orderLineId = OrderLineId.ofRepoId(createOrderLine(createOrder(warehouse1), product1_wh1).getC_OrderLine_ID());
 		final I_M_ReceiptSchedule rs = createReceiptScheduleForOrderLine(bpartner1, warehouse1, date, product1_wh1, 10, orderLineId);
-		createReceiptScheduleAlloc(rs, 999 /* non-zero M_InOutLine_ID = goods already received */);
+		createReceiptScheduleAlloc(rs, InOutLineId.ofRepoId(999) /* M_InOutLine_ID set = goods already received */);
 
 		Assertions.assertThrows(
 				AdempiereException.class,
@@ -133,7 +134,7 @@ public class ReceiptScheduleDAOTest extends ReceiptScheduleTestBase
 		// The guard must NOT block deletion; only active received allocs should block.
 		final OrderLineId orderLineId = OrderLineId.ofRepoId(createOrderLine(createOrder(warehouse1), product1_wh1).getC_OrderLine_ID());
 		final I_M_ReceiptSchedule rs = createReceiptScheduleForOrderLine(bpartner1, warehouse1, date, product1_wh1, 10, orderLineId);
-		final I_M_ReceiptSchedule_Alloc alloc = createReceiptScheduleAlloc(rs, 999 /* M_InOutLine_ID set, as after reversal */);
+		final I_M_ReceiptSchedule_Alloc alloc = createReceiptScheduleAlloc(rs, InOutLineId.ofRepoId(999) /* M_InOutLine_ID set, as after reversal */);
 		alloc.setIsActive(false);
 		saveRecord(alloc);
 
@@ -174,7 +175,7 @@ public class ReceiptScheduleDAOTest extends ReceiptScheduleTestBase
 		final OrderLineId orderLineId = OrderLineId.ofRepoId(createOrderLine(createOrder(warehouse1), product1_wh1).getC_OrderLine_ID());
 
 		final I_M_ReceiptSchedule rs1 = createReceiptScheduleForOrderLine(bpartner1, warehouse1, date, product1_wh1, 10, orderLineId);
-		createReceiptScheduleAlloc(rs1, 0 /* unreceived alloc */);
+		createReceiptScheduleAlloc(rs1, null /* unreceived alloc */);
 
 		createReceiptScheduleForOrderLine(bpartner1, warehouse1, date, product1_wh1, 5, orderLineId);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAOTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAOTest.java
@@ -132,4 +132,45 @@ public class ReceiptScheduleDAOTest extends ReceiptScheduleTestBase
 				.anyMatch();
 		Assertions.assertFalse(stillExists, "Receipt schedule should have been deleted after reversed-receipt alloc");
 	}
+
+	@Test
+	public void deleteByOrderLineId_withProcessedSchedule_deletesSchedule()
+	{
+		// The updateDirectly(Processed=false) bypass must allow deletion of a Processed=Y schedule.
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(createOrderLine(createOrder(warehouse1), product1_wh1).getC_OrderLine_ID());
+		final I_M_ReceiptSchedule rs = createReceiptScheduleForOrderLine(bpartner1, warehouse1, date, product1_wh1, 10, orderLineId);
+		rs.setProcessed(true);
+		saveRecord(rs);
+
+		receiptScheduleDAO.deleteByOrderLineId(orderLineId);
+
+		final boolean stillExists = Services.get(IQueryBL.class)
+				.createQueryBuilder(I_M_ReceiptSchedule.class)
+				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineId)
+				.create()
+				.anyMatch();
+		Assertions.assertFalse(stillExists, "Processed receipt schedule should have been deleted");
+	}
+
+	@Test
+	public void deleteByOrderLineId_withMultipleSchedules_deletesAll()
+	{
+		// Two schedules on the same order line: one with an unreceived alloc, one clean.
+		// Both must be deleted to verify the bulk-delete sub-query covers all rows.
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(createOrderLine(createOrder(warehouse1), product1_wh1).getC_OrderLine_ID());
+
+		final I_M_ReceiptSchedule rs1 = createReceiptScheduleForOrderLine(bpartner1, warehouse1, date, product1_wh1, 10, orderLineId);
+		createReceiptScheduleAlloc(rs1, 0 /* unreceived alloc */);
+
+		createReceiptScheduleForOrderLine(bpartner1, warehouse1, date, product1_wh1, 5, orderLineId);
+
+		receiptScheduleDAO.deleteByOrderLineId(orderLineId);
+
+		final long remaining = Services.get(IQueryBL.class)
+				.createQueryBuilder(I_M_ReceiptSchedule.class)
+				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineId)
+				.create()
+				.count();
+		Assertions.assertEquals(0, remaining, "All receipt schedules for the order line should have been deleted");
+	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAOTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAOTest.java
@@ -33,9 +33,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
+import de.metas.inoutcandidate.model.I_M_ReceiptSchedule_Alloc;
 import de.metas.order.OrderLineId;
 import de.metas.util.Services;
 import de.metas.util.collections.IteratorUtils;
+
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 
 public class ReceiptScheduleDAOTest extends ReceiptScheduleTestBase
 {
@@ -107,5 +110,26 @@ public class ReceiptScheduleDAOTest extends ReceiptScheduleTestBase
 				AdempiereException.class,
 				() -> receiptScheduleDAO.deleteByOrderLineId(orderLineId),
 				"Should throw when a receipt already exists for the schedule");
+	}
+
+	@Test
+	public void deleteByOrderLineId_withReversedReceiptAlloc_deletesSchedule()
+	{
+		// Alloc has M_InOutLine_ID set but IsActive=false — receipt was reversed.
+		// The guard must NOT block deletion; only active received allocs should block.
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(createOrderLine(createOrder(warehouse1), product1_wh1).getC_OrderLine_ID());
+		final I_M_ReceiptSchedule rs = createReceiptScheduleForOrderLine(bpartner1, warehouse1, date, product1_wh1, 10, orderLineId);
+		final I_M_ReceiptSchedule_Alloc alloc = createReceiptScheduleAlloc(rs, 999 /* M_InOutLine_ID set, as after reversal */);
+		alloc.setIsActive(false);
+		saveRecord(alloc);
+
+		Assertions.assertDoesNotThrow(() -> receiptScheduleDAO.deleteByOrderLineId(orderLineId));
+
+		final boolean stillExists = Services.get(IQueryBL.class)
+				.createQueryBuilder(I_M_ReceiptSchedule.class)
+				.addEqualsFilter(I_M_ReceiptSchedule.COLUMNNAME_C_OrderLine_ID, orderLineId)
+				.create()
+				.anyMatch();
+		Assertions.assertFalse(stillExists, "Receipt schedule should have been deleted after reversed-receipt alloc");
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAOTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleDAOTest.java
@@ -67,6 +67,15 @@ public class ReceiptScheduleDAOTest extends ReceiptScheduleTestBase
 	}
 
 	@Test
+	public void deleteByOrderLineId_noSchedules_isNoOp()
+	{
+		// Order line with no linked receipt schedules: method must complete without throwing.
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(createOrderLine(createOrder(warehouse1), product1_wh1).getC_OrderLine_ID());
+
+		Assertions.assertDoesNotThrow(() -> receiptScheduleDAO.deleteByOrderLineId(orderLineId));
+	}
+
+	@Test
 	public void deleteByOrderLineId_noAllocations_deletesSchedule()
 	{
 		final OrderLineId orderLineId = OrderLineId.ofRepoId(createOrderLine(createOrder(warehouse1), product1_wh1).getC_OrderLine_ID());
@@ -85,6 +94,11 @@ public class ReceiptScheduleDAOTest extends ReceiptScheduleTestBase
 	@Test
 	public void deleteByOrderLineId_withUnreceivedAlloc_deletesSchedule()
 	{
+		// Note: this test only verifies that the receipt schedule row is removed.
+		// Alloc row cleanup is delegated to the M_ReceiptSchedule TYPE_BEFORE_DELETE interceptor in
+		// de.metas.handlingunits.base (M_ReceiptSchedule.onReceiptScheduleDelete), which is not
+		// registered in the unit-test context. Integration coverage for alloc + HU destruction lives
+		// in the HU module's test suite.
 		final OrderLineId orderLineId = OrderLineId.ofRepoId(createOrderLine(createOrder(warehouse1), product1_wh1).getC_OrderLine_ID());
 		final I_M_ReceiptSchedule rs = createReceiptScheduleForOrderLine(bpartner1, warehouse1, date, product1_wh1, 10, orderLineId);
 		createReceiptScheduleAlloc(rs, 0 /* no M_InOutLine_ID = not yet received */);

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleTestBase.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleTestBase.java
@@ -38,6 +38,7 @@ import de.metas.inoutcandidate.api.IReceiptScheduleProducerFactory;
 import de.metas.inoutcandidate.document.dimension.ReceiptScheduleDimensionFactory;
 import de.metas.inoutcandidate.filter.GenerateReceiptScheduleForModelAggregateFilter;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
+import de.metas.inout.InOutLineId;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule_Alloc;
 import de.metas.order.OrderLineId;
 import de.metas.inoutcandidate.modelvalidator.InOutCandidateValidator;
@@ -414,17 +415,17 @@ public abstract class ReceiptScheduleTestBase
 	/**
 	 * Creates an {@link I_M_ReceiptSchedule_Alloc} for the given receipt schedule.
 	 *
-	 * @param inOutLineId set to a positive value to simulate a received alloc (goods were received); 0 means not yet received
+	 * @param inOutLineId non-null to simulate a received alloc (goods were received); null means not yet received
 	 */
 	protected I_M_ReceiptSchedule_Alloc createReceiptScheduleAlloc(
 			final I_M_ReceiptSchedule receiptSchedule,
-			final int inOutLineId)
+			@Nullable final InOutLineId inOutLineId)
 	{
 		final I_M_ReceiptSchedule_Alloc alloc = InterfaceWrapperHelper.newInstance(I_M_ReceiptSchedule_Alloc.class);
 		alloc.setM_ReceiptSchedule_ID(receiptSchedule.getM_ReceiptSchedule_ID());
-		if (inOutLineId > 0)
+		if (inOutLineId != null)
 		{
-			alloc.setM_InOutLine_ID(inOutLineId);
+			alloc.setM_InOutLine_ID(inOutLineId.getRepoId());
 		}
 		saveRecord(alloc);
 		return alloc;

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleTestBase.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleTestBase.java
@@ -38,6 +38,8 @@ import de.metas.inoutcandidate.api.IReceiptScheduleProducerFactory;
 import de.metas.inoutcandidate.document.dimension.ReceiptScheduleDimensionFactory;
 import de.metas.inoutcandidate.filter.GenerateReceiptScheduleForModelAggregateFilter;
 import de.metas.inoutcandidate.model.I_M_ReceiptSchedule;
+import de.metas.inoutcandidate.model.I_M_ReceiptSchedule_Alloc;
+import de.metas.order.OrderLineId;
 import de.metas.inoutcandidate.modelvalidator.InOutCandidateValidator;
 import de.metas.inoutcandidate.modelvalidator.ReceiptScheduleValidator;
 import de.metas.interfaces.I_C_DocType;
@@ -393,6 +395,39 @@ public abstract class ReceiptScheduleTestBase
 		// Save & return
 		saveRecord(orderLine);
 		return orderLine;
+	}
+
+	protected I_M_ReceiptSchedule createReceiptScheduleForOrderLine(
+			final BPartnerLocationId bpartnerLocationId,
+			final I_M_Warehouse warehouse,
+			final Timestamp date,
+			final I_M_Product product,
+			final int qty,
+			final OrderLineId orderLineId)
+	{
+		final I_M_ReceiptSchedule rs = createReceiptSchedule(bpartnerLocationId, warehouse, date, product, qty);
+		rs.setC_OrderLine_ID(orderLineId.getRepoId());
+		saveRecord(rs);
+		return rs;
+	}
+
+	/**
+	 * Creates an {@link I_M_ReceiptSchedule_Alloc} for the given receipt schedule.
+	 *
+	 * @param inOutLineId set to a positive value to simulate a received alloc (goods were received); 0 means not yet received
+	 */
+	protected I_M_ReceiptSchedule_Alloc createReceiptScheduleAlloc(
+			final I_M_ReceiptSchedule receiptSchedule,
+			final int inOutLineId)
+	{
+		final I_M_ReceiptSchedule_Alloc alloc = InterfaceWrapperHelper.newInstance(I_M_ReceiptSchedule_Alloc.class);
+		alloc.setM_ReceiptSchedule_ID(receiptSchedule.getM_ReceiptSchedule_ID());
+		if (inOutLineId > 0)
+		{
+			alloc.setM_InOutLine_ID(inOutLineId);
+		}
+		saveRecord(alloc);
+		return alloc;
 	}
 
 	public I_M_Attribute createM_Attribute(final String name,


### PR DESCRIPTION
When a C_OrderLine is deleted, also delete any associated M_ReceiptSchedule records to prevent orphaned data and potential FK-constraint errors.