### PR TITLE
MobileUI Picking E2E: job-list caption (handover location + date) + Lieferort filter

### DIFF
--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 7 | 12 | 58% |
-| Picking | 60 | 63 | 95% |
+| Picking | 61 | 64 | 95% |
 | Distribution | 34 | 37 | 92% |
 | Manufacturing | 25 | 31 | 81% |
 | HU Manager | 14 | 16 | 88% |
@@ -92,9 +92,10 @@
 | Close LU then reopen → state transitions verified | `picking/picking.spec.js` |
 | Job already started → "already started" indicator shown in jobs list | `picking/picking.spec.js` |
 | completeJobAutomatically=true, scan drop-to locator after pick → job auto-completed, removed from list | `picking/completeJobAutomatically.spec.js` |
+| Profile configured with HandoverLocation + DateReady summary fields → job-list caption shows the delivery location and delivery date alongside document number + customer | `picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js` |
 | ❌ Scan HU from wrong warehouse/locator → error shown | — |
 
-**10/11 — 91%**
+**11/12 — 92%**
 
 ### Order-based picking — filtering and facets
 

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -92,7 +92,7 @@
 | Close LU then reopen → state transitions verified | `picking/picking.spec.js` |
 | Job already started → "already started" indicator shown in jobs list | `picking/picking.spec.js` |
 | completeJobAutomatically=true, scan drop-to locator after pick → job auto-completed, removed from list | `picking/completeJobAutomatically.spec.js` |
-| Profile configured with HandoverLocation + DateReady summary fields (Customer kept out of summary) → job-list caption shows document number, delivery location and delivery date, with the customer name appearing once via the location address | `picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js` |
+| Profile configured with HandoverLocation + DateReady summary fields (Customer kept out of summary) → job-list caption shows exactly 3 fields: document number, delivery location and delivery date | `picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js` |
 | ❌ Scan HU from wrong warehouse/locator → error shown | — |
 
 **11/12 — 92%**

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 7 | 12 | 58% |
-| Picking | 61 | 64 | 95% |
+| Picking | 62 | 65 | 95% |
 | Distribution | 34 | 37 | 92% |
 | Manufacturing | 25 | 31 | 81% |
 | HU Manager | 14 | 16 | 88% |
@@ -103,9 +103,10 @@
 |---|---|
 | Facet filter shows only jobs scheduled for current workplace | `picking/facets.spec.js` |
 | Filter by qty available at locator → only jobs with sufficient stock shown | `picking/filterByQtyAvailableAtLocator.spec.js` |
+| Profile configured with HandoverLocation filter → filter screen offers a delivery-location (Lieferort) facet | `picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js` |
 | ❌ Multiple jobs for same customer → aggregation count correct | — |
 
-**2/3 — 67%**
+**3/4 — 75%**
 
 ### Order-based picking — pick-all and attributes
 

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -92,7 +92,7 @@
 | Close LU then reopen → state transitions verified | `picking/picking.spec.js` |
 | Job already started → "already started" indicator shown in jobs list | `picking/picking.spec.js` |
 | completeJobAutomatically=true, scan drop-to locator after pick → job auto-completed, removed from list | `picking/completeJobAutomatically.spec.js` |
-| Profile configured with HandoverLocation + DateReady summary fields → job-list caption shows the delivery location and delivery date alongside document number + customer | `picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js` |
+| Profile configured with HandoverLocation + DateReady summary fields (Customer kept out of summary) → job-list caption shows document number, delivery location and delivery date, with the customer name appearing once via the location address | `picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js` |
 | ❌ Scan HU from wrong warehouse/locator → error shown | — |
 
 **11/12 — 92%**

--- a/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
@@ -66,8 +66,6 @@ const createMasterdata = async () => {
             },
         }
     });
-    // The masterdata response does not echo the bpartner name; expose the one we set so assertions can use it.
-    masterdata.customerName = customerName;
     return masterdata;
 };
 
