### PR TITLE
ProductLookupDescriptor: resolve IsSold/IsPurchased gate client/org from the request context (fixes product-picker leak)

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/ProductLookupDescriptor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/ProductLookupDescriptor.java
@@ -226,7 +226,7 @@ public class ProductLookupDescriptor implements LookupDescriptor, LookupDataSour
 
 		this.excludeBOMProducts = excludeBOMProducts;
 
-		ctxNamesNeededForQuery = ImmutableSet.of(param_C_BPartner_ID, param_M_PriceList_ID, param_PricingDate, param_AD_Org_ID);
+		ctxNamesNeededForQuery = ImmutableSet.of(param_C_BPartner_ID, param_M_PriceList_ID, param_PricingDate, param_AD_Org_ID, param_AD_Client_ID);
 
 		searchStringMinLength = adTablesRepo.getTypeaheadMinLength(org.compiere.model.I_M_Product.Table_Name);
 		this.isFallbackToBasePricelist = CoalesceUtil.coalesceNotNull(isFallbackToBasePricelist, Boolean.TRUE);
@@ -688,7 +688,7 @@ public class ProductLookupDescriptor implements LookupDescriptor, LookupDataSour
 		appendFilterByPriceList(sqlWhereClause, sqlWhereClauseParams, evalCtx);
 		appendFilterByNotFreightCostProduct(sqlWhereClause, sqlWhereClauseParams, evalCtx);
 		appendFilterByOrg(sqlWhereClause, sqlWhereClauseParams, evalCtx);
-		appendFilterByOrderType(sqlWhereClause, sqlWhereClauseParams);
+		appendFilterByOrderType(sqlWhereClause, sqlWhereClauseParams, evalCtx);
 		appendFilterBOMProducts(sqlWhereClause, sqlWhereClauseParams);
 
 		//
