### PR TITLE
Cucumber: DDOrderAggregation.header.byProductId (single-product DD_Orders)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/ddordercandidate/DD_Order_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/ddordercandidate/DD_Order_Candidate_StepDef.java
@@ -18,7 +18,6 @@ import de.metas.cucumber.stepdefs.pporder.PP_Order_Candidate_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.PP_Order_StepDefData;
 import de.metas.cucumber.stepdefs.shipper.M_Shipper_StepDefData;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
-import de.metas.distribution.ddorder.DDOrderAndLineId;
 import de.metas.distribution.ddorder.DDOrderId;
 import de.metas.distribution.ddorder.lowlevel.DDOrderLowLevelDAO;
 import de.metas.distribution.ddordercandidate.DDOrderCandidate;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/ddordercandidate/DD_Order_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/ddordercandidate/DD_Order_Candidate_StepDef.java
@@ -1,5 +1,6 @@
 package de.metas.cucumber.stepdefs.ddordercandidate;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import de.metas.cucumber.stepdefs.M_Locator_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_OrderLine_StepDefData;
@@ -19,6 +20,7 @@ import de.metas.cucumber.stepdefs.shipper.M_Shipper_StepDefData;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
 import de.metas.distribution.ddorder.DDOrderAndLineId;
 import de.metas.distribution.ddorder.DDOrderId;
+import de.metas.distribution.ddorder.lowlevel.DDOrderLowLevelDAO;
 import de.metas.distribution.ddordercandidate.DDOrderCandidate;
 import de.metas.distribution.ddordercandidate.DDOrderCandidateAlloc;
 import de.metas.distribution.ddordercandidate.DDOrderCandidateAllocList;
@@ -39,7 +41,6 @@ import de.metas.quantity.Quantity;
 import de.metas.shipping.ShipperId;
 import de.metas.uom.IUOMDAO;
 import de.metas.util.Services;
-import com.google.common.collect.ImmutableList;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
@@ -77,6 +78,7 @@ public class DD_Order_Candidate_StepDef
 	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	@NonNull private final DDOrderCandidateService ddOrderCandidateService = SpringContextHolder.instance.getBean(DDOrderCandidateService.class);
 	@NonNull private final DDOrderCandidateAllocRepository ddOrderCandidateAllocRepository = SpringContextHolder.instance.getBean(DDOrderCandidateAllocRepository.class);
+	@NonNull private final DDOrderLowLevelDAO ddOrderLowLevelDAO = SpringContextHolder.instance.getBean(DDOrderLowLevelDAO.class);
 	@NonNull private final DD_Order_Candidate_StepDefData ddOrderCandidateTable;
 	@NonNull private final M_Product_StepDefData productTable;
 	@NonNull private final M_Locator_StepDefData locatorTable;
