### PR TITLE
EDI DESADV JSON — omit non-closed no-pack lines via SysConfig toggle

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
@@ -11,6 +11,9 @@ Feature: EDI DESADV export via postgREST
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
     And metasfresh has date and time 2025-05-15T16:30:17+02:00[Europe/Berlin]
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    # Default the DESADV no-pack suppression toggle OFF for every scenario, so the toggle-on
+    # scenario below cannot leak 'Y' into sibling scenarios/features on the same CI executor.
+    And set sys config boolean value false for sys config de.metas.edi.desadv.OmitNonClosedNoPackLines
     And documents are accounted immediately
 
     And metasfresh contains M_PricingSystems
@@ -692,6 +695,116 @@ Feature: EDI DESADV export via postgREST
     And verify DESADV JSON export has DesadvLineWithNoPacking:
       | OrderLine | QtyOrderedInDesadvLineUOM | QtyDeliveredInDesadvLineUOM | IsDeliveryClosed | QtyCUsPerTU |
       | 20        | 50                        | 0                           | false            | 0           |
+
+  @Id:S30770_010
+  @from:cucumber
+  Scenario: DESADV export omits non-closed no-pack lines when OmitNonClosedNoPackLines is on
+
+    # Same shape as "includes unshipped order lines": one shipped line (-> pack) and one
+    # unshipped line (-> would be a non-closed no-pack line). With the suppression toggle ON,
+    # the non-closed no-pack line must be omitted entirely (the receiver's SAP treats any
+    # no-pack line it receives as a closed delivery link).
+    Given metasfresh contains M_Products:
+      | Identifier      |
+      | prod_shipped    |
+      | prod_notShipped |
+
+    And metasfresh contains M_Product_ASI_Data:
+      | Identifier        | M_Product_ID    | C_BPartner_ID | SeqNo |
+      | asiData_shipped   | prod_shipped    | customer1     | 10    |
+      | asiData_notShip   | prod_notShipped | customer1     | 10    |
+    And metasfresh contains M_HU_PackingMaterial:
+      | M_HU_PackingMaterial_ID | M_Product_ID | Name        |
+      | pm_shipped              | prod_shipped | pmShipped   |
+    And load M_HU_PackagingCode:
+      | M_HU_PackagingCode_ID | PackagingCode | HU_UnitType |
+      | huPkgCodeLU_ns        | ISO1          | LU          |
+      | huPkgCodeTU_ns        | CART          | TU          |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID     |
+      | huPILU_ns      |
+      | huPITU_ns      |
+      | huPIVirtual_ns |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID     | HU_UnitType | IsCurrent | M_HU_PackagingCode_ID |
+      | huPIVerLU_ns       | huPILU_ns      | LU          | Y         |                       |
+      | huPIVerTU_ns       | huPITU_ns      | TU          | Y         | huPkgCodeTU_ns        |
+      | huPIVerCU_ns       | huPIVirtual_ns | V           | Y         |                       |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID | Qty | ItemType | Included_HU_PI_ID | M_HU_PackingMaterial_ID |
+      | huPiItemLU_ns              | huPIVerLU_ns       | 10  | HU       | huPITU_ns         |                         |
+      | huPiItemTU_ns              | huPIVerTU_ns       | 0   | PM       |                    | pm_shipped              |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID | M_Product_ID | Qty | ValidFrom  | M_HU_PackagingCode_LU_Fallback_ID | GTIN_LU_PackingMaterial_Fallback |
+      | huPiProd_ns             | huPiItemTU_ns    | prod_shipped | 10  | 2025-01-01 | huPkgCodeLU_ns                    | nsLuGTIN                         |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
+      | salesPLV               | prod_shipped    | 5.00     | PCE      |
+      | salesPLV               | prod_notShipped | 3.00     | PCE      |
+
+    # Order with 2 lines
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | OPT.POReference   |
+      | o_ns       | true    | customer1     | 2025-04-17  | 2025-04-18Z  | partialShipRef    |
+    And metasfresh contains C_OrderLines:
+      | Identifier    | C_Order_ID | M_Product_ID    | QtyEntered | OPT.M_HU_PI_Item_Product_ID |
+      | ol_shipped    | o_ns       | prod_shipped    | 100        | huPiProd_ns                 |
+      | ol_notShipped | o_ns       | prod_notShipped | 50         |                             |
+    And the order identified by o_ns is completed
+
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And after not more than 180s, M_ShipmentSchedules are found:
+      | Identifier    | C_OrderLine_ID | IsToRecompute |
+      | ss_shipped    | ol_shipped     | N             |
+      | ss_notShipped | ol_notShipped  | N             |
+
+    And setup the SSCC18 code generator with GS1ManufacturerCode 1234567, GS1ExtensionDigit 0 and next sequence number always=1000000.
+
+    # Only ship the first line — the second line is NOT shipped at all
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_shipped                       | D            | true                | false       |
+
+    And after not more than 180s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | REST.Context.M_InOut_ID | REST.Context.DocumentNo     |
+      | ss_shipped                       | s_ns                  | shipment_ns_ID          | shipment_ns_DocumentNo      |
+
+    And reset the SSCC18 code generator's next sequence number back to its actual sequence.
+
+    And EDI_Desadv is found:
+      | EDI_Desadv_ID.Identifier | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_ExportStatus | REST.Context |
+      | d_ns                     | customer1                | o_ns                  | P                | d_ns         |
+
+    And the following API_Audit_Config records are created:
+      | Identifier | SeqNo | OPT.Method | OPT.PathPrefix   | IsForceProcessedAsync | IsSynchronousAuditLoggingEnabled | IsWrapApiResponse |
+      | c_ns       | 10    | GET        | api/v2/processes | N                     | Y                                | N                 |
+    And add HTTP headers
+      | Key          | Value                          |
+      | Content-Type | application/json;charset=UTF-8 |
+      | accept       | application/json;charset=UTF-8 |
+
+    # Enable the DESADV no-pack suppression toggle for this scenario only
+    And set sys config boolean value true for sys config de.metas.edi.desadv.OmitNonClosedNoPackLines
+
+    When a 'POST' request with the below payload and headers from context is sent to the metasfresh REST-API 'api/v2/processes/M_InOut_EDI_Export_JSON/invoke' and fulfills with '200' status code
+    """
+{
+    "processParameters": [
+    {
+      "name": "M_InOut_ID",
+      "value": "@shipment_ns_ID@"
+    }
+  ]
+}
+    """
+    # The shipped line stays in Packings (delivery closed); the unshipped, non-closed
+    # no-pack line must be OMITTED — DesadvLineWithNoPacking is empty (0 rows below).
+    Then verify DESADV JSON export has compensation group packing:
+      | PackingCount | MainArticleCount | SubArticleCount | IsDeliveryClosed |
+      | 1            | 1                | 0               | true             |
+
+    And verify DESADV JSON export has DesadvLineWithNoPacking:
+      | OrderLine | QtyOrderedInDesadvLineUOM | QtyDeliveredInDesadvLineUOM | IsDeliveryClosed | QtyCUsPerTU |
 
   @Id:S0468_050
   @from:cucumber

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediDesadvExport.feature
@@ -702,8 +702,11 @@ Feature: EDI DESADV export via postgREST
 
     # Same shape as "includes unshipped order lines": one shipped line (-> pack) and one
     # unshipped line (-> would be a non-closed no-pack line). With the suppression toggle ON,
