### PR TITLE
Outbound Emails — invoice mail: bill-to location-email fallback

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
@@ -230,6 +230,11 @@ public class C_BPartner_StepDef
 		bPartnerRecord.setIsCustomer(row.getAsOptionalBoolean(COLUMNNAME_IsCustomer).orElseFalse());
 		bPartnerRecord.setIsSalesRep(row.getAsOptionalBoolean(COLUMNNAME_IsSalesRep).orElseFalse());
 		bPartnerRecord.setAD_Org_ID(orgId);
+
+		row.getAsOptionalString(de.metas.document.archive.model.I_C_BPartner.COLUMNNAME_IsInvoiceEmailEnabled)
+				.ifPresent(isInvoiceEmailEnabled -> InterfaceWrapperHelper
+						.create(bPartnerRecord, de.metas.document.archive.model.I_C_BPartner.class)
+						.setIsInvoiceEmailEnabled(isInvoiceEmailEnabled));
 		bPartnerRecord.setDeliveryRule(DeliveryRule.FORCE.getCode());
 
 		final StepDefDataIdentifier discountSchemaIdentifier = row.getAsOptionalIdentifier(COLUMNNAME_PO_DiscountSchema_ID).orElse(null);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
@@ -125,6 +125,13 @@ public class C_BPartner_StepDef
 
 	private final ExternalReferenceRestControllerService externalReferenceRestControllerService = SpringContextHolder.instance.getBean(ExternalReferenceRestControllerService.class);
 
+	/**
+	 * Creates C_BPartner records (auto-generates Value/Name; default location added).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>IsInvoiceEmailEnabled</b> — (optional) partner-level invoice-email flag (Y/N); when Y, invoices are emailable to the bill-to location email even without a bill contact.<br>
+	 */
 	@Given("metasfresh contains C_BPartners:")
 	public void metasfresh_contains_c_bpartners(@NonNull final DataTable dataTable) throws Throwable
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/docoutbound/C_Doc_Outbound_Log_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/docoutbound/C_Doc_Outbound_Log_StepDef.java
@@ -24,6 +24,7 @@ package de.metas.cucumber.stepdefs.docoutbound;
 
 import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
 import de.metas.cucumber.stepdefs.C_Order_StepDefData;
+import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.DataTableUtil;
 import de.metas.cucumber.stepdefs.StepDefUtil;
 import de.metas.document.archive.model.I_C_Doc_Outbound_Log;
@@ -39,6 +40,7 @@ import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.I_AD_Table;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_DocType;
+import org.compiere.model.I_C_Invoice;
 import org.compiere.model.I_C_Order;
 
 import java.util.Map;
@@ -59,17 +61,20 @@ public class C_Doc_Outbound_Log_StepDef
 	private final C_Doc_Outbound_Log_Line_StepDefData docOutboundLogLineTable;
 	private final C_BPartner_StepDefData bpartnerTable;
 	private final C_Order_StepDefData orderTable;
+	private final C_Invoice_StepDefData invoiceTable;
 
 	public C_Doc_Outbound_Log_StepDef(
 			@NonNull final C_Doc_Outbound_Log_StepDefData docOutboundLogTable,
 			@NonNull final C_Doc_Outbound_Log_Line_StepDefData docOutboundLogLineTable,
 			@NonNull final C_BPartner_StepDefData bpartnerTable,
-			@NonNull final C_Order_StepDefData orderTable)
+			@NonNull final C_Order_StepDefData orderTable,
+			@NonNull final C_Invoice_StepDefData invoiceTable)
 	{
 		this.docOutboundLogTable = docOutboundLogTable;
 		this.docOutboundLogLineTable = docOutboundLogLineTable;
 		this.bpartnerTable = bpartnerTable;
 		this.orderTable = orderTable;
+		this.invoiceTable = invoiceTable;
 	}
 
 	@And("^after not more than (.*)s validate C_Doc_Outbound_Log:$")
@@ -168,6 +173,12 @@ public class C_Doc_Outbound_Log_StepDef
 				assertThat(order).isNotNull();
 
 				return TableRecordReference.of(order);
+
+			case I_C_Invoice.Table_Name:
+				final I_C_Invoice invoice = invoiceTable.get(recordIdentifier);
+				assertThat(invoice).isNotNull();
+
+				return TableRecordReference.of(invoice);
 
 			default:
 				throw new AdempiereException("Unhandled tableName")

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/docOutbound/invoiceDocOutbound.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/docOutbound/invoiceDocOutbound.feature
@@ -12,6 +12,7 @@ Feature: Invoice doc outbound log - bill-to location email fallback
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
     And metasfresh has date and time 2022-02-01T13:30:13+01:00[Europe/Berlin]
     And set sys config boolean value false for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
     And set sys config boolean value true for sys config de.metas.report.jasper.IsMockReportService
 
   @Id:S30521_TC1
@@ -27,7 +28,7 @@ Feature: Invoice doc outbound log - bill-to location email fallback
       | pl         | ps                            | DE                        | EUR                 | price_list | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID.Identifier | Name | ValidFrom  |
-      | plv        | pl                        | plv  | 2022-01-30 |
+      | plv        | pl                        | plv  | 2022-01-01 |
     And metasfresh contains M_ProductPrices
       | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
       | pp         | plv                               | product                 | 10.0     | PCE               | Normal                        |