@@ -592,19 +594,12 @@ public class DD_Order_Candidate_StepDef
 				.collect(Collectors.groupingBy(id -> id, Collectors.counting()));
 
 		candidatesPerDDOrder.forEach((ddOrderId, candidateCount) -> {
-			final List<I_DD_OrderLine> lines = queryBL.createQueryBuilder(I_DD_OrderLine.class)
-					.addEqualsFilter(I_DD_OrderLine.COLUMNNAME_DD_Order_ID, ddOrderId)
-					.addOnlyActiveRecordsFilter()
-					.create()
-					.list(I_DD_OrderLine.class);
+			final I_DD_Order ddOrder = ddOrderLowLevelDAO.getById(ddOrderId);
+			final List<I_DD_OrderLine> lines = ddOrderLowLevelDAO.retrieveLines(ddOrder);
 			assertThat(lines)
 					.as("generated DD_Order %s must have one DD_OrderLine per aggregated candidate", ddOrderId)
 					.hasSize(candidateCount.intValue());
 
-			final I_DD_Order ddOrder = queryBL.createQueryBuilder(I_DD_Order.class)
-					.addEqualsFilter(I_DD_Order.COLUMNNAME_DD_Order_ID, ddOrderId)
-					.create()
-					.firstOnlyNotNull(I_DD_Order.class);
 			assertThat(DocStatus.ofNullableCodeOrUnknown(ddOrder.getDocStatus()))
 					.as("generated DD_Order %s DocStatus", ddOrderId)
 					.isEqualTo(DocStatus.Completed);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/ddordercandidate/DD_Order_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/ddordercandidate/DD_Order_Candidate_StepDef.java
@@ -15,21 +15,31 @@ import de.metas.cucumber.stepdefs.pporder.PP_OrderLine_Candidate_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.PP_Order_BOMLine_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.PP_Order_Candidate_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.PP_Order_StepDefData;
+import de.metas.cucumber.stepdefs.shipper.M_Shipper_StepDefData;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
+import de.metas.distribution.ddorder.DDOrderAndLineId;
+import de.metas.distribution.ddorder.DDOrderId;
 import de.metas.distribution.ddordercandidate.DDOrderCandidate;
+import de.metas.distribution.ddordercandidate.DDOrderCandidateAlloc;
+import de.metas.distribution.ddordercandidate.DDOrderCandidateAllocList;
+import de.metas.distribution.ddordercandidate.DDOrderCandidateAllocRepository;
 import de.metas.distribution.ddordercandidate.DDOrderCandidateId;
 import de.metas.distribution.ddordercandidate.DDOrderCandidateQuery;
 import de.metas.distribution.ddordercandidate.DDOrderCandidateService;
+import de.metas.document.engine.DocStatus;
 import de.metas.impex.model.I_AD_InputDataSource;
 import de.metas.impexp.InputDataSourceId;
 import de.metas.material.event.pporder.PPOrderRef;
 import de.metas.order.OrderAndLineId;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
+import de.metas.organization.ClientAndOrgId;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
+import de.metas.shipping.ShipperId;
 import de.metas.uom.IUOMDAO;
 import de.metas.util.Services;
+import com.google.common.collect.ImmutableList;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
@@ -38,14 +48,20 @@ import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.SpringContextHolder;
+import org.compiere.util.Env;
 import org.eevolution.api.PPOrderBOMLineId;
 import org.eevolution.api.PPOrderId;
+import org.eevolution.model.I_DD_Order;
+import org.eevolution.model.I_DD_OrderLine;
 import org.eevolution.model.I_DD_Order_Candidate;
 import org.eevolution.productioncandidate.model.PPOrderCandidateId;
 import org.eevolution.productioncandidate.model.PPOrderLineCandidateId;
 
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -54,13 +70,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RequiredArgsConstructor
 public class DD_Order_Candidate_StepDef
 {
+	/** Fixed order/supply/demand date shared by all directly-created candidates, so they land in the same header aggregation key. */
+	private static final Instant GROUND_REPLENISH_DATE = Instant.parse("2021-04-14T08:00:00Z");
+
 	@NonNull private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
 	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	@NonNull private final DDOrderCandidateService ddOrderCandidateService = SpringContextHolder.instance.getBean(DDOrderCandidateService.class);
+	@NonNull private final DDOrderCandidateAllocRepository ddOrderCandidateAllocRepository = SpringContextHolder.instance.getBean(DDOrderCandidateAllocRepository.class);
 	@NonNull private final DD_Order_Candidate_StepDefData ddOrderCandidateTable;
 	@NonNull private final M_Product_StepDefData productTable;
 	@NonNull private final M_Locator_StepDefData locatorTable;
 	@NonNull private final M_Warehouse_StepDefData warehouseTable;
+	@NonNull private final M_Shipper_StepDefData shipperTable;
 	@NonNull private final C_Order_StepDefData orderTable;
 	@NonNull private final C_OrderLine_StepDefData orderLineTable;
 	@NonNull private final PP_Order_Candidate_StepDefData ppOrderCandidateTable;
@@ -410,10 +431,184 @@ public class DD_Order_Candidate_StepDef
 		return InputDataSourceId.ofRepoId(dataSource.getAD_InputDataSource_ID());
 	}
 
+	/**
+	 * Directly creates planning-less {@link DDOrderCandidate}s (no product planning, no distribution network,
+	 * no sales order) and stores each by its {@code Identifier}.
+	 *
+	 * <p>Stands in for the {@code DD_AutoGroundReplenish} ground-replenishment source, which is the real-world
+	 * trigger that produces distribution-order candidates carrying only a source/target warehouse, a shipper and
+	 * a quantity. That source is a scheduled batch driven by live warehouse stock levels and cannot be reproduced
+	 * from within a cucumber scenario, so the candidates are created directly here.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>Identifier</b> — (required) alias for cross-step reference<br>
+	 *   <b>M_Product_ID</b> — (required, identifier-ref) product to replenish<br>
+	 *   <b>M_Warehouse_From_ID</b> — (required, identifier-ref) source warehouse<br>
+	 *   <b>M_WarehouseTo_ID</b> — (required, identifier-ref) target warehouse<br>
+	 *   <b>M_Shipper_ID</b> — (required, identifier-ref) shipper<br>
+	 *   <b>Qty</b> — (required) quantity with UOM, e.g. "2 PCE"<br>
+	 * @cucumber.depends StepDefData: M_Product_StepDefData, M_Warehouse_StepDefData, M_Shipper_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And metasfresh contains DD_Order_Candidates:
+	 *   | Identifier | M_Product_ID | M_Warehouse_From_ID | M_WarehouseTo_ID | M_Shipper_ID | Qty   |
+	 *   | cand_p1    | p_1          | sourceWH            | targetWH         | shipper      | 2 PCE |
+	 * </pre>
+	 */
+	@And("metasfresh contains DD_Order_Candidates:")
+	public void metasfresh_contains_DD_Order_Candidates(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::createDDOrderCandidate);
+	}
+
+	private void createDDOrderCandidate(@NonNull final DataTableRow row)
+	{
+		final ProductId productId = row.getAsIdentifier(I_DD_Order_Candidate.COLUMNNAME_M_Product_ID).lookupIdIn(productTable);
+		final WarehouseId sourceWarehouseId = row.getAsIdentifier(I_DD_Order_Candidate.COLUMNNAME_M_Warehouse_From_ID).lookupIdIn(warehouseTable);
+		final WarehouseId targetWarehouseId = row.getAsIdentifier(I_DD_Order_Candidate.COLUMNNAME_M_WarehouseTo_ID).lookupIdIn(warehouseTable);
+		final ShipperId shipperId = row.getAsIdentifier(I_DD_Order_Candidate.COLUMNNAME_M_Shipper_ID).lookupIdIn(shipperTable);
+		final Quantity qtyEntered = row.getAsQuantity("Qty", null, uomDAO::getByX12DE355);
+
+		final DDOrderCandidate candidate = DDOrderCandidate.builder()
+				.clientAndOrgId(ClientAndOrgId.ofClientAndOrg(Env.getClientId(), Env.getOrgId()))
+				.dateOrdered(GROUND_REPLENISH_DATE)
+				.supplyDate(GROUND_REPLENISH_DATE)
+				.demandDate(GROUND_REPLENISH_DATE)
+				.productId(productId)
+				.qtyEntered(qtyEntered)
+				.sourceWarehouseId(sourceWarehouseId)
+				.targetWarehouseId(targetWarehouseId)
+				.shipperId(shipperId)
+				// planning-less: no productPlanningId, distributionNetworkAndLineId, salesOrderLineId or forwardPPOrderRef
+				.build();
+
+		ddOrderCandidateService.save(candidate);
+
+		row.getAsOptionalIdentifier().ifPresent(identifier -> ddOrderCandidateTable.putOrReplace(identifier, candidate));
+	}
+
 	@And("the following DD_Order_Candidates are enqueued for generating DD_Orders")
 	public void enqueueDD_Order_Candidates(@NonNull final DataTable dataTable)
 	{
 		ddOrderCandidateService.enqueueToProcess(getDDOrderCandidateIds(dataTable));
+	}
+
+	/**
+	 * Asserts how the enqueued {@link DDOrderCandidate}s were aggregated into generated {@code DD_Order}s, using the
+	 * real {@code DD_Order_Candidate_DDOrder} allocation link the processing writes back onto each candidate.
+	 *
+	 * <p>For each row the candidate's allocation is resolved (polling until processing completed) and its generated
+	 * {@code DD_Order} is grouped under the {@code DD_Order} label: rows sharing a label must resolve to the SAME
+	 * {@code DD_Order}, rows with different labels to DIFFERENT ones. Each generated {@code DD_Order} is then asserted
+	 * to be Completed and to hold exactly as many {@code DD_OrderLine}s as candidates grouped under its label. This is
+	 * the assertion that proves the {@code DDOrderAggregation.header.byProductId} sysconfig both ways.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>DD_Order_Candidate_ID</b> — (required, identifier-ref) a candidate previously enqueued<br>
+	 *   <b>DD_Order</b> — (required) grouping label; same label ⇒ same generated DD_Order, different label ⇒ different one<br>
+	 * @cucumber.depends StepDefData: DD_Order_Candidate_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * Then after not more than 30s, the DD_Order_Candidates are aggregated into DD_Orders:
+	 *   | DD_Order_Candidate_ID | DD_Order |
+	 *   | cand_p1               | ddo      |
+	 *   | cand_p2               | ddo      |
+	 * </pre>
+	 */
+	@And("^after not more than (.*)s, the DD_Order_Candidates are aggregated into DD_Orders:$")
+	public void validateDDOrderCandidateAggregation(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
+	{
+		final List<DataTableRow> rows = DataTableRows.of(dataTable).stream().collect(ImmutableList.toImmutableList());
+
+		final Map<StepDefDataIdentifier, List<DDOrderCandidateAlloc>> allocsByCandidate = StepDefUtil.<Map<StepDefDataIdentifier, List<DDOrderCandidateAlloc>>>tryAndWaitForItem()
+				.worker(() -> resolveCandidateAllocations(rows))
+				.maxWaitSeconds(timeoutSec)
+				.execute();
+
+		assertAggregation(rows, allocsByCandidate);
+	}
+
+	private ItemProvider.ProviderResult<Map<StepDefDataIdentifier, List<DDOrderCandidateAlloc>>> resolveCandidateAllocations(@NonNull final List<DataTableRow> rows)
+	{
+		final LinkedHashMap<StepDefDataIdentifier, List<DDOrderCandidateAlloc>> result = new LinkedHashMap<>();
+		for (final DataTableRow row : rows)
+		{
+			final StepDefDataIdentifier candidateIdentifier = row.getAsIdentifier("DD_Order_Candidate_ID");
+			final DDOrderCandidateId candidateId = candidateIdentifier.lookupIdIn(ddOrderCandidateTable);
+
+			final DDOrderCandidateAllocList allocList = ddOrderCandidateAllocRepository.getByCandidateIds(ImmutableSet.of(candidateId));
+			final List<DDOrderCandidateAlloc> allocs = ImmutableList.copyOf(allocList);
+			if (allocs.isEmpty())
+			{
+				return ItemProvider.ProviderResult.resultWasNotFound("No generated DD_Order yet for candidate " + candidateIdentifier);
+			}
+
+			result.put(candidateIdentifier, allocs);
+		}
+
+		return ItemProvider.ProviderResult.resultWasFound(result);
+	}
+
+	private void assertAggregation(
+			@NonNull final List<DataTableRow> rows,
+			@NonNull final Map<StepDefDataIdentifier, List<DDOrderCandidateAlloc>> allocsByCandidate)
+	{
+		final LinkedHashMap<String, DDOrderId> ddOrderIdByLabel = new LinkedHashMap<>();
+		final List<DDOrderId> ddOrderIdByCandidate = new ArrayList<>();
+
+		for (final DataTableRow row : rows)
+		{
+			final StepDefDataIdentifier candidateIdentifier = row.getAsIdentifier("DD_Order_Candidate_ID");
+			final String label = row.getAsString("DD_Order");
+
+			final List<DDOrderCandidateAlloc> allocs = allocsByCandidate.get(candidateIdentifier);
+			assertThat(allocs)
+					.as("candidate %s must be allocated to exactly one DD_OrderLine", candidateIdentifier)
+					.hasSize(1);
+
+			final DDOrderId ddOrderId = allocs.get(0).getDdOrderId();
+			ddOrderIdByCandidate.add(ddOrderId);
+
+			final DDOrderId existing = ddOrderIdByLabel.get(label);
+			if (existing == null)
+			{
+				ddOrderIdByLabel.put(label, ddOrderId);
+			}
+			else
+			{
+				assertThat(ddOrderId)
+						.as("candidates grouped under DD_Order '%s' must share the same generated DD_Order", label)
+						.isEqualTo(existing);
+			}
+		}
+
+		assertThat(ImmutableSet.copyOf(ddOrderIdByLabel.values()))
+				.as("each distinct DD_Order label must map to a distinct generated DD_Order")
+				.hasSize(ddOrderIdByLabel.size());
+
+		final Map<DDOrderId, Long> candidatesPerDDOrder = ddOrderIdByCandidate.stream()
+				.collect(Collectors.groupingBy(id -> id, Collectors.counting()));
+
+		candidatesPerDDOrder.forEach((ddOrderId, candidateCount) -> {
+			final List<I_DD_OrderLine> lines = queryBL.createQueryBuilder(I_DD_OrderLine.class)
+					.addEqualsFilter(I_DD_OrderLine.COLUMNNAME_DD_Order_ID, ddOrderId)
+					.addOnlyActiveRecordsFilter()
+					.create()
+					.list(I_DD_OrderLine.class);
+			assertThat(lines)
+					.as("generated DD_Order %s must have one DD_OrderLine per aggregated candidate", ddOrderId)
+					.hasSize(candidateCount.intValue());
+
+			final I_DD_Order ddOrder = queryBL.createQueryBuilder(I_DD_Order.class)
+					.addEqualsFilter(I_DD_Order.COLUMNNAME_DD_Order_ID, ddOrderId)
+					.create()
+					.firstOnlyNotNull(I_DD_Order.class);
+			assertThat(DocStatus.ofNullableCodeOrUnknown(ddOrder.getDocStatus()))
+					.as("generated DD_Order %s DocStatus", ddOrderId)
+					.isEqualTo(DocStatus.Completed);
+		});
 	}
 
 	private Set<DDOrderCandidateId> getDDOrderCandidateIds(final @NonNull DataTable table)

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/distributionAgg.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/distributionAgg.feature
@@ -13,6 +13,7 @@ Feature: create distribution order based on aggregation sysconfig
     And metasfresh contains M_Products:
       | Identifier |
       | p_1        |
+      | p_2        |
     And metasfresh contains M_PricingSystems
       | Identifier |
       | ps_1       |
@@ -268,4 +269,58 @@ Feature: create distribution order based on aggregation sysconfig
       | Identifier | M_Product_ID | DD_Order_ID | QtyEntered | M_Locator_ID    | M_LocatorTo_ID  |
       | ddol1      | p_1          | ddo1        | 14         | sourceWHLocator | targetWHLocator |
 
+
+# ###############################################################################################################################################
+# ###############################################################################################################################################
+# ###############################################################################################################################################
+# Ground-replenishment case: planning-less candidates differing only by product.
+# HeaderAggregationKey already carries productPlanningId, so candidates with a planning always split per product.
+# The DDOrderAggregation.header.byProductId flag only matters when candidates share the header key across products,
+# i.e. productPlanningId = null. These two scenarios prove the flag both ways.
+# ###############################################################################################################################################
+# ###############################################################################################################################################
+# ###############################################################################################################################################
+  @from:cucumber
+@allure.label.epic:E0155_Material_Disposition
+@allure.label.feature:F5100
+  @Id:DDOrderAggregationByProductId_Off
+  Scenario: Planning-less candidates for different products aggregate into one DD_Order when byProductId is off
+    When set sys config boolean value false for sys config DDOrderAggregation.header.byProductId
+    And metasfresh contains DD_Order_Candidates:
+      | Identifier | M_Product_ID | M_Warehouse_From_ID | M_WarehouseTo_ID | M_Shipper_ID | Qty   |
+      | cand_p1    | p_1          | sourceWH            | targetWH         | shipper      | 2 PCE |
+      | cand_p2    | p_2          | sourceWH            | targetWH         | shipper      | 3 PCE |
+    And the following DD_Order_Candidates are enqueued for generating DD_Orders
+      | DD_Order_Candidate_ID |
+      | cand_p1               |
+      | cand_p2               |
+    # both candidates share the header key => one DD_Order, one line per product
+    Then after not more than 30s, the DD_Order_Candidates are aggregated into DD_Orders:
+      | DD_Order_Candidate_ID | DD_Order |
+      | cand_p1               | ddo      |
+      | cand_p2               | ddo      |
+
+
+# ###############################################################################################################################################
+# ###############################################################################################################################################
+# ###############################################################################################################################################
+  @from:cucumber
+@allure.label.epic:E0155_Material_Disposition
+@allure.label.feature:F5100
+  @Id:DDOrderAggregationByProductId_On
+  Scenario: Planning-less candidates for different products split into separate DD_Orders when byProductId is on
+    When set sys config boolean value true for sys config DDOrderAggregation.header.byProductId
+    And metasfresh contains DD_Order_Candidates:
+      | Identifier | M_Product_ID | M_Warehouse_From_ID | M_WarehouseTo_ID | M_Shipper_ID | Qty   |
+      | cand_p1    | p_1          | sourceWH            | targetWH         | shipper      | 2 PCE |
+      | cand_p2    | p_2          | sourceWH            | targetWH         | shipper      | 3 PCE |
+    And the following DD_Order_Candidates are enqueued for generating DD_Orders
+      | DD_Order_Candidate_ID |
+      | cand_p1               |
+      | cand_p2               |
+    # product added to the header key => one DD_Order per product, each with a single line
+    Then after not more than 30s, the DD_Order_Candidates are aggregated into DD_Orders:
+      | DD_Order_Candidate_ID | DD_Order |
+      | cand_p1               | ddo_p1   |
+      | cand_p2               | ddo_p2   |
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/distributionAgg.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/materialDispo/distributionAgg.feature
@@ -283,7 +283,6 @@ Feature: create distribution order based on aggregation sysconfig
   @from:cucumber
 @allure.label.epic:E0155_Material_Disposition
 @allure.label.feature:F5100
-  @Id:DDOrderAggregationByProductId_Off
   Scenario: Planning-less candidates for different products aggregate into one DD_Order when byProductId is off
     When set sys config boolean value false for sys config DDOrderAggregation.header.byProductId
     And metasfresh contains DD_Order_Candidates:
@@ -307,7 +306,6 @@ Feature: create distribution order based on aggregation sysconfig
   @from:cucumber
 @allure.label.epic:E0155_Material_Disposition
 @allure.label.feature:F5100
-  @Id:DDOrderAggregationByProductId_On
   Scenario: Planning-less candidates for different products split into separate DD_Orders when byProductId is on
     When set sys config boolean value true for sys config DDOrderAggregation.header.byProductId
     And metasfresh contains DD_Order_Candidates:

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
@@ -326,6 +326,12 @@ class DDOrderCandidateProcessCommand
 		boolean aggregateBySalesOrderId;
 		boolean aggregateByPPOrderRef;
 		boolean aggregateBySalesOrderLineId;
+		/**
+		 * If {@code true}, {@link DDOrderCandidate}s of different products are kept in separate {@link I_DD_Order}s
+		 * (productId becomes part of the {@link HeaderAggregationKey}). This yields one product — and therefore one
+		 * UOM — per DD_Order, i.e. single-line DD_Orders instead of one big multi-product order.
+		 */
+		boolean aggregateByProductId;
 	}
 	//
 	//
@@ -357,6 +363,8 @@ class DDOrderCandidateProcessCommand
 
 		@Nullable String traceId;
 
+		@Nullable ProductId productId;
+
 		public static HeaderAggregationKey of(@NonNull final DDOrderCandidate candidate, @NonNull final AggregationConfig aggregationConfig)
 		{
 			final HeaderAggregationKeyBuilder keyBuilder = builder()
@@ -378,6 +386,10 @@ class DDOrderCandidateProcessCommand
 			if (aggregationConfig.isAggregateByPPOrderRef())
 			{
 				keyBuilder.forwardPPOrderRef(candidate.getForwardPPOrderRef());
+			}
+			if (aggregationConfig.isAggregateByProductId())
+			{
+				keyBuilder.productId(candidate.getProductId());
 			}
 			return keyBuilder.build();
 		}

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
@@ -328,8 +328,10 @@ class DDOrderCandidateProcessCommand
 		boolean aggregateBySalesOrderLineId;
 		/**
 		 * If {@code true}, {@link DDOrderCandidate}s of different products are kept in separate {@link I_DD_Order}s
-		 * (productId becomes part of the {@link HeaderAggregationKey}). This yields one product — and therefore one
-		 * UOM — per DD_Order, i.e. single-line DD_Orders instead of one big multi-product order.
+		 * (productId becomes part of the {@link HeaderAggregationKey}), instead of collapsing into one big
+		 * multi-product order. Lines are still aggregated independently by {@link LineAggregationKey} (ASI / UOM /
+		 * HU-PI / distribution-network / …), so a single product carrying several such variants can still produce
+		 * more than one line — this flag only bounds a header to one product, it does not force a single line.
 		 */
 		boolean aggregateByProductId;
 	}

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
@@ -326,13 +326,6 @@ class DDOrderCandidateProcessCommand
 		boolean aggregateBySalesOrderId;
 		boolean aggregateByPPOrderRef;
 		boolean aggregateBySalesOrderLineId;
