### PR TITLE
#30320 fix lookup spinner stuck when typeahead request fails

### DIFF
--- a/frontend/src/components/widget/Lookup/RawLookup.js
+++ b/frontend/src/components/widget/Lookup/RawLookup.js
@@ -688,14 +688,18 @@ export class RawLookup extends Component {
       });
     }
 
-    typeaheadRequest.then((response) => {
-      if (
-        this.typeaheadQuery &&
-        this.typeaheadQuery === typeaheadParams.query
-      ) {
-        this.populateTypeaheadData(response.data);
-      }
-    });
+    typeaheadRequest
+      .then((response) => {
+        if (
+          this.typeaheadQuery &&
+          this.typeaheadQuery === typeaheadParams.query
+        ) {
+          this.populateTypeaheadData(response.data);
+        }
+      })
+      .catch(() => {
+        this.setState({ loading: false });
+      });
   };
 
   populateTypeaheadData = (responseData) => {


### PR DESCRIPTION
Missing .catch() on the typeahead promise in RawLookup caused the loading spinner to hang indefinitely whenever the backend returned an error (HTTP 500, timeout, etc.). loading:true was set before the request; only populateTypeaheadData (success path) reset it to false.

Now .catch() resets loading:false so the user sees an empty dropdown instead of a permanent spinner and can retry by typing.

Same pattern already used in buildTypeaheadRequestForQuery (line 423).