### PR TITLE
Carry candidate locators onto DD_OrderLine + gated locator-aware aggregation

### DIFF
--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
@@ -343,6 +343,8 @@ class DDOrderCandidateProcessCommand
 		boolean aggregateByPPOrderRef;
 		boolean aggregateBySalesOrderLineId;
 		boolean aggregateByProductId;
+		boolean aggregateByLocatorFrom;
+		boolean aggregateByLocatorTo;
 	}
 	//
 	//
@@ -376,8 +378,12 @@ class DDOrderCandidateProcessCommand
 
 		@Nullable ProductId productId;
 
-		@NonNull LocatorId sourceLocatorId;
-		@NonNull LocatorId targetLocatorId;
+		// Locators are part of the header key only when the corresponding sysconfig is enabled
+		// (DDOrderAggregation.header.byLocatorFrom / .byLocatorTo). When disabled they stay null here,
+		// so candidates that differ only by locator share one DD_Order header. The DD_OrderLine still
+		// carries the resolved locator unconditionally — that comes from LineAggregationKey, not this key.
+		@Nullable LocatorId sourceLocatorId;
+		@Nullable LocatorId targetLocatorId;
 
 		public static HeaderAggregationKey of(
 				@NonNull final DDOrderCandidate candidate,
@@ -396,9 +402,15 @@ class DDOrderCandidateProcessCommand
 					.shipperId(candidate.getShipperId())
 					.isSimulated(candidate.isSimulated())
 					.productPlanningId(candidate.getProductPlanningId())
-					.traceId(candidate.getTraceId())
-					.sourceLocatorId(sourceLocatorId)
-					.targetLocatorId(targetLocatorId);
+					.traceId(candidate.getTraceId());
+			if (aggregationConfig.isAggregateByLocatorFrom())
+			{
+				keyBuilder.sourceLocatorId(sourceLocatorId);
+			}
+			if (aggregationConfig.isAggregateByLocatorTo())
+			{
+				keyBuilder.targetLocatorId(targetLocatorId);
+			}
 			if (aggregationConfig.isAggregateBySalesOrderId())
 			{
 				keyBuilder.salesOrderId(candidate.getSalesOrderId());

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
@@ -327,6 +327,7 @@ class DDOrderCandidateProcessCommand
 		boolean aggregateByPPOrderRef;
 		boolean aggregateBySalesOrderLineId;
 		boolean aggregateByProductId;
+		boolean aggregateByLocatorId;
 	}
 	//
 	//

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
@@ -331,7 +331,6 @@ class DDOrderCandidateProcessCommand
 		boolean aggregateByPPOrderRef;
 		boolean aggregateBySalesOrderLineId;
 		boolean aggregateByProductId;
-		boolean aggregateByLocatorId;
 	}
 	//
 	//
@@ -394,11 +393,8 @@ class DDOrderCandidateProcessCommand
 			{
 				keyBuilder.productId(candidate.getProductId());
 			}
-			if (aggregationConfig.isAggregateByLocatorId())
-			{
-				keyBuilder.sourceLocatorId(candidate.getSourceLocatorId());
-				keyBuilder.targetLocatorId(candidate.getTargetLocatorId());
-			}
+			keyBuilder.sourceLocatorId(candidate.getSourceLocatorId());
+			keyBuilder.targetLocatorId(candidate.getTargetLocatorId());
 			return keyBuilder.build();
 		}
 	}
@@ -478,11 +474,8 @@ class DDOrderCandidateProcessCommand
 			{
 				lineKeyBuilder.salesOrderLineId(candidate.getSalesOrderLineId());
 			}
-			if (aggregationConfig.isAggregateByLocatorId())
-			{
-				lineKeyBuilder.sourceLocatorId(candidate.getSourceLocatorId());
-				lineKeyBuilder.targetLocatorId(candidate.getTargetLocatorId());
-			}
+			lineKeyBuilder.sourceLocatorId(candidate.getSourceLocatorId());
+			lineKeyBuilder.targetLocatorId(candidate.getTargetLocatorId());
 			return lineKeyBuilder
 					.build();
 		}

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
@@ -55,6 +55,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Objects;
 
@@ -85,6 +86,8 @@ class DDOrderCandidateProcessCommand
 	// State
 	private final LinkedHashMap<HeaderAggregationKey, HeaderAggregate> aggregates = new LinkedHashMap<>();
 	private final AggregationConfig aggregationConfig;