@@ -42,7 +43,7 @@ Feature: Invoice doc outbound log - bill-to location email fallback
 
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
-      | order      | true    | bpartner                 | 2022-02-02  |
+      | order      | true    | bpartner                 | 2022-01-15  |
     And metasfresh contains C_OrderLines:
       | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
       | orderLine  | order                 | product                 | 10         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/docOutbound/invoiceDocOutbound.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/docOutbound/invoiceDocOutbound.feature
@@ -1,0 +1,73 @@
+@from:cucumber
+@allure.label.epic:E0280_Document_and_Email_Management
+@allure.label.feature:F00580_Outbound_Emails
+@ghActions:run_on_executor2
+Feature: Invoice doc outbound log - bill-to location email fallback
+  A bill partner that is invoice-email-enabled at partner level and has a bill-to
+  location email, but no bill contact, must still get its invoice emailable:
+  C_Doc_Outbound_Log.CurrentEMailAddress must carry the bill-to location email.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-02-01T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value false for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value true for sys config de.metas.report.jasper.IsMockReportService
+
+  @Id:S30521_TC1
+  Scenario: Invoice for an invoice-email-enabled partner with only a bill-to location email carries the location email
+    Given metasfresh contains M_Products:
+      | Identifier | Name         |
+      | product    | test_product |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name           | Value          |
+      | ps         | pricing_system | pricing_system |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name       | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl         | ps                            | DE                        | EUR                 | price_list | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name | ValidFrom  |
+      | plv        | pl                        | plv  | 2022-01-30 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp         | plv                               | product                 | 10.0     | PCE               | Normal                        |
+
+    # Partner is invoice-email-enabled at PARTNER level; bill-to location has an email; NO bill contact (AD_User)
+    And metasfresh contains C_BPartners:
+      | Identifier | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.IsInvoiceEmailEnabled |
+      | bpartner   | Y              | ps                            | Y                         |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault | OPT.EMail            |
+      | bpLocation | 1111123456789 | bpartner                 | Y                   | Y                   | billto@location.test |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | order      | true    | bpartner                 | 2022-02-02  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine  | order                 | product                 | 10         |
+    And the order identified by order is completed
+
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic                                | orderLine                 | 0            |
+    And update invoice candidates
+      | C_Invoice_Candidate_ID.Identifier | OPT.InvoiceRule_Override |
+      | ic                                | I                       |
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic                                | orderLine                 | 10           |
+    When process invoice candidates and wait 60s for C_Invoice_Candidate to be processed
+      | C_Invoice_Candidate_ID.Identifier | OPT.IsCompleteInvoices |
+      | ic                                | true                   |
+    And after not more than 60s, C_Invoice are found:
+      | C_Invoice_Candidate_ID.Identifier | C_Invoice_ID.Identifier |
+      | ic                                | invoice                 |
+
+    Then after not more than 60s validate C_Doc_Outbound_Log:
+      | C_Doc_Outbound_Log_ID.Identifier | Record_ID.Identifier | AD_Table.Name | OPT.CurrentEMailAddress | OPT.C_BPartner_ID.Identifier |
+      | invoiceOutboundLog               | invoice              | C_Invoice     | billto@location.test    | bpartner                     |
+
+  Scenario: reset global sys config
+    Given set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config de.metas.report.jasper.IsMockReportService

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/report/baseandcustom/report.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/report/baseandcustom/report.feature
@@ -6,6 +6,7 @@ Feature: Jasper Report Tests
     Given infrastructure and metasfresh are running
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config de.metas.report.jasper.IsMockReportService
     And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
     And metasfresh has date and time 2025-04-01T13:30:13+01:00[Europe/Berlin]
     And set sys config boolean value false for sys config de.metas.payment.esr.Enabled

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/mailrecipient/DocOutBoundRecipient.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/mailrecipient/DocOutBoundRecipient.java
@@ -37,7 +37,7 @@ import java.util.function.Supplier;
 @Builder
 public class DocOutBoundRecipient
 {
-	@NonNull DocOutBoundRecipientId id;
+	@Nullable DocOutBoundRecipientId id;
 	@Nullable @With String emailAddress;
 	boolean invoiceAsEmail;
 	@Nullable Language userLanguage;
@@ -55,6 +55,18 @@ public class DocOutBoundRecipient
 
 		final String newEmailAddressNorm = StringUtils.trimBlankToNull(newEmailAddressSupplier.get());
 		return newEmailAddressNorm != null ? withEmailAddress(newEmailAddressNorm) : this;
+	}
+
+	public static DocOutBoundRecipient ofEmailAddress(
+			@NonNull final String emailAddress,
+			@Nullable final Language bPartnerLanguage,
+			final boolean invoiceAsEmail)
+	{
+		return DocOutBoundRecipient.builder()
+				.emailAddress(emailAddress)
+				.invoiceAsEmail(invoiceAsEmail)
+				.bPartnerLanguage(bPartnerLanguage)
+				.build();
 	}
 
 }

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/mailrecipient/DocOutBoundRecipientCC.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/mailrecipient/DocOutBoundRecipientCC.java
@@ -1,5 +1,6 @@
 package de.metas.document.archive.mailrecipient;
 
