### PR TITLE
cucumber: deterministic wait in "validate C_PaymentTerm" step to fix a payment-term completion flake

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/paymentterm/C_PaymentTerm_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/paymentterm/C_PaymentTerm_StepDef.java
@@ -191,12 +191,15 @@ public class C_PaymentTerm_StepDef
 	{
 		final PaymentTermId paymentTermId = paymentTermTable.getId(identifier);
 
-		StepDefUtil.tryAndWait(
+		final boolean actualIsValid = StepDefUtil.tryAndWaitForItem(
 				VALIDATE_TIMEOUT_SECONDS,
 				VALIDATE_CHECK_INTERVAL_MS,
-				() -> paymentTermRepo.getById(paymentTermId).isValid() == expectedIsValid);
+				() -> {
+					final boolean isValid = paymentTermRepo.getById(paymentTermId).isValid();
+					return isValid == expectedIsValid ? Optional.of(isValid) : Optional.empty();
+				});
 
-		softly.assertThat(paymentTermRepo.getById(paymentTermId).isValid())
+		softly.assertThat(actualIsValid)
 				.as("IsValid (PaymentTermRepository-computed)")
 				.isEqualTo(expectedIsValid);
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/paymentterm/C_PaymentTerm_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/paymentterm/C_PaymentTerm_StepDef.java
@@ -27,11 +27,13 @@ import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.StepDefConstants;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.cucumber.stepdefs.StepDefUtil;
 import de.metas.cucumber.stepdefs.ValueAndName;
 import de.metas.payment.paymentterm.PaymentTermId;
 import de.metas.payment.paymentterm.ReferenceDateType;
 import de.metas.payment.paymentterm.repository.IPaymentTermRepository;
 import de.metas.payment.paymentterm.repository.PaymentTermQuery;
+import de.metas.util.OptionalBoolean;
 import de.metas.util.Optionals;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
@@ -59,6 +61,10 @@ public class C_PaymentTerm_StepDef
 
 	@NonNull private final C_PaymentTerm_StepDefData paymentTermTable;
 	@NonNull private final C_PaymentTerm_Break_StepDefData paymentTermBreakTable;
+
+	/** Wait budget for the PaymentTermRepository cache-reset to land after the C_PaymentTerm_Break rows were committed. */
+	private static final int VALIDATE_TIMEOUT_SECONDS = 30;
+	private static final int VALIDATE_CHECK_INTERVAL_MS = 200;
 
 	@And("metasfresh contains C_PaymentTerm")
 	public void createPaymentTerms(@NonNull final DataTable dataTable)
@@ -146,7 +152,8 @@ public class C_PaymentTerm_StepDef
 				.forEach(row -> {
 					final SoftAssertions softly = new SoftAssertions();
 
-					final I_C_PaymentTerm paymentTerm = row.getAsIdentifier().lookupNotNullIn(paymentTermTable);
+					final StepDefDataIdentifier identifier = row.getAsIdentifier();
+					final I_C_PaymentTerm paymentTerm = identifier.lookupNotNullIn(paymentTermTable);
 
 					row.getAsOptionalString("Value")
 							.ifPresent(value -> softly.assertThat(paymentTerm.getValue()).as("Value").isEqualTo(value));
@@ -154,11 +161,44 @@ public class C_PaymentTerm_StepDef
 							.ifPresent(name -> softly.assertThat(paymentTerm.getName()).as("Name").isEqualTo(name));
 					row.getAsOptionalBoolean("IsComplex")
 							.ifPresent(isComplex -> softly.assertThat(paymentTerm.isComplex()).as("IsComplex").isEqualTo(isComplex));
-					row.getAsOptionalBoolean("IsValid")
-							.ifPresent(isValid -> softly.assertThat(paymentTerm.isValid()).as("IsValid").isEqualTo(isValid));
+
+					final OptionalBoolean expectedIsValid = row.getAsOptionalBoolean("IsValid");
+					if (expectedIsValid.isPresent())
+					{
+						assertPaymentTermRepoIsValid(identifier, expectedIsValid.isTrue(), softly);
+					}
 
 					softly.assertAll();
 				});
+	}
+
+	/**
+	 * Asserts the {@code IsValid} flag against the {@link IPaymentTermRepository}-computed validity, polling until it settles.
+	 * <p>
+	 * The repository caches all payment terms in one monolithic entry, whose per-term {@code valid} flag is derived at load
+	 * time from the {@code C_PaymentTerm_Break} rows visible then. The cache reset triggered by inserting the breaks is
+	 * delivered asynchronously and can lag under executor load. Reading the persisted {@code I_C_PaymentTerm.IsValid} column
+	 * would neither exercise nor wait on that cache, so a scenario could proceed to order completion while the repository
+	 * still served a stale partial term (e.g. only a 30% break -> "Total percent ... 30%"), and
+	 * {@code PaymentTerm.assertValid()} would then throw during {@code C_Order} completion. Polling the repository here
+	 * internalizes that wait: the step blocks until {@code getById()} reflects all committed breaks before the scenario
+	 * continues, going through the exact same load path that completion later uses.
+	 */
+	private void assertPaymentTermRepoIsValid(
+			@NonNull final StepDefDataIdentifier identifier,
+			final boolean expectedIsValid,
+			@NonNull final SoftAssertions softly) throws InterruptedException
+	{
+		final PaymentTermId paymentTermId = paymentTermTable.getId(identifier);
+
+		StepDefUtil.tryAndWait(
+				VALIDATE_TIMEOUT_SECONDS,
+				VALIDATE_CHECK_INTERVAL_MS,
+				() -> paymentTermRepo.getById(paymentTermId).isValid() == expectedIsValid);
+
+		softly.assertThat(paymentTermRepo.getById(paymentTermId).isValid())
+				.as("IsValid (PaymentTermRepository-computed)")
+				.isEqualTo(expectedIsValid);
 	}
 
 	public Optional<PaymentTermId> extractPaymentTermId(final @NonNull DataTableRow row)


