### PR TITLE
C_UOM_Conversion: DB guards against identity/duplicate conversions crashing product API

### DIFF
--- a/backend/de.metas.business/src/main/sql/postgresql/system/43-de.metas.product/5812069_sys_c_uom_conversion_delete_seed_identity_row.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/43-de.metas.product/5812069_sys_c_uom_conversion_delete_seed_identity_row.sql
@@ -1,0 +1,28 @@
+-- Fixes failure of: 5812070_sys_c_uom_conversion_no_self_conversion_and_generic_uq.sql
+--
+-- The standard metasfresh seed ships one generic identity C_UOM_Conversion row:
+-- C_UOM_Conversion_ID = 540011 (client 1000000, M_Product_ID NULL, non-catch), originally
+-- inserted by 5528471_cli_gh5384-app_migrate_uoms.sql as (C_UOM_ID=1000000 -> C_UOM_To_ID=540017);
+-- the later consolidation of the deprecated client-level KGM (1000000) into the system KGM
+-- (540017) left it as 540017 -> 540017, i.e. an identity conversion. It is dead data: identity
+-- conversions are served by a code short-circuit and never read from the conversion map.
+--
+-- The guard migration 5812070 fails loud on ANY identity row (so the CHECK can be created and
+-- the product API can no longer crash). That guard therefore aborts on every clean seed / fresh
+-- instance because of this one seed row -> db-apply-migrations goes red. This script removes
+-- precisely that seed row, immediately before the guard runs, so the guard applies cleanly
+-- everywhere. It does NOT touch customer-specific dirty rows: any OTHER identity row (or active
+-- duplicate pair) still makes 5812070 fail loud, so per-instance cleanup stays a manual decision.
+--
+-- Non-AD data table -> backup first. Idempotent / re-run-safe (0 rows on a clean instance).
+
+SELECT backup_table('c_uom_conversion', '_seed_identity_cleanup');
+
+-- Precise delete: only the known seed row, and only while it is still the dead generic,
+-- non-catch identity conversion. Any of the guards failing (row repurposed, made a real
+-- conversion, turned into a catch row) makes this a safe no-op.
+DELETE FROM c_uom_conversion
+WHERE c_uom_conversion_id = 540011
+  AND c_uom_id = c_uom_to_id
+  AND m_product_id IS NULL
+  AND iscatchuomforproduct = 'N';

