### PR TITLE
MobileUI Picking: unpick + scan target HU — re-resolve current HU QR before move

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobUnPickCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobUnPickCommand.java
@@ -177,12 +177,28 @@ public class PickingJobUnPickCommand
 		shipmentScheduleService.deleteByTopLevelHUsAndShipmentScheduleId(topLevelHUs, step.getScheduleId().getShipmentScheduleId());
 		changeHUStatusFromPickedToActive(topLevelHUs);
 
-		moveToTargetHUIfNeeded(huIdAndQRCodeList);
+		// extractToTopLevel above may have relocated/regenerated the QR codes (and the picked HU can carry
+		// surplus QR rows), so the pre-extraction snapshot no longer matches a live M_HU_QRCode. Re-resolve
+		// each extracted top-level HU's current QR by its id before moving it to the scanned target.
+		moveToTargetHUIfNeeded(toCurrentHuIdAndQRCodes(topLevelHUs));
 
 		return step.reduceWithUnpickEvent(
 				pickFromKey,
 				PickingJobStepUnpickInfo.ofUnpickedHUs(pickedToHUs)
 		);
+	}
+
+	private ImmutableSet<HUIdAndQRCode> toCurrentHuIdAndQRCodes(@NonNull final Collection<I_M_HU> hus)
+	{
+		return hus.stream()
+				.map(hu -> {
+					final HuId huId = HuId.ofRepoId(hu.getM_HU_ID());
+					return HUIdAndQRCode.builder()
+							.huId(huId)
+							.huQRCode(huService.getQRCodeByHuId(huId))
+							.build();
+				})
+				.collect(ImmutableSet.toImmutableSet());
 	}
 
 	private void moveToTargetHUIfNeeded(final ImmutableSet<HUIdAndQRCode> huIdAndQRCodeList)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesRepository.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesRepository.java
@@ -180,6 +180,49 @@ public class HUQRCodesRepository
 				.orElse(false);
 	}
 
