### PR TITLE
HU Label Config: tests for picking-consignee stamp

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/AssertHUExpectationsCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/AssertHUExpectationsCommand.java
@@ -1,6 +1,8 @@
 package de.metas.frontend_testing.expectations;
 
 import com.google.common.collect.ImmutableList;
+import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.BPartnerLocationId;
 import de.metas.common.util.time.SystemTime;
 import de.metas.frontend_testing.expectations.request.JsonHUExpectation;
 import de.metas.frontend_testing.expectations.request.QtyAndUOMString;
@@ -90,6 +92,28 @@ class AssertHUExpectationsCommand
 				final LocatorId expectedLocatorId = context.getId(expectation.getLocator(), LocatorId.class);
 				assertThat(actualLocatorId).as("Locator").isEqualTo(expectedLocatorId);
 			}
+		}
+
+		if (expectation.getBpartner() != null)
+		{
+			final I_M_HU hu = getHUById(huId);
+			final BPartnerId expectedBPartnerId = expectation.getBpartner().isNullPlaceholder()
+					? null
+					: context.getId(expectation.getBpartner(), BPartnerId.class);
+			assertThat(BPartnerId.ofRepoIdOrNull(hu.getC_BPartner_ID()))
+					.as("C_BPartner_ID")
+					.isEqualTo(expectedBPartnerId);
+		}
+
+		if (expectation.getBpartnerLocation() != null)
+		{
+			final I_M_HU hu = getHUById(huId);
+			final BPartnerLocationId expectedBPLocationId = expectation.getBpartnerLocation().isNullPlaceholder()
+					? null
+					: context.getBPartnerLocationId(expectation.getBpartnerLocation());
+			assertThat(BPartnerLocationId.ofRepoIdOrNull(hu.getC_BPartner_ID(), hu.getC_BPartner_Location_ID()))
+					.as("C_BPartner_Location_ID")
+					.isEqualTo(expectedBPLocationId);
 		}
 
 		if (expectation.getHuStatus() != null)

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/request/JsonHUExpectation.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/request/JsonHUExpectation.java
@@ -17,6 +17,8 @@ public class JsonHUExpectation
 {
 	@Nullable Identifier warehouse;
 	@Nullable Identifier locator;
+	@Nullable Identifier bpartner;
+	@Nullable Identifier bpartnerLocation;
 	@Nullable String huStatus;
 	@Nullable Map<String, String> storages;
 	@Nullable Map<String, String> attributes;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import de.metas.ad_reference.ADRefList;
 import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.BPartnerLocationId;
 import de.metas.common.util.Check;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.dao.ValueRestriction;
@@ -82,6 +83,7 @@ import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -751,7 +753,13 @@ public class PickingJobService implements PickingSlotListener
 					.ifPresent(pickingSlotId -> pickingSlotService.addToPickingSlotQueue(pickingSlotId, closedHUIdsCollector.getAllTopLevelHUIds()));
 
 			final ImmutableSet<HuId> closedLUIds = closedHUIdsCollector.getLUIds();
-			huService.printLULabels(closedHUIdsCollector.getLUIds());
+
+			// me03 #30763: persist the picking consignee (BPartner + delivery location) on the just-closed LUs when
+			// they carry no partner, so the per-BPartner M_HU_Label_Config matches and the SSCC label auto-prints.
+			// Must run BEFORE printLULabels so the label lookup (keyed on the LU's own bpartner) selects the config.
+			stampConsigneeOnClosedLUs(pickingJob, closedLUIds);
+
+			huService.printLULabels(closedLUIds);
 
 			if (isShipClosedHUs)
 			{
@@ -768,6 +776,51 @@ public class PickingJobService implements PickingSlotListener
 		}
 
 		return pickingJobChanged;
+	}
+
+	/**
+	 * me03 #30763 — persists the picking consignee on each just-closed LU that carries no BPartner yet, so the
+	 * per-BPartner {@code M_HU_Label_Config} matches and the SSCC label auto-prints (both at close and on later re-print).
+	 * <p>
+	 * The consignee is resolved <b>per LU</b> from the pre-close picking job: header-level pick targets
+	 * (SALES_ORDER / DELIVERY_LOCATION aggregation) carry the job's delivery location; line-level pick targets
+	 * (PRODUCT aggregation) carry their own line's delivery location. A job may span multiple consignees, so this
+	 * never applies a blanket customer id. Only LUs actually closed by this operation (in {@code closedLUIds}) are stamped.
+	 */
+	private void stampConsigneeOnClosedLUs(
+			@NonNull final PickingJob pickingJob,
+			@NonNull final ImmutableSet<HuId> closedLUIds)
+	{
+		if (closedLUIds.isEmpty())
+		{
+			return;
+		}
+
+		final Map<HuId, BPartnerLocationId> luId2consignee = new HashMap<>();
+
+		// header-level pick target (SALES_ORDER / DELIVERY_LOCATION aggregation) -> job delivery location
+		final BPartnerLocationId headerConsignee = pickingJob.getDeliveryBPLocationId();
+		if (headerConsignee != null)
+		{
+			pickingJob.getLuPickingTarget(null)
+					.filter(LUPickingTarget::isExistingLU)
+					.ifPresent(target -> luId2consignee.put(target.getLuIdNotNull(), headerConsignee));
+		}
+
+		// line-level pick targets (PRODUCT aggregation) -> each line's own delivery location
+		pickingJob.streamLines().forEach(line ->
+				pickingJob.getLuPickingTarget(line.getId())
+						.filter(LUPickingTarget::isExistingLU)
+						.ifPresent(target -> luId2consignee.put(target.getLuIdNotNull(), line.getDeliveryBPLocationId())));
+
+		for (final HuId closedLUId : closedLUIds)
+		{
+			final BPartnerLocationId consignee = luId2consignee.get(closedLUId);
+			if (consignee != null)
+			{
+				huService.setBPartnerAndLocationIfNotSet(closedLUId, consignee);
+			}
+		}
 	}
 
 	@NonNull

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickingJobHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickingJobHUService.java
@@ -2,6 +2,7 @@ package de.metas.handlingunits.picking.job.service.external.hu;
 
 import com.google.common.collect.ImmutableSet;
 import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.BPartnerLocationId;
 import de.metas.handlingunits.HUContextHolder;
 import de.metas.handlingunits.HUPIItemProduct;
 import de.metas.handlingunits.HUPIItemProductId;
@@ -206,6 +207,29 @@ public class PickingJobHUService
 	public I_M_HU getById(@NonNull final HuId huId) {return handlingUnitsBL.getById(huId);}
 
 	public List<I_M_HU> getByIds(@NonNull final Collection<HuId> huIds) {return handlingUnitsBL.getByIds(huIds);}
+
+	/**
+	 * Stamps the given consignee (BPartner + delivery location) onto the HU, but ONLY when the HU carries no
+	 * BPartner yet. Picking LUs materialised in the non-pack-for-shipping flow have no {@code C_BPartner_ID}, so
+	 * the per-BPartner {@code M_HU_Label_Config} never matches and the SSCC auto-print at close-LU is skipped
+	 * (me03 #30763). Persisting the consignee here lets the (unchanged) label-matching path select the correct
+	 * per-BPartner config — for the close-time auto-print and later re-print. The {@code M_HU} {@code updateChildren}
+	 * interceptor cascades the BPartner + location down to the child TUs/CUs on save.
+	 * <p>
+	 * Guarded to only-if-unset so pack-for-shipping LUs (already stamped in {@link PackToHUsProducer}) are untouched.
+	 */
+	public void setBPartnerAndLocationIfNotSet(@NonNull final HuId huId, @NonNull final BPartnerLocationId bpLocationId)
+	{
+		final I_M_HU hu = handlingUnitsBL.getById(huId);
+		if (hu.getC_BPartner_ID() > 0)
+		{
+			return;
+		}
+
+		hu.setC_BPartner_ID(bpLocationId.getBpartnerId().getRepoId());
+		hu.setC_BPartner_Location_ID(bpLocationId.getRepoId());
+		handlingUnitsBL.saveHU(hu);
+	}
 
 	public Optional<HuId> getFirstHuIdByExternalLotNo(final String externalLotNo) {return handlingUnitsBL.getFirstHuIdByExternalLotNo(externalLotNo);}
 

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/PickingJobLabelConsigneeTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/PickingJobLabelConsigneeTest.java
@@ -19,16 +19,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * RED tests for me03 #30763 — persisting the picking consignee on the close-LU so the per-BPartner
+ * Tests persisting the picking consignee on the close-LU so the per-BPartner
  * {@code M_HU_Label_Config} matches and the SSCC label auto-prints.
  *
