### PR TITLE
Port flaky-CI test fixes to deep_tundra_release

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_Candidate_StepDef.java
@@ -40,6 +40,7 @@ import de.metas.cucumber.stepdefs.order.C_OrderLine_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.maturing.M_Maturing_Configuration_Line_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.maturing.M_Maturing_Configuration_StepDefData;
 import de.metas.cucumber.stepdefs.productplanning.PP_Product_Planning_StepDefData;
+import de.metas.cucumber.stepdefs.rabbitMQ.RabbitMQ_StepDef;
 import de.metas.cucumber.stepdefs.resource.S_Resource_StepDefData;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
 import de.metas.handlingunits.HUPIItemProductId;
@@ -152,13 +153,31 @@ public class PP_Order_Candidate_StepDef
 	private final M_HU_StepDefData huTable;
 	@NonNull
 	private final S_Resource_StepDefData resourceTable;
+	@NonNull
+	private final RabbitMQ_StepDef rabbitMQStepDef;
 
 	private static final AdMessageKey MSG_QTY_ENTERED_LOWER_THAN_QTY_PROCESSED = AdMessageKey.of("org.eevolution.productioncandidate.model.interceptor.QtyEnteredLowerThanQtyProcessed");
 	private static final AdMessageKey MSG_QTY_TO_PROCESS_GREATER_THAN_QTY_LEFT = AdMessageKey.of("org.eevolution.productioncandidate.model.interceptor.QtyToProcessGreaterThanQtyLeftToBeProcessed");
 
+	/**
+	 * Waits (up to {@code timeoutSec}) for the committed {@code PP_Order_Candidate} records matching the DataTable.
+	 * <p>
+	 * The rabbitMQ queues are drained first via {@link RabbitMQ_StepDef#wait_empty_all_queues()} (material-events
+	 * then async-batch) so the async material-dispo chain that creates / updates the candidates has fully settled
+	 * before the poll asserts. This keeps the technical drain out of the feature file — see module CLAUDE.md rule 7
+	 * ("drain inside the consuming step def, as late as possible, never as a bare step in the .feature file").
+	 * <p>
+	 * Example:
+	 * <pre>
+	 * Then after not more than 60s, PP_Order_Candidates are found
+	 *   | Identifier | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised | DateStartSchedule | OPT.IsClosed | OPT.Processed |
+	 * </pre>
+	 */
 	@And("^after not more than (.*)s, PP_Order_Candidates are found$")
