### PR TITLE
Remove HU label config UI elements

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5810260_FixHuLabelConfigWindow.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5810260_FixHuLabelConfigWindow.sql
@@ -1,0 +1,12 @@
+-- UI Element: HU-Labels Konfiguration(541647,de.metas.handlingunits) -> HU-Labels Konfiguration(546701,de.metas.handlingunits) -> main -> 20 -> flags.Sofort drucken
+-- Column: M_HU_Label_Config.IsAutoPrint
+-- 2026-07-01T14:18:36.910Z
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=652376
+;
+
+-- UI Element: HU-Labels Konfiguration(541647,de.metas.handlingunits) -> HU-Labels Konfiguration(546701,de.metas.handlingunits) -> main -> 20 -> flags.Exemplare zum Sofortdruck
+-- Column: M_HU_Label_Config.AutoPrintCopies
+-- 2026-07-01T14:18:40.094Z
+DELETE FROM AD_UI_Element WHERE AD_UI_Element_ID=652377
+;
+


### PR DESCRIPTION
Add SQL migration to delete two AD_UI_Element entries related to the HU-Labels Konfiguration window: IsAutoPrint (AD_UI_Element_ID=652376) and AutoPrintCopies (AD_UI_Element_ID=652377). The script removes obsolete UI flags for immediate printing and print copies.