### PR TITLE
Fix dlm.archive_c_queue_data: add missing lockedat column to C_Queue_Workpackage_Archived

### DIFF
--- a/backend/de.metas.async/src/main/sql/postgresql/system/80-async-dlm/5810130_sys_add_lockedat_to_C_Queue_Workpackage_Archived.sql
+++ b/backend/de.metas.async/src/main/sql/postgresql/system/80-async-dlm/5810130_sys_add_lockedat_to_C_Queue_Workpackage_Archived.sql
@@ -1,0 +1,10 @@
+-- Add the missing 'lockedat' column to dlm.C_Queue_Workpackage_Archived.
+-- The polling-lock column LockedAt was added to C_Queue_Workpackage but never to its
+-- archive twin, so dlm.archive_c_queue_data's "INSERT INTO ...Archived SELECT * FROM
+-- (deleted C_Queue_Workpackage rows)" had one more source column than target columns and
+-- aborted every run with: "INSERT has more expressions than target columns".
+-- Result: async workpackage data was never archived and the C_Queue_* tables grew unbounded.
+-- Mirrors the type/nullability of C_Queue_Workpackage.LockedAt (timestamptz, nullable).
+
+ALTER TABLE IF EXISTS dlm.C_Queue_Workpackage_Archived
+    ADD COLUMN IF NOT EXISTS lockedat timestamptz;


### PR DESCRIPTION
## Problem
The async DLM archive process `dlm.archive_c_queue_data` aborts on every run with:

```
ERROR: INSERT has more expressions than target columns
  PL/pgSQL function dlm.archive_c_queue_data(integer,integer) ... at SQL statement
```

The function archives each queue table via `INSERT INTO dlm.<t>_Archived SELECT * FROM (deleted rows)`. The `LockedAt` polling-lock column was added to `C_Queue_Workpackage` (gh26328 / migration 5777120) but **never** to its archive twin `dlm.C_Queue_Workpackage_Archived` — so the live table has one more column than the archive target and the positional INSERT fails.

Effect: async workpackage data is never archived; the `C_Queue_*` tables grow unbounded.

## Fix
Migration `5810130` adds `lockedat timestamptz` (nullable) to `dlm.C_Queue_Workpackage_Archived`, mirroring `C_Queue_Workpackage.LockedAt`. Same pattern as prior archive-column fixes (5617100, 5691780).

## Verification
- Reproduced the exact error on a local stack (`INSERT INTO dlm.c_queue_workpackage_archived SELECT * FROM c_queue_workpackage WHERE false`).
- Confirmed the column-count drift (live 31 cols vs archive 30) and that `lockedat` (ordinal 32, last) is the only divergence — positionally safe to append.
- After the migration the same INSERT succeeds (GREEN).