### PR TITLE
EDI INVOIC: exclude packaging-material invoice lines from export, party resolution and validation

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/adempiere/model/I_C_InvoiceLine.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/adempiere/model/I_C_InvoiceLine.java
@@ -110,7 +110,7 @@ public interface I_C_InvoiceLine extends org.compiere.model.I_C_InvoiceLine
 
 	// @formatter:off
 	String COLUMNNAME_IsPackagingMaterial = "IsPackagingMaterial";
-	boolean IsPackagingMaterial();
+	boolean isPackagingMaterial();
 	void setIsPackagingMaterial(boolean IsPackagingMaterial);
 	// @formatter:on
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_InvoiceLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_InvoiceLine_StepDef.java
@@ -35,6 +35,7 @@ import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.activity.C_Activity_StepDefData;
 import de.metas.cucumber.stepdefs.tax.C_TaxCategory_StepDefData;
 import de.metas.cucumber.stepdefs.project.C_Project_StepDefData;
+import de.metas.cucumber.stepdefs.order.C_OrderLine_StepDefData;
 import de.metas.cucumber.stepdefs.shipment.M_InOutLine_StepDefData;
 import de.metas.invoice.InvoiceId;
 import de.metas.invoice.matchinv.service.MatchInvoiceService;
@@ -108,6 +109,7 @@ public class C_InvoiceLine_StepDef
 	private final C_Tax_StepDefData taxTable;
 	private final C_TaxCategory_StepDefData taxCategoryTable;
 	private final C_Activity_StepDefData activityTable;