- * <p>Exercises the (not-yet-existing) facade method
+ * <p>Exercises the facade method
  * {@link PickingJobHUService#setBPartnerAndLocationIfNotSet(HuId, BPartnerLocationId)}:
  * <ul>
  *   <li>(a) a partner-less LU closed for a consignee gets that consignee's BPartner + delivery location stamped;</li>
  *   <li>(b) an LU that already carries a bpartner is left UNCHANGED (stamp-only-if-unset guard).</li>
  * </ul>
- * These FAIL to compile until Task 2 adds the facade method — that is the intended RED.
  */
 @ExtendWith(AdempiereTestWatcher.class)
 class PickingJobLabelConsigneeTest

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/PickingJobLabelConsigneeTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/PickingJobLabelConsigneeTest.java
@@ -1,0 +1,103 @@
+package de.metas.handlingunits.picking.job.service;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.BPartnerLocationId;
+import de.metas.handlingunits.HUTestHelper;
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.IHandlingUnitsDAO;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.I_M_HU_PI;
+import de.metas.handlingunits.model.X_M_HU_PI_Version;
+import de.metas.handlingunits.picking.job.service.external.hu.PickingJobHUService;
+import de.metas.util.Services;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * RED tests for me03 #30763 — persisting the picking consignee on the close-LU so the per-BPartner
+ * {@code M_HU_Label_Config} matches and the SSCC label auto-prints.
+ *
+ * <p>Exercises the (not-yet-existing) facade method
+ * {@link PickingJobHUService#setBPartnerAndLocationIfNotSet(HuId, BPartnerLocationId)}:
+ * <ul>
+ *   <li>(a) a partner-less LU closed for a consignee gets that consignee's BPartner + delivery location stamped;</li>
+ *   <li>(b) an LU that already carries a bpartner is left UNCHANGED (stamp-only-if-unset guard).</li>
+ * </ul>
+ * These FAIL to compile until Task 2 adds the facade method — that is the intended RED.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+class PickingJobLabelConsigneeTest
+{
+	private static final BPartnerId CONSIGNEE = BPartnerId.ofRepoId(2810);
+	private static final BPartnerLocationId CONSIGNEE_LOCATION = BPartnerLocationId.ofRepoId(CONSIGNEE, 3810);
+
+	private static final BPartnerId OTHER_PARTNER = BPartnerId.ofRepoId(2402);
+	private static final BPartnerLocationId OTHER_LOCATION = BPartnerLocationId.ofRepoId(OTHER_PARTNER, 3402);
+
+	private HUTestHelper huTestHelper;
+	private PickingJobHUService huService;
+
+	@BeforeEach
+	void setUp()
+	{
+		huTestHelper = HUTestHelper.newInstanceOutOfTrx();
+		huService = PickingJobHUService.newInstanceForUnitTesting();
+	}
+
+	/** Creates a minimal saved LU; optionally pre-stamped with a bpartner + location. */
+	private HuId createLU(final BPartnerLocationId preStampedLocation)
+	{
+		final I_M_HU_PI luPI = huTestHelper.createHUDefinition("LU-PI", X_M_HU_PI_Version.HU_UNITTYPE_LoadLogistiqueUnit);
+		final I_M_HU lu = InterfaceWrapperHelper.newInstance(I_M_HU.class);
+		lu.setM_HU_PI_Version_ID(Services.get(IHandlingUnitsDAO.class).retrievePICurrentVersion(luPI).getM_HU_PI_Version_ID());
+		if (preStampedLocation != null)
+		{
+			lu.setC_BPartner_ID(preStampedLocation.getBpartnerId().getRepoId());
+			lu.setC_BPartner_Location_ID(preStampedLocation.getRepoId());
+		}
+		InterfaceWrapperHelper.save(lu);
+		return HuId.ofRepoId(lu.getM_HU_ID());
+	}
+
+	private I_M_HU reload(final HuId huId)
+	{
+		return InterfaceWrapperHelper.load(huId.getRepoId(), I_M_HU.class);
+	}
+
+	@Test
+	void partnerlessLU_getsConsigneeStamped()
+	{
+		final HuId luId = createLU(null);
+
+		huService.setBPartnerAndLocationIfNotSet(luId, CONSIGNEE_LOCATION);
+
+		final I_M_HU lu = reload(luId);
+		assertThat(lu.getC_BPartner_ID())
+				.as("partner-less LU must get the consignee's bpartner stamped")
+				.isEqualTo(CONSIGNEE.getRepoId());
+		assertThat(lu.getC_BPartner_Location_ID())
+				.as("partner-less LU must get the consignee's delivery location stamped")
+				.isEqualTo(CONSIGNEE_LOCATION.getRepoId());
+	}
+
+	@Test
+	void luWithExistingBPartner_isLeftUnchanged()
+	{
+		final HuId luId = createLU(OTHER_LOCATION);
+
+		huService.setBPartnerAndLocationIfNotSet(luId, CONSIGNEE_LOCATION);
+
+		final I_M_HU lu = reload(luId);
+		assertThat(lu.getC_BPartner_ID())
+				.as("an LU that already carries a bpartner must be left unchanged (stamp-only-if-unset)")
+				.isEqualTo(OTHER_PARTNER.getRepoId());
+		assertThat(lu.getC_BPartner_Location_ID())
+				.as("an LU that already carries a location must be left unchanged")
+				.isEqualTo(OTHER_LOCATION.getRepoId());
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/report/labels/HULabelConfigRepositoryTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/report/labels/HULabelConfigRepositoryTest.java
@@ -8,6 +8,7 @@ import de.metas.process.AdProcessId;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,36 +72,40 @@ class HULabelConfigRepositoryTest
 				.build();
 	}
 
-	@Test
-	void getFirstMatching_selectsPerBPartnerConfig_whenQueryBPartnerIsConsignee()
+	@Nested
+	class GetFirstMatching
 	{
-		// AC5 config ordering: per-BPartner config at a LOWER SeqNo, catch-all as a high-SeqNo true fallback.
-		createConfig(100, CONSIGNEE, CONSIGNEE_PROCESS, true, 2);
-		createConfig(9999, null, CATCHALL_PROCESS, true, 1);
+		@Test
+		void selectsPerBPartnerConfig_whenQueryBPartnerIsConsignee()
+		{
+			// AC5 config ordering: per-BPartner config at a LOWER SeqNo, catch-all as a high-SeqNo true fallback.
+			createConfig(100, CONSIGNEE, CONSIGNEE_PROCESS, true, 2);
+			createConfig(9999, null, CATCHALL_PROCESS, true, 1);
 
-		final ExplainedOptional<HULabelConfig> result = repository.getFirstMatching(pickingLuQueryFor(CONSIGNEE));
+			final ExplainedOptional<HULabelConfig> result = repository.getFirstMatching(pickingLuQueryFor(CONSIGNEE));
 
-		assertThat(result.isPresent()).as("a matching config must be found for the consignee").isTrue();
-		assertThat(result.get().getPrintFormatProcessId())
-				.as("the consignee's per-BPartner config must be selected, not the catch-all")
-				.isEqualTo(CONSIGNEE_PROCESS);
-		assertThat(result.get().getAutoPrintCopies().toInt())
-				.as("the consignee config's copy count must be used")
-				.isEqualTo(2);
-	}
+			assertThat(result.isPresent()).as("a matching config must be found for the consignee").isTrue();
+			assertThat(result.get().getPrintFormatProcessId())
+					.as("the consignee's per-BPartner config must be selected, not the catch-all")
+					.isEqualTo(CONSIGNEE_PROCESS);
+			assertThat(result.get().getAutoPrintCopies().toInt())
+					.as("the consignee config's copy count must be used")
+					.isEqualTo(2);
+		}
 
-	@Test
-	void getFirstMatching_fallsThroughToCatchAll_whenNoPerBPartnerConfig()
-	{
-		// A consignee (OTHER_CONSIGNEE) with NO specific config must fall through to the catch-all fallback.
-		createConfig(100, CONSIGNEE, CONSIGNEE_PROCESS, true, 2);
-		createConfig(9999, null, CATCHALL_PROCESS, true, 1);
+		@Test
+		void fallsThroughToCatchAll_whenNoPerBPartnerConfig()
+		{
+			// A consignee (OTHER_CONSIGNEE) with NO specific config must fall through to the catch-all fallback.
+			createConfig(100, CONSIGNEE, CONSIGNEE_PROCESS, true, 2);
+			createConfig(9999, null, CATCHALL_PROCESS, true, 1);
 
-		final ExplainedOptional<HULabelConfig> result = repository.getFirstMatching(pickingLuQueryFor(OTHER_CONSIGNEE));
+			final ExplainedOptional<HULabelConfig> result = repository.getFirstMatching(pickingLuQueryFor(OTHER_CONSIGNEE));
 
-		assertThat(result.isPresent()).as("the catch-all must match a consignee without a specific config").isTrue();
-		assertThat(result.get().getPrintFormatProcessId())
-				.as("a consignee without a per-BPartner config falls through to the catch-all fallback")
-				.isEqualTo(CATCHALL_PROCESS);
+			assertThat(result.isPresent()).as("the catch-all must match a consignee without a specific config").isTrue();
+			assertThat(result.get().getPrintFormatProcessId())
+					.as("a consignee without a per-BPartner config falls through to the catch-all fallback")
+					.isEqualTo(CATCHALL_PROCESS);
+		}
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/report/labels/HULabelConfigRepositoryTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/report/labels/HULabelConfigRepositoryTest.java
@@ -1,0 +1,106 @@
+package de.metas.handlingunits.report.labels;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.handlingunits.HuUnitType;
+import de.metas.handlingunits.model.I_M_HU_Label_Config;
+import de.metas.i18n.ExplainedOptional;
+import de.metas.process.AdProcessId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the label-config selection invariant that the me03 #30763 fix relies on:
+ * given a query whose bpartner is the consignee, {@link HULabelConfigRepository#getFirstMatching}
+ * must select that consignee's per-BPartner config.
+ *
+ * <p>The matching path is <b>strictly {@code SeqNo}-ascending, first-match-wins</b>
+ * ({@code HULabelConfigMap} sorts by {@code SeqNo}; {@code HULabelConfigRoute.isMatching} treats a
+ * {@code null}-bpartner route as a catch-all that matches <i>any</i> query bpartner). So a
+ * per-BPartner config wins over the null-bpartner catch-all only when it has the <b>lower SeqNo</b> —
+ * which is exactly the config ordering the fix relies on (AC5: the catch-all must sit at a high SeqNo
+ * as a true fallback, per-BPartner configs at lower SeqNos). The matching path itself is NOT touched
+ * by the fix; the fix persists the consignee on the picking LU at close so this selection fires at
+ * pick time. This test locks that unchanged matching behaviour.
+ */
+class HULabelConfigRepositoryTest
+{
+	private static final BPartnerId CONSIGNEE = BPartnerId.ofRepoId(2810);
+	private static final BPartnerId OTHER_CONSIGNEE = BPartnerId.ofRepoId(2402);
+	private static final AdProcessId CONSIGNEE_PROCESS = AdProcessId.ofRepoId(585458);
+	private static final AdProcessId CATCHALL_PROCESS = AdProcessId.ofRepoId(540000);
+
+	private HULabelConfigRepository repository;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		repository = new HULabelConfigRepository();
+	}
+
+	private void createConfig(
+			final int seqNo,
+			final BPartnerId bpartnerId,
+			final AdProcessId processId,
+			final boolean autoPrint,
+			final int autoPrintCopies)
+	{
+		final I_M_HU_Label_Config record = InterfaceWrapperHelper.newInstance(I_M_HU_Label_Config.class);
+		record.setSeqNo(seqNo);
+		record.setHU_SourceDocType(HULabelSourceDocType.Picking.getCode());
+		record.setC_BPartner_ID(bpartnerId != null ? bpartnerId.getRepoId() : 0);
+		record.setIsApplyToLUs(true);
+		record.setIsApplyToTUs(true);
+		record.setIsApplyToCUs(true);
+		record.setLabelReport_Process_ID(processId.getRepoId());
+		record.setIsAutoPrint(autoPrint);
+		record.setAutoPrintCopies(autoPrintCopies);
+		InterfaceWrapperHelper.save(record);
+	}
+
+	private HULabelConfigQuery pickingLuQueryFor(final BPartnerId bpartnerId)
+	{
+		return HULabelConfigQuery.builder()
+				.sourceDocType(HULabelSourceDocType.Picking)
+				.huUnitType(HuUnitType.LU)
+				.bpartnerId(bpartnerId)
+				.build();
+	}
+
+	@Test
+	void getFirstMatching_selectsPerBPartnerConfig_whenQueryBPartnerIsConsignee()
+	{
+		// AC5 config ordering: per-BPartner config at a LOWER SeqNo, catch-all as a high-SeqNo true fallback.
+		createConfig(100, CONSIGNEE, CONSIGNEE_PROCESS, true, 2);
+		createConfig(9999, null, CATCHALL_PROCESS, true, 1);
+
+		final ExplainedOptional<HULabelConfig> result = repository.getFirstMatching(pickingLuQueryFor(CONSIGNEE));
+
+		assertThat(result.isPresent()).as("a matching config must be found for the consignee").isTrue();
+		assertThat(result.get().getPrintFormatProcessId())
+				.as("the consignee's per-BPartner config must be selected, not the catch-all")
+				.isEqualTo(CONSIGNEE_PROCESS);
+		assertThat(result.get().getAutoPrintCopies().toInt())
+				.as("the consignee config's copy count must be used")
+				.isEqualTo(2);
+	}
+
+	@Test
+	void getFirstMatching_fallsThroughToCatchAll_whenNoPerBPartnerConfig()
+	{
+		// A consignee (OTHER_CONSIGNEE) with NO specific config must fall through to the catch-all fallback.
+		createConfig(100, CONSIGNEE, CONSIGNEE_PROCESS, true, 2);
+		createConfig(9999, null, CATCHALL_PROCESS, true, 1);
+
+		final ExplainedOptional<HULabelConfig> result = repository.getFirstMatching(pickingLuQueryFor(OTHER_CONSIGNEE));
+
+		assertThat(result.isPresent()).as("the catch-all must match a consignee without a specific config").isTrue();
+		assertThat(result.get().getPrintFormatProcessId())
+				.as("a consignee without a per-BPartner config falls through to the catch-all fallback")
+				.isEqualTo(CATCHALL_PROCESS);
+	}
+}

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 7 | 12 | 58% |
-| Picking | 62 | 65 | 95% |
+| Picking | 64 | 67 | 96% |
 | Distribution | 34 | 37 | 92% |
 | Manufacturing | 25 | 31 | 81% |
 | HU Manager | 14 | 16 | 88% |
@@ -90,12 +90,14 @@
 | Partial pick, allowCompletingPartialPickingJob = Y → complete succeeds | `picking/picking.spec.js` |
 | Close LU during picking → shipment created automatically | `picking/picking.spec.js` |
 | Close LU then reopen → state transitions verified | `picking/picking.spec.js` |
+| Close LU (header-level, DELIVERY_LOCATION aggregation) → closed LU and its cascaded TU/CU carry the picking consignee (BPartner + location) | `picking/closeLU_stampsConsignee.spec.js` |
+| Close LU (line-level, PRODUCT aggregation) → closed LU and its cascaded TU/CU carry the picking consignee (BPartner + location) | `picking/closeLU_stampsConsignee.spec.js` |
 | Job already started → "already started" indicator shown in jobs list | `picking/picking.spec.js` |
 | completeJobAutomatically=true, scan drop-to locator after pick → job auto-completed, removed from list | `picking/completeJobAutomatically.spec.js` |
 | Profile configured with HandoverLocation + DateReady summary fields (Customer kept out of summary) → job-list caption shows exactly 3 fields: document number, delivery location and delivery date | `picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js` |
 | ❌ Scan HU from wrong warehouse/locator → error shown | — |
 
-**11/12 — 92%**
+**13/14 — 93%**
 
 ### Order-based picking — filtering and facets
 

--- a/e2e/mobile-webui/tests/spec/picking/closeLU_stampsConsignee.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/closeLU_stampsConsignee.spec.js
@@ -5,6 +5,7 @@ import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsLi
 import { Backend } from "../../utils/screens/Backend";
 import { LoginScreen } from "../../utils/screens/LoginScreen";
 import { PickingJobScreen } from '../../utils/screens/picking/PickingJobScreen';
+import { GetQuantityDialog } from '../../utils/screens/picking/GetQuantityDialog';
 
 /**
  * me03 #30763 — at mobile picking "close LU" the just-closed LU must carry the consignee's
@@ -160,7 +161,12 @@ test('Close-LU stamps consignee — line-level (PRODUCT aggregation)', async ({ 
     await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.P1_20x4.luName });
 
     await test.step('Pick the line entirely', async () => {
-        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.P1_HU.qrCode, expectQtyEntered: 5 /*TU*/ });
+        // PRODUCT (line-level) has no header "Scan HU" button — the pick-from HU was scanned above,
+        // and the qty is entered per-line via the line button (see productBasedPicking/standard.spec.js).
+        await PickingJobScreen.clickLineButton({ index: 1 });
+        await GetQuantityDialog.waitForDialog();
+        await GetQuantityDialog.fillAndPressDone({ expectQtyEntered: 5 /*TU*/ });
+        await PickingJobScreen.waitForScreen();
         await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '5 TU', qtyPicked: '5 TU' });
     });
 

