### PR TITLE
TableModelLoader.getPOs: chunk large id loads to avoid JDBC 2-byte bind-param limit

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/persistence/TableModelLoader.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/persistence/TableModelLoader.java
@@ -22,7 +22,9 @@ package org.adempiere.ad.persistence;
  * #L%
  */
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import de.metas.cache.interceptor.CacheInterceptor;
 import de.metas.cache.model.IModelCacheService;
 import de.metas.logging.LogManager;
@@ -47,6 +49,7 @@ import java.lang.reflect.Constructor;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -63,6 +66,26 @@ public final class TableModelLoader
 
 	private static final Logger log = LogManager.getLogger(TableModelLoader.class);
 	private final TableModelClassLoader tableModelClassLoader = TableModelClassLoader.instance;
+
+	/**
+	 * Max number of record IDs to load per "IN (?,?,...)" query, to stay below the PostgreSQL/JDBC
+	 * 2-byte bind-parameter limit (max 32767 params per statement). Larger sets are loaded in chunks.
+	 * Kept conservative (plan-friendly); it only ever engages for loads that would otherwise fail.
+	 * MUST stay &lt;= 32767 or the very bug this guards against returns (see {@code TableModelLoaderChunkingTest}).
+	 */
+	@VisibleForTesting
+	static final int MAX_IDS_PER_QUERY = 1000;
+
+	/**
+	 * @return {@code true} if {@code recordIdCount} record IDs can be loaded in one query (the fast path),
+	 * i.e. the count stays within {@link #MAX_IDS_PER_QUERY}; {@code false} if the load must be chunked.
+	 * This is the exact decision {@link #getPOs} uses to pick the fast path vs. chunked loading.
+	 */
+	@VisibleForTesting
+	static boolean isSingleQueryLoad(final int recordIdCount)
+	{
+		return recordIdCount <= MAX_IDS_PER_QUERY;
+	}
 
 	private TableModelLoader()
 	{
@@ -174,35 +197,69 @@ public final class TableModelLoader
 		{
 			final POInfo poInfo = POInfo.getPOInfo(tableName);
 
-			final List<Object> sqlParams = new ArrayList<>();
-			final String sql = poInfo.buildSelect()
-					.append(" WHERE ").append(DB.buildSqlList(poInfo.getSingleKeyColumnName(), recordIdsToLoad, sqlParams))
-					.toString();
-			PreparedStatement pstmt = null;
-			ResultSet rs = null;
-			try
+			// Avoid the PostgreSQL/JDBC 2-byte bind-parameter limit (max 32767 params per statement).
+			// A single "IN (?,?,...)" with all IDs overflows once there are ~32k+ IDs, failing with
+			// "Tried to send an out-of-range integer as a 2-byte value". Load in chunks when needed.
+			// Fast path: for the common (small) case run exactly as before (single query, no partitioning/copy).
+			if (isSingleQueryLoad(recordIdsToLoad.size()))
 			{
-				pstmt = DB.prepareStatement(sql, trxName);
-				DB.setParameters(pstmt, sqlParams);
-				rs = pstmt.executeQuery();
-				while (rs.next())
+				loadPOsFromDB(ctx, tableName, poInfo, recordIdsToLoad, trxName, result);
+			}
+			else
+			{
+				for (final List<Integer> recordIdsChunk : Iterables.partition(recordIdsToLoad, MAX_IDS_PER_QUERY))
 				{
-					final PO po = getPO(ctx, tableName, rs, trxName);
-					result.add(po);
+					loadPOsFromDB(ctx, tableName, poInfo, recordIdsChunk, trxName, result);
 				}
-			}
-			catch (Exception ex)
-			{
-				throw new DBException(ex, sql, sqlParams);
-			}
-			finally
-			{
-				DB.close(rs, pstmt);
 			}
 		}
 
 		//
 		return result;
+	}
+
+	/**
+	 * Loads the POs with the given (already cache-missed) IDs directly from the database and appends them to {@code result}.
+	 * The number of IDs must not exceed the JDBC bind-parameter limit; callers split larger sets into chunks
+	 * (see {@link #MAX_IDS_PER_QUERY}).
+	 * <p>
+	 * NOTE: each chunk is loaded by an independent SQL statement, so under READ COMMITTED there is no
+	 * cross-chunk MVCC snapshot consistency for loads &gt; {@link #MAX_IDS_PER_QUERY} ids. A caller needing an
+	 * atomic snapshot across a huge id set must arrange it itself (e.g. REPEATABLE READ).
+	 */
+	private void loadPOsFromDB(
+			final Properties ctx,
+			@NonNull final String tableName,
+			@NonNull final POInfo poInfo,
+			@NonNull final Collection<Integer> recordIds,
+			final String trxName,
+			@NonNull final List<PO> result)
+	{
+		final List<Object> sqlParams = new ArrayList<>();
+		final String sql = poInfo.buildSelect()
+				.append(" WHERE ").append(DB.buildSqlList(poInfo.getSingleKeyColumnName(), recordIds, sqlParams))
+				.toString();
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		try
+		{
+			pstmt = DB.prepareStatement(sql, trxName);
+			DB.setParameters(pstmt, sqlParams);
+			rs = pstmt.executeQuery();
+			while (rs.next())
+			{
+				final PO po = getPO(ctx, tableName, rs, trxName);
+				result.add(po);
+			}
+		}
+		catch (Exception ex)
+		{
+			throw new DBException(ex, sql, sqlParams);
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+		}
 	}
 
 	/**

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/persistence/TableModelLoader.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/persistence/TableModelLoader.java
@@ -70,11 +70,13 @@ public final class TableModelLoader
 	/**
 	 * Max number of record IDs to load per "IN (?,?,...)" query, to stay below the PostgreSQL/JDBC
 	 * 2-byte bind-parameter limit (max 32767 params per statement). Larger sets are loaded in chunks.
-	 * Kept conservative (plan-friendly); it only ever engages for loads that would otherwise fail.
+	 * Set well below that cap with headroom (not AT the limit, so an off-by-one or a future extra bind
+	 * param can't reintroduce the overflow), yet large enough to keep the chunk count low — an ~83k-id
+	 * load becomes 3 queries, not 84. It only ever engages for loads that would otherwise fail.
 	 * MUST stay &lt;= 32767 or the very bug this guards against returns (see {@code TableModelLoaderChunkingTest}).
 	 */
 	@VisibleForTesting
