### PR TITLE
Port: flaky-CI test fixes to boomerang_signal_hotfix (items 3/4/6)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_Candidate_StepDef.java
@@ -40,6 +40,7 @@ import de.metas.cucumber.stepdefs.order.C_OrderLine_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.maturing.M_Maturing_Configuration_Line_StepDefData;
 import de.metas.cucumber.stepdefs.pporder.maturing.M_Maturing_Configuration_StepDefData;
 import de.metas.cucumber.stepdefs.productplanning.PP_Product_Planning_StepDefData;
+import de.metas.cucumber.stepdefs.rabbitMQ.RabbitMQ_StepDef;
 import de.metas.cucumber.stepdefs.resource.S_Resource_StepDefData;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
 import de.metas.handlingunits.HUPIItemProductId;
@@ -152,13 +153,31 @@ public class PP_Order_Candidate_StepDef
 	private final M_HU_StepDefData huTable;
 	@NonNull
 	private final S_Resource_StepDefData resourceTable;
+	@NonNull
+	private final RabbitMQ_StepDef rabbitMQStepDef;
 
 	private static final AdMessageKey MSG_QTY_ENTERED_LOWER_THAN_QTY_PROCESSED = AdMessageKey.of("org.eevolution.productioncandidate.model.interceptor.QtyEnteredLowerThanQtyProcessed");
 	private static final AdMessageKey MSG_QTY_TO_PROCESS_GREATER_THAN_QTY_LEFT = AdMessageKey.of("org.eevolution.productioncandidate.model.interceptor.QtyToProcessGreaterThanQtyLeftToBeProcessed");
 
+	/**
+	 * Waits (up to {@code timeoutSec}) for the committed {@code PP_Order_Candidate} records matching the DataTable.
+	 * <p>
+	 * The rabbitMQ queues are drained first via {@link RabbitMQ_StepDef#wait_empty_all_queues()} (material-events
+	 * then async-batch) so the async material-dispo chain that creates / updates the candidates has fully settled
+	 * before the poll asserts. This keeps the technical drain out of the feature file — see module CLAUDE.md rule 7
+	 * ("drain inside the consuming step def, as late as possible, never as a bare step in the .feature file").
+	 * <p>
+	 * Example:
+	 * <pre>
+	 * Then after not more than 60s, PP_Order_Candidates are found
+	 *   | Identifier | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised | DateStartSchedule | OPT.IsClosed | OPT.Processed |
+	 * </pre>
+	 */
 	@And("^after not more than (.*)s, PP_Order_Candidates are found$")
