### PR TITLE
Serial No Picking: drop redundant attribute-set gate (checkbox alone enables serial picking)

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/product/PickingJobProductService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/product/PickingJobProductService.java
@@ -16,8 +16,6 @@ import de.metas.uom.UomId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.adempiere.mm.attributes.AttributeId;
-import org.adempiere.mm.attributes.AttributeSetId;
 import org.adempiere.mm.attributes.api.AttributeConstants;
 import org.adempiere.mm.attributes.api.IAttributeDAO;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -75,9 +73,16 @@ public class PickingJobProductService
 	}
 
 	/**
-	 * @return {@code true} when the product opts into serial-no picking ({@code M_Product.IsSerialNoPicked='Y'})
-	 * AND its attribute set actually supports the {@code SerialNo} attribute. The HU-storage check at pick time
-	 * (in the pick command) remains the authoritative gate; this drives the UI prompt.
+	 * @return {@code true} when the product opts into serial-no picking ({@code M_Product.IsSerialNoPicked='Y'}).
+	 * <p>
+	 * The checkbox alone drives the UI prompt. The picked HU's ability to <em>store</em> the {@code SerialNo} comes
+	 * from the PI wiring ({@code M_HU_PI_Attribute} for {@code SerialNo}, active on the virtual PI version), NOT from
+	 * the product's own attribute set — so the product attribute set is irrelevant here. The HU-storage check at pick
+	 * time (in the pick command) remains the authoritative gate; this only decides whether to prompt.
+	 * <p>
+	 * The system-wide {@code SerialNo} attribute being defined is kept as a defensive guard: on an instance where the
+	 * {@code SerialNo} attribute does not exist at all, the serial cannot be stored anywhere, so prompting would be
+	 * pointless.
 	 */
 	public boolean isSerialNoPickingEnabled(@NonNull final ProductId productId)
 	{
@@ -87,17 +92,9 @@ public class PickingJobProductService
 			return false;
 		}
 