+import de.metas.util.Check;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
@@ -15,8 +16,10 @@ public class DocOutBoundRecipientCC
 
 	public static DocOutBoundRecipientCC of(@NonNull final DocOutBoundRecipient recipient)
 	{
+		// A CC recipient always corresponds to an AD_User; email-only recipients (id == null) are never valid as CC.
+		final DocOutBoundRecipientId id = Check.assumeNotNull(recipient.getId(), "CC recipient must have a user id: {}", recipient);
 		return DocOutBoundRecipientCC.builder()
-				.id(recipient.getId())
+				.id(id)
 				.emailAddress(recipient.getEmailAddress())
 				.build();
 	}

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/mailrecipient/DocOutBoundRecipientId.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/mailrecipient/DocOutBoundRecipientId.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import de.metas.user.UserId;
 import de.metas.util.Check;
 import de.metas.util.lang.RepoIdAware;
+import javax.annotation.Nullable;
 import lombok.NonNull;
 import lombok.Value;
 import org.adempiere.exceptions.AdempiereException;
@@ -49,6 +50,11 @@ public class DocOutBoundRecipientId implements RepoIdAware
 			return null;
 		}
 		return new DocOutBoundRecipientId(repoId);
+	}
+
+	public static int toRepoId(@Nullable final DocOutBoundRecipientId id)
+	{
+		return id != null ? id.getRepoId() : -1;
 	}
 
 	public static DocOutBoundRecipientId ofUserId(@NonNull UserId userId)

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/mailrecipient/impl/InvoiceDocOutboundLogMailRecipientProvider.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/mailrecipient/impl/InvoiceDocOutboundLogMailRecipientProvider.java
@@ -12,6 +12,7 @@ import de.metas.document.archive.mailrecipient.DocOutBoundRecipientService;
 import de.metas.document.archive.mailrecipient.DocOutBoundRecipients;
 import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientProvider;
 import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRequest;
+import de.metas.i18n.Language;
 import de.metas.invoice.InvoiceId;
 import de.metas.invoice.service.IInvoiceBL;
 import de.metas.order.IOrderBL;
@@ -22,7 +23,9 @@ import de.metas.user.User;
 import de.metas.user.UserId;
 import de.metas.util.Check;
 import de.metas.util.Services;
+import de.metas.util.StringUtils;
 import lombok.NonNull;
+import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_Invoice;
 import org.compiere.model.I_C_Order;
 import org.springframework.stereotype.Component;
@@ -164,6 +167,16 @@ public class InvoiceDocOutboundLogMailRecipientProvider
 			{
 				return Optional.of(docOutBoundRecipient);
 			}
+		}
+
+		// No usable bill contact resolved above, but the partner is explicitly invoice-email-enabled
+		// and the bill-to location has an email => send to the location email (recipient without an AD_User).
+		final I_C_BPartner billPartnerRecord = bpartnerBL.getById(billPartnerId);
+		final boolean partnerInvoiceEmailEnabled = StringUtils.toBoolean(billPartnerRecord.getIsInvoiceEmailEnabled(), false);
+		if (partnerInvoiceEmailEnabled && Check.isNotBlank(locationEmail))
+		{
+			final Language bPartnerLanguage = bpartnerBL.getLanguage(billPartnerRecord).orElse(null);
+			return Optional.of(DocOutBoundRecipient.ofEmailAddress(locationEmail, bPartnerLanguage, true));
 		}
 
 		return Optional.empty();

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/mailrecipient/impl/InvoiceDocOutboundLogMailRecipientProvider.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/mailrecipient/impl/InvoiceDocOutboundLogMailRecipientProvider.java
@@ -12,6 +12,7 @@ import de.metas.document.archive.mailrecipient.DocOutBoundRecipientService;
 import de.metas.document.archive.mailrecipient.DocOutBoundRecipients;
 import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientProvider;
 import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRequest;
+import de.metas.document.archive.model.I_C_BPartner;
 import de.metas.i18n.Language;
 import de.metas.invoice.InvoiceId;
 import de.metas.invoice.service.IInvoiceBL;
@@ -25,7 +26,6 @@ import de.metas.util.Check;
 import de.metas.util.Services;
 import de.metas.util.StringUtils;
 import lombok.NonNull;
-import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_Invoice;
 import org.compiere.model.I_C_Order;
 import org.springframework.stereotype.Component;
@@ -171,7 +171,7 @@ public class InvoiceDocOutboundLogMailRecipientProvider
 
 		// No usable bill contact resolved above, but the partner is explicitly invoice-email-enabled
 		// and the bill-to location has an email => send to the location email (recipient without an AD_User).
