### PR TITLE
PO Reactivate — allow when pay schedule has no downstream activity

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5812360_sys_me03_30621_reactivate_message_proforma.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5812360_sys_me03_30621_reactivate_message_proforma.sql
@@ -1,0 +1,37 @@
+-- 2026-07-06
+-- AD_Message 545676 — Order_Reactivate_Blocked_By_PaySchedule_Activity
+-- Add proforma de-allocation as an alternative remediation step in the block message.
+
+-- Base row (German base language)
+UPDATE ad_message
+SET MsgText = 'Beleg kann nicht reaktiviert werden, da mindestens eine Zeile im Zahlungsplan nicht mehr Pending ist. Bitte zuerst die Wareneingänge / Rechnungen / Zahlungen stornieren oder die Proformarechnung-Zuordnung aufheben.',
+    Updated  = TO_TIMESTAMP('2026-07-06 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Message_ID = 545676;
+
+-- de_DE translation
+UPDATE ad_message_trl
+SET MsgText      = 'Beleg kann nicht reaktiviert werden, da mindestens eine Zeile im Zahlungsplan nicht mehr Pending ist. Bitte zuerst die Wareneingänge / Rechnungen / Zahlungen stornieren oder die Proformarechnung-Zuordnung aufheben.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-06 10:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Message_ID = 545676
+  AND AD_Language   = 'de_DE';
+
+-- de_CH translation
+UPDATE ad_message_trl
+SET MsgText      = 'Beleg kann nicht reaktiviert werden, da mindestens eine Zeile im Zahlungsplan nicht mehr Pending ist. Bitte zuerst die Wareneingänge / Rechnungen / Zahlungen stornieren oder die Proformarechnung-Zuordnung aufheben.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-06 10:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Message_ID = 545676
+  AND AD_Language   = 'de_CH';
+
+-- en_US translation
+UPDATE ad_message_trl
+SET MsgText      = 'Cannot reactivate the order because at least one payment-schedule row is no longer Pending. Please first reverse the goods receipts / invoices / payments, or de-allocate the proforma invoice.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-06 10:00:03', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Message_ID = 545676
+  AND AD_Language   = 'en_US';

--- a/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/core/OrderPaySchedule.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/core/OrderPaySchedule.java
@@ -63,6 +63,15 @@ public class OrderPaySchedule
 		return lines.stream();
 	}
 