+	/**
+	 * Read-only diagnostic for a failed {@link #isQRCodeAssignedToHU(HUQRCode, HuId)}: inspects the live
+	 * {@code M_HU_QRCode} row (including inactive) and its active assignments and returns a precise cause
+	 * string, so the raised error distinguishes the distinct failure modes. Performs no writes.
+	 */
+	public String diagnoseAssignmentFailure(@NonNull final HUQRCode qrCode, @NonNull final HuId huId)
+	{
+		final HUQRCodeUniqueId uniqueId = qrCode.getId();
+
+		// look up the QR-code row(s) by UniqueId WITHOUT the active filter, so an inactive row is still seen
+		final List<I_M_HU_QRCode> qrRecords = queryBL.createQueryBuilder(I_M_HU_QRCode.class)
+				.addEqualsFilter(I_M_HU_QRCode.COLUMNNAME_UniqueId, uniqueId.getAsString())
+				.create()
+				.list(I_M_HU_QRCode.class);
+		if (qrRecords.isEmpty())
+		{
+			return "no M_HU_QRCode row for UniqueId=" + uniqueId.getAsString();
+		}
+
+		final I_M_HU_QRCode activeQrRecord = qrRecords.stream()
+				.filter(I_M_HU_QRCode::isActive)
+				.findFirst()
+				.orElse(null);
+		if (activeQrRecord == null)
+		{
+			return "M_HU_QRCode row inactive for UniqueId=" + uniqueId.getAsString();
+		}
+
+		final ImmutableSet<HuId> assignedHuIds = queryBL.createQueryBuilder(I_M_HU_QRCode_Assignment.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_HU_QRCode_Assignment.COLUMNNAME_M_HU_QRCode_ID, activeQrRecord.getM_HU_QRCode_ID())
+				.create()
+				.stream()
+				.map(assignment -> HuId.ofRepoId(assignment.getM_HU_ID()))
+				.collect(ImmutableSet.toImmutableSet());
+		if (assignedHuIds.isEmpty())
+		{
+			return "QR active but has no active assignment";
+		}
+
+		return "QR active but assigned to HU(s) " + assignedHuIds + ", not " + huId;
+	}
+
 	public Optional<HUQRCode> getFirstQRCodeByHuId(@NonNull final HuId huId)
 	{
 		return queryByHuId(huId)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -344,7 +344,8 @@ public class HUQRCodesService
 	{
 		if (!huQRCodesRepository.isQRCodeAssignedToHU(qrCode, huId))
 		{
-			throw new AdempiereException("QR Code " + qrCode.toDisplayableQRCode() + " is not assigned to HU " + huId);
+			throw new AdempiereException("QR Code " + qrCode.toDisplayableQRCode() + " is not assigned to HU " + huId
+					+ " (" + huQRCodesRepository.diagnoseAssignmentFailure(qrCode, huId) + ")");
 		}
 	}
 

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
@@ -31,10 +31,14 @@ import de.metas.handlingunits.QtyTU;
 import de.metas.handlingunits.attribute.storage.IAttributeStorage;
 import de.metas.handlingunits.attribute.weightable.Weightables;
 import de.metas.handlingunits.model.I_M_HU;
+import com.google.common.collect.ImmutableSet;
 import de.metas.handlingunits.model.I_M_HU_PI;
 import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.handlingunits.model.I_M_HU_QRCode;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.model.InterfaceWrapperHelper;
 import de.metas.handlingunits.qrcodes.ean13.EAN13HUQRCode;
 import de.metas.handlingunits.qrcodes.gs1.GS1HUQRCode;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
@@ -377,6 +381,81 @@ class HUQRCodesServiceTest
 			assertThatThrownBy(() -> huQRCodesService.parse(junkCode))
 					.isInstanceOf(AdempiereException.class)
 					.satisfies(ex -> assertThat(((AdempiereException)ex).isUserValidationError()).isTrue());
+		}
+	}
+
+	@Nested
+	class assertQRCodeAssignedToHU
+	{
+		private I_M_HU_QRCode getQRCodeRecord(@NonNull final HUQRCode qrCode)
+		{
+			return Services.get(IQueryBL.class)
+					.createQueryBuilder(I_M_HU_QRCode.class)
+					.addEqualsFilter(I_M_HU_QRCode.COLUMNNAME_UniqueId, qrCode.getId().getAsString())
+					.create()
+					.firstOnlyNotNull(I_M_HU_QRCode.class);
+		}
+
+		@Test
+		void assignedToDifferentHU_messageDistinguishesTheCause()
+		{
+			final HuId assignedHuId = createTU();
+			final HuId otherHuId = createTU();
+
+			// generate + assign a QR code to assignedHuId
+			final HUQRCode qrCode = huQRCodesService.generateForExistingHU(assignedHuId).getSingleQRCode(assignedHuId);
+
+			// Asserting it against a DIFFERENT HU must fail — and the message must distinguish the cause
+			// (the QR is active and assigned, just to another HU), not merely say "not assigned".
+			assertThatThrownBy(() -> huQRCodesService.assertQRCodeAssignedToHU(qrCode, otherHuId))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("is not assigned to HU")
+					.hasMessageContaining("assigned to HU(s)")
+					.hasMessageContaining(String.valueOf(assignedHuId.getRepoId()));
+		}
+
+		@Test
+		void noActiveAssignment_messageDistinguishesTheCause()
+		{
+			final HuId huId = createTU();
+			final HUQRCode qrCode = huQRCodesService.generateForExistingHU(huId).getSingleQRCode(huId);
+
+			// remove the assignment: the QR row stays active but no active assignment remains
+			huQRCodesService.removeAssignment(qrCode, ImmutableSet.of(huId));
+
+			assertThatThrownBy(() -> huQRCodesService.assertQRCodeAssignedToHU(qrCode, huId))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("QR active but has no active assignment");
+		}
+
+		@Test
+		void inactiveQRCodeRow_messageDistinguishesTheCause()
+		{
+			final HuId huId = createTU();
+			final HUQRCode qrCode = huQRCodesService.generateForExistingHU(huId).getSingleQRCode(huId);
+
+			// deactivate the M_HU_QRCode row itself
+			final I_M_HU_QRCode record = getQRCodeRecord(qrCode);
+			record.setIsActive(false);
+			InterfaceWrapperHelper.save(record);
+
+			assertThatThrownBy(() -> huQRCodesService.assertQRCodeAssignedToHU(qrCode, huId))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("M_HU_QRCode row inactive");
+		}
+
+		@Test
+		void noQRCodeRow_messageDistinguishesTheCause()
+		{
+			final HuId huId = createTU();
+			final HUQRCode qrCode = huQRCodesService.generateForExistingHU(huId).getSingleQRCode(huId);
+
+			// delete the M_HU_QRCode row entirely
+			InterfaceWrapperHelper.delete(getQRCodeRecord(qrCode));
+
+			assertThatThrownBy(() -> huQRCodesService.assertQRCodeAssignedToHU(qrCode, huId))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("no M_HU_QRCode row for UniqueId");
 		}
 	}
 }

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -84,6 +84,7 @@
 |---|---|
 | Full pick, single HU, confirm, shipment schedule marked picked | `picking/picking.spec.js` |
 | Pick HU then unpick → HU returns to unallocated | `picking/picking.spec.js` |
