### PR TITLE
Port: flaky-CI test fixes (rabbitMQ drain, HU Manager Move, shipmentScheduleExport poll) to intensive_care_hotfix

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_Candidate_StepDef.java
@@ -40,6 +40,7 @@ import de.metas.cucumber.stepdefs.order.C_OrderLine_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.maturing.M_Maturing_Configuration_Line_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.maturing.M_Maturing_Configuration_StepDefData;
 import de.metas.cucumber.stepdefs.productplanning.PP_Product_Planning_StepDefData;
+import de.metas.cucumber.stepdefs.rabbitMQ.RabbitMQ_StepDef;
 import de.metas.cucumber.stepdefs.resource.S_Resource_StepDefData;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
 import de.metas.handlingunits.HUPIItemProductId;
@@ -152,13 +153,31 @@ public class PP_Order_Candidate_StepDef
 	private final M_HU_StepDefData huTable;
 	@NonNull
 	private final S_Resource_StepDefData resourceTable;
+	@NonNull
+	private final RabbitMQ_StepDef rabbitMQStepDef;
 
 	private static final AdMessageKey MSG_QTY_ENTERED_LOWER_THAN_QTY_PROCESSED = AdMessageKey.of("org.eevolution.productioncandidate.model.interceptor.QtyEnteredLowerThanQtyProcessed");
 	private static final AdMessageKey MSG_QTY_TO_PROCESS_GREATER_THAN_QTY_LEFT = AdMessageKey.of("org.eevolution.productioncandidate.model.interceptor.QtyToProcessGreaterThanQtyLeftToBeProcessed");
 
+	/**
+	 * Waits (up to {@code timeoutSec}) for the committed {@code PP_Order_Candidate} records matching the DataTable.
+	 * <p>
+	 * The rabbitMQ queues are drained first via {@link RabbitMQ_StepDef#wait_empty_all_queues()} (material-events
+	 * then async-batch) so the async material-dispo chain that creates / updates the candidates has fully settled
+	 * before the poll asserts. This keeps the technical drain out of the feature file — see module CLAUDE.md rule 7
+	 * ("drain inside the consuming step def, as late as possible, never as a bare step in the .feature file").
+	 * <p>
+	 * Example:
+	 * <pre>
+	 * Then after not more than 60s, PP_Order_Candidates are found
+	 *   | Identifier | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised | DateStartSchedule | OPT.IsClosed | OPT.Processed |
+	 * </pre>
+	 */
 	@And("^after not more than (.*)s, PP_Order_Candidates are found$")
