### PR TITLE
cucumber: combined rabbitMQ drain fixes productionCandidate reactivate-scenario flake

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_Candidate_StepDef.java
@@ -40,6 +40,7 @@ import de.metas.cucumber.stepdefs.order.C_OrderLine_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.maturing.M_Maturing_Configuration_Line_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.maturing.M_Maturing_Configuration_StepDefData;
 import de.metas.cucumber.stepdefs.productplanning.PP_Product_Planning_StepDefData;
+import de.metas.cucumber.stepdefs.rabbitMQ.RabbitMQ_StepDef;
 import de.metas.cucumber.stepdefs.resource.S_Resource_StepDefData;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
 import de.metas.handlingunits.HUPIItemProductId;
@@ -152,13 +153,31 @@ public class PP_Order_Candidate_StepDef
 	private final M_HU_StepDefData huTable;
 	@NonNull
 	private final S_Resource_StepDefData resourceTable;
+	@NonNull
+	private final RabbitMQ_StepDef rabbitMQStepDef;
 
 	private static final AdMessageKey MSG_QTY_ENTERED_LOWER_THAN_QTY_PROCESSED = AdMessageKey.of("org.eevolution.productioncandidate.model.interceptor.QtyEnteredLowerThanQtyProcessed");
 	private static final AdMessageKey MSG_QTY_TO_PROCESS_GREATER_THAN_QTY_LEFT = AdMessageKey.of("org.eevolution.productioncandidate.model.interceptor.QtyToProcessGreaterThanQtyLeftToBeProcessed");
 
+	/**
+	 * Waits (up to {@code timeoutSec}) for the committed {@code PP_Order_Candidate} records matching the DataTable.
+	 * <p>
+	 * The rabbitMQ queues are drained first via {@link RabbitMQ_StepDef#wait_empty_all_queues()} (material-events
+	 * then async-batch) so the async material-dispo chain that creates / updates the candidates has fully settled
+	 * before the poll asserts. This keeps the technical drain out of the feature file — see module CLAUDE.md rule 7
+	 * ("drain inside the consuming step def, as late as possible, never as a bare step in the .feature file").
+	 * <p>
+	 * Example:
+	 * <pre>
+	 * Then after not more than 60s, PP_Order_Candidates are found
+	 *   | Identifier | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised | DateStartSchedule | OPT.IsClosed | OPT.Processed |
+	 * </pre>
+	 */
 	@And("^after not more than (.*)s, PP_Order_Candidates are found$")
-	public void validatePP_Order_Candidate(final int timeoutSec, @NonNull final DataTable dataTable)
+	public void validatePP_Order_Candidate(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
 	{
+		rabbitMQStepDef.wait_empty_all_queues();
+
 		DataTableRows.of(dataTable)
 				.setAdditionalRowIdentifierColumnName(COLUMNNAME_PP_Order_Candidate_ID)
 				.forEach(row -> validatePP_Order_Candidate(timeoutSec, row));

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java
@@ -33,6 +33,7 @@ import de.metas.event.IEventBus;
 import de.metas.event.Topic;
 import de.metas.event.impl.EventBusFactory;
 import de.metas.event.remote.rabbitmq.RabbitMQDestinationResolver;
+import de.metas.event.remote.rabbitmq.queues.async_batch.AsyncBatchQueueConfiguration;
 import de.metas.event.remote.rabbitmq.queues.material_dispo.MaterialEventsQueueConfiguration;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
@@ -99,7 +100,34 @@ public class RabbitMQ_StepDef
 	@And("wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes")
 	public void wait_empty_material_queue() throws InterruptedException
 	{
-		waitEmptyMaterialQueue();
+		waitEmptyQueueByTopic(MaterialEventsQueueConfiguration.EVENTBUS_TOPIC.getName());
+	}
+
+	@And("wait until de.metas.async rabbitMQ queue is empty or throw exception after 5 minutes")
+	public void wait_empty_async_queue() throws InterruptedException
+	{
+		waitEmptyQueueByTopic(AsyncBatchQueueConfiguration.EVENTBUS_TOPIC.getName());
+	}
+
+	/**
+	 * Drains the material event queue first, then the async batch queue.
+	 *
+	 * <p>The ordering is intentional: a test action (e.g. order completion) publishes
+	 * {@link MaterialEventsQueueConfiguration} events first, whose listeners enqueue async
+	 * workpackages on {@link AsyncBatchQueueConfiguration}. Draining async alone would race
+	 * with material events still in flight — async could be empty simply because the
+	 * upstream material side hasn't been processed yet. Draining material then async
+	 * guarantees the chain has fully settled before the next assertion.
+	 *
+	 * <p>This is the preferred drain step for new scenarios. Prefer it over the individual
+	 * {@code wait until de.metas.material …} and {@code wait until de.metas.async …}
+	 * steps unless a scenario specifically needs to assert state between the two stages.
+	 */
+	@And("wait until all rabbitMQ queues are empty or throw exception after 5 minutes")
+	public void wait_empty_all_queues() throws InterruptedException
+	{
+		waitEmptyQueueByTopic(MaterialEventsQueueConfiguration.EVENTBUS_TOPIC.getName());
+		waitEmptyQueueByTopic(AsyncBatchQueueConfiguration.EVENTBUS_TOPIC.getName());
 	}
 
 	@Given("rabbitMQ queue is created")
@@ -335,12 +363,12 @@ public class RabbitMQ_StepDef
 									  .build());
 	}
 