+	private final C_OrderLine_StepDefData orderLineTable;
 
 	/**
 	 * @cucumber.stepdef Creates C_InvoiceLine records on existing C_Invoices.
@@ -118,10 +120,11 @@ public class C_InvoiceLine_StepDef
 	 *   <b>C_UOM_ID</b> — (optional) UOM x12de355 code, when not embedded in QtyInvoiced<br>
 	 *   <b>Price</b> — (optional) manual price; sets IsManualPrice + PriceEntered/PriceActual<br>
 	 *   <b>IsPackagingMaterial</b> — (optional) mark the line as packaging material; omit to keep the model default (N)<br>
+	 *   <b>C_OrderLine_ID</b> — (optional, identifier-ref) link the line to a C_OrderLine<br>
 	 *   <b>C_Tax_ID$set</b> — (optional, identifier-ref) force this tax on the line<br>
 	 *   <b>C_Tax_ID</b> — (optional, identifier-ref) store the resolved tax under this alias<br>
 	 *   <b>Identifier</b> — (optional) alias for cross-step reference<br>
-	 * @cucumber.depends StepDefData: C_Invoice_StepDefData, M_Product_StepDefData, C_Tax_StepDefData
+	 * @cucumber.depends StepDefData: C_Invoice_StepDefData, M_Product_StepDefData, C_Tax_StepDefData, C_OrderLine_StepDefData
 	 * @cucumber.example
 	 * <pre>
 	 * And metasfresh contains C_InvoiceLines
@@ -440,6 +443,9 @@ public class C_InvoiceLine_StepDef
 		{
 			invoiceLine.setIsPackagingMaterial(isPackagingMaterial);
 		}
+
+		row.getAsOptionalIdentifier(I_C_InvoiceLine.COLUMNNAME_C_OrderLine_ID)
+				.ifPresent(orderLineId -> invoiceLine.setC_OrderLine_ID(orderLineId.lookupNotNullIn(orderLineTable).getC_OrderLine_ID()));
 
 		invoiceLineBL.updatePrices(invoiceLine);
 		invoiceLineBL.updateLineNetAmt(invoiceLine, qtyEntered.toBigDecimal());

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_InvoiceLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_InvoiceLine_StepDef.java
@@ -415,6 +415,12 @@ public class C_InvoiceLine_StepDef
 					invoiceLine.setC_Tax_ID(taxId.getRepoId());
 				});
 
+		final Boolean isPackagingMaterial = row.getAsOptionalBoolean(I_C_InvoiceLine.COLUMNNAME_IsPackagingMaterial).toBooleanOrNull();
+		if (isPackagingMaterial != null)
+		{
+			invoiceLine.setIsPackagingMaterial(isPackagingMaterial);
+		}
+
 		invoiceLineBL.updatePrices(invoiceLine);
 		invoiceLineBL.updateLineNetAmt(invoiceLine, qtyEntered.toBigDecimal());
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_InvoiceLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_InvoiceLine_StepDef.java
@@ -109,6 +109,26 @@ public class C_InvoiceLine_StepDef
 	private final C_TaxCategory_StepDefData taxCategoryTable;
 	private final C_Activity_StepDefData activityTable;
 
+	/**
+	 * @cucumber.stepdef Creates C_InvoiceLine records on existing C_Invoices.
+	 * @cucumber.columns
+	 *   <b>C_Invoice_ID</b> — (required, identifier-ref) the invoice to add the line to<br>
+	 *   <b>M_Product_ID</b> — (required, identifier-ref) the line's product<br>
+	 *   <b>QtyInvoiced</b> — (required) quantity; the UOM may be embedded (e.g. "1 PCE") or given via C_UOM_ID<br>
+	 *   <b>C_UOM_ID</b> — (optional) UOM x12de355 code, when not embedded in QtyInvoiced<br>
+	 *   <b>Price</b> — (optional) manual price; sets IsManualPrice + PriceEntered/PriceActual<br>
+	 *   <b>IsPackagingMaterial</b> — (optional) mark the line as packaging material; omit to keep the model default (N)<br>
+	 *   <b>C_Tax_ID$set</b> — (optional, identifier-ref) force this tax on the line<br>
+	 *   <b>C_Tax_ID</b> — (optional, identifier-ref) store the resolved tax under this alias<br>
+	 *   <b>Identifier</b> — (optional) alias for cross-step reference<br>
+	 * @cucumber.depends StepDefData: C_Invoice_StepDefData, M_Product_StepDefData, C_Tax_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And metasfresh contains C_InvoiceLines
+	 *   | C_Invoice_ID | M_Product_ID | QtyInvoiced | IsPackagingMaterial |
+	 *   | invoice      | product      | 1 PCE       | Y                   |
+	 * </pre>
+	 */
 	@And("metasfresh contains C_InvoiceLines")
 	public void addC_InvoiceLines(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
@@ -282,6 +282,14 @@ public class C_Order_StepDef
 				.map(bpartnerLocationTable::getId)
 				.ifPresent(id -> order.setDropShip_Location_ID(id.getRepoId()));
 
+		// handover (delivery) location — distinct from the bill/ship location
+		tableRow.getAsOptionalIdentifier(COLUMNNAME_HandOver_Location_ID)
+				.map(bpartnerLocationTable::getId)
+				.ifPresent(id -> {
+					order.setHandOver_Location_ID(id.getRepoId());
+					order.setIsUseHandOver_Location(true);
+				});
+
 		final OrgId orgId = tableRow.getAsOptionalIdentifier(COLUMNNAME_AD_Org_ID)
 				.map(orgTable::getId)
 				.orElse(StepDefConstants.ORG_ID);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
@@ -230,6 +230,7 @@ public class C_Order_StepDef
 	 * <ul>
 	 *   <li>{@code C_PromotionCode_ID} (optional) — identifier referencing a {@code C_PromotionCode} record</li>
 	 *   <li>{@code C_PromotionCode2_ID} (optional) — identifier referencing a second {@code C_PromotionCode} record</li>
+	 *   <li>{@code HandOver_Location_ID} (optional) — identifier referencing the delivery/hand-over {@code C_BPartner_Location} (also sets {@code IsUseHandOver_Location})</li>
 	 * </ul>
 	 */
 	@Given("metasfresh contains C_Orders:")

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediInvoicExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediInvoicExport.feature
@@ -520,32 +520,52 @@ Feature: EDI INVOIC export via postgREST
 
   @from:cucumber
 @allure.label.epic:E0292_EDI
-@allure.label.feature:F00350_EDI
-@F00350
-  Scenario: packaging-material invoice lines are excluded from the INVOIC export
+@allure.label.feature:F00359_EDI_INVOICE_JSON
+@F00359
+  Scenario: a packaging-material invoice line does not add a second delivery party (DP)
     # A packaging-material line (deposit / Leergut) carries no C_OrderLine_ID.
-    # It must NOT be exported as an INVOIC line item; only the normal product line is exported.
+    # It must not be exported as an INVOIC line item, and — because it would otherwise fall back to
+    # the invoice's own bill-to location — it must not emit a second DP party. The order's delivery
+    # (HandOver) location differs from the bill-to, so the genuine DP is the delivery location and a
+    # spurious second DP (= bill-to, from the packaging line) is detectable.
     Given metasfresh contains C_BPartners without locations:
       | Identifier | IsCustomer | REST.Context.Name | REST.Context.Value | IsVendor | M_PricingSystem_ID |
       | customer1  | Y          | customerName      | customerValue      | N        | pricingSystem      |
+    And metasfresh contains C_Location:
+      | C_Location_ID.Identifier | CountryCode | OPT.Address1 | OPT.Postal | OPT.City   |
+      | loc_bill                 | DE          | billAddr     | 111        | billCity   |
+      | loc_delivery             | DE          | delivAddr    | 222        | delivCity  |
     And metasfresh contains C_BPartner_Locations:
-      | Identifier          | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
-      | bpartner_location_1 | customer1     | Y               | Y               |
+      | Identifier   | GLN           | C_BPartner_ID.Identifier | OPT.C_Location_ID.Identifier | OPT.IsShipTo | OPT.IsBillTo | OPT.BPartnerName |
+      | bpLoc_bill   | 1111111111111 | customer1                | loc_bill                     | true         | true         | billBPName       |
+      | bpLoc_deliv  | 2222222222222 | customer1                | loc_delivery                 | true         | false        | delivBPName      |
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID | C_BPartner_ID | C_BPartner_Location_ID |
+      | wh             | customer1     | bpLoc_bill             |
     And metasfresh contains M_Products:
-      | Identifier       | Value              | Name              | Description              |
-      | productNormal    | normalProductValue | normalProductName | normalProductDescription |
-      | productPackaging | pkgProductValue    | pkgProductName    | pkgProductDescription    |
+      | Identifier    | Value              | Name              | Description              |
+      | productNormal | normalProductValue | normalProductName | normalProductDescription |
     And metasfresh contains M_ProductPrices
-      | M_PriceList_Version_ID | M_Product_ID     | PriceStd | C_UOM_ID |
-      | salesPLV               | productNormal    | 5.00     | PCE      |
-      | salesPLV               | productPackaging | 3.00     | PCE      |
+      | M_PriceList_Version_ID | M_Product_ID  | PriceStd | C_UOM_ID |
+      | salesPLV               | productNormal | 5.00     | PCE      |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | C_BPartner_Location_ID | HandOver_Location_ID | DeliveryRule | DateOrdered | DatePromised | M_Warehouse_ID |
+      | o_1        | true    | customer1     | bpLoc_bill             | bpLoc_deliv          | F            | 2025-05-01  | 2025-05-01Z  | wh             |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID  | QtyEntered |
+      | ol_1       | o_1                   | productNormal | 1          |
+    And the order identified by o_1 is completed
+
+    # Build the invoice directly (not via the IC pipeline): a product line linked to the order line
+    # (so its delivery party resolves to the order's HandOver location) plus an order-less
+    # packaging-material line (as a deposit / Leergut line would be — no C_OrderLine_ID).
     And metasfresh contains C_Invoice:
-      | Identifier | REST.Context  | C_BPartner_ID | C_DocTypeTarget_ID.Name | DocumentNo    | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
-      | pkgInvoice | pkgInvoice_ID | customer1     | Ausgangsrechnung        | invoicePkg010 | 2025-05-01   | Spot                     | true    | EUR                 |
+      | Identifier | REST.Context  | C_BPartner_ID | C_BPartner_Location_ID | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | pkgInvoice | pkgInvoice_ID | customer1     | bpLoc_bill             | Ausgangsrechnung        | 2025-05-01   | Spot                     | true    | EUR                 |
     And metasfresh contains C_InvoiceLines
-      | C_Invoice_ID | M_Product_ID     | QtyInvoiced | IsPackagingMaterial |
-      | pkgInvoice   | productNormal    | 1 PCE       | N                   |
-      | pkgInvoice   | productPackaging | 1 PCE       | Y                   |
+      | C_Invoice_ID | M_Product_ID  | C_OrderLine_ID | QtyInvoiced | IsPackagingMaterial |
+      | pkgInvoice   | productNormal | ol_1           | 1 PCE       | N                   |
+      | pkgInvoice   | productNormal |                | 1 PCE       | Y                   |
     And the invoice identified by pkgInvoice is completed
 
     And the following API_Audit_Config records are created:
@@ -568,19 +588,29 @@ Feature: EDI INVOIC export via postgREST
 }
     """
 
+    # The packaging line is excluded from Lines (only the product line is exported), and Partners
+    # carries exactly ONE "DP" (the HandOver delivery location) — NOT a second DP at the bill-to
+    # location. Without the fix the order-less packaging line adds that second DP and the Partners
+    # array has 6 entries, so this assertion fails.
     Then the metasfresh REST-API responds with
     """
 {
   "metasfresh_INVOIC": [
     {
       "Invoice_ID": @pkgInvoice_ID@,
-      "Invoice_DocumentNo": "invoicePkg010",
       "Lines": [
         {
           "Invoice_Line": 10,
           "Product_Name": "normalProductName",
           "Product_Supplier_ProductNo": "normalProductValue"
         }
+      ],
+      "Partners": [
+        { "EANCOM_LocationType": "SU", "Name": "metasfresh AG", "City": "Bonn" },
+        { "EANCOM_LocationType": "BY", "GLN": "1111111111111", "Address1": "billAddr", "City": "billCity" },
+        { "EANCOM_LocationType": "IV", "GLN": "1111111111111", "Address1": "billAddr", "City": "billCity" },
+        { "EANCOM_LocationType": "SN", "GLN": "1111111111111", "Address1": "billAddr", "City": "billCity" },
+        { "EANCOM_LocationType": "DP", "GLN": "2222222222222", "Address1": "delivAddr", "City": "delivCity" }
       ]
     }
   ]

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediInvoicExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/postgrestBased/ediInvoicExport.feature
@@ -517,3 +517,72 @@ Feature: EDI INVOIC export via postgREST
   ]
 }
     """
+
+  @from:cucumber
+@allure.label.epic:E0292_EDI
+@allure.label.feature:F00350_EDI
+@F00350
+  Scenario: packaging-material invoice lines are excluded from the INVOIC export
+    # A packaging-material line (deposit / Leergut) carries no C_OrderLine_ID.
+    # It must NOT be exported as an INVOIC line item; only the normal product line is exported.
+    Given metasfresh contains C_BPartners without locations:
+      | Identifier | IsCustomer | REST.Context.Name | REST.Context.Value | IsVendor | M_PricingSystem_ID |
+      | customer1  | Y          | customerName      | customerValue      | N        | pricingSystem      |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier          | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
+      | bpartner_location_1 | customer1     | Y               | Y               |
+    And metasfresh contains M_Products:
+      | Identifier       | Value              | Name              | Description              |
+      | productNormal    | normalProductValue | normalProductName | normalProductDescription |
+      | productPackaging | pkgProductValue    | pkgProductName    | pkgProductDescription    |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID     | PriceStd | C_UOM_ID |
+      | salesPLV               | productNormal    | 5.00     | PCE      |
+      | salesPLV               | productPackaging | 3.00     | PCE      |
+    And metasfresh contains C_Invoice:
+      | Identifier | REST.Context  | C_BPartner_ID | C_DocTypeTarget_ID.Name | DocumentNo    | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | pkgInvoice | pkgInvoice_ID | customer1     | Ausgangsrechnung        | invoicePkg010 | 2025-05-01   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID | M_Product_ID     | QtyInvoiced | IsPackagingMaterial |
+      | pkgInvoice   | productNormal    | 1 PCE       | N                   |
+      | pkgInvoice   | productPackaging | 1 PCE       | Y                   |
+    And the invoice identified by pkgInvoice is completed
+
+    And the following API_Audit_Config records are created:
+      | Identifier | SeqNo | OPT.Method | OPT.PathPrefix   | IsForceProcessedAsync | IsSynchronousAuditLoggingEnabled | IsWrapApiResponse |
+      | c_1        | 10    | GET        | api/v2/processes | N                     | Y                                | N                 |
+    And add HTTP headers
+      | Key          | Value                          |
+      | Content-Type | application/json;charset=UTF-8 |
+      | accept       | application/json;charset=UTF-8 |
+
+    When a 'POST' request with the below payload and headers from context is sent to the metasfresh REST-API 'api/v2/processes/C_Invoice_EDI_Export_JSON/invoke' and fulfills with '200' status code
+    """
+{
+  "processParameters": [
+    {
+      "name": "C_Invoice_ID",
+      "value": "@pkgInvoice_ID@"
+    }
+  ]
+}
+    """
+
+    Then the metasfresh REST-API responds with
+    """
+{
+  "metasfresh_INVOIC": [
+    {
+      "Invoice_ID": @pkgInvoice_ID@,
+      "Invoice_DocumentNo": "invoicePkg010",
+      "Lines": [
+        {
+          "Invoice_Line": 10,
+          "Product_Name": "normalProductName",
+          "Product_Supplier_ProductNo": "normalProductValue"
+        }
+      ]
+    }
+  ]
+}
+    """

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/EDIDocumentBL.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/EDIDocumentBL.java
@@ -306,9 +306,9 @@ public class EDIDocumentBL
 				ilMissingFields.add(org.compiere.model.I_C_InvoiceLine.COLUMNNAME_Line);
 			}
 
-			if (il.getC_OrderLine_ID() <= 0 && !invoiceIsRMCreditMemo)
+			if (il.getC_OrderLine_ID() <= 0 && !invoiceIsRMCreditMemo && !il.isPackagingMaterial())
 			{
-				// task 09182: on line level, we need an order line reference,
+				// task 09182: on line-level for not-packaging-material-lines, we need an order line reference,
 				// only for docSubType='CS' an orderLine does not have to be linked to an invoiceLine for successful EDI export.
 				// note: if this changes in a new project, use AD_SysConfig
 				ilMissingFields.add(org.compiere.model.I_C_InvoiceLine.COLUMNNAME_C_OrderLine_ID);

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/EDIDocumentBL.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/EDIDocumentBL.java
@@ -94,6 +94,7 @@ import java.util.Set;
 public class EDIDocumentBL
 {
 	private static final String ERR_NotExistsShipmentForOrderError = "NotExistsShipmentForOrderError";
+	private static final String ERR_NotExistsNonPackagingInvoiceLineError = "NotExistsNonPackagingInvoiceLineError";
 	private static final String MSG_Partner_ValidateIsEDIRecipient_Error = "de.metas.edi.ValidateIsEDIRecipientError";
 	private static final String MSG_Invalid_Invoice_Aggregation_Error = "de.metas.edi.InvalidInvoiceAggregationError";
 
@@ -298,8 +299,14 @@ public class EDIDocumentBL
 
 		final Set<String> ilMissingFields = new HashSet<>();
 		final List<I_C_InvoiceLine> invoiceLines = Services.get(IInvoiceDAO.class).retrieveLines(invoice);
+		boolean hasExportableLine = false;
 		for (final I_C_InvoiceLine il : invoiceLines)
 		{
+			if (!il.isPackagingMaterial())
+			{
+				hasExportableLine = true;
+			}
+
 			if (il.getLine() <= 0)
 			{
 				// use invoice here, it's easier to identify as a user
@@ -318,6 +325,17 @@ public class EDIDocumentBL
 		if (!ilMissingFields.isEmpty())
 		{
 			feedback.add(new EDIFillMandatoryException(ilMissingFields));
+		}
+
+		// Packaging-material lines are exempt from the C_OrderLine_ID check above and are filtered out
+		// of the INVOIC export views. Guard the boundary case where an invoice's lines are ALL packaging
+		// material: it would otherwise pass validation and export an empty INVOIC (no line items, no
+		// DP/SN party address). Fail loudly instead. (RM credit memos and line-less invoices keep their
+		// prior behaviour.)
+		if (!invoiceIsRMCreditMemo && !invoiceLines.isEmpty() && !hasExportableLine)
+		{
+			feedback.add(new EDIMissingDependencyException(ERR_NotExistsNonPackagingInvoiceLineError,
+														   org.compiere.model.I_C_Invoice.Table_Name, invoice.getDocumentNo()));
 		}
 
 		if (logger.isDebugEnabled() && !feedback.isEmpty())

--- a/backend/de.metas.edi/src/main/sql/postgresql/ddl/views/edi_cctop_119_v_view.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/ddl/views/edi_cctop_119_v_view.sql
@@ -147,7 +147,7 @@ FROM (SELECT union_lookup.*
                             NULL::TEXT           AS GLN_Override,
                             i.CreatedBy
             FROM C_Invoice i
-                     INNER JOIN C_Invoiceline il ON il.C_Invoice_ID = i.C_Invoice_ID AND il.ispackagingmaterial = 'N' /* exclude package-lines that have no c_orderline_id, to avoid two 'ship' rows in conjunction with the "Fallback if the C_Invoice has no C_Order "*/
+                     INNER JOIN C_Invoiceline il ON il.C_Invoice_ID = i.C_Invoice_ID AND il.ispackagingmaterial = 'N' /* exclude package-lines that have no c_orderline_id, to avoid two 'snum' rows in conjunction with the "Fallback if the C_Invoice has no C_Order "*/
                      LEFT JOIN C_OrderLine ol ON ol.C_OrderLine_ID = il.C_OrderLine_ID
                      LEFT JOIN C_Order o ON o.C_Order_ID = ol.C_Order_ID
                      LEFT JOIN M_InOutline sl ON ( -- try to join directly from C_InvoiceLine

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5812510_sys_invoic_500_exclude_packaging_material.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5812510_sys_invoic_500_exclude_packaging_material.sql
@@ -1,31 +1,11 @@
-/*
- * #%L
- * de.metas.edi
- * %%
- * Copyright (C) 2025 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
+-- Source DDL: backend/de.metas.edi/src/main/sql/postgresql/ddl/views/edi_cctop_invoic_500_v_view.sql
+-- INVOIC export: exclude packaging-material invoice lines (IsPackagingMaterial='Y').
+-- Packaging-material lines (deposit / Leergut, pallets) carry no C_OrderLine_ID and must not
+-- be exported as INVOIC line items; they otherwise fail the mandatory-C_OrderLine_ID check.
 
--- View: public.edi_cctop_invoic_500_v
+DROP VIEW IF EXISTS edi_cctop_invoic_500_v$new;
 
-DROP VIEW IF EXISTS public.edi_cctop_invoic_500_v
-;
-
-CREATE OR REPLACE VIEW edi_cctop_invoic_500_v AS
+CREATE OR REPLACE VIEW edi_cctop_invoic_500_v$new AS
 SELECT SUM(il.qtyEntered)                                                        AS QtyInvoiced,
        CASE
            WHEN u.x12de355 = 'TU' THEN 'PCE'
@@ -165,9 +145,11 @@ GROUP BY il.c_invoice_id,
 ORDER BY COALESCE(ol.line, il.line)
 ;
 
-COMMENT ON VIEW edi_cctop_invoic_500_v IS 'Notes:
-we output the Qty in the customer''s UOM (i.e. QtyEntered), but we call it QtyInvoiced for historical reasons.
-task 08878: Note: we try to aggregate ils which have the same order line. Grouping by C_OrderLine_ID to make sure that we don''t aggregate too much;
-task 09182: in OrderPOReference and OrderLine we show reference and line for the original order, but fall back to the invoice''s own reference and line if there is no order(line).
-'
-;
+SELECT db_alter_view(
+    'edi_cctop_invoic_500_v',
+    (SELECT view_definition
+     FROM information_schema.views
+     WHERE lower(views.table_name) = lower('edi_cctop_invoic_500_v$new'))
+);
+
+DROP VIEW IF EXISTS edi_cctop_invoic_500_v$new;

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5812520_sys_edi_cctop_119_v_exclude_packaging_material.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5812520_sys_edi_cctop_119_v_exclude_packaging_material.sql
@@ -1,9 +1,13 @@
--- View: EDI_Cctop_119_v
+-- Source DDL: backend/de.metas.edi/src/main/sql/postgresql/ddl/views/edi_cctop_119_v_view.sql
+-- EDI INVOIC party view: exclude packaging-material invoice lines from the ship (DP), snum (SN)
+-- and cust (BY) location resolution. A packaging line has no C_OrderLine_ID, so it falls through
+-- to the "no C_Order" branch (i.C_BPartner_Location_ID) and, via SELECT DISTINCT, emitted a
+-- spurious second party row (two DP addresses). Filtering IsPackagingMaterial='N' removes it
+-- without a per-invoice ORDER BY/LIMIT (which broke performance).
 
-DROP VIEW IF EXISTS EDI_Cctop_119_v
-;
+DROP VIEW IF EXISTS edi_cctop_119_v$new;
 
-CREATE OR REPLACE VIEW EDI_Cctop_119_v AS
+CREATE OR REPLACE VIEW edi_cctop_119_v$new AS
 SELECT lookup.C_Invoice_ID                                               AS EDI_Cctop_119_v_ID,
        lookup.C_Invoice_ID,
        lookup.C_Invoice_ID                                               AS EDI_Cctop_INVOIC_v_ID,
@@ -186,3 +190,12 @@ ORDER BY (
                                 ELSE 'Error EANCOM_Type'::TEXT
           END)
 ;
+
+SELECT db_alter_view(
+    'edi_cctop_119_v',
+    (SELECT view_definition
+     FROM information_schema.views
+     WHERE lower(views.table_name) = lower('edi_cctop_119_v$new'))
+);
+
+DROP VIEW IF EXISTS edi_cctop_119_v$new;

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5812520_sys_edi_cctop_119_v_exclude_packaging_material.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5812520_sys_edi_cctop_119_v_exclude_packaging_material.sql
@@ -151,7 +151,7 @@ FROM (SELECT union_lookup.*
                             NULL::TEXT           AS GLN_Override,
                             i.CreatedBy
             FROM C_Invoice i
-                     INNER JOIN C_Invoiceline il ON il.C_Invoice_ID = i.C_Invoice_ID AND il.ispackagingmaterial = 'N' /* exclude package-lines that have no c_orderline_id, to avoid two 'ship' rows in conjunction with the "Fallback if the C_Invoice has no C_Order "*/
+                     INNER JOIN C_Invoiceline il ON il.C_Invoice_ID = i.C_Invoice_ID AND il.ispackagingmaterial = 'N' /* exclude package-lines that have no c_orderline_id, to avoid two 'snum' rows in conjunction with the "Fallback if the C_Invoice has no C_Order "*/
                      LEFT JOIN C_OrderLine ol ON ol.C_OrderLine_ID = il.C_OrderLine_ID
                      LEFT JOIN C_Order o ON o.C_Order_ID = ol.C_Order_ID
                      LEFT JOIN M_InOutline sl ON ( -- try to join directly from C_InvoiceLine

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5812530_sys_AD_Message_NotExistsNonPackagingInvoiceLine.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5812530_sys_AD_Message_NotExistsNonPackagingInvoiceLine.sql
@@ -1,0 +1,31 @@
+-- AD_Message for EDIDocumentBL.isValidInvoice guard: an invoice whose lines are all packaging
+-- material has no exportable INVOIC line and must fail EDI validation loudly (resolved via the
+-- @NotExistsNonPackagingInvoiceLineError@ marker in EDIMissingDependencyException).
+
+-- 1. the message (base text = German)
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545773 /*From ID Server*/,0,TO_TIMESTAMP('2026-07-07 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y',
+        'Die Rechnung enthält nur Verpackungsmaterial-Positionen und keine exportierbare Position; ein EDI-Versand ist nicht möglich.',
+        'E',TO_TIMESTAMP('2026-07-07 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'NotExistsNonPackagingInvoiceLineError');
+
+-- 2. short ErrorCode
+UPDATE AD_Message SET ErrorCode='NonPackagingInvoiceLineMissing', Updated=TO_TIMESTAMP('2026-07-07 10:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Message_ID=545773;
+
+-- 3. seed AD_Message_Trl for ALL active system languages with the base (DE) text, IsTranslated='N'
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545773
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID);
+
+-- 4. en_US override (the real English text) + IsTranslated='Y'
+UPDATE AD_Message_Trl SET MsgText='The invoice contains only packaging-material lines and no exportable line; an EDI export is not possible.',
+       IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-07 10:00:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='en_US' AND AD_Message_ID=545773;
+
+-- 5. flip de_DE + de_CH to IsTranslated='Y' (their text already equals the DE base)
+UPDATE AD_Message_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-07 10:00:03','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='de_DE' AND AD_Message_ID=545773;
+UPDATE AD_Message_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-07 10:00:04','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Language='de_CH' AND AD_Message_ID=545773;


### PR DESCRIPTION
## What

Packaging-material invoice lines (deposit / Leergut, pallets — `C_InvoiceLine.IsPackagingMaterial='Y'`) carry no `C_OrderLine_ID`. On EDI INVOIC export this caused three problems:

- the mandatory-`C_OrderLine_ID` validation rejected the whole invoice;
- the packaging line was exported as an INVOIC line item;
- a spurious **second** delivery-party (`DP`) / `SN` / `BY` address appeared — the order-less line fell through the party-location `CASE` to the invoice's own `C_BPartner_Location_ID`, and `SELECT DISTINCT` emitted it as an extra party row.

## Change

- **`EDIDocumentBL.isValidInvoice`** — exempt packaging-material lines from the mandatory `C_OrderLine_ID` check; and, to keep the boundary case loud, fail with a new user-facing message (`NotExistsNonPackagingInvoiceLineError`) when an invoice's lines are *all* packaging material (which would otherwise pass and export an empty INVOIC).
- **`edi_cctop_invoic_500_v`** — exclude packaging lines from the exported INVOIC `Lines`.
- **`edi_cctop_119_v`** — exclude packaging lines from the `ship` (DP), `snum` (SN) and `cust` (BY) party-location resolution (the `cust` guard is on the `LEFT JOIN` `ON` clause, preserving the fallback row for line-less invoices).
- Migrations `5812510` / `5812520` (`db_alter_view`) for the two views, `5812530` for the `AD_Message`.
- Cucumber: `ediInvoicExport` scenario asserting a packaging-material line is excluded from the exported `Lines`; `C_InvoiceLine` stepdef gains an optional `IsPackagingMaterial` column.