-	public void validatePP_Order_Candidate(final int timeoutSec, @NonNull final DataTable dataTable)
+	public void validatePP_Order_Candidate(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
 	{
+		rabbitMQStepDef.wait_empty_all_queues();
+
 		DataTableRows.of(dataTable)
 				.setAdditionalRowIdentifierColumnName("PP_Order_Candidate_ID")
 				.forEach(row -> validatePP_Order_Candidate(timeoutSec, row));

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java
@@ -33,6 +33,7 @@ import de.metas.event.IEventBus;
 import de.metas.event.Topic;
 import de.metas.event.impl.EventBusFactory;
 import de.metas.event.remote.rabbitmq.RabbitMQDestinationResolver;
+import de.metas.event.remote.rabbitmq.queues.async_batch.AsyncBatchQueueConfiguration;
 import de.metas.event.remote.rabbitmq.queues.material_dispo.MaterialEventsQueueConfiguration;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
@@ -96,10 +97,51 @@ public class RabbitMQ_StepDef
 		connectionFactory.setPassword(commandLineOptions.getRabbitPassword());
 	}
 
+	/**
+	 * Drains the material-events queue ({@link MaterialEventsQueueConfiguration}) only, waiting up to 5 minutes.
+	 * <p>
+	 * Use this when a scenario needs to assert the state produced by material events alone, <b>before</b> the
+	 * downstream async workpackages run. When the full material→async chain must settle, prefer
+	 * {@link #wait_empty_all_queues()}.
+	 */
 	@And("wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes")
 	public void wait_empty_material_queue() throws InterruptedException
 	{
-		waitEmptyMaterialQueue();
+		waitEmptyQueueByTopic(MaterialEventsQueueConfiguration.EVENTBUS_TOPIC.getName());
+	}
+
+	/**
+	 * Drains the async-batch queue ({@link AsyncBatchQueueConfiguration}) only, waiting up to 5 minutes.
+	 * <p>
+	 * Draining async alone can race with material events still in flight (async may be empty only because the
+	 * upstream material side hasn't been processed yet). Use this only when the material side is already known to
+	 * be settled; otherwise prefer {@link #wait_empty_all_queues()}, which drains material then async in order.
+	 */
+	@And("wait until de.metas.async rabbitMQ queue is empty or throw exception after 5 minutes")
+	public void wait_empty_async_queue() throws InterruptedException
+	{
+		waitEmptyQueueByTopic(AsyncBatchQueueConfiguration.EVENTBUS_TOPIC.getName());
+	}
+
+	/**
+	 * Drains the material event queue first, then the async batch queue.
+	 *
+	 * <p>The ordering is intentional: a test action (e.g. order completion) publishes
+	 * {@link MaterialEventsQueueConfiguration} events first, whose listeners enqueue async
+	 * workpackages on {@link AsyncBatchQueueConfiguration}. Draining async alone would race
+	 * with material events still in flight — async could be empty simply because the
+	 * upstream material side hasn't been processed yet. Draining material then async
+	 * guarantees the chain has fully settled before the next assertion.
+	 *
+	 * <p>This is the preferred drain step for new scenarios. Prefer it over the individual
+	 * {@code wait until de.metas.material …} and {@code wait until de.metas.async …}
+	 * steps unless a scenario specifically needs to assert state between the two stages.
+	 */
+	@And("wait until all rabbitMQ queues are empty or throw exception after 5 minutes")
+	public void wait_empty_all_queues() throws InterruptedException
+	{
+		waitEmptyQueueByTopic(MaterialEventsQueueConfiguration.EVENTBUS_TOPIC.getName());
+		waitEmptyQueueByTopic(AsyncBatchQueueConfiguration.EVENTBUS_TOPIC.getName());
 	}
 
 	@Given("rabbitMQ queue is created")
@@ -335,12 +377,12 @@ public class RabbitMQ_StepDef
 									  .build());
 	}
 