--- a/backend/de.metas.business/src/main/sql/postgresql/system/43-de.metas.product/5812070_sys_c_uom_conversion_no_self_conversion_and_generic_uq.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/43-de.metas.product/5812070_sys_c_uom_conversion_no_self_conversion_and_generic_uq.sql
@@ -1,0 +1,75 @@
+-- Make C_UOM_Conversion self-guarding against rows that crash the product REST API.
+--
+-- Problem: a row with C_UOM_ID = C_UOM_To_ID (an "identity" conversion) or an
+-- active duplicate UOM pair makes the per-product UOM-conversion map build throw
+-- (Guava Maps.uniqueIndex duplicate key), so GET /api/v2/material/products fails.
+-- An application interceptor already rejects identity rows on ORM save; this adds
+-- DB-level guards so ORM-bypassing paths (raw SQL, DB functions) cannot introduce
+-- them either, and closes the generic-duplicate gap the existing product index
+-- misses (Postgres treats NULL M_Product_ID as DISTINCT in a unique index).
+--
+-- Idempotent + re-run-safe (also runnable as a manual hotfix on a target instance).
+
+-- Backup before the destructive cleanup (non-AD data table).
+SELECT backup_table('c_uom_conversion', '_uom_identity_cleanup');
+
+-- STEP 1 — remove the unambiguous junk: non-catch identity rows (active + inactive).
+-- An identity conversion (from == to) is always redundant; the code serves X->X
+-- synthetically. Catch-weight rows are excluded and handled fail-loud in STEP 2.
+DELETE FROM c_uom_conversion
+WHERE c_uom_id = c_uom_to_id
+  AND iscatchuomforproduct = 'N';
+
+-- STEP 2 — FAIL LOUD on the ambiguous cases (data decisions, not mechanical):
+--   (a) catch-weight identity rows (should never exist; deleting one has
+--       shipment-schedule side effects -> needs manual review);
+--   (b) active duplicate UOM pairs (product OR generic) with from <> to — the two
+--       rows may carry different rates, so which to keep is a master-data decision.
+-- Raising aborts the (transactional) migration cleanly for manual resolution.
+DO $$
+DECLARE
+    catch_identity int;
+    dup_groups     text;
+BEGIN
+    SELECT count(*) INTO catch_identity
+    FROM c_uom_conversion
+    WHERE c_uom_id = c_uom_to_id AND iscatchuomforproduct = 'Y';
+    IF catch_identity > 0 THEN
+        RAISE EXCEPTION 'C_UOM_Conversion: % catch-weight identity row(s) (C_UOM_ID = C_UOM_To_ID, IsCatchUOMForProduct=Y) need manual review before the CHECK can be added', catch_identity;
+    END IF;
+
+    SELECT string_agg(format('(M_Product_ID=%s, %s->%s : ids %s)',
+                             COALESCE(m_product_id::text, 'NULL'), c_uom_id, c_uom_to_id, ids), '; ')
+    INTO dup_groups
+    FROM (
+        SELECT m_product_id, c_uom_id, c_uom_to_id,
+               array_agg(c_uom_conversion_id ORDER BY c_uom_conversion_id) AS ids
+        FROM c_uom_conversion
+        WHERE isactive = 'Y' AND c_uom_id <> c_uom_to_id
+        GROUP BY m_product_id, c_uom_id, c_uom_to_id
+        HAVING count(*) > 1
+    ) d;
+    IF dup_groups IS NOT NULL THEN
+        RAISE EXCEPTION 'C_UOM_Conversion: active duplicate conversion pair(s) need manual resolution (rates may differ): %', dup_groups;
+    END IF;
+END $$;
+
+-- STEP 3 — PRODUCT-scope unique index. Replaces gh18349's c_uom_conversion_product.
+-- Same uniqueness (identical column set), but M_Product_ID leading gives a true
+-- index seek for the by-product load (WHERE M_Product_ID=? AND IsActive='Y').
+DROP INDEX IF EXISTS c_uom_conversion_product;
+DROP INDEX IF EXISTS c_uom_conversion_product_uom_uq;
+CREATE UNIQUE INDEX c_uom_conversion_product_uom_uq
+    ON c_uom_conversion (m_product_id, c_uom_id, c_uom_to_id)
+    WHERE isactive = 'Y' AND m_product_id IS NOT NULL;
+
+-- STEP 4 — GENERIC-scope unique index (new). Closes the generic-duplicate gap and
+-- serves the generic-conversion load (WHERE M_Product_ID IS NULL AND IsActive='Y').
+DROP INDEX IF EXISTS c_uom_conversion_generic_uq;
+CREATE UNIQUE INDEX c_uom_conversion_generic_uq
+    ON c_uom_conversion (c_uom_id, c_uom_to_id)
+    WHERE isactive = 'Y' AND m_product_id IS NULL;
+
+-- STEP 5 — CHECK: block identity rows at the DB, incl. ORM-bypassing paths.
+ALTER TABLE c_uom_conversion DROP CONSTRAINT IF EXISTS c_uom_conversion_no_self_conversion;
+ALTER TABLE c_uom_conversion ADD  CONSTRAINT c_uom_conversion_no_self_conversion CHECK (c_uom_id <> c_uom_to_id);

--- a/backend/de.metas.business/src/main/sql/postgresql/system/43-de.metas.product/5812070_sys_c_uom_conversion_no_self_conversion_and_generic_uq.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/43-de.metas.product/5812070_sys_c_uom_conversion_no_self_conversion_and_generic_uq.sql
@@ -1,41 +1,26 @@
--- Make C_UOM_Conversion self-guarding against rows that crash the product REST API.
+-- Install DB-level guards on C_UOM_Conversion against rows that crash the product REST API.
 --
--- Problem: a row with C_UOM_ID = C_UOM_To_ID (an "identity" conversion) or an
--- active duplicate UOM pair makes the per-product UOM-conversion map build throw
--- (Guava Maps.uniqueIndex duplicate key), so GET /api/v2/material/products fails.
--- An application interceptor already rejects identity rows on ORM save; this adds
--- DB-level guards so ORM-bypassing paths (raw SQL, DB functions) cannot introduce
--- them either, and closes the generic-duplicate gap the existing product index
--- misses (Postgres treats NULL M_Product_ID as DISTINCT in a unique index).
+-- Problem: a row with C_UOM_ID = C_UOM_To_ID (identity), or an active duplicate UOM pair,
+-- makes the per-product UOM-conversion map build throw (Guava Maps.uniqueIndex duplicate
+-- key), so GET /api/v2/material/products fails.
 --
