### PR TITLE
Manufacturing mobile on-the-fly issue — fix stocking-vs-BOM UOM handling (Packmenge display, Menge Ist, Qty cap)

### DIFF
--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/model/RawMaterialsIssueLine.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/model/RawMaterialsIssueLine.java
@@ -174,6 +174,22 @@ public class RawMaterialsIssueLine
 		return qtyToIssue.subtract(qtyIssued);
 	}
 
+	/**
+	 * The quantity still allowed to be issued (including the issuing tolerance), converted to {@code targetUomId}
+	 * and rounded UP to that UOM's precision. Used to cap the mobile "Qty to issue" input, which the operator
+	 * enters in the picked HU's stocking UOM (e.g. Stk), against the BOM line's remaining demand (e.g. kg):
+	 * for a 35 kg/Stk product with 34.5 kg still to issue, this yields 1 Stk (0.986 rounded UP) — so the operator
+	 * cannot enter more than one whole wheel toward that demand. Without the conversion the frontend would compare
+	 * the entered Stk value against a kg ceiling and silently accept a massive over-issue.
+	 */
+	@NonNull
+	public Quantity getRemainingQtyToIssueMaxInUOM(@NonNull final UomId targetUomId)
+	{
+		final Quantity maxToIssue = getQtyToIssueMax().orElse(qtyToIssue); // BOM line UOM, incl. issuing tolerance
+		final Quantity remaining = maxToIssue.subtract(qtyIssued).toZeroIfNegative();
+		return uomConversionBL.convertQuantityTo(remaining, productId, targetUomId);
+	}
+
 	public boolean isAllowManualIssue()
 	{
 		return !issueMethod.isIssueOnlyForReceived();

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/model/RawMaterialsIssueLine.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/model/RawMaterialsIssueLine.java
@@ -179,7 +179,7 @@ public class RawMaterialsIssueLine
 	 * and rounded UP to that UOM's precision. Used to cap the mobile "Qty to issue" input, which the operator
 	 * enters in the picked HU's stocking UOM (e.g. Stk), against the BOM line's remaining demand (e.g. kg):
 	 * for a 35 kg/Stk product with 34.5 kg still to issue, this yields 1 Stk (0.986 rounded UP) — so the operator
-	 * cannot enter more than one whole wheel toward that demand. Without the conversion the frontend would compare
+	 * cannot enter more than one whole piece toward that demand. Without the conversion the frontend would compare
 	 * the entered Stk value against a kg ceiling and silently accept a massive over-issue.
 	 */
 	@NonNull

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobService.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/job/service/ManufacturingJobService.java
@@ -788,7 +788,7 @@ public class ManufacturingJobService
 
 		// Determine how much to issue: whole stocking units, rounded up to cover the BOM line's remaining
 		// demand, capped at what the scanned HU actually holds. This avoids both mislabeling the UOM and
-		// over-issuing the HU's full qty when the product is stocked in whole units (e.g. cheese wheels)
+		// over-issuing the HU's full qty when the product is stocked in whole units (e.g. pieces)
 		// but the BOM demands a fractional-unit UOM (e.g. kg).
 		final UomId stockingUomId = productBL.getStockUOMId(matchingProductId);
 		final Quantity remainingDemand = ppOrderBOMBL.getQuantities(matchingBomLine).getRemainingQtyToIssue();

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/activity_handlers/issue/json/JsonRawMaterialsIssueLine.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/activity_handlers/issue/json/JsonRawMaterialsIssueLine.java
@@ -51,7 +51,10 @@ public class JsonRawMaterialsIssueLine
 				.readOnly(!from.isAllowManualIssue())
 				.steps(from.getSteps()
 						.stream()
-						.map(step -> JsonRawMaterialsIssueLineStep.of(step, jsonOpts))
+						.map(step -> JsonRawMaterialsIssueLineStep.of(
+								step,
+								from.getRemainingQtyToIssueMaxInUOM(step.getQtyToIssue().getUomId()).toBigDecimal(),
+								jsonOpts))
 						.collect(ImmutableList.toImmutableList()));
 	}
 }

--- a/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/activity_handlers/issue/json/JsonRawMaterialsIssueLineStep.java
+++ b/backend/de.metas.manufacturing.rest-api/src/main/java/de/metas/manufacturing/workflows_api/activity_handlers/issue/json/JsonRawMaterialsIssueLineStep.java
@@ -30,15 +30,19 @@ public class JsonRawMaterialsIssueLineStep
 	@NonNull String uom;
 	@NonNull BigDecimal qtyHUCapacity;
 	@NonNull BigDecimal qtyToIssue;