+	/** memoizes the warehouse default locator so the null-locator fallback resolves once per warehouse, not once per candidate */
+	private final HashMap<WarehouseId, LocatorId> defaultLocatorByWarehouse = new HashMap<>();
 
 	@Builder
 	private DDOrderCandidateProcessCommand(
@@ -132,10 +135,25 @@ class DDOrderCandidateProcessCommand
 
 	private void addToAggregates(@NonNull final DDOrderCandidate ddOrderCandidate)
 	{
-		final HeaderAggregationKey headerAggregationKey = HeaderAggregationKey.of(ddOrderCandidate, aggregationConfig);
+		// Resolve the source/target locators once here (candidate's own, else the warehouse default) so the
+		// aggregation key always carries concrete, non-null locators and createLine just reads them.
+		final LocatorId sourceLocatorId = resolveLocatorId(ddOrderCandidate.getSourceLocatorId(), ddOrderCandidate.getSourceWarehouseId());
+		final LocatorId targetLocatorId = resolveLocatorId(ddOrderCandidate.getTargetLocatorId(), ddOrderCandidate.getTargetWarehouseId());
+
+		final HeaderAggregationKey headerAggregationKey = HeaderAggregationKey.of(ddOrderCandidate, aggregationConfig, sourceLocatorId, targetLocatorId);
 
 		aggregates.computeIfAbsent(headerAggregationKey, aggKey -> new HeaderAggregate(aggKey, aggregationConfig))
-				.add(ddOrderCandidate);
+				.add(ddOrderCandidate, sourceLocatorId, targetLocatorId);
+	}
+
+	@NonNull
+	private LocatorId resolveLocatorId(@Nullable final LocatorId candidateLocatorId, @NonNull final WarehouseId warehouseId)
+	{
+		if (candidateLocatorId != null)
+		{
+			return candidateLocatorId;
+		}
+		return defaultLocatorByWarehouse.computeIfAbsent(warehouseId, warehouseBL::getOrCreateDefaultLocatorId);
 	}
 
 	private void createDDOrder(@NonNull final HeaderAggregate headerAggregate,
@@ -268,15 +286,9 @@ class DDOrderCandidateProcessCommand
 		lineRecord.setDD_NetworkDistributionLine_ID(distributionNetworkAndLineId != null ? distributionNetworkAndLineId.getLineId().getRepoId() : -1);
 
 		//
-		// Locator From/To
-		final LocatorId locatorFromId = key.getSourceLocatorId() != null
-				? key.getSourceLocatorId()
-				: warehouseBL.getOrCreateDefaultLocatorId(WarehouseId.ofRepoId(header.getM_Warehouse_From_ID()));
-		final LocatorId locatorToId = key.getTargetLocatorId() != null
-				? key.getTargetLocatorId()
-				: warehouseBL.getOrCreateDefaultLocatorId(WarehouseId.ofRepoId(header.getM_Warehouse_To_ID()));
-		lineRecord.setM_Locator_ID(locatorFromId.getRepoId());
-		lineRecord.setM_LocatorTo_ID(locatorToId.getRepoId());
+		// Locator From/To — resolved (candidate's own, else warehouse default) already in the key
+		lineRecord.setM_Locator_ID(key.getSourceLocatorId().getRepoId());
+		lineRecord.setM_LocatorTo_ID(key.getTargetLocatorId().getRepoId());
 
 		//
 		// Product, UOM, Qty
@@ -364,10 +376,14 @@ class DDOrderCandidateProcessCommand
 
 		@Nullable ProductId productId;
 
-		@Nullable LocatorId sourceLocatorId;
-		@Nullable LocatorId targetLocatorId;
+		@NonNull LocatorId sourceLocatorId;
+		@NonNull LocatorId targetLocatorId;
 
-		public static HeaderAggregationKey of(@NonNull final DDOrderCandidate candidate, @NonNull final AggregationConfig aggregationConfig)
+		public static HeaderAggregationKey of(
+				@NonNull final DDOrderCandidate candidate,
+				@NonNull final AggregationConfig aggregationConfig,
+				@NonNull final LocatorId sourceLocatorId,
+				@NonNull final LocatorId targetLocatorId)
 		{
 			final HeaderAggregationKeyBuilder keyBuilder = builder()
 					.orgId(candidate.getOrgId())
@@ -380,7 +396,9 @@ class DDOrderCandidateProcessCommand
 					.shipperId(candidate.getShipperId())
 					.isSimulated(candidate.isSimulated())
 					.productPlanningId(candidate.getProductPlanningId())
-					.traceId(candidate.getTraceId());
+					.traceId(candidate.getTraceId())
+					.sourceLocatorId(sourceLocatorId)
+					.targetLocatorId(targetLocatorId);
 			if (aggregationConfig.isAggregateBySalesOrderId())
 			{
 				keyBuilder.salesOrderId(candidate.getSalesOrderId());
@@ -393,8 +411,6 @@ class DDOrderCandidateProcessCommand
 			{
 				keyBuilder.productId(candidate.getProductId());
 			}
-			keyBuilder.sourceLocatorId(candidate.getSourceLocatorId());
-			keyBuilder.targetLocatorId(candidate.getTargetLocatorId());
 			return keyBuilder.build();
 		}
 	}
@@ -412,9 +428,9 @@ class DDOrderCandidateProcessCommand
 		@NonNull private final LinkedHashMap<LineAggregationKey, LineAggregate> lineAggregates = new LinkedHashMap<>();
 		@NonNull private final AggregationConfig aggregationConfig;
 
-		public void add(@NonNull final DDOrderCandidate candidate)
+		public void add(@NonNull final DDOrderCandidate candidate, @NonNull final LocatorId sourceLocatorId, @NonNull final LocatorId targetLocatorId)
 		{
-			lineAggregates.computeIfAbsent(LineAggregationKey.of(candidate, aggregationConfig), LineAggregate::new)
+			lineAggregates.computeIfAbsent(LineAggregationKey.of(candidate, aggregationConfig, sourceLocatorId, targetLocatorId), LineAggregate::new)
 					.add(candidate);
 		}
 
@@ -457,10 +473,14 @@ class DDOrderCandidateProcessCommand
 		boolean isAllowPush;
 		boolean isKeepTargetPlant;
 
-		@Nullable LocatorId sourceLocatorId;
-		@Nullable LocatorId targetLocatorId;
+		@NonNull LocatorId sourceLocatorId;
+		@NonNull LocatorId targetLocatorId;
 
-		public static LineAggregationKey of(final DDOrderCandidate candidate, final @NonNull AggregationConfig aggregationConfig)
+		public static LineAggregationKey of(
+				final DDOrderCandidate candidate,
+				final @NonNull AggregationConfig aggregationConfig,
+				final @NonNull LocatorId sourceLocatorId,
+				final @NonNull LocatorId targetLocatorId)
 		{
 			final LineAggregationKeyBuilder lineKeyBuilder = builder()
 					.productId(candidate.getProductId())
@@ -469,13 +489,13 @@ class DDOrderCandidateProcessCommand
 					.uomId(candidate.getQtyEntered().getUomId())
 					.distributionNetworkAndLineId(candidate.getDistributionNetworkAndLineId())
 					.isAllowPush(candidate.isAllowPush())
-					.isKeepTargetPlant(candidate.isKeepTargetPlant());
+					.isKeepTargetPlant(candidate.isKeepTargetPlant())
+					.sourceLocatorId(sourceLocatorId)
+					.targetLocatorId(targetLocatorId);
 			if (aggregationConfig.isAggregateBySalesOrderLineId())
 			{
 				lineKeyBuilder.salesOrderLineId(candidate.getSalesOrderLineId());
 			}
-			lineKeyBuilder.sourceLocatorId(candidate.getSourceLocatorId());
-			lineKeyBuilder.targetLocatorId(candidate.getTargetLocatorId());
 			return lineKeyBuilder
 					.build();
 		}

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommand.java
@@ -269,8 +269,12 @@ class DDOrderCandidateProcessCommand
 
 		//
 		// Locator From/To
-		final LocatorId locatorFromId = warehouseBL.getOrCreateDefaultLocatorId(WarehouseId.ofRepoId(header.getM_Warehouse_From_ID()));
-		final LocatorId locatorToId = warehouseBL.getOrCreateDefaultLocatorId(WarehouseId.ofRepoId(header.getM_Warehouse_To_ID()));
+		final LocatorId locatorFromId = key.getSourceLocatorId() != null
+				? key.getSourceLocatorId()
+				: warehouseBL.getOrCreateDefaultLocatorId(WarehouseId.ofRepoId(header.getM_Warehouse_From_ID()));
+		final LocatorId locatorToId = key.getTargetLocatorId() != null
+				? key.getTargetLocatorId()
+				: warehouseBL.getOrCreateDefaultLocatorId(WarehouseId.ofRepoId(header.getM_Warehouse_To_ID()));
 		lineRecord.setM_Locator_ID(locatorFromId.getRepoId());
 		lineRecord.setM_LocatorTo_ID(locatorToId.getRepoId());
 
@@ -361,6 +365,9 @@ class DDOrderCandidateProcessCommand
 
 		@Nullable ProductId productId;
 
+		@Nullable LocatorId sourceLocatorId;
+		@Nullable LocatorId targetLocatorId;
+
 		public static HeaderAggregationKey of(@NonNull final DDOrderCandidate candidate, @NonNull final AggregationConfig aggregationConfig)
 		{
 			final HeaderAggregationKeyBuilder keyBuilder = builder()
@@ -386,6 +393,11 @@ class DDOrderCandidateProcessCommand
 			if (aggregationConfig.isAggregateByProductId())
 			{
 				keyBuilder.productId(candidate.getProductId());
+			}
+			if (aggregationConfig.isAggregateByLocatorId())
+			{
+				keyBuilder.sourceLocatorId(candidate.getSourceLocatorId());
+				keyBuilder.targetLocatorId(candidate.getTargetLocatorId());
 			}
 			return keyBuilder.build();
 		}
@@ -449,6 +461,9 @@ class DDOrderCandidateProcessCommand
 		boolean isAllowPush;
 		boolean isKeepTargetPlant;
 
+		@Nullable LocatorId sourceLocatorId;
+		@Nullable LocatorId targetLocatorId;
+
 		public static LineAggregationKey of(final DDOrderCandidate candidate, final @NonNull AggregationConfig aggregationConfig)
 		{
 			final LineAggregationKeyBuilder lineKeyBuilder = builder()
@@ -462,6 +477,11 @@ class DDOrderCandidateProcessCommand
 			if (aggregationConfig.isAggregateBySalesOrderLineId())
 			{
 				lineKeyBuilder.salesOrderLineId(candidate.getSalesOrderLineId());
+			}
+			if (aggregationConfig.isAggregateByLocatorId())
+			{
+				lineKeyBuilder.sourceLocatorId(candidate.getSourceLocatorId());
+				lineKeyBuilder.targetLocatorId(candidate.getTargetLocatorId());
 			}
 			return lineKeyBuilder
 					.build();

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
@@ -37,6 +37,8 @@ public class DDOrderCandidateService
 	public static final String SYSCONFIG_DDOrderAggregation_header_byPPOrderRef = "DDOrderAggregation.header.byPPOrderRef";
 	public static final String SYSCONFIG_DDOrderAggregation_line_bySalesOrderLineId = "DDOrderAggregation.line.bySalesOrderLineId";
 	public static final String SYSCONFIG_DDOrderAggregation_header_byProductId = "DDOrderAggregation.header.byProductId";
+	public static final String SYSCONFIG_DDOrderAggregation_header_byLocatorFrom = "DDOrderAggregation.header.byLocatorFrom";
+	public static final String SYSCONFIG_DDOrderAggregation_header_byLocatorTo = "DDOrderAggregation.header.byLocatorTo";
 
 	@NonNull private final DDOrderCandidateRepository ddOrderCandidateRepository;
 	@NonNull private final DDOrderCandidateAllocRepository ddOrderCandidateAllocRepository;
@@ -127,6 +129,8 @@ public class DDOrderCandidateService
 				.aggregateByPPOrderRef(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byPPOrderRef, true))
 				.aggregateBySalesOrderLineId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_line_bySalesOrderLineId, true))
 				.aggregateByProductId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byProductId, false))
