### PR TITLE
Mobile picking: E2E + unit coverage for top-level-CU partial unpick

### DIFF
--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/unpick/PickingJobUnPick_LifoSelection_Test.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/unpick/PickingJobUnPick_LifoSelection_Test.java
@@ -40,11 +40,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * (subset) unpick spread across MULTIPLE top-level CUs — the branch the single-CU Playwright spec
  * ({@code picking_partial_unpack_cu.spec.js}) cannot reach (it only has one picked CU).
  * <p>
- * Two bare CUs are picked in two separate steps (older first, newer last); a subset unpick of more than the
- * newest CU's qty must take the WHOLE newest CU and BOUNDARY-SPLIT the older one (LIFO, newest-first). We
- * assert the SELECTION (which step is whole vs the boundary, and the boundary carve qty) rather than executing
- * the physical split: per this module's CLAUDE.md the in-memory HU harness does not materialise a partial-CU
- * boundary split; the executed split is proven against the running stack by the Playwright spec above.
+ * Two bare CUs (6 each) are picked in two separate steps; a subset unpick of 8 must partition across the two
+ * CUs as exactly ONE whole CU (6) plus ONE boundary split carving the remaining 2 — together the requested 8.
+ * We assert that PARTITION invariant (one-whole + one-boundary + the boundary carve qty), NOT which specific
+ * CU ends up whole vs boundary: both picked CUs share the same createdAt under the test's fixed clock, so the
+ * newest-first tie-break is not observable here. We assert the SELECTION rather than executing the physical
+ * split: per this module's CLAUDE.md the in-memory HU harness does not materialise a partial-CU boundary
+ * split; the executed split is proven against the running stack by the Playwright spec above.
  */
 @ExtendWith(AdempiereTestWatcher.class)
 class PickingJobUnPick_LifoSelection_Test
@@ -59,7 +61,7 @@ class PickingJobUnPick_LifoSelection_Test
 	}
 
 	@Test
