### PR TITLE
MHD-Kontrolle: resolve shelf-life C_BPartner_Product by shipment schedule org (not only OrgId.ANY)

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
@@ -1035,7 +1035,7 @@ public class PickingJobPickCommand
 			return;
 		}
 
-		if (shelfLifeCheck.isRemainingShelfLifeTooShort(ssi.getProductId(), ssi.getBpartnerId(), bestBefore, deliveryDate))
+		if (shelfLifeCheck.isRemainingShelfLifeTooShort(ssi.getProductId(), ssi.getBpartnerId(), ssi.getClientAndOrgId().getOrgId(), bestBefore, deliveryDate))
 		{
 			throw new ShelfLifeTooShortException();
 		}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/bpartner/PickingJobBPartnerService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/bpartner/PickingJobBPartnerService.java
@@ -68,15 +68,16 @@ public class PickingJobBPartnerService
 
 	/**
 	 * @return C_BPartner_Product.ShelfLifeMinDays for the given (bpartner, product) pair,
-	 *         or 0 if no association exists.
+	 *         or 0 if no association exists. The org-specific row for {@code orgId} is preferred,
+	 *         with {@code OrgId.ANY} as fallback (handled by the DAO query).
 	 */
-	public int getBPartnerProductShelfLifeMinDays(@NonNull final BPartnerId bpartnerId, @NonNull final ProductId productId)
+	public int getBPartnerProductShelfLifeMinDays(@NonNull final BPartnerId bpartnerId, @NonNull final ProductId productId, @NonNull final OrgId orgId)
 	{
 		final I_C_BPartner_Product bpProduct = bpartnerProductDAO.retrieveBPartnerProductAssociation(
 				Env.getCtx(),
 				bpartnerId,
 				productId,
-				OrgId.ANY);
+				orgId);
 		if (bpProduct == null)
 		{
 			return 0;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/shelflife/PickingShelfLifeCheck.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/shelflife/PickingShelfLifeCheck.java
@@ -3,6 +3,7 @@ package de.metas.handlingunits.picking.job.service.shelflife;
 import de.metas.bpartner.BPartnerId;
 import de.metas.handlingunits.picking.job.service.external.bpartner.PickingJobBPartnerService;
 import de.metas.handlingunits.picking.job.service.external.product.PickingJobProductService;
+import de.metas.organization.OrgId;
 import de.metas.product.ProductId;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -34,12 +35,15 @@ public class PickingShelfLifeCheck
 	 *
 	 * @param productId      the product being picked
 	 * @param bpartnerId     the customer business partner
+	 * @param orgId          the org of the shipment schedule (used to resolve the org-specific
+	 *                       {@code C_BPartner_Product} row, falling back to {@code OrgId.ANY})
 	 * @param bestBeforeDate the best-before / MHD date of the HU (may be {@code null} — treated as "no undercut")
 	 * @param deliveryDate   the planned delivery date
 	 */
 	public boolean isRemainingShelfLifeTooShort(
 			@NonNull final ProductId productId,
 			@NonNull final BPartnerId bpartnerId,
+			@NonNull final OrgId orgId,
 			@Nullable final LocalDate bestBeforeDate,
 			@NonNull final LocalDate deliveryDate)
 	{
@@ -48,7 +52,7 @@ public class PickingShelfLifeCheck
 			return false;
 		}
 
-		final int guaranteedDays = resolveGuaranteedDays(productId, bpartnerId);
+		final int guaranteedDays = resolveGuaranteedDays(productId, bpartnerId, orgId);
 		if (guaranteedDays <= 0)
 		{
 			return false;
@@ -66,9 +70,9 @@ public class PickingShelfLifeCheck
 	 *   <li>{@code M_Product.GuaranteeDaysMin} (with fallback to product category)</li>
 	 * </ol>
 	 */
-	private int resolveGuaranteedDays(@NonNull final ProductId productId, @NonNull final BPartnerId bpartnerId)
+	private int resolveGuaranteedDays(@NonNull final ProductId productId, @NonNull final BPartnerId bpartnerId, @NonNull final OrgId orgId)
 	{
-		final int bpShelfLifeMinDays = bpartnerService.getBPartnerProductShelfLifeMinDays(bpartnerId, productId);
+		final int bpShelfLifeMinDays = bpartnerService.getBPartnerProductShelfLifeMinDays(bpartnerId, productId, orgId);
 		if (bpShelfLifeMinDays > 0)
 		{
 			return bpShelfLifeMinDays;

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/shelflife/PickingShelfLifeCheckTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/shelflife/PickingShelfLifeCheckTest.java
@@ -3,6 +3,7 @@ package de.metas.handlingunits.picking.job.service.shelflife;
 import de.metas.bpartner.BPartnerId;
 import de.metas.handlingunits.picking.job.service.external.bpartner.PickingJobBPartnerService;
 import de.metas.handlingunits.picking.job.service.external.product.PickingJobProductService;
+import de.metas.organization.OrgId;
 import de.metas.product.ProductId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -28,6 +29,7 @@ class PickingShelfLifeCheckTest
 {
 	private static final ProductId PRODUCT_ID = ProductId.ofRepoId(1);
 	private static final BPartnerId BPARTNER_ID = BPartnerId.ofRepoId(2);
+	private static final OrgId ORG_ID = OrgId.ofRepoId(3);
 
 	private PickingJobProductService productService;
 	private PickingJobBPartnerService bpartnerService;
@@ -44,7 +46,7 @@ class PickingShelfLifeCheckTest
 	/** Sets up mock guaranteed days for the given product and bpartner. */
 	private void givenGuaranteedDays(final int bpProductShelfLifeMinDays, final int productGuaranteeDaysMin)
 	{
-		when(bpartnerService.getBPartnerProductShelfLifeMinDays(BPARTNER_ID, PRODUCT_ID))
+		when(bpartnerService.getBPartnerProductShelfLifeMinDays(BPARTNER_ID, PRODUCT_ID, ORG_ID))
 				.thenReturn(bpProductShelfLifeMinDays);
 		when(productService.getGuaranteeDaysMin(PRODUCT_ID))
 				.thenReturn(productGuaranteeDaysMin);
@@ -52,7 +54,7 @@ class PickingShelfLifeCheckTest
 
 	private boolean check(@Nullable final LocalDate bestBeforeDate, final LocalDate deliveryDate)
 	{
-		return pickingShelfLifeCheck.isRemainingShelfLifeTooShort(PRODUCT_ID, BPARTNER_ID, bestBeforeDate, deliveryDate);
+		return pickingShelfLifeCheck.isRemainingShelfLifeTooShort(PRODUCT_ID, BPARTNER_ID, ORG_ID, bestBeforeDate, deliveryDate);
 	}
 
 	@Nested


### PR DESCRIPTION
## Summary

Follow-up to the MobileUI picking shelf-life ("RLZ") warning: resolve `C_BPartner_Product.ShelfLifeMinDays` by the **shipment schedule's org**, not only `OrgId.ANY`.

**Bug:** `PickingJobBPartnerService.getBPartnerProductShelfLifeMinDays(...)` hardcoded `OrgId.ANY` in its `retrieveBPartnerProductAssociation(...)` call, so a `C_BPartner_Product` row created at a specific `AD_Org_ID` (the shipment schedule's org) was never found → `ShelfLifeMinDays` read as 0 → the warning silently never fired for org-scoped rows.

**Fix:** thread the shipment schedule's `OrgId` (already available at the pick call site via `ShipmentScheduleInfo.getClientAndOrgId()`) through `PickingJobPickCommand` → `PickingShelfLifeCheck.isRemainingShelfLifeTooShort` → `resolveGuaranteedDays` → `getBPartnerProductShelfLifeMinDays`, and pass it to the DAO instead of `OrgId.ANY`. The DAO query (`retrieveBPartnerProductAssociationsQueryBuilder`) already does `addInArrayOrAllFilter(AD_Org_ID, orgId, OrgId.ANY)` ordered `AD_Org_ID DESC NULLS LAST`, so the org-specific row is **preferred** with `OrgId.ANY` as automatic fallback — no manual fallback added.

## Testing

- `PickingShelfLifeCheckTest`: **6/6 green** (updated to the new signature; the facade mock is stubbed per-org, so the org is threaded end-to-end).
