### PR TITLE
HU Label Config: stamp picking consignee on close-LU so SSCC label matches (#30763)

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import de.metas.ad_reference.ADRefList;
 import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.BPartnerLocationId;
 import de.metas.common.util.Check;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.dao.ValueRestriction;
@@ -82,6 +83,7 @@ import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -751,7 +753,13 @@ public class PickingJobService implements PickingSlotListener
 					.ifPresent(pickingSlotId -> pickingSlotService.addToPickingSlotQueue(pickingSlotId, closedHUIdsCollector.getAllTopLevelHUIds()));
 
 			final ImmutableSet<HuId> closedLUIds = closedHUIdsCollector.getLUIds();
-			huService.printLULabels(closedHUIdsCollector.getLUIds());
+
+			// me03 #30763: persist the picking consignee (BPartner + delivery location) on the just-closed LUs when
+			// they carry no partner, so the per-BPartner M_HU_Label_Config matches and the SSCC label auto-prints.
+			// Must run BEFORE printLULabels so the label lookup (keyed on the LU's own bpartner) selects the config.
+			stampConsigneeOnClosedLUs(pickingJob, closedLUIds);
+
+			huService.printLULabels(closedLUIds);
 
 			if (isShipClosedHUs)
 			{
@@ -768,6 +776,51 @@ public class PickingJobService implements PickingSlotListener
 		}
 
 		return pickingJobChanged;
+	}
+
+	/**
+	 * me03 #30763 — persists the picking consignee on each just-closed LU that carries no BPartner yet, so the
+	 * per-BPartner {@code M_HU_Label_Config} matches and the SSCC label auto-prints (both at close and on later re-print).
+	 * <p>
+	 * The consignee is resolved <b>per LU</b> from the pre-close picking job: header-level pick targets
+	 * (SALES_ORDER / DELIVERY_LOCATION aggregation) carry the job's delivery location; line-level pick targets
+	 * (PRODUCT aggregation) carry their own line's delivery location. A job may span multiple consignees, so this
+	 * never applies a blanket customer id. Only LUs actually closed by this operation (in {@code closedLUIds}) are stamped.
+	 */
+	private void stampConsigneeOnClosedLUs(
+			@NonNull final PickingJob pickingJob,
+			@NonNull final ImmutableSet<HuId> closedLUIds)
+	{
+		if (closedLUIds.isEmpty())
+		{
+			return;
+		}
+
+		final Map<HuId, BPartnerLocationId> luId2consignee = new HashMap<>();
+
+		// header-level pick target (SALES_ORDER / DELIVERY_LOCATION aggregation) -> job delivery location
+		final BPartnerLocationId headerConsignee = pickingJob.getDeliveryBPLocationId();
+		if (headerConsignee != null)
+		{
+			pickingJob.getLuPickingTarget(null)
+					.filter(LUPickingTarget::isExistingLU)
+					.ifPresent(target -> luId2consignee.put(target.getLuIdNotNull(), headerConsignee));
+		}
+
+		// line-level pick targets (PRODUCT aggregation) -> each line's own delivery location
+		pickingJob.streamLines().forEach(line ->
+				pickingJob.getLuPickingTarget(line.getId())
+						.filter(LUPickingTarget::isExistingLU)
+						.ifPresent(target -> luId2consignee.put(target.getLuIdNotNull(), line.getDeliveryBPLocationId())));
+
+		for (final HuId closedLUId : closedLUIds)
+		{
+			final BPartnerLocationId consignee = luId2consignee.get(closedLUId);
+			if (consignee != null)
+			{
+				huService.setBPartnerAndLocationIfNotSet(closedLUId, consignee);
+			}
+		}
 	}
 
 	@NonNull

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickingJobHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickingJobHUService.java
@@ -2,6 +2,7 @@ package de.metas.handlingunits.picking.job.service.external.hu;
 
 import com.google.common.collect.ImmutableSet;
 import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.BPartnerLocationId;
 import de.metas.handlingunits.HUContextHolder;
 import de.metas.handlingunits.HUPIItemProduct;
 import de.metas.handlingunits.HUPIItemProductId;
@@ -206,6 +207,29 @@ public class PickingJobHUService
 	public I_M_HU getById(@NonNull final HuId huId) {return handlingUnitsBL.getById(huId);}
 
 	public List<I_M_HU> getByIds(@NonNull final Collection<HuId> huIds) {return handlingUnitsBL.getByIds(huIds);}