-		final AttributeId serialNoAttributeId = attributeDAO.retrieveActiveAttributeIdByValueOrNull(AttributeConstants.ATTR_SerialNo);
-		if (serialNoAttributeId == null)
-		{
-			return false;
-		}
-
-		// The product's OWN attribute set seeds the picked HU's attributes (NOT IProductBL.getAttributeSetId,
-		// which resolves the product *category*'s set). The HU-storage hasAttribute(SerialNo) check at pick time
-		// remains the authoritative gate; this drives the UI prompt.
-		final AttributeSetId attributeSetId = AttributeSetId.ofRepoIdOrNone(product.getM_AttributeSet_ID());
-		return attributeDAO.containsAttribute(attributeSetId, serialNoAttributeId);
+		// Defensive guard only: if the SerialNo attribute is not defined system-wide, the serial can't be stored
+		// anywhere, so don't prompt. The product's own attribute set is intentionally NOT consulted.
+		return attributeDAO.retrieveActiveAttributeIdByValueOrNull(AttributeConstants.ATTR_SerialNo) != null;
 	}
 
 	public ITranslatableString getProductNameTrl(@NonNull final ProductId productId)

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/external/product/PickingJobProductServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/external/product/PickingJobProductServiceTest.java
@@ -39,8 +39,7 @@ class PickingJobProductServiceTest
 
 	private ProductId createProduct(final boolean serialNoPicked)
 	{
-		// Build the product directly (mirrors CreateProductCommand): NO M_AttributeSet_ID is set,
-		// so M_Product.M_AttributeSet_ID stays None — modelling a serial-no product with no attribute set.
+		// mirrors CreateProductCommand — no attribute set is assigned, by design.
 		final I_M_Product product = InterfaceWrapperHelper.newInstance(I_M_Product.class);
 		product.setValue("P1");
 		product.setName("P1");

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/external/product/PickingJobProductServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/external/product/PickingJobProductServiceTest.java
@@ -1,0 +1,89 @@
+package de.metas.handlingunits.picking.job.service.external.product;
+
+import de.metas.product.ProductId;
+import de.metas.product.ProductType;
+import org.adempiere.mm.attributes.AttributesTestHelper;
+import org.adempiere.mm.attributes.api.AttributeConstants;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.model.I_M_Product;
+import org.compiere.model.X_M_Attribute;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit coverage for {@link PickingJobProductService#isSerialNoPickingEnabled(ProductId)}.
+ * <p>
+ * The serial-no picking prompt is driven by the {@code M_Product.IsSerialNoPicked} checkbox alone (plus the
+ * defensive system-wide {@code SerialNo}-attribute-defined guard). The product's own attribute set is irrelevant
+ * to whether the prompt appears — the picked HU's ability to store the {@code SerialNo} comes from the PI wiring,
+ * not from the product attribute set.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+class PickingJobProductServiceTest
+{
+	private AttributesTestHelper attributesTestHelper;
+	private PickingJobProductService pickingJobProductService;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		attributesTestHelper = new AttributesTestHelper();
+		pickingJobProductService = PickingJobProductService.newInstanceForUnitTesting();
+	}
+
+	private ProductId createProduct(final boolean serialNoPicked)
+	{
+		// Build the product directly (mirrors CreateProductCommand): NO M_AttributeSet_ID is set,
+		// so M_Product.M_AttributeSet_ID stays None — modelling a serial-no product with no attribute set.
+		final I_M_Product product = InterfaceWrapperHelper.newInstance(I_M_Product.class);
+		product.setValue("P1");
+		product.setName("P1");
+		product.setProductType(ProductType.Item.getCode());
+		product.setIsSerialNoPicked(serialNoPicked);
+		InterfaceWrapperHelper.saveRecord(product);
+		return ProductId.ofRepoId(product.getM_Product_ID());
+	}
+
+	/** Ensures the system-wide {@code SerialNo} attribute is defined and active (the defensive guard's precondition). */
+	private void givenSerialNoAttributeDefined()
+	{
+		attributesTestHelper.createM_Attribute(
+				AttributeConstants.ATTR_SerialNo_String,
+				X_M_Attribute.ATTRIBUTEVALUETYPE_StringMax40,
+				true);
+	}
+
+	@Test
+	void flagSet_noAttributeSet_enabled()
+	{
+		givenSerialNoAttributeDefined();
+		// Product flagged IsSerialNoPicked=Y but with NO attribute set (M_AttributeSet_ID stays None).
+		final ProductId productId = createProduct(true);
+
+		assertThat(pickingJobProductService.isSerialNoPickingEnabled(productId)).isTrue();
+	}
+
+	@Test
+	void flagNotSet_disabled()
+	{
+		givenSerialNoAttributeDefined();
+		final ProductId productId = createProduct(false);
+
+		assertThat(pickingJobProductService.isSerialNoPickingEnabled(productId)).isFalse();
+	}
+
+	@Test
+	void flagSet_serialNoAttributeUndefined_disabled()
+	{
+		// No SerialNo M_Attribute defined system-wide → the defensive guard short-circuits to false.
+		final ProductId productId = createProduct(true);
+
+		assertThat(pickingJobProductService.isSerialNoPickingEnabled(productId)).isFalse();
+	}
+}

--- a/e2e/mobile-webui/tests/spec/picking/picking_serialNo.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_serialNo.spec.js
@@ -10,11 +10,11 @@ import { BarcodeScannerComponent } from '../../utils/components/BarcodeScannerCo
 import { generateEAN13 } from '../../utils/ean13';
 
 // Serial No Picking — enforce serial-number scan when packing serial-no products.
-// serialProduct=true  → IsSerialNoPicked=Y AND has the "Serial" attribute set (supports SerialNo)
-//                       → mobile picking prompts to scan a serial and persists it on the picked HU.
-// serialProduct=false → misconfig: IsSerialNoPicked=Y but NO SerialNo-capable attribute set
-//                       → no prompt, no error (settled config-gap behaviour) → picks directly.
-const createMasterdata = async ({ serialProduct, orderQty = 1 }) => {
+// The IsSerialNoPicked=Y checkbox ALONE drives the prompt: mobile picking prompts to scan a serial
+// and persists it on the picked HU. The product's own attribute set is irrelevant — the picked HU's
+// ability to store the SerialNo comes from the PI wiring (M_HU_PI_Attribute on the virtual PI),
+// not from the product attribute set. So a serial-no product needs no `attributeSetName`.
+const createMasterdata = async ({ orderQty = 1 } = {}) => {
     return await Backend.createMasterdata({
         language: "en_US",
         request: {
@@ -42,7 +42,6 @@ const createMasterdata = async ({ serialProduct, orderQty = 1 }) => {
                     price: 1,
                     gtin: generateEAN13().ean13,
                     isSerialNoPicked: true,
-                    ...(serialProduct ? { attributeSetName: 'Serial' } : {}),
                 },
             },
             packingInstructions: { "LU_CU": { cu: true, lu: "LU", qtyTUsPerLU: 1 } },
@@ -77,7 +76,7 @@ test('Serial-no product: scan one serial per picked unit (N of N), deduped, pers
     allure.story('Serial number scan when picking');
     allure.severity('critical');
 
-    const masterdata = await createMasterdata({ serialProduct: true, orderQty: 3 });
+    const masterdata = await createMasterdata({ orderQty: 3 });
     const { pickingJobId } = await startPickingJob(masterdata);
     const ts = Date.now();
     const [s1, s2, s3] = [`SN-${ts}-1`, `SN-${ts}-2`, `SN-${ts}-3`];
@@ -147,26 +146,46 @@ test('Serial-no product: scan one serial per picked unit (N of N), deduped, pers
     });
 });
 
-test('Misconfigured serial-no product (no SerialNo attribute set): no prompt, picks directly', async ({ page: _page }) => {
+test('Serial-no product with NO attribute set: checkbox alone still prompts, serial captured and persisted', async ({ page: _page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
     allure.story('Serial number scan when picking');
     allure.severity('normal');
 
-    const masterdata = await createMasterdata({ serialProduct: false });
-    await startPickingJob(masterdata);
+    // The product carries IsSerialNoPicked=Y but has NO attribute set (createMasterdata sets no `attributeSetName`).
+    // New contract: the checkbox alone enables serial-no picking — the prompt STILL appears and the scanned serial
+    // is persisted on the picked HU. The product attribute set is irrelevant; storage comes from the PI wiring.
+    const masterdata = await createMasterdata({ orderQty: 1 });
+    const { pickingJobId } = await startPickingJob(masterdata);
+    const serial = `SN-${Date.now()}`;
 
-    await test.step("Pick — qty dialog shows no serial control, pick succeeds with no error", async () => {
+    await test.step("Pick qty 1 — serial control IS shown, gated until one serial scanned, then persisted", async () => {
         await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '1 Stk', qtyPicked: '0 Stk', color: 'red' });
-        // dialog still opens for the job-default attributes (BestBeforeDate/LotNo) — but NO serial control,
-        // and confirm is not gated by a serial (config gap → silent no-prompt).
+
         await BarcodeScannerComponent.type(masterdata.products.P1.gtin);
         await GetQuantityDialog.waitForDialog();
-        await GetQuantityDialog.expectSerialNoNotVisible();
+
+        // checkbox-alone enables the serial prompt → control visible, confirm gated until 1 serial scanned
+        await GetQuantityDialog.expectSerialNoScanButtonVisible();
+        await GetQuantityDialog.expectSerialNoCount({ scanned: 0, total: 1 });
+        await GetQuantityDialog.expectDoneDisabled();
+
+        await GetQuantityDialog.scanSerialNos([serial]);
+        await GetQuantityDialog.expectSerialNoCount({ scanned: 1, total: 1 });
+        await GetQuantityDialog.expectSerialNoChipCount(1);
         await GetQuantityDialog.expectDoneEnabled();
         await GetQuantityDialog.clickDone();
+
         await PickingJobScreen.waitForScreen();
         await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '1 Stk', qtyPicked: '1 Stk', waitForColor: 'green' });
+
+        // the picked HU carries the scanned serial — proving storage works without a product attribute set
+        await Backend.expect({
+            hus: {
+                [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '999 PCE' } },
+                vhu1: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { SerialNo: serial } },
+            }
+        });
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/picking_serialNo.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_serialNo.spec.js
@@ -182,10 +182,32 @@ test('Serial-no product with NO attribute set: checkbox alone still prompts, ser
 
         // the picked HU carries the scanned serial — proving storage works without a product attribute set
         await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: "1 PCE", qtyTUs: 0, qtyLUs: 0, vhu: 'vhu1', tu: '-', lu: '-', processed: false, shipmentLineId: '-' }] }
+                    }
+                }
+            },
             hus: {
                 [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '999 PCE' } },
                 vhu1: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { SerialNo: serial } },
             }
         });