### PR DESCRIPTION
## Problem

The `validate C_PaymentTerm:` cucumber step (`C_PaymentTerm_StepDef`) asserted the `IsValid` flag by reading the persisted `I_C_PaymentTerm.IsValid` **column** off the step's cached model record. That read never goes through `PaymentTermRepository`, so it neither exercises nor waits on the repository cache that order completion later relies on.

`PaymentTermRepository` caches all payment terms in a single monolithic entry, and each term's computed `valid` flag is derived at load time from the `C_PaymentTerm_Break` rows visible at that moment. The cache reset triggered by inserting the breaks is delivered asynchronously and can lag under executor load. When it lagged, a split-payment scenario could proceed to `C_Order` completion while the repository still served a stale, partial term (e.g. only the first `30%` break). `PaymentTerm.assertValid()` then threw during completion:

```
Total percent must be exactly 100%, but it was: 30%
```

This surfaced as an intermittent cucumber failure (`splitPayments`-style features) that passed on re-run and on a lightly loaded executor -- a shared-executor timing flake, not a product defect.

## Fix

Test-harness change only. When the `validate C_PaymentTerm:` step asserts `IsValid`, it now asserts against the **`PaymentTermRepository`-computed** validity (`getById(id).isValid()`) and polls until it settles, using the existing `StepDefUtil.tryAndWait` helper (the same poll-until-committed pattern used elsewhere in the suite).

This internalizes the wait into the step: it blocks until `getById()` reflects all committed breaks -- going through the exact load path completion later uses -- before the scenario continues, so the reset-lag race can no longer leak a stale partial term into order completion. The `100%` `assertValid` business invariant is left untouched; only the test's readiness gate is made deterministic.

Other columns (`Value`, `Name`, `IsComplex`) and the no-`IsValid` case are unchanged. All existing features that use the step assert `IsValid=Y`, which is the intended settled state, so the poll returns as soon as the cache reflects both breaks.
