### PR TITLE
Dropship PO — make auto-completion configurable (CompleteDropshipPO SysConfig)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5810270_sys_CompleteDropshipPO_SysConfig.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5810270_sys_CompleteDropshipPO_SysConfig.sql
@@ -1,0 +1,17 @@
+-- SysConfig gate for auto-completion of dropship-warehouse purchase orders auto-created from sales orders.
+-- When Y (default), the created dropship PO is completed immediately in the SO transaction (original behaviour).
+-- When N, the PO is left in DocStatus=Drafted so procurement can review it before completing manually.
+-- This seeds the row with the safe default Y (no behaviour change for existing tenants); the per-instance
+-- value (e.g. 'N' to leave POs in draft) is set in the customer repo via set_sysconfig_value once this row exists.
+
+INSERT INTO AD_SysConfig (AD_Client_ID, AD_Org_ID, AD_SysConfig_ID, ConfigurationLevel,
+                          Created, CreatedBy, Updated, UpdatedBy,
+                          EntityType, IsActive, Name, Value, Description)
+VALUES (0, 0, 541828 /*From ID Server*/, 'O',
+        TO_TIMESTAMP('2026-07-01 12:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        TO_TIMESTAMP('2026-07-01 12:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        'D', 'Y',
+        'de.metas.order.C_Order_CreatePOFromSOs.CompleteDropshipPO',
+        'Y',
+        'Wenn ''Y'' (Standard), wird die aus einem Verkaufsauftrag automatisch erzeugte Streckengeschäft-Bestellung sofort abgeschlossen. Bei ''N'' bleibt die Bestellung im Status Entwurf, damit der Einkauf sie vor dem Abschluss prüfen kann.')
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/createFrom/po_from_so/DropshipPOFromSOService.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/createFrom/po_from_so/DropshipPOFromSOService.java
@@ -137,10 +137,17 @@ public class DropshipPOFromSOService
 		// warehouses via the isDropShipWarehouse flag on receipt-schedule events (see
 		// M_ReceiptSchedule_PostMaterialEvent and the dispo-service ReceiptsSchedule*Handlers),
 		// so no MD_Candidate rows are created.
-		final IDocumentBL documentBL = Services.get(IDocumentBL.class);
-		for (final I_C_Order po : createdPOs)
+		//
+		// Guarded by SysConfig de.metas.order.C_Order_CreatePOFromSOs.CompleteDropshipPO (default Y):
+		// when N, the created dropship PO(s) are left in DocStatus=DR so procurement can review and
+		// complete them manually. Default Y preserves the original auto-complete behaviour.
+		if (orderCreatePOFromSOsBL.isCompleteDropshipPO())
 		{
-			documentBL.processEx(po, IDocument.ACTION_Complete, IDocument.STATUS_Completed);
+			final IDocumentBL documentBL = Services.get(IDocumentBL.class);
+			for (final I_C_Order po : createdPOs)
+			{
+				documentBL.processEx(po, IDocument.ACTION_Complete, IDocument.STATUS_Completed);
+			}
 		}
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/createFrom/po_from_so/IC_Order_CreatePOFromSOsBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/createFrom/po_from_so/IC_Order_CreatePOFromSOsBL.java
@@ -49,4 +49,11 @@ public interface IC_Order_CreatePOFromSOsBL extends ISingletonService
 	 * @return <code>QtyOrdered</code> or <code>QtyReserved</code>. Never anything else.
 	 */
 	String getConfigPurchaseQtySource();
+
+	/**
+	 * @return whether a dropship purchase order auto-created from a sales order should be completed (default {@code true}).
+	 * When {@code false}, the created dropship PO is left in DocStatus=Drafted for manual review.
+	 * Controlled by SysConfig {@code de.metas.order.C_Order_CreatePOFromSOs.CompleteDropshipPO}.
+	 */
+	boolean isCompleteDropshipPO();
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/createFrom/po_from_so/impl/C_Order_CreatePOFromSOsBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/createFrom/po_from_so/impl/C_Order_CreatePOFromSOsBL.java
@@ -42,6 +42,7 @@ public class C_Order_CreatePOFromSOsBL implements IC_Order_CreatePOFromSOsBL
 
 	private static final String SYSCONFIG_PURCHASE_QTY_SOURCE = "de.metas.order.C_Order_CreatePOFromSOs.PurchaseQtySource";
 	private static final String SYSCONFIG_PURCHASE_QTY_SOURCE_DEFAULT = I_C_OrderLine.COLUMNNAME_QtyOrdered;
+	private static final String SYSCONFIG_COMPLETE_DROPSHIP_PO = "de.metas.order.C_Order_CreatePOFromSOs.CompleteDropshipPO";
 
 	private final ArrayList<IC_Order_CreatePOFromSOsListener> listeners = new ArrayList<>();
 
@@ -79,5 +80,11 @@ public class C_Order_CreatePOFromSOsBL implements IC_Order_CreatePOFromSOsBL
 			return SYSCONFIG_PURCHASE_QTY_SOURCE_DEFAULT;
 		}
 		return purchaseQtySource;
