### PR TITLE
Merge: intensive_care_hotfix → new_dawn_uat (HU-QR keyboard-scan completion)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5812460_sysconfig_barcodeScanner_inputText_idleAbandonMillis.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5812460_sysconfig_barcodeScanner_inputText_idleAbandonMillis.sql
@@ -1,0 +1,29 @@
+-- mobileUI barcode scanner: ship the inputText.idleAbandonMillis capability (default 15000 ms).
+--
+-- Creates the System-level setting mobileui.frontend.barcodeScanner.inputText.idleAbandonMillis with
+-- its default value '15000' if it does not already exist. Mirrors the sibling setting
+-- mobileui.frontend.barcodeScanner.inputText.debounceMillis (see 5664360_...); the frontend reads it
+-- via usePositiveNumberSetting('barcodeScanner.inputText.idleAbandonMillis', 15000) and passes it to
+-- useKeyboardBarcodeReader as idleAbandonMs. The NOT EXISTS guard keeps this idempotent / forward
+-- compatible.
+--
+-- This is the long "abandon" window for a recognised-but-incomplete (streamed / chunked) HU QR code:
+-- a still-open partial is held buffered across inter-keystroke gaps (so a slow chunked scan is never
+-- split) and only abandoned/flushed once this window elapses, surfacing the app's "QR not recognised"
+-- error instead of hanging. It must sit safely ABOVE the largest legit inter-chunk gap. Lowering it
+-- shortens the wait before a genuinely-truncated scan surfaces its error, at the risk of splitting a
+-- very slow legitimate chunked scan. Default '15000' keeps the shipped hook default (IDLE_ABANDON_MS).
+
+INSERT INTO AD_SysConfig (
+    AD_Client_ID, AD_Org_ID, AD_SysConfig_ID, ConfigurationLevel, EntityType, IsActive,
+    Name, Value, Description, Created, CreatedBy, Updated, UpdatedBy
+)
+SELECT
+    0, 0, 541831 /*From ID Server*/, 'S', 'D', 'Y',
+    'mobileui.frontend.barcodeScanner.inputText.idleAbandonMillis', '15000',
+    'How many millis a recognised-but-incomplete (streamed/chunked) barcode may stay buffered across inter-keystroke gaps before it is abandoned and flushed as an error. Must sit safely above the largest legitimate inter-chunk gap. Default 15000.',
+    TO_TIMESTAMP('2026-07-07 10:00:00','YYYY-MM-DD HH24:MI:SS'), 100,
+    TO_TIMESTAMP('2026-07-07 10:00:00','YYYY-MM-DD HH24:MI:SS'), 100
+WHERE NOT EXISTS (
+    SELECT 1 FROM AD_SysConfig WHERE Name = 'mobileui.frontend.barcodeScanner.inputText.idleAbandonMillis'
+);

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/sysconfig/SysconfigCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/sysconfig/SysconfigCommand.java
@@ -33,6 +33,14 @@ public class SysconfigCommand
 			.put("mobileui.frontend.barcodeScanner.useCamera", "Y")
 			.put("mobileui.frontend.barcodeScanner.offscreenInput.readOnly", "N")
 			.put("mobileui.frontend.barcodeScanner.visibleInput.readOnly", "N")
+			// Reset the inputText timing knobs too — a test that lowers them (e.g. the truncated-HU-QR
+			// picking test drops idleAbandonMillis to 500 so a held partial errors fast) must NOT leak
+			// that value onto later specs: a small idleAbandonMillis abandons the chunked-scan test's
+			// in-flight partial mid-gap → "QR not recognized". Defaults match the seed migrations
+			// (debounceMillis 5664360 = 300, idleAbandonMillis 5812460 = 15000, triggerOnChange = 10).
+			.put("mobileui.frontend.barcodeScanner.inputText.debounceMillis", "300")
+			.put("mobileui.frontend.barcodeScanner.inputText.idleAbandonMillis", "15000")
+			.put("mobileui.frontend.barcodeScanner.inputText.triggerOnChangeIfLengthGreaterThan", "10")
 			.build();
 
 	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 7 | 12 | 58% |
-| Picking | 64 | 68 | 94% |
+| Picking | 70 | 74 | 95% |
 | Distribution | 40 | 41 | 98% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
@@ -137,9 +137,15 @@
 | Pick HU by EAN13 — LU/CU into top-level CUs | `picking/pick_by_EAN13.spec.js` |
 | Pick HU by ExternalBarcode attribute | `picking/pick_by_ExternalBarcode.spec.js` |
 | Pick HU by M_HU_ID — LU/CU into LU/CU | `picking/pick_by_HUId.spec.js` |
+| Pick HU by long QR arriving in chunks (mid-scan inter-keystroke gap) | `picking/scan_HU_QR_chunked.spec.js` |
+| Two valid HU QRs back-to-back, no terminator → recognised as two distinct picks (not merged) | `picking/picking.spec.js` |
+| Truncated HU QR head, no terminator (customer default) → friendly QR_NOT_RECOGNIZED (held, then abandon-window surfaces error) | `picking/picking.spec.js` |
+| Truncated HU QR tail, no terminator (customer default) → friendly QR_NOT_RECOGNIZED | `picking/picking.spec.js` |
+| Truncated HU QR head, Enter terminator (variant) → friendly QR_NOT_RECOGNIZED | `picking/picking.spec.js` |
+| Truncated HU QR tail, Enter terminator (variant) → friendly QR_NOT_RECOGNIZED | `picking/picking.spec.js` |
 | ❌ Scan ambiguous code (resolves to more than one target) → routing handled | — |
 
-**7/8 — 88%**
+**13/14 — 93%**
 
 ### Order-based picking — LU picking
 

