### PR TITLE
Manufacturing mobile issue — on-the-fly HU scan: issue whole stocking units (rounded up, capped at HU)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/ManufacturingIssueScheduleOnTheFly_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/ManufacturingIssueScheduleOnTheFly_StepDef.java
@@ -13,6 +13,8 @@ import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
 import de.metas.handlingunits.qrcodes.service.HUQRCodesService;
 import de.metas.cache.CacheMgt;
+import de.metas.quantity.Quantity;
+import de.metas.uom.IUOMDAO;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
@@ -25,6 +27,7 @@ import org.compiere.model.I_MobileUI_MFG_Config;
 import org.compiere.SpringContextHolder;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ManufacturingIssueScheduleOnTheFly_StepDef
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
 
 	@NonNull private final TestContext testContext;
 	@NonNull private final M_HU_StepDefData huTable;
@@ -180,7 +184,13 @@ public class ManufacturingIssueScheduleOnTheFly_StepDef
 	 * Verifies PP_Order_IssueSchedule record details.
 	 *
 	 * <p>Required columns: {@code PP_Order_ID.Identifier}, {@code M_Product_ID.Identifier}, {@code M_HU_ID.Identifier}
-	 * <p>Optional columns: {@code SeqNo}
+	 * <p>Optional columns:
+	 * <ul>
+	 *   <li>{@code SeqNo}</li>
+	 *   <li>{@code QtyToIssue} — expected {@code PP_Order_IssueSchedule.QtyToIssue} with its UOM, e.g. {@code "20 KGM"}.
+	 *       Asserts both the quantity and the UOM (X12DE355 code) of the stored value, i.e. the schedule's qty must
+	 *       be expressed in the given UOM, not merely numerically equal after an implicit conversion.</li>
+	 * </ul>
 	 */
 	@Then("verify PP_Order_IssueSchedule:")
 	public void verifyIssueSchedule(@NonNull final DataTable dataTable)
@@ -210,6 +220,16 @@ public class ManufacturingIssueScheduleOnTheFly_StepDef
 					assertThat(schedule.getSeqNo())
 							.as("SeqNo")
 							.isEqualTo(expectedSeqNo));
+
+			final Optional<Quantity> expectedQtyToIssue = row.getAsOptionalQuantity("QtyToIssue", uomDAO::getByX12DE355);
+			expectedQtyToIssue.ifPresent(expectedQty -> {
+				assertThat(schedule.getC_UOM_ID())
+						.as("PP_Order_IssueSchedule.C_UOM_ID for PP_Order %s and HU %s", ppOrderIdentifier, huIdentifier)
+						.isEqualTo(expectedQty.getUomId().getRepoId());
+				assertThat(schedule.getQtyToIssue())
+						.as("PP_Order_IssueSchedule.QtyToIssue for PP_Order %s and HU %s", ppOrderIdentifier, huIdentifier)
+						.isEqualByComparingTo(expectedQty.toBigDecimal());
+			});
 		});
 	}
 }

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/manufacturing/issueScheduleOnTheFly.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/manufacturing/issueScheduleOnTheFly.feature
@@ -306,3 +306,66 @@ Feature: Manufacturing Mobile UI - On-the-fly issue schedule creation
     Then verify PP_Order_IssueSchedule:
       | PP_Order_ID.Identifier | M_Product_ID.Identifier | M_HU_ID.Identifier | QtyToIssue |
       | ppOrder7               | comp3Prod               | huComp3            | 2 PCE      |
+
+  @from:cucumber
+  Scenario: TC-D7 — Sub-0.5 fractional demand still rounds UP to a whole stocking unit (locks round-UP, not HALF_UP)
+    And set MobileUI_MFG_Config IsAllowIssuingAnyHU to 'Y'
+
+    # comp4Prod is stocked in PCE; 1 PCE = 10 kg.
+    # BOM demands 12 kg of comp4Prod for a 1-unit order -> 12 / 10 = 1.2 PCE.
+    # 1.2 is BELOW the 0.5 rounding boundary, so HALF_UP would give 1 PCE — only round-UP gives 2 PCE.
+    # This scenario therefore passes ONLY with round-UP, locking the behaviour against a future HALF_UP change.
+    # The scanned HU holds 3 whole PCE (= 30 kg available), well over the 2 PCE needed, so the cap is not hit.
+    And metasfresh contains M_Products:
+      | Identifier  | X12DE355 |
+      | comp4Prod   | PCE      |
+      | finProdKg2  | PCE      |
+    And metasfresh contains C_UOM_Conversions
+      | M_Product_ID.Identifier | FROM_C_UOM_ID.X12DE355 | TO_C_UOM_ID.X12DE355 | MultiplyRate |
+      | comp4Prod               | PCE                    | KGM                  | 10           |
+    And metasfresh contains PP_Product_BOM
+      | Identifier | M_Product_ID | PP_Product_BOMVersions_ID |
+      | bomKg2     | finProdKg2   | bomVersionKg2             |
+    And metasfresh contains PP_Product_BOMLines
+      | Identifier | PP_Product_BOM_ID.Identifier | M_Product_ID.Identifier | C_UOM_ID.X12DE355 | ValidFrom  | QtyBatch |
+      | bomLineKg2 | bomKg2                       | comp4Prod               | KGM               | 2021-01-02 | 12       |
+    And the PP_Product_BOM identified by bomKg2 is completed
+
+    And metasfresh contains PP_Product_Plannings
+      | Identifier  | OPT.AD_Workflow_ID.Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan |
+      | prodPlanKg2 | mobileWorkflow                | finProdKg2              | bomVersionKg2                            | false        |
+
+    # Stock comp4Prod as an HU holding 3 whole PCE (= 30 kg available, over the 20 kg / 2 PCE needed)
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID | MovementDate | M_Warehouse_ID |
+      | invRoundUp     | 2026-03-20   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | M_InventoryLine_ID | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | invRoundUp     | invLineRoundUp     | comp4Prod               | 0       | 3        | PCE          |
+    And complete inventory with inventoryIdentifier 'invRoundUp'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID | M_HU_ID |
+      | invLineRoundUp     | huComp4 |
+
+    And create PP_Order:
+      | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument | OPT.PP_Product_Planning_ID.Identifier |
+      | ppOrder8               | MOP         | finProdKg2              | 1          | testResource             | 2026-03-20T23:59:00.00Z | 2026-03-20T23:59:00.00Z | 2026-03-20T23:59:00.00Z | Y                | prodPlanKg2                           |
+    When complete planning for PP_Order:
+      | PP_Order_ID.Identifier |
+      | ppOrder8               |
+    And create JsonWFProcessStartRequest for manufacturing and store it in context as request payload:
+      | PP_Order_ID.Identifier |
+      | ppOrder8               |
+    And the metasfresh REST-API endpoint path 'api/v2/userWorkflows/wfProcess/start' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    # Scan the HU holding 3 PCE of comp4Prod
+    And create JsonCreateIssueScheduleOnTheFlyRequest and store it in context:
+      | WorkflowProcess.Identifier | M_HU_ID.Identifier |
+      | from_last_response         | huComp4            |
+    And the metasfresh REST-API endpoint path 'api/v2/manufacturing/issueSchedule/createOnTheFly' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    # 12 kg demand / 10 kg per PCE = 1.2 PCE -> round UP -> 2 whole PCE, in the STOCKING UOM (PCE).
+    # HALF_UP would round 1.2 down to 1 PCE — so a green result here is only possible with RoundingMode.UP.
+    Then verify PP_Order_IssueSchedule:
+      | PP_Order_ID.Identifier | M_Product_ID.Identifier | M_HU_ID.Identifier | QtyToIssue |
+      | ppOrder8               | comp4Prod               | huComp4            | 2 PCE      |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/manufacturing/issueScheduleOnTheFly.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/mobileui/manufacturing/issueScheduleOnTheFly.feature
@@ -36,8 +36,8 @@ Feature: Manufacturing Mobile UI - On-the-fly issue schedule creation
       | AD_Workflow_ID.Identifier | Name                   |
       | mobileWorkflow            | mobileUI_workflow_test |
     And metasfresh contains PP_Product_Plannings
-      | Identifier  | OPT.AD_Workflow_ID.Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan |
-      | prodPlan1   | mobileWorkflow                | finProd                 | bomVersion1                              | false        |
+      | Identifier | OPT.AD_Workflow_ID.Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan |
+      | prodPlan1  | mobileWorkflow                | finProd                 | bomVersion1                              | false        |
 
     And load S_Resource:
       | S_Resource_ID.Identifier | S_Resource_ID |
@@ -53,9 +53,9 @@ Feature: Manufacturing Mobile UI - On-the-fly issue schedule creation
       | inv1           | invLine2           | comp2Prod               | 0       | 200      | PCE          |
     And complete inventory with inventoryIdentifier 'inv1'
     And after not more than 60s, there are added M_HUs for inventory
-      | M_InventoryLine_ID | M_HU_ID   |
-      | invLine1           | huComp1   |
-      | invLine2           | huComp2   |
+      | M_InventoryLine_ID | M_HU_ID |
+      | invLine1           | huComp1 |
+      | invLine2           | huComp2 |
 
   # ========================================================================
   # TC-B3 runs FIRST — before any IsAllowIssuingAnyHU=Y config is created.
@@ -121,8 +121,8 @@ Feature: Manufacturing Mobile UI - On-the-fly issue schedule creation
       | invUnrelated   | invLineUnrelated   | unrelated               | 0       | 50       | PCE          |
     And complete inventory with inventoryIdentifier 'invUnrelated'
     And after not more than 60s, there are added M_HUs for inventory
-      | M_InventoryLine_ID | M_HU_ID      |
-      | invLineUnrelated   | huUnrelated  |
+      | M_InventoryLine_ID | M_HU_ID     |
+      | invLineUnrelated   | huUnrelated |
 
     And create PP_Order:
       | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument | OPT.PP_Product_Planning_ID.Identifier |
@@ -194,3 +194,115 @@ Feature: Manufacturing Mobile UI - On-the-fly issue schedule creation
     And set M_HU status:
       | M_HU_ID.Identifier | HUStatus |
       | huComp1            | A        |
+
+  @from:cucumber
+  Scenario: TC-D5 — Component stocked in PCE, BOM line demands kg: on-the-fly schedule issues whole stocking units (exact multiple)
+    And set MobileUI_MFG_Config IsAllowIssuingAnyHU to 'Y'
+
+    # comp1Prod is stocked in PCE (Background) but this BOM demands it in kg, 1 PCE = 2 kg.
+    # A separate finished product + BOM is used so the Background's bom1 (already completed) stays untouched.
+    # BOM demand: QtyBOM(20 kg) * QtyEntered(5) = 100 kg required -> 100 / 2 = 50 PCE needed (exact, no rounding).
+    # The scanned HU holds 100 PCE (per Background), well above the 50 PCE needed, so the cap is not hit.
+    And metasfresh contains C_UOM_Conversions
+      | M_Product_ID.Identifier | FROM_C_UOM_ID.X12DE355 | TO_C_UOM_ID.X12DE355 | MultiplyRate |
+      | comp1Prod               | PCE                    | KGM                  | 2            |
+    And metasfresh contains M_Products:
+      | Identifier | X12DE355 |
+      | finProdKg  | PCE      |
+    And metasfresh contains PP_Product_BOM
+      | Identifier | M_Product_ID | PP_Product_BOMVersions_ID |
+      | bomKg      | finProdKg    | bomVersionKg              |
+    And metasfresh contains PP_Product_BOMLines
+      | Identifier | PP_Product_BOM_ID.Identifier | M_Product_ID.Identifier | C_UOM_ID.X12DE355 | ValidFrom  | QtyBatch |
+      | bomLineKg  | bomKg                        | comp1Prod               | KGM               | 2021-01-02 | 20       |
+    And the PP_Product_BOM identified by bomKg is completed
+
+    And metasfresh contains PP_Product_Plannings
+      | Identifier | OPT.AD_Workflow_ID.Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan |
+      | prodPlanKg | mobileWorkflow                | finProdKg               | bomVersionKg                             | false        |
+
+    And create PP_Order:
+      | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument | OPT.PP_Product_Planning_ID.Identifier |
+      | ppOrder6               | MOP         | finProdKg               | 5          | testResource             | 2026-03-20T23:59:00.00Z | 2026-03-20T23:59:00.00Z | 2026-03-20T23:59:00.00Z | Y                | prodPlanKg                            |
+    When complete planning for PP_Order:
+      | PP_Order_ID.Identifier |
+      | ppOrder6               |
+    And create JsonWFProcessStartRequest for manufacturing and store it in context as request payload:
+      | PP_Order_ID.Identifier |
+      | ppOrder6               |
+    And the metasfresh REST-API endpoint path 'api/v2/userWorkflows/wfProcess/start' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    # Scan the HU holding comp1Prod in PCE (100 PCE, per Background)
+    And create JsonCreateIssueScheduleOnTheFlyRequest and store it in context:
+      | WorkflowProcess.Identifier | M_HU_ID.Identifier |
+      | from_last_response         | huComp1            |
+    And the metasfresh REST-API endpoint path 'api/v2/manufacturing/issueSchedule/createOnTheFly' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    # The on-the-fly schedule must be created in comp1Prod's STOCKING UOM (PCE), as whole units covering the
+    # 100 kg BOM demand: 100 / 2 = 50 PCE exactly. It must NOT carry the HU's full 100 PCE nor the BOM's kg UOM.
+    Then verify PP_Order_IssueSchedule:
+      | PP_Order_ID.Identifier | M_Product_ID.Identifier | M_HU_ID.Identifier | QtyToIssue |
+      | ppOrder6               | comp1Prod               | huComp1            | 50 PCE     |
+
+  @from:cucumber
+  Scenario: TC-D6 — On-the-fly rounds the demand UP to whole stocking units and caps at the scanned HU (over-issue defect)
+    And set MobileUI_MFG_Config IsAllowIssuingAnyHU to 'Y'
+
+    # comp3Prod is stocked in PCE; 1 PCE = 20 kg.
+    # BOM demands 34.5 kg of comp3Prod for a 1-unit order -> 34.5 / 20 = 1.725 PCE -> rounded UP = 2 whole PCE.
+    # The scanned HU holds 3 whole PCE (= 60 kg available), which EXCEEDS the 2 PCE (40 kg) needed.
+    # Correct behaviour: issue schedule = 2 PCE (rounded-up whole units). Buggy behaviour: issues the FULL HU (3 PCE).
+    And metasfresh contains M_Products:
+      | Identifier  | X12DE355 |
+      | comp3Prod   | PCE      |
+      | finProdOver | PCE      |
+    And metasfresh contains C_UOM_Conversions
+      | M_Product_ID.Identifier | FROM_C_UOM_ID.X12DE355 | TO_C_UOM_ID.X12DE355 | MultiplyRate |
+      | comp3Prod               | PCE                    | KGM                  | 20           |
+    And metasfresh contains PP_Product_BOM
+      | Identifier | M_Product_ID | PP_Product_BOMVersions_ID |
+      | bomOver    | finProdOver  | bomVersionOver            |
+    And metasfresh contains PP_Product_BOMLines
+      | Identifier  | PP_Product_BOM_ID.Identifier | M_Product_ID.Identifier | C_UOM_ID.X12DE355 | ValidFrom  | QtyBatch |
+      | bomLineOver | bomOver                      | comp3Prod               | KGM               | 2021-01-02 | 34.5     |
+    And the PP_Product_BOM identified by bomOver is completed
+
+    And metasfresh contains PP_Product_Plannings
+      | Identifier   | OPT.AD_Workflow_ID.Identifier | M_Product_ID.Identifier | OPT.PP_Product_BOMVersions_ID.Identifier | IsCreatePlan |
+      | prodPlanOver | mobileWorkflow                | finProdOver             | bomVersionOver                           | false        |
+
+    # Stock comp3Prod as an HU holding 3 whole PCE (= 60 kg available, over the 40 kg / 2 PCE needed)
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID | MovementDate | M_Warehouse_ID |
+      | invOver        | 2026-03-20   | 540008         |
+    And metasfresh contains M_InventoriesLines:
+      | M_Inventory_ID | M_InventoryLine_ID | M_Product_ID.Identifier | QtyBook | QtyCount | UOM.X12DE355 |
+      | invOver        | invLineOver        | comp3Prod               | 0       | 3        | PCE          |
+    And complete inventory with inventoryIdentifier 'invOver'
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID | M_HU_ID |
+      | invLineOver        | huComp3 |
+
+    And create PP_Order:
+      | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument | OPT.PP_Product_Planning_ID.Identifier |
+      | ppOrder7               | MOP         | finProdOver             | 1          | testResource             | 2026-03-20T23:59:00.00Z | 2026-03-20T23:59:00.00Z | 2026-03-20T23:59:00.00Z | Y                | prodPlanOver                          |
+    When complete planning for PP_Order:
+      | PP_Order_ID.Identifier |
+      | ppOrder7               |
+    And create JsonWFProcessStartRequest for manufacturing and store it in context as request payload:
+      | PP_Order_ID.Identifier |
+      | ppOrder7               |
+    And the metasfresh REST-API endpoint path 'api/v2/userWorkflows/wfProcess/start' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    # Scan the HU holding 3 PCE of comp3Prod
+    And create JsonCreateIssueScheduleOnTheFlyRequest and store it in context:
+      | WorkflowProcess.Identifier | M_HU_ID.Identifier |
+      | from_last_response         | huComp3            |
+    And the metasfresh REST-API endpoint path 'api/v2/manufacturing/issueSchedule/createOnTheFly' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    # The schedule must issue 2 whole PCE (34.5 kg demand rounded UP to whole stocking units), in the STOCKING UOM (PCE).
+    # It must NOT issue the full scanned HU (3 PCE / 60 kg). This proves BOTH defects:
+    # wrong UOM (kg instead of PCE) AND over-issue (full HU 3 PCE instead of the rounded-up 2 PCE demand).
+    Then verify PP_Order_IssueSchedule:
+      | PP_Order_ID.Identifier | M_Product_ID.Identifier | M_HU_ID.Identifier | QtyToIssue |
+      | ppOrder7               | comp3Prod               | huComp3            | 2 PCE      |

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobService.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobService.java
@@ -56,11 +56,14 @@ import de.metas.material.planning.ResourceType;
 import de.metas.material.planning.ResourceTypeId;
 import de.metas.material.planning.pporder.IPPOrderBOMBL;
 import de.metas.material.planning.pporder.RawMaterialsIssueStrategy;
+import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
 import de.metas.product.ResourceId;
 import de.metas.quantity.Quantity;
 import de.metas.uom.IUOMConversionBL;
 import de.metas.uom.IUOMDAO;
+import de.metas.uom.UOMConversionContext;
+import de.metas.uom.UomId;
 import de.metas.user.UserId;
 import de.metas.util.Check;
 import de.metas.util.lang.SeqNo;
@@ -112,6 +115,7 @@ public class ManufacturingJobService
 	@NonNull private final IHUPPOrderQtyBL huPPOrderQtyBL = Services.get(IHUPPOrderQtyBL.class);
 	@NonNull private final IUOMConversionBL uomConversionBL = Services.get(IUOMConversionBL.class);
 	@NonNull private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
+	@NonNull private final IProductBL productBL = Services.get(IProductBL.class);
 	@NonNull private final IHUPPOrderBL ppOrderBL = Services.get(IHUPPOrderBL.class);
 	@NonNull private final IPPOrderBOMBL ppOrderBOMBL = Services.get(IPPOrderBOMBL.class);
 	@NonNull private final PPOrderIssueScheduleService ppOrderIssueScheduleService;
@@ -754,7 +758,7 @@ public class ManufacturingJobService
 		// Find a BOM line that matches one of the HU's products
 		final List<I_PP_Order_BOMLine> bomLines = ppOrderBOMBL.getOrderBOMLines(ppOrderId);
 		IHUProductStorage matchingStorage = null;
-		PPOrderBOMLineId matchingBomLineId = null;
+		I_PP_Order_BOMLine matchingBomLine = null;
 		ProductId matchingProductId = null;
 
 		for (final I_PP_Order_BOMLine bomLine : bomLines)
@@ -766,7 +770,7 @@ public class ManufacturingJobService
 					.orElse(null);
 			if (matchingStorage != null)
 			{
-				matchingBomLineId = PPOrderBOMLineId.ofRepoId(bomLine.getPP_Order_BOMLine_ID());
+				matchingBomLine = bomLine;
 				matchingProductId = bomLineProductId;
 				break;
 			}
@@ -780,8 +784,22 @@ public class ManufacturingJobService
 					.markAsUserValidationError();
 		}
 
+		final PPOrderBOMLineId matchingBomLineId = PPOrderBOMLineId.ofRepoId(matchingBomLine.getPP_Order_BOMLine_ID());
+
+		// Determine how much to issue: whole stocking units, rounded up to cover the BOM line's remaining
+		// demand, capped at what the scanned HU actually holds. This avoids both mislabeling the UOM and
+		// over-issuing the HU's full qty when the product is stocked in whole units (e.g. cheese wheels)
+		// but the BOM demands a fractional-unit UOM (e.g. kg).
+		final UomId stockingUomId = productBL.getStockUOMId(matchingProductId);
+		final Quantity remainingDemand = ppOrderBOMBL.getQuantities(matchingBomLine).getRemainingQtyToIssue();
+		final Quantity demandInStockingUOM = uomConversionBL.convertQuantityTo(
+				remainingDemand,
+				UOMConversionContext.of(matchingProductId),
+				stockingUomId);
+		final Quantity qtyAvailableInStockingUOM = matchingStorage.getQtyInStockingUOM();
+		final Quantity qtyToIssue = demandInStockingUOM.min(qtyAvailableInStockingUOM);
+
 		// Validate qty
-		final Quantity qtyToIssue = matchingStorage.getQty();
 		if (qtyToIssue.isZero())
 		{
 			throw new AdempiereException("HU has zero quantity for the matching product")


### PR DESCRIPTION
## What

Fixes a mobile-manufacturing on-the-fly issue bug found during UAT of the mobile manufacturing raw-material issue flow.

When a user scans a HU on the fly to issue raw material into a production order (`IsAllowIssuingAnyHU=Y`), `ManufacturingJobService.createOnTheFlyIssueScheduleInTrx` set `qtyToIssue = matchingStorage.getQty()` — the scanned HU's **full** qty in the product's **stocking UOM** — with no regard for the BOM line's demand or UOM. For a product stocked in whole units (e.g. cheese wheels, `Stk`) whose BOM line demands a fractional-unit UOM (e.g. `kg`), this both **mislabeled the UOM** and **over-issued** (consumed the whole HU instead of the amount needed — e.g. destroying 35 wheels to cover a 34.5 kg demand that needed 1 wheel).

## Fix

The on-the-fly issue qty is now computed as:

```
qtyToIssue = min( convert(BOM-line remaining demand → product stocking UOM), HU available )   // in the stocking UOM
```

- The remaining demand is `getRemainingQtyToIssue()` (BOM line required − already issued), so a scan after a partial issue only covers what is left.
- The UOM conversion rounds **up** to whole stocking units by design (`UOMPrecision` uses `RoundingMode.UP` — "we need one piece and not 0"), so indivisible stock (whole wheels) is issued rounded up to cover the demand.
- Capped at what the scanned HU actually holds.

Result: enough **whole stocking units**, rounded up to cover the remaining demand, never more than the HU has — expressed in the stocking UOM.

## Testing

`de.metas.cucumber` — `issueScheduleOnTheFly.feature`, **8/8 scenarios pass**:
- TC-D5 (exact multiple), TC-D6 (round-up ≥0.5 + over-issue/cap), **TC-D7 (sub-0.5 boundary: 12 kg ÷ 10 kg/PCE = 1.2 → 2 PCE — locks round-UP vs HALF_UP)**. RED-confirmed before the fix (issued the full HU / wrong UOM).
- `de.metas.manufacturing.rest-api` unit suite: 64 tests, 0 failures (JDK 8, local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