-		/**
-		 * If {@code true}, {@link DDOrderCandidate}s of different products are kept in separate {@link I_DD_Order}s
-		 * (productId becomes part of the {@link HeaderAggregationKey}), instead of collapsing into one big
-		 * multi-product order. Lines are still aggregated independently by {@link LineAggregationKey} (ASI / UOM /
-		 * HU-PI / distribution-network / …), so a single product carrying several such variants can still produce
-		 * more than one line — this flag only bounds a header to one product, it does not force a single line.
-		 */
 		boolean aggregateByProductId;
 	}
 	//

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
@@ -36,6 +36,7 @@ public class DDOrderCandidateService
 	public static final String SYSCONFIG_DDOrderAggregation_header_bySalesOrderId = "DDOrderAggregation.header.bySalesOrderId";
 	public static final String SYSCONFIG_DDOrderAggregation_header_byPPOrderRef = "DDOrderAggregation.header.byPPOrderRef";
 	public static final String SYSCONFIG_DDOrderAggregation_line_bySalesOrderLineId = "DDOrderAggregation.line.bySalesOrderLineId";
+	public static final String SYSCONFIG_DDOrderAggregation_header_byProductId = "DDOrderAggregation.header.byProductId";
 
 	@NonNull private final DDOrderCandidateRepository ddOrderCandidateRepository;
 	@NonNull private final DDOrderCandidateAllocRepository ddOrderCandidateAllocRepository;
