### PR TITLE
EDI DESADV: fall back EAN_TU to the TU-level GTIN when no explicit EAN_TU is maintained

### DIFF
--- a/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/DesadvBL.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/DesadvBL.java
@@ -277,7 +277,12 @@ public class DesadvBL
 		final I_M_HU_PI_Item_Product materialItemProduct = hupiItemProductBL.extractHUPIItemProduct(orderRecord, orderLineRecord);
 		newDesadvLine.setGTIN_TU(materialItemProduct.getGTIN());
 		newDesadvLine.setUPC_TU(materialItemProduct.getUPC());
-		newDesadvLine.setEAN_TU(materialItemProduct.getEAN_TU());
+		// mirror the EAN_CU handling above: fall back to the TU-level GTIN when no explicit EAN_TU
+		// is maintained, so a TU-delivered line always carries a TU product identifier
+		// (else the EANCOM/ecosio mapping emits only the buyer number PIA+1+..:IN, which Migros rejects)
+		newDesadvLine.setEAN_TU(CoalesceUtil.firstNotBlank(
+				materialItemProduct.getEAN_TU(),
+				materialItemProduct.getGTIN()));
 
 		newDesadvLine.setIsSubsequentDeliveryPlanned(false); // the default
 

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/DesadvBL.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/DesadvBL.java
@@ -279,7 +279,7 @@ public class DesadvBL
 		newDesadvLine.setUPC_TU(materialItemProduct.getUPC());
 		// mirror the EAN_CU handling above: fall back to the TU-level GTIN when no explicit EAN_TU
 		// is maintained, so a TU-delivered line always carries a TU product identifier
-		// (else the EANCOM/ecosio mapping emits only the buyer number PIA+1+..:IN, which Migros rejects)
+		// (else the EANCOM mapping emits only the buyer number PIA+1+..:IN, which the recipient's guideline rejects)
 		newDesadvLine.setEAN_TU(CoalesceUtil.firstNotBlank(
 				materialItemProduct.getEAN_TU(),
 				materialItemProduct.getGTIN()));

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_addToDesadvCreateForInOutIfNotExist_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_addToDesadvCreateForInOutIfNotExist_Test.java
@@ -252,6 +252,53 @@ class DesadvBL_addToDesadvCreateForInOutIfNotExist_Test
 				);
 	}
 