-		final I_C_BPartner billPartnerRecord = bpartnerBL.getById(billPartnerId);
+		final I_C_BPartner billPartnerRecord = bpartnerBL.getById(billPartnerId, I_C_BPartner.class);
 		final boolean partnerInvoiceEmailEnabled = StringUtils.toBoolean(billPartnerRecord.getIsInvoiceEmailEnabled(), false);
 		if (partnerInvoiceEmailEnabled && Check.isNotBlank(locationEmail))
 		{

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/spi/impl/DocOutboundArchiveEventListener.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/spi/impl/DocOutboundArchiveEventListener.java
@@ -12,6 +12,7 @@ import de.metas.common.util.time.SystemTime;
 import de.metas.document.DocTypeId;
 import de.metas.document.archive.DocOutboundUtils;
 import de.metas.document.archive.api.IDocOutboundDAO;
+import de.metas.document.archive.mailrecipient.DocOutBoundRecipientId;
 import de.metas.document.archive.mailrecipient.DocOutBoundRecipients;
 import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRegistry;
 import de.metas.document.archive.mailrecipient.DocOutboundLogMailRecipientRequest;
@@ -283,7 +284,12 @@ public class DocOutboundArchiveEventListener implements IArchiveEventListener
 
 		if (recipients.getTo() != null)
 		{
-			docOutboundLogRecord.setCurrentEMailRecipient_ID(recipients.getTo().getId().getRepoId());
+			// an email-only recipient (e.g. the bill-to location fallback) has no AD_User => no CurrentEMailRecipient_ID
+			final DocOutBoundRecipientId toId = recipients.getTo().getId();
+			if (toId != null)
+			{
+				docOutboundLogRecord.setCurrentEMailRecipient_ID(toId.getRepoId());
+			}
 			docOutboundLogRecord.setCurrentEMailAddress(recipients.getTo().getEmailAddress());
 		}
 

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/spi/impl/DocOutboundArchiveEventListener.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/main/java/de/metas/document/archive/spi/impl/DocOutboundArchiveEventListener.java
@@ -284,12 +284,8 @@ public class DocOutboundArchiveEventListener implements IArchiveEventListener
 
 		if (recipients.getTo() != null)
 		{
-			// an email-only recipient (e.g. the bill-to location fallback) has no AD_User => no CurrentEMailRecipient_ID
-			final DocOutBoundRecipientId toId = recipients.getTo().getId();
-			if (toId != null)
-			{
-				docOutboundLogRecord.setCurrentEMailRecipient_ID(toId.getRepoId());
-			}
+			// an email-only recipient (e.g. the bill-to location fallback) has no AD_User => toRepoId returns -1
+			docOutboundLogRecord.setCurrentEMailRecipient_ID(DocOutBoundRecipientId.toRepoId(recipients.getTo().getId()));
 			docOutboundLogRecord.setCurrentEMailAddress(recipients.getTo().getEmailAddress());
 		}
 

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/test/java/de/metas/document/archive/mailrecipient/DocOutBoundRecipientTest.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/test/java/de/metas/document/archive/mailrecipient/DocOutBoundRecipientTest.java
@@ -1,0 +1,25 @@
+package de.metas.document.archive.mailrecipient;
+
+import de.metas.i18n.Language;
+import org.junit.jupiter.api.Test;
+
+import static de.metas.i18n.Language.AD_Language_en_US;
+import static de.metas.i18n.Language.asLanguage;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DocOutBoundRecipientTest
+{
+	@Test
+	void ofEmailAddress_setsFieldsCorrectly()
+	{
+		final Language bpLanguage = asLanguage(AD_Language_en_US);
+		final DocOutBoundRecipient recipient = DocOutBoundRecipient.ofEmailAddress("x@y.z", bpLanguage, true);
+
+		assertThat(recipient.getId()).isNull();
+		assertThat(recipient.getEmailAddress()).isEqualTo("x@y.z");
+		assertThat(recipient.isEmailAddressSet()).isTrue();
+		assertThat(recipient.isInvoiceAsEmail()).isTrue();
+		assertThat(recipient.getBPartnerLanguage()).isEqualTo(bpLanguage);
+		assertThat(recipient.getUserLanguage()).isNull();
+	}
+}

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/test/java/de/metas/document/archive/spi/impl/InvoiceDocOutboundLogMailRecipientProviderTest.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/test/java/de/metas/document/archive/spi/impl/InvoiceDocOutboundLogMailRecipientProviderTest.java
@@ -21,8 +21,8 @@ import org.compiere.model.I_AD_User;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_BPartner_Location;
 import org.compiere.model.I_C_Invoice;
+import lombok.NonNull;
 import org.compiere.model.I_C_Order;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -67,6 +67,7 @@ public class InvoiceDocOutboundLogMailRecipientProviderTest
 
 	private I_C_BPartner shipToBPartnerRecord;
 	private I_C_BPartner billBPartnerRecord;
+	private I_C_BPartner_Location billBPLocationRecord;
 	private I_C_Order orderRecord;
 	private I_C_Invoice invoiceRecord;
 
@@ -95,7 +96,7 @@ public class InvoiceDocOutboundLogMailRecipientProviderTest
 		final I_C_BPartner_Location shipToBPLocationRecord = createBPLocation(shipToBPartnerRecord);
 
 		billBPartnerRecord = createBPartner();
-		final I_C_BPartner_Location billBPLocationRecord = createBPLocation(billBPartnerRecord);
+		billBPLocationRecord = createBPLocation(billBPartnerRecord);
 
 		orderRecord = newInstance(I_C_Order.class);
 		orderRecord.setC_BPartner_ID(shipToBPartnerRecord.getC_BPartner_ID());
@@ -119,7 +120,7 @@ public class InvoiceDocOutboundLogMailRecipientProviderTest
 		return bpartnerRecord;
 	}
 