@@ -125,6 +126,9 @@ public class DDOrderCandidateService
 				.aggregateBySalesOrderId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_bySalesOrderId, true))
 				.aggregateByPPOrderRef(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byPPOrderRef, true))
 				.aggregateBySalesOrderLineId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_line_bySalesOrderLineId, true))
+				// Defaults to false: enabling it splits a multi-product DD_Order into one single-line DD_Order per
+				// product (changes today's aggregation), so it is opt-in per instance rather than on by default.
+				.aggregateByProductId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byProductId, false))
 				.build();
 	}
 

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
@@ -126,8 +126,8 @@ public class DDOrderCandidateService
 				.aggregateBySalesOrderId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_bySalesOrderId, true))
 				.aggregateByPPOrderRef(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byPPOrderRef, true))
 				.aggregateBySalesOrderLineId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_line_bySalesOrderLineId, true))
-				// Defaults to false: enabling it splits a multi-product DD_Order into one single-line DD_Order per
-				// product (changes today's aggregation), so it is opt-in per instance rather than on by default.
+				// Defaults to false: enabling it keeps different products in separate DD_Orders (adds M_Product_ID
+				// to the header key), changing today's aggregation, so it is opt-in per instance rather than on by default.
 				.aggregateByProductId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byProductId, false))
 				.build();
 	}

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
@@ -126,8 +126,6 @@ public class DDOrderCandidateService
 				.aggregateBySalesOrderId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_bySalesOrderId, true))
 				.aggregateByPPOrderRef(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byPPOrderRef, true))
 				.aggregateBySalesOrderLineId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_line_bySalesOrderLineId, true))
