### PR TITLE
Merge: soft_panda_hotfix → new_dawn_uat (unblock stuck train)

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -397,8 +397,6 @@ jobs:
     permissions:
       packages: write
     needs: init
-    permissions:
-      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v4
@@ -1322,8 +1320,6 @@ jobs:
     permissions:
       packages: write
     needs: [ init, java ]
-    permissions:
-      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v4

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -62,6 +62,7 @@ jobs:
           fi
       - uses: actions/checkout@v6
       - uses: testspace-com/setup-testspace@v1
+        continue-on-error: true  # testspace retired — never fail the build on it
         if: env.ACT != 'true' && steps.skip-checks.outputs.skip-testspace != 'true'
         with:
           domain: metasfresh
@@ -391,6 +392,8 @@ jobs:
   frontend:
     runs-on: ${{ vars.RUNNER_HEAVY }}
     needs: init
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v4
@@ -430,10 +433,10 @@ jobs:
           --progress=auto \
           --file docker-builds/Dockerfile.mobile.test \
           --cache-to type=inline \
-          --cache-from metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-floating }} \
-          --cache-from metasfresh/metas-mobile-test:${{ needs.init.outputs.base-tag-floating }} \
-          --tag metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-floating }} \
-          --tag metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-fixed }} \
+          --cache-from ghcr.io/metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-floating }} \
+          --cache-from ghcr.io/metasfresh/metas-mobile-test:${{ needs.init.outputs.base-tag-floating }} \
+          --tag ghcr.io/metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-floating }} \
+          --tag ghcr.io/metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-fixed }} \
           .
       - name: build-frontend-test
         run: |
@@ -441,10 +444,10 @@ jobs:
           --progress=auto \
           --file docker-builds/Dockerfile.frontend.test \
           --cache-to type=inline \
-          --cache-from metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-floating }} \
-          --cache-from metasfresh/metas-frontend-test:${{ needs.init.outputs.base-tag-floating }} \
-          --tag metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-floating }} \
-          --tag metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-fixed }} \
+          --cache-from ghcr.io/metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-floating }} \
+          --cache-from ghcr.io/metasfresh/metas-frontend-test:${{ needs.init.outputs.base-tag-floating }} \
+          --tag ghcr.io/metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-floating }} \
+          --tag ghcr.io/metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-fixed }} \
           .
       - name: push-image metasfresh/metas-frontend:${{ needs.init.outputs.tag-fixed }}
         if: env.ACT != 'true'
@@ -478,45 +481,45 @@ jobs:
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
           command: docker push --quiet metasfresh/metas-mobile:${{ needs.init.outputs.tag-floating }}
-      - name: push-image metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-fixed }}
+      - name: push-image ghcr.io/metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-fixed }}
         if: env.ACT != 'true'
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-fixed }}
-      - name: push-image metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-floating }}
+          command: docker push ghcr.io/metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-fixed }}
+      - name: push-image ghcr.io/metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-floating }}
         if: env.ACT != 'true'
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-floating }}
-      - name: push-image metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-fixed }}
+          command: docker push ghcr.io/metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-floating }}
+      - name: push-image ghcr.io/metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-fixed }}
         if: env.ACT != 'true'
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-fixed }}
-      - name: push-image metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-floating }}
+          command: docker push ghcr.io/metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-fixed }}
+      - name: push-image ghcr.io/metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-floating }}
         if: env.ACT != 'true'
         uses: nick-fields/retry@v4
         with:
           max_attempts: ${{ vars.RETRY_ATTEMPTS }}
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
-          command: docker push --quiet metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-floating }}
+          command: docker push ghcr.io/metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-floating }}
       - name: produce-summary
         run: |
           echo '#### images' >> $GITHUB_STEP_SUMMARY
           echo '* metasfresh/metas-frontend:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
           echo '* metasfresh/metas-mobile:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
-          echo '* metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
-          echo '* metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
+          echo '* ghcr.io/metasfresh/metas-mobile-test:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
+          echo '* ghcr.io/metasfresh/metas-frontend-test:${{ needs.init.outputs.tag-fixed }}' >> $GITHUB_STEP_SUMMARY
 
   test-frontend:
     name: test (frontend)
@@ -525,6 +528,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: testspace-com/setup-testspace@v1
+        continue-on-error: true  # testspace retired — never fail the build on it
         if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
         with:
           domain: metasfresh
@@ -1281,6 +1285,8 @@ jobs:
     name: test (java)
     runs-on: ${{ vars.RUNNER_TEST }}
     needs: [ init, java ]
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v4
@@ -1293,6 +1299,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: testspace-com/setup-testspace@v1
+        continue-on-error: true  # testspace retired — never fail the build on it
         if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
         with:
           domain: metasfresh
@@ -1312,13 +1319,13 @@ jobs:
           --progress=auto \
           --file docker-builds/Dockerfile.junit \
           --cache-to type=inline \
-          --cache-from metasfresh/metas-junit:${{ needs.init.outputs.tag-floating }} \
-          --cache-from metasfresh/metas-junit:${{ needs.init.outputs.base-tag-floating }} \
+          --cache-from ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-floating }} \
+          --cache-from ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.base-tag-floating }} \
           --secret id=mvn-settings,src=docker-builds/mvn/local-settings.xml \
           --build-arg REFNAME=${{ needs.init.outputs.tag-fixed }} \
           --build-arg SKIP_MIGRATION_SCRIPTS_TEST=true \
-          --tag metasfresh/metas-junit:${{ needs.init.outputs.tag-floating }} \
-          --tag metasfresh/metas-junit:${{ needs.init.outputs.tag-fixed }} \
+          --tag ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-floating }} \
+          --tag ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-fixed }} \
           .
       - name: cleanup-after-j8
         run: |
@@ -1336,12 +1343,12 @@ jobs:
           --progress=auto \
           --file docker-builds/Dockerfile.camel.junit \
           --cache-to type=inline \
-          --cache-from metasfresh/metas-junit:${{ needs.init.outputs.tag-floating }}-j14 \
-          --cache-from metasfresh/metas-junit:${{ needs.init.outputs.base-tag-floating }}-j14 \
+          --cache-from ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-floating }}-j14 \
+          --cache-from ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.base-tag-floating }}-j14 \
           --secret id=mvn-settings,src=docker-builds/mvn/local-settings.xml \
           --build-arg REFNAME=${{ needs.init.outputs.tag-fixed }} \
-          --tag metasfresh/metas-junit:${{ needs.init.outputs.tag-floating }}-j14 \
-          --tag metasfresh/metas-junit:${{ needs.init.outputs.tag-fixed }}-j14 \
+          --tag ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-floating }}-j14 \
+          --tag ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-fixed }}-j14 \
           .
       - name: push-result-image
         if: env.ACT != 'true'
@@ -1351,12 +1358,12 @@ jobs:
           retry_wait_seconds: ${{ vars.RETRY_DELAY }}
           timeout_minutes: ${{ vars.RETRY_TIMEOUT }}
           command: |
-            docker push --quiet metasfresh/metas-junit:${{ needs.init.outputs.tag-floating }}
-            docker push --quiet metasfresh/metas-junit:${{ needs.init.outputs.tag-floating }}-j14
+            docker push ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-floating }}
+            docker push ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-floating }}-j14
       - name: extract-results
         run: |
-          docker run --rm --volume "$(pwd)/junit:/reports" metasfresh/metas-junit:${{ needs.init.outputs.tag-fixed }}           # extracting java8 test results from docker image
-          docker run --rm --volume "$(pwd)/junit:/reports" metasfresh/metas-junit:${{ needs.init.outputs.tag-fixed }}-j14       # extracting java14 test results from docker image
+          docker run --rm --volume "$(pwd)/junit:/reports" ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-fixed }}           # extracting java8 test results from docker image
+          docker run --rm --volume "$(pwd)/junit:/reports" ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-fixed }}-j14       # extracting java14 test results from docker image
       - name: push-results to testspace
         if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
         continue-on-error: true  # Testspace may not have a space for this branch