-	private @NotNull I_C_BPartner_Location createBPLocation(I_C_BPartner bPartnerRecord)
+	private @NonNull I_C_BPartner_Location createBPLocation(I_C_BPartner bPartnerRecord)
 	{
 		final I_C_BPartner_Location billBPLocationRecord = newInstance(I_C_BPartner_Location.class);
 		billBPLocationRecord.setC_BPartner_ID(bPartnerRecord.getC_BPartner_ID());
@@ -315,6 +316,72 @@ public class InvoiceDocOutboundLogMailRecipientProviderTest
 		assertThat(result.get().getTo().getEmailAddress()).isEqualTo("test@test.test");
 		assertThat(result.get().getTo().getUserLanguage()).isEqualTo(asLanguage(AD_Language_en_GB));
 		assertThat(result.get().getTo().getBPartnerLanguage()).isEqualTo(asLanguage(AD_Language_en_US));
+	}
+
+	@Nested
+	class locationEmailFallback_noUsableContact
+	{
+		private Optional<DocOutBoundRecipients> provide()
+		{
+			return invoiceDocOutboundLogMailRecipientProvider.provideMailRecipient(
+					DocOutboundLogMailRecipientRequest.builder()
+							.recordRef(TableRecordReference.of(I_C_Invoice.Table_Name, invoiceRecord.getC_Invoice_ID()))
+							.clientId(ClientId.ofRepoId(invoiceRecord.getAD_Client_ID()))
+							.orgId(OrgId.ofRepoId(invoiceRecord.getAD_Org_ID()))
+							.build());
+		}
+
+		private void setPartnerInvoiceEmailEnabled(final String value)
+		{
+			billBPartnerRecord.setIsInvoiceEmailEnabled(value);
+			saveRecord(billBPartnerRecord);
+		}
+
+		private void setLocationEmail(final String email)
+		{
+			billBPLocationRecord.setEMail(email);
+			saveRecord(billBPLocationRecord);
+		}
+
+		// TC1
+		@Test
+		void partnerY_locationEmail_noContact_emailsLocation()
+		{
+			setPartnerInvoiceEmailEnabled("Y");
+			setLocationEmail("bill.location@example.com");
+
+			final Optional<DocOutBoundRecipients> result = provide();
+			assertThat(result).isPresent();
+			assertThat(result.get().getTo()).isNotNull();
+			assertThat(result.get().getTo().getId()).isNull();
+			assertThat(result.get().getTo().getEmailAddress()).isEqualTo("bill.location@example.com");
+			assertThat(result.get().getTo().isInvoiceAsEmail()).isTrue();
+		}
+
+		// TC2
+		@Test
+		void partnerBlank_locationEmail_noContact_noRecipient()
+		{
+			setLocationEmail("bill.location@example.com");
+			assertThat(provide()).isEmpty();
+		}
+
+		// TC3
+		@Test
+		void partnerN_locationEmail_noContact_noRecipient()
+		{
+			setPartnerInvoiceEmailEnabled("N");
+			setLocationEmail("bill.location@example.com");
+			assertThat(provide()).isEmpty();
+		}
+
+		// TC4
+		@Test
+		void partnerY_noLocationEmail_noContact_noRecipient()
+		{
+			setPartnerInvoiceEmailEnabled("Y");
+			assertThat(provide()).isEmpty();
+		}
 	}
 
 	private void createSysConfigOrderEmailPropagation(final String value)

--- a/backend/de.metas.document.archive/de.metas.document.archive.base/src/test/java/de/metas/document/archive/spi/impl/InvoiceDocOutboundLogMailRecipientProviderTest.java
+++ b/backend/de.metas.document.archive/de.metas.document.archive.base/src/test/java/de/metas/document/archive/spi/impl/InvoiceDocOutboundLogMailRecipientProviderTest.java
@@ -33,6 +33,7 @@ import static de.metas.i18n.Language.AD_Language_en_AU;
 import static de.metas.i18n.Language.AD_Language_en_GB;
 import static de.metas.i18n.Language.AD_Language_en_US;
 import static de.metas.i18n.Language.asLanguage;
+import static org.adempiere.model.InterfaceWrapperHelper.create;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.save;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
@@ -333,8 +334,10 @@ public class InvoiceDocOutboundLogMailRecipientProviderTest
 
 		private void setPartnerInvoiceEmailEnabled(final String value)
 		{
-			billBPartnerRecord.setIsInvoiceEmailEnabled(value);
-			saveRecord(billBPartnerRecord);
+			final de.metas.document.archive.model.I_C_BPartner billPartner =
+					create(billBPartnerRecord, de.metas.document.archive.model.I_C_BPartner.class);
+			billPartner.setIsInvoiceEmailEnabled(value);
+			saveRecord(billPartner);
 		}
 
 		private void setLocationEmail(final String email)

--- a/misc/dev-support/bootstrap-scripts/mvn_build.sh
+++ b/misc/dev-support/bootstrap-scripts/mvn_build.sh
@@ -21,33 +21,331 @@
 # L%
 #
 
-set -e
+set -e          # Exit immediately if a command exits with a non-zero status
+set -o pipefail # Return value of a pipeline is the status of the last command to exit with a non-zero status
 
-#needed if your locally installed "default" java is not the one expected by maven
-#export JAVA_HOME=c:/Users/tobia/.jdks/temurin-21.0.7 
-#export JAVA_HOME=c:/Users/tobia/.jdks/temurin-17.0.15
-export JAVA_HOME=c:/Users/tobia/.jdks/temurin-1.8.0_452
+# ============================================================================
+# Configuration
+# ======================================================================
 
+# Java versions for different build phases
+# Java 8 for: parent-pom, de-metas-common, backend
+# Java 17 for: services (camel, procurement-webui, federated-rabbitmq)
+
+# Default Java 8 home (only used if JAVA8_HOME is not already set)
+DEFAULT_JAVA8_HOME="$HOME/.jdks/temurin-1.8.0_452"
+
+# Default Java 17 home (only used if JAVA17_HOME is not already set)
+DEFAULT_JAVA17_HOME="$HOME/.jdks/temurin-17.0.15"
+
+# Multithreading configuration
 MULTITHREAD_PARAM=''
 #MULTITHREAD_PARAM='-T2C'
 