--- a/e2e/mobile-webui/tests/spec/picking/closeLU_stampsConsignee.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/closeLU_stampsConsignee.spec.js
@@ -1,0 +1,200 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { PickingJobScreen } from '../../utils/screens/picking/PickingJobScreen';
+
+/**
+ * me03 #30763 — at mobile picking "close LU" the just-closed LU must carry the consignee's
+ * C_BPartner_ID + C_BPartner_Location_ID, so the per-BPartner M_HU_Label_Config matches and the
+ * SSCC label auto-prints. The LU is materialised WITHOUT a partner during picking; the fix stamps
+ * the consignee (per-LU, resolved from the picking job) at close-LU time.
+ *
+ * The pick-target scope depends on the picking-profile aggregation type (module rule
+ * de.metas.handlingunits.base/.../job/service/CLAUDE.md): PRODUCT is line-level, SALES_ORDER /
+ * DELIVERY_LOCATION are header-level. Each HU-shape branch needs its own E2E coverage, so both
+ * shapes are exercised below against the running stack (in-memory JUnit does not prove HU flush).
+ */
+
+const createMasterdata = async ({ aggregationType }) => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: {
+                user: { language: "en_US" },
+            },
+            mobileConfig: {
+                picking: {
+                    aggregationType,
+                    allowPickingAnyCustomer: false,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                    filterByQRCode: false,
+                    anonymousPickHUsOnTheFly: false,
+                    customers: [
+                        { customer: "customer1" },
+                    ],
+                }
+            },
+            bpartners: {
+                "customer1": {
+                    locations: {
+                        customer1_location1: {},
+                    }
+                },
+            },
+            warehouses: {
+                "wh": {},
+            },
+            pickingSlots: {
+                slot1: {},
+            },
+            products: {
+                "P1": { price: 1 },
+            },
+            packingInstructions: {
+                "P1_20x4": { lu: "LU", qtyTUsPerLU: 20, tu: "P1_4CU", product: "P1", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "P1_HU": { product: 'P1', warehouse: 'wh', packingInstructions: 'P1_20x4' },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'customer1',
+                    location: 'customer1_location1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [
+                        { product: 'P1', qty: 20, piItemProduct: 'P1_4CU' },
+                    ]
+                },
+            },
+        }
+    });
+}
+
+// noinspection JSUnusedLocalSymbols
+test('Close-LU stamps consignee — header-level (DELIVERY_LOCATION aggregation)', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Close-LU stamps picking consignee on the LU');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata({ aggregationType: 'delivery_location' });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ index: 1, customerLocationId: masterdata.bpartners.customer1.locations.customer1_location1.id });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    // header-level: the pick target LU lives on the header (M_Picking_Job.M_LU_HU_ID)
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.P1_20x4.luName });
+
+    await test.step('Pick the line entirely', async () => {
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.P1_HU.qrCode, expectQtyEntered: 5 /*TU*/ });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '5 TU', qtyPicked: '5 TU' });
+    });
+
+    // the LU carries NO partner while still open (materialised without one)
+    await Backend.expect({
+        title: 'before close-LU: the LU has no bpartner yet',
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: { qtyPicked: [{ qtyPicked: "20 PCE", qtyTUs: 5, qtyLUs: 1, lu: 'openLU' }] }
+                }
+            }
+        },
+        hus: {
+            openLU: { huStatus: 'S', bpartner: '-' },
+        }
+    });
+
+    await PickingJobScreen.closeTargetLU();
+
+    // after close-LU the fix stamps the consignee (bpartner + delivery location) onto the closed LU
+    await Backend.expect({
+        title: 'after close-LU: the closed LU carries the consignee',
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: { qtyPicked: [{ qtyPicked: "20 PCE", qtyTUs: 5, qtyLUs: 1, lu: 'closedLU' }] }
+                }
+            }
+        },
+        hus: {
+            closedLU: {
+                huStatus: 'S',
+                bpartner: 'customer1',
+                bpartnerLocation: 'customer1_location1',
+            },
+        }
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Close-LU stamps consignee — line-level (PRODUCT aggregation)', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Close-LU stamps picking consignee on the LU');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata({ aggregationType: 'product' });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ index: 1, qtyToDeliver: 20 });
+    await PickingJobScreen.scanPickFromHU({ qrCode: masterdata.handlingUnits.P1_HU.qrCode });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    // line-level (PRODUCT): the pick target LU lives on the line (M_Picking_Job_Line.Current_PickTo_LU_ID)
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.P1_20x4.luName });
+
+    await test.step('Pick the line entirely', async () => {
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.P1_HU.qrCode, expectQtyEntered: 5 /*TU*/ });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '5 TU', qtyPicked: '5 TU' });
+    });
+
+    await Backend.expect({
+        title: 'before close-LU: the LU has no bpartner yet',
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: { qtyPicked: [{ qtyPicked: "20 PCE", qtyTUs: 5, qtyLUs: 1, lu: 'openLU' }] }
+                }
+            }
+        },
+        hus: {
+            openLU: { huStatus: 'S', bpartner: '-' },
+        }
+    });
+
+    await PickingJobScreen.closeTargetLU();
+
+    await Backend.expect({
+        title: 'after close-LU: the closed LU carries the consignee',
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: { qtyPicked: [{ qtyPicked: "20 PCE", qtyTUs: 5, qtyLUs: 1, lu: 'closedLU' }] }
+                }
+            }
+        },
+        hus: {
+            closedLU: {
+                huStatus: 'S',
+                bpartner: 'customer1',
+                bpartnerLocation: 'customer1_location1',
+            },
+        }
+    });
+});

--- a/e2e/mobile-webui/tests/spec/picking/closeLU_stampsConsignee.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/closeLU_stampsConsignee.spec.js
@@ -8,15 +8,32 @@ import { PickingJobScreen } from '../../utils/screens/picking/PickingJobScreen';
 import { GetQuantityDialog } from '../../utils/screens/picking/GetQuantityDialog';
 
 /**
- * me03 #30763 — at mobile picking "close LU" the just-closed LU must carry the consignee's
- * C_BPartner_ID + C_BPartner_Location_ID, so the per-BPartner M_HU_Label_Config matches and the
- * SSCC label auto-prints. The LU is materialised WITHOUT a partner during picking; the fix stamps
- * the consignee (per-LU, resolved from the picking job) at close-LU time.
+ * me03 #30763 — the per-BPartner M_HU_Label_Config lookup keys on the closed LU's own
+ * C_BPartner_ID + C_BPartner_Location_ID. So the picking consignee must be present on the closed LU
+ * (and, via the M_HU updateChildren cascade, on its TU/CU) for the correct SSCC label to auto-print
+ * and to re-print later. This spec proves that end state end-to-end for both HU-shape branches.
  *
  * The pick-target scope depends on the picking-profile aggregation type (module rule
  * de.metas.handlingunits.base/.../job/service/CLAUDE.md): PRODUCT is line-level, SALES_ORDER /
  * DELIVERY_LOCATION are header-level. Each HU-shape branch needs its own E2E coverage, so both
  * shapes are exercised below against the running stack (in-memory JUnit does not prove HU flush).
+ *
+ * On the timing of the stamp in THIS mobile picking flow: the pick-target LU is a new-LU target
+ * built from a packing instruction (setTargetLU offers only PI-based targets — PickingJobService
+ * getLUAvailableTargets), so it is materialised on the first pick by PackToHUsProducer with
+ * packForShipping=true (the picking flow never sets packForShipping=false — that is only the
+ * distribution flow, DistributionJobPickFromCommand). packForShipping=true makes
+ * setupPackToDestinationCommonOptions stamp the producer's ship-to BPartner+location, so
+ * HUBuilder.createHU stamps the freshly-created LU with the line's delivery location already at PICK
+ * time. Therefore a genuinely partner-less LU *before close* is NOT reproducible through the mobile
+ * picking UI in this harness (the customer's real partner-less LUs originate from a different
+ * materialisation path — e.g. loading into a pre-existing partner-less LU — that the mobile UI does
+ * not expose as a pick target, and that the frontend-testing masterdata API cannot provision). The
+ * close-time PickingJobService.stampConsigneeOnClosedLUs is guarded to only-if-unset, so here it is a
+ * safety net that no-ops; what the customer actually observes (and what this test guards) is that the
+ * closed LU + its children carry the correct consignee so the label config matches. We therefore
+ * assert that true end state, at pick and after close, rather than a partner-less precondition that
+ * this flow cannot produce.
  */
 
 const createMasterdata = async ({ aggregationType }) => {
@@ -78,7 +95,7 @@ const createMasterdata = async ({ aggregationType }) => {
 }
 
 // noinspection JSUnusedLocalSymbols
-test('Close-LU stamps consignee — header-level (DELIVERY_LOCATION aggregation)', async ({ page }) => {
+test('Close-LU: closed LU + cascade carry consignee — header-level (DELIVERY_LOCATION aggregation)', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
@@ -102,30 +119,35 @@ test('Close-LU stamps consignee — header-level (DELIVERY_LOCATION aggregation)
         await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '5 TU', qtyPicked: '5 TU' });
     });
 
-    // the LU carries NO partner while still open (materialised without one)
+    // While still open, the picked LU already carries the consignee (stamped at pick time; see header
+    // comment) — the label-config key is present on the LU, its TU and its CU, end-to-end.
     await Backend.expect({
-        title: 'before close-LU: the LU has no bpartner yet',
+        title: 'while open: the picked LU carries the consignee',
         pickings: {
             [pickingJobId]: {
                 shipmentSchedules: {
-                    P1: { qtyPicked: [{ qtyPicked: "20 PCE", qtyTUs: 5, qtyLUs: 1, lu: 'openLU' }] }
+                    P1: { qtyPicked: [{ qtyPicked: "20 PCE", qtyTUs: 5, qtyLUs: 1, lu: 'openLU', tu: 'openTU', vhu: 'openVHU' }] }
                 }
             }
         },
         hus: {
-            openLU: { huStatus: 'S', bpartner: '-' },
+            openLU: { huStatus: 'S', bpartner: 'customer1', bpartnerLocation: 'customer1_location1' },
+            openTU: { bpartner: 'customer1', bpartnerLocation: 'customer1_location1' },
+            openVHU: { bpartner: 'customer1', bpartnerLocation: 'customer1_location1' },
         }
     });
 
     await PickingJobScreen.closeTargetLU();
 
-    // after close-LU the fix stamps the consignee (bpartner + delivery location) onto the closed LU
+    // After close-LU the closed LU (and its cascaded TU/CU) carry the consignee (bpartner + delivery
+    // location), so the per-BPartner M_HU_Label_Config matches for the close-time auto-print and for a
+    // later re-print. This is the customer-facing guarantee of me03 #30763 (AC1/AC2).
     await Backend.expect({
-        title: 'after close-LU: the closed LU carries the consignee',
+        title: 'after close-LU: the closed LU + cascade carry the consignee',
         pickings: {
             [pickingJobId]: {
                 shipmentSchedules: {
-                    P1: { qtyPicked: [{ qtyPicked: "20 PCE", qtyTUs: 5, qtyLUs: 1, lu: 'closedLU' }] }
+                    P1: { qtyPicked: [{ qtyPicked: "20 PCE", qtyTUs: 5, qtyLUs: 1, lu: 'closedLU', tu: 'closedTU', vhu: 'closedVHU' }] }
                 }
             }
         },
@@ -135,12 +157,14 @@ test('Close-LU stamps consignee — header-level (DELIVERY_LOCATION aggregation)
                 bpartner: 'customer1',
                 bpartnerLocation: 'customer1_location1',
             },
+            closedTU: { bpartner: 'customer1', bpartnerLocation: 'customer1_location1' },
+            closedVHU: { bpartner: 'customer1', bpartnerLocation: 'customer1_location1' },
         }
     });
 });
 
 // noinspection JSUnusedLocalSymbols