+				.aggregateByLocatorFrom(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byLocatorFrom, false))
+				.aggregateByLocatorTo(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byLocatorTo, false))
 				.build();
 	}
 

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
@@ -37,6 +37,7 @@ public class DDOrderCandidateService
 	public static final String SYSCONFIG_DDOrderAggregation_header_byPPOrderRef = "DDOrderAggregation.header.byPPOrderRef";
 	public static final String SYSCONFIG_DDOrderAggregation_line_bySalesOrderLineId = "DDOrderAggregation.line.bySalesOrderLineId";
 	public static final String SYSCONFIG_DDOrderAggregation_header_byProductId = "DDOrderAggregation.header.byProductId";
+	public static final String SYSCONFIG_DDOrderAggregation_header_byLocatorId = "DDOrderAggregation.header.byLocatorId";
 
 	@NonNull private final DDOrderCandidateRepository ddOrderCandidateRepository;
 	@NonNull private final DDOrderCandidateAllocRepository ddOrderCandidateAllocRepository;
@@ -127,6 +128,7 @@ public class DDOrderCandidateService
 				.aggregateByPPOrderRef(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byPPOrderRef, true))
 				.aggregateBySalesOrderLineId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_line_bySalesOrderLineId, true))
 				.aggregateByProductId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byProductId, false))
+				.aggregateByLocatorId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byLocatorId, false))
 				.build();
 	}
 

--- a/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
+++ b/backend/de.metas.manufacturing/src/main/java/de/metas/distribution/ddordercandidate/DDOrderCandidateService.java
@@ -37,7 +37,6 @@ public class DDOrderCandidateService
 	public static final String SYSCONFIG_DDOrderAggregation_header_byPPOrderRef = "DDOrderAggregation.header.byPPOrderRef";
 	public static final String SYSCONFIG_DDOrderAggregation_line_bySalesOrderLineId = "DDOrderAggregation.line.bySalesOrderLineId";
 	public static final String SYSCONFIG_DDOrderAggregation_header_byProductId = "DDOrderAggregation.header.byProductId";
-	public static final String SYSCONFIG_DDOrderAggregation_header_byLocatorId = "DDOrderAggregation.header.byLocatorId";
 
 	@NonNull private final DDOrderCandidateRepository ddOrderCandidateRepository;
 	@NonNull private final DDOrderCandidateAllocRepository ddOrderCandidateAllocRepository;
@@ -128,7 +127,6 @@ public class DDOrderCandidateService
 				.aggregateByPPOrderRef(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byPPOrderRef, true))
 				.aggregateBySalesOrderLineId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_line_bySalesOrderLineId, true))
 				.aggregateByProductId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byProductId, false))
-				.aggregateByLocatorId(sysConfigBL.getBooleanValue(SYSCONFIG_DDOrderAggregation_header_byLocatorId, false))
 				.build();
 	}
 

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812710_sys_DDOrderAggregation_header_byLocatorId.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812710_sys_DDOrderAggregation_header_byLocatorId.sql
@@ -1,8 +1,0 @@
--- Run mode: SWING_CLIENT
-
--- IDs allocated from idserver: AD_MigrationScript=5812710, AD_SysConfig_ID=541833
--- SysConfig Name: DDOrderAggregation.header.byLocatorId
--- SysConfig Value: N
--- When 'Y', the source/target locator is part of the DD_Order header+line aggregation key (one DD_Order per from/to locator move). Default 'N'.
-INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541833 /*From ID Server*/,'O',TO_TIMESTAMP('2026-07-08 11:30:00','YYYY-MM-DD HH24:MI:SS'),100,'When enabled, prevents DD_Order_Candidates of different source/target locators from ending up in the same DD_Order.','D','Y','DDOrderAggregation.header.byLocatorId',TO_TIMESTAMP('2026-07-08 11:30:00','YYYY-MM-DD HH24:MI:SS'),100,'N')
-;

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812710_sys_DDOrderAggregation_header_byLocatorId.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812710_sys_DDOrderAggregation_header_byLocatorId.sql
@@ -1,0 +1,8 @@
+-- Run mode: SWING_CLIENT
+
+-- IDs allocated from idserver: AD_MigrationScript=5812710, AD_SysConfig_ID=541833
+-- SysConfig Name: DDOrderAggregation.header.byLocatorId
+-- SysConfig Value: N
+-- When 'Y', the source/target locator is part of the DD_Order header+line aggregation key (one DD_Order per from/to locator move). Default 'N'.
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541833 /*From ID Server*/,'O',TO_TIMESTAMP('2026-07-08 11:30:00','YYYY-MM-DD HH24:MI:SS'),100,'When enabled, prevents DD_Order_Candidates of different source/target locators from ending up in the same DD_Order.','D','Y','DDOrderAggregation.header.byLocatorId',TO_TIMESTAMP('2026-07-08 11:30:00','YYYY-MM-DD HH24:MI:SS'),100,'N')
+;

