### PR TITLE
Async batch — enqueue CheckProcessed work-package only for completion-consuming types

### DIFF
--- a/backend/de.metas.async/src/main/java-gen/de/metas/async/model/I_C_Async_Batch_Type.java
+++ b/backend/de.metas.async/src/main/java-gen/de/metas/async/model/I_C_Async_Batch_Type.java
@@ -1,8 +1,7 @@
 package de.metas.async.model;
 
-import org.adempiere.model.ModelColumn;
-
 import javax.annotation.Nullable;
+import org.adempiere.model.ModelColumn;
 
 /** Generated Interface for C_Async_Batch_Type
  *  @author metasfresh (generated) 
@@ -119,6 +118,27 @@ public interface I_C_Async_Batch_Type
 	String COLUMNNAME_CreatedBy = "CreatedBy";
 
 	/**
+	 * Set Description.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setDescription (@Nullable java.lang.String Description);
+
+	/**
+	 * Get Description.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	@Nullable java.lang.String getDescription();
+
+	ModelColumn<I_C_Async_Batch_Type, Object> COLUMN_Description = new ModelColumn<>(I_C_Async_Batch_Type.class, "Description", null);
+	String COLUMNNAME_Description = "Description";
+
+	/**
 	 * Set Internal Name.
 	 * Generally used to give records a name that can be safely referenced from code.
 	 *
@@ -126,7 +146,7 @@ public interface I_C_Async_Batch_Type
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	void setInternalName (String InternalName);
+	void setInternalName (java.lang.String InternalName);
 
 	/**
 	 * Get Internal Name.
@@ -136,7 +156,7 @@ public interface I_C_Async_Batch_Type
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
-	String getInternalName();
+	java.lang.String getInternalName();
 
 	ModelColumn<I_C_Async_Batch_Type, Object> COLUMN_InternalName = new ModelColumn<>(I_C_Async_Batch_Type.class, "InternalName", null);
 	String COLUMNNAME_InternalName = "InternalName";
@@ -165,6 +185,29 @@ public interface I_C_Async_Batch_Type
 	String COLUMNNAME_IsActive = "IsActive";
 
 	/**
+	 * Set Check Processed.
+	 * Controls whether, once all elements of a batch complete, the batch's processed status is checked and set.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsCheckProcessed (boolean IsCheckProcessed);
+
+	/**
+	 * Get Check Processed.
+	 * Controls whether, once all elements of a batch complete, the batch's processed status is checked and set.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isCheckProcessed();
+
+	ModelColumn<I_C_Async_Batch_Type, Object> COLUMN_IsCheckProcessed = new ModelColumn<>(I_C_Async_Batch_Type.class, "IsCheckProcessed", null);
+	String COLUMNNAME_IsCheckProcessed = "IsCheckProcessed";
+
+	/**
 	 * Set Keep Alive Time (Hours).
 	 * If set greater than zero, the batch has to be processed within the given number of hours, or it is flagged with Error=Yes.
 	 *
@@ -172,7 +215,7 @@ public interface I_C_Async_Batch_Type
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	void setKeepAliveTimeHours (@Nullable String KeepAliveTimeHours);
+	void setKeepAliveTimeHours (@Nullable java.lang.String KeepAliveTimeHours);
 
 	/**
 	 * Get Keep Alive Time (Hours).
@@ -182,30 +225,30 @@ public interface I_C_Async_Batch_Type
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	@Nullable String getKeepAliveTimeHours();
+	@Nullable java.lang.String getKeepAliveTimeHours();
 
 	ModelColumn<I_C_Async_Batch_Type, Object> COLUMN_KeepAliveTimeHours = new ModelColumn<>(I_C_Async_Batch_Type.class, "KeepAliveTimeHours", null);
 	String COLUMNNAME_KeepAliveTimeHours = "KeepAliveTimeHours";
 
 	/**
-	 * Set Benachrichtigungs-Art.
-	 * Art der Benachrichtigung
+	 * Set Notification Type.
+	 * Type of Notifications
 	 *
 	 * <br>Type: List
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	void setNotificationType (@Nullable String NotificationType);
+	void setNotificationType (@Nullable java.lang.String NotificationType);
 
 	/**
-	 * Get Benachrichtigungs-Art.
-	 * Art der Benachrichtigung
+	 * Get Notification Type.
+	 * Type of Notifications
 	 *
 	 * <br>Type: List
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
-	@Nullable String getNotificationType();
+	@Nullable java.lang.String getNotificationType();
 
 	ModelColumn<I_C_Async_Batch_Type, Object> COLUMN_NotificationType = new ModelColumn<>(I_C_Async_Batch_Type.class, "NotificationType", null);
 	String COLUMNNAME_NotificationType = "NotificationType";

--- a/backend/de.metas.async/src/main/java-gen/de/metas/async/model/X_C_Async_Batch_Type.java
+++ b/backend/de.metas.async/src/main/java-gen/de/metas/async/model/X_C_Async_Batch_Type.java
@@ -1,9 +1,9 @@
 // Generated Model - DO NOT CHANGE
 package de.metas.async.model;
 
-import javax.annotation.Nullable;
 import java.sql.ResultSet;
 import java.util.Properties;
+import javax.annotation.Nullable;
 
 /** Generated Model for C_Async_Batch_Type
  *  @author metasfresh (generated) 
@@ -12,7 +12,7 @@ import java.util.Properties;
 public class X_C_Async_Batch_Type extends org.compiere.model.PO implements I_C_Async_Batch_Type, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 851172719L;
+	private static final long serialVersionUID = 1316652081L;
 
     /** Standard Constructor */
     public X_C_Async_Batch_Type (final Properties ctx, final int C_Async_Batch_Type_ID, @Nullable final String trxName)
@@ -65,25 +65,49 @@ public class X_C_Async_Batch_Type extends org.compiere.model.PO implements I_C_A
 	}
 
 	@Override
-	public void setInternalName (final String InternalName)
+	public void setDescription (final @Nullable java.lang.String Description)
+	{
+		set_Value (COLUMNNAME_Description, Description);
+	}
+
+	@Override
+	public java.lang.String getDescription() 
+	{
+		return get_ValueAsString(COLUMNNAME_Description);
+	}
+
+	@Override
+	public void setInternalName (final java.lang.String InternalName)
 	{
 		set_Value (COLUMNNAME_InternalName, InternalName);
 	}
 
 	@Override
-	public String getInternalName()
+	public java.lang.String getInternalName() 
 	{
 		return get_ValueAsString(COLUMNNAME_InternalName);
 	}
 
 	@Override
-	public void setKeepAliveTimeHours (final @Nullable String KeepAliveTimeHours)
+	public void setIsCheckProcessed (final boolean IsCheckProcessed)
+	{
+		set_Value (COLUMNNAME_IsCheckProcessed, IsCheckProcessed);
+	}
+
+	@Override
+	public boolean isCheckProcessed() 
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsCheckProcessed);
+	}
+
+	@Override
+	public void setKeepAliveTimeHours (final @Nullable java.lang.String KeepAliveTimeHours)
 	{
 		set_Value (COLUMNNAME_KeepAliveTimeHours, KeepAliveTimeHours);
 	}
 
 	@Override
-	public String getKeepAliveTimeHours()
+	public java.lang.String getKeepAliveTimeHours() 
 	{
 		return get_ValueAsString(COLUMNNAME_KeepAliveTimeHours);
 	}
@@ -98,13 +122,13 @@ public class X_C_Async_Batch_Type extends org.compiere.model.PO implements I_C_A
 	/** Workpackage Processed = WPP */
 	public static final String NOTIFICATIONTYPE_WorkpackageProcessed = "WPP";
 	@Override
-	public void setNotificationType (final @Nullable String NotificationType)
+	public void setNotificationType (final @Nullable java.lang.String NotificationType)
 	{
 		set_Value (COLUMNNAME_NotificationType, NotificationType);
 	}
 
 	@Override
-	public String getNotificationType()
+	public java.lang.String getNotificationType() 
 	{
 		return get_ValueAsString(COLUMNNAME_NotificationType);
 	}

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/AsyncBatchType.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/AsyncBatchType.java
@@ -39,4 +39,10 @@ public class AsyncBatchType
 	@NonNull Duration keepAlive;
 	@NonNull Duration skipTimeout;
 	int adBoilderPlateId;
+	boolean checkProcessed;
+
+	public boolean isCheckProcessedNeeded()
+	{
+		return checkProcessed || adBoilderPlateId > 0;
+	}
 }

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/IAsyncBatchBL.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/IAsyncBatchBL.java
@@ -147,6 +147,13 @@ public interface IAsyncBatchBL extends ISingletonService
 
 	Optional<AsyncBatchType> getAsyncBatchType(@NonNull I_C_Async_Batch asyncBatch);
 