+    });
+
+    // completion persists the serial through to the shipped HU — the serial is not lost at shipment time.
+    await PickingJobScreen.complete();
+    await Backend.expect({
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: { qtyPicked: [{ qtyPicked: "1 PCE", qtyTUs: 0, qtyLUs: 0, vhu: 'vhu1', tu: '-', lu: '-', processed: true, shipmentLineId: 'shipmentLine1' }] }
+                }
+            }
+        },
+        hus: {
+            vhu1: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { SerialNo: serial } },
+        }
     });
 });


### PR DESCRIPTION
## Why

Serial-no picking was gated on **two** conditions: (1) `M_Product.IsSerialNoPicked='Y'` **and** (2) the product's own attribute set (`M_Product.M_AttributeSet_ID`) containing the `SerialNo` attribute.

Condition (2) is redundant:
- The picked HU's ability to **store** the `SerialNo` is provided by the PI wiring (`M_HU_PI_Attribute` for `SerialNo`, active on the virtual PI version), **not** by the product's attribute set.
- No consumer reads `SerialNo` as a product ASI attribute.
- The attribute-set gate only added hidden, mis-configurable setup (a product flagged for serial picking but whose attribute set lacked `SerialNo` would silently skip the prompt).

The owner approved dropping it: **the checkbox alone shall drive serial-no picking.**

