### PR TITLE
Sales Order Candidate to Order — keep per-line DatePromised through completion

### DIFF
--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MOrder.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MOrder.java
@@ -1075,8 +1075,8 @@ public class MOrder extends X_C_Order implements IDocument
 				}
 				// Propagate the header DatePromised to the line only on a UI action (a user editing the header
 				// expects all lines to follow) or when the line has no own date yet. A line that already carries
-				// its own DatePromised - e.g. a per-line delivery date set programmatically by OLCandOrderFactory,
-				// or a cloned line - keeps it, so the header value cannot clobber an intentional per-line date.
+				// its own DatePromised - e.g. a per-line delivery date set programmatically, or a cloned line -
+				// keeps it, so the header value cannot clobber an intentional per-line date.
 				if (is_ValueChanged(MOrder.COLUMNNAME_DatePromised)
 						&& (InterfaceWrapperHelper.isUIAction(this) || line.getDatePromised() == null))
 				{

--- a/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MOrder.java
+++ b/backend/de.metas.business/src/main/java-legacy/org/compiere/model/MOrder.java
@@ -1073,7 +1073,12 @@ public class MOrder extends X_C_Order implements IDocument
 				{
 					line.setDateOrdered(getDateOrdered());
 				}
-				if (is_ValueChanged(MOrder.COLUMNNAME_DatePromised))
+				// Propagate the header DatePromised to the line only on a UI action (a user editing the header
+				// expects all lines to follow) or when the line has no own date yet. A line that already carries
+				// its own DatePromised - e.g. a per-line delivery date set programmatically by OLCandOrderFactory,
+				// or a cloned line - keeps it, so the header value cannot clobber an intentional per-line date.
+				if (is_ValueChanged(MOrder.COLUMNNAME_DatePromised)
+						&& (InterfaceWrapperHelper.isUIAction(this) || line.getDatePromised() == null))
 				{
 					line.setDatePromised(getDatePromised());
 				}

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
@@ -178,8 +178,8 @@ class OLCandOrderFactory
 	private final Collection<I_C_Order_Line_Alloc> allocations = new HashSet<>();
 	private I_C_OrderLine currentOrderLine = null;
 	private final Map<Integer, I_C_OrderLine> orderLines = new LinkedHashMap<>();
-	// Applied AFTER MOrder.afterSave (the header->lines broadcast) so each line's own DatePromised survives.
-	private final Map<OrderLineId, Timestamp> orderLineId2DatePromised = new LinkedHashMap<>();
+	// The earliest of the per-line DatePromised values; the header C_Order.DatePromised is set to it in completeOrDelete().
+	private Timestamp earliestLineDatePromised = null;
 	private final List<OLCand> candidates = new ArrayList<>();
 	private final ListMultimap<String, OrderLineId> groupsToOrderLines = ArrayListMultimap.create();
 	private final Map<OrderLineId, OrderLineGroup> primaryOrderLineToGroup = new HashMap<>();
@@ -245,12 +245,10 @@ class OLCandOrderFactory
 
 		// task 06269 (see KurzBeschreibung)
 		// note that C_Order.DatePromised is propagated to C_OrderLine.DatePromised in MOrder.afterSave() and MOrderLine.setOrder().
-		// We seed the header with the first candidate's DatePromised here only so the order can be saved (lines need the FK).
-		// the final header DatePromised is set to the earliest of the group's lines in completeOrDelete(),
-		// and each line keeps its own olcand DatePromised. The header DatePromised is deliberately set-and-saved one last
-		// time (to the earliest) BEFORE the per-line dates are written, so the MOrder.afterSave() header->lines broadcast
-		// fires once on a value the lines don't yet override, and never again afterwards (DatePromised stays unchanged
-		// through processEx) -> per-line dates survive.
+		// We seed the header with the first candidate's DatePromised here so the order can be saved (lines need the FK).
+		// Each line then gets its own olcand DatePromised at creation (see addOLCand0), and the header is set to the
+		// earliest of those line dates in completeOrDelete() via applyEarliestHeaderDatePromised(). The MOrder.afterSave()
+		// header->line broadcast does not overwrite the per-line dates (guarded by isUIAction || lineDateNotSet there).
 		order.setDatePromised(TimeUtil.asTimestamp(candidateOfGroup.getDatePromised()));
 
 		// if the olc has no value set, we are not falling back here!
@@ -370,7 +368,7 @@ class OLCandOrderFactory
 		}
 		else
 		{
-			applyPerLineDatePromised(order);
+			applyEarliestHeaderDatePromised(order);
 
 			try
 			{
@@ -410,51 +408,28 @@ class OLCandOrderFactory
 	}
 
 	/**
-	 * Makes each {@link I_C_OrderLine} keep the {@code DatePromised} of the source candidate that created
-	 * it, and sets the header {@code C_Order.DatePromised} to the earliest of the lines' dates.
+	 * Sets the header {@code C_Order.DatePromised} to the earliest of the lines' own delivery dates.
 	 * <p>
-	 * Sequencing is critical because {@code MOrder.afterSave()} broadcasts a changed header {@code DatePromised} to ALL
-	 * order lines. We therefore:
-	 * <ol>
-	 *     <li>set the header to the earliest line date and save it ONCE (the broadcast then overwrites the lines with that
-	 *     earliest value - harmless, the per-line values are written next),</li>
-	 *     <li>write each line's own {@code DatePromised} and save the line LAST.</li>
-	 * </ol>
-	 * After this, the header {@code DatePromised} stays unchanged through completion ({@code processEx}), so the broadcast
-	 * never fires again and the per-line dates survive.
+	 * Each line already carries its own {@code DatePromised} from creation (see {@link #addOLCand0(OLCand)}). The
+	 * {@code MOrder.afterSave()} header-&gt;line broadcast does NOT overwrite those per-line dates: the lines are non-null
+	 * and this is not a UI action, so the {@code isUIAction || lineDateNotSet} guard in {@code MOrder.afterSave()} skips
+	 * them. So the header can be set to the earliest date without clobbering the per-line dates - and no stale header
+	 * value is ever stamped onto a line (which previously left a stale cached line instance for a later re-save - e.g. the
+	 * material-dispo ATP reset on completion - to write back, silently reverting the per-line date).
 	 * <p>
-	 * Lines whose creating candidate had no {@code DatePromised} are left untouched (they keep the header fallback) and are
-	 * excluded from the earliest-computation.
+	 * When no line carried a {@code DatePromised}, the header keeps its fallback and nothing is changed here.
 	 */
-	private void applyPerLineDatePromised(@NonNull final I_C_Order order)
+	private void applyEarliestHeaderDatePromised(@NonNull final I_C_Order order)
 	{
-		if (orderLineId2DatePromised.isEmpty())
+		if (earliestLineDatePromised == null)
 		{
 			return;
 		}
 
-		final Timestamp earliest = orderLineId2DatePromised.values().stream()
-				.min(Comparator.naturalOrder())
-				.orElse(null);
-
-		if (earliest != null && !Objects.equals(earliest, order.getDatePromised()))
+		if (!Objects.equals(earliestLineDatePromised, order.getDatePromised()))
 		{
-			// changing-and-saving the header broadcasts `earliest` to all lines via MOrder.afterSave() - that's fine,
-			// the per-line dates are (re)written right below.
-			order.setDatePromised(earliest);
-			save(order);
-		}
-
-		// write each line's own DatePromised LAST, so it is not clobbered by the header->lines broadcast above.
-		for (final Map.Entry<OrderLineId, Timestamp> entry : orderLineId2DatePromised.entrySet())
-		{
-			final I_C_OrderLine orderLine = orderLines.get(entry.getKey().getRepoId());
-			if (orderLine == null)
-			{
-				continue;
-			}
-			orderLine.setDatePromised(entry.getValue());
-			save(orderLine);
+			order.setDatePromised(earliestLineDatePromised);
+			orderDAO.save(order);
 		}
 	}
 
@@ -587,6 +562,22 @@ class OLCandOrderFactory
 		{
 			currentOrderLine = newOrderLine(candidate);
 			isNewOrderLine = true;
+
+			// Carry this candidate's own delivery date onto the new line from creation, so the line owns its
+			// per-line DatePromised. MOrder.afterSave()'s header->line broadcast will not overwrite it (the line
+			// is non-null and processing is not a UI action -> the guard there skips it), and it is never
+			// transiently replaced by the header's earliest value. When several candidates aggregate into one
+			// line, the line keeps the creating candidate's date. The header is set to the earliest such date in
+			// completeOrDelete() via applyEarliestHeaderDatePromised().
+			final Timestamp lineDatePromised = TimeUtil.asTimestamp(candidate.getDatePromised());
+			if (lineDatePromised != null)
+			{
+				currentOrderLine.setDatePromised(lineDatePromised);
+				if (earliestLineDatePromised == null || lineDatePromised.before(earliestLineDatePromised))
+				{
+					earliestLineDatePromised = lineDatePromised;
+				}
+			}
 		}
 		else
 		{
@@ -708,17 +699,6 @@ class OLCandOrderFactory
 
 		//
 		orderLines.put(currentOrderLine.getC_OrderLine_ID(), currentOrderLine);
-
-		// remember the per-line DatePromised, taken from the candidate that CREATED the line.
-		// When several candidates aggregate into one line, the line keeps the creating candidate's DatePromised.
-		if (isNewOrderLine)
-		{
-			final Timestamp lineDatePromised = TimeUtil.asTimestamp(candidate.getDatePromised());
-			if (lineDatePromised != null)
-			{
-				orderLineId2DatePromised.put(OrderLineId.ofRepoId(currentOrderLine.getC_OrderLine_ID()), lineDatePromised);
-			}
-		}
 
 		candidates.add(candidate);
 	}

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
@@ -410,14 +410,9 @@ class OLCandOrderFactory
 	/**
 	 * Sets the header {@code C_Order.DatePromised} to the earliest of the lines' own delivery dates.
 	 * <p>
-	 * Each line already carries its own {@code DatePromised} from creation (see {@link #addOLCand0(OLCand)}). The
-	 * {@code MOrder.afterSave()} header-&gt;line broadcast does NOT overwrite those per-line dates: the lines are non-null
-	 * and this is not a UI action, so the {@code isUIAction || lineDateNotSet} guard in {@code MOrder.afterSave()} skips
-	 * them. So the header can be set to the earliest date without clobbering the per-line dates - and no stale header
-	 * value is ever stamped onto a line (which previously left a stale cached line instance for a later re-save - e.g. the
-	 * material-dispo ATP reset on completion - to write back, silently reverting the per-line date).
-	 * <p>
-	 * When no line carried a {@code DatePromised}, the header keeps its fallback and nothing is changed here.
+	 * Each line already carries its own {@code DatePromised} from creation (see {@link #addOLCand0(OLCand)}); this method
+	 * only sets the header, leaving the per-line dates intact. When no line carried a {@code DatePromised}, the header
+	 * keeps its fallback and nothing is changed here.
 	 */
 	private void applyEarliestHeaderDatePromised(@NonNull final I_C_Order order)
 	{
@@ -564,11 +559,9 @@ class OLCandOrderFactory
 			isNewOrderLine = true;
 
 			// Carry this candidate's own delivery date onto the new line from creation, so the line owns its
-			// per-line DatePromised. MOrder.afterSave()'s header->line broadcast will not overwrite it (the line
-			// is non-null and processing is not a UI action -> the guard there skips it), and it is never
-			// transiently replaced by the header's earliest value. When several candidates aggregate into one
-			// line, the line keeps the creating candidate's date. The header is set to the earliest such date in
-			// completeOrDelete() via applyEarliestHeaderDatePromised().
+			// per-line DatePromised. When several candidates aggregate into one line, the line keeps the creating
+			// candidate's date. The header is set to the earliest such date in completeOrDelete() via
+			// applyEarliestHeaderDatePromised().
 			final Timestamp lineDatePromised = TimeUtil.asTimestamp(candidate.getDatePromised());
 			if (lineDatePromised != null)
 			{


### PR DESCRIPTION
## What

Follow-up fix to https://github.com/metasfresh/metasfresh/pull/24700 : the per-line `C_OrderLine.DatePromised` was silently reverted to the header's *earliest* value on order completion.

## Root cause

PR #24700 set the header `DatePromised` late and re-wrote each line's own date afterwards, relying on write-ordering. `MOrder.afterSave` broadcasts a changed header `DatePromised` onto every line; the completion-time material-dispo **ATP reset** (`OrderAvailableToPromiseTool.resetQtyAvailableToPromise`, `@DocValidate(AFTER_COMPLETE)`) then re-read a **stale line instance** still holding `earliest` and wrote it back, clobbering the per-line date. The wrong date propagated line → `M_ShipmentSchedule.DeliveryDate` → WebUI.

## Fix

- **`OLCandOrderFactory`**: set each line's `DatePromised` at creation (`addOLCand0`); set the header to the earliest once; remove the `orderLineId2DatePromised` map + the late per-line re-write loop.
- **`MOrder.afterSave`**: guard the header→line `DatePromised` broadcast with `InterfaceWrapperHelper.isUIAction(this) || line.getDatePromised()==null` — an intentional per-line date is never overwritten (also fixes clone losing per-line dates).

## Verification status (in progress — checkpoint)

- Compiles: `de.metas.business` + `de.metas.salescandidate.base` — BUILD SUCCESS.
- Clobber **reproduced on a running instance** via debugger (ATP reset re-saves a stale line; header goes `13-07 → 29-06`).
- **Automated cucumber reproduce is under investigation**: the existing aggregation scenario is genuinely green because its seed candidate (lowest `C_OLCand_ID`) is already the earliest, so the header→line broadcast never fires — it doesn't exercise the fragile path. Determining the faithful reproduce (seed = a non-earliest date) is open; instance re-verification pending.

Not yet declared mergeable — pushed to checkpoint state and start CI.