+	/**
+	 * Convenience overload that loads the {@link I_C_Async_Batch} record for the given id out-of-trx.
+	 * Returns empty if no such record exists (i.e. {@code retrieveAsyncBatchRecordOutOfTrx} returned {@code null}),
+	 * so callers never dereference a {@code null} record.
+	 */
+	Optional<AsyncBatchType> getAsyncBatchType(@NonNull AsyncBatchId asyncBatchId);
+
 	AsyncBatchType getAsyncBatchTypeById(@NonNull AsyncBatchTypeId asyncBatchTypeId);
 
 	Duration getTimeUntilProcessedRecheck(@NonNull I_C_Async_Batch asyncBatch);

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchBL.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchBL.java
@@ -168,6 +168,14 @@ public class AsyncBatchBL implements IAsyncBatchBL
 	@Override
 	public void enqueueAsyncBatch(@NonNull final AsyncBatchId asyncBatchId)
 	{
+		final I_C_Async_Batch asyncBatchRecord = asyncBatchDAO.retrieveAsyncBatchRecordOutOfTrx(asyncBatchId);
+		final Optional<AsyncBatchType> asyncBatchType = getAsyncBatchType(asyncBatchRecord);
+		if (asyncBatchType.isPresent() && !asyncBatchType.get().isCheckProcessedNeeded())
+		{
+			// the batch's type has no consumer of the Processed flag (no IsCheckProcessed and no boilerplate) -> skip enqueuing the CheckProcessed WP
+			return;
+		}
+
 		final Properties ctx = Env.getCtx();
 		final IWorkPackageQueue queue = workPackageQueueFactory.getQueueForEnqueuing(ctx, CheckProcessedAsynBatchWorkpackageProcessor.class);
 
@@ -468,6 +476,7 @@ public class AsyncBatchBL implements IAsyncBatchBL
 				.keepAlive(extractKeepAlive(record))
 				.skipTimeout(extractSkipTimeout(record))
 				.adBoilderPlateId(record.getAD_BoilerPlate_ID())
+				.checkProcessed(record.isCheckProcessed())
 				.build();
 	}
 

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchBL.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchBL.java
@@ -151,6 +151,11 @@ public class AsyncBatchBL implements IAsyncBatchBL
 		try
 		{
 			final I_C_Async_Batch asyncBatch = asyncBatchDAO.retrieveAsyncBatchRecordOutOfTrx(asyncBatchId);
+			if (asyncBatch == null)
+			{
+				// record no longer exists out-of-trx -> nothing to increment
+				return;
+			}
 			final Timestamp processed = SystemTime.asTimestamp();
 			asyncBatch.setLastProcessed(processed);
 			asyncBatch.setLastProcessed_WorkPackage_ID(workPackage.getC_Queue_WorkPackage_ID());
@@ -199,6 +204,12 @@ public class AsyncBatchBL implements IAsyncBatchBL
 	public boolean updateProcessedOutOfTrx(@NonNull final AsyncBatchId asyncBatchId)
 	{
 		final I_C_Async_Batch asyncBatchRecord = asyncBatchDAO.retrieveAsyncBatchRecordOutOfTrx(asyncBatchId);
+		if (asyncBatchRecord == null)
+		{
+			// record no longer exists out-of-trx -> nothing left to wait for; treat as processed so the
+			// CheckProcessed work-package completes instead of re-checking a vanished batch forever.
+			return true;
+		}
 		if (asyncBatchRecord.isProcessed())
 		{
 			return true;

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchBL.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchBL.java
@@ -575,6 +575,12 @@ public class AsyncBatchBL implements IAsyncBatchBL
 		try
 		{
 			final I_C_Async_Batch asyncBatch = asyncBatchDAO.retrieveAsyncBatchRecordOutOfTrx(asyncBatchId);
+			if (asyncBatch == null)
+			{
+				// record no longer exists out-of-trx -> nothing to count
+				return 0;
+			}
+
 			final Timestamp enqueued = SystemTime.asTimestamp();
 			if (asyncBatch.getFirstEnqueued() == null)
 			{

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchBL.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchBL.java
@@ -121,8 +121,7 @@ public class AsyncBatchBL implements IAsyncBatchBL
 			return;
 		}
 
-		final I_C_Async_Batch asyncBatch = asyncBatchDAO.retrieveAsyncBatchRecordOutOfTrx(asyncBatchId);
-		final AsyncBatchType asyncBatchType = getAsyncBatchType(asyncBatch).orElse(null);
+		final AsyncBatchType asyncBatchType = getAsyncBatchType(asyncBatchId).orElse(null);
 		if (asyncBatchType != null && X_C_Async_Batch_Type.NOTIFICATIONTYPE_WorkpackageProcessed.equals(asyncBatchType.getNotificationType()))
 		{
 			final Properties ctx = InterfaceWrapperHelper.getCtx(workPackage);
@@ -168,8 +167,7 @@ public class AsyncBatchBL implements IAsyncBatchBL
 	@Override
 	public void enqueueAsyncBatch(@NonNull final AsyncBatchId asyncBatchId)
 	{
-		final I_C_Async_Batch asyncBatchRecord = asyncBatchDAO.retrieveAsyncBatchRecordOutOfTrx(asyncBatchId);
-		final AsyncBatchType asyncBatchType = getAsyncBatchType(asyncBatchRecord).orElse(null);
+		final AsyncBatchType asyncBatchType = getAsyncBatchType(asyncBatchId).orElse(null);
 		if (asyncBatchType != null && !asyncBatchType.isCheckProcessedNeeded())
 		{
 			// the batch's type has no consumer of the Processed flag (no IsCheckProcessed and no boilerplate) -> skip enqueuing the CheckProcessed WP
@@ -286,6 +284,10 @@ public class AsyncBatchBL implements IAsyncBatchBL
 	public boolean keepAliveTimeExpired(@NonNull final AsyncBatchId asyncBatchId)
 	{
 		final I_C_Async_Batch asyncBatchRecord = asyncBatchDAO.retrieveAsyncBatchRecordOutOfTrx(asyncBatchId);
+		if (asyncBatchRecord == null)
+		{
+			return false;
+		}
 
 		final AsyncBatchType asyncBatchType = getAsyncBatchType(asyncBatchRecord).orElse(null);
 		if (asyncBatchType == null)
@@ -458,6 +460,17 @@ public class AsyncBatchBL implements IAsyncBatchBL
 	{
 		return AsyncBatchTypeId.optionalOfRepoId(asyncBatch.getC_Async_Batch_Type_ID())
 				.map(this::getAsyncBatchTypeById);
+	}
+
+	@Override
+	public Optional<AsyncBatchType> getAsyncBatchType(@NonNull final AsyncBatchId asyncBatchId)
+	{
+		final I_C_Async_Batch asyncBatch = asyncBatchDAO.retrieveAsyncBatchRecordOutOfTrx(asyncBatchId);
+		if (asyncBatch == null)
+		{
+			return Optional.empty();
+		}
+		return getAsyncBatchType(asyncBatch);
 	}
 
 	@Override

--- a/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchBL.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/api/impl/AsyncBatchBL.java
@@ -169,8 +169,8 @@ public class AsyncBatchBL implements IAsyncBatchBL
 	public void enqueueAsyncBatch(@NonNull final AsyncBatchId asyncBatchId)
 	{
 		final I_C_Async_Batch asyncBatchRecord = asyncBatchDAO.retrieveAsyncBatchRecordOutOfTrx(asyncBatchId);
-		final Optional<AsyncBatchType> asyncBatchType = getAsyncBatchType(asyncBatchRecord);
-		if (asyncBatchType.isPresent() && !asyncBatchType.get().isCheckProcessedNeeded())
+		final AsyncBatchType asyncBatchType = getAsyncBatchType(asyncBatchRecord).orElse(null);
+		if (asyncBatchType != null && !asyncBatchType.isCheckProcessedNeeded())
 		{
 			// the batch's type has no consumer of the Processed flag (no IsCheckProcessed and no boilerplate) -> skip enqueuing the CheckProcessed WP
 			return;

--- a/backend/de.metas.async/src/main/sql/postgresql/system/42-de.metas.async/5812240_sys_C_Async_Batch_Type_IsCheckProcessed.sql
+++ b/backend/de.metas.async/src/main/sql/postgresql/system/42-de.metas.async/5812240_sys_C_Async_Batch_Type_IsCheckProcessed.sql
@@ -79,12 +79,12 @@ WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=592920
 INSERT INTO AD_Field (
     AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, Created, CreatedBy, DisplayLength,
     EntityType, IsActive, IsDisplayed, IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly,
-    IsSameLine, Name, SeqNo, Updated, UpdatedBy
+    IsSameLine, Name, SeqNo, SeqNoGrid, Updated, UpdatedBy
 ) VALUES (
     0, 592920, 781326 /*From ID Server*/, 0, 540640,
     TO_TIMESTAMP('2026-07-04 10:02:00','YYYY-MM-DD HH24:MI:SS'), 100, 1,
-    'de.metas.async', 'Y', 'Y', 'N', 'N', 'N', 'N', 'N',
-    'N', 'Verarbeitung prüfen', 65, TO_TIMESTAMP('2026-07-04 10:02:00','YYYY-MM-DD HH24:MI:SS'), 100
+    'de.metas.async', 'Y', 'Y', 'Y', 'N', 'N', 'N', 'N',
+    'N', 'Verarbeitung prüfen', 65, 60, TO_TIMESTAMP('2026-07-04 10:02:00','YYYY-MM-DD HH24:MI:SS'), 100
 )
 ;
 
@@ -112,7 +112,7 @@ INSERT INTO AD_UI_Element (
     IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy
 ) VALUES (
     0, 781326, 0, 540640, 541060, 652438 /*From ID Server*/, 'F',
-    TO_TIMESTAMP('2026-07-04 10:02:30','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'N', 'Y', 'N',
-    'N', 'N', 0, 'Verarbeitung prüfen', 20, 0, 0, TO_TIMESTAMP('2026-07-04 10:02:30','YYYY-MM-DD HH24:MI:SS'), 100
+    TO_TIMESTAMP('2026-07-04 10:02:30','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'N', 'Y', 'Y',
+    'N', 'N', 0, 'Verarbeitung prüfen', 20, 60, 0, TO_TIMESTAMP('2026-07-04 10:02:30','YYYY-MM-DD HH24:MI:SS'), 100
 )
 ;

--- a/backend/de.metas.async/src/main/sql/postgresql/system/42-de.metas.async/5812240_sys_C_Async_Batch_Type_IsCheckProcessed.sql
+++ b/backend/de.metas.async/src/main/sql/postgresql/system/42-de.metas.async/5812240_sys_C_Async_Batch_Type_IsCheckProcessed.sql
@@ -1,0 +1,118 @@
+-- IDs allocated from idserver.metas.de on 2026-07-04:
+--   AD_Element     585078 (IsCheckProcessed label for C_Async_Batch_Type)
+--   AD_Column      592920 (C_Async_Batch_Type.IsCheckProcessed)
+--   AD_Field       781326 (C_Async_Batch_Type maintenance window field)
+--   AD_UI_Element  652438 (WebUI element for the field)
+--
+-- Gates whether the CheckProcessedAsynBatch work-package is enqueued for a given async batch type.
+-- Default 'N'; seeded to 'Y' for the proven consumers in a follow-up migration.
+
+-- 1) AD_Element
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, ColumnName, EntityType, Name, PrintName, Description, Help)
+VALUES (585078 /*From ID Server*/, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-07-04 10:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+        TO_TIMESTAMP('2026-07-04 10:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+        'IsCheckProcessed', 'de.metas.async', 'Verarbeitung prüfen', 'Verarbeitung prüfen',
+        'Steuert, ob nach Abschluss aller Elemente eines Stapels dessen Verarbeitungsstatus geprüft und gesetzt wird.',
+        'Ist dieses Kennzeichen gesetzt, wird für Stapel dieses Typs nach Abschluss aller enthaltenen Elemente zusätzlich der Verarbeitungsstatus (Processed) des Stapels aktualisiert. Wird dies nicht benötigt, entfällt dieser zusätzliche Arbeitsschritt.')
+;
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Name, PrintName, Description, Help, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.Name, t.PrintName, t.Description, t.Help, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy,
+       TO_TIMESTAMP('2026-07-04 10:00:01','YYYY-MM-DD HH24:MI:SS'), 100, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Element_ID=585078
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+UPDATE AD_Element_Trl
+SET Name='Check Processed', PrintName='Check Processed',
+    Description='Controls whether, once all elements of a batch complete, the batch''s processed status is checked and set.',
+    Help='When enabled, an extra step verifies and updates the processed status of batches of this type once all their elements complete. When not needed, this step is skipped.',
+    IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-04 10:00:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Element_ID=585078
+;
+
+UPDATE AD_Element_Trl
+SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-04 10:00:03','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language IN ('de_DE','de_CH') AND AD_Element_ID=585078
+;
+
+-- 2) AD_Column on C_Async_Batch_Type (540625)
+INSERT INTO AD_Column (
+    AD_Client_ID, AD_Column_ID, AD_Element_ID, AD_Org_ID, AD_Reference_ID, AD_Table_ID, ColumnName,
+    Created, CreatedBy, DDL_NoForeignKey, DefaultValue, EntityType, FacetFilterSeqNo, FieldLength,
+    IsActive, IsAdvancedText, IsAllowLogging, IsAlwaysUpdateable, IsAutoApplyValidationRule, IsAutocomplete,
+    IsCalculated, IsDimension, IsDLMPartitionBoundary, IsEncrypted, IsExcludeFromZoomTargets, IsFacetFilter,
+    IsForceIncludeInGeneratedModel, IsGenericZoomKeyColumn, IsGenericZoomOrigin, IsIdentifier, IsKey,
+    IsLazyLoading, IsMandatory, IsParent, IsSelectionColumn, IsShowFilterIncrementButtons, IsShowFilterInline,
+    IsStaleable, IsSyncDatabase, IsTranslated, IsUpdateable, IsUseDocSequence, MaxFacetsToFetch, Name,
+    PersonalDataCategory, SelectionColumnSeqNo, SeqNo, Updated, UpdatedBy, Version
+) VALUES (
+    0, 592920 /*From ID Server*/, 585078 /*From ID Server*/, 0, 20, 540625, 'IsCheckProcessed',
+    TO_TIMESTAMP('2026-07-04 10:01:00','YYYY-MM-DD HH24:MI:SS'), 100, 'N', 'N', 'de.metas.async', 0, 1,
+    'Y', 'N', 'Y', 'N', 'N', 'N',
+    'N', 'N', 'N', 'N', 'Y', 'N',
+    'N', 'N', 'N', 'N', 'N',
+    'N', 'Y', 'N', 'N', 'N', 'N',
+    'N', 'N', 'N', 'Y', 'N', 0, 'Verarbeitung prüfen',
+    'NP', 0, 0, TO_TIMESTAMP('2026-07-04 10:01:00','YYYY-MM-DD HH24:MI:SS'), 100, 0
+)
+;
+
+INSERT INTO AD_Column_Trl (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy,
+       TO_TIMESTAMP('2026-07-04 10:01:01','YYYY-MM-DD HH24:MI:SS'), 100, 'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=592920
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+/* DDL */ select update_Column_Translation_From_AD_Element(585078)
+;
+
+-- 3) Physical DB column (new column -> ALTER TABLE ADD COLUMN wrapped in db_alter_table)
+/* DDL */ SELECT public.db_alter_table('C_Async_Batch_Type','ALTER TABLE public.C_Async_Batch_Type ADD COLUMN IsCheckProcessed CHAR(1) NOT NULL DEFAULT ''N''')
+;
+
+-- 4) AD_Field on the C_Async_Batch_Type maintenance tab (540640, window 540248)
+INSERT INTO AD_Field (
+    AD_Client_ID, AD_Column_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, Created, CreatedBy, DisplayLength,
+    EntityType, IsActive, IsDisplayed, IsDisplayedGrid, IsEncrypted, IsFieldOnly, IsHeading, IsReadOnly,
+    IsSameLine, Name, SeqNo, Updated, UpdatedBy
+) VALUES (
+    0, 592920, 781326 /*From ID Server*/, 0, 540640,
+    TO_TIMESTAMP('2026-07-04 10:02:00','YYYY-MM-DD HH24:MI:SS'), 100, 1,
+    'de.metas.async', 'Y', 'Y', 'N', 'N', 'N', 'N', 'N',
+    'N', 'Verarbeitung prüfen', 65, TO_TIMESTAMP('2026-07-04 10:02:00','YYYY-MM-DD HH24:MI:SS'), 100
+)
+;
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, Description, Help, Name, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description, t.Help, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy,
+       TO_TIMESTAMP('2026-07-04 10:02:01','YYYY-MM-DD HH24:MI:SS'), 100, 'Y'
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781326
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+/* DDL */ select update_FieldTranslation_From_AD_Name_Element(585078)
+;
+
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781326
+;
+
+/* DDL */ select AD_Element_Link_Create_Missing_Field(781326)
+;
+
+-- 5) WebUI placement — "flags" element group (541060), alongside IsActive (SeqNo 10)
+INSERT INTO AD_UI_Element (
+    AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+    Created, CreatedBy, IsActive, IsAdvancedField, IsAllowFiltering, IsDisplayed, IsDisplayedGrid,
+    IsDisplayed_SideList, IsMultiLine, MultiLine_LinesCount, Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy
+) VALUES (
+    0, 781326, 0, 540640, 541060, 652438 /*From ID Server*/, 'F',
+    TO_TIMESTAMP('2026-07-04 10:02:30','YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'N', 'Y', 'N',
+    'N', 'N', 0, 'Verarbeitung prüfen', 20, 0, 0, TO_TIMESTAMP('2026-07-04 10:02:30','YYYY-MM-DD HH24:MI:SS'), 100
+)
+;

--- a/backend/de.metas.async/src/main/sql/postgresql/system/42-de.metas.async/5812250_sys_C_Async_Batch_Type_IsCheckProcessed_seed.sql
+++ b/backend/de.metas.async/src/main/sql/postgresql/system/42-de.metas.async/5812250_sys_C_Async_Batch_Type_IsCheckProcessed_seed.sql
@@ -1,6 +1,13 @@
 -- Seed IsCheckProcessed='Y' for the exhaustive set of C_Async_Batch_Type rows whose
 -- Processed flag is actually consumed downstream (PDF-concat, serial-letter creation,
 -- and the two registered note listeners). Idempotent -- keyed on InternalName, not ID.
+--
+-- Not affected: the following types carry NotificationType='ABP' but are deliberately
+-- left IsCheckProcessed='N' because they have no active listener (no AD_BoilerPlate_ID,
+-- no registered note listener -- verified in code and by a live-instance probe):
+-- OLCand_Processing, ProcessOLCands, ShipmentSchedule_Processing, EnqueueScheduleForOrder,
+-- ReCreatePDF, VoidAndRecreateInvoice, EnqueueInvoiceCandidateForOrder,
+-- EnqueueInvoiceCandidateCreation.
 UPDATE C_Async_Batch_Type
 SET IsCheckProcessed='Y', Updated=TO_TIMESTAMP('2026-07-04 10:03:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE InternalName IN ('InvoiceCandidate_Processing','CreateLettersAsync','AutomaticallyInvoicePdfPrinting','PDFPrinting')

--- a/backend/de.metas.async/src/main/sql/postgresql/system/42-de.metas.async/5812250_sys_C_Async_Batch_Type_IsCheckProcessed_seed.sql
+++ b/backend/de.metas.async/src/main/sql/postgresql/system/42-de.metas.async/5812250_sys_C_Async_Batch_Type_IsCheckProcessed_seed.sql
@@ -1,0 +1,7 @@
+-- Seed IsCheckProcessed='Y' for the exhaustive set of C_Async_Batch_Type rows whose
+-- Processed flag is actually consumed downstream (PDF-concat, serial-letter creation,
+-- and the two registered note listeners). Idempotent -- keyed on InternalName, not ID.
+UPDATE C_Async_Batch_Type
+SET IsCheckProcessed='Y', Updated=TO_TIMESTAMP('2026-07-04 10:03:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE InternalName IN ('InvoiceCandidate_Processing','CreateLettersAsync','AutomaticallyInvoicePdfPrinting','PDFPrinting')
+;

--- a/backend/de.metas.async/src/main/sql/postgresql/system/42-de.metas.async/5812260_sys_cleanup_stuck_CheckProcessedAsynBatch.sql
+++ b/backend/de.metas.async/src/main/sql/postgresql/system/42-de.metas.async/5812260_sys_cleanup_stuck_CheckProcessedAsynBatch.sql
@@ -1,0 +1,62 @@
+/*
+ * #%L
+ * de.metas.async
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+-- One-time, idempotent, non-destructive cleanup of the CheckProcessedAsynBatch backlog.
+-- C_Async_Batch_Type.IsCheckProcessed (5812240/5812250) now gates enqueueing so that only
+-- consumer types get a CheckProcessedAsynBatch work-package. This backlog cleanup closes the
+-- already-accumulated stuck work-packages (and their orphan C_Async_Batch rows) for the
+-- non-consumer types, using the exact same predicate as the enqueue gate:
+--   IsCheckProcessed='N' AND (AD_Boilerplate_ID IS NULL OR AD_Boilerplate_ID<=0)
+-- Only flips Processed='Y' on rows currently Processed='N' -- no DELETE, no other column touched.
+-- Re-running is a no-op once every matching row is closed (WHERE Processed='N' guarantees this).
+
+SELECT backup_table('c_queue_workpackage', '_20260704_cleanup_stuck_checkprocessed')
+;
+
+SELECT backup_table('c_async_batch', '_20260704_cleanup_stuck_checkprocessed')
+;
+
+-- 1) Close the stuck CheckProcessedAsynBatch work-packages of non-consumer async batch types.
+UPDATE c_queue_workpackage wp
+SET processed='Y', Updated=TO_TIMESTAMP('2026-07-04 11:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=99
+FROM c_queue_packageprocessor pp, c_queue_element qe, c_async_batch b, c_async_batch_type t
+WHERE pp.c_queue_packageprocessor_id=wp.c_queue_packageprocessor_id
+  AND pp.classname LIKE '%CheckProcessedAsynBatch%'
+  AND wp.processed='N'
+  AND wp.iserror='N'
+  AND qe.c_queue_workpackage_id=wp.c_queue_workpackage_id
+  AND qe.ad_table_id=(SELECT ad_table_id FROM ad_table WHERE tablename='C_Async_Batch')
+  AND b.c_async_batch_id=qe.record_id
+  AND t.c_async_batch_type_id=b.c_async_batch_type_id
+  AND t.ischeckprocessed='N'
+  AND (t.ad_boilerplate_id IS NULL OR t.ad_boilerplate_id<=0)
+;
+
+-- 2) Close the orphan C_Async_Batch rows of non-consumer async batch types.
+UPDATE c_async_batch b
+SET processed='Y', Updated=TO_TIMESTAMP('2026-07-04 11:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=99
+FROM c_async_batch_type t
+WHERE t.c_async_batch_type_id=b.c_async_batch_type_id
+  AND b.processed='N'
+  AND t.ischeckprocessed='N'
+  AND (t.ad_boilerplate_id IS NULL OR t.ad_boilerplate_id<=0)
+;

--- a/backend/de.metas.async/src/test/java/de/metas/async/api/AsyncBatchTypeTest.java
+++ b/backend/de.metas.async/src/test/java/de/metas/async/api/AsyncBatchTypeTest.java
@@ -1,0 +1,74 @@
+/*
+ * #%L
+ * de.metas.async
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.async.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AsyncBatchTypeTest
+{
+	private AsyncBatchType.AsyncBatchTypeBuilder builder()
+	{
+		return AsyncBatchType.builder()
+				.id(AsyncBatchTypeId.ofRepoId(1))
+				.internalName("testInternalName")
+				.keepAlive(Duration.ZERO)
+				.skipTimeout(Duration.ZERO);
+	}
+
+	@Test
+	public void isCheckProcessedNeeded_checkProcessedTrue()
+	{
+		final AsyncBatchType asyncBatchType = builder()
+				.checkProcessed(true)
+				.adBoilderPlateId(0)
+				.build();
+
+		assertThat(asyncBatchType.isCheckProcessedNeeded()).isTrue();
+	}
+
+	@Test
+	public void isCheckProcessedNeeded_checkProcessedFalse_noBoilerplate()
+	{
+		final AsyncBatchType asyncBatchType = builder()
+				.checkProcessed(false)
+				.adBoilderPlateId(0)
+				.build();
+
+		assertThat(asyncBatchType.isCheckProcessedNeeded()).isFalse();
+	}
+
+	@Test
+	public void isCheckProcessedNeeded_checkProcessedFalse_withBoilerplate()
+	{
+		final AsyncBatchType asyncBatchType = builder()
+				.checkProcessed(false)
+				.adBoilderPlateId(12345)
+				.build();
+
+		assertThat(asyncBatchType.isCheckProcessedNeeded()).isTrue();
+	}
+}

--- a/backend/de.metas.async/src/test/java/de/metas/async/api/impl/AsyncBatchBLTest.java
+++ b/backend/de.metas.async/src/test/java/de/metas/async/api/impl/AsyncBatchBLTest.java
@@ -1,6 +1,7 @@
 package de.metas.async.api.impl;
 
 import de.metas.async.AsyncBatchId;
+import de.metas.async.api.IAsyncBatchDAO;
 import de.metas.async.model.I_C_Async_Batch;
 import de.metas.async.model.I_C_Async_Batch_Type;
 import de.metas.async.model.I_C_Queue_WorkPackage;
@@ -128,6 +129,32 @@ public class AsyncBatchBLTest
 			asyncBatchBL.enqueueAsyncBatch(asyncBatchId);
 
 			// then
+			Assertions.assertThat(countCheckProcessedWorkPackages()).isEqualTo(1);
+		}
+
+		@Test
+		public void nullBatchRecord_doesNotThrowNPE_andEnqueues()
+		{
+			// given: the DAO returns null for the id (the production "record not found out-of-trx" path;
+			// the in-memory POJOLookupMap would instead throw, so we register a DAO that returns null).
+			final AsyncBatchId asyncBatchId = AsyncBatchId.ofRepoId(999_999);
+			Services.registerService(IAsyncBatchDAO.class, new AsyncBatchDAO()
+			{
+				@Override
+				public I_C_Async_Batch retrieveAsyncBatchRecordOutOfTrx(final AsyncBatchId id)
+				{
+					return null;
+				}
+			});
+			final AsyncBatchBL blWithNullReturningDao = new AsyncBatchBL();
+			blWithNullReturningDao.setUseMetasfreshSystemTime(true);
+
+			// then: the null-safe overload yields empty rather than NPE...
+			Assertions.assertThat(blWithNullReturningDao.getAsyncBatchType(asyncBatchId)).isEmpty();
+
+			// ...and the enqueue gate must not NPE (defaults to enqueuing the CheckProcessed WP)
+			Assertions.assertThatCode(() -> blWithNullReturningDao.enqueueAsyncBatch(asyncBatchId))
+					.doesNotThrowAnyException();
 			Assertions.assertThat(countCheckProcessedWorkPackages()).isEqualTo(1);
 		}
 	}

--- a/backend/de.metas.async/src/test/java/de/metas/async/api/impl/AsyncBatchBLTest.java
+++ b/backend/de.metas.async/src/test/java/de/metas/async/api/impl/AsyncBatchBLTest.java
@@ -1,7 +1,13 @@
 package de.metas.async.api.impl;
 
+import de.metas.async.AsyncBatchId;
 import de.metas.async.model.I_C_Async_Batch;
+import de.metas.async.model.I_C_Async_Batch_Type;
+import de.metas.async.model.I_C_Queue_WorkPackage;
+import de.metas.async.processor.impl.CheckProcessedAsynBatchWorkpackageProcessor;
 import de.metas.common.util.time.SystemTime;
+import de.metas.util.Services;
+import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
@@ -64,5 +70,90 @@ public class AsyncBatchBLTest
 	private I_C_Async_Batch newAsyncBatch()
 	{
 		return InterfaceWrapperHelper.create(ctx, I_C_Async_Batch.class, ITrx.TRXNAME_None);
+	}
+
+	@Test
+	public void givenNonConsumerAsyncBatchType_whenEnqueueAsyncBatch_thenNoCheckProcessedWorkPackageIsCreated()
+	{
+		// given: a C_Async_Batch_Type that nobody consumes (IsCheckProcessed='N', no boilerplate)
+		final I_C_Async_Batch_Type asyncBatchType = newAsyncBatchType();
+		asyncBatchType.setIsCheckProcessed(false);
+		asyncBatchType.setAD_BoilerPlate_ID(0);
+		InterfaceWrapperHelper.save(asyncBatchType);
+
+		final AsyncBatchId asyncBatchId = createAsyncBatchOfType(asyncBatchType);
+
+		// when
+		asyncBatchBL.enqueueAsyncBatch(asyncBatchId);
+
+		// then: AC1 - the gate must SKIP creating the CheckProcessedAsynBatch work-package
+		Assertions.assertThat(countCheckProcessedWorkPackages()).isZero();
+	}
+
+	@Test
+	public void givenConsumerAsyncBatchType_whenEnqueueAsyncBatch_thenCheckProcessedWorkPackageIsCreated()
+	{
+		// given: a C_Async_Batch_Type that IS a consumer of the Processed flag (IsCheckProcessed='Y')
+		final I_C_Async_Batch_Type asyncBatchType = newAsyncBatchType();
+		asyncBatchType.setIsCheckProcessed(true);
+		asyncBatchType.setAD_BoilerPlate_ID(0);
+		InterfaceWrapperHelper.save(asyncBatchType);
+
+		final AsyncBatchId asyncBatchId = createAsyncBatchOfType(asyncBatchType);
+
+		// when
+		asyncBatchBL.enqueueAsyncBatch(asyncBatchId);
+
+		// then: AC2 - the gate must CREATE exactly one CheckProcessedAsynBatch work-package
+		Assertions.assertThat(countCheckProcessedWorkPackages()).isEqualTo(1);
+	}
+
+	@Test
+	public void givenBoilerplateAsyncBatchType_whenEnqueueAsyncBatch_thenCheckProcessedWorkPackageIsCreated()
+	{
+		// given: IsCheckProcessed='N' but AD_BoilerPlate_ID>0 -> boilerplate is also a consumer of the Processed flag
+		final I_C_Async_Batch_Type asyncBatchType = newAsyncBatchType();
+		asyncBatchType.setIsCheckProcessed(false);
+		asyncBatchType.setAD_BoilerPlate_ID(1_000_000);
+		InterfaceWrapperHelper.save(asyncBatchType);
+
+		final AsyncBatchId asyncBatchId = createAsyncBatchOfType(asyncBatchType);
+
+		// when
+		asyncBatchBL.enqueueAsyncBatch(asyncBatchId);
+
+		// then
+		Assertions.assertThat(countCheckProcessedWorkPackages()).isEqualTo(1);
+	}
+
+	private I_C_Async_Batch_Type newAsyncBatchType()
+	{
+		final I_C_Async_Batch_Type asyncBatchType = InterfaceWrapperHelper.create(ctx, I_C_Async_Batch_Type.class, ITrx.TRXNAME_None);
+		asyncBatchType.setInternalName(getClass().getSimpleName() + "_" + java.util.UUID.randomUUID());
+		return asyncBatchType;
+	}
+
+	private AsyncBatchId createAsyncBatchOfType(final I_C_Async_Batch_Type asyncBatchType)
+	{
+		final I_C_Async_Batch asyncBatch = newAsyncBatch();
+		asyncBatch.setC_Async_Batch_Type_ID(asyncBatchType.getC_Async_Batch_Type_ID());
+		InterfaceWrapperHelper.save(asyncBatch);
+
+		return AsyncBatchId.ofRepoId(asyncBatch.getC_Async_Batch_ID());
+	}
+
+	/**
+	 * Counts the real {@link I_C_Queue_WorkPackage} rows enqueued for {@link CheckProcessedAsynBatchWorkpackageProcessor} -
+	 * i.e. the actual side effect that {@link AsyncBatchBL#enqueueAsyncBatch(AsyncBatchId)} is supposed to gate.
+	 */
+	private long countCheckProcessedWorkPackages()
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_C_Queue_WorkPackage.class)
+				.create()
+				.stream()
+				.filter(workPackage -> workPackage.getC_Queue_PackageProcessor() != null
+						&& CheckProcessedAsynBatchWorkpackageProcessor.class.getCanonicalName().equals(workPackage.getC_Queue_PackageProcessor().getClassname()))
+				.count();
 	}
 }

--- a/backend/de.metas.async/src/test/java/de/metas/async/api/impl/AsyncBatchBLTest.java
+++ b/backend/de.metas.async/src/test/java/de/metas/async/api/impl/AsyncBatchBLTest.java
@@ -156,7 +156,23 @@ public class AsyncBatchBLTest
 			Assertions.assertThatCode(() -> blWithNullReturningDao.enqueueAsyncBatch(asyncBatchId))
 					.doesNotThrowAnyException();
 			Assertions.assertThat(countCheckProcessedWorkPackages()).isEqualTo(1);
+
+			// ...and the CheckProcessed processWorkPackage chain (updateProcessedOutOfTrx -> keepAliveTimeExpired)
+			// must not NPE either. updateProcessedOutOfTrx runs FIRST, so it must handle the null record:
+			// a vanished batch -> "processed" so the checker WP completes rather than looping forever.
+			Assertions.assertThat(blWithNullReturningDao.updateProcessedOutOfTrx(asyncBatchId)).isTrue();
+			Assertions.assertThat(blWithNullReturningDao.keepAliveTimeExpired(asyncBatchId)).isFalse();
+			Assertions.assertThatCode(() -> blWithNullReturningDao.increaseProcessed(newAsyncBatchWorkPackage(asyncBatchId)))
+					.doesNotThrowAnyException();
 		}
+	}
+
+	private I_C_Queue_WorkPackage newAsyncBatchWorkPackage(final AsyncBatchId asyncBatchId)
+	{
+		final I_C_Queue_WorkPackage workPackage = InterfaceWrapperHelper.create(ctx, I_C_Queue_WorkPackage.class, ITrx.TRXNAME_None);
+		workPackage.setC_Async_Batch_ID(asyncBatchId.getRepoId());
+		InterfaceWrapperHelper.save(workPackage);
+		return workPackage;
 	}
 
 	private I_C_Async_Batch_Type newAsyncBatchType()

--- a/backend/de.metas.async/src/test/java/de/metas/async/api/impl/AsyncBatchBLTest.java
+++ b/backend/de.metas.async/src/test/java/de/metas/async/api/impl/AsyncBatchBLTest.java
@@ -15,11 +15,13 @@ import org.assertj.core.api.Assertions;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.util.Properties;
+import java.util.UUID;
 
 public class AsyncBatchBLTest
 {
@@ -72,64 +74,68 @@ public class AsyncBatchBLTest
 		return InterfaceWrapperHelper.create(ctx, I_C_Async_Batch.class, ITrx.TRXNAME_None);
 	}
 
-	@Test
-	public void givenNonConsumerAsyncBatchType_whenEnqueueAsyncBatch_thenNoCheckProcessedWorkPackageIsCreated()
+	@Nested
+	class EnqueueAsyncBatch
 	{
-		// given: a C_Async_Batch_Type that nobody consumes (IsCheckProcessed='N', no boilerplate)
-		final I_C_Async_Batch_Type asyncBatchType = newAsyncBatchType();
-		asyncBatchType.setIsCheckProcessed(false);
-		asyncBatchType.setAD_BoilerPlate_ID(0);
-		InterfaceWrapperHelper.save(asyncBatchType);
+		@Test
+		public void nonConsumerType_skipsCheckProcessedWorkPackage()
+		{
+			// given: a C_Async_Batch_Type that nobody consumes (IsCheckProcessed='N', no boilerplate)
+			final I_C_Async_Batch_Type asyncBatchType = newAsyncBatchType();
+			asyncBatchType.setIsCheckProcessed(false);
+			asyncBatchType.setAD_BoilerPlate_ID(0);
+			InterfaceWrapperHelper.save(asyncBatchType);
 
-		final AsyncBatchId asyncBatchId = createAsyncBatchOfType(asyncBatchType);
+			final AsyncBatchId asyncBatchId = createAsyncBatchOfType(asyncBatchType);
 
-		// when
-		asyncBatchBL.enqueueAsyncBatch(asyncBatchId);
+			// when
+			asyncBatchBL.enqueueAsyncBatch(asyncBatchId);
 
-		// then: AC1 - the gate must SKIP creating the CheckProcessedAsynBatch work-package
-		Assertions.assertThat(countCheckProcessedWorkPackages()).isZero();
-	}
+			// then: AC1 - the gate must SKIP creating the CheckProcessedAsynBatch work-package
+			Assertions.assertThat(countCheckProcessedWorkPackages()).isZero();
+		}
 
-	@Test
-	public void givenConsumerAsyncBatchType_whenEnqueueAsyncBatch_thenCheckProcessedWorkPackageIsCreated()
-	{
-		// given: a C_Async_Batch_Type that IS a consumer of the Processed flag (IsCheckProcessed='Y')
-		final I_C_Async_Batch_Type asyncBatchType = newAsyncBatchType();
-		asyncBatchType.setIsCheckProcessed(true);
-		asyncBatchType.setAD_BoilerPlate_ID(0);
-		InterfaceWrapperHelper.save(asyncBatchType);
+		@Test
+		public void consumerType_createsCheckProcessedWorkPackage()
+		{
+			// given: a C_Async_Batch_Type that IS a consumer of the Processed flag (IsCheckProcessed='Y')
+			final I_C_Async_Batch_Type asyncBatchType = newAsyncBatchType();
+			asyncBatchType.setIsCheckProcessed(true);
+			asyncBatchType.setAD_BoilerPlate_ID(0);
+			InterfaceWrapperHelper.save(asyncBatchType);
 
-		final AsyncBatchId asyncBatchId = createAsyncBatchOfType(asyncBatchType);
+			final AsyncBatchId asyncBatchId = createAsyncBatchOfType(asyncBatchType);
 
-		// when
-		asyncBatchBL.enqueueAsyncBatch(asyncBatchId);
+			// when
+			asyncBatchBL.enqueueAsyncBatch(asyncBatchId);
 
-		// then: AC2 - the gate must CREATE exactly one CheckProcessedAsynBatch work-package
-		Assertions.assertThat(countCheckProcessedWorkPackages()).isEqualTo(1);
-	}
+			// then: AC2 - the gate must CREATE exactly one CheckProcessedAsynBatch work-package
+			Assertions.assertThat(countCheckProcessedWorkPackages()).isEqualTo(1);
+		}
 
-	@Test
-	public void givenBoilerplateAsyncBatchType_whenEnqueueAsyncBatch_thenCheckProcessedWorkPackageIsCreated()
-	{
-		// given: IsCheckProcessed='N' but AD_BoilerPlate_ID>0 -> boilerplate is also a consumer of the Processed flag
-		final I_C_Async_Batch_Type asyncBatchType = newAsyncBatchType();
-		asyncBatchType.setIsCheckProcessed(false);
-		asyncBatchType.setAD_BoilerPlate_ID(1_000_000);
-		InterfaceWrapperHelper.save(asyncBatchType);
+		@Test
+		public void boilerplateType_createsCheckProcessedWorkPackage()
+		{
+			// given: IsCheckProcessed='N' but AD_BoilerPlate_ID>0 -> boilerplate is also a consumer of the Processed flag
+			final I_C_Async_Batch_Type asyncBatchType = newAsyncBatchType();
+			asyncBatchType.setIsCheckProcessed(false);
+			asyncBatchType.setAD_BoilerPlate_ID(1_000_000);
+			InterfaceWrapperHelper.save(asyncBatchType);
 
-		final AsyncBatchId asyncBatchId = createAsyncBatchOfType(asyncBatchType);
+			final AsyncBatchId asyncBatchId = createAsyncBatchOfType(asyncBatchType);
 
-		// when
-		asyncBatchBL.enqueueAsyncBatch(asyncBatchId);
+			// when
+			asyncBatchBL.enqueueAsyncBatch(asyncBatchId);
 
-		// then
-		Assertions.assertThat(countCheckProcessedWorkPackages()).isEqualTo(1);
+			// then
+			Assertions.assertThat(countCheckProcessedWorkPackages()).isEqualTo(1);
+		}
 	}
 
 	private I_C_Async_Batch_Type newAsyncBatchType()
 	{
 		final I_C_Async_Batch_Type asyncBatchType = InterfaceWrapperHelper.create(ctx, I_C_Async_Batch_Type.class, ITrx.TRXNAME_None);
-		asyncBatchType.setInternalName(getClass().getSimpleName() + "_" + java.util.UUID.randomUUID());
+		asyncBatchType.setInternalName(getClass().getSimpleName() + "_" + UUID.randomUUID());
 		return asyncBatchType;
 	}
 

--- a/backend/de.metas.async/src/test/java/de/metas/async/api/impl/AsyncBatchBLTest.java
+++ b/backend/de.metas.async/src/test/java/de/metas/async/api/impl/AsyncBatchBLTest.java
@@ -164,6 +164,13 @@ public class AsyncBatchBLTest
 			Assertions.assertThat(blWithNullReturningDao.keepAliveTimeExpired(asyncBatchId)).isFalse();
 			Assertions.assertThatCode(() -> blWithNullReturningDao.increaseProcessed(newAsyncBatchWorkPackage(asyncBatchId)))
 					.doesNotThrowAnyException();
+
+			// ...and the enqueued-count updaters (increaseEnqueued/decreaseEnqueued -> setAsyncBatchCountEnqueued)
+			// must not NPE on the null out-of-trx record path either.
+			Assertions.assertThatCode(() -> blWithNullReturningDao.increaseEnqueued(newAsyncBatchWorkPackage(asyncBatchId)))
+					.doesNotThrowAnyException();
+			Assertions.assertThatCode(() -> blWithNullReturningDao.decreaseEnqueued(newAsyncBatchWorkPackage(asyncBatchId)))
+					.doesNotThrowAnyException();
 		}
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
@@ -97,6 +97,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -688,8 +689,14 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 			return;
 		}
 
-		// Track which schedules were fully shipped in this shipment (MovementQty >= QtyOrdered)
-		final HashSet<ShipmentScheduleId> fullyShippedScheduleIds = new HashSet<>();
+		// Sum up how much each schedule got delivered by THIS shipment (MovementQty), per schedule.
+		// Note on timing: this method runs synchronously at TIMING_AFTER_COMPLETE of the M_InOut, but the
+		// schedule's own QtyDelivered is only updated in a runAfterCommit hook (see
+		// M_InOut_Shipment.invalidateShipmentSchedulesForLines), i.e. AFTER this method. So at this point
+		// QtyDelivered does NOT yet reflect the current shipment - it only reflects deliveries from sibling
+		// shipments of the same order that were completed in earlier, already-committed transactions.
+		// We therefore add this shipment's just-shipped MovementQty on top of QtyDelivered below.
+		final HashMap<ShipmentScheduleId, BigDecimal> qtyDeliveredByThisShipmentByScheduleId = new HashMap<>();
 		final HashSet<OrderId> orderIds = new HashSet<>();
 
 		for (final I_M_InOutLine iolrecord : inOutDAO.retrieveLines(inoutRecord))
@@ -705,34 +712,42 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 						orderIds.add(orderId);
 					}
 
-					if (iolrecord.getMovementQty().compareTo(shipmentScheduleRecord.getQtyOrdered()) >= 0)
-					{
-						fullyShippedScheduleIds.add(scheduleId);
-					}
+					qtyDeliveredByThisShipmentByScheduleId.merge(scheduleId, iolrecord.getMovementQty(), BigDecimal::add);
 				}
 			}
 		}
 