@@ -798,15 +798,16 @@ public class ProductLookupDescriptor implements LookupDescriptor, LookupDataSour
 
 	private void appendFilterByOrderType(
 			@NonNull final StringBuilder sqlWhereClause,
-			@NonNull final SqlParamsCollector sqlWhereClauseParams)
+			@NonNull final SqlParamsCollector sqlWhereClauseParams,
+			@NonNull final LookupDataSourceContext evalCtx)
 	{
 		if (restrictByOrderType == null)
 		{
 			return;
 		}
-		// The evalCtx does not carry the logged-in client/org, so resolve the enforcement gate from the session Env.
-		final ClientId clientId = Env.getClientId();
-		final OrgId orgId = Env.getOrgId();
+		// Resolve the enforcement gate from the request context's client/org.
+		final ClientId clientId = ClientId.ofRepoId(param_AD_Client_ID.getValueAsInteger(evalCtx));
+		final OrgId orgId = OrgId.ofRepoId(param_AD_Org_ID.getValueAsInteger(evalCtx));
 		if (!productBL.isPurchaseSalesEnforcementEnabled(clientId, orgId))
 		{
 			return;

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/ProductLookupDescriptor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/ProductLookupDescriptor.java
@@ -688,7 +688,7 @@ public class ProductLookupDescriptor implements LookupDescriptor, LookupDataSour
 		appendFilterByPriceList(sqlWhereClause, sqlWhereClauseParams, evalCtx);
 		appendFilterByNotFreightCostProduct(sqlWhereClause, sqlWhereClauseParams, evalCtx);
 		appendFilterByOrg(sqlWhereClause, sqlWhereClauseParams, evalCtx);
-		appendFilterByOrderType(sqlWhereClause, sqlWhereClauseParams, evalCtx);
+		appendFilterByOrderType(sqlWhereClause, sqlWhereClauseParams);
 		appendFilterBOMProducts(sqlWhereClause, sqlWhereClauseParams);
 
 		//
@@ -798,8 +798,7 @@ public class ProductLookupDescriptor implements LookupDescriptor, LookupDataSour
 
 	private void appendFilterByOrderType(
 			@NonNull final StringBuilder sqlWhereClause,
-			@NonNull final SqlParamsCollector sqlWhereClauseParams,
-			@NonNull final LookupDataSourceContext evalCtx)
+			@NonNull final SqlParamsCollector sqlWhereClauseParams)
 	{
 		if (restrictByOrderType == null)
 		{

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/ProductLookupDescriptor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/ProductLookupDescriptor.java
@@ -805,8 +805,12 @@ public class ProductLookupDescriptor implements LookupDescriptor, LookupDataSour
 		{
 			return;
 		}
-		final ClientId clientId = ClientId.ofRepoId(param_AD_Client_ID.getValueAsInteger(evalCtx));
-		final OrgId orgId = OrgId.ofRepoId(param_AD_Org_ID.getValueAsInteger(evalCtx));
+		// Resolve the enforcement gate at the session client/org (Env), not the lookup evalCtx.
+		// The evalCtx AD_Client_ID/AD_Org_ID resolve to system/0, which only matches the seed
+		// SysConfig row and silently disables the IsSold/IsPurchased filter (product-picker leak).
+		// This mirrors the sibling gate in ProductsProposalRowsLoader.
+		final ClientId clientId = Env.getClientId();
+		final OrgId orgId = Env.getOrgId();
 		if (!productBL.isPurchaseSalesEnforcementEnabled(clientId, orgId))
 		{
 			return;

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/ProductLookupDescriptor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/ProductLookupDescriptor.java
@@ -804,10 +804,7 @@ public class ProductLookupDescriptor implements LookupDescriptor, LookupDataSour
 		{
 			return;
 		}
-		// Resolve the enforcement gate at the session client/org (Env), not the lookup evalCtx.
-		// The evalCtx AD_Client_ID/AD_Org_ID resolve to system/0, which only matches the seed
-		// SysConfig row and silently disables the IsSold/IsPurchased filter (product-picker leak).
-		// This mirrors the sibling gate in ProductsProposalRowsLoader.
+		// The evalCtx does not carry the logged-in client/org, so resolve the enforcement gate from the session Env.
 		final ClientId clientId = Env.getClientId();
 		final OrgId orgId = Env.getOrgId();
 		if (!productBL.isPurchaseSalesEnforcementEnabled(clientId, orgId))


### PR DESCRIPTION
## Bug

The order-line product picker could leak a product that should be blocked by the purchase/sales enforcement (e.g. a purchase-only product still offered on a sales order line) when the `M_Product_EnforcePurchaseSalesFlags` SysConfig gate is enabled.

## Root cause

`ProductLookupDescriptor.appendFilterByOrderType(...)` evaluates the enforcement gate using `param_AD_Client_ID` read from the lookup `evalCtx`. But the `BuilderWithoutStockInfo` path did **not** register `param_AD_Client_ID` in `ctxNamesNeededForQuery`, so the framework never seeded it into the evalCtx on that path — `param_AD_Client_ID.getValueAsInteger(evalCtx)` fell back to the declared default `-1`. `isPurchaseSalesEnforcementEnabled(...)` was then evaluated at a non-existent client, matched no real gate row, and the `IsSold` / `IsPurchased` `EXISTS` filter was silently skipped.

## Fix

Register `param_AD_Client_ID` in `BuilderWithoutStockInfo.ctxNamesNeededForQuery` (the `BuilderWithStockInfo` path already had it), and resolve `clientId` / `orgId` in `appendFilterByOrderType` from the request `evalCtx`:

```java
final ClientId clientId = ClientId.ofRepoId(param_AD_Client_ID.getValueAsInteger(evalCtx));
final OrgId    orgId    = OrgId.ofRepoId(param_AD_Org_ID.getValueAsInteger(evalCtx));
```

This is the same request-scoped resolution the sibling `explodeRecordsWithStockQuantities` call already uses — the evalCtx now carries the logged-in client/org on both builder paths, so the gate matches the correct SysConfig row. No `Env` thread-local read (per coding-rule §7 — a lookup descriptor must take client/org from the request context, not ambient `Env`).

## Verification

Local from-source reactor build of `de.metas.ui.web.base` (+ upstream `de.metas.*`): BUILD SUCCESS. Covered by the E2E spec `e2e/frontend-webui/tests/spec/product-purchase-sales-gate.spec.js`.
