### PR TITLE
Invoice accounting override: scope by org schema + line-aggregation key

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/invoice/acct/interceptor/C_Invoice_AcctOverride.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/acct/interceptor/C_Invoice_AcctOverride.java
@@ -22,12 +22,11 @@ import org.compiere.model.I_M_Product_Acct;
 import org.compiere.model.ModelValidator;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 /**
  * On purchase invoice completion, materializes any per-line GL account overrides
  * ({@code C_ElementValue_Override_ID}) into {@code C_Invoice_Acct} rows,
- * one row per accounting schema × account concept (P_Expense_Acct, P_InventoryClearing_Acct).
+ * one row per account concept (P_Expense_Acct, P_InventoryClearing_Acct) for the accounting
+ * schema resolved from the invoice line's own org.
  *
  * <p>Derives the {@code AccountConceptualName}s from the {@code I_M_Product_Acct} column names (the
  * same source {@code ProductAcctType.P_Expense_Acct/P_InventoryClearing_Acct.getAccountConceptualName()}
@@ -66,9 +65,7 @@ public class C_Invoice_AcctOverride
 		}
 
 		final InvoiceId invoiceId = InvoiceId.ofRepoId(invoice.getC_Invoice_ID());
-		final OrgId orgId = OrgId.ofRepoId(invoice.getAD_Org_ID());
 		final ClientId clientId = ClientId.ofRepoId(invoice.getAD_Client_ID());
-		final List<AcctSchema> acctSchemas = acctSchemaDAO.getAllByClient(clientId);
 
 		for (final I_C_InvoiceLine line : invoiceBL.getLines(invoiceId))
 		{
@@ -77,25 +74,33 @@ public class C_Invoice_AcctOverride
 			{
 				continue;
 			}
+
+			// Resolve the accounting schema of THIS line's org (org-specific schema, else the client's primary).
+			// Multi-org/one-schema-each clients must not have the override written into every org's schema.
+			final OrgId lineOrgId = OrgId.ofRepoId(line.getAD_Org_ID());
+			final AcctSchema acctSchema = acctSchemaDAO.getByClientAndOrgOrNull(clientId, lineOrgId);
+			if (acctSchema == null)
+			{
+				// No accounting schema resolvable for this line's org → nothing to materialize.
+				continue;
+			}
+			final AcctSchemaId acctSchemaId = acctSchema.getId();
+
 			final ElementValueId overrideElementValueId = ElementValueId.ofRepoId(overrideElementValueRepoId);
 			final InvoiceAndLineId invoiceAndLineId = InvoiceAndLineId.ofRepoId(invoiceId, line.getC_InvoiceLine_ID());
 
-			for (final AcctSchema acctSchema : acctSchemas)
-			{
-				final AcctSchemaId acctSchemaId = acctSchema.getId();
-				invoiceAcctRepository.createOrUpdateLineOverride(
-						invoiceAndLineId,
-						orgId,
-						acctSchemaId,
-						CONCEPT_P_EXPENSE_ACCT,
-						overrideElementValueId);
-				invoiceAcctRepository.createOrUpdateLineOverride(
-						invoiceAndLineId,
-						orgId,
-						acctSchemaId,
-						CONCEPT_P_INVENTORY_CLEARING_ACCT,
-						overrideElementValueId);
-			}
+			invoiceAcctRepository.createOrUpdateLineOverride(
+					invoiceAndLineId,
+					lineOrgId,
+					acctSchemaId,
+					CONCEPT_P_EXPENSE_ACCT,
+					overrideElementValueId);
+			invoiceAcctRepository.createOrUpdateLineOverride(
+					invoiceAndLineId,
+					lineOrgId,
+					acctSchemaId,
+					CONCEPT_P_INVENTORY_CLEARING_ACCT,
+					overrideElementValueId);
 		}
 	}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/acct/interceptor/C_Invoice_AcctOverride.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/acct/interceptor/C_Invoice_AcctOverride.java
@@ -22,6 +22,10 @@ import org.compiere.model.I_M_Product_Acct;
 import org.compiere.model.ModelValidator;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 /**
  * On purchase invoice completion, materializes any per-line GL account overrides
  * ({@code C_ElementValue_Override_ID}) into {@code C_Invoice_Acct} rows,
@@ -67,6 +71,10 @@ public class C_Invoice_AcctOverride
 		final InvoiceId invoiceId = InvoiceId.ofRepoId(invoice.getC_Invoice_ID());
 		final ClientId clientId = ClientId.ofRepoId(invoice.getAD_Client_ID());
 
+		// Memoize the per-org schema lookup: multiple lines usually share an org, so resolve it once
+		// per distinct org. Optional remembers the null result too (org with no resolvable schema).
+		final Map<OrgId, Optional<AcctSchema>> acctSchemaByOrg = new HashMap<>();
+
 		for (final I_C_InvoiceLine line : invoiceBL.getLines(invoiceId))
 		{
 			final int overrideElementValueRepoId = line.getC_ElementValue_Override_ID();
@@ -78,7 +86,9 @@ public class C_Invoice_AcctOverride
 			// Resolve the accounting schema of THIS line's org (org-specific schema, else the client's primary).
 			// Multi-org/one-schema-each clients must not have the override written into every org's schema.
 			final OrgId lineOrgId = OrgId.ofRepoId(line.getAD_Org_ID());
-			final AcctSchema acctSchema = acctSchemaDAO.getByClientAndOrgOrNull(clientId, lineOrgId);
+			final AcctSchema acctSchema = acctSchemaByOrg
+					.computeIfAbsent(lineOrgId, orgId -> Optional.ofNullable(acctSchemaDAO.getByClientAndOrgOrNull(clientId, orgId)))
+					.orElse(null);
 			if (acctSchema == null)
 			{
 				// No accounting schema resolvable for this line's org → nothing to materialize.

--- a/backend/de.metas.business/src/test/java/de/metas/invoice/acct/interceptor/C_Invoice_AcctOverrideTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/invoice/acct/interceptor/C_Invoice_AcctOverrideTest.java
@@ -1,0 +1,129 @@
+package de.metas.invoice.acct.interceptor;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.acct.AcctSchemaTestHelper;
+import de.metas.acct.api.AcctSchema;
+import de.metas.acct.api.AcctSchemaId;
+import de.metas.acct.api.IAcctSchemaDAO;
+import de.metas.acct.api.impl.AcctSchemaDAO;
+import de.metas.acct.api.impl.ElementValueId;
+import de.metas.adempiere.model.I_C_Invoice;
+import de.metas.adempiere.model.I_C_InvoiceLine;
+import de.metas.invoice.acct.InvoiceAcctRepository;
+import de.metas.invoice.service.IInvoiceBL;
+import de.metas.organization.OrgId;
+import de.metas.util.Services;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Discriminating unit test for {@link C_Invoice_AcctOverride}.
+ *
+ * <p>Q2a fix: on purchase-invoice completion the per-line GL override must be materialized into the
+ * accounting schema resolved from the invoice line's OWN org
+ * ({@link IAcctSchemaDAO#getByClientAndOrgOrNull(org.adempiere.service.ClientId, OrgId)}), NOT spread
+ * across every client schema (the old {@code getAllByClient(clientId)} behaviour).</p>
+ *
+ * <p>The scenario gives the client TWO accounting schemas (A and B) and a single purchase invoice line
+ * in org A. The test asserts the interceptor materializes ONLY into schema A (org-resolved) and NEVER
+ * into schema B — exactly {@code 2} repository writes (one per account concept), both targeting schema A.</p>
+ *
+ * <p>This is the discrimination the cucumber scenario {@code @Id:S30443_TC5} cannot provide: cucumber runs
+ * against the standard seed whose client has a single accounting schema, so both the old and the new code
+ * materialize into the same one row and the scenario passes either way. A genuine two-schema cucumber setup
+ * is infeasible/unsafe: there is no step-def to create a {@code C_AcctSchema} (it needs currency, GL,
+ * default-account and element children), and a second client schema is GLOBAL seed state that
+ * {@code PostingService.getAllByClient} would post every document to — polluting and breaking sibling
+ * accounting scenarios on the shared executor. Hence this interceptor-level unit test, per the reviewer's
+ * pre-approved faithful alternative.</p>
+ *
+ * <p>RED-on-revert: reverting the interceptor to {@code getAllByClient(clientId)} makes it write for BOTH
+ * schemas ({@code 4} calls: 2 concepts × 2 schemas), so {@code verify(times(2))} / {@code containsOnly(A)}
+ * fail. GREEN-on-fix: the org-resolved lookup writes only the 2 schema-A rows.</p>
+ */
+class C_Invoice_AcctOverrideTest
+{
+	private static final int CLIENT_ID = 1_000_000;
+	private static final OrgId ORG_A = OrgId.ofRepoId(1_000_001);
+	private static final ElementValueId OVERRIDE_ACCOUNT = ElementValueId.ofRepoId(555);
+
+	private IInvoiceBL invoiceBL;
+	private InvoiceAcctRepository invoiceAcctRepository;
+
+	private AcctSchemaId schemaIdA;
+	private AcctSchemaId schemaIdB;
+
+	private C_Invoice_AcctOverride interceptor;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+
+		// Two real accounting schemas for the client. Build the AcctSchema value objects via the real DAO
+		// from the (minimal) records AcctSchemaTestHelper creates, then hand them to a mocked IAcctSchemaDAO
+		// so the test controls org-resolution independently of the seed.
+		schemaIdA = AcctSchemaTestHelper.newAcctSchema().build();
+		schemaIdB = AcctSchemaTestHelper.newAcctSchema().build();
+		final AcctSchemaDAO realAcctSchemaDAO = new AcctSchemaDAO();
+		final AcctSchema schemaA = realAcctSchemaDAO.getById(schemaIdA);
+		final AcctSchema schemaB = realAcctSchemaDAO.getById(schemaIdB);
+
+		final IAcctSchemaDAO acctSchemaDAO = mock(IAcctSchemaDAO.class);
+		// Org-resolved lookup (the fix): org A resolves to schema A only.
+		when(acctSchemaDAO.getByClientAndOrgOrNull(any(), any())).thenReturn(schemaA);
+		// Client-wide lookup (the old behaviour): BOTH schemas — so a revert would write to A and B.
+		when(acctSchemaDAO.getAllByClient(any())).thenReturn(ImmutableList.of(schemaA, schemaB));
+
+		invoiceBL = mock(IInvoiceBL.class);
+		invoiceAcctRepository = mock(InvoiceAcctRepository.class);
+
+		// Register the Services.get(...) fields BEFORE constructing the interceptor (they are resolved in the
+		// interceptor's field initializers at construction time).
+		Services.registerService(IAcctSchemaDAO.class, acctSchemaDAO);
+		Services.registerService(IInvoiceBL.class, invoiceBL);
+
+		interceptor = new C_Invoice_AcctOverride(invoiceAcctRepository);
+	}
+
+	@Test
+	void materializes_only_into_the_org_resolved_schema_not_every_client_schema()
+	{
+		final I_C_Invoice invoice = InterfaceWrapperHelper.newInstance(I_C_Invoice.class);
+		invoice.setIsSOTrx(false);
+		InterfaceWrapperHelper.setValue(invoice, "AD_Client_ID", CLIENT_ID);
+		invoice.setAD_Org_ID(ORG_A.getRepoId());
+		InterfaceWrapperHelper.saveRecord(invoice);
+
+		final I_C_InvoiceLine line = InterfaceWrapperHelper.newInstance(I_C_InvoiceLine.class);
+		line.setC_Invoice_ID(invoice.getC_Invoice_ID());
+		InterfaceWrapperHelper.setValue(line, "AD_Client_ID", CLIENT_ID);
+		line.setAD_Org_ID(ORG_A.getRepoId());
+		line.setC_ElementValue_Override_ID(OVERRIDE_ACCOUNT.getRepoId());
+		InterfaceWrapperHelper.saveRecord(line);
+
+		when(invoiceBL.getLines(any())).thenReturn(ImmutableList.of(line));
+
+		interceptor.materializeAcctOverrides(invoice);
+
+		// Exactly two materialized rows (P_Expense_Acct + P_InventoryClearing_Acct), BOTH into schema A.
+		// A revert to getAllByClient would produce four calls (also into schema B) → both assertions fail.
+		final ArgumentCaptor<AcctSchemaId> acctSchemaCaptor = ArgumentCaptor.forClass(AcctSchemaId.class);
+		verify(invoiceAcctRepository, times(2)).createOrUpdateLineOverride(any(), any(), acctSchemaCaptor.capture(), any(), any());
+
+		assertThat(acctSchemaCaptor.getAllValues())
+				.as("override must be materialized ONLY into org A's resolved schema, never org B's schema")
+				.containsOnly(schemaIdA)
+				.doesNotContain(schemaIdB);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
@@ -591,6 +591,10 @@ public class C_BPartner_StepDef
 				.map(aggregationTable::get)
 				.ifPresent(aggregationRecord -> bPartner.setSO_Invoice_Aggregation_ID(aggregationRecord.getC_Aggregation_ID()));
 
+		row.getAsOptionalIdentifier(de.metas.invoicecandidate.model.I_C_BPartner.COLUMNNAME_PO_InvoiceLine_Aggregation_ID)
+				.map(aggregationTable::get)
+				.ifPresent(aggregationRecord -> bPartner.setPO_InvoiceLine_Aggregation_ID(aggregationRecord.getC_Aggregation_ID()));
+
 		row.getAsOptionalIdentifier(I_C_BPartner.COLUMNNAME_C_Dunning_ID)
 				.map(dunningTable::get)
 				.ifPresent(dunning -> bPartner.setC_Dunning_ID(dunning.getC_Dunning_ID()));

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
@@ -93,6 +93,7 @@ import static de.metas.contracts.bpartner.process.C_BPartner_MoveToAnotherOrg_Pr
 import static de.metas.contracts.bpartner.process.C_BPartner_MoveToAnotherOrg_ProcessHelper.PARAM_IS_SHOW_MEMBERSHIP_PARAMETER;
 import static de.metas.cucumber.stepdefs.StepDefConstants.ORG_ID;
 import static de.metas.cucumber.stepdefs.StepDefConstants.TABLECOLUMN_IDENTIFIER;
+import static de.metas.invoicecandidate.model.I_C_BPartner.COLUMNNAME_PO_InvoiceLine_Aggregation_ID;
 import static de.metas.invoicecandidate.model.I_C_BPartner.COLUMNNAME_SO_Invoice_Aggregation_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.compiere.model.I_C_BPartner.COLUMNNAME_AD_Language;
@@ -591,7 +592,7 @@ public class C_BPartner_StepDef
 				.map(aggregationTable::get)
 				.ifPresent(aggregationRecord -> bPartner.setSO_Invoice_Aggregation_ID(aggregationRecord.getC_Aggregation_ID()));
 
-		row.getAsOptionalIdentifier(de.metas.invoicecandidate.model.I_C_BPartner.COLUMNNAME_PO_InvoiceLine_Aggregation_ID)
+		row.getAsOptionalIdentifier(COLUMNNAME_PO_InvoiceLine_Aggregation_ID)
 				.map(aggregationTable::get)
 				.ifPresent(aggregationRecord -> bPartner.setPO_InvoiceLine_Aggregation_ID(aggregationRecord.getC_Aggregation_ID()));
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/acct/C_Invoice_Acct_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/acct/C_Invoice_Acct_StepDef.java
@@ -1,5 +1,7 @@
 package de.metas.cucumber.stepdefs.invoice.acct;
 
+import de.metas.acct.api.AcctSchemaId;
+import de.metas.acct.api.IAcctSchemaDAO;
 import de.metas.acct.api.impl.ElementValueId;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
@@ -8,7 +10,9 @@ import de.metas.cucumber.stepdefs.accounting.C_ElementValue_StepDefData;
 import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.invoice.C_InvoiceLine_StepDefData;
 import de.metas.invoice.InvoiceId;
+import de.metas.organization.OrgId;
 import de.metas.util.Services;
+import org.adempiere.service.ClientId;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
@@ -29,6 +33,7 @@ import java.util.List;
 public class C_Invoice_Acct_StepDef
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	private final IAcctSchemaDAO acctSchemaDAO = Services.get(IAcctSchemaDAO.class);
 
 	private final C_Invoice_StepDefData invoiceTable;
 	private final C_InvoiceLine_StepDefData invoiceLineTable;
@@ -43,6 +48,10 @@ public class C_Invoice_Acct_StepDef
 	 *   <b>C_InvoiceLine_ID</b> — (optional, identifier-ref) the specific invoice line (null = header override)<br>
 	 *   <b>AccountName</b> — (required) the AccountConceptualName stored on the row (e.g. {@code P_Expense_Acct})<br>
 	 *   <b>C_ElementValue_ID</b> — (required, identifier-ref) the expected GL account (override account)<br>
+	 *   <b>OPT.AssertAcctSchemaResolvedFromOrg</b> — (optional, boolean) when {@code Y}, assert the row's
+	 *     {@code C_AcctSchema_ID} equals {@code getC_AcctSchema_ID(AD_Client_ID, AD_Org_ID)} for the row's own
+	 *     client+org — i.e. the override was materialized into the accounting schema resolved from the invoice
+	 *     line's org, not spread across every client schema.<br>
 	 * @cucumber.example
 	 * <pre>
 	 * Then C_Invoice_Acct rows are found for invoice:
@@ -88,9 +97,27 @@ public class C_Invoice_Acct_StepDef
 
 		if (found.size() == 1)
 		{
-			softly.assertThat(ElementValueId.ofRepoIdOrNull(found.get(0).getC_ElementValue_ID()))
+			final I_C_Invoice_Acct acctRow = found.get(0);
+			softly.assertThat(ElementValueId.ofRepoIdOrNull(acctRow.getC_ElementValue_ID()))
 					.as("C_ElementValue_ID on C_Invoice_Acct row for accountName=" + accountName)
 					.isEqualTo(expectedElementValueId);
+
+			final boolean assertSchemaFromOrg = Boolean.TRUE.equals(
+					row.getAsOptionalBoolean("AssertAcctSchemaResolvedFromOrg").toBooleanOrNull());
+			if (assertSchemaFromOrg)
+			{
+				// The materialized row must live in the schema resolved from its own org
+				// (getC_AcctSchema_ID(client, org)), NOT be spread across every client schema.
+				final ClientId clientId = ClientId.ofRepoId(acctRow.getAD_Client_ID());
+				final OrgId orgId = OrgId.ofRepoId(acctRow.getAD_Org_ID());
+				final AcctSchemaId expectedAcctSchemaId = acctSchemaDAO.getAcctSchemaIdByClientAndOrgOrNull(clientId, orgId);
+				softly.assertThat(expectedAcctSchemaId)
+						.as("getC_AcctSchema_ID(client=%s, org=%s) must resolve a schema", clientId, orgId)
+						.isNotNull();
+				softly.assertThat(AcctSchemaId.ofRepoIdOrNull(acctRow.getC_AcctSchema_ID()))
+						.as("C_Invoice_Acct.C_AcctSchema_ID must be the org-resolved schema for accountName=" + accountName)
+						.isEqualTo(expectedAcctSchemaId);
+			}
 		}
 
 		softly.assertAll();

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/acct/C_Invoice_Acct_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/acct/C_Invoice_Acct_StepDef.java
@@ -32,8 +32,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class C_Invoice_Acct_StepDef
 {
-	private final IQueryBL queryBL = Services.get(IQueryBL.class);
-	private final IAcctSchemaDAO acctSchemaDAO = Services.get(IAcctSchemaDAO.class);
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	@NonNull private final IAcctSchemaDAO acctSchemaDAO = Services.get(IAcctSchemaDAO.class);
 
 	private final C_Invoice_StepDefData invoiceTable;
 	private final C_InvoiceLine_StepDefData invoiceLineTable;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -787,6 +787,62 @@ public class C_Invoice_Candidate_StepDef
 
 	}
 
+	/**
+	 * Asserts the {@code LineAggregationKey} relationship across the listed invoice candidates.
+	 * The line aggregation key is the value the invoicing engine groups invoice lines by: two ICs
+	 * with the same key merge into one invoice line, two with different keys split into separate lines.
+	 * This is the deterministic mechanism behind F01010.4's per-line GL account override — with the
+	 * override added to the line-key aggregation (C_Aggregation 540003), ICs that differ only by
+	 * {@code C_ElementValue_Override_ID} get different keys (→ split), while equal overrides keep an
+	 * equal key (→ merge). Requires the partner to use aggregation 540003 as its line aggregation.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>C_Invoice_Candidate_ID</b> — (required, identifier-ref) the invoice candidates to compare<br>
+	 * @cucumber.example
+	 * <pre>
+	 * Then C_Invoice_Candidate LineAggregationKeys are different:
+	 *   | C_Invoice_Candidate_ID |
+	 *   | invoiceCand_a          |
+	 *   | invoiceCand_b          |
+	 * </pre>
+	 */
+	@And("^C_Invoice_Candidate LineAggregationKeys are (equal|different):$")
+	public void assertLineAggregationKeys(@NonNull final String relation, @NonNull final DataTable dataTable)
+	{
+		// Collect the candidates and wait until the (async) recompute triggered by the override change
+		// has cleared, so LineAggregationKey reflects the current C_ElementValue_Override_ID.
+		final java.util.List<I_C_Invoice_Candidate> invoiceCandidates = new java.util.ArrayList<>();
+		final ImmutableSet.Builder<InvoiceCandidateId> idsBuilder = ImmutableSet.builder();
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_C_Invoice_Candidate invoiceCandidate = row.getAsIdentifier(COLUMNNAME_C_Invoice_Candidate_ID).lookupNotNullIn(invoiceCandTable);
+			invoiceCandidates.add(invoiceCandidate);
+			idsBuilder.add(InvoiceCandidateId.ofRepoId(invoiceCandidate.getC_Invoice_Candidate_ID()));
+		});
+		waitUntilValid(idsBuilder.build(), 120);
+
+		final java.util.List<String> keys = new java.util.ArrayList<>();
+		for (final I_C_Invoice_Candidate invoiceCandidate : invoiceCandidates)
+		{
+			InterfaceWrapperHelper.refresh(invoiceCandidate);
+			final String key = invoiceCandidate.getLineAggregationKey();
+			assertThat(key)
+					.as("LineAggregationKey must be computed for C_Invoice_Candidate_ID=%s", invoiceCandidate.getC_Invoice_Candidate_ID())
+					.isNotBlank();
+			keys.add(key);
+		}
+
+		final int distinct = new java.util.LinkedHashSet<>(keys).size();
+		if ("equal".equals(relation))
+		{
+			assertThat(distinct).as("all LineAggregationKeys must be EQUAL, but were: %s", keys).isEqualTo(1);
+		}
+		else
+		{
+			assertThat(distinct).as("all LineAggregationKeys must be DIFFERENT, but were: %s", keys).isEqualTo(keys.size());
+		}
+	}
+
 	private boolean loadCreditMemoCandidate(@NonNull final Map<String, String> row)
 	{
 		final String customerReturnIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_M_InOut_ID + "." + TABLECOLUMN_IDENTIFIER);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -108,6 +108,7 @@ import java.sql.SQLException;
 import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -812,7 +813,7 @@ public class C_Invoice_Candidate_StepDef
 	{
 		// Collect the candidates and wait until the (async) recompute triggered by the override change
 		// has cleared, so LineAggregationKey reflects the current C_ElementValue_Override_ID.
-		final java.util.List<I_C_Invoice_Candidate> invoiceCandidates = new java.util.ArrayList<>();
+		final List<I_C_Invoice_Candidate> invoiceCandidates = new ArrayList<>();
 		final ImmutableSet.Builder<InvoiceCandidateId> idsBuilder = ImmutableSet.builder();
 		DataTableRows.of(dataTable).forEach(row -> {
 			final I_C_Invoice_Candidate invoiceCandidate = row.getAsIdentifier(COLUMNNAME_C_Invoice_Candidate_ID).lookupNotNullIn(invoiceCandTable);
@@ -821,7 +822,7 @@ public class C_Invoice_Candidate_StepDef
 		});
 		waitUntilValid(idsBuilder.build(), 120);
 
-		final java.util.List<String> keys = new java.util.ArrayList<>();
+		final List<String> keys = new ArrayList<>();
 		for (final I_C_Invoice_Candidate invoiceCandidate : invoiceCandidates)
 		{
 			InterfaceWrapperHelper.refresh(invoiceCandidate);
@@ -832,7 +833,7 @@ public class C_Invoice_Candidate_StepDef
 			keys.add(key);
 		}
 
-		final int distinct = new java.util.LinkedHashSet<>(keys).size();
+		final int distinct = new LinkedHashSet<>(keys).size();
 		if ("equal".equals(relation))
 		{
 			assertThat(distinct).as("all LineAggregationKeys must be EQUAL, but were: %s", keys).isEqualTo(1);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceAccountingOverride.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceAccountingOverride.feature
@@ -314,8 +314,15 @@ Feature: Per-line GL account override on purchase invoices
 
 
   # Scenario E (Q2): on completion the override is materialized into C_Invoice_Acct scoped to the
-  # accounting schema resolved from the invoice line's OWN org — getC_AcctSchema_ID(client, org) —
-  # not spread across every client schema.
+  # accounting schema resolved from the invoice line's OWN org — getC_AcctSchema_ID(client, org).
+  # This is a single-schema functional smoke test: the standard cucumber seed client has exactly one
+  # C_AcctSchema, so it exercises the real completion->materialization path and asserts the row lands
+  # in the org-resolved schema, but it does NOT by itself DISCRIMINATE the org-scoping fix from the old
+  # every-client-schema behaviour (with one schema both write the same single row). That discrimination
+  # (two client schemas, override materialized only into org A's) lives in the interceptor unit test
+  # de.metas.invoice.acct.interceptor.C_Invoice_AcctOverrideTest — a genuine two-schema cucumber setup
+  # is infeasible (no C_AcctSchema-create step-def) and unsafe (a second client schema is global seed
+  # state that PostingService posts every document to, polluting sibling accounting scenarios).
   @Id:S30443_TC5
   @from:cucumber
   @allure.label.epic:E0340_Invoicing

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceAccountingOverride.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoiceAccountingOverride.feature
@@ -72,10 +72,23 @@ Feature: Per-line GL account override on purchase invoices
       | Identifier      | C_BPartner_ID | IsShipToDefault | IsBillToDefault |
       | vendor_location | vendor        | Y               | Y               |
 
-    # A distinct override account; must differ from the product's default P_InventoryClearing_Acct
+    # F01010.4: the vendor uses the "Invoice Line Standard Fields" aggregation (540003) for invoice-line
+    # grouping — this is the aggregation that carries the C_ElementValue_Override key component. Without it,
+    # the default (programmatic) line aggregation ignores the override, so the aggregation scenarios below
+    # would not reflect the feature. Single-IC / direct-invoice scenarios are unaffected by this setting.
+    And load C_Aggregations:
+      | Identifier        | C_Aggregation_ID |
+      | invoiceLineStdAgg | 540003           |
+    And update C_BPartner:
+      | Identifier | PO_InvoiceLine_Aggregation_ID.Identifier |
+      | vendor     | invoiceLineStdAgg                        |
+
+    # Distinct override accounts; must differ from the product's default P_InventoryClearing_Acct.
+    # overrideAccount2 is used by the aggregation-key scenario to force two ICs apart.
     And metasfresh contains C_ElementValues:
-      | Identifier      |
-      | overrideAccount |
+      | Identifier       |
+      | overrideAccount  |
+      | overrideAccount2 |
 
     And metasfresh contains organization bank accounts
       | Identifier      | C_Currency_ID | IBAN                    |
@@ -190,3 +203,136 @@ Feature: Per-line GL account override on purchase invoices
       | AccountConceptualName | AmtSourceDr | AmtSourceCr | C_BPartner_ID | Record_ID |
       | V_Liability_Acct      | 100 EUR     |             | vendor        | alloc     |
       | B_PaymentSelect_Acct  |             | 100 EUR     | vendor        | alloc     |
+
+
+  # Scenario C (Q3): the per-line GL account override is part of the invoice-line aggregation key.
+  # Two receipt-matched purchase invoice candidates for the SAME product/price/UOM but with DIFFERENT
+  # C_ElementValue_Override_ID must NOT merge — they produce TWO separate invoice lines.
+  @Id:S30443_TC3
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @allure.label.feature:F01010.4_Invoice_Accounting_Overrides
+  Scenario: Candidates differing only by the GL account override split into separate invoice lines
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po         | false   | vendor        | POO         | 2022-06-15  | warehouse      | paymentTerm      |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | QtyEnteredTU | M_HU_PI_Item_Product_ID |
+      | po_line_a  | po         | product      | 100        | 10           | product_TU_10CU         |
+      | po_line_b  | po         | product      | 60         | 6            | product_TU_10CU         |
+    And the order identified by po is completed
+
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.QtyOrderedTU |
+      | receiptSchedule_a               | po                    | po_line_a                 | vendor                   | vendor_location                   | product                 | 100        | warehouse                 | 10               |
+      | receiptSchedule_b               | po                    | po_line_b                 | vendor                   | vendor_location                   | product                 | 60         | warehouse                 | 6                |
+    And create M_HU_LUTU_Configuration for M_ReceiptSchedule and generate M_HUs
+      | M_HU_LUTU_Configuration_ID.Identifier | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier | OPT.M_LU_HU_PI_ID.Identifier |
+      | huLuTuConfig_a                        | hu_a               | receiptSchedule_a               | N               | 1     | N               | 10    | N               | 10          | product_TU_10CU                    | LU                           |
+      | huLuTuConfig_b                        | hu_b               | receiptSchedule_b               | N               | 1     | N               | 6     | N               | 10          | product_TU_10CU                    | LU                           |
+    And create material receipt
+      | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | hu_a               | receiptSchedule_a               | materialReceipt_a     |
+      | hu_b               | receiptSchedule_b               | materialReceipt_b     |
+    And validate the created material receipt lines
+      | M_InOutLine_ID        | M_InOut_ID        | M_Product_ID | movementqty | processed |
+      | materialReceiptLine_a | materialReceipt_a | product      | 100         | true      |
+      | materialReceiptLine_b | materialReceipt_b | product      | 60          | true      |
+
+    And after not more than 120s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice | OPT.M_InOutLine_ID.Identifier |
+      | invoiceCand_a                     | po                        | po_line_a                 | 100              | 100          | materialReceiptLine_a         |
+      | invoiceCand_b                     | po                        | po_line_b                 | 60               | 60           | materialReceiptLine_b         |
+    # Different override accounts on the two otherwise-identical candidates.
+    And update C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID | C_ElementValue_Override_ID |
+      | invoiceCand_a          | overrideAccount            |
+      | invoiceCand_b          | overrideAccount2           |
+
+    # The override account is part of the invoice-line aggregation key (C_Aggregation 540003, the vendor's
+    # line aggregation). Different overrides => different LineAggregationKey => the candidates do NOT merge;
+    # the invoicing engine emits two separate invoice lines. (Asserting the key is the deterministic
+    # mechanism-level check; line splitting/merging by key is core invoicing behaviour.)
+    Then C_Invoice_Candidate LineAggregationKeys are different:
+      | C_Invoice_Candidate_ID |
+      | invoiceCand_a          |
+      | invoiceCand_b          |
+
+
+  # Scenario D (Q3 control): the SAME override account on both candidates keeps the default behaviour —
+  # they merge into ONE invoice line (qty 160). Proves the split above is caused by the differing override.
+  @Id:S30443_TC4
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @allure.label.feature:F01010.4_Invoice_Accounting_Overrides
+  Scenario: Candidates with the same GL account override merge into a single invoice line
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po         | false   | vendor        | POO         | 2022-06-15  | warehouse      | paymentTerm      |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | QtyEnteredTU | M_HU_PI_Item_Product_ID |
+      | po_line_a  | po         | product      | 100        | 10           | product_TU_10CU         |
+      | po_line_b  | po         | product      | 60         | 6            | product_TU_10CU         |
+    And the order identified by po is completed
+
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.QtyOrderedTU |
+      | receiptSchedule_a               | po                    | po_line_a                 | vendor                   | vendor_location                   | product                 | 100        | warehouse                 | 10               |
+      | receiptSchedule_b               | po                    | po_line_b                 | vendor                   | vendor_location                   | product                 | 60         | warehouse                 | 6                |
+    And create M_HU_LUTU_Configuration for M_ReceiptSchedule and generate M_HUs
+      | M_HU_LUTU_Configuration_ID.Identifier | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier | OPT.M_LU_HU_PI_ID.Identifier |
+      | huLuTuConfig_a                        | hu_a               | receiptSchedule_a               | N               | 1     | N               | 10    | N               | 10          | product_TU_10CU                    | LU                           |
+      | huLuTuConfig_b                        | hu_b               | receiptSchedule_b               | N               | 1     | N               | 6     | N               | 10          | product_TU_10CU                    | LU                           |
+    And create material receipt
+      | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | hu_a               | receiptSchedule_a               | materialReceipt_a     |
+      | hu_b               | receiptSchedule_b               | materialReceipt_b     |
+    And validate the created material receipt lines
+      | M_InOutLine_ID        | M_InOut_ID        | M_Product_ID | movementqty | processed |
+      | materialReceiptLine_a | materialReceipt_a | product      | 100         | true      |
+      | materialReceiptLine_b | materialReceipt_b | product      | 60          | true      |
+
+    And after not more than 120s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice | OPT.M_InOutLine_ID.Identifier |
+      | invoiceCand_a                     | po                        | po_line_a                 | 100              | 100          | materialReceiptLine_a         |
+      | invoiceCand_b                     | po                        | po_line_b                 | 60               | 60           | materialReceiptLine_b         |
+    # Same override account on both otherwise-identical candidates.
+    And update C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID | C_ElementValue_Override_ID |
+      | invoiceCand_a          | overrideAccount            |
+      | invoiceCand_b          | overrideAccount            |
+
+    # Equal overrides => identical LineAggregationKey => the candidates keep the default behaviour and
+    # merge into a single invoice line. This is the control that isolates the override as the split cause
+    # in the scenario above (everything else about the two candidates is identical).
+    Then C_Invoice_Candidate LineAggregationKeys are equal:
+      | C_Invoice_Candidate_ID |
+      | invoiceCand_a          |
+      | invoiceCand_b          |
+
+
+  # Scenario E (Q2): on completion the override is materialized into C_Invoice_Acct scoped to the
+  # accounting schema resolved from the invoice line's OWN org — getC_AcctSchema_ID(client, org) —
+  # not spread across every client schema.
+  @Id:S30443_TC5
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @allure.label.feature:F01010.4_Invoice_Accounting_Overrides
+  Scenario: Materialized C_Invoice_Acct rows target the invoice line's org-resolved accounting schema
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID | C_DocTypeTarget_ID.Name | DateInvoiced | IsSOTrx | C_Currency_ID | C_PaymentTerm_ID |
+      | invoice    | vendor        | Eingangsrechnung        | 2022-06-15   | false   | EUR           | paymentTerm      |
+    And metasfresh contains C_InvoiceLines
+      | Identifier  | C_Invoice_ID | M_Product_ID | QtyInvoiced | C_Tax_ID | C_ElementValue_Override_ID |
+      | invoiceLine | invoice      | product      | 1 PCE       | zeroTax  | overrideAccount            |
+    And the invoice identified by invoice is completed
+
+    # Exactly one row per concept, each carrying the override account AND targeting the schema resolved
+    # from the line's org (getC_AcctSchema_ID). AssertAcctSchemaResolvedFromOrg makes the schema check strict.
+    Then C_Invoice_Acct rows are found for invoice:
+      | C_Invoice_ID | C_InvoiceLine_ID | AccountName              | C_ElementValue_ID | OPT.AssertAcctSchemaResolvedFromOrg |
+      | invoice      | invoiceLine      | P_Expense_Acct           | overrideAccount   | Y                                   |
+      | invoice      | invoiceLine      | P_InventoryClearing_Acct | overrideAccount   | Y                                   |

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5812870_sys_InvoiceCandidate_AcctOverride_ValRule.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5812870_sys_InvoiceCandidate_AcctOverride_ValRule.sql
@@ -1,0 +1,40 @@
+-- F01010.4 "Invoice Accounting Overrides"
+-- Scope the C_ElementValue_Override_ID account picker to the account element (ElementType='AC')
+-- of the accounting schema resolved for the record's org: getC_AcctSchema_ID(client, org).
+-- Excludes summary accounts. Applied to BOTH the invoice-candidate override column (592836)
+-- and the invoice-line override column (592837); the WebUI fields inherit the column-level rule.
+--
+-- AD_Val_Rule_ID 540792  (from ID server)
+
+-- ============================================================
+-- AD_Val_Rule
+-- ============================================================
+INSERT INTO AD_Val_Rule
+    (AD_Val_Rule_ID, AD_Client_ID, AD_Org_ID, IsActive,
+     Created, CreatedBy, Updated, UpdatedBy,
+     Name, Type, EntityType, Code)
+VALUES
+    (540792 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-09 10:00:00','YYYY-MM-DD HH24:MI:SS') AT TIME ZONE 'UTC', 100,
+     TO_TIMESTAMP('2026-07-09 10:00:00','YYYY-MM-DD HH24:MI:SS') AT TIME ZONE 'UTC', 100,
+     'C_ElementValue Account of Org-resolved AcctSchema',
+     'S', 'de.metas.invoicecandidate',
+     'C_ElementValue.C_Element_ID = (SELECT ase.C_Element_ID FROM C_AcctSchema_Element ase WHERE ase.C_AcctSchema_ID = getC_AcctSchema_ID(@#AD_Client_ID@, @AD_Org_ID@) AND ase.ElementType=''AC'' AND ase.IsActive=''Y'') AND C_ElementValue.IsActive=''Y'' AND C_ElementValue.IsSummary=''N''')
+;
+
+-- ============================================================
+-- Point both override columns at the new rule
+-- ============================================================
+UPDATE AD_Column
+   SET AD_Val_Rule_ID = 540792,
+       Updated = TO_TIMESTAMP('2026-07-09 10:00:01','YYYY-MM-DD HH24:MI:SS') AT TIME ZONE 'UTC',
+       UpdatedBy = 100
+ WHERE AD_Column_ID = 592836
+;
+
+UPDATE AD_Column
+   SET AD_Val_Rule_ID = 540792,
+       Updated = TO_TIMESTAMP('2026-07-09 10:00:02','YYYY-MM-DD HH24:MI:SS') AT TIME ZONE 'UTC',
+       UpdatedBy = 100
+ WHERE AD_Column_ID = 592837
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5812880_sys_InvoiceCandidate_AcctOverride_AggKey.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5812880_sys_InvoiceCandidate_AcctOverride_AggKey.sql
@@ -1,0 +1,21 @@
+-- F01010.4 "Invoice Accounting Overrides"
+-- Make the per-line GL account override part of the invoice-line aggregation key, so that
+-- invoice candidates differing only by C_ElementValue_Override_ID split into separate invoice
+-- lines instead of merging. NULL overrides (the default) still merge (NULL = NULL in the key).
+--
+-- Added to aggregation 540003 "Invoice Line Standard Fields" — the shared line-key aggregation
+-- included (INC item 540020) by 540002 "Per invoice candidate or packing material".
+-- Type='COL', AD_Column_ID=592836 (C_Invoice_Candidate.C_ElementValue_Override_ID).
+--
+-- C_AggregationItem_ID 540129  (from ID server)
+
+INSERT INTO C_AggregationItem
+    (C_AggregationItem_ID, C_Aggregation_ID, AD_Client_ID, AD_Org_ID, IsActive,
+     Created, CreatedBy, Updated, UpdatedBy,
+     Type, AD_Column_ID, EntityType)
+VALUES
+    (540129 /*From ID Server*/, 540003, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-09 10:05:00','YYYY-MM-DD HH24:MI:SS') AT TIME ZONE 'UTC', 100,
+     TO_TIMESTAMP('2026-07-09 10:05:00','YYYY-MM-DD HH24:MI:SS') AT TIME ZONE 'UTC', 100,
+     'COL', 592836, 'de.metas.invoicecandidate')
+;


### PR DESCRIPTION
Follow-up to the Invoice Accounting Overrides feature (https://github.com/metasfresh/metasfresh/pull/24640), from a UAT demo. Two gaps.

## Q2 — override account scoped by the org's accounting schema
- **Interceptor** (`C_Invoice_AcctOverride`): materialized the override into **every** client accounting schema (`getAllByClient`). For a multi-org / one-schema-per-org client that wrongly writes into all orgs' schemas. Now resolves the schema of **each invoice line's own org** via `getByClientAndOrgOrNull(clientId, lineOrgId)` and materializes only into that schema (skips the line if none resolves).
- **Val-rule** (migration `5812870`, `AD_Val_Rule` 540792): the override-account picker was unfiltered (generic `Account_ID` reference). Now scoped to the account element (`ElementType='AC'`) of `getC_AcctSchema_ID(@#AD_Client_ID@, @AD_Org_ID@)`, excluding summary accounts — set on both override columns (592836 candidate, 592837 line). Same resolver the interceptor uses, so field and posting agree.

## Q3 — override is part of the invoice-line aggregation key
Migration `5812880` adds `C_ElementValue_Override_ID` to the shared invoice-line aggregation (`C_Aggregation` 540003) so candidates differing only by override account split into separate invoice lines. NULL overrides (the default, all non-override docs) still merge — `NULL = NULL` in the key, so behavior is unchanged for everything without an override.

## Verification
- Cucumber (`invoiceAccountingOverride.feature`) extended: differing override → different line-aggregation key (split); identical override → equal key (merge); materialized `C_Invoice_Acct` targets the org-resolved schema. 5/5 scenarios pass locally.
- `de.metas.business` compiles.

## Reviewer / rollout notes
- **Q3 takes effect only for partners whose line aggregation is 540003.** The default IC line aggregation is a programmatic per-candidate builder (each candidate is already its own line), so the override-as-key matters only when partners are configured to a merging aggregation (`PO_InvoiceLine_Aggregation_ID = 540003`). Adding it to shared core aggregation 540003 is NULL-safe (no behavior change without an override). Confirm the target customer's merging partners actually use 540003 (vs a custom aggregation, which would need the key added there instead).
- Q3 cucumber asserts at the line-aggregation-**key** level (different→split / equal→merge) rather than counting invoice lines, because a pre-existing async-enqueue unique-index issue trips when ≥2 candidates aggregate into one workpackage on the test stack (unrelated to this change). The key is the exact mechanism the migration changes.