--- a/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812770_sys_DDOrderAggregation_header_byLocator.sql
+++ b/backend/de.metas.manufacturing/src/main/sql/postgresql/system/30-de.metas.adempiere.libero/5812770_sys_DDOrderAggregation_header_byLocator.sql
@@ -1,0 +1,17 @@
+-- Run mode: SWING_CLIENT
+
+-- SysConfig Name: DDOrderAggregation.header.byLocatorFrom
+-- SysConfig Value: N
+-- When 'Y', the (resolved) source locator is part of the DD_Order header aggregation key -> one source
+-- locator per DD_Order. Default 'N' (header does not split by source locator). The DD_OrderLine always
+-- carries the resolved source locator regardless of this flag (line-level aggregation is unconditional).
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541834 /*From ID Server*/,'O',TO_TIMESTAMP('2026-07-08 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'If enabled, the source locator is part of the DD_Order header aggregation key (one source locator per DD_Order). The DD_OrderLine always carries the resolved locator regardless.','D','Y','DDOrderAggregation.header.byLocatorFrom',TO_TIMESTAMP('2026-07-08 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'N')
+;
+
+-- SysConfig Name: DDOrderAggregation.header.byLocatorTo
+-- SysConfig Value: N
+-- When 'Y', the (resolved) target locator is part of the DD_Order header aggregation key -> one target
+-- locator per DD_Order. Default 'N' (header does not split by target locator). The DD_OrderLine always
+-- carries the resolved target locator regardless of this flag (line-level aggregation is unconditional).
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value) VALUES (0,0,541835 /*From ID Server*/,'O',TO_TIMESTAMP('2026-07-08 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'If enabled, the target locator is part of the DD_Order header aggregation key (one target locator per DD_Order). The DD_OrderLine always carries the resolved locator regardless.','D','Y','DDOrderAggregation.header.byLocatorTo',TO_TIMESTAMP('2026-07-08 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'N')
+;

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
@@ -254,7 +254,14 @@ class DDOrderCandidateProcessCommandTest
 
 		final List<I_DD_Order> orders = queryOrders();
 		assertThat(orders).hasSize(1);
-		assertThat(queryLines(orders.get(0))).hasSize(1);
+
+		final List<I_DD_OrderLine> lines = queryLines(orders.get(0));
+		assertThat(lines).hasSize(1);
+		// AC4 byte-for-byte: with the knob off the candidate's own locators (1001/1002/1003) are ignored
+		// and the warehouse default locator (stubbed to repoId 540003 for every warehouse) is used — the
+		// exact prior behaviour of createLine before this change.
+		assertThat(lines.get(0).getM_Locator_ID()).isEqualTo(540003);
+		assertThat(lines.get(0).getM_LocatorTo_ID()).isEqualTo(540003);
 	}
 
 	/**

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
@@ -45,22 +45,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Regression test for the NPE that occurred while processing a {@link DDOrderCandidate} whose
- * {@code productPlanningId} is {@code null} (no product planning).
- * <p>
- * The header-record creation used to dereference {@code productPlanningDAO.getById(null)} unconditionally;
- * with no product planning this threw a {@link NullPointerException}. The fix guards the lookup and clears
- * {@code PP_Product_Planning_ID} / {@code AD_User_ID} / {@code SalesRep_ID} with the {@code -1} sentinel.
- * <p>
- * Also covers the optional {@code aggregateByProductId} header-aggregation dimension: with the flag off,
- * candidates of different products share one DD_Order (one line each); with it on, each product gets its
- * own DD_Order.
- * <p>
- * Also covers locator handling: the candidate's {@code sourceLocatorId}/{@code targetLocatorId} are
- * <b>unconditionally</b> part of the aggregation key and are carried onto the generated line -- distinct
- * grounds (locators) always get their own DD_Order. When a candidate has no locator, the warehouse's
- * get-create default locator is used instead (per side), which is what keeps existing (null-locator)
- * customers byte-for-byte unchanged.
+ * Unit tests for {@link DDOrderCandidateProcessCommand} — see each test method for its case.
  */
 class DDOrderCandidateProcessCommandTest
 {

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
@@ -55,6 +55,11 @@ import static org.mockito.Mockito.when;
  * Also covers the optional {@code aggregateByProductId} header-aggregation dimension: with the flag off,
  * candidates of different products share one DD_Order (one line each); with it on, each product gets its
  * own DD_Order.
+ * <p>
+ * Also covers locator handling: the candidate's {@code sourceLocatorId}/{@code targetLocatorId} must be
+ * carried onto the generated line, and the optional {@code aggregateByLocatorId} dimension must give each
+ * distinct ground (locator) its own DD_Order when on, while candidates keep collapsing into one DD_Order
+ * when off.
  */
 class DDOrderCandidateProcessCommandTest
 {
@@ -183,10 +188,9 @@ class DDOrderCandidateProcessCommandTest
 	}
 
 	/**
-	 * RED (me03 30782 CASE 14): today {@code createLine} ignores the candidate's source/target locators and always
-	 * falls back to {@code warehouseBL.getOrCreateDefaultLocatorId(...)}, which this test's harness stubs to
-	 * locator repoId 540003 for every warehouse. A candidate that carries its own locators (distinct from 540003)
-	 * must have those locators carried onto the generated line instead.
+	 * A candidate that carries its own {@code sourceLocatorId}/{@code targetLocatorId} must have those locators
+	 * carried onto the generated DD_Order line, rather than falling back to the warehouse default locator
+	 * (which the harness stubs to locator repoId 540003 for every warehouse).
 	 */
 	@Test
 	void locatorsCarriedOntoLine()
@@ -224,10 +228,9 @@ class DDOrderCandidateProcessCommandTest
 	}
 
 	/**
-	 * RED (me03 30782 CASE 14): today neither the header nor the line aggregation key considers the candidate's
-	 * locators, so two candidates that differ only by {@code targetLocatorId} (i.e. different grounds) still
-	 * collapse into a single DD_Order with a single aggregated line. Once locators are part of the aggregation
-	 * key, each ground must get its own order+line.
+	 * With {@code aggregateByLocatorId=true}, two candidates that differ only by {@code targetLocatorId}
+	 * (i.e. different grounds) must each get their own DD_Order with a single line, rather than collapsing
+	 * into one DD_Order with a single aggregated line.
 	 */
 	@Test
 	void oneOrderOneLinePerMove()
