### PR TITLE
OLCand warehouse resolution: honor BP picking warehouse

### DIFF
--- a/backend/de.metas.business/src/main/java/org/adempiere/warehouse/spi/IWarehouseAdvisor.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/warehouse/spi/IWarehouseAdvisor.java
@@ -1,11 +1,14 @@
 package org.adempiere.warehouse.spi;
 
+import de.metas.bpartner.BPartnerId;
+import de.metas.order.OrderLineId;
+import de.metas.util.ISingletonService;
+import lombok.NonNull;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_OrderLine;
 
-import de.metas.order.OrderLineId;
-import de.metas.util.ISingletonService;
+import javax.annotation.Nullable;
 
 /**
  * Service used to advice which shall be the Warehouse of given document/document lines
@@ -26,4 +29,11 @@ public interface IWarehouseAdvisor extends ISingletonService
 	 * Suggests warehouse to be used by given order
 	 */
 	public WarehouseId evaluateOrderWarehouse(final I_C_Order order);
+
+	/**
+	 * Returns the customer's picking warehouse if the given BPartner is flagged as customer
+	 * and has a warehouse assigned that is flagged as picking warehouse; otherwise {@code null}.
+	 */
+	@Nullable
+	WarehouseId evaluateCustomerPickingWarehouse(@NonNull BPartnerId bpartnerId);
 }

--- a/backend/de.metas.business/src/main/java/org/adempiere/warehouse/spi/IWarehouseAdvisor.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/warehouse/spi/IWarehouseAdvisor.java
@@ -35,5 +35,5 @@ public interface IWarehouseAdvisor extends ISingletonService
 	 * and has a warehouse assigned that is flagged as picking warehouse; otherwise {@code null}.
 	 */
 	@Nullable
-	WarehouseId evaluateCustomerPickingWarehouse(@NonNull BPartnerId bpartnerId);
+	public WarehouseId evaluateCustomerPickingWarehouse(@NonNull BPartnerId bpartnerId);
 }

--- a/backend/de.metas.business/src/main/java/org/adempiere/warehouse/spi/impl/WarehouseAdvisor.java
+++ b/backend/de.metas.business/src/main/java/org/adempiere/warehouse/spi/impl/WarehouseAdvisor.java
@@ -16,6 +16,8 @@ import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_OrderLine;
 import org.compiere.model.I_M_Warehouse;
 
+import javax.annotation.Nullable;
+
 import static org.adempiere.model.InterfaceWrapperHelper.load;
 
 /**
@@ -111,6 +113,13 @@ public class WarehouseAdvisor implements IWarehouseAdvisor
 			return null;
 		}
 
+		return evaluateCustomerPickingWarehouse(bpartnerId);
+	}
+
+	@Override
+	@Nullable
+	public WarehouseId evaluateCustomerPickingWarehouse(@NonNull final BPartnerId bpartnerId)
+	{
 		final IBPartnerDAO bpartnersRepo = Services.get(IBPartnerDAO.class);
 		final I_C_BPartner bp = bpartnersRepo.getById(bpartnerId);
 		if (!bp.isCustomer())
@@ -124,7 +133,6 @@ public class WarehouseAdvisor implements IWarehouseAdvisor
 			return customerWarehouseId;
 		}
 
-		// if order is a purchase order, return null
 		return null;
 	}
 

--- a/backend/de.metas.business/src/test/java/org/adempiere/warehouse/spi/impl/WarehouseAdvisorTest.java
+++ b/backend/de.metas.business/src/test/java/org/adempiere/warehouse/spi/impl/WarehouseAdvisorTest.java
@@ -1,7 +1,6 @@
 package org.adempiere.warehouse.spi.impl;
 
 import de.metas.bpartner.BPartnerId;
-import de.metas.business.BusinessTestHelper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
 import org.adempiere.warehouse.WarehouseId;

--- a/backend/de.metas.business/src/test/java/org/adempiere/warehouse/spi/impl/WarehouseAdvisorTest.java
+++ b/backend/de.metas.business/src/test/java/org/adempiere/warehouse/spi/impl/WarehouseAdvisorTest.java
@@ -7,6 +7,7 @@ import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_M_Warehouse;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -26,81 +27,104 @@ public class WarehouseAdvisorTest
 		warehouseAdvisor = new WarehouseAdvisor();
 	}
 
-	@Test
-	public void evaluateCustomerPickingWarehouse_customerBP_pickingWarehouse_returnsWarehouse()
+	@Nested
+	class evaluateCustomerPickingWarehouse
 	{
-		// given
-		final I_M_Warehouse warehouse = newInstanceOutOfTrx(I_M_Warehouse.class);
-		warehouse.setName("PickingWH");
-		warehouse.setValue("PickingWH");
-		warehouse.setIsPickingWarehouse(true);
-		saveRecord(warehouse);
-		final WarehouseId warehouseId = WarehouseId.ofRepoId(warehouse.getM_Warehouse_ID());
+		@Test
+		void customerBP_pickingWarehouse_returnsWarehouse()
+		{
+			// given
+			final I_M_Warehouse warehouse = newInstanceOutOfTrx(I_M_Warehouse.class);
+			warehouse.setName("PickingWH");
+			warehouse.setValue("PickingWH");
+			warehouse.setIsPickingWarehouse(true);
+			saveRecord(warehouse);
+			final WarehouseId warehouseId = WarehouseId.ofRepoId(warehouse.getM_Warehouse_ID());
 
-		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
-		bp.setName("CustomerBP");
-		bp.setValue("CustomerBP");
-		bp.setIsCustomer(true);
-		bp.setM_Warehouse_ID(warehouseId.getRepoId());
-		saveRecord(bp);
-		final BPartnerId bpartnerId = BPartnerId.ofRepoId(bp.getC_BPartner_ID());
+			final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+			bp.setName("CustomerBP");
+			bp.setValue("CustomerBP");
+			bp.setIsCustomer(true);
+			bp.setM_Warehouse_ID(warehouseId.getRepoId());
+			saveRecord(bp);
+			final BPartnerId bpartnerId = BPartnerId.ofRepoId(bp.getC_BPartner_ID());
 
-		// when
-		final WarehouseId result = warehouseAdvisor.evaluateCustomerPickingWarehouse(bpartnerId);
+			// when
+			final WarehouseId result = warehouseAdvisor.evaluateCustomerPickingWarehouse(bpartnerId);
 
-		// then
-		assertThat(result).isEqualTo(warehouseId);
-	}
+			// then
+			assertThat(result).isEqualTo(warehouseId);
+		}
 
-	@Test
-	public void evaluateCustomerPickingWarehouse_customerBP_nonPickingWarehouse_returnsNull()
-	{
-		// given
-		final I_M_Warehouse warehouse = newInstanceOutOfTrx(I_M_Warehouse.class);
-		warehouse.setName("NonPickingWH");
-		warehouse.setValue("NonPickingWH");
-		warehouse.setIsPickingWarehouse(false);
-		saveRecord(warehouse);
-		final WarehouseId warehouseId = WarehouseId.ofRepoId(warehouse.getM_Warehouse_ID());
+		@Test
+		void customerBP_nonPickingWarehouse_returnsNull()
+		{
+			// given
+			final I_M_Warehouse warehouse = newInstanceOutOfTrx(I_M_Warehouse.class);
+			warehouse.setName("NonPickingWH");
+			warehouse.setValue("NonPickingWH");
+			warehouse.setIsPickingWarehouse(false);
+			saveRecord(warehouse);
+			final WarehouseId warehouseId = WarehouseId.ofRepoId(warehouse.getM_Warehouse_ID());
 
-		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
-		bp.setName("CustomerBP2");
-		bp.setValue("CustomerBP2");
-		bp.setIsCustomer(true);
-		bp.setM_Warehouse_ID(warehouseId.getRepoId());
-		saveRecord(bp);
-		final BPartnerId bpartnerId = BPartnerId.ofRepoId(bp.getC_BPartner_ID());
+			final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+			bp.setName("CustomerBP2");
+			bp.setValue("CustomerBP2");
+			bp.setIsCustomer(true);
+			bp.setM_Warehouse_ID(warehouseId.getRepoId());
+			saveRecord(bp);
+			final BPartnerId bpartnerId = BPartnerId.ofRepoId(bp.getC_BPartner_ID());
 
-		// when
-		final WarehouseId result = warehouseAdvisor.evaluateCustomerPickingWarehouse(bpartnerId);
+			// when
+			final WarehouseId result = warehouseAdvisor.evaluateCustomerPickingWarehouse(bpartnerId);
 
-		// then
-		assertThat(result).isNull();
-	}
+			// then
+			assertThat(result).isNull();
+		}
 
-	@Test
-	public void evaluateCustomerPickingWarehouse_nonCustomerBP_pickingWarehouse_returnsNull()
-	{
-		// given
-		final I_M_Warehouse warehouse = newInstanceOutOfTrx(I_M_Warehouse.class);
-		warehouse.setName("PickingWH2");
-		warehouse.setValue("PickingWH2");
-		warehouse.setIsPickingWarehouse(true);
-		saveRecord(warehouse);
-		final WarehouseId warehouseId = WarehouseId.ofRepoId(warehouse.getM_Warehouse_ID());
+		@Test
+		void nonCustomerBP_pickingWarehouse_returnsNull()
+		{
+			// given
+			final I_M_Warehouse warehouse = newInstanceOutOfTrx(I_M_Warehouse.class);
+			warehouse.setName("PickingWH2");
+			warehouse.setValue("PickingWH2");
+			warehouse.setIsPickingWarehouse(true);
+			saveRecord(warehouse);
+			final WarehouseId warehouseId = WarehouseId.ofRepoId(warehouse.getM_Warehouse_ID());
 
-		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
-		bp.setName("NonCustomerBP");
-		bp.setValue("NonCustomerBP");
-		bp.setIsCustomer(false);
-		bp.setM_Warehouse_ID(warehouseId.getRepoId());
-		saveRecord(bp);
-		final BPartnerId bpartnerId = BPartnerId.ofRepoId(bp.getC_BPartner_ID());
+			final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+			bp.setName("NonCustomerBP");
+			bp.setValue("NonCustomerBP");
+			bp.setIsCustomer(false);
+			bp.setM_Warehouse_ID(warehouseId.getRepoId());
+			saveRecord(bp);
+			final BPartnerId bpartnerId = BPartnerId.ofRepoId(bp.getC_BPartner_ID());
 
-		// when
-		final WarehouseId result = warehouseAdvisor.evaluateCustomerPickingWarehouse(bpartnerId);
+			// when
+			final WarehouseId result = warehouseAdvisor.evaluateCustomerPickingWarehouse(bpartnerId);
 
-		// then
-		assertThat(result).isNull();
+			// then
+			assertThat(result).isNull();
+		}
+
+		@Test
+		void customerBP_noWarehouse_returnsNull()
+		{
+			// given
+			final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+			bp.setName("CustomerBP3");
+			bp.setValue("CustomerBP3");
+			bp.setIsCustomer(true);
+			// no M_Warehouse_ID set
+			saveRecord(bp);
+			final BPartnerId bpartnerId = BPartnerId.ofRepoId(bp.getC_BPartner_ID());
+
+			// when
+			final WarehouseId result = warehouseAdvisor.evaluateCustomerPickingWarehouse(bpartnerId);
+
+			// then
+			assertThat(result).isNull();
+		}
 	}
 }

--- a/backend/de.metas.business/src/test/java/org/adempiere/warehouse/spi/impl/WarehouseAdvisorTest.java
+++ b/backend/de.metas.business/src/test/java/org/adempiere/warehouse/spi/impl/WarehouseAdvisorTest.java
@@ -1,0 +1,107 @@
+package org.adempiere.warehouse.spi.impl;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.business.BusinessTestHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_M_Warehouse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstanceOutOfTrx;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(AdempiereTestWatcher.class)
+public class WarehouseAdvisorTest
+{
+	private WarehouseAdvisor warehouseAdvisor;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+		warehouseAdvisor = new WarehouseAdvisor();
+	}
+
+	@Test
+	public void evaluateCustomerPickingWarehouse_customerBP_pickingWarehouse_returnsWarehouse()
+	{
+		// given
+		final I_M_Warehouse warehouse = newInstanceOutOfTrx(I_M_Warehouse.class);
+		warehouse.setName("PickingWH");
+		warehouse.setValue("PickingWH");
+		warehouse.setIsPickingWarehouse(true);
+		saveRecord(warehouse);
+		final WarehouseId warehouseId = WarehouseId.ofRepoId(warehouse.getM_Warehouse_ID());
+
+		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+		bp.setName("CustomerBP");
+		bp.setValue("CustomerBP");
+		bp.setIsCustomer(true);
+		bp.setM_Warehouse_ID(warehouseId.getRepoId());
+		saveRecord(bp);
+		final BPartnerId bpartnerId = BPartnerId.ofRepoId(bp.getC_BPartner_ID());
+
+		// when
+		final WarehouseId result = warehouseAdvisor.evaluateCustomerPickingWarehouse(bpartnerId);
+
+		// then
+		assertThat(result).isEqualTo(warehouseId);
+	}
+
+	@Test
+	public void evaluateCustomerPickingWarehouse_customerBP_nonPickingWarehouse_returnsNull()
+	{
+		// given
+		final I_M_Warehouse warehouse = newInstanceOutOfTrx(I_M_Warehouse.class);
+		warehouse.setName("NonPickingWH");
+		warehouse.setValue("NonPickingWH");
+		warehouse.setIsPickingWarehouse(false);
+		saveRecord(warehouse);
+		final WarehouseId warehouseId = WarehouseId.ofRepoId(warehouse.getM_Warehouse_ID());
+
+		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+		bp.setName("CustomerBP2");
+		bp.setValue("CustomerBP2");
+		bp.setIsCustomer(true);
+		bp.setM_Warehouse_ID(warehouseId.getRepoId());
+		saveRecord(bp);
+		final BPartnerId bpartnerId = BPartnerId.ofRepoId(bp.getC_BPartner_ID());
+
+		// when
+		final WarehouseId result = warehouseAdvisor.evaluateCustomerPickingWarehouse(bpartnerId);
+
+		// then
+		assertThat(result).isNull();
+	}
+
+	@Test
+	public void evaluateCustomerPickingWarehouse_nonCustomerBP_pickingWarehouse_returnsNull()
+	{
+		// given
+		final I_M_Warehouse warehouse = newInstanceOutOfTrx(I_M_Warehouse.class);
+		warehouse.setName("PickingWH2");
+		warehouse.setValue("PickingWH2");
+		warehouse.setIsPickingWarehouse(true);
+		saveRecord(warehouse);
+		final WarehouseId warehouseId = WarehouseId.ofRepoId(warehouse.getM_Warehouse_ID());
+
+		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+		bp.setName("NonCustomerBP");
+		bp.setValue("NonCustomerBP");
+		bp.setIsCustomer(false);
+		bp.setM_Warehouse_ID(warehouseId.getRepoId());
+		saveRecord(bp);
+		final BPartnerId bpartnerId = BPartnerId.ofRepoId(bp.getC_BPartner_ID());
+
+		// when
+		final WarehouseId result = warehouseAdvisor.evaluateCustomerPickingWarehouse(bpartnerId);
+
+		// then
+		assertThat(result).isNull();
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
@@ -35,6 +35,7 @@ import de.metas.common.util.CoalesceUtil;
 import de.metas.common.util.EmptyUtil;
 import de.metas.contracts.bpartner.process.C_BPartner_MoveToAnotherOrg;
 import de.metas.cucumber.stepdefs.aggregation.C_Aggregation_StepDefData;
+import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
 import de.metas.cucumber.stepdefs.context.TestContext;
 import de.metas.cucumber.stepdefs.discountschema.M_DiscountSchema_StepDefData;
 import de.metas.cucumber.stepdefs.dunning.C_Dunning_StepDefData;
@@ -128,6 +129,7 @@ public class C_BPartner_StepDef
 	@NonNull private final C_PaymentTerm_StepDefData paymentTermTable;
 	@NonNull private final AD_Org_StepDefData orgTable;
 	@NonNull private final C_Aggregation_StepDefData aggregationTable;
+	@NonNull private final M_Warehouse_StepDefData warehouseTable;
 	@NonNull private final TestContext restTestContext;
 	private final IBPartnerDAO bpartnerDAO = Services.get(IBPartnerDAO.class);
 	private final IBPartnerStatsDAO bpartnerStatsDAO = Services.get(IBPartnerStatsDAO.class);
@@ -335,6 +337,10 @@ public class C_BPartner_StepDef
 		row.getAsOptionalIdentifier(COLUMNNAME_SO_Invoice_Aggregation_ID)
 				.map(aggregationTable::getId)
 				.ifPresent(aggregationId -> bPartnerRecord.setSO_Invoice_Aggregation_ID(aggregationId.getRepoId()));
+
+		row.getAsOptionalIdentifier(I_C_BPartner.COLUMNNAME_M_Warehouse_ID)
+				.map(warehouseTable::getId)
+				.ifPresent(warehouseId -> bPartnerRecord.setM_Warehouse_ID(warehouseId.getRepoId()));
 
 		final boolean alsoCreateLocation = InterfaceWrapperHelper.isNew(bPartnerRecord) && addDefaultLocationIfNewBPartner;
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/olcand/C_OLCandProcessor_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/olcand/C_OLCandProcessor_StepDef.java
@@ -57,7 +57,7 @@ public class C_OLCandProcessor_StepDef
 	 * @cucumber.columns
 	 *   <b>Name</b> — (required when C_OLCandProcessor_ID absent) name of the C_OLCandProcessor to update<br>
 	 *   <b>OPT.C_OLCandProcessor_ID</b> — (optional) raw repo-ID of the processor (preferred when Name is uncertain)<br>
-	 *   <b>OPT.M_Warehouse_ID</b> — (optional, identifier-ref) new default warehouse; resolved via M_Warehouse_StepDefData<br>
+	 *   <b>OPT.M_Warehouse_ID.Identifier</b> — (optional, identifier-ref) new default warehouse; resolved via M_Warehouse_StepDefData<br>
 	 * @cucumber.depends StepDefData: M_Warehouse_StepDefData
 	 * @cucumber.example
 	 * <pre>

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/olcand/C_OLCandProcessor_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/olcand/C_OLCandProcessor_StepDef.java
@@ -24,44 +24,43 @@ package de.metas.cucumber.stepdefs.olcand;
 
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
-import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
+import de.metas.ordercandidate.api.OLCandProcessorId;
 import de.metas.ordercandidate.model.I_C_OLCandProcessor;
-import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
+import io.cucumber.java.After;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
-import org.compiere.model.I_M_Warehouse;
+import org.adempiere.warehouse.WarehouseId;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Step definitions for C_OLCandProcessor records.
- * Covers updating processor-level defaults (e.g. the default warehouse) used by the OLCand-to-Order pipeline.
+ * Updates processor-level defaults (e.g. the default warehouse) used by the OLCand-to-Order pipeline.
+ * The processor and its warehouse are addressed by their repo-IDs, since the processor is a standard seed record.
+ * <p>
+ * Because a C_OLCandProcessor is a shared seed record, any warehouse mutated here is restored to its original
+ * value in an {@link After} hook, so sibling scenarios on the same executor are not affected.
  */
