### PR TITLE
Tolerate surplus HU QR-code assignments in mobile picking

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
@@ -906,11 +906,8 @@ public class PickingJobPickCommand
 	{
 
 		final List<HUQRCode> huQRCodes = huService.getOrCreateQRCodesByHuId(tu.getId());
-		// An aggregate HU can accumulate MORE active QR-code assignments than its current TU count:
-		// QR codes are generated one-per-TU and never trimmed when TUs are split/picked out of the aggregate.
-		// Picking only needs one code per current TU, so tolerate a surplus and use the first N (the loop below
-		// consumes only huQRCodes.get(i) for i in 0..qtyTU-1). Only a DEFICIT of codes is a real error.
-		// The stale extra assignments are reconciled by a separate data cleanup.
+		// An aggregate can hold more active QR codes than its current TU count (codes are generated one-per-TU
+		// and not trimmed on split/pick-out). Only the first N are used below, so tolerate a surplus; error only on a deficit.
 		if (huQRCodes.size() < tu.getQtyTU().toInt())
 		{
 			throw new AdempiereException(INVALID_NUMBER_QR_CODES_ERROR_MSG, tu.getQtyTU(), huQRCodes.size());
@@ -944,11 +941,8 @@ public class PickingJobPickCommand
 	{
 
 		final List<HUQRCode> huQRCodes = huService.getOrCreateQRCodesByHuId(tu1.getId());
-		// An aggregate HU can accumulate MORE active QR-code assignments than its current TU count:
-		// QR codes are generated one-per-TU and never trimmed when TUs are split/picked out of the aggregate.
-		// This CU-in-TU path needs exactly one code and uses the first one (huQRCodes.get(0)), so tolerate a
-		// surplus and only error on a DEFICIT (zero codes). The stale extra assignments are reconciled by a
-		// separate data cleanup.
+		// Same surplus tolerance as the aggregate-TU path: this path uses only the first code (get(0) below),
+		// so a surplus is fine; error only when there are zero codes.
 		if (huQRCodes.size() < 1)
 		{
 			throw new AdempiereException(INVALID_NUMBER_QR_CODES_ERROR_MSG, 1, huQRCodes.size());

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
@@ -906,7 +906,12 @@ public class PickingJobPickCommand
 	{
 
 		final List<HUQRCode> huQRCodes = huService.getOrCreateQRCodesByHuId(tu.getId());
-		if (huQRCodes.size() != tu.getQtyTU().toInt())
+		// An aggregate HU can accumulate MORE active QR-code assignments than its current TU count:
+		// QR codes are generated one-per-TU and never trimmed when TUs are split/picked out of the aggregate.
+		// Picking only needs one code per current TU, so tolerate a surplus and use the first N (the loop below
+		// consumes only huQRCodes.get(i) for i in 0..qtyTU-1). Only a DEFICIT of codes is a real error.
+		// The stale extra assignments are reconciled by a separate data cleanup.
+		if (huQRCodes.size() < tu.getQtyTU().toInt())
 		{
 			throw new AdempiereException(INVALID_NUMBER_QR_CODES_ERROR_MSG, tu.getQtyTU(), huQRCodes.size());
 		}
@@ -939,7 +944,12 @@ public class PickingJobPickCommand
 	{
 
 		final List<HUQRCode> huQRCodes = huService.getOrCreateQRCodesByHuId(tu1.getId());
-		if (huQRCodes.size() != 1)
+		// An aggregate HU can accumulate MORE active QR-code assignments than its current TU count:
+		// QR codes are generated one-per-TU and never trimmed when TUs are split/picked out of the aggregate.
+		// This CU-in-TU path needs exactly one code and uses the first one (huQRCodes.get(0)), so tolerate a
+		// surplus and only error on a DEFICIT (zero codes). The stale extra assignments are reconciled by a
+		// separate data cleanup.
+		if (huQRCodes.size() < 1)
 		{
 			throw new AdempiereException(INVALID_NUMBER_QR_CODES_ERROR_MSG, 1, huQRCodes.size());
 		}


### PR DESCRIPTION
## Symptom

Mobile picking hard-failed for aggregate HUs that carry MORE active `M_HU_QRCode_Assignment` rows than their current TU count. The picking-time validation asserted `#QRCodes == #TU` exactly and threw `Erwartet {0} QR-Codes, aber nur {1} erhalten`, blocking the pick.

This surplus arises naturally: QR codes are generated one-per-TU and are never trimmed when TUs are split/picked out of the aggregate, so the number of active assignments drifts above the current TU count.

## Fix (scoped)

`PickingJobPickCommand` only — two check sites:

1. Aggregate-TU path: changed the guard from `size() != qtyTU` to `size() < qtyTU`. The loop below already consumes only the first N codes (`huQRCodes.get(i)` for `i` in `0..qtyTU-1`), so surplus entries are simply unused.
2. CU-in-TU path: changed the guard from `size() != 1` to `size() < 1`. The code below uses only the first code (`huQRCodes.get(0)`).

A DEFICIT of codes is still a hard error; only a surplus is now tolerated (use the first N).

No shared HU-transform / unpick / QR-code-generation code is touched. Deactivating or deleting surplus codes is deliberately avoided because it breaks unpick, which re-extracts TUs from the aggregate by their recorded QR code.

## Follow-up / out of scope

- Automated tests + local Playwright verification are being added by the main session.
- Reconciliation (shrinking) of existing surplus assignment rows is handled separately as a data cleanup (Torby).