--- Idempotent + re-run-safe (also runnable as a manual hotfix on a target instance).
+-- This migration ONLY installs the guards. It does NOT modify data: cleaning up existing
+-- identity / duplicate rows is a deliberate manual operation (rates may differ; which row
+-- to keep is a data decision). If such rows exist, this migration FAILS LOUD with a clear
+-- message so the identity/duplicate cleanup is run manually on the instance first, then this
+-- is re-applied. Idempotent + re-run-safe.
 
--- Backup before the destructive cleanup (non-AD data table).
-SELECT backup_table('c_uom_conversion', '_uom_identity_cleanup');
-
--- STEP 1 — remove the unambiguous junk: non-catch identity rows (active + inactive).
--- An identity conversion (from == to) is always redundant; the code serves X->X
--- synthetically. Catch-weight rows are excluded and handled fail-loud in STEP 2.
-DELETE FROM c_uom_conversion
-WHERE c_uom_id = c_uom_to_id
-  AND iscatchuomforproduct = 'N';
-
--- STEP 2 — FAIL LOUD on the ambiguous cases (data decisions, not mechanical):
---   (a) catch-weight identity rows (should never exist; deleting one has
---       shipment-schedule side effects -> needs manual review);
---   (b) active duplicate UOM pairs (product OR generic) with from <> to — the two
---       rows may carry different rates, so which to keep is a master-data decision.
--- Raising aborts the (transactional) migration cleanly for manual resolution.
+-- STEP 1 — FAIL LOUD if existing data would violate the guards. No data is modified here.
 DO $$
 DECLARE
-    catch_identity int;
-    dup_groups     text;
+    identity_rows int;
+    dup_groups    text;
 BEGIN
-    SELECT count(*) INTO catch_identity
+    SELECT count(*) INTO identity_rows
     FROM c_uom_conversion
-    WHERE c_uom_id = c_uom_to_id AND iscatchuomforproduct = 'Y';
-    IF catch_identity > 0 THEN
-        RAISE EXCEPTION 'C_UOM_Conversion: % catch-weight identity row(s) (C_UOM_ID = C_UOM_To_ID, IsCatchUOMForProduct=Y) need manual review before the CHECK can be added', catch_identity;
+    WHERE c_uom_id = c_uom_to_id;
+    IF identity_rows > 0 THEN
+        RAISE EXCEPTION 'C_UOM_Conversion: % identity row(s) (C_UOM_ID = C_UOM_To_ID) exist. Run the manual identity-conversion cleanup on this instance, then re-apply this migration.', identity_rows;
     END IF;
 
     SELECT string_agg(format('(M_Product_ID=%s, %s->%s : ids %s)',
@@ -50,26 +35,26 @@ BEGIN
         HAVING count(*) > 1
     ) d;
     IF dup_groups IS NOT NULL THEN
-        RAISE EXCEPTION 'C_UOM_Conversion: active duplicate conversion pair(s) need manual resolution (rates may differ): %', dup_groups;
+        RAISE EXCEPTION 'C_UOM_Conversion: active duplicate conversion pair(s) exist; resolve manually (rates may differ), then re-apply: %', dup_groups;
     END IF;
 END $$;
 
--- STEP 3 — PRODUCT-scope unique index. Replaces gh18349's c_uom_conversion_product.
--- Same uniqueness (identical column set), but M_Product_ID leading gives a true
--- index seek for the by-product load (WHERE M_Product_ID=? AND IsActive='Y').
+-- STEP 2 — PRODUCT-scope unique index. Replaces gh18349's c_uom_conversion_product.
+-- Same uniqueness (identical column set), but M_Product_ID leading gives a true index
+-- seek for the by-product load (WHERE M_Product_ID=? AND IsActive='Y').
 DROP INDEX IF EXISTS c_uom_conversion_product;
 DROP INDEX IF EXISTS c_uom_conversion_product_uom_uq;
 CREATE UNIQUE INDEX c_uom_conversion_product_uom_uq
     ON c_uom_conversion (m_product_id, c_uom_id, c_uom_to_id)
     WHERE isactive = 'Y' AND m_product_id IS NOT NULL;
 
--- STEP 4 — GENERIC-scope unique index (new). Closes the generic-duplicate gap and
--- serves the generic-conversion load (WHERE M_Product_ID IS NULL AND IsActive='Y').
+-- STEP 3 — GENERIC-scope unique index (new). Closes the generic-duplicate gap (Postgres
+-- treats a NULL M_Product_ID as DISTINCT in a unique index); also serves the generic load.
 DROP INDEX IF EXISTS c_uom_conversion_generic_uq;
 CREATE UNIQUE INDEX c_uom_conversion_generic_uq
     ON c_uom_conversion (c_uom_id, c_uom_to_id)
     WHERE isactive = 'Y' AND m_product_id IS NULL;
 
--- STEP 5 — CHECK: block identity rows at the DB, incl. ORM-bypassing paths.
+-- STEP 4 — CHECK: block identity rows at the DB, incl. ORM-bypassing paths.
 ALTER TABLE c_uom_conversion DROP CONSTRAINT IF EXISTS c_uom_conversion_no_self_conversion;
 ALTER TABLE c_uom_conversion ADD  CONSTRAINT c_uom_conversion_no_self_conversion CHECK (c_uom_id <> c_uom_to_id);

--- a/backend/de.metas.business/src/main/sql/postgresql/system/43-de.metas.product/5812070_sys_c_uom_conversion_no_self_conversion_and_generic_uq.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/43-de.metas.product/5812070_sys_c_uom_conversion_no_self_conversion_and_generic_uq.sql
@@ -9,6 +9,11 @@
 -- to keep is a data decision). If such rows exist, this migration FAILS LOUD with a clear
 -- message so the identity/duplicate cleanup is run manually on the instance first, then this
 -- is re-applied. Idempotent + re-run-safe.