@@ -263,9 +266,9 @@ class DDOrderCandidateProcessCommandTest
 	}
 
 	/**
-	 * Control for {@link #oneOrderOneLinePerMove()}: with {@code aggregateByLocatorId=false} (today's behaviour,
-	 * and still the behaviour once the flag exists but is off), the two per-ground candidates collapse into ONE
-	 * DD_Order with a single aggregated line. This must pass both today and after Task 2's fix.
+	 * Control for {@link #oneOrderOneLinePerMove()}: with {@code aggregateByLocatorId=false} the two per-ground
+	 * candidates collapse into ONE DD_Order with a single aggregated line (locators are not part of the
+	 * aggregation key when the flag is off).
 	 */
 	@Test
 	void flagOff_unchanged()

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
@@ -213,14 +213,57 @@ class DDOrderCandidateProcessCommandTest
 	}
 
 	/**
-	 * Locator aggregation is unconditional: two candidates that differ only by {@code targetLocatorId}
-	 * (i.e. different grounds) must each get their own DD_Order with a single line, rather than collapsing
-	 * into one DD_Order with a single aggregated line.
+	 * Header locator aggregation is OFF by default ({@code DDOrderAggregation.header.byLocatorTo=false}):
+	 * two candidates that differ only by {@code targetLocatorId} collapse into ONE DD_Order, yet still get a
+	 * separate line each because the line aggregation key always carries the locator (line-level is unconditional).
 	 */
 	@Test
-	void oneOrderOneLinePerMove()
+	void twoGrounds_byLocatorToDisabled_singleDDOrderWithTwoLines()
 	{
-		processTwoGroundCandidates();
+		processTwoGroundCandidates(false);
+
+		final List<I_DD_Order> orders = queryOrders();
+		assertThat(orders).hasSize(1);
+		assertThat(queryLines(orders.get(0))).hasSize(2);
+	}
+
+	/**
+	 * With {@code DDOrderAggregation.header.byLocatorTo=true}: the same two candidates (differing only by
+	 * {@code targetLocatorId}, i.e. different grounds) produce TWO DD_Orders, each with a single line.
+	 */
+	@Test
+	void twoGrounds_byLocatorToEnabled_twoSingleLineDDOrders()
+	{
+		processTwoGroundCandidates(true);
+
+		final List<I_DD_Order> orders = queryOrders();
+		assertThat(orders).hasSize(2);
+		assertThat(orders).allSatisfy(order -> assertThat(queryLines(order)).hasSize(1));
+	}
+
+	/**
+	 * Header locator aggregation is OFF by default ({@code DDOrderAggregation.header.byLocatorFrom=false}):
+	 * two candidates that differ only by {@code sourceLocatorId} collapse into ONE DD_Order with a separate
+	 * line each (line key always carries the locator).
+	 */
+	@Test
+	void twoSourceGrounds_byLocatorFromDisabled_singleDDOrderWithTwoLines()
+	{
+		processTwoSourceGroundCandidates(false);
+
+		final List<I_DD_Order> orders = queryOrders();
+		assertThat(orders).hasSize(1);
+		assertThat(queryLines(orders.get(0))).hasSize(2);
+	}
+
+	/**
+	 * With {@code DDOrderAggregation.header.byLocatorFrom=true}: the same two candidates (differing only by
+	 * {@code sourceLocatorId}) produce TWO DD_Orders, each with a single line.
+	 */
+	@Test
+	void twoSourceGrounds_byLocatorFromEnabled_twoSingleLineDDOrders()
+	{
+		processTwoSourceGroundCandidates(true);
 
 		final List<I_DD_Order> orders = queryOrders();
 		assertThat(orders).hasSize(2);
@@ -249,14 +292,14 @@ class DDOrderCandidateProcessCommandTest
 	}
 
 	/**
-	 * Boundary of the unconditional aggregation: a candidate that carries explicit locators must NOT collapse
-	 * with an otherwise-identical candidate that has none. Because locators are always part of the key, the
-	 * explicit-locator candidate (key holds the concrete locator) and the null-locator candidate (key holds
-	 * {@code null}) compare unequal, so each gets its own DD_Order. The null-locator line still falls back to
-	 * the warehouse default (540003).
+	 * With header locator aggregation ENABLED ({@code byLocatorFrom=byLocatorTo=true}): a candidate that carries
+	 * explicit locators must NOT collapse with an otherwise-identical candidate that has none. The explicit-locator
+	 * candidate's header key holds its concrete locators (1001/1002); the null-locator candidate's key holds the
+	 * warehouse-default locators (540003/540003), so the two headers compare unequal and each gets its own DD_Order.
+	 * The null-locator line still falls back to the warehouse default (540003).
 	 */
 	@Test
-	void locatorPresentAndAbsent_notCollapsed()
+	void locatorPresentAndAbsent_byLocatorEnabled_notCollapsed()
 	{
 		final DDOrderCandidate base = DDOrderCandidateRepositoryTest.newFullyFilled();
 		final DDOrderCandidate withLocators = base.toBuilder()
@@ -272,6 +315,8 @@ class DDOrderCandidateProcessCommandTest
 						.aggregateBySalesOrderId(true)
 						.aggregateByPPOrderRef(true)
 						.aggregateBySalesOrderLineId(true)
+						.aggregateByLocatorFrom(true)
+						.aggregateByLocatorTo(true)
 						.build())
 				.request(DDOrderCandidateProcessRequest.builder()
 						.userId(UserId.METASFRESH)
@@ -293,7 +338,7 @@ class DDOrderCandidateProcessCommandTest
 	 * {@code newFullyFilled()} call creates a fresh UOM with a distinct id, which would otherwise split the
 	 * line aggregation by UOM and defeat the "differ only by locator" intent).
 	 */