+# Additional Maven parameters
 ADDITIONAL_PARAMS='-Djib.skip=true -Dmaven.gitcommitid.skip=true -Dlicense.skip=true'
-#ADDITIONAL_PARAMS='${ADDITIONAL_PARAMS} -DskipTests'
-#ADDITIONAL_PARAMS='${ADDITIONAL_PARAMS} -Dmaven.test.skip=true'
+#ADDITIONAL_PARAMS="${ADDITIONAL_PARAMS} -DskipTests"
+#ADDITIONAL_PARAMS="${ADDITIONAL_PARAMS} -Dmaven.test.skip=true"
 
-#GOALS='test'
-GOALS='clean install'
+# Backend-specific parameters (migration scripts test skip)
+# By default, skip migration scripts test for faster builds
+# Override by setting environment variable: export SKIP_MIGRATION_SCRIPTS_TEST=false
+SKIP_MIGRATION_SCRIPTS_TEST="${SKIP_MIGRATION_SCRIPTS_TEST:-true}"
+BACKEND_PARAMS="-DSKIP_MIGRATION_SCRIPTS_TEST=${SKIP_MIGRATION_SCRIPTS_TEST}"
 
-mvn --file ../../parent-pom/pom.xml --settings ../maven/settings.xml $ADDITIONAL_PARAMS $GOALS && \
+# Default Maven goals (used if no goals provided as arguments)
+# Incremental build by default (no clean) for faster development cycles
+# Use --clean flag or pass "clean install" explicitly for full clean builds
+DEFAULT_GOALS='install'
 
-mvn --file ../../de-metas-common/pom.xml --settings ../maven/settings.xml $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS && \
+# ============================================================================
+# Functions
+# ============================================================================
 
-mvn -e --file ../../../backend/pom.xml --settings ../maven/settings.xml $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS && \
+# Function to run Maven build and handle errors
+run_mvn_build() {
+    local module_name="$1"
+    local java_version="$2"
+    shift 2
+    local mvn_args=("$@")
 
-mvn --file ../../services/camel/pom.xml --settings ../maven/settings.xml $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS && \
+    echo "$(date): Building $module_name ($java_version)..."
 
-mvn --file ../../services/procurement-webui/procurement-webui-backend/pom.xml --settings ../maven/settings.xml $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS && \
+    if JAVA_HOME="$java_version" mvn "${mvn_args[@]}"; then
+        echo "$(date): ✓ $module_name build succeeded"
+        return 0
+    else
+        local exit_code=$?
+        echo ""
+        echo "============================================================================"
+        echo "ERROR: Build failed for $module_name"
+        echo "============================================================================"
+        echo "Exit code: $exit_code"
+        echo "Java version: $java_version"
+        echo "Maven command: mvn ${mvn_args[*]}"
+        echo "============================================================================"
+        exit $exit_code
+    fi
+}
 
