### PR TITLE
e2e: fix flaky product-purchase-sales-gate cross-JVM SysConfig cache race

### DIFF
--- a/e2e/frontend-webui/tests/utils/Backend.js
+++ b/e2e/frontend-webui/tests/utils/Backend.js
@@ -1,5 +1,6 @@
 import { test, testContext } from '../../playwright.config';
 import { getPage } from './common';
+import { WEBAPI_BASE_URL } from './WebAPIValidation';
 
 /**
  * Backend API client for interacting with /rest/api/v2/frontendTesting endpoints.
@@ -42,6 +43,20 @@ export const Backend = {
 
       // Store masterdata in test context for later use
       testContext.lastMasterdata = responseBody;
+
+      // The sysconfigs in the request are written on the app node (8282). Any
+      // sysconfig-gated query (e.g. the product-lookup picker) runs on the
+      // separate webapi node (8080), whose AD_SysConfig cache never time-expires
+      // and is refreshed across JVMs only by a fire-and-forget RabbitMQ
+      // broadcast with no delivery guarantee (see CacheInvalidationRemoteHandler).
+      // A test that opens a gated view can therefore race that broadcast and read
+      // the stale (pre-write) value. Force webapi to reload AD_SysConfig
+      // synchronously so the just-committed values are observable before the test
+      // proceeds; the reset runs inside webapi's own request thread, so the 200 is
+      // a hard confirmation. Only needed when the request actually set sysconfigs.
+      if (request && request.sysconfigs && Object.keys(request.sysconfigs).length > 0) {
+        await resetWebApiSysConfigCache();
+      }
 
       return responseBody;
     }),
@@ -100,6 +115,30 @@ const getBackendBaseUrl = async () => {
   }
   return _testingApiBaseUrl;
 };
+
+/**
+ * Force the webapi node (8080) to reload its AD_SysConfig cache synchronously.
+ *
+ * The frontendTesting endpoint writes sysconfigs on the app node (8282). The
+ * webapi node caches the whole AD_SysConfig table with no time-expiry and is
+ * only refreshed cross-JVM by an unconfirmed RabbitMQ broadcast, so a gated
+ * query on webapi can serve a stale value right after the write. Hitting
+ * webapi's own /cache/resetByTable clears that cache inside the request thread,
+ * making the just-committed values immediately observable. The endpoint needs
+ * no auth (it is called before the UI login).
+ */
+const resetWebApiSysConfigCache = async () =>
+  await test.step('Backend: reset webapi AD_SysConfig cache', async () => {
+    const page = getPage();
+    const response = await page.request.get(
+      `${WEBAPI_BASE_URL}/cache/resetByTable?tableName=AD_SysConfig`
+    );
+    if (!response.ok()) {
+      throw new Error(
+        `Failed to reset webapi AD_SysConfig cache: HTTP ${response.status()} ${response.statusText()}`
+      );
+    }
+  });
 
 /**
  * Assert that the response body contains no errors.


### PR DESCRIPTION
## Problem
`e2e/frontend-webui/tests/spec/product-purchase-sales-gate.spec.js` is flaky in CI (per-run-sticky): the assertion that an `IsSold=N` / `IsPurchased=N` product is absent from the batch-entry product picker (`expect(matchingOptions).toHaveCount(0)`) intermittently fails with `Received: 1` — the blocked product is visible.

## Root cause (cross-JVM SysConfig cache race)
- The test enables the gate by writing SysConfig `M_Product_EnforcePurchaseSalesFlags=Y` through the frontendTesting masterdata API, which runs on the **app** node (:8282).
- The gate is read by the product-lookup picker on the **webapi** node (:8080) — `ProductLookupDescriptor.appendFilterByOrderType` → `ProductBL.isPurchaseSalesEnforcementEnabled` → `sysConfigBL.getBooleanValue`.
- `SysConfigDAO` caches the whole `AD_SysConfig` table in a `CCache` with `EXPIREMINUTES_Never`. Across JVMs it is refreshed **only** by a fire-and-forget RabbitMQ broadcast (`CacheInvalidationRemoteHandler`) — no publisher confirm, exceptions swallowed. So webapi can serve the stale (pre-write) value indefinitely if it already had the map cached and misses/lags the broadcast → gate off → blocked product shown.
- This is the first e2e where the sysconfig writer (app) and reader (webapi) are different JVMs; the existing `barcodeScanner.*` sysconfig tests read on the same (app) node and so never raced. Production is unaffected (gate set once at config time).

## Fix (test-harness only, zero production impact)
`Backend.createMasterdata` now, when the request sets `sysconfigs`, synchronously calls webapi's existing `GET /rest/api/cache/resetByTable?tableName=AD_SysConfig` (auth-free; runs inside webapi's own request thread, so the `200` is a hard confirmation that webapi reloaded the committed value) before returning. This makes the just-written sysconfigs deterministically observable on webapi and **fixes every SysConfig-gated e2e**, not just this spec.

- No production code touched; no DB reach-in (uses an already-deployed REST endpoint).
- Reviewed clean (metasfresh conventions, no import cycle, correctly table-scoped reset vs. full `/reset`).

## Verification
Verified via CI (the real two-JVM e2e topology where the flake lives); the frontend-webui e2e shard is re-run for flake confidence. Local full-stack reproduction was not run because this shared build host already hosts other sessions' stacks on the required ports.

Merges into `deep_tundra_release`; propagates to `new_dawn_uat` via the normal merge train. Relates to the F00315 / F00320 Product Purchase/Sales Gate feature.