+	/**
+	 * True if any line is linked to a committed downstream document (a goods receipt or a matched invoice).
+	 * See {@link OrderPayScheduleLine#isLinkedToDownstreamDocument()}.
+	 */
+	public boolean hasLineLinkedToDownstreamDocument()
+	{
+		return lines.stream().anyMatch(OrderPayScheduleLine::isLinkedToDownstreamDocument);
+	}
+
 	public OrderPayScheduleLine getLineById(@NonNull final OrderPayScheduleId payScheduleLineId)
 	{
 		return lines.stream()

--- a/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/core/OrderPayScheduleLine.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/core/OrderPayScheduleLine.java
@@ -124,6 +124,14 @@ public class OrderPayScheduleLine
 
 	public boolean isLetterOfCreditDate() {return referenceDateType.isLetterOfCreditDate();}
 
+	/**
+	 * True if this line is linked to a committed downstream document — a goods receipt ({@code inoutId})
+	 * or a matched invoice ({@code invoiceId}). Such a link reflects real activity that a reactivate
+	 * (drop-and-rebuild) would orphan; a line that is merely {@code Awaiting_Pay}/{@code Paid} because its
+	 * reference date was known at completion carries no such link.
+	 */
+	public boolean isLinkedToDownstreamDocument() {return inoutId != null || invoiceId != null;}
+
 	public void applyAndProcess(@NonNull final OrderPayScheduleLineContext context)
 	{
 		final OrderPayScheduleStatus nextStatus = context.getStatus();

--- a/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/interceptor/C_Order.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/interceptor/C_Order.java
@@ -25,8 +25,9 @@ package de.metas.order.paymentschedule.interceptor;
 import de.metas.i18n.AdMessageKey;
 import de.metas.order.OrderId;
 import de.metas.order.paymentschedule.core.OrderPaySchedule;
-import de.metas.order.paymentschedule.core.OrderPayScheduleStatus;
+import de.metas.order.paymentschedule.core.OrderPayScheduleLine;
 import de.metas.order.paymentschedule.core.service.OrderPayScheduleService;
+import de.metas.order.paymentschedule.referenced_docs.proforma_invoice.OrderPayScheduleProformaService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.modelvalidator.annotations.DocValidate;
@@ -37,18 +38,21 @@ import org.compiere.model.ModelValidator;
 import org.springframework.stereotype.Component;
 
 /**
- * Blocks reactivation of a {@code C_Order} whose {@link OrderPaySchedule} has any line whose
- * {@link OrderPayScheduleStatus} is no longer {@code Pending}
- * (i.e. {@code Awaiting_Pay} or {@code Paid}).
+ * Blocks reactivation of a {@code C_Order} whose {@link OrderPaySchedule} reflects committed
+ * downstream activity — i.e. at least one of:
+ * <ul>
+ *   <li>any pay-schedule line has a goods-receipt link ({@code inoutId != null}), or</li>
+ *   <li>any pay-schedule line has a matched-invoice link ({@code invoiceId != null}), or</li>
+ *   <li>a proforma allocation exists for the order (detected via
+ *       {@link OrderPayScheduleProformaService#getByOrderId}; the LC/proforma row carries no
+ *       per-line link, so it must be detected through the proforma service).</li>
+ * </ul>
  *
- * <p>Rationale: the standard metasfresh re-activate flow drops {@code C_OrderPaySchedule} rows,
- * but those rows carry meaningful per-receipt state (Status, BaseAmt, {@code C_Invoice_ID} link,
- * allocations); a subsequent re-completion would recreate them from scratch and silently destroy
- * that state.
+ * <p>A {@code Paid} line always implies one of the above, so no separate status guard is needed.
  *
- * <p>Reactivation is allowed when ALL pay-schedule lines are still {@code Pending} (nothing has
- * happened yet — the standard drop-and-rebuild path is safe), or when the order has no
- * pay-schedule at all.
+ * <p>Reactivation is allowed when no pay-schedule line carries any downstream link AND no proforma
+ * allocation exists — meaning nothing has been committed yet and the standard drop-and-rebuild
+ * reactivation path is safe. Reactivation is also allowed when the order has no pay-schedule at all.
  */
 @Interceptor(I_C_Order.class)
 @Component
@@ -58,6 +62,7 @@ public class C_Order
 	private static final AdMessageKey MSG_OrderReactivateBlocked = AdMessageKey.of("Order_Reactivate_Blocked_By_PaySchedule_Activity");
 
 	@NonNull private final OrderPayScheduleService orderPayScheduleService;
+	@NonNull private final OrderPayScheduleProformaService orderPayScheduleProformaService;
 
 	@DocValidate(timings = ModelValidator.TIMING_BEFORE_REACTIVATE)
 	public void blockReactivateWhenScheduleNotPending(@NonNull final I_C_Order order)
@@ -65,16 +70,16 @@ public class C_Order
 		final OrderId orderId = OrderId.ofRepoId(order.getC_Order_ID());
 
 		orderPayScheduleService.getByOrderId(orderId)
-				.filter(this::hasAnyNonPendingLine)
+				.filter(schedule -> reflectsDownstreamActivity(orderId, schedule))
 				.ifPresent(schedule -> {
-					throw new AdempiereException(MSG_OrderReactivateBlocked)
-							.markAsUserValidationError();
+					throw new AdempiereException(MSG_OrderReactivateBlocked).markAsUserValidationError();
 				});
 	}
 
-	private boolean hasAnyNonPendingLine(@NonNull final OrderPaySchedule schedule)
+	private boolean reflectsDownstreamActivity(@NonNull final OrderId orderId, @NonNull final OrderPaySchedule schedule)
 	{
-		return schedule.streamLines()
-				.anyMatch(line -> !line.getStatus().isPending());
+		final boolean anyLineLinked = schedule.streamLines()
+				.anyMatch(line -> line.getInoutId() != null || line.getInvoiceId() != null);
+		return anyLineLinked || orderPayScheduleProformaService.getByOrderId(orderId).isPresent();
 	}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/interceptor/C_Order.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/interceptor/C_Order.java
@@ -69,6 +69,11 @@ public class C_Order
 	{
 		final OrderId orderId = OrderId.ofRepoId(order.getC_Order_ID());
 
+		// The proforma check inside reflectsDownstreamActivity is reached only when a pay-schedule
+		// exists. That is safe because an allocated LC/proforma always creates at least one
+		// pay-schedule line (OrderPayScheduleLCStepService), so "a proforma exists but there is no
+		// pay-schedule" is not a producible state — an order with no pay-schedule at all has nothing
+		// downstream to protect and is always reactivatable.
 		orderPayScheduleService.getByOrderId(orderId)
 				.filter(schedule -> reflectsDownstreamActivity(orderId, schedule))
 				.ifPresent(schedule -> {

--- a/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/interceptor/C_Order.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/interceptor/C_Order.java
@@ -25,7 +25,6 @@ package de.metas.order.paymentschedule.interceptor;
 import de.metas.i18n.AdMessageKey;
 import de.metas.order.OrderId;
 import de.metas.order.paymentschedule.core.OrderPaySchedule;
-import de.metas.order.paymentschedule.core.OrderPayScheduleLine;
 import de.metas.order.paymentschedule.core.service.OrderPayScheduleService;
 import de.metas.order.paymentschedule.referenced_docs.proforma_invoice.OrderPayScheduleProformaService;
 import lombok.NonNull;
@@ -75,16 +74,19 @@ public class C_Order
 		// pay-schedule" is not a producible state — an order with no pay-schedule at all has nothing
 		// downstream to protect and is always reactivatable.
 		orderPayScheduleService.getByOrderId(orderId)
-				.filter(schedule -> reflectsDownstreamActivity(orderId, schedule))
+				.filter(schedule -> isBlockedByDownstreamActivity(orderId, schedule))
 				.ifPresent(schedule -> {
 					throw new AdempiereException(MSG_OrderReactivateBlocked).markAsUserValidationError();
 				});
 	}
 
-	private boolean reflectsDownstreamActivity(@NonNull final OrderId orderId, @NonNull final OrderPaySchedule schedule)
+	/**
+	 * True if the schedule carries committed downstream state that a drop-and-rebuild re-completion would
+	 * orphan: a line linked to a goods receipt or matched invoice, or a proforma allocation on the order.
+	 */
+	private boolean isBlockedByDownstreamActivity(@NonNull final OrderId orderId, @NonNull final OrderPaySchedule schedule)
 	{
-		final boolean anyLineLinked = schedule.streamLines()
-				.anyMatch(line -> line.getInoutId() != null || line.getInvoiceId() != null);
-		return anyLineLinked || orderPayScheduleProformaService.getByOrderId(orderId).isPresent();
+		return schedule.hasLineLinkedToDownstreamDocument()
+				|| orderPayScheduleProformaService.getByOrderId(orderId).isPresent();
 	}
 }

--- a/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
@@ -23,6 +23,8 @@
 package de.metas.order.paymentschedule.interceptor;
 
 import com.google.common.collect.ImmutableList;
+import de.metas.inout.InOutId;
+import de.metas.invoice.InvoiceId;
 import de.metas.money.CurrencyId;
 import de.metas.money.Money;
 import de.metas.order.OrderId;
@@ -31,6 +33,8 @@ import de.metas.order.paymentschedule.core.OrderPayScheduleId;
 import de.metas.order.paymentschedule.core.OrderPayScheduleLine;
 import de.metas.order.paymentschedule.core.OrderPayScheduleStatus;
 import de.metas.order.paymentschedule.core.service.OrderPayScheduleService;
+import de.metas.order.paymentschedule.referenced_docs.proforma_invoice.OrderPayScheduleProformaService;
+import de.metas.order.paymentschedule.referenced_docs.proforma_invoice.ProformaInvoice;
 import de.metas.payment.paymentterm.PaymentTermBreakId;
 import de.metas.payment.paymentterm.ReferenceDateType;
 import de.metas.util.lang.Percent;
@@ -53,6 +57,7 @@ class C_Order_Test
 	private static final OrderId ORDER_ID = OrderId.ofRepoId(9001);
 
 	private OrderPayScheduleService orderPayScheduleService;
+	private OrderPayScheduleProformaService proformaService;
 	private C_Order guard;
 
 	@BeforeEach
@@ -61,7 +66,8 @@ class C_Order_Test
 		AdempiereTestHelper.get().init();
 
 		this.orderPayScheduleService = Mockito.mock(OrderPayScheduleService.class);
-		this.guard = new C_Order(orderPayScheduleService);
+		this.proformaService = Mockito.mock(OrderPayScheduleProformaService.class);
+		this.guard = new C_Order(orderPayScheduleService, proformaService);
 	}
 
 	@Test
@@ -70,29 +76,63 @@ class C_Order_Test
 		final I_C_Order order = newOrder();
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.of(scheduleWithStatuses(OrderPayScheduleStatus.Pending, OrderPayScheduleStatus.Pending)));
+		Mockito.when(proformaService.getByOrderId(ORDER_ID))
+				.thenReturn(Optional.empty());
 
 		assertThatCode(() -> guard.blockReactivateWhenScheduleNotPending(order))
 				.doesNotThrowAnyException();
 	}
 