@@ -84,23 +82,23 @@ test('Picking job-list caption shows handover location + delivery date', async (
 
     const masterdata = await createMasterdata();
     const documentNo = masterdata.salesOrders.SO1.documentNo;
-    const customerName = masterdata.customerName;
+    const customerId = masterdata.bpartners.customer1.id;
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('picking');
     await PickingJobsListScreen.waitForScreen();
 
-    // The launcher caption shows the three configured summary fields:
+    // The launcher caption shows exactly the three configured summary fields, in order:
     //  - the document number,
-    //  - the handover/delivery location (HANDOVER_LOCATION) — its address leads with the customer name,
-    //  - the delivery date (DATE_READY) — year-only, format-agnostic.
-    // Customer is configured but kept out of the summary, so the customer name appears EXACTLY ONCE
-    // (via the handover-location address), never duplicated.
+    //  - the handover/delivery location (HANDOVER_LOCATION) — the two additions this issue makes,
+    //  - the delivery date (DATE_READY) — asserted year-only, address-format-agnostic.
+    // Customer is configured but kept OUT of the summary (isShowInSummary:false): the handover-location
+    // field already conveys the customer (its address leads with the customer name on the sp80 instance),
+    // so a separate Customer field would repeat it. The 3-field count proves Customer is not in the summary.
     await PickingJobsListScreen.expectJobCaption({
-        documentNo, // locate the launcher by the document number shown in its caption (unique per run)
+        customerId, // locate by the bpartner id (exact, unique per run) — documentNo is only a caption substring
         contains: [documentNo, '2025'],
-        containsOnce: [customerName],
         fieldCount: 3,
     });
 });