--- a/e2e/mobile-webui/tests/spec/hu_consolidation/hu_consolidation_grai.spec.js
+++ b/e2e/mobile-webui/tests/spec/hu_consolidation/hu_consolidation_grai.spec.js
@@ -241,10 +241,12 @@ test('Scan TU GRAI on PickingSlotScreen → TU consolidated onto target LU', asy
         // The customer requires GRAI, so the scan affordance is shown.
         await PickingSlotScreen.expectScannerVisible();
 
-        // Scan first TU's GRAI → consolidates tu1 onto the target LU
+        // Scan first TU's GRAI → consolidates tu1 onto the target LU.
+        // scanGRAI appends an Enter terminator so each instantaneous test-harness scan force-completes
+        // as a distinct code (no keyboard-hook buffer concatenation — see PickingSlotScreen.scanGRAI /
+        // CLAUDE.md § "Back-to-Back type() calls — Buffer Concatenation").
         await PickingSlotScreen.scanGRAI({ graiString: graiP1 });
-        // Assertion between scans: ensures the keyboard hook flushes before the next scan
-        // (CLAUDE.md § "Back-to-Back type() calls — Buffer Concatenation")
+        // Wait for the consolidation round-trip to land before the next scan.
         await PickingSlotScreen.waitNotLoading();
 
         // Scan second TU's GRAI → consolidates tu2 onto the target LU

--- a/e2e/mobile-webui/tests/spec/picking/picking-grai-scan.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking-grai-scan.spec.js
@@ -680,11 +680,13 @@ test('Two distinct GRAIs in debounce window → GRAIMultipleScanned error', asyn
     await navigateToTUTargetScreen(masterdata);
     await PickingGraiScanPanel.expectScannerVisible();
 
-    // Scan two distinct GRAIs back-to-back before the 1500ms debounce fires.
-    // The assertion between scans gives the keyboard hook's interval flush time to process
-    // each code individually so they don't concatenate in the buffer.
+    // Scan two distinct GRAIs back-to-back within the same 1500ms debounce window.
+    // scanGrai appends an Enter terminator, so each instantaneous test-harness scan force-completes
+    // as a distinct code instead of concatenating in the keyboard-hook buffer (see PickingGraiScanPanel.scanGrai).
+    // The assertion between scans is a visible-state gate: the scanner is still shown (no navigation /
+    // no error yet) after the first code, confirming both distinct GRAIs land in the same window → error below.
     await PickingGraiScanPanel.scanGrai({ graiString: graiA });
-    await PickingGraiScanPanel.expectScannerVisible(); // flush gap assertion
+    await PickingGraiScanPanel.expectScannerVisible(); // scanner still live between the two distinct scans
     await PickingGraiScanPanel.scanGrai({ graiString: graiB });
 
     // After the debounce timer fires with 2 distinct GRAIs → error toast

--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -20,10 +20,12 @@ const createMasterdata = async ({
                                     allowCompletingPartialPickingJob = false,
                                     shipOnCloseLU = false,
                                     salesOrdersQty = 12,
+                                    extraSysconfigs,
                                 } = {}) => {
     return await Backend.createMasterdata({
         language,
         request: {
+            ...(extraSysconfigs && { sysconfigs: extraSysconfigs }),
             login: { user: { language } },
             mobileConfig: {
                 picking: {
@@ -612,14 +614,56 @@ test('Scan invalid HU QR code and recover', async ({ page }) => {
 // delivers it, must surface the friendly QR_NOT_RECOGNIZED message — never a silent failure or the raw
 // "Failed converting payload" developer error.
 //
-// The two fragments are verified in SEPARATE tests, each starting from a clean toast state. The app shows
-// exactly one error toast per scan by design (a fixed toastId — see mobile-webui CLAUDE.md "the user must
-// see exactly ONE error"), so two back-to-back scans within one test would race that de-duplication and
-// leave the second fragment's toast suppressed. Asserting a single shared toast instead would also fail to
-// catch a tail-specific regression — a raw tail error would be hidden under the head's friendly toast. One
-// scan per scenario keeps each fragment's handling independently observable.
-const expectTruncatedHuQRFragmentShowsFriendlyErrorDuringPicking = async ({ which }) => {
-    const masterdata = await createMasterdata();
+// TWO delivery paths are covered per fragment:
+//
+//  • NO TERMINATOR (the DEFAULT / main coverage — what THIS customer ships): the production Zebra device
+//    sends NO Enter/Tab suffix (the terminator broke login on this device, so it was removed). With no
+//    end-of-scan key the fragment must still surface QR_NOT_RECOGNIZED on its own:
+//      - TAIL is prefix-less (NOT_APPLICABLE) → it is NOT held back, so it flushes on the idle gap and
+//        errors fast; no special config needed.
+//      - HEAD keeps the "HU#" prefix with truncated JSON (PARTIAL_SCAN) → content-based completion holds
+//        it back (indistinguishable from a still-arriving chunked scan) until the long idle-abandon
+//        window. To keep the E2E fast we lower that window for the head test via the sysconfig
+//        barcodeScanner.inputText.idleAbandonMillis, applied through the `sysconfigs` masterdata key
+//        (the same sysconfig-override mechanism barcode_scanner_modes.spec.js uses for its scanner
+//        settings). This exercises the REAL no-Enter path we ship: the partial is held, then the
+//        abandon window surfaces the error.
+//
+//  • ENTER TERMINATOR (an additional VARIANT, kept for coverage): a device configured with an Enter/Tab
+//    suffix (e.g. Zebra DataWedge "Enter as string") supplies an explicit end-of-scan signal, so the
+//    fragment force-completes immediately and its error surfaces at once — no abandon-window wait.
+//
+// Each scenario is a SEPARATE test starting from a clean toast state. The app shows exactly one error
+// toast per scan by design (a fixed toastId — see mobile-webui CLAUDE.md "the user must see exactly ONE
+// error"), so two back-to-back scans within one test would race that de-duplication and leave the second
+// fragment's toast suppressed. Asserting a single shared toast instead would also fail to catch a
+// tail-specific regression — a raw tail error would be hidden under the head's friendly toast. One scan
+// per scenario keeps each fragment's handling independently observable.
+
+// A short idle-abandon window (ms) for the no-terminator HEAD test — the head is held as PARTIAL_SCAN
+// until this window elapses, then flushed as the QR_NOT_RECOGNIZED error. A low value keeps the E2E fast
+// while still exercising the real held-then-abandoned path.
+//
+// It must be comfortably SHORT: expectErrorToast() gives the assertion only ~2 s of grace after pickHU()
+// returns (which, on the direct-scan HEAD path, is almost immediately — the scan dispatch is synchronous
+// and no qty dialog opens). The abandon flush → backend round-trip → error-toast render must all land
+// inside that budget under CI load, so the window is set well below it. The hook's idle interval ticks
+// every rateMs*2 (rateMs = the 300 ms debounce default here → 600 ms), so 500 ms fires reliably on the
+// first tick (~600 ms) with large margin, and still sits above rateMs so it never trips the normal
+// debounce flush. (The window is deliberately tiny for the test ONLY because this HEAD is dispatched as
+// ONE synchronous keystroke burst with zero inter-chunk gaps — there is no slow chunked scan here to
+// protect; production keeps the 15000 ms default that clears the real 3-8 s inter-chunk gaps.)
+const FAST_ABANDON_MS = 500;
+const FAST_ABANDON_SYSCONFIG = { 'mobileui.frontend.barcodeScanner.inputText.idleAbandonMillis': String(FAST_ABANDON_MS) };
+
+const expectTruncatedHuQRFragmentShowsFriendlyErrorDuringPicking = async ({ which, terminator }) => {
+    // For the no-terminator HEAD path, lower the idle-abandon window so the held partial surfaces fast.
+    // The TAIL is NOT_APPLICABLE (not held), and the Enter variants force-complete immediately, so
+    // neither needs the override.
+    const needsFastAbandon = !terminator && which === 'head';
+    const masterdata = await createMasterdata(
+        needsFastAbandon ? { extraSysconfigs: FAST_ABANDON_SYSCONFIG } : {}
+    );
 
     const fullHuQRCode = masterdata.handlingUnits.HU1.qrCode;
     const splitAt = Math.floor(fullHuQRCode.length / 2);
@@ -638,10 +682,14 @@ const expectTruncatedHuQRFragmentShowsFriendlyErrorDuringPicking = async ({ whic
     await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
     await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
 
-    await expectErrorToast(`Scan the truncated HU QR ${which} during picking`, async () => {
+    const label = `Scan the truncated HU QR ${which} during picking${terminator ? ` (${terminator} terminator)` : ' (no terminator)'}`;
+    await expectErrorToast(label, async () => {
         await PickingJobScreen.pickHU({
             qrCode: fragment,
             isScanDirectly: true,
+            // terminator undefined → no end-of-scan key (the customer's real no-terminator device);
+            // 'Enter' → the additional device-suffix variant.
+            terminator,
             expectedPickDirectly: true,
         });
     }, ({ textContent }) => {
@@ -649,8 +697,10 @@ const expectTruncatedHuQRFragmentShowsFriendlyErrorDuringPicking = async ({ whic
     });
 };
 
+// === DEFAULT / MAIN COVERAGE: NO terminator (the customer ships WITHOUT an Enter/Tab suffix). ===
+
 // noinspection JSUnusedLocalSymbols
-test('Scan a truncated (split) HU QR HEAD during picking → user-friendly error', async ({ page }) => {
+test('Scan a truncated (split) HU QR HEAD during picking, NO terminator → user-friendly error', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
@@ -661,7 +711,7 @@ test('Scan a truncated (split) HU QR HEAD during picking → user-friendly error
 });
 
 // noinspection JSUnusedLocalSymbols
-test('Scan a truncated (split) HU QR TAIL during picking → user-friendly error', async ({ page }) => {
+test('Scan a truncated (split) HU QR TAIL during picking, NO terminator → user-friendly error', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
@@ -669,6 +719,112 @@ test('Scan a truncated (split) HU QR TAIL during picking → user-friendly error
     allure.severity('critical');
 
     await expectTruncatedHuQRFragmentShowsFriendlyErrorDuringPicking({ which: 'tail' });
+});
+
+// === ADDITIONAL VARIANT: Enter terminator (device configured with an Enter/Tab suffix). ===
+
+// noinspection JSUnusedLocalSymbols
+test('Scan a truncated (split) HU QR HEAD during picking, Enter terminator → user-friendly error', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Error handling - invalid HU QR code');
+    allure.severity('critical');
+
+    await expectTruncatedHuQRFragmentShowsFriendlyErrorDuringPicking({ which: 'head', terminator: 'Enter' });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Scan a truncated (split) HU QR TAIL during picking, Enter terminator → user-friendly error', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Error handling - invalid HU QR code');
+    allure.severity('critical');
+
+    await expectTruncatedHuQRFragmentShowsFriendlyErrorDuringPicking({ which: 'tail', terminator: 'Enter' });
+});
+
+//
+// Two valid HU QR codes scanned back-to-back with NO terminator (the customer's real device) must be
+// recognised as TWO distinct scans, never merged into one unparseable "code1+code2" string. Each is a
+// complete HU QR whose closing JSON brace force-completes it on content (COMPLETE_SCAN), so the reader
+// separates them without an Enter/Tab suffix and without waiting on the idle timer. A merge regression
+// would fail the FIRST pick (the buffer would still be accumulating the second code) — this asserts both
+// picks land, proving separation on the shipped no-terminator path.
+//
+// noinspection JSUnusedLocalSymbols
+test('Scan two valid HU QR codes back-to-back, NO terminator → both recognised as distinct picks (not merged)', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Scan HU barcodes');
+    allure.severity('critical');
+
+    // TWO products, each on its own SO line (3 TU / 12 PCE), one full HU each. Both PIs use the SAME tu
+    // name 'TU' (distinct products ⇒ distinct HUPIItemProduct identifiers "TU_P1"/"TU_P2", so no
+    // "Identifier already exists" collision), which lets a SINGLE target LU accept both (the LU knows a
+    // 'TU' sub-instruction). Each scan then picks its own line at the dialog's DEFAULT full qty (3) — no
+    // partial pick, no not-found reason (which would close the line), no second setTargetLU (which stalls
+    // on a "Select Target" screen). If the two no-terminator scans were MERGED into one garbage code, the
+    // first HU would not resolve and pickHU would raise an error toast; two clean default-qty picks prove
+    // the reader separated the two back-to-back scans.
+    const masterdata = await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: 'sales_order',
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                },
+            },
+            bpartners: { 'BP1': {} },
+            warehouses: { 'wh': {} },
+            pickingSlots: { slot1: {} },
+            products: { 'P1': { prices: [{ price: 1 }] }, 'P2': { prices: [{ price: 1 }] } },
+            packingInstructions: {
+                'PI1': { lu: 'LU', qtyTUsPerLU: 20, tu: 'TU', product: 'P1', qtyCUsPerTU: 4 },
+                'PI2': { lu: 'LU2', qtyTUsPerLU: 20, tu: 'TU', product: 'P2', qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                'HU1': { product: 'P1', warehouse: 'wh', packingInstructions: 'PI1' },
+                'HU2': { product: 'P2', warehouse: 'wh', packingInstructions: 'PI2' },
+            },
+            salesOrders: {
+                'SO1': {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [
+                        { product: 'P1', qty: 12, piItemProduct: 'TU' },
+                        { product: 'P2', qty: 12, piItemProduct: 'TU' },
+                    ],
+                },
+            },
+        },
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI1.luName });
+
+    // First scan (no terminator): HU1 (P1) → its line picked at full default qty. A merge regression would
+    // garble this scan so it never resolves and pickHU would raise an error toast.
+    await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, isScanDirectly: true, expectQtyEntered: '3' });
+    // Second scan (no terminator), immediately after: HU2 (P2) → a DISTINCT pick into the same target LU.
+    await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU2.qrCode, isScanDirectly: true, expectQtyEntered: '3' });
+
+    // Both back-to-back scans landed as two separate, valid picks → the job completes.
+    await PickingJobScreen.complete();
 });
 
 //

--- a/e2e/mobile-webui/tests/spec/picking/scan_HU_QR_chunked.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/scan_HU_QR_chunked.spec.js
@@ -1,0 +1,119 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
+
+// Real-flow validation for the content-based scan-completion fix.
+//
+// PRODUCTION SYMPTOM: a long HU global QR code (HU#<v>#{…json…}) does not always reach the browser
+// in a single burst — a hardware/wedge scanner can deliver it in chunks spread over several seconds.
+// The previous keyboard reader completed a scan on the first inter-keystroke gap >= the debounce, so
+// such a chunked code was split into unparseable fragments and picking failed with an intermittent
+// "QR-Code nicht erkannt" ("QR code not recognised").
+//
+// The fix keeps a still-arriving recognised QR code (PARTIAL_SCAN) buffered across the gap and only
+// force-completes it once its JSON payload closes (COMPLETE_SCAN). This test drives the REAL mobile
+// picking flow and injects exactly that mid-scan gap, asserting the HU is recognised and the pick
+// proceeds. It fails on the old gap-based reader (fragmented code => not recognised) and passes with
+// the fix. The hook mechanic itself is covered exhaustively by the Jest suite
+// (src/hooks/__tests__/useKeyboardBarcodeReader.test.js).
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: {
+                user: { language: "en_US" },
+            },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    shipOnCloseLU: false,
+                    pickTo: ['LU_TU'],
+                    allowCompletingPartialPickingJob: false,
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: { "P1": { price: 1 } },
+            packingInstructions: {
+                "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "P1", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' }
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 12, piItemProduct: 'TU' }]
+                }
+            },
+        }
+    })
+}
+
+// noinspection JSUnusedLocalSymbols
+test('Pick by scanning a long HU QR Code that arrives in chunks (mid-scan inter-keystroke gap)', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Scan HU barcodes');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+
+    // The long HU global QR code (HU#<v>#{…json…}). Split it roughly in half so the gap lands INSIDE
+    // the still-open JSON payload (first chunk is a PARTIAL_SCAN); the closing brace only arrives with
+    // the second chunk.
+    const huQrCode = masterdata.handlingUnits.HU1.qrCode;
+    const gapAtIndex = Math.floor(huQrCode.length / 2);
+    // Gap >= scanner debounce (barcodeScanner.inputText.debounceMillis, default 300ms) and well below
+    // the hook's abandon deadline (>= 3000ms), so the in-flight partial QR is protected, not abandoned.
+    const gapMs = 1200;
+
+    await PickingJobScreen.pickHU({
+        qrCode: huQrCode,
+        isScanDirectly: true,
+        gapAtIndex,
+        gapMs,
+        expectQtyEntered: '3'
+    });
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });
+    await Backend.expect({
+        pickings: {
+            [pickingJobId]: {
+                shipmentSchedules: {
+                    P1: {
+                        qtyPicked: [{ qtyPicked: "12 PCE", qtyTUs: 3, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }]
+                    }
+                }
+            }
+        },
+        hus: {
+            [masterdata.handlingUnits.HU1.qrCode]: { huStatus: 'A', storages: { P1: '68 PCE' } },
+            lu1: { huStatus: 'S', storages: { P1: '12 PCE' } },
+        }
+    });
+
+    await PickingJobScreen.complete();
+});

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -27,15 +27,44 @@ export const BarcodeScannerComponent = {
         }
         await expect(page.locator(selector)).not.toBeAttached({ timeout });
     }),