@@ -1545,6 +1552,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: testspace-com/setup-testspace@v1
+        continue-on-error: true  # testspace retired — never fail the build on it
         if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
         with:
           domain: metasfresh
@@ -1903,6 +1911,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: testspace-com/setup-testspace@v1
+        continue-on-error: true  # testspace retired — never fail the build on it
         if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
         with:
           domain: metasfresh
@@ -2019,6 +2028,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: testspace-com/setup-testspace@v1
+        continue-on-error: true  # testspace retired — never fail the build on it
         if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
         with:
           domain: metasfresh

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5812350_sys_gh30844_get_epcis_events_json_fn.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5812350_sys_gh30844_get_epcis_events_json_fn.sql
@@ -91,38 +91,38 @@ BEGIN
           AND ha.isactive = 'Y'
           AND iol.m_inout_id = p_m_inout_id
     )
-    AND EXISTS (
-        -- Close-gate (AC1): block emission until EVERY physical child TU on every touched LU is
-        -- covered by a CO/CL shipment. This is intentional: we emit one complete merged event only
-        -- once the entire physical pallet is shipped. A TU that belongs to a still-open (IP) or
-        -- not-yet-assigned shipment will keep the gate open. When this shipment touches multiple
-        -- LUs the gate is all-or-nothing across ALL of them — the event is emitted together for
-        -- the complete set of LUs or not at all.
-        SELECT 1
-        FROM m_hu_assignment ha
-                 JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
-                 -- enumerate child TUs of each touched LU via the HU hierarchy
-                 JOIN m_hu lu ON lu.m_hu_id = ha.m_lu_hu_id
-                 JOIN m_hu_item hi ON hi.m_hu_id = lu.m_hu_id
-                                  AND hi.itemtype IN ('HU', 'HA')
-                 JOIN m_hu tu ON tu.m_hu_item_parent_id = hi.m_hu_item_id
-        WHERE ha.ad_table_id = v_m_inoutline_table_id
-          AND ha.m_lu_hu_id IS NOT NULL
-          AND ha.isactive = 'Y'
-          AND iol.m_inout_id = p_m_inout_id
-          -- TU is uncovered: no active m_hu_assignment from this TU to a CO/CL inoutline
-          AND NOT EXISTS (
-              SELECT 1
-              FROM m_hu_assignment ha2
-                       JOIN m_inoutline iol2 ON iol2.m_inoutline_id = ha2.record_id
-                       JOIN m_inout io2 ON io2.m_inout_id = iol2.m_inout_id and io2.issotrx='Y' /*only a sales shipment counts as coverage - a purchase-receipt of the same goods from a vendor must not open the close-gate*/
-              WHERE ha2.ad_table_id = v_m_inoutline_table_id
-                AND ha2.isactive = 'Y'
-                AND iol2.isactive = 'Y'
-                AND (ha2.m_tu_hu_id = tu.m_hu_id OR ha2.vhu_id = tu.m_hu_id)
-                AND io2.docstatus IN ('CO', 'CL')
-          )
-    )
+        AND EXISTS (
+            -- Close-gate (AC1): block emission until EVERY physical child TU on every touched LU is
+            -- covered by a CO/CL shipment. This is intentional: we emit one complete merged event only
+            -- once the entire physical pallet is shipped. A TU that belongs to a still-open (IP) or
+            -- not-yet-assigned shipment will keep the gate open. When this shipment touches multiple
+            -- LUs the gate is all-or-nothing across ALL of them — the event is emitted together for
+            -- the complete set of LUs or not at all.
+            SELECT 1
+            FROM m_hu_assignment ha
+                     JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
+                -- enumerate child TUs of each touched LU via the HU hierarchy
+                     JOIN m_hu lu ON lu.m_hu_id = ha.m_lu_hu_id
+                     JOIN m_hu_item hi ON hi.m_hu_id = lu.m_hu_id
+                AND hi.itemtype IN ('HU', 'HA')
+                     JOIN m_hu tu ON tu.m_hu_item_parent_id = hi.m_hu_item_id
+            WHERE ha.ad_table_id = v_m_inoutline_table_id
+              AND ha.m_lu_hu_id IS NOT NULL
+              AND ha.isactive = 'Y'
+              AND iol.m_inout_id = p_m_inout_id
+              -- TU is uncovered: no active m_hu_assignment from this TU to a CO/CL inoutline
+              AND NOT EXISTS (
+                SELECT 1
+                FROM m_hu_assignment ha2
+                         JOIN m_inoutline iol2 ON iol2.m_inoutline_id = ha2.record_id
+                         JOIN m_inout io2 ON io2.m_inout_id = iol2.m_inout_id and io2.issotrx='Y' /*only a sales shipment counts as coverage - a purchase-receipt of the same goods from a vendor must not open the close-gate*/
+                WHERE ha2.ad_table_id = v_m_inoutline_table_id
+                  AND ha2.isactive = 'Y'
+                  AND iol2.isactive = 'Y'
+                  AND (ha2.m_tu_hu_id = tu.m_hu_id OR ha2.vhu_id = tu.m_hu_id)
+                  AND io2.docstatus IN ('CO', 'CL')
+            )
+        )
     THEN
         RETURN '{}'::jsonb;
     END IF;
@@ -140,87 +140,87 @@ BEGIN
           AND ha.isactive = 'Y'
           AND iol.m_inout_id = p_m_inout_id
     ),