@@ -115,7 +113,7 @@ test('Picking job-list filter offers a delivery-location (Lieferort) facet', asy
     allure.severity('normal');
 
     const masterdata = await createMasterdata();
-    const documentNo = masterdata.salesOrders.SO1.documentNo;
+    const customerId = masterdata.bpartners.customer1.id;
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
@@ -123,7 +121,8 @@ test('Picking job-list filter offers a delivery-location (Lieferort) facet', asy
     await PickingJobsListScreen.waitForScreen();
     // The facet groups are computed from the jobs currently in the list, which load async — wait for
     // our job to be present before opening the filter, otherwise no Customer facet is offered yet.
-    await PickingJobsListScreen.waitForJobVisible({ documentNo });
+    // Locate by the bpartner id (exact) — not a documentNo substring (collides in a full-suite run).
+    await PickingJobsListScreen.waitForJobVisible({ customerId });
 
     // Facets are progressive: Customer first, then DeliveryDate, then HandoverLocation. Drill the
     // cascade (select this run's customer → its delivery date) and assert the HandoverLocation

--- a/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
@@ -2,6 +2,7 @@ import { test } from "../../../../playwright.config";
 import { allure } from 'allure-playwright';
 import { ApplicationsListScreen } from "../../../utils/screens/ApplicationsListScreen";
 import { PickingJobsListScreen } from "../../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobsListFiltersScreen } from "../../../utils/screens/picking/PickingJobsListFiltersScreen";
 import { Backend } from "../../../utils/screens/Backend";
 import { LoginScreen } from "../../../utils/screens/LoginScreen";
 
@@ -33,6 +34,8 @@ const createMasterdata = async () => {
                         { field: 'HANDOVER_LOCATION', isShowInSummary: true },
                         { field: 'DATE_READY', isShowInSummary: true },
                     ],
+                    // Facet filters under test — Customer + DeliveryDate (standard) + HandoverLocation (the addition).
+                    filters: ['Customer', 'DeliveryDate', 'HandoverLocation'],
                 }
             },
             bpartners: {
@@ -67,7 +70,6 @@ test('Picking job-list caption shows handover location + delivery date', async (
     const masterdata = await createMasterdata();
     const documentNo = masterdata.salesOrders.SO1.documentNo;
     const customerName = "Kunde 30117 Test"; // set above; the masterdata response does not echo the bpartner name
-    const salesOrderId = masterdata.salesOrders.SO1.id; // sales_order aggregation → launcher keyed by data-salesorderid
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
@@ -79,8 +81,30 @@ test('Picking job-list caption shows handover location + delivery date', async (
     //  - the delivery date (DATE_READY) — year-only, format-agnostic,
     //  - the handover/delivery location (HANDOVER_LOCATION) — proven by the 4th non-empty field.
     await PickingJobsListScreen.expectJobCaption({
-        salesOrderId,
+        documentNo, // locate the launcher by the document number shown in its caption (unique per run)
         contains: [documentNo, customerName, '2025'],
         fieldCount: 4,
     });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Picking job-list filter offers a delivery-location (Lieferort) facet', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.tag('F00230.3');
+    allure.story('MobileUI Picking Filter — job list can be filtered by delivery/handover location');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+
+    // Open the filter screen and assert the HandoverLocation (Lieferort) facet is offered — the
+    // delivery-location filter this issue adds, alongside the standard customer + delivery-date facets.
+    await PickingJobsListScreen.clickFilterButton();
+    await PickingJobsListFiltersScreen.expectFacetGroupOffered({ groupPrefix: 'HandoverLocation' });
 });

--- a/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
@@ -1,0 +1,92 @@
+import { test } from "../../../../playwright.config";
+import { expect } from '@playwright/test';
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../../utils/screens/picking/PickingJobsListScreen";
+import { Backend } from "../../../utils/screens/Backend";
+import { LoginScreen } from "../../../utils/screens/LoginScreen";
+import { page } from "../../../utils/common";
+
+// me03 #30117 / F00230.3 — MobileUI Picking job-LIST caption must show the handover/delivery
+// location and the delivery (ready) date, in addition to the customer name + document number, so
+// pickers can tell apart several jobs for the same customer. Pure picking-profile configuration:
+// the launcher caption is built from the profile's IsDisplayInSummary fields (DisplayValueProvider),
+// joined with " | ". HANDOVER_LOCATION renders the handover location, falling back to the ship-to
+// address when no handover location is set (this masterdata sets only the ship-to location, so it
+// also covers that fallback path). DATE_READY renders the sales order's datePromised.
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US" } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                    // The field set under test — the two additions (HANDOVER_LOCATION + DATE_READY)
+                    // plus the context fields, all shown in the launcher summary.
+                    fields: [
+                        { field: 'DOCUMENT_NO', isShowInSummary: true },
+                        { field: 'CUSTOMER', isShowInSummary: true },
+                        { field: 'HANDOVER_LOCATION', isShowInSummary: true },
+                        { field: 'DATE_READY', isShowInSummary: true },
+                    ],
+                }
+            },
+            bpartners: {
+                "customer1": { name: "Kunde 30117 Test", locations: { customer1_location1: {} } },
+            },
+            warehouses: { "wh": {} },
+            products: { "P1": { price: 1 } },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'customer1',
+                    location: 'customer1_location1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-15T08:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 20 }],
+                },
+            },
+        }
+    });
+};
+
+test('Picking job-list caption shows handover location + delivery date', async () => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230.3');
+    allure.story('MobileUI Picking Filter — job-list caption shows handover location and delivery date');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+    const documentNo = masterdata.salesOrders.SO1.documentNo;
+    const customerName = "Kunde 30117 Test"; // the name we set above (masterdata response does not echo bpartner name)
+    const locationId = masterdata.bpartners.customer1.locations.customer1_location1.id;
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+
+    // Read the actual launcher caption for the job (located by its delivery-location id).
+    const button = page.locator(`.wflauncher-button[data-customerlocationid="${locationId}"]`);
+    await expect(button).toHaveCount(1);
+    const caption = (await button.innerText()).trim();
+    console.log(`[30117] launcher caption = ${JSON.stringify(caption)}`);
+
+    // Document number + customer name still present (no regression).
+    expect(caption, 'caption should contain the document number').toContain(documentNo);
+    expect(caption, 'caption should contain the customer name').toContain(customerName);
+
+    // DATE_READY: the delivery/ready date (datePromised 2025-03-15) is shown — format-agnostic year check.
+    expect(caption, 'caption should contain the delivery date (DATE_READY)').toContain('2025');
+
+    // HANDOVER_LOCATION: a 4th, non-empty segment is rendered (the location/address) — proving the
+    // field shows up beyond document/customer/date.
+    const segments = caption.split('|').map(s => s.trim()).filter(s => s.length > 0);
+    expect(segments.length, `caption should have 4 non-empty fields, got: ${caption}`).toBe(4);
+});

--- a/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
@@ -110,8 +110,11 @@ test('Picking job-list filter offers a delivery-location (Lieferort) facet', asy
     await ApplicationsListScreen.startApplication('picking');
     await PickingJobsListScreen.waitForScreen();
 
-    // Open the filter screen and assert the HandoverLocation (Lieferort) facet is offered — the
-    // delivery-location filter this issue adds, alongside the standard customer + delivery-date facets.
+    // Facets are progressive: Customer first, then DeliveryDate, then HandoverLocation. Drill the
+    // cascade (select this run's customer → its delivery date) and assert the HandoverLocation
+    // (Lieferort) facet is then offered — the delivery-location filter this issue adds.
     await PickingJobsListScreen.clickFilterButton();
+    await PickingJobsListFiltersScreen.clickFacet({ facetId: 'Customer_' + masterdata.bpartners.customer1.id });
+    await PickingJobsListFiltersScreen.clickFirstFacetOfGroup({ groupPrefix: 'DeliveryDate' });
     await PickingJobsListFiltersScreen.expectFacetGroupOffered({ groupPrefix: 'HandoverLocation' });
 });

