### PR TITLE
EDI DESADV no-pack export: regression scenarios for emptied lines

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_DesadvLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_DesadvLine_StepDef.java
@@ -22,8 +22,11 @@
 
 package de.metas.cucumber.stepdefs.edi;
 
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.esb.edi.model.I_EDI_Desadv;
 import de.metas.esb.edi.model.I_EDI_DesadvLine;
 import de.metas.uom.IUOMDAO;
@@ -34,6 +37,7 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Then;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.IQueryBuilder;
 import org.compiere.model.I_M_Product;
 
 import java.math.BigDecimal;
@@ -41,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 
 import static de.metas.cucumber.stepdefs.StepDefConstants.TABLECOLUMN_IDENTIFIER;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class EDI_DesadvLine_StepDef
@@ -60,6 +65,100 @@ public class EDI_DesadvLine_StepDef
 		this.desadvLineTable = desadvLineTable;
 		this.desadvTable = desadvTable;
 		this.productTable = productTable;
+	}
+
+	/**
+	 * Finds EDI_DesadvLine records by EDI_Desadv_ID and registers each under the given identifier.
+	 * Useful when a test needs to reference an auto-created DESADV line by identifier (e.g. to mutate it).
+	 *
+	 * <p>Required columns:
+	 * <ul>
+	 *   <li>{@code EDI_DesadvLine_ID} – identifier under which the found record is registered</li>
+	 *   <li>{@code EDI_Desadv_ID} – identifier of the parent DESADV (registered in {@link EDI_Desadv_StepDefData})</li>
+	 * </ul>
+	 * Optional disambiguator columns (use when the DESADV has more than one line):
+	 * <ul>
+	 *   <li>{@code M_Product_ID} – narrows the match to the line with this product</li>
+	 *   <li>{@code Line} – narrows the match to the line with this line number</li>
+	 * </ul>
+	 * When no disambiguator is provided the query must return exactly one result.
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * Then EDI_DesadvLine records are found:
+	 *   | EDI_DesadvLine_ID | EDI_Desadv_ID |
+	 *   | desadvLine        | myDesadv      |
+	 * </pre>
+	 */
+	@Then("EDI_DesadvLine records are found:")
+	public void edi_desadv_line_records_are_found(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::findAndRegisterDesadvLine);
+	}
+
+	private void findAndRegisterDesadvLine(@NonNull final DataTableRow row)
+	{
+		final StepDefDataIdentifier desadvIdentifier = row.getAsIdentifier(I_EDI_DesadvLine.COLUMNNAME_EDI_Desadv_ID);
+		final I_EDI_Desadv desadvRecord = desadvTable.get(desadvIdentifier);
+
+		final IQueryBuilder<I_EDI_DesadvLine> queryBuilder = queryBL.createQueryBuilder(I_EDI_DesadvLine.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_EDI_DesadvLine.COLUMNNAME_EDI_Desadv_ID, desadvRecord.getEDI_Desadv_ID());
+
+		row.getAsOptionalIdentifier(I_EDI_DesadvLine.COLUMNNAME_M_Product_ID)
+				.ifPresent(productIdentifier -> {
+					final I_M_Product productRecord = productTable.get(productIdentifier);
+					queryBuilder.addEqualsFilter(I_EDI_DesadvLine.COLUMNNAME_M_Product_ID, productRecord.getM_Product_ID());
+				});
+
+		row.getAsOptionalInt(I_EDI_DesadvLine.COLUMNNAME_Line)
+				.ifPresent(line -> queryBuilder.addEqualsFilter(I_EDI_DesadvLine.COLUMNNAME_Line, line));
+
+		final I_EDI_DesadvLine desadvLine = queryBuilder.create().firstOnlyNotNull(I_EDI_DesadvLine.class);
+
+		final StepDefDataIdentifier lineIdentifier = row.getAsIdentifier(I_EDI_DesadvLine.COLUMNNAME_EDI_DesadvLine_ID);
+		desadvLineTable.putOrReplace(lineIdentifier, desadvLine);
+	}
+
+	/**
+	 * Updates fields of an EDI_DesadvLine previously registered under an identifier.
+	 *
+	 * <p>Real-world trigger: a user edits the DESADV line in the WebUI (window 540256) after the
+	 * delivery was "emptied" — e.g. zeroing the delivered quantity or deactivating the line. Such a
+	 * line drops out of the pack export and must still surface in the no-pack export section.
+	 *
+	 * <p>Required column:
+	 * <ul>
+	 *   <li>{@code EDI_DesadvLine_ID} – identifier of the line to update</li>
+	 * </ul>
+	 * At least one optional field column must be present:
+	 * <ul>
+	 *   <li>{@code IsActive} – new IsActive flag (Y/N)</li>
+	 *   <li>{@code QtyDeliveredInUOM} – new delivered quantity in the line's UOM</li>
+	 * </ul>
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * Then EDI_DesadvLine records are updated:
+	 *   | EDI_DesadvLine_ID | QtyDeliveredInUOM |
+	 *   | desadvLine        | 0                 |
+	 * </pre>
+	 */
+	@Then("EDI_DesadvLine records are updated:")
+	public void edi_desadv_line_records_are_updated(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::updateDesadvLine);
+	}
+
+	private void updateDesadvLine(@NonNull final DataTableRow row)
+	{
+		final I_EDI_DesadvLine desadvLine = row.getAsIdentifier(I_EDI_DesadvLine.COLUMNNAME_EDI_DesadvLine_ID)
+				.lookupNotNullIn(desadvLineTable);
+
+		row.getAsOptionalBoolean(I_EDI_DesadvLine.COLUMNNAME_IsActive).ifPresent(desadvLine::setIsActive);
+		row.getAsOptionalBigDecimal(I_EDI_DesadvLine.COLUMNNAME_QtyDeliveredInUOM).ifPresent(desadvLine::setQtyDeliveredInUOM);
+
+		saveRecord(desadvLine);
 	}
 
 	@Then("validate created edi desadv line")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Export_Format_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Export_Format_StepDef.java
