### PR TITLE
MD_Candidate: add missing FK-supporting indexes to fix retraction/delete seq-scans

### DIFF
--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5812860_sys_md_candidate_fk_indexes.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5812860_sys_md_candidate_fk_indexes.sql
@@ -1,0 +1,28 @@
+-- Add missing FK-supporting indexes for MD_Candidate.
+--
+-- Every detail table has a NO ACTION FK to md_candidate, and MaterialDispo deletes/retracts
+-- candidates row-by-row -- so each parent-row delete fires a referential-integrity probe
+-- "SELECT 1 FROM <detail> WHERE md_candidate_id = $1" per referencing table. Two detail tables
+-- and the parent self-FK lack a usable (non-partial) index on that column, so the probe
+-- seq-scans the whole referencing table per deleted row -- pathological on large instances
+-- (both normal per-candidate retraction and bulk removals).
+--
+-- The sibling detail tables (dist_detail / demand_detail / prod_detail / qtydetails) already
+-- carry this index; md_candidate_transaction_detail and md_candidate_purchase_detail were
+-- missed. md_candidate_parent_id is covered only by a STOCK-partial index (for the ATP virtual
+-- column), which the general RI/delete probe cannot use -- add a NOT-NULL partial that serves it
+-- while staying small (the self-FK probe never matches NULL).
+--
+-- Plain CREATE INDEX (the migration runner applies scripts inside one transaction, so
+-- CREATE INDEX CONCURRENTLY is not usable). IF NOT EXISTS keeps it a no-op on any instance that
+-- already added the index manually.
+
+CREATE INDEX IF NOT EXISTS md_candidate_transaction_detail_md_candidate_id
+    ON md_candidate_transaction_detail (md_candidate_id);
+
+CREATE INDEX IF NOT EXISTS md_candidate_purchase_detail_md_candidate_id
+    ON md_candidate_purchase_detail (md_candidate_id);
+
+CREATE INDEX IF NOT EXISTS md_candidate_parent_id_notnull
+    ON md_candidate (md_candidate_parent_id)
+    WHERE md_candidate_parent_id IS NOT NULL;

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5812860_sys_md_candidate_fk_indexes.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5812860_sys_md_candidate_fk_indexes.sql
@@ -23,6 +23,8 @@ CREATE INDEX IF NOT EXISTS md_candidate_transaction_detail_md_candidate_id
 CREATE INDEX IF NOT EXISTS md_candidate_purchase_detail_md_candidate_id
     ON md_candidate_purchase_detail (md_candidate_id);
 
-CREATE INDEX IF NOT EXISTS md_candidate_parent_id_notnull
+-- sibling convention is <table>_<column> (= md_candidate_md_candidate_parent_id), but that
+-- name is taken by the existing STOCK-partial ATP index; disambiguate with a _notnull suffix.
+CREATE INDEX IF NOT EXISTS md_candidate_md_candidate_parent_id_notnull
     ON md_candidate (md_candidate_parent_id)
     WHERE md_candidate_parent_id IS NOT NULL;


### PR DESCRIPTION
## Problem
Foreign-key-referencing columns into `md_candidate` lack a usable (non-partial) index. The detail→`md_candidate` FKs are `ON DELETE NO ACTION` and MaterialDispo deletes/retracts candidates row-by-row, so every parent-row delete fires a referential-integrity probe `SELECT 1 FROM <detail> WHERE md_candidate_id = $1` against each referencing table. When that column is unindexed the probe **seq-scans the whole referencing table per deleted row** — degrading normal per-candidate retraction on large instances and making bulk removals pathological (observed: a large `md_candidate` cleanup stalled for hours at commit on the deferred-FK validation against the unindexed `md_candidate_transaction_detail`).

## Fix
Migration `5812860` adds the three missing indexes:
- `md_candidate_transaction_detail (md_candidate_id)` — previously only a partial `WHERE IsActive='Y'` unique index (unusable for the RI/delete probe, which must see inactive rows).
- `md_candidate_purchase_detail (md_candidate_id)` — previously no index at all.
- `md_candidate (md_candidate_parent_id) WHERE md_candidate_parent_id IS NOT NULL` — the self-FK was covered only by the STOCK-partial index built for the ATP virtual column; add a NOT-NULL partial that serves the general RI/delete probe while staying small.

The sibling detail tables (`dist_detail` / `demand_detail` / `prod_detail` / `qtydetails`) already carry the equivalent full index — these two tables and the parent self-FK were the gaps.

Plain `CREATE INDEX` (the migration runner applies scripts inside one transaction, so `CONCURRENTLY` is not usable here); `IF NOT EXISTS` keeps it a no-op on any instance that already added the index manually.