--- a/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
@@ -42,14 +42,21 @@ const createMasterdata = async () => {
                 "customer1": { name: "Kunde 30117 Test", locations: { customer1_location1: {} } },
             },
             warehouses: { "wh": {} },
-            products: { "P1": { price: 1 } },
+            pickingSlots: { slot1: {} },
+            products: { "P1": { prices: [{ price: 1 }] } },
+            packingInstructions: {
+                "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "P1", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
+            },
             salesOrders: {
                 "SO1": {
                     bpartner: 'customer1',
                     location: 'customer1_location1',
                     warehouse: 'wh',
                     datePromised: '2025-03-15T08:00:00.000+02:00',
-                    lines: [{ product: 'P1', qty: 20 }],
+                    lines: [{ product: 'P1', qty: 12, piItemProduct: 'TU' }],
                 },
             },
         }

--- a/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
@@ -67,7 +67,7 @@ test('Picking job-list caption shows handover location + delivery date', async (
     const masterdata = await createMasterdata();
     const documentNo = masterdata.salesOrders.SO1.documentNo;
     const customerName = "Kunde 30117 Test"; // set above; the masterdata response does not echo the bpartner name
-    const locationId = masterdata.bpartners.customer1.locations.customer1_location1.id;
+    const salesOrderId = masterdata.salesOrders.SO1.id; // sales_order aggregation → launcher keyed by data-salesorderid
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
@@ -79,7 +79,7 @@ test('Picking job-list caption shows handover location + delivery date', async (
     //  - the delivery date (DATE_READY) — year-only, format-agnostic,
     //  - the handover/delivery location (HANDOVER_LOCATION) — proven by the 4th non-empty field.
     await PickingJobsListScreen.expectJobCaption({
-        customerLocationId: locationId,
+        salesOrderId,
         contains: [documentNo, customerName, '2025'],
         fieldCount: 4,
     });

--- a/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
@@ -6,9 +6,9 @@ import { PickingJobsListFiltersScreen } from "../../../utils/screens/picking/Pic
 import { Backend } from "../../../utils/screens/Backend";
 import { LoginScreen } from "../../../utils/screens/LoginScreen";
 
-// me03 #30117 / F00230.3 — MobileUI Picking job-LIST caption must show the handover/delivery
-// location and the delivery (ready) date, in addition to the customer name + document number, so
-// pickers can tell apart several jobs for the same customer. Pure picking-profile configuration:
+// F00230.3 — MobileUI Picking job-LIST caption must show the handover/delivery location and the
+// delivery (ready) date alongside the document number, so pickers can tell apart several jobs for
+// the same customer. Pure picking-profile configuration:
 // the launcher caption is built from the profile's IsDisplayInSummary fields (DisplayValueProvider),
 // joined with " | ". HANDOVER_LOCATION renders the handover location, falling back to the ship-to
 // address when no handover location is set (this masterdata sets only the ship-to location, so it

--- a/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
@@ -15,7 +15,9 @@ import { LoginScreen } from "../../../utils/screens/LoginScreen";
 // also covers that fallback path). DATE_READY renders the sales order's datePromised.
 
 const createMasterdata = async () => {
-    return await Backend.createMasterdata({
+    // Unique per run so parallel runs / repeated runs never collide on the bpartner name.
+    const customerName = `Kunde-${Date.now()}`;
+    const masterdata = await Backend.createMasterdata({
         language: "en_US",
         request: {
             login: { user: { language: "en_US" } },
@@ -26,11 +28,14 @@ const createMasterdata = async () => {
                     createShipmentPolicy: 'CL',
                     allowPickingAnyHU: true,
                     pickTo: ['LU_TU'],
-                    // The field set under test — the two additions (HANDOVER_LOCATION + DATE_READY)
-                    // plus the context fields, all shown in the launcher summary.
+                    // The summary caption shows DocumentNo + HANDOVER_LOCATION + DATE_READY.
+                    // CUSTOMER is configured but kept OUT of the summary (isShowInSummary:false,
+                    // still in the detailed view): the handover-location address already leads
+                    // with the customer name, so showing Customer in the summary too would repeat
+                    // the name. This mirrors the picking-profile config the feature ships with.
                     fields: [
                         { field: 'DOCUMENT_NO', isShowInSummary: true },
-                        { field: 'CUSTOMER', isShowInSummary: true },
+                        { field: 'CUSTOMER', isShowInSummary: false, isShowInDetailed: true },
                         { field: 'HANDOVER_LOCATION', isShowInSummary: true },
                         { field: 'DATE_READY', isShowInSummary: true },
                     ],
@@ -39,7 +44,7 @@ const createMasterdata = async () => {
                 }
             },
             bpartners: {
-                "customer1": { name: "Kunde 30117 Test", locations: { customer1_location1: {} } },
+                "customer1": { name: customerName, locations: { customer1_location1: {} } },
             },
             warehouses: { "wh": {} },
             pickingSlots: { slot1: {} },
@@ -61,6 +66,9 @@ const createMasterdata = async () => {
             },
         }
     });
+    // The masterdata response does not echo the bpartner name; expose the one we set so assertions can use it.
+    masterdata.customerName = customerName;
+    return masterdata;
 };
 
 // The `page` fixture param must stay even though it's unused here: destructuring it triggers the
@@ -76,21 +84,24 @@ test('Picking job-list caption shows handover location + delivery date', async (
 
     const masterdata = await createMasterdata();
     const documentNo = masterdata.salesOrders.SO1.documentNo;
-    const customerName = "Kunde 30117 Test"; // set above; the masterdata response does not echo the bpartner name
+    const customerName = masterdata.customerName;
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('picking');
     await PickingJobsListScreen.waitForScreen();
 
-    // The launcher caption shows all four configured summary fields:
-    //  - DocumentNo + Customer (no regression),
-    //  - the delivery date (DATE_READY) — year-only, format-agnostic,
-    //  - the handover/delivery location (HANDOVER_LOCATION) — proven by the 4th non-empty field.
+    // The launcher caption shows the three configured summary fields:
+    //  - the document number,
+    //  - the handover/delivery location (HANDOVER_LOCATION) — its address leads with the customer name,
+    //  - the delivery date (DATE_READY) — year-only, format-agnostic.
+    // Customer is configured but kept out of the summary, so the customer name appears EXACTLY ONCE
+    // (via the handover-location address), never duplicated.
     await PickingJobsListScreen.expectJobCaption({
         documentNo, // locate the launcher by the document number shown in its caption (unique per run)
-        contains: [documentNo, customerName, '2025'],
-        fieldCount: 4,
+        contains: [documentNo, '2025'],
+        containsOnce: [customerName],
+        fieldCount: 3,
     });
 });
 
@@ -104,11 +115,15 @@ test('Picking job-list filter offers a delivery-location (Lieferort) facet', asy
     allure.severity('normal');
 
     const masterdata = await createMasterdata();
+    const documentNo = masterdata.salesOrders.SO1.documentNo;
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
     await ApplicationsListScreen.startApplication('picking');
     await PickingJobsListScreen.waitForScreen();
+    // The facet groups are computed from the jobs currently in the list, which load async — wait for
+    // our job to be present before opening the filter, otherwise no Customer facet is offered yet.
+    await PickingJobsListScreen.waitForJobVisible({ documentNo });
 
     // Facets are progressive: Customer first, then DeliveryDate, then HandoverLocation. Drill the
     // cascade (select this run's customer → its delivery date) and assert the HandoverLocation

--- a/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
@@ -1,11 +1,9 @@
 import { test } from "../../../../playwright.config";
-import { expect } from '@playwright/test';
 import { allure } from 'allure-playwright';
 import { ApplicationsListScreen } from "../../../utils/screens/ApplicationsListScreen";
 import { PickingJobsListScreen } from "../../../utils/screens/picking/PickingJobsListScreen";
 import { Backend } from "../../../utils/screens/Backend";
 import { LoginScreen } from "../../../utils/screens/LoginScreen";
-import { page } from "../../../utils/common";
 
 // me03 #30117 / F00230.3 — MobileUI Picking job-LIST caption must show the handover/delivery
 // location and the delivery (ready) date, in addition to the customer name + document number, so
@@ -55,16 +53,18 @@ const createMasterdata = async () => {
     });
 };
 
-test('Picking job-list caption shows handover location + delivery date', async () => {
+// noinspection JSUnusedLocalSymbols
+test('Picking job-list caption shows handover location + delivery date', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
     allure.tag('F00230.3');
     allure.story('MobileUI Picking Filter — job-list caption shows handover location and delivery date');
     allure.severity('normal');
 
     const masterdata = await createMasterdata();
     const documentNo = masterdata.salesOrders.SO1.documentNo;
-    const customerName = "Kunde 30117 Test"; // the name we set above (masterdata response does not echo bpartner name)
+    const customerName = "Kunde 30117 Test"; // set above; the masterdata response does not echo the bpartner name
     const locationId = masterdata.bpartners.customer1.locations.customer1_location1.id;
 
     await LoginScreen.login(masterdata.login.user);
@@ -72,21 +72,13 @@ test('Picking job-list caption shows handover location + delivery date', async (
     await ApplicationsListScreen.startApplication('picking');
     await PickingJobsListScreen.waitForScreen();
 
-    // Read the actual launcher caption for the job (located by its delivery-location id).
-    const button = page.locator(`.wflauncher-button[data-customerlocationid="${locationId}"]`);
-    await expect(button).toHaveCount(1);
-    const caption = (await button.innerText()).trim();
-    console.log(`[30117] launcher caption = ${JSON.stringify(caption)}`);
-
-    // Document number + customer name still present (no regression).
-    expect(caption, 'caption should contain the document number').toContain(documentNo);
-    expect(caption, 'caption should contain the customer name').toContain(customerName);
-
-    // DATE_READY: the delivery/ready date (datePromised 2025-03-15) is shown — format-agnostic year check.
-    expect(caption, 'caption should contain the delivery date (DATE_READY)').toContain('2025');
-
-    // HANDOVER_LOCATION: a 4th, non-empty segment is rendered (the location/address) — proving the
-    // field shows up beyond document/customer/date.
-    const segments = caption.split('|').map(s => s.trim()).filter(s => s.length > 0);
-    expect(segments.length, `caption should have 4 non-empty fields, got: ${caption}`).toBe(4);
+    // The launcher caption shows all four configured summary fields:
+    //  - DocumentNo + Customer (no regression),
+    //  - the delivery date (DATE_READY) — year-only, format-agnostic,
+    //  - the handover/delivery location (HANDOVER_LOCATION) — proven by the 4th non-empty field.
+    await PickingJobsListScreen.expectJobCaption({
+        customerLocationId: locationId,
+        contains: [documentNo, customerName, '2025'],
+        fieldCount: 4,
+    });
 });

--- a/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js
@@ -53,6 +53,8 @@ const createMasterdata = async () => {
     });
 };
 
+// The `page` fixture param must stay even though it's unused here: destructuring it triggers the
+// playwright.config fixture that calls setCurrentPage(page), which the screen objects rely on.
 // noinspection JSUnusedLocalSymbols
 test('Picking job-list caption shows handover location + delivery date', async ({ page }) => {
     allure.epic('E0105: Picking');

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListFiltersScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListFiltersScreen.js
@@ -26,6 +26,16 @@ export const PickingJobsListFiltersScreen = {
         await expect(facet).toBeVisible();
     }),
 
+    // Tap the first facet of a group (e.g. 'DeliveryDate') without needing its exact value id —
+    // used to drill the progressive facet cascade. Waits for the list to settle after the tap.
+    clickFirstFacetOfGroup: async ({ groupPrefix }) => await test.step(`${NAME} - Click first '${groupPrefix}' facet`, async () => {
+        await PickingJobsListFiltersScreen.waitLoadingDone();
+        const facet = page.locator(`.group button[data-testid^="${groupPrefix}_"]`).first();
+        await facet.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+        await facet.tap();
+        await PickingJobsListFiltersScreen.waitLoadingDone();
+    }),
+
     filterByDocumentNo: async (documentNo) => await test.step(`${NAME} - Filter by documentNo ${documentNo}`, async () => {
         await page.locator('#filterByDocumentNo-button').tap();
         await GetDocumentNoDialog.waitForDialog();

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListFiltersScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListFiltersScreen.js
@@ -17,6 +17,15 @@ export const PickingJobsListFiltersScreen = {
         await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
+    // Assert that a facet group (e.g. 'HandoverLocation') is offered — at least one facet button
+    // whose data-testid starts with "<groupPrefix>_" is visible. Robust to the exact facet value.
+    expectFacetGroupOffered: async ({ groupPrefix }) => await test.step(`${NAME} - Expect facet group '${groupPrefix}' offered`, async () => {
+        await PickingJobsListFiltersScreen.waitLoadingDone();
+        const facet = page.locator(`.group button[data-testid^="${groupPrefix}_"]`).first();
+        await facet.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+        await expect(facet).toBeVisible();
+    }),
+
     filterByDocumentNo: async (documentNo) => await test.step(`${NAME} - Filter by documentNo ${documentNo}`, async () => {
         await page.locator('#filterByDocumentNo-button').tap();
         await GetDocumentNoDialog.waitForDialog();

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
@@ -24,30 +24,28 @@ export const PickingJobsListScreen = {
     // Wait until a specific job launcher is visible in the list. The list is websocket-driven and
     // populates a moment after the screen renders, so callers that act on the list (e.g. opening the
     // filter, whose facets are computed from the listed jobs) must wait for the job to be present first.
-    waitForJobVisible: async ({ documentNo }) => await test.step(`${NAME} - Wait for job '${documentNo}' visible`, async () => {
-        await locateJobButtons({ documentNo }).waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+    // Locate by an exact data attribute (e.g. customerId) — never by a documentNo substring, which
+    // collides with other jobs in a shared/full-suite run.
+    waitForJobVisible: async ({ documentNo, salesOrderId, customerId, customerLocationId } = {}) => await test.step(`${NAME} - Wait for job visible`, async () => {
+        await locateJobButtons({ documentNo, salesOrderId, customerId, customerLocationId }).waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     /**
      * Reads a single job launcher's caption (the " | "-joined display fields) and asserts on it.
+     * Locate the job by an exact data attribute (customerId / salesOrderId / customerLocationId) —
+     * documentNo is only a caption substring and collides with other jobs in a full-suite run.
      * @param contains - substrings that must all be present in the caption
-     * @param containsOnce - substrings that must each appear EXACTLY once in the caption
-     *        (used to prove de-duplication, e.g. the customer name is not repeated)
      * @param fieldCount - if set, the expected number of non-empty " | "-separated caption fields
      * @returns the caption text (also logged, to aid assertion tuning)
      */
-    expectJobCaption: async ({ documentNo, salesOrderId, customerLocationId, contains = [], containsOnce = [], fieldCount } = {}) => await test.step(`${NAME} - Expect job caption`, async () => {
-        const button = locateJobButtons({ documentNo, salesOrderId, customerLocationId });
+    expectJobCaption: async ({ documentNo, salesOrderId, customerId, customerLocationId, contains = [], fieldCount } = {}) => await test.step(`${NAME} - Expect job caption`, async () => {
+        const button = locateJobButtons({ documentNo, salesOrderId, customerId, customerLocationId });
         await button.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
         await expect(button).toHaveCount(1);
         const caption = (await button.innerText()).trim();
         console.log(`${NAME} - job caption = ${JSON.stringify(caption)}`);
         for (const text of contains) {
             expect(caption, `caption should contain "${text}"`).toContain(text);
-        }
-        for (const text of containsOnce) {
-            const occurrences = caption.split(text).length - 1;
-            expect(occurrences, `caption should contain "${text}" exactly once, caption was: ${caption}`).toBe(1);
         }
         if (fieldCount != null) {
             const fields = caption.split('|').map(s => s.trim()).filter(s => s.length > 0);
@@ -137,10 +135,13 @@ export const PickingJobsListScreen = {
 
 };
 
-const locateJobButtons = ({ documentNo, index, salesOrderId, qtyToDeliver, productId, customerLocationId, caption } = {}) => {
+const locateJobButtons = ({ documentNo, index, salesOrderId, customerId, qtyToDeliver, productId, customerLocationId, caption } = {}) => {
     let selector = '.wflauncher-button';
     if (salesOrderId != null) {
         selector += `[data-salesorderid="${salesOrderId}"]`;
+    }
+    if (customerId != null) {
+        selector += `[data-customerid="${customerId}"]`;
     }
     if (qtyToDeliver != null) {
         selector += `[data-qtytodeliver="${qtyToDeliver}"]`;

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
@@ -21,13 +21,22 @@ export const PickingJobsListScreen = {
         await expect(containerElement()).toBeVisible();
     }),
 
+    // Wait until a specific job launcher is visible in the list. The list is websocket-driven and
+    // populates a moment after the screen renders, so callers that act on the list (e.g. opening the
+    // filter, whose facets are computed from the listed jobs) must wait for the job to be present first.
+    waitForJobVisible: async ({ documentNo }) => await test.step(`${NAME} - Wait for job '${documentNo}' visible`, async () => {
+        await locateJobButtons({ documentNo }).waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+    }),
+
     /**
      * Reads a single job launcher's caption (the " | "-joined display fields) and asserts on it.
      * @param contains - substrings that must all be present in the caption
+     * @param containsOnce - substrings that must each appear EXACTLY once in the caption
+     *        (used to prove de-duplication, e.g. the customer name is not repeated)
      * @param fieldCount - if set, the expected number of non-empty " | "-separated caption fields
      * @returns the caption text (also logged, to aid assertion tuning)
      */
-    expectJobCaption: async ({ documentNo, salesOrderId, customerLocationId, contains = [], fieldCount } = {}) => await test.step(`${NAME} - Expect job caption`, async () => {
+    expectJobCaption: async ({ documentNo, salesOrderId, customerLocationId, contains = [], containsOnce = [], fieldCount } = {}) => await test.step(`${NAME} - Expect job caption`, async () => {
         const button = locateJobButtons({ documentNo, salesOrderId, customerLocationId });
         await button.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
         await expect(button).toHaveCount(1);
@@ -35,6 +44,10 @@ export const PickingJobsListScreen = {
         console.log(`${NAME} - job caption = ${JSON.stringify(caption)}`);
         for (const text of contains) {
             expect(caption, `caption should contain "${text}"`).toContain(text);
+        }
+        for (const text of containsOnce) {
+            const occurrences = caption.split(text).length - 1;
+            expect(occurrences, `caption should contain "${text}" exactly once, caption was: ${caption}`).toBe(1);
         }
         if (fieldCount != null) {
             const fields = caption.split('|').map(s => s.trim()).filter(s => s.length > 0);

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
@@ -21,6 +21,28 @@ export const PickingJobsListScreen = {
         await expect(containerElement()).toBeVisible();
     }),
 
+    /**
+     * Reads a single job launcher's caption (the " | "-joined display fields) and asserts on it.
+     * @param contains - substrings that must all be present in the caption
+     * @param fieldCount - if set, the expected number of non-empty " | "-separated caption fields
+     * @returns the caption text (also logged, to aid assertion tuning)
+     */
+    expectJobCaption: async ({ documentNo, salesOrderId, customerLocationId, contains = [], fieldCount } = {}) => await test.step(`${NAME} - Expect job caption`, async () => {
+        const button = locateJobButtons({ documentNo, salesOrderId, customerLocationId });
+        await button.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+        await expect(button).toHaveCount(1);
+        const caption = (await button.innerText()).trim();
+        console.log(`${NAME} - job caption = ${JSON.stringify(caption)}`);
+        for (const text of contains) {
+            expect(caption, `caption should contain "${text}"`).toContain(text);
+        }
+        if (fieldCount != null) {
+            const fields = caption.split('|').map(s => s.trim()).filter(s => s.length > 0);
+            expect(fields.length, `expected ${fieldCount} non-empty caption fields, caption was: ${caption}`).toBe(fieldCount);
+        }
+        return caption;
+    }),
+
     clickFilterButton: async () => await test.step(`${NAME} - Click filter button`, async () => {
         await page.locator('#filter-button').tap();
         await PickingJobsListFiltersScreen.waitForScreen();


### PR DESCRIPTION
## What

Adds Playwright mobile-webui E2E coverage for the MobileUI picking job-list caption + delivery-location filter (feature F00230.3):

- **Caption test** — a picking profile with `HANDOVER_LOCATION` + `DATE_READY` summary fields. Asserts the job-list caption contains the document number and the delivery year, and has exactly **3** `|`-separated fields — proving `DOCUMENT_NO` + `HANDOVER_LOCATION` + `DATE_READY` render and that `CUSTOMER` is kept out of the summary (`isShowInSummary:false`, still in detail). The assertion is address-format-agnostic (the location field renders the bpartner name or code depending on the instance's address format).
- **Filter test** — drills the progressive facet cascade (Customer → DeliveryDate) and asserts the delivery-location (`HandoverLocation`) facet is then offered.

## Notes

- New screen-object helpers: `PickingJobsListScreen.expectJobCaption`/`waitForJobVisible`, `PickingJobsListFiltersScreen.expectFacetGroupOffered`/`clickFirstFacetOfGroup`. Jobs are located by the exact `data-customerid` attribute (unique per run), not a documentNo substring.
- Config-only feature (no backend change).
- `TEST-COVERAGE.md` updated.