### PR TITLE
HU Label Config: desktop picking label consignee parity (#30763 AC8)

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/picking/pickingslot/process/PickingSlotViewBasedProcess.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/picking/pickingslot/process/PickingSlotViewBasedProcess.java
@@ -1,8 +1,12 @@
 package de.metas.ui.web.picking.pickingslot.process;
 
+import de.metas.bpartner.BPartnerLocationId;
+import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.model.I_M_ShipmentSchedule;
+import de.metas.handlingunits.picking.job.service.external.hu.PickingJobHUService;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
+import de.metas.inoutcandidate.api.IShipmentScheduleEffectiveBL;
 import de.metas.inoutcandidate.api.IShipmentSchedulePA;
 import de.metas.process.IProcessPrecondition;
 import de.metas.ui.web.picking.packageable.PackageableView;
@@ -12,8 +16,11 @@ import de.metas.ui.web.picking.pickingslot.PickingSlotView;
 import de.metas.ui.web.process.adprocess.ViewBasedProcessTemplate;
 import de.metas.ui.web.view.ViewId;
 import de.metas.util.Services;
+import lombok.NonNull;
+import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_UOM;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 /*
@@ -42,6 +49,8 @@ abstract class PickingSlotViewBasedProcess extends ViewBasedProcessTemplate impl
 {
 	private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
 	private final IShipmentSchedulePA shipmentSchedulesRepo = Services.get(IShipmentSchedulePA.class);
+	private final IShipmentScheduleEffectiveBL shipmentScheduleEffectiveBL = Services.get(IShipmentScheduleEffectiveBL.class);
+	private final PickingJobHUService pickingJobHUService = SpringContextHolder.instance.getBean(PickingJobHUService.class);
 
 	private I_M_ShipmentSchedule _shipmentSchedule; // lazy
 
@@ -108,5 +117,44 @@ abstract class PickingSlotViewBasedProcess extends ViewBasedProcessTemplate impl
 	protected Optional<ProductBarcodeFilterData> getBarcodeFilterData()
 	{
 		return Optional.ofNullable(getPackageableView().getBarcodeFilterData());
+	}
+
+	/**
+	 * Desktop-picking parity with the mobile close-LU fix (me03 #30763, AC8): a picking HU materialised without a
+	 * {@code C_BPartner_ID} misses the per-BPartner {@code M_HU_Label_Config} (the label lookup keys on the HU's own
+	 * bpartner), so the SSCC label auto-print is skipped — or, for {@code failOnMissingLabelConfig=true} callers, the
+	 * print throws. Resolve the consignee from the current shipment schedule and stamp it (only-if-unset) BEFORE the
+	 * label print, so the unchanged label-matching path selects the correct per-BPartner config. Reuses the same
+	 * guarded stamp method as the mobile fix; the {@code M_HU} {@code updateChildren} interceptor cascades the
+	 * bpartner + location to child TUs/CUs.
+	 */
+	protected final void stampConsigneeIfNotSet(@NonNull final HuId huId)
+	{
+		final BPartnerLocationId bpLocationId = getConsigneeLocationOrNull(getCurrentShipmentSchedule());
+		if (bpLocationId == null)
+		{
+			return;
+		}
+
+		pickingJobHUService.setBPartnerAndLocationIfNotSet(huId, bpLocationId);
+	}
+
+	/**
+	 * The effective consignee delivery location of the schedule, or {@code null} if none is resolvable.
+	 * <p>
+	 * {@link IShipmentScheduleEffectiveBL#getBPartnerLocationId(I_M_ShipmentSchedule)} resolves through the
+	 * value-object factory {@code BPartnerLocationId.ofRepoId(...)}, which <b>throws</b> (not returns null) when the
+	 * effective delivery-location FK is unset — so we guard the optional FK before calling, per the module convention
+	 * (guard an optional FK {@code <= 0} before {@code ofRepoId}). A schedule without a resolvable delivery location
+	 * simply gets no stamp (label matching then behaves as before this fix) rather than aborting the print.
+	 */
+	@Nullable
+	private BPartnerLocationId getConsigneeLocationOrNull(@NonNull final I_M_ShipmentSchedule shipmentSchedule)
+	{
+		final boolean hasEffectiveLocation = shipmentSchedule.getC_BP_Location_Override_ID() > 0
+				|| shipmentSchedule.getC_BPartner_Location_ID() > 0;
+		return hasEffectiveLocation
+				? shipmentScheduleEffectiveBL.getBPartnerLocationId(shipmentSchedule)
+				: null;
 	}
 }

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/picking/pickingslot/process/WEBUI_Picking_PickQtyToNewHU.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/picking/pickingslot/process/WEBUI_Picking_PickQtyToNewHU.java
@@ -1,6 +1,7 @@
 package de.metas.ui.web.picking.pickingslot.process;
 
 import com.google.common.collect.ImmutableList;
