### PR TITLE
DDOrderCandidate: optional header aggregation by product (single-line DD_Orders)

### DIFF
--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
@@ -326,6 +326,12 @@ class DDOrderCandidateProcessCommand
 		boolean aggregateBySalesOrderId;
 		boolean aggregateByPPOrderRef;
 		boolean aggregateBySalesOrderLineId;
+		/**
+		 * If {@code true}, {@link DDOrderCandidate}s of different products are kept in separate {@link I_DD_Order}s
+		 * (productId becomes part of the {@link HeaderAggregationKey}). This yields one product — and therefore one
+		 * UOM — per DD_Order, i.e. single-line DD_Orders instead of one big multi-product order.
+		 */
+		boolean aggregateByProductId;
 	}
 	//
 	//
@@ -357,6 +363,8 @@ class DDOrderCandidateProcessCommand
 
 		@Nullable String traceId;
 
+		@Nullable ProductId productId;
+
 		public static HeaderAggregationKey of(@NonNull final DDOrderCandidate candidate, @NonNull final AggregationConfig aggregationConfig)
 		{
 			final HeaderAggregationKeyBuilder keyBuilder = builder()
@@ -378,6 +386,10 @@ class DDOrderCandidateProcessCommand
 			if (aggregationConfig.isAggregateByPPOrderRef())
 			{
 				keyBuilder.forwardPPOrderRef(candidate.getForwardPPOrderRef());
+			}
+			if (aggregationConfig.isAggregateByProductId())
+			{
+				keyBuilder.productId(candidate.getProductId());
 			}
 			return keyBuilder.build();
 		}

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
@@ -328,8 +328,10 @@ class DDOrderCandidateProcessCommand
 		boolean aggregateBySalesOrderLineId;
 		/**
 		 * If {@code true}, {@link DDOrderCandidate}s of different products are kept in separate {@link I_DD_Order}s
-		 * (productId becomes part of the {@link HeaderAggregationKey}). This yields one product — and therefore one
-		 * UOM — per DD_Order, i.e. single-line DD_Orders instead of one big multi-product order.
+		 * (productId becomes part of the {@link HeaderAggregationKey}), instead of collapsing into one big
+		 * multi-product order. Lines are still aggregated independently by {@link LineAggregationKey} (ASI / UOM /
+		 * HU-PI / distribution-network / …), so a single product carrying several such variants can still produce
+		 * more than one line — this flag only bounds a header to one product, it does not force a single line.
 		 */
 		boolean aggregateByProductId;
 	}

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
@@ -326,13 +326,6 @@ class DDOrderCandidateProcessCommand
 		boolean aggregateBySalesOrderId;
 		boolean aggregateByPPOrderRef;
 		boolean aggregateBySalesOrderLineId;
-		/**
-		 * If {@code true}, {@link DDOrderCandidate}s of different products are kept in separate {@link I_DD_Order}s
-		 * (productId becomes part of the {@link HeaderAggregationKey}), instead of collapsing into one big
-		 * multi-product order. Lines are still aggregated independently by {@link LineAggregationKey} (ASI / UOM /
-		 * HU-PI / distribution-network / …), so a single product carrying several such variants can still produce
-		 * more than one line — this flag only bounds a header to one product, it does not force a single line.
-		 */
 		boolean aggregateByProductId;
 	}
 	//

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
@@ -36,6 +36,7 @@ public class DDOrderCandidateService
 	public static final String SYSCONFIG_DDOrderAggregation_header_bySalesOrderId = "DDOrderAggregation.header.bySalesOrderId";
 	public static final String SYSCONFIG_DDOrderAggregation_header_byPPOrderRef = "DDOrderAggregation.header.byPPOrderRef";
 	public static final String SYSCONFIG_DDOrderAggregation_line_bySalesOrderLineId = "DDOrderAggregation.line.bySalesOrderLineId";
+	public static final String SYSCONFIG_DDOrderAggregation_header_byProductId = "DDOrderAggregation.header.byProductId";
 
 	@NonNull private final DDOrderCandidateRepository ddOrderCandidateRepository;
 	@NonNull private final DDOrderCandidateAllocRepository ddOrderCandidateAllocRepository;
@@ -125,6 +126,9 @@ public class DDOrderCandidateService
 				.aggregateBySalesOrderId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_bySalesOrderId, true))
 				.aggregateByPPOrderRef(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byPPOrderRef, true))
 				.aggregateBySalesOrderLineId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_line_bySalesOrderLineId, true))
+				// Defaults to false: enabling it splits a multi-product DD_Order into one single-line DD_Order per
+				// product (changes today's aggregation), so it is opt-in per instance rather than on by default.
+				.aggregateByProductId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byProductId, false))
 				.build();
 	}
 

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
@@ -126,8 +126,8 @@ public class DDOrderCandidateService
 				.aggregateBySalesOrderId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_bySalesOrderId, true))
 				.aggregateByPPOrderRef(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byPPOrderRef, true))
 				.aggregateBySalesOrderLineId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_line_bySalesOrderLineId, true))
