### PR TITLE
frontend-testing: restore product IsSold/IsPurchased masterdata flags (fixes gate E2E on new_dawn_uat)

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/product/CreateProductCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/product/CreateProductCommand.java
@@ -146,8 +146,8 @@ public class CreateProductCommand
 			productRecord.setIsSerialNoPicked(isSerialNoPicked);
 		}
 		productRecord.setM_Product_Category_ID(productCategoryId.getRepoId());
-		productRecord.setIsSold(true);
-		productRecord.setIsPurchased(true);
+		productRecord.setIsSold(CoalesceUtil.coalesceNotNull(request.getIsSold(), true));
+		productRecord.setIsPurchased(CoalesceUtil.coalesceNotNull(request.getIsPurchased(), true));
 		if (request.getGuaranteeDaysMin() != null)
 		{
 			productRecord.setGuaranteeDaysMin(request.getGuaranteeDaysMin());


### PR DESCRIPTION
## Problem
`product-purchase-sales-gate.spec.js` (4 cases: sales/purchase × EN/DE) has failed on **every** `new_dawn_uat` cicd run since ~2026-07-01, keeping the `frontend webui test (2/3)` job red. It passes on `deep_tundra_release`.

## Root cause (merge regression, unrelated to the earlier cache-race fix)
Merge https://github.com/metasfresh/metasfresh/commit/89664f12e5d (https://github.com/metasfresh/metasfresh/pull/24901, "intensive_care_release_into_new_dawn_uat_20260701") reverted the `CreateProductCommand` hunk from https://github.com/metasfresh/metasfresh/pull/24861 back to hardcoded `setIsSold(true)/setIsPurchased(true)`, because `intensive_care_release` carried an edit to the same file (adding `guaranteeDaysMin`) based on the pre-gate version. The conflict resolution took that side and dropped the `IsSold`/`IsPurchased` handling. The `JsonCreateProductRequest.isSold/isPurchased` DTO fields survived (different file), which masked the regression.

Effect: the spec's "blocked" product was created with `IsSold='Y'/IsPurchased='Y'` (verified in the post-shard-2 DB snapshot: `M_Product 2005614` = `IsSold=Y`), so it was **not actually blocked**. The order-line picker gate works correctly and therefore (correctly) offered it -> the absence assertion failed. https://github.com/metasfresh/metasfresh/pull/24950 (cross-JVM SysConfig cache fix) is unrelated and cannot help.

## Verification (live stack against the 39390 post-shard-2 DB snapshot)
- The picker SQL already contains the gate filter `AND EXISTS (SELECT 1 FROM M_Product mp WHERE mp.M_Product_ID=p.M_Product_ID AND mp.IsSold=$14)` -- the feature works.
- The blocked product was created `IsSold=Y`; `CreateProductCommand.class` in the app image lacks `getIsSold`/`coalesceNotNull`.
- With the blocked product corrected to `IsSold='N'/IsPurchased='N'` (what the fixed command produces), the SALES picker returned `{"values":[]}` (excluded) while the control product still appeared.

## Fix
Restore honouring `request.getIsSold()/getIsPurchased()` in `CreateProductCommand` (`CoalesceUtil` already imported; DTO getters already present).

## Out of scope
- The mobile `fork_lift_1 (IsPackingPlace=N)` failure (`mobile test` job) is a **separate** issue -- https://github.com/metasfresh/metasfresh/pull/24581's workplace masterdata is intact; needs its own investigation.
- `intensive_care_release` still carries the hardcoded version, so a future merge could re-revert this; aligning that branch is a larger follow-up (it lacks the DTO field).