+	/**
+	 * me03 #30813: a DESADV line delivered in TU must carry a TU-level product identifier.
+	 * When the {@code M_HU_PI_Item_Product} has a GTIN but no explicit {@code EAN_TU}, the created
+	 * desadv line must fall back to that GTIN for {@code EAN_TU} — otherwise the line ships with no
+	 * TU identifier and the downstream EANCOM mapping (ecosio) emits only the buyer number
+	 * ({@code PIA+1+..:IN}), which the Migros guideline rejects.
+	 */
+	@Test
+	void createdDesadvLine_EAN_TU_fallsBackToGTIN_whenNoExplicitEanTu()
+	{
+		// arrange: the HU PI Item Product has a TU-level GTIN but no explicit EAN_TU
+		huPIItemProductRecord.setGTIN("7624500074007");
+		huPIItemProductRecord.setEAN_TU(null);
+		saveRecord(huPIItemProductRecord);
+
+		// a DESADV that retrieveOrCreateDesadv will match by POReference (so no full header setup is needed)
+		final String poReference = "PO-30813-EANTU";
+		final I_EDI_Desadv desadvRecord = newInstance(I_EDI_Desadv.class);
+		desadvRecord.setPOReference(poReference);
+		desadvRecord.setC_BPartner_ID(recipientBPartnerId.getRepoId());
+		saveRecord(desadvRecord);
+
+		// an order whose line is NOT yet linked to a desadv line -> exercises the create path
+		final I_C_Order orderRecord = newInstance(I_C_Order.class);
+		orderRecord.setPOReference(poReference);
+		orderRecord.setC_BPartner_ID(recipientBPartnerId.getRepoId());
+		saveRecord(orderRecord);
+
+		final I_C_OrderLine orderLineRecord = newInstance(I_C_OrderLine.class);
+		orderLineRecord.setC_Order_ID(orderRecord.getC_Order_ID());
+		orderLineRecord.setC_BPartner_ID(recipientBPartnerId.getRepoId());
+		orderLineRecord.setM_Product_ID(huPIItemProductRecord.getM_Product_ID());
+		orderLineRecord.setM_HU_PI_Item_Product_ID(huPIItemProductRecord.getM_HU_PI_Item_Product_ID());
+		orderLineRecord.setLine(10);
+		orderLineRecord.setInvoicableQtyBasedOn(InvoicableQtyBasedOn.NominalWeight.getCode());
+		saveRecord(orderLineRecord);
+
+		// invoke the method under test (the create path: retrieveOrCreateDesadvLine)
+		desadvBL.addToDesadvCreateForOrderIfNotExist(orderRecord);
+
+		InterfaceWrapperHelper.refresh(orderLineRecord);
+		final I_EDI_DesadvLine createdDesadvLine = orderLineRecord.getEDI_DesadvLine();
+		assertThat(createdDesadvLine).as("a desadv line must have been created for the order line").isNotNull();
+		assertThat(createdDesadvLine.getGTIN_TU()).as("guard: GTIN_TU is populated from the HU PI Item Product's GTIN").isEqualTo("7624500074007");
+		assertThat(createdDesadvLine.getEAN_TU()).as("EAN_TU must fall back to GTIN_TU when no explicit EAN_TU is maintained").isEqualTo("7624500074007");
+	}
+
 	@Test
 	void addToDesadvCreateForInOutIfNotExist_no_HU_catch_weight()
 	{

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_addToDesadvCreateForInOutIfNotExist_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_addToDesadvCreateForInOutIfNotExist_Test.java
@@ -253,11 +253,11 @@ class DesadvBL_addToDesadvCreateForInOutIfNotExist_Test
 	}
 
 	/**
-	 * me03 #30813: a DESADV line delivered in TU must carry a TU-level product identifier.
+	 * A DESADV line delivered in TU must carry a TU-level product identifier.
 	 * When the {@code M_HU_PI_Item_Product} has a GTIN but no explicit {@code EAN_TU}, the created
 	 * desadv line must fall back to that GTIN for {@code EAN_TU} — otherwise the line ships with no
-	 * TU identifier and the downstream EANCOM mapping (ecosio) emits only the buyer number
-	 * ({@code PIA+1+..:IN}), which the Migros guideline rejects.
+	 * TU identifier and the downstream EANCOM mapping emits only the buyer number
+	 * ({@code PIA+1+..:IN}), which the recipient's guideline rejects.
 	 */
 	@Test
 	void createdDesadvLine_EAN_TU_fallsBackToGTIN_whenNoExplicitEanTu()


### PR DESCRIPTION
## Problem

A DESADV line delivered in **TU** must carry a TU-level product identifier. `DesadvBL.retrieveOrCreateDesadvLine()` populated `EAN_TU` from a single source — `M_HU_PI_Item_Product.EAN_TU` — with **no fallback**, unlike `EAN_CU` (which uses `CoalesceUtil.firstNotBlank(...)`). So a product with no explicit `EAN_TU` maintained shipped with **no TU identifier**.

Downstream, the EANCOM/EDIFACT conversion then emits only the buyer number as `PIA+1+<buyerNo>:IN` for that line, which the recipient's guideline rejects (it requires the product identifier as `PIA+5+…:SUE`/`AT`).

## Fix

Mirror the `EAN_CU` handling: fall back to the TU-level GTIN (`materialItemProduct.getGTIN()`, the same value already written to `GTIN_TU`) when no explicit `EAN_TU` is maintained.

## Test

`DesadvBL_addToDesadvCreateForInOutIfNotExist_Test#createdDesadvLine_EAN_TU_fallsBackToGTIN_whenNoExplicitEanTu` — exercises the create path (previously **zero** coverage) for a TU product with a GTIN but no explicit `EAN_TU`, and asserts the created desadv line's `EAN_TU` falls back to the GTIN. Verified RED before the fix, GREEN after; full class (9 tests) green.