+import de.metas.bpartner.BPartnerLocationId;
 import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHUPIItemProductBL;
@@ -11,6 +12,7 @@ import de.metas.handlingunits.model.I_M_HU_PI;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.handlingunits.model.I_M_ShipmentSchedule;
 import de.metas.handlingunits.model.X_M_HU;
+import de.metas.handlingunits.picking.job.service.external.hu.PickingJobHUService;
 import de.metas.handlingunits.report.HUToReportWrapper;
 import de.metas.handlingunits.report.labels.HULabelPrintRequest;
 import de.metas.handlingunits.report.labels.HULabelService;
@@ -82,6 +84,8 @@ public class WEBUI_Picking_PickQtyToNewHU
 	private final IWarehouseBL warehouseBL = Services.get(IWarehouseBL.class);
 	private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
 	private final HULabelService huLabelService = SpringContextHolder.instance.getBean(HULabelService.class);
+	private final PickingJobHUService pickingJobHUService = SpringContextHolder.instance.getBean(PickingJobHUService.class);
+	private final IShipmentScheduleEffectiveBL shipmentScheduleEffectiveBL = Services.get(IShipmentScheduleEffectiveBL.class);
 
 	protected static final String PARAM_M_HU_PI_Item_Product_ID = I_M_HU_PI_Item_Product.COLUMNNAME_M_HU_PI_Item_Product_ID;
 	@Param(parameterName = PARAM_M_HU_PI_Item_Product_ID, mandatory = true)
@@ -171,12 +175,34 @@ public class WEBUI_Picking_PickQtyToNewHU
 
 	protected final void printPickingLabelIfAutoPrint(@NonNull final HuId huId)
 	{
+		stampConsigneeIfNotSet(huId);
+
 		huLabelService.print(HULabelPrintRequest.builder()
 									 .sourceDocType(HULabelSourceDocType.Picking)
 									 .hu(HUToReportWrapper.of(handlingUnitsDAO.getById(huId)))
 									 .onlyIfAutoPrint(true)
 									 .failOnMissingLabelConfig(false)
 									 .build());
+	}
+
+	/**
+	 * Desktop-picking parity with the mobile close-LU fix (me03 #30763, AC8): {@link #createTU(I_M_HU_PI_Item_Product, LocatorId)}
+	 * materialises the pack-to HU with no {@code C_BPartner_ID}, so the per-BPartner {@code M_HU_Label_Config} never
+	 * matches and the SSCC auto-print is silently skipped. Resolve the consignee from the current shipment schedule and
+	 * stamp it (only-if-unset) so the unchanged label-matching path selects the correct per-BPartner config. Reuses the
+	 * same guarded stamp method as the mobile fix; the {@code M_HU} {@code updateChildren} interceptor cascades it to
+	 * child TUs/CUs.
+	 */
+	private void stampConsigneeIfNotSet(@NonNull final HuId huId)
+	{
+		final I_M_ShipmentSchedule shipmentSchedule = getCurrentShipmentSchedule();
+		final BPartnerLocationId bpLocationId = shipmentScheduleEffectiveBL.getBPartnerLocationId(shipmentSchedule);
+		if (bpLocationId == null)
+		{
+			return;
+		}
+
+		pickingJobHUService.setBPartnerAndLocationIfNotSet(huId, bpLocationId);
 	}
 
 	@NonNull

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/picking/pickingslot/process/WEBUI_Picking_PickQtyToNewHU.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/picking/pickingslot/process/WEBUI_Picking_PickQtyToNewHU.java
@@ -1,7 +1,6 @@
 package de.metas.ui.web.picking.pickingslot.process;
 
 import com.google.common.collect.ImmutableList;
-import de.metas.bpartner.BPartnerLocationId;
 import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHUPIItemProductBL;
@@ -12,7 +11,6 @@ import de.metas.handlingunits.model.I_M_HU_PI;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.handlingunits.model.I_M_ShipmentSchedule;
 import de.metas.handlingunits.model.X_M_HU;