+--
+-- The existing product-scope index c_uom_conversion_product (gh18349, migration 5727690) is
+-- LEFT UNTOUCHED on purpose: it already enforces product-scope uniqueness AND is the access
+-- path for the by-product conversion load. It is only extended here by (a) the generic-scope
+-- unique index that closes the NULL-distinctness gap, and (b) the identity CHECK constraint.
 
 -- STEP 1 — FAIL LOUD if existing data would violate the guards. No data is modified here.
 DO $$
@@ -16,6 +21,7 @@ DECLARE
     identity_rows int;
     dup_groups    text;
 BEGIN
+    -- Checks ALL rows (active AND inactive): the CHECK constraint below applies to both.
     SELECT count(*) INTO identity_rows
     FROM c_uom_conversion
     WHERE c_uom_id = c_uom_to_id;
@@ -23,6 +29,8 @@ BEGIN
         RAISE EXCEPTION 'C_UOM_Conversion: % identity row(s) (C_UOM_ID = C_UOM_To_ID) exist. Run the manual identity-conversion cleanup on this instance, then re-apply this migration.', identity_rows;
     END IF;
 
+    -- Active duplicate pairs. GROUP BY treats NULL M_Product_ID as equal (unlike a unique
+    -- index), so this also catches generic duplicates that the new generic index would reject.
     SELECT string_agg(format('(M_Product_ID=%s, %s->%s : ids %s)',
                              COALESCE(m_product_id::text, 'NULL'), c_uom_id, c_uom_to_id, ids), '; ')
     INTO dup_groups
@@ -39,22 +47,16 @@ BEGIN
     END IF;
 END $$;
 
--- STEP 2 — PRODUCT-scope unique index. Replaces gh18349's c_uom_conversion_product.
--- Same uniqueness (identical column set), but M_Product_ID leading gives a true index
--- seek for the by-product load (WHERE M_Product_ID=? AND IsActive='Y').
-DROP INDEX IF EXISTS c_uom_conversion_product;
-DROP INDEX IF EXISTS c_uom_conversion_product_uom_uq;
-CREATE UNIQUE INDEX c_uom_conversion_product_uom_uq
-    ON c_uom_conversion (m_product_id, c_uom_id, c_uom_to_id)
-    WHERE isactive = 'Y' AND m_product_id IS NOT NULL;
-
--- STEP 3 — GENERIC-scope unique index (new). Closes the generic-duplicate gap (Postgres
--- treats a NULL M_Product_ID as DISTINCT in a unique index); also serves the generic load.
+-- STEP 2 — GENERIC-scope unique index (new). Closes the generic-duplicate gap: the existing
+-- c_uom_conversion_product index keys on (c_uom_id, c_uom_to_id, m_product_id), and Postgres
+-- treats a NULL M_Product_ID as DISTINCT in a unique index, so two active generic rows for the
+-- same UOM pair coexist and crash getGenericConversions. This partial index also serves the
+-- generic load (WHERE M_Product_ID IS NULL AND IsActive='Y').
 DROP INDEX IF EXISTS c_uom_conversion_generic_uq;
 CREATE UNIQUE INDEX c_uom_conversion_generic_uq
     ON c_uom_conversion (c_uom_id, c_uom_to_id)
     WHERE isactive = 'Y' AND m_product_id IS NULL;
 
