### PR TITLE
Distribution launcher: tolerate multi-UOM DD_Orders (no crash on mixed UOM)

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/quantity/MixedQuantity.java
+++ b/backend/de.metas.business/src/main/java/de/metas/quantity/MixedQuantity.java
@@ -8,6 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -99,6 +100,17 @@ public final class MixedQuantity
 		{
 			throw new AdempiereException("Expected none or single value but got many: " + map.values());
 		}
+	}
+
+	/**
+	 * Tolerant variant of {@link #toNoneOrSingleValue()}: returns {@code null} when there is no value
+	 * <b>or</b> when the values span multiple UOMs (instead of throwing). Use where a single-UOM quantity
+	 * is wanted for display but a genuine multi-UOM aggregate must simply resolve to "no single value".
+	 */
+	@Nullable
+	public Quantity toSingleValueOrNull()
+	{
+		return map.size() == 1 ? map.values().iterator().next() : null;
 	}
 
 	public MixedQuantity add(@NonNull final Quantity qtyToAdd)

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/model/DistributionJob.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/model/DistributionJob.java
@@ -258,7 +258,9 @@ public class DistributionJob
 				.distinct()
 				.collect(MixedQuantity.collectAndSum());
 
-		return qty.toNoneOrSingleValue().orElse(null);
+		// A distribution job whose lines span multiple UOMs has no single caption quantity;
+		// resolve to null (rendered as blank) instead of throwing, so the launcher still loads.
+		return qty.toSingleValueOrNull();
 	}
 
 	public Optional<DistributionJobLineId> getNextEligiblePickFromLineId(@NonNull final ProductId productId)

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/model/DistributionJob.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/job/model/DistributionJob.java
@@ -253,9 +253,10 @@ public class DistributionJob
 	@Nullable
 	public Quantity getSingleUnitQuantityOrNull()
 	{
+		// Sum every line's qty (no .distinct(): two lines with an equal qty+UOM must both count,
+		// otherwise the caption under-reports the total).
 		final MixedQuantity qty = lines.stream()
 				.map(DistributionJobLine::getQtyToMove)
-				.distinct()
 				.collect(MixedQuantity.collectAndSum());
 
 		// A distribution job whose lines span multiple UOMs has no single caption quantity;

--- a/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/model/DistributionJobTest.java
+++ b/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/model/DistributionJobTest.java
@@ -153,4 +153,18 @@ class DistributionJobTest
 		assertThat(result.toBigDecimal()).isEqualByComparingTo("8");
 		assertThat(result.getUomId()).isEqualTo(UomId.ofRepoId(stk.getC_UOM_ID()));
 	}
+
+	@Test
+	void getSingleUnitQuantityOrNull_sumsAllLines_evenWhenTwoLinesCarryTheSameQtyAndUOM()
+	{
+		final I_C_UOM stk = BusinessTestHelper.createUOM("Stk", 0, 0);
+
+		// Two lines each moving 5 Stk must total 10 — they must NOT be collapsed to a single 5 (the .distinct() trap).
+		final DistributionJob job = jobWithLines(ImmutableList.of(line(1, stk, "5"), line(2, stk, "5")));
+
+		final Quantity result = job.getSingleUnitQuantityOrNull();
+		assertThat(result).isNotNull();
+		assertThat(result.toBigDecimal()).isEqualByComparingTo("10");
+		assertThat(result.getUomId()).isEqualTo(UomId.ofRepoId(stk.getC_UOM_ID()));
+	}
 }

--- a/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/model/DistributionJobTest.java
+++ b/backend/de.metas.distribution.rest-api/src/test/java/de/metas/distribution/mobileui/job/model/DistributionJobTest.java
@@ -2,30 +2,66 @@ package de.metas.distribution.mobileui.job.model;
 
 import com.google.common.collect.ImmutableList;
 import de.metas.bpartner.BPartnerId;
+import de.metas.business.BusinessTestHelper;
 import de.metas.distribution.ddorder.DDOrderId;
+import de.metas.distribution.ddorder.DDOrderLineId;
+import de.metas.distribution.mobileui.external_services.product.ProductInfo;
+import de.metas.distribution.mobileui.external_services.warehouse.LocatorInfo;
 import de.metas.distribution.mobileui.external_services.warehouse.WarehouseInfo;
+import de.metas.i18n.TranslatableStrings;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.uom.UomId;
 import de.metas.user.UserId;
 import de.metas.util.lang.SeqNo;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