-import de.metas.handlingunits.picking.job.service.external.hu.PickingJobHUService;
 import de.metas.handlingunits.report.HUToReportWrapper;
 import de.metas.handlingunits.report.labels.HULabelPrintRequest;
 import de.metas.handlingunits.report.labels.HULabelService;
@@ -84,8 +82,6 @@ public class WEBUI_Picking_PickQtyToNewHU
 	private final IWarehouseBL warehouseBL = Services.get(IWarehouseBL.class);
 	private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
 	private final HULabelService huLabelService = SpringContextHolder.instance.getBean(HULabelService.class);
-	private final PickingJobHUService pickingJobHUService = SpringContextHolder.instance.getBean(PickingJobHUService.class);
-	private final IShipmentScheduleEffectiveBL shipmentScheduleEffectiveBL = Services.get(IShipmentScheduleEffectiveBL.class);
 
 	protected static final String PARAM_M_HU_PI_Item_Product_ID = I_M_HU_PI_Item_Product.COLUMNNAME_M_HU_PI_Item_Product_ID;
 	@Param(parameterName = PARAM_M_HU_PI_Item_Product_ID, mandatory = true)
@@ -175,6 +171,9 @@ public class WEBUI_Picking_PickQtyToNewHU
 
 	protected final void printPickingLabelIfAutoPrint(@NonNull final HuId huId)
 	{
+		// AC8 (me03 #30763): createTU builds the pack-to HU with no C_BPartner_ID, so the per-BPartner
+		// M_HU_Label_Config never matches and the auto-print is silently skipped. Stamp the consignee
+		// (only-if-unset) before the print so the unchanged label-matching path selects the correct config.
 		stampConsigneeIfNotSet(huId);
 
 		huLabelService.print(HULabelPrintRequest.builder()
@@ -183,26 +182,6 @@ public class WEBUI_Picking_PickQtyToNewHU
 									 .onlyIfAutoPrint(true)
 									 .failOnMissingLabelConfig(false)
 									 .build());
-	}
-
-	/**
-	 * Desktop-picking parity with the mobile close-LU fix (me03 #30763, AC8): {@link #createTU(I_M_HU_PI_Item_Product, LocatorId)}
-	 * materialises the pack-to HU with no {@code C_BPartner_ID}, so the per-BPartner {@code M_HU_Label_Config} never
-	 * matches and the SSCC auto-print is silently skipped. Resolve the consignee from the current shipment schedule and
-	 * stamp it (only-if-unset) so the unchanged label-matching path selects the correct per-BPartner config. Reuses the
-	 * same guarded stamp method as the mobile fix; the {@code M_HU} {@code updateChildren} interceptor cascades it to
-	 * child TUs/CUs.
-	 */
-	private void stampConsigneeIfNotSet(@NonNull final HuId huId)
-	{
-		final I_M_ShipmentSchedule shipmentSchedule = getCurrentShipmentSchedule();
-		final BPartnerLocationId bpLocationId = shipmentScheduleEffectiveBL.getBPartnerLocationId(shipmentSchedule);
-		if (bpLocationId == null)
-		{
-			return;
-		}
-
-		pickingJobHUService.setBPartnerAndLocationIfNotSet(huId, bpLocationId);
 	}
 
 	@NonNull

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/picking/pickingslot/process/WEBUI_Picking_TU_Label.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/picking/pickingslot/process/WEBUI_Picking_TU_Label.java
@@ -1,15 +1,11 @@
 package de.metas.ui.web.picking.pickingslot.process;
 
-import de.metas.bpartner.BPartnerLocationId;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHandlingUnitsDAO;
-import de.metas.handlingunits.model.I_M_ShipmentSchedule;
-import de.metas.handlingunits.picking.job.service.external.hu.PickingJobHUService;
 import de.metas.handlingunits.report.HUToReportWrapper;
 import de.metas.handlingunits.report.labels.HULabelPrintRequest;
 import de.metas.handlingunits.report.labels.HULabelService;
 import de.metas.handlingunits.report.labels.HULabelSourceDocType;
-import de.metas.inoutcandidate.api.IShipmentScheduleEffectiveBL;
 import de.metas.process.ProcessPreconditionsResolution;
 import de.metas.ui.web.picking.pickingslot.PickingSlotRow;
 import de.metas.util.Services;
