### PR TITLE
Mobile-picking QR-code surplus tolerance — tests (JUnit + Playwright E2E)

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreateHUCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreateHUCommand.java
@@ -1,16 +1,17 @@
 package de.metas.frontend_testing.masterdata.hu;
 
+import com.google.common.collect.ImmutableSet;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.common.util.time.SystemTime;
 import de.metas.frontend_testing.masterdata.Identifier;
 import de.metas.frontend_testing.masterdata.MasterdataContext;
-import com.google.common.collect.ImmutableSet;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHUContext;
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.IHandlingUnitsDAO;
 import de.metas.handlingunits.QtyTU;
+import de.metas.handlingunits.allocation.transfer.HUTransformService;
 import de.metas.handlingunits.allocation.impl.AllocationUtils;
 import de.metas.handlingunits.allocation.impl.HUListAllocationSourceDestination;
 import de.metas.handlingunits.allocation.impl.HULoader;
@@ -99,6 +100,11 @@ public class CreateHUCommand
 			generateQRCodesForAllTUs(huId);
 		}
 
+		if (request.getSplitOutTUsCountAfterQRCodes() > 0)
+		{
+			splitOutTUsLeavingQRCodesBehind(huId, request.getSplitOutTUsCountAfterQRCodes());
+		}
+
 		final String huQRCodeStr;
 		if (request.isGenerateHUQRCode())
 		{
@@ -127,8 +133,9 @@ public class CreateHUCommand
 	 * Generate one active {@code M_HU_QRCode_Assignment} per TU for the given HU <b>and every HU included under it</b>,
 	 * mirroring the desktop "Print Labels" / {@code M_HU_Report_QRCode} process (which runs
 	 * {@code huQRCodesService.generateForExistingHUs(selectedHuIds)}). The HU keeps its current status — no picking, no
-	 * split — so the codes stay at the current (full) TU count. Picking a subset of the TUs out afterwards then leaves
-	 * more active assignments than the current TU count: the me03 #30767 "surplus" state.
+	 * split — so the codes stay at the current (full) TU count. Combined with {@code splitOutTUsCountAfterQRCodes}
+	 * (a non-picking repack that lowers the TU count without trimming these codes), this yields the me03 #30767
+	 * "surplus" state: more active assignments than the current TU count.
 	 */
 	private void generateQRCodesForAllTUs(@NonNull final HuId huId)
 	{
@@ -146,6 +153,48 @@ public class CreateHUCommand
 		{
 			collectHuAndIncludedHuIds(HuId.ofRepoId(includedHU.getM_HU_ID()), collector);
 		}
+	}
+
+	/**
+	 * Split {@code count} whole TUs out of the aggregate reachable from the given HU — a NON-picking repack that
+	 * lowers the aggregate's TU count WITHOUT trimming its QR-code assignments (the me03 #30767 surplus mechanism).
+	 * Routes through {@link HUTransformService#tuToNewTUs(I_M_HU, QtyTU)} (the same qty-decrease-without-QR-cleanup
+	 * path a real repack uses), so the source aggregate is left Active and re-pickable with more active
+	 * {@code M_HU_QRCode_Assignment} rows than its now-reduced TU count.
+	 */
+	private void splitOutTUsLeavingQRCodesBehind(@NonNull final HuId huId, final int count)
+	{
+		huTrxBL.process(huContext -> {
+			final I_M_HU aggregateTU = findAggregateTU(huId);
+			if (aggregateTU == null)
+			{
+				throw new AdempiereException("No aggregate TU found under HU " + huId + " to split TUs out of");
+			}
+			HUTransformService.newInstance(huContext).tuToNewTUs(aggregateTU, QtyTU.ofInt(count));
+		});
+	}
+
+	/**
+	 * Find the aggregate TU in the HU hierarchy rooted at {@code huId} (the HU itself if it is the aggregate, else the
+	 * first aggregate among its included HUs, recursively).
+	 */
+	@Nullable
+	private I_M_HU findAggregateTU(@NonNull final HuId huId)
+	{
+		final I_M_HU hu = handlingUnitsBL.getById(huId);
+		if (handlingUnitsBL.isAggregateHU(hu))
+		{
+			return hu;
+		}
+		for (final I_M_HU includedHU : handlingUnitsDAO.retrieveIncludedHUs(huId))
+		{
+			final I_M_HU found = findAggregateTU(HuId.ofRepoId(includedHU.getM_HU_ID()));
+			if (found != null)
+			{
+				return found;
+			}
+		}
+		return null;
 	}
 
 	private @NonNull HuId createCU()

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreateHUCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreateHUCommand.java
@@ -5,9 +5,11 @@ import de.metas.common.util.CoalesceUtil;
 import de.metas.common.util.time.SystemTime;
 import de.metas.frontend_testing.masterdata.Identifier;
 import de.metas.frontend_testing.masterdata.MasterdataContext;
+import com.google.common.collect.ImmutableSet;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHUContext;
 import de.metas.handlingunits.IHandlingUnitsBL;
+import de.metas.handlingunits.IHandlingUnitsDAO;
 import de.metas.handlingunits.QtyTU;
 import de.metas.handlingunits.allocation.impl.AllocationUtils;
 import de.metas.handlingunits.allocation.impl.HUListAllocationSourceDestination;
@@ -50,6 +52,7 @@ public class CreateHUCommand
 	@NonNull private final ITrxManager trxManager = Services.get(ITrxManager.class);
 	@NonNull private final IProductBL productBL = Services.get(IProductBL.class);
 	@NonNull private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
+	@NonNull private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
 	@NonNull private final IHUTrxBL huTrxBL = Services.get(IHUTrxBL.class);
 	@NonNull private final InventoryService inventoryService;
 	@NonNull private final HUQRCodesService huQRCodesService;
@@ -91,6 +94,11 @@ public class CreateHUCommand
 
 		context.putIdentifier(identifier, huId);
 
+		if (request.isGenerateHUQRCodesForAllTUs())
+		{
+			generateQRCodesForAllTUs(huId);
+		}
+
 		final String huQRCodeStr;
 		if (request.isGenerateHUQRCode())
 		{
@@ -113,6 +121,31 @@ public class CreateHUCommand
 				.warehouseId(getWarehouseId())
 				.externalBarcode(huAttributes != null && huAttributes.hasAttribute(AttributeConstants.ATTR_ExternalBarcode) ? huAttributes.getValueAsString(AttributeConstants.ATTR_ExternalBarcode) : null)
 				.build();
+	}
+
+	/**
+	 * Generate one active {@code M_HU_QRCode_Assignment} per TU for the given HU <b>and every HU included under it</b>,
+	 * mirroring the desktop "Print Labels" / {@code M_HU_Report_QRCode} process (which runs
+	 * {@code huQRCodesService.generateForExistingHUs(selectedHuIds)}). The HU keeps its current status — no picking, no
+	 * split — so the codes stay at the current (full) TU count. Picking a subset of the TUs out afterwards then leaves
+	 * more active assignments than the current TU count: the me03 #30767 "surplus" state.
+	 */
+	private void generateQRCodesForAllTUs(@NonNull final HuId huId)
+	{
+		trxManager.runInThreadInheritedTrx(() -> {
+			final ImmutableSet.Builder<HuId> huIds = ImmutableSet.builder();
+			collectHuAndIncludedHuIds(huId, huIds);
+			huQRCodesService.generateForExistingHUs(huIds.build());
+		});
+	}
+
+	private void collectHuAndIncludedHuIds(@NonNull final HuId huId, @NonNull final ImmutableSet.Builder<HuId> collector)
+	{
+		collector.add(huId);
+		for (final I_M_HU includedHU : handlingUnitsDAO.retrieveIncludedHUs(huId))
+		{
+			collectHuAndIncludedHuIds(HuId.ofRepoId(includedHU.getM_HU_ID()), collector);
+		}
 	}
 
 	private @NonNull HuId createCU()

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreateHUCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreateHUCommand.java
@@ -154,11 +154,9 @@ public class CreateHUCommand
 	}
 
 	/**
-	 * Split {@code count} whole TUs out of the aggregate reachable from the given HU — a NON-picking repack that
-	 * lowers the aggregate's TU count WITHOUT trimming its QR-code assignments (the QR-code surplus mechanism).
-	 * Routes through {@link HUTransformService#tuToNewTUs(I_M_HU, QtyTU)} (the same qty-decrease-without-QR-cleanup
-	 * path a real repack uses), so the source aggregate is left Active and re-pickable with more active
-	 * {@code M_HU_QRCode_Assignment} rows than its now-reduced TU count.
+	 * Split {@code count} whole TUs out of the aggregate reachable from the given HU via
+	 * {@link HUTransformService#tuToNewTUs(I_M_HU, QtyTU)} — the non-picking-repack half of the surplus setup (see
+	 * {@link #generateQRCodesForAllTUs}): it lowers the TU count without trimming the QR-code assignments.
 	 */
 	private void splitOutTUsLeavingQRCodesBehind(@NonNull final HuId huId, final int count)
 	{

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreateHUCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreateHUCommand.java
@@ -9,12 +9,11 @@ import de.metas.frontend_testing.masterdata.MasterdataContext;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.IHUContext;
 import de.metas.handlingunits.IHandlingUnitsBL;
-import de.metas.handlingunits.IHandlingUnitsDAO;
 import de.metas.handlingunits.QtyTU;
-import de.metas.handlingunits.allocation.transfer.HUTransformService;
 import de.metas.handlingunits.allocation.impl.AllocationUtils;
 import de.metas.handlingunits.allocation.impl.HUListAllocationSourceDestination;
 import de.metas.handlingunits.allocation.impl.HULoader;
+import de.metas.handlingunits.allocation.transfer.HUTransformService;
 import de.metas.handlingunits.allocation.transfer.impl.LUTUProducerDestination;
 import de.metas.handlingunits.attribute.storage.IAttributeStorage;
 import de.metas.handlingunits.attribute.weightable.IWeightable;
@@ -53,7 +52,6 @@ public class CreateHUCommand
 	@NonNull private final ITrxManager trxManager = Services.get(ITrxManager.class);
 	@NonNull private final IProductBL productBL = Services.get(IProductBL.class);
 	@NonNull private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
-	@NonNull private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
 	@NonNull private final IHUTrxBL huTrxBL = Services.get(IHUTrxBL.class);
 	@NonNull private final InventoryService inventoryService;
 	@NonNull private final HUQRCodesService huQRCodesService;
@@ -141,17 +139,17 @@ public class CreateHUCommand
 	{
 		trxManager.runInThreadInheritedTrx(() -> {
 			final ImmutableSet.Builder<HuId> huIds = ImmutableSet.builder();
-			collectHuAndIncludedHuIds(huId, huIds);
+			collectHuAndIncludedHuIds(handlingUnitsBL.getById(huId), huIds);
 			huQRCodesService.generateForExistingHUs(huIds.build());
 		});
 	}
 
-	private void collectHuAndIncludedHuIds(@NonNull final HuId huId, @NonNull final ImmutableSet.Builder<HuId> collector)
+	private void collectHuAndIncludedHuIds(@NonNull final I_M_HU hu, @NonNull final ImmutableSet.Builder<HuId> collector)
 	{
-		collector.add(huId);
-		for (final I_M_HU includedHU : handlingUnitsDAO.retrieveIncludedHUs(huId))
+		collector.add(HuId.ofRepoId(hu.getM_HU_ID()));
+		for (final I_M_HU includedHU : handlingUnitsBL.retrieveIncludedHUs(hu))
 		{
-			collectHuAndIncludedHuIds(HuId.ofRepoId(includedHU.getM_HU_ID()), collector);
+			collectHuAndIncludedHuIds(includedHU, collector);
 		}
 	}
 
@@ -165,7 +163,7 @@ public class CreateHUCommand
 	private void splitOutTUsLeavingQRCodesBehind(@NonNull final HuId huId, final int count)
 	{
 		huTrxBL.process(huContext -> {
-			final I_M_HU aggregateTU = findAggregateTU(huId);
+			final I_M_HU aggregateTU = findAggregateTU(handlingUnitsBL.getById(huId));
 			if (aggregateTU == null)
 			{
 				throw new AdempiereException("No aggregate TU found under HU " + huId + " to split TUs out of");
@@ -175,20 +173,19 @@ public class CreateHUCommand
 	}
 
 	/**
-	 * Find the aggregate TU in the HU hierarchy rooted at {@code huId} (the HU itself if it is the aggregate, else the
+	 * Find the aggregate TU in the HU hierarchy rooted at {@code hu} (the HU itself if it is the aggregate, else the
 	 * first aggregate among its included HUs, recursively).
 	 */
 	@Nullable
-	private I_M_HU findAggregateTU(@NonNull final HuId huId)
+	private I_M_HU findAggregateTU(@NonNull final I_M_HU hu)
 	{
-		final I_M_HU hu = handlingUnitsBL.getById(huId);
 		if (handlingUnitsBL.isAggregateHU(hu))
 		{
 			return hu;
 		}
-		for (final I_M_HU includedHU : handlingUnitsDAO.retrieveIncludedHUs(huId))
+		for (final I_M_HU includedHU : handlingUnitsBL.retrieveIncludedHUs(hu))
 		{
-			final I_M_HU found = findAggregateTU(HuId.ofRepoId(includedHU.getM_HU_ID()));
+			final I_M_HU found = findAggregateTU(includedHU);
 			if (found != null)
 			{
 				return found;

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreateHUCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreateHUCommand.java
@@ -132,7 +132,7 @@ public class CreateHUCommand
 	 * mirroring the desktop "Print Labels" / {@code M_HU_Report_QRCode} process (which runs
 	 * {@code huQRCodesService.generateForExistingHUs(selectedHuIds)}). The HU keeps its current status — no picking, no
 	 * split — so the codes stay at the current (full) TU count. Combined with {@code splitOutTUsCountAfterQRCodes}
-	 * (a non-picking repack that lowers the TU count without trimming these codes), this yields the me03 #30767
+	 * (a non-picking repack that lowers the TU count without trimming these codes), this yields the QR-code
 	 * "surplus" state: more active assignments than the current TU count.
 	 */
 	private void generateQRCodesForAllTUs(@NonNull final HuId huId)
@@ -155,7 +155,7 @@ public class CreateHUCommand
 
 	/**
 	 * Split {@code count} whole TUs out of the aggregate reachable from the given HU — a NON-picking repack that
-	 * lowers the aggregate's TU count WITHOUT trimming its QR-code assignments (the me03 #30767 surplus mechanism).
+	 * lowers the aggregate's TU count WITHOUT trimming its QR-code assignments (the QR-code surplus mechanism).
 	 * Routes through {@link HUTransformService#tuToNewTUs(I_M_HU, QtyTU)} (the same qty-decrease-without-QR-cleanup
 	 * path a real repack uses), so the source aggregate is left Active and re-pickable with more active
 	 * {@code M_HU_QRCode_Assignment} rows than its now-reduced TU count.

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHURequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHURequest.java
@@ -20,6 +20,7 @@ public class JsonCreateHURequest
 	@Nullable Identifier packingInstructions;
 	@Nullable Boolean generateHUQRCode;
 	@Nullable Boolean generateHUQRCodesForAllTUs;
+	@Nullable Integer splitOutTUsCountAfterQRCodes;
 	@Nullable Boolean sourceHU;
 	@Nullable BigDecimal weightNet;
 	@Nullable String lotNo;
@@ -38,6 +39,16 @@ public class JsonCreateHURequest
 	 */
 	@JsonIgnore
 	public boolean isGenerateHUQRCodesForAllTUs() {return generateHUQRCodesForAllTUs != null && generateHUQRCodesForAllTUs;}
+
+	/**
+	 * After the full-count QR codes are generated (see {@link #generateHUQRCodesForAllTUs}), split this many whole TUs
+	 * OUT of the aggregate — a NON-picking repack, mirroring the real-world path that produces the me03 #30767 surplus:
+	 * QR codes are generated at the aggregate's high-water TU count, then a repack lowers the TU count WITHOUT trimming
+	 * the QR-code assignments. The result is an Active, still-pickable aggregate carrying MORE active QR codes than its
+	 * current TU count (the surplus). Only meaningful together with {@code generateHUQRCodesForAllTUs=true}.
+	 */
+	@JsonIgnore
+	public int getSplitOutTUsCountAfterQRCodes() {return splitOutTUsCountAfterQRCodes != null ? splitOutTUsCountAfterQRCodes : 0;}
 
 	@JsonIgnore
 	public boolean isSourceHU() { return sourceHU != null && sourceHU;}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHURequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHURequest.java
@@ -32,20 +32,16 @@ public class JsonCreateHURequest
 
 	/**
 	 * When {@code true}, generate one active {@code M_HU_QRCode_Assignment} per TU for the created HU and every HU
-	 * included under it (the full-count QR-code generation that the desktop "Print Labels" / {@code M_HU_Report_QRCode}
-	 * process does for an aggregate LU while it stays Active). Used to set up the QR-code "surplus" state:
-	 * generate full-count codes on an active aggregate, then pick out a subset of its TUs so the code count exceeds the
-	 * current TU count.
+	 * included under it — the first half of the QR-code "surplus" test setup
+	 * (see {@code CreateHUCommand.generateQRCodesForAllTUs} for the full mechanism).
 	 */
 	@JsonIgnore
 	public boolean isGenerateHUQRCodesForAllTUs() {return generateHUQRCodesForAllTUs != null && generateHUQRCodesForAllTUs;}
 
 	/**
-	 * After the full-count QR codes are generated (see {@link #generateHUQRCodesForAllTUs}), split this many whole TUs
-	 * OUT of the aggregate — a NON-picking repack, mirroring the real-world path that produces the QR-code surplus:
-	 * QR codes are generated at the aggregate's high-water TU count, then a repack lowers the TU count WITHOUT trimming
-	 * the QR-code assignments. The result is an Active, still-pickable aggregate carrying MORE active QR codes than its
-	 * current TU count (the surplus). Only meaningful together with {@code generateHUQRCodesForAllTUs=true}.
+	 * After the full-count codes are generated, split this many whole TUs OUT of the aggregate — the non-picking
+	 * repack that completes the surplus setup (see {@code CreateHUCommand.splitOutTUsLeavingQRCodesBehind}).
+	 * Only meaningful together with {@code generateHUQRCodesForAllTUs=true}.
 	 */
 	@JsonIgnore
 	public int getSplitOutTUsCountAfterQRCodes() {return splitOutTUsCountAfterQRCodes != null ? splitOutTUsCountAfterQRCodes : 0;}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHURequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHURequest.java
@@ -33,7 +33,7 @@ public class JsonCreateHURequest
 	/**
 	 * When {@code true}, generate one active {@code M_HU_QRCode_Assignment} per TU for the created HU and every HU
 	 * included under it (the full-count QR-code generation that the desktop "Print Labels" / {@code M_HU_Report_QRCode}
-	 * process does for an aggregate LU while it stays Active). Used to set up the me03 #30767 "surplus" state:
+	 * process does for an aggregate LU while it stays Active). Used to set up the QR-code "surplus" state:
 	 * generate full-count codes on an active aggregate, then pick out a subset of its TUs so the code count exceeds the
 	 * current TU count.
 	 */
@@ -42,7 +42,7 @@ public class JsonCreateHURequest
 
 	/**
 	 * After the full-count QR codes are generated (see {@link #generateHUQRCodesForAllTUs}), split this many whole TUs
-	 * OUT of the aggregate — a NON-picking repack, mirroring the real-world path that produces the me03 #30767 surplus:
+	 * OUT of the aggregate — a NON-picking repack, mirroring the real-world path that produces the QR-code surplus:
 	 * QR codes are generated at the aggregate's high-water TU count, then a repack lowers the TU count WITHOUT trimming
 	 * the QR-code assignments. The result is an Active, still-pickable aggregate carrying MORE active QR codes than its
 	 * current TU count (the surplus). Only meaningful together with {@code generateHUQRCodesForAllTUs=true}.

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHURequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonCreateHURequest.java
@@ -19,6 +19,7 @@ public class JsonCreateHURequest
 	@Nullable BigDecimal qty;
 	@Nullable Identifier packingInstructions;
 	@Nullable Boolean generateHUQRCode;
+	@Nullable Boolean generateHUQRCodesForAllTUs;
 	@Nullable Boolean sourceHU;
 	@Nullable BigDecimal weightNet;
 	@Nullable String lotNo;
@@ -27,6 +28,16 @@ public class JsonCreateHURequest
 
 	@JsonIgnore
 	public boolean isGenerateHUQRCode() {return generateHUQRCode != null ? generateHUQRCode : true;}
+
+	/**
+	 * When {@code true}, generate one active {@code M_HU_QRCode_Assignment} per TU for the created HU and every HU
+	 * included under it (the full-count QR-code generation that the desktop "Print Labels" / {@code M_HU_Report_QRCode}
+	 * process does for an aggregate LU while it stays Active). Used to set up the me03 #30767 "surplus" state:
+	 * generate full-count codes on an active aggregate, then pick out a subset of its TUs so the code count exceeds the
+	 * current TU count.
+	 */
+	@JsonIgnore
+	public boolean isGenerateHUQRCodesForAllTUs() {return generateHUQRCodesForAllTUs != null && generateHUQRCodesForAllTUs;}
 
 	@JsonIgnore
 	public boolean isSourceHU() { return sourceHU != null && sourceHU;}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
@@ -908,10 +908,7 @@ public class PickingJobPickCommand
 		final List<HUQRCode> huQRCodes = huService.getOrCreateQRCodesByHuId(tu.getId());
 		// An aggregate can hold more active QR codes than its current TU count (codes are generated one-per-TU
 		// and not trimmed on split/pick-out). Only the first N are used below, so tolerate a surplus; error only on a deficit.
-		if (huQRCodes.size() < tu.getQtyTU().toInt())
-		{
-			throw new AdempiereException(INVALID_NUMBER_QR_CODES_ERROR_MSG, tu.getQtyTU(), huQRCodes.size());
-		}
+		assertEnoughQRCodes(huQRCodes, tu.getQtyTU().toInt());
 
 		final List<Quantity> qtyPickedPerTU = qtyPicked.spreadEqually(tu.getQtyTU().toInt());
 
@@ -943,10 +940,7 @@ public class PickingJobPickCommand
 		final List<HUQRCode> huQRCodes = huService.getOrCreateQRCodesByHuId(tu1.getId());
 		// Same surplus tolerance as the aggregate-TU path: this path uses only the first code (get(0) below),
 		// so a surplus is fine; error only when there are zero codes.
-		if (huQRCodes.size() < 1)
-		{
-			throw new AdempiereException(INVALID_NUMBER_QR_CODES_ERROR_MSG, 1, huQRCodes.size());
-		}
+		assertEnoughQRCodes(huQRCodes, 1);
 		final HUQRCode huQRCode = huQRCodes.get(0);
 
 		return ImmutableList.of(
@@ -958,6 +952,26 @@ public class PickingJobPickCommand
 						.createdAt(SystemTime.asInstant())
 						.build()
 		);
+	}
+
+	/**
+	 * The me03 #30767 QR-code count guard for picking, shared by both {@code toPickingJobStepPickedToHU} overloads.
+	 * <p>
+	 * An aggregate HU can hold MORE active QR codes than its current TU count (codes are generated one-per-TU and
+	 * are never trimmed when TUs are split/picked out), so the pick must TOLERATE a surplus and only ever consume
+	 * the first {@code requiredCount} codes. It errors only on a DEFICIT — strictly fewer codes than needed
+	 * ({@code < requiredCount}) — never on a surplus. Pre-#30767 this used {@code != requiredCount}, which threw on
+	 * a surplus with "Erwartet {0} QR-Codes, aber nur {1} erhalten".
+	 * <p>
+	 * Package-visible so {@code PickingJobPickCommand_QRCodeSurplusToleranceTest} exercises the real production
+	 * predicate (reverting the operator here fails that test).
+	 */
+	static void assertEnoughQRCodes(@NonNull final List<HUQRCode> huQRCodes, final int requiredCount)
+	{
+		if (huQRCodes.size() < requiredCount)
+		{
+			throw new AdempiereException(INVALID_NUMBER_QR_CODES_ERROR_MSG, requiredCount, huQRCodes.size());
+		}
 	}
 
 	private LUTUResult pickWholeTUs(

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
@@ -907,8 +907,7 @@ public class PickingJobPickCommand
 	{
 
 		final List<HUQRCode> huQRCodes = huService.getOrCreateQRCodesByHuId(tu.getId());
-		// An aggregate can hold more active QR codes than its current TU count (codes are generated one-per-TU
-		// and not trimmed on split/pick-out). Only the first N are used below, so tolerate a surplus; error only on a deficit.
+		// Consumes only the first qtyTU codes; assertEnoughQRCodes tolerates a surplus (rationale in its Javadoc).
 		assertEnoughQRCodes(huQRCodes, tu.getQtyTU().toInt());
 
 		final List<Quantity> qtyPickedPerTU = qtyPicked.spreadEqually(tu.getQtyTU().toInt());
@@ -939,8 +938,7 @@ public class PickingJobPickCommand
 	{
 
 		final List<HUQRCode> huQRCodes = huService.getOrCreateQRCodesByHuId(tu1.getId());
-		// Same surplus tolerance as the aggregate-TU path: this path uses only the first code (get(0) below),
-		// so a surplus is fine; error only when there are zero codes.
+		// Consumes only the first code (get(0) below); assertEnoughQRCodes tolerates a surplus (rationale in its Javadoc).
 		assertEnoughQRCodes(huQRCodes, 1);
 		final HUQRCode huQRCode = huQRCodes.get(0);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
@@ -1,5 +1,6 @@
 package de.metas.handlingunits.picking.job.service.commands.pick;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import de.metas.bpartner.BPartnerId;
@@ -955,17 +956,18 @@ public class PickingJobPickCommand
 	}
 
 	/**
-	 * The me03 #30767 QR-code count guard for picking, shared by both {@code toPickingJobStepPickedToHU} overloads.
+	 * The QR-code count guard for picking, shared by both {@code toPickingJobStepPickedToHU} overloads.
 	 * <p>
 	 * An aggregate HU can hold MORE active QR codes than its current TU count (codes are generated one-per-TU and
 	 * are never trimmed when TUs are split/picked out), so the pick must TOLERATE a surplus and only ever consume
 	 * the first {@code requiredCount} codes. It errors only on a DEFICIT — strictly fewer codes than needed
-	 * ({@code < requiredCount}) — never on a surplus. Pre-#30767 this used {@code != requiredCount}, which threw on
-	 * a surplus with "Erwartet {0} QR-Codes, aber nur {1} erhalten".
+	 * ({@code < requiredCount}) — never on a surplus. An equality check ({@code != requiredCount}) would instead
+	 * throw on a surplus with "Erwartet {0} QR-Codes, aber nur {1} erhalten".
 	 * <p>
 	 * Package-visible so {@code PickingJobPickCommand_QRCodeSurplusToleranceTest} exercises the real production
 	 * predicate (reverting the operator here fails that test).
 	 */
+	@VisibleForTesting
 	static void assertEnoughQRCodes(@NonNull final List<HUQRCode> huQRCodes, final int requiredCount)
 	{
 		if (huQRCodes.size() < requiredCount)

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand_QRCodeSurplusToleranceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand_QRCodeSurplusToleranceTest.java
@@ -117,7 +117,7 @@ public class PickingJobPickCommand_QRCodeSurplusToleranceTest
 		InterfaceWrapperHelper.refresh(aggregateTU);
 
 		// then (surplus precondition): active QR-code assignments (3) now EXCEED the current TU count (2).
-		// This is the exact "surplus" state #30767 is about.
+		// This is the exact "surplus" state under test.
 		final int tuCountAfterSplit = tuCountOf(aggregateTU);
 		final long activeAssignmentsAfterSplit = countActiveAssignments(aggregateHuId);
 		assertThat(tuCountAfterSplit)

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand_QRCodeSurplusToleranceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand_QRCodeSurplusToleranceTest.java
@@ -49,52 +49,17 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Proves the me03 #30767 fix: mobile picking TOLERATES an aggregate HU that carries MORE active QR-code
- * assignments than its current TU count (a "surplus").
+ * Proves the mobile-picking QR-code surplus tolerance in the shared guard
+ * {@link PickingJobPickCommand#assertEnoughQRCodes(java.util.List, int)} (changed from {@code size() != required}
+ * to {@code size() < required}): a pick must tolerate an aggregate that carries MORE active QR-code assignments
+ * than its current TU count and consume only the first N. The test builds that surplus faithfully (generate codes
+ * at the TU count, split a TU out so codes outnumber TUs) and calls the real guard — see the inline steps below.
  * <p>
- * The fix lives in {@link PickingJobPickCommand#assertEnoughQRCodes(java.util.List, int)}, the guard shared by
- * both {@code toPickingJobStepPickedToHU} overloads: it changed from {@code huQRCodes.size() != requiredCount}
- * to {@code huQRCodes.size() < requiredCount} — i.e. error only on a <b>deficit</b>, tolerate a <b>surplus</b>,
- * and consume only the first {@code requiredCount} codes.
- *
- * <h3>Faithful surplus setup (the real mechanism — not a fabricated state)</h3>
- * <ol>
- *   <li>Build an aggregate HU representing {@code N=3} TUs (24 CU / 8 CU-per-TU) via
- *       {@code HUTransformTestsBase.getData().mkAggregateHUWithTotalQtyCUandCustomQtyCUsPerTU(...)}.</li>
- *   <li>Generate QR codes at the initial TU count via {@link HUQRCodesService#generateForExistingHU(HuId)}
- *       — one active {@code M_HU_QRCode_Assignment} per TU (N=3).</li>
- *   <li>Split one TU out via {@link HUTransformService#tuToNewTUs(I_M_HU, QtyTU)} — the aggregate's TU count
- *       drops to {@code N-1=2}, while the QR-code assignments stay at {@code N=3}. That is the SURPLUS
- *       (QR codes are generated one-per-TU and never trimmed on split/pick-out).</li>
- * </ol>
- *
- * <h3>What this test asserts</h3>
- * <ol>
- *   <li><b>The surplus precondition holds</b> — active {@code M_HU_QRCode_Assignment} count for the aggregate
- *       ({@code 3}) is strictly greater than {@link IHandlingUnitsBL#getTUsCount(I_M_HU)} ({@code 2}).</li>
- *   <li><b>The pick tolerates the surplus</b> — it calls the <b>real production guard</b>
- *       {@link PickingJobPickCommand#assertEnoughQRCodes(java.util.List, int)} with the surplus data read via
- *       the same collaborator the pick uses ({@link HUQRCodesService#getOrCreateQRCodesByHuId(HuId)}, which for a
- *       surplus aggregate returns all {@code N=3} active codes without trimming) and asserts it does NOT throw
- *       {@code INVALID_NUMBER_QR_CODES_ERROR_MSG}. Reverting the operator inside {@code assertEnoughQRCodes}
- *       (back to {@code !=}) makes this test RED — it exercises production code, not a hand-copied predicate.</li>
- * </ol>
- *
- * <h3>RED / GREEN</h3>
- * With the pre-fix operator ({@code huQRCodes.size() != requiredCount}) the surplus (3 != 2) makes
- * {@code assertEnoughQRCodes} throw {@code INVALID_NUMBER_QR_CODES_ERROR_MSG} ("Erwartet {0} QR-Codes, aber nur
- * {1} erhalten"); with the fixed {@code <} it does not. The assertion below calls that exact method, so it flips
- * red/green with the operator.
- *
- * <h3>Scope (why the full {@code processStepEvent} pick is covered by Playwright, not here)</h3>
- * The qtyTU&gt;1 branch of {@code PickingJobPickCommand.toPickingJobStepPickedToHU} that carries this guard is
- * NOT reachable through {@code PickingJobService.processStepEvent} in the in-memory harness: an aggregate HU is
- * virtual ({@code IHandlingUnitsBL.isVirtual} is true for the aggregate's virtual PI version), so
- * {@code PickingJobPickCommand.splitOutPickToHUs} routes a pick-from-aggregate to {@code pickCUsAndPackTo} (the
- * VHU branch) rather than {@code pickWholeTUs}. This test therefore drives the <b>exact production guard against
- * the real surplus data and the real {@link HUQRCodesService#getOrCreateQRCodesByHuId(HuId)} collaborator</b>;
- * the full browser-driven pick of a surplus aggregate on the running stack is covered by the #30767 Playwright
- * spec ({@code e2e/mobile-webui/tests/spec/picking/picking_qrCodeSurplus.spec.js}).
+ * It drives the guard directly rather than through {@code PickingJobService.processStepEvent} because the
+ * qtyTU&gt;1 branch that carries the guard is not reachable in the in-memory harness: an aggregate HU is virtual,
+ * so {@code splitOutPickToHUs} routes a pick-from-aggregate to the VHU branch, not {@code pickWholeTUs}. The full
+ * browser-driven pick of a surplus aggregate is covered by the Playwright spec
+ * {@code e2e/mobile-webui/tests/spec/picking/picking_qrCodeSurplus.spec.js}.
  */
 @ExtendWith(AdempiereTestWatcher.class)
 public class PickingJobPickCommand_QRCodeSurplusToleranceTest

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand_QRCodeSurplusToleranceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand_QRCodeSurplusToleranceTest.java
@@ -1,0 +1,196 @@
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.handlingunits.picking.job.service.commands.pick;
+
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.IHandlingUnitsBL;
+import de.metas.handlingunits.QtyTU;
+import de.metas.handlingunits.allocation.transfer.HUTransformService;
+import de.metas.handlingunits.allocation.transfer.HUTransformTestsBase;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.I_M_HU_QRCode_Assignment;
+import de.metas.handlingunits.qrcodes.model.HUQRCode;
+import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
+import de.metas.util.Services;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.SpringContextHolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Proves the me03 #30767 fix: mobile picking TOLERATES an aggregate HU that carries MORE active QR-code
+ * assignments than its current TU count (a "surplus").
+ * <p>
+ * The fix lives in {@link de.metas.handlingunits.picking.job.service.commands.pick.PickingJobPickCommand}#{@code toPickingJobStepPickedToHU(TU, Quantity, PickingJobStepPickFrom)}:
+ * the guard changed from {@code huQRCodes.size() != tu.getQtyTU().toInt()} to
+ * {@code huQRCodes.size() < tu.getQtyTU().toInt()} — i.e. error only on a <b>deficit</b>, tolerate a
+ * <b>surplus</b>, and consume only the first {@code N} codes.
+ *
+ * <h3>Faithful surplus setup (the real mechanism — not a fabricated state)</h3>
+ * Mirrors the sibling {@code AggregateHUTrxListener_QRCodeSurplusCleanupTest} setup exactly:
+ * <ol>
+ *   <li>Build an aggregate HU representing {@code N=3} TUs (24 CU / 8 CU-per-TU) via
+ *       {@code HUTransformTestsBase.getData().mkAggregateHUWithTotalQtyCUandCustomQtyCUsPerTU(...)}.</li>
+ *   <li>Generate QR codes at the initial TU count via {@link HUQRCodesService#generateForExistingHU(HuId)}
+ *       — one active {@code M_HU_QRCode_Assignment} per TU (N=3).</li>
+ *   <li>Split one TU out via {@link HUTransformService#tuToNewTUs(I_M_HU, QtyTU)} — the aggregate's TU count
+ *       drops to {@code N-1=2}, while the QR-code assignments stay at {@code N=3}. That is the SURPLUS
+ *       (QR codes are generated one-per-TU and never trimmed on split/pick-out — see the fix commit message).</li>
+ * </ol>
+ *
+ * <h3>What this test asserts</h3>
+ * <ol>
+ *   <li><b>The surplus precondition holds</b> — active {@code M_HU_QRCode_Assignment} count for the aggregate
+ *       ({@code 3}) is strictly greater than {@link IHandlingUnitsBL#getTUsCount(I_M_HU)} ({@code 2}).</li>
+ *   <li><b>The pick tolerates the surplus</b> — the exact production predicate the fix changed is evaluated
+ *       against the real surplus data, via the same collaborator method the pick calls
+ *       ({@code PickingJobHUService#getOrCreateQRCodesByHuId} → {@link HUQRCodesService#getOrCreateQRCodesByHuId(HuId)},
+ *       which for a surplus aggregate returns all {@code N=3} active codes without trimming): the fix's condition
+ *       {@code huQRCodes.size() < tu.getQtyTU().toInt()} is FALSE (3 &lt; 2 is false), so NO
+ *       {@code INVALID_NUMBER_QR_CODES_ERROR_MSG} would be thrown; and only the first
+ *       {@code tu.getQtyTU()=2} codes are consumed.</li>
+ * </ol>
+ *
+ * <h3>RED / GREEN</h3>
+ * With the pre-fix operator ({@code huQRCodes.size() != tu.getQtyTU().toInt()}) the surplus (3 != 2) makes the
+ * guard throw {@code INVALID_NUMBER_QR_CODES_ERROR_MSG} ("Erwartet {0} QR-Codes, aber nur {1} erhalten"); the
+ * final assertion below (which asserts {@code size >= tuCount}, i.e. the surplus is accepted) encodes exactly
+ * that flip. The main session verifies RED by temporarily reverting the operator to {@code !=} — under which the
+ * production guard on the same data throws, whereas the fixed {@code <} passes.
+ *
+ * <h3>Limitation (why this is not a full end-to-end {@code processStepEvent} pick)</h3>
+ * The qtyTU&gt;1 branch of {@code PickingJobPickCommand.toPickingJobStepPickedToHU} that carries the surplus
+ * guard is NOT reachable through {@code PickingJobService.processStepEvent} in the in-memory harness: an
+ * aggregate HU is virtual ({@code IHandlingUnitsBL.isVirtual} is true for the aggregate's virtual PI version),
+ * so {@code PickingJobPickCommand.splitOutPickToHUs} always routes a pick-from-aggregate to
+ * {@code pickCUsAndPackTo} (the VHU branch) rather than {@code pickWholeTUs}; only {@code pickWholeTUs} can
+ * produce a {@code TU.ofAggregatedTU} with {@code qtyTU>1}, and reaching it would require picking-from the
+ * aggregate WITH an LU target — impossible because the aggregate is virtual. This test therefore drives the
+ * <b>exact predicate the fix changed against the real surplus data and the real
+ * {@link HUQRCodesService#getOrCreateQRCodesByHuId(HuId)} collaborator</b> (the only gap being the
+ * {@code processStepEvent} plumbing around it, which cannot carry a qtyTU&gt;1 aggregate anyway). The full
+ * browser-driven pick of a surplus aggregate on the running stack is covered by the #30767 Playwright spec.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class PickingJobPickCommand_QRCodeSurplusToleranceTest
+{
+	private IHandlingUnitsBL handlingUnitsBL;
+	private HUTransformTestsBase testsBase;
+	private HUTransformService huTransformService;
+	private HUQRCodesService huQRCodesService;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+		handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
+		testsBase = new HUTransformTestsBase();
+		huTransformService = HUTransformService.newInstance(testsBase.getData().helper.getHUContext());
+
+		huQRCodesService = HUQRCodesService.newInstanceForUnitTesting();
+		SpringContextHolder.registerJUnitBean(huQRCodesService);
+	}
+
+	private long countActiveAssignments(final HuId huId)
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_M_HU_QRCode_Assignment.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_HU_QRCode_Assignment.COLUMNNAME_M_HU_ID, huId)
+				.create()
+				.count();
+	}
+
+	private int tuCountOf(final I_M_HU aggregateTU)
+	{
+		return handlingUnitsBL.getTUsCount(aggregateTU).toInt();
+	}
+
+	@Test
+	public void pickTolerates_surplusQRCodeAssignments_onAggregate()
+	{
+		// given: an aggregate HU representing 3 TUs (24 CU / 8 CU-per-TU)
+		final I_M_HU aggregateTU = testsBase.getData().mkAggregateHUWithTotalQtyCUandCustomQtyCUsPerTU("24", 8);
+		assertThat(handlingUnitsBL.isAggregateHU(aggregateTU)).isTrue(); // guard
+		assertThat(tuCountOf(aggregateTU)).isEqualTo(3); // guard
+
+		final HuId aggregateHuId = HuId.ofRepoId(aggregateTU.getM_HU_ID());
+
+		// and: QR codes generated/assigned at the initial TU count (one active assignment per TU)
+		huQRCodesService.generateForExistingHU(aggregateHuId);
+		assertThat(countActiveAssignments(aggregateHuId))
+				.as("one active assignment per TU before the split")
+				.isEqualTo(3);
+
+		// when: one TU is split out of the aggregate -> its TU count drops to 2, but QR-code assignments stay at 3
+		huTransformService.tuToNewTUs(aggregateTU, QtyTU.ONE);
+		InterfaceWrapperHelper.refresh(aggregateTU);
+
+		// then (surplus precondition): active QR-code assignments (3) now EXCEED the current TU count (2).
+		// This is the exact "surplus" state #30767 is about.
+		final int tuCountAfterSplit = tuCountOf(aggregateTU);
+		final long activeAssignmentsAfterSplit = countActiveAssignments(aggregateHuId);
+		assertThat(tuCountAfterSplit)
+				.as("aggregate now represents one less TU")
+				.isEqualTo(2);
+		assertThat(activeAssignmentsAfterSplit)
+				.as("QR-code assignments are NOT trimmed on split -> surplus (count > TU count)")
+				.isEqualTo(3)
+				.isGreaterThan(tuCountAfterSplit);
+
+		// then (the fix): the pick reads the aggregate's QR codes via exactly the collaborator method
+		// PickingJobPickCommand.toPickingJobStepPickedToHU calls (PickingJobHUService#getOrCreateQRCodesByHuId
+		// -> HUQRCodesService#getOrCreateQRCodesByHuId). For a surplus aggregate this returns ALL active codes (3)
+		// without trimming down to the TU count.
+		final List<HUQRCode> huQRCodes = huQRCodesService.getOrCreateQRCodesByHuId(aggregateHuId);
+		assertThat(huQRCodes)
+				.as("getOrCreateQRCodesByHuId returns the surplus codes untrimmed (one per originally-generated TU)")
+				.hasSize(3);
+
+		// The fix's guard is `huQRCodes.size() < tu.getQtyTU().toInt()` (error only on a DEFICIT).
+		// With a surplus (3 codes vs 2 TUs) that condition is FALSE -> no INVALID_NUMBER_QR_CODES error is thrown.
+		// (Pre-fix the guard was `!=`, so 3 != 2 threw "Erwartet {0} QR-Codes, aber nur {1} erhalten".)
+		assertThat(huQRCodes.size() < tuCountAfterSplit)
+				.as("fixed guard tolerates surplus: size(3) < tuCount(2) is false -> pick does NOT fail")
+				.isFalse();
+		assertThat(huQRCodes.size())
+				.as("ENOUGH codes to cover the TU count (>=), i.e. no deficit")
+				.isGreaterThanOrEqualTo(tuCountAfterSplit);
+
+		// and: the pick consumes only the first N=tuCount codes (get(0)..get(tuCount-1)); the surplus tail is ignored.
+		for (int i = 0; i < tuCountAfterSplit; i++)
+		{
+			assertThat(huQRCodes.get(i))
+					.as("the first %d codes are the ones the pick consumes", tuCountAfterSplit)
+					.isNotNull();
+		}
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand_QRCodeSurplusToleranceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand_QRCodeSurplusToleranceTest.java
@@ -33,6 +33,7 @@ import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
 import de.metas.util.Services;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
@@ -44,18 +45,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Proves the me03 #30767 fix: mobile picking TOLERATES an aggregate HU that carries MORE active QR-code
  * assignments than its current TU count (a "surplus").
  * <p>
- * The fix lives in {@link de.metas.handlingunits.picking.job.service.commands.pick.PickingJobPickCommand}#{@code toPickingJobStepPickedToHU(TU, Quantity, PickingJobStepPickFrom)}:
- * the guard changed from {@code huQRCodes.size() != tu.getQtyTU().toInt()} to
- * {@code huQRCodes.size() < tu.getQtyTU().toInt()} — i.e. error only on a <b>deficit</b>, tolerate a
- * <b>surplus</b>, and consume only the first {@code N} codes.
+ * The fix lives in {@link PickingJobPickCommand#assertEnoughQRCodes(java.util.List, int)}, the guard shared by
+ * both {@code toPickingJobStepPickedToHU} overloads: it changed from {@code huQRCodes.size() != requiredCount}
+ * to {@code huQRCodes.size() < requiredCount} — i.e. error only on a <b>deficit</b>, tolerate a <b>surplus</b>,
+ * and consume only the first {@code requiredCount} codes.
  *
  * <h3>Faithful surplus setup (the real mechanism — not a fabricated state)</h3>
- * Mirrors the sibling {@code AggregateHUTrxListener_QRCodeSurplusCleanupTest} setup exactly:
  * <ol>
  *   <li>Build an aggregate HU representing {@code N=3} TUs (24 CU / 8 CU-per-TU) via
  *       {@code HUTransformTestsBase.getData().mkAggregateHUWithTotalQtyCUandCustomQtyCUsPerTU(...)}.</li>
@@ -63,41 +65,36 @@ import static org.assertj.core.api.Assertions.assertThat;
  *       — one active {@code M_HU_QRCode_Assignment} per TU (N=3).</li>
  *   <li>Split one TU out via {@link HUTransformService#tuToNewTUs(I_M_HU, QtyTU)} — the aggregate's TU count
  *       drops to {@code N-1=2}, while the QR-code assignments stay at {@code N=3}. That is the SURPLUS
- *       (QR codes are generated one-per-TU and never trimmed on split/pick-out — see the fix commit message).</li>
+ *       (QR codes are generated one-per-TU and never trimmed on split/pick-out).</li>
  * </ol>
  *
  * <h3>What this test asserts</h3>
  * <ol>
  *   <li><b>The surplus precondition holds</b> — active {@code M_HU_QRCode_Assignment} count for the aggregate
  *       ({@code 3}) is strictly greater than {@link IHandlingUnitsBL#getTUsCount(I_M_HU)} ({@code 2}).</li>
- *   <li><b>The pick tolerates the surplus</b> — the exact production predicate the fix changed is evaluated
- *       against the real surplus data, via the same collaborator method the pick calls
- *       ({@code PickingJobHUService#getOrCreateQRCodesByHuId} → {@link HUQRCodesService#getOrCreateQRCodesByHuId(HuId)},
- *       which for a surplus aggregate returns all {@code N=3} active codes without trimming): the fix's condition
- *       {@code huQRCodes.size() < tu.getQtyTU().toInt()} is FALSE (3 &lt; 2 is false), so NO
- *       {@code INVALID_NUMBER_QR_CODES_ERROR_MSG} would be thrown; and only the first
- *       {@code tu.getQtyTU()=2} codes are consumed.</li>
+ *   <li><b>The pick tolerates the surplus</b> — it calls the <b>real production guard</b>
+ *       {@link PickingJobPickCommand#assertEnoughQRCodes(java.util.List, int)} with the surplus data read via
+ *       the same collaborator the pick uses ({@link HUQRCodesService#getOrCreateQRCodesByHuId(HuId)}, which for a
+ *       surplus aggregate returns all {@code N=3} active codes without trimming) and asserts it does NOT throw
+ *       {@code INVALID_NUMBER_QR_CODES_ERROR_MSG}. Reverting the operator inside {@code assertEnoughQRCodes}
+ *       (back to {@code !=}) makes this test RED — it exercises production code, not a hand-copied predicate.</li>
  * </ol>
  *
  * <h3>RED / GREEN</h3>
- * With the pre-fix operator ({@code huQRCodes.size() != tu.getQtyTU().toInt()}) the surplus (3 != 2) makes the
- * guard throw {@code INVALID_NUMBER_QR_CODES_ERROR_MSG} ("Erwartet {0} QR-Codes, aber nur {1} erhalten"); the
- * final assertion below (which asserts {@code size >= tuCount}, i.e. the surplus is accepted) encodes exactly
- * that flip. The main session verifies RED by temporarily reverting the operator to {@code !=} — under which the
- * production guard on the same data throws, whereas the fixed {@code <} passes.
+ * With the pre-fix operator ({@code huQRCodes.size() != requiredCount}) the surplus (3 != 2) makes
+ * {@code assertEnoughQRCodes} throw {@code INVALID_NUMBER_QR_CODES_ERROR_MSG} ("Erwartet {0} QR-Codes, aber nur
+ * {1} erhalten"); with the fixed {@code <} it does not. The assertion below calls that exact method, so it flips
+ * red/green with the operator.
  *
- * <h3>Limitation (why this is not a full end-to-end {@code processStepEvent} pick)</h3>
- * The qtyTU&gt;1 branch of {@code PickingJobPickCommand.toPickingJobStepPickedToHU} that carries the surplus
- * guard is NOT reachable through {@code PickingJobService.processStepEvent} in the in-memory harness: an
- * aggregate HU is virtual ({@code IHandlingUnitsBL.isVirtual} is true for the aggregate's virtual PI version),
- * so {@code PickingJobPickCommand.splitOutPickToHUs} always routes a pick-from-aggregate to
- * {@code pickCUsAndPackTo} (the VHU branch) rather than {@code pickWholeTUs}; only {@code pickWholeTUs} can
- * produce a {@code TU.ofAggregatedTU} with {@code qtyTU>1}, and reaching it would require picking-from the
- * aggregate WITH an LU target — impossible because the aggregate is virtual. This test therefore drives the
- * <b>exact predicate the fix changed against the real surplus data and the real
- * {@link HUQRCodesService#getOrCreateQRCodesByHuId(HuId)} collaborator</b> (the only gap being the
- * {@code processStepEvent} plumbing around it, which cannot carry a qtyTU&gt;1 aggregate anyway). The full
- * browser-driven pick of a surplus aggregate on the running stack is covered by the #30767 Playwright spec.
+ * <h3>Scope (why the full {@code processStepEvent} pick is covered by Playwright, not here)</h3>
+ * The qtyTU&gt;1 branch of {@code PickingJobPickCommand.toPickingJobStepPickedToHU} that carries this guard is
+ * NOT reachable through {@code PickingJobService.processStepEvent} in the in-memory harness: an aggregate HU is
+ * virtual ({@code IHandlingUnitsBL.isVirtual} is true for the aggregate's virtual PI version), so
+ * {@code PickingJobPickCommand.splitOutPickToHUs} routes a pick-from-aggregate to {@code pickCUsAndPackTo} (the
+ * VHU branch) rather than {@code pickWholeTUs}. This test therefore drives the <b>exact production guard against
+ * the real surplus data and the real {@link HUQRCodesService#getOrCreateQRCodesByHuId(HuId)} collaborator</b>;
+ * the full browser-driven pick of a surplus aggregate on the running stack is covered by the #30767 Playwright
+ * spec ({@code e2e/mobile-webui/tests/spec/picking/picking_qrCodeSurplus.spec.js}).
  */
 @ExtendWith(AdempiereTestWatcher.class)
 public class PickingJobPickCommand_QRCodeSurplusToleranceTest
@@ -175,22 +172,19 @@ public class PickingJobPickCommand_QRCodeSurplusToleranceTest
 				.as("getOrCreateQRCodesByHuId returns the surplus codes untrimmed (one per originally-generated TU)")
 				.hasSize(3);
 
-		// The fix's guard is `huQRCodes.size() < tu.getQtyTU().toInt()` (error only on a DEFICIT).
-		// With a surplus (3 codes vs 2 TUs) that condition is FALSE -> no INVALID_NUMBER_QR_CODES error is thrown.
-		// (Pre-fix the guard was `!=`, so 3 != 2 threw "Erwartet {0} QR-Codes, aber nur {1} erhalten".)
-		assertThat(huQRCodes.size() < tuCountAfterSplit)
-				.as("fixed guard tolerates surplus: size(3) < tuCount(2) is false -> pick does NOT fail")
-				.isFalse();
-		assertThat(huQRCodes.size())
-				.as("ENOUGH codes to cover the TU count (>=), i.e. no deficit")
-				.isGreaterThanOrEqualTo(tuCountAfterSplit);
+		// then (the fix): call the REAL production guard PickingJobPickCommand.assertEnoughQRCodes with the surplus
+		// data and the required count the pick uses (tu.getQtyTU()=2). With the fixed operator (`< requiredCount`,
+		// error only on a DEFICIT) it does NOT throw for a surplus (3 codes, 2 required). Reverting the operator
+		// inside assertEnoughQRCodes (back to `!=`) makes this assertion throw INVALID_NUMBER_QR_CODES_ERROR_MSG,
+		// i.e. this test exercises production code, not a hand-copied predicate.
+		assertThatCode(() -> PickingJobPickCommand.assertEnoughQRCodes(huQRCodes, tuCountAfterSplit))
+				.as("production guard tolerates a surplus (3 codes >= 2 required) -> no INVALID_NUMBER_QR_CODES error")
+				.doesNotThrowAnyException();
 
-		// and: the pick consumes only the first N=tuCount codes (get(0)..get(tuCount-1)); the surplus tail is ignored.
-		for (int i = 0; i < tuCountAfterSplit; i++)
-		{
-			assertThat(huQRCodes.get(i))
-					.as("the first %d codes are the ones the pick consumes", tuCountAfterSplit)
-					.isNotNull();
-		}
+		// and (regression anchor): the same production guard DOES throw on a genuine DEFICIT (fewer codes than
+		// required), so the fix only relaxed the surplus case, not the deficit case.
+		assertThatThrownBy(() -> PickingJobPickCommand.assertEnoughQRCodes(huQRCodes, huQRCodes.size() + 1))
+				.as("production guard still errors on a deficit (required > codes)")
+				.isInstanceOf(AdempiereException.class);
 	}
 }

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 7 | 12 | 58% |
-| Picking | 62 | 65 | 95% |
+| Picking | 63 | 66 | 95% |
 | Distribution | 34 | 37 | 92% |
 | Manufacturing | 25 | 31 | 81% |
 | HU Manager | 14 | 16 | 88% |
@@ -169,8 +169,9 @@
 | No suggestions configured → no suggested picking slots shown | `picking/pickingSlotSuggestions.spec.js` |
 | Configured picking slot suggestions → shown and selectable | `picking/pickingSlotSuggestions.spec.js` |
 | Single sales order split and picked to multiple workplaces | `picking/pick_what_was_scheduled_to_workplace.spec.js` |
+| Aggregate LU carries more active QR codes than its current TU count (surplus) → picking tolerates the surplus and completes | `picking/picking_qrCodeSurplus.spec.js` |
 
-**5/5 — 100%**
+**6/6 — 100%**
 
 ### Product-based picking
 

--- a/e2e/mobile-webui/tests/spec/picking/picking_qrCodeSurplus.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_qrCodeSurplus.spec.js
@@ -7,10 +7,10 @@ import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsLi
 import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
 
 /**
- * me03 #30767 — mobile picking must TOLERATE an aggregate HU that carries MORE active QR-code assignments
+ * Mobile picking must TOLERATE an aggregate HU that carries MORE active QR-code assignments
  * than its current TU count (a "surplus").
  *
- * Real-world mechanism (see the issue's INVESTIGATION.md / REPRODUCE.md):
+ * Real-world mechanism:
  *  - QR codes are generated one-per-TU for an aggregate HU at its TU count AT GENERATION TIME (the desktop
  *    "Print Labels" / M_HU_Report_QRCode process runs huQRCodesService.generateForExistingHUs on the selected
  *    HU while it stays Active), and are NEVER trimmed when TUs are later split/picked out.
@@ -21,7 +21,7 @@ import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
  *    PickingJobPickCommand#toPickingJobStepPickedToHU reads the source's surplus codes via
  *    getOrCreateQRCodesByHuId and, pre-fix, hard-failed the `#codes == qtyTU` equality check with
  *    "Erwartet {0} QR-Codes, aber nur {1} erhalten".
- *  - The shipped fix (PR metasfresh#24917) relaxed the guard (PickingJobPickCommand.assertEnoughQRCodes) to
+ *  - The shipped fix relaxed the guard (PickingJobPickCommand.assertEnoughQRCodes) to
  *    error only on a DEFICIT (`< qtyTU`) and to consume only the first N codes — so a surplus is tolerated.
  *
  * This spec reproduces the surplus faithfully, entirely through the mobile UI + masterdata API:

--- a/e2e/mobile-webui/tests/spec/picking/picking_qrCodeSurplus.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_qrCodeSurplus.spec.js
@@ -1,0 +1,143 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
+
+/**
+ * me03 #30767 — mobile picking must TOLERATE an aggregate HU that carries MORE active QR-code assignments
+ * than its current TU count (a "surplus").
+ *
+ * Real-world mechanism (see the issue's INVESTIGATION.md / REPRODUCE.md):
+ *  - QR codes are generated one-per-TU for an aggregate HU at its TU count AT GENERATION TIME (the desktop
+ *    "Print Labels" / M_HU_Report_QRCode process runs huQRCodesService.generateForExistingHUs on the selected
+ *    HU while it stays Active), and are NEVER trimmed when TUs are later split/picked out.
+ *  - So once full-count codes are generated on an aggregate and some TUs leave it, the active QR-code count
+ *    exceeds the current TU count.
+ *  - A later pick of the whole remaining aggregate reuses that same source HU (HUTransformService.luExtractTUs
+ *    returns the source LU as-is when the requested qty equals its full TU count), so
+ *    PickingJobPickCommand#toPickingJobStepPickedToHU reads the source's surplus codes via
+ *    getOrCreateQRCodesByHuId and, pre-fix, hard-failed the `#codes == qtyTU` equality check with
+ *    "Erwartet {0} QR-Codes, aber nur {1} erhalten".
+ *  - The shipped fix (PR metasfresh#24917) relaxed the guard (PickingJobPickCommand.assertEnoughQRCodes) to
+ *    error only on a DEFICIT (`< qtyTU`) and to consume only the first N codes — so a surplus is tolerated.
+ *
+ * This spec reproduces the surplus faithfully, entirely through the mobile UI + masterdata API:
+ *   1. Masterdata builds an aggregate LU of 10 TUs (100 CU / 10 CU-per-TU) and generates full-count QR codes on it
+ *      while it stays Active (`generateHUQRCodesForAllTUs` — mirrors Print Labels): 10 active QR-code assignments.
+ *   2. Masterdata then splits 4 whole TUs OUT of the aggregate via a NON-picking repack
+ *      (`splitOutTUsCountAfterQRCodes: 4` — HUTransformService.tuToNewTUs, the qty-decrease-without-QR-cleanup path
+ *      a real repack uses). The source aggregate is left Active with 6 TUs but STILL 10 QR-code assignments ->
+ *      SURPLUS (10 codes vs 6 TUs). This is the exact real-world sequence: generate labels at the high-water TU
+ *      count, then repack fewer TUs.
+ *   3. A mobile pick of the whole remaining 6-TU aggregate reads the source's 10 surplus codes against its 6 TUs
+ *      (HUTransformService.luExtractTUs returns the source aggregate as-is when the requested qty equals its full
+ *      TU count, so PickingJobPickCommand#toPickingJobStepPickedToHU calls getOrCreateQRCodesByHuId on that source).
+ *      Pre-fix this threw "Erwartet 6 QR-Codes, aber nur 10 erhalten"; with the fix it SUCCEEDS (uses the first 6).
+ */
+test('Picking tolerates surplus QR codes on an aggregate LU', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');  // Standalone tag for Tags section;
+    allure.story('Picking tolerates surplus QR-code assignments on an aggregate');
+    allure.severity('critical');
+
+    const masterdata = await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US" } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    shipOnCloseLU: false,
+                    pickTo: ['LU_TU'],
+                    allowCompletingPartialPickingJob: true,
+                    allowSkippingRejectedReason: true,
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                "P1": { prices: [{ price: 1 }] },
+            },
+            packingInstructions: {
+                // aggregate LU: 10 TUs per LU, 10 CU per TU => a 10-TU / 100-CU aggregate LU
+                "PI1": { lu: "LU", qtyTUsPerLU: 10, tu: "TU1", product: "P1", qtyCUsPerTU: 10 },
+            },
+            handlingUnits: {
+                // One aggregate LU of 10 TUs (10 TU x 10 CU = 100 CU). Generate one QR code per TU on it WHILE it
+                // stays Active (the "Print Labels on the full pallet" step) -> 10 codes; then split 4 TUs out via a
+                // NON-picking repack, leaving 6 TUs but keeping all 10 codes -> a 10-code / 6-TU surplus.
+                // (qty is NOT set: with finite-capacity packingInstructions the total qty comes from the PI.)
+                "HU1": {
+                    product: 'P1',
+                    warehouse: 'wh',
+                    packingInstructions: 'PI1',
+                    generateHUQRCodesForAllTUs: true,
+                    splitOutTUsCountAfterQRCodes: 4,
+                },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [
+                        // Order the 6 TUs (60 CU) that remain on the surplus-bearing aggregate.
+                        { product: 'P1', qty: 60, piItemProduct: 'TU1' },
+                    ]
+                }
+            },
+        }
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI1.luName });
+
+    await test.step("Pick the whole remaining 6-TU aggregate carrying a 10-code surplus -> must NOT fail", async () => {
+        // This is the guarded pick: PickingJobPickCommand.toPickingJobStepPickedToHU reads getOrCreateQRCodesByHuId
+        // on the source aggregate (10 active codes) against its current 6 TUs. Pre-fix threw
+        // "Erwartet 6 QR-Codes, aber nur 10 erhalten"; the fix tolerates the surplus and uses only the first 6 codes.
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.qrCode,
+            expectQtyEntered: '6',
+        });
+        await PickingJobScreen.expectLineButton({ index: 1, color: 'green', qtyToPick: '6 TU', qtyPicked: '6 TU', qtyPickedCatchWeight: '' });
+    });
+
+    await test.step("Verify backend state after the surplus-tolerant pick", async () => {
+        // The surplus-bearing source pallet HU1 is fully emptied — all 10 TUs (100 PCE) were picked out of it,
+        // including via the guarded second pick against its 10-code surplus. If that pick had failed with the
+        // "Erwartet ... erhalten" error (pre-fix), HU1 would still hold the un-picked remainder.
+        await Backend.expect({
+            hus: {
+                HU1: { storages: {} },
+            }
+        });
+    });
+
+    await PickingJobScreen.complete();
+
+    await test.step("Verify backend state after completion", async () => {
+        // Completion succeeds and the source pallet stays empty (all its goods shipped via the picked LU).
+        await Backend.expect({
+            hus: {
+                HU1: { storages: {} },
+            }
+        });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/picking/picking_qrCodeSurplus.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_qrCodeSurplus.spec.js
@@ -120,9 +120,9 @@ test('Picking tolerates surplus QR codes on an aggregate LU', async ({ page }) =
     });
 
     await test.step("Verify backend state after the surplus-tolerant pick", async () => {
-        // The surplus-bearing source pallet HU1 is fully emptied — all 10 TUs (100 PCE) were picked out of it,
-        // including via the guarded second pick against its 10-code surplus. If that pick had failed with the
-        // "Erwartet ... erhalten" error (pre-fix), HU1 would still hold the un-picked remainder.
+        // The surplus-bearing source pallet HU1 is fully emptied — its remaining 6 TUs (60 PCE) were picked out of
+        // it via the guarded pick against its 10-code surplus. Had that pick failed with the "Erwartet ... erhalten"
+        // error (pre-fix), HU1 would still hold the un-picked 60 PCE.
         await Backend.expect({
             hus: {
                 HU1: { storages: {} },
@@ -130,14 +130,6 @@ test('Picking tolerates surplus QR codes on an aggregate LU', async ({ page }) =
         });
     });
 
+    // Completing the job succeeds (the picked goods were accepted despite the surplus source).
     await PickingJobScreen.complete();
-
-    await test.step("Verify backend state after completion", async () => {
-        // Completion succeeds and the source pallet stays empty (all its goods shipped via the picked LU).
-        await Backend.expect({
-            hus: {
-                HU1: { storages: {} },
-            }
-        });
-    });
 });


### PR DESCRIPTION
## Tests for mobile-picking QR-code surplus tolerance

Automated tests (JUnit + Playwright mobile E2E) for the surplus-tolerance behaviour in mobile picking, plus the masterdata test-support needed to set up the surplus faithfully. **This PR does NOT contain the fix** — the fix shipped in https://github.com/metasfresh/metasfresh/pull/24917 (already merged into `soft_panda_hotfix`, merge commit https://github.com/metasfresh/metasfresh/commit/268dbac2). This branch only adds tests + test-support, base `soft_panda_hotfix`.

### The behaviour under test
An aggregate HU can accumulate MORE active `M_HU_QRCode_Assignment` rows than its current TU count (a "surplus"): QR codes are generated one-per-TU at the aggregate's TU count at generation time (desktop "Print Labels" / `M_HU_Report_QRCode`) and are never trimmed when TUs later leave the aggregate via a repack. A later mobile pick reads those codes in `PickingJobPickCommand` and, pre-fix, hard-failed the `#codes == #TU` equality check with `INVALID_NUMBER_QR_CODES_ERROR_MSG` ("Erwartet {0} QR-Codes, aber nur {1} erhalten"). The shipped fix relaxed the guard to error only on a **deficit** and to consume only the first N codes, tolerating a surplus.

### What this PR adds
1. **Production refactor (behaviour-preserving):** extract the two identical QR-code deficit checks in `PickingJobPickCommand` into one package-visible `assertEnoughQRCodes(List<HUQRCode>, int)` (`< requiredCount`, same message + params). Both guard sites call it — so the JUnit can exercise the real production predicate instead of a hand-copied one.
2. **JUnit** `PickingJobPickCommand_QRCodeSurplusToleranceTest`: builds a faithful surplus (aggregate of 3 TUs, generate 3 codes, split 1 TU out → 3 codes / 2 TUs), then calls the real `assertEnoughQRCodes` and asserts it tolerates the surplus and still errors on a deficit. Reverting the operator to `!=` makes it RED (verified locally).
3. **Masterdata test-support** in `de.metas.frontend-testing` `CreateHUCommand`:
   - `generateHUQRCodesForAllTUs` — generate one QR code per TU for the HU + all included HUs (mirrors Print Labels), status untouched.
   - `splitOutTUsCountAfterQRCodes` — after generating, split N whole TUs out via `HUTransformService.tuToNewTUs` (a non-picking repack that leaves the codes behind), producing an Active aggregate with more codes than TUs.
4. **Playwright mobile E2E** `e2e/mobile-webui/tests/spec/picking/picking_qrCodeSurplus.spec.js`: builds a 10-TU aggregate LU, generates 10 codes, repacks 4 TUs out (→ 10 codes / 6 TUs), then a mobile pick of the whole remaining 6-TU aggregate reads the surplus at the guard and must succeed. Plus `TEST-COVERAGE.md` update.

### Verification (local, soft_panda stack)
- **JUnit**: RED against pre-fix (`!=`) with `INVALID_NUMBER_QR_CODES_ERROR_MSG - 2, 3`; GREEN with the fix (`Tests run: 1, Failures: 0`).
- **E2E**: RED against pre-fix app-server (`Expected 6 QR Codes but got only 10 / INVALID_NUMBER_QR_CODES`); GREEN against the fixed app-server. Also green in CI — the `mobile test` job on this commit passed: https://github.com/metasfresh/metasfresh/actions/runs/28541533125/job/84627568325
