### PR TITLE
HU hotfix: deactivate surplus HU QR-code assignments when aggregate TU count decreases

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/spi/impl/AggregateHUTrxListener.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/allocation/spi/impl/AggregateHUTrxListener.java
@@ -22,6 +22,7 @@ package de.metas.handlingunits.allocation.spi.impl;
  * #L%
  */
 
+import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHUContext;
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.IHandlingUnitsDAO;
@@ -228,9 +229,18 @@ public class AggregateHUTrxListener implements IHUTrxListener
 		}
 
 		// TODO: i think we can move this shit or something better into a model interceptor that is fired when item.qty is changed
+		final List<I_M_HU> includedHUs = handlingUnitsDAO.retrieveIncludedHUs(item);
+		if (!includedHUs.isEmpty())
 		{
 			// update the tare of our aggregate VHU (*if* its storage has such a thing)
-			final I_M_HU aggregateVHU = handlingUnitsDAO.retrieveIncludedHUs(item).get(0);
+			final I_M_HU aggregateVHU = includedHUs.get(0);
+
+			// The aggregate's TU count (item.getQty()) was just reduced above. QR-code assignments are only ever
+			// added (one per TU) and removed on HU-destroy, so the now-excess assignments would stay active and
+			// make the aggregate carry more active QR codes than TUs, breaking the mobile picking check
+			// (#QRCodes == getQtyTU()). Deactivate the surplus, keeping the current TU count.
+			huqrCodesService.deactivateSurplusAssignments(HuId.ofRepoId(aggregateVHU.getM_HU_ID()), item.getQty().intValueExact());
+
 			final IAttributeStorage aggregateVHUAttributeStorage = huContext.getHUAttributeStorageFactory().getAttributeStorage(aggregateVHU);
 
 			final IWeightable aggregateVHUWeightable = Weightables.wrap(aggregateVHUAttributeStorage);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesRepository.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesRepository.java
@@ -173,6 +173,41 @@ public class HUQRCodesRepository
 				});
 	}
 
+	/**
+	 * Soft-delete the SURPLUS active {@code M_HU_QRCode_Assignment} rows of the given HU: keep the oldest
+	 * {@code keepCount} active assignments (ordered ascending by {@code Created}, then
+	 * {@code M_HU_QRCode_Assignment_ID}) and set {@code IsActive='N'} on every row beyond that.
+	 * <p>
+	 * Needed because splitting/picking TUs out of an aggregate HU reduces its TU count (its
+	 * {@code M_HU_Item.Qty}) but leaves the previously-generated QR-code assignments active, so the aggregate
+	 * ends up with more active assignments than TUs. Mobile picking then fails its
+	 * {@code #QRCodes == getQtyTU()} check. Keeping the oldest ones deactivates the newer surplus.
+	 * <p>
+	 * When {@code keepCount <= 0}, all active assignments are deactivated.
+	 */
+	public void deactivateSurplusAssignments(@NonNull final HuId huId, final int keepCount)
+	{
+		final List<I_M_HU_QRCode_Assignment> activeAssignments = queryBL.createQueryBuilder(I_M_HU_QRCode_Assignment.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_HU_QRCode_Assignment.COLUMNNAME_M_HU_ID, huId)
+				.orderBy(I_M_HU_QRCode_Assignment.COLUMNNAME_Created)
+				.orderBy(I_M_HU_QRCode_Assignment.COLUMNNAME_M_HU_QRCode_Assignment_ID)
+				.create()
+				.list();
+
+		final int keep = Math.max(keepCount, 0);
+		if (activeAssignments.size() <= keep)
+		{
+			return; // no surplus to deactivate
+		}
+
+		activeAssignments.subList(keep, activeAssignments.size())
+				.forEach(assignment -> {
+					assignment.setIsActive(false);
+					InterfaceWrapperHelper.save(assignment);
+				});
+	}
+
 	public boolean isQRCodeAssignedToHU(@NonNull final HUQRCode qrCode, @NonNull final HuId huId)
 	{
 		return getHUAssignmentByQRCode(qrCode)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -313,6 +313,17 @@ public class HUQRCodesService
 		huQRCodesRepository.deactivateAssignmentsByHuId(huId);
 	}
 
+	/**
+	 * Keep the oldest {@code keepCount} active QR-code assignments of the given HU and soft-delete the rest.
+	 * Called when an aggregate HU's TU count drops (split/pick out of the aggregate) so its active
+	 * assignments stay in sync with the current TU count. See
+	 * {@link HUQRCodesRepository#deactivateSurplusAssignments(HuId, int)}.
+	 */
+	public void deactivateSurplusAssignments(@NonNull final HuId huId, final int keepCount)
+	{
+		huQRCodesRepository.deactivateSurplusAssignments(huId, keepCount);
+	}
+
 	private List<HUQRCode> getOrCreateQRCodesByHuId(@NonNull final HuId huId, boolean isGenerateQRCodesIfMissing)
 	{
 		if (isGenerateQRCodesIfMissing)


### PR DESCRIPTION
## Root cause

**Hypothesis (mechanism verified by code, runtime symptom not re-reproduced in this code-only PR — a faithful reproduction test lands in the follow-up test PR):**

When TUs are split/picked out of an **aggregate HU**, `AggregateHUTrxListener.updateItemQtyAndSplitIfNeeded` reduces the aggregate's `M_HU_Item.Qty` (its TU count) but **never deactivated the now-excess `M_HU_QRCode_Assignment` rows** (there is an explicit `TODO` in that method acknowledging the missing cleanup).

QR-code generation only ever **adds** codes (one per TU) and only removes them on HU-destroy. As a result an aggregate HU accumulates more active QR-code assignments than its current TU count. Mobile picking then throws `Erwartet {X} QR-Codes, aber nur {Y} erhalten` — `PickingJobPickCommand` checks `getOrCreateQRCodesByHuId(hu).size() == tu.getQtyTU()`.

Verified (mechanism): `AggregateHUTrxListener.updateItemQtyAndSplitIfNeeded` calls `item.setQty(newTuQty)` then has no QR-assignment cleanup (explicit `TODO`); `PickingJobPickCommand` asserts `#QRCodes == getQtyTU()`. No path deactivates surplus assignments except HU-destroy (`deactivateAssignmentsByHuId`).

## Fix

After the aggregate's TU qty is finalized, keep the **oldest** N active assignments (N = current TU count) and soft-delete the surplus (`IsActive='N'`), so the active assignment count stays in sync with the TU count. Hooked on the proven trx-listener path (not a model interceptor).

- **`HUQRCodesRepository.deactivateSurplusAssignments(HuId, keepCount)`** — query the HU's active assignments ordered by `Created` then `M_HU_QRCode_Assignment_ID`, keep the first `keepCount`, deactivate the rest (deactivate all if `keepCount <= 0`). Mirrors the existing `deactivateAssignmentsByHuId` soft-delete pattern.
- **`HUQRCodesService.deactivateSurplusAssignments(HuId, keepCount)`** — delegates to the repository.
- **`AggregateHUTrxListener.updateItemQtyAndSplitIfNeeded`** — calls the service on the aggregate VHU after qty is finalized, guarded on a non-empty included-HUs list.

No DB column / migration is needed.

## Tests

None in this PR by design — this is the **code fix only, part of a multi-part delivery**. Automated tests are added in a **separate follow-up PR**.

## Verification

Module `de.metas.handlingunits.base` compiles clean (`mvn install -pl de.metas.handlingunits.base -am`, BUILD SUCCESS).