-mvn --file ../../services/federated-rabbitmq/pom.xml --settings ../maven/settings.xml $MULTITHREAD_PARAM $ADDITIONAL_PARAMS $GOALS
+show_help() {
+    cat << EOF
+Usage: $(basename "$0") [OPTIONS] [MAVEN_GOALS]
 
-echo "$(date): Done"
+Builds metasfresh using Maven with workspace-specific local repository.
+
+IMPORTANT - FULL BUILD DURATION:
+    Full builds (clean install) take 20-25 minutes to complete.
+    Consider running in background and monitoring periodically:
+
+    ./mvn_build.sh > /tmp/metasfresh_build.log 2>&1 &
+
+    Then check progress with:
+    tail -f /tmp/metasfresh_build.log
+
+OPTIONS:
+    -h, --help              Show this help message
+    --clean                 Clean before building (adds 'clean' goal)
+                            By default, builds are incremental (no clean)
+    --deps-only             Build only core dependencies (parent-pom, de-metas-common)
+                            Fast option for installing dependencies (~2-3 minutes)
+    --skip-tests            Skip running tests (adds -DskipTests)
+    --parallel              Enable parallel build (-T2C)
+
+MAVEN_GOALS:
+    Maven goals to execute (default: clean install)
+    Examples: "test", "clean install", "verify", "package"
+
+EXAMPLES:
+    $(basename "$0")                          # Default: incremental install (no clean)
+    $(basename "$0") --clean                  # Full clean install
+    $(basename "$0") --deps-only              # Install only dependencies (parent-pom, de-metas-common)
+    $(basename "$0") test                     # Run tests only
+    $(basename "$0") clean verify             # Clean and verify
+    $(basename "$0") --skip-tests             # Install without tests
+    $(basename "$0") --parallel --clean       # Parallel clean build
+
+ENVIRONMENT VARIABLES:
+    JAVA8_HOME                      Java 8 installation for parent-pom, de-metas-common, backend
+                                    (default: $DEFAULT_JAVA8_HOME)
+    JAVA17_HOME                     Java 17 installation for services (camel, procurement-webui, federated-rabbitmq)
+                                    (default: $DEFAULT_JAVA17_HOME)
+    SKIP_MIGRATION_SCRIPTS_TEST     Skip migration scripts test during backend build
+                                    (default: true, set to 'false' to run the test)
+
+WORKSPACE-SPECIFIC LOCAL REPOSITORY:
+    This script uses a workspace-specific Maven local repository at:
+    <metasfresh-root>/.m2-local
+
+    This keeps artifacts isolated per workspace, useful for working with
+    multiple branches in parallel.
+
+EOF
+}
+
+# ============================================================================
+# Parse command line arguments
+# ============================================================================
+
+MAVEN_GOALS=""
+SKIP_TESTS=""
+DEPS_ONLY=false
+DO_CLEAN=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        --clean)
+            DO_CLEAN=true
+            shift
+            ;;
+        --deps-only)
+            DEPS_ONLY=true
+            shift
+            ;;
+        --skip-tests)
+            SKIP_TESTS="-DskipTests"
+            shift
+            ;;
+        --parallel)
+            MULTITHREAD_PARAM="-T2C"
+            shift
+            ;;
+        *)
+            # Treat as Maven goals
+            MAVEN_GOALS="$MAVEN_GOALS $1"
+            shift
+            ;;
+    esac
+done
+
+# Use default goals if none provided
+if [ -z "$MAVEN_GOALS" ]; then
+    MAVEN_GOALS="$DEFAULT_GOALS"
+fi
+
+# Prepend 'clean' if --clean flag was used
+if [ "$DO_CLEAN" = true ]; then
+    MAVEN_GOALS="clean $MAVEN_GOALS"
+fi
+
+# If deps-only mode, force skip tests and skip test compilation
+if [ "$DEPS_ONLY" = true ]; then
+    SKIP_TESTS="-DskipTests -Dmaven.test.skip=true"
+fi
+
+# Add skip tests if requested
+if [ -n "$SKIP_TESTS" ]; then
+    ADDITIONAL_PARAMS="$ADDITIONAL_PARAMS $SKIP_TESTS"
+fi
+
+# ============================================================================
+# Setup paths and environment
+# ============================================================================
+
+# Get script directory and compute workspace root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# Setup workspace-specific Maven local repository
+LOCAL_REPO="$WORKSPACE_ROOT/.m2-local"
+mkdir -p "$LOCAL_REPO"
+
+# Maven local repo parameter
+MAVEN_REPO_PARAM="-Dmaven.repo.local=$LOCAL_REPO"
+
+# Setup Java homes (use environment variables if set, otherwise use defaults)
+if [ -z "$JAVA8_HOME" ]; then
+    JAVA8_HOME="$DEFAULT_JAVA8_HOME"
+    echo "JAVA8_HOME not set, using default: $JAVA8_HOME"
+else
+    echo "Using JAVA8_HOME from environment: $JAVA8_HOME"
+fi
+
+if [ -z "$JAVA17_HOME" ]; then
+    JAVA17_HOME="$DEFAULT_JAVA17_HOME"
+    echo "JAVA17_HOME not set, using default: $JAVA17_HOME"
+else
+    echo "Using JAVA17_HOME from environment: $JAVA17_HOME"
+fi
+
+# Verify Java installations exist
+if [ ! -d "$JAVA8_HOME" ]; then
+    echo "ERROR: JAVA8_HOME directory does not exist: $JAVA8_HOME"
+    exit 1
+fi
+
+if [ ! -d "$JAVA17_HOME" ]; then
+    echo "ERROR: JAVA17_HOME directory does not exist: $JAVA17_HOME"
+    exit 1
+fi
+
+# Maven settings file (relative to WORKSPACE_ROOT)
+MAVEN_SETTINGS="$WORKSPACE_ROOT/misc/dev-support/maven/settings.xml"
+
+# ============================================================================
+# Build configuration summary
+# ============================================================================
+
+echo "============================================================================"
+if [ "$DEPS_ONLY" = true ]; then
+    echo "metasfresh Core Dependencies Installation"
+else
+    echo "metasfresh Maven Build"
+fi
+echo "============================================================================"
+echo "Workspace:        $WORKSPACE_ROOT"
+echo "Local Repository: $LOCAL_REPO"
+echo "JAVA8_HOME:       $JAVA8_HOME"
+if [ "$DEPS_ONLY" = false ]; then
+    echo "JAVA17_HOME:      $JAVA17_HOME (for services)"
+fi
+echo "Maven Goals:      $MAVEN_GOALS"
+if [ "$DEPS_ONLY" = true ]; then
+    echo "Build Mode:       Dependencies only (parent-pom, de-metas-common)"
+else
+    echo "Build Mode:       Full build (parent-pom, de-metas-common, backend, services)"
+fi
+echo "Multithreading:   ${MULTITHREAD_PARAM:-disabled}"
+echo "Additional Params: $ADDITIONAL_PARAMS"
+if [ "$DEPS_ONLY" = false ]; then
+    echo "Backend Params:   $BACKEND_PARAMS"
+fi
+echo "============================================================================"
+echo ""
+
+# ============================================================================
+# Build modules in order
+# ============================================================================
+
+run_mvn_build "parent-pom" "$JAVA8_HOME" \
+    --file "$WORKSPACE_ROOT/misc/parent-pom/pom.xml" \
+    --settings "$MAVEN_SETTINGS" \
+    $MAVEN_REPO_PARAM \
+    $ADDITIONAL_PARAMS \
+    $MAVEN_GOALS
+
+run_mvn_build "de-metas-common" "$JAVA8_HOME" \
+    --file "$WORKSPACE_ROOT/misc/de-metas-common/pom.xml" \
+    --settings "$MAVEN_SETTINGS" \
+    $MAVEN_REPO_PARAM \
+    $MULTITHREAD_PARAM \
+    $ADDITIONAL_PARAMS \
+    $MAVEN_GOALS
+
+# Only build backend and services if not in deps-only mode
+if [ "$DEPS_ONLY" = false ]; then
+    run_mvn_build "backend" "$JAVA8_HOME" \
+        -e --file "$WORKSPACE_ROOT/backend/pom.xml" \
+        --settings "$MAVEN_SETTINGS" \
+        $MAVEN_REPO_PARAM \
+        $MULTITHREAD_PARAM \
+        $ADDITIONAL_PARAMS \
+        $BACKEND_PARAMS \
+        $MAVEN_GOALS
+
+    run_mvn_build "camel" "$JAVA17_HOME" \
+        --file "$WORKSPACE_ROOT/misc/services/camel/pom.xml" \
+        --settings "$MAVEN_SETTINGS" \
+        $MAVEN_REPO_PARAM \
+        $MULTITHREAD_PARAM \
+        $ADDITIONAL_PARAMS \
+        $MAVEN_GOALS
+
+    run_mvn_build "procurement-webui-backend" "$JAVA17_HOME" \
+        --file "$WORKSPACE_ROOT/misc/services/procurement-webui/procurement-webui-backend/pom.xml" \
+        --settings "$MAVEN_SETTINGS" \
+        $MAVEN_REPO_PARAM \
+        $MULTITHREAD_PARAM \
+        $ADDITIONAL_PARAMS \
+        $MAVEN_GOALS
+
+    run_mvn_build "federated-rabbitmq" "$JAVA17_HOME" \
+        --file "$WORKSPACE_ROOT/misc/services/federated-rabbitmq/pom.xml" \
+        --settings "$MAVEN_SETTINGS" \
+        $MAVEN_REPO_PARAM \
+        $MULTITHREAD_PARAM \
+        $ADDITIONAL_PARAMS \
+        $MAVEN_GOALS
+fi
+
+echo ""
+echo "============================================================================"
+if [ "$DEPS_ONLY" = true ]; then
+    echo "$(date): Dependencies installed successfully!"
+    echo "============================================================================"
+    echo ""
+    echo "Core dependencies (parent-pom, de-metas-common) are now available in:"
+    echo "  $LOCAL_REPO"
+    echo ""
+    echo "You can now:"
+    echo "  - Compile individual modules"
+    echo "  - Run unit tests in specific modules"
+    echo "  - Build the full codebase with: ./mvn_build.sh"
+else
+    echo "$(date): Build completed successfully!"
+fi
+echo "============================================================================"