## Behaviour change

`PickingJobProductService.isSerialNoPickingEnabled(ProductId)` now returns `true` iff:
- `M_Product.IsSerialNoPicked='Y'`, **and**
- the system-wide `SerialNo` attribute is defined (`retrieveActiveAttributeIdByValueOrNull(ATTR_SerialNo) != null`) — kept as a defensive guard so we don't prompt on an instance where the serial can't be stored anywhere.

Dropped: the `M_Product.M_AttributeSet_ID` read and the `containsAttribute(productSet, SerialNo)` check. Javadoc + inline comment updated to the new rationale.

## Test changes

- **New unit test** `PickingJobProductServiceTest` (mirror test package, `newInstanceForUnitTesting()` pattern):
  - flag set + **no** attribute set -> `isSerialNoPickingEnabled == true` (this was RED before the change, GREEN after);
  - flag not set -> `false`;
  - flag set + `SerialNo` attribute undefined system-wide -> `false` (defensive guard).
- **E2E** `e2e/mobile-webui/tests/spec/picking/picking_serialNo.spec.js`:
  - The serial product is now set up with the checkbox alone (no `attributeSetName`).
  - The former "misconfig: flag set, no attribute set -> no prompt, picks directly" scenario no longer represents misconfig under the new contract. It is reworked (not weakened) to the new intended behaviour: flag set, no attribute set -> the serial prompt **still appears**, a serial is captured and **persisted** on the picked HU.

## Notes

- The Serial-attribute-set migration and the PI-wiring migration are intentionally **not** reverted — the PI wiring is still required for storage; only the dependency of the prompt gate on the product attribute set is removed.