-				// Defaults to false: enabling it splits a multi-product DD_Order into one single-line DD_Order per
-				// product (changes today's aggregation), so it is opt-in per instance rather than on by default.
+				// Defaults to false: enabling it keeps different products in separate DD_Orders (adds M_Product_ID
+				// to the header key), changing today's aggregation, so it is opt-in per instance rather than on by default.
 				.aggregateByProductId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byProductId, false))
 				.build();
 	}

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
@@ -126,8 +126,6 @@ public class DDOrderCandidateService
 				.aggregateBySalesOrderId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_bySalesOrderId, true))
 				.aggregateByPPOrderRef(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byPPOrderRef, true))
 				.aggregateBySalesOrderLineId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_line_bySalesOrderLineId, true))
-				// Defaults to false: enabling it keeps different products in separate DD_Orders (adds M_Product_ID
-				// to the header key), changing today's aggregation, so it is opt-in per instance rather than on by default.
 				.aggregateByProductId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byProductId, false))
 				.build();
 	}

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812470_sys_DDOrderAggregation_header_byProductId.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812470_sys_DDOrderAggregation_header_byProductId.sql
@@ -1,0 +1,9 @@
+-- Run mode: SWING_CLIENT
+
+-- SysConfig Name: DDOrderAggregation.header.byProductId
+-- Seeds the on-switch (default 'N') for keeping DD_Order_Candidates of different products in separate DD_Orders.
+-- When 'Y', M_Product_ID becomes part of the DD_Order header aggregation key, so each product gets its own
+-- single-line DD_Order (one product -> one UOM per order) instead of one big multi-product order.
+-- Default 'N' preserves today's behaviour; enable per instance via the customer repo.
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541832 /*From ID Server*/,'O',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'If enabled, prevents DD_Order_Candidates of different products from ending up in the same DD_Order (one product - and one UOM - per DD_Order).','D','Y','DDOrderAggregation.header.byProductId',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'N')
+;

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812470_sys_DDOrderAggregation_header_byProductId.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812470_sys_DDOrderAggregation_header_byProductId.sql
@@ -1,9 +1,7 @@
 -- Run mode: SWING_CLIENT
 
 -- SysConfig Name: DDOrderAggregation.header.byProductId
--- Seeds the on-switch (default 'N') for keeping DD_Order_Candidates of different products in separate DD_Orders.
--- When 'Y', M_Product_ID becomes part of the DD_Order header aggregation key, so candidates of different
--- products no longer share a DD_Order (each product gets its own order) instead of one big multi-product order.
--- Default 'N' preserves today's behaviour; enable per instance via the customer repo.
+-- SysConfig Value: N
+-- When 'Y', M_Product_ID is part of the DD_Order header aggregation key (one product per DD_Order). Default 'N'.
 INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541832 /*From ID Server*/,'O',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'If enabled, prevents DD_Order_Candidates of different products from ending up in the same DD_Order.','D','Y','DDOrderAggregation.header.byProductId',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'N')
 ;

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812470_sys_DDOrderAggregation_header_byProductId.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812470_sys_DDOrderAggregation_header_byProductId.sql
@@ -2,8 +2,8 @@
 
 -- SysConfig Name: DDOrderAggregation.header.byProductId
 -- Seeds the on-switch (default 'N') for keeping DD_Order_Candidates of different products in separate DD_Orders.
--- When 'Y', M_Product_ID becomes part of the DD_Order header aggregation key, so each product gets its own
--- single-line DD_Order (one product -> one UOM per order) instead of one big multi-product order.
+-- When 'Y', M_Product_ID becomes part of the DD_Order header aggregation key, so candidates of different
+-- products no longer share a DD_Order (each product gets its own order) instead of one big multi-product order.
 -- Default 'N' preserves today's behaviour; enable per instance via the customer repo.
-INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541832 /*From ID Server*/,'O',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'If enabled, prevents DD_Order_Candidates of different products from ending up in the same DD_Order (one product - and one UOM - per DD_Order).','D','Y','DDOrderAggregation.header.byProductId',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'N')
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541832 /*From ID Server*/,'O',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'If enabled, prevents DD_Order_Candidates of different products from ending up in the same DD_Order.','D','Y','DDOrderAggregation.header.byProductId',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'N')
 ;

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
@@ -51,6 +51,10 @@ import static org.mockito.Mockito.when;
  * The header-record creation used to dereference {@code productPlanningDAO.getById(null)} unconditionally;
  * with no product planning this threw a {@link NullPointerException}. The fix guards the lookup and clears
  * {@code PP_Product_Planning_ID} / {@code AD_User_ID} / {@code SalesRep_ID} with the {@code -1} sentinel.