+
+	/**
+	 * Stamps the given consignee (BPartner + delivery location) onto the HU, but ONLY when the HU carries no
+	 * BPartner yet. Picking LUs materialised in the non-pack-for-shipping flow have no {@code C_BPartner_ID}, so
+	 * the per-BPartner {@code M_HU_Label_Config} never matches and the SSCC auto-print at close-LU is skipped
+	 * (me03 #30763). Persisting the consignee here lets the (unchanged) label-matching path select the correct
+	 * per-BPartner config — for the close-time auto-print and later re-print. The {@code M_HU} {@code updateChildren}
+	 * interceptor cascades the BPartner + location down to the child TUs/CUs on save.
+	 * <p>
+	 * Guarded to only-if-unset so pack-for-shipping LUs (already stamped in {@link PackToHUsProducer}) are untouched.
+	 */
+	public void setBPartnerAndLocationIfNotSet(@NonNull final HuId huId, @NonNull final BPartnerLocationId bpLocationId)
+	{
+		final I_M_HU hu = handlingUnitsBL.getById(huId);
+		if (hu.getC_BPartner_ID() > 0)
+		{
+			return;
+		}
+
+		hu.setC_BPartner_ID(bpLocationId.getBpartnerId().getRepoId());
+		hu.setC_BPartner_Location_ID(bpLocationId.getRepoId());
+		handlingUnitsBL.saveHU(hu);
+	}
 
 	public Optional<HuId> getFirstHuIdByExternalLotNo(final String externalLotNo) {return handlingUnitsBL.getFirstHuIdByExternalLotNo(externalLotNo);}
 


### PR DESCRIPTION
## What

At mobile picking **"LU fertigstellen"** (close-LU), the SSCC label was not auto-printed for consignees with a per-BPartner `M_HU_Label_Config`. Root cause: picking LUs in the non-pack-for-shipping flow are materialised **without** a `C_BPartner_ID`, so the per-BPartner label-config lookup (keyed on the LU's own bpartner) never matches → the auto-print is silently skipped.

**Verified:**
- Label-config lookup keys on the HU's own bpartner: `HULabelPrintCommand.java:110-117` → `HUToReportWrapper.java:68`; route match `HULabelConfigRoute.java:39-42`.
- Picking LU produced **without** bpartner unless pack-for-shipping: `PackToHUsProducer.java:528-534` (`setBPartnerAndLocationId` only inside `isPackForShipping()`).
- Prod diagnostics (`diag/09_intellij_checks.sql`, run by the customer team on the prod instance) confirmed the per-BPartner configs exist but never fire, and the interim catch-all `1000060` at `SeqNo=6` shadows them.

## Fix (Approach B — persist the consignee on the LU)

When a picking LU is closed and carries no partner, stamp the picking **consignee** (BPartner + delivery location) onto it, resolved **per-LU** from the picking job:
- header-level pick target (`SALES_ORDER` / `DELIVERY_LOCATION` aggregation) → the job's delivery location;
- line-level pick target (`PRODUCT` aggregation) → that line's own delivery location.

The existing `M_HU` `updateChildren` interceptor cascades the bpartner + location to the child TUs/CUs. The **label-matching path is unchanged** — it now selects the correct per-BPartner config for both the close-time auto-print and later re-print (the LU is self-describing).

**Guarded to only-if-unset** → pack-for-shipping LUs (already stamped at pack time) are untouched; no regression to other label flows (Manufacturing / Receipt / Inventory / desktop / consolidation — their matching path is not touched).

Files:
- `PickingJobHUService.setBPartnerAndLocationIfNotSet(HuId, BPartnerLocationId)` (new facade method, only-if-unset guard)
- `PickingJobService.closeLUAndTUPickingTargets` — per-LU consignee resolution + stamp, before `printLULabels`

## Scope

This PR delivers the code fix (AC1–AC4). Follow-ups (tracked on the issue): the customer-instance catch-all `M_HU_Label_Config` reprioritisation (AC5, config SQL), the cache-without-restart track (AC6), backfill of already-closed partner-less LUs (AC7), and desktop-picking parity (AC8). Automated tests (JUnit + Playwright both-shapes + Cucumber) land in a follow-up PR.

Issue: https://github.com/metasfresh/me03/issues/30763