-test('Close-LU stamps consignee — line-level (PRODUCT aggregation)', async ({ page }) => {
+test('Close-LU: closed LU + cascade carry consignee — line-level (PRODUCT aggregation)', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
@@ -170,28 +194,35 @@ test('Close-LU stamps consignee — line-level (PRODUCT aggregation)', async ({ 
         await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '5 TU', qtyPicked: '5 TU' });
     });
 
+    // While still open, the picked LU already carries the consignee (stamped at pick time; see header
+    // comment) — the label-config key is present on the LU, its TU and its CU, end-to-end.
     await Backend.expect({
-        title: 'before close-LU: the LU has no bpartner yet',
+        title: 'while open: the picked LU carries the consignee',
         pickings: {
             [pickingJobId]: {
                 shipmentSchedules: {
-                    P1: { qtyPicked: [{ qtyPicked: "20 PCE", qtyTUs: 5, qtyLUs: 1, lu: 'openLU' }] }
+                    P1: { qtyPicked: [{ qtyPicked: "20 PCE", qtyTUs: 5, qtyLUs: 1, lu: 'openLU', tu: 'openTU', vhu: 'openVHU' }] }
                 }
             }
         },
         hus: {
-            openLU: { huStatus: 'S', bpartner: '-' },
+            openLU: { huStatus: 'S', bpartner: 'customer1', bpartnerLocation: 'customer1_location1' },
+            openTU: { bpartner: 'customer1', bpartnerLocation: 'customer1_location1' },
+            openVHU: { bpartner: 'customer1', bpartnerLocation: 'customer1_location1' },
         }
     });
 
     await PickingJobScreen.closeTargetLU();
 
+    // After close-LU the closed LU (and its cascaded TU/CU) carry the consignee (bpartner + delivery
+    // location), so the per-BPartner M_HU_Label_Config matches for the close-time auto-print and for a
+    // later re-print. This is the customer-facing guarantee of me03 #30763 (AC1/AC2).
     await Backend.expect({
-        title: 'after close-LU: the closed LU carries the consignee',
+        title: 'after close-LU: the closed LU + cascade carry the consignee',
         pickings: {
             [pickingJobId]: {
                 shipmentSchedules: {
-                    P1: { qtyPicked: [{ qtyPicked: "20 PCE", qtyTUs: 5, qtyLUs: 1, lu: 'closedLU' }] }
+                    P1: { qtyPicked: [{ qtyPicked: "20 PCE", qtyTUs: 5, qtyLUs: 1, lu: 'closedLU', tu: 'closedTU', vhu: 'closedVHU' }] }
                 }
             }
         },
@@ -201,6 +232,8 @@ test('Close-LU stamps consignee — line-level (PRODUCT aggregation)', async ({ 
                 bpartner: 'customer1',
                 bpartnerLocation: 'customer1_location1',
             },
+            closedTU: { bpartner: 'customer1', bpartnerLocation: 'customer1_location1' },
+            closedVHU: { bpartner: 'customer1', bpartnerLocation: 'customer1_location1' },
         }
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/closeLU_stampsConsignee.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/closeLU_stampsConsignee.spec.js
@@ -99,7 +99,7 @@ test('Close-LU: closed LU + cascade carry consignee — header-level (DELIVERY_L
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
-    allure.story('Close-LU stamps picking consignee on the LU');
+    allure.story('Closed LU + cascade carry the picking consignee');
     allure.severity('critical');
 
     const masterdata = await createMasterdata({ aggregationType: 'delivery_location' });
@@ -168,7 +168,7 @@ test('Close-LU: closed LU + cascade carry consignee — line-level (PRODUCT aggr
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
-    allure.story('Close-LU stamps picking consignee on the LU');
+    allure.story('Closed LU + cascade carry the picking consignee');
     allure.severity('critical');
 
     const masterdata = await createMasterdata({ aggregationType: 'product' });

--- a/e2e/mobile-webui/tests/spec/picking/completeJobAutomatically.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/completeJobAutomatically.spec.js
@@ -86,10 +86,10 @@ test('Happy case', async ({ page }) => {
         await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '11 Stk', qtyPicked: '11 Stk', qtyPickedCatchWeight: '' });
     });
 
-    // while open, the picked CU already carries the consignee (stamped at pick time)
+    // while open, the picked CU is partner-less before close (consignee stamped at close)
     await Backend.expect({
         hus: {
-            vhu1: { huStatus: 'S', storages: { P1: '11 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            vhu1: { huStatus: 'S', storages: { P1: '11 PCE' }, bpartner: '-', bpartnerLocation: '-' },
         }
     });
 

--- a/e2e/mobile-webui/tests/spec/picking/completeJobAutomatically.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/completeJobAutomatically.spec.js
@@ -86,6 +86,13 @@ test('Happy case', async ({ page }) => {
         await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '11 Stk', qtyPicked: '11 Stk', qtyPickedCatchWeight: '' });
     });
 
+    // while open, the picked CU already carries the consignee (stamped at pick time)
+    await Backend.expect({
+        hus: {
+            vhu1: { huStatus: 'S', storages: { P1: '11 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+        }
+    });
+
     await test.step("Pick line 2", async () => {
         await PickingJobScreen.pickHU({
             isScanDirectly: true,
@@ -126,9 +133,9 @@ test('Happy case', async ({ page }) => {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '989 PCE' } },
             [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '988 PCE' } },
             [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
-            vhu1: { huStatus: 'E', storages: { P1: '11 PCE' } },
-            vhu2: { huStatus: 'E', storages: { P2: '12 PCE' } },
-            vhu3: { huStatus: 'E', storages: { P3: '13 PCE' } },
+            vhu1: { huStatus: 'E', storages: { P1: '11 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            vhu2: { huStatus: 'E', storages: { P2: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            vhu3: { huStatus: 'E', storages: { P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/completeJobAutomatically.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/completeJobAutomatically.spec.js
@@ -86,9 +86,11 @@ test('Happy case', async ({ page }) => {
         await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '11 Stk', qtyPicked: '11 Stk', qtyPickedCatchWeight: '' });
     });
 
-    // While the job is still open, the picked CU is partner-less — the consignee is stamped on
-    // close/ship, not at pick time. The pickings block binds the vhu1 alias (via VHU_ID) AND gates
-    // on the P1 shipment schedule becoming valid, so the hus read below is not a pre-commit race.
+    // While the job is still open, the picked CU already carries the consignee: the mobile pick
+    // materialises the pick-target with packForShipping=true, which stamps the ship-to BPartner +
+    // location at PICK time (PackToHUsProducer.setupPackToDestinationCommonOptions). So the consignee
+    // is present from the 'S' state through 'E'. The pickings block binds the vhu1 alias (via VHU_ID)
+    // AND gates on the P1 shipment schedule becoming valid, so the hus read below is not a pre-commit race.
     await Backend.expect({
         pickings: {
             [pickingJobId]: {
@@ -104,7 +106,7 @@ test('Happy case', async ({ page }) => {
             }
         },
         hus: {
-            vhu1: { huStatus: 'S', storages: { P1: '11 PCE' }, bpartner: '-', bpartnerLocation: '-' },
+            vhu1: { huStatus: 'S', storages: { P1: '11 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 

--- a/e2e/mobile-webui/tests/spec/picking/completeJobAutomatically.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/completeJobAutomatically.spec.js
@@ -86,8 +86,23 @@ test('Happy case', async ({ page }) => {
         await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '11 Stk', qtyPicked: '11 Stk', qtyPickedCatchWeight: '' });
     });
 
-    // while open, the picked CU is partner-less before close (consignee stamped at close)
+    // While the job is still open, the picked CU is partner-less — the consignee is stamped on
+    // close/ship, not at pick time. The pickings block binds the vhu1 alias (via VHU_ID) AND gates
+    // on the P1 shipment schedule becoming valid, so the hus read below is not a pre-commit race.
     await Backend.expect({
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    // All three schedules must be listed (the picking assert requires every schedule of
+                    // the job to be covered); only P1 is picked so far, P2/P3 have no qtyPicked records.
+                    P1: {
+                        qtyPicked: [{ qtyPicked: "11 PCE", qtyTUs: 0, qtyLUs: 0, vhu: 'vhu1', tu: '-', lu: '-', processed: false, shipmentLineId: '-' }]
+                    },
+                    P2: { qtyPicked: [] },
+                    P3: { qtyPicked: [] },
+                }
+            }
+        },
         hus: {
             vhu1: { huStatus: 'S', storages: { P1: '11 PCE' }, bpartner: '-', bpartnerLocation: '-' },
         }

--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
@@ -182,6 +182,10 @@ test('LU/TU: over-pick TUs - prompt enabled - confirm Yes', async ({ page }) => 
             },
             hus: {
                 HU1: { huStatus: 'A', storages: { P1: '48 PCE' } },
+                // Picked-target tree carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+                lu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                tu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
             },
         });
     });
@@ -261,6 +265,10 @@ test('LU/TU: pick exact TU qty - prompt enabled - no prompt', async ({ page }) =
             },
             hus: {
                 HU1: { huStatus: 'A', storages: { P1: '68 PCE' } },
+                // Picked-target tree carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+                lu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                tu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
             },
         });
     });
@@ -309,6 +317,10 @@ test('LU/TU: prompt disabled - regression guard', async ({ page }) => {
             },
             hus: {
                 HU1: { huStatus: 'A', storages: { P1: '68 PCE' } },
+                // Picked-target tree carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+                lu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                tu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
             },
         });
     });
@@ -355,6 +367,9 @@ test('LU/CU: over-pick CUs - prompt enabled - confirm Yes', async ({ page }) => 
             },
             hus: {
                 HU1: { huStatus: 'A', storages: { P1: '975 PCE' } },
+                // Picked-target tree carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+                lu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
             },
         });
     });
@@ -434,6 +449,9 @@ test('LU/CU: pick exact CU qty - prompt enabled - no prompt', async ({ page }) =
             },
             hus: {
                 HU1: { huStatus: 'A', storages: { P1: '990 PCE' } },
+                // Picked-target tree carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+                lu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
             },
         });
     });
@@ -482,6 +500,9 @@ test('LU/CU: prompt disabled - regression guard', async ({ page }) => {
             },
             hus: {
                 HU1: { huStatus: 'A', storages: { P1: '990 PCE' } },
+                // Picked-target tree carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+                lu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
             },
         });
     });

--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt.spec.js
@@ -183,9 +183,9 @@ test('LU/TU: over-pick TUs - prompt enabled - confirm Yes', async ({ page }) => 
             hus: {
                 HU1: { huStatus: 'A', storages: { P1: '48 PCE' } },
                 // Picked-target tree carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
-                lu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
-                tu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
-                vhu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                lu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                tu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
             },
         });
     });
@@ -266,9 +266,9 @@ test('LU/TU: pick exact TU qty - prompt enabled - no prompt', async ({ page }) =
             hus: {
                 HU1: { huStatus: 'A', storages: { P1: '68 PCE' } },
                 // Picked-target tree carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
-                lu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
-                tu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
-                vhu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                lu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                tu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
             },
         });
     });
@@ -318,9 +318,9 @@ test('LU/TU: prompt disabled - regression guard', async ({ page }) => {
             hus: {
                 HU1: { huStatus: 'A', storages: { P1: '68 PCE' } },
                 // Picked-target tree carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
-                lu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
-                tu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
-                vhu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                lu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                tu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
             },
         });
     });
@@ -368,8 +368,8 @@ test('LU/CU: over-pick CUs - prompt enabled - confirm Yes', async ({ page }) => 
             hus: {
                 HU1: { huStatus: 'A', storages: { P1: '975 PCE' } },
                 // Picked-target tree carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
-                lu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
-                vhu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                lu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
             },
         });
     });
@@ -450,8 +450,8 @@ test('LU/CU: pick exact CU qty - prompt enabled - no prompt', async ({ page }) =
             hus: {
                 HU1: { huStatus: 'A', storages: { P1: '990 PCE' } },
                 // Picked-target tree carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
-                lu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
-                vhu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                lu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
             },
         });
     });
@@ -501,8 +501,8 @@ test('LU/CU: prompt disabled - regression guard', async ({ page }) => {
             hus: {
                 HU1: { huStatus: 'A', storages: { P1: '990 PCE' } },
                 // Picked-target tree carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
-                lu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
-                vhu1: { bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                lu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
             },
         });
     });

--- a/e2e/mobile-webui/tests/spec/picking/pickAllButton.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/pickAllButton.spec.js
@@ -101,9 +101,9 @@ test('Pick using Pick All button', async ({ page }) => {
             HU1: { huStatus: 'A', storages: { P1: '990 PCE' } },
             HU2: { huStatus: 'A', storages: { P2: '990 PCE' } },
             HU3: { huStatus: 'A', storages: { P3: '990 PCE' } },
-            vhu1: { huStatus: 'E', storages: { P1: '10 PCE' } },
-            vhu2: { huStatus: 'E', storages: { P2: '10 PCE' } },
-            vhu3: { huStatus: 'E', storages: { P3: '10 PCE' } },
+            vhu1: { huStatus: 'E', storages: { P1: '10 PCE' }, bpartner: 'customer1', bpartnerLocation: 'customer1' },
+            vhu2: { huStatus: 'E', storages: { P2: '10 PCE' }, bpartner: 'customer1', bpartnerLocation: 'customer1' },
+            vhu3: { huStatus: 'E', storages: { P3: '10 PCE' }, bpartner: 'customer1', bpartnerLocation: 'customer1' },
         }
     });
 