@@ -1,0 +1,250 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2024 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.edi;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.esb.edi.model.I_EDI_Desadv;
+import de.metas.esb.edi.model.I_EDI_DesadvLine;
+import de.metas.esb.edi.model.I_EDI_Desadv_Pack;
+import de.metas.esb.edi.model.I_EDI_Desadv_Pack_Item;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Then;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.impl.TypedSqlQueryFilter;
+import org.compiere.model.I_EXP_Format;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Step definitions that verify which records the live {@code EXP_Format} WhereClauses
+ * would select for a given DESADV, by applying each format's WhereClause exactly as the
+ * production export ({@code ExportHelper}) does.
+ *
+ * <p>Two formats are covered:
+ * <ul>
+ *   <li>{@code EDI_Exp_Desadv_Pack_Item} (pack-item export) — must select pack items by the
+ *       item's own {@code MovementQty>0}, not the parent line's {@code QtyDeliveredInUOM}.
+ *       A pack item with {@code MovementQty=0} on a line whose total {@code QtyDeliveredInUOM>0}
+ *       must be excluded.</li>
+ *   <li>{@code EDI_Exp_DesadvLineWithNoPack} (no-pack line export) — must select a delivered line
+ *       that was then "emptied" (delivered qty zeroed, line deactivated, or no longer covered by
+ *       an active pack), so such a line still appears in the DESADV instead of vanishing.</li>
+ * </ul>
+ */
+@RequiredArgsConstructor
+public class EDI_Desadv_Export_Format_StepDef
+{
+	/**
+	 * Name of the {@code EXP_Format} row for pack-item export.
+	 * Used to look up the record via IQueryBL rather than hardcoding its AD_ID.
+	 */
+	private static final String EXP_FORMAT_NAME_PACK_ITEM = "EDI_Exp_Desadv_Pack_Item";
+
+	/**
+	 * Name of the {@code EXP_Format} row for the single-mode no-pack line export
+	 * (One-DESADV-Per-ORDERS). Reads the physical {@code EDI_DesadvLine} table.
+	 */
+	private static final String EXP_FORMAT_NAME_NO_PACK_LINE = "EDI_Exp_DesadvLineWithNoPack";
+
+	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@NonNull private final EDI_Desadv_StepDefData desadvTable;
+	@NonNull private final EDI_Desadv_Pack_Item_StepDefData packItemTable;
+	@NonNull private final EDI_DesadvLine_StepDefData desadvLineTable;
+
+	/**
+	 * Loads the live WhereClause from the {@code EXP_Format} named
+	 * {@value #EXP_FORMAT_NAME_PACK_ITEM}, applies it as a
+	 * {@link TypedSqlQueryFilter} on {@link I_EDI_Desadv_Pack_Item} records belonging to the
+	 * given DESADV (via the pack), and asserts that the resulting set of records equals exactly
+	 * the listed pack-item identifiers.
+	 *
+	 * <p>Required columns:
+	 * <ul>
+	 *   <li>{@code EDI_Desadv_ID} – identifier of the DESADV whose packs are examined</li>
+	 *   <li>{@code EDI_Desadv_Pack_Item_ID} – identifiers expected to be selected (one row per item)</li>
+	 * </ul>
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * Then the DESADV pack-item export-format selects only:
+	 *   | EDI_Desadv_ID | EDI_Desadv_Pack_Item_ID |
+	 *   | myDesadv      | pi_nonzero              |
+	 * </pre>
+	 */
+	@Then("the DESADV pack-item export-format selects only:")
+	public void desadv_pack_item_export_format_selects_only(@NonNull final DataTable dataTable)
+	{
+		final I_EXP_Format expFormat = queryBL.createQueryBuilder(I_EXP_Format.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_EXP_Format.COLUMNNAME_Name, EXP_FORMAT_NAME_PACK_ITEM)
+				.create()
+				.firstOnlyNotNull(I_EXP_Format.class);
+		final String whereClause = expFormat.getWhereClause();
+		assertThat(whereClause).as("EXP_Format '%s' WhereClause must not be blank", EXP_FORMAT_NAME_PACK_ITEM).isNotBlank();
+
+		final DataTableRows rows = DataTableRows.of(dataTable);
+		// Guard: all DataTable rows must reference the same DESADV; a caller passing rows for
+		// different DESADVs would be silently broken (only the first row's DESADV is used).
+		final Set<StepDefDataIdentifier> distinctDesadvIdentifiers = rows.stream()
+				.map(row -> row.getAsIdentifier(I_EDI_Desadv.COLUMNNAME_EDI_Desadv_ID))
+				.collect(ImmutableSet.toImmutableSet());
+		assertThat(distinctDesadvIdentifiers)
+				.as("All DataTable rows must reference the same EDI_Desadv_ID identifier, but found multiple: %s", distinctDesadvIdentifiers)
+				.hasSize(1);
+
+		final DataTableRow firstRow = rows.getFirstRow();
+		final StepDefDataIdentifier desadvIdentifier = firstRow.getAsIdentifier(I_EDI_Desadv.COLUMNNAME_EDI_Desadv_ID);
+		final I_EDI_Desadv desadvRecord = desadvTable.get(desadvIdentifier);
+		final int desadvId = desadvRecord.getEDI_Desadv_ID();
+
+		final Set<StepDefDataIdentifier> expectedIdentifiers = rows.stream()
+				.map(row -> row.getAsIdentifier(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_Item_ID))
+				.collect(ImmutableSet.toImmutableSet());
+
+		final Set<Integer> expectedPackItemIds = expectedIdentifiers.stream()
+				.map(id -> packItemTable.get(id).getEDI_Desadv_Pack_Item_ID())
+				.collect(ImmutableSet.toImmutableSet());
+
+		final Set<Integer> packIdsForDesadv = queryBL.createQueryBuilder(I_EDI_Desadv_Pack.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_EDI_Desadv_Pack.COLUMNNAME_EDI_Desadv_ID, desadvId)
+				.create()
+				.list(I_EDI_Desadv_Pack.class)
+				.stream()
+				.map(I_EDI_Desadv_Pack::getEDI_Desadv_Pack_ID)
+				.collect(ImmutableSet.toImmutableSet());
+
+		assertThat(packIdsForDesadv)
+				.as("There must be at least one EDI_Desadv_Pack for EDI_Desadv_ID=%s", desadvId)
+				.isNotEmpty();
+
+		final Set<Integer> actualPackItemIds = queryBL.createQueryBuilder(I_EDI_Desadv_Pack_Item.class)
+				.addOnlyActiveRecordsFilter()
+				.addInArrayFilter(I_EDI_Desadv_Pack_Item.COLUMNNAME_EDI_Desadv_Pack_ID, packIdsForDesadv)
+				.filter(TypedSqlQueryFilter.of(whereClause))
+				.create()
+				.list(I_EDI_Desadv_Pack_Item.class)
+				.stream()
+				.map(I_EDI_Desadv_Pack_Item::getEDI_Desadv_Pack_Item_ID)
+				.collect(ImmutableSet.toImmutableSet());
+
+		assertThat(actualPackItemIds)
+				.as("Pack items selected by EXP_Format '%s' WhereClause for EDI_Desadv_ID=%s must match exactly the expected identifiers.\n"
+								+ "WhereClause used: %s\n"
+								+ "Expected pack-item IDs: %s\n"
+								+ "Actual pack-item IDs:   %s",
+						EXP_FORMAT_NAME_PACK_ITEM,
+						desadvId,
+						whereClause,
+						expectedPackItemIds,
+						actualPackItemIds)
+				.isEqualTo(expectedPackItemIds);
+	}
+
+	/**
+	 * Loads the live WhereClause from the {@code EXP_Format} named
+	 * {@value #EXP_FORMAT_NAME_NO_PACK_LINE}, applies it as a {@link TypedSqlQueryFilter} on the
+	 * {@link I_EDI_DesadvLine} records belonging to the given DESADV, and asserts that the resulting
+	 * set of lines equals exactly the listed line identifiers.
+	 *
+	 * <p>The query intentionally does <b>not</b> add an only-active-records filter: production
+	 * {@code ExportHelper} fetches embedded-format records with just {@code <link>=? AND (<WhereClause>)}
+	 * and no implicit {@code IsActive='Y'}. An active filter here would drop a deactivated line before
+	 * the WhereClause is evaluated, hiding the very case (line {@code IsActive='N'}) under test.
+	 *
+	 * <p>Required columns:
+	 * <ul>
+	 *   <li>{@code EDI_Desadv_ID} – identifier of the DESADV whose lines are examined</li>
+	 *   <li>{@code EDI_DesadvLine_ID} – identifiers expected to be selected (one row per line)</li>
+	 * </ul>
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * Then the DESADV no-pack-line export-format selects only:
+	 *   | EDI_Desadv_ID | EDI_DesadvLine_ID |
+	 *   | myDesadv      | emptiedLine       |
+	 * </pre>
+	 */
+	@Then("the DESADV no-pack-line export-format selects only:")
+	public void desadv_no_pack_line_export_format_selects_only(@NonNull final DataTable dataTable)
+	{
+		final I_EXP_Format expFormat = queryBL.createQueryBuilder(I_EXP_Format.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_EXP_Format.COLUMNNAME_Name, EXP_FORMAT_NAME_NO_PACK_LINE)
+				.create()
+				.firstOnlyNotNull(I_EXP_Format.class);
+		final String whereClause = expFormat.getWhereClause();
+		assertThat(whereClause).as("EXP_Format '%s' WhereClause must not be blank", EXP_FORMAT_NAME_NO_PACK_LINE).isNotBlank();
+
+		final DataTableRows rows = DataTableRows.of(dataTable);
+		// Guard: all DataTable rows must reference the same DESADV; a caller passing rows for
+		// different DESADVs would be silently broken (only the first row's DESADV is used).
+		final Set<StepDefDataIdentifier> distinctDesadvIdentifiers = rows.stream()
+				.map(row -> row.getAsIdentifier(I_EDI_Desadv.COLUMNNAME_EDI_Desadv_ID))
+				.collect(ImmutableSet.toImmutableSet());
+		assertThat(distinctDesadvIdentifiers)
+				.as("All DataTable rows must reference the same EDI_Desadv_ID identifier, but found multiple: %s", distinctDesadvIdentifiers)
+				.hasSize(1);
+
+		final DataTableRow firstRow = rows.getFirstRow();
+		final StepDefDataIdentifier desadvIdentifier = firstRow.getAsIdentifier(I_EDI_Desadv.COLUMNNAME_EDI_Desadv_ID);
+		final I_EDI_Desadv desadvRecord = desadvTable.get(desadvIdentifier);
+		final int desadvId = desadvRecord.getEDI_Desadv_ID();
+
+		final Set<Integer> expectedLineIds = rows.stream()
+				.map(row -> row.getAsIdentifier(I_EDI_DesadvLine.COLUMNNAME_EDI_DesadvLine_ID))
+				.map(id -> desadvLineTable.get(id).getEDI_DesadvLine_ID())
+				.collect(ImmutableSet.toImmutableSet());
+
+		// Mirror ExportHelper: filter by the embedded link (EDI_Desadv_ID) and the format WhereClause only.
+		final Set<Integer> actualLineIds = queryBL.createQueryBuilder(I_EDI_DesadvLine.class)
+				.addEqualsFilter(I_EDI_DesadvLine.COLUMNNAME_EDI_Desadv_ID, desadvId)
+				.filter(TypedSqlQueryFilter.of(whereClause))
+				.create()
+				.list(I_EDI_DesadvLine.class)
+				.stream()
+				.map(I_EDI_DesadvLine::getEDI_DesadvLine_ID)
+				.collect(ImmutableSet.toImmutableSet());
+
+		assertThat(actualLineIds)
+				.as("Lines selected by EXP_Format '%s' WhereClause for EDI_Desadv_ID=%s must match exactly the expected identifiers.\n"
+								+ "WhereClause used: %s\n"
+								+ "Expected line IDs: %s\n"
+								+ "Actual line IDs:   %s",
+						EXP_FORMAT_NAME_NO_PACK_LINE,
+						desadvId,
+						whereClause,
+						expectedLineIds,
+						actualLineIds)
+				.isEqualTo(expectedLineIds);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Pack_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_Pack_StepDef.java
@@ -102,6 +102,21 @@ public class EDI_Desadv_Pack_StepDef
 				.forEach(row -> packIsFound(row, timeoutSec));
 	}
 
+	/**
+	 * Updates fields of EDI_Desadv_Pack records previously registered under an identifier.
+	 *
+	 * <p>Required column:
+	 * <ul>
+	 *   <li>{@code EDI_Desadv_Pack_ID} – identifier of the pack to update</li>
+	 * </ul>
+	 * Optional field columns:
+	 * <ul>
+	 *   <li>{@code OPT.IPA_SSCC18} – new SSCC18 code</li>
+	 *   <li>{@code OPT.IsActive} – new IsActive flag (Y/N). Real-world trigger: a user deactivates the
+	 *       pack in the WebUI because the delivery was emptied; the underlying line must then surface
+	 *       in the no-pack export section (it is no longer covered by an active pack).</li>
+	 * </ul>
+	 */
 	@Then("EDI_Desadv_Pack records are updated")
 	public void update_EDI_Desadv_Pack(@NonNull final DataTable table)
 	{
@@ -134,6 +149,12 @@ public class EDI_Desadv_Pack_StepDef
 		if (ipaSSCC18 != null)
 		{
 			packRecord.setIPA_SSCC18(ipaSSCC18.trim());
+		}
+
+		final Boolean isActive = DataTableUtil.extractBooleanForColumnNameOr(tableRow, "OPT." + I_EDI_Desadv_Pack.COLUMNNAME_IsActive, null);
+		if (isActive != null)
+		{
+			packRecord.setIsActive(isActive);
 		}
 
 		saveRecord(packRecord);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvNoPackExportEmptiedLines.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediDesadvNoPackExportEmptiedLines.feature
@@ -1,0 +1,115 @@
+@from:cucumber
+@ghActions:run_on_executor5
+@allure.label.epic:E0292_EDI
+@allure.label.feature:F00353_EDI
+Feature: EDI DESADV no-pack export must include emptied DESADV lines
+# The single-mode no-pack EXP_Format (Name: EDI_Exp_DesadvLineWithNoPack) reads the physical
+# EDI_DesadvLine table. A line that had a delivery but is then "emptied" drops out of the pack
+# export and must still surface in the no-pack section, otherwise it disappears from the DESADV:
+#   - scn 31: delivered qty set to 0        -> line must be selected by the no-pack format
+#   - scn 32: line set inactive             -> line must be selected by the no-pack format
+#   - scn 33: the line's pack set inactive  -> line no longer covered by an active pack, must be selected
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And set sys config boolean value true for sys config de.metas.report.jasper.IsMockReportService
+    And metasfresh has date and time 2024-06-10T13:30:13+02:00[Europe/Berlin]
+    And metasfresh is configured for One-DESADV-Per-ORDERS
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh initially has no EDI_Desadv_Pack_Item data
+    And metasfresh initially has no EDI_Desadv_Pack data
+    And destroy existing M_HUs
+    And load M_Warehouse:
+      | M_Warehouse_ID | Value        |
+      | warehouseStd   | StdWarehouse |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl         | ps                 | DE           | EUR           | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv        | pl             |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | pp         | plv                    | product      | 10.0     | PCE      | Normal           |
+    # new_dawn_uat keys the EDI recipient config on C_BPartner_EDI_Setting; an EDI_Setting with no
+    # C_BPartner_Location_ID applies to all of the partner's locations.
+    And metasfresh contains C_BPartners:
+      | Identifier  | IsCustomer | M_PricingSystem_ID | GLN          |
+      | endcustomer | Y          | ps                 | location_gln |
+    And metasfresh contains C_BPartner_EDI_Setting:
+      | C_BPartner_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN      | Identifier |
+      | endcustomer   | true                 | bPartnerDesadvRecipientGLN | ediSetting |
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID.Identifier | M_Product_ID.Identifier |
+      | endcustomer              | product                 |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference   |
+      | order      | true    | endcustomer   | 2024-06-10  | po_ref_@Date@ |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | orderLine  | order      | product      | 10         |
+    When the order identified by order is completed
+    And after not more than 30s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | shipSched  | orderLine                 | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | shipSched                        | D            | true                | false       |
+    Then after not more than 30s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | shipSched                        | shipment              |
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed | OPT.C_OrderLine_ID.Identifier |
+      | shipmentLine              | shipment              | product                 | 10          | true      | orderLine                     |
+    And after not more than 30s, EDI_Desadv_Pack records are found:
+      | EDI_Desadv_Pack_ID.Identifier | IsManual_IPA_SSCC18 | OPT.M_HU_ID.Identifier | OPT.M_HU_PackagingCode_ID.Identifier | OPT.GTIN_PackingMaterial | OPT.SeqNo |
+      | packMain                      | true                | null                   | null                                 | null                     | 1         |
+    Then EDI_Desadv is found:
+      | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_Desadv_ID.Identifier |
+      | endcustomer              | order                 | desadv                   |
+    # This DESADV has exactly one line (single order line); capture it for the emptying mutations below.
+    Then EDI_DesadvLine records are found:
+      | EDI_DesadvLine_ID | EDI_Desadv_ID |
+      | desadvLine        | desadv        |
+
+  @from:cucumber
+  @Id:S0353_031
+  Scenario: A DESADV line whose delivered qty is set to 0 is exported in the no-pack section
+    # A user zeroes the delivered qty of the line in the WebUI (window 540256).
+    Then EDI_DesadvLine records are updated:
+      | EDI_DesadvLine_ID | QtyDeliveredInUOM |
+      | desadvLine        | 0                 |
+    # The emptied line no longer belongs in the pack export, so the no-pack format must select it.
+    Then the DESADV no-pack-line export-format selects only:
+      | EDI_Desadv_ID | EDI_DesadvLine_ID |
+      | desadv        | desadvLine        |
+
+  @from:cucumber
+  @Id:S0353_032
+  Scenario: A DESADV line that is set inactive is exported in the no-pack section
+    # A user deactivates the line in the WebUI (window 540256).
+    Then EDI_DesadvLine records are updated:
+      | EDI_DesadvLine_ID | IsActive |
+      | desadvLine        | N        |
+    # The inactive line must be selected by the no-pack format (its WhereClause matches IsActive='N').
+    Then the DESADV no-pack-line export-format selects only:
+      | EDI_Desadv_ID | EDI_DesadvLine_ID |
+      | desadv        | desadvLine        |
+
+  @from:cucumber
+  @Id:S0353_033
+  Scenario: When the line's DESADV-Pack is set inactive the line is exported in the no-pack section
+    # A user deactivates the line's DESADV-Pack in the WebUI; the line then has no active pack.
+    Then EDI_Desadv_Pack records are updated
+      | EDI_Desadv_Pack_ID.Identifier | OPT.IsActive |
+      | packMain                      | N            |
+    Then the DESADV no-pack-line export-format selects only:
+      | EDI_Desadv_ID | EDI_DesadvLine_ID |
+      | desadv        | desadvLine        |


### PR DESCRIPTION
## What

Adds GREEN cucumber regression scenarios guarding that a delivered `EDI_DesadvLine` which is then **emptied** still appears in the no-pack DESADV export section (`EXP_Format` `EDI_Exp_DesadvLineWithNoPack`), instead of vanishing from the DESADV.

Scenarios (`ediDesadvNoPackExportEmptiedLines.feature`, `@Id:S0353_031/032/033`):
- **scn 31** — `QtyDeliveredInUOM` set to 0
- **scn 32** — line set inactive
- **scn 33** — the line's DESADV-Pack set inactive

The feature drives the real flow (order → shipment → auto `EDI_Desadv`), then applies the **live** no-pack `EXP_Format` WhereClause exactly as production `ExportHelper` does (via `TypedSqlQueryFilter`, no implicit active filter) and asserts the emptied line is selected.

## Port note

The export-format cucumber harness did not yet exist on this branch, so this PR brings it over: a new `EDI_Desadv_Export_Format_StepDef` (the no-pack-line + pack-item selectors — the file is identical to the main-line version for clean propagation), the `EDI_DesadvLine records are found:` / `EDI_DesadvLine records are updated:` steps, and an `OPT.IsActive` column on the existing `EDI_Desadv_Pack records are updated` step.

## Why

The behaviour is already correct on this branch — migration `5755200` made the no-pack format WhereClause catch `IsActive='N' OR QtyDeliveredInUOM<=0 OR not-in-active-pack`. These scenarios lock the behaviour in as regression guards; no product code change.

## Test
- All feature steps verified to resolve to defined stepdefs.
- Selection logic independently confirmed via direct SQL on a customer-faithful DB (baseline not selected; scn 31/32/33 selected).
- Full scenario run: on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