+ * <p>
+ * Also covers the optional {@code aggregateByProductId} header-aggregation dimension: with the flag off,
+ * candidates of different products share one DD_Order (one line each); with it on, each product gets its
+ * own DD_Order.
  */
 class DDOrderCandidateProcessCommandTest
 {

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
@@ -28,10 +28,12 @@ import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.IWarehouseBL;
 import org.compiere.util.Env;
 import org.eevolution.model.I_DD_Order;
+import org.eevolution.model.I_DD_OrderLine;
 import org.eevolution.model.X_DD_Order;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -146,5 +148,76 @@ class DDOrderCandidateProcessCommandTest
 		assertThat(header.getAD_User_ID()).isEqualTo(-1);
 		assertThat(header.getSalesRep_ID()).isEqualTo(-1);
 		assertThat(header.getDocStatus()).isEqualTo(X_DD_Order.DOCSTATUS_Drafted);
+	}
+
+	/**
+	 * Control: with {@code aggregateByProductId=false} (today's behaviour), two candidates that differ only by
+	 * product collapse into ONE DD_Order carrying one line per product.
+	 */
+	@Test
+	void process_twoProducts_byProductIdDisabled_singleDDOrderWithTwoLines()
+	{
+		processTwoProductCandidates(false);
+
+		final List<I_DD_Order> orders = queryOrders();
+		assertThat(orders).hasSize(1);
+		assertThat(queryLines(orders.get(0))).hasSize(2);
+	}
+
+	/**
+	 * Target: with {@code aggregateByProductId=true}, the same two candidates produce TWO DD_Orders, each with a
+	 * single line (one product — and therefore one UOM — per order).
+	 */
+	@Test
+	void process_twoProducts_byProductIdEnabled_twoSingleLineDDOrders()
+	{
+		processTwoProductCandidates(true);
+
+		final List<I_DD_Order> orders = queryOrders();
+		assertThat(orders).hasSize(2);
+		assertThat(orders).allSatisfy(order -> assertThat(queryLines(order)).hasSize(1));
+	}
+
+	private void processTwoProductCandidates(final boolean aggregateByProductId)
+	{
+		final DDOrderCandidate product20 = DDOrderCandidateRepositoryTest.newFullyFilled().toBuilder()
+				.productId(ProductId.ofRepoId(20))
+				.build();
+		final DDOrderCandidate product21 = DDOrderCandidateRepositoryTest.newFullyFilled().toBuilder()
+				.productId(ProductId.ofRepoId(21))
+				.build();
+		ddOrderCandidateRepository.save(product20);
+		ddOrderCandidateRepository.save(product21);
+
+		commandBuilder
+				.aggregationConfig(DDOrderCandidateProcessCommand.AggregationConfig.builder()
+						.aggregateBySalesOrderId(true)
+						.aggregateByPPOrderRef(true)
+						.aggregateBySalesOrderLineId(true)
+						.aggregateByProductId(aggregateByProductId)
+						.build())
+				.request(DDOrderCandidateProcessRequest.builder()
+						.userId(UserId.METASFRESH)
+						.candidates(ImmutableList.of(product20, product21))
+						.build())
+				.build()
+				.execute();
+	}
+
+	private static List<I_DD_Order> queryOrders()
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_DD_Order.class)
+				.create()
+				.list(I_DD_Order.class);
+	}
+
+	private static List<I_DD_OrderLine> queryLines(final I_DD_Order order)
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_DD_OrderLine.class)
+				.addEqualsFilter(I_DD_OrderLine.COLUMNNAME_DD_Order_ID, order.getDD_Order_ID())
+				.create()
+				.list(I_DD_OrderLine.class);
 	}
 }


### PR DESCRIPTION
## What
Adds an optional DD_Order **header** aggregation dimension: `M_Product_ID`.

`AggregationConfig.aggregateByProductId` — driven by a new sysconfig `DDOrderAggregation.header.byProductId` (default `N`). When enabled, `M_Product_ID` becomes part of the `HeaderAggregationKey`, so `DD_Order_Candidate`s of different products no longer collapse into one large multi-product `DD_Order`. Each product then gets its own **single-line** `DD_Order` (one product → one UOM per order).

## Why
Extends the existing `AggregationConfig` pattern (the three existing `DDOrderAggregation.*` sysconfig toggles that conditionally add a field to the aggregation key). Some deployments produce very large multi-product intra-warehouse replenishment `DD_Order`s — one order with hundreds of lines spanning several UOMs. This flag makes it possible to split those into single-product, single-line orders.

## Behaviour / safety
- **Default `N` → no behaviour change** for any existing instance. Fully opt-in per instance via the sysconfig.
- Change is confined to `de.metas.manufacturing`; `AggregationConfig` has no callers in other modules.

## Tests
`DDOrderCandidateProcessCommandTest`:
- `process_twoProducts_byProductIdDisabled_singleDDOrderWithTwoLines` — control: current behaviour (1 DD_Order, 2 lines).
- `process_twoProducts_byProductIdEnabled_twoSingleLineDDOrders` — two candidates differing only by product → 2 single-line DD_Orders.

## Migration
`5812470_sys_DDOrderAggregation_header_byProductId.sql` — seeds the sysconfig row with default `N`.