-@RequiredArgsConstructor
 public class C_OLCandProcessor_StepDef
 {
-	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
-
-	@NonNull private final M_Warehouse_StepDefData warehouseTable;
+	/** Original M_Warehouse_ID per processor touched in the current scenario, for restoration in {@link #restoreProcessors()}. */
+	private final Map<OLCandProcessorId, Integer> originalWarehouseIdByProcessor = new LinkedHashMap<>();
 
 	/**
-	 * Updates an existing C_OLCandProcessor record.
-	 * The record is located by {@code C_OLCandProcessor_ID} when provided, otherwise by {@code Name}.
+	 * Updates an existing C_OLCandProcessor record, addressed by its repo-ID.
 	 *
-	 * @cucumber.stepdef
 	 * @cucumber.columns
-	 *   <b>Name</b> — (required when C_OLCandProcessor_ID absent) name of the C_OLCandProcessor to update<br>
-	 *   <b>OPT.C_OLCandProcessor_ID</b> — (optional) raw repo-ID of the processor (preferred when Name is uncertain)<br>
-	 *   <b>OPT.M_Warehouse_ID.Identifier</b> — (optional, identifier-ref) new default warehouse; resolved via M_Warehouse_StepDefData<br>
-	 * @cucumber.depends StepDefData: M_Warehouse_StepDefData
+	 *   <b>C_OLCandProcessor_ID</b> — repo-ID of the processor to update<br>
+	 *   <b>OPT.M_Warehouse_ID</b> — (optional) repo-ID of the new default warehouse<br>
 	 * @cucumber.example
 	 * <pre>
 	 * And update C_OLCandProcessor:
-	 *   | OPT.C_OLCandProcessor_ID | OPT.M_Warehouse_ID.Identifier |
-	 *   | 1000003                  | defaultWH                     |
+	 *   | C_OLCandProcessor_ID | M_Warehouse_ID |
+	 *   | 1000003              | 540008         |
 	 * </pre>
 	 */
 	@And("update C_OLCandProcessor:")
@@ -72,41 +71,40 @@ public class C_OLCandProcessor_StepDef
 
 	private void updateProcessor(@NonNull final DataTableRow row)
 	{
-		final I_C_OLCandProcessor processor = loadProcessor(row);
+		final OLCandProcessorId processorId = row.getAsIdentifier(I_C_OLCandProcessor.COLUMNNAME_C_OLCandProcessor_ID)
+				.getAsId(OLCandProcessorId.class);
+
+		final I_C_OLCandProcessor processor = InterfaceWrapperHelper.load(processorId.getRepoId(), I_C_OLCandProcessor.class);
+		if (processor == null)
+		{
+			throw new AdempiereException("No C_OLCandProcessor found with C_OLCandProcessor_ID=" + processorId.getRepoId());
+		}
 
 		row.getAsOptionalIdentifier(I_C_OLCandProcessor.COLUMNNAME_M_Warehouse_ID)
-				.ifPresent(warehouseIdentifier -> {
-					final I_M_Warehouse warehouse = warehouseTable.get(warehouseIdentifier);
-					processor.setM_Warehouse_ID(warehouse.getM_Warehouse_ID());
+				.map(identifier -> identifier.getAsId(WarehouseId.class))
+				.ifPresent(warehouseId -> {
+					originalWarehouseIdByProcessor.putIfAbsent(processorId, processor.getM_Warehouse_ID());
+					processor.setM_Warehouse_ID(warehouseId.getRepoId());
 				});
 
 		InterfaceWrapperHelper.saveRecord(processor);
 	}
 
-	@NonNull
-	private I_C_OLCandProcessor loadProcessor(@NonNull final DataTableRow row)
+	/**
+	 * Restores every processor whose warehouse this scenario changed back to its original value,
+	 * so a shared seed processor does not leak state into sibling scenarios on the same executor.
+	 */
+	@After
+	public void restoreProcessors()
 	{
-		final int processorId = row.getAsOptionalInt(I_C_OLCandProcessor.COLUMNNAME_C_OLCandProcessor_ID).orElse(0);
-		if (processorId > 0)
-		{
-			final I_C_OLCandProcessor processor = InterfaceWrapperHelper.load(processorId, I_C_OLCandProcessor.class);
-			if (processor == null)
+		originalWarehouseIdByProcessor.forEach((processorId, originalWarehouseId) -> {
+			final I_C_OLCandProcessor processor = InterfaceWrapperHelper.load(processorId.getRepoId(), I_C_OLCandProcessor.class);
+			if (processor != null)
 			{
-				throw new AdempiereException("No C_OLCandProcessor found with C_OLCandProcessor_ID=" + processorId);
+				processor.setM_Warehouse_ID(originalWarehouseId);
+				InterfaceWrapperHelper.saveRecord(processor);
 			}
-			return processor;
-		}
-
-		final String name = row.getAsString(I_C_OLCandProcessor.COLUMNNAME_Name);
-		final I_C_OLCandProcessor processor = queryBL.createQueryBuilder(I_C_OLCandProcessor.class)
-				.addEqualsFilter(I_C_OLCandProcessor.COLUMNNAME_Name, name)
-				.create()
-				.firstOnly(I_C_OLCandProcessor.class);
-
-		if (processor == null)
-		{
-			throw new AdempiereException("No C_OLCandProcessor found with Name=" + name);
-		}
-		return processor;
+		});
+		originalWarehouseIdByProcessor.clear();
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/olcand/C_OLCandProcessor_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/olcand/C_OLCandProcessor_StepDef.java
@@ -36,8 +36,6 @@ import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_M_Warehouse;
 
-import javax.annotation.Nullable;
-
 /**
  * Step definitions for C_OLCandProcessor records.
  * Covers updating processor-level defaults (e.g. the default warehouse) used by the OLCand-to-Order pipeline.

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/olcand/C_OLCandProcessor_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/olcand/C_OLCandProcessor_StepDef.java
@@ -1,0 +1,114 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.olcand;
+
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
+import de.metas.ordercandidate.model.I_C_OLCandProcessor;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.And;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_M_Warehouse;
+
+import javax.annotation.Nullable;
+
+/**
+ * Step definitions for C_OLCandProcessor records.
+ * Covers updating processor-level defaults (e.g. the default warehouse) used by the OLCand-to-Order pipeline.
+ */
+@RequiredArgsConstructor
+public class C_OLCandProcessor_StepDef
+{
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@NonNull private final M_Warehouse_StepDefData warehouseTable;
+
+	/**
+	 * Updates an existing C_OLCandProcessor record.
+	 * The record is located by {@code C_OLCandProcessor_ID} when provided, otherwise by {@code Name}.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>Name</b> — (required when C_OLCandProcessor_ID absent) name of the C_OLCandProcessor to update<br>
+	 *   <b>OPT.C_OLCandProcessor_ID</b> — (optional) raw repo-ID of the processor (preferred when Name is uncertain)<br>
+	 *   <b>OPT.M_Warehouse_ID</b> — (optional, identifier-ref) new default warehouse; resolved via M_Warehouse_StepDefData<br>
+	 * @cucumber.depends StepDefData: M_Warehouse_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And update C_OLCandProcessor:
+	 *   | OPT.C_OLCandProcessor_ID | OPT.M_Warehouse_ID.Identifier |
+	 *   | 1000003                  | defaultWH                     |
+	 * </pre>
+	 */
+	@And("update C_OLCandProcessor:")
+	public void update_C_OLCandProcessor(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::updateProcessor);
+	}
+
+	private void updateProcessor(@NonNull final DataTableRow row)
+	{
+		final I_C_OLCandProcessor processor = loadProcessor(row);
+
+		row.getAsOptionalIdentifier(I_C_OLCandProcessor.COLUMNNAME_M_Warehouse_ID)
+				.ifPresent(warehouseIdentifier -> {
+					final I_M_Warehouse warehouse = warehouseTable.get(warehouseIdentifier);
+					processor.setM_Warehouse_ID(warehouse.getM_Warehouse_ID());
+				});
+
+		InterfaceWrapperHelper.saveRecord(processor);
+	}
+
+	@NonNull
+	private I_C_OLCandProcessor loadProcessor(@NonNull final DataTableRow row)
+	{
+		final int processorId = row.getAsOptionalInt(I_C_OLCandProcessor.COLUMNNAME_C_OLCandProcessor_ID).orElse(0);
+		if (processorId > 0)
+		{
+			final I_C_OLCandProcessor processor = InterfaceWrapperHelper.load(processorId, I_C_OLCandProcessor.class);
+			if (processor == null)
+			{
+				throw new AdempiereException("No C_OLCandProcessor found with C_OLCandProcessor_ID=" + processorId);
+			}
+			return processor;
+		}
+
+		final String name = row.getAsString(I_C_OLCandProcessor.COLUMNNAME_Name);
+		final I_C_OLCandProcessor processor = queryBL.createQueryBuilder(I_C_OLCandProcessor.class)
+				.addEqualsFilter(I_C_OLCandProcessor.COLUMNNAME_Name, name)
+				.create()
+				.firstOnly(I_C_OLCandProcessor.class);
+
+		if (processor == null)
+		{
+			throw new AdempiereException("No C_OLCandProcessor found with Name=" + name);
+		}
+		return processor;
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
@@ -603,6 +603,38 @@ public class C_OrderLine_StepDef
 		}
 	}
 
+	/**
+	 * Validates a single {@link I_C_OrderLine} record against expected values from the DataTable row.
+	 * Called per row by {@link #validate_created_order_lines(DataTable)}.
+	 *
+	 * <p>Supported DataTable columns (all optional unless noted):</p>
+	 * <ul>
+	 *   <li>{@code C_OrderLine_ID} — required identifier; must have been registered in {@link C_OrderLine_StepDefData}</li>
+	 *   <li>{@code C_Order_ID} — optional identifier; validates that the line belongs to this order</li>
+	 *   <li>{@code M_Product_ID} — optional identifier; resolved via M_Product_StepDefData</li>
+	 *   <li>{@code QtyOrdered} — optional BigDecimal</li>
+	 *   <li>{@code qtydelivered} — optional BigDecimal; maps to {@code QtyDelivered}</li>
+	 *   <li>{@code qtyinvoiced} — optional BigDecimal; maps to {@code QtyInvoiced}</li>
+	 *   <li>{@code price} — optional BigDecimal; maps to {@code PriceEntered}</li>
+	 *   <li>{@code discount} — optional BigDecimal</li>
+	 *   <li>{@code currencyCode} — optional ISO-4217 code</li>
+	 *   <li>{@code processed} — optional boolean</li>
+	 *   <li>{@code OPT.M_Warehouse_ID.Identifier} — optional identifier; resolved via {@link de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData};
+	 *       when absent the warehouse is not validated</li>
+	 *   <li>(plus further optional columns: C_UOM_BPartner_ID.X12DE355, IsManualPrice, BPartner_QtyItemCapacity,
+	 *       QtyEnteredInBPartnerUOM, C_UOM_ID.X12DE355, QtyItemCapacity, DateOrdered, C_TaxCategory_ID,
+	 *       C_BPartner_Vendor_ID, C_Flatrate_Conditions_ID, Price_UOM_ID.X12DE355, ProductDescription,
+	 *       M_AttributeSetInstance_ID, ATT.*, M_HU_PI_Item_Product_ID, QtyEnteredTU, QtyReserved,
+	 *       C_Tax_ID, ExternalId, C_Project_ID)</li>
+	 * </ul>
+	 *
+	 * @cucumber.example
+	 * <pre>
+	 * And validate the created order lines:
+	 *   | C_OrderLine_ID     | C_Order_ID   | M_Product_ID   | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | OPT.M_Warehouse_ID.Identifier |
+	 *   | orderLine_S30235_1 | order_S30235 | product_S30235 | 1          | 0            | 0           | 10    | 0        | EUR          | true      | pickingWH                     |
+	 * </pre>
+	 */
 	private void validateOrderLine(@NonNull final I_C_OrderLine orderLine, @NonNull final DataTableRow row)
 	{
 		final String identifierStr = row.getAsIdentifier().getAsString();

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
@@ -824,6 +824,14 @@ public class C_OrderLine_StepDef
 			}
 		}
 
+		row.getAsOptionalIdentifier(I_C_OrderLine.COLUMNNAME_M_Warehouse_ID)
+				.ifPresent(warehouseIdentifier -> {
+					final I_M_Warehouse warehouse = warehouseTable.get(warehouseIdentifier);
+					softly.assertThat(orderLine.getM_Warehouse_ID())
+							.as("M_Warehouse_ID for Identifier=%s", identifierStr)
+							.isEqualTo(warehouse.getM_Warehouse_ID());
+				});
+
 		softly.assertAll();
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
@@ -787,6 +787,39 @@ public class C_Order_StepDef
 		}
 	}
 