+	/**
+	 * A line with status Awaiting_Pay but no downstream link (no inoutId, no invoiceId, no proforma)
+	 * must NOT block reactivation under the new semantics.
+	 */
 	@Test
-	void rejectReactivate_whenAnyScheduleAwaitingPay()
+	void allowReactivate_whenNonPendingLineHasNoDownstreamActivity()
+	{
+		final I_C_Order order = newOrder();
+		// schedule has one Awaiting_Pay and one Pending line — but NO downstream links
+		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
+				.thenReturn(Optional.of(scheduleWithStatuses(OrderPayScheduleStatus.Awaiting_Pay, OrderPayScheduleStatus.Pending)));
+		Mockito.when(proformaService.getByOrderId(ORDER_ID))
+				.thenReturn(Optional.empty());
+
+		assertThatCode(() -> guard.blockReactivateWhenScheduleNotPending(order))
+				.doesNotThrowAnyException();
+	}
+
+	/**
+	 * Previously: rejectReactivate_whenAnyScheduleAwaitingPay asserted that bare Awaiting_Pay status blocks.
+	 * Under new semantics bare status no longer blocks — block requires a downstream link.
+	 * This test drives the block via an inoutId on the Awaiting_Pay line.
+	 */
+	@Test
+	void rejectReactivate_whenAwaitingPayLineHasInoutLink()
 	{
 		final I_C_Order order = newOrder();
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.of(scheduleWithStatuses(OrderPayScheduleStatus.Pending, OrderPayScheduleStatus.Awaiting_Pay)));
+				.thenReturn(Optional.of(scheduleWithInoutLink()));
+		Mockito.when(proformaService.getByOrderId(ORDER_ID))
+				.thenReturn(Optional.empty());
 
 		assertThatThrownBy(() -> guard.blockReactivateWhenScheduleNotPending(order))
 				.isInstanceOf(AdempiereException.class)
 				.hasMessageContaining("Order_Reactivate_Blocked_By_PaySchedule_Activity");
 	}
 
+	/**
+	 * Previously: rejectReactivate_whenAnyScheduleStatusPaid asserted that bare Paid status blocks.
+	 * Under new semantics bare status no longer blocks — block requires a downstream link.
+	 * This test drives the block via an invoiceId on the Paid line.
+	 */
 	@Test