-		// Close all schedules from the involved orders that were NOT fully shipped.
-		// This includes partially shipped schedules (MovementQty < QtyOrdered) and
-		// completely unshipped schedules (no shipment line at all).
+		// Close all not-yet-closed schedules of the involved orders that are NOT already fully delivered.
+		// A schedule that is already fully delivered must stay open, regardless of which shipment delivered
+		// it: whether by THIS shipment (its MovementQty is not yet in QtyDelivered - see above) or by a
+		// sibling shipment of the same order (multi-InOut split; its qty IS already in QtyDelivered).
+		// Only genuinely partially/unshipped schedules are closed here.
 		for (final OrderId orderId : orderIds)
 		{
 			final ImmutableSet<ShipmentScheduleId> allScheduleIds = shipmentSchedulePA.retrieveScheduleIdsByOrderId(orderId);
 			for (final ShipmentScheduleId scheduleId : allScheduleIds)
 			{
-				if (fullyShippedScheduleIds.contains(scheduleId))
+				final I_M_ShipmentSchedule schedule = shipmentSchedulePA.getById(scheduleId);
+				if (schedule.isClosed())
 				{
-					logger.debug("Not closing shipment schedule {} - fully shipped in this delivery", scheduleId);
 					continue;
 				}
 
-				final I_M_ShipmentSchedule schedule = shipmentSchedulePA.getById(scheduleId);
-				if (!schedule.isClosed())
+				final BigDecimal effectiveQtyOrdered = shipmentScheduleEffectiveBL.computeQtyOrdered(schedule);
+
+				final BigDecimal qtyDeliveredPersisted = schedule.getQtyDelivered() != null ? schedule.getQtyDelivered() : BigDecimal.ZERO;
+				final BigDecimal qtyDeliveredThisShipment = qtyDeliveredByThisShipmentByScheduleId.getOrDefault(scheduleId, BigDecimal.ZERO);
+				final BigDecimal qtyDeliveredTotal = qtyDeliveredPersisted.add(qtyDeliveredThisShipment);
+
+				if (qtyDeliveredTotal.compareTo(effectiveQtyOrdered) >= 0)
 				{
-					logger.debug("Closing shipment schedule {} for order {} (M_ShipmentSchedule_Close_PartiallyShipped=Y)", scheduleId, orderId);
-					closeShipmentSchedule(schedule);
+					logger.debug("Not closing shipment schedule {} - already fully delivered (qtyDeliveredTotal={} >= effectiveQtyOrdered={})",
+							scheduleId, qtyDeliveredTotal, effectiveQtyOrdered);
+					continue;
 				}
+
+				logger.debug("Closing shipment schedule {} for order {} (M_ShipmentSchedule_Close_PartiallyShipped=Y)", scheduleId, orderId);
+				closeShipmentSchedule(schedule);
 			}
 		}
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
@@ -10,6 +10,7 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.bpartner.ShipmentAllocationBestBeforePolicy;
 import de.metas.bpartner.service.IBPartnerBL;