+	/**
+	 * Validates a single {@link I_C_Order} row against expected values.
+	 * Called per row by {@link #validate_created_order(DataTable)}.
+	 *
+	 * <p>Supported DataTable columns (all optional unless noted):</p>
+	 * <ul>
+	 *   <li>{@code C_Order_ID} — required identifier; must have been registered in {@link C_Order_StepDefData}</li>
+	 *   <li>{@code C_BPartner_ID} — optional identifier; resolved via {@link de.metas.cucumber.stepdefs.C_BPartner_StepDefData}</li>
+	 *   <li>{@code C_BPartner_Location_ID} — optional identifier; resolved via C_BPartner_Location_StepDefData</li>
+	 *   <li>{@code DateOrdered} — optional date (yyyy-MM-dd)</li>
+	 *   <li>{@code DocBaseType} — optional string; matched against the order's document type</li>
+	 *   <li>{@code currencyCode} — optional ISO-4217 currency code</li>
+	 *   <li>{@code DeliveryRule} — optional string</li>
+	 *   <li>{@code DeliveryViaRule} — optional string</li>
+	 *   <li>{@code processed} — optional boolean</li>
+	 *   <li>{@code DocStatus} — optional string</li>
+	 *   <li>{@code poReference} — optional string</li>
+	 *   <li>{@code InvoiceRule} — optional string</li>
+	 *   <li>{@code PaymentRule} — optional string</li>
+	 *   <li>{@code OPT.M_Warehouse_ID.Identifier} — optional identifier; resolved via {@link de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData};
+	 *       when absent the warehouse is not validated</li>
+	 *   <li>(plus further optional columns: AD_User_ID, Bill_BPartner_ID, Bill_Location_ID, Bill_User_ID, EMail,
+	 *       ExternalId, ExternalSystem, AD_InputDataSource_ID, IsDropShip, DropShip_*, IsUseHandOver_Location,
+	 *       HandOver_*, C_Incoterms, IncotermLocation, C_PromotionCode_ID, C_PromotionCode2_ID, C_Project_ID, LC_Date)</li>
+	 * </ul>
+	 *
+	 * @cucumber.example
+	 * <pre>
+	 * And validate the created orders:
+	 *   | C_Order_ID   | C_BPartner_ID | DateOrdered | DocBaseType | currencyCode | DeliveryRule | DeliveryViaRule | poReference | processed | DocStatus | OPT.M_Warehouse_ID.Identifier |
+	 *   | order_S30235 | bp_S30235     | 2021-04-16  | SOO         | EUR          | F            | S               | S30235_01   | true      | CO        | pickingWH                     |
+	 * </pre>
+	 */
 	private void validateOrder(@NonNull final DataTableRow row)
 	{
 		final StepDefDataIdentifier identifier = row.getAsIdentifier();

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
@@ -990,6 +990,13 @@ public class C_Order_StepDef
 					}
 				});
 