@@ -44,9 +40,7 @@ import static de.metas.ui.web.picking.PickingConstants.MSG_WEBUI_PICKING_SELECT_
 public class WEBUI_Picking_TU_Label extends PickingSlotViewBasedProcess
 {
 	private final HULabelService huLabelService = SpringContextHolder.instance.getBean(HULabelService.class);
-	private final PickingJobHUService pickingJobHUService = SpringContextHolder.instance.getBean(PickingJobHUService.class);
 	private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
-	private final IShipmentScheduleEffectiveBL shipmentScheduleEffectiveBL = Services.get(IShipmentScheduleEffectiveBL.class);
 
 	@Override
 	protected ProcessPreconditionsResolution checkPreconditionsApplicable()
@@ -86,6 +80,8 @@ public class WEBUI_Picking_TU_Label extends PickingSlotViewBasedProcess
 
 	protected void printPickingLabel(@NonNull final HuId huId)
 	{
+		// AC8 (me03 #30763): stamp the consignee (only-if-unset) so a partner-less picking HU matches the correct
+		// per-BPartner M_HU_Label_Config instead of throwing here (failOnMissingLabelConfig=true).
 		stampConsigneeIfNotSet(huId);
 
 		huLabelService.print(HULabelPrintRequest.builder()
@@ -94,24 +90,5 @@ public class WEBUI_Picking_TU_Label extends PickingSlotViewBasedProcess
 				.onlyIfAutoPrint(false)
 				.failOnMissingLabelConfig(true)
 				.build());
-	}
-
-	/**
-	 * Desktop-picking parity with the mobile close-LU fix (me03 #30763, AC8): a picking HU materialised without a
-	 * {@code C_BPartner_ID} would miss the per-BPartner {@code M_HU_Label_Config} and — because this process prints
-	 * with {@code failOnMissingLabelConfig=true} — throw instead of printing the consignee's label. Resolve the
-	 * consignee from the current shipment schedule and stamp it (only-if-unset) so the unchanged label-matching path
-	 * selects the correct per-BPartner config. Reuses the same guarded stamp method as the mobile fix.
-	 */
-	private void stampConsigneeIfNotSet(@NonNull final HuId huId)
-	{
-		final I_M_ShipmentSchedule shipmentSchedule = getCurrentShipmentSchedule();
-		final BPartnerLocationId bpLocationId = shipmentScheduleEffectiveBL.getBPartnerLocationId(shipmentSchedule);
-		if (bpLocationId == null)
-		{
-			return;
-		}
-
-		pickingJobHUService.setBPartnerAndLocationIfNotSet(huId, bpLocationId);
 	}
 }

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/picking/pickingslot/process/WEBUI_Picking_TU_Label.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/picking/pickingslot/process/WEBUI_Picking_TU_Label.java
@@ -1,11 +1,15 @@
 package de.metas.ui.web.picking.pickingslot.process;
 
+import de.metas.bpartner.BPartnerLocationId;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHandlingUnitsDAO;
+import de.metas.handlingunits.model.I_M_ShipmentSchedule;
+import de.metas.handlingunits.picking.job.service.external.hu.PickingJobHUService;
 import de.metas.handlingunits.report.HUToReportWrapper;
 import de.metas.handlingunits.report.labels.HULabelPrintRequest;
 import de.metas.handlingunits.report.labels.HULabelService;
 import de.metas.handlingunits.report.labels.HULabelSourceDocType;
+import de.metas.inoutcandidate.api.IShipmentScheduleEffectiveBL;
 import de.metas.process.ProcessPreconditionsResolution;
 import de.metas.ui.web.picking.pickingslot.PickingSlotRow;
 import de.metas.util.Services;