-	void rejectReactivate_whenAnyScheduleStatusPaid()
+	void rejectReactivate_whenPaidLineHasInvoiceLink()
 	{
 		final I_C_Order order = newOrder();
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.of(scheduleWithStatuses(OrderPayScheduleStatus.Paid, OrderPayScheduleStatus.Pending)));
+				.thenReturn(Optional.of(scheduleWithInvoiceLink()));
+		Mockito.when(proformaService.getByOrderId(ORDER_ID))
+				.thenReturn(Optional.empty());
 
 		assertThatThrownBy(() -> guard.blockReactivateWhenScheduleNotPending(order))
 				.isInstanceOf(AdempiereException.class)
@@ -108,6 +148,37 @@ class C_Order_Test
 
 		assertThatCode(() -> guard.blockReactivateWhenScheduleNotPending(order))
 				.doesNotThrowAnyException();
+	}
+
+	/** NEW: proforma allocation alone (no per-line link) must block reactivation. */
+	@Test
+	void rejectReactivate_whenProformaAllocationExists()
+	{
+		final I_C_Order order = newOrder();
+		// schedule has non-pending lines but no per-line downstream link
+		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
+				.thenReturn(Optional.of(scheduleWithStatuses(OrderPayScheduleStatus.Awaiting_Pay, OrderPayScheduleStatus.Pending)));
+		Mockito.when(proformaService.getByOrderId(ORDER_ID))
+				.thenReturn(Optional.of(stubProformaInvoice()));
+
+		assertThatThrownBy(() -> guard.blockReactivateWhenScheduleNotPending(order))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("Order_Reactivate_Blocked_By_PaySchedule_Activity");
+	}
+
+	/** NEW: a line carrying an inoutId (goods-receipt link) must block reactivation. */
+	@Test
+	void rejectReactivate_whenAnyLineHasInoutLink()
+	{
+		final I_C_Order order = newOrder();
+		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
+				.thenReturn(Optional.of(scheduleWithInoutLink()));
+		Mockito.when(proformaService.getByOrderId(ORDER_ID))
+				.thenReturn(Optional.empty());
+
+		assertThatThrownBy(() -> guard.blockReactivateWhenScheduleNotPending(order))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("Order_Reactivate_Blocked_By_PaySchedule_Activity");
 	}
 
 	// -------------------------------------------------------------------------
@@ -132,7 +203,41 @@ class C_Order_Test
 		return OrderPaySchedule.ofList(ORDER_ID, lines.build());
 	}
 
+	/** Schedule with one Pending line carrying a goods-receipt link (inoutId). */
+	private OrderPaySchedule scheduleWithInoutLink()
+	{
+		final OrderPayScheduleLine line = scheduleLineBuilder(1, OrderPayScheduleStatus.Pending)
+				.inoutId(InOutId.ofRepoId(500))
+				.build();
+		return OrderPaySchedule.ofList(ORDER_ID, ImmutableList.of(line));
+	}
+
+	/** Schedule with one Pending line carrying a matched-invoice link (invoiceId). */
+	private OrderPaySchedule scheduleWithInvoiceLink()
+	{
+		final OrderPayScheduleLine line = scheduleLineBuilder(1, OrderPayScheduleStatus.Pending)
+				.invoiceId(InvoiceId.ofRepoId(600))
+				.build();
+		return OrderPaySchedule.ofList(ORDER_ID, ImmutableList.of(line));
+	}
+
+	/** Minimal real ProformaInvoice instance (ProformaInvoice is @Value/final — cannot be mocked). */
+	private ProformaInvoice stubProformaInvoice()
+	{
+		return ProformaInvoice.builder()
+				.id(InvoiceId.ofRepoId(700))
+				.grandTotal(de.metas.money.Money.of(1000, CurrencyId.EUR))
+				.dateInvoiced(LocalDate.of(2026, 1, 1))
+				.dueDate(LocalDate.of(2026, 2, 1))
+				.build();
+	}
+
 	private OrderPayScheduleLine scheduleLine(final int seq, final OrderPayScheduleStatus status)
+	{
+		return scheduleLineBuilder(seq, status).build();
+	}
+
+	private OrderPayScheduleLine.OrderPayScheduleLineBuilder scheduleLineBuilder(final int seq, final OrderPayScheduleStatus status)
 	{
 		// PaymentTermBreakId must be unique within the schedule (used as a key in some lookups).
 		// PaymentTermBreakId.ofRepoId requires both the parent PaymentTermId and the break id.
@@ -148,7 +253,6 @@ class C_Order_Test
 				.offsetDays(0)
 				.status(status)
 				.dueDate(LocalDate.of(2026, 1, 1))
-				.dueAmount(Money.of(1000, CurrencyId.EUR))
-				.build();
+				.dueAmount(Money.of(1000, CurrencyId.EUR));
 	}
 }

--- a/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
@@ -102,10 +102,10 @@ class C_Order_Test
 	}
 
 	/**
-	 * Reconciled from the pre-existing rejectReactivate_whenAnyScheduleAwaitingPay, which asserted that
-	 * bare Awaiting_Pay status blocks. Under the new semantics bare status no longer blocks — the block
-	 * requires a downstream link. This test drives the block via an inoutId on an Awaiting_Pay line,
-	 * also demonstrating the guard is status-agnostic (blocks on the link, regardless of status).
+	 * Status Awaiting_Pay without a downstream link must NOT block reactivation — the block requires
+	 * an actual inoutId/invoiceId/proforma. This test drives the block via an inoutId on an
+	 * Awaiting_Pay line, demonstrating the guard is status-agnostic (blocks on the link, regardless
+	 * of status).
 	 */
 	@Test
 	void rejectReactivate_whenAwaitingPayLineHasInoutLink()