-	public void validatePP_Order_Candidate(final int timeoutSec, @NonNull final DataTable dataTable)
+	public void validatePP_Order_Candidate(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
 	{
+		rabbitMQStepDef.wait_empty_all_queues();
+
 		DataTableRows.of(dataTable)
 				.setAdditionalRowIdentifierColumnName(COLUMNNAME_PP_Order_Candidate_ID)
 				.forEach(row -> validatePP_Order_Candidate(timeoutSec, row));

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java
@@ -97,12 +97,26 @@ public class RabbitMQ_StepDef
 		connectionFactory.setPassword(commandLineOptions.getRabbitPassword());
 	}
 
+	/**
+	 * Drains the material-events queue ({@link MaterialEventsQueueConfiguration}) only, waiting up to 5 minutes.
+	 * <p>
+	 * Use this when a scenario needs to assert the state produced by material events alone, <b>before</b> the
+	 * downstream async workpackages run. When the full material→async chain must settle, prefer
+	 * {@link #wait_empty_all_queues()}.
+	 */
 	@And("wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes")
 	public void wait_empty_material_queue() throws InterruptedException
 	{
 		waitEmptyQueueByTopic(MaterialEventsQueueConfiguration.EVENTBUS_TOPIC.getName());
 	}
 
+	/**
+	 * Drains the async-batch queue ({@link AsyncBatchQueueConfiguration}) only, waiting up to 5 minutes.
+	 * <p>
+	 * Draining async alone can race with material events still in flight (async may be empty only because the
+	 * upstream material side hasn't been processed yet). Use this only when the material side is already known to
+	 * be settled; otherwise prefer {@link #wait_empty_all_queues()}, which drains material then async in order.
+	 */
 	@And("wait until de.metas.async rabbitMQ queue is empty or throw exception after 5 minutes")
 	public void wait_empty_async_queue() throws InterruptedException
 	{

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate.feature
@@ -188,8 +188,6 @@ Feature: Production dispo scenarios
 
     And the order identified by o_2 is reactivated
 
-    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
-
     Then after not more than 60s, PP_Order_Candidates are found
       | Identifier | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | OPT.IsClosed | OPT.Processed |
       | oc_1       | p_1          | bom_1             | ppln_1                 | 540006        | 200 PCE    | 200 PCE      | 0 PCE        | 2025-02-25T00:00:00Z | 2025-02-25T00:00:00Z | false        | false         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentScheduleExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentScheduleExport.feature
@@ -122,9 +122,7 @@ Feature: Shipment schedule export rest-api
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
       | orderLine_1               | order_1               | 2022-02-02      | product_25_02           | 1          | 0            | 0           | 10.0  | 0        | EUR          | true      |
 
-    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
-
-    And after not more than 60s, M_ShipmentSchedules are found:
+    And after not more than 300s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | schedule_1 | orderLine_1               | N             |
     And after not more than 60s, validate shipment schedules:
@@ -218,9 +216,7 @@ Feature: Shipment schedule export rest-api
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
       | orderLine_1               | order_1               | 2022-02-02      | product_25_02           | 1          | 0            | 0           | 10.0  | 0        | EUR          | true      |
 
-    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
-
-    And after not more than 60s, M_ShipmentSchedules are found:
+    And after not more than 300s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | schedule_1 | orderLine_1               | N             |
     And after not more than 60s, validate shipment schedules:

--- a/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
@@ -11,9 +11,9 @@ const NAME = 'HOME';
 const containerElement = () => page.locator('#ApplicationsListScreen');
 
 export const ApplicationsListScreen = {
-    waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
-        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
+    waitForScreen: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
+        await containerElement().waitFor({ timeout });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
@@ -13,9 +13,9 @@ const NAME = 'DistributionJobsListScreen';
 const containerElement = () => page.locator('#WFLaunchersScreen');
 
 export const DistributionJobsListScreen = {
-    waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
-        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
+    waitForScreen: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
+        await containerElement().waitFor({ timeout });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout });
     }),
 
     filterByFacetId: async ({

--- a/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page, SLOW_ACTION_TIMEOUT } from '../../common';
+import { page, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../../common';
 import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
@@ -24,6 +24,18 @@ export const HUBulkActionsScreen = {
         await page.getByTestId('toggle-target-scanner-button').getByText('Close scanner').waitFor({ timeout: SLOW_ACTION_TIMEOUT });
         await BarcodeScannerComponent.type(targetLocator);
 
-        await ApplicationsListScreen.waitForScreen();
+        // The bulk move commits via an async REST round-trip (api.moveBulkHUs -> POST /bulk/move);
+        // only once it resolves does the frontend navigate home (history.goHome()). The home screen
+        // appearing IS the commit-confirming, user-visible landing signal — but its single default
+        // SLOW_ACTION_TIMEOUT (20s) budget has to absorb that whole round-trip, so under CI load the
+        // commit can overshoot 20s and the wait times out (the flake). A transient success toast is
+        // NOT usable as an earlier signal here: ScreenToaster dismisses all toasts on the very
+        // navigation that follows it (useLocationChange -> toast.dismiss()), so it races the dismissal.
+        // Give the transition the VERY_SLOW_ACTION_TIMEOUT (40s) budget instead — the same budget idiom
+        // used for other heavy async-commit flows that return to a list/home screen (e.g.
+        // PickingJobScreen.complete, ManufacturingJobScreen, InventoryJobScreen; those return to a
+        // *jobs-list* screen, here we return to the *home* ApplicationsListScreen — same topology).
+        // No new signal is invented; the genuinely-slow commit is simply given room to land.
+        await ApplicationsListScreen.waitForScreen({ timeout: VERY_SLOW_ACTION_TIMEOUT });
     }),
 };


### PR DESCRIPTION
Cherry-picks the relevant flaky-CI test-harness fixes onto `deep_tundra_release`. Test-only changes (cucumber step-defs / feature files + mobile-webui e2e utils); no production code.

## Ported fixes

- **combined rabbitMQ drain fixes productionCandidate reactivate-scenario flake** (https://github.com/metasfresh/metasfresh/pull/24965) — internalizes the ordered material→async rabbitMQ drain into the consuming `PP_Order_Candidates are found` step-def and drops the bare drain step from `productionCandidate.feature`, so the async recompute chain settles deterministically before the qty poll.
- **Shipment Schedule export — fix flaky queue-drain dependency** (https://github.com/metasfresh/metasfresh/pull/24966) — drops the racy queue-drain proxy in the two export scenarios and polls the committed `IsToRecompute=N` business state directly (ceiling raised 60s→300s). No assertion weakened.
- **mobile-webui e2e: fix async-commit race in HU Manager bulk "Move" flake** (https://github.com/metasfresh/metasfresh/pull/24999) — fixes the async-commit race in the HU Manager bulk-Move flow; uses a VERY_SLOW budget for the home transition and makes `DistributionJobsListScreen.waitForScreen` honor a timeout param.

## Notes

- The barcode-scanner camera-mode assertion fix (https://github.com/metasfresh/metasfresh/pull/24693 / commit https://github.com/metasfresh/metasfresh/commit/d5a4b01da6ee1e14abba96918ab8d4e902291c8e) is already present on `deep_tundra_release`, so its cherry-pick was empty and skipped.
- `productionCandidate.feature` and `shipmentScheduleExport.feature` cherry-picks conflicted because this branch already carried the combined-drain step; resolved by taking the fix's intent (drop the now-internalized / racy bare drain step) while preserving the surrounding scenario content.
- The merge-train then carries these up.
