### PR TITLE
Product purchase/sales gate: also filter the order Products Proposal view

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRowsLoader.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/order/products_proposal/model/ProductsProposalRowsLoader.java
@@ -202,12 +202,24 @@ public final class ProductsProposalRowsLoader
 		final ZoneId zoneId = orgDAO.getTimeZone(Env.getOrgId());
 		final LocalDate currentDate = LocalDate.now(zoneId);
 
+		// When the purchase/sales enforcement gate is on, a not-sellable product (sales order) /
+		// not-purchasable product (purchase order) must not even be offered in the proposal.
+		// Inert when the gate is off (default) — mirrors the order mass-entry product picker.
+		final boolean enforcePurchaseSalesFlags = productBL.isPurchaseSalesEnforcementEnabled(Env.getClientId(), Env.getOrgId());
+
 		return priceListVersionIds.stream()
 				.flatMap(this::loadAndStreamRowsForPriceListVersionId)
 				.sorted(Comparator.comparing(ProductsProposalRow::getSeqNo)
 								.thenComparing(ProductsProposalRow::getProductName))
 				.filter(p -> !productBL.isDiscontinuedAt(productsRepo.getById(p.getProductId()), currentDate))
+				.filter(p -> !enforcePurchaseSalesFlags || isPurchasableOrSellable(p.getProductId()))
 				.collect(ImmutableList.toImmutableList());
+	}
+
+	private boolean isPurchasableOrSellable(@NonNull final ProductId productId)
+	{
+		final I_M_Product product = productsRepo.getById(productId);
+		return soTrx.isSales() ? product.isSold() : product.isPurchased();
 	}
 
 	private Stream<ProductsProposalRow> loadAndStreamRowsForPriceListVersionId(final PriceListVersionId priceListVersionId)


### PR DESCRIPTION
Follow-up to https://github.com/metasfresh/metasfresh/pull/24861.

## What
When the `M_Product_EnforcePurchaseSalesFlags` gate is enabled, the order **Products Proposal** view (`WEBUI_Order_ProductsProposal`) still listed products regardless of their `IsPurchased` / `IsSold` flag. A user could pick a blocked product from the proposal and only hit the `C_OrderLine` interceptor rejection at save — poor UX and an enforcement gap versus the mass-entry product picker.

## How
`ProductsProposalRowsLoader.loadRows()` now drops `IsSold=N` rows for a sales order and `IsPurchased=N` rows for a purchase order when the gate is enabled (client/org from the session). Inert when the gate is off (default), mirroring the order mass-entry picker filter.

No behaviour change unless `M_Product_EnforcePurchaseSalesFlags=Y`.