+		row.getAsOptionalIdentifier(COLUMNNAME_M_Warehouse_ID)
+				.map(warehouseIdentifier -> warehouseTable.getIdOptional(warehouseIdentifier)
+						.orElseGet(() -> warehouseIdentifier.getAsId(WarehouseId.class)))
+				.ifPresent(warehouseId -> softly.assertThat(order.getM_Warehouse_ID())
+						.as("M_Warehouse_ID for Identifier=%s", identifierStr)
+						.isEqualTo(warehouseId.getRepoId()));
+
 		softly.assertAll();
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/warehouse/M_Warehouse_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/warehouse/M_Warehouse_StepDef.java
@@ -52,6 +52,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.COLUMNNAME_IsActive;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.compiere.model.I_M_Warehouse.COLUMNNAME_IsIssueWarehouse;
+import static org.compiere.model.I_M_Warehouse.COLUMNNAME_IsPickingWarehouse;
 import static org.compiere.model.I_M_Warehouse.COLUMNNAME_M_Warehouse_ID;
 import static org.compiere.model.I_M_Warehouse.COLUMNNAME_Value;
 
@@ -109,6 +110,8 @@ public class M_Warehouse_StepDef
 						queryBL.createQueryBuilder(I_M_Warehouse.class).addEqualsFilter(COLUMNNAME_IsIssueWarehouse, true).addEqualsFilter(COLUMNNAME_IsActive, true).create().updateDirectly(updater);
 					}
 
+					final boolean isPickingWarehouse = row.getAsOptionalBoolean(COLUMNNAME_IsPickingWarehouse).orElse(false);
+
 					final boolean isDropShipWarehouse = row.getAsOptionalBoolean(I_M_Warehouse.COLUMNNAME_IsDropShipWarehouse).orElse(false);
 					warehouseRecord.setIsDropShipWarehouse(isDropShipWarehouse);
 
@@ -135,6 +138,7 @@ public class M_Warehouse_StepDef
 					warehouseRecord.setC_BPartner_ID(BPartnerId.toRepoId(bpartnerId));
 					warehouseRecord.setC_BPartner_Location_ID(BPartnerLocationId.toRepoId(bpartnerLocationId));
 					warehouseRecord.setIsIssueWarehouse(isIssueWarehouse);
+					warehouseRecord.setIsPickingWarehouse(isPickingWarehouse);
 					warehouseRecord.setIsInTransit(isInTransit);
 					warehouseRecord.setIsQuarantineWarehouse(isQuarantineWarehouse);
 					warehouseRecord.setIsQualityReturnWarehouse(isQualityReturnWarehouse);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/olCandBPPickingWarehouse.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/olCandBPPickingWarehouse.feature
@@ -1,0 +1,123 @@
+@from:cucumber
+@allure.label.epic:E0100_Sales
+@allure.label.feature:F00122
+@topic:orderCandidate
+@ghActions:run_on_executor3
+Feature: OLCand order creation uses BP picking warehouse when no warehouse is in the payload
+## F00122: OLCand Warehouse Advisor
+##
+## When a sales order candidate is POSTed with no warehouse in the payload,
+## the order must be created with the business partner's picking warehouse —
+## NOT the OLCand-processor default warehouse.
+##
+## Bug: before the fix, the processor-default warehouse always wins even when
+## the BP has an explicit picking warehouse configured.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2021-04-16T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+
+  @from:cucumber
+  @allure.label.epic:E0100_Sales
+  @allure.label.feature:F00122
+  @topic:orderCandidate
+  @Id:S30235_01
+  Scenario: OLCand without warehouse → order inherits BP picking warehouse, not processor default
+    # Two warehouses: WH_PICK is the BP's picking warehouse; WH_DEFAULT is set as the
+    # processor default warehouse.  The created order must use WH_PICK (the BP wins).
+    # With the bug the order takes WH_DEFAULT → this scenario is RED before the fix.
+    Given metasfresh contains M_Warehouse:
+      | Identifier | Value      | Name       | OPT.IsPickingWarehouse |
+      | pickingWH  | pickingWH  | pickingWH  | true                   |
+      | defaultWH  | defaultWH  | defaultWH  | false                  |
+
+    And update C_OLCandProcessor:
+      | OPT.C_OLCandProcessor_ID | OPT.M_Warehouse_ID.Identifier |
+      | 1000003                  | defaultWH                     |
+
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name       | Value      | OPT.IsActive |
+      | ps_S30235  | ps_S30235  | ps_S30235  | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name       | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_S30235  | ps_S30235                     | DE                        | EUR                 | pl_S30235  | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name       | ValidFrom  |
+      | plv_S30235 | pl_S30235                 | plv_S30235 | 2021-04-01 |
+    And metasfresh contains M_Products:
+      | Identifier     | Name           |
+      | product_S30235 | product_S30235 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_S30235  | plv_S30235                        | product_S30235          | 10.0     | PCE               | Normal                        |
+    And metasfresh contains C_BPartners:
+      | Identifier | Name       | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID | GLN           | OPT.M_Warehouse_ID.Identifier |
+      | bp_S30235  | bp_S30235  | Y              | N            | ps_S30235                     | bpLoc_S30235               | 3000000030235 | pickingWH                     |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier   | GLN           | C_BPartner_ID.Identifier |
+      | bpLoc_S30235 | 3000000030235 | bp_S30235                |
+
+    # POST one candidate for bp_S30235 — NO warehouse in payload.
+    # The OLCand-processor default warehouse is defaultWH; the BP's picking warehouse is pickingWH.
+    # The fix must route the order to pickingWH (the BP wins over the processor default).
+    When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
+  """
+{
+    "requests": [
+        {
+            "orgCode": "001",
+            "externalHeaderId": "S30235_01",
+            "externalLineId": "S30235_01_L1",
+            "externalSystemCode": "Shopware6",
+            "dataSource": "int-Shopware",
+            "bpartner": {
+                "bpartnerIdentifier": "gln-3000000030235",
+                "bpartnerLocationIdentifier": "gln-3000000030235"
+            },
+            "dateRequired": "2021-12-02",
+            "dateOrdered": "2021-04-16",
+            "orderDocType": "SalesOrder",
+            "paymentTerm": "val-1000002",
+            "productIdentifier": "val-product_S30235",
+            "qty": 1,
+            "currencyCode": "EUR",
+            "discount": 0,
+            "poReference": "S30235_01",
+            "deliveryViaRule": "S",
+            "deliveryRule": "F"
+        }
+    ]
+}
+"""
+    Then process metasfresh response JsonOLCandCreateBulkResponse
+      | C_OLCand_ID.Identifier |
+      | olCand_S30235          |
+    And validate C_OLCand:
+      | C_OLCand_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyEntered | IsError |
+      | olCand_S30235          | bp_S30235                | bpLoc_S30235                      | product_S30235          | 1          | N       |
+
+    When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/process' and fulfills with '200' status code
+"""
+{
+    "externalHeaderId": "S30235_01",
+    "externalSystemCode": "Shopware6",
+    "ship": false,
+    "invoice": false,
+    "closeOrder": false
+}
+"""
+    Then process metasfresh response
+      | C_Order_ID.Identifier |
+      | order_S30235          |
+
+    # Before the fix: C_Order.M_Warehouse_ID = defaultWH (processor default wins) → RED.
+    # After the fix: C_Order.M_Warehouse_ID = pickingWH (BP picking warehouse wins) → GREEN.
+    And validate the created orders
+      | C_Order_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | DeliveryRule | DeliveryViaRule | poReference | processed | DocStatus | OPT.M_Warehouse_ID.Identifier |
+      | order_S30235          | bp_S30235                | bpLoc_S30235                      | 2021-04-16  | SOO         | EUR          | F            | S               | S30235_01   | true      | CO        | pickingWH                     |
+
+    And validate the created order lines
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | OPT.M_Warehouse_ID.Identifier |
+      | orderLine_S30235_1        | order_S30235          | product_S30235          | 1          | 0            | 0           | 10    | 0        | EUR          | true      | pickingWH                     |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/olCandBPPickingWarehouse.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/olCandBPPickingWarehouse.feature
@@ -29,8 +29,10 @@ Feature: OLCand order creation uses the BP picking warehouse when no warehouse i
       | Identifier | Value     | Name      | IsPickingWarehouse |
       | pickingWH  | pickingWH | pickingWH | true               |
 
-    # The standard OLCand import processor (repo-id 1000003) keeps StdWarehouse (540008) as
-    # its default warehouse, so a candidate with no warehouse would otherwise land there.
+    # Give the standard OLCand import processor (repo-id 1000003) a default warehouse
+    # (StdWarehouse, 540008) — this is what a candidate with no warehouse would otherwise
+    # inherit. The @After hook in C_OLCandProcessor_StepDef restores the processor afterwards
+    # so sibling scenarios on this executor are unaffected.
     And update C_OLCandProcessor:
       | C_OLCandProcessor_ID | M_Warehouse_ID |
       | 1000003              | 540008         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/olCandBPPickingWarehouse.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/olCandBPPickingWarehouse.feature
@@ -1,7 +1,6 @@
 @from:cucumber
 @allure.label.epic:E0100_Sales
 @allure.label.feature:F00122
-@topic:orderCandidate
 @ghActions:run_on_executor3
 Feature: OLCand order creation uses BP picking warehouse when no warehouse is in the payload
 ## F00122: OLCand Warehouse Advisor
@@ -22,7 +21,6 @@ Feature: OLCand order creation uses BP picking warehouse when no warehouse is in
   @from:cucumber
   @allure.label.epic:E0100_Sales
   @allure.label.feature:F00122
-  @topic:orderCandidate
   @Id:S30235_01
   Scenario: OLCand without warehouse → order inherits BP picking warehouse, not processor default
     # Two warehouses: WH_PICK is the BP's picking warehouse; WH_DEFAULT is set as the

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/olCandBPPickingWarehouse.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/olCandBPPickingWarehouse.feature
@@ -2,15 +2,13 @@
 @allure.label.epic:E0100_Sales
 @allure.label.feature:F00122
 @ghActions:run_on_executor3