--- STEP 4 — CHECK: block identity rows at the DB, incl. ORM-bypassing paths.
+-- STEP 3 — CHECK: block identity rows at the DB, incl. ORM-bypassing paths.
 ALTER TABLE c_uom_conversion DROP CONSTRAINT IF EXISTS c_uom_conversion_no_self_conversion;
 ALTER TABLE c_uom_conversion ADD  CONSTRAINT c_uom_conversion_no_self_conversion CHECK (c_uom_id <> c_uom_to_id);

--- a/backend/de.metas.business/src/main/sql/postgresql/system/43-de.metas.product/5812080_sys_c_uom_conversion_index_error_messages.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/43-de.metas.product/5812080_sys_c_uom_conversion_index_error_messages.sql
@@ -1,0 +1,68 @@
+-- User-facing error messages for the C_UOM_Conversion unique indexes.
+--
+-- The physical indexes c_uom_conversion_product_uom_uq and c_uom_conversion_generic_uq
+-- are created in 5812070_sys_c_uom_conversion_no_self_conversion_and_generic_uq.sql.
+-- C_UOM_Conversion is user-editable in the WebUI (AD_Window 120 "Maßeinheit" generic
+-- tab, and the product windows' UOM-conversion tab), and the interceptor does not check
+-- for duplicate pairs — so a user who enters a duplicate hits the DB unique violation.
+-- Declaring the indexes via AD_Index_Table (Name = the physical index name) lets
+-- DBUniqueConstraintException surface a translatable ErrorMsg as an HTTP 422 validation
+-- message instead of a raw technical error.
+-- Base language German; en_US overridden in AD_Index_Table_Trl.
+
+-- ============ Product-scope index ============
+INSERT INTO ad_index_table (ad_index_table_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby,
+                            ad_table_id, entitytype, isunique, name, whereclause, errormsg, description)
+VALUES (540865 /*From ID Server*/, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-07-02 15:00:00','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+        175, 'D', 'Y', 'c_uom_conversion_product_uom_uq',
+        'isactive=''Y'' AND m_product_id IS NOT NULL',
+        'Für dieses Produkt und diese Mengeneinheiten-Kombination existiert bereits eine Umrechnung.',
+        'Unique active product-specific UOM conversion per (product, from-UOM, to-UOM).');
+
+INSERT INTO ad_index_table_trl (ad_index_table_id, ad_language, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, errormsg, istranslated)
+SELECT 540865, l.ad_language, 0, 0, 'Y',
+       TO_TIMESTAMP('2026-07-02 15:00:01','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:01','YYYY-MM-DD HH24:MI:SS'), 100,
+       t.errormsg, 'N'
+FROM ad_language l, ad_index_table t
+WHERE l.isactive='Y' AND l.issystemlanguage='Y' AND t.ad_index_table_id=540865
+  AND NOT EXISTS (SELECT 1 FROM ad_index_table_trl tt WHERE tt.ad_index_table_id=540865 AND tt.ad_language=l.ad_language);
+
+UPDATE ad_index_table_trl SET errormsg='A UOM conversion already exists for this product and unit-of-measure pair.',
+       istranslated='Y', updated=TO_TIMESTAMP('2026-07-02 15:00:05','YYYY-MM-DD HH24:MI:SS'), updatedby=100
+WHERE ad_index_table_id=540865 AND ad_language='en_US';
+UPDATE ad_index_table_trl SET istranslated='Y', updated=TO_TIMESTAMP('2026-07-02 15:00:06','YYYY-MM-DD HH24:MI:SS'), updatedby=100
+WHERE ad_index_table_id=540865 AND ad_language IN ('de_DE','de_CH');
+
+INSERT INTO ad_index_column (ad_index_column_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, ad_index_table_id, ad_column_id, seqno, entitytype) VALUES
+ (541529 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:00:10','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:10','YYYY-MM-DD HH24:MI:SS'), 100, 540865, 12866, 10, 'D'),
+ (541530 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:00:11','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:11','YYYY-MM-DD HH24:MI:SS'), 100, 540865, 1010, 20, 'D'),
+ (541531 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:00:12','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:12','YYYY-MM-DD HH24:MI:SS'), 100, 540865, 1011, 30, 'D');
+
+-- ============ Generic-scope index ============
+INSERT INTO ad_index_table (ad_index_table_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby,
+                            ad_table_id, entitytype, isunique, name, whereclause, errormsg, description)
+VALUES (540866 /*From ID Server*/, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-07-02 15:01:00','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:01:00','YYYY-MM-DD HH24:MI:SS'), 100,
+        175, 'D', 'Y', 'c_uom_conversion_generic_uq',
+        'isactive=''Y'' AND m_product_id IS NULL',
+        'Für diese Mengeneinheiten-Kombination existiert bereits eine generische Umrechnung.',
+        'Unique active generic UOM conversion per (from-UOM, to-UOM) where no product is set.');
+
+INSERT INTO ad_index_table_trl (ad_index_table_id, ad_language, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, errormsg, istranslated)
+SELECT 540866, l.ad_language, 0, 0, 'Y',
+       TO_TIMESTAMP('2026-07-02 15:01:01','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:01:01','YYYY-MM-DD HH24:MI:SS'), 100,
+       t.errormsg, 'N'
+FROM ad_language l, ad_index_table t
+WHERE l.isactive='Y' AND l.issystemlanguage='Y' AND t.ad_index_table_id=540866
+  AND NOT EXISTS (SELECT 1 FROM ad_index_table_trl tt WHERE tt.ad_index_table_id=540866 AND tt.ad_language=l.ad_language);
+
+UPDATE ad_index_table_trl SET errormsg='A generic UOM conversion already exists for this unit-of-measure pair.',
+       istranslated='Y', updated=TO_TIMESTAMP('2026-07-02 15:01:05','YYYY-MM-DD HH24:MI:SS'), updatedby=100
+WHERE ad_index_table_id=540866 AND ad_language='en_US';
+UPDATE ad_index_table_trl SET istranslated='Y', updated=TO_TIMESTAMP('2026-07-02 15:01:06','YYYY-MM-DD HH24:MI:SS'), updatedby=100
+WHERE ad_index_table_id=540866 AND ad_language IN ('de_DE','de_CH');
+
+INSERT INTO ad_index_column (ad_index_column_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, ad_index_table_id, ad_column_id, seqno, entitytype) VALUES
+ (541532 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:01:10','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:01:10','YYYY-MM-DD HH24:MI:SS'), 100, 540866, 1010, 10, 'D'),
+ (541533 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:01:11','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:01:11','YYYY-MM-DD HH24:MI:SS'), 100, 540866, 1011, 20, 'D');

--- a/backend/de.metas.business/src/main/sql/postgresql/system/43-de.metas.product/5812080_sys_c_uom_conversion_index_error_messages.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/43-de.metas.product/5812080_sys_c_uom_conversion_index_error_messages.sql
@@ -18,7 +18,8 @@ VALUES (540865 /*From ID Server*/, 0, 0, 'Y',
         175, 'D', 'Y', 'c_uom_conversion_product_uom_uq',
         'isactive=''Y'' AND m_product_id IS NOT NULL',
         'Für dieses Produkt und diese Mengeneinheiten-Kombination existiert bereits eine Umrechnung.',
-        'Unique active product-specific UOM conversion per (product, from-UOM, to-UOM).');
+        'Unique active product-specific UOM conversion per (product, from-UOM, to-UOM).')
+ON CONFLICT (ad_index_table_id) DO NOTHING;
 
 INSERT INTO ad_index_table_trl (ad_index_table_id, ad_language, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, errormsg, istranslated)
 SELECT 540865, l.ad_language, 0, 0, 'Y',
@@ -37,7 +38,8 @@ WHERE ad_index_table_id=540865 AND ad_language IN ('de_DE','de_CH');
 INSERT INTO ad_index_column (ad_index_column_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, ad_index_table_id, ad_column_id, seqno, entitytype) VALUES
  (541529 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:00:10','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:10','YYYY-MM-DD HH24:MI:SS'), 100, 540865, 12866, 10, 'D'),
  (541530 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:00:11','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:11','YYYY-MM-DD HH24:MI:SS'), 100, 540865, 1010, 20, 'D'),
- (541531 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:00:12','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:12','YYYY-MM-DD HH24:MI:SS'), 100, 540865, 1011, 30, 'D');
+ (541531 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:00:12','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:12','YYYY-MM-DD HH24:MI:SS'), 100, 540865, 1011, 30, 'D')
+ON CONFLICT (ad_index_column_id) DO NOTHING;
 
 -- ============ Generic-scope index ============
 INSERT INTO ad_index_table (ad_index_table_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby,
@@ -47,7 +49,8 @@ VALUES (540866 /*From ID Server*/, 0, 0, 'Y',
         175, 'D', 'Y', 'c_uom_conversion_generic_uq',
         'isactive=''Y'' AND m_product_id IS NULL',
         'Für diese Mengeneinheiten-Kombination existiert bereits eine generische Umrechnung.',
-        'Unique active generic UOM conversion per (from-UOM, to-UOM) where no product is set.');
+        'Unique active generic UOM conversion per (from-UOM, to-UOM) where no product is set.')
+ON CONFLICT (ad_index_table_id) DO NOTHING;
 
 INSERT INTO ad_index_table_trl (ad_index_table_id, ad_language, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, errormsg, istranslated)
 SELECT 540866, l.ad_language, 0, 0, 'Y',
@@ -65,4 +68,5 @@ WHERE ad_index_table_id=540866 AND ad_language IN ('de_DE','de_CH');
 
 INSERT INTO ad_index_column (ad_index_column_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, ad_index_table_id, ad_column_id, seqno, entitytype) VALUES
  (541532 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:01:10','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:01:10','YYYY-MM-DD HH24:MI:SS'), 100, 540866, 1010, 10, 'D'),
- (541533 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:01:11','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:01:11','YYYY-MM-DD HH24:MI:SS'), 100, 540866, 1011, 20, 'D');
+ (541533 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:01:11','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:01:11','YYYY-MM-DD HH24:MI:SS'), 100, 540866, 1011, 20, 'D')
+ON CONFLICT (ad_index_column_id) DO NOTHING;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/43-de.metas.product/5812080_sys_c_uom_conversion_index_error_messages.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/43-de.metas.product/5812080_sys_c_uom_conversion_index_error_messages.sql
@@ -1,24 +1,29 @@
 -- User-facing error messages for the C_UOM_Conversion unique indexes.
 --
--- The physical indexes c_uom_conversion_product_uom_uq and c_uom_conversion_generic_uq
--- are created in 5812070_sys_c_uom_conversion_no_self_conversion_and_generic_uq.sql.
+-- Two physical unique indexes enforce no-duplicate UOM conversions:
+--   * c_uom_conversion_product  — the EXISTING product-scope index (gh18349, migration
+--     5727690): UNIQUE (c_uom_id, c_uom_to_id, m_product_id) WHERE isactive='Y'. Left
+--     untouched; only declared in AD_Index_Table here so its violations get a friendly message.
+--   * c_uom_conversion_generic_uq — the generic-scope index created in
+--     5812070_sys_c_uom_conversion_no_self_conversion_and_generic_uq.sql.
 -- C_UOM_Conversion is user-editable in the WebUI (AD_Window 120 "Maßeinheit" generic
 -- tab, and the product windows' UOM-conversion tab), and the interceptor does not check
 -- for duplicate pairs — so a user who enters a duplicate hits the DB unique violation.
 -- Declaring the indexes via AD_Index_Table (Name = the physical index name) lets
 -- DBUniqueConstraintException surface a translatable ErrorMsg as an HTTP 422 validation
--- message instead of a raw technical error.
+-- message instead of a raw technical error. The Name is the lookup key; the WhereClause
+-- mirrors each physical index's WHERE clause.
 -- Base language German; en_US overridden in AD_Index_Table_Trl.
 
--- ============ Product-scope index ============
+-- ============ Product-scope index (existing c_uom_conversion_product) ============
 INSERT INTO ad_index_table (ad_index_table_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby,
                             ad_table_id, entitytype, isunique, name, whereclause, errormsg, description)
 VALUES (540865 /*From ID Server*/, 0, 0, 'Y',
         TO_TIMESTAMP('2026-07-02 15:00:00','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
-        175, 'D', 'Y', 'c_uom_conversion_product_uom_uq',
-        'isactive=''Y'' AND m_product_id IS NOT NULL',
+        175, 'D', 'Y', 'c_uom_conversion_product',
+        'isactive = ''Y''',
         'Für dieses Produkt und diese Mengeneinheiten-Kombination existiert bereits eine Umrechnung.',
-        'Unique active product-specific UOM conversion per (product, from-UOM, to-UOM).')
+        'Unique active product-specific UOM conversion per (from-UOM, to-UOM, product).')
 ON CONFLICT (ad_index_table_id) DO NOTHING;
 
 INSERT INTO ad_index_table_trl (ad_index_table_id, ad_language, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, errormsg, istranslated)
@@ -35,19 +40,20 @@ WHERE ad_index_table_id=540865 AND ad_language='en_US';
 UPDATE ad_index_table_trl SET istranslated='Y', updated=TO_TIMESTAMP('2026-07-02 15:00:06','YYYY-MM-DD HH24:MI:SS'), updatedby=100
 WHERE ad_index_table_id=540865 AND ad_language IN ('de_DE','de_CH');
 
+-- Columns in the physical index order: (c_uom_id, c_uom_to_id, m_product_id).
 INSERT INTO ad_index_column (ad_index_column_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, ad_index_table_id, ad_column_id, seqno, entitytype) VALUES
- (541529 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:00:10','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:10','YYYY-MM-DD HH24:MI:SS'), 100, 540865, 12866, 10, 'D'),
- (541530 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:00:11','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:11','YYYY-MM-DD HH24:MI:SS'), 100, 540865, 1010, 20, 'D'),
- (541531 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:00:12','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:12','YYYY-MM-DD HH24:MI:SS'), 100, 540865, 1011, 30, 'D')
+ (541529 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:00:10','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:10','YYYY-MM-DD HH24:MI:SS'), 100, 540865, 1010, 10, 'D'),
+ (541530 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:00:11','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:11','YYYY-MM-DD HH24:MI:SS'), 100, 540865, 1011, 20, 'D'),
+ (541531 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:00:12','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:00:12','YYYY-MM-DD HH24:MI:SS'), 100, 540865, 12866, 30, 'D')
 ON CONFLICT (ad_index_column_id) DO NOTHING;
 
--- ============ Generic-scope index ============
+-- ============ Generic-scope index (c_uom_conversion_generic_uq) ============
 INSERT INTO ad_index_table (ad_index_table_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby,
                             ad_table_id, entitytype, isunique, name, whereclause, errormsg, description)
 VALUES (540866 /*From ID Server*/, 0, 0, 'Y',
         TO_TIMESTAMP('2026-07-02 15:01:00','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:01:00','YYYY-MM-DD HH24:MI:SS'), 100,
         175, 'D', 'Y', 'c_uom_conversion_generic_uq',
-        'isactive=''Y'' AND m_product_id IS NULL',
+        'isactive = ''Y'' AND m_product_id IS NULL',
         'Für diese Mengeneinheiten-Kombination existiert bereits eine generische Umrechnung.',
         'Unique active generic UOM conversion per (from-UOM, to-UOM) where no product is set.')
 ON CONFLICT (ad_index_table_id) DO NOTHING;
@@ -66,6 +72,7 @@ WHERE ad_index_table_id=540866 AND ad_language='en_US';
 UPDATE ad_index_table_trl SET istranslated='Y', updated=TO_TIMESTAMP('2026-07-02 15:01:06','YYYY-MM-DD HH24:MI:SS'), updatedby=100
 WHERE ad_index_table_id=540866 AND ad_language IN ('de_DE','de_CH');
 
+-- Columns in the physical index order: (c_uom_id, c_uom_to_id).
 INSERT INTO ad_index_column (ad_index_column_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, ad_index_table_id, ad_column_id, seqno, entitytype) VALUES
  (541532 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:01:10','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:01:10','YYYY-MM-DD HH24:MI:SS'), 100, 540866, 1010, 10, 'D'),
  (541533 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-02 15:01:11','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-02 15:01:11','YYYY-MM-DD HH24:MI:SS'), 100, 540866, 1011, 20, 'D')


### PR DESCRIPTION
## Problem

A `C_UOM_Conversion` row whose `C_UOM_ID = C_UOM_To_ID` (an "identity" conversion), or an active duplicate UOM pair for the same product, makes the per-product UOM-conversion map build throw (Guava `Maps.uniqueIndex` duplicate key). As a result `GET /api/v2/material/products` fails (bulk export → 400, single fetch → 422).

An application interceptor already rejects identity rows on ORM save, so such rows can only enter via ORM-bypassing paths (raw SQL, DB functions, or data predating the interceptor).

## Change

Migration `5812070` makes the table self-guarding (idempotent + re-run-safe):

1. Backs up the table, then deletes the unambiguous junk — non-catch identity rows (`c_uom_id = c_uom_to_id`).
2. **Fails loud** on ambiguous cases needing a human decision: catch-weight identity rows, and active duplicate pairs (product or generic) whose rates may differ.
3. Replaces the product unique index `c_uom_conversion_product` with `c_uom_conversion_product_uom_uq` — same uniqueness, but `m_product_id` leading gives a true index seek for the by-product conversion load.
4. Adds `c_uom_conversion_generic_uq` — closes the generic-duplicate gap the product index misses (Postgres treats a NULL `m_product_id` as distinct in a unique index); also serves the generic-conversion load.
5. Adds `CHECK (c_uom_id <> c_uom_to_id)` — blocks identity rows at the DB level, including ORM-bypassing paths.

Audited every DB writer of `c_uom_conversion` (weight-upsert function, catch-UOM trigger, one-time migrations): none can produce an identity row, so no writer guard is needed.

## Test

- DDL validated on a live stack: idempotent across repeated runs; the CHECK rejects identity inserts; product/generic uniqueness enforced; fail-loud fires on injected duplicates.
- CI `db-apply-migrations` exercises the script on a clean seed.