@@ -122,10 +122,9 @@ class C_Order_Test
 	}
 
 	/**
-	 * Reconciled from the pre-existing rejectReactivate_whenAnyScheduleStatusPaid, which asserted that
-	 * bare Paid status blocks. Under the new semantics bare status no longer blocks — the block requires
-	 * a downstream link. A Paid line always implies a matched-invoice link, so this test drives the block
-	 * via an invoiceId on a Paid line.
+	 * A Paid line always implies a matched-invoice link; bare Paid status alone does not block —
+	 * the block requires the actual downstream link. This test drives the block via an invoiceId on
+	 * a Paid line.
 	 */
 	@Test
 	void rejectReactivate_whenPaidLineHasInvoiceLink()
@@ -146,6 +145,8 @@ class C_Order_Test
 	{
 		final I_C_Order order = newOrder();
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
+				.thenReturn(Optional.empty());
+		Mockito.when(proformaService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.empty());
 
 		assertThatCode(() -> guard.blockReactivateWhenScheduleNotPending(order))

--- a/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
@@ -229,7 +229,7 @@ class C_Order_Test
 	{
 		return ProformaInvoice.builder()
 				.id(InvoiceId.ofRepoId(700))
-				.grandTotal(de.metas.money.Money.of(1000, CurrencyId.EUR))
+				.grandTotal(Money.of(1000, CurrencyId.EUR))
 				.dateInvoiced(LocalDate.of(2026, 1, 1))
 				.dueDate(LocalDate.of(2026, 2, 1))
 				.build();

--- a/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
@@ -102,16 +102,17 @@ class C_Order_Test
 	}
 
 	/**
-	 * Previously: rejectReactivate_whenAnyScheduleAwaitingPay asserted that bare Awaiting_Pay status blocks.
-	 * Under new semantics bare status no longer blocks — block requires a downstream link.
-	 * This test drives the block via an inoutId on the Awaiting_Pay line.
+	 * Reconciled from the pre-existing rejectReactivate_whenAnyScheduleAwaitingPay, which asserted that
+	 * bare Awaiting_Pay status blocks. Under the new semantics bare status no longer blocks — the block
+	 * requires a downstream link. This test drives the block via an inoutId on an Awaiting_Pay line,
+	 * also demonstrating the guard is status-agnostic (blocks on the link, regardless of status).
 	 */
 	@Test
 	void rejectReactivate_whenAwaitingPayLineHasInoutLink()
 	{
 		final I_C_Order order = newOrder();
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.of(scheduleWithInoutLink()));
+				.thenReturn(Optional.of(scheduleWithInoutLink(OrderPayScheduleStatus.Awaiting_Pay)));
 		Mockito.when(proformaService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.empty());
 
@@ -121,16 +122,17 @@ class C_Order_Test
 	}
 
 	/**
-	 * Previously: rejectReactivate_whenAnyScheduleStatusPaid asserted that bare Paid status blocks.
-	 * Under new semantics bare status no longer blocks — block requires a downstream link.
-	 * This test drives the block via an invoiceId on the Paid line.
+	 * Reconciled from the pre-existing rejectReactivate_whenAnyScheduleStatusPaid, which asserted that
+	 * bare Paid status blocks. Under the new semantics bare status no longer blocks — the block requires
+	 * a downstream link. A Paid line always implies a matched-invoice link, so this test drives the block
+	 * via an invoiceId on a Paid line.
 	 */
 	@Test
 	void rejectReactivate_whenPaidLineHasInvoiceLink()
 	{
 		final I_C_Order order = newOrder();
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.of(scheduleWithInvoiceLink()));
+				.thenReturn(Optional.of(scheduleWithInvoiceLink(OrderPayScheduleStatus.Paid)));
 		Mockito.when(proformaService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.empty());
 
@@ -155,9 +157,9 @@ class C_Order_Test
 	void rejectReactivate_whenProformaAllocationExists()
 	{
 		final I_C_Order order = newOrder();
-		// schedule has non-pending lines but no per-line downstream link
+		// schedule lines carry NO per-line downstream link — the block must come from the proforma alone
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.of(scheduleWithStatuses(OrderPayScheduleStatus.Awaiting_Pay, OrderPayScheduleStatus.Pending)));
+				.thenReturn(Optional.of(scheduleWithStatuses(OrderPayScheduleStatus.Pending, OrderPayScheduleStatus.Pending)));
 		Mockito.when(proformaService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.of(stubProformaInvoice()));
 
@@ -166,13 +168,13 @@ class C_Order_Test
 				.hasMessageContaining("Order_Reactivate_Blocked_By_PaySchedule_Activity");
 	}
 
-	/** NEW: a line carrying an inoutId (goods-receipt link) must block reactivation. */
+	/** NEW: even a Pending line carrying an inoutId (goods-receipt link) must block reactivation. */
 	@Test
 	void rejectReactivate_whenAnyLineHasInoutLink()
 	{
 		final I_C_Order order = newOrder();
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.of(scheduleWithInoutLink()));
+				.thenReturn(Optional.of(scheduleWithInoutLink(OrderPayScheduleStatus.Pending)));
 		Mockito.when(proformaService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.empty());
 