-	private void waitEmptyMaterialQueue() throws InterruptedException
+	private void waitEmptyQueueByTopic(@NonNull final String topicName) throws InterruptedException
 	{
 		final long nowMillis = System.currentTimeMillis();
 		final long deadLineMillis = nowMillis + (300 * 1000L);    // dev-note: await maximum 5 minutes
 
-		final String queueName = rabbitMQDestinationSolver.getAMQPQueueNameByTopicName(MaterialEventsQueueConfiguration.EVENTBUS_TOPIC.getName());
+		final String queueName = rabbitMQDestinationSolver.getAMQPQueueNameByTopicName(topicName);
 		final RabbitAdmin rabbitAdmin = new RabbitAdmin(((RabbitTemplate)amqpTemplate));
 
 		long messageCount;

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentScheduleExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentSchedule/shipmentScheduleExport.feature
@@ -123,7 +123,7 @@ Feature: Shipment schedule export rest-api
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
       | orderLine_1               | order_1               | 2022-02-02      | product_25_02           | 1          | 0            | 0           | 10.0  | 0        | EUR          | true      |
 
-    And after not more than 60s, M_ShipmentSchedules are found:
+    And after not more than 300s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | schedule_1 | orderLine_1               | N             |
     And after not more than 60s, validate shipment schedules:
@@ -217,7 +217,7 @@ Feature: Shipment schedule export rest-api
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | OPT.DateOrdered | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed |
       | orderLine_1               | order_1               | 2022-02-02      | product_25_02           | 1          | 0            | 0           | 10.0  | 0        | EUR          | true      |
 
-    And after not more than 60s, M_ShipmentSchedules are found:
+    And after not more than 300s, M_ShipmentSchedules are found:
       | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
       | schedule_1 | orderLine_1               | N             |
     And after not more than 60s, validate shipment schedules:

--- a/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
@@ -1,4 +1,4 @@
-import { page } from "../common";
+import { page, SLOW_ACTION_TIMEOUT } from "../common";
 import { test } from "../../../playwright.config";
 import { expect } from "@playwright/test";
 import { LoginScreen } from "./LoginScreen";
@@ -11,9 +11,9 @@ const NAME = 'HOME';
 const containerElement = () => page.locator('#ApplicationsListScreen');
 
 export const ApplicationsListScreen = {
-    waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
-        await page.locator('.loading').waitFor({ state: 'detached' });
+    waitForScreen: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
+        await containerElement().waitFor({ timeout });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
@@ -13,9 +13,9 @@ const NAME = 'DistributionJobsListScreen';
 const containerElement = () => page.locator('#WFLaunchersScreen');
 
 export const DistributionJobsListScreen = {
-    waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
-        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
+    waitForScreen: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
+        await containerElement().waitFor({ timeout });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout });
     }),
 
     filterByFacetId: async ({

--- a/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page } from '../../common';
+import { page, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../../common';
 import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
@@ -24,6 +24,18 @@ export const HUBulkActionsScreen = {
         await page.getByTestId('toggle-target-scanner-button').getByText('Close scanner').waitFor();
         await BarcodeScannerComponent.type(targetLocator);
 
-        await ApplicationsListScreen.waitForScreen();
+        // The bulk move commits via an async REST round-trip (api.moveBulkHUs -> POST /bulk/move);
+        // only once it resolves does the frontend navigate home (history.goHome()). The home screen
+        // appearing IS the commit-confirming, user-visible landing signal — but its single default
+        // SLOW_ACTION_TIMEOUT (20s) budget has to absorb that whole round-trip, so under CI load the
+        // commit can overshoot 20s and the wait times out (the flake). A transient success toast is
+        // NOT usable as an earlier signal here: ScreenToaster dismisses all toasts on the very
+        // navigation that follows it (useLocationChange -> toast.dismiss()), so it races the dismissal.
+        // Give the transition the VERY_SLOW_ACTION_TIMEOUT (40s) budget instead — the same budget idiom
+        // used for other heavy async-commit flows that return to a list/home screen (e.g.
+        // PickingJobScreen.complete, ManufacturingJobScreen, InventoryJobScreen; those return to a
+        // *jobs-list* screen, here we return to the *home* ApplicationsListScreen — same topology).
+        // No new signal is invented; the genuinely-slow commit is simply given room to land.
+        await ApplicationsListScreen.waitForScreen({ timeout: VERY_SLOW_ACTION_TIMEOUT });
     }),
 };


### PR DESCRIPTION
Port of flaky-CI test fixes onto `intensive_care_hotfix` (cherry-picks from `new_dawn_uat`).

## Cherry-picked commits

- **rabbitMQ drain — productionCandidate reactivate flake** — squash of https://github.com/metasfresh/metasfresh/pull/24965 (https://github.com/metasfresh/metasfresh/commit/102fa21e659abdcd07ce9c9e7cbfa4d696cf89a6). Removes the bare racy-drain step and internalizes the drain into the consuming step-def (`RabbitMQ_StepDef` + `PP_Order_Candidate_StepDef`). Applied clean.
- **mobile-webui HU Manager bulk "Move" async-commit race** — squash of https://github.com/metasfresh/metasfresh/pull/24999 (https://github.com/metasfresh/metasfresh/commit/c7b199b2368da055643c5a3ab60543f65823c8a6). Gives the async bulk-move commit the `VERY_SLOW_ACTION_TIMEOUT` budget on the return-to-home wait. Conflicts in `ApplicationsListScreen.js` and `HUBulkActionsScreen.js` resolved to the fix side (added the missing `SLOW_ACTION_TIMEOUT` / `VERY_SLOW_ACTION_TIMEOUT` imports the fix relies on).
- **shipmentScheduleExport — flaky queue-drain dependency** — squash of https://github.com/metasfresh/metasfresh/pull/24966 (https://github.com/metasfresh/metasfresh/commit/80490eb151411c7ed9a06a494361c18525f524f6). Polls the committed `IsToRecompute=N` row with a 300s budget instead of depending on a bare rabbitMQ drain. Conflict in `shipmentScheduleExport.feature` resolved to the fix side (60s to 300s on the two `M_ShipmentSchedules are found:` steps; the bare-drain steps were already absent on this branch).

## Verification

- `git diff --check` clean — no conflict markers.
- Changed JS files parse (`node --check` as ESM).
- Changed Java step-defs brace-balanced.
- No `git revert`, no history rewrite; feature branch only.