+import de.metas.common.util.CoalesceUtil;
 import de.metas.common.util.time.SystemTime;
 import de.metas.document.location.DocumentLocation;
 import de.metas.document.location.IDocumentLocationBL;
@@ -735,7 +736,7 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 
 				final BigDecimal effectiveQtyOrdered = shipmentScheduleEffectiveBL.computeQtyOrdered(schedule);
 
-				final BigDecimal qtyDeliveredPersisted = schedule.getQtyDelivered() != null ? schedule.getQtyDelivered() : BigDecimal.ZERO;
+				final BigDecimal qtyDeliveredPersisted = CoalesceUtil.coalesce(schedule.getQtyDelivered(), BigDecimal.ZERO);
 				final BigDecimal qtyDeliveredThisShipment = qtyDeliveredByThisShipmentByScheduleId.getOrDefault(scheduleId, BigDecimal.ZERO);
 				final BigDecimal qtyDeliveredTotal = qtyDeliveredPersisted.add(qtyDeliveredThisShipment);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL_closePartiallyShipped_Test.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL_closePartiallyShipped_Test.java
@@ -1,0 +1,149 @@
+package de.metas.inoutcandidate.api.impl;
+
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.inoutcandidate.api.IShipmentScheduleBL;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.organization.OrgId;
+import de.metas.util.Services;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.service.ISysConfigBL;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_OrderLine;
+import org.compiere.model.I_M_InOut;
+import org.compiere.model.I_M_InOutLine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.refresh;
+import static org.adempiere.model.InterfaceWrapperHelper.save;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test: when a single sales order's shipment schedules get shipped via TWO (or more)
+ * separate {@code M_InOut} documents (e.g. a picking job split by the async shipment-generation
+ * pipeline), a schedule that was already fully delivered by a <b>sibling</b> {@code M_InOut} must
+ * not be wrongly closed when a later, unrelated sibling {@code M_InOut} of the same order completes.
+ * <p>
+ * {@link ShipmentScheduleBL#closePartiallyShipped_ShipmentSchedules(I_M_InOut)} only looked at the
+ * lines of the <b>current</b> {@code M_InOut} to decide which schedules were "fully shipped" before
+ * closing every other not-yet-closed schedule of the order — so a schedule fully delivered by a
+ * previous, separate {@code M_InOut} was invisible to that check and got closed.
+ */
+public class ShipmentScheduleBL_closePartiallyShipped_Test
+{
+	private ShipmentScheduleBL shipmentScheduleBL;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+		shipmentScheduleBL = (ShipmentScheduleBL)Services.get(IShipmentScheduleBL.class);
+	}
+
+	@Test
+	public void closePartiallyShipped_ShipmentSchedules_doesNotCloseScheduleAlreadyFullyDeliveredBySiblingInOut()
+	{
+		final OrgId orgId = OrgId.ANY;
+
+		// enable "close partially shipped schedules" for this org
+		Services.get(ISysConfigBL.class).setValue(
+				"M_ShipmentSchedule_Close_PartiallyShipped",
+				true,
+				ClientId.METASFRESH,
+				orgId);
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setIsSOTrx(true);
+		save(order);
+
+		// S_full: already fully delivered by a SIBLING M_InOut (not part of this test's inout at all)
+		final I_C_OrderLine orderLineFull = newInstance(I_C_OrderLine.class);
+		orderLineFull.setC_Order(order);
+		save(orderLineFull);
+
+		final int orderLineTableId = InterfaceWrapperHelper.getTableId(I_C_OrderLine.class);
+
+		final I_M_ShipmentSchedule scheduleFull = newInstance(I_M_ShipmentSchedule.class);
+		scheduleFull.setAD_Org_ID(orgId.getRepoId());
+		scheduleFull.setC_Order_ID(order.getC_Order_ID());
+		scheduleFull.setC_OrderLine_ID(orderLineFull.getC_OrderLine_ID());
+		// M_ShipmentSchedule links to its order line via the generic (AD_Table_ID, Record_ID) reference
+		scheduleFull.setAD_Table_ID(orderLineTableId);
+		scheduleFull.setRecord_ID(orderLineFull.getC_OrderLine_ID());
+		scheduleFull.setQtyOrdered(new BigDecimal("12"));
+		scheduleFull.setQtyOrdered_Calculated(new BigDecimal("12")); // effective QtyOrdered (no override)
+		scheduleFull.setQtyDelivered(new BigDecimal("12")); // fully delivered already, e.g. by a sibling InOut
+		scheduleFull.setIsClosed(false);
+		save(scheduleFull);
+
+		// S_partial: shipped by the CURRENT InOut with MovementQty=8 of 12 ordered (partial delivery).
+		// QtyDelivered is still 0 at TIMING_AFTER_COMPLETE - the QtyPicked->QtyDelivered shift for this
+		// InOut happens in a runAfterCommit hook that fires AFTER closePartiallyShipped runs.
+		final I_C_OrderLine orderLinePartial = newInstance(I_C_OrderLine.class);
+		orderLinePartial.setC_Order(order);
+		save(orderLinePartial);
+
+		final I_M_ShipmentSchedule schedulePartial = newInstance(I_M_ShipmentSchedule.class);
+		schedulePartial.setAD_Org_ID(orgId.getRepoId());
+		schedulePartial.setC_Order_ID(order.getC_Order_ID());
+		schedulePartial.setC_OrderLine_ID(orderLinePartial.getC_OrderLine_ID());
+		schedulePartial.setAD_Table_ID(orderLineTableId);
+		schedulePartial.setRecord_ID(orderLinePartial.getC_OrderLine_ID());
+		schedulePartial.setQtyOrdered(new BigDecimal("12"));
+		schedulePartial.setQtyOrdered_Calculated(new BigDecimal("12")); // effective QtyOrdered (no override)
+		schedulePartial.setQtyDelivered(BigDecimal.ZERO); // not yet updated for THIS InOut at close-time
+		schedulePartial.setIsClosed(false);
+		save(schedulePartial);
+
+		// the M_InOut being completed now contains ONLY S_partial's line (simulating the sibling-InOut split:
+		// S_full was already delivered by a *different*, previously completed M_InOut)
+		final I_M_InOut inout = newInstance(I_M_InOut.class);
+		inout.setAD_Org_ID(orgId.getRepoId());
+		inout.setIsSOTrx(true);
+		save(inout);
+
+		final I_M_InOutLine inoutLinePartial = newInstance(I_M_InOutLine.class);
+		inoutLinePartial.setM_InOut(inout);
+		inoutLinePartial.setC_OrderLine_ID(orderLinePartial.getC_OrderLine_ID());
+		inoutLinePartial.setMovementQty(new BigDecimal("8"));
+		save(inoutLinePartial);
+
+		shipmentScheduleBL.closePartiallyShipped_ShipmentSchedules(inout);
+
+		refresh(scheduleFull);
+		refresh(schedulePartial);
+
+		assertThat(scheduleFull.isClosed())
+				.as("S_full is already fully delivered (by a sibling InOut) and must stay open")
+				.isFalse();
+		assertThat(schedulePartial.isClosed())
+				.as("S_partial is not fully delivered and M_ShipmentSchedule_Close_PartiallyShipped=Y => must be closed")
+				.isTrue();
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL_closePartiallyShipped_Test.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL_closePartiallyShipped_Test.java
@@ -146,4 +146,136 @@ public class ShipmentScheduleBL_closePartiallyShipped_Test
 				.as("S_partial is not fully delivered and M_ShipmentSchedule_Close_PartiallyShipped=Y => must be closed")
 				.isTrue();
 	}
+
+	@Test
+	public void closePartiallyShipped_ShipmentSchedules_closesCompletelyUnshippedSchedule()
+	{
+		final OrgId orgId = OrgId.ANY;
+
+		// enable "close partially shipped schedules" for this org
+		Services.get(ISysConfigBL.class).setValue(
+				"M_ShipmentSchedule_Close_PartiallyShipped",
+				true,
+				ClientId.METASFRESH,
+				orgId);
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setIsSOTrx(true);
+		save(order);
+
+		final int orderLineTableId = InterfaceWrapperHelper.getTableId(I_C_OrderLine.class);
+
+		// S_unshipped: zero delivery anywhere (not persisted, not on ANY M_InOut line, not even the current one)
+		final I_C_OrderLine orderLineUnshipped = newInstance(I_C_OrderLine.class);
+		orderLineUnshipped.setC_Order(order);
+		save(orderLineUnshipped);
+
+		final I_M_ShipmentSchedule scheduleUnshipped = newInstance(I_M_ShipmentSchedule.class);
+		scheduleUnshipped.setAD_Org_ID(orgId.getRepoId());
+		scheduleUnshipped.setC_Order_ID(order.getC_Order_ID());
+		scheduleUnshipped.setC_OrderLine_ID(orderLineUnshipped.getC_OrderLine_ID());
+		scheduleUnshipped.setAD_Table_ID(orderLineTableId);
+		scheduleUnshipped.setRecord_ID(orderLineUnshipped.getC_OrderLine_ID());
+		scheduleUnshipped.setQtyOrdered(new BigDecimal("12"));
+		scheduleUnshipped.setQtyOrdered_Calculated(new BigDecimal("12")); // effective QtyOrdered (no override)
+		scheduleUnshipped.setQtyDelivered(BigDecimal.ZERO); // never delivered
+		scheduleUnshipped.setIsClosed(false);
+		save(scheduleUnshipped);
+
+		// S_shipped: another schedule of the SAME order, fully shipped by the CURRENT InOut - only needed so
+		// the order gets picked up by closePartiallyShipped_ShipmentSchedules (which derives the order(s) to
+		// process from the current InOut's lines).
+		final I_C_OrderLine orderLineShipped = newInstance(I_C_OrderLine.class);
+		orderLineShipped.setC_Order(order);
+		save(orderLineShipped);
+
+		final I_M_ShipmentSchedule scheduleShipped = newInstance(I_M_ShipmentSchedule.class);
+		scheduleShipped.setAD_Org_ID(orgId.getRepoId());
+		scheduleShipped.setC_Order_ID(order.getC_Order_ID());
+		scheduleShipped.setC_OrderLine_ID(orderLineShipped.getC_OrderLine_ID());
+		scheduleShipped.setAD_Table_ID(orderLineTableId);
+		scheduleShipped.setRecord_ID(orderLineShipped.getC_OrderLine_ID());
+		scheduleShipped.setQtyOrdered(new BigDecimal("12"));
+		scheduleShipped.setQtyOrdered_Calculated(new BigDecimal("12")); // effective QtyOrdered (no override)
+		scheduleShipped.setQtyDelivered(BigDecimal.ZERO); // not yet updated for THIS InOut at close-time
+		scheduleShipped.setIsClosed(false);
+		save(scheduleShipped);
+
+		final I_M_InOut inout = newInstance(I_M_InOut.class);
+		inout.setAD_Org_ID(orgId.getRepoId());
+		inout.setIsSOTrx(true);
+		save(inout);
+
+		final I_M_InOutLine inoutLineShipped = newInstance(I_M_InOutLine.class);
+		inoutLineShipped.setM_InOut(inout);
+		inoutLineShipped.setC_OrderLine_ID(orderLineShipped.getC_OrderLine_ID());
+		inoutLineShipped.setMovementQty(new BigDecimal("12"));
+		save(inoutLineShipped);
+
+		shipmentScheduleBL.closePartiallyShipped_ShipmentSchedules(inout);
+
+		refresh(scheduleUnshipped);
+
+		assertThat(scheduleUnshipped.isClosed())
+				.as("S_unshipped has zero delivery anywhere (persisted and current shipment) and M_ShipmentSchedule_Close_PartiallyShipped=Y => must be closed")
+				.isTrue();
+	}
+
+	@Test
+	public void closePartiallyShipped_ShipmentSchedules_doesNotCloseScheduleFullyDeliveredSolelyByCurrentInOut()
+	{
+		final OrgId orgId = OrgId.ANY;
+
+		// enable "close partially shipped schedules" for this org
+		Services.get(ISysConfigBL.class).setValue(
+				"M_ShipmentSchedule_Close_PartiallyShipped",
+				true,
+				ClientId.METASFRESH,
+				orgId);
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setIsSOTrx(true);
+		save(order);
+
+		final int orderLineTableId = InterfaceWrapperHelper.getTableId(I_C_OrderLine.class);
+
+		// S_currentFull: fully delivered SOLELY by the CURRENT InOut's line (MovementQty=12 == QtyOrdered=12).
+		// Persisted QtyDelivered is still 0 at TIMING_AFTER_COMPLETE (see timing note in the sibling test
+		// above) - this exercises the "add this shipment's MovementQty on top of persisted QtyDelivered" path
+		// for the CURRENT (non-split) InOut.
+		final I_C_OrderLine orderLineCurrentFull = newInstance(I_C_OrderLine.class);
+		orderLineCurrentFull.setC_Order(order);
+		save(orderLineCurrentFull);
+
+		final I_M_ShipmentSchedule scheduleCurrentFull = newInstance(I_M_ShipmentSchedule.class);
+		scheduleCurrentFull.setAD_Org_ID(orgId.getRepoId());
+		scheduleCurrentFull.setC_Order_ID(order.getC_Order_ID());
+		scheduleCurrentFull.setC_OrderLine_ID(orderLineCurrentFull.getC_OrderLine_ID());
+		scheduleCurrentFull.setAD_Table_ID(orderLineTableId);
+		scheduleCurrentFull.setRecord_ID(orderLineCurrentFull.getC_OrderLine_ID());
+		scheduleCurrentFull.setQtyOrdered(new BigDecimal("12"));
+		scheduleCurrentFull.setQtyOrdered_Calculated(new BigDecimal("12")); // effective QtyOrdered (no override)
+		scheduleCurrentFull.setQtyDelivered(BigDecimal.ZERO); // not yet updated for THIS InOut at close-time
+		scheduleCurrentFull.setIsClosed(false);
+		save(scheduleCurrentFull);
+
+		final I_M_InOut inout = newInstance(I_M_InOut.class);
+		inout.setAD_Org_ID(orgId.getRepoId());
+		inout.setIsSOTrx(true);
+		save(inout);
+
+		final I_M_InOutLine inoutLineCurrentFull = newInstance(I_M_InOutLine.class);
+		inoutLineCurrentFull.setM_InOut(inout);
+		inoutLineCurrentFull.setC_OrderLine_ID(orderLineCurrentFull.getC_OrderLine_ID());
+		inoutLineCurrentFull.setMovementQty(new BigDecimal("12"));
+		save(inoutLineCurrentFull);
+
+		shipmentScheduleBL.closePartiallyShipped_ShipmentSchedules(inout);
+
+		refresh(scheduleCurrentFull);
+
+		assertThat(scheduleCurrentFull.isClosed())
+				.as("S_currentFull is fully delivered once THIS shipment's MovementQty (12) is added on top of persisted QtyDelivered (0) => must stay open")
+				.isFalse();
+	}
 }


