### PR TITLE
mobile distribution: non-packing workplace excludes all bring-to-packing orders (fixes fork_lift packingplace E2E)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceRepository.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceRepository.java
@@ -109,7 +109,7 @@ public class WorkplaceRepository
 
 	public List<Workplace> getAllActive() {return getMap().getAllActive();}
 
-	public ImmutableSet<LocatorId> getPackingPlacePickFromLocatorIds(@NonNull final WarehouseId warehouseId) {return getMap().getPackingPlacePickFromLocatorIds(warehouseId);}
+	public ImmutableSet<LocatorId> getAllPackingPlacePickFromLocatorIds() {return getMap().getAllPackingPlacePickFromLocatorIds();}
 
 	public Workplace create(@NonNull final WorkplaceCreateRequest request)
 	{
@@ -441,11 +441,10 @@ public class WorkplaceRepository
 			return workplace != null ? workplace.getSeqNo().next() : SeqNo.ofInt(10);
 		}
 
-		public ImmutableSet<LocatorId> getPackingPlacePickFromLocatorIds(@NonNull final WarehouseId warehouseId)
+		public ImmutableSet<LocatorId> getAllPackingPlacePickFromLocatorIds()
 		{
 			return allActive.stream()
 					.filter(Workplace::isPackingPlace)
-					.filter(workplace -> WarehouseId.equals(workplace.getWarehouseId(), warehouseId))
 					.map(Workplace::getPickFromLocatorId)
 					.filter(Objects::nonNull)
 					.collect(ImmutableSet.toImmutableSet());

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceService.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/workplace/WorkplaceService.java
@@ -94,9 +94,9 @@ public class WorkplaceService
 		return workplaceRepository.isAnyWorkplaceActive();
 	}
 
-	public ImmutableSet<LocatorId> getPackingPlacePickFromLocatorIds(@NonNull final WarehouseId warehouseId)
+	public ImmutableSet<LocatorId> getAllPackingPlacePickFromLocatorIds()
 	{
-		return workplaceRepository.getPackingPlacePickFromLocatorIds(warehouseId);
+		return workplaceRepository.getAllPackingPlacePickFromLocatorIds();
 	}
 
 	public Set<LocatorId> getPickFromLocatorIds(final Workplace workplace)

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceRepositoryTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/workplace/WorkplaceRepositoryTest.java
@@ -82,7 +82,7 @@ public class WorkplaceRepositoryTest
 	}
 
 	@Test
-	public void getPackingPlacePickFromLocatorIds_returnsOnlyPackingPlacesWithLocator()
+	public void getAllPackingPlacePickFromLocatorIds_returnsAllPackingPlacesWithLocator()
 	{
 		final WarehouseId warehouseId = WarehouseId.ofRepoId(1);
 		final WarehouseId otherWarehouseId = WarehouseId.ofRepoId(2);
@@ -99,12 +99,13 @@ public class WorkplaceRepositoryTest
 		saveWorkplace("WP-C", warehouseId, false, L3.getRepoId());
 		// WP-D: isPackingPlace=Y but NO locator — contributes nothing
 		saveWorkplace("WP-D", warehouseId, true, 0);
-		// WP-E: isPackingPlace=Y, locator L4 but in ANOTHER warehouse — must NOT appear when querying warehouseId
+		// WP-E: isPackingPlace=Y, locator L4 in ANOTHER warehouse — MUST appear (the set is warehouse-agnostic,
+		// so a non-packing workplace excludes bring-to-packing orders regardless of which warehouse hosts the packing place)
 		saveWorkplace("WP-E", otherWarehouseId, true, L4.getRepoId());
 
-		final ImmutableSet<LocatorId> result = WorkplaceRepository.newInstanceForUnitTesting().getPackingPlacePickFromLocatorIds(warehouseId);
+		final ImmutableSet<LocatorId> result = WorkplaceRepository.newInstanceForUnitTesting().getAllPackingPlacePickFromLocatorIds();
 
-		assertThat(result).containsExactlyInAnyOrder(L1, L2);
+		assertThat(result).containsExactlyInAnyOrder(L1, L2, L4);
 	}
 
 	private static void saveWorkplace(

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/DistributionWarehouseService.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/external_services/warehouse/DistributionWarehouseService.java
@@ -45,9 +45,9 @@ public class DistributionWarehouseService
 	}
 
 	@NonNull
-	public Set<LocatorId> getPackingPlacePickFromLocatorIds(@NonNull final WarehouseId warehouseId)
+	public Set<LocatorId> getAllPackingPlacePickFromLocatorIds()
 	{
-		return workplaceService.getPackingPlacePickFromLocatorIds(warehouseId);
+		return workplaceService.getAllPackingPlacePickFromLocatorIds();
 	}
 
 	public WarehouseInfo getWarehouseInfoByRepoId(final int warehouseRepoId)

