### PR TITLE
Picking: batch-load HU QR codes when loading a picking job

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/DefaultPickingJobLoaderSupportingServices.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/DefaultPickingJobLoaderSupportingServices.java
@@ -68,6 +68,7 @@ public class DefaultPickingJobLoaderSupportingServices implements PickingJobLoad
 	private final HashMap<PickingSlotId, PickingSlotIdAndCaption> pickingSlotIdAndCaptionsCache = new HashMap<>();
 	private final HashMap<ProductId, ProductInfo> productInfoCache = new HashMap<>();
 	private final HashMap<LocatorId, String> locatorNamesCache = new HashMap<>();
+	private final HashMap<HuId, HUQRCode> qrCodesCache = new HashMap<>();
 
 	@Override
 	public PickingJobOptions getPickingJobOptions(@Nullable final BPartnerId customerId) {return profileService.getPickingJobOptions(customerId);}
@@ -171,9 +172,17 @@ public class DefaultPickingJobLoaderSupportingServices implements PickingJobLoad
 	}
 
 	@Override
+	public void warmUpQRCodesCache(@NonNull final Collection<HuId> huIds)
+	{
+		CollectionUtils.getAllOrLoad(qrCodesCache, huIds, huService::getSingleQRCodeByHuIds);
+	}
+
+	@Override
 	public HUQRCode getQRCodeByHUId(final HuId huId)
 	{
-		return huService.getQRCodeByHuId(huId);
+		// Served from the batch-warmed cache (see warmUpQRCodesCache); on a miss (HU with no or with multiple
+		// assigned QR codes) fall back to the single-HU lookup, preserving the exact generate-if-missing semantics.
+		return qrCodesCache.computeIfAbsent(huId, huService::getQRCodeByHuId);
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/DefaultPickingJobLoaderSupportingServices.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/DefaultPickingJobLoaderSupportingServices.java
@@ -68,6 +68,9 @@ public class DefaultPickingJobLoaderSupportingServices implements PickingJobLoad
 	private final HashMap<PickingSlotId, PickingSlotIdAndCaption> pickingSlotIdAndCaptionsCache = new HashMap<>();
 	private final HashMap<ProductId, ProductInfo> productInfoCache = new HashMap<>();
 	private final HashMap<LocatorId, String> locatorNamesCache = new HashMap<>();
+	// Per-load lifetime: this class is built fresh per PickingJobLoaderAndSaver.forLoading(...) call (it is @Builder,
+	// caller-constructed, never a shared @Component), so these caches — qrCodesCache included — cannot serve stale data
+	// across separate load operations. Same lifetime as the sibling caches above.
 	private final HashMap<HuId, HUQRCode> qrCodesCache = new HashMap<>();
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaver.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaver.java
@@ -255,33 +255,41 @@ class PickingJobLoaderAndSaver extends PickingJobSaver
 	}
 
 	/**
-	 * Collects every HU id whose QR code will be resolved while building the loaded picking jobs — the picked HUs
-	 * (one per {@link I_M_Picking_Job_Step_PickedHU}) plus the header LU/TU pick targets — so their QR codes can be
-	 * fetched in a single batch instead of one query per HU (see {@link PickingJobLoaderSupportingServices#warmUpQRCodesCache}).
+	 * Collects every HU id whose QR code will be resolved while building the loaded picking jobs, so those QR codes can
+	 * be fetched in a single batch (see {@link PickingJobLoaderSupportingServices#warmUpQRCodesCache}) instead of one
+	 * query per HU. Covers every {@code getQRCodeByHUId} call site of the load: the picked HUs, the pick-from HUs of the
+	 * steps and of the step/job HU-alternatives, and the header + line-level LU/TU pick targets. Any id that is missed
+	 * (or has no/ambiguous QR code) still resolves correctly via the single-HU fallback — it just isn't batched.
 	 */
 	private ImmutableSet<HuId> extractHUIdsFromCachedObjects()
 	{
 		final ImmutableSet.Builder<HuId> result = ImmutableSet.builder();
-
-		this.pickedHUs.values().forEach(pickedHU -> {
-			final HuId pickedHUId = HuId.ofRepoIdOrNull(pickedHU.getPicked_HU_ID());
-			if (pickedHUId != null)
+		final java.util.function.IntConsumer addHuId = repoId -> {
+			final HuId huId = HuId.ofRepoIdOrNull(repoId);
+			if (huId != null)
 			{
-				result.add(pickedHUId);
+				result.add(huId);
 			}
+		};
+
+		// picked HUs (one per step-picked-HU record) — the dominant N after picking
+		this.pickedHUs.values().forEach(pickedHU -> addHuId.accept(pickedHU.getPicked_HU_ID()));
+
+		// pick-from HUs: step main pick-from, step HU-alternatives, job-level HU-alternatives
+		this.pickingJobSteps.values().forEach(step -> addHuId.accept(step.getPickFrom_HU_ID()));
+		this.pickingJobStepAlternatives.values().forEach(alt -> addHuId.accept(alt.getPickFrom_HU_ID()));
+		this.pickingJobHUAlternatives.values().forEach(alt -> addHuId.accept(alt.getPickFrom_HU_ID()));
+
+		// header LU/TU pick targets
+		this.pickingJobs.values().forEach(pickingJobRecord -> {
+			addHuId.accept(pickingJobRecord.getM_LU_HU_ID());
+			addHuId.accept(pickingJobRecord.getM_TU_HU_ID());
 		});
 
-		this.pickingJobs.values().forEach(pickingJobRecord -> {
-			final HuId luId = HuId.ofRepoIdOrNull(pickingJobRecord.getM_LU_HU_ID());
-			if (luId != null)
-			{
-				result.add(luId);
-			}
-			final HuId tuId = HuId.ofRepoIdOrNull(pickingJobRecord.getM_TU_HU_ID());
-			if (tuId != null)
-			{
-				result.add(tuId);
-			}
+		// line-level LU/TU pick targets
+		this.pickingJobLines.values().forEach(line -> {
+			addHuId.accept(line.getCurrent_PickTo_LU_ID());
+			addHuId.accept(line.getCurrent_PickTo_TU_ID());
 		});
 
 		return result.build();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaver.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaver.java
@@ -209,6 +209,7 @@ class PickingJobLoaderAndSaver extends PickingJobSaver
 
 		loadingSupportingServices.warmUpSalesOrderDocumentNosCache(extractSalesOrderIdsFromCachedObjects());
 		loadingSupportingServices.warmUpBPartnerNamesCache(extractCustomerIdsFromCachedObjects());
+		loadingSupportingServices.warmUpQRCodesCache(extractHUIdsFromCachedObjects());
 
 		hasLocks.putAll(computePickingJobHasLocks(pickingJobIds));
 	}
@@ -248,6 +249,39 @@ class PickingJobLoaderAndSaver extends PickingJobSaver
 		this.pickingJobLines.values().forEach((pickingJobLineRecord) -> {
 			final BPartnerLocationId deliveryBPLocationId = extractDeliveryBPLocationId(pickingJobLineRecord);
 			result.add(deliveryBPLocationId.getBpartnerId());
+		});
+
+		return result.build();
+	}
+
+	/**
+	 * Collects every HU id whose QR code will be resolved while building the loaded picking jobs — the picked HUs
+	 * (one per {@link I_M_Picking_Job_Step_PickedHU}) plus the header LU/TU pick targets — so their QR codes can be
+	 * fetched in a single batch instead of one query per HU (see {@link PickingJobLoaderSupportingServices#warmUpQRCodesCache}).
+	 */
+	private ImmutableSet<HuId> extractHUIdsFromCachedObjects()
+	{
+		final ImmutableSet.Builder<HuId> result = ImmutableSet.builder();
+
+		this.pickedHUs.values().forEach(pickedHU -> {
+			final HuId pickedHUId = HuId.ofRepoIdOrNull(pickedHU.getPicked_HU_ID());
+			if (pickedHUId != null)
+			{
+				result.add(pickedHUId);
+			}
+		});
+
+		this.pickingJobs.values().forEach(pickingJobRecord -> {
+			final HuId luId = HuId.ofRepoIdOrNull(pickingJobRecord.getM_LU_HU_ID());
+			if (luId != null)
+			{
+				result.add(luId);
+			}
+			final HuId tuId = HuId.ofRepoIdOrNull(pickingJobRecord.getM_TU_HU_ID());
+			if (tuId != null)
+			{
+				result.add(tuId);
+			}
 		});
 
 		return result.build();

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderSupportingServices.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderSupportingServices.java
@@ -66,6 +66,8 @@ public interface PickingJobLoaderSupportingServices
 
 	String getLocatorName(@NonNull LocatorId locatorId);
 
+	void warmUpQRCodesCache(@NonNull Collection<HuId> huIds);
+
 	HUQRCode getQRCodeByHUId(HuId huId);
 
 	ScheduledPackageableLocks getLocks(ShipmentScheduleAndJobScheduleIdSet scheduleIds);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickingJobHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickingJobHUService.java
@@ -69,6 +69,7 @@ import org.springframework.stereotype.Service;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -207,6 +208,8 @@ public class PickingJobHUService
 	}
 
 	public HUQRCode getQRCodeByHuId(@NonNull final HuId huId) {return huQRCodesService.getQRCodeByHuId(huId);}
+
+	public Map<HuId, HUQRCode> getSingleQRCodeByHuIds(@NonNull final Collection<HuId> huIds) {return huQRCodesService.getSingleQRCodeByHuIds(huIds);}
 
 	public List<HUQRCode> getOrCreateQRCodesByHuId(@NonNull final HuId huId) {return huQRCodesService.getOrCreateQRCodesByHuId(huId);}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/qrcodes/service/HUQRCodesService.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import de.metas.global_qrcodes.GlobalQRCode;
 import de.metas.global_qrcodes.service.GlobalQRCodeService;
 import de.metas.global_qrcodes.service.QRCodePDFResource;
@@ -243,6 +244,32 @@ public class HUQRCodesService
 		{
 			throw new AdempiereException("No QR Code attached to HU " + huId.getRepoId());
 		}
+	}
+
+	/**
+	 * Batch, cache-warm-up variant of {@link #getQRCodeByHuId(HuId)}: resolves the assigned QR codes for many HUs in a
+	 * single DB round-trip instead of one query per HU.
+	 * <p>
+	 * Returns a mapping only for HUs that have <b>exactly one</b> assigned QR code — the unambiguous, overwhelmingly
+	 * common case. HUs with no assigned QR code, or with more than one, are intentionally omitted so the caller falls
+	 * back to the single-HU {@link #getQRCodeByHuId(HuId)}, which preserves the exact generate-if-missing and
+	 * first-QR-by-id semantics for those edge cases. Because of that fallback this method never changes behaviour; it
+	 * only removes the per-HU query for the common case.
+	 */
+	public Map<HuId, HUQRCode> getSingleQRCodeByHuIds(@NonNull final Collection<HuId> huIds)
+	{
+		final ImmutableSetMultimap<HuId, HUQRCode> qrCodesByHuId = huQRCodesRepository.getQRCodeByHuIds(huIds);
+
+		final ImmutableMap.Builder<HuId, HUQRCode> result = ImmutableMap.builder();
+		for (final HuId huId : qrCodesByHuId.keySet())
+		{
+			final ImmutableSet<HUQRCode> qrCodes = qrCodesByHuId.get(huId);
+			if (qrCodes.size() == 1)
+			{
+				result.put(huId, qrCodes.iterator().next());
+			}
+		}
+		return result.build();
 	}
 
 	@NonNull

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/DefaultPickingJobLoaderSupportingServicesTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/DefaultPickingJobLoaderSupportingServicesTest.java
@@ -95,4 +95,21 @@ class DefaultPickingJobLoaderSupportingServicesTest
 		// ... and the per-HU accessor must NOT fall back to a single lookup for already-warmed HUs
 		verify(huService, never()).getQRCodeByHuId(any());
 	}
+
+	@Test
+	void getQRCode_cacheMiss_fallsBackToSingleLookupOnce()
+	{
+		final HuId huNotWarmed = HuId.ofRepoId(999);
+		// the batch omits this HU (as it would for an HU with no / multiple assigned QR codes)
+		when(huService.getSingleQRCodeByHuIds(any())).thenReturn(ImmutableMap.of());
+		when(huService.getQRCodeByHuId(huNotWarmed)).thenReturn(qr1);
+
+		loaderServices.warmUpQRCodesCache(ImmutableSet.of(huNotWarmed));
+
+		// first access falls back to the single-HU lookup (preserving generate-if-missing semantics) ...
+		assertThat(loaderServices.getQRCodeByHUId(huNotWarmed)).isSameAs(qr1);
+		// ... and the fallback result is itself cached, so a second access does NOT re-query
+		assertThat(loaderServices.getQRCodeByHUId(huNotWarmed)).isSameAs(qr1);
+		verify(huService, times(1)).getQRCodeByHuId(huNotWarmed);
+	}
 }

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/DefaultPickingJobLoaderSupportingServicesTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/DefaultPickingJobLoaderSupportingServicesTest.java
@@ -1,0 +1,98 @@
+package de.metas.handlingunits.picking.job.repository;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.HuPackingInstructionsId;
+import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileService;
+import de.metas.handlingunits.picking.job.service.PickingJobLockService;
+import de.metas.handlingunits.picking.job.service.PickingJobSlotService;
+import de.metas.handlingunits.picking.job.service.external.bpartner.PickingJobBPartnerService;
+import de.metas.handlingunits.picking.job.service.external.hu.PickingJobHUService;
+import de.metas.handlingunits.picking.job.service.external.product.PickingJobProductService;
+import de.metas.handlingunits.picking.job.service.external.salesorder.PickingJobSalesOrderService;
+import de.metas.handlingunits.picking.job.service.external.warehouse.PickingJobWarehouseService;
+import de.metas.handlingunits.qrcodes.model.HUQRCode;
+import de.metas.handlingunits.qrcodes.model.HUQRCodePackingInfo;
+import de.metas.handlingunits.qrcodes.model.HUQRCodeUnitType;
+import de.metas.handlingunits.qrcodes.model.HUQRCodeUniqueId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that {@link DefaultPickingJobLoaderSupportingServices} resolves picked-HU QR codes through a single
+ * batch warm-up (one round-trip for N HUs) instead of one lookup per HU — the fix for the picking write-path
+ * QR-code N+1 (me03 #30802).
+ */
+@ExtendWith({ AdempiereTestWatcher.class })
+class DefaultPickingJobLoaderSupportingServicesTest
+{
+	private PickingJobHUService huService;
+	private DefaultPickingJobLoaderSupportingServices loaderServices;
+
+	private final HuId hu1 = HuId.ofRepoId(101);
+	private final HuId hu2 = HuId.ofRepoId(102);
+	private final HUQRCode qr1 = newQRCode();
+	private final HUQRCode qr2 = newQRCode();
+
+	private static HUQRCode newQRCode()
+	{
+		return HUQRCode.builder()
+				.id(HUQRCodeUniqueId.random())
+				.packingInfo(HUQRCodePackingInfo.builder()
+						.huUnitType(HUQRCodeUnitType.TU)
+						.packingInstructionsId(HuPackingInstructionsId.ofRepoId(540))
+						.caption("test")
+						.build())
+				.attributes(ImmutableList.of())
+				.build();
+	}
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		huService = mock(PickingJobHUService.class);
+
+		loaderServices = DefaultPickingJobLoaderSupportingServices.builder()
+				.orderService(mock(PickingJobSalesOrderService.class))
+				.warehouseService(mock(PickingJobWarehouseService.class))
+				.bpartnerService(mock(PickingJobBPartnerService.class))
+				.productService(mock(PickingJobProductService.class))
+				.pickingSlotService(mock(PickingJobSlotService.class))
+				.pickingJobLockService(mock(PickingJobLockService.class))
+				.huService(huService)
+				.profileService(mock(MobileUIPickingUserProfileService.class))
+				.build();
+	}
+
+	@Test
+	void warmUp_then_getQRCode_servesFromCache_withoutPerHuLookup()
+	{
+		when(huService.getSingleQRCodeByHuIds(any()))
+				.thenReturn(ImmutableMap.of(hu1, qr1, hu2, qr2));
+
+		loaderServices.warmUpQRCodesCache(ImmutableSet.of(hu1, hu2));
+
+		assertThat(loaderServices.getQRCodeByHUId(hu1)).isSameAs(qr1);
+		assertThat(loaderServices.getQRCodeByHUId(hu2)).isSameAs(qr2);
+
+		// the warm-up must batch-load exactly once ...
+		verify(huService, times(1)).getSingleQRCodeByHuIds(any());
+		// ... and the per-HU accessor must NOT fall back to a single lookup for already-warmed HUs
+		verify(huService, never()).getQRCodeByHuId(any());
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/MockedPickingJobLoaderSupportingServices.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/MockedPickingJobLoaderSupportingServices.java
@@ -68,6 +68,12 @@ public class MockedPickingJobLoaderSupportingServices implements PickingJobLoade
 	}
 
 	@Override
+	public void warmUpQRCodesCache(@NonNull final Collection<HuId> huIds)
+	{
+		// do nothing (this mock already serves QR codes from its in-memory map)
+	}
+
+	@Override
 	public String getBPartnerName(@NonNull final BPartnerId bpartnerId)
 	{
 		return "bpname-" + bpartnerId.getRepoId();

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/qrcodes/service/HUQRCodesServiceTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import de.metas.business.BusinessTestHelper;
 import de.metas.handlingunits.HUTestHelper;
 import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.HuPackingInstructionsId;
 import de.metas.handlingunits.IHUContext;
 import de.metas.handlingunits.QtyTU;
 import de.metas.handlingunits.attribute.storage.IAttributeStorage;
@@ -39,6 +40,8 @@ import de.metas.handlingunits.qrcodes.ean13.EAN13HUQRCode;
 import de.metas.handlingunits.qrcodes.gs1.GS1HUQRCode;
 import de.metas.handlingunits.qrcodes.mobile.MobileQRCodeMessages;
 import de.metas.handlingunits.qrcodes.model.HUQRCode;
+import de.metas.handlingunits.qrcodes.model.HUQRCodePackingInfo;
+import de.metas.handlingunits.qrcodes.model.HUQRCodeUniqueId;
 import de.metas.handlingunits.qrcodes.model.HUQRCodeUnitType;
 import de.metas.handlingunits.qrcodes.model.IHUQRCode;
 import de.metas.handlingunits.qrcodes.special.PickOnTheFlyQRCode;
@@ -63,6 +66,8 @@ import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -167,6 +172,46 @@ class HUQRCodesServiceTest
 		huAttributes.setValue(AttributeConstants.ATTR_BestBeforeDate, attributes.getBestBeforeDate() != null ? LocalDate.parse(attributes.getBestBeforeDate()) : null);
 		huAttributes.setValue(AttributeConstants.ATTR_LotNumber, attributes.getLotNumber());
 		huAttributes.setValue(Weightables.ATTR_WeightNet, attributes.getWeightNet() != null ? new BigDecimal(attributes.getWeightNet()) : null);
+	}
+
+	@Nested
+	class getSingleQRCodeByHuIds
+	{
+		private final HUQRCodesRepository repo = new HUQRCodesRepository();
+
+		private HUQRCode newQRCode()
+		{
+			return HUQRCode.builder()
+					.id(HUQRCodeUniqueId.ofUUID(UUID.randomUUID()))
+					.packingInfo(HUQRCodePackingInfo.builder()
+							.huUnitType(HUQRCodeUnitType.TU)
+							.packingInstructionsId(HuPackingInstructionsId.ofRepoId(123))
+							.caption("Some TU")
+							.build())
+					.attributes(ImmutableList.of())
+					.build();
+		}
+
+		@Test
+		void returnsOnlyHUsWithExactlyOneAssignedQRCode()
+		{
+			final HuId huSingle = HuId.ofRepoId(701);
+			final HuId huMulti = HuId.ofRepoId(702);
+			final HuId huNone = HuId.ofRepoId(703);
+
+			final HUQRCode qrSingle = newQRCode();
+			repo.createNew(qrSingle, huSingle);
+			// two distinct QR codes assigned to the same HU -> ambiguous -> must be omitted
+			repo.createNew(newQRCode(), huMulti);
+			repo.createNew(newQRCode(), huMulti);
+			// huNone has no assigned QR code
+
+			final Map<HuId, HUQRCode> result = huQRCodesService.getSingleQRCodeByHuIds(
+					ImmutableList.of(huSingle, huMulti, huNone));
+
+			assertThat(result).containsOnlyKeys(huSingle);
+			assertThat(result.get(huSingle).getId()).isEqualTo(qrSingle.getId());
+		}
 	}
 
 	@Nested


### PR DESCRIPTION
Loading a picking job resolved each handling unit's QR code with its own query. On a pallet with many handling units this produced one query per HU and slowed the picking write path (closing a loading unit / recording a pick), the effect growing with pallet size.

This change batch-loads the QR codes for all handling units of a picking job in a single query (warmed before the per-HU load loop), then serves them from a per-load cache — the same warm-up pattern already used for business-partner names and sales-order document numbers. Handling units with exactly one assigned QR code are served from the batch; any other case (no QR code, or several) falls back to the unchanged single-HU lookup, so behaviour is identical.

### Tests
- `DefaultPickingJobLoaderSupportingServicesTest` — after warm-up, the per-HU accessor is served from the cache and never issues a single-HU lookup.
- `HUQRCodesServiceTest.getSingleQRCodeByHuIds` — returns the QR code per HU for single-QR handling units and omits handling units with none or with several.
- Full `de.metas.handlingunits.base` unit suite green (690 tests, 0 failures).
