### PR TITLE
Port: Fix dlm.archive_c_queue_data (add missing lockedat column) -> deep_tundra_release

### DIFF
--- a/backend/de.metas.async/src/main/sql/postgresql/system/80-async-dlm/5810130_sys_add_lockedat_to_C_Queue_Workpackage_Archived.sql
+++ b/backend/de.metas.async/src/main/sql/postgresql/system/80-async-dlm/5810130_sys_add_lockedat_to_C_Queue_Workpackage_Archived.sql
@@ -1,0 +1,10 @@
+-- Add the missing 'lockedat' column to dlm.C_Queue_Workpackage_Archived.
+-- The polling-lock column LockedAt was added to C_Queue_Workpackage but never to its
+-- archive twin, so dlm.archive_c_queue_data's "INSERT INTO ...Archived SELECT * FROM
+-- (deleted C_Queue_Workpackage rows)" had one more source column than target columns and
+-- aborted every run with: "INSERT has more expressions than target columns".
+-- Result: async workpackage data was never archived and the C_Queue_* tables grew unbounded.
+-- Mirrors the type/nullability of C_Queue_Workpackage.LockedAt (timestamptz, nullable).
+
+ALTER TABLE IF EXISTS dlm.C_Queue_Workpackage_Archived
+    ADD COLUMN IF NOT EXISTS lockedat timestamptz;


### PR DESCRIPTION
Port of https://github.com/metasfresh/metasfresh/pull/24886 (merged to new_dawn_uat) to deep_tundra_release so the fix reaches the deep-tundra deployment.

Migration 5810130 adds the missing `lockedat` column to `dlm.C_Queue_Workpackage_Archived`. Without it, `dlm.archive_c_queue_data` fails every run with 'INSERT has more expressions than target columns' and async workpackage data is never archived.

Cherry-pick of 84b14f0a50d. Same fix, idempotent (ADD COLUMN IF NOT EXISTS). Validated green on new_dawn_uat (db-apply-migrations + full suite).