### PR TITLE
BPartner VAT-ID Validation — align docs/tests/allure tag with reject-unknown-prefix behaviour

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/IBPBankAccountDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/IBPBankAccountDAO.java
@@ -62,4 +62,6 @@ public interface IBPBankAccountDAO extends ISingletonService
 	ImmutableListMultimap<BPartnerId, I_C_BP_BankAccount> getAllByBPartnerIds(@NonNull Collection<BPartnerId> bpartnerIds);
 
 	List<BPartnerBankAccount> getBpartnerBankAccount(BankAccountQuery query);
+
+	void save(@NonNull I_C_BP_BankAccount bankAccount);
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPBankAccountDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPBankAccountDAO.java
@@ -41,6 +41,7 @@ import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.IQueryOrderBy.Direction;
 import org.adempiere.ad.dao.IQueryOrderBy.Nulls;
 import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_BP_BankAccount;
 import org.compiere.model.I_C_Invoice;
 import org.compiere.util.Env;
@@ -163,6 +164,12 @@ public class BPBankAccountDAO implements IBPBankAccountDAO
 				.stream()
 				.map(this::of)
 				.collect(ImmutableList.toImmutableList());
+	}
+
+	@Override
+	public void save(@NonNull final I_C_BP_BankAccount bankAccount)
+	{
+		InterfaceWrapperHelper.saveRecord(bankAccount);
 	}
 
 	@NonNull

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/vatid/EUVatIdValidator.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/vatid/EUVatIdValidator.java
@@ -134,8 +134,9 @@ public final class EUVatIdValidator
 	 *
 	 * <ul>
 	 *   <li>Null, empty, or blank values are always accepted ({@code true}).</li>
-	 *   <li>Values whose first two normalised characters are not a recognised prefix are
-	 *       accepted without further checking — lenient pass-through for other formats.</li>
+	 *   <li>Any other value whose first two normalised characters are not one of the supported country
+	 *       prefixes is <em>rejected</em> ({@code false}) — only an empty value or a supported country's
+	 *       valid VAT-ID is accepted.</li>
 	 *   <li>Values with a recognised prefix must pass both the structural regex and the
 	 *       country-specific check-digit algorithm.</li>
 	 * </ul>

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/vatid/EUVatIdValidator.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/vatid/EUVatIdValidator.java
@@ -133,10 +133,10 @@ public final class EUVatIdValidator
 	 * Returns {@code true} if the given VAT-ID value is acceptable to store, {@code false} if it must be rejected.
 	 *
 	 * <ul>
-	 *   <li>Null, empty, or blank values are always accepted ({@code true}).</li>
+	 *   <li>Null, empty, blank, or any value that normalises to fewer than two characters is always
+	 *       accepted ({@code true}).</li>
 	 *   <li>Any other value whose first two normalised characters are not one of the supported country
-	 *       prefixes is <em>rejected</em> ({@code false}) — only an empty value or a supported country's
-	 *       valid VAT-ID is accepted.</li>
+	 *       prefixes is <em>rejected</em> ({@code false}).</li>
 	 *   <li>Values with a recognised prefix must pass both the structural regex and the
 	 *       country-specific check-digit algorithm.</li>
 	 * </ul>

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/bpartner/vatid/EUVatIdValidatorTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/bpartner/vatid/EUVatIdValidatorTest.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class EUVatIdValidatorTest
 {
 	// ===================================================================
-	// Edge cases — null / blank → accepted; unrecognised prefix → rejected
+	// Edge cases — null / blank / too-short → accepted; unrecognised prefix → rejected
 	// ===================================================================
 
 	@Test
@@ -58,10 +58,19 @@ class EUVatIdValidatorTest
 	}
 
 	@ParameterizedTest
+	@ValueSource(strings = { "A", "." })
+	void tooShortToHavePrefix_isAccepted(final String vatId)
+	{
+		// A non-blank value that normalises to fewer than two characters can't carry a country prefix → accepted.
+		assertThat(EUVatIdValidator.isValid(vatId)).isTrue();
+	}
+
+	@ParameterizedTest
 	@ValueSource(strings = { "US123456789", "XX999", "123456" })
 	void unrecognisedPrefix_isRejected(final String vatId)
 	{
-		// Only an empty value or a supported country's valid VAT-ID is accepted; everything else is rejected.
+		// Apart from the empty/too-short cases above, a value is accepted only if it is a supported country's
+		// valid VAT-ID; an unrecognised prefix is rejected.
 		assertThat(EUVatIdValidator.isValid(vatId)).isFalse();
 	}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/bpartner/vatid/EUVatIdValidatorTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/bpartner/vatid/EUVatIdValidatorTest.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class EUVatIdValidatorTest
 {
 	// ===================================================================
-	// Edge cases — null / blank / unknown prefix → always true
+	// Edge cases — null / blank → accepted; unrecognised prefix → rejected
 	// ===================================================================
 
 	@Test
@@ -55,6 +55,14 @@ class EUVatIdValidatorTest
 	void emptyOrBlank_isValid(final String vatId)
 	{
 		assertThat(EUVatIdValidator.isValid(vatId)).isTrue();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "US123456789", "XX999", "123456" })
+	void unrecognisedPrefix_isRejected(final String vatId)
+	{
+		// Only an empty value or a supported country's valid VAT-ID is accepted; everything else is rejected.
+		assertThat(EUVatIdValidator.isValid(vatId)).isFalse();
 	}
 
 	// ===================================================================

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/vatIdValidation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/vatIdValidation.feature
@@ -1,11 +1,12 @@
 @from:cucumber
 @ghActions:run_on_executor3
 @allure.label.epic:E2200_Automatic_Tax_Determination
-@allure.label.feature:F66030_Partner_Location_VAT_ID
+@allure.label.feature:F66040_Business_Partner_VAT_ID_Validation
 Feature: VAT-ID format is validated when saving a Business Partner
   When a Business Partner (or its location) is saved, the VAT-ID is checked against the country's
-  format and check digit. Invalid values are rejected with a user error; values with an unsupported
-  (non-EU/non-listed) prefix or an empty value are accepted. The check can be switched off per system.
+  format and check digit. An empty value is accepted; any non-empty value is rejected unless it is a
+  valid VAT-ID of a supported country (its prefix must be one of the recognised set). The check can be
+  switched off per system.
 
   Background:
     Given infrastructure and metasfresh are running

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/einvoice/eInvoiceZugferdEmail.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/einvoice/eInvoiceZugferdEmail.feature
@@ -56,7 +56,7 @@ Feature: ZUGFeRD e-invoice generated, embedded in PDF/A-3 and emailed on sales-i
     #    linked as sellerOrg's org-bpartner (CII mapper reads seller from org-bpartner). ──
     And metasfresh contains C_BPartners without locations:
       | Identifier    | Value | Name        | CompanyName | M_PricingSystem_ID | VATaxID     | AD_OrgBP_ID.Identifier |
-      | seller_org_bp | zfd   | Muster GmbH | Muster GmbH | ps_1               | DE123456789 | sellerOrg              |
+      | seller_org_bp | zfd   | Muster GmbH | Muster GmbH | ps_1               | DE136695976 | sellerOrg              |
     And metasfresh contains C_BPartner_Locations:
       | Identifier      | GLN           | C_BPartner_ID.Identifier | OPT.IsShipTo | OPT.IsBillTo | C_Country_ID | City   | Postal | Address1       |
       | seller_location | 4099999000002 | seller_org_bp            | true         | true         | DE           | Berlin | 10115  | Musterstraße 1 |

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/adprocess/SetAdProcessFlagsCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/adprocess/SetAdProcessFlagsCommand.java
@@ -1,5 +1,6 @@
 package de.metas.frontend_testing.masterdata.adprocess;
 
+import de.metas.process.IADProcessDAO;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.Builder;
@@ -9,8 +10,6 @@ import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.I_AD_Process;
 
 import java.util.List;
-
-import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 
 /**
  * Sets flag columns on {@code AD_Process} records matched by a {@code JasperReport} substring.
@@ -52,7 +51,7 @@ public class SetAdProcessFlagsCommand
 			{
 				process.setIsPdfA3Output(isPdfA3Output);
 			}
-			saveRecord(process);
+			Services.get(IADProcessDAO.class).save(process);
 		}
 	}
 }

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/bpartner/CreateBPartnerCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/bpartner/CreateBPartnerCommand.java
@@ -5,6 +5,7 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.bpartner.GLN;
 import de.metas.bpartner.RandomGLNGenerator;
+import de.metas.bpartner.service.IBPBankAccountDAO;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.common.util.time.SystemTime;
 import de.metas.currency.CurrencyCode;
@@ -14,6 +15,7 @@ import de.metas.frontend_testing.masterdata.MasterdataContext;
 import de.metas.handlingunits.grai.GRAIRequired;
 import de.metas.location.CountryId;
 import de.metas.location.ICountryDAO;
+import de.metas.location.ILocationDAO;
 import de.metas.location.LocationId;
 import de.metas.money.CurrencyId;
 import de.metas.order.DeliveryRule;
@@ -22,6 +24,7 @@ import de.metas.user.UserId;
 import de.metas.pricing.PriceListVersionId;
 import de.metas.pricing.PricingSystemId;
 import de.metas.util.Check;
+import de.metas.util.Services;
 import de.metas.util.StringUtils;
 import lombok.Builder;
 import lombok.NonNull;
@@ -370,7 +373,7 @@ public class CreateBPartnerCommand
 		{
 			locationRecord.setAddress1(locationRequest.getAddress1());
 		}
-		InterfaceWrapperHelper.saveRecord(locationRecord);
+		Services.get(ILocationDAO.class).save(locationRecord);
 		return LocationId.ofRepoId(locationRecord.getC_Location_ID());
 	}
 
@@ -389,7 +392,7 @@ public class CreateBPartnerCommand
 		bankAccount.setC_Currency_ID(currencyId.getRepoId());
 		bankAccount.setIBAN(req.getIban());
 		bankAccount.setIsActive(true);
-		InterfaceWrapperHelper.saveRecord(bankAccount);
+		Services.get(IBPBankAccountDAO.class).save(bankAccount);
 	}
 
 	private PricingSystemId createPricingSystem()

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/bpartner/CreateBPartnerCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/bpartner/CreateBPartnerCommand.java
@@ -351,7 +351,7 @@ public class CreateBPartnerCommand
 		CountryId resolvedCountryId = countryId;
 		if (locationRequest.getCountryCode() != null)
 		{
-			final CountryId lookedUp = de.metas.util.Services.get(ICountryDAO.class)
+			final CountryId lookedUp = Services.get(ICountryDAO.class)
 					.getCountryIdByCountryCodeOrNull(locationRequest.getCountryCode());
 			if (lookedUp != null)
 			{

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/bpartner/JsonCreateBPartnerRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/bpartner/JsonCreateBPartnerRequest.java
@@ -46,7 +46,7 @@ public class JsonCreateBPartnerRequest
 	@Nullable String eInvoiceBuyerReference;
 
 	/**
-	 * Sets {@code C_BPartner.VATaxID} (VAT identification number, e.g. {@code "DE123456789"}).
+	 * Sets {@code C_BPartner.VATaxID} (VAT identification number, e.g. {@code "DE136695976"}).
 	 * Required by EN16931 for both seller (resolved via org-bpartner) and buyer.
 	 * If null, the field is left unchanged.
 	 */

--- a/e2e/frontend-webui/tests/spec/zugferd-invoice.spec.js
+++ b/e2e/frontend-webui/tests/spec/zugferd-invoice.spec.js
@@ -112,7 +112,7 @@ de_DE to prove the full page-object flow is language-independent.
                             // auto-generate a unique Value; GLN is not required for ZUGFeRD EN16931
                             // validity (VATaxID covers BR-CO-26; BT-34 comes from the mailbox).
                             name: 'Muster GmbH',