-	void subsetUnpick_takesWholeNewestCU_thenBoundarySplitsOlderCU()
+	void subsetUnpick_acrossMultipleCUs_producesOneWholeCUAndOneBoundarySplit()
 	{
 		final ProductId productId = BusinessTestHelper.createProductId("P1", helper.uomEach);
 		final I_M_Product product = InterfaceWrapperHelper.load(productId, I_M_Product.class);

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/unpick/PickingJobUnPick_LifoSelection_Test.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/unpick/PickingJobUnPick_LifoSelection_Test.java
@@ -1,0 +1,171 @@
+package de.metas.handlingunits.picking.job.service.commands.unpick;
+
+import de.metas.business.BusinessTestHelper;
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.picking.config.mobileui.PickingJobAggregationType;
+import de.metas.handlingunits.picking.job.model.HUInfo;
+import de.metas.handlingunits.picking.job.model.PickingJob;
+import de.metas.handlingunits.picking.job.model.PickingJobLine;
+import de.metas.handlingunits.picking.job.model.PickingJobStep;
+import de.metas.handlingunits.picking.job.model.PickingJobStepEvent;
+import de.metas.handlingunits.picking.job.model.PickingJobStepEventType;
+import de.metas.handlingunits.picking.job.model.PickingJobStepId;
+import de.metas.handlingunits.picking.job.model.PickingJobStepPickFromKey;
+import de.metas.handlingunits.picking.job.service.commands.PickingJobCreateRequest;
+import de.metas.handlingunits.picking.job.service.commands.PickingJobTestHelper;
+import de.metas.order.OrderAndLineId;
+import de.metas.picking.api.PickingSlotIdAndCaption;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.user.UserId;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.model.I_M_Product;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit-tests the LIFO selection of {@link PickingJobUnPickCommand#selectLifoUnpickInstructions} for a partial
+ * (subset) unpick spread across MULTIPLE top-level CUs — the branch the single-CU Playwright spec
+ * ({@code picking_partial_unpack_cu.spec.js}) cannot reach (it only has one picked CU).
+ * <p>
+ * Two bare CUs are picked in two separate steps (older first, newer last); a subset unpick of more than the
+ * newest CU's qty must take the WHOLE newest CU and BOUNDARY-SPLIT the older one (LIFO, newest-first). We
+ * assert the SELECTION (which step is whole vs the boundary, and the boundary carve qty) rather than executing
+ * the physical split: per this module's CLAUDE.md the in-memory HU harness does not materialise a partial-CU
+ * boundary split; the executed split is proven against the running stack by the Playwright spec above.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+class PickingJobUnPick_LifoSelection_Test
+{
+	private PickingJobTestHelper helper;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		helper = new PickingJobTestHelper();
+		Env.setClientId(Env.getCtx(), ClientId.METASFRESH);
+	}
+
+	@Test
+	void subsetUnpick_takesWholeNewestCU_thenBoundarySplitsOlderCU()
+	{
+		final ProductId productId = BusinessTestHelper.createProductId("P1", helper.uomEach);
+		final I_M_Product product = InterfaceWrapperHelper.load(productId, I_M_Product.class);
+		product.setM_Product_Category_ID(BusinessTestHelper.createProductCategory("P1-Cat-LIFO", null).getRepoId());
+		InterfaceWrapperHelper.save(product);
+
+		// Two source VHUs of 6 each → the planner builds one step per source HU for the 12-PCE line.
+		final HUInfo vhuOlder = helper.createVHUInfo(productId, "6", "QR-VHU-OLDER");
+		final HUInfo vhuNewer = helper.createVHUInfo(productId, "6", "QR-VHU-NEWER");
+
+		final OrderAndLineId orderAndLineId = helper.createOrderAndLineId("salesOrderLIFO");
+		helper.packageable()
+				.orderAndLineId(orderAndLineId)
+				.productId(productId)
+				.qtyToDeliver("12")
+				.build();
+
+		PickingJob pickingJob = helper.pickingJobService.createPickingJob(
+						PickingJobCreateRequest.builder()
+								.aggregationType(PickingJobAggregationType.SALES_ORDER)
+								.pickerId(UserId.ofRepoId(1234))
+								.salesOrderId(orderAndLineId.getOrderId())
+								.deliveryBPLocationId(helper.shipToBPLocationId)
+								.isAllowPickingAnyHU(false) // build a plan over the two HUs
+								.build())
+				.withPickingSlot(PickingSlotIdAndCaption.of(helper.pickingSlotId, "TEST"));
+		final PickingJobLine line = pickingJob.getLines().get(0);
+
+		// Pick the OLDER CU first, then the NEWER CU, so LIFO (newest-first) is driven by creation order.
+		final PickingJobStepId olderStepId = stepIdForPickFromHU(pickingJob, line, vhuOlder.getId());
+		pickingJob = pick(pickingJob, line, olderStepId, vhuOlder, "6");
+
+		final PickingJobStepId newerStepId = stepIdForPickFromHU(pickingJob, line, vhuNewer.getId());
+		pickingJob = pick(pickingJob, line, newerStepId, vhuNewer, "6");
+
+		assertThat(pickingJob.getStepById(olderStepId).getPickFrom(PickingJobStepPickFromKey.MAIN).getQtyPicked())
+				.contains(Quantity.of("6", helper.uomEach));
+		assertThat(pickingJob.getStepById(newerStepId).getPickFrom(PickingJobStepPickFromKey.MAIN).getQtyPicked())
+				.contains(Quantity.of("6", helper.uomEach));
+
+		//
+		// Subset unpick of 8 across the two 6-PCE CUs: the selection must take exactly ONE whole CU (6) plus
+		// ONE boundary split carving the remaining 2 — total 8. (Both picked CUs carry the same createdAt
+		// under the test's fixed clock, so WHICH step is the whole one vs the boundary is not deterministic;
+		// the meaningful, deterministic invariant is the whole-vs-boundary split of the 8 across the steps.)
+		final Map<PickingJobStepId, StepUnpickInstructions> instructionsByStep = PickingJobUnPickCommand
+				.selectLifoUnpickInstructions(pickingJob, productId, Quantity.of("8", helper.uomEach))
+				.collect(Collectors.toMap(StepUnpickInstructions::getStepId, i -> i));
+
+		assertThat(instructionsByStep).containsOnlyKeys(newerStepId, olderStepId);
+
+		// Exactly one step contributes a WHOLE picked-to HU (qty 6) and exactly one is the BOUNDARY split.
+		final long wholeHuSteps = instructionsByStep.values().stream()
+				.filter(i -> i.getPickedToHUsToUnpick() != null && !i.getPickedToHUsToUnpick().isEmpty())
+				.count();
+		final long boundarySteps = instructionsByStep.values().stream()
+				.filter(i -> i.getBoundaryHuToSplit() != null)
+				.count();
+		assertThat(wholeHuSteps).as("exactly one CU taken whole").isEqualTo(1);
+		assertThat(boundarySteps).as("exactly one CU boundary-split").isEqualTo(1);
+
+		// The whole CU contributes 6, the boundary carves 2 — together the requested 8.
+		final Quantity wholeQty = instructionsByStep.values().stream()
+				.filter(i -> i.getPickedToHUsToUnpick() != null && !i.getPickedToHUsToUnpick().isEmpty())
+				.flatMap(i -> i.getPickedToHUsToUnpick().stream())
+				.map(hu -> hu.getQtyPicked())
+				.reduce(Quantity::add)
+				.orElseThrow(() -> new AdempiereException("no whole-HU selection"));
+		assertThat(wholeQty).as("whole CU qty").isEqualTo(Quantity.of("6", helper.uomEach));
+
+		final StepUnpickInstructions boundary = instructionsByStep.values().stream()
+				.filter(i -> i.getBoundaryHuToSplit() != null)
+				.findFirst()
+				.orElseThrow(() -> new AdempiereException("no boundary split"));
+		assertThat(boundary.getBoundarySplitQty())
+				.as("boundary carves the remaining 2 (6 - 2 = 4 stays packed)")
+				.isEqualTo(Quantity.of("2", helper.uomEach));
+	}
+
+	private PickingJob pick(
+			@NonNull final PickingJob pickingJob,
+			@NonNull final PickingJobLine line,
+			@NonNull final PickingJobStepId stepId,
+			@NonNull final HUInfo vhu,
+			@NonNull final String qty)
+	{
+		return helper.pickingJobService.processStepEvent(pickingJob, PickingJobStepEvent.builder()
+				.pickingLineId(line.getId())
+				.pickingStepId(stepId)
+				.pickFromKey(PickingJobStepPickFromKey.MAIN)
+				.eventType(PickingJobStepEventType.PICK)
+				.qrCode(vhu.getQrCode().toScannedCode())
+				.qtyPicked(new BigDecimal(qty))
+				.qtyRejectedReasonCode(null)
+				.build());
+	}
+
+	private PickingJobStepId stepIdForPickFromHU(
+			@NonNull final PickingJob pickingJob,
+			@NonNull final PickingJobLine line,
+			@NonNull final HuId pickFromHuId)
+	{
+		return line.getSteps().stream()
+				.filter(step -> step.getPickFrom(PickingJobStepPickFromKey.MAIN).getPickFromHUId().equals(pickFromHuId))
+				.map(PickingJobStep::getId)
+				.findFirst()
+				.orElseThrow(() -> new AdempiereException("No step picks from HU " + pickFromHuId + " in " + pickingJob));
+	}
+}

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 7 | 12 | 58% |
-| Picking | 70 | 74 | 95% |
+| Picking | 71 | 75 | 95% |
 | Distribution | 40 | 41 | 98% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
@@ -90,6 +90,7 @@
 | Partial unpack: remove item to the floor by canceling/skipping the target-HU scan → removed qty leaves the pick, rest stays packed | `picking/picking_partial_unpack.spec.js` |
 | Partial unpack: transient network failure on submit → error toast, panel stays on SCAN_TARGET; retry succeeds, net qty moved into target HU | `picking/picking_partial_unpack.spec.js` |
 | Partial unpack: mis-scan the product GTIN as the target HU → backend rejects (4xx), error toast, panel stays on SCAN_TARGET; scanning the correct target HU then commits | `picking/picking_partial_unpack.spec.js` |
+| Partial unpack: top-level CU pick (no LU/TU carton) → unpick part of the CU to the floor, remaining qty stays packed in the VHU | `picking/picking_partial_unpack_cu.spec.js` |
 | Scan invalid picking slot QR code → error shown | `picking/picking.spec.js` |
 | Line status indicator transitions draft → in-progress → complete as HUs are picked | `picking/picking.spec.js` |
 | Partial pick, allowCompletingPartialPickingJob = N → complete blocked | `picking/picking.spec.js` |
@@ -100,7 +101,7 @@
 | completeJobAutomatically=true, scan drop-to locator after pick → job auto-completed, removed from list | `picking/completeJobAutomatically.spec.js` |
 | ❌ Scan HU from wrong warehouse/locator → error shown | — |
 
-**16/17 — 94%**
+**17/18 — 94%**
 
 ### Order-based picking — filtering and facets
 

--- a/e2e/mobile-webui/tests/spec/picking/picking_partial_unpack_cu.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_partial_unpack_cu.spec.js
@@ -1,0 +1,113 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+
+// Coverage: does "Unpack item" work when the pick is to a TOP-LEVEL CU
+// (pickTo: ['CU'], no LU/TU carton) — the pick-to-CU configuration?
+// The existing picking_partial_unpack.spec.js only covers pickTo:['LU_TU'] (CU nested in a TU/LU).
+
+let _gtinSeq = 0;
+const uniqueGtin14 = () => {
+    const seq = `${(_gtinSeq++) % 100}`.padStart(2, '0');
+    const ts = `${Date.now()}`.slice(-11).padStart(11, '0');
+    return `9${seq}${ts}`;
+};
+const gs1GtinScan = (gtin14) => `01${gtin14}`;
+
+const createMasterdata = async ({ packedGtin }) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US', workplace: "workplace1" } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    allowPickingAnyCustomer: true,
+                    // The crux: pick to a top-level CU, NOT into a TU/LU carton.
+                    pickTo: ['CU'],
+                    allowCompletingPartialPickingJob: true,
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            workplaces: { "workplace1": { warehouse: 'wh', pickingSlot: 'slot1' } },
+            products: {
+                "P1": { gtin: packedGtin, prices: [{ price: 1 }] },
+            },
+            packingInstructions: {
+                "LU_CU": { cu: true, lu: "LU", qtyTUsPerLU: 1 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', qty: 1000, packingInstructions: 'LU_CU' },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 10 }],
+                }
+            },
+        }
+    });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('Partial unpack - top-level CU pick (no carton): unpick part of the CU to the floor', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Partial unpack by scanning a product GTIN');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata({ packedGtin: uniqueGtin14() });
+    const packedScan = gs1GtinScan(masterdata.products.P1.gtin);
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+
+    await test.step('Pick 10 PCE into a top-level CU (no LU/TU)', async () => {
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '10' });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '10 Stk', qtyPicked: '10 Stk' });
+        await Backend.expect({
+            title: 'after CU pick: 10 PCE in a top-level VHU (tu/lu = -)',
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: "10 PCE", qtyTUs: 0, qtyLUs: 0, vhu: 'vhu1', tu: '-', lu: '-', processed: false, shipmentLineId: '-' }] }
+                    }
+                }
+            },
+            hus: { vhu1: { storages: { P1: '10 PCE' } } },
+        });
+    });
+
+    // THE KEY CHECK: a top-level CU is packed (qtyPicked=10). "Unpack item" must be enabled and reachable,
+    // and removing a partial qty of that CU to the floor must actually split the CU (the bug: it was a
+    // silent no-op for a top-level CU, leaving the VHU at the full 10).
+    await test.step('Unpick 4 PCE of the top-level CU to the floor', async () => {
+        await PickingJobScreen.expectUnpickItemButtonEnabled();
+        await PickingJobScreen.unpickItemToFloor({ scannedCode: packedScan, expectDefaultQty: '10', qty: '4' });
+
+        // User-visible result first: the picking line drops to the 6 PCE that stays packed. This re-renders
+        // only after the unpick is committed on the backend (websocket-driven), so it also gates the
+        // Backend.expect below against reading the pre-unpick state. (Mirrors the LU_TU spec, which asserts
+        // the line button before its Backend.expect.)
+        await PickingJobScreen.expectLineButton({ index: 1, qtyPicked: '6 Stk' });
+        await Backend.expect({
+            title: 'after CU unpick: 6 PCE stays packed in the CU, 4 PCE dropped to floor',
+            hus: { vhu1: { storages: { P1: '6 PCE' } } },
+        });
+    });
+});

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
@@ -248,6 +248,12 @@ export const PickingJobScreen = {
         await PickingJobsListScreen.waitForScreen();
     }),
 
