### PR TITLE
M_ShipmentSchedule_Recompute performance: ChunkUUID + AD_PInstance_ID indexes + dedup function

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/de_metas_inoutcandidate/m_shipmentschedule_recompute_dedup.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/de_metas_inoutcandidate/m_shipmentschedule_recompute_dedup.sql
@@ -1,0 +1,39 @@
+-- Purpose: collapse duplicate enqueued recompute flags to ONE row per M_ShipmentSchedule_ID.
+-- Context: the recompute processors bulk-UPDATE every enqueued row each cycle, so N duplicate
+-- flags per schedule make each cycle N× more expensive. Keeping one flag per schedule is safe:
+-- a schedule's recompute is holistic, so a single pending flag fully recomputes it.
+-- This is a STOPGAP; the real fix is not over-enqueuing (dedup at enqueue time in core).
+
+DROP FUNCTION IF EXISTS m_shipmentschedule_recompute_dedup();
+
+CREATE OR REPLACE FUNCTION m_shipmentschedule_recompute_dedup()
+RETURNS bigint
+LANGUAGE plpgsql
+AS $func$
+DECLARE
+    v_deleted bigint;
+BEGIN
+    -- Fail fast rather than hang/deadlock behind a running recompute batch's bulk UPDATE.
+    SET LOCAL lock_timeout = '5s';
+
+    -- Only UNCLAIMED rows (AD_PInstance_ID IS NULL): never removes a row an in-flight
+    -- batch has claimed and is processing. Keep the lowest-ctid row per schedule.
+    WITH ranked AS (
+        SELECT ctid,
+               row_number() OVER (PARTITION BY M_ShipmentSchedule_ID ORDER BY ctid) AS rn
+        FROM M_ShipmentSchedule_Recompute
+        WHERE AD_PInstance_ID IS NULL
+    )
+    DELETE FROM M_ShipmentSchedule_Recompute t
+    USING ranked r
+    WHERE t.ctid = r.ctid
+      AND r.rn > 1;
+
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    RAISE NOTICE 'm_shipmentschedule_recompute_dedup: deleted % duplicate flag(s)', v_deleted;
+    RETURN v_deleted;
+END;
+$func$;
+
+COMMENT ON FUNCTION m_shipmentschedule_recompute_dedup() IS
+'Deduplicates enqueued M_ShipmentSchedule_Recompute rows: keeps one per M_ShipmentSchedule_ID (unclaimed rows only). Returns number of duplicate flags deleted. Stopgap for over-enqueuing; run on demand or periodically.';

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5811320_sys_M_ShipmentSchedule_Recompute_ChunkUUID_index.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5811320_sys_M_ShipmentSchedule_Recompute_ChunkUUID_index.sql
@@ -1,0 +1,8 @@
+-- Index on M_ShipmentSchedule_Recompute.ChunkUUID.
+-- The recompute processors query this table with WHERE ChunkUUID=?; the column was
+-- added without a supporting index, forcing sequential scans on a hot, high-churn queue.
+-- IF NOT EXISTS: the index may already have been created live on some instances.
+
+CREATE INDEX IF NOT EXISTS M_ShipmentSchedule_Recompute_ChunkUUID
+    ON M_ShipmentSchedule_Recompute (ChunkUUID)
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5811330_sys_M_ShipmentSchedule_Recompute_AD_PInstance_ID_index.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5811330_sys_M_ShipmentSchedule_Recompute_AD_PInstance_ID_index.sql
@@ -1,0 +1,8 @@
+-- Index on M_ShipmentSchedule_Recompute.AD_PInstance_ID.
+-- The recompute processors filter the queue by AD_PInstance_ID (claimed vs. unclaimed rows);
+-- without a supporting index this scans the whole hot, high-churn queue.
+-- IF NOT EXISTS: the index may already have been created live on some instances.
+
+CREATE INDEX IF NOT EXISTS M_ShipmentSchedule_Recompute_AD_PInstance_ID
+    ON M_ShipmentSchedule_Recompute (AD_PInstance_ID)
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5811340_sys_M_ShipmentSchedule_Recompute_dedup_function.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5811340_sys_M_ShipmentSchedule_Recompute_dedup_function.sql
@@ -1,0 +1,35 @@
+-- Source DDL: backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/de_metas_inoutcandidate/m_shipmentschedule_recompute_dedup.sql
+
+DROP FUNCTION IF EXISTS m_shipmentschedule_recompute_dedup();
+
+CREATE OR REPLACE FUNCTION m_shipmentschedule_recompute_dedup()
+RETURNS bigint
+LANGUAGE plpgsql
+AS $func$
+DECLARE
+    v_deleted bigint;
+BEGIN
+    -- Fail fast rather than hang/deadlock behind a running recompute batch's bulk UPDATE.
+    SET LOCAL lock_timeout = '5s';
+
+    -- Only UNCLAIMED rows (AD_PInstance_ID IS NULL): never removes a row an in-flight
+    -- batch has claimed and is processing. Keep the lowest-ctid row per schedule.
+    WITH ranked AS (
+        SELECT ctid,
+               row_number() OVER (PARTITION BY M_ShipmentSchedule_ID ORDER BY ctid) AS rn
+        FROM M_ShipmentSchedule_Recompute
+        WHERE AD_PInstance_ID IS NULL
+    )
+    DELETE FROM M_ShipmentSchedule_Recompute t
+    USING ranked r
+    WHERE t.ctid = r.ctid
+      AND r.rn > 1;
+
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    RAISE NOTICE 'm_shipmentschedule_recompute_dedup: deleted % duplicate flag(s)', v_deleted;
+    RETURN v_deleted;
+END;
+$func$;
+
+COMMENT ON FUNCTION m_shipmentschedule_recompute_dedup() IS
+'Deduplicates enqueued M_ShipmentSchedule_Recompute rows: keeps one per M_ShipmentSchedule_ID (unclaimed rows only). Returns number of duplicate flags deleted. Stopgap for over-enqueuing; run on demand or periodically.';


### PR DESCRIPTION
## M_ShipmentSchedule_Recompute recompute-queue performance

Ships three DB changes that were applied live and verified on the affected instance during a production recompute-queue performance incident, so they can be re-applied on other systems as migrations.

### Migrations

1. **`5811320` — index on `ChunkUUID`.** The recompute processors query `M_ShipmentSchedule_Recompute WHERE ChunkUUID=?`. The `ChunkUUID` column exists but had no supporting index, forcing sequential scans on a hot, high-churn queue. Adds a plain `CREATE INDEX IF NOT EXISTS`.
2. **`5811330` — index on `AD_PInstance_ID`.** The processors also filter the queue by `AD_PInstance_ID` (claimed vs. unclaimed rows); adds a supporting index. Plain `CREATE INDEX IF NOT EXISTS`.
3. **`5811340` — function `m_shipmentschedule_recompute_dedup()`.** De-duplicates the queue, keeping one flag per `M_ShipmentSchedule_ID` (unclaimed rows only, with a short `lock_timeout` so it fails fast rather than blocking a running batch). A recompute is holistic, so a single pending flag fully recomputes the schedule; collapsing duplicates removes the N× per-cycle cost of over-enqueuing. This is a stopgap; the real fix is to avoid over-enqueuing at the source. Shipped as both a migration script and a matching DDL file under `ddl/de_metas_inoutcandidate/`.

Indexes use `IF NOT EXISTS` (plain, not `CONCURRENTLY`) because migrations run inside a transaction and the affected instance already has these objects.

### Rollout

Pilot on `deep_tundra_release`. Merge up to `new_dawn_uat` will follow; cherry-pick to the other hotfix branches at the end.