+	// The BOM line's remaining demand (incl. tolerance) converted to this step's stocking UOM and rounded UP.
+	// Caps the mobile Qty input, which is entered in the stocking UOM. See RawMaterialsIssueLine.getRemainingQtyToIssueMaxInUOM.
+	@Nullable BigDecimal qtyToIssueMax;
 	@Nullable BigDecimal qtyIssued;
 	@Nullable BigDecimal qtyRejected;
 	@Nullable String qtyRejectedReasonCode;
 	@Nullable JsonScaleTolerance scaleTolerance;
 	@Nullable JsonDisplayableQRCode huQRCode;
 
-	public static JsonRawMaterialsIssueLineStep of(RawMaterialsIssueStep step, JsonOpts jsonOpts)
+	public static JsonRawMaterialsIssueLineStep of(RawMaterialsIssueStep step, @Nullable BigDecimal qtyToIssueMax, JsonOpts jsonOpts)
 	{
 		final JsonRawMaterialsIssueLineStepBuilder builder = builder()
+				.qtyToIssueMax(qtyToIssueMax)
 				.id(String.valueOf(step.getId().getRepoId()))
 				.isAlternativeIssue(step.isAlternativeIssue())
 				.productId(String.valueOf(step.getProductId().getRepoId()))

--- a/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/job/model/RawMaterialsIssueLineTest.java
+++ b/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/job/model/RawMaterialsIssueLineTest.java
@@ -56,8 +56,8 @@ class RawMaterialsIssueLineTest
 		uomStk = BusinessTestHelper.createUOM("Stk", 0); // pieces are whole units (precision 0)
 		uomKgId = UomId.ofRepoId(uomKg.getC_UOM_ID());
 
-		// Product stocked in pieces (a 35kg cheese wheel = 1 Stk)
-		final I_M_Product product = BusinessTestHelper.createProduct("CheeseWheel35kg", uomStk);
+		// Product stocked in pieces (1 Stk = 35 kg)
+		final I_M_Product product = BusinessTestHelper.createProduct("PieceStocked35kg", uomStk);
 		productId = ProductId.ofRepoId(product.getM_Product_ID());
 
 		// 1 Stk = 35 kg
@@ -76,7 +76,7 @@ class RawMaterialsIssueLineTest
 				.id(id)
 				.isAlternativeIssue(false)
 				.productId(productId)
-				.productName(TranslatableStrings.anyLanguage("CheeseWheel35kg"))
+				.productName(TranslatableStrings.anyLanguage("PieceStocked35kg"))
 				.qtyToIssue(Quantity.of(qtyToIssueKg, uomKg))
 				.issueFromLocator(LocatorInfo.builder()
 						.id(locatorId)
@@ -97,8 +97,8 @@ class RawMaterialsIssueLineTest
 				.uomConversionBL(Services.get(IUOMConversionBL.class))
 				.orderBOMLineId(PPOrderBOMLineId.ofRepoId(1))
 				.productId(productId)
-				.productName(TranslatableStrings.anyLanguage("CheeseWheel35kg"))
-				.productValue("CheeseWheel35kg")
+				.productName(TranslatableStrings.anyLanguage("PieceStocked35kg"))
+				.productValue("PieceStocked35kg")
 				.isWeightable(false)
 				.qtyToIssue(Quantity.of(qtyToIssueKg, uomKg))
 				.steps(steps)

--- a/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/job/model/RawMaterialsIssueLineTest.java
+++ b/backend/de.metas.manufacturing.rest-api/src/test/java/de/metas/manufacturing/job/model/RawMaterialsIssueLineTest.java
@@ -53,7 +53,7 @@ class RawMaterialsIssueLineTest
 		AdempiereTestHelper.get().init();
 
 		uomKg = BusinessTestHelper.createUOM("Kg", 3);
-		uomStk = BusinessTestHelper.createUOM("Stk", 4);
+		uomStk = BusinessTestHelper.createUOM("Stk", 0); // pieces are whole units (precision 0)
 		uomKgId = UomId.ofRepoId(uomKg.getC_UOM_ID());
 
 		// Product stocked in pieces (a 35kg cheese wheel = 1 Stk)
@@ -130,6 +130,33 @@ class RawMaterialsIssueLineTest
 		assertThat(issued.getQtyLeftToIssue().getUomId()).isEqualTo(uomKgId);
 		assertThat(issued.getQtyLeftToIssue().toBigDecimal()).isEqualByComparingTo("0");
 		assertThat(issued.getStatus()).isEqualTo(WFActivityStatus.COMPLETED);
+	}
+
+	@Test
+	void remainingQtyToIssueMaxInUOM_convertsKgDemandToWholeStk_roundedUp()
+	{
+		final UomId uomStkId = UomId.ofRepoId(uomStk.getC_UOM_ID());
+
+		// 34.5 kg still to issue against a 35 kg/Stk product => 0.986 Stk => rounded UP to 1 Stk.
+		final RawMaterialsIssueLine line = newLine("34.5", ImmutableList.of(newStep(SCHEDULE_ID, "34.5")));
+
+		final Quantity max = line.getRemainingQtyToIssueMaxInUOM(uomStkId);
+		assertThat(max.getUomId()).isEqualTo(uomStkId);
+		assertThat(max.toBigDecimal()).isEqualByComparingTo("1");
+	}
+
+	@Test
+	void remainingQtyToIssueMaxInUOM_afterPartialIssue_convertsTheRemainderInStk()
+	{
+		final UomId uomStkId = UomId.ofRepoId(uomStk.getC_UOM_ID());
+
+		// 70 kg demand, one 35 kg (=1 Stk) already issued => 35 kg left => exactly 1 Stk.
+		RawMaterialsIssueLine line = newLine("70", ImmutableList.of(newStep(SCHEDULE_ID, "70")));
+		line = line.withChangedRawMaterialsIssueStep(SCHEDULE_ID, step -> issueStk(step, "1", uomStk));
+
+		final Quantity max = line.getRemainingQtyToIssueMaxInUOM(uomStkId);
+		assertThat(max.getUomId()).isEqualTo(uomStkId);
+		assertThat(max.toBigDecimal()).isEqualByComparingTo("1");
 	}
 
 	@Test

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.test.js
@@ -44,6 +44,27 @@ describe('computeStepScanPropsFromActivity', () => {
     expect(result.isIssueWholeHU).toEqual(true);
   });
 
+  // Stk-stocked HU issued against a kg BOM line: the Qty ceiling must be the backend-provided
+  // step.qtyToIssueMax (remaining demand converted to the stocking UOM, rounded up = 1 Stk), NOT the
+  // raw kg line max (34.5) — otherwise a manual override could issue 34 Stk against a 34.5 kg demand.
+  it('non-weightable Stk step caps at the converted step.qtyToIssueMax, not the kg line max', () => {
+    const result = call_computeStepScanPropsFromActivity({
+      line: { weightable: false, uom: 'kg', qtyToIssue: 34.5, qtyToIssueMax: 34.5, qtyIssued: 0 },
+      step: { uom: 'Stk', qtyToIssue: 1, qtyToIssueMax: 1, qtyHUCapacity: 40 },
+    });
+    expect(result.qtyToIssueMax).toEqual(1); // 1 Stk — not 34.5
+    expect(result.qtyToIssueTarget).toEqual(1); // capped in Stk; the kg remaining (34.5) must not leak in
+  });
+
+  it('non-weightable step without a backend max falls back to the line remaining (same-UOM)', () => {
+    const result = call_computeStepScanPropsFromActivity({
+      line: { weightable: false, uom: 'kg', qtyToIssue: 10, qtyToIssueMax: 12, qtyIssued: 3 },
+      step: { uom: 'kg', qtyToIssue: 5, qtyHUCapacity: 100 }, // no qtyToIssueMax
+    });
+    expect(result.qtyToIssueMax).toEqual(12 - 3); // fallback: line max (incl. tolerance) minus issued
+    expect(result.qtyToIssueTarget).toEqual(5); // min(stepQtyToIssue, qtyToIssueMax)
+  });
+
   it('line qty < step qty', () => {
     const result = call_computeStepScanPropsFromActivity({
       line: { qtyToIssue: 10, qtyToIssueMax: 15, qtyIssued: 3 },

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/manufacturing/issue/step_scan/computeStepScanUserInfoQtys.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/manufacturing/issue/step_scan/computeStepScanUserInfoQtys.test.js
@@ -29,7 +29,6 @@ const call = ({ line, step }) => {
   });
 
   return computeStepScanUserInfoQtys({
-    uom: props.uom,
     lineUom: props.lineUom,
     lineQtyToIssue: props.lineQtyToIssue,
     lineQtyToIssueTolerance: props.lineQtyToIssueTolerance,

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/manufacturing/issue/step_scan/computeStepScanUserInfoQtys.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/manufacturing/issue/step_scan/computeStepScanUserInfoQtys.test.js
@@ -1,0 +1,53 @@
+import { computeStepScanPropsFromActivity } from '../../../../../../containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity';
+import { computeStepScanUserInfoQtys } from '../../../../../../containers/activities/manufacturing/issue/step_scan/computeStepScanUserInfoQtys';
+
+const call = ({ line, step }) => {
+  const props = computeStepScanPropsFromActivity({
+    activity: {
+      dataStored: {
+        lines: {
+          L1: {
+            qtyIssued: 0,
+            weightable: false,
+            uom: 'kg',
+            ...line,
+            steps: {
+              S1: {
+                huQRCode: 'blabla',
+                uom: 'Stk',
+                ...step,
+              },
+            },
+          },
+        },
+        qtyRejectedReasons: { reasons: [] },
+        scaleDevice: null,
+      },
+    },
+    lineId: 'L1',
+    stepId: 'S1',
+  });
+
+  return computeStepScanUserInfoQtys({
+    uom: props.uom,
+    lineUom: props.lineUom,
+    lineQtyToIssue: props.lineQtyToIssue,
+    lineQtyToIssueTolerance: props.lineQtyToIssueTolerance,
+    lineQtyToIssueRemaining: props.lineQtyToIssueRemaining,
+  });
+};
+
+describe('computeStepScanUserInfoQtys', () => {
+  // The scanned HU is stocked in Stk; the BOM line demands kg. The two line-level
+  // "Packmenge"/"Packmenge (total)" rows describe the BOM-line demand, so they must be
+  // shown in the LINE uom (kg) — not the step/HU stocking uom (Stk).
+  it('renders line-level qtys in the LINE uom, not the step (stocking) uom', () => {
+    const [total, remaining] = call({
+      line: { qtyToIssue: 34.5, qtyToIssueMax: 34.5, qtyIssued: 0, uom: 'kg' },
+      step: { qtyToIssue: 1, qtyHUCapacity: 35, uom: 'Stk' },
+    });
+
+    expect(total.value).toEqual('34.5 kg');
+    expect(remaining.value).toEqual('34.5 kg');
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/reducers/wfProcesses/manufacturing_issue.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/reducers/wfProcesses/manufacturing_issue.test.js
@@ -72,6 +72,7 @@ describe('reducers: manufacturing issue tests', () => {
         const draftActivityDataStored = {
           lines: [
             {
+              qtyToIssue: 4, // line demand, met by the 4 issued across the steps
               steps: {
                 1: { qtyToIssue: 8, qtyIssued: 4, qtyRejectedReasonCode: null },
                 2: { qtyToIssue: 0, qtyIssued: 0, qtyRejectedReasonCode: null }, // alternative step
@@ -87,6 +88,7 @@ describe('reducers: manufacturing issue tests', () => {
         const draftActivityDataStored = {
           lines: [
             {
+              qtyToIssue: 4, // line demand, met by the 4 issued on the alternative step
               steps: {
                 1: { qtyToIssue: 8, qtyIssued: 0, qtyRejectedReasonCode: null },
                 2: { qtyToIssue: 0, qtyIssued: 4, qtyRejectedReasonCode: null }, // alternative step
@@ -102,6 +104,7 @@ describe('reducers: manufacturing issue tests', () => {
         const draftActivityDataStored = {
           lines: [
             {
+              qtyToIssue: 7, // line demand, met by the 3 + 4 issued across the steps
               steps: {
                 1: { qtyToIssue: 8, qtyIssued: 3, qtyRejectedReasonCode: null },
                 2: { qtyToIssue: 0, qtyIssued: 4, qtyRejectedReasonCode: null }, // alternative step

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/reducers/wfProcesses/manufacturing_issue.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/reducers/wfProcesses/manufacturing_issue.test.js
@@ -2,6 +2,7 @@ import * as CompleteStatus from '../../../constants/CompleteStatus';
 import {
   computeLineQtyIssuedFromSteps,
   computeStepStatus,
+  normalizeLines,
   updateActivityBottomUp,
 } from '../../../reducers/wfProcesses/manufacturing_issue';
 
@@ -178,4 +179,43 @@ describe('reducers: manufacturing issue tests', () => {
       ).toEqual(14);
     });
   }); // computeLineQtyIssuedFromSteps
+
+  // Regression: when the picked HU is stocked in a different uom than the BOM line demands
+  // (e.g. 1 Stk = 35 kg, BOM line in kg), the backend aggregates line.qtyIssued in the LINE uom
+  // (RawMaterialsIssueLine.computeQtyIssued converts each step's issued qty). The frontend must
+  // NOT re-derive it by summing step qtys (which are in the step/stocking uom, un-convertible here).
+  describe('line qtyIssued uom (Stk-stocked HU issued against a kg BOM line)', () => {
+    it('normalizeLines carries the backend line.qtyIssued', () => {
+      const [line] = normalizeLines([
+        {
+          uom: 'kg',
+          qtyToIssue: 34.5,
+          qtyIssued: 35, // backend value, in the LINE uom (kg)
+          steps: [{ id: 'S1', qtyIssued: 1 /* Stk */ }],
+        },
+      ]);
+      expect(line.qtyIssued).toEqual(35);
+    });
+
+    it('updateActivityBottomUp keeps the backend line.qtyIssued instead of summing step (Stk) qtys', () => {
+      const draftActivityDataStored = {
+        lines: [
+          {
+            uom: 'kg',
+            qtyToIssue: 34.5,
+            qtyIssued: 35, // backend value, in the LINE uom (kg)
+            steps: {
+              S1: { qtyToIssue: 1, qtyIssued: 1 /* Stk */, qtyRejectedReasonCode: null },
+            },
+          },
+        ],
+      };
+      updateActivityBottomUp({ draftActivityDataStored });
+
+      const line = draftActivityDataStored.lines[0];
+      expect(line.qtyIssued).toEqual(35); // NOT 1
+      expect(line.qtyToIssueRemaining).toEqual(0); // 35 kg covers the 34.5 kg demand
+      expect(line.completeStatus).toEqual(CompleteStatus.COMPLETED);
+    });
+  });
 });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/RawMaterialIssueStepScanComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/RawMaterialIssueStepScanComponent.jsx
@@ -91,6 +91,7 @@ const RawMaterialIssueStepScanComponent = ({ wfProcessId, activityId, lineId, st
 
     const {
       uom,
+      lineUom,
       qtyToIssueTarget,
       qtyToIssueMax,
       lineQtyToIssue,
@@ -114,7 +115,7 @@ const RawMaterialIssueStepScanComponent = ({ wfProcessId, activityId, lineId, st
       //
       // Props needed for ScanHUAndGetQtyComponent:
       userInfo: computeStepScanUserInfoQtys({
-        uom,
+        lineUom,
         lineQtyToIssue,
         lineQtyToIssueTolerance,
         lineQtyToIssueRemaining,

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.js
@@ -9,6 +9,7 @@ export const computeStepScanPropsFromActivity = ({ activity, lineId, stepId, isP
   const line = getLineByIdFromActivity(activity, lineId);
   const step = getStepByIdFromLine(line, stepId);
 
+  const lineUom = line.uom;
   const lineQtyToIssue = line.qtyToIssue;
   const lineQtyToIssueMax = Math.max(line.qtyToIssueMax, lineQtyToIssue);
   const lineQtyIssued = line.qtyIssued;
@@ -52,6 +53,7 @@ export const computeStepScanPropsFromActivity = ({ activity, lineId, stepId, isP
   return {
     huQRCode: step.huQRCode,
     uom,
+    lineUom,
     qtyToIssueTarget,
     qtyToIssueMax,
     qtyHUCapacity,

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/computeStepScanPropsFromActivity.js
@@ -19,17 +19,28 @@ export const computeStepScanPropsFromActivity = ({ activity, lineId, stepId, isP
   const uom = step.uom;
   const stepQtyToIssue = step.qtyToIssue;
   const qtyHUCapacity = step.qtyHUCapacity;
+  // Backend-provided: the BOM line's remaining demand (incl. tolerance) converted to this step's
+  // stocking UOM and rounded UP. The Qty input is entered in the stocking UOM, so its ceiling must be
+  // in that UOM too — the line-level `lineQtyToIssueMax`/`lineQtyIssued` are in the BOM line UOM (e.g. kg)
+  // and cannot cap a Stk entry (that let a manual override issue e.g. 30 Stk against a 34.5 kg demand).
+  const stepQtyToIssueMax = step.qtyToIssueMax;
 
   const qtyToIssueMax =
     isWeightable && isProcessedQtyStillOnScale
       ? Math.max(lineQtyToIssueMax, 0)
-      : Math.max(lineQtyToIssueMax - lineQtyIssued, 0);
+      : Math.max(stepQtyToIssueMax ?? lineQtyToIssueMax - lineQtyIssued, 0);
 
   const qtyAlreadyOnScale = isWeightable && isProcessedQtyStillOnScale ? Math.max(lineQtyIssued, 0) : undefined;
   //qtyToIssueMax = Math.min(qtyToIssueMax, qtyHUCapacity); // allow exceeding the HU capacity
 
   const lineQtyToIssueRemaining = Math.max(lineQtyToIssue - lineQtyIssued, 0);
-  const qtyToIssueTarget = Math.min(stepQtyToIssue, lineQtyToIssueRemaining, qtyToIssueMax);
+  // For a weightable line the step UOM equals the line UOM (weight), so all three terms share a UOM.
+  // Otherwise the target is capped purely in the stocking UOM: stepQtyToIssue and qtyToIssueMax are both
+  // in the stocking UOM, while lineQtyToIssueRemaining is in the (different) BOM line UOM — mixing it in
+  // would wrongly cap the target (e.g. undo the round-up to a whole stocking unit).
+  const qtyToIssueTarget = isWeightable
+    ? Math.min(stepQtyToIssue, lineQtyToIssueRemaining, qtyToIssueMax)
+    : Math.min(stepQtyToIssue, qtyToIssueMax);
 
   const isIssueWholeHU = qtyToIssueTarget >= qtyHUCapacity;
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/computeStepScanUserInfoQtys.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/manufacturing/issue/step_scan/computeStepScanUserInfoQtys.js
@@ -1,7 +1,10 @@
 import { formatQtyToHumanReadableStr } from '../../../../../utils/qtys';
 
 export const computeStepScanUserInfoQtys = ({
-  uom,
+  // `lineUom` is the BOM-line demand uom (e.g. kg); `uom` (the step/HU stocking uom, e.g. Stk)
+  // may differ when the HU is stocked in a different uom than the line demands. The two rows
+  // below are LINE-level quantities, so they must be shown in `lineUom`, not the step uom.
+  lineUom,
   lineQtyToIssue,
   lineQtyToIssueTolerance,
   lineQtyToIssueRemaining,
@@ -9,11 +12,11 @@ export const computeStepScanUserInfoQtys = ({
   return [
     {
       captionKey: 'general.QtyToPick_Total',
-      value: formatQtyToHumanReadableStr({ qty: lineQtyToIssue, uom, tolerance: lineQtyToIssueTolerance }),
+      value: formatQtyToHumanReadableStr({ qty: lineQtyToIssue, uom: lineUom, tolerance: lineQtyToIssueTolerance }),
     },
     {
       captionKey: 'general.QtyToPick',
-      value: formatQtyToHumanReadableStr({ qty: lineQtyToIssueRemaining, uom }),
+      value: formatQtyToHumanReadableStr({ qty: lineQtyToIssueRemaining, uom: lineUom }),
     },
   ];
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/wfProcesses/manufacturing_issue.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/wfProcesses/manufacturing_issue.js
@@ -19,7 +19,15 @@ export const computeStepStatus = ({ draftStep }) => {
 };
 
 const updateLineFromSteps = ({ draftLine }) => {
-  draftLine.qtyIssued = computeLineQtyIssuedFromSteps({ draftLine });
+  // Prefer the backend-provided line.qtyIssued: it is already aggregated in the BOM-line UOM
+  // (RawMaterialsIssueLine.computeQtyIssued converts each step's issued qty from the picked HU's
+  // stocking UOM — e.g. Stk — to the line UOM — e.g. kg — before summing). Summing step qtys here
+  // would be wrong whenever the step (stocking) UOM differs from the line UOM, because the frontend
+  // has no conversion factor. Fall back to the step sum only when the backend value is absent
+  // (legacy/malformed payloads); that fallback is correct only when step UOM == line UOM.
+  if (draftLine.qtyIssued == null) {
+    draftLine.qtyIssued = computeLineQtyIssuedFromSteps({ draftLine });
+  }
   draftLine.qtyToIssueRemaining = Math.max(draftLine.qtyToIssue - draftLine.qtyIssued, 0);
   draftLine.completeStatus = computeLineStatus({ draftLine });
 };
@@ -79,7 +87,8 @@ const computeActivityStatusFromLines = ({ draftActivityDataStored }) => {
   return CompleteStatus.reduceFromCompleteStatuesUniqueArray(lineStatuses);
 };
 
-const normalizeLines = (lines) => {
+// @VisibleForTesting
+export const normalizeLines = (lines) => {
   return lines.map((line) => {
     return {
       productName: line.productName,
@@ -90,6 +99,7 @@ const normalizeLines = (lines) => {
       weightable: line.weightable,
       readOnly: line.readOnly ?? false,
       qtyToIssue: line.qtyToIssue,
+      qtyIssued: line.qtyIssued,
       qtyToIssueMin: line.qtyToIssueMin,
       qtyToIssueMax: line.qtyToIssueMax,
       qtyToIssueTolerance: line.qtyToIssueTolerance,


### PR DESCRIPTION
Three related display/aggregation bugs in the mobile **on-the-fly raw-material issue** flow, surfaced when a component is stocked in a different UOM than the BOM line demands (e.g. a component stocked in pieces `Stk`, BOM line in `kg`). All were masked before the merged qty-to-issue fix, because the step qty and line qty were numerically equal.

## Bug 1 — "Packmenge" rows shown in the stocking UOM

The scan dialog's two **line-level** rows *Packmenge (total)* / *Packmenge* were rendered with the **step/HU stocking UOM** (`Stk`) while the values are the BOM-line demand (`kg`) — e.g. `34,5 Stk` instead of `34,5 kg`. Fix: format the two line-level rows with `line.uom`. The step-level **Qty** input keeps the stocking UOM.

## Bug 2 — line "Menge Ist" summed step Stk qtys as kg

After issuing 1 `Stk` (= 35 `kg`), the line showed **Menge Ist** `1 kg` / **noch offen** `33,5 kg`. The reducer dropped the backend `line.qtyIssued` and re-summed `step.qtyIssued` (stocking UOM) into the line UOM. Fix: `normalizeLines` carries the backend `line.qtyIssued` (backend already converts each step); `updateLineFromSteps` prefers it.

## Bug 3 — Qty ceiling was a kg number for a Stk input

`computeStepScanPropsFromActivity` derived the Qty field's max (`qtyToIssueMax`) from line-level kg quantities, while the Qty is entered in the stocking UOM. The over-entry guard compared a `Stk` value against a `kg` ceiling — a manual override could issue ~34 `Stk` (≈34 whole pieces) against a 34,5 `kg` demand. Fix:
- **Backend**: `RawMaterialsIssueLine.getRemainingQtyToIssueMaxInUOM(uomId)` converts the remaining demand (incl. tolerance) to a UOM, rounded **UP** (standard UOM conversion, `RoundingMode.UP`); exposed per step as `JsonRawMaterialsIssueLineStep.qtyToIssueMax` in the step's stocking UOM.
- **Frontend**: uses `step.qtyToIssueMax` as the ceiling (falls back to the old line computation when absent — correct only for same-UOM), and caps the non-weightable target purely in the stocking UOM. Weightable (scale) behaviour unchanged (step UOM == line UOM).

## Testing

- Backend `RawMaterialsIssueLineTest` (JDK8, local): 34,5 kg → 1 Stk (0.986 rounded up); after a partial issue, 35 kg left → 1 Stk.
- Jest (local; mobile-webui jest is not a CI gate — CI builds the `metas-mobile` app + Playwright `metas-mobile-test` image): `computeStepScanUserInfoQtys` renders `34.5 kg` not `34.5 Stk`; `manufacturing_issue` keeps backend `qtyIssued` (35 kg, remaining 0, COMPLETED); `computeStepScanPropsFromActivity` caps at the converted `step.qtyToIssueMax` (1 Stk), fallback preserved.
- Playwright E2E waived by the feature owner for these display/aggregation fixes.

Also repairs 3 stale reducer-test fixtures (`updateActivityBottomUp` "issued on …") that asserted COMPLETED without a line-level `qtyToIssue` — red on the base branch since the issuing-tolerance change made `computeLineStatus` require it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