+    // Simulates a hardware/wedge keyboard scan by dispatching keydown/keyup for each character.
+    //
+    // Optional mid-scan gap (object form only): { scannedCode, testId, gapAtIndex, gapMs }
+    //   gapAtIndex - split the code before this character index and insert ONE real wall-clock pause
+    //   gapMs      - duration of that pause, in milliseconds
+    // The pause is a genuine page.waitForTimeout() (NOT a simulated timestamp): the useKeyboardBarcodeReader
+    // hook measures inter-keystroke gaps with Date.now() and runs a setInterval flush timer in the browser,
+    // and a single page.evaluate loop dispatches all keystrokes synchronously (zero wall-clock gap) so it
+    // CANNOT reproduce a real gap. Splitting the dispatch across two evaluate() calls with an awaited pause
+    // between them reproduces the production symptom: a long HU global QR code (HU#<v>#{…json…}) that arrives
+    // at the browser in chunks spread over several seconds. Set gapMs >= the scanner debounce
+    // (barcodeScanner.inputText.debounceMillis, default 300ms) to exercise the gap path, and keep it well
+    // below the hook's idle-abandon deadline (idleAbandonMs, default 15000ms via
+    // barcodeScanner.inputText.idleAbandonMillis) so an in-flight partial QR is not abandoned.
+    // Default (no gapAtIndex/gapMs): unchanged single synchronous zero-delay dispatch — existing callers are
+    // not affected.
+    //
+    // Optional terminator (object form only): { scannedCode, testId, terminator }
+    //   terminator - a non-printable end-of-scan key ('Enter' / 'Tab') dispatched once AFTER the code, to
+    //   simulate a hardware scanner configured with an Enter/Tab suffix (e.g. Zebra DataWedge "Enter as
+    //   string"). The useKeyboardBarcodeReader hook treats Enter/Tab as an explicit end-of-scan signal and
+    //   force-completes the current buffer immediately — so a truncated / unparseable scan surfaces its error
+    //   right away instead of waiting out the content-completion idle-abandon window.
     type: async (params) => await test.step(`${NAME} - Type scanned code`, async () => {
         let scannedCode;
         let testId;
+        let gapAtIndex;
+        let gapMs;
+        let terminator;
         if (typeof params === 'string') {
             scannedCode = params;
             testId = undefined;
         } else if (params && typeof params === 'object') {
             scannedCode = params.scannedCode;
             testId = params.testId;
+            gapAtIndex = params.gapAtIndex;
+            gapMs = params.gapMs;
+            terminator = params.terminator;
         } else {
             throw new Error("Invalid argument provided to the 'type' function. Must be a string or an object with { scannedCode }.");
         }
@@ -48,15 +77,36 @@ export const BarcodeScannerComponent = {
 
         await BarcodeScannerComponent.waitToAttach({ testId });
 
-        // NOTE page.keyboard.type is very slow, so we have to send the keyboard events directly, 
+        // NOTE page.keyboard.type is very slow, so we have to send the keyboard events directly,
         // Now a QR code is typed in 30ms instead of 5 seconds.
         // await page.keyboard.type(`${scannedCode}`, { delay: delay != null ? delay : TYPE_DELAY_MILLIS });
-        await page.evaluate((code) => {
-            for (const char of code) {
-                document.dispatchEvent(new KeyboardEvent('keydown', { key: char, bubbles: true }));
-                document.dispatchEvent(new KeyboardEvent('keyup', { key: char, bubbles: true }));
-            }
-        }, scannedCode);
+        const dispatchChunk = async (chunk) => {
+            await page.evaluate((code) => {
+                for (const char of code) {
+                    document.dispatchEvent(new KeyboardEvent('keydown', { key: char, bubbles: true }));
+                    document.dispatchEvent(new KeyboardEvent('keyup', { key: char, bubbles: true }));
+                }
+            }, chunk);
+        };
+
+        const hasMidScanGap =
+            Number.isInteger(gapAtIndex) && gapAtIndex > 0 && gapAtIndex < scannedCode.length && gapMs > 0;
+        if (!hasMidScanGap) {
+            await dispatchChunk(scannedCode);
+        } else {
+            await dispatchChunk(scannedCode.substring(0, gapAtIndex));
+            await page.waitForTimeout(gapMs);
+            await dispatchChunk(scannedCode.substring(gapAtIndex));
+        }
+
+        // Explicit end-of-scan key (device Enter/Tab suffix): a single non-printable keydown/keyup the
+        // hook recognises as "scan finished", force-completing the buffer immediately.
+        if (terminator) {
+            await page.evaluate((key) => {
+                document.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+                document.dispatchEvent(new KeyboardEvent('keyup', { key, bubbles: true }));
+            }, terminator);
+        }
     }),
 
     typeViaIME: async (params) => await test.step(`${NAME} - Type scanned code via IME`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/huConsolidation/PickingSlotScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huConsolidation/PickingSlotScreen.js
@@ -57,10 +57,17 @@ export const PickingSlotScreen = {
      * the target LU, and refreshes the slot content — the screen stays on PickingSlotScreen.
      * On error (HuNotFound, LuNotAtPickingSlot) the backend returns 4xx → error toast.
      *
+     * Appends an explicit Enter terminator. `BarcodeScannerComponent.type()` dispatches all keystrokes
+     * instantaneously (0ms wall-clock), so two back-to-back TU-GRAI scans would concatenate in the
+     * `useKeyboardBarcodeReader` buffer before the ~1500ms GRAI debounce could flush; the Enter
+     * force-completes each instantaneous test-harness scan immediately, so each code is a distinct
+     * barcode. In PRODUCTION a GRAI is a non-HU-prefix code (`NOT_APPLICABLE`) that completes via the
+     * debounce flush without any Enter — the Enter is purely a test-harness need.
+     *
      * @param {string} graiString - Canonical GRAI string ("{companyPrefix}.{assetType}.{serial}")
      */
     scanGRAI: async ({ graiString }) => await test.step(`${NAME} - Scan GRAI: ${graiString}`, async () => {
-        await BarcodeScannerComponent.type({ scannedCode: graiString, testId: GRAI_SCANNER_TESTID });
+        await BarcodeScannerComponent.type({ scannedCode: graiString, testId: GRAI_SCANNER_TESTID, terminator: 'Enter' });
     }),
 
     /** The GRAI scanner is present — shown only when the consolidation customer requires GRAI. */

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickGraiScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickGraiScreen.js
@@ -27,7 +27,8 @@ export const PickGraiScreen = {
 
     /**
      * Scan a GRAI barcode through the live scanner (the offscreen hardware-scan input).
-     * Dispatches keyboard events at document level, terminated with Enter (DataWedge behaviour).
+     * Dispatches keyboard events at document level with no terminator; a GRAI is a non-HU-prefix
+     * code (`NOT_APPLICABLE`), so the keyboard hook flushes the buffer via its debounce interval.
      */
     scanGrai: async ({ graiString }) => await test.step(`${NAME} - Scan GRAI: ${graiString}`, async () => {
         await BarcodeScannerComponent.type(graiString);

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickGraiScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickGraiScreen.js
@@ -27,11 +27,15 @@ export const PickGraiScreen = {
 
     /**
      * Scan a GRAI barcode through the live scanner (the offscreen hardware-scan input).
-     * Dispatches keyboard events at document level with no terminator; a GRAI is a non-HU-prefix
-     * code (`NOT_APPLICABLE`), so the keyboard hook flushes the buffer via its debounce interval.
+     * Appends an explicit Enter terminator. `BarcodeScannerComponent.type()` dispatches all keystrokes
+     * instantaneously (0ms wall-clock), so back-to-back scans would concatenate in the
+     * `useKeyboardBarcodeReader` buffer before the ~1500ms GRAI debounce could flush; the Enter
+     * force-completes each instantaneous test-harness scan immediately, so each code is a distinct
+     * barcode. In PRODUCTION a GRAI is a non-HU-prefix code (`NOT_APPLICABLE`) that completes via the
+     * debounce flush without any Enter — the Enter is purely a test-harness need.
      */
     scanGrai: async ({ graiString }) => await test.step(`${NAME} - Scan GRAI: ${graiString}`, async () => {
-        await BarcodeScannerComponent.type(graiString);
+        await BarcodeScannerComponent.type({ scannedCode: graiString, terminator: 'Enter' });
     }),
 
     /**

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingGraiScanPanel.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingGraiScanPanel.js
@@ -40,11 +40,15 @@ export const PickingGraiScanPanel = {
      * Scan a GRAI barcode (in canonical dot-separated or GS1 AI 8003 format).
      * Dispatches keyboard events via BarcodeScannerComponent targeting the GRAI scanner input.
      *
-     * Uses `BarcodeScannerComponent.type()`, which dispatches keydown/keyup at document level with
-     * no terminator. A GRAI is a non-HU-prefix code (`NOT_APPLICABLE` completion state), so the
-     * `useKeyboardBarcodeReader` hook flushes the buffer via its debounce interval — no Enter needed.
+     * Appends an explicit Enter terminator. `BarcodeScannerComponent.type()` dispatches all
+     * keystrokes instantaneously (0ms wall-clock), so two back-to-back scans would concatenate in the
+     * `useKeyboardBarcodeReader` buffer before the ~1500ms GRAI debounce could flush the first one.
+     * The Enter force-completes each instantaneous test-harness scan immediately, so each code is
+     * processed as a distinct barcode. In PRODUCTION a GRAI is a non-HU-prefix code (`NOT_APPLICABLE`
+     * completion state) that completes via the debounce flush without any Enter — real scans carry
+     * inter-keystroke timing so no concatenation occurs; the Enter is purely a test-harness need.
      */
     scanGrai: async ({ graiString }) => await test.step(`${NAME} - Scan GRAI: ${graiString}`, async () => {
-        await BarcodeScannerComponent.type({ scannedCode: graiString, testId: GRAI_SCAN_TESTID });
+        await BarcodeScannerComponent.type({ scannedCode: graiString, testId: GRAI_SCAN_TESTID, terminator: 'Enter' });
     }),
 };

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingGraiScanPanel.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingGraiScanPanel.js
@@ -40,9 +40,9 @@ export const PickingGraiScanPanel = {
      * Scan a GRAI barcode (in canonical dot-separated or GS1 AI 8003 format).
      * Dispatches keyboard events via BarcodeScannerComponent targeting the GRAI scanner input.
      *
-     * Uses `BarcodeScannerComponent.type()` which dispatches at document level and appends Enter.
-     * The `useKeyboardBarcodeReader` hook calls `event.preventDefault()` on Enter, preventing
-     * the focused input's `handleInputTextKeyPress` from double-invoking validateScannedBarcodeAndForward.
+     * Uses `BarcodeScannerComponent.type()`, which dispatches keydown/keyup at document level with
+     * no terminator. A GRAI is a non-HU-prefix code (`NOT_APPLICABLE` completion state), so the
+     * `useKeyboardBarcodeReader` hook flushes the buffer via its debounce interval — no Enter needed.
      */
     scanGrai: async ({ graiString }) => await test.step(`${NAME} - Scan GRAI: ${graiString}`, async () => {
         await BarcodeScannerComponent.type({ scannedCode: graiString, testId: GRAI_SCAN_TESTID });

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
@@ -123,12 +123,14 @@ export const PickingJobScreen = {
     pickHU: async ({
                        qrCode,
                        isScanDirectly,
+                       gapAtIndex, gapMs, // optional: inject ONE real mid-scan inter-keystroke gap (chunked QR arrival); only used when isScanDirectly
+                       terminator, // optional: end-of-scan key ('Enter'/'Tab') appended after the code (device suffix); only used when isScanDirectly
                        expectedPickDirectly,
                        expectNextScreen,
                        switchToManualInput, qtyEntered, expectQtyEntered, catchWeight, catchWeightQRCode, qtyNotFoundReason, expectQtyNotFoundReason
                    }) => await step(`${NAME} - Scan HU and Pick`, async () => {
         if (isScanDirectly) {
-            await BarcodeScannerComponent.type(qrCode);
+            await BarcodeScannerComponent.type({ scannedCode: qrCode, gapAtIndex, gapMs, terminator });
         } else {
             await page.locator('#scanQRCode-button').tap(); // click the Scan QR Code button
             await PickingJobScanHUScreen.waitForScreen();

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/picking/PickLineScanScreen.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/picking/PickLineScanScreen.test.js
@@ -1,17 +1,33 @@
 import { convertScannedBarcodeToResolvedResult } from '../../../../containers/activities/picking/PickLineScanScreen';
 
 describe('PickingLineScanScreen', () => {
-  it('convertScannedBarcodeToResolvedResult', () => {
-    const result = convertScannedBarcodeToResolvedResult({
-      scannedBarcode:
-        'HU#1#{"id":"59c0e3b5845d9fca58ccd9f2a906-30926","packingInfo":{"huUnitType":"V","packingInstructionsId":101,"caption":"No Packing Item"},"product":{"id":2009297,"code":"MyCode","name":"MyProduct"},"attributes":[{"code":"HU_BestBeforeDate","displayName":"Mindesthaltbarkeit","value":"2024-04-10"},{"code":"Lot-Nummer","displayName":"Lot-Nummer","value":"010124"},{"code":"WeightNet","displayName":"Gewicht Netto","value":"180.000"}]}',
+  it('convertScannedBarcodeToResolvedResult', async () => {
+    const scannedBarcode =
+      'HU#1#{"id":"59c0e3b5845d9fca58ccd9f2a906-30926","packingInfo":{"huUnitType":"V","packingInstructionsId":101,"caption":"No Packing Item"},"product":{"id":2009297,"code":"MyCode","name":"MyProduct"},"attributes":[{"code":"HU_BestBeforeDate","displayName":"Mindesthaltbarkeit","value":"2024-04-10"},{"code":"Lot-Nummer","displayName":"Lot-Nummer","value":"010124"},{"code":"WeightNet","displayName":"Gewicht Netto","value":"180.000"}]}';
+
+    // convertScannedBarcodeToResolvedResult is async and returns the full resolved result
+    // (the parsed qrCode + the extracted pick attributes + the scannedHU unit type).
+    const result = await convertScannedBarcodeToResolvedResult({
+      scannedBarcode,
       expectedProductId: '2009297',
     });
 
     expect(result).toEqual({
-      bestBeforeDate: '2024-04-10',
+      qrCode: {
+        code: scannedBarcode,
+        displayable: '30926',
+        barcodeType: 'HU',
+        isUnique: true,
+        huUnitType: 'V',
+        productId: '2009297',
+        weightNet: 180,
+        bestBeforeDate: '2024-04-10',
+        lotNo: '010124',
+      },
       catchWeight: 180,
+      bestBeforeDate: '2024-04-10',
       lotNo: '010124',
+      scannedHU: { huUnitType: 'V' },
     });
   });
 });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/qrCode/common.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/qrCode/common.test.js
@@ -1,6 +1,24 @@
-import { isBarcodeProductNoMatching } from '../../../utils/qrCode/common';
+import { checkPartialScannedCode, isBarcodeProductNoMatching, ScanCompleteness } from '../../../utils/qrCode/common';
 
 describe('common tests', () => {
+  // Dispatcher-level tests only: it delegates to the per-format checkers (HU classification cases
+  // live in hu.test.js) and must never throw.
+  describe('checkPartialScannedCode', () => {
+    it('NOT_APPLICABLE for empty / plain barcodes / non-string (never throws)', () => {
+      expect(checkPartialScannedCode('')).toBe(ScanCompleteness.NOT_APPLICABLE);
+      expect(checkPartialScannedCode(null)).toBe(ScanCompleteness.NOT_APPLICABLE);
+      expect(checkPartialScannedCode(undefined)).toBe(ScanCompleteness.NOT_APPLICABLE);
+      expect(checkPartialScannedCode(12345)).toBe(ScanCompleteness.NOT_APPLICABLE);
+      expect(checkPartialScannedCode({ not: 'a string' })).toBe(ScanCompleteness.NOT_APPLICABLE);
+      expect(checkPartialScannedCode('2100001234567')).toBe(ScanCompleteness.NOT_APPLICABLE);
+    });
+
+    it('delegates HU classification (PARTIAL while arriving, COMPLETE once closed)', () => {
+      expect(checkPartialScannedCode('HU#1#{"id":"x')).toBe(ScanCompleteness.PARTIAL_SCAN);
+      expect(checkPartialScannedCode('HU#1#{"id":"x"}')).toBe(ScanCompleteness.COMPLETE_SCAN);
+    });
+  });
+
   describe('isBarcodeProductNoMatching', () => {
     it('expectedProductNo is null', () => {
       expect(

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/qrCode/hu.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/qrCode/hu.test.js
@@ -1,5 +1,15 @@
-import { parseQRCodeString, toQRCodeDisplayable, toQRCodeObject, toQRCodeString } from '../../../utils/qrCode/hu';
+import {
+  checkPartialHUScannedCode,
+  parseQRCodeString,
+  toQRCodeDisplayable,
+  toQRCodeObject,
+  toQRCodeString,
+} from '../../../utils/qrCode/hu';
+import { ScanCompleteness } from '../../../utils/qrCode/common';
 import { setupCounterpart } from '../../../utils/translations';
+
+const COMPLETE_HU_QR =
+  'HU#1#{"id":"0de63cbd34708add7a9afbb423d0-05650","packingInfo":{"huUnitType":"LU","packingInstructionsId":1000006,"caption":"Euro Palette"},"product":{"id":1000001,"code":"2680","name":"Sternflow 11 Raps"},"attributes":[]}';
 
 describe('huQRCodes tests', () => {
   describe('toQRCodeDisplayable', () => {
@@ -88,6 +98,7 @@ describe('huQRCodes tests', () => {
       expect(parseQRCodeString(code)).toEqual({
         code,
         barcodeType: 'HU',
+        huUnitType: 'LU',
         displayable: '05650',
         productId: '1000001',
         isUnique: true,
@@ -99,6 +110,7 @@ describe('huQRCodes tests', () => {
       expect(parseQRCodeString(code)).toEqual({
         code,
         barcodeType: 'HU',
+        huUnitType: 'V',
         displayable: '28193',
         productId: '2005577',
         weightNet: 2427.425,
@@ -272,6 +284,42 @@ describe('huQRCodes tests', () => {
           isTUToBePickedAsWhole: true,
         });
       });
+    });
+  });
+
+  describe('checkPartialHUScannedCode', () => {
+    it('NOT_APPLICABLE for non-HU / empty / non-string inputs', () => {
+      expect(checkPartialHUScannedCode('')).toBe(ScanCompleteness.NOT_APPLICABLE);
+      expect(checkPartialHUScannedCode(null)).toBe(ScanCompleteness.NOT_APPLICABLE);
+      expect(checkPartialHUScannedCode(undefined)).toBe(ScanCompleteness.NOT_APPLICABLE);
+      expect(checkPartialHUScannedCode(12345)).toBe(ScanCompleteness.NOT_APPLICABLE);
+      expect(checkPartialHUScannedCode('2100001234567')).toBe(ScanCompleteness.NOT_APPLICABLE); // EAN-like
+      expect(checkPartialHUScannedCode('LMQ#1#12.5')).toBe(ScanCompleteness.NOT_APPLICABLE); // other QR type
+      expect(checkPartialHUScannedCode('HUGE123')).toBe(ScanCompleteness.NOT_APPLICABLE); // starts with HU but no separator
+    });
+
+    it('PARTIAL_SCAN while the HU prefix / JSON payload is still arriving', () => {
+      expect(checkPartialHUScannedCode('H')).toBe(ScanCompleteness.PARTIAL_SCAN);
+      expect(checkPartialHUScannedCode('HU')).toBe(ScanCompleteness.PARTIAL_SCAN);
+      expect(checkPartialHUScannedCode('HU#')).toBe(ScanCompleteness.PARTIAL_SCAN);
+      expect(checkPartialHUScannedCode('HU#1')).toBe(ScanCompleteness.PARTIAL_SCAN);
+      expect(checkPartialHUScannedCode('HU#1#')).toBe(ScanCompleteness.PARTIAL_SCAN);
+      expect(checkPartialHUScannedCode('HU#1#{')).toBe(ScanCompleteness.PARTIAL_SCAN);
+      expect(checkPartialHUScannedCode('HU#1#{"id":"0de63cbd')).toBe(ScanCompleteness.PARTIAL_SCAN);
+      // truncated at half of a real code (nested object still open)
+      expect(checkPartialHUScannedCode(COMPLETE_HU_QR.substring(0, Math.floor(COMPLETE_HU_QR.length / 2)))).toBe(
+        ScanCompleteness.PARTIAL_SCAN
+      );
+      // recognised HU but non-JSON payload → never completes on its own (bounded by abandon timer)
+      expect(checkPartialHUScannedCode('HU#1#not-json')).toBe(ScanCompleteness.PARTIAL_SCAN);
+    });
+
+    it('COMPLETE_SCAN once the JSON payload is closed (nesting / string-internal braces handled by JSON.parse)', () => {
+      expect(checkPartialHUScannedCode('HU#1#{}')).toBe(ScanCompleteness.COMPLETE_SCAN);
+      expect(checkPartialHUScannedCode('HU#1#{"id":"x"}')).toBe(ScanCompleteness.COMPLETE_SCAN);
+      expect(checkPartialHUScannedCode(COMPLETE_HU_QR)).toBe(ScanCompleteness.COMPLETE_SCAN);
+      // a literal brace inside a JSON string value must NOT confuse completeness
+      expect(checkPartialHUScannedCode('HU#1#{"name":"Box {A}","attributes":[]}')).toBe(ScanCompleteness.COMPLETE_SCAN);
     });
   });
 });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/qrCode/parseCustomQRCode.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/utils/qrCode/parseCustomQRCode.test.js
@@ -2,52 +2,52 @@ import { parseLocalDate, parseNumber } from '../../../utils/qrCode/parseCustomQR
 
 describe('parseNumber', () => {
   test('should return the number as is if decimalPoint is 0', () => {
-    const result = parseNumber({ string: '123456', decimalPoint: 0 });
+    const result = parseNumber({ string: '123456', decimalPointPosition: 0 });
     expect(result).toBe(123456);
   });
 
   test('should apply the decimal point starting from the right', () => {
-    const result = parseNumber({ string: '123456', decimalPoint: 2 });
+    const result = parseNumber({ string: '123456', decimalPointPosition: 2 });
     expect(result).toBe(1234.56);
   });
 
   test('should handle a decimalPoint equal to the string length', () => {
-    const result = parseNumber({ string: '123456', decimalPoint: 6 });
+    const result = parseNumber({ string: '123456', decimalPointPosition: 6 });
     expect(result).toBe(0.123456);
   });
 
   test('should handle a decimalPoint greater than the string length', () => {
-    const result = parseNumber({ string: '123456', decimalPoint: 8 });
+    const result = parseNumber({ string: '123456', decimalPointPosition: 8 });
     expect(result).toBe(0.00123456);
   });
 
   test('should handle input with leading zeros', () => {
-    const result = parseNumber({ string: '00123456', decimalPoint: 3 });
+    const result = parseNumber({ string: '00123456', decimalPointPosition: 3 });
     expect(result).toBe(123.456);
   });
 
   test('should throw an error for invalid string input', () => {
-    expect(() => parseNumber({ string: 'abc', decimalPoint: 2 })).toThrow('Invalid number format: "abc"');
+    expect(() => parseNumber({ string: 'abc', decimalPointPosition: 2 })).toThrow('Invalid number format: "abc"');
   });
 
   test('should throw an error for invalid decimalPoint', () => {
-    expect(() => parseNumber({ string: '123456', decimalPoint: -1 })).toThrow('Invalid decimalPoint: "-1"');
-    expect(() => parseNumber({ string: '123456', decimalPoint: 1.5 })).toThrow('Invalid decimalPoint: "1.5"');
-    expect(() => parseNumber({ string: '123456', decimalPoint: '2' })).toThrow('Invalid decimalPoint: "2"');
+    expect(() => parseNumber({ string: '123456', decimalPointPosition: -1 })).toThrow('Invalid decimalPoint: "-1"');
+    expect(() => parseNumber({ string: '123456', decimalPointPosition: 1.5 })).toThrow('Invalid decimalPoint: "1.5"');
+    expect(() => parseNumber({ string: '123456', decimalPointPosition: '2' })).toThrow('Invalid decimalPoint: "2"');
   });
 
   test('should handle large numbers correctly', () => {
-    const result = parseNumber({ string: '12345678901234567890', decimalPoint: 10 });
+    const result = parseNumber({ string: '12345678901234567890', decimalPointPosition: 10 });
     expect(result).toBe(1234567890.123456789);
   });
 
   test('should return 0 if the input is "0"', () => {
-    const result = parseNumber({ string: '0', decimalPoint: 5 });
+    const result = parseNumber({ string: '0', decimalPointPosition: 5 });
     expect(result).toBe(0);
   });
 
   test('should return a valid output for input with decimalPoint less than string length', () => {
-    const result = parseNumber({ string: '123', decimalPoint: 1 });
+    const result = parseNumber({ string: '123', decimalPointPosition: 1 });
     expect(result).toBe(12.3);
   });
 });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/HardwareModePanel.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/HardwareModePanel.jsx
@@ -17,12 +17,18 @@ const useHardwareConfigParams = () => {
       0
     ),
     textChangedDebounceMillis: usePositiveNumberSetting('barcodeScanner.inputText.debounceMillis', 300),
+    idleAbandonMillis: usePositiveNumberSetting('barcodeScanner.inputText.idleAbandonMillis', 15000),
   };
 };
 
 const HardwareModePanel = ({ invisible, inputPlaceholderText, isProcessing, disabled, onBarcodeScanned, testId }) => {
-  const { hardwareInputMode, isHardwareInputReadOnly, triggerOnChangeIfLengthGreaterThan, textChangedDebounceMillis } =
-    useHardwareConfigParams();
+  const {
+    hardwareInputMode,
+    isHardwareInputReadOnly,
+    triggerOnChangeIfLengthGreaterThan,
+    textChangedDebounceMillis,
+    idleAbandonMillis,
+  } = useHardwareConfigParams();
   const inputTextRef = useRef();
   // Tracks the LIVE `disabled` prop so the 2s blur-refocus setTimeout below can check the
   // current value at fire time, not the stale closure value at schedule time. Without this,
@@ -62,6 +68,7 @@ const HardwareModePanel = ({ invisible, inputPlaceholderText, isProcessing, disa
     isHardwareInputReadOnly,
     triggerOnChangeIfLengthGreaterThan,
     textChangedDebounceMillis,
+    idleAbandonMillis,
   };
 
   const handleInputTextChanged = (e) => {
@@ -106,6 +113,7 @@ const HardwareModePanel = ({ invisible, inputPlaceholderText, isProcessing, disa
     },
     rateMs: textChangedDebounceMillis,
     minLength: triggerOnChangeIfLengthGreaterThan,
+    idleAbandonMs: idleAbandonMillis,
     // Parent owns the disabled decision (see BarcodeScannerComponent — combines isProcessing
     // with `activeMode === MANUAL` so keystrokes flow to the visible manual input instead
     // of the offscreen hardware one).

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/__tests__/useKeyboardBarcodeReader.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/__tests__/useKeyboardBarcodeReader.test.js
@@ -1,0 +1,300 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import { useKeyboardBarcodeReader, IDLE_ABANDON_MS } from '../useKeyboardBarcodeReader';
+
+// These tests cover the HOOK MECHANIC (gap-independence, content-complete flush, Enter/Tab
+// terminator, idle fallback, abandon-on-stuck). The classification of a code as
+// NOT_APPLICABLE / PARTIAL_SCAN / COMPLETE_SCAN is exhaustively covered by the util tests
+// (src/__tests__/utils/qrCode/{hu,common}.test.js) and is NOT re-derived here — we only use a
+// real HU QR code and a plain barcode as representative inputs.
+
+// Prod SysConfig debounceMillis sits in the 300-1000 ms range; use the low end.
+const RATE_MS = 300;
+const MIN_LENGTH = 10;
+// IDLE_ABANDON_MS (the hook's fixed long-idle "abandon"/"stuck partial" deadline, decoupled from
+// rateMs) is imported from the hook so a rename/retune can't silently desync this test.
+
+// A real, complete HU global QR code (with nested JSON objects) — parses successfully.
+const HU_QR =
+  'HU#1#{"id":"0de63cbd34708add7a9afbb423d0-05650","packingInfo":{"huUnitType":"LU","packingInstructionsId":1000006,"caption":"Euro Palette"},"product":{"id":1000001,"code":"2680","name":"Sternflow 11 Raps"},"attributes":[]}';
+
+// A recognised HU QR whose JSON payload has not fully arrived (opening braces never closed).
+const PARTIAL_HU_QR = 'HU#1#{"id":"0de63cbd34708add7a9afbb423d0-05650","packingInfo":{"huUnitType":"LU"';
+
+// Manually-controlled monotonic clock so the inter-keystroke gap logic is deterministic.
+let now;
+
+function mountReader(props = {}) {
+  const onReadDone = jest.fn();
+  const onReadInProgress = jest.fn();
+
+  function TestComponent() {
+    useKeyboardBarcodeReader({
+      onReadDone,
+      onReadInProgress,
+      rateMs: RATE_MS,
+      minLength: MIN_LENGTH,
+      ...props,
+    });
+    return null;
+  }
+
+  const utils = render(<TestComponent />);
+  return { onReadDone, onReadInProgress, ...utils };
+}
+
+function pressKey(key, opts = {}) {
+  act(() => {
+    const event = new KeyboardEvent('keydown', {
+      key,
+      bubbles: true,
+      cancelable: true,
+      ...opts,
+    });
+    window.dispatchEvent(event);
+  });
+}
+
+// Type a string as window keydown events. `gapAtIndex` inserts ONE long inter-keystroke
+// gap (>= rateMs) before that character; every other character arrives fast (< rateMs).
+function typeString(str, { gapAtIndex, stepMs = 10, gapMs = RATE_MS + 100 } = {}) {
+  for (let i = 0; i < str.length; i += 1) {
+    now += i === gapAtIndex ? gapMs : stepMs;
+    pressKey(str[i]);
+  }
+}
+
+// Advance past the idle (rateMs) threshold and let the flush interval fire.
+function goIdleAndTick() {
+  now += RATE_MS * 3;
+  act(() => {
+    jest.advanceTimersByTime(RATE_MS * 2);
+  });
+}
+
+beforeEach(() => {
+  now = 10_000;
+  jest.spyOn(Date, 'now').mockImplementation(() => now);
+  // Legacy fake timers so the flush setInterval only runs when we explicitly advance,
+  // and never auto-fires mid-scan.
+  jest.useFakeTimers('legacy');
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  Date.now.mockRestore();
+  jest.clearAllMocks();
+});
+
+describe('useKeyboardBarcodeReader', () => {
+  it('force-completes a complete HU QR on JSON-close WITHOUT waiting for the idle timer, despite a mid-scan gap', () => {
+    const { onReadDone } = mountReader();
+
+    // One long gap in the middle of the JSON payload — the real-world symptom (a long QR arrives
+    // in chunks spread over seconds). The old gap-based reader split it into fragments here.
+    typeString(HU_QR, { gapAtIndex: Math.floor(HU_QR.length / 2) });
+
+    // The closing '}' makes the buffer a complete, terminal HU QR → force-completed immediately,
+    // with NO idle-timer advance (no goIdleAndTick), exactly once, with the full code.
+    expect(onReadDone).toHaveBeenCalledTimes(1);
+    expect(onReadDone).toHaveBeenCalledWith(HU_QR);
+  });
+
+  it('holds a partial HU QR back across an idle tick (mid-scan gap), then force-completes when the final chunk closes the JSON', () => {
+    const { onReadDone } = mountReader();
+
+    const splitAt = Math.floor(HU_QR.length / 2);
+    const firstChunk = HU_QR.substring(0, splitAt); // JSON still open => PARTIAL_SCAN
+    const secondChunk = HU_QR.substring(splitAt);
+
+    // First chunk arrives, then a real inter-chunk gap that crosses an idle tick.
+    typeString(firstChunk);
+    now += RATE_MS + 50;
+    act(() => {
+      jest.advanceTimersByTime(RATE_MS * 2);
+    });
+    // Held back — a still-incomplete recognised QR must NOT be flushed as a fragment.
+    expect(onReadDone).not.toHaveBeenCalled();
+
+    // The remaining chunk arrives and closes the JSON → force-completed on content (no idle wait).
+    typeString(secondChunk);
+    expect(onReadDone).toHaveBeenCalledTimes(1);
+    expect(onReadDone).toHaveBeenCalledWith(HU_QR);
+  });
+
+  it('separates back-to-back scans: a complete HU QR force-completes at its close even if another code follows immediately', () => {
+    const { onReadDone } = mountReader();
+
+    // A second (non-HU) code delivered right after the HU QR must NOT merge into it: the HU QR
+    // force-completes at its terminal '}', resetting the buffer so the next code accumulates clean.
+    const NEXT_CODE = 'LMQ#1#12.5';
+    typeString(HU_QR + NEXT_CODE);
+
+    // Exactly the HU QR was emitted (the trailing code did not merge into it).
+    expect(onReadDone).toHaveBeenCalledTimes(1);
+    expect(onReadDone).toHaveBeenCalledWith(HU_QR);
+
+    // The trailing (NOT_APPLICABLE) code then completes via the idle-flush, on its own.
+    goIdleAndTick();
+    expect(onReadDone).toHaveBeenCalledTimes(2);
+    expect(onReadDone).toHaveBeenNthCalledWith(2, NEXT_CODE);
+  });
+
+  it('separates two back-to-back plain codes split by a real gap shorter than one interval tick (must NOT merge)', () => {
+    const { onReadDone } = mountReader();
+
+    // Two independent non-QR scans. The gap between them (typeString default = rateMs+100) is
+    // >= rateMs (a NEW scan is starting) but < 2*rateMs (before the idle interval would tick) — the
+    // exact window in which a wholesale unconditional-append reader merges them into one garbage
+    // string. The gap-flush must separate them because the first buffer is NOT_APPLICABLE (not a
+    // still-arriving PARTIAL_SCAN).
+    const CODE1 = '1111111111';
+    const CODE2 = '2222222222';
+    typeString(CODE1 + CODE2, { gapAtIndex: CODE1.length });
+
+    // The gap flushed CODE1 as its own completed scan (not merged with CODE2).
+    expect(onReadDone).toHaveBeenCalledTimes(1);
+    expect(onReadDone).toHaveBeenCalledWith(CODE1);
+
+    // CODE2 then completes on its own via the idle fallback — two distinct scans, never merged.
+    goIdleAndTick();
+    expect(onReadDone).toHaveBeenCalledTimes(2);
+    expect(onReadDone).toHaveBeenNthCalledWith(2, CODE2);
+  });
+
+  it('completes on an Enter keydown with the full buffer (reacts to the device terminator)', () => {
+    const { onReadDone } = mountReader();
+
+    // Plain (non-QR, NOT_APPLICABLE) code: completion here comes from the Enter terminator.
+    const CODE = '1234567890ABCDEF';
+    typeString(CODE);
+    expect(onReadDone).not.toHaveBeenCalled();
+
+    now += 10;
+    pressKey('Enter');
+
+    expect(onReadDone).toHaveBeenCalledTimes(1);
+    expect(onReadDone).toHaveBeenCalledWith(CODE);
+  });
+
+  it('completes a Tab-terminated scan with the full buffer', () => {
+    const { onReadDone } = mountReader();
+
+    const CODE = 'ABCDEFGHIJ12345';
+    typeString(CODE);
+    expect(onReadDone).not.toHaveBeenCalled();
+
+    now += 10;
+    pressKey('Tab');
+
+    expect(onReadDone).toHaveBeenCalledTimes(1);
+    expect(onReadDone).toHaveBeenCalledWith(CODE);
+  });
+
+  it('a plain (non-QR) barcode completes via the idle-timer fallback', () => {
+    const { onReadDone } = mountReader();
+
+    const CODE = '2100001234567'; // EAN-like weight label, not a recognised streamed QR code
+    typeString(CODE);
+    expect(onReadDone).not.toHaveBeenCalled();
+
+    goIdleAndTick();
+
+    expect(onReadDone).toHaveBeenCalledTimes(1);
+    expect(onReadDone).toHaveBeenCalledWith(CODE);
+  });
+
+  it('the FAST idle tier does NOT flush a recognised, still-incomplete HU QR (no mid-scan truncation)', () => {
+    const { onReadDone } = mountReader();
+
+    typeString(PARTIAL_HU_QR);
+    goIdleAndTick();
+
+    expect(onReadDone).not.toHaveBeenCalled();
+  });
+
+  it('does NOT merge a genuinely-stuck partial HU QR with a later re-scan: the stuck partial is abandoned on the new-scan gap and the new code completes on its own', () => {
+    const { onReadDone } = mountReader();
+
+    // A truncated HU QR whose JSON never closes: it stays PARTIAL_SCAN and, with no further
+    // keystrokes and no idle tick here, sits buffered.
+    typeString(PARTIAL_HU_QR);
+    expect(onReadDone).not.toHaveBeenCalled();
+
+    // The operator waits longer than any legit inter-chunk gap, then re-scans a fresh, DISTINCT
+    // (different id), complete HU QR. The stuck partial must be flushed (abandoned) on this new-scan
+    // gap — NOT merged with the re-scan — so the new code assembles and completes cleanly on its own.
+    const HU_QR_RESCAN =
+      'HU#1#{"id":"11111111111111111111111111111-99999","packingInfo":{"huUnitType":"TU"},"product":{"id":2000002,"code":"9999","name":"Re-scan"},"attributes":[]}';
+    now += IDLE_ABANDON_MS + RATE_MS;
+    typeString(HU_QR_RESCAN);
+
+    // The new scan completed as itself; nothing was emitted as "stuck-partial + new" merged garbage.
+    expect(onReadDone).toHaveBeenCalledWith(HU_QR_RESCAN);
+    const emittedCodes = onReadDone.mock.calls.map((call) => call[0]);
+    expect(emittedCodes).not.toContain(PARTIAL_HU_QR + HU_QR_RESCAN);
+    // No emitted code is longer than the re-scan (a merge would carry the stuck partial's chars too).
+    expect(emittedCodes.every((code) => code.length <= HU_QR_RESCAN.length)).toBe(true);
+  });
+
+  it('surfaces a SHORT (< minLength) stuck partial HU QR abandoned on a new-scan gap, instead of silently dropping it', () => {
+    const { onReadDone } = mountReader();
+
+    // A truncated partial shorter than minLength that still classifies as PARTIAL_SCAN. If the
+    // new-scan-gap abandon enforced minLength (the pre-fix behaviour) this would be silently
+    // dropped; it must instead be surfaced (matching the interval-based abandon path) so the app
+    // shows its "QR not recognised" error rather than swallowing the code.
+    const SHORT_PARTIAL = 'HU#1#{'; // PARTIAL_SCAN, length 6 < MIN_LENGTH (10)
+    typeString(SHORT_PARTIAL);
+    expect(onReadDone).not.toHaveBeenCalled();
+
+    // Operator gives up and re-scans after longer than any legit inter-chunk gap: the new-scan gap
+    // (NOT the interval poll — no timer advance here) abandons the short partial, surfacing it.
+    now += IDLE_ABANDON_MS + RATE_MS;
+    pressKey('X');
+
+    expect(onReadDone).toHaveBeenCalledWith(SHORT_PARTIAL);
+  });
+
+  it('eventually ABANDONS and flushes a genuinely stuck / truncated HU QR after the long idle deadline (surfaces the app error instead of hanging)', () => {
+    const { onReadDone } = mountReader();
+
+    typeString(PARTIAL_HU_QR);
+
+    // Within the fast idle window it must stay buffered (in-flight QR is protected)...
+    now += RATE_MS * 2;
+    act(() => {
+      jest.advanceTimersByTime(RATE_MS * 2);
+    });
+    expect(onReadDone).not.toHaveBeenCalled();
+
+    // ...but past the abandon deadline it is flushed unconditionally so the app can react.
+    now += IDLE_ABANDON_MS + RATE_MS;
+    act(() => {
+      jest.advanceTimersByTime(RATE_MS * 2);
+    });
+    expect(onReadDone).toHaveBeenCalledTimes(1);
+    expect(onReadDone).toHaveBeenCalledWith(PARTIAL_HU_QR);
+  });
+
+  it('honours an explicit idleAbandonMs param: a stuck partial is abandoned after the CONFIGURED window, not IDLE_ABANDON_MS', () => {
+    // Wire a SHORT configured window (as the sysconfig barcodeScanner.inputText.idleAbandonMillis
+    // would, via HardwareModePanel → useKeyboardBarcodeReader's idleAbandonMs param). The stuck
+    // partial must surface after THIS window, and it must NOT still be waiting on the 15000 ms default.
+    const CONFIGURED_ABANDON_MS = 1000;
+    expect(CONFIGURED_ABANDON_MS).toBeLessThan(IDLE_ABANDON_MS); // guard: the override is genuinely shorter
+    const { onReadDone } = mountReader({ idleAbandonMs: CONFIGURED_ABANDON_MS });
+
+    typeString(PARTIAL_HU_QR);
+
+    // Just past the CONFIGURED window (but far below the 15000 ms default) the partial is abandoned
+    // and flushed — proving the param, not the module default, drives the deadline.
+    now += CONFIGURED_ABANDON_MS + RATE_MS;
+    act(() => {
+      jest.advanceTimersByTime(RATE_MS * 2);
+    });
+    expect(onReadDone).toHaveBeenCalledTimes(1);
+    expect(onReadDone).toHaveBeenCalledWith(PARTIAL_HU_QR);
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
@@ -1,10 +1,21 @@
 import { useEffect, useRef } from 'react';
+import { checkPartialScannedCode, ScanCompleteness } from '../utils/qrCode/common';
+
+// Abandon window for a stuck/truncated streamed QR partial (see the note in the effect below).
+// FIXED, and deliberately DECOUPLED from rateMs: it must sit safely ABOVE the largest legit
+// inter-chunk gap (observed 3-8 s) so a slow-but-completing chunked scan is never re-split, yet
+// it must NOT scale with the debounce — with the old Math.max(3000, rateMs * 10) a debounce of
+// 300 ms shrank this to 3 s, i.e. INTO the real inter-chunk range, which would abandon a genuine
+// chunked scan mid-stream. 15 s clears the max real gap with margin and is independent of debounce.
+// Exported so the test asserts against the real value instead of mirroring a magic number.
+export const IDLE_ABANDON_MS = 15000;
 
 export const useKeyboardBarcodeReader = ({
   onReadDone,
   onReadInProgress,
   rateMs = 50,
   minLength = 10,
+  idleAbandonMs = IDLE_ABANDON_MS,
   disabled = false,
 }) => {
   // Use refs so values persist across rerenders but don't trigger state updates
@@ -12,15 +23,34 @@ export const useKeyboardBarcodeReader = ({
   const lastKeyTimeRef = useRef(0);
 
   useEffect(() => {
-    const handleKeyDown = async (event) => {
-      // console.log('[scanner] keydown', {
-      //   key: event.key,
-      //   alt: event.altKey,
-      //   ctrl: event.ctrlKey,
-      //   meta: event.metaKey,
-      //   len: event.key?.length,
-      // });
+    // A recognised-but-incomplete streamed QR code (e.g. a long HU QR arriving in chunks over
+    // several seconds) is kept buffered across inter-keystroke gaps instead of being flushed as a
+    // fragment. If it never completes (genuinely truncated: device disconnect / out-of-range) we
+    // abandon and flush it once this window elapses — either while idle (below) or when a brand-new
+    // scan arrives after this long a gap (the pre-append flush below). Surfacing the app's "QR not
+    // recognised" error and, crucially, preventing a stuck partial from swallowing the next scan.
+    // The window itself (idleAbandonMs, decoupled from rateMs) is a hook param defaulting to
+    // IDLE_ABANDON_MS (defined and explained at module scope above); a caller may override it via a
+    // sysconfig (barcodeScanner.inputText.idleAbandonMillis) the same way rateMs is wired from
+    // barcodeScanner.inputText.debounceMillis.
 
+    const resetBuffer = () => {
+      bufferRef.current = '';
+      lastKeyTimeRef.current = 0;
+    };
+
+    // Emit the assembled buffer as a completed scan and reset for the next one.
+    // Capture-then-reset before firing onReadDone: the callback may re-render / unmount this
+    // component, so the refs must already be in their next-scan state.
+    const completeScan = ({ shouldEnforceMinLength }) => {
+      const code = bufferRef.current;
+      resetBuffer();
+      if (code && (!shouldEnforceMinLength || !minLength || code.length >= minLength)) {
+        onReadDone(code);
+      }
+    };
+
+    const handleKeyDown = async (event) => {
       if (event.key === 'Unidentified') {
         return;
       }
@@ -36,8 +66,7 @@ export const useKeyboardBarcodeReader = ({
 
           event.preventDefault(); // Prevent default paste behavior
           onReadDone(clipboardText);
-          bufferRef.current = '';
-          lastKeyTimeRef.current = 0;
+          resetBuffer();
           return;
         } catch (error) {
           console.error('Failed to read clipboard:', error);
@@ -61,11 +90,12 @@ export const useKeyboardBarcodeReader = ({
       //
       // Non-printable characters
       if (event.key.length !== 1) {
-        // Optional: if your barcode uses Enter/Tab to finish, handle here
+        // Enter/Tab terminator: a device configured to send Enter/Tab as a KeyEvent finishes the
+        // current scan immediately. Kept as a belt-and-suspenders path — production Zebra devices
+        // currently send NO terminator, but one may be enabled later. An explicit terminator is an
+        // end-of-scan signal, so do not gate on minLength; fires regardless of the timing.
         if ((event.key === 'Enter' || event.key === 'Tab') && bufferRef.current) {
-          onReadDone(bufferRef.current);
-          bufferRef.current = '';
-          lastKeyTimeRef.current = 0;
+          completeScan({ shouldEnforceMinLength: false });
           event.preventDefault();
         }
       }
@@ -73,46 +103,82 @@ export const useKeyboardBarcodeReader = ({
       // Printable characters
       else {
         const now = Date.now();
+
+        // A real gap since the last keystroke means a NEW scan is starting: flush the current buffer
+        // FIRST so two back-to-back codes are separated, not merged into one garbage string. A
+        // still-arriving recognised format (PARTIAL_SCAN) is normally EXEMPT from this flush — a long
+        // QR reaches the browser in chunks over several seconds and a mid-stream gap must NOT split
+        // it — which keeps chunked-QR assembly working while preserving the deterministic back-to-back
+        // separation for NOT_APPLICABLE / already-COMPLETE buffers.
         //
-        // If the type rate is kept, collect the character
-        if (now - lastKeyTimeRef.current < rateMs) {
-          bufferRef.current += event.key;
-          onReadInProgress?.(bufferRef.current);
-          // Prevent the browser from also inserting the character into a focused input.
-          // The hook handles value updates via onReadInProgress. Without this, the character
-          // would be inserted twice: once by onReadInProgress and once by the browser's default action.
-          // (Before the readOnly→inputMode="none" change, readOnly prevented browser insertion.)
-          event.preventDefault();
+        // BUT a genuinely-stuck PARTIAL (truncated scan whose JSON never closes) must not swallow the
+        // NEXT scan forever: once the gap exceeds idleAbandonMs — well beyond the largest legit
+        // inter-chunk gap — the partial is abandoned here too, so the incoming keystroke starts a
+        // clean new scan instead of merging into the stuck buffer. (A re-scan WITHIN that window is
+        // NOT isolated immediately: its keystrokes still append to the stuck partial and merely
+        // restart the abandon window from the re-scan's last keystroke, so the combined buffer is
+        // flushed by the idle-abandon fallback below rather than here. The guarantee here is only
+        // that a deliberate re-scan after the gap has exceeded idleAbandonMs — the operator has
+        // clearly given up — is never merged.)
+        const gapMs = now - lastKeyTimeRef.current;
+        const isPartial = checkPartialScannedCode(bufferRef.current) === ScanCompleteness.PARTIAL_SCAN;
+        if (bufferRef.current && gapMs >= rateMs && (!isPartial || gapMs >= idleAbandonMs)) {
+          // A normal back-to-back scan (non-partial) is length-gated exactly as before; a partial we
+          // abandon here is surfaced unconditionally (shouldEnforceMinLength:false) — matching the
+          // interval-based abandon path below — so a genuinely-stuck code reaches the app as its
+          // "QR not recognised" error instead of being silently dropped.
+          completeScan({ shouldEnforceMinLength: !isPartial });
         }
-        //
-        // Type rate dropped => send the collected string if any
-        else {
-          if (bufferRef.current && (!minLength || bufferRef.current.length >= minLength)) {
-            onReadDone(bufferRef.current);
-          }
-          bufferRef.current = event.key;
-        }
+
+        bufferRef.current += event.key;
+        onReadInProgress?.(bufferRef.current);
+        // Prevent the browser from also inserting the character into a focused input.
+        // The hook handles value updates via onReadInProgress. Without this, the character
+        // would be inserted twice: once by onReadInProgress and once by the browser's default action.
+        // (Before the readOnly→inputMode="none" change, readOnly prevented browser insertion.)
+        event.preventDefault();
         lastKeyTimeRef.current = now;
+
+        // Content-based completion: force-complete immediately (no idle wait) once the buffer is a
+        // COMPLETE, TERMINAL recognised code. Safe ONLY because COMPLETE_SCAN is invariant-bound to
+        // terminal codes (no continuation could yield a different valid code — see the
+        // checkPartialScannedCode contract), and it correctly separates back-to-back scans instead
+        // of merging them. shouldEnforceMinLength:false — a content-verified terminal code has
+        // proven itself by content, so length is irrelevant (and the buffer is already cleared, so a
+        // minLength drop would be silently unrecoverable). PARTIAL_SCAN holds the idle flush back; a
+        // NOT_APPLICABLE (plain) code completes via the gap-flush above, Enter/Tab, or the idle-flush.
+        if (checkPartialScannedCode(bufferRef.current) === ScanCompleteness.COMPLETE_SCAN) {
+          completeScan({ shouldEnforceMinLength: false });
+        }
       }
     };
 
-    // console.log('Enabling keyboard barcode reader', { disabled });
     let intervalId;
     if (!disabled) {
-      // Flush leftovers if needed, using interval
+      // Idle-timer fallback for codes without a content-completion signal (plain brace-less
+      // barcodes: EAN / weight labels) and for genuinely stuck scans.
       intervalId = setInterval(() => {
-        if (bufferRef.current && Date.now() - lastKeyTimeRef.current > rateMs) {
-          onReadDone(bufferRef.current);
-          bufferRef.current = '';
-          lastKeyTimeRef.current = 0;
+        if (!bufferRef.current) {
+          return;
+        }
+        const idleMs = Date.now() - lastKeyTimeRef.current;
+        if (checkPartialScannedCode(bufferRef.current) === ScanCompleteness.PARTIAL_SCAN) {
+          // A recognised QR code that is still incomplete: protect it from the normal idle flush so
+          // a chunked scan is never truncated. Only the long abandon deadline flushes it, so a
+          // genuinely truncated scan still reaches the app (as an error) instead of hanging.
+          if (idleMs > idleAbandonMs) {
+            completeScan({ shouldEnforceMinLength: false });
+          }
+        } else if (idleMs > rateMs) {
+          // NOT_APPLICABLE (plain barcode) or COMPLETE_SCAN: normal debounce flush.
+          completeScan({ shouldEnforceMinLength: false });
         }
       }, rateMs * 2);
 
       window.addEventListener('keydown', handleKeyDown);
       console.log('Enabled keyboard barcode reader', { rateMs, minLength });
     } else {
-      bufferRef.current = '';
-      lastKeyTimeRef.current = 0;
+      resetBuffer();
     }
 
     // Clean up on unmount
@@ -121,5 +187,5 @@ export const useKeyboardBarcodeReader = ({
       clearInterval(intervalId);
       console.log('Disabled keyboard barcode reader');
     };
-  }, [onReadDone, onReadInProgress, rateMs, minLength, disabled]);
+  }, [onReadDone, onReadInProgress, rateMs, minLength, idleAbandonMs, disabled]);
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/numbers.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/numbers.js
@@ -31,7 +31,11 @@ export const toNumberOrNaN = (arg) => {
     }
 
     try {
-      const number = Number(string.replaceAll(',', '.'));
+      // Use a global regex replace instead of String.prototype.replaceAll: the mobile build/test
+      // image is node:14 (Dockerfile.mobile), where replaceAll (ES2021 / node 15+) is absent — under
+      // node 14 it throws, gets swallowed by the catch, and this comma-decimal path silently returns
+      // NaN. replace(/,/g, '.') is behaviour-identical and works on node 14 and every browser.
+      const number = Number(string.replace(/,/g, '.'));
       if (Number.isFinite(number)) {
         return number;
       }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/common.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/common.js
@@ -1,3 +1,6 @@
+import { checkPartialHUScannedCode } from './hu';
+import { ScanCompleteness } from './scanCompleteness';
+
 export const ATTR_barcodeType = 'barcodeType';
 export const ATTR_isUnique = 'isUnique';
 export const ATTR_productId = 'productId';
@@ -77,6 +80,49 @@ export const isBarcodeProductNoMatching = ({
     return isProductValueMatching || isEAN13MatchingGS1ProductCodes({ barcodeProductNo, expectedGS1ProductCodes });
   } else {
     return expectedProductNoStr === barcodeProductNoStr;
+  }
+};
+
+//
+// Partial-scan (streamed QR code) completeness classification.
+//
+
+// ScanCompleteness is defined in ./scanCompleteness (a leaf module both ./common and ./hu import
+// from), so the ENUM itself is not part of any cycle. NOTE: ./common and ./hu DO still import each
+// other — common.js → checkPartialHUScannedCode, hu.js → the ATTR_*/QRCODE_* constants — a real
+// circular dependency. It stays safe ONLY because every cross-module symbol is read inside a
+// FUNCTION BODY (this file's lazy PARTIAL_SCAN_CHECKS list; hu.js's in-function "HU#" prefix), never
+// at module top level, so neither module reads a half-initialised sibling during load. Imported
+// above for internal use and re-exported here so existing importers of './common' keep working.
+// See ./scanCompleteness for the full contract, incl. the TERMINAL INVARIANT that gates COMPLETE_SCAN.
+export { ScanCompleteness };
+
+// Classify how complete an in-progress scanned code is (see ScanCompleteness).
+// MUST NOT throw: any unexpected error degrades to NOT_APPLICABLE (i.e. default reader behaviour).
+//
+// The per-format classifier list is built lazily HERE (at call time), NOT at module scope, on
+// purpose: common.js imports checkPartialHUScannedCode from ./hu while ./hu imports constants back
+// from ./common. Referencing the imported check only at call time — never at module-load — keeps
+// that dependency out of the module-init order, so it can't silently degrade to NOT_APPLICABLE
+// after a future reorder. Extend the list as more streamed QR-code formats need partial-scan
+// awareness; each returns NOT_APPLICABLE when the code is not its format, and must honour the
+// TERMINAL INVARIANT (see ./scanCompleteness) before returning COMPLETE_SCAN.
+export const checkPartialScannedCode = (scannedCode) => {
+  try {
+    if (!scannedCode) {
+      return ScanCompleteness.NOT_APPLICABLE;
+    }
+    const partialScanChecks = [checkPartialHUScannedCode];
+    for (const check of partialScanChecks) {
+      const result = check(scannedCode);
+      if (result && result !== ScanCompleteness.NOT_APPLICABLE) {
+        return result;
+      }
+    }
+    return ScanCompleteness.NOT_APPLICABLE;
+  } catch (error) {
+    console.debug('checkPartialScannedCode: unexpected error, treating as NOT_APPLICABLE', { scannedCode, error });
+    return ScanCompleteness.NOT_APPLICABLE;
   }
 };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/hu.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/hu.js
@@ -38,6 +38,7 @@ import {
   QRCODE_SEPARATOR,
   toLocalDateString,
 } from './common';
+import { ScanCompleteness } from './scanCompleteness';
 import { trl } from '../translations';
 import { HU_ATTRIBUTE_BestBeforeDate, HU_ATTRIBUTE_LotNo, HU_ATTRIBUTE_WeightNet } from '../../constants/HUAttributes';
 import { parseGS1CodeString } from './gs1';
@@ -359,4 +360,61 @@ const parseLMQBestBeforeDate = (string) => {
 export const isKnownQRCodeFormat = (qrCodeString) => {
   const returnFalseOnError = true;
   return !!parseQRCodeString(qrCodeString, returnFalseOnError);
+};
+
+// "TYPE#VERSION#<json>" => the <json> payload, or null while both separators haven't arrived yet.
+const extractGlobalQRCodeJsonPayload = (scannedCode) => {
+  const firstSeparatorIdx = scannedCode.indexOf(QRCODE_SEPARATOR);
+  if (firstSeparatorIdx <= 0) {
+    return null;
+  }
+  const secondSeparatorIdx = scannedCode.indexOf(QRCODE_SEPARATOR, firstSeparatorIdx + 1);
+  if (secondSeparatorIdx < 0) {
+    return null;
+  }
+  return scannedCode.substring(secondSeparatorIdx + 1);
+};
+
+// Classify an in-progress scanned code w.r.t. the HU global QR code format (see ScanCompleteness):
+//   NOT_APPLICABLE - it is not (nor becoming) an HU global QR code
+//   PARTIAL_SCAN   - it looks like an HU QR code but the JSON payload has not fully arrived yet
+//   COMPLETE_SCAN  - it is an HU QR code whose JSON payload is complete (closed) AND terminal
+// Completeness is decided by JSON.parse of the payload after "HU#<version>#": the real JSON parser
+// handles nesting, escaping and literal braces inside string values, and throws while the payload
+// is still arriving. MUST NOT throw (hard requirement) — any error stays PARTIAL_SCAN for an
+// identified HU code (the reader keeps waiting, bounded by its abandon timer).
+//
+// TERMINAL INVARIANT (see ScanCompleteness in ./common): a complete HU#<v>#{json} IS terminal —
+// appending any character makes it invalid JSON, so returning COMPLETE_SCAN (force-complete) is
+// safe here and correctly SEPARATES back-to-back scans (e.g. the "...}]}LMQ#1#..." merges seen in
+// prod when a second code is delivered right after the HU QR) instead of merging them.
+// NOTE for future per-format checks: return COMPLETE_SCAN ONLY for a TERMINAL code. A non-terminal
+// format (e.g. a bare numeric m_hu_id where both "123" and "1234" are valid) must NEVER return
+// COMPLETE_SCAN — use PARTIAL_SCAN / NOT_APPLICABLE and rely on the Enter terminator / idle-flush.
+export const checkPartialHUScannedCode = (scannedCode) => {
+  try {
+    if (!scannedCode || typeof scannedCode !== 'string') {
+      return ScanCompleteness.NOT_APPLICABLE;
+    }
+    // Applicable if it already looks like an HU QR code (HU#...) OR is still receiving the leading
+    // "HU#" prefix itself (e.g. a chunk gap landed at 'H' / 'HU'). Compute the "HU#" prefix HERE,
+    // inside the function — NOT at module top level: common.js and hu.js import each other (a real
+    // cycle), so reading the imported QRCODE_SEPARATOR at hu.js *load* time can observe an undefined
+    // value from a partially-initialised common.js, depending on which module loads first. By the
+    // time this function runs, common.js is fully initialised, so the read is always correct.
+    const huQrCodePrefix = QRCODE_TYPE_HU + QRCODE_SEPARATOR; // "HU#"
+    if (!isHUQRCode(scannedCode) && !huQrCodePrefix.startsWith(scannedCode)) {
+      return ScanCompleteness.NOT_APPLICABLE;
+    }
+    const jsonPayload = extractGlobalQRCodeJsonPayload(scannedCode);
+    if (jsonPayload) {
+      JSON.parse(jsonPayload); // throws while still arriving => caught below => PARTIAL_SCAN
+      return ScanCompleteness.COMPLETE_SCAN;
+    }
+    return ScanCompleteness.PARTIAL_SCAN;
+  } catch (error) {
+    // The normal "payload still arriving" case (JSON.parse throws) plus any unexpected error:
+    // both are safe as PARTIAL_SCAN for an identified HU code.
+    return ScanCompleteness.PARTIAL_SCAN;
+  }
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/scanCompleteness.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/qrCode/scanCompleteness.js
@@ -1,0 +1,21 @@
+// How complete an in-progress scanned code is. Lets a keyboard/wedge reader keep waiting while a
+// long multi-chunk QR code is still arriving, instead of flushing a fragment.
+//
+// The reader acts on each value as: COMPLETE_SCAN => force-complete now (no idle wait);
+// PARTIAL_SCAN => hold back the idle flush; NOT_APPLICABLE => normal timing (Enter/idle as before).
+//
+// TERMINAL INVARIANT (per-format checks MUST honour it): return COMPLETE_SCAN ONLY when the code is
+// unambiguously TERMINAL — there is NO way a continuation of the current string could produce a
+// (different) valid scanned code. Because the reader force-completes on COMPLETE_SCAN, a
+// non-terminal "looks complete now, but a longer string is also valid" format (e.g. a bare numeric
+// m_hu_id where both "123" and "1234" parse) must NEVER return COMPLETE_SCAN — it uses
+// PARTIAL_SCAN / NOT_APPLICABLE and relies on the Enter terminator / idle-flush instead.
+//
+// This enum lives in its own leaf module (imported by both ./common and ./hu) so the ENUM is not
+// part of any import cycle. (./common and ./hu themselves DO still import each other; that cycle is
+// kept safe by reading cross-module symbols only inside function bodies — see the note in ./common.)
+export const ScanCompleteness = Object.freeze({
+  NOT_APPLICABLE: 'NOT_APPLICABLE', // not a recognised streamed QR code => keep default behaviour
+  PARTIAL_SCAN: 'PARTIAL_SCAN', //     a recognised QR code that is still arriving => keep waiting
+  COMPLETE_SCAN: 'COMPLETE_SCAN', //   a recognised code that is complete AND terminal => flush now
+});


### PR DESCRIPTION
Forward-merge of `intensive_care_hotfix` → `new_dawn_uat` (up-propagation of the merged HU-QR keyboard-scan completion fix).

**Conflicts resolved (3 files, all mobile-webui E2E test artifacts):**
- `tests/utils/components/BarcodeScannerComponent.js` — kept the superset `type()` (parameterized `terminator` + chunked mid-scan gap). `new_dawn_uat`'s unconditional-Enter was a workaround for the old hook; the parameterized default-none terminator models the customer's real no-Enter device and is required by the no-terminator scenarios.
- `tests/spec/picking/picking.spec.js` — combined both branches' `createMasterdata` params (`shipperConfig` + `extraSysconfigs`).
- `TEST-COVERAGE.md` — Picking 92/96 (`new_dawn_uat` baseline 86/90 + 6 net-new scan scenarios); Distribution/Manufacturing kept from `new_dawn_uat`.

**Verification:** mobile-webui Jest suite 233/233 green (19 suites) on the merged tree. E2E validation runs in the blocking `Playwright (Mobile WebUI)` CI job (full stack un-runnable on the dev host).

Merge commit (no squash — preserves branch parentage).