-    shared_lu_inout AS MATERIALIZED (
-        -- (lu, m_inout) pairs: every CO/CL shipment that has goods physically assigned to an LU
-        -- touched by THIS shipment. Voided/reversed/in-progress shipments are excluded.
-        -- Scoped to the LUs THIS shipment touches (this_inout_lu) so the m_lu_hu_id IN-list
-        -- drives the m_hu_assignment_m_lu_hu_id index (a handful of LUs) instead of a full scan.
-        -- Used to enumerate all sibling CO/CL shipments sharing an LU — feeds DESADV/PO reference
-        -- aggregation (desadv_agg, po_agg, pallet_list) and gives the full set of co-shippers.
-        SELECT DISTINCT ha.m_lu_hu_id AS lu_hu_id, iol.m_inout_id
-        FROM m_hu_assignment ha
-                 JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
-                 JOIN m_inout io ON io.m_inout_id = iol.m_inout_id and io.issotrx='Y' /*sibling CO/CL shipments only - exclude purchase-receipts of the same goods from a vendor*/
-        WHERE ha.ad_table_id = v_m_inoutline_table_id
-          AND ha.m_lu_hu_id IN (SELECT lu_hu_id FROM this_inout_lu)
-          AND ha.isactive = 'Y'
-          AND iol.isactive = 'Y'
-          AND io.docstatus IN ('CO', 'CL')
-    ),
-    inout_context AS (
-        -- Materialize all context data ONCE to avoid correlated subqueries
-        SELECT io.m_inout_id,
-               io.documentno,
-               io.movementdate,
-               io.m_warehouse_id,
-               io.ad_org_id,
-               io.edi_desadv_id,
-               io.c_bpartner_location_id,
-               io.dropship_location_id,
-               io.poreference,
-               io.docstatus,
-               io.isactive,
-               COALESCE(bpl_desadv_drop.c_bpartner_id,
-                        bpl_desadv_buyer.c_bpartner_id,
-                        bpl_ship_drop.c_bpartner_id,
-                        bpl_ship_buyer.c_bpartner_id) AS buyer_bpartner_id,
-               bpl_desadv_buyer.gln                   AS buyer_gln_desadv,
-               bpl_desadv_buyer.gln_gcpLength         AS buyer_gcplength_desadv,
-               bpl_ship_buyer.gln                     AS buyer_gln_ship,
-               bpl_ship_buyer.gln_gcpLength           AS buyer_gcplength_ship,
-               bpl_desadv_drop.gln                    AS drop_gln_desadv,
-               bpl_desadv_drop.gln_gcpLength          AS drop_gcplength_desadv,
-               bpl_ship_drop.gln                      AS drop_gln_ship,
-               bpl_ship_drop.gln_gcpLength            AS drop_gcplength_ship,
-               d.handover_location_id,
-               d.documentno                           AS desadv_documentno,
-               d.poreference                          AS desadv_poreference,
-               -- arrays from junction (all DESADVs linked to this shipment)
-               desadv_agg.desadv_documentnos,
-               desadv_agg.desadv_poreferences,
-               desadv_agg.shipment_documentnos
-        FROM m_inout io
-                 LEFT JOIN edi_desadv d ON d.edi_desadv_id = io.edi_desadv_id
+         shared_lu_inout AS MATERIALIZED (
+             -- (lu, m_inout) pairs: every CO/CL shipment that has goods physically assigned to an LU
+             -- touched by THIS shipment. Voided/reversed/in-progress shipments are excluded.
+             -- Scoped to the LUs THIS shipment touches (this_inout_lu) so the m_lu_hu_id IN-list
+             -- drives the m_hu_assignment_m_lu_hu_id index (a handful of LUs) instead of a full scan.
+             -- Used to enumerate all sibling CO/CL shipments sharing an LU — feeds DESADV/PO reference
+             -- aggregation (desadv_agg, po_agg, pallet_list) and gives the full set of co-shippers.
+             SELECT DISTINCT ha.m_lu_hu_id AS lu_hu_id, iol.m_inout_id
+             FROM m_hu_assignment ha
+                      JOIN m_inoutline iol ON iol.m_inoutline_id = ha.record_id
+                      JOIN m_inout io ON io.m_inout_id = iol.m_inout_id and io.issotrx='Y' /*sibling CO/CL shipments only - exclude purchase-receipts of the same goods from a vendor*/
+             WHERE ha.ad_table_id = v_m_inoutline_table_id
+               AND ha.m_lu_hu_id IN (SELECT lu_hu_id FROM this_inout_lu)
+               AND ha.isactive = 'Y'
+               AND iol.isactive = 'Y'
+               AND io.docstatus IN ('CO', 'CL')
+         ),
+         inout_context AS (
+             -- Materialize all context data ONCE to avoid correlated subqueries
+             SELECT io.m_inout_id,
+                    io.documentno,
+                    io.movementdate,
+                    io.m_warehouse_id,
+                    io.ad_org_id,
+                    io.edi_desadv_id,
+                    io.c_bpartner_location_id,
+                    io.dropship_location_id,
+                    io.poreference,
+                    io.docstatus,
+                    io.isactive,
+                    COALESCE(bpl_desadv_drop.c_bpartner_id,
+                             bpl_desadv_buyer.c_bpartner_id,
+                             bpl_ship_drop.c_bpartner_id,
+                             bpl_ship_buyer.c_bpartner_id) AS buyer_bpartner_id,
+                    bpl_desadv_buyer.gln                   AS buyer_gln_desadv,
+                    bpl_desadv_buyer.gln_gcpLength         AS buyer_gcplength_desadv,
+                    bpl_ship_buyer.gln                     AS buyer_gln_ship,
+                    bpl_ship_buyer.gln_gcpLength           AS buyer_gcplength_ship,
+                    bpl_desadv_drop.gln                    AS drop_gln_desadv,
+                    bpl_desadv_drop.gln_gcpLength          AS drop_gcplength_desadv,
+                    bpl_ship_drop.gln                      AS drop_gln_ship,
+                    bpl_ship_drop.gln_gcpLength            AS drop_gcplength_ship,
+                    d.handover_location_id,
+                    d.documentno                           AS desadv_documentno,
+                    d.poreference                          AS desadv_poreference,
+                    -- arrays from junction (all DESADVs linked to this shipment)
+                    desadv_agg.desadv_documentnos,
+                    desadv_agg.desadv_poreferences,
+                    desadv_agg.shipment_documentnos
+             FROM m_inout io
+                      LEFT JOIN edi_desadv d ON d.edi_desadv_id = io.edi_desadv_id
                  -- aggregate all DESADV references via N:M junction, across all shipments
                  -- sharing owned LUs (so the owner event carries refs from sibling shipments too)
-                 LEFT JOIN LATERAL (
-                     SELECT jsonb_agg(da.documentno ORDER BY da.documentno)   AS desadv_documentnos,
-                            jsonb_agg(da.poreference ORDER BY da.documentno)  AS desadv_poreferences,
-                            -- Delivery-note numbers (M_InOut.DocumentNo) of the DESADV messages on this SSCC.
-                            -- This is the value the receiver's EPCIS desadv bizTransaction must carry
-                            -- ("Lieferschein") — NOT EDI_Desadv.DocumentNo, which is 1:1 per ORDER and not
-                            -- unique across partial deliveries.
-                            -- DISTINCT: two orders on ONE M_InOut collapse to one delivery note; two M_InOuts
-                            -- sharing the SSCC yield two.
-                            jsonb_agg(DISTINCT mio.documentno ORDER BY mio.documentno) AS shipment_documentnos
-                     FROM edi_desadv_m_inout link
-                     JOIN edi_desadv da ON da.edi_desadv_id = link.edi_desadv_id
-                     JOIN m_inout mio ON mio.m_inout_id = link.m_inout_id
-                     WHERE link.isactive = 'Y'
-                       AND link.m_inout_id IN (
-                           -- all shipments sharing a touched LU (includes this shipment and all siblings)
-                           SELECT DISTINCT m_inout_id FROM shared_lu_inout
-                       )
+                      LEFT JOIN LATERAL (
+                 SELECT jsonb_agg(da.documentno ORDER BY da.documentno)   AS desadv_documentnos,
+                        jsonb_agg(da.poreference ORDER BY da.documentno)  AS desadv_poreferences,
+                        -- Delivery-note numbers (M_InOut.DocumentNo) of the DESADV messages on this SSCC.
+                        -- This is the value the receiver's EPCIS desadv bizTransaction must carry
+                        -- ("Lieferschein") — NOT EDI_Desadv.DocumentNo, which is 1:1 per ORDER and not
+                        -- unique across partial deliveries.
+                        -- DISTINCT: two orders on ONE M_InOut collapse to one delivery note; two M_InOuts
+                        -- sharing the SSCC yield two.
+                        jsonb_agg(DISTINCT mio.documentno ORDER BY mio.documentno) AS shipment_documentnos
+                 FROM edi_desadv_m_inout link
+                          JOIN edi_desadv da ON da.edi_desadv_id = link.edi_desadv_id
+                          JOIN m_inout mio ON mio.m_inout_id = link.m_inout_id
+                 WHERE link.isactive = 'Y'
+                   AND link.m_inout_id IN (
+                     -- all shipments sharing a touched LU (includes this shipment and all siblings)
+                     SELECT DISTINCT m_inout_id FROM shared_lu_inout
+                 )
                  ) desadv_agg ON true
-                 LEFT JOIN c_bpartner_location bpl_desadv_buyer
-                           ON bpl_desadv_buyer.c_bpartner_location_id = d.c_bpartner_location_id
-                 LEFT JOIN c_bpartner_location bpl_ship_buyer
-                           ON bpl_ship_buyer.c_bpartner_location_id = io.c_bpartner_location_id
-                 LEFT JOIN c_bpartner_location bpl_desadv_drop
-                           ON bpl_desadv_drop.c_bpartner_location_id = d.dropship_location_id
-                 LEFT JOIN c_bpartner_location bpl_ship_drop
-                           ON bpl_ship_drop.c_bpartner_location_id = io.dropship_location_id
-        WHERE io.m_inout_id = p_m_inout_id),
+                      LEFT JOIN c_bpartner_location bpl_desadv_buyer
+                                ON bpl_desadv_buyer.c_bpartner_location_id = d.c_bpartner_location_id
+                      LEFT JOIN c_bpartner_location bpl_ship_buyer
+                                ON bpl_ship_buyer.c_bpartner_location_id = io.c_bpartner_location_id
+                      LEFT JOIN c_bpartner_location bpl_desadv_drop
+                                ON bpl_desadv_drop.c_bpartner_location_id = d.dropship_location_id
+                      LEFT JOIN c_bpartner_location bpl_ship_drop
+                                ON bpl_ship_drop.c_bpartner_location_id = io.dropship_location_id
+             WHERE io.m_inout_id = p_m_inout_id),
 
          pallet_list AS MATERIALIZED (
              -- All LU HU IDs for this shipment, enriched with the left-zero-padded POReference of
@@ -233,37 +233,37 @@ BEGIN
              SELECT lwp.lu_hu_id,
                     LPAD(COALESCE(MIN(lwp.poreference), '0'), 10, '0') AS lu_poreference_padded
              FROM (
-                 -- Primary: M_HU_Assignment → InOutLine → OrderLine → Order path
-                 SELECT ha.m_lu_hu_id AS lu_hu_id,
-                        ord.poreference
-                 FROM inout_context ctx
-                          JOIN m_inoutline iol ON iol.m_inout_id = ctx.m_inout_id
-                          JOIN m_inout io ON io.m_inout_id = iol.m_inout_id and io.issotrx='Y' /*exclude material-receipt-lines - we might have received the goods from another vendor*/
-                          JOIN m_hu_assignment ha
-                               ON ha.ad_table_id = v_m_inoutline_table_id
-                                   AND ha.record_id = iol.m_inoutline_id
-                          LEFT JOIN c_orderline ol ON ol.c_orderline_id = iol.c_orderline_id
-                          LEFT JOIN c_order ord ON ord.c_order_id = ol.c_order_id and ord.IsSoTrx='Y' /*also exclude purchase-orders*/
-                 WHERE ha.m_lu_hu_id IS NOT NULL
-                   AND ha.isactive = 'Y'
+                      -- Primary: M_HU_Assignment → InOutLine → OrderLine → Order path
+                      SELECT ha.m_lu_hu_id AS lu_hu_id,
+                             ord.poreference
+                      FROM inout_context ctx
+                               JOIN m_inoutline iol ON iol.m_inout_id = ctx.m_inout_id
+                               JOIN m_inout io ON io.m_inout_id = iol.m_inout_id and io.issotrx='Y' /*exclude material-receipt-lines - we might have received the goods from another vendor*/
+                               JOIN m_hu_assignment ha
+                                    ON ha.ad_table_id = v_m_inoutline_table_id
+                                        AND ha.record_id = iol.m_inoutline_id
+                               LEFT JOIN c_orderline ol ON ol.c_orderline_id = iol.c_orderline_id
+                               LEFT JOIN c_order ord ON ord.c_order_id = ol.c_order_id and ord.IsSoTrx='Y' /*also exclude purchase-orders*/
+                      WHERE ha.m_lu_hu_id IS NOT NULL
+                        AND ha.isactive = 'Y'
 
-                 UNION ALL
+                      UNION ALL
 
-                 -- Fallback: M_ShipmentSchedule_QtyPicked path (no per-LU order link available)
-                 SELECT qp.m_lu_hu_id AS lu_hu_id,
-                        NULL::text AS poreference
-                 FROM inout_context ctx
-                          JOIN m_inoutline iol ON iol.m_inout_id = ctx.m_inout_id
-                          JOIN m_shipmentschedule_qtypicked qp ON qp.m_inoutline_id = iol.m_inoutline_id
-                 WHERE qp.m_lu_hu_id IS NOT NULL
-                   AND qp.isactive = 'Y'
-                   AND NOT EXISTS (
-                       SELECT 1 FROM m_hu_assignment ha2
-                       WHERE ha2.m_lu_hu_id = qp.m_lu_hu_id
-                         AND ha2.ad_table_id = v_m_inoutline_table_id
-                         AND ha2.isactive = 'Y'
-                   )
-             ) lwp
+                      -- Fallback: M_ShipmentSchedule_QtyPicked path (no per-LU order link available)
+                      SELECT qp.m_lu_hu_id AS lu_hu_id,
+                             NULL::text AS poreference
+                      FROM inout_context ctx
+                               JOIN m_inoutline iol ON iol.m_inout_id = ctx.m_inout_id
+                               JOIN m_shipmentschedule_qtypicked qp ON qp.m_inoutline_id = iol.m_inoutline_id
+                      WHERE qp.m_lu_hu_id IS NOT NULL
+                        AND qp.isactive = 'Y'
+                        AND NOT EXISTS (
+                          SELECT 1 FROM m_hu_assignment ha2
+                          WHERE ha2.m_lu_hu_id = qp.m_lu_hu_id
+                            AND ha2.ad_table_id = v_m_inoutline_table_id
+                            AND ha2.isactive = 'Y'
+                      )
+                  ) lwp
              GROUP BY lwp.lu_hu_id),
 
          individual_tu_ids AS MATERIALIZED (
@@ -337,34 +337,34 @@ BEGIN
              -- Scoped to the already-discovered TUs so the m_hu_assignment scan stays bounded.
              SELECT hu_id, poreference, shipment_documentno
              FROM (
-                 SELECT asg.hu_id,
-                        ord.poreference,
-                        io.documentno                                                  AS shipment_documentno,
-                        ROW_NUMBER() OVER (PARTITION BY asg.hu_id ORDER BY io.m_inout_id) AS rn
-                 FROM (
-                          SELECT ha.record_id, ha.m_tu_hu_id AS hu_id
-                          FROM m_hu_assignment ha
-                          WHERE ha.ad_table_id = v_m_inoutline_table_id
-                            AND ha.isactive = 'Y'
-                            AND ha.m_tu_hu_id IN (SELECT tu_hu_id FROM individual_tu_ids
-                                                  UNION ALL
-                                                  SELECT vtu_hu_id FROM ha_items_with_vtu)
-                          UNION ALL
-                          SELECT ha.record_id, ha.vhu_id AS hu_id
-                          FROM m_hu_assignment ha
-                          WHERE ha.ad_table_id = v_m_inoutline_table_id
-                            AND ha.isactive = 'Y'
-                            AND ha.vhu_id IN (SELECT tu_hu_id FROM individual_tu_ids
-                                              UNION ALL
-                                              SELECT vtu_hu_id FROM ha_items_with_vtu)
-                      ) asg
-                          JOIN m_inoutline iol ON iol.m_inoutline_id = asg.record_id
-                          JOIN m_inout io ON io.m_inout_id = iol.m_inout_id and io.issotrx='Y' /*exclude material-receipts, as might have received the goods from another vendor*/
-                          LEFT JOIN c_orderline ol ON ol.c_orderline_id = iol.c_orderline_id
-                          LEFT JOIN c_order ord ON ord.c_order_id = ol.c_order_id and ord.IsSoTrx='Y' /*also exclude purchase-orders*/
-                 WHERE iol.isactive = 'Y'
-                   AND io.docstatus IN ('CO', 'CL')
-             ) ranked
+                      SELECT asg.hu_id,
+                             ord.poreference,
+                             io.documentno                                                  AS shipment_documentno,
+                             ROW_NUMBER() OVER (PARTITION BY asg.hu_id ORDER BY io.m_inout_id) AS rn
+                      FROM (
+                               SELECT ha.record_id, ha.m_tu_hu_id AS hu_id
+                               FROM m_hu_assignment ha
+                               WHERE ha.ad_table_id = v_m_inoutline_table_id
+                                 AND ha.isactive = 'Y'
+                                 AND ha.m_tu_hu_id IN (SELECT tu_hu_id FROM individual_tu_ids
+                                                       UNION ALL
+                                                       SELECT vtu_hu_id FROM ha_items_with_vtu)
+                               UNION ALL
+                               SELECT ha.record_id, ha.vhu_id AS hu_id
+                               FROM m_hu_assignment ha
+                               WHERE ha.ad_table_id = v_m_inoutline_table_id
+                                 AND ha.isactive = 'Y'
+                                 AND ha.vhu_id IN (SELECT tu_hu_id FROM individual_tu_ids
+                                                   UNION ALL
+                                                   SELECT vtu_hu_id FROM ha_items_with_vtu)
+                           ) asg
+                               JOIN m_inoutline iol ON iol.m_inoutline_id = asg.record_id
+                               JOIN m_inout io ON io.m_inout_id = iol.m_inout_id and io.issotrx='Y' /*exclude material-receipts, as might have received the goods from another vendor*/
+                               LEFT JOIN c_orderline ol ON ol.c_orderline_id = iol.c_orderline_id
+                               LEFT JOIN c_order ord ON ord.c_order_id = ol.c_order_id and ord.IsSoTrx='Y' /*also exclude purchase-orders*/
+                      WHERE iol.isactive = 'Y'
+                        AND io.docstatus IN ('CO', 'CL')
+                  ) ranked
              WHERE rn = 1),
 
          hu_attrs AS MATERIALIZED (
@@ -420,18 +420,18 @@ BEGIN
                       LEFT JOIN c_uom uom ON uom.c_uom_id = stor.c_uom_id
                       LEFT JOIN m_hu_pi_item_product pi_prod
                                 ON pi_prod.m_hu_pi_item_product_id = it.tu_pi_item_product_id
-                          -- ASI-aware CU GTIN lookup (M_Product_ASI_Data, content-based ASI subset match), mirroring DESADV get_desadv_packs_json_fn.
-                          -- Buyer scoping uses the inout_context-resolved buyer (DESADV is optional for EPCIS; the DESADV fn uses its own edi_desadv.C_BPartner_ID).
+                 -- ASI-aware CU GTIN lookup (M_Product_ASI_Data, content-based ASI subset match), mirroring DESADV get_desadv_packs_json_fn.
+                 -- Buyer scoping uses the inout_context-resolved buyer (DESADV is optional for EPCIS; the DESADV fn uses its own edi_desadv.C_BPartner_ID).
                       LEFT JOIN LATERAL (
-                          SELECT gtin, ean_cu, ean13_productcode
-                          FROM m_product_asi_data
-                          WHERE isactive = 'Y'
-                            AND m_product_id = prod.m_product_id
-                            AND (c_bpartner_id IS NULL OR c_bpartner_id = (SELECT buyer_bpartner_id FROM inout_context))
-                            AND IsASIAttributesKeySubset(m_attributesetinstance_id, stor.m_attributesetinstance_id)
-                          ORDER BY seqno
-                          LIMIT 1
-                          ) asi_data ON TRUE
+                 SELECT gtin, ean_cu, ean13_productcode
+                 FROM m_product_asi_data
+                 WHERE isactive = 'Y'
+                   AND m_product_id = prod.m_product_id
+                   AND (c_bpartner_id IS NULL OR c_bpartner_id = (SELECT buyer_bpartner_id FROM inout_context))
+                   AND IsASIAttributesKeySubset(m_attributesetinstance_id, stor.m_attributesetinstance_id)
+                 ORDER BY seqno
+                 LIMIT 1
+                 ) asi_data ON TRUE
              GROUP BY it.tu_hu_id),
 
          aggregated_tu_base AS MATERIALIZED (
@@ -484,18 +484,18 @@ BEGIN
                       LEFT JOIN c_uom uom ON uom.c_uom_id = stor.c_uom_id
                       LEFT JOIN m_hu_pi_item_product pi_prod
                                 ON pi_prod.m_hu_pi_item_product_id = atb.vtu_pi_item_product_id
-                          -- ASI-aware CU GTIN lookup (M_Product_ASI_Data, content-based ASI subset match), mirroring DESADV get_desadv_packs_json_fn.
-                          -- Buyer scoping uses the inout_context-resolved buyer (DESADV is optional for EPCIS; the DESADV fn uses its own edi_desadv.C_BPartner_ID).
+                 -- ASI-aware CU GTIN lookup (M_Product_ASI_Data, content-based ASI subset match), mirroring DESADV get_desadv_packs_json_fn.
+                 -- Buyer scoping uses the inout_context-resolved buyer (DESADV is optional for EPCIS; the DESADV fn uses its own edi_desadv.C_BPartner_ID).
                       LEFT JOIN LATERAL (
-                          SELECT gtin, ean_cu, ean13_productcode
-                          FROM m_product_asi_data
-                          WHERE isactive = 'Y'
-                            AND m_product_id = prod.m_product_id
-                            AND (c_bpartner_id IS NULL OR c_bpartner_id = (SELECT buyer_bpartner_id FROM inout_context))
-                            AND IsASIAttributesKeySubset(m_attributesetinstance_id, stor.m_attributesetinstance_id)
-                          ORDER BY seqno
-                          LIMIT 1
-                          ) asi_data ON TRUE
+                 SELECT gtin, ean_cu, ean13_productcode
+                 FROM m_product_asi_data
+                 WHERE isactive = 'Y'
+                   AND m_product_id = prod.m_product_id
+                   AND (c_bpartner_id IS NULL OR c_bpartner_id = (SELECT buyer_bpartner_id FROM inout_context))
+                   AND IsASIAttributesKeySubset(m_attributesetinstance_id, stor.m_attributesetinstance_id)
+                 ORDER BY seqno
+                 LIMIT 1
+                 ) asi_data ON TRUE
              GROUP BY atb.tu_hu_id, atb.qty),
 
          all_crates_raw AS (
@@ -552,8 +552,8 @@ BEGIN
                                  LPAD(
                                          (COUNT(*) FILTER (WHERE grai_raw IS NULL)
                                              OVER (PARTITION BY lu_hu_id
-                                                   ORDER BY tu_hu_id, sort_ord
-                                                   ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))::text,
+                                             ORDER BY tu_hu_id, sort_ord
+                                             ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))::text,
                                          2, '0')
                     END AS grai,
                     lot_number,