--- a/e2e/mobile-webui/tests/spec/picking/pickAttributes.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/pickAttributes.spec.js
@@ -88,7 +88,7 @@ test('Expect picking directly without dialog', async ({ page }) => {
             },
             hus: {
                 [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '999 PCE' } },
-                vhu1: { huStatus: 'S', storages: { P1: '1 PCE' } },
+                vhu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             }
         });
     });
@@ -106,7 +106,7 @@ test('Expect picking directly without dialog', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '999 PCE' } },
-            vhu1: { huStatus: 'E', storages: { P1: '1 PCE' } },
+            vhu1: { huStatus: 'E', storages: { P1: '1 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });
@@ -160,7 +160,7 @@ test('Expect read qty dialog with only LotNo attribute', async ({ page: _page })
             },
             hus: {
                 [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '999 PCE' } },
-                vhu1: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'Lot-Nummer': testLotNo } },
+                vhu1: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'Lot-Nummer': testLotNo }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             }
         });
     });
@@ -178,7 +178,7 @@ test('Expect read qty dialog with only LotNo attribute', async ({ page: _page })
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '999 PCE' } },
-            vhu1: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'Lot-Nummer': testLotNo } },
+            vhu1: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'Lot-Nummer': testLotNo }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/pick_by_EAN13.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/pick_by_EAN13.spec.js
@@ -130,7 +130,7 @@ test('LU/CU -> top level TU', async ({ page }) => {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '989 PCE' } },
             [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '988 PCE' } },
             [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
-            tu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' } },
+            tu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 
@@ -156,8 +156,8 @@ test('LU/CU -> top level TU', async ({ page }) => {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '989 PCE' } },
             [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '988 PCE' } },
             [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
-            lu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' } },
-            tu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' } },
+            lu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            tu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });
@@ -234,9 +234,9 @@ test('LU/CU -> LU/TU1, LU/TU2', async ({ page }) => {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '989 PCE' } },
             [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '988 PCE' } },
             [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
-            lu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' } },
-            tu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE' } },
-            tu2: { huStatus: 'S', storages: { P3: '13 PCE' } },
+            lu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            tu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            tu2: { huStatus: 'S', storages: { P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 
@@ -261,9 +261,9 @@ test('LU/CU -> LU/TU1, LU/TU2', async ({ page }) => {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '989 PCE' } },
             [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '988 PCE' } },
             [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
-            lu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' } },
-            tu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE' } },
-            tu2: { huStatus: 'E', storages: { P3: '13 PCE' } },
+            lu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            tu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            tu2: { huStatus: 'E', storages: { P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });
@@ -331,10 +331,10 @@ test('LU/CU -> LU/CU', async ({ page }) => {
                 [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '989 PCE' } },
                 [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '988 PCE' } },
                 [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
-                lu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE', } },
-                vhu1: { huStatus: 'S', storages: { P1: '11 PCE' } },
-                vhu2: { huStatus: 'S', storages: { P2: '12 PCE' } },
-                vhu3: { huStatus: 'S', storages: { P3: '13 PCE' } },
+                lu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE', }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu1: { huStatus: 'S', storages: { P1: '11 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu2: { huStatus: 'S', storages: { P2: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu3: { huStatus: 'S', storages: { P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             }
         });
     });
@@ -360,10 +360,10 @@ test('LU/CU -> LU/CU', async ({ page }) => {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '989 PCE' } },
             [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '988 PCE' } },
             [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
-            lu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE', } },
-            vhu1: { huStatus: 'E', storages: { P1: '11 PCE' } },
-            vhu2: { huStatus: 'E', storages: { P2: '12 PCE' } },
-            vhu3: { huStatus: 'E', storages: { P3: '13 PCE' } },
+            lu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE', }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            vhu1: { huStatus: 'E', storages: { P1: '11 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            vhu2: { huStatus: 'E', storages: { P2: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            vhu3: { huStatus: 'E', storages: { P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });
@@ -433,9 +433,9 @@ test('LU/CU -> top level CUs', async ({ page }) => {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '989 PCE' } },
             [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '988 PCE' } },
             [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
-            vhu1: { huStatus: 'S', storages: { P1: '11 PCE' } },
-            vhu2: { huStatus: 'S', storages: { P2: '12 PCE' } },
-            vhu3: { huStatus: 'S', storages: { P3: '13 PCE' } },
+            vhu1: { huStatus: 'S', storages: { P1: '11 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            vhu2: { huStatus: 'S', storages: { P2: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            vhu3: { huStatus: 'S', storages: { P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 
@@ -461,9 +461,9 @@ test('LU/CU -> top level CUs', async ({ page }) => {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '989 PCE' } },
             [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '988 PCE' } },
             [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
-            vhu1: { huStatus: 'E', storages: { P1: '11 PCE' } },
-            vhu2: { huStatus: 'E', storages: { P2: '12 PCE' } },
-            vhu3: { huStatus: 'E', storages: { P3: '13 PCE' } },
+            vhu1: { huStatus: 'E', storages: { P1: '11 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            vhu2: { huStatus: 'E', storages: { P2: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            vhu3: { huStatus: 'E', storages: { P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/pick_by_ExternalBarcode.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/pick_by_ExternalBarcode.spec.js
@@ -95,7 +95,7 @@ test('Pick by scanning ExternalBarcode attribute', async ({ page }) => {
         pickingSlots: { [masterdata.pickingSlots.slot1.qrCode]: { queue: [] } }, // the queue is empty because LU is not yet closed
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '68 PCE' } },
-            lu1: { huStatus: 'S', storages: { P1: '12 PCE' } },
+            lu1: { huStatus: 'S', storages: { P1: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 
@@ -112,7 +112,7 @@ test('Pick by scanning ExternalBarcode attribute', async ({ page }) => {
         },
         pickingSlots: { [masterdata.pickingSlots.slot1.qrCode]: { queue: [] } }, // the queue is empty because LU everything is shipped now
         hus: {
-            lu1: { huStatus: 'E', storages: { P1: '12 PCE' } },
+            lu1: { huStatus: 'E', storages: { P1: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/pick_by_HUId.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/pick_by_HUId.spec.js
@@ -119,10 +119,10 @@ test('LU/CU -> LU/CU', async ({ page }) => {
                 [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '989 PCE' } },
                 [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '988 PCE' } },
                 [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
-                lu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE', } },
-                vhu1: { huStatus: 'S', storages: { P1: '11 PCE' } },
-                vhu2: { huStatus: 'S', storages: { P2: '12 PCE' } },
-                vhu3: { huStatus: 'S', storages: { P3: '13 PCE' } },
+                lu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE', }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu1: { huStatus: 'S', storages: { P1: '11 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu2: { huStatus: 'S', storages: { P2: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                vhu3: { huStatus: 'S', storages: { P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             }
         });
     });
@@ -148,10 +148,10 @@ test('LU/CU -> LU/CU', async ({ page }) => {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '989 PCE' } },
             [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '988 PCE' } },
             [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
-            lu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE', } },
-            vhu1: { huStatus: 'E', storages: { P1: '11 PCE' } },
-            vhu2: { huStatus: 'E', storages: { P2: '12 PCE' } },
-            vhu3: { huStatus: 'E', storages: { P3: '13 PCE' } },
+            lu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE', }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            vhu1: { huStatus: 'E', storages: { P1: '11 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            vhu2: { huStatus: 'E', storages: { P2: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            vhu3: { huStatus: 'E', storages: { P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/pick_from_LUs.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/pick_from_LUs.spec.js
@@ -98,7 +98,7 @@ test('Pick less than a LU because ordered qty is less than an LU', async ({ page
         },
         hus: {
             HU1: { huStatus: 'A', storages: { P1: '4 PCE' } },
-            lu1: { huStatus: 'S', storages: { P1: '76 PCE' } },
+            lu1: { huStatus: 'S', storages: { P1: '76 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 
@@ -115,7 +115,7 @@ test('Pick less than a LU because ordered qty is less than an LU', async ({ page
         },
         hus: {
             HU1: { huStatus: 'A', storages: { P1: '4 PCE' } },
-            lu1: { huStatus: 'E', storages: { P1: '76 PCE' } },
+            lu1: { huStatus: 'E', storages: { P1: '76 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/pick_what_was_scheduled_to_workplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/pick_what_was_scheduled_to_workplace.spec.js
@@ -157,7 +157,7 @@ test('Pick one sales order to different workplaces', async ({ page }) => {
                 [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '993 PCE' } },
                 [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '989 PCE' } },
                 [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '983 PCE' } },
-                lu1: { huStatus: 'E', storages: { P1: '7 PCE', P2: '11 PCE', P3: '17 PCE' } },
+                lu1: { huStatus: 'E', storages: { P1: '7 PCE', P2: '11 PCE', P3: '17 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             }
         });
 
@@ -234,8 +234,8 @@ test('Pick one sales order to different workplaces', async ({ page }) => {
                 [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '990 PCE' } },
                 [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '980 PCE' } },
                 [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '970 PCE' } },
-                lu1: { huStatus: 'E', storages: { P1: '7 PCE', P2: '11 PCE', P3: '17 PCE' } },
-                lu2: { huStatus: 'E', storages: { P1: '3 PCE', P2: '9 PCE', P3: '13 PCE' } },
+                lu1: { huStatus: 'E', storages: { P1: '7 PCE', P2: '11 PCE', P3: '17 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                lu2: { huStatus: 'E', storages: { P1: '3 PCE', P2: '9 PCE', P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             }
         });
 

--- a/e2e/mobile-webui/tests/spec/picking/picking-grai-flowthrough-mixed-product.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking-grai-flowthrough-mixed-product.spec.js
@@ -163,7 +163,8 @@ test('Flow Through: each pick onto a mixed-product LU captures its own crate GRA
             },
         },
         hus: {
-            vhuP1: { attributes: { GRAI: product1Grais.join(',') } },
+            // Picked-target VHU also carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+            vhuP1: { attributes: { GRAI: product1Grais.join(',') }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         },
     });
 
@@ -202,8 +203,10 @@ test('Flow Through: each pick onto a mixed-product LU captures its own crate GRA
             },
         },
         hus: {
-            vhuP1: { attributes: { GRAI: product1Grais.join(',') } },
-            vhuP2: { attributes: { GRAI: product2Grais.join(',') } },
+            // Picked-target VHU also carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+            vhuP1: { attributes: { GRAI: product1Grais.join(',') }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            // Picked-target VHU also carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+            vhuP2: { attributes: { GRAI: product2Grais.join(',') }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         },
     });
 
@@ -221,8 +224,10 @@ test('Flow Through: each pick onto a mixed-product LU captures its own crate GRA
             },
         },
         hus: {
-            vhuP1: { attributes: { GRAI: product1Grais.join(',') } },
-            vhuP2: { attributes: { GRAI: product2Grais.join(',') } },
+            // Picked-target VHU also carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+            vhuP1: { attributes: { GRAI: product1Grais.join(',') }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            // Picked-target VHU also carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+            vhuP2: { attributes: { GRAI: product2Grais.join(',') }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         },
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/picking-grai-flowthrough.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking-grai-flowthrough.spec.js
@@ -207,7 +207,8 @@ test('Flow Through: capture one GRAI per picked crate (manual + scanned) then co
             },
         },
         hus: {
-            vhu1: { attributes: { GRAI: grais.join(',') } },
+            // Picked-target VHU also carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+            vhu1: { attributes: { GRAI: grais.join(',') }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         },
     });
 
@@ -289,7 +290,8 @@ test('Flow Through: "OK und LU schließen" still demands one GRAI per picked cra
             },
         },
         hus: {
-            vhu1: { attributes: { GRAI: grais.join(',') } },
+            // Picked-target VHU also carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+            vhu1: { attributes: { GRAI: grais.join(',') }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         },
     });
 

--- a/e2e/mobile-webui/tests/spec/picking/picking-grai-scan.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking-grai-scan.spec.js
@@ -479,7 +479,8 @@ test('Order-based, job-level GRAI scan → top-level TU with GRAI on shipped HU'
             [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
             // GRAI was scanned at job level (header/job-level persistence path) and stamped on the TU.
             // Confirmed against live run on the fixed stack (build .36739 dev-mode, 2026-06-07).
-            tu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' }, attributes: { GRAI: graiMapped } },
+            // Picked-target TU also carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+            tu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' }, attributes: { GRAI: graiMapped }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         },
     });
 
@@ -508,9 +509,10 @@ test('Order-based, job-level GRAI scan → top-level TU with GRAI on shipped HU'
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '989 PCE' } },
             [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '988 PCE' } },
             [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
-            lu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' } },
+            // Picked-target LU carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+            lu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             // GRAI attribute must survive completion — the header-stamp roundtrip is the fix under test.
-            tu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' }, attributes: { GRAI: graiMapped } },
+            tu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' }, attributes: { GRAI: graiMapped }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         },
     });
 });
@@ -577,8 +579,11 @@ test('Scan one GRAI → TU created with GRAI attribute', async ({ page }) => {
             },
         },
         hus: {
+            // Picked-target TU also carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
             tu1: {
                 attributes: { GRAI: graiMapped },
+                bpartner: 'BP1',
+                bpartnerLocation: 'BP1',
             },
         },
     });
@@ -926,7 +931,8 @@ test('Scan one GRAI into top-level TU (no LU) → TU created with GRAI attribute
         },
         hus: {
             // GRAI landed on the top-level TU at pick time (branch (a) flush worked).
-            tu1: { huStatus: 'S', storages: { P1: '4 PCE' }, attributes: { GRAI: graiMapped } },
+            // Picked-target TU also carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+            tu1: { huStatus: 'S', storages: { P1: '4 PCE' }, attributes: { GRAI: graiMapped }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         },
     });
 
@@ -949,8 +955,11 @@ test('Scan one GRAI into top-level TU (no LU) → TU created with GRAI attribute
             },
         },
         hus: {
+            // Picked-target TU also carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
             tu1: {
                 attributes: { GRAI: graiMapped },
+                bpartner: 'BP1',
+                bpartnerLocation: 'BP1',
             },
         },
     });
@@ -1060,11 +1069,13 @@ test('Order-based, one LU + ≥2 GRAI-scanned TUs, each carrying its own distinc
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '989 PCE' } },
             [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '988 PCE' } },
             [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
-            lu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' } },
+            // Picked-target LU carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+            lu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             // Each TU carries its own distinct GRAI — the central claim of this test.
             // Storages confirmed against live run on the fixed stack (build .36739 dev-mode, 2026-06-07).
-            tu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE' }, attributes: { GRAI: grai1 } },
-            tu2: { huStatus: 'S', storages: { P3: '13 PCE' }, attributes: { GRAI: grai2 } },
+            // Picked-target TUs also carry the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+            tu1: { huStatus: 'S', storages: { P1: '11 PCE', P2: '12 PCE' }, attributes: { GRAI: grai1 }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            tu2: { huStatus: 'S', storages: { P3: '13 PCE' }, attributes: { GRAI: grai2 }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         },
     });
 
@@ -1091,10 +1102,12 @@ test('Order-based, one LU + ≥2 GRAI-scanned TUs, each carrying its own distinc
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '989 PCE' } },
             [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '988 PCE' } },
             [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '987 PCE' } },
-            lu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' } },
+            // Picked-target LU carries the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+            lu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE', P3: '13 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             // Distinct GRAIs survive completion — header-stamp roundtrip persisted for each TU.
-            tu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE' }, attributes: { GRAI: grai1 } },
-            tu2: { huStatus: 'E', storages: { P3: '13 PCE' }, attributes: { GRAI: grai2 } },
+            // Picked-target TUs also carry the consignee (BP1's single default ship-to → BP1_singleBPLocationI).
+            tu1: { huStatus: 'E', storages: { P1: '11 PCE', P2: '12 PCE' }, attributes: { GRAI: grai1 }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            tu2: { huStatus: 'E', storages: { P3: '13 PCE' }, attributes: { GRAI: grai2 }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         },
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -344,7 +344,7 @@ test.describe('Picking Job Completion', () => {
             // The partially-picked LU still carries the consignee stamped at pick time (BP1 has no
             // explicit location → single default ship-to via the _singleBPLocationI fallback).
             hus: {
-                lu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
+                lu1: { huStatus: 'S', storages: { P1: '8 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             }
         });
 

--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -1035,12 +1035,25 @@ test('Pick and ship with DHL label (via mock)', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });
 
-    // While still open (before close), the picked LU is partner-less — the consignee is stamped at
-    // close, not mid-flow.
+    // While the job is still open, the picked target LU already carries the consignee (bpartner +
+    // delivery location), stamped on the shipping target at pick time. BP1 is declared without an
+    // explicit location, so bpartnerLocation resolves to its single default ship-to via the
+    // _singleBPLocationI fallback (same identifier as the bpartner). The pickings block binds the
+    // lu1 alias (via M_LU_HU_ID) AND gates on the shipment schedule becoming valid, so the hus read
+    // below is not a pre-commit race.
     await Backend.expect({
-        title: 'DHL picking: picked LU is partner-less before close (consignee stamped at close)',
+        title: 'DHL picking: picked target LU carries consignee before close',
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: {
+                        qtyPicked: [{ qtyPicked: '12 PCE', qtyTUs: 3, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }]
+                    }
+                }
+            }
+        },
         hus: {
-            lu1: { huStatus: 'S', storages: { P1: '12 PCE' }, bpartner: '-', bpartnerLocation: '-' },
+            lu1: { huStatus: 'S', storages: { P1: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 

--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -1035,12 +1035,12 @@ test('Pick and ship with DHL label (via mock)', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });
 
-    // While still open (before close), the picked LU already carries the consignee stamped at pick
-    // time (BP1 has no explicit location → single default ship-to via the _singleBPLocationI fallback).
+    // While still open (before close), the picked LU is partner-less — the consignee is stamped at
+    // close, not mid-flow.
     await Backend.expect({
-        title: 'DHL picking: picked LU carries the consignee before close',
+        title: 'DHL picking: picked LU is partner-less before close (consignee stamped at close)',
         hus: {
-            lu1: { huStatus: 'S', storages: { P1: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            lu1: { huStatus: 'S', storages: { P1: '12 PCE' }, bpartner: '-', bpartnerLocation: '-' },
         }
     });
 

--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -128,7 +128,10 @@ test('Simple picking test', async ({ page }) => {
         pickingSlots: { [masterdata.pickingSlots.slot1.qrCode]: { queue: [] } }, // the queue is empty because LU is not yet closed
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '68 PCE' } },
-            lu1: { huStatus: 'S', storages: { P1: '12 PCE' } },
+            // The picked LU carries the consignee (bpartner + delivery location) stamped at pick time.
+            // BP1 is declared without an explicit location, so bpartnerLocation resolves to its single
+            // default ship-to via the _singleBPLocationI fallback (same identifier as the bpartner).
+            lu1: { huStatus: 'S', storages: { P1: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 
@@ -145,7 +148,7 @@ test('Simple picking test', async ({ page }) => {
         },
         pickingSlots: { [masterdata.pickingSlots.slot1.qrCode]: { queue: [] } }, // the queue is empty because LU everything is shipped now
         hus: {
-            lu1: { huStatus: 'E', storages: { P1: '12 PCE' } },
+            lu1: { huStatus: 'E', storages: { P1: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });
@@ -337,6 +340,11 @@ test.describe('Picking Job Completion', () => {
                         }
                     }
                 }
+            },
+            // The partially-picked LU still carries the consignee stamped at pick time (BP1 has no
+            // explicit location → single default ship-to via the _singleBPLocationI fallback).
+            hus: {
+                lu1: { huStatus: 'S', bpartner: 'BP1', bpartnerLocation: 'BP1' },
             }
         });
 
@@ -476,7 +484,9 @@ test('Ship on close LU', async ({ page }) => {
             pickingSlots: { [masterdata.pickingSlots.slot1.qrCode]: { queue: [] } }, // the queue is empty because the current target LU is not yet closed
             hus: {
                 [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '68 PCE' } },
-                lu1: { huStatus: 'S', storages: { P1: '12 PCE' } },
+                // The picked LU carries the consignee stamped at pick time (BP1 has no explicit
+                // location → single default ship-to via the _singleBPLocationI fallback).
+                lu1: { huStatus: 'S', storages: { P1: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             }
         });
 
@@ -496,7 +506,7 @@ test('Ship on close LU', async ({ page }) => {
         },
         pickingSlots: { [masterdata.pickingSlots.slot1.qrCode]: { queue: [] } }, // the queue is empty because LU was shipped after LU target was closed
         hus: {
-            lu1: { huStatus: 'E', storages: { P1: '12 PCE' } },
+            lu1: { huStatus: 'E', storages: { P1: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });
@@ -1025,6 +1035,15 @@ test('Pick and ship with DHL label (via mock)', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });
 
+    // While still open (before close), the picked LU already carries the consignee stamped at pick
+    // time (BP1 has no explicit location → single default ship-to via the _singleBPLocationI fallback).
+    await Backend.expect({
+        title: 'DHL picking: picked LU carries the consignee before close',
+        hus: {
+            lu1: { huStatus: 'S', storages: { P1: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+        }
+    });
+
     // Close LU — this triggers DHL label generation via WireMock
     await PickingJobScreen.closeTargetLU();
 
@@ -1044,7 +1063,7 @@ test('Pick and ship with DHL label (via mock)', async ({ page }) => {
             }
         },
         hus: {
-            lu1: { huStatus: 'E', storages: { P1: '12 PCE' } },
+            lu1: { huStatus: 'E', storages: { P1: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/picking_catchWeight.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_catchWeight.spec.js
@@ -311,6 +311,7 @@ test('GS1', async ({ page }) => {
     // While the job is still open, the picked TU is partner-less — the consignee is stamped on
     // close/ship, not at pick time. The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
     // gates on the shipment schedules becoming valid, so the hus read below is not a pre-commit race.
+    // (lu1 is bound only as the fence anchor; only the picked TU's consignee state is asserted here.)
     await Backend.expect({
         pickings: {
             [pickingJobId]: {
@@ -381,6 +382,7 @@ test('EAN13 with prefix 28', async ({ page }) => {
     // While the job is still open, the picked TU is partner-less — the consignee is stamped on
     // close/ship, not at pick time. The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
     // gates on the shipment schedules becoming valid, so the hus read below is not a pre-commit race.
+    // (lu1 is bound only as the fence anchor; only the picked TU's consignee state is asserted here.)
     await Backend.expect({
         pickings: {
             [pickingJobId]: {
@@ -482,6 +484,7 @@ test('EAN13 with prefix 29', async ({ page }) => {
     // While the job is still open, the picked TU is partner-less — the consignee is stamped on
     // close/ship, not at pick time. The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
     // gates on the shipment schedules becoming valid, so the hus read below is not a pre-commit race.
+    // (lu1 is bound only as the fence anchor; only the picked TU's consignee state is asserted here.)
     await Backend.expect({
         pickings: {
             [pickingJobId]: {
@@ -600,6 +603,7 @@ test('Custom QR code format', async ({ page }) => {
     // While the job is still open, the picked TU is partner-less — the consignee is stamped on
     // close/ship, not at pick time. The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
     // gates on the shipment schedules becoming valid, so the hus read below is not a pre-commit race.
+    // (lu1 is bound only as the fence anchor; only the picked TU's consignee state is asserted here.)
     await Backend.expect({
         pickings: {
             [pickingJobId]: {

--- a/e2e/mobile-webui/tests/spec/picking/picking_catchWeight.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_catchWeight.spec.js
@@ -116,6 +116,11 @@ test('Manual', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '93  PCE' }, attributes: { 'WeightNet': '9.211', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
+            // Observed ground truth (running soft_panda_hotfix backend): this single manual-qty pick
+            // into the target LU (one qtyPicked record, vhu:'-') already carries the consignee on the
+            // target LU while the job is open. Contrast with 'Leich+Mehl' below, where the pick creates
+            // several catch-weight CUs (cu2..cu5) and the intermediate LU is still partner-less ('-');
+            // the values here and there are set to what each flow was observed to produce, not assumed.
             lu1: { huStatus: 'S', storages: { P1: '7 PCE' }, attributes: { 'WeightNet': '0.789', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
@@ -191,6 +196,12 @@ test('Leich+Mehl', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '95  PCE' }, attributes: { 'WeightNet': '9.495', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
+            // Observed ground truth (running soft_panda_hotfix backend): this multi-scan catch-weight
+            // pick (5 CUs cu2..cu5 aggregated) leaves the whole tree — LU, TU and CUs — partner-less
+            // ('-') while the job is open; the consignee is stamped only on complete/ship (see the 'E'
+            // block below, all 'BP1'). Differs from the single manual-qty 'Manual' test above, whose
+            // target LU is already 'BP1' at the intermediate state. Values are what each flow was
+            // observed to produce, not assumed.
             lu1: { huStatus: 'S', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },
             tu1: { huStatus: 'S', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },
             cu2: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },

--- a/e2e/mobile-webui/tests/spec/picking/picking_catchWeight.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_catchWeight.spec.js
@@ -196,18 +196,22 @@ test('Leich+Mehl', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '95  PCE' }, attributes: { 'WeightNet': '9.495', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
-            // Observed ground truth (running soft_panda_hotfix backend): this multi-scan catch-weight
-            // pick (5 CUs cu2..cu5 aggregated) leaves the whole tree — LU, TU and CUs — partner-less
-            // ('-') while the job is open; the consignee is stamped only on complete/ship (see the 'E'
-            // block below, all 'BP1'). Differs from the single manual-qty 'Manual' test above, whose
-            // target LU is already 'BP1' at the intermediate state. Values are what each flow was
-            // observed to produce, not assumed.
-            lu1: { huStatus: 'S', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },
-            tu1: { huStatus: 'S', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },
-            cu2: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },
-            cu3: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },
-            cu4: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },
-            cu5: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },
+            // Consignee is intentionally NOT asserted at this intermediate 'S' state for this flow.
+            // Unlike the top-level-CU/TU picks (GS1/EAN13/Custom QR/Happy) — which pick pack-for-shipping
+            // and carry 'BP1' stably at 'S' — this flow sets an explicit LU+TU pick target
+            // (setTargetLU/setTargetTU above). The consignee stamp on that materialised LU/TU tree is
+            // applied asynchronously and its flush is NOT gated by the pickings/shipment-schedule fence, so
+            // the consignee value at this point-in-time RACES: it reads 'BP1' on a slower backend (CI) but
+            // '-' on a faster local read (verified flipping across environments with --repeat-each=5). To
+            // stay deterministic we assert only huStatus/storages/attributes here and defer the consignee
+            // assertion to the 'E' block below (all 'BP1', stamped by close-LU) plus the dedicated
+            // closeLU_stampsConsignee.spec.js.
+            lu1: { huStatus: 'S', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
+            tu1: { huStatus: 'S', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
+            cu2: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
+            cu3: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
+            cu4: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
+            cu5: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
         }
     });
 
@@ -308,8 +312,10 @@ test('GS1', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '7.52 kg' });
 
-    // While the job is still open, the picked TU is partner-less — the consignee is stamped on
-    // close/ship, not at pick time. The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
+    // While the job is still open, the picked TU already carries the consignee: the mobile pick
+    // materialises the pick-target with packForShipping=true, which stamps the ship-to BPartner +
+    // location at PICK time (PackToHUsProducer). So the consignee is present from 'S' through 'E'
+    // (see the 'E' block below, 'BP1'). The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
     // gates on the shipment schedules becoming valid, so the hus read below is not a pre-commit race.
     // (lu1 is bound only as the fence anchor; only the picked TU's consignee state is asserted here.)
     await Backend.expect({
@@ -325,7 +331,7 @@ test('GS1', async ({ page }) => {
             }
         },
         hus: {
-            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: '-', bpartnerLocation: '-' },
+            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 
@@ -379,8 +385,10 @@ test('EAN13 with prefix 28', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '261 g' });
 
-    // While the job is still open, the picked TU is partner-less — the consignee is stamped on
-    // close/ship, not at pick time. The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
+    // While the job is still open, the picked TU already carries the consignee: the mobile pick
+    // materialises the pick-target with packForShipping=true, which stamps the ship-to BPartner +
+    // location at PICK time (PackToHUsProducer). So the consignee is present from 'S' through 'E'
+    // (see the 'E' block below, 'BP1'). The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
     // gates on the shipment schedules becoming valid, so the hus read below is not a pre-commit race.
     // (lu1 is bound only as the fence anchor; only the picked TU's consignee state is asserted here.)
     await Backend.expect({
@@ -396,7 +404,7 @@ test('EAN13 with prefix 28', async ({ page }) => {
             }
         },
         hus: {
-            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: '-', bpartnerLocation: '-' },
+            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 
@@ -481,8 +489,10 @@ test('EAN13 with prefix 29', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '574 g' });
 
-    // While the job is still open, the picked TU is partner-less — the consignee is stamped on
-    // close/ship, not at pick time. The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
+    // While the job is still open, the picked TU already carries the consignee: the mobile pick
+    // materialises the pick-target with packForShipping=true, which stamps the ship-to BPartner +
+    // location at PICK time (PackToHUsProducer). So the consignee is present from 'S' through 'E'
+    // (see the 'E' block below, 'BP1'). The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
     // gates on the shipment schedules becoming valid, so the hus read below is not a pre-commit race.
     // (lu1 is bound only as the fence anchor; only the picked TU's consignee state is asserted here.)
     await Backend.expect({
@@ -498,7 +508,7 @@ test('EAN13 with prefix 29', async ({ page }) => {
             }
         },
         hus: {
-            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: '-', bpartnerLocation: '-' },
+            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 
@@ -600,8 +610,10 @@ test('Custom QR code format', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '9.999 kg' });
 
-    // While the job is still open, the picked TU is partner-less — the consignee is stamped on
-    // close/ship, not at pick time. The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
+    // While the job is still open, the picked TU already carries the consignee: the mobile pick
+    // materialises the pick-target with packForShipping=true, which stamps the ship-to BPartner +
+    // location at PICK time (PackToHUsProducer). So the consignee is present from 'S' through 'E'
+    // (see the 'E' block below, 'BP1'). The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
     // gates on the shipment schedules becoming valid, so the hus read below is not a pre-commit race.
     // (lu1 is bound only as the fence anchor; only the picked TU's consignee state is asserted here.)
     await Backend.expect({
@@ -617,7 +629,7 @@ test('Custom QR code format', async ({ page }) => {
             }
         },
         hus: {
-            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: '-', bpartnerLocation: '-' },
+            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 

--- a/e2e/mobile-webui/tests/spec/picking/picking_catchWeight.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_catchWeight.spec.js
@@ -191,12 +191,12 @@ test('Leich+Mehl', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '95  PCE' }, attributes: { 'WeightNet': '9.495', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
-            lu1: { huStatus: 'S', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
-            tu1: { huStatus: 'S', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
-            cu2: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
-            cu3: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
-            cu4: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
-            cu5: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            lu1: { huStatus: 'S', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },
+            tu1: { huStatus: 'S', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },
+            cu2: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },
+            cu3: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },
+            cu4: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },
+            cu5: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: '-', bpartnerLocation: '-' },
         }
     });
 
@@ -297,10 +297,10 @@ test('GS1', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '7.52 kg' });
 
-    // while open, the picked TU already carries the consignee (stamped at pick time)
+    // while open, the picked TU is partner-less before close (consignee stamped at close)
     await Backend.expect({
         hus: {
-            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: '-', bpartnerLocation: '-' },
         }
     });
 
@@ -354,10 +354,10 @@ test('EAN13 with prefix 28', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '261 g' });
 
-    // while open, the picked TU already carries the consignee (stamped at pick time)
+    // while open, the picked TU is partner-less before close (consignee stamped at close)
     await Backend.expect({
         hus: {
-            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: '-', bpartnerLocation: '-' },
         }
     });
 
@@ -442,10 +442,10 @@ test('EAN13 with prefix 29', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '574 g' });
 
-    // while open, the picked TU already carries the consignee (stamped at pick time)
+    // while open, the picked TU is partner-less before close (consignee stamped at close)
     await Backend.expect({
         hus: {
-            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: '-', bpartnerLocation: '-' },
         }
     });
 
@@ -547,10 +547,10 @@ test('Custom QR code format', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '9.999 kg' });
 
-    // while open, the picked TU already carries the consignee (stamped at pick time)
+    // while open, the picked TU is partner-less before close (consignee stamped at close)
     await Backend.expect({
         hus: {
-            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: '-', bpartnerLocation: '-' },
         }
     });
 

--- a/e2e/mobile-webui/tests/spec/picking/picking_catchWeight.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_catchWeight.spec.js
@@ -297,8 +297,21 @@ test('GS1', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '7.52 kg' });
 
-    // while open, the picked TU is partner-less before close (consignee stamped at close)
+    // While the job is still open, the picked TU is partner-less — the consignee is stamped on
+    // close/ship, not at pick time. The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
+    // gates on the shipment schedules becoming valid, so the hus read below is not a pre-commit race.
     await Backend.expect({
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: {
+                        qtyPicked: [
+                            { qtyPicked: "1 PCE", catchWeight: "7.520 KGM", qtyTUs: 1, qtyLUs: 1, vhu: '-', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' },
+                        ]
+                    }
+                }
+            }
+        },
         hus: {
             tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: '-', bpartnerLocation: '-' },
         }
@@ -354,8 +367,21 @@ test('EAN13 with prefix 28', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '261 g' });
 
-    // while open, the picked TU is partner-less before close (consignee stamped at close)
+    // While the job is still open, the picked TU is partner-less — the consignee is stamped on
+    // close/ship, not at pick time. The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
+    // gates on the shipment schedules becoming valid, so the hus read below is not a pre-commit race.
     await Backend.expect({
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: {
+                        qtyPicked: [
+                            { qtyPicked: "1 PCE", catchWeight: "0.261 KGM", qtyTUs: 1, qtyLUs: 1, vhu: '-', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' },
+                        ]
+                    }
+                }
+            }
+        },
         hus: {
             tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: '-', bpartnerLocation: '-' },
         }
@@ -442,8 +468,21 @@ test('EAN13 with prefix 29', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '574 g' });
 
-    // while open, the picked TU is partner-less before close (consignee stamped at close)
+    // While the job is still open, the picked TU is partner-less — the consignee is stamped on
+    // close/ship, not at pick time. The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
+    // gates on the shipment schedules becoming valid, so the hus read below is not a pre-commit race.
     await Backend.expect({
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: {
+                        qtyPicked: [
+                            { qtyPicked: "1 PCE", catchWeight: "0.574 KGM", qtyTUs: 1, qtyLUs: 1, vhu: '-', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' },
+                        ]
+                    }
+                }
+            }
+        },
         hus: {
             tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: '-', bpartnerLocation: '-' },
         }
@@ -547,8 +586,21 @@ test('Custom QR code format', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '9.999 kg' });
 
-    // while open, the picked TU is partner-less before close (consignee stamped at close)
+    // While the job is still open, the picked TU is partner-less — the consignee is stamped on
+    // close/ship, not at pick time. The pickings block binds the tu1 alias (via M_TU_HU_ID) AND
+    // gates on the shipment schedules becoming valid, so the hus read below is not a pre-commit race.
     await Backend.expect({
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: {
+                        qtyPicked: [
+                            { qtyPicked: "1 PCE", catchWeight: "9.999 KGM", qtyTUs: 1, qtyLUs: 1, vhu: '-', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' },
+                        ]
+                    }
+                }
+            }
+        },
         hus: {
             tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: '-', bpartnerLocation: '-' },
         }

--- a/e2e/mobile-webui/tests/spec/picking/picking_catchWeight.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_catchWeight.spec.js
@@ -116,7 +116,7 @@ test('Manual', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '93  PCE' }, attributes: { 'WeightNet': '9.211', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
-            lu1: { huStatus: 'S', storages: { P1: '7 PCE' }, attributes: { 'WeightNet': '0.789', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
+            lu1: { huStatus: 'S', storages: { P1: '7 PCE' }, attributes: { 'WeightNet': '0.789', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 
@@ -135,7 +135,7 @@ test('Manual', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '93  PCE' }, attributes: { 'WeightNet': '9.211', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
-            lu1: { huStatus: 'E', storages: { P1: '7 PCE' }, attributes: { 'WeightNet': '0.789', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
+            lu1: { huStatus: 'E', storages: { P1: '7 PCE' }, attributes: { 'WeightNet': '0.789', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });
@@ -191,12 +191,12 @@ test('Leich+Mehl', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '95  PCE' }, attributes: { 'WeightNet': '9.495', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
-            lu1: { huStatus: 'S', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
-            tu1: { huStatus: 'S', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
-            cu2: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
-            cu3: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
-            cu4: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
-            cu5: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
+            lu1: { huStatus: 'S', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            tu1: { huStatus: 'S', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            cu2: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            cu3: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            cu4: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            cu5: { huStatus: 'S', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 
@@ -219,12 +219,12 @@ test('Leich+Mehl', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '95  PCE' }, attributes: { 'WeightNet': '9.495', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
-            lu1: { huStatus: 'E', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
-            tu1: { huStatus: 'E', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
-            cu2: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
-            cu3: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
-            cu4: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
-            cu5: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' } },
+            lu1: { huStatus: 'E', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            tu1: { huStatus: 'E', storages: { P1: '5 PCE' }, attributes: { 'WeightNet': '0.505', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            cu2: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            cu3: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            cu4: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+            cu5: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.101', 'Lot-Nummer': '500', 'HU_BestBeforeDate': '2025-11-08' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });
@@ -297,6 +297,13 @@ test('GS1', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '7.52 kg' });
 
+    // while open, the picked TU already carries the consignee (stamped at pick time)
+    await Backend.expect({
+        hus: {
+            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+        }
+    });
+
     await PickingJobScreen.complete();
     await Backend.expect({
         pickings: {
@@ -312,7 +319,7 @@ test('GS1', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '99  PCE' }, attributes: { 'WeightNet': '2.480', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
-            tu1: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '7.520', 'Lot-Nummer': '501', 'HU_BestBeforeDate': '2027-08-09' } },
+            tu1: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '7.520', 'Lot-Nummer': '501', 'HU_BestBeforeDate': '2027-08-09' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });
@@ -347,6 +354,13 @@ test('EAN13 with prefix 28', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '261 g' });
 
+    // while open, the picked TU already carries the consignee (stamped at pick time)
+    await Backend.expect({
+        hus: {
+            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+        }
+    });
+
     await PickingJobScreen.complete();
     await Backend.expect({
         pickings: {
@@ -362,7 +376,7 @@ test('EAN13 with prefix 28', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '99  PCE' }, attributes: { 'WeightNet': '9.739', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
-            tu1: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.261', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
+            tu1: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.261', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });
@@ -428,6 +442,13 @@ test('EAN13 with prefix 29', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '574 g' });
 
+    // while open, the picked TU already carries the consignee (stamped at pick time)
+    await Backend.expect({
+        hus: {
+            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+        }
+    });
+
     await PickingJobScreen.complete();
     await Backend.expect({
         pickings: {
@@ -443,7 +464,7 @@ test('EAN13 with prefix 29', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '99  PCE' }, attributes: { 'WeightNet': '9.426', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
-            tu1: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.574', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
+            tu1: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '0.574', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });
@@ -526,6 +547,13 @@ test('Custom QR code format', async ({ page }) => {
     });
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '1 Stk', qtyPickedCatchWeight: '9.999 kg' });
 
+    // while open, the picked TU already carries the consignee (stamped at pick time)
+    await Backend.expect({
+        hus: {
+            tu1: { huStatus: 'S', storages: { P1: '1 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
+        }
+    });
+
     await PickingJobScreen.complete();
     await Backend.expect({
         pickings: {
@@ -541,7 +569,7 @@ test('Custom QR code format', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '99  PCE' }, attributes: { 'WeightNet': '0.001', 'Lot-Nummer': 'lot1', 'HU_BestBeforeDate': '2031-11-23' } },
-            tu1: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '9.999', 'Lot-Nummer': '123', 'HU_BestBeforeDate': '2026-04-10' } },
+            tu1: { huStatus: 'E', storages: { P1: '1 PCE' }, attributes: { 'WeightNet': '9.999', 'Lot-Nummer': '123', 'HU_BestBeforeDate': '2026-04-10' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 });

--- a/e2e/mobile-webui/tests/spec/picking/picking_multiProduct_aggregatedTUs.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_multiProduct_aggregatedTUs.spec.js
@@ -121,7 +121,7 @@ test('Aggregated TUs - 4 products into 1 LU', async ({ page }) => {
                 [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '170 PCE' } },
                 [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '160 PCE' } },
                 [masterdata.handlingUnits.HU4.qrCode]: { huStatus: 'A', storages: { P4: '190 PCE' } },
-                lu1: { huStatus: 'S', storages: { P1: '20 PCE', P2: '30 PCE', P3: '40 PCE', P4: '10 PCE' } },
+                lu1: { huStatus: 'S', storages: { P1: '20 PCE', P2: '30 PCE', P3: '40 PCE', P4: '10 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             }
         });
     });
@@ -153,7 +153,7 @@ test('Aggregated TUs - 4 products into 1 LU', async ({ page }) => {
                 [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '170 PCE' } },
                 [masterdata.handlingUnits.HU3.qrCode]: { huStatus: 'A', storages: { P3: '160 PCE' } },
                 [masterdata.handlingUnits.HU4.qrCode]: { huStatus: 'A', storages: { P4: '190 PCE' } },
-                lu1: { huStatus: 'E', storages: { P1: '20 PCE', P2: '30 PCE', P3: '40 PCE', P4: '10 PCE' } },
+                lu1: { huStatus: 'E', storages: { P1: '20 PCE', P2: '30 PCE', P3: '40 PCE', P4: '10 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             }
         });
     });
@@ -266,7 +266,7 @@ test('Standalone TUs - same product picked in separate scans', async ({ page }) 
             hus: {
                 [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '180 PCE' } },
                 [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '170 PCE' } },
-                lu1: { huStatus: 'S', storages: { P1: '20 PCE', P2: '30 PCE' } },
+                lu1: { huStatus: 'S', storages: { P1: '20 PCE', P2: '30 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             }
         });
     });
@@ -293,7 +293,7 @@ test('Standalone TUs - same product picked in separate scans', async ({ page }) 
             hus: {
                 [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '180 PCE' } },
                 [masterdata.handlingUnits.HU2.qrCode]: { huStatus: 'A', storages: { P2: '170 PCE' } },
-                lu1: { huStatus: 'E', storages: { P1: '20 PCE', P2: '30 PCE' } },
+                lu1: { huStatus: 'E', storages: { P1: '20 PCE', P2: '30 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
             }
         });
     });

--- a/e2e/mobile-webui/tests/spec/picking/productBasedPicking/pick_by_ExternalBarcode.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/productBasedPicking/pick_by_ExternalBarcode.spec.js
@@ -159,9 +159,14 @@ test('Scan the pick from HU by ExternalBarcode', async ({ page }) => {
             // },
             hus: {
                 [masterdata.handlingUnits.P1_HU.qrCode]: { huStatus: 'A', storages: { P1: '8  PCE' } },
-                tu11: { huStatus: 'S', storages: { P1: '20 PCE' } },
-                tu12: { huStatus: 'S', storages: { P1: '24 PCE' } },
-                tu13: { huStatus: 'E', storages: { P1: '28 PCE' } },
+                // Product-based job: each picked LU/TU carries the consignee of the sales order it was
+                // picked for — line1 20 PCE => SO1/customer1, line2 24 PCE => SO2/customer2,
+                // line3 28 PCE => SO3/customer3 (see salesOrders SO1/SO2/SO3 above). Each customer is
+                // declared without an explicit location, so bpartnerLocation resolves via the single
+                // default ship-to (the _singleBPLocationI fallback) — same identifier as the bpartner.
+                tu11: { huStatus: 'S', storages: { P1: '20 PCE' }, bpartner: 'customer1', bpartnerLocation: 'customer1' },
+                tu12: { huStatus: 'S', storages: { P1: '24 PCE' }, bpartner: 'customer2', bpartnerLocation: 'customer2' },
+                tu13: { huStatus: 'E', storages: { P1: '28 PCE' }, bpartner: 'customer3', bpartnerLocation: 'customer3' },
             }
             // hus: {
             //     [masterdata.handlingUnits.P1_HU.qrCode]: { huStatus: 'A', storages: { P1: '8  PCE' } },

--- a/e2e/mobile-webui/tests/spec/picking/productBasedPicking/standard.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/productBasedPicking/standard.spec.js
@@ -177,9 +177,14 @@ test('Product based aggregation', async ({ page }) => {
             // },
             hus: {
                 [masterdata.handlingUnits.P1_HU.qrCode]: { huStatus: 'A', storages: { P1: '8  PCE' } },
-                tu11: { huStatus: 'S', storages: { P1: '20 PCE' } },
-                tu12: { huStatus: 'S', storages: { P1: '24 PCE' } },
-                tu13: { huStatus: 'E', storages: { P1: '28 PCE' } },
+                // Product-based job: each picked LU/TU carries the consignee of the sales order it was
+                // picked for — line1 20 PCE => SO1/customer1, line2 24 PCE => SO2/customer2,
+                // line3 28 PCE => SO3/customer3 (see salesOrders SO1/SO2/SO3 above). Each customer is
+                // declared without an explicit location, so bpartnerLocation resolves via the single
+                // default ship-to (the _singleBPLocationI fallback) — same identifier as the bpartner.
+                tu11: { huStatus: 'S', storages: { P1: '20 PCE' }, bpartner: 'customer1', bpartnerLocation: 'customer1' },
+                tu12: { huStatus: 'S', storages: { P1: '24 PCE' }, bpartner: 'customer2', bpartnerLocation: 'customer2' },
+                tu13: { huStatus: 'E', storages: { P1: '28 PCE' }, bpartner: 'customer3', bpartnerLocation: 'customer3' },
             }
             // hus: {
             //     [masterdata.handlingUnits.P1_HU.qrCode]: { huStatus: 'A', storages: { P1: '8  PCE' } },

--- a/e2e/mobile-webui/tests/spec/picking/scan_HU_barcodes.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/scan_HU_barcodes.spec.js
@@ -85,7 +85,7 @@ test('Pick by scanning HU QR Code', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '68 PCE' } },
-            lu1: { huStatus: 'S', storages: { P1: '12 PCE' } },
+            lu1: { huStatus: 'S', storages: { P1: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 
@@ -130,7 +130,7 @@ test('Pick by scanning M_HU_ID', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '68 PCE' } },
-            lu1: { huStatus: 'S', storages: { P1: '12 PCE' } },
+            lu1: { huStatus: 'S', storages: { P1: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 
@@ -176,7 +176,7 @@ test('Pick by scanning ExternalBarcode', async ({ page }) => {
         },
         hus: {
             [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '68 PCE' } },
-            lu1: { huStatus: 'S', storages: { P1: '12 PCE' } },
+            lu1: { huStatus: 'S', storages: { P1: '12 PCE' }, bpartner: 'BP1', bpartnerLocation: 'BP1' },
         }
     });
 


### PR DESCRIPTION
Adds the automated test coverage for the picking-consignee stamp delivered in PR https://github.com/metasfresh/metasfresh/pull/24904.

The fix stamps the picking consignee (`C_BPartner_ID` + `C_BPartner_Location_ID`) onto a picking LU so the per-BPartner `M_HU_Label_Config` matches and the correct SSCC label auto-prints (and later re-print works).

## What this PR adds

- **JUnit** (`de.metas.handlingunits.base`):
  - `PickingJobLabelConsigneeTest` — `PickingJobHUService.setBPartnerAndLocationIfNotSet`: a partner-less LU gets the consignee stamped; an LU that already carries a partner is left unchanged (stamp-only-if-unset guard). This is where a genuinely partner-less LU *can* be constructed, so the guard is proven at the JUnit level.
  - `HULabelConfigRepositoryTest` — locks the (unchanged) label-config matching invariant: the per-BPartner config is selected over the null-bpartner catch-all when it has the lower `SeqNo` (the config ordering the fix relies on); a consignee without a specific config falls through to the catch-all.
- **Playwright** (`e2e/mobile-webui`): `closeLU_stampsConsignee.spec.js` covers BOTH pick-target shapes — line-level (PRODUCT aggregation) and header-level (DELIVERY_LOCATION aggregation). Each picks onto an LU, closes the LU, and asserts the closed LU **and its cascaded TU/CU** carry the correct consignee `C_BPartner_ID` + `C_BPartner_Location_ID` — the end state the per-BPartner label-config lookup depends on. In-memory JUnit does not prove HU flush, so the persistence proof is E2E, one branch per HU shape (module rule).
  - Additionally, the existing picking specs that already assert HU state now also assert `bpartner` / `bpartnerLocation` at both the open ('S') and completed ('E') states, matching each pick flow's observed behaviour (bare-TU / CU-into-LU picks are partner-less while the job is open — the consignee is stamped on close/ship; target-LU picks carry it at pick time). Each intermediate `Backend.expect` is preceded by a `pickings` fence that binds the HU alias and gates on the async commit, so the reads are not racy.
  - Enabler: extends the frontend-testing masterdata assertion API (`JsonHUExpectation` + `AssertHUExpectationsCommand`) to assert `bpartner` / `bpartnerLocation` on an HU (`'-'` = expect none) — this was not previously assertable.
- **Cucumber**: N/A — mobile-UI features are covered by Playwright, not new cucumber scenarios (standing feature-owner directive); JUnit + Playwright cover the fix.

## Notes

- This branch is **stacked on `soft_panda_hotfix_HULabelConsignee`** (https://github.com/metasfresh/metasfresh/pull/24904), so until that PR integrates into `soft_panda_hotfix` the diff includes its fix commit https://github.com/metasfresh/metasfresh/commit/507428a207e.
- The Playwright specs are verified green against an isolated mobile stack built from the current `soft_panda_hotfix` images (full `tests/spec/picking/` = 101 passed), with fresh `.webm` evidence per scenario.
