### PR TITLE
MobileUI Picking E2E: settle launcher-start (port of #24959 to new_dawn_uat)

### DIFF
--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
@@ -101,13 +101,18 @@ export const PickingJobsListScreen = {
                 // re-resolved from its stable identity rather than from its (reorder-prone) position.
 
                 // Settle: the addressed launcher must be painted and the loading spinner cleared.
+                // This is only a readiness gate, so it can use the full (index + attributes) locator;
+                // it need not be the same query as the final pin below.
                 await locateJobButtons({ index, qtyToDeliver, customerLocationId }).waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
                 await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
 
                 // Pin by identity attributes when the caller gave one (qtyToDeliver / customerLocationId):
                 // an attribute locator resolves the same launcher no matter how a push reorders the
                 // list, and asserting exactly one match rules out an ambiguous selection. Fall back to
-                // the positional index only when no identifying attribute was provided.
+                // the positional index only when no identifying attribute was provided — that fallback
+                // is reorder-safe only when the list is already narrowed to a single candidate (e.g. a
+                // prior filterByDocumentNo, or single-order masterdata); against a genuinely
+                // multi-launcher unfiltered list, pass qtyToDeliver / customerLocationId instead.
                 const target = (qtyToDeliver != null || customerLocationId != null)
                     ? locateJobButtons({ qtyToDeliver, customerLocationId })
                     : locateJobButtons({ index });

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
@@ -11,6 +11,19 @@ import { MassPrintingScanScreen } from './MassPrintingScanScreen';
 const NAME = 'PickingJobsListScreen';
 /** @returns {import('@playwright/test').Locator} */
 const containerElement = () => page.locator('#WFLaunchersScreen');
+// The job (workflow-process) screen reached after starting a launcher. This id mirrors the private
+// containerElement in PickingJobScreen.js — keep the two in sync if the workflow-process screen id changes.
+/** @returns {import('@playwright/test').Locator} */
+const jobScreenElement = () => page.locator('#WFProcessScreen');
+
+// Bounded tap-and-recover for the launcher-start navigation (see tapLauncherUntilJobScreen).
+// Small attempt count with explicit per-step timeouts so the retry cost stays modest: only the first
+// attempt pays the full slow-action settle budget; retries re-settle an already-populated list on a
+// short budget, so a few attempts do not multiply the full 20s screen wait.
+const JOB_START_TAP_ATTEMPTS = 3;
+// Short per-attempt wait for the job screen to appear after a tap. On the happy path the first
+// attempt succeeds immediately; only a slow/lost workflow-start round-trip pays this.
+const JOB_START_ARRIVAL_TIMEOUT = 8000; // 8sec
 
 export const PickingJobsListScreen = {
     waitForScreen: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
@@ -93,9 +106,7 @@ export const PickingJobsListScreen = {
             });
         } else if (index != null) {
             return await test.step(`${NAME} - Start job by index ${index - 1}`, async () => {
-                const target = await resolveLauncherTapTarget({ index, qtyToDeliver, customerLocationId });
-                await target.tap();
-                await PickingJobScreen.waitForScreen();
+                await tapLauncherUntilJobScreen({ index, qtyToDeliver, customerLocationId });
                 return {
                     pickingJobId: await PickingJobScreen.getPickingJobId(),
                 }
@@ -152,16 +163,19 @@ export const PickingJobsListScreen = {
 /**
  * Settle the launcher list, then pin the tap target by stable identity — its data-testid when the
  * launcher exposes one (unique, reorder-immune), else its attribute/index locator — read at runtime.
+ * @param settleTimeout - wait budget for the list to settle (spinner detached + launcher visible).
+ *        Defaults to the full slow-action budget for a first, freshly-navigated (websocket-populating)
+ *        list; a retry that is already back on a populated list can pass a shorter budget.
  * @returns {Promise<import('@playwright/test').Locator>} the locator to tap
  */
-const resolveLauncherTapTarget = async ({ index, qtyToDeliver, customerLocationId }) => {
-    await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
+const resolveLauncherTapTarget = async ({ index, qtyToDeliver, customerLocationId, settleTimeout = SLOW_ACTION_TIMEOUT }) => {
+    await page.locator('.loading').waitFor({ state: 'detached', timeout: settleTimeout });
 
     const byAttribute = qtyToDeliver != null || customerLocationId != null;
     const identified = byAttribute
         ? locateJobButtons({ qtyToDeliver, customerLocationId })
         : locateJobButtons({ index });
-    await identified.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+    await identified.waitFor({ state: 'visible', timeout: settleTimeout });
 
     // Exactly one launcher must be addressed. A bare index (.nth is always ≤1) is reorder-safe only
     // against a single-candidate list (a prior filterByDocumentNo / single-order masterdata), so the
@@ -170,6 +184,49 @@ const resolveLauncherTapTarget = async ({ index, qtyToDeliver, customerLocationI
 
     const testId = await identified.getAttribute('data-testid');
     return (testId != null && testId.length > 0) ? page.getByTestId(testId) : identified;
+};
+
+/**
+ * Reach the picking job screen from a launcher tap, recovering like a real user from a slow or lost
+ * workflow-start round-trip: tap the launcher; if the job screen has not come up and we are still on
+ * the launcher list, re-resolve the launcher FRESH and tap again — bounded to a few attempts.
+ *
+ * This retries ONLY the setup navigation (reaching the job screen); it asserts nothing about the
+ * feature under test. Each wait is explicitly bounded (no unbounded/120s fallback). Idempotency guard:
+ * a re-tap fires only while we are demonstrably back on the (websocket-driven) launcher list — never
+ * mid-transition, so a start already in flight is not double-fired. If the job screen never arrives,
+ * the trailing full-settle waitForScreen throws and the test fails loud (a genuine broken start is
+ * never swallowed).
+ */
+const tapLauncherUntilJobScreen = async ({ index, qtyToDeliver, customerLocationId }) => {
+    for (let attempt = 1; attempt <= JOB_START_TAP_ATTEMPTS; attempt++) {
+        // First attempt settles the freshly-navigated (websocket-populating) list on the full budget;
+        // a retry is already back on a populated list, so it re-settles on a short budget.
+        const settleTimeout = attempt === 1 ? SLOW_ACTION_TIMEOUT : FAST_ACTION_TIMEOUT;
+        const target = await resolveLauncherTapTarget({ index, qtyToDeliver, customerLocationId, settleTimeout });
+        await target.tap();
+
+        const arrived = await jobScreenElement()
+            .waitFor({ state: 'attached', timeout: JOB_START_ARRIVAL_TIMEOUT })
+            .then(() => true, () => false);
+        if (arrived || attempt === JOB_START_TAP_ATTEMPTS) {
+            break;
+        }
+
+        // Not on the job screen yet, and attempts remain. Only loop to re-tap if we are back on the
+        // launcher list — the launcher and job screens are mutually-exclusive routes, so its presence
+        // (attached) means we truly returned, not a mid-transition overlap. Otherwise a navigation may
+        // still be in flight — give it a bounded moment to land rather than blindly re-tapping (which
+        // could double-start the workflow), then let the final settle below settle-or-fail.
+        const backOnLauncherList = await containerElement()
+            .waitFor({ state: 'attached', timeout: FAST_ACTION_TIMEOUT })
+            .then(() => true, () => false);
+        if (!backOnLauncherList) {
+            break;
+        }
+    }
+
+    await PickingJobScreen.waitForScreen();
 };
 
 const locateJobButtons = ({ documentNo, index, salesOrderId, customerId, qtyToDeliver, productId, customerLocationId, caption } = {}) => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
@@ -95,7 +95,6 @@ export const PickingJobsListScreen = {
             return await test.step(`${NAME} - Start job by index ${index - 1}`, async () => {
                 const target = await resolveLauncherTapTarget({ index, qtyToDeliver, customerLocationId });
                 await target.tap();
-
                 await PickingJobScreen.waitForScreen();
                 return {
                     pickingJobId: await PickingJobScreen.getPickingJobId(),
@@ -151,30 +150,23 @@ export const PickingJobsListScreen = {
 };
 
 /**
- * Settle the websocket-driven launcher list, then pin the tap target by stable identity so a push
- * reordering the list can't misdirect the tap: a launcher that exposes a stable data-testid (e.g.
- * distribution) is tapped by it (unique, reorder-immune); one that exposes none (picking launchers
- * currently do) degrades to its identifying attribute/index locator. Presence of a testId is read at
- * runtime, never assumed.
+ * Settle the launcher list, then pin the tap target by stable identity — its data-testid when the
+ * launcher exposes one (unique, reorder-immune), else its attribute/index locator — read at runtime.
  * @returns {Promise<import('@playwright/test').Locator>} the locator to tap
  */
 const resolveLauncherTapTarget = async ({ index, qtyToDeliver, customerLocationId }) => {
-    // Settle: the addressed launcher must be painted and the loading spinner cleared before we tap.
-    await locateJobButtons({ index, qtyToDeliver, customerLocationId }).waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
     await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
 
-    let identified;
-    if (qtyToDeliver != null || customerLocationId != null) {
-        // Attribute locator re-resolves the same launcher regardless of push-reordering; exactly one must match.
-        identified = locateJobButtons({ qtyToDeliver, customerLocationId });
-        await expect(identified).toHaveCount(1);
-    } else {
-        // Bare index is reorder-safe only against a single-candidate list (a prior filterByDocumentNo,
-        // or single-order masterdata); assert the unfiltered launcher set is that single candidate, so
-        // a future caller passing an index against a multi-launcher list fails loud instead of racing.
-        await expect(locateJobButtons()).toHaveCount(1);
-        identified = locateJobButtons({ index });
-    }
+    const byAttribute = qtyToDeliver != null || customerLocationId != null;
+    const identified = byAttribute
+        ? locateJobButtons({ qtyToDeliver, customerLocationId })
+        : locateJobButtons({ index });
+    await identified.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+    // Exactly one launcher must be addressed. A bare index (.nth is always ≤1) is reorder-safe only
+    // against a single-candidate list (a prior filterByDocumentNo / single-order masterdata), so the
+    // real guard there is the unfiltered set — a bare index against a multi-launcher list fails loud.
+    await expect(byAttribute ? identified : locateJobButtons()).toHaveCount(1);
 
     const testId = await identified.getAttribute('data-testid');
     return (testId != null && testId.length > 0) ? page.getByTestId(testId) : identified;

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
@@ -93,30 +93,7 @@ export const PickingJobsListScreen = {
             });
         } else if (index != null) {
             return await test.step(`${NAME} - Start job by index ${index - 1}`, async () => {
-                // The launcher list is websocket-driven: it re-renders — and may reorder — on every
-                // push, and tapping a launcher fires an async start request whose navigation only
-                // happens in the response callback. Tapping before the list has settled, or while a
-                // push is reordering it, can misdirect the tap to a neighbouring launcher and overrun
-                // the downstream screen wait. So settle the list first, then tap the launcher
-                // re-resolved from its stable identity rather than from its (reorder-prone) position.
-
-                // Settle: the addressed launcher must be painted and the loading spinner cleared.
-                // This is only a readiness gate, so it can use the full (index + attributes) locator;
-                // it need not be the same query as the final pin below.
-                await locateJobButtons({ index, qtyToDeliver, customerLocationId }).waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-                await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
-
-                // Pin by identity attributes when the caller gave one (qtyToDeliver / customerLocationId):
-                // an attribute locator resolves the same launcher no matter how a push reorders the
-                // list, and asserting exactly one match rules out an ambiguous selection. Fall back to
-                // the positional index only when no identifying attribute was provided — that fallback
-                // is reorder-safe only when the list is already narrowed to a single candidate (e.g. a
-                // prior filterByDocumentNo, or single-order masterdata); against a genuinely
-                // multi-launcher unfiltered list, pass qtyToDeliver / customerLocationId instead.
-                const target = (qtyToDeliver != null || customerLocationId != null)
-                    ? locateJobButtons({ qtyToDeliver, customerLocationId })
-                    : locateJobButtons({ index });
-                await expect(target).toHaveCount(1);
+                const target = await resolveLauncherTapTarget({ index, qtyToDeliver, customerLocationId });
                 await target.tap();
 
                 await PickingJobScreen.waitForScreen();
@@ -171,6 +148,36 @@ export const PickingJobsListScreen = {
         await ApplicationsListScreen.waitForScreen();
     }),
 
+};
+
+/**
+ * Settle the websocket-driven launcher list, then pin the tap target by stable identity so a push
+ * reordering the list can't misdirect the tap: a launcher that exposes a stable data-testid (e.g.
+ * distribution) is tapped by it (unique, reorder-immune); one that exposes none (picking launchers
+ * currently do) degrades to its identifying attribute/index locator. Presence of a testId is read at
+ * runtime, never assumed.
+ * @returns {Promise<import('@playwright/test').Locator>} the locator to tap
+ */
+const resolveLauncherTapTarget = async ({ index, qtyToDeliver, customerLocationId }) => {
+    // Settle: the addressed launcher must be painted and the loading spinner cleared before we tap.
+    await locateJobButtons({ index, qtyToDeliver, customerLocationId }).waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+    await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
+
+    let identified;
+    if (qtyToDeliver != null || customerLocationId != null) {
+        // Attribute locator re-resolves the same launcher regardless of push-reordering; exactly one must match.
+        identified = locateJobButtons({ qtyToDeliver, customerLocationId });
+        await expect(identified).toHaveCount(1);
+    } else {
+        // Bare index is reorder-safe only against a single-candidate list (a prior filterByDocumentNo,
+        // or single-order masterdata); assert the unfiltered launcher set is that single candidate, so
+        // a future caller passing an index against a multi-launcher list fails loud instead of racing.
+        await expect(locateJobButtons()).toHaveCount(1);
+        identified = locateJobButtons({ index });
+    }
+
+    const testId = await identified.getAttribute('data-testid');
+    return (testId != null && testId.length > 0) ? page.getByTestId(testId) : identified;
 };
 
 const locateJobButtons = ({ documentNo, index, salesOrderId, customerId, qtyToDeliver, productId, customerLocationId, caption } = {}) => {

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
@@ -93,7 +93,27 @@ export const PickingJobsListScreen = {
             });
         } else if (index != null) {
             return await test.step(`${NAME} - Start job by index ${index - 1}`, async () => {
-                await locateJobButtons({ index, qtyToDeliver, customerLocationId }).tap()
+                // The launcher list is websocket-driven: it re-renders — and may reorder — on every
+                // push, and tapping a launcher fires an async start request whose navigation only
+                // happens in the response callback. Tapping before the list has settled, or while a
+                // push is reordering it, can misdirect the tap to a neighbouring launcher and overrun
+                // the downstream screen wait. So settle the list first, then tap the launcher
+                // re-resolved from its stable identity rather than from its (reorder-prone) position.
+
+                // Settle: the addressed launcher must be painted and the loading spinner cleared.
+                await locateJobButtons({ index, qtyToDeliver, customerLocationId }).waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+                await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
+
+                // Pin by identity attributes when the caller gave one (qtyToDeliver / customerLocationId):
+                // an attribute locator resolves the same launcher no matter how a push reorders the
+                // list, and asserting exactly one match rules out an ambiguous selection. Fall back to
+                // the positional index only when no identifying attribute was provided.
+                const target = (qtyToDeliver != null || customerLocationId != null)
+                    ? locateJobButtons({ qtyToDeliver, customerLocationId })
+                    : locateJobButtons({ index });
+                await expect(target).toHaveCount(1);
+                await target.tap();
+
                 await PickingJobScreen.waitForScreen();
                 return {
                     pickingJobId: await PickingJobScreen.getPickingJobId(),


### PR DESCRIPTION
Direct port to `new_dawn_uat` of the MobileUI picking launcher-start flaky-test fix (source PR on `soft_panda_hotfix`: https://github.com/metasfresh/metasfresh/pull/24959).

Stabilizes `PickingJobsListScreen.startJob` against the websocket launcher-reorder race (bounded idempotent retry + stable testId tap target). Test-only; no production code.