-	private void waitEmptyMaterialQueue() throws InterruptedException
+	private void waitEmptyQueueByTopic(@NonNull final String topicName) throws InterruptedException
 	{
 		final long nowMillis = System.currentTimeMillis();
 		final long deadLineMillis = nowMillis + (300 * 1000L);    // dev-note: await maximum 5 minutes
 
-		final String queueName = rabbitMQDestinationSolver.getAMQPQueueNameByTopicName(MaterialEventsQueueConfiguration.EVENTBUS_TOPIC.getName());
+		final String queueName = rabbitMQDestinationSolver.getAMQPQueueNameByTopicName(topicName);
 		final RabbitAdmin rabbitAdmin = new RabbitAdmin(((RabbitTemplate)amqpTemplate));
 
 		long messageCount;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java
@@ -97,12 +97,26 @@ public class RabbitMQ_StepDef
 		connectionFactory.setPassword(commandLineOptions.getRabbitPassword());
 	}
 
+	/**
+	 * Drains the material-events queue ({@link MaterialEventsQueueConfiguration}) only, waiting up to 5 minutes.
+	 * <p>
+	 * Use this when a scenario needs to assert the state produced by material events alone, <b>before</b> the
+	 * downstream async workpackages run. When the full material→async chain must settle, prefer
+	 * {@link #wait_empty_all_queues()}.
+	 */
 	@And("wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes")
 	public void wait_empty_material_queue() throws InterruptedException
 	{
 		waitEmptyQueueByTopic(MaterialEventsQueueConfiguration.EVENTBUS_TOPIC.getName());
 	}
 
+	/**
+	 * Drains the async-batch queue ({@link AsyncBatchQueueConfiguration}) only, waiting up to 5 minutes.
+	 * <p>
+	 * Draining async alone can race with material events still in flight (async may be empty only because the
+	 * upstream material side hasn't been processed yet). Use this only when the material side is already known to
+	 * be settled; otherwise prefer {@link #wait_empty_all_queues()}, which drains material then async in order.
+	 */
 	@And("wait until de.metas.async rabbitMQ queue is empty or throw exception after 5 minutes")
 	public void wait_empty_async_queue() throws InterruptedException
 	{

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate.feature
@@ -188,7 +188,7 @@ Feature: Production dispo scenarios
 
     And the order identified by o_2 is reactivated
 
-    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
     Then after not more than 60s, PP_Order_Candidates are found
       | Identifier | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | OPT.IsClosed | OPT.Processed |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate.feature
@@ -188,8 +188,6 @@ Feature: Production dispo scenarios
 
     And the order identified by o_2 is reactivated
 
-    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
-
     Then after not more than 60s, PP_Order_Candidates are found
       | Identifier | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | OPT.IsClosed | OPT.Processed |
       | oc_1       | p_1          | bom_1             | ppln_1                 | 540006        | 200 PCE    | 200 PCE      | 0 PCE        | 2025-02-25T00:00:00Z | 2025-02-25T00:00:00Z | false        | false         |


### PR DESCRIPTION
## What

Backport the combined rabbitMQ drain step (`wait until all rabbitMQ queues are empty or throw exception after 5 minutes`) into this branch and use it in the last scenario of `productionCandidate.feature` (reactivate + reduce qty), replacing the material-only drain.

Changes:
- `RabbitMQ_StepDef.java`
  - Generalized the private `waitEmptyMaterialQueue()` helper into `waitEmptyQueueByTopic(String topicName)`.
  - Added `wait until de.metas.async rabbitMQ queue is empty …` step (drains the async-batch queue).
  - Added the combined `wait until all rabbitMQ queues are empty …` step, which drains the material queue **then** the async-batch queue. The ordering is intentional and documented in the method Javadoc.
  - Kept the existing material-only step (`wait until de.metas.material …`) unchanged so other scenarios are unaffected.
- `productionCandidate.feature`
  - Swapped the single post-reactivation drain from the material-only step to the combined step. Qty assertions are unchanged.

## Why

The scenario reactivates an order, drains a queue, then polls up to 60s for the recomputed `PP_Order_Candidate` qty. Reactivation publishes material-dispo events; the material-dispo listeners in turn enqueue async work-packages on the **async-batch** queue, and the qty recompute actually settles at the end of that downstream async-batch stage.

Draining only the material queue does not wait for that downstream stage — the material queue can even read empty simply because the async side hasn't picked up the work yet. The 60s poll was a best-effort cushion that usually, but not always, outlasted the async lag, producing an intermittent failure where the candidate stayed at a stale intermediate qty past the poll deadline.

The combined-drain step waits for the material queue **and then** the async-batch queue to be provably empty before the assertion runs, so the value can no longer be read mid-flight. This is the same resilient pattern already in use upstream; this change brings it to this branch (where the feature and the flake both live, and which was missing the step plus its helper).

No assertion is weakened — only the wait becomes deterministic.