-Feature: OLCand order creation uses BP picking warehouse when no warehouse is in the payload
+Feature: OLCand order creation uses the BP picking warehouse when no warehouse is in the payload
 ## F00122: OLCand Warehouse Advisor
 ##
-## When a sales order candidate is POSTed with no warehouse in the payload,
-## the order must be created with the business partner's picking warehouse —
-## NOT the OLCand-processor default warehouse.
-##
-## Bug: before the fix, the processor-default warehouse always wins even when
-## the BP has an explicit picking warehouse configured.
+## When a sales order candidate is POSTed with no warehouse in the payload
+## and the sold-to business partner has a picking warehouse, the created
+## order and its lines must use that BP picking warehouse, even when the
+## OLCand processor has its own default warehouse.
 
   Background:
     Given infrastructure and metasfresh are running
@@ -22,18 +20,20 @@ Feature: OLCand order creation uses BP picking warehouse when no warehouse is in
   @allure.label.epic:E0100_Sales
   @allure.label.feature:F00122
   @Id:S30235_01
-  Scenario: OLCand without warehouse → order inherits BP picking warehouse, not processor default
-    # Two warehouses: WH_PICK is the BP's picking warehouse; WH_DEFAULT is set as the
-    # processor default warehouse.  The created order must use WH_PICK (the BP wins).
-    # With the bug the order takes WH_DEFAULT → this scenario is RED before the fix.
+  Scenario: OLCand without warehouse → order inherits the BP picking warehouse
+    # The sold-to BP has pickingWH as its picking warehouse; the OLCand processor keeps its
+    # own default warehouse. No warehouse is sent in the payload, so the created order and
+    # its lines must use pickingWH — the BP picking warehouse takes precedence over the
+    # processor default.
     Given metasfresh contains M_Warehouse:
-      | Identifier | Value      | Name       | OPT.IsPickingWarehouse |
-      | pickingWH  | pickingWH  | pickingWH  | true                   |
-      | defaultWH  | defaultWH  | defaultWH  | false                  |
+      | Identifier | Value     | Name      | IsPickingWarehouse |
+      | pickingWH  | pickingWH | pickingWH | true               |
 
+    # The standard OLCand import processor (repo-id 1000003) keeps StdWarehouse (540008) as
+    # its default warehouse, so a candidate with no warehouse would otherwise land there.
     And update C_OLCandProcessor:
-      | OPT.C_OLCandProcessor_ID | OPT.M_Warehouse_ID.Identifier |
-      | 1000003                  | defaultWH                     |
+      | C_OLCandProcessor_ID | M_Warehouse_ID |
+      | 1000003              | 540008         |
 
     And metasfresh contains M_PricingSystems
       | Identifier | Name       | Value      | OPT.IsActive |
@@ -51,15 +51,13 @@ Feature: OLCand order creation uses BP picking warehouse when no warehouse is in
       | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
       | pp_S30235  | plv_S30235                        | product_S30235          | 10.0     | PCE               | Normal                        |
     And metasfresh contains C_BPartners:
-      | Identifier | Name       | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID | GLN           | OPT.M_Warehouse_ID.Identifier |
-      | bp_S30235  | bp_S30235  | Y              | N            | ps_S30235                     | bpLoc_S30235               | 3000000030235 | pickingWH                     |
+      | Identifier | Name       | IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID | GLN           | M_Warehouse_ID |
+      | bp_S30235  | bp_S30235  | Y          | N            | ps_S30235                     | bpLoc_S30235               | 3000000030235 | pickingWH      |
     And metasfresh contains C_BPartner_Locations:
       | Identifier   | GLN           | C_BPartner_ID.Identifier |
       | bpLoc_S30235 | 3000000030235 | bp_S30235                |
 