-	static final int MAX_IDS_PER_QUERY = 1000;
+	static final int MAX_IDS_PER_QUERY = 30000;
 
 	/**
 	 * @return {@code true} if {@code recordIdCount} record IDs can be loaded in one query (the fast path),

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/persistence/TableModelLoaderChunkingTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/persistence/TableModelLoaderChunkingTest.java
@@ -1,0 +1,118 @@
+package org.adempiere.ad.persistence;
+
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.collect.Iterables;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure (no-DB) guard for {@link TableModelLoader}'s large-id-load chunking that fixes the PostgreSQL/JDBC
+ * 2-byte bind-parameter overflow. Covers what does NOT need a DB: the production fast-path-vs-chunked
+ * decision ({@link TableModelLoader#isSingleQueryLoad(int)}), the chunk-size cap invariant, and the
+ * partition semantics used by the chunked path. The actual DB-executed load (the {@code for} loop calling
+ * {@code loadPOsFromDB} per chunk) needs a real DB and is exercised by the {@code @Disabled
+ * TableModelLoader_DBTest} (this base module has no automated real-DB harness).
+ */
+class TableModelLoaderChunkingTest
+{
+	/** The whole point of the fix: the chunk size must stay under the JDBC 2-byte bind-parameter cap. */
+	@Test
+	void chunkSize_staysUnderJdbc2ByteParamLimit()
+	{
+		assertTrue(TableModelLoader.MAX_IDS_PER_QUERY > 0,
+				"MAX_IDS_PER_QUERY must be positive");
+		assertTrue(TableModelLoader.MAX_IDS_PER_QUERY <= 32767,
+				"MAX_IDS_PER_QUERY (" + TableModelLoader.MAX_IDS_PER_QUERY
+						+ ") must stay <= 32767, else the 2-byte bind-param overflow this fix guards against returns");
+	}
+
+	/** The production dispatch decision: <= MAX ids -> single query (fast path); > MAX -> chunked. */
+	@Test
+	void isSingleQueryLoad_boundary()
+	{
+		final int max = TableModelLoader.MAX_IDS_PER_QUERY;
+		assertTrue(TableModelLoader.isSingleQueryLoad(0), "empty -> single query");
+		assertTrue(TableModelLoader.isSingleQueryLoad(1), "1 id -> single query");
+		assertTrue(TableModelLoader.isSingleQueryLoad(max), "exactly MAX -> single query (fast path)");
+		assertFalse(TableModelLoader.isSingleQueryLoad(max + 1), "MAX+1 -> chunked");
+		assertFalse(TableModelLoader.isSingleQueryLoad(2 * max), "2xMAX -> chunked");
+	}
+
+	/** The partitioning used by the chunked path (mirrors {@code getPOs}'s {@code Iterables.partition} call). */
+	@Nested
+	class Partition
+	{
+		/** A large set (well past the old failing threshold) partitions with every id preserved and no chunk over the cap. */
+		@Test
+		void preservesAllIds_andNeverExceedsChunkSize()
+		{
+			final int max = TableModelLoader.MAX_IDS_PER_QUERY;
+			final Set<Integer> ids = new HashSet<>();
+			for (int i = 1; i <= 40000; i++)
+			{
+				ids.add(i);
+			}
+
+			final Set<Integer> seen = new HashSet<>();
+			int chunkCount = 0;
+			for (final List<Integer> chunk : Iterables.partition(ids, max))
+			{
+				assertTrue(chunk.size() <= max, "no chunk may exceed MAX_IDS_PER_QUERY");
+				seen.addAll(chunk);
+				chunkCount++;
+			}
+
+			assertEquals(ids, seen, "every id must appear exactly once across chunks (no loss, no duplication)");
+			assertEquals((40000 + max - 1) / max, chunkCount, "chunk count must be ceil(n / max)");
+		}
+
+		/** Boundary: exactly MAX ids -> one chunk; MAX+1 -> two chunks (mirrors the fast-path vs chunked split). */
+		@Test
+		void boundaryAtMax()
+		{
+			final int max = TableModelLoader.MAX_IDS_PER_QUERY;
+			assertEquals(1, countChunks(max), "exactly MAX ids -> one chunk");
+			assertEquals(2, countChunks(max + 1), "MAX+1 ids -> two chunks");
+		}
+
+		private int countChunks(final int n)
+		{
+			final List<Integer> ids = new ArrayList<>(n);
+			for (int i = 0; i < n; i++)
+			{
+				ids.add(i);
+			}
+			return Iterables.size(Iterables.partition(ids, TableModelLoader.MAX_IDS_PER_QUERY));
+		}
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/persistence/TableModelLoader_DBTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/persistence/TableModelLoader_DBTest.java
@@ -1,0 +1,100 @@
+package org.adempiere.ad.persistence;
+
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.util.Check;
+import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.Adempiere.RunMode;
+import org.compiere.model.I_Test;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Database-coupled test for {@link TableModelLoader#getPOs(java.util.Properties, String, Set, String)}.
+ * <p>
+ * Reproduces the bug where loading more than the PostgreSQL/JDBC 2-byte bind-parameter limit
+ * (32767) of record IDs in a single {@code IN (?,?,...)} query fails with
+ * {@code java.io.IOException: Tried to send an out-of-range integer as a 2-byte value: N}
+ * (surfacing as {@code DBException: An I/O error occurred while sending to the backend}).
+ * The fix chunks the load into batches of {@link TableModelLoader#MAX_IDS_PER_QUERY}.
+ * <p>
+ * This test is {@link Disabled} because this module has no automated real-DB harness and the
+ * in-memory {@code POJOWrapper} does NOT exercise the JDBC path where the bug lives. Run it
+ * manually against a real PostgreSQL instance (set the {@code PropertyFile} system property, as
+ * the sibling {@code GuaranteedPOBufferedIterator_DBTest} does).
+ * <p>
+ * Ground-truth red/green for this fix was captured at the raw-JDBC level against a live
+ * PostgreSQL 15 instance: a monolithic {@code IN} with 40000 bound params reproduced the exact
+ * error above (and dropped the connection), while chunking by 1000 loaded all 40000 rows.
+ */
+@Disabled // requires a real database connection (see class javadoc)
+public class TableModelLoader_DBTest
+{
+	private void setupAdempiere()
+	{
+		if (Check.isEmpty(System.getProperty("PropertyFile"), true))
+		{
+			final String propertyFile = new File(".").getAbsolutePath()
+					+ File.separator + ".." + File.separator + ".."
+					+ File.separator + "de.metas.endcustomer."
+					+ File.separator + "Adempiere.properties_" + System.getProperty("user.name");
+			System.out.println("Set default PropertyFile=" + propertyFile);
+			System.setProperty("PropertyFile", propertyFile);
+		}
+		Env.getSingleAdempiereInstance(null).startup(RunMode.SWING_CLIENT);
+	}
+
+	/**
+	 * Creates more than {@link TableModelLoader#MAX_IDS_PER_QUERY} records (and more than the
+	 * 32767 JDBC bind-param limit) and asserts {@code loadByIds} returns them all without error.
+	 * Fails on the pre-fix code with the 2-byte overflow; passes once getPOs chunks the load.
+	 */
+	@Test
+	public void loadByIds_moreThanBindParameterLimit()
+	{
+		setupAdempiere();
+
+		final int count = 33000; // > 32767 JDBC bind-param limit and > MAX_IDS_PER_QUERY
+		final Set<Integer> ids = new HashSet<>(count);
+		for (int i = 0; i < count; i++)
+		{
+			final I_Test record = InterfaceWrapperHelper.create(Env.getCtx(), I_Test.class, ITrx.TRXNAME_None);
+			record.setName("Test_" + UUID.randomUUID());
+			InterfaceWrapperHelper.save(record);
+			ids.add(record.getTest_ID());
+		}
+
+		final List<I_Test> loaded = InterfaceWrapperHelper.loadByIds(ids, I_Test.class);
+
+		Assertions.assertEquals(ids.size(), loaded.size(), "all created records must be loaded");
+	}
+}


### PR DESCRIPTION
## Problem

`InterfaceWrapperHelper.loadByIds(ids, …)` → `POWrapper.loadByIds` → `TableModelLoader.getPOs` builds a single `keyColumn IN (?, ?, … )` with **one bind parameter per id**. When the id set is large, the number of bind parameters exceeds PostgreSQL's wire-protocol limit (the Bind message encodes the parameter count as a signed 2-byte integer, max **32,767**), so the JDBC driver throws before the query runs:

```
java.io.IOException: Tried to send an out-of-range integer as a 2-byte value: <N>
```

surfacing as `DBException: An I/O error occurred while sending to the backend` (SQLState 08006) and dropping the connection. Any bulk `loadByIds` of more than ~32k ids hits this. `getPOs` is the single choke point for all `loadByIds` callers, so the fix belongs there.

## Fix

Chunk the DB load when the id set is large, keeping the common (small) case unchanged:

- New `MAX_IDS_PER_QUERY = 1000` (well under the 32,767 cap; plan-friendly).
- Extracted the existing DB-load body into `loadPOsFromDB(...)`, preserving the per-load `DBException(ex, sql, sqlParams)` wrapping.
- **Fast path — zero overhead for the common case:** for `size <= MAX_IDS_PER_QUERY` the code runs the exact same single query as before (no copy, no partition, no loop — only one O(1) size check, via the extracted `isSingleQueryLoad(int)` predicate). Only larger loads iterate `Iterables.partition(...)` (no full copy of the id set) and concatenate results.

Result semantics are unchanged: `getPOs` has no `ORDER BY` and its caller maps results by id, so chunk-and-concatenate is identical to the single-query result. Each chunk is an independent statement (documented on `loadPOsFromDB`): under READ COMMITTED there is no cross-chunk snapshot consistency for huge loads — a caller needing that must arrange it itself.

## Tests

- `TableModelLoaderChunkingTest` (CI-runnable, no DB): asserts the chunk-size cap stays `<= 32767`, the dispatch decision (`isSingleQueryLoad`) at the `MAX`/`MAX+1` boundary, and the partition invariants (all ids preserved, no chunk over the cap, `ceil(n/max)` chunk count).
- `TableModelLoader_DBTest` (`@Disabled`): end-to-end reproduction that loads > 32,767 rows and asserts all are returned — mirrors this base module's existing manual-run DB-test convention (no automated real-DB harness).

## Scope

Standalone core bugfix — benefits every bulk `loadByIds` caller. Removes the crash; does not change batch sizing/throughput of any specific caller.