-				// Defaults to false: enabling it keeps different products in separate DD_Orders (adds M_Product_ID
-				// to the header key), changing today's aggregation, so it is opt-in per instance rather than on by default.
 				.aggregateByProductId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byProductId, false))
 				.build();
 	}

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812470_sys_DDOrderAggregation_header_byProductId.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812470_sys_DDOrderAggregation_header_byProductId.sql
@@ -1,0 +1,9 @@
+-- Run mode: SWING_CLIENT
+
+-- SysConfig Name: DDOrderAggregation.header.byProductId
+-- Seeds the on-switch (default 'N') for keeping DD_Order_Candidates of different products in separate DD_Orders.
+-- When 'Y', M_Product_ID becomes part of the DD_Order header aggregation key, so each product gets its own
+-- single-line DD_Order (one product -> one UOM per order) instead of one big multi-product order.
+-- Default 'N' preserves today's behaviour; enable per instance via the customer repo.
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541832 /*From ID Server*/,'O',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'If enabled, prevents DD_Order_Candidates of different products from ending up in the same DD_Order (one product - and one UOM - per DD_Order).','D','Y','DDOrderAggregation.header.byProductId',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'N')
+;

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812470_sys_DDOrderAggregation_header_byProductId.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812470_sys_DDOrderAggregation_header_byProductId.sql
@@ -1,9 +1,7 @@
 -- Run mode: SWING_CLIENT
 
 -- SysConfig Name: DDOrderAggregation.header.byProductId