-                            vatTaxId: 'DE123456789',
+                            vatTaxId: 'DE136695976',
                             isCustomer: false,
                             // true: the masterdata shares one pricing system across bpartners, and the
                             // first-created one sets its price list's IsSOPriceList — the buyer needs a sales list.
@@ -148,7 +148,7 @@ de_DE to prove the full page-object flow is language-independent.
                             isEInvoiceRecipeint: true,
                             eInvoiceType: 'Z',
                             eInvoiceBuyerReference: '991-1234512345-06',
-                            vatTaxId: 'DE987654321',
+                            vatTaxId: 'DE811569869',
                             locations: {
                                 buyerLoc: {
                                     city: 'Hamburg',


### PR DESCRIPTION
Post-merge fixups for the Business Partner VAT-ID validation feature (follow-up to merged PR https://github.com/metasfresh/metasfresh/pull/24648), plus fixes surfaced by the `deep_tundra_release → new_dawn_uat` integration merge (PR https://github.com/metasfresh/metasfresh/pull/24793).

### 1. VAT-ID docs/tests/tagging (reject-unknown-prefix)
The validator was intentionally changed to **reject** any non-empty value whose prefix is not one of the 31 supported countries (only an empty value or a supported country's valid VAT-ID is accepted). Aligns the surrounding artefacts:
- **EUVatIdValidator** javadoc documents all accept-paths (null/empty/blank/too-short accepted; unrecognised prefix rejected).
- **EUVatIdValidatorTest**: adds `unrecognisedPrefix_isRejected` + `tooShortToHavePrefix_isAccepted`; fixes stale comments. Tests run: 113, Failures: 0.
- **vatIdValidation.feature**: allure feature label → `F66040_Business_Partner_VAT_ID_Validation`; description updated.

### 2. ArchUnit fix (frontend-testing masterdata)
The merge failed `test (java)` with **3 new** `persistencePrimitivesConfinedToRepositoryOrDao` violations — new direct `InterfaceWrapperHelper.saveRecord` calls in frontend-testing commands. Routed each through the model's own DAO (behaviour-neutral — all three DAO `save` methods are plain saves):
- `CreateBPartnerCommand.createLocation` → `ILocationDAO.save(I_C_Location)`
- `CreateBPartnerCommand.createBankAccount` → `IBPBankAccountDAO.save(I_C_BP_BankAccount)` (new DAO method)
- `SetAdProcessFlagsCommand.execute` → `IADProcessDAO.save(I_AD_Process)`

Pre-existing (frozen) direct saves in the same module are left untouched.

### 3. Checksum-valid seller VAT-IDs in e-invoice fixtures
The merge failed `frontend webui (3/3)` and `cucumber (profile4)`: fixtures seeded the placeholder VAT-IDs `DE123456789`/`DE987654321` (format OK, checksum invalid), which this issue's default-on validation now rejects (`VAT_ID_INVALID_FORMAT`), failing the seller masterdata seed. Replaced with checksum-valid numbers (verified against the validator; consistent with the already-valid `eInvoiceXRechnungEmail` fixture):
- `zugferd-invoice.spec.js` (e2e webui): `DE123456789`/`DE987654321` → `DE136695976`/`DE811569869`.
- `eInvoiceZugferdEmail.feature` (cucumber): seller `DE123456789` → `DE136695976`.
- `JsonCreateBPartnerRequest` javadoc: example VAT-ID → valid, so it is not copy-pasted into new fixtures.

Scope verified repo-wide: `DE123456789` was the only invalid VAT-ID seeded through the masterdata API; the einvoice **unit** tests set it on POJO mocks (no interceptor fires) and some assert it, so they are left as-is. (The other two `frontend webui (3/3)` failures — `purchase-sales-overview`, `widget-test` — passed on retry and are pre-existing async/timing flakes unrelated to this feature.)

_Note: `de.metas.architecture-tests` exists only on `new_dawn_uat`, and the e2e-webui + integration cucumber suites run on the integration merge — so this PR's CI (base `deep_tundra_release`) does not exercise fixes 2 & 3; both are validated locally (compile + validator-verified VAT-IDs) and take effect on the merge PR once this lands and the merge is refreshed._