-	public void validatePP_Order_Candidate(final int timeoutSec, @NonNull final DataTable dataTable)
+	public void validatePP_Order_Candidate(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
 	{
+		rabbitMQStepDef.wait_empty_all_queues();
+
 		DataTableRows.of(dataTable)
 				.setAdditionalRowIdentifierColumnName(COLUMNNAME_PP_Order_Candidate_ID)
 				.forEach(row -> validatePP_Order_Candidate(timeoutSec, row));

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/rabbitMQ/RabbitMQ_StepDef.java
@@ -97,12 +97,26 @@ public class RabbitMQ_StepDef
 		connectionFactory.setPassword(commandLineOptions.getRabbitPassword());
 	}
 
+	/**
+	 * Drains the material-events queue ({@link MaterialEventsQueueConfiguration}) only, waiting up to 5 minutes.
+	 * <p>
+	 * Use this when a scenario needs to assert the state produced by material events alone, <b>before</b> the
+	 * downstream async workpackages run. When the full material→async chain must settle, prefer
+	 * {@link #wait_empty_all_queues()}.
+	 */
 	@And("wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes")
 	public void wait_empty_material_queue() throws InterruptedException
 	{
 		waitEmptyQueueByTopic(MaterialEventsQueueConfiguration.EVENTBUS_TOPIC.getName());
 	}
 
+	/**
+	 * Drains the async-batch queue ({@link AsyncBatchQueueConfiguration}) only, waiting up to 5 minutes.
+	 * <p>
+	 * Draining async alone can race with material events still in flight (async may be empty only because the
+	 * upstream material side hasn't been processed yet). Use this only when the material side is already known to
+	 * be settled; otherwise prefer {@link #wait_empty_all_queues()}, which drains material then async in order.
+	 */
 	@And("wait until de.metas.async rabbitMQ queue is empty or throw exception after 5 minutes")
 	public void wait_empty_async_queue() throws InterruptedException
 	{

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/production/productionCandidate.feature
@@ -188,8 +188,6 @@ Feature: Production dispo scenarios
 
     And the order identified by o_2 is reactivated
 
-    And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
-
     Then after not more than 60s, PP_Order_Candidates are found
       | Identifier | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | OPT.IsClosed | OPT.Processed |
       | oc_1       | p_1          | bom_1             | ppln_1                 | 540006        | 200 PCE    | 200 PCE      | 0 PCE        | 2025-02-25T00:00:00Z | 2025-02-25T00:00:00Z | false        | false         |

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -68,7 +68,7 @@
 | ❌ Mode B — Camera (ZXing/BrowserMultiFormatReader): getUserMedia() decode → barcode forwarded | — (not testable in CI, requires real camera) |
 | ❌ `scanDuplicatesIntervalMillis` — duplicate barcode within interval suppressed, outside interval forwarded | — |
 | ❌ `triggerOnChangeIfLengthGreaterThan` — onChange fires only once input length exceeds threshold | — |
-| Footer — hardware/camera toggle: renders only when both hw + camera enabled; clicking toggle switches to camera mode and renders `<video>` (feed validation requires physical hardware) | `barcode_scanner_modes.spec.js` |
+| Footer — hardware/camera toggle: renders only when both hw + camera enabled; clicking toggle switches to camera mode (camera panel shown; live `<video>` feed validation requires physical hardware) | `barcode_scanner_modes.spec.js` |
 | ❌ Footer — "Enter manually": shows only when manual mode enabled and activeMode ≠ MANUAL; clicking sets activeMode to MANUAL | — |
 | ❌ Footer — "Back to scanner": shows when activeMode=MANUAL and at least one of hw/camera enabled; clicking returns to HARDWARE (or CAMERA if only camera enabled) | — |
 

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -140,7 +140,7 @@ test('Honeywell CT60 keystroke-wedge mode — input is off-screen + readOnly, no
 
     await BarcodeScannerComponent.expectAttributes({ type: 'text', inputmode: 'none', readonly: true });
     await BarcodeScannerComponent.expectCssClass({ present: 'input-text-offscreen' });
-    await BarcodeScannerComponent.expectCameraVideoAbsent();
+    await BarcodeScannerComponent.expectCameraModeInactive();
 });
 
 // Each test drives one real-world way a barcode reaches the app, end to end:
@@ -330,7 +330,7 @@ test.describe('Modes', () => {
         // readonly PRESENT — hard suppression for Android 11 firmware that ignores inputMode="none".
         await BarcodeScannerComponent.expectAttributes({ type: 'text', inputmode: 'none', readonly: true });
         await BarcodeScannerComponent.expectCssClass({ present: 'input-text-offscreen' });
-        await BarcodeScannerComponent.expectCameraVideoAbsent();
+        await BarcodeScannerComponent.expectCameraModeInactive();
     });
 
     // invisible=true (ApplicationsListScreen / BarcodeScannerButton callers):
@@ -353,7 +353,7 @@ test.describe('Modes', () => {
         // invisible=true → useBarcodeScannerModes returns hardware-only, no camera, no manual.
         // The component renders ONLY the off-screen #input-text and the keyboard listener.
         await BarcodeScannerComponent.expectAttached({});
-        await BarcodeScannerComponent.expectCameraVideoAbsent();
+        await BarcodeScannerComponent.expectCameraModeInactive();
         await BarcodeScannerComponent.expectFooterAbsent();
     });
 
@@ -390,7 +390,7 @@ test.describe('Modes', () => {
         await BarcodeScannerComponent.expectManualEntryInputPresent();
         // The manual-entry input must NOT be readOnly — the user must be able to type.
         await BarcodeScannerComponent.expectManualEntryInputNotReadOnly();
-        await BarcodeScannerComponent.expectCameraVideoAbsent();
+        await BarcodeScannerComponent.expectCameraModeInactive();
         // Hardware scanner is enabled → manual mode offers the "Use hardware scanner" button
         // (testId barcode-scanner-back-to-scanner) so the operator can return to the scanner.
         await BarcodeScannerComponent.expectButtonPresent('barcode-scanner-back-to-scanner');
@@ -398,9 +398,9 @@ test.describe('Modes', () => {
 
     // camera toggle: hardware + camera both enabled →
     //   • footer toggle button present
-    //   • clicking toggle → <video> renders
+    //   • clicking toggle → camera mode becomes active (camera panel shown)
     // noinspection JSUnusedLocalSymbols
-    test('camera toggle — clicking hw/camera toggle renders <video>', async ({ page }) => {
+    test('camera toggle — clicking hw/camera toggle activates camera mode', async ({ page }) => {
         await allure.epic('E0295: Frontend MobileUI');
         await allure.feature('F12000: Frontend MobileUI');
         await allure.story('Barcode scanning modes');
@@ -419,12 +419,12 @@ test.describe('Modes', () => {
         await ApplicationsListScreen.startApplication('huManager');
         await HUManagerScreen.waitForScreen();
 
-        // Starting in hardware mode — no video yet.
-        await BarcodeScannerComponent.expectCameraVideoAbsent();
+        // Starting in hardware mode — camera mode not active.
+        await BarcodeScannerComponent.expectCameraModeInactive();
         // Toggle to camera mode via footer button.
         await BarcodeScannerComponent.clickFooterButton('barcode-scanner-toggle-hw-camera');
-        // After toggle, <video> element must be rendered.
-        await BarcodeScannerComponent.expectCameraVideoPresent();
+        // After toggle, camera mode must be active (the camera panel is shown).
+        await BarcodeScannerComponent.expectCameraModeActive();
     });
 
     // THE canonical hardware-handheld deployment: hardware scanner is the default, manual typing is
@@ -454,9 +454,9 @@ test.describe('Modes', () => {
         await ApplicationsListScreen.startApplication('huManager');
         await HUManagerScreen.waitForScreen();
 
-        // Boots in hardware mode: off-screen scan input present, device camera absent.
+        // Boots in hardware mode: off-screen scan input present, camera mode not active.
         await BarcodeScannerComponent.expectAttached({});
-        await BarcodeScannerComponent.expectCameraVideoAbsent();
+        await BarcodeScannerComponent.expectCameraModeInactive();
 
         // Footer contract for this deployment: manual-entry fallback shown, camera toggle hidden
         // (camera toggle needs BOTH hardware and camera enabled).

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -173,16 +173,15 @@ export const BarcodeScannerComponent = {
         }
     }),
 
-    // Asserts the device camera <video> element is NOT rendered inside .barcode-scanner.
-    // Used by the hardware-scanner-only deployments (useCamera=N) to guard against a
-    // regression that would silently re-enable the camera capture preview.
-    //
-    // Uses FAST_ACTION_TIMEOUT (5s): absence-of-element assertions should fail fast — a
-    // <video> that doesn't appear within seconds is not going to appear, and falling back
-    // to the 120s global assertion timeout would silently consume the test budget on a
-    // genuine regression.
-    expectCameraVideoAbsent: async () => await test.step(`${NAME} - Expect no camera <video> rendered`, async () => {
-        await expect(page.locator('.barcode-scanner video')).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
+    // Asserts camera mode is NOT active — the CameraModePanel wrapper (`.camera-mode-panel`,
+    // rendered iff activeMode===CAMERA) is not mounted. Used by hardware-scanner-only deployments
+    // (camera disabled) to guard against a regression that would silently re-enable camera capture.
+    // We assert on the always-mounted wrapper rather than the inner <video> — see
+    // expectCameraModeActive for why the <video> is unreliable.
+    // Uses FAST_ACTION_TIMEOUT (5s): absence-of-element assertions should fail fast — falling back
+    // to the 120s global assertion timeout would silently consume the test budget on a genuine regression.
+    expectCameraModeInactive: async () => await test.step(`${NAME} - Expect camera mode not active`, async () => {
+        await expect(page.locator('.camera-mode-panel')).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
     }),
 
     // Simulates Ctrl+V paste: mocks navigator.clipboard.readText to return the barcode,
@@ -229,9 +228,17 @@ export const BarcodeScannerComponent = {
         await expect(page.getByTestId('manual-entry-input')).not.toHaveAttribute('readonly', { timeout: SLOW_ACTION_TIMEOUT });
     }),
 
-    // Asserts the device camera <video> element IS rendered inside .barcode-scanner.
-    expectCameraVideoPresent: async () => await test.step(`${NAME} - Expect camera <video> rendered`, async () => {
-        await expect(page.locator('.barcode-scanner video')).toHaveCount(1, { timeout: SLOW_ACTION_TIMEOUT });
+    // Asserts camera mode IS active by checking the always-mounted CameraModePanel wrapper
+    // (`.camera-mode-panel`, rendered iff activeMode===CAMERA).
+    // NOT the inner <video>: CameraModePanel renders the <video> only `{!isProcessing && <video/>}`,
+    // so it unmounts whenever a barcode is processed. In CI the synthetic fake-media stream
+    // (--use-fake-device-for-media-stream) can make ZXing false-positive a 1-D barcode → isProcessing
+    // flips → the <video> unmounts mid-assertion (and a getUserMedia error tears the panel down via
+    // onCancel). Asserting on the stable wrapper verifies the toggle switched into camera mode without
+    // depending on a transient, hardware-feed-dependent element. Real video-feed validation needs
+    // physical camera hardware and cannot be deterministic in CI.
+    expectCameraModeActive: async () => await test.step(`${NAME} - Expect camera mode active`, async () => {
+        await expect(page.locator('.camera-mode-panel')).toHaveCount(1, { timeout: SLOW_ACTION_TIMEOUT });
     }),
 
     // Clicks a footer button by its testId (e.g. 'barcode-scanner-toggle-hw-camera',

--- a/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
@@ -11,9 +11,9 @@ const NAME = 'HOME';
 const containerElement = () => page.locator('#ApplicationsListScreen');
 
 export const ApplicationsListScreen = {
-    waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
-        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
+    waitForScreen: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
+        await containerElement().waitFor({ timeout });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
@@ -13,9 +13,9 @@ const NAME = 'DistributionJobsListScreen';
 const containerElement = () => page.locator('#WFLaunchersScreen');
 
 export const DistributionJobsListScreen = {
-    waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
-        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
+    waitForScreen: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
+        await containerElement().waitFor({ timeout });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout });
     }),
 
     filterByFacetId: async ({

--- a/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page, FAST_ACTION_TIMEOUT, SLOW_ACTION_TIMEOUT } from '../../common';
+import { page, FAST_ACTION_TIMEOUT, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../../common';
 import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
@@ -45,6 +45,18 @@ export const HUBulkActionsScreen = {
             }
         }
 
-        await ApplicationsListScreen.waitForScreen();
+        // The bulk move commits via an async REST round-trip (api.moveBulkHUs -> POST /bulk/move);
+        // only once it resolves does the frontend navigate home (history.goHome()). The home screen
+        // appearing IS the commit-confirming, user-visible landing signal — but its single default
+        // SLOW_ACTION_TIMEOUT (20s) budget has to absorb that whole round-trip, so under CI load the
+        // commit can overshoot 20s and the wait times out (the flake). A transient success toast is
+        // NOT usable as an earlier signal here: ScreenToaster dismisses all toasts on the very
+        // navigation that follows it (useLocationChange -> toast.dismiss()), so it races the dismissal.
+        // Give the transition the VERY_SLOW_ACTION_TIMEOUT (40s) budget instead — the same budget idiom
+        // used for other heavy async-commit flows that return to a list/home screen (e.g.
+        // PickingJobScreen.complete, ManufacturingJobScreen, InventoryJobScreen; those return to a
+        // *jobs-list* screen, here we return to the *home* ApplicationsListScreen — same topology).
+        // No new signal is invented; the genuinely-slow commit is simply given room to land.
+        await ApplicationsListScreen.waitForScreen({ timeout: VERY_SLOW_ACTION_TIMEOUT });
     }),
 };


### PR DESCRIPTION
Ports flaky-CI test fixes onto `boomerang_signal_hotfix`. Test-only changes (cucumber step-defs / feature files + mobile-webui e2e helpers); no product/backend behaviour change.

## Cherry-picked commits

- **Barcode camera-mode assertion** (from https://github.com/metasfresh/metasfresh/pull/24693): assert camera-mode-active via the always-mounted `.camera-mode-panel` wrapper instead of the transient `<video>` element, which unmounts mid-assertion in CI. Renames `expectCameraVideoPresent/Absent` -> `expectCameraModeActive/Inactive`. Conflict-resolved: took the new panel-wrapper API and migrated all surviving branch-only call-sites (this branch still used the old `<video>` assertions).
- **productionCandidate rabbitMQ drain** (squash of https://github.com/metasfresh/metasfresh/pull/24965): internalize the ordered material->async rabbitMQ drain into the consuming `PP_Order_Candidates are found` step-def and drop the bare drain step from `productionCandidate.feature`; the reactivate scenario read a stale qty because only the material queue was drained. Conflict-resolved: took the fix side (bare drain step removed; `wait_empty_async_queue` Javadoc kept).
- **huManager Move + Distribution waitForScreen** (squash of https://github.com/metasfresh/metasfresh/pull/24999): give the bulk-Move home transition the `VERY_SLOW_ACTION_TIMEOUT` (40s) budget so the async commit round-trip has room to land, and make `DistributionJobsListScreen.waitForScreen` honour a `{ timeout }` param. Conflict-resolved: kept both this branch's dropped-scan retry loop AND the fix's `VERY_SLOW_ACTION_TIMEOUT` transition wait (complementary fixes for different seams of the same flake).

## Not ported

- **shipmentScheduleExport IsToRecompute poll** (https://github.com/metasfresh/metasfresh/pull/24966): cherry-pick came out empty -- the fix (poll committed `IsToRecompute=N` at 300s, no bare queue-drain) is already present on `boomerang_signal_hotfix`.

## Verification

- `git diff --check` clean -- no conflict markers.
- `node --check` passes on all 5 changed `.js` files.
- Feature-file structure intact (`productionCandidate.feature`: 1 Feature, 5 scenarios).