+| Unpick a whole step and scan a target HU → picked goods move onto the scanned target HU | `picking/picking_unpick_scan_target.spec.js` |
 | Scan invalid picking slot QR code → error shown | `picking/picking.spec.js` |
 | Line status indicator transitions draft → in-progress → complete as HUs are picked | `picking/picking.spec.js` |
 | Partial pick, allowCompletingPartialPickingJob = N → complete blocked | `picking/picking.spec.js` |
@@ -97,7 +98,7 @@
 | Profile configured with HandoverLocation + DateReady summary fields (Customer kept out of summary) → job-list caption shows exactly 3 fields: document number, delivery location and delivery date | `picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js` |
 | ❌ Scan HU from wrong warehouse/locator → error shown | — |
 
-**13/14 — 93%**
+**14/15 — 93%**
 
 ### Order-based picking — filtering and facets
 

--- a/e2e/mobile-webui/tests/spec/picking/picking_unpick_scan_target.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_unpick_scan_target.spec.js
@@ -1,0 +1,135 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobLineScreen } from "../../utils/screens/picking/PickingJobLineScreen";
+import { PickingJobStepScreen } from "../../utils/screens/picking/PickingJobStepScreen";
+import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+
+// Whole-step unpick + scan a target HU must physically move the previously-picked goods onto the
+// scanned target HU. Before this fix, it failed: PickingJobUnPickCommand forwarded the stale
+// picked-CU (huId, QR) snapshot to MoveHUCommand after its own extractToTopLevel had already
+// relocated the QR, so HUQRCodesService.assertQRCodeAssignedToHU threw HTTP 422
+// "QR Code ... is not assigned to HU ..." and the goods never landed on the target.
+//
+// The target HU (HU2) must be an LU built from the SAME packing instruction as the picked HU:
+//   - Only an LU accepts the extracted top-level TU (moving into a TU/CU target fails).
+//   - The LU's TU child must be the SAME TU packing instruction as the picked HU's, else stacking
+//     is rejected ("cannot stack TU ... no link between them"); the masterdata API mints a fresh TU
+//     PI per packingInstructions entry, so the only LU that can receive the picked TU is one built
+//     from PI itself.
+//   - A PI-backed HU is force-filled to the PI's full capacity, so HU2 starts at 20 TU x 4 = 80 PCE.
+// Hence the target ends at its starting 80 PCE + the whole-step unpicked qty (12 PCE) = 92 PCE.
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                "P1": { prices: [{ price: 1 }] },
+            },
+            packingInstructions: {
+                "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "P1", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
+                // HU2: the target LU the whole picked step is unpicked into (same PI as HU1, starts at 80 PCE).
+                "HU2": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 12, piItemProduct: 'TU' }]
+                }
+            },
+        }
+    });
+};
+
+const loginAndStartJob = async ({ masterdata }) => {
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+    return { pickingJobId };
+};
+
+// noinspection JSUnusedLocalSymbols
+test('Unpick whole step + scan target HU — goods land on the scanned target', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');  // Standalone tag for Tags section
+    allure.story('Unpick a whole step and scan a target HU');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+    const targetHUQRCode = masterdata.handlingUnits.HU2.qrCode;
+
+    const { pickingJobId } = await loginAndStartJob({ masterdata });
+
+    await test.step("Pick all 3 TU (12 PCE) from HU1", async () => {
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '0 TU', qtyPickedCatchWeight: '' });
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '3' });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });
+        // Registers the dynamically-created `lu1` HU in the backend test context so the assertion
+        // below can refer to it by identifier.
+        await Backend.expect({
+            title: 'after full pick: 12 PCE packed on lu1, target HU2 still at its starting 80 PCE',
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: "12 PCE", qtyTUs: 3, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }] }
+                    }
+                }
+            },
+            hus: {
+                lu1: { huStatus: 'S', storages: { P1: '12 PCE' } },
+                [targetHUQRCode]: { storages: { P1: '80 PCE' } },
+            }
+        });
+    });
+
+    await test.step("Unpick the whole step and scan target HU2 — goods must move onto HU2", async () => {
+        await PickingJobScreen.clickLineButton({ index: 1 });
+        await PickingJobLineScreen.waitForScreen();
+        await PickingJobLineScreen.clickStepButton({ index: 0 });
+        await PickingJobStepScreen.unpick({ targetHUQRCode });
+        await PickingJobLineScreen.goBack();
+    });
+
+    // Commit-confirming, user-visible signal: the line falls back to 0 TU picked once the unpick has
+    // committed (guards the backend read below against reading pre-commit state).
+    await PickingJobScreen.waitForScreen();
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '0 TU', qtyPickedCatchWeight: '' });
+
+    // The end result: the previously-picked 12 PCE now physically reside on the scanned target HU2
+    // (its starting 80 PCE + the unpicked 12 PCE = 92 PCE), and the picked LU lu1 is emptied.
+    await Backend.expect({
+        title: 'after unpick + scan target: 12 PCE moved onto target HU2 (80 + 12 = 92), lu1 emptied',
+        hus: {
+            lu1: { storages: { P1: '0 PCE' } },
+            [targetHUQRCode]: { storages: { P1: '92 PCE' } },
+        }
+    });
+});