### PR DESCRIPTION
## Problem

`CheckProcessedAsynBatchWorkpackageProcessor` work-packages accumulate without bound. One such work-package is enqueued per `C_Async_Batch`, unconditionally, for every batch type — its only job is to set the persistent `C_Async_Batch.Processed` flag. But for the high-volume plumbing batch types (OLCand / order / shipment processing) nothing consumes that flag. Because these types have `KeepAliveTimeHours=0` (= keep alive forever) and the DLM archive only reaps `Processed='Y'` work-packages, the useless checker work-packages stay pending forever and are re-skipped every polling cycle — pure churn.

## Fix

- **New column `C_Async_Batch_Type.IsCheckProcessed`** (Yes-No, default `N`). Seeded `Y` for exactly the code-verified consumers of `C_Async_Batch.Processed`:
  - `InvoiceCandidate_Processing` — invoice-candidate PDF concatenation
  - `CreateLettersAsync` — serial-letter print
  - `AutomaticallyInvoicePdfPrinting`, `PDFPrinting` — registered note listeners
- **Gate the enqueue** (`AsyncBatchBL.enqueueAsyncBatch`): the `CheckProcessedAsynBatch` work-package is enqueued only when the batch's type satisfies `IsCheckProcessed='Y' OR AD_BoilerPlate_ID>0`. The `AD_BoilerPlate_ID>0` belt keeps the checker firing for any type that has a completion email configured, so no configured side-effect is dropped. New types default `N`, so no future churn without an explicit opt-in.
- **One-time cleanup migration**: idempotent, non-destructive (`Processed='N'` → `'Y'`, no DELETE, `backup_table` first) close of the already-accumulated stuck checker work-packages and their orphan `C_Async_Batch` rows for non-consumer types. The predicate matches the enqueue gate exactly.