--- a/misc/dev-support/maven/settings.xml
+++ b/misc/dev-support/maven/settings.xml
@@ -28,37 +28,10 @@
                 -->
             </properties>
 
-            <repositories>
-                <!--
-                    <repository>
-                        <id>metasfresh-repo</id>
-                        <releases>
-                            <enabled>true</enabled>
-                            <updatePolicy>always</updatePolicy>
-                            <checksumPolicy>warn</checksumPolicy>
-                        </releases>
-                        <url>https://repo.metasfresh.com/content/groups/mvn-master/</url>
-                    </repository>
-                 -->
-                <repository>
-                    <id>metasfresh-3rdparty</id>
-                    <releases>
-                        <enabled>true</enabled>
-                        <updatePolicy>daily</updatePolicy>
-                        <checksumPolicy>warn</checksumPolicy>
-                    </releases>
-                    <url>https://repo.metasfresh.com/repository/mvn-3rdparty-all/</url>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <!-- our main repo is also our plugin repo; also see https://maven.apache.org/pom.html#Plugin_Repositories -->
-                <!-- see https://github.com/metasfresh/metasfresh-parent/issues/3 -->
-                <pluginRepository>
-                    <id>metasfresh-repo</id>
-                    <name>metasfresh maven repository (master branch)</name>
-                    <url>https://repo.metasfresh.com/repository/mvn-master/</url>
-                </pluginRepository>
-            </pluginRepositories>
+            <!--
+                repo.metasfresh.com was the legacy Jenkins-era artifact server; it is no longer in use.
+                Build dependencies resolve against Maven Central (the default) only.
+            -->
         </profile>
 
     </profiles>


### PR DESCRIPTION
## What

Invoices for a bill partner that is opted in for invoice-email at the **partner** level
(`C_BPartner.IsInvoiceEmailEnabled='Y'`) and has a bill-to **location** email, but **no usable
`AD_User` bill contact**, were left with an empty `C_Doc_Outbound_Log.CurrentEMailAddress` and could
not be sent by email.

`InvoiceDocOutboundLogMailRecipientProvider.getMailTo` now — after both existing contact branches
yield no recipient — falls back to the bill-to **location email** via an email-only
`DocOutBoundRecipient` (no `AD_User`), when the partner flag is explicitly `Y` and the location has an
email.

## Scope

- **Explicit `Y` only** — blank / `N` on the partner flag do NOT trigger the fallback.
- Existing behaviour unchanged: branch A (invoice's own contact) and branch B (a `Y`-flagged bill-to
  default contact) are untouched.
- Supporting: `DocOutBoundRecipient.id` made nullable + `ofEmailAddress(...)`; `DocOutBoundRecipientCC.of`
  asserts a non-null id (CC is always user-based); `DocOutboundArchiveEventListener` null-guards
  `CurrentEMailRecipient_ID` for the user-less recipient.
- No AD_* / migration / window change.

## Tests

JUnit `InvoiceDocOutboundLogMailRecipientProviderTest` (email-the-location; blank→none; `N`→none;
no-location-email→none) + `DocOutBoundRecipientTest`.