+	}
+
+	@Override
+	public boolean isCompleteDropshipPO()
+	{
+		return Services.get(ISysConfigBL.class).getBooleanValue(SYSCONFIG_COMPLETE_DROPSHIP_PO, true);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/createFrom/po_from_so/DropshipPOFromSOServiceTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/createFrom/po_from_so/DropshipPOFromSOServiceTest.java
@@ -91,6 +91,7 @@ class DropshipPOFromSOServiceTest
 		when(orderCreatePOFromSOsBL.getConfigPurchaseQtySource()).thenReturn("QtyOrdered");
 		when(orderCreatePOFromSOsDAO.retrieveOrderLines(any(), anyBoolean(), anyString()))
 				.thenReturn(Collections.emptyList());
+		when(orderCreatePOFromSOsBL.isCompleteDropshipPO()).thenReturn(true);
 
 		service = new TestableDropshipPOFromSOService();
 	}
@@ -245,6 +246,32 @@ class DropshipPOFromSOServiceTest
 				.isInstanceOf(AdempiereException.class);
 
 		// and processEx was never called
+		verify(documentBL, never()).processEx(any(), anyString(), anyString());
+	}
+
+	/**
+	 * AC1: when isCompleteDropshipPO() returns false, the created dropship PO is left in
+	 * DocStatus=DR — processEx must NOT be called.
+	 */
+	@Test
+	void createDropshipPOForSO_leavesPODraftWhenCompleteDropshipPOIsFalse()
+	{
+		// Given: draft mode configured
+		when(orderCreatePOFromSOsBL.isCompleteDropshipPO()).thenReturn(false);
+		final I_C_Order salesOrder = createSalesOrder();
+
+		// and a draft dropship PO linked to it (what the aggregator produces)
+		final I_C_Order draftPO = newInstance(I_C_Order.class);
+		draftPO.setIsSOTrx(false);
+		draftPO.setLink_Order_ID(salesOrder.getC_Order_ID());
+		draftPO.setDocStatus(IDocument.STATUS_Drafted);
+		draftPO.setIsDropShip(true);
+		saveRecord(draftPO);
+
+		// When
+		service.createDropshipPOForSO(salesOrder);
+
+		// Then: PO left in draft — no completion
 		verify(documentBL, never()).processEx(any(), anyString(), anyString());
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/createFrom/po_from_so/DropshipPOFromSOServiceTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/createFrom/po_from_so/DropshipPOFromSOServiceTest.java
@@ -250,7 +250,7 @@ class DropshipPOFromSOServiceTest
 	}
 
 	/**
-	 * AC1: when isCompleteDropshipPO() returns false, the created dropship PO is left in
+	 * When isCompleteDropshipPO() returns false, the created dropship PO is left in
 	 * DocStatus=DR — processEx must NOT be called.
 	 */
 	@Test


### PR DESCRIPTION
## What
Make auto-completion of the dropship-warehouse purchase order configurable.

When a sales order on a dropship warehouse is completed, the system auto-creates one vendor purchase order and, until now, always auto-completed it in the same transaction. This adds a SysConfig gate:

- `de.metas.order.C_Order_CreatePOFromSOs.CompleteDropshipPO` (boolean, default `Y`).
- `Y` (default): unchanged behaviour — the created dropship PO is completed immediately.
- `N`: the dropship PO is left in `DocStatus=Drafted` so procurement can review and complete it manually.

## Why
Some deployments want procurement to review the vendor PO before it is committed. The default preserves the existing auto-complete behaviour for everyone else (no regression).

## Changes
- `IC_Order_CreatePOFromSOsBL#isCompleteDropshipPO()` accessor; implementation reads the SysConfig with default `true`.
- `DropshipPOFromSOService.createDropshipPOForSO` guards the PO-completion loop with the accessor.
- Unit tests cover both modes (PO completed vs. left in draft).
- Migration `5810270` seeds the SysConfig row with the safe default `Y`.

## Safety of draft mode
All PO-completion side-effects (the per-PO project chain, receipt schedules / material events) are triggered by PO completion or are post-commit-deferred. In draft mode they simply run later when the PO is completed manually — nothing in the sales-order transaction reads them back synchronously.