@@ -40,7 +44,9 @@ import static de.metas.ui.web.picking.PickingConstants.MSG_WEBUI_PICKING_SELECT_
 public class WEBUI_Picking_TU_Label extends PickingSlotViewBasedProcess
 {
 	private final HULabelService huLabelService = SpringContextHolder.instance.getBean(HULabelService.class);
+	private final PickingJobHUService pickingJobHUService = SpringContextHolder.instance.getBean(PickingJobHUService.class);
 	private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
+	private final IShipmentScheduleEffectiveBL shipmentScheduleEffectiveBL = Services.get(IShipmentScheduleEffectiveBL.class);
 
 	@Override
 	protected ProcessPreconditionsResolution checkPreconditionsApplicable()
@@ -80,11 +86,32 @@ public class WEBUI_Picking_TU_Label extends PickingSlotViewBasedProcess
 
 	protected void printPickingLabel(@NonNull final HuId huId)
 	{
+		stampConsigneeIfNotSet(huId);
+
 		huLabelService.print(HULabelPrintRequest.builder()
 				.sourceDocType(HULabelSourceDocType.Picking)
 				.hu(HUToReportWrapper.of(handlingUnitsDAO.getById(huId)))
 				.onlyIfAutoPrint(false)
 				.failOnMissingLabelConfig(true)
 				.build());
+	}
+
+	/**
+	 * Desktop-picking parity with the mobile close-LU fix (me03 #30763, AC8): a picking HU materialised without a
+	 * {@code C_BPartner_ID} would miss the per-BPartner {@code M_HU_Label_Config} and — because this process prints
+	 * with {@code failOnMissingLabelConfig=true} — throw instead of printing the consignee's label. Resolve the
+	 * consignee from the current shipment schedule and stamp it (only-if-unset) so the unchanged label-matching path
+	 * selects the correct per-BPartner config. Reuses the same guarded stamp method as the mobile fix.
+	 */
+	private void stampConsigneeIfNotSet(@NonNull final HuId huId)
+	{
+		final I_M_ShipmentSchedule shipmentSchedule = getCurrentShipmentSchedule();
+		final BPartnerLocationId bpLocationId = shipmentScheduleEffectiveBL.getBPartnerLocationId(shipmentSchedule);
+		if (bpLocationId == null)
+		{
+			return;
+		}
+
+		pickingJobHUService.setBPartnerAndLocationIfNotSet(huId, bpLocationId);
 	}
 }


### PR DESCRIPTION
## What

Desktop-picking label parity for me03 #30763 **AC8**: https://github.com/metasfresh/me03/issues/30763

Stamps the picking consignee (BPartner + delivery location) onto the desktop WebUI picking HU **before** the label print, so the unchanged `M_HU_Label_Config` matching path selects the correct per-BPartner config for a partner-less picking HU.

Two call sites in `de.metas.ui.web.base`:
- `WEBUI_Picking_TU_Label.printPickingLabel` — stamp before `huLabelService.print(...)`.
- `WEBUI_Picking_PickQtyToNewHU.printPickingLabelIfAutoPrint` — stamp before the auto-print.

The consignee is resolved from the current shipment schedule via `IShipmentScheduleEffectiveBL.getBPartnerLocationId(...)` and stamped by reusing the **same** guarded facade method as the merged mobile fix: `PickingJobHUService.setBPartnerAndLocationIfNotSet` (only-if-unset). The `M_HU` `updateChildren` interceptor cascades the bpartner + location to child TUs/CUs.

## Why

The desktop picking label processes key the label-config lookup on the HU's **own** bpartner (via `HUToReportWrapper`). Picking HUs in the non-pack-for-shipping flow are materialised **without** a partner, so the per-BPartner `M_HU_Label_Config` rows never match — the same root cause as the mobile bug fixed in https://github.com/metasfresh/metasfresh/pull/24904 (AC1-AC5, commit 3ec948c1fae).

Concretely on the desktop flow:
- `WEBUI_Picking_TU_Label` prints with `failOnMissingLabelConfig=true`, so a partner-less HU **throws** rather than printing the consignee's label.
- `WEBUI_Picking_PickQtyToNewHU` creates its pack-to TU via `createTU` with no bpartner, so its auto-print is silently skipped.

This PR brings the desktop flow to parity with the mobile fix.

## Scope / safety

- The matching path is **untouched** (`HULabelPrintRequest` / `HULabelPrintCommand` / `HULabelConfigRoute` / `HUToReportWrapper`).
- Guard is only-if-unset (`C_BPartner_ID > 0` short-circuit inside the reused method), so pack-for-shipping HUs that already carry a partner are not disturbed.
- No AD / migration / schema change.

## Testing

- Offline reactor compile of `de.metas.ui.web.base` + all upstream dependencies: **success** (JDK8, `mvn -o install -pl de.metas.ui.web.base -am`).
- No unit-test harness exists for these `ViewBasedProcessTemplate` process classes (they require live view/selection state that only the WebUI produces); the stamp logic is a thin guarded delegate. A faithful desktop-picking Playwright/manual proof is deferred (same note as the approach memo).