+import org.adempiere.warehouse.qrcode.LocatorQRCode;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.annotation.Nullable;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Covers {@link DistributionJob#assertCanEdit(UserId)}: a DD_Order-backed distribution job that was closed under
- * the picker (its DD_Order is no longer Completed) must no longer be editable, even by its responsible user.
+ * Covers {@link DistributionJob#assertCanEdit(UserId)} and {@link DistributionJob#getSingleUnitQuantityOrNull()}.
+ *
+ * <p>The latter must be resilient to a DD_Order whose lines span multiple UOMs: the launcher caption can only show
+ * one UOM, so a multi-UOM job must resolve to {@code null} (rendered blank) rather than throw — otherwise the whole
+ * distribution launcher fails to load.</p>
  */
+@ExtendWith(AdempiereTestWatcher.class)
 class DistributionJobTest
 {
 	private static final UserId PICKER = UserId.ofRepoId(1234);
 
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+	}
+
 	private static DistributionJob job(final boolean isClosed, @Nullable final UserId responsibleId)
+	{
+		return jobBuilder(isClosed, responsibleId).lines(ImmutableList.of()).build();
+	}
+
+	private static DistributionJob jobWithLines(final ImmutableList<DistributionJobLine> lines)
+	{
+		return jobBuilder(false, PICKER).lines(lines).build();
+	}
+
+	private static DistributionJob.DistributionJobBuilder jobBuilder(final boolean isClosed, @Nullable final UserId responsibleId)
 	{
 		final ZonedDateTime when = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC"));
 		return DistributionJob.builder()
@@ -40,8 +76,31 @@ class DistributionJobTest
 				.priority("5")
 				.responsibleId(responsibleId)
 				.isClosed(isClosed)
-				.allowPickingAnyHU(false)
-				.lines(ImmutableList.of())
+				.allowPickingAnyHU(false);
+	}
+
+	private static DistributionJobLine line(final int lineId, final I_C_UOM uom, final String qty)
+	{
+		return DistributionJobLine.builder()
+				.id(DistributionJobLineId.ofDDOrderLineId(DDOrderLineId.ofRepoId(lineId)))
+				.product(ProductInfo.builder()
+						.productId(ProductId.ofRepoId(1000000 + lineId))
+						.caption(TranslatableStrings.anyLanguage("P" + lineId))
+						.build())
+				.qtyToMove(Quantity.of(qty, uom))
+				.pickFromLocator(locator(200 + lineId))
+				.dropToLocator(locator(300 + lineId))
+				.steps(ImmutableList.of())
+				.build();
+	}
+
+	private static LocatorInfo locator(final int locId)
+	{
+		final LocatorId locatorId = LocatorId.ofRepoId(100, locId);
+		return LocatorInfo.builder()
+				.locatorId(locatorId)
+				.qrCode(LocatorQRCode.builder().locatorId(locatorId).caption("L" + locId).build())
+				.caption("L" + locId)
 				.build();
 	}
 
@@ -68,5 +127,30 @@ class DistributionJobTest
 		assertThatThrownBy(() -> open.assertCanEdit(PICKER))
 				.isInstanceOf(AdempiereException.class)
 				.hasMessageContaining("not assigned");
+	}
+
+	@Test
+	void getSingleUnitQuantityOrNull_returnsNull_whenLinesSpanMultipleUOMs()
+	{
+		final I_C_UOM stk = BusinessTestHelper.createUOM("Stk", 0, 0);
+		final I_C_UOM meter = BusinessTestHelper.createUOM("M", 2, 2);
+
+		final DistributionJob job = jobWithLines(ImmutableList.of(line(1, stk, "5"), line(2, meter, "3")));
+
+		// Multi-UOM job has no single caption quantity -> null, never a throw (the launcher must still load).
+		assertThat(job.getSingleUnitQuantityOrNull()).isNull();
+	}
+
+	@Test
+	void getSingleUnitQuantityOrNull_returnsSum_whenAllLinesShareOneUOM()
+	{
+		final I_C_UOM stk = BusinessTestHelper.createUOM("Stk", 0, 0);
+
+		final DistributionJob job = jobWithLines(ImmutableList.of(line(1, stk, "5"), line(2, stk, "3")));
+
+		final Quantity result = job.getSingleUnitQuantityOrNull();
+		assertThat(result).isNotNull();
+		assertThat(result.toBigDecimal()).isEqualByComparingTo("8");
+		assertThat(result.getUomId()).isEqualTo(UomId.ofRepoId(stk.getC_UOM_ID()));
 	}
 }


### PR DESCRIPTION
## What
The distribution workflow launcher fails to load when a Completed DD_Order has lines in more than one UOM. Separately, when two lines of a DD_Order carry the same quantity and UOM, the launcher caption under-counts the total quantity.

## Why
`DistributionJob.getSingleUnitQuantityOrNull()` sums the per-line quantities into a `MixedQuantity` and collapses them with `MixedQuantity.toNoneOrSingleValue()`, which throws (`Expected none or single value but got many`) when the lines span multiple UOMs. The launcher computes this caption quantity for every Completed DD_Order, so a single multi-UOM order aborts the entire launcher list for the affected users.

Additionally, the same aggregation applied `.distinct()` to the per-line quantities before summing. Because `Quantity` has value-based equality (two quantities are equal on qty + UOM), two independent lines carrying the same qty and UOM were collapsed into one, under-counting the caption sum.

## Change
- Add `MixedQuantity.toSingleValueOrNull()` — returns `null` when the aggregate is empty **or** spans multiple UOMs, instead of throwing.
- `DistributionJob.getSingleUnitQuantityOrNull()` uses it, so a multi-UOM job resolves to a blank quantity caption rather than crashing the launcher. This mirrors the picking launcher's `PickingJob.getSingleQtyToPickOrNull()`, which already degrades gracefully; the launcher caption renderer already treats a `null` quantity as empty.
- Remove the erroneous `.distinct()` from the per-line quantity aggregation, so lines with an equal qty + UOM are all counted instead of being collapsed into one.
- Unit tests: multi-UOM job → `null` (no throw); single-UOM job → summed quantity; two lines with equal qty + UOM → correctly summed (not collapsed).

No behavior change for single-UOM orders.