@@ -609,15 +609,15 @@ BEGIN
                -- shared across a partial delivery.
                    'shipmentDocumentNos', COALESCE(ctx.shipment_documentnos,
                                                    CASE WHEN ctx.documentno IS NOT NULL
-                                                        THEN jsonb_build_array(ctx.documentno)
-                                                        ELSE '[]'::jsonb END),
+                                                            THEN jsonb_build_array(ctx.documentno)
+                                                            ELSE '[]'::jsonb END),
                -- PO references: same scalar + array pattern.
                -- Scalar falls back to InOut.POReference for shipments without junction rows.
                    'poReference', COALESCE((ctx.desadv_poreferences ->> 0), ctx.poreference),
                    'poReferences', COALESCE(ctx.desadv_poreferences,
                                             CASE WHEN ctx.poreference IS NOT NULL
-                                                 THEN jsonb_build_array(ctx.poreference)
-                                                 ELSE '[]'::jsonb END),
+                                                     THEN jsonb_build_array(ctx.poreference)
+                                                     ELSE '[]'::jsonb END),
                -- Pallets
                    'pallets', COALESCE(
                            (SELECT JSONB_AGG(
@@ -635,7 +635,7 @@ BEGIN
                                                          'lotNumber', c.lot_number,
                                                          'bestBeforeDate', c.best_before_date,
                                                          'tuHuId', c.tu_hu_id,
-                                                         -- per-crate source-order refs so PACKING events are order-pure (me03 #30279)
+                                                     -- per-crate source-order refs so PACKING events are order-pure (me03 #30279)
                                                          'poReference', c.po_reference,
                                                          'shipmentDocumentNo', c.shipment_documentno,
                                                          'items', COALESCE(c.items_json, '[]'::jsonb)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobUnPickCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/PickingJobUnPickCommand.java
@@ -177,12 +177,28 @@ public class PickingJobUnPickCommand
 		shipmentScheduleService.deleteByTopLevelHUsAndShipmentScheduleId(topLevelHUs, step.getScheduleId().getShipmentScheduleId());
 		changeHUStatusFromPickedToActive(topLevelHUs);
 
-		moveToTargetHUIfNeeded(huIdAndQRCodeList);
+		// extractToTopLevel above may have relocated/regenerated the QR codes (and the picked HU can carry
+		// surplus QR rows), so the pre-extraction snapshot no longer matches a live M_HU_QRCode. Re-resolve
+		// each extracted top-level HU's current QR by its id before moving it to the scanned target.
+		moveToTargetHUIfNeeded(toCurrentHuIdAndQRCodes(topLevelHUs));
 
 		return step.reduceWithUnpickEvent(
 				pickFromKey,
 				PickingJobStepUnpickInfo.ofUnpickedHUs(pickedToHUs)
 		);
+	}
+
+	private ImmutableSet<HUIdAndQRCode> toCurrentHuIdAndQRCodes(@NonNull final Collection<I_M_HU> hus)
+	{
+		return hus.stream()
+				.map(hu -> {
+					final HuId huId = HuId.ofRepoId(hu.getM_HU_ID());
+					return HUIdAndQRCode.builder()
+							.huId(huId)
+							.huQRCode(huService.getQRCodeByHuId(huId))
+							.build();
+				})
+				.collect(ImmutableSet.toImmutableSet());
 	}
 
 	private void moveToTargetHUIfNeeded(final ImmutableSet<HUIdAndQRCode> huIdAndQRCodeList)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesRepository.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesRepository.java
@@ -180,6 +180,49 @@ public class HUQRCodesRepository
 				.orElse(false);
 	}
 
+	/**
+	 * Read-only diagnostic for a failed {@link #isQRCodeAssignedToHU(HUQRCode, HuId)}: inspects the live
+	 * {@code M_HU_QRCode} row (including inactive) and its active assignments and returns a precise cause
+	 * string, so the raised error distinguishes the distinct failure modes. Performs no writes.
+	 */
+	public String diagnoseAssignmentFailure(@NonNull final HUQRCode qrCode, @NonNull final HuId huId)
+	{
+		final HUQRCodeUniqueId uniqueId = qrCode.getId();
+
+		// look up the QR-code row(s) by UniqueId WITHOUT the active filter, so an inactive row is still seen
+		final List<I_M_HU_QRCode> qrRecords = queryBL.createQueryBuilder(I_M_HU_QRCode.class)
+				.addEqualsFilter(I_M_HU_QRCode.COLUMNNAME_UniqueId, uniqueId.getAsString())
+				.create()
+				.list(I_M_HU_QRCode.class);
+		if (qrRecords.isEmpty())
+		{
+			return "no M_HU_QRCode row for UniqueId=" + uniqueId.getAsString();
+		}
+
+		final I_M_HU_QRCode activeQrRecord = qrRecords.stream()
+				.filter(I_M_HU_QRCode::isActive)
+				.findFirst()
+				.orElse(null);
+		if (activeQrRecord == null)
+		{
+			return "M_HU_QRCode row inactive for UniqueId=" + uniqueId.getAsString();
+		}
+
+		final ImmutableSet<HuId> assignedHuIds = queryBL.createQueryBuilder(I_M_HU_QRCode_Assignment.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_HU_QRCode_Assignment.COLUMNNAME_M_HU_QRCode_ID, activeQrRecord.getM_HU_QRCode_ID())
+				.create()
+				.stream()
+				.map(assignment -> HuId.ofRepoId(assignment.getM_HU_ID()))
+				.collect(ImmutableSet.toImmutableSet());
+		if (assignedHuIds.isEmpty())
+		{
+			return "QR active but has no active assignment";
+		}
+
+		return "QR active but assigned to HU(s) " + assignedHuIds + ", not " + huId;
+	}
+
 	public Optional<HUQRCode> getFirstQRCodeByHuId(@NonNull final HuId huId)
 	{
 		return queryByHuId(huId)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -344,7 +344,8 @@ public class HUQRCodesService
 	{
 		if (!huQRCodesRepository.isQRCodeAssignedToHU(qrCode, huId))
 		{
-			throw new AdempiereException("QR Code " + qrCode.toDisplayableQRCode() + " is not assigned to HU " + huId);
+			throw new AdempiereException("QR Code " + qrCode.toDisplayableQRCode() + " is not assigned to HU " + huId
+					+ " (" + huQRCodesRepository.diagnoseAssignmentFailure(qrCode, huId) + ")");
 		}
 	}
 

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
@@ -31,10 +31,14 @@ import de.metas.handlingunits.QtyTU;
 import de.metas.handlingunits.attribute.storage.IAttributeStorage;
 import de.metas.handlingunits.attribute.weightable.Weightables;
 import de.metas.handlingunits.model.I_M_HU;
+import com.google.common.collect.ImmutableSet;
 import de.metas.handlingunits.model.I_M_HU_PI;
 import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.handlingunits.model.I_M_HU_QRCode;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.model.InterfaceWrapperHelper;
 import de.metas.handlingunits.qrcodes.ean13.EAN13HUQRCode;
 import de.metas.handlingunits.qrcodes.gs1.GS1HUQRCode;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
@@ -377,6 +381,81 @@ class HUQRCodesServiceTest
 			assertThatThrownBy(() -> huQRCodesService.parse(junkCode))
 					.isInstanceOf(AdempiereException.class)
 					.satisfies(ex -> assertThat(((AdempiereException)ex).isUserValidationError()).isTrue());
+		}
+	}
+
+	@Nested
+	class assertQRCodeAssignedToHU
+	{
+		private I_M_HU_QRCode getQRCodeRecord(@NonNull final HUQRCode qrCode)
+		{
+			return Services.get(IQueryBL.class)
+					.createQueryBuilder(I_M_HU_QRCode.class)
+					.addEqualsFilter(I_M_HU_QRCode.COLUMNNAME_UniqueId, qrCode.getId().getAsString())
+					.create()
+					.firstOnlyNotNull(I_M_HU_QRCode.class);
+		}
+
+		@Test
+		void assignedToDifferentHU_messageDistinguishesTheCause()
+		{
+			final HuId assignedHuId = createTU();
+			final HuId otherHuId = createTU();
+
+			// generate + assign a QR code to assignedHuId
+			final HUQRCode qrCode = huQRCodesService.generateForExistingHU(assignedHuId).getSingleQRCode(assignedHuId);
+
+			// Asserting it against a DIFFERENT HU must fail — and the message must distinguish the cause
+			// (the QR is active and assigned, just to another HU), not merely say "not assigned".
+			assertThatThrownBy(() -> huQRCodesService.assertQRCodeAssignedToHU(qrCode, otherHuId))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("is not assigned to HU")
+					.hasMessageContaining("assigned to HU(s)")
+					.hasMessageContaining(String.valueOf(assignedHuId.getRepoId()));
+		}
+
+		@Test
+		void noActiveAssignment_messageDistinguishesTheCause()
+		{
+			final HuId huId = createTU();
+			final HUQRCode qrCode = huQRCodesService.generateForExistingHU(huId).getSingleQRCode(huId);
+
+			// remove the assignment: the QR row stays active but no active assignment remains
+			huQRCodesService.removeAssignment(qrCode, ImmutableSet.of(huId));
+
+			assertThatThrownBy(() -> huQRCodesService.assertQRCodeAssignedToHU(qrCode, huId))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("QR active but has no active assignment");
+		}
+
+		@Test
+		void inactiveQRCodeRow_messageDistinguishesTheCause()
+		{
+			final HuId huId = createTU();
+			final HUQRCode qrCode = huQRCodesService.generateForExistingHU(huId).getSingleQRCode(huId);
+
+			// deactivate the M_HU_QRCode row itself
+			final I_M_HU_QRCode record = getQRCodeRecord(qrCode);
+			record.setIsActive(false);
+			InterfaceWrapperHelper.save(record);
+
+			assertThatThrownBy(() -> huQRCodesService.assertQRCodeAssignedToHU(qrCode, huId))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("M_HU_QRCode row inactive");
+		}
+
+		@Test
+		void noQRCodeRow_messageDistinguishesTheCause()
+		{
+			final HuId huId = createTU();
+			final HUQRCode qrCode = huQRCodesService.generateForExistingHU(huId).getSingleQRCode(huId);
+
+			// delete the M_HU_QRCode row entirely
+			InterfaceWrapperHelper.delete(getQRCodeRecord(qrCode));
+
+			assertThatThrownBy(() -> huQRCodesService.assertQRCodeAssignedToHU(qrCode, huId))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("no M_HU_QRCode row for UniqueId");
 		}
 	}
 }

--- a/docker-builds/e2e-tests/compose.yml
+++ b/docker-builds/e2e-tests/compose.yml
@@ -165,7 +165,7 @@ services:
       replicas: 1
 
   playwright-frontend:
-    image: $mfregistry/metas-frontend-test:$mfversion
+    image: ghcr.io/metasfresh/metas-frontend-test:$mfversion
     profiles: ["frontend"]
     volumes:
       - ./playwright-report-frontend:/app/playwright-report
@@ -208,7 +208,7 @@ services:
       replicas: 1
 
   playwright-mobile:
-    image: $mfregistry/metas-mobile-test:$mfversion
+    image: ghcr.io/metasfresh/metas-mobile-test:$mfversion
     profiles: ["mobile"]
     volumes:
       - ./playwright-report-mobile:/app/playwright-report

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -84,6 +84,7 @@
 |---|---|
 | Full pick, single HU, confirm, shipment schedule marked picked | `picking/picking.spec.js` |
 | Pick HU then unpick → HU returns to unallocated | `picking/picking.spec.js` |
+| Unpick a whole step and scan a target HU → picked goods move onto the scanned target HU | `picking/picking_unpick_scan_target.spec.js` |
 | Scan invalid picking slot QR code → error shown | `picking/picking.spec.js` |
 | Line status indicator transitions draft → in-progress → complete as HUs are picked | `picking/picking.spec.js` |
 | Partial pick, allowCompletingPartialPickingJob = N → complete blocked | `picking/picking.spec.js` |
@@ -97,7 +98,7 @@
 | Profile configured with HandoverLocation + DateReady summary fields (Customer kept out of summary) → job-list caption shows exactly 3 fields: document number, delivery location and delivery date | `picking/orderBasedPicking/launcher_caption_handover_location_and_date.spec.js` |
 | ❌ Scan HU from wrong warehouse/locator → error shown | — |
 
-**13/14 — 93%**
+**14/15 — 93%**
 
 ### Order-based picking — filtering and facets
 

--- a/e2e/mobile-webui/tests/spec/picking/picking_unpick_scan_target.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_unpick_scan_target.spec.js
@@ -1,0 +1,135 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobLineScreen } from "../../utils/screens/picking/PickingJobLineScreen";
+import { PickingJobStepScreen } from "../../utils/screens/picking/PickingJobStepScreen";
+import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+
+// Whole-step unpick + scan a target HU must physically move the previously-picked goods onto the
+// scanned target HU. Before this fix, it failed: PickingJobUnPickCommand forwarded the stale
+// picked-CU (huId, QR) snapshot to MoveHUCommand after its own extractToTopLevel had already
+// relocated the QR, so HUQRCodesService.assertQRCodeAssignedToHU threw HTTP 422
+// "QR Code ... is not assigned to HU ..." and the goods never landed on the target.
+//
+// The target HU (HU2) must be an LU built from the SAME packing instruction as the picked HU:
+//   - Only an LU accepts the extracted top-level TU (moving into a TU/CU target fails).
+//   - The LU's TU child must be the SAME TU packing instruction as the picked HU's, else stacking
+//     is rejected ("cannot stack TU ... no link between them"); the masterdata API mints a fresh TU
+//     PI per packingInstructions entry, so the only LU that can receive the picked TU is one built
+//     from PI itself.
+//   - A PI-backed HU is force-filled to the PI's full capacity, so HU2 starts at 20 TU x 4 = 80 PCE.
+// Hence the target ends at its starting 80 PCE + the whole-step unpicked qty (12 PCE) = 92 PCE.
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                "P1": { prices: [{ price: 1 }] },
+            },
+            packingInstructions: {
+                "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "P1", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
+                // HU2: the target LU the whole picked step is unpicked into (same PI as HU1, starts at 80 PCE).
+                "HU2": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 12, piItemProduct: 'TU' }]
+                }
+            },
+        }
+    });
+};
+
+const loginAndStartJob = async ({ masterdata }) => {
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+    return { pickingJobId };
+};
+
+// noinspection JSUnusedLocalSymbols
+test('Unpick whole step + scan target HU — goods land on the scanned target', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');  // Standalone tag for Tags section
+    allure.story('Unpick a whole step and scan a target HU');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+    const targetHUQRCode = masterdata.handlingUnits.HU2.qrCode;
+
+    const { pickingJobId } = await loginAndStartJob({ masterdata });
+
+    await test.step("Pick all 3 TU (12 PCE) from HU1", async () => {
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '0 TU', qtyPickedCatchWeight: '' });
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '3' });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '3 TU', qtyPickedCatchWeight: '' });
+        // Registers the dynamically-created `lu1` HU in the backend test context so the assertion
+        // below can refer to it by identifier.
+        await Backend.expect({
+            title: 'after full pick: 12 PCE packed on lu1, target HU2 still at its starting 80 PCE',
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: "12 PCE", qtyTUs: 3, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }] }
+                    }
+                }
+            },
+            hus: {
+                lu1: { huStatus: 'S', storages: { P1: '12 PCE' } },
+                [targetHUQRCode]: { storages: { P1: '80 PCE' } },
+            }
+        });
+    });
+
+    await test.step("Unpick the whole step and scan target HU2 — goods must move onto HU2", async () => {
+        await PickingJobScreen.clickLineButton({ index: 1 });
+        await PickingJobLineScreen.waitForScreen();
+        await PickingJobLineScreen.clickStepButton({ index: 0 });
+        await PickingJobStepScreen.unpick({ targetHUQRCode });
+        await PickingJobLineScreen.goBack();
+    });
+
+    // Commit-confirming, user-visible signal: the line falls back to 0 TU picked once the unpick has
+    // committed (guards the backend read below against reading pre-commit state).
+    await PickingJobScreen.waitForScreen();
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 TU', qtyPicked: '0 TU', qtyPickedCatchWeight: '' });
+
+    // The end result: the previously-picked 12 PCE now physically reside on the scanned target HU2
+    // (its starting 80 PCE + the unpicked 12 PCE = 92 PCE), and the picked LU lu1 is emptied.
+    await Backend.expect({
+        title: 'after unpick + scan target: 12 PCE moved onto target HU2 (80 + 12 = 92), lu1 emptied',
+        hus: {
+            lu1: { storages: { P1: '0 PCE' } },
+            [targetHUQRCode]: { storages: { P1: '92 PCE' } },
+        }
+    });
+});

