### PR TITLE
Quickpack — skip fully-picked lines in pick-all

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick_all/PickingJobPickAllCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick_all/PickingJobPickAllCommand.java
@@ -35,6 +35,12 @@ public class PickingJobPickAllCommand
 
 		for (PickingJobLine line : pickingJob.getLines())
 		{
+			// A zero qtyRemainingToPick would trip the pick command's "qtyToPickCUs shall not be zero" guard and roll back the whole Quick Pack.
+			if (line.isFullyPicked())
+			{
+				continue;
+			}
+
 			pickingJobChanged = pickingJobService.newPickCommand()
 					.pickingJob(pickingJobChanged)
 					.pickingJobLineId(line.getId())

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 7 | 12 | 58% |
-| Picking | 70 | 74 | 95% |
+| Picking | 71 | 75 | 95% |
 | Distribution | 40 | 41 | 98% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
@@ -117,10 +117,11 @@
 | Scenario | Test |
 |---|---|
 | Pick All button picks all remaining HUs in one action | `picking/pickAllButton.spec.js` |
+| Pick All completes a job that already has a fully-picked line (no abort on the zero-remaining line) | `picking/pickAllButton.spec.js` |
 | Pick All button hidden when feature disabled in mobile config | `picking/pickAllButton.spec.js` |
 | Only one matching HU → picking proceeds without qty dialog | `picking/pickAttributes.spec.js` |
 
-**3/3 — 100%**
+**4/4 — 100%**
 
 ### Order-based picking — serial-no scan
 

--- a/e2e/mobile-webui/tests/spec/picking/pickAllButton.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/pickAllButton.spec.js
@@ -110,6 +110,67 @@ test('Pick using Pick All button', async ({ page }) => {
 });
 
 // noinspection JSUnusedLocalSymbols
+test('Pick All completes a job that already has a fully-picked line', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00246: Quickpack');
+        allure.tag('F00246');  // Standalone tag for Tags section;
+    allure.story('Pick All button');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({ allowQuickPackAll: true });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+
+    // Pick the first line (P1) manually to full BEFORE using Quick Pack.
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode, expectNextScreen: 'PickLineScanScreen', gotoPickingJobScreen: true });
+    await PickingJobScreen.pickHU({
+        qrCode: masterdata.handlingUnits.HU1.qrCode,
+        isScanDirectly: true,
+        expectQtyEntered: '10',
+    });
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '10 Stk', qtyPicked: '10 Stk', waitForColor: 'green' });
+
+    // Quick Pack must finish the remaining lines and complete the job — it must NOT abort
+    // because the already-picked P1 line has nothing left to pick.
+    await PickingJobScreen.clickPickAllButton();
+    await PickingJobsListScreen.expectJobButtons([]);
+
+    await Backend.expect({
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: {
+                        qtyPicked: [{ qtyPicked: "10 PCE", qtyTUs: 0, qtyLUs: 0, vhu: 'vhu1', tu: '-', lu: '-', processed: true, shipmentLineId: 'shipmentLineId1' }]
+                    },
+                    P2: {
+                        qtyPicked: [{ qtyPicked: "10 PCE", qtyTUs: 0, qtyLUs: 0, vhu: 'vhu2', tu: '-', lu: '-', processed: true, shipmentLineId: 'shipmentLineId2' }]
+                    },
+                    P3: {
+                        qtyPicked: [{ qtyPicked: "10 PCE", qtyTUs: 0, qtyLUs: 0, vhu: 'vhu3', tu: '-', lu: '-', processed: true, shipmentLineId: 'shipmentLineId3' }]
+                    }
+                }
+            }
+        },
+        pickingSlots: { [masterdata.pickingSlots.slot1.qrCode]: { queue: [] } },
+        hus: {
+            HU1: { huStatus: 'A', storages: { P1: '990 PCE' } },
+            HU2: { huStatus: 'A', storages: { P2: '990 PCE' } },
+            HU3: { huStatus: 'A', storages: { P3: '990 PCE' } },
+            vhu1: { huStatus: 'E', storages: { P1: '10 PCE' } },
+            vhu2: { huStatus: 'E', storages: { P2: '10 PCE' } },
+            vhu3: { huStatus: 'E', storages: { P3: '10 PCE' } },
+        }
+    });
+
+});
+
+// noinspection JSUnusedLocalSymbols
 test('Expect Pick All button hidden when feature is not active', async ({ page }) => {
     // === ALLURE METADATA ===
     allure.epic('E0105: Picking');


### PR DESCRIPTION
## Problem
Quick Pack (mobile Pick-All / `pickAllAndComplete`) throws and rolls back the **whole** picking job when any line has nothing left to pick (e.g. a line the operator already picked manually). `PickingJobPickAllCommand` iterates every line and feeds `qtyRemainingToPick` (= 0 for a fully-picked line) into the pick command, tripping the guard `qtyToPickCUs shall not be zero if isPickWholeTU is false` (`PickingJobPickCommand.splitOutPickToHUs`). Result: Quick Pack is unusable on any partially-picked order.

## Fix
Skip lines with nothing left to pick (`line.isFullyPicked()`) in the pick-all loop — matching the predicate already used by the sibling line-iterating commands (`GetNextEligibleLineToPackCommand`, `PickingJobGetQtyAvailableCommand`). The deliberate zero-qty guard in `PickingJobPickCommand` is unchanged.

## Test (Playwright, mobile-webui)
New scenario in `pickAllButton.spec.js`: pick one line manually to full, then Quick Pack → job completes, all lines picked. Verified locally RED (before) → GREEN (after) against a from-source app-server on a deep_tundra stack. The existing fresh-order Pick-All scenario still passes.

Issue: https://github.com/metasfresh/me03/issues/30519