--- Seeds the on-switch (default 'N') for keeping DD_Order_Candidates of different products in separate DD_Orders.
--- When 'Y', M_Product_ID becomes part of the DD_Order header aggregation key, so candidates of different
--- products no longer share a DD_Order (each product gets its own order) instead of one big multi-product order.
--- Default 'N' preserves today's behaviour; enable per instance via the customer repo.
+-- SysConfig Value: N
+-- When 'Y', M_Product_ID is part of the DD_Order header aggregation key (one product per DD_Order). Default 'N'.
 INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541832 /*From ID Server*/,'O',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'If enabled, prevents DD_Order_Candidates of different products from ending up in the same DD_Order.','D','Y','DDOrderAggregation.header.byProductId',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'N')
 ;

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812470_sys_DDOrderAggregation_header_byProductId.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812470_sys_DDOrderAggregation_header_byProductId.sql
@@ -2,8 +2,8 @@
 
 -- SysConfig Name: DDOrderAggregation.header.byProductId
 -- Seeds the on-switch (default 'N') for keeping DD_Order_Candidates of different products in separate DD_Orders.
--- When 'Y', M_Product_ID becomes part of the DD_Order header aggregation key, so each product gets its own
--- single-line DD_Order (one product -> one UOM per order) instead of one big multi-product order.
+-- When 'Y', M_Product_ID becomes part of the DD_Order header aggregation key, so candidates of different
+-- products no longer share a DD_Order (each product gets its own order) instead of one big multi-product order.
 -- Default 'N' preserves today's behaviour; enable per instance via the customer repo.
-INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541832 /*From ID Server*/,'O',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'If enabled, prevents DD_Order_Candidates of different products from ending up in the same DD_Order (one product - and one UOM - per DD_Order).','D','Y','DDOrderAggregation.header.byProductId',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'N')
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541832 /*From ID Server*/,'O',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'If enabled, prevents DD_Order_Candidates of different products from ending up in the same DD_Order.','D','Y','DDOrderAggregation.header.byProductId',TO_TIMESTAMP('2026-07-07 10:40:00','YYYY-MM-DD HH24:MI:SS'),100,'N')
 ;

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
@@ -51,6 +51,10 @@ import static org.mockito.Mockito.when;
  * The header-record creation used to dereference {@code productPlanningDAO.getById(null)} unconditionally;
  * with no product planning this threw a {@link NullPointerException}. The fix guards the lookup and clears
  * {@code PP_Product_Planning_ID} / {@code AD_User_ID} / {@code SalesRep_ID} with the {@code -1} sentinel.
+ * <p>
+ * Also covers the optional {@code aggregateByProductId} header-aggregation dimension: with the flag off,
+ * candidates of different products share one DD_Order (one line each); with it on, each product gets its
+ * own DD_Order.
  */
 class DDOrderCandidateProcessCommandTest
 {

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
@@ -28,10 +28,12 @@ import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.IWarehouseBL;
 import org.compiere.util.Env;
 import org.eevolution.model.I_DD_Order;
+import org.eevolution.model.I_DD_OrderLine;
 import org.eevolution.model.X_DD_Order;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -146,5 +148,76 @@ class DDOrderCandidateProcessCommandTest
 		assertThat(header.getAD_User_ID()).isEqualTo(-1);
 		assertThat(header.getSalesRep_ID()).isEqualTo(-1);
 		assertThat(header.getDocStatus()).isEqualTo(X_DD_Order.DOCSTATUS_Drafted);
+	}
+
+	/**
+	 * Control: with {@code aggregateByProductId=false} (today's behaviour), two candidates that differ only by
+	 * product collapse into ONE DD_Order carrying one line per product.
+	 */
+	@Test
+	void process_twoProducts_byProductIdDisabled_singleDDOrderWithTwoLines()
+	{
+		processTwoProductCandidates(false);
+
+		final List<I_DD_Order> orders = queryOrders();
+		assertThat(orders).hasSize(1);
+		assertThat(queryLines(orders.get(0))).hasSize(2);
+	}
+
+	/**
+	 * Target: with {@code aggregateByProductId=true}, the same two candidates produce TWO DD_Orders, each with a
+	 * single line (one product — and therefore one UOM — per order).
+	 */
+	@Test
+	void process_twoProducts_byProductIdEnabled_twoSingleLineDDOrders()
+	{
+		processTwoProductCandidates(true);
+
+		final List<I_DD_Order> orders = queryOrders();
+		assertThat(orders).hasSize(2);
+		assertThat(orders).allSatisfy(order -> assertThat(queryLines(order)).hasSize(1));
+	}
+
+	private void processTwoProductCandidates(final boolean aggregateByProductId)
+	{
+		final DDOrderCandidate product20 = DDOrderCandidateRepositoryTest.newFullyFilled().toBuilder()
+				.productId(ProductId.ofRepoId(20))
+				.build();
+		final DDOrderCandidate product21 = DDOrderCandidateRepositoryTest.newFullyFilled().toBuilder()
+				.productId(ProductId.ofRepoId(21))
+				.build();
+		ddOrderCandidateRepository.save(product20);
+		ddOrderCandidateRepository.save(product21);
+
+		commandBuilder
+				.aggregationConfig(DDOrderCandidateProcessCommand.AggregationConfig.builder()
+						.aggregateBySalesOrderId(true)
+						.aggregateByPPOrderRef(true)
+						.aggregateBySalesOrderLineId(true)
+						.aggregateByProductId(aggregateByProductId)
+						.build())
+				.request(DDOrderCandidateProcessRequest.builder()
+						.userId(UserId.METASFRESH)
+						.candidates(ImmutableList.of(product20, product21))
+						.build())
+				.build()
+				.execute();
+	}
+
+	private static List<I_DD_Order> queryOrders()
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_DD_Order.class)
+				.create()
+				.list(I_DD_Order.class);
+	}
+
+	private static List<I_DD_OrderLine> queryLines(final I_DD_Order order)
+	{
+		return Services.get(IQueryBL.class)
+				.createQueryBuilder(I_DD_OrderLine.class)
+				.addEqualsFilter(I_DD_OrderLine.COLUMNNAME_DD_Order_ID, order.getDD_Order_ID())
+				.create()
+				.list(I_DD_OrderLine.class);
 	}
 }


### PR DESCRIPTION
## What
Cucumber coverage for the opt-in DD_Order header-aggregation flag `DDOrderAggregation.header.byProductId` (implemented by the base PR this is stacked on).

Two scenarios added to `materialDispo/distributionAgg.feature` drive the **real** enqueue → generate-DD_Order pipeline with **planning-less** `DD_Order_Candidate`s — the only case where the flag matters (candidates that carry a product planning already split per product via the existing `productPlanningId` header key):
- flag **OFF** → two different products collapse into **one** DD_Order (2 lines).
- flag **ON** → two different products produce **two single-line** DD_Orders.

Adds a `metasfresh contains DD_Order_Candidates:` direct-create step to `DD_Order_Candidate_StepDef` (mirrors the accepted `M_ShipmentSchedule` create-as-setup precedent), Javadoc'd with the real-world trigger it stands in for (the automatic ground-replenishment source that produces planning-less candidates).

## Stacked on the flag PR
Base is `deep_tundra_release_DDOrderOneLinePerProduct` (the flag implementation) so this diff shows only the test. Merge that PR first; GitHub will retarget this to `deep_tundra_release`.

## Test-only
No production code — a cucumber step def + feature scenarios.