--- a/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/launchers/DistributionWorkflowLaunchersProvider.java
+++ b/backend/de.metas.distribution.rest-api/src/main/java/de/metas/distribution/mobileui/launchers/DistributionWorkflowLaunchersProvider.java
@@ -104,7 +104,7 @@ public class DistributionWorkflowLaunchersProvider
 
 		if (workplace != null && !workplace.isPackingPlace())
 		{
-			builder.excludeLocatorToIds(warehouseService.getPackingPlacePickFromLocatorIds(workplace.getWarehouseId()));
+			builder.excludeLocatorToIds(warehouseService.getAllPackingPlacePickFromLocatorIds());
 		}
 		else
 		{


### PR DESCRIPTION
## Problem
`e2e/mobile-webui/tests/spec/distribution/filter_by_packingplace.spec.js` — the `fork_lift_1 (IsPackingPlace=N)` case — has failed on every `new_dawn_uat` cicd run since ~2026-07-01 (`mobile test` job). A non-packing (fork-lift, warehouse=storage) workplace was offered **all four** DD orders instead of only the intra-storage groundfill orders DD3, DD4. It passes on `deep_tundra_release`.

## Root cause
`intensive_care_release` commit https://github.com/metasfresh/metasfresh/pull/24701 added *source-warehouse* visibility to the mobile distribution launcher: `M_Warehouse_From_ID = workplaceWarehouse OR (M_Warehouse_To_ID = workplaceWarehouse ...)`. That change was integrated into `new_dawn_uat` via merge https://github.com/metasfresh/metasfresh/pull/24901.

For a storage fork-lift, all of DD1–DD4 ship **from** storage, so the `From = storage` branch matches them all. The bring-to-packing DD1/DD2 are supposed to be removed by the `excludeLocatorToIds` set — but the provider built that set with `getPackingPlacePickFromLocatorIds(workplace.getWarehouseId())`, scoped to the workplace's **own** warehouse (storage). The packing stations live in the **packing** warehouse, so the set was empty and nothing was excluded → DD1/DD2 leaked in.

This is a genuine two-feature integration conflict (source-warehouse visibility vs. the IsPackingPlace packing-place split), not a plain revert.

## Fix
Make the packing-place exclusion **warehouse-agnostic**: a non-packing workplace excludes DD orders targeting **any** packing-place pick-from locator (`getAllPackingPlacePickFromLocatorIds()`), regardless of which warehouse hosts the packing place. This preserves https://github.com/metasfresh/metasfresh/pull/24701's source-warehouse visibility while restoring the packing-place-split guarantee (non-packing workplace = intra-storage groundfill only).

## Verification (live stack, 39390 post-shard-2 DB snapshot)
Ran the DD-order query with the corrected exclusion against the created masterdata:
- Before: `From=storage OR To=storage` → DD1,DD2,DD3,DD4 (all four).
- After: also exclude orders targeting the packing-place locators `{packing_station_1, packing_station_2}` → **DD3, DD4** only. Packing workplaces (wpPacking1 → DD1, wpPacking2 → DD2) unaffected.

Unit test `WorkplaceRepositoryTest` updated to assert the new warehouse-agnostic contract (a packing place in another warehouse now correctly contributes to the exclusion set).

## Note
Local module compile is blocked only by an unrelated stale-`.m2-local` dependency on this cross-branch worktree (`DB_PostgreSQL` long->int, not a touched file); CI compiles authoritatively. Separate from the frontend gate regression fixed in https://github.com/metasfresh/metasfresh/pull/24982 (both stem from merge https://github.com/metasfresh/metasfresh/pull/24901).

**Verified (root cause + fix, live 39390 post-shard-2 DB `metas-db:5.175-new-dawn-uat.39390-postfrontendtest-shard2`):**
`psql -c "SELECT DocumentNo FROM DD_Order o WHERE (o.M_Warehouse_From_ID=1000113 OR o.M_Warehouse_To_ID=1000113) [AND o.DD_Order_ID NOT IN (SELECT l.DD_Order_ID FROM DD_OrderLine l WHERE l.M_LocatorTo_ID IN (1000002,1000003))] AND o.DocumentNo IN (...)"`
- current filter (From OR To only) -> `1253999,1254000,1254001,1254002` (all 4 — the bug)
- with the packing-place exclusion added -> `1254001,1254002` (DD3, DD4 — the expected result)
Confirmed via the live launcher REST that the current build returns count:4 for the fork-lift workplace.