@@ -203,19 +205,19 @@ class C_Order_Test
 		return OrderPaySchedule.ofList(ORDER_ID, lines.build());
 	}
 
-	/** Schedule with one Pending line carrying a goods-receipt link (inoutId). */
-	private OrderPaySchedule scheduleWithInoutLink()
+	/** Schedule with one line (given status) carrying a goods-receipt link (inoutId). */
+	private OrderPaySchedule scheduleWithInoutLink(final OrderPayScheduleStatus status)
 	{
-		final OrderPayScheduleLine line = scheduleLineBuilder(1, OrderPayScheduleStatus.Pending)
+		final OrderPayScheduleLine line = scheduleLineBuilder(1, status)
 				.inoutId(InOutId.ofRepoId(500))
 				.build();
 		return OrderPaySchedule.ofList(ORDER_ID, ImmutableList.of(line));
 	}
 
-	/** Schedule with one Pending line carrying a matched-invoice link (invoiceId). */
-	private OrderPaySchedule scheduleWithInvoiceLink()
+	/** Schedule with one line (given status) carrying a matched-invoice link (invoiceId). */
+	private OrderPaySchedule scheduleWithInvoiceLink(final OrderPayScheduleStatus status)
 	{
-		final OrderPayScheduleLine line = scheduleLineBuilder(1, OrderPayScheduleStatus.Pending)
+		final OrderPayScheduleLine line = scheduleLineBuilder(1, status)
 				.invoiceId(InvoiceId.ofRepoId(600))
 				.build();
 		return OrderPaySchedule.ofList(ORDER_ID, ImmutableList.of(line));

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
@@ -3,17 +3,11 @@
 @allure.label.feature:F00994_Multiple_Levels_of_Payment
 @ghActions:run_on_executor1
 Feature: PO reactivation guard — downstream-activity check
-  # Domain: the reactivation guard on a purchase order with a complex payment term.
-  # The guard must block reactivation ONLY when the pay schedule reflects committed
-  # downstream state (goods receipt, matched invoice, or proforma allocation).
-  # A line that is Awaiting_Pay purely because its break's reference date (e.g. OrderDate)
-  # was known at completion — with no downstream documents — must NOT block reactivation.
-  #
-  # Payment term setup:
-  #   pt_od: LC 30% + OD 70%  — OrderDate break always resolves at completion → OD row WP
-  #   pt_bl: LC 30% + BL 70%  — BillOfLadingDate break resolves only on goods receipt
-  #
-  # PO numbers: 700 PCE × 100 EUR = 70,000 EUR (IsTaxIncluded=Y → GrandTotal = 70,000)
+  # Guard blocks reactivation only when the pay schedule carries committed downstream
+  # state: a goods-receipt link (M_InOut_ID), a matched-invoice link (C_Invoice_ID),
+  # or a proforma allocation. An Awaiting_Pay line with no downstream must NOT block.
+  # pt_od = LC 30% + OD 70% (OD resolves at completion); pt_bl = LC 30% + BL 70%.
+  # PO: 700 PCE × 100 EUR = 70,000 EUR (IsTaxIncluded=Y → GrandTotal = 70,000).
 
   Background:
     Given infrastructure and metasfresh are running

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
@@ -1,0 +1,176 @@
+@from:cucumber
+@allure.label.epic:E0130_Payment
+@allure.label.feature:F00994_Multiple_Levels_of_Payment
+@ghActions:run_on_executor1
+Feature: PO reactivation guard — downstream-activity check
+  # Domain: the reactivation guard on a purchase order with a complex payment term.
+  # The guard must block reactivation ONLY when the pay schedule reflects committed
+  # downstream state (goods receipt, matched invoice, or proforma allocation).
+  # A line that is Awaiting_Pay purely because its break's reference date (e.g. OrderDate)
+  # was known at completion — with no downstream documents — must NOT block reactivation.
+  #
+  # Payment term setup:
+  #   pt_od: LC 30% + OD 70%  — OrderDate break always resolves at completion → OD row WP
+  #   pt_bl: LC 30% + BL 70%  — BillOfLadingDate break resolves only on goods receipt
+  #
+  # PO numbers: 700 PCE × 100 EUR = 70,000 EUR (IsTaxIncluded=Y → GrandTotal = 70,000)
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And metasfresh has date and time 2026-04-24T10:00:00+02:00[Europe/Berlin]
+
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps         |
+    And metasfresh contains M_PriceLists
+      | Identifier  | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx | IsTaxIncluded |
+      | pl_purchase | ps                 | DE           | EUR           | false | Y             |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier   | M_PriceList_ID |
+      | plv_purchase | pl_purchase    |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | plv_purchase           | product      | 100.00   | PCE      |
+
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID | PaymentRulePO |
+      | vendor     | Y        | N          | ps                 | P             |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | vendor_loc | vendor        | Y               | Y               |
+
+    # pt_od: LC 30% + OD 70% — OrderDate break resolves at completion, OD row immediately WP
+    # pt_bl: LC 30% + BL 70% — BillOfLadingDate break resolves only on goods receipt
+    And metasfresh contains C_PaymentTerm
+      | Identifier   |
+      | pt_od        |
+      | pt_bl        |
+      | pt_immediate |
+    And metasfresh contains C_PaymentTerm_Break
+      | Identifier  | C_PaymentTerm_ID | Percent | OffsetDays | ReferenceDateType | SeqNo |
+      | ptb_od_lc   | pt_od            | 30      | 0          | LC                | 10    |
+      | ptb_od_od   | pt_od            | 70      | 0          | OD                | 20    |
+      | ptb_bl_lc   | pt_bl            | 30      | 0          | LC                | 10    |
+      | ptb_bl_bl   | pt_bl            | 70      | 0          | BL                | 20    |
+    And validate C_PaymentTerm:
+      | Identifier | IsComplex | IsValid |
+      | pt_od      | Y         | Y       |
+      | pt_bl      | Y         | Y       |
+
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID |
+      | wh             |
+
+
+  @from:cucumber
+  @Id:S30621_TC1
+  Scenario: Reactivate allowed — Awaiting_Pay OD row with no downstream (regression guard)
+    # A buyer completes a PO on a LC+OD term. The OD row is immediately Awaiting_Pay because
+    # DateOrdered is always set at completion. No goods receipt, invoice, payment, or proforma exists.
+    # The guard must allow reactivation — nothing downstream would be lost.
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po         | N       | vendor        | 2026-04-24  | POO         | wh             | pt_od            |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | poL1       | po         | product      | 700        |
+    And the order identified by po is completed
+
+    # OD row: Awaiting_Pay (DateOrdered known at completion); no M_InOut_ID, no C_Invoice_ID, no proforma
+    Then the order identified by po has following pay schedule lines by ReferenceDateType
+      | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
+      | LC                | 21000.00 | null          | null          | 9999-12-01 | PR     |
+      | OD                | 49000.00 | null          | 2026-04-24    | 2026-04-24 | WP     |
+
+    # Guard allows reactivation — OD Awaiting_Pay with no downstream does not block
+    And the order identified by po is reactivated
+
+
+  @from:cucumber
+  @Id:S30621_TC2
+  Scenario: Reactivate blocked — proforma allocation exists
+    # A buyer allocates a purchase proforma invoice to the order (LC step → Awaiting_Pay).
+    # The guard detects the proforma allocation and blocks reactivation. The buyer must
+    # de-allocate the proforma before they can reactivate.
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po         | N       | vendor        | 2026-04-24  | POO         | wh             | pt_od            |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | poL1       | po         | product      | 700        |
+    And the order identified by po is completed
+
+    # Allocate a proforma invoice to the order (LC row → Awaiting_Pay, proforma service records the link)
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID | C_DocTypeTarget_ID.Name       | DateInvoiced | IsSOTrx | C_Currency_ID | C_PaymentTerm_ID |
+      | proforma   | vendor        | Proforma-Rechnung (Lieferant) | 2026-04-24   | false   | EUR           | pt_immediate     |
+    And metasfresh contains C_InvoiceLines
+      | Identifier | C_Invoice_ID | M_Product_ID | QtyInvoiced | Price    |
+      | proformaL1 | proforma     | product      | 1 PCE       | 21000.00 |
+    And the invoice identified by proforma is completed
+    And I allocate proforma 'proforma' to order 'po'
+
+    Then the order identified by po has following pay schedule lines by ReferenceDateType
+      | ReferenceDateType | DueAmt   | DueAmt_Actual | Status |
+      | LC                | 21000.00 | 21000.00      | WP     |
+
+    # Guard blocks — proforma allocation exists; user must de-allocate first
+    And the order identified by po cannot be reactivated
+
+
+  @from:cucumber
+  @Id:S30621_TC3
+  Scenario: Reactivate blocked — goods receipt links a pay-schedule line
+    # A buyer completes a goods receipt against a LC+BL order. The receipt creates a BL
+    # delivery sub-row carrying M_InOut_ID — committed downstream state that blocks reactivation.
+    # A matched financial invoice is also completed (M_MatchInv created); on an order with no
+    # proforma prepayment, split-payment tracking is dormant, so the invoice does not project
+    # onto the sub-row (C_Invoice_ID stays null, status Pending). The receipt link alone blocks.
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po         | N       | vendor        | 2026-04-24  | POO         | wh             | pt_bl            |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | poL1       | po         | product      | 700        |
+    And the order identified by po is completed
+
+    # Wait for WP processor to create M_ReceiptSchedule (async after order completion)
+    And after not more than 30s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID | C_Order_ID | C_OrderLine_ID | C_BPartner_ID | C_BPartner_Location_ID | M_Product_ID | QtyOrdered | M_Warehouse_ID |
+      | rs1                  | po         | poL1           | vendor        | vendor_loc             | product      | 700        | wh             |
+
+    # Goods receipt: 700 PCE in 1 TU → receipt r1 with line r1_line1
+    And create M_HU_LUTU_Configuration for M_ReceiptSchedule and generate M_HUs
+      | M_HU_ID | C_OrderLine_ID | M_HU_PI_Item_Product_ID | QtyCUsPerTU |
+      | hu1     | poL1           | 101                     | 700         |
+    And create material receipt
+      | C_OrderLine_ID | M_HU_ID | M_InOut_ID |
+      | poL1           | hu1     | r1         |
+    And load M_InOut:
+      | QtyEntered | M_InOutLine_ID | M_InOut_ID | DocStatus | C_OrderLine_ID |
+      | 700        | r1_line1       | r1         | CO        | poL1           |
+
+    # BL sub-row now exists with M_InOut_ID=r1; matched financial invoice sets C_Invoice_ID on it
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | IsSOTrx | C_Currency_ID |
+      | inv1       | vendor        | Eingangsrechnung        | 2026-04-24   | false   | EUR           |
+    And metasfresh contains C_InvoiceLines
+      | Identifier | C_Invoice_ID | M_Product_ID | QtyInvoiced | Price  | C_OrderLine_ID | M_InOutLine_ID |
+      | inv1L1     | inv1         | product      | 700 PCE     | 100.00 | poL1           | r1_line1       |
+    And the invoice identified by inv1 is completed
+
+    # BL sub-row carries the receipt link (M_InOut_ID=r1) — committed downstream state
+    Then the order identified by po has following pay schedule lines by ReferenceDateType
+      | ReferenceDateType | M_InOut_ID | DueAmt   |
+      | BL                | r1         | 49000.00 |
+
+    # Guard blocks — pay-schedule line carries a downstream goods-receipt link
+    And the order identified by po cannot be reactivated

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
@@ -152,7 +152,9 @@ Feature: PO reactivation guard — downstream-activity check
       | QtyEntered | M_InOutLine_ID | M_InOut_ID | DocStatus | C_OrderLine_ID |
       | 700        | r1_line1       | r1         | CO        | poL1           |
 
-    # BL sub-row now exists with M_InOut_ID=r1; matched financial invoice sets C_Invoice_ID on it
+    # BL sub-row now has M_InOut_ID=r1. The matched financial invoice does NOT set C_Invoice_ID on the
+    # pay-schedule line: C_Invoice.onComplete returns early when the order has no proforma allocation, so
+    # split-payment delivery-step tracking is dormant and the invoice does not project onto the sub-row.
     And metasfresh contains C_Invoice:
       | Identifier | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | IsSOTrx | C_Currency_ID |
       | inv1       | vendor        | Eingangsrechnung        | 2026-04-24   | false   | EUR           |
@@ -161,10 +163,11 @@ Feature: PO reactivation guard — downstream-activity check
       | inv1L1     | inv1         | product      | 700 PCE     | 100.00 | poL1           | r1_line1       |
     And the invoice identified by inv1 is completed
 
-    # BL sub-row carries the receipt link (M_InOut_ID=r1) — committed downstream state
+    # BL sub-row carries the receipt link (M_InOut_ID=r1) — committed downstream state — while
+    # C_Invoice_ID stays null (invoice does not project onto the sub-row without a proforma).
     Then the order identified by po has following pay schedule lines by ReferenceDateType
-      | ReferenceDateType | M_InOut_ID | DueAmt   |
-      | BL                | r1         | 49000.00 |
+      | ReferenceDateType | M_InOut_ID | C_Invoice_ID | DueAmt   |
+      | BL                | r1         | null         | 49000.00 |
 
     # Guard blocks — pay-schedule line carries a downstream goods-receipt link
     And the order identified by po cannot be reactivated


### PR DESCRIPTION
## Problem
A purchase order with a multi-step payment term (e.g. *25% TT, 25% before delivery, 50% against BL date*) could not be reactivated after completion — even before any goods receipt, invoice, payment, or proforma existed. Reactivation failed with a 500 (`Order_Reactivate_Blocked_By_PaySchedule_Activity`) telling the user to cancel receipts/invoices/payments that do not exist, leaving the order permanently un-editable.

## Root cause
At completion, `OrderSchedulingContext.computeLineContext` sets a pay-schedule line to `Awaiting_Pay` whenever its break's reference date is already known on the order header. An `OrderDate` break resolves to `DateOrdered` (always set on a completed order), so that line is `Awaiting_Pay` immediately, with zero downstream documents. The reactivate guard `C_Order#blockReactivateWhenScheduleNotPending` blocked on `Status != Pending`, conflating "line active" with "downstream activity happened".

## Fix
The guard now blocks reactivation only on **committed downstream state**:
- any pay-schedule line with `M_InOut_ID` (goods receipt) or `C_Invoice_ID` (matched invoice) set, OR
- an existing proforma allocation for the order (`OrderPayScheduleProformaService.getByOrderId` — the LC/proforma row carries no per-line link, so it is detected via the proforma service).

A line that is `Awaiting_Pay`/`Paid` purely because its reference date was known at completion no longer blocks. The reactivate guard's original purpose (protect real downstream state from a drop-and-rebuild re-completion) is preserved. The method name is kept intentionally (renaming would change the `InterceptorEnabled_…` disable-SysConfig key). No change to the pay-schedule status model, due-date logic, or pay-selection.

The block message (AD_Message 545676 + de_DE/de_CH/en_US trls) now also names de-allocating the proforma.

## Tests
- Unit (`C_Order_Test`, 7/7): allow when non-Pending line has no downstream link; block on inout link, invoice link, or proforma allocation.
- Cucumber (`orderReactivatePayScheduleGuard.feature`, 3/3): TC1 reactivate allowed with nothing downstream (regression guard for the reported bug); TC2 proforma allocation still blocks; TC3 goods-receipt link still blocks.
- Migration verified on the local `deep_tundra_release` stack (message text updated across base + all trls).