-	private void processTwoGroundCandidates()
+	private void processTwoGroundCandidates(final boolean aggregateByLocatorTo)
 	{
 		final DDOrderCandidate base = DDOrderCandidateRepositoryTest.newFullyFilled();
 		final DDOrderCandidate move1 = base.toBuilder()
@@ -312,6 +357,41 @@ class DDOrderCandidateProcessCommandTest
 						.aggregateBySalesOrderId(true)
 						.aggregateByPPOrderRef(true)
 						.aggregateBySalesOrderLineId(true)
+						.aggregateByLocatorTo(aggregateByLocatorTo)
+						.build())
+				.request(DDOrderCandidateProcessRequest.builder()
+						.userId(UserId.METASFRESH)
+						.candidates(ImmutableList.of(move1, move2))
+						.build())
+				.build()
+				.execute();
+	}
+
+	/**
+	 * Like {@link #processTwoGroundCandidates(boolean)} but the two candidates differ only by their
+	 * {@code sourceLocatorId} (two source grounds under the same source warehouse); runs with the given
+	 * {@code aggregateByLocatorFrom} header setting.
+	 */
+	private void processTwoSourceGroundCandidates(final boolean aggregateByLocatorFrom)
+	{
+		final DDOrderCandidate base = DDOrderCandidateRepositoryTest.newFullyFilled();
+		final DDOrderCandidate move1 = base.toBuilder()
+				.sourceLocatorId(LocatorId.ofRepoId(60, 1001))
+				.targetLocatorId(LocatorId.ofRepoId(70, 1002))
+				.build();
+		final DDOrderCandidate move2 = base.toBuilder()
+				.sourceLocatorId(LocatorId.ofRepoId(60, 1004))
+				.targetLocatorId(LocatorId.ofRepoId(70, 1002))
+				.build();
+		ddOrderCandidateRepository.save(move1);
+		ddOrderCandidateRepository.save(move2);
+
+		commandBuilder
+				.aggregationConfig(DDOrderCandidateProcessCommand.AggregationConfig.builder()
+						.aggregateBySalesOrderId(true)
+						.aggregateByPPOrderRef(true)
+						.aggregateBySalesOrderLineId(true)
+						.aggregateByLocatorFrom(aggregateByLocatorFrom)
 						.build())
 				.request(DDOrderCandidateProcessRequest.builder()
 						.userId(UserId.METASFRESH)

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
@@ -249,6 +249,43 @@ class DDOrderCandidateProcessCommandTest
 	}
 
 	/**
+	 * Boundary of the unconditional aggregation: a candidate that carries explicit locators must NOT collapse
+	 * with an otherwise-identical candidate that has none. Because locators are always part of the key, the
+	 * explicit-locator candidate (key holds the concrete locator) and the null-locator candidate (key holds
+	 * {@code null}) compare unequal, so each gets its own DD_Order. The null-locator line still falls back to
+	 * the warehouse default (540003).
+	 */
+	@Test
+	void locatorPresentAndAbsent_notCollapsed()
+	{
+		final DDOrderCandidate base = DDOrderCandidateRepositoryTest.newFullyFilled();
+		final DDOrderCandidate withLocators = base.toBuilder()
+				.sourceLocatorId(LocatorId.ofRepoId(60, 1001))
+				.targetLocatorId(LocatorId.ofRepoId(70, 1002))
+				.build();
+		final DDOrderCandidate withoutLocators = base.toBuilder().build();
+		ddOrderCandidateRepository.save(withLocators);
+		ddOrderCandidateRepository.save(withoutLocators);
+
+		commandBuilder
+				.aggregationConfig(DDOrderCandidateProcessCommand.AggregationConfig.builder()
+						.aggregateBySalesOrderId(true)
+						.aggregateByPPOrderRef(true)
+						.aggregateBySalesOrderLineId(true)
+						.build())
+				.request(DDOrderCandidateProcessRequest.builder()
+						.userId(UserId.METASFRESH)
+						.candidates(ImmutableList.of(withLocators, withoutLocators))
+						.build())
+				.build()
+				.execute();
+
+		final List<I_DD_Order> orders = queryOrders();
+		assertThat(orders).hasSize(2);
+		assertThat(orders).allSatisfy(order -> assertThat(queryLines(order)).hasSize(1));
+	}
+
+	/**
 	 * Saves two candidates that differ only by their {@code targetLocatorId} (two grounds under the same target
 	 * warehouse) and runs the command.
 	 * <p>

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
@@ -56,10 +56,11 @@ import static org.mockito.Mockito.when;
  * candidates of different products share one DD_Order (one line each); with it on, each product gets its
  * own DD_Order.
  * <p>
- * Also covers locator handling: the candidate's {@code sourceLocatorId}/{@code targetLocatorId} must be
- * carried onto the generated line, and the optional {@code aggregateByLocatorId} dimension must give each
- * distinct ground (locator) its own DD_Order when on, while candidates keep collapsing into one DD_Order
- * when off.
+ * Also covers locator handling: the candidate's {@code sourceLocatorId}/{@code targetLocatorId} are
+ * <b>unconditionally</b> part of the aggregation key and are carried onto the generated line -- distinct
+ * grounds (locators) always get their own DD_Order. When a candidate has no locator, the warehouse's
+ * get-create default locator is used instead (per side), which is what keeps existing (null-locator)
+ * customers byte-for-byte unchanged.
  */
 class DDOrderCandidateProcessCommandTest
 {
@@ -209,7 +210,6 @@ class DDOrderCandidateProcessCommandTest
 						.aggregateBySalesOrderId(true)
 						.aggregateByPPOrderRef(true)
 						.aggregateBySalesOrderLineId(true)
-						.aggregateByLocatorId(true)
 						.build())
 				.request(DDOrderCandidateProcessRequest.builder()
 						.userId(UserId.METASFRESH)
@@ -228,14 +228,14 @@ class DDOrderCandidateProcessCommandTest
 	}
 
 	/**
-	 * With {@code aggregateByLocatorId=true}, two candidates that differ only by {@code targetLocatorId}
+	 * Locator aggregation is unconditional: two candidates that differ only by {@code targetLocatorId}
 	 * (i.e. different grounds) must each get their own DD_Order with a single line, rather than collapsing
 	 * into one DD_Order with a single aggregated line.
 	 */
 	@Test
 	void oneOrderOneLinePerMove()
 	{
-		processTwoGroundCandidates(true);
+		processTwoGroundCandidates();
 
 		final List<I_DD_Order> orders = queryOrders();
 		assertThat(orders).hasSize(2);
@@ -243,36 +243,35 @@ class DDOrderCandidateProcessCommandTest
 	}
 
 	/**
-	 * Control for {@link #oneOrderOneLinePerMove()}: with {@code aggregateByLocatorId=false} the two per-ground
-	 * candidates collapse into ONE DD_Order with a single aggregated line (locators are not part of the
-	 * aggregation key when the flag is off).
+	 * Byte-for-byte control for existing (null-locator) customers: two candidates that have no
+	 * source/target locator at all must still collapse into ONE DD_Order with a single aggregated line
+	 * (both locators are {@code null} in the aggregation key, so they compare equal), and the generated
+	 * line falls back -- per side -- to the warehouse's get-create default locator (stubbed here to repoId
+	 * 540003 for every warehouse).
 	 */
 	@Test
-	void flagOff_unchanged()
+	void nullLocators_defaultAndAggregated()
 	{
-		processTwoGroundCandidates(false);
+		processTwoNullLocatorCandidates();
 
 		final List<I_DD_Order> orders = queryOrders();
 		assertThat(orders).hasSize(1);
 
 		final List<I_DD_OrderLine> lines = queryLines(orders.get(0));
 		assertThat(lines).hasSize(1);
-		// AC4 byte-for-byte: with the knob off the candidate's own locators (1001/1002/1003) are ignored
-		// and the warehouse default locator (stubbed to repoId 540003 for every warehouse) is used — the
-		// exact prior behaviour of createLine before this change.
 		assertThat(lines.get(0).getM_Locator_ID()).isEqualTo(540003);
 		assertThat(lines.get(0).getM_LocatorTo_ID()).isEqualTo(540003);
 	}
 
 	/**
 	 * Saves two candidates that differ only by their {@code targetLocatorId} (two grounds under the same target
-	 * warehouse) and runs the command with the given {@code aggregateByLocatorId} setting.
+	 * warehouse) and runs the command.
 	 * <p>
 	 * Both are derived from a single {@code base} candidate so they share the same UOM instance (each
 	 * {@code newFullyFilled()} call creates a fresh UOM with a distinct id, which would otherwise split the
 	 * line aggregation by UOM and defeat the "differ only by locator" intent).
 	 */
-	private void processTwoGroundCandidates(final boolean aggregateByLocatorId)
+	private void processTwoGroundCandidates()
 	{
 		final DDOrderCandidate base = DDOrderCandidateRepositoryTest.newFullyFilled();
 		final DDOrderCandidate move1 = base.toBuilder()
@@ -291,7 +290,32 @@ class DDOrderCandidateProcessCommandTest
 						.aggregateBySalesOrderId(true)
 						.aggregateByPPOrderRef(true)
 						.aggregateBySalesOrderLineId(true)
-						.aggregateByLocatorId(aggregateByLocatorId)
+						.build())
+				.request(DDOrderCandidateProcessRequest.builder()
+						.userId(UserId.METASFRESH)
+						.candidates(ImmutableList.of(move1, move2))
+						.build())
+				.build()
+				.execute();
+	}
+
+	/**
+	 * Saves two candidates with no source/target locator at all (both {@code null}), sharing the same UOM
+	 * instance (see {@link #processTwoGroundCandidates()}), and runs the command.
+	 */
+	private void processTwoNullLocatorCandidates()
+	{
+		final DDOrderCandidate base = DDOrderCandidateRepositoryTest.newFullyFilled();
+		final DDOrderCandidate move1 = base.toBuilder().build();
+		final DDOrderCandidate move2 = base.toBuilder().build();
+		ddOrderCandidateRepository.save(move1);
+		ddOrderCandidateRepository.save(move2);
+
+		commandBuilder
+				.aggregationConfig(DDOrderCandidateProcessCommand.AggregationConfig.builder()
+						.aggregateBySalesOrderId(true)
+						.aggregateByPPOrderRef(true)
+						.aggregateBySalesOrderLineId(true)
 						.build())
 				.request(DDOrderCandidateProcessRequest.builder()
 						.userId(UserId.METASFRESH)

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
@@ -235,30 +235,7 @@ class DDOrderCandidateProcessCommandTest
 	@Test
 	void oneOrderOneLinePerMove()
 	{
-		final DDOrderCandidate move1 = DDOrderCandidateRepositoryTest.newFullyFilled().toBuilder()
-				.sourceLocatorId(LocatorId.ofRepoId(60, 1001))
-				.targetLocatorId(LocatorId.ofRepoId(70, 1002))
-				.build();
-		final DDOrderCandidate move2 = DDOrderCandidateRepositoryTest.newFullyFilled().toBuilder()
-				.sourceLocatorId(LocatorId.ofRepoId(60, 1001))
-				.targetLocatorId(LocatorId.ofRepoId(70, 1003))
-				.build();
-		ddOrderCandidateRepository.save(move1);
-		ddOrderCandidateRepository.save(move2);
-
-		commandBuilder
-				.aggregationConfig(DDOrderCandidateProcessCommand.AggregationConfig.builder()
-						.aggregateBySalesOrderId(true)
-						.aggregateByPPOrderRef(true)
-						.aggregateBySalesOrderLineId(true)
-						.aggregateByLocatorId(true)
-						.build())
-				.request(DDOrderCandidateProcessRequest.builder()
-						.userId(UserId.METASFRESH)
-						.candidates(ImmutableList.of(move1, move2))
-						.build())
-				.build()
-				.execute();
+		processTwoGroundCandidates(true);
 
 		final List<I_DD_Order> orders = queryOrders();
 		assertThat(orders).hasSize(2);
@@ -273,11 +250,29 @@ class DDOrderCandidateProcessCommandTest
 	@Test
 	void flagOff_unchanged()
 	{
-		final DDOrderCandidate move1 = DDOrderCandidateRepositoryTest.newFullyFilled().toBuilder()
+		processTwoGroundCandidates(false);
+
+		final List<I_DD_Order> orders = queryOrders();
+		assertThat(orders).hasSize(1);
+		assertThat(queryLines(orders.get(0))).hasSize(1);
+	}
+
+	/**
+	 * Saves two candidates that differ only by their {@code targetLocatorId} (two grounds under the same target
+	 * warehouse) and runs the command with the given {@code aggregateByLocatorId} setting.
+	 * <p>
+	 * Both are derived from a single {@code base} candidate so they share the same UOM instance (each
+	 * {@code newFullyFilled()} call creates a fresh UOM with a distinct id, which would otherwise split the
+	 * line aggregation by UOM and defeat the "differ only by locator" intent).
+	 */
+	private void processTwoGroundCandidates(final boolean aggregateByLocatorId)
+	{
+		final DDOrderCandidate base = DDOrderCandidateRepositoryTest.newFullyFilled();
+		final DDOrderCandidate move1 = base.toBuilder()
 				.sourceLocatorId(LocatorId.ofRepoId(60, 1001))
 				.targetLocatorId(LocatorId.ofRepoId(70, 1002))
 				.build();
-		final DDOrderCandidate move2 = DDOrderCandidateRepositoryTest.newFullyFilled().toBuilder()
+		final DDOrderCandidate move2 = base.toBuilder()
 				.sourceLocatorId(LocatorId.ofRepoId(60, 1001))
 				.targetLocatorId(LocatorId.ofRepoId(70, 1003))
 				.build();
@@ -289,7 +284,7 @@ class DDOrderCandidateProcessCommandTest
 						.aggregateBySalesOrderId(true)
 						.aggregateByPPOrderRef(true)
 						.aggregateBySalesOrderLineId(true)
-						.aggregateByLocatorId(false)
+						.aggregateByLocatorId(aggregateByLocatorId)
 						.build())
 				.request(DDOrderCandidateProcessRequest.builder()
 						.userId(UserId.METASFRESH)
@@ -297,9 +292,6 @@ class DDOrderCandidateProcessCommandTest
 						.build())
 				.build()
 				.execute();
-
-		final List<I_DD_Order> orders = queryOrders();
-		assertThat(orders).hasSize(1);
 	}
 
 	private void processTwoProductCandidates(final boolean aggregateByProductId)

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/distribution/ddordercandidate/DDOrderCandidateProcessCommandTest.java
@@ -182,6 +182,123 @@ class DDOrderCandidateProcessCommandTest
 		assertThat(orders).allSatisfy(order -> assertThat(queryLines(order)).hasSize(1));
 	}
 
+	/**
+	 * RED (me03 30782 CASE 14): today {@code createLine} ignores the candidate's source/target locators and always
+	 * falls back to {@code warehouseBL.getOrCreateDefaultLocatorId(...)}, which this test's harness stubs to
+	 * locator repoId 540003 for every warehouse. A candidate that carries its own locators (distinct from 540003)
+	 * must have those locators carried onto the generated line instead.
+	 */
+	@Test
+	void locatorsCarriedOntoLine()
+	{
+		final LocatorId sourceLocatorId = LocatorId.ofRepoId(60, 1001);
+		final LocatorId targetLocatorId = LocatorId.ofRepoId(70, 1002);
+
+		final DDOrderCandidate candidate = DDOrderCandidateRepositoryTest.newFullyFilled().toBuilder()
+				.sourceLocatorId(sourceLocatorId)
+				.targetLocatorId(targetLocatorId)
+				.build();
+		ddOrderCandidateRepository.save(candidate);
+
+		commandBuilder
+				.aggregationConfig(DDOrderCandidateProcessCommand.AggregationConfig.builder()
+						.aggregateBySalesOrderId(true)
+						.aggregateByPPOrderRef(true)
+						.aggregateBySalesOrderLineId(true)
+						.aggregateByLocatorId(true)
+						.build())
+				.request(DDOrderCandidateProcessRequest.builder()
+						.userId(UserId.METASFRESH)
+						.candidates(ImmutableList.of(candidate))
+						.build())
+				.build()
+				.execute();
+
+		final List<I_DD_Order> orders = queryOrders();
+		assertThat(orders).hasSize(1);
+
+		final List<I_DD_OrderLine> lines = queryLines(orders.get(0));
+		assertThat(lines).hasSize(1);
+		assertThat(lines.get(0).getM_Locator_ID()).isEqualTo(sourceLocatorId.getRepoId());
+		assertThat(lines.get(0).getM_LocatorTo_ID()).isEqualTo(targetLocatorId.getRepoId());
+	}
+
+	/**
+	 * RED (me03 30782 CASE 14): today neither the header nor the line aggregation key considers the candidate's
+	 * locators, so two candidates that differ only by {@code targetLocatorId} (i.e. different grounds) still
+	 * collapse into a single DD_Order with a single aggregated line. Once locators are part of the aggregation
+	 * key, each ground must get its own order+line.
+	 */
+	@Test
+	void oneOrderOneLinePerMove()
+	{
+		final DDOrderCandidate move1 = DDOrderCandidateRepositoryTest.newFullyFilled().toBuilder()
+				.sourceLocatorId(LocatorId.ofRepoId(60, 1001))
+				.targetLocatorId(LocatorId.ofRepoId(70, 1002))
+				.build();
+		final DDOrderCandidate move2 = DDOrderCandidateRepositoryTest.newFullyFilled().toBuilder()
+				.sourceLocatorId(LocatorId.ofRepoId(60, 1001))
+				.targetLocatorId(LocatorId.ofRepoId(70, 1003))
+				.build();
+		ddOrderCandidateRepository.save(move1);
+		ddOrderCandidateRepository.save(move2);
+
+		commandBuilder
+				.aggregationConfig(DDOrderCandidateProcessCommand.AggregationConfig.builder()
+						.aggregateBySalesOrderId(true)
+						.aggregateByPPOrderRef(true)
+						.aggregateBySalesOrderLineId(true)
+						.aggregateByLocatorId(true)
+						.build())
+				.request(DDOrderCandidateProcessRequest.builder()
+						.userId(UserId.METASFRESH)
+						.candidates(ImmutableList.of(move1, move2))
+						.build())
+				.build()
+				.execute();
+
+		final List<I_DD_Order> orders = queryOrders();
+		assertThat(orders).hasSize(2);
+		assertThat(orders).allSatisfy(order -> assertThat(queryLines(order)).hasSize(1));
+	}
+
+	/**
+	 * Control for {@link #oneOrderOneLinePerMove()}: with {@code aggregateByLocatorId=false} (today's behaviour,
+	 * and still the behaviour once the flag exists but is off), the two per-ground candidates collapse into ONE
+	 * DD_Order with a single aggregated line. This must pass both today and after Task 2's fix.
+	 */
+	@Test
+	void flagOff_unchanged()
+	{
+		final DDOrderCandidate move1 = DDOrderCandidateRepositoryTest.newFullyFilled().toBuilder()
+				.sourceLocatorId(LocatorId.ofRepoId(60, 1001))
+				.targetLocatorId(LocatorId.ofRepoId(70, 1002))
+				.build();
+		final DDOrderCandidate move2 = DDOrderCandidateRepositoryTest.newFullyFilled().toBuilder()
+				.sourceLocatorId(LocatorId.ofRepoId(60, 1001))
+				.targetLocatorId(LocatorId.ofRepoId(70, 1003))
+				.build();
+		ddOrderCandidateRepository.save(move1);
+		ddOrderCandidateRepository.save(move2);
+
+		commandBuilder
+				.aggregationConfig(DDOrderCandidateProcessCommand.AggregationConfig.builder()
+						.aggregateBySalesOrderId(true)
+						.aggregateByPPOrderRef(true)
+						.aggregateBySalesOrderLineId(true)
+						.aggregateByLocatorId(false)
+						.build())
+				.request(DDOrderCandidateProcessRequest.builder()
+						.userId(UserId.METASFRESH)
+						.candidates(ImmutableList.of(move1, move2))
+						.build())
+				.build()
+				.execute();
+
+		final List<I_DD_Order> orders = queryOrders();
+		assertThat(orders).hasSize(1);
+	}
+
 	private void processTwoProductCandidates(final boolean aggregateByProductId)
 	{
 		final DDOrderCandidate product20 = DDOrderCandidateRepositoryTest.newFullyFilled().toBuilder()


### PR DESCRIPTION
## What

Adds a gated aggregation dimension to the `DD_Order_Candidate` → `DD_Order` processing so that a candidate carrying its own source/target locator produces a **single-line `DD_Order` that carries those locators**, instead of collapsing per-locator moves and overwriting the line with warehouse-default locators.

- New sysconfig **`DDOrderAggregation.header.byLocatorId`** (seeded, default **`N`**).
- When **off** (default): behaviour is byte-for-byte unchanged — every existing installation is unaffected.
- When **on**: the candidate's source/target locator joins the header + line aggregation keys (one `DD_Order` per from/to locator move), and `DDOrderCandidateProcessCommand.createLine` carries the candidate's own locator onto the line, falling back per-side to the warehouse default when the candidate has none.

## Why

Without this, a candidate that already knows its exact source/target locator (e.g. an automated ground-replenishment source) had those locators discarded — every generated line got the warehouse default locator, and same-product candidates for different target locators were merged into one line. Downstream dedup/guard logic that keys on the line's target locator could then never detect an already-scheduled move, causing repeated regeneration of equivalent orders.

## Tests

`DDOrderCandidateProcessCommandTest` (module `de.metas.manufacturing`), 6/6 green:
- `locatorsCarriedOntoLine` — knob on: line carries the candidate's source/target locator.
- `oneOrderOneLinePerMove` — knob on: same product, two target locators → two single-line orders.
- `flagOff_unchanged` — knob off (control): default-locator fallback + single aggregated line, asserting the exact prior behaviour (AC of byte-for-byte compatibility).

## Migration

One system sysconfig seed at value `N` (mirrors the existing `DDOrderAggregation.header.byProductId` seed).