--- a/e2e/mobile-webui/tests/utils/dialogs/UnpickDialog.js
+++ b/e2e/mobile-webui/tests/utils/dialogs/UnpickDialog.js
@@ -1,5 +1,6 @@
 import { test } from "../../../playwright.config";
 import { page, SLOW_ACTION_TIMEOUT } from "../common";
+import { BarcodeScannerComponent } from "../components/BarcodeScannerComponent";
 
 const NAME = 'UnpickDialog';
 /** @returns {import('@playwright/test').Locator} */
@@ -12,5 +13,9 @@ export const UnpickDialog = {
 
     clickSkipScanningTargetHUButton: async () => await test.step(`${NAME} - Click Skip button`, async () => {
         await page.locator('#skip-button').tap();
+    }),
+
+    scanTargetHU: async (qrCode) => await test.step(`${NAME} - Scan target HU ${qrCode}`, async () => {
+        await BarcodeScannerComponent.type(qrCode);
     }),
 };

--- a/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
@@ -11,9 +11,9 @@ const NAME = 'HOME';
 const containerElement = () => page.locator('#ApplicationsListScreen');
 
 export const ApplicationsListScreen = {
-    waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
-        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
+    waitForScreen: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
+        await containerElement().waitFor({ timeout });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionJobsListScreen.js
@@ -13,9 +13,9 @@ const NAME = 'DistributionJobsListScreen';
 const containerElement = () => page.locator('#WFLaunchersScreen');
 
 export const DistributionJobsListScreen = {
-    waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor({ timeout: SLOW_ACTION_TIMEOUT });
-        await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
+    waitForScreen: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
+        await containerElement().waitFor({ timeout });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout });
     }),
 
     filterByFacetId: async ({

--- a/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page, SLOW_ACTION_TIMEOUT } from '../../common';
+import { page, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../../common';
 import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
@@ -24,6 +24,18 @@ export const HUBulkActionsScreen = {
         await page.getByTestId('toggle-target-scanner-button').getByText('Close scanner').waitFor({ timeout: SLOW_ACTION_TIMEOUT });
         await BarcodeScannerComponent.type(targetLocator);
 
-        await ApplicationsListScreen.waitForScreen();
+        // The bulk move commits via an async REST round-trip (api.moveBulkHUs -> POST /bulk/move);
+        // only once it resolves does the frontend navigate home (history.goHome()). The home screen
+        // appearing IS the commit-confirming, user-visible landing signal — but its single default
+        // SLOW_ACTION_TIMEOUT (20s) budget has to absorb that whole round-trip, so under CI load the
+        // commit can overshoot 20s and the wait times out (the flake). A transient success toast is
+        // NOT usable as an earlier signal here: ScreenToaster dismisses all toasts on the very
+        // navigation that follows it (useLocationChange -> toast.dismiss()), so it races the dismissal.
+        // Give the transition the VERY_SLOW_ACTION_TIMEOUT (40s) budget instead — the same budget idiom
+        // used for other heavy async-commit flows that return to a list/home screen (e.g.
+        // PickingJobScreen.complete, ManufacturingJobScreen, InventoryJobScreen; those return to a
+        // *jobs-list* screen, here we return to the *home* ApplicationsListScreen — same topology).
+        // No new signal is invented; the genuinely-slow commit is simply given room to land.
+        await ApplicationsListScreen.waitForScreen({ timeout: VERY_SLOW_ACTION_TIMEOUT });
     }),
 };

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobStepScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobStepScreen.js
@@ -13,10 +13,17 @@ export const PickingJobStepScreen = {
         await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
-    unpick: async () => await test.step(`${NAME} - Click unpick`, async () => {
+    // Whole-step unpick. With no argument the target-HU scan is skipped (the goods drop to loose
+    // top-level TUs). Passing { targetHUQRCode } instead scans a target HU, so the unpicked goods
+    // are moved onto that scanned HU. No-arg behaviour is preserved for existing callers.
+    unpick: async ({ targetHUQRCode } = {}) => await test.step(`${NAME} - Click unpick`, async () => {
         await page.locator(`#unpick-button`).tap();
         await UnpickDialog.waitForDialog();
-        await UnpickDialog.clickSkipScanningTargetHUButton();
+        if (targetHUQRCode) {
+            await UnpickDialog.scanTargetHU(targetHUQRCode);
+        } else {
+            await UnpickDialog.clickSkipScanningTargetHUButton();
+        }
         await PickingJobLineScreen.waitForScreen();
     }),
 };


### PR DESCRIPTION
Propagation merge (merge-commit, **not** squash) carrying `soft_panda_hotfix` up to `new_dawn_uat`. Unblocks the auto-port train, which was **conflict-stuck** (6 conflicts) so no rolling train could refresh.

### Commits carried up (all already merged on `soft_panda_hotfix`)
- **https://github.com/metasfresh/metasfresh/pull/24999** — mobile-webui e2e: huManager bulk-Move + Distribution async-commit fix (the trigger for this train)
- **https://github.com/metasfresh/metasfresh/pull/24994** — MobileUI Picking: unpick + scan target HU (re-resolve QR before move) + diagnostic message
- **https://github.com/metasfresh/metasfresh/pull/24990** — EPCIS `get_epcis_events_json_fn` rewrite
- **https://github.com/metasfresh/metasfresh/pull/25015** — CI: move test images to ghcr (Wave 2 top-up)

### Conflict resolutions (6)
| File | Resolution |
|---|---|
| `PickingJobUnPickCommand.java` (flat) | Accepted `new_dawn_uat`'s deletion — the fix already lives in the refactored `unpick/` package on the target (no regression) |
| `TEST-COVERAGE.md` | Union of both scenario sets; Picking recount 93/97, core-flow 19/20 |
| `HUBulkActionsScreen.js` | Union import (`FAST_`, `SLOW_`, `VERY_SLOW_ACTION_TIMEOUT` all used) |
| `PickingJobStepScreen.js` | Kept `new_dawn_uat`'s new `goBack()` + https://github.com/metasfresh/metasfresh/pull/24994's `unpick({targetHUQRCode})` signature |
| `HUQRCodesServiceTest.java` | Kept https://github.com/metasfresh/metasfresh/pull/24994's `@Nested assertQRCodeAssignedToHU` tests (Service+Repository counterparts present) |
| `cicd.yaml` | Kept `new_dawn_uat`'s no-`--quiet` push convention (cosmetic log flag) |

### DDL gate
Carries https://github.com/metasfresh/metasfresh/pull/24990's `get_epcis_events_json_fn` migration `5812350`. Per-object regression check: incoming is a **designed superset** of the target (adds `io.issotrx='Y'` correctness filter + new fields), DDL reference matches the migration output — **no whole-object revert**. It is another owner's DDL, so it needs the owner's cross-owner sign-off before merge.