## Behaviour guarantee

Synchronous batch flows (shipment / order / invoice / OLCand / POS) are unchanged: they block on the in-JVM work-package counter (`AsyncBatchObserver`), never on `C_Async_Batch.Processed`. The recompute work-package they depend on is a batch member independent of this gate.

## Tests

- `AsyncBatchTypeTest` — unit test of the `isCheckProcessedNeeded()` predicate (checkProcessed / not-needed / boilerplate-belt).
- `AsyncBatchBLTest` — DB-backed integration test asserting real work-package row counts: non-consumer type → 0 checker work-packages, consumer type → 1, boilerplate-belt → 1.
- Full `de.metas.async` unit suite green.

## Also in this PR — a latent shipment-close bug fix

While validating the change, CI surfaced an intermittent failure in the `close_partially_shipped` scenario. Root-cause showed it was **not** caused by this change (the async-batch gate cannot alter shipment aggregation — `M_ShipmentSchedule.C_Async_Batch_ID` is immutable once set, and the checker work-package runs on its own dedicated queue). It exposed a **pre-existing latent bug** in `ShipmentScheduleBL.closePartiallyShipped_ShipmentSchedules`: it decided "fully shipped" from the *current* `M_InOut`'s line quantity only, so when one order shipped as ≥2 `M_InOut` documents, a schedule already fully delivered by a **sibling** shipment was wrongly closed.

Fix: a schedule is now spared from closing when its **cumulative** delivered quantity (persisted `QtyDelivered`, which reflects sibling shipments, **plus** the current shipment's just-shipped `MovementQty`) meets its **effective** `QtyOrdered` — split-safe. Covered by new unit tests (RED-verified).

## Note on the model regen

Regenerating `I_/X_C_Async_Batch_Type` for the new column also picked up pre-existing drift unrelated to this change (the generator always reflects the full current `AD_Column` state, not a targeted diff): a long-missing `Description` getter/setter and a stale `NotificationType` javadoc corrected to the DB's actual `en_US` translation. No behaviour change.
