### PR TITLE
Fix DistributionJobQueriesTest merge-resolution failure (test-java job)

### DIFF
--- a/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/service/DistributionJobQueriesTest.java
+++ b/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/service/DistributionJobQueriesTest.java
@@ -17,8 +17,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests {@link DistributionJobQueries#toActiveNotAssignedDDOrderQuery(DDOrderReferenceQuery)}:
  * <ul>
- *   <li>Y case — packing-place workplace (IsPackingPlace=Y): locatorToId present, excludeLocatorToIds absent → locatorToIds predicate matches exactly that locator, excludeLocatorToIds null</li>
- *   <li>N case — replenishment workplace (IsPackingPlace=N): locatorToId absent, excludeLocatorToIds populated → locatorToIds is any-match, excludeLocatorToIds propagated</li>
+ *   <li>Y case — packing-place workplace (IsPackingPlace=Y): pick-from locator present, excludeLocatorToIds absent → workplacePickFromLocatorId set, excludeLocatorToIds null</li>
+ *   <li>N case — replenishment workplace (IsPackingPlace=N): pick-from locator absent, excludeLocatorToIds populated → workplacePickFromLocatorId null, excludeLocatorToIds propagated</li>
  * </ul>
  */
 class DistributionJobQueriesTest
@@ -30,7 +30,7 @@ class DistributionJobQueriesTest
 	@Test
 	void toActiveNotAssignedDDOrderQuery_regularWorkplace_locatorToIdSet()
 	{
-		// Given: regular (non-packing) workplace — locatorToId set, excludeLocatorToIds absent
+		// Given: regular (non-packing) workplace — pick-from locator set, excludeLocatorToIds absent
 		final DDOrderReferenceQuery query = DDOrderReferenceQuery.builder()
 				.responsibleId(UserId.ofRepoId(999))
 				.workplaceWarehouseId(W1)
@@ -41,12 +41,9 @@ class DistributionJobQueriesTest
 		// When
 		final DDOrderQuery result = DistributionJobQueries.toActiveNotAssignedDDOrderQuery(query);
 
-		// Then: locatorToIds matches exactly L1; excludeLocatorToIds is null/empty
-		final InSetPredicate<LocatorId> locatorToIds = result.getLocatorToIds();
-		assertThat(locatorToIds).isNotNull();
-		assertThat(locatorToIds.isAny()).isFalse();
-		assertThat(locatorToIds.test(L1)).isTrue();
-		assertThat(locatorToIds.test(L2)).isFalse();
+		// Then: the pick-from locator flows through to workplacePickFromLocatorId; excludeLocatorToIds is null/empty
+		assertThat(result.getWorkplaceWarehouseId()).isEqualTo(W1);
+		assertThat(result.getWorkplacePickFromLocatorId()).isEqualTo(L1);
 
 		@Nullable final Set<LocatorId> excludeLocatorToIds = result.getExcludeLocatorToIds();
 		assertThat(excludeLocatorToIds).isNullOrEmpty();
@@ -55,7 +52,7 @@ class DistributionJobQueriesTest
 	@Test
 	void toActiveNotAssignedDDOrderQuery_replenishmentWorkplace_excludeLocatorToIdsSet()
 	{
-		// Given: replenishment (non-packing, IsPackingPlace=N) workplace — locatorToId absent, excludeLocatorToIds populated
+		// Given: replenishment (non-packing, IsPackingPlace=N) workplace — pick-from locator absent, excludeLocatorToIds populated
 		final ImmutableSet<LocatorId> packingLocators = ImmutableSet.of(L1, L2);
 		final DDOrderReferenceQuery query = DDOrderReferenceQuery.builder()
 				.responsibleId(UserId.ofRepoId(999))
@@ -67,10 +64,9 @@ class DistributionJobQueriesTest
 		// When
 		final DDOrderQuery result = DistributionJobQueries.toActiveNotAssignedDDOrderQuery(query);
 
-		// Then: locatorToIds is any-match (null or isAny()); excludeLocatorToIds == {L1, L2}
-		final InSetPredicate<LocatorId> locatorToIds = result.getLocatorToIds();
-		// locatorToId was null → InSetPredicate.onlyOrAny(null) → isAny()
-		assertThat(locatorToIds == null || locatorToIds.isAny()).isTrue();
+		// Then: no specific pick-from locator; excludeLocatorToIds == {L1, L2}
+		assertThat(result.getWorkplaceWarehouseId()).isEqualTo(W1);
+		assertThat(result.getWorkplacePickFromLocatorId()).isNull();
 
 		final Set<LocatorId> excludeLocatorToIds = result.getExcludeLocatorToIds();
 		assertThat(excludeLocatorToIds).containsExactlyInAnyOrderElementsOf(packingLocators);

--- a/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/service/DistributionJobQueriesTest.java
+++ b/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/service/DistributionJobQueriesTest.java
@@ -28,9 +28,9 @@ class DistributionJobQueriesTest
 	private static final LocatorId L2 = LocatorId.ofRepoId(1, 102);
 
 	@Test
-	void toActiveNotAssignedDDOrderQuery_regularWorkplace_locatorToIdSet()
+	void toActiveNotAssignedDDOrderQuery_packingPlaceWorkplace_pickFromLocatorIdSet()
 	{
-		// Given: regular (non-packing) workplace — pick-from locator set, excludeLocatorToIds absent
+		// Given: packing-place workplace (IsPackingPlace=Y) — pick-from locator set, excludeLocatorToIds absent
 		final DDOrderReferenceQuery query = DDOrderReferenceQuery.builder()
 				.responsibleId(UserId.ofRepoId(999))
 				.workplaceWarehouseId(W1)


### PR DESCRIPTION
## What
Fixes the `test (java)` failure on the merge PR https://github.com/metasfresh/metasfresh/pull/24901 — a bad merge conflict resolution in `DistributionJobQueriesTest.java` (module `de.metas.distribution.rest-api`).

## Root cause
The `intensive_care_release → new_dawn_uat` merge (commit `0b5b75b2c3f`) combined two divergent generations of the DD-order query model:
- **new_dawn_uat side** added two tests against the OLD model: `.locatorToId(L1)` → assert `DDOrderQuery.getLocatorToIds()`.
- **intensive_care_release side** refactored the model: the pick-from locator became a distinct field `workplacePickFromLocatorId`; `locatorToIds` is `@Nullable` and never populated. It added its own `@Nested Workplace` tests for the new model.

The conflict resolution renamed the two tests' **builder setters** to compile against the new builder but left the **OLD assertions** intact. So `toActiveNotAssignedDDOrderQuery_regularWorkplace_locatorToIdSet` failed at runtime on `assertThat(getLocatorToIds()).isNotNull()` (value is `null`).

## Fix
Realign both migrated tests' assertions to the current model (`getWorkplaceWarehouseId` / `getWorkplacePickFromLocatorId` / `getExcludeLocatorToIds`), preserving their original intent (pick-from-locator mapping in the Y case; `excludeLocatorToIds` propagation in the N case).

## Verification
Local offline run of `DistributionJobQueriesTest` (JDK 8): RED before the fix (1 failure), GREEN after — 4 tests, 0 failures.