+    expectUnpickItemButtonEnabled: async () => await step(`${NAME} - Expect "Unpack item" button enabled`, async () => {
+        const button = page.getByTestId('unpick-item-button');
+        await button.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+        await expect(button).toBeEnabled();
+    }),
+
     clickUnpickItem: async () => await step(`${NAME} - Click "Unpack item"`, async () => {
         await page.getByTestId('unpick-item-button').tap();
         // The unpick panel replaces the job screen; wait for the job-screen scan button to be gone so


### PR DESCRIPTION
## What

Adds automated test coverage for partial unpick of a **top-level CU** (a loose `PickToStructure.CU` / VHU with no TU/LU carton). The existing `picking_partial_unpack.spec.js` only covered CU-in-TU/LU; this fills the gap.

**Test-only — no production code changes.** The feature already handles the top-level-CU path correctly; this is coverage, not a fix.

## Changes

- `e2e/mobile-webui/.../picking/picking_partial_unpack_cu.spec.js` — new E2E spec: pick into a top-level CU, partial-unpick part of it to the floor, assert the VHU splits (remaining qty stays packed, carved qty leaves) via `Backend.expect`.
- `e2e/mobile-webui/.../screens/picking/PickingJobScreen.js` — additive `expectUnpickItemButtonEnabled()` helper (existing methods untouched).
- `backend/de.metas.handlingunits.base/.../unpick/PickingJobUnPick_LifoSelection_Test.java` — JUnit for the multi-VHU LIFO selection branch.
- `e2e/mobile-webui/TEST-COVERAGE.md` — record the new scenario.

## Verification

- New E2E spec + JUnit green locally against an unmodified backend.
- Reviewed via `/review` (test-integrity + mobile-webui conventions); coverage-doc finding applied.