--- a/e2e/mobile-webui/tests/utils/dialogs/UnpickDialog.js
+++ b/e2e/mobile-webui/tests/utils/dialogs/UnpickDialog.js
@@ -1,5 +1,6 @@
 import { test } from "../../../playwright.config";
 import { page, SLOW_ACTION_TIMEOUT } from "../common";
+import { BarcodeScannerComponent } from "../components/BarcodeScannerComponent";
 
 const NAME = 'UnpickDialog';
 /** @returns {import('@playwright/test').Locator} */
@@ -12,5 +13,9 @@ export const UnpickDialog = {
 
     clickSkipScanningTargetHUButton: async () => await test.step(`${NAME} - Click Skip button`, async () => {
         await page.locator('#skip-button').tap();
+    }),
+
+    scanTargetHU: async (qrCode) => await test.step(`${NAME} - Scan target HU ${qrCode}`, async () => {
+        await BarcodeScannerComponent.type(qrCode);
     }),
 };

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobStepScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobStepScreen.js
@@ -13,10 +13,17 @@ export const PickingJobStepScreen = {
         await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
-    unpick: async () => await test.step(`${NAME} - Click unpick`, async () => {
+    // Whole-step unpick. With no argument the target-HU scan is skipped (the goods drop to loose
+    // top-level TUs). Passing { targetHUQRCode } instead scans a target HU, so the unpicked goods
+    // are moved onto that scanned HU. No-arg behaviour is preserved for existing callers.
+    unpick: async ({ targetHUQRCode } = {}) => await test.step(`${NAME} - Click unpick`, async () => {
         await page.locator(`#unpick-button`).tap();
         await UnpickDialog.waitForDialog();
-        await UnpickDialog.clickSkipScanningTargetHUButton();
+        if (targetHUQRCode) {
+            await UnpickDialog.scanTargetHU(targetHUQRCode);
+        } else {
+            await UnpickDialog.clickSkipScanningTargetHUButton();
+        }
         await PickingJobLineScreen.waitForScreen();
     }),
 };


### PR DESCRIPTION
## What

Fixes mobile Picking **"unpick a picked step + scan a target HU"**, which failed with HTTP 422 `QR Code … is not assigned to HU …` instead of moving the picked goods onto the scanned target HU.

## Root cause

`PickingJobUnPickCommand.unpickStep` computed the extracted top-level HUs via `extractToTopLevel`, but then forwarded the **pre-extraction** `(huId, QR)` snapshot to `moveToTargetHUIfNeeded`. Extraction relocates/regenerates the QR (and the picked HU can carry surplus QR rows), so the snapshot QR no longer matched a live `M_HU_QRCode.UniqueId` → `MoveHUCommand → HUQRCodesService.assertQRCodeAssignedToHU` threw 422.

## Fix

Re-resolve each extracted top-level HU's **current live QR by id** (`PickingJobHUService.getQRCodeByHuId`) right before the move — behaviour-identical to the upstream fix already on `new_dawn_uat` (commit https://github.com/metasfresh/metasfresh/commit/6767c6056b0 , https://github.com/metasfresh/metasfresh/pull/24772), backported here. Being stale-cause-agnostic, it also covers the surplus-QR condition.

Also makes the `assertQRCodeAssignedToHU` failure message **diagnostic** (distinguishes: no QR row / QR row inactive / no active assignment / assigned to a different HU) instead of the single ambiguous text.

## Tests

- **Mobile-webui Playwright E2E** `picking_unpick_scan_target.spec.js` (new): whole-step unpick + scan target HU → asserts the picked goods physically land on the scanned target HU. **RED** against the unfixed backend (reproduced the exact 422), **GREEN** after the fix.
- **JUnit** `HUQRCodesServiceTest$assertQRCodeAssignedToHU` (4 cases): the diagnostic message distinguishes each failure cause.