-    # the non-closed no-pack line must be omitted entirely (the receiver's SAP treats any
+    # the non-closed no-pack line must be omitted entirely (the receiving system treats any
     # no-pack line it receives as a closed delivery link).
+    # NOTE: uses its own POReference (omitClosedRef) — DESADV aggregates orders by
+    # (bpartner, POReference), so sharing partialShipRef with the sibling scenario on this
+    # executor would merge both orders into one DESADV and collide on line numbers.
     Given metasfresh contains M_Products:
       | Identifier      |
       | prod_shipped    |
@@ -744,8 +747,8 @@ Feature: EDI DESADV export via postgREST
 
     # Order with 2 lines
     And metasfresh contains C_Orders:
-      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | OPT.POReference   |
-      | o_ns       | true    | customer1     | 2025-04-17  | 2025-04-18Z  | partialShipRef    |
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | OPT.POReference |
+      | o_ns       | true    | customer1     | 2025-04-17  | 2025-04-18Z  | omitClosedRef   |
     And metasfresh contains C_OrderLines:
       | Identifier    | C_Order_ID | M_Product_ID    | QtyEntered | OPT.M_HU_PI_Item_Product_ID |
       | ol_shipped    | o_ns       | prod_shipped    | 100        | huPiProd_ns                 |

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5810320_sys_desadv_no_pack_omit_non_closed_lines.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5810320_sys_desadv_no_pack_omit_non_closed_lines.sql
@@ -1,35 +1,10 @@
-/*
- * #%L
- * de.metas.edi
- * %%
- * Copyright (C) 2025 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
+-- DESADV JSON: optionally omit no-pack lines whose delivery is not closed.
+-- Adds a SysConfig-gated filter to get_desadv_lines_no_pack_json_fn: when
+-- de.metas.edi.desadv.OmitNonClosedNoPackLines = 'Y', a no-pack line is kept only if its
+-- delivery is closed. Some receiving systems treat every no-pack line they receive as a
+-- closed delivery link, so a not-closed no-pack line would be mis-interpreted.
+-- Default 'N' preserves the previous behaviour (all matching no-pack lines emitted).
 
--- Function for desadv lines with no pack.
--- Builds the JSON for desadv lines that have no edi_desadv_pack_item: both unshipped lines
--- (must still appear in DESADV with qty 0) and shipped-but-not-packed lines.
---
--- Note: the per-line JSON object was previously assembled via the view
--- edi_desadv_line_object_v. That view had an unguarded LEFT JOIN to m_inoutline and
--- produced row multiplication (and inconsistent GTIN resolution) when one edi_desadvline
--- mapped to multiple m_inoutline rows. The same logic is now inlined here with
--- LATERAL + LIMIT 1 on m_inoutline to guarantee exactly one row per desadv line — the
--- pattern that get_desadv_packs_json_fn already used to side-step the same view.
 CREATE OR REPLACE FUNCTION "de.metas.edi".get_desadv_lines_no_pack_json_fn(p_edi_desadv_id NUMERIC, p_m_inout_id NUMERIC)
     RETURNS JSONB AS $$
 DECLARE
@@ -192,3 +167,22 @@ BEGIN
     RETURN COALESCE(v_lines_no_pack_json, '[]'::jsonb);
 END;
 $$ LANGUAGE plpgsql STABLE;
+
+-- AD_SysConfig default for the new toggle (default OFF preserves existing behaviour).
+-- Guarded INSERT: idempotent if the row already exists (re-apply / faithful-DB rebuild).
+INSERT INTO AD_SysConfig
+    (AD_Client_ID, AD_Org_ID, AD_SysConfig_ID, ConfigurationLevel, Created, CreatedBy, Description, EntityType, IsActive, Name, Updated, UpdatedBy, Value)
+SELECT 0, 0, 541829 /*From ID Server*/, 'S',
+        TO_TIMESTAMP('2026-07-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+        100,
+        'When Y, get_desadv_lines_no_pack_json_fn omits no-pack lines whose delivery is not closed (some receiving systems treat every received no-pack line as a closed delivery link). Default N keeps all matching no-pack lines. Set per instance via set_sysconfig_value.',
+        'D', 'Y',
+        'de.metas.edi.desadv.OmitNonClosedNoPackLines',
+        TO_TIMESTAMP('2026-07-01 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+        100,
+        'N'
+WHERE NOT EXISTS (
+    SELECT 1 FROM AD_SysConfig
+    WHERE Name = 'de.metas.edi.desadv.OmitNonClosedNoPackLines'
+      AND AD_Client_ID = 0 AND AD_Org_ID = 0
+);

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5810320_sys_desadv_no_pack_omit_non_closed_lines.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5810320_sys_desadv_no_pack_omit_non_closed_lines.sql
@@ -1,3 +1,5 @@
+-- Source DDL: backend/de.metas.edi/src/main/sql/postgresql/ddl/functions/desadv_json/get_desadv_lines_no_pack_json_fn.sql
+--
 -- DESADV JSON: optionally omit no-pack lines whose delivery is not closed.
 -- Adds a SysConfig-gated filter to get_desadv_lines_no_pack_json_fn: when
 -- de.metas.edi.desadv.OmitNonClosedNoPackLines = 'Y', a no-pack line is kept only if its


### PR DESCRIPTION
## What

Adds an optional filter to the DESADV JSON export function `get_desadv_lines_no_pack_json_fn`:
when the SysConfig `de.metas.edi.desadv.OmitNonClosedNoPackLines` is `Y`, a "no-pack" line is
emitted only if its delivery is closed. When the toggle is `N` (the default), behaviour is
unchanged — all matching no-pack lines are emitted.

## Why

Some receiving systems treat every no-pack line they receive as a *closed* delivery link and do
not read the `IsDeliveryClosed` field. Sending them a line whose delivery is not yet closed is
therefore mis-interpreted. The toggle lets an instance suppress non-closed no-pack lines entirely
rather than emit a line the receiver would read incorrectly.

## Changes

- `get_desadv_lines_no_pack_json_fn`: read the toggle via `get_sysconfig_value(...)` and add a
  guarded `WHERE` predicate that reuses the function's existing `IsDeliveryClosed` expression.
  (DDL file + migration script.)
- New `AD_SysConfig` seed row for the toggle, default `N` (guarded/idempotent insert).
- Cucumber coverage in `ediDesadvExport.feature`: a toggle-on scenario asserting the non-closed
  no-pack line is omitted; the existing unshipped-line scenario continues to guard the default
  (toggle-off) behaviour, with a Background reset so the toggle does not leak across scenarios.

Default-off means existing DESADV-JSON consumers are unaffected until an instance opts in.