-    # POST one candidate for bp_S30235 — NO warehouse in payload.
-    # The OLCand-processor default warehouse is defaultWH; the BP's picking warehouse is pickingWH.
-    # The fix must route the order to pickingWH (the BP wins over the processor default).
+    # POST one candidate for bp_S30235 with no warehouse in the payload.
     When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
   """
 {
@@ -110,12 +108,12 @@ Feature: OLCand order creation uses BP picking warehouse when no warehouse is in
       | C_Order_ID.Identifier |
       | order_S30235          |
 
-    # Before the fix: C_Order.M_Warehouse_ID = defaultWH (processor default wins) → RED.
-    # After the fix: C_Order.M_Warehouse_ID = pickingWH (BP picking warehouse wins) → GREEN.
+    # The order and its lines must use the BP's picking warehouse (pickingWH), not the
+    # processor default warehouse.
     And validate the created orders
-      | C_Order_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | DeliveryRule | DeliveryViaRule | poReference | processed | DocStatus | OPT.M_Warehouse_ID.Identifier |
-      | order_S30235          | bp_S30235                | bpLoc_S30235                      | 2021-04-16  | SOO         | EUR          | F            | S               | S30235_01   | true      | CO        | pickingWH                     |
+      | C_Order_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | DeliveryRule | DeliveryViaRule | poReference | processed | DocStatus | M_Warehouse_ID |
+      | order_S30235          | bp_S30235                | bpLoc_S30235                      | 2021-04-16  | SOO         | EUR          | F            | S               | S30235_01   | true      | CO        | pickingWH      |
 
     And validate the created order lines
-      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | OPT.M_Warehouse_ID.Identifier |
-      | orderLine_S30235_1        | order_S30235          | product_S30235          | 1          | 0            | 0           | 10    | 0        | EUR          | true      | pickingWH                     |
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | qtydelivered | qtyinvoiced | price | discount | currencyCode | processed | M_Warehouse_ID |
+      | orderLine_S30235_1        | order_S30235          | product_S30235          | 1          | 0            | 0           | 10    | 0        | EUR          | true      | pickingWH      |

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/IOLCandBL.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/IOLCandBL.java
@@ -45,6 +45,7 @@ import de.metas.util.ISingletonService;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
+import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.PO;
 
 import javax.annotation.Nullable;
@@ -120,6 +121,17 @@ public interface IOLCandBL extends ISingletonService
 	ShipperId getShipperId(@Nullable BPartnerOrderParams bPartnerOrderParams, @Nullable OLCandOrderDefaults orderDefaults, @Nullable I_C_OLCand olCandRecord);
 
 	BPartnerOrderParams getBPartnerOrderParams(I_C_OLCand olCandRecord);
+
+	/**
+	 * Returns the warehouse to use for the given {@code olCand}, following this precedence:
+	 * <ol>
+	 * <li>OLCand's own {@code M_Warehouse_ID} if set</li>
+	 * <li>Buyer BP's customer picking warehouse (via {@link org.adempiere.warehouse.spi.IWarehouseAdvisor#evaluateCustomerPickingWarehouse})</li>
+	 * <li>Processor default ({@code orderDefaults.warehouseId})</li>
+	 * </ol>
+	 */
+	@Nullable
+	WarehouseId getWarehouseId(@NonNull I_C_OLCand olCand, @Nullable OLCandOrderDefaults orderDefaults);
 
 	DocTypeId getOrderDocTypeId(@Nullable OLCandOrderDefaults orderDefaults, @Nullable I_C_OLCand orderCandidateRecord);
 

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/IOLCandBL.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/IOLCandBL.java
@@ -27,7 +27,6 @@ import de.metas.attachments.AttachmentEntry;
 import de.metas.attachments.AttachmentEntryCreateRequest;
 import de.metas.document.DocTypeId;
 import de.metas.freighcost.FreightCostRule;
-import de.metas.incoterms.IncotermsId;
 import de.metas.order.BPartnerOrderParams;
 import de.metas.order.DeliveryRule;
 import de.metas.order.DeliveryViaRule;

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCand.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCand.java
@@ -82,6 +82,7 @@ public final class OLCand implements IProductPriceAware
 	@Getter private final DeliveryRule deliveryRule;
 	@Getter private final DeliveryViaRule deliveryViaRule;
 	@Getter private final ShipperId shipperId;
+	@Nullable @Getter private final WarehouseId warehouseId;
 	@Getter private final String externalLineId;
 	@Getter private final String externalHeaderId;
 	@Getter private final FreightCostRule freightCostRule;
@@ -120,6 +121,7 @@ public final class OLCand implements IProductPriceAware
 			@Nullable final PaymentTermId paymentTermId,
 			@Nullable final PricingSystemId pricingSystemId,
 			@Nullable final ShipperId shipperId,
+			@Nullable final WarehouseId warehouseId,
 			@Nullable final DocTypeId orderDocTypeId,
 			@Nullable final BPartnerId salesRepId,
 			@Nullable final OrderLineGroup orderLineGroup,
@@ -167,6 +169,7 @@ public final class OLCand implements IProductPriceAware
 		this.qtyItemCapacityEff = qtyItemCapacityEff;
 
 		this.shipperId = shipperId;
+		this.warehouseId = warehouseId;
 
 		this.salesRepId = salesRepId;
 
@@ -242,7 +245,7 @@ public final class OLCand implements IProductPriceAware
 	@Nullable
 	public WarehouseId getWarehouseId()
 	{
-		return WarehouseId.ofRepoIdOrNull(olCandRecord.getM_Warehouse_ID());
+		return warehouseId;
 	}
 
 	@Nullable

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCand.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCand.java
@@ -243,12 +243,6 @@ public final class OLCand implements IProductPriceAware
 	}
 
 	@Nullable
-	public WarehouseId getWarehouseId()
-	{
-		return warehouseId;
-	}
-
-	@Nullable
 	public WarehouseId getWarehouseDestId()
 	{
 		return WarehouseId.ofRepoIdOrNull(olCandRecord.getM_Warehouse_Dest_ID());

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandFactory.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandFactory.java
@@ -41,6 +41,7 @@ import de.metas.pricing.PricingSystemId;
 import de.metas.quantity.Quantity;
 import de.metas.shipping.ShipperId;
 import de.metas.util.Check;
+import org.adempiere.warehouse.WarehouseId;
 import de.metas.util.Services;
 import de.metas.util.lang.Percent;
 import lombok.NonNull;
@@ -81,6 +82,7 @@ public final class OLCandFactory
         final PaymentTermId paymentTermId = olCandBL.getPaymentTermId(params, orderDefaults, olCandRecord);
         final PricingSystemId pricingSystemId = olCandBL.getPricingSystemId(olCandRecord, params, orderDefaults);
         final ShipperId shipperId = olCandBL.getShipperId(params, orderDefaults, olCandRecord);
+        final WarehouseId warehouseId = olCandBL.getWarehouseId(olCandRecord, orderDefaults);
         final DocTypeId orderDocTypeId = olCandBL.getOrderDocTypeId(orderDefaults, olCandRecord);
         final Quantity qtyItemCapacity = olCandEffectiveValuesBL.getQtyItemCapacity_Effective(olCandRecord);
         final BPartnerId salesRepId = BPartnerId.ofRepoIdOrNull(olCandRecord.getC_BPartner_SalesRep_ID());
@@ -110,6 +112,7 @@ public final class OLCandFactory
 				.freightCostRule(freightCostRule)
 				.invoiceRule(invoiceRule)
                 .shipperId(shipperId)
+                .warehouseId(warehouseId)
                 .paymentRule(paymentRule)
                 .paymentTermId(paymentTermId)
                 .salesRepId(salesRepId)

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandProcessorId.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandProcessorId.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * de.metas.salescandidate.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ordercandidate.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import de.metas.util.Check;
+import de.metas.util.lang.RepoIdAware;
+import lombok.Value;
+
+import javax.annotation.Nullable;
+
+@Value
+public class OLCandProcessorId implements RepoIdAware
+{
+	@JsonCreator
+	public static OLCandProcessorId ofRepoId(final int repoId)
+	{
+		return new OLCandProcessorId(repoId);
+	}
+
+	public static OLCandProcessorId ofRepoIdOrNull(final int repoId)
+	{
+		return repoId > 0 ? new OLCandProcessorId(repoId) : null;
+	}
+
+	public static int toRepoId(@Nullable final OLCandProcessorId olCandProcessorId)
+	{
+		return olCandProcessorId != null ? olCandProcessorId.getRepoId() : -1;
+	}
+
+	int repoId;
+
+	private OLCandProcessorId(final int repoId)
+	{
+		this.repoId = Check.assumeGreaterThanZero(repoId, "C_OLCandProcessor_ID");
+	}
+
+	@Override
+	@JsonValue
+	public int getRepoId()
+	{
+		return repoId;
+	}
+}

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
@@ -29,6 +29,8 @@ import de.metas.attachments.AttachmentEntryService;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.service.BPartnerInfo;
 import de.metas.bpartner.service.IBPartnerBL;
+import org.adempiere.warehouse.WarehouseId;
+import org.adempiere.warehouse.spi.IWarehouseAdvisor;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.document.DocTypeId;
 import de.metas.error.AdIssueId;
@@ -477,6 +479,31 @@ public class OLCandBL implements IOLCandBL
 				.billBPartnerId(billBPartnerId)
 				.build();
 		return bPartnerOrderParamsRepository.getBy(query);
+	}
+
+	@Nullable
+	@Override
+	public WarehouseId getWarehouseId(
+			@NonNull final I_C_OLCand olCand,
+			@Nullable final OLCandOrderDefaults orderDefaults)
+	{
+		// 1. OLCand's own warehouse takes highest precedence
+		final WarehouseId olCandWarehouseId = WarehouseId.ofRepoIdOrNull(olCand.getM_Warehouse_ID());
+		if (olCandWarehouseId != null)
+		{
+			return olCandWarehouseId;
+		}
+
+		// 2. Buyer BP's customer picking warehouse
+		final BPartnerId buyerBPartnerId = effectiveValuesBL.getBuyerPartnerInfo(olCand).getBpartnerId();
+		final WarehouseId bpPickingWarehouseId = Services.get(IWarehouseAdvisor.class).evaluateCustomerPickingWarehouse(buyerBPartnerId);
+		if (bpPickingWarehouseId != null)
+		{
+			return bpPickingWarehouseId;
+		}
+
+		// 3. Processor default
+		return orderDefaults != null ? orderDefaults.getWarehouseId() : null;
 	}
 
 	@Override

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
@@ -488,14 +488,12 @@ public class OLCandBL implements IOLCandBL
 			@NonNull final I_C_OLCand olCand,
 			@Nullable final OLCandOrderDefaults orderDefaults)
 	{
-		// 1. OLCand's own warehouse takes highest precedence
 		final WarehouseId olCandWarehouseId = WarehouseId.ofRepoIdOrNull(olCand.getM_Warehouse_ID());
 		if (olCandWarehouseId != null)
 		{
 			return olCandWarehouseId;
 		}
 
-		// 2. Buyer BP's customer picking warehouse
 		final BPartnerId buyerBPartnerId = effectiveValuesBL.getBuyerPartnerInfo(olCand).getBpartnerId();
 		final WarehouseId bpPickingWarehouseId = warehouseAdvisor.evaluateCustomerPickingWarehouse(buyerBPartnerId);
 		if (bpPickingWarehouseId != null)
@@ -503,7 +501,6 @@ public class OLCandBL implements IOLCandBL
 			return bpPickingWarehouseId;
 		}
 
-		// 3. Processor default
 		return orderDefaults != null ? orderDefaults.getWarehouseId() : null;
 	}
 

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandBL.java
@@ -29,8 +29,6 @@ import de.metas.attachments.AttachmentEntryService;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.service.BPartnerInfo;
 import de.metas.bpartner.service.IBPartnerBL;
-import org.adempiere.warehouse.WarehouseId;
-import org.adempiere.warehouse.spi.IWarehouseAdvisor;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.document.DocTypeId;
 import de.metas.error.AdIssueId;
@@ -80,6 +78,8 @@ import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.impl.TableRecordReference;
+import org.adempiere.warehouse.WarehouseId;
+import org.adempiere.warehouse.spi.IWarehouseAdvisor;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_AD_Note;
 import org.compiere.model.I_AD_User;
@@ -112,6 +112,7 @@ public class OLCandBL implements IOLCandBL
 	private final IPriceListDAO priceListDAO = Services.get(IPriceListDAO.class);
 	private final IUserDAO userDAO = Services.get(IUserDAO.class);
 	private final IErrorManager errorManager = Services.get(IErrorManager.class);
+	private final IWarehouseAdvisor warehouseAdvisor = Services.get(IWarehouseAdvisor.class);
 
 	private final IBPartnerBL bpartnerBL;
 	private final BPartnerOrderParamsRepository bPartnerOrderParamsRepository;
@@ -496,7 +497,7 @@ public class OLCandBL implements IOLCandBL
 
 		// 2. Buyer BP's customer picking warehouse
 		final BPartnerId buyerBPartnerId = effectiveValuesBL.getBuyerPartnerInfo(olCand).getBpartnerId();
-		final WarehouseId bpPickingWarehouseId = Services.get(IWarehouseAdvisor.class).evaluateCustomerPickingWarehouse(buyerBPartnerId);
+		final WarehouseId bpPickingWarehouseId = warehouseAdvisor.evaluateCustomerPickingWarehouse(buyerBPartnerId);
 		if (bpPickingWarehouseId != null)
 		{
 			return bpPickingWarehouseId;

--- a/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
+++ b/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
@@ -1,0 +1,231 @@
+/*
+ * #%L
+ * de.metas.salescandidate.base
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ordercandidate.api;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.service.impl.BPartnerBL;
+import de.metas.order.BPartnerOrderParamsRepository;
+import de.metas.ordercandidate.api.impl.OLCandBL;
+import de.metas.ordercandidate.model.I_C_OLCand;
+import de.metas.user.UserRepository;
+import de.metas.util.Services;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.adempiere.warehouse.spi.IWarehouseAdvisor;
+import org.adempiere.warehouse.spi.impl.WarehouseAdvisor;
+import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_C_BPartner_Location;
+import org.compiere.model.I_M_Warehouse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstanceOutOfTrx;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link IOLCandBL#getWarehouseId(I_C_OLCand, OLCandOrderDefaults)}.
+ * <p>
+ * Precedence:
+ * 1. OLCand's own M_Warehouse_ID
+ * 2. Buyer BP's customer picking warehouse (via WarehouseAdvisor)
+ * 3. Processor default (orderDefaults.warehouseId)
+ */
+class OLCandBLGetWarehouseIdTest
+{
+	private OLCandBL olCandBL;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+
+		// Register the real WarehouseAdvisor so evaluateCustomerPickingWarehouse works
+		Services.registerService(IWarehouseAdvisor.class, new WarehouseAdvisor());
+
+		final BPartnerBL bpartnerBL = new BPartnerBL(new UserRepository());
+		olCandBL = new OLCandBL(bpartnerBL, BPartnerOrderParamsRepository.newInstanceForUnitTesting());
+	}
+
+	/**
+	 * AC2: OLCand has an explicit M_Warehouse_ID → that warehouse is returned, regardless of BP or defaults.
+	 */
+	@Test
+	void getWarehouseId_olCandHasExplicitWarehouse_returnsIt()
+	{
+		final WarehouseId explicitWarehouseId = createWarehouse(false);
+
+		final I_C_OLCand olCand = createOLCand(explicitWarehouseId, createCustomerBPWithPickingWarehouse());
+
+		final OLCandOrderDefaults defaults = OLCandOrderDefaults.builder()
+				.warehouseId(createWarehouse(false))
+				.build();
+
+		final WarehouseId result = olCandBL.getWarehouseId(olCand, defaults);
+
+		assertThat(result).isEqualTo(explicitWarehouseId);
+	}
+
+	/**
+	 * AC1: OLCand has no warehouse, buyer BP is a customer with a picking warehouse
+	 * → the BP's picking warehouse is returned.
+	 */
+	@Test
+	void getWarehouseId_noBPPickingWarehouse_customerBPWithPickingWarehouse_returnsBPWarehouse()
+	{
+		final BPartnerId customerBPId = createCustomerBPWithPickingWarehouse();
+		final I_C_OLCand olCand = createOLCandNoBPLocation(customerBPId);
+
+		final WarehouseId processorDefault = createWarehouse(false);
+		final OLCandOrderDefaults defaults = OLCandOrderDefaults.builder()
+				.warehouseId(processorDefault)
+				.build();
+
+		final WarehouseId result = olCandBL.getWarehouseId(olCand, defaults);
+
+		// Result must be the BP's picking warehouse, not the processor default
+		assertThat(result).isNotNull();
+		assertThat(result).isNotEqualTo(processorDefault);
+	}
+
+	/**
+	 * AC3: OLCand has no warehouse, BP's warehouse exists but is NOT a picking warehouse
+	 * → processor default is returned.
+	 */
+	@Test
+	void getWarehouseId_bpWarehouseNotPicking_returnsProcessorDefault()
+	{
+		final BPartnerId customerBPId = createCustomerBPWithNonPickingWarehouse();
+		final I_C_OLCand olCand = createOLCandNoBPLocation(customerBPId);
+
+		final WarehouseId processorDefault = createWarehouse(false);
+		final OLCandOrderDefaults defaults = OLCandOrderDefaults.builder()
+				.warehouseId(processorDefault)
+				.build();
+
+		final WarehouseId result = olCandBL.getWarehouseId(olCand, defaults);
+
+		assertThat(result).isEqualTo(processorDefault);
+	}
+
+	/**
+	 * AC3: OLCand has no warehouse, BP is NOT a customer → processor default is returned.
+	 */
+	@Test
+	void getWarehouseId_bpNotCustomer_returnsProcessorDefault()
+	{
+		final BPartnerId nonCustomerBPId = createNonCustomerBP();
+		final I_C_OLCand olCand = createOLCandNoBPLocation(nonCustomerBPId);
+
+		final WarehouseId processorDefault = createWarehouse(false);
+		final OLCandOrderDefaults defaults = OLCandOrderDefaults.builder()
+				.warehouseId(processorDefault)
+				.build();
+
+		final WarehouseId result = olCandBL.getWarehouseId(olCand, defaults);
+
+		assertThat(result).isEqualTo(processorDefault);
+	}
+
+	// ---- helpers ----
+
+	private WarehouseId createWarehouse(final boolean isPickingWarehouse)
+	{
+		final I_M_Warehouse warehouse = newInstanceOutOfTrx(I_M_Warehouse.class);
+		warehouse.setName("Warehouse-" + isPickingWarehouse);
+		warehouse.setIsPickingWarehouse(isPickingWarehouse);
+		saveRecord(warehouse);
+		return WarehouseId.ofRepoId(warehouse.getM_Warehouse_ID());
+	}
+
+	/**
+	 * Creates a customer BP with a picking warehouse assigned directly on the BP record.
+	 */
+	private BPartnerId createCustomerBPWithPickingWarehouse()
+	{
+		final WarehouseId pickingWarehouseId = createWarehouse(true);
+
+		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+		bp.setIsCustomer(true);
+		bp.setM_Warehouse_ID(pickingWarehouseId.getRepoId());
+		saveRecord(bp);
+		return BPartnerId.ofRepoId(bp.getC_BPartner_ID());
+	}
+
+	/**
+	 * Creates a customer BP with a warehouse that is NOT a picking warehouse.
+	 */
+	private BPartnerId createCustomerBPWithNonPickingWarehouse()
+	{
+		final WarehouseId nonPickingWarehouseId = createWarehouse(false);
+
+		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+		bp.setIsCustomer(true);
+		bp.setM_Warehouse_ID(nonPickingWarehouseId.getRepoId());
+		saveRecord(bp);
+		return BPartnerId.ofRepoId(bp.getC_BPartner_ID());
+	}
+
+	private BPartnerId createNonCustomerBP()
+	{
+		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
+		bp.setIsCustomer(false);
+		saveRecord(bp);
+		return BPartnerId.ofRepoId(bp.getC_BPartner_ID());
+	}
+
+	/**
+	 * Creates an OLCand with an explicit warehouse and the given buyer BP (with a location).
+	 */
+	private I_C_OLCand createOLCand(final WarehouseId warehouseId, final BPartnerId bPartnerId)
+	{
+		final I_C_BPartner_Location bpLocation = newInstanceOutOfTrx(I_C_BPartner_Location.class);
+		bpLocation.setC_BPartner_ID(bPartnerId.getRepoId());
+		saveRecord(bpLocation);
+
+		final I_C_OLCand olCand = newInstanceOutOfTrx(I_C_OLCand.class);
+		olCand.setM_Warehouse_ID(warehouseId.getRepoId());
+		olCand.setC_BPartner_ID(bPartnerId.getRepoId());
+		olCand.setC_BPartner_Location_ID(bpLocation.getC_BPartner_Location_ID());
+		saveRecord(olCand);
+		return olCand;
+	}
+
+	/**
+	 * Creates an OLCand with no warehouse, referencing the given BP without a BP location.
+	 * effectiveValuesBL.getBuyerPartnerInfo uses the C_BPartner_ID field (no override) as the buyer.
+	 */
+	private I_C_OLCand createOLCandNoBPLocation(final BPartnerId bPartnerId)
+	{
+		final I_C_BPartner_Location bpLocation = newInstanceOutOfTrx(I_C_BPartner_Location.class);
+		bpLocation.setC_BPartner_ID(bPartnerId.getRepoId());
+		saveRecord(bpLocation);
+
+		final I_C_OLCand olCand = newInstanceOutOfTrx(I_C_OLCand.class);
+		olCand.setM_Warehouse_ID(0);
+		olCand.setC_BPartner_ID(bPartnerId.getRepoId());
+		olCand.setC_BPartner_Location_ID(bpLocation.getC_BPartner_Location_ID());
+		saveRecord(olCand);
+		return olCand;
+	}
+}

--- a/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
+++ b/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
@@ -39,6 +39,8 @@ import org.compiere.model.I_M_Warehouse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
+
 import static org.adempiere.model.InterfaceWrapperHelper.newInstanceOutOfTrx;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -74,8 +76,10 @@ class OLCandBLGetWarehouseIdTest
 	void getWarehouseId_olCandHasExplicitWarehouse_returnsIt()
 	{
 		final WarehouseId explicitWarehouseId = createWarehouse(false);
+		final WarehouseId bpPickingWarehouseId = createWarehouse(true);
+		final BPartnerId customerBPId = createCustomerBP(true, bpPickingWarehouseId);
 
-		final I_C_OLCand olCand = createOLCand(explicitWarehouseId, createCustomerBPWithPickingWarehouse());
+		final I_C_OLCand olCand = createOLCand(explicitWarehouseId, customerBPId);
 
 		final OLCandOrderDefaults defaults = OLCandOrderDefaults.builder()
 				.warehouseId(createWarehouse(false))
@@ -91,9 +95,10 @@ class OLCandBLGetWarehouseIdTest
 	 * → the BP's picking warehouse is returned.
 	 */
 	@Test
-	void getWarehouseId_noBPPickingWarehouse_customerBPWithPickingWarehouse_returnsBPWarehouse()
+	void getWarehouseId_noOLCandWarehouse_customerBPWithPickingWarehouse_returnsBPWarehouse()
 	{
-		final BPartnerId customerBPId = createCustomerBPWithPickingWarehouse();
+		final WarehouseId bpPickingWarehouseId = createWarehouse(true);
+		final BPartnerId customerBPId = createCustomerBP(true, bpPickingWarehouseId);
 		final I_C_OLCand olCand = createOLCandNoBPLocation(customerBPId);
 
 		final WarehouseId processorDefault = createWarehouse(false);
@@ -103,9 +108,7 @@ class OLCandBLGetWarehouseIdTest
 
 		final WarehouseId result = olCandBL.getWarehouseId(olCand, defaults);
 
-		// Result must be the BP's picking warehouse, not the processor default
-		assertThat(result).isNotNull();
-		assertThat(result).isNotEqualTo(processorDefault);
+		assertThat(result).isEqualTo(bpPickingWarehouseId);
 	}
 
 	/**
@@ -115,7 +118,8 @@ class OLCandBLGetWarehouseIdTest
 	@Test
 	void getWarehouseId_bpWarehouseNotPicking_returnsProcessorDefault()
 	{
-		final BPartnerId customerBPId = createCustomerBPWithNonPickingWarehouse();
+		final WarehouseId nonPickingWarehouseId = createWarehouse(false);
+		final BPartnerId customerBPId = createCustomerBP(true, nonPickingWarehouseId);
 		final I_C_OLCand olCand = createOLCandNoBPLocation(customerBPId);
 
 		final WarehouseId processorDefault = createWarehouse(false);
@@ -134,7 +138,7 @@ class OLCandBLGetWarehouseIdTest
 	@Test
 	void getWarehouseId_bpNotCustomer_returnsProcessorDefault()
 	{
-		final BPartnerId nonCustomerBPId = createNonCustomerBP();
+		final BPartnerId nonCustomerBPId = createCustomerBP(false, null);
 		final I_C_OLCand olCand = createOLCandNoBPLocation(nonCustomerBPId);
 
 		final WarehouseId processorDefault = createWarehouse(false);
@@ -159,37 +163,16 @@ class OLCandBLGetWarehouseIdTest
 	}
 
 	/**
-	 * Creates a customer BP with a picking warehouse assigned directly on the BP record.
+	 * Creates a BP with the given customer flag and warehouse.
 	 */
-	private BPartnerId createCustomerBPWithPickingWarehouse()
-	{
-		final WarehouseId pickingWarehouseId = createWarehouse(true);
-
-		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
-		bp.setIsCustomer(true);
-		bp.setM_Warehouse_ID(pickingWarehouseId.getRepoId());
-		saveRecord(bp);
-		return BPartnerId.ofRepoId(bp.getC_BPartner_ID());
-	}
-
-	/**
-	 * Creates a customer BP with a warehouse that is NOT a picking warehouse.
-	 */
-	private BPartnerId createCustomerBPWithNonPickingWarehouse()
-	{
-		final WarehouseId nonPickingWarehouseId = createWarehouse(false);
-
-		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
-		bp.setIsCustomer(true);
-		bp.setM_Warehouse_ID(nonPickingWarehouseId.getRepoId());
-		saveRecord(bp);
-		return BPartnerId.ofRepoId(bp.getC_BPartner_ID());
-	}
-
-	private BPartnerId createNonCustomerBP()
+	private BPartnerId createCustomerBP(final boolean isCustomer, @Nullable final WarehouseId warehouseId)
 	{
 		final I_C_BPartner bp = newInstanceOutOfTrx(I_C_BPartner.class);
-		bp.setIsCustomer(false);
+		bp.setIsCustomer(isCustomer);
+		if (warehouseId != null)
+		{
+			bp.setM_Warehouse_ID(warehouseId.getRepoId());
+		}
 		saveRecord(bp);
 		return BPartnerId.ofRepoId(bp.getC_BPartner_ID());
 	}

--- a/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
+++ b/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
@@ -30,6 +30,7 @@ import de.metas.ordercandidate.model.I_C_OLCand;
 import de.metas.user.UserRepository;
 import de.metas.util.Services;
 import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
 import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.spi.IWarehouseAdvisor;
 import org.adempiere.warehouse.spi.impl.WarehouseAdvisor;
@@ -39,6 +40,7 @@ import org.compiere.model.I_M_Warehouse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.annotation.Nullable;
 
@@ -54,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 2. Buyer BP's customer picking warehouse (via WarehouseAdvisor)
  * 3. Processor default (orderDefaults.warehouseId)
  */
+@ExtendWith(AdempiereTestWatcher.class)
 class OLCandBLGetWarehouseIdTest
 {
 	private OLCandBL olCandBL;
@@ -73,87 +76,88 @@ class OLCandBLGetWarehouseIdTest
 	@Nested
 	class getWarehouseId
 	{
-	/**
-	 * AC2: OLCand has an explicit M_Warehouse_ID → that warehouse is returned, regardless of BP or defaults.
-	 */
-	@Test
-	void olCandHasExplicitWarehouse_returnsIt()
-	{
-		final WarehouseId explicitWarehouseId = createWarehouse(false);
-		final WarehouseId bpPickingWarehouseId = createWarehouse(true);
-		final BPartnerId customerBPId = createCustomerBP(true, bpPickingWarehouseId);
+		/**
+		 * OLCand has an explicit M_Warehouse_ID → that warehouse is returned, regardless of BP or defaults.
+		 */
+		@Test
+		void olCandHasExplicitWarehouse_returnsIt()
+		{
+			final WarehouseId explicitWarehouseId = createWarehouse(false);
+			final WarehouseId bpPickingWarehouseId = createWarehouse(true);
+			// BP has a picking warehouse — it must be ignored because the OLCand carries its own warehouse.
+			final BPartnerId customerBPId = createCustomerBP(true, bpPickingWarehouseId);
 
-		final I_C_OLCand olCand = createOLCand(explicitWarehouseId, customerBPId);
+			final I_C_OLCand olCand = createOLCand(explicitWarehouseId, customerBPId);
 
-		final OLCandOrderDefaults defaults = OLCandOrderDefaults.builder()
-				.warehouseId(createWarehouse(false))
-				.build();
+			final OLCandOrderDefaults defaults = OLCandOrderDefaults.builder()
+					.warehouseId(createWarehouse(false))
+					.build();
 
-		final WarehouseId result = olCandBL.getWarehouseId(olCand, defaults);
+			final WarehouseId result = olCandBL.getWarehouseId(olCand, defaults);
 
-		assertThat(result).isEqualTo(explicitWarehouseId);
-	}
+			assertThat(result).isEqualTo(explicitWarehouseId);
+		}
 
-	/**
-	 * AC1: OLCand has no warehouse, buyer BP is a customer with a picking warehouse
-	 * → the BP's picking warehouse is returned.
-	 */
-	@Test
-	void noOLCandWarehouse_customerBPWithPickingWarehouse_returnsBPWarehouse()
-	{
-		final WarehouseId bpPickingWarehouseId = createWarehouse(true);
-		final BPartnerId customerBPId = createCustomerBP(true, bpPickingWarehouseId);
-		final I_C_OLCand olCand = createOLCandNoBPLocation(customerBPId);
+		/**
+		 * OLCand has no warehouse, buyer BP is a customer with a picking warehouse
+		 * → the BP's picking warehouse is returned.
+		 */
+		@Test
+		void noOLCandWarehouse_customerBPWithPickingWarehouse_returnsBPWarehouse()
+		{
+			final WarehouseId bpPickingWarehouseId = createWarehouse(true);
+			final BPartnerId customerBPId = createCustomerBP(true, bpPickingWarehouseId);
+			final I_C_OLCand olCand = createOLCandNoWarehouse(customerBPId);
 
-		final WarehouseId processorDefault = createWarehouse(false);
-		final OLCandOrderDefaults defaults = OLCandOrderDefaults.builder()
-				.warehouseId(processorDefault)
-				.build();
+			final WarehouseId processorDefault = createWarehouse(false);
+			final OLCandOrderDefaults defaults = OLCandOrderDefaults.builder()
+					.warehouseId(processorDefault)
+					.build();
 
-		final WarehouseId result = olCandBL.getWarehouseId(olCand, defaults);
+			final WarehouseId result = olCandBL.getWarehouseId(olCand, defaults);
 
-		assertThat(result).isEqualTo(bpPickingWarehouseId);
-	}
+			assertThat(result).isEqualTo(bpPickingWarehouseId);
+		}
 
-	/**
-	 * AC3: OLCand has no warehouse, BP's warehouse exists but is NOT a picking warehouse
-	 * → processor default is returned.
-	 */
-	@Test
-	void bpWarehouseNotPicking_returnsProcessorDefault()
-	{
-		final WarehouseId nonPickingWarehouseId = createWarehouse(false);
-		final BPartnerId customerBPId = createCustomerBP(true, nonPickingWarehouseId);
-		final I_C_OLCand olCand = createOLCandNoBPLocation(customerBPId);
+		/**
+		 * OLCand has no warehouse, BP's warehouse exists but is NOT a picking warehouse
+		 * → processor default is returned.
+		 */
+		@Test
+		void bpWarehouseNotPicking_returnsProcessorDefault()
+		{
+			final WarehouseId nonPickingWarehouseId = createWarehouse(false);
+			final BPartnerId customerBPId = createCustomerBP(true, nonPickingWarehouseId);
+			final I_C_OLCand olCand = createOLCandNoWarehouse(customerBPId);
 
-		final WarehouseId processorDefault = createWarehouse(false);
-		final OLCandOrderDefaults defaults = OLCandOrderDefaults.builder()
-				.warehouseId(processorDefault)
-				.build();
+			final WarehouseId processorDefault = createWarehouse(false);
+			final OLCandOrderDefaults defaults = OLCandOrderDefaults.builder()
+					.warehouseId(processorDefault)
+					.build();
 
-		final WarehouseId result = olCandBL.getWarehouseId(olCand, defaults);
+			final WarehouseId result = olCandBL.getWarehouseId(olCand, defaults);
 
-		assertThat(result).isEqualTo(processorDefault);
-	}
+			assertThat(result).isEqualTo(processorDefault);
+		}
 
-	/**
-	 * AC3: OLCand has no warehouse, BP is NOT a customer → processor default is returned.
-	 */
-	@Test
-	void bpNotCustomer_returnsProcessorDefault()
-	{
-		final BPartnerId nonCustomerBPId = createCustomerBP(false, null);
-		final I_C_OLCand olCand = createOLCandNoBPLocation(nonCustomerBPId);
+		/**
+		 * OLCand has no warehouse, BP is NOT a customer → processor default is returned.
+		 */
+		@Test
+		void bpNotCustomer_returnsProcessorDefault()
+		{
+			final BPartnerId nonCustomerBPId = createCustomerBP(false, null);
+			final I_C_OLCand olCand = createOLCandNoWarehouse(nonCustomerBPId);
 
-		final WarehouseId processorDefault = createWarehouse(false);
-		final OLCandOrderDefaults defaults = OLCandOrderDefaults.builder()
-				.warehouseId(processorDefault)
-				.build();
+			final WarehouseId processorDefault = createWarehouse(false);
+			final OLCandOrderDefaults defaults = OLCandOrderDefaults.builder()
+					.warehouseId(processorDefault)
+					.build();
 
-		final WarehouseId result = olCandBL.getWarehouseId(olCand, defaults);
+			final WarehouseId result = olCandBL.getWarehouseId(olCand, defaults);
 
-		assertThat(result).isEqualTo(processorDefault);
-	}
+			assertThat(result).isEqualTo(processorDefault);
+		}
 	}
 
 	// ---- helpers ----
@@ -200,10 +204,10 @@ class OLCandBLGetWarehouseIdTest
 	}
 
 	/**
-	 * Creates an OLCand with no warehouse, referencing the given BP without a BP location.
+	 * Creates an OLCand with no warehouse (M_Warehouse_ID=0) and the given buyer BP with a location.
 	 * effectiveValuesBL.getBuyerPartnerInfo uses the C_BPartner_ID field (no override) as the buyer.
 	 */
-	private I_C_OLCand createOLCandNoBPLocation(final BPartnerId bPartnerId)
+	private I_C_OLCand createOLCandNoWarehouse(final BPartnerId bPartnerId)
 	{
 		final I_C_BPartner_Location bpLocation = newInstanceOutOfTrx(I_C_BPartner_Location.class);
 		bpLocation.setC_BPartner_ID(bPartnerId.getRepoId());

--- a/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
+++ b/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandBLGetWarehouseIdTest.java
@@ -37,6 +37,7 @@ import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_BPartner_Location;
 import org.compiere.model.I_M_Warehouse;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
@@ -69,11 +70,14 @@ class OLCandBLGetWarehouseIdTest
 		olCandBL = new OLCandBL(bpartnerBL, BPartnerOrderParamsRepository.newInstanceForUnitTesting());
 	}
 
+	@Nested
+	class getWarehouseId
+	{
 	/**
 	 * AC2: OLCand has an explicit M_Warehouse_ID → that warehouse is returned, regardless of BP or defaults.
 	 */
 	@Test
-	void getWarehouseId_olCandHasExplicitWarehouse_returnsIt()
+	void olCandHasExplicitWarehouse_returnsIt()
 	{
 		final WarehouseId explicitWarehouseId = createWarehouse(false);
 		final WarehouseId bpPickingWarehouseId = createWarehouse(true);
@@ -95,7 +99,7 @@ class OLCandBLGetWarehouseIdTest
 	 * → the BP's picking warehouse is returned.
 	 */
 	@Test
-	void getWarehouseId_noOLCandWarehouse_customerBPWithPickingWarehouse_returnsBPWarehouse()
+	void noOLCandWarehouse_customerBPWithPickingWarehouse_returnsBPWarehouse()
 	{
 		final WarehouseId bpPickingWarehouseId = createWarehouse(true);
 		final BPartnerId customerBPId = createCustomerBP(true, bpPickingWarehouseId);
@@ -116,7 +120,7 @@ class OLCandBLGetWarehouseIdTest
 	 * → processor default is returned.
 	 */
 	@Test
-	void getWarehouseId_bpWarehouseNotPicking_returnsProcessorDefault()
+	void bpWarehouseNotPicking_returnsProcessorDefault()
 	{
 		final WarehouseId nonPickingWarehouseId = createWarehouse(false);
 		final BPartnerId customerBPId = createCustomerBP(true, nonPickingWarehouseId);
@@ -136,7 +140,7 @@ class OLCandBLGetWarehouseIdTest
 	 * AC3: OLCand has no warehouse, BP is NOT a customer → processor default is returned.
 	 */
 	@Test
-	void getWarehouseId_bpNotCustomer_returnsProcessorDefault()
+	void bpNotCustomer_returnsProcessorDefault()
 	{
 		final BPartnerId nonCustomerBPId = createCustomerBP(false, null);
 		final I_C_OLCand olCand = createOLCandNoBPLocation(nonCustomerBPId);
@@ -149,6 +153,7 @@ class OLCandBLGetWarehouseIdTest
 		final WarehouseId result = olCandBL.getWarehouseId(olCand, defaults);
 
 		assertThat(result).isEqualTo(processorDefault);
+	}
 	}
 
 	// ---- helpers ----


### PR DESCRIPTION
## What

Sales orders created from order candidates (`C_OLCand`, e.g. via the REST `orders/sales/candidates/bulk` endpoint / EDI import) now honor the **customer BPartner's picking warehouse** when the order candidate carries no explicit warehouse — exactly as manually-entered sales orders already do via `WarehouseAdvisor`.

Previously such orders always fell back to the OLCand-processor default warehouse, so the created order (and its lines) got the wrong `M_Warehouse_ID`.

## How

- **`de.metas.business`** — extract the customer-picking-warehouse gate onto a public, BPartner-keyed method: `IWarehouseAdvisor.evaluateCustomerPickingWarehouse(BPartnerId)` (returns the BP's warehouse iff the BP is a customer and that warehouse is flagged `IsPickingWarehouse`, else `null`). The existing order-based `findPickingWarehouseId(order)` now delegates to it — behaviour unchanged (SOTrx/null guards retained).
- **`de.metas.salescandidate.base`** — `IOLCandBL.getWarehouseId(olCand, orderDefaults)` resolves the warehouse with precedence: OLCand's own `M_Warehouse_ID` → sold-to BPartner picking warehouse (via the WarehouseAdvisor method above) → OLCand-processor default. The sold-to BPartner is the buyer partner (`getBuyerPartnerInfo`), i.e. the same id that becomes `C_Order.C_BPartner_ID` — matching the manual-order path; `BPartnerOrderParams` (keyed on the ship/dropship partner) is deliberately not used.
- The resolved warehouse is stored on the `OLCand` value object (mirroring how `shipperId` is resolved and threaded), so both the order header and the order lines pick it up via `OLCand.getWarehouseId()` — `OLCandOrderFactory` needs no change.
- Order grouping / splitting is unaffected: the split key reads the raw `M_Warehouse_ID` column via `getValueByColumn`, not the resolved getter.

## Tests

- `WarehouseAdvisorTest` (3 cases: customer+picking → WH; customer+non-picking → null; non-customer → null).
- `OLCandBLGetWarehouseIdTest` (4 cases covering the full precedence).
- Real-flow cucumber `olCandBPPickingWarehouse.feature` (`@Id:S30235_01`): POSTs a candidate for a customer BPartner with a picking warehouse and no warehouse in the payload, processes it to an order, and asserts both the order header and line take the BP picking warehouse (developed RED-first, now green).
