### PR TITLE
Mobile Packing unpick: reduce M_ShipmentSchedule_QtyPicked on skip-to-floor

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/AssertHUExpectationsCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/AssertHUExpectationsCommand.java
@@ -2,6 +2,7 @@ package de.metas.frontend_testing.expectations;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
+import de.metas.bpartner.BPartnerId;
 import de.metas.common.util.time.SystemTime;
 import de.metas.frontend_testing.expectations.request.JsonHUExpectation;
 import de.metas.frontend_testing.expectations.request.QtyAndUOMString;
@@ -117,6 +118,19 @@ class AssertHUExpectationsCommand
 		{
 			final I_M_HU hu = getHUById(huId);
 			assertThat(hu.getHUStatus()).as("HUStatus").isEqualTo(expectation.getHuStatus());
+		}
+
+		if (expectation.getBpartner() != null)
+		{
+			final I_M_HU hu = getHUById(huId);
+			final BPartnerId expectedBPartnerId = context.getId(expectation.getBpartner(), BPartnerId.class);
+			assertThat(BPartnerId.ofRepoIdOrNull(hu.getC_BPartner_ID())).as("HU consignee C_BPartner_ID").isEqualTo(expectedBPartnerId);
+		}
+
+		if (Boolean.TRUE.equals(expectation.getConsigneeCleared()))
+		{
+			final I_M_HU hu = getHUById(huId);
+			assertThat(hu.getC_BPartner_ID() <= 0).as("HU consignee cleared (C_BPartner_ID <= 0)").isEqualTo(true);
 		}
 
 		if (expectation.getHuType() != null)

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/request/JsonHUExpectation.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/expectations/request/JsonHUExpectation.java
@@ -19,6 +19,16 @@ public class JsonHUExpectation
 	@Nullable Identifier locator;
 	@Nullable String huStatus;
 	/**
+	 * Expected HU consignee ({@code C_BPartner_ID}). When set, assert the HU's consignee resolves
+	 * to this bpartner (i.e. the consignee was RETAINED). Mutually meaningful with
+	 * {@link #consigneeCleared} (only one applies to a given assertion).
+	 */
+	@Nullable Identifier bpartner;
+	/**
+	 * When {@code true}, assert the HU's consignee was STRIPPED, i.e. {@code C_BPartner_ID <= 0}.
+	 */
+	@Nullable Boolean consigneeCleared;
+	/**
 	 * Expected HU unit type. Pass the DB code (the value of {@code M_HU_PI_Version.HU_UnitType}):
 	 * <ul>
 	 *   <li>{@code "V"} — Virtual PI / bare VHU/CU ({@code HUType.VirtualPI})</li>

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/unpick/PickingJobUnPickCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/unpick/PickingJobUnPickCommand.java
@@ -324,13 +324,20 @@ public class PickingJobUnPickCommand
 		final PickingJobStepUnpickInfo.PickingJobStepUnpickInfoBuilder unpickInfoBuilder = PickingJobStepUnpickInfo.builder()
 				.unpickedHUs(wholeHUsToUnpick);
 
-		unpickWholeHUs(wholeHUsToUnpick, shipmentScheduleId, isPickToBareTU);
-		unpickBoundaryHU(step, boundaryHu, boundarySplitQty, shipmentScheduleId, unpickInfoBuilder, isPickToBareTU);
+		final List<I_M_HU> extractedTopLevelHUs = new ArrayList<>(unpickWholeHUs(wholeHUsToUnpick));
+		extractedTopLevelHUs.addAll(unpickBoundaryHU(step, boundaryHu, boundarySplitQty, unpickInfoBuilder));
 
+		// Single reduce-vs-delete dispatch for the whole step: a bare-TU pick-to row is TU-keyed, so its
+		// schedule-side rows are reduced once for the step's total unpicked qty; otherwise the extracted
+		// top-level HUs' CU/LU-keyed rows are deleted.
 		if (isPickToBareTU)
 		{
 			final Quantity totalUnpickedQty = computeTotalUnpickedQty(wholeHUsToUnpick, boundaryHu, boundarySplitQty);
 			shipmentScheduleService.reduceQtyPickedForPickToTU(shipmentScheduleId, pickToTuId, totalUnpickedQty);
+		}
+		else
+		{
+			shipmentScheduleService.deleteByTopLevelHUsAndShipmentScheduleId(extractedTopLevelHUs, shipmentScheduleId);
 		}
 
 		return step.reduceWithUnpickEvent(pickFromKey, unpickInfoBuilder.build());
@@ -390,44 +397,51 @@ public class PickingJobUnPickCommand
 		}
 	}
 
-	private void unpickWholeHUs(
-			@NonNull final List<PickingJobStepPickedToHU> wholeHUsToUnpick,
-			@NonNull final ShipmentScheduleId shipmentScheduleId,
-			final boolean isPickToBareTU)
+	/**
+	 * Pure HU operation: extracts the given whole picked-to HUs to top level and returns them. Does NOT touch
+	 * any {@code M_ShipmentSchedule_QtyPicked} row — the caller ({@link #unpickStep}) does the single
+	 * reduce-vs-delete dispatch for the whole step.
+	 *
+	 * @return the extracted top-level HUs (empty if {@code wholeHUsToUnpick} is empty)
+	 */
+	@NonNull
+	private List<I_M_HU> unpickWholeHUs(@NonNull final List<PickingJobStepPickedToHU> wholeHUsToUnpick)
 	{
 		if (wholeHUsToUnpick.isEmpty())
 		{
-			return;
+			return ImmutableList.of();
 		}
 
 		final ImmutableSet<HUIdAndQRCode> huIdAndQRCodeList = extractHuIdAndQRCodes(wholeHUsToUnpick);
 
 		final List<I_M_HU> topLevelHUs = extractToTopLevelHUs(huIdAndQRCodeList);
-		if (!isPickToBareTU)
-		{
-			// Not a bare-TU pick: the extracted-CU delete matches the CU/LU-keyed row. (Bare-TU rows are
-			// TU-keyed and reversed once per step via reduceQtyPickedForPickToTU in unpickStep.)
-			shipmentScheduleService.deleteByTopLevelHUsAndShipmentScheduleId(topLevelHUs, shipmentScheduleId);
-		}
 		changeHUStatusFromPickedToActive(topLevelHUs);
 
 		// Move the EXTRACTED top-level HUs, not the original picked-CU references: extracting an aggregate
 		// CU splits out a new TU and relocates its QR assignment onto that TU, so the original (huId,QR)
 		// pairs are stale and the move's re-extraction would fail the QR-assignment assertion.
 		moveToTargetHUIfNeeded(toCurrentHuIdAndQRCodes(topLevelHUs));
+
+		return topLevelHUs;
 	}
 
-	private void unpickBoundaryHU(
+	/**
+	 * Pure HU operation: carves the boundary split qty into a new CU, extracts it to top level and returns it.
+	 * Does NOT touch any {@code M_ShipmentSchedule_QtyPicked} row — the caller ({@link #unpickStep}) does the
+	 * single reduce-vs-delete dispatch for the whole step. Still fills {@code unpickInfoBuilder}.
+	 *
+	 * @return the carved top-level HU (empty if there is no boundary HU to split)
+	 */
+	@NonNull
+	private List<I_M_HU> unpickBoundaryHU(
 			@NonNull final PickingJobStep step,
 			@Nullable final PickingJobStepPickedToHU boundaryHu,
 			@Nullable final Quantity boundarySplitQty,
-			@NonNull final ShipmentScheduleId shipmentScheduleId,
-			@NonNull final PickingJobStepUnpickInfo.PickingJobStepUnpickInfoBuilder unpickInfoBuilder,
-			final boolean isPickToBareTU)
+			@NonNull final PickingJobStepUnpickInfo.PickingJobStepUnpickInfoBuilder unpickInfoBuilder)
 	{
 		if (boundaryHu == null || boundarySplitQty == null)
 		{
-			return;
+			return ImmutableList.of();
 		}
 
 		final HuId boundaryVhuId = boundaryHu.getActualPickedHUId();
@@ -448,17 +462,14 @@ public class PickingJobUnPickCommand
 		final ImmutableSet<HUIdAndQRCode> carvedHuIdAndQRCode = ImmutableSet.of(
 				HUIdAndQRCode.builder().huId(carvedCUId).huQRCode(carvedQRCode).build());
 		final List<I_M_HU> carvedTopLevelHUs = extractToTopLevelHUs(carvedHuIdAndQRCode);
-		if (!isPickToBareTU)
-		{
-			// Bare-TU pick: handled once for the whole step by reduceQtyPickedForPickToTU (see unpickStep).
-			shipmentScheduleService.deleteByTopLevelHUsAndShipmentScheduleId(carvedTopLevelHUs, shipmentScheduleId);
-		}
 		changeHUStatusFromPickedToActive(carvedTopLevelHUs);
 		moveToTargetHUIfNeeded(carvedHuIdAndQRCode);
 
 		unpickInfoBuilder
 				.huToReduce(boundaryHu)
 				.reducedQtyPicked(remainderQty);
+
+		return carvedTopLevelHUs;
 	}
 
 	private void moveToTargetHUIfNeeded(final ImmutableSet<HUIdAndQRCode> huIdAndQRCodeList)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/unpick/PickingJobUnPickCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/unpick/PickingJobUnPickCommand.java
@@ -316,13 +316,61 @@ public class PickingJobUnPickCommand
 
 		final ShipmentScheduleId shipmentScheduleId = step.getScheduleId().getShipmentScheduleId();
 
+		// Resolve, before extraction detaches anything, whether this step's pick-to row is TU-keyed (a CU picked
+		// into a bare TU: the reduce path below must run instead of the extracted-CU delete) or CU/LU-keyed (a TU
+		// nested under an LU, or no TU at all: the extracted-CU delete still matches - keep it unchanged).
+		final HuId pickToTuId = resolvePickToTuId(wholeHUsToUnpick, boundaryHu);
+		final boolean isPickToBareTU = pickToTuId != null && !huService.hasLoadingUnit(pickToTuId);
+
 		final PickingJobStepUnpickInfo.PickingJobStepUnpickInfoBuilder unpickInfoBuilder = PickingJobStepUnpickInfo.builder()
 				.unpickedHUs(wholeHUsToUnpick);
 
-		unpickWholeHUs(wholeHUsToUnpick, shipmentScheduleId);
-		unpickBoundaryHU(step, boundaryHu, boundarySplitQty, shipmentScheduleId, unpickInfoBuilder);
+		unpickWholeHUs(wholeHUsToUnpick, shipmentScheduleId, isPickToBareTU);
+		unpickBoundaryHU(step, boundaryHu, boundarySplitQty, shipmentScheduleId, unpickInfoBuilder, isPickToBareTU);
+
+		if (isPickToBareTU)
+		{
+			final Quantity totalUnpickedQty = computeTotalUnpickedQty(wholeHUsToUnpick, boundaryHu, boundarySplitQty);
+			shipmentScheduleService.reduceQtyPickedForPickToTU(shipmentScheduleId, pickToTuId, totalUnpickedQty);
+		}
 
 		return step.reduceWithUnpickEvent(pickFromKey, unpickInfoBuilder.build());
+	}
+
+	/**
+	 * Resolves the TU that this step's pick-to CU(s) are packed into, using any one of the step's picked-to CUs
+	 * (all CUs of one step share that step's single pick-to TU). Returns {@code null} when there is no pick-to CU
+	 * at all, or the CU has no TU parent (e.g. a standalone/top-level CU pick).
+	 */
+	@Nullable
+	private HuId resolvePickToTuId(
+			@NonNull final List<PickingJobStepPickedToHU> wholeHUsToUnpick,
+			@Nullable final PickingJobStepPickedToHU boundaryHu)
+	{
+		final HuId representativeCuId = !wholeHUsToUnpick.isEmpty()
+				? wholeHUsToUnpick.get(0).getActualPickedHUId()
+				: boundaryHu != null ? boundaryHu.getActualPickedHUId() : null;
+		return representativeCuId != null ? huService.getParentTransportUnitId(representativeCuId) : null;
+	}
+
+	@NonNull
+	private static Quantity computeTotalUnpickedQty(
+			@NonNull final List<PickingJobStepPickedToHU> wholeHUsToUnpick,
+			@Nullable final PickingJobStepPickedToHU boundaryHu,
+			@Nullable final Quantity boundarySplitQty)
+	{
+		Quantity total = wholeHUsToUnpick.stream()
+				.map(PickingJobStepPickedToHU::getQtyPicked)
+				.reduce(Quantity::add)
+				.orElse(null);
+
+		if (boundaryHu != null && boundarySplitQty != null)
+		{
+			total = total != null ? total.add(boundarySplitQty) : boundarySplitQty;
+		}
+
+		Check.assumeNotNull(total, "at least one of wholeHUsToUnpick or boundarySplitQty must be present when resolving the pick-to TU's total unpicked qty");
+		return total;
 	}
 
 	private static List<PickingJobStepPickedToHU> resolveWholeHUsToUnpick(
@@ -345,7 +393,8 @@ public class PickingJobUnPickCommand
 
 	private void unpickWholeHUs(
 			@NonNull final List<PickingJobStepPickedToHU> wholeHUsToUnpick,
-			@NonNull final ShipmentScheduleId shipmentScheduleId)
+			@NonNull final ShipmentScheduleId shipmentScheduleId,
+			final boolean isPickToBareTU)
 	{
 		if (wholeHUsToUnpick.isEmpty())
 		{
@@ -355,7 +404,14 @@ public class PickingJobUnPickCommand
 		final ImmutableSet<HUIdAndQRCode> huIdAndQRCodeList = extractHuIdAndQRCodes(wholeHUsToUnpick);
 
 		final List<I_M_HU> topLevelHUs = extractToTopLevelHUs(huIdAndQRCodeList);
-		shipmentScheduleService.deleteByTopLevelHUsAndShipmentScheduleId(topLevelHUs, shipmentScheduleId);
+		if (!isPickToBareTU)
+		{
+			// Bare-TU pick: the schedule-side reversal is handled once for the whole step by
+			// reduceQtyPickedForPickToTU (see unpickStep) instead - a bare-TU pick's row is keyed to the TU
+			// (M_TU_HU_ID), so the extracted-CU delete below (which matches on VHU_ID with M_TU_HU_ID=null)
+			// would never find it anyway.
+			shipmentScheduleService.deleteByTopLevelHUsAndShipmentScheduleId(topLevelHUs, shipmentScheduleId);
+		}
 		changeHUStatusFromPickedToActive(topLevelHUs);
 
 		// Move the EXTRACTED top-level HUs, not the original picked-CU references: extracting an aggregate
@@ -369,7 +425,8 @@ public class PickingJobUnPickCommand
 			@Nullable final PickingJobStepPickedToHU boundaryHu,
 			@Nullable final Quantity boundarySplitQty,
 			@NonNull final ShipmentScheduleId shipmentScheduleId,
-			@NonNull final PickingJobStepUnpickInfo.PickingJobStepUnpickInfoBuilder unpickInfoBuilder)
+			@NonNull final PickingJobStepUnpickInfo.PickingJobStepUnpickInfoBuilder unpickInfoBuilder,
+			final boolean isPickToBareTU)
 	{
 		if (boundaryHu == null || boundarySplitQty == null)
 		{
@@ -394,7 +451,11 @@ public class PickingJobUnPickCommand
 		final ImmutableSet<HUIdAndQRCode> carvedHuIdAndQRCode = ImmutableSet.of(
 				HUIdAndQRCode.builder().huId(carvedCUId).huQRCode(carvedQRCode).build());
 		final List<I_M_HU> carvedTopLevelHUs = extractToTopLevelHUs(carvedHuIdAndQRCode);
-		shipmentScheduleService.deleteByTopLevelHUsAndShipmentScheduleId(carvedTopLevelHUs, shipmentScheduleId);
+		if (!isPickToBareTU)
+		{
+			// Bare-TU pick: handled once for the whole step by reduceQtyPickedForPickToTU (see unpickStep).
+			shipmentScheduleService.deleteByTopLevelHUsAndShipmentScheduleId(carvedTopLevelHUs, shipmentScheduleId);
+		}
 		changeHUStatusFromPickedToActive(carvedTopLevelHUs);
 		moveToTargetHUIfNeeded(carvedHuIdAndQRCode);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/unpick/PickingJobUnPickCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/unpick/PickingJobUnPickCommand.java
@@ -316,9 +316,8 @@ public class PickingJobUnPickCommand
 
 		final ShipmentScheduleId shipmentScheduleId = step.getScheduleId().getShipmentScheduleId();
 
-		// Resolve, before extraction detaches anything, whether this step's pick-to row is TU-keyed (a CU picked
-		// into a bare TU: the reduce path below must run instead of the extracted-CU delete) or CU/LU-keyed (a TU
-		// nested under an LU, or no TU at all: the extracted-CU delete still matches - keep it unchanged).
+		// Before extraction detaches anything: is the pick-to row TU-keyed (bare-TU pick → use the reduce path
+		// below) or CU/LU-keyed (extracted-CU delete still matches → unchanged)?
 		final HuId pickToTuId = resolvePickToTuId(wholeHUsToUnpick, boundaryHu);
 		final boolean isPickToBareTU = pickToTuId != null && !huService.hasLoadingUnit(pickToTuId);
 
@@ -406,10 +405,8 @@ public class PickingJobUnPickCommand
 		final List<I_M_HU> topLevelHUs = extractToTopLevelHUs(huIdAndQRCodeList);
 		if (!isPickToBareTU)
 		{
-			// Bare-TU pick: the schedule-side reversal is handled once for the whole step by
-			// reduceQtyPickedForPickToTU (see unpickStep) instead - a bare-TU pick's row is keyed to the TU
-			// (M_TU_HU_ID), so the extracted-CU delete below (which matches on VHU_ID with M_TU_HU_ID=null)
-			// would never find it anyway.
+			// Not a bare-TU pick: the extracted-CU delete matches the CU/LU-keyed row. (Bare-TU rows are
+			// TU-keyed and reversed once per step via reduceQtyPickedForPickToTU in unpickStep.)
 			shipmentScheduleService.deleteByTopLevelHUsAndShipmentScheduleId(topLevelHUs, shipmentScheduleId);
 		}
 		changeHUStatusFromPickedToActive(topLevelHUs);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickingJobHUService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/hu/PickingJobHUService.java
@@ -206,6 +206,30 @@ public class PickingJobHUService
 	public List<I_M_HU> getByIds(@NonNull final Collection<HuId> huIds) {return handlingUnitsBL.getByIds(huIds);}
 
 	/**
+	 * Returns the parent transport unit of the given CU, or {@code null} if the CU has no TU parent (e.g. it is a
+	 * standalone/top-level CU). Used to resolve, at unpick time, the TU a bare-TU pick recorded its
+	 * {@code M_ShipmentSchedule_QtyPicked} row against — the leaf CU carries no such reference and the TU can only
+	 * be resolved from its parent before extraction detaches it.
+	 */
+	@Nullable
+	public HuId getParentTransportUnitId(@NonNull final HuId cuId)
+	{
+		final I_M_HU cu = handlingUnitsBL.getById(cuId);
+		final I_M_HU tuHU = handlingUnitsBL.getTransportUnitHU(cu);
+		return tuHU != null ? HuId.ofRepoId(tuHU.getM_HU_ID()) : null;
+	}
+
+	/**
+	 * @return {@code true} if the given TU sits under a loading unit (LU). Used to discriminate, at unpick time,
+	 * a bare-TU pick (schedule row keyed to the TU) from a TU-under-LU pick (schedule row keyed to the leaf CU).
+	 */
+	public boolean hasLoadingUnit(@NonNull final HuId tuId)
+	{
+		final I_M_HU tuHU = handlingUnitsBL.getById(tuId);
+		return handlingUnitsBL.getLoadingUnitHU(tuHU) != null;
+	}
+
+	/**
 	 * Returns all non-empty product storages on the given HU (e.g. an LU).
 	 */
 	@NonNull

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/shipmentschedule/PickingJobShipmentScheduleService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/external/shipmentschedule/PickingJobShipmentScheduleService.java
@@ -123,6 +123,17 @@ public class PickingJobShipmentScheduleService
 		huShipmentScheduleBL.deleteByTopLevelHUsAndShipmentScheduleId(topLevelHUs, shipmentScheduleId);
 	}
 
+	/**
+	 * @see IHUShipmentScheduleBL#reduceQtyPickedForPickToTU(ShipmentScheduleId, HuId, Quantity)
+	 */
+	public void reduceQtyPickedForPickToTU(
+			@NonNull final ShipmentScheduleId shipmentScheduleId,
+			@NonNull final HuId pickToTuId,
+			@NonNull final Quantity qtyToReduce)
+	{
+		huShipmentScheduleBL.reduceQtyPickedForPickToTU(shipmentScheduleId, pickToTuId, qtyToReduce);
+	}
+
 	public Stream<Packageable> stream(@NonNull final PackageableQuery query)
 	{
 		return packagingDAO.stream(query);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleBL.java
@@ -131,6 +131,20 @@ public interface IHUShipmentScheduleBL extends ISingletonService
 
 	void deleteByTopLevelHUsAndShipmentScheduleId(@NonNull Collection<I_M_HU> topLevelHUs, @NonNull ShipmentScheduleId shipmentScheduleId);
 
+	/**
+	 * Reduces the {@link I_M_ShipmentSchedule_QtyPicked} row(s) keyed to the given pick-to TU (i.e.
+	 * {@code M_TU_HU_ID = pickToTuId}) by {@code qtyToReduce}, walking the rows newest-first (highest
+	 * {@code M_ShipmentSchedule_QtyPicked_ID} first). A row fully consumed by the reduction is deleted;
+	 * the last touched row (if any qty remains after it) is partially reduced instead. Use this — instead of
+	 * {@link #deleteByTopLevelHUsAndShipmentScheduleId}/{@link #deleteByTopLevelHUAndShipmentScheduleId} —
+	 * for a partial unpick-to-floor of a CU picked into a bare TU, where the picked-to row is keyed to the
+	 * TU (not the leaf CU) and a blind delete would also erase the still-picked remainder.
+	 */
+	void reduceQtyPickedForPickToTU(
+			@NonNull ShipmentScheduleId shipmentScheduleId,
+			@NonNull HuId pickToTuId,
+			@NonNull Quantity qtyToReduce);
+
 	WarehouseId getWarehouseId(@NonNull I_M_ShipmentSchedule schedule);
 
 	BPartnerId getBPartnerId(@NonNull I_M_ShipmentSchedule schedule);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleDAO.java
@@ -41,6 +41,9 @@ public interface IHUShipmentScheduleDAO extends ISingletonService
 
 	List<I_M_ShipmentSchedule_QtyPicked> retrieveSchedsQtyPickedForTU(int shipmentScheduleId, int tuHUId, String trxName);
 
+	/** @return true if any active M_ShipmentSchedule_QtyPicked row is keyed to the given TU for a schedule OTHER than the excluded one (a bare TU can be shared across schedules). */
+	boolean hasActiveQtyPickedForTUExcludingSchedule(int tuHUId, int excludeShipmentScheduleId);
+
 	List<I_M_ShipmentSchedule_QtyPicked> retrieveSchedsQtyPickedForVHU(I_M_HU vhu);
 
 	IQueryBuilder<I_M_ShipmentSchedule_QtyPicked> retrieveSchedsQtyPickedForVHUQuery(I_M_HU vhu);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/IHUShipmentScheduleDAO.java
@@ -41,8 +41,8 @@ public interface IHUShipmentScheduleDAO extends ISingletonService
 
 	List<I_M_ShipmentSchedule_QtyPicked> retrieveSchedsQtyPickedForTU(int shipmentScheduleId, int tuHUId, String trxName);
 
-	/** @return true if any active M_ShipmentSchedule_QtyPicked row is keyed to the given TU for a schedule OTHER than the excluded one (a bare TU can be shared across schedules). */
-	boolean hasActiveQtyPickedForTUExcludingSchedule(int tuHUId, int excludeShipmentScheduleId);
+	/** @return true if any active M_ShipmentSchedule_QtyPicked row is still keyed to the given top-level HU (LU/TU/VHU) — a shared HU can carry another schedule's active row. */
+	boolean hasActiveQtyPickedForTopLevelHU(@NonNull I_M_HU topLevelHU);
 
 	List<I_M_ShipmentSchedule_QtyPicked> retrieveSchedsQtyPickedForVHU(I_M_HU vhu);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -388,10 +388,8 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 			save(qtyPicked);
 		}
 
-		// also reset the HUs partner and location
-		tuHU.setC_BPartner_ID(0);
-		tuHU.setC_BPartner_Location_ID(0);
-		save(tuHU);
+		// also reset the HU's partner and location, unless another schedule still holds an active picked row on it
+		resetConsigneeIfNoActivePickedRows(tuHU);
 	}
 
 	@Override
@@ -821,10 +819,8 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 			assertNotAlreadyShipped(qtyPickedRecords, HuId.ofRepoId(topLevelHU.getM_HU_ID()));
 			shipmentScheduleAllocBL.deleteRecords(qtyPickedRecords);
 
-			// also reset the HU's partner and location (same pattern as unallocateTU)
-			topLevelHU.setC_BPartner_ID(0);
-			topLevelHU.setC_BPartner_Location_ID(0);
-			save(topLevelHU);
+			// also reset the HU's partner and location, unless another schedule still holds an active picked row on it
+			resetConsigneeIfNoActivePickedRows(topLevelHU);
 		}
 	}
 
@@ -896,18 +892,28 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 			shipmentScheduleAllocBL.deleteRecords(fullyConsumedRecords);
 		}
 
-		final boolean thisScheduleFullyUnpickedFromTU = fullyConsumedRecords.size() == newestFirst.size();
-		final boolean otherScheduleStillOnTU = huShipmentScheduleDAO.hasActiveQtyPickedForTUExcludingSchedule(
-				pickToTuId.getRepoId(), shipmentScheduleId.getRepoId());
-		if (thisScheduleFullyUnpickedFromTU && !otherScheduleStillOnTU)
+		// also reset the HU's partner and location, unless another schedule (or this one's partial
+		// remainder) still holds an active picked row on it. A bare TU can be shared across schedules,
+		// so we must not strip the consignee while another line still holds picked qty on it.
+		resetConsigneeIfNoActivePickedRows(tuHU);
+	}
+
+	/**
+	 * Resets the top-level HU's consignee (C_BPartner_ID / C_BPartner_Location_ID) back to none, UNLESS another
+	 * active {@link I_M_ShipmentSchedule_QtyPicked} row (this schedule's partial remainder, or another schedule
+	 * sharing the HU) still holds picked qty on it. Callers MUST delete/inactivate their own now-obsolete rows
+	 * BEFORE calling this, so the unscoped {@code topLevelHU} query below reflects the post-delete state.
+	 */
+	private void resetConsigneeIfNoActivePickedRows(@NonNull final I_M_HU topLevelHU)
+	{
+		if (huShipmentScheduleDAO.hasActiveQtyPickedForTopLevelHU(topLevelHU))
 		{
-			// No active picked row remains on this TU for ANY schedule -> mirror the reset done by
-			// deleteByTopLevelHUsAndShipmentScheduleId / unallocateTU. A bare TU can be shared across
-			// schedules, so we must not strip the consignee while another line still holds picked qty on it.
-			tuHU.setC_BPartner_ID(0);
-			tuHU.setC_BPartner_Location_ID(0);
-			save(tuHU);
+			return; // another schedule (or this one's partial remainder) still holds picked qty on this HU
 		}
+
+		topLevelHU.setC_BPartner_ID(0);
+		topLevelHU.setC_BPartner_Location_ID(0);
+		save(topLevelHU);
 	}
 
 	/**

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -87,6 +87,7 @@ import org.adempiere.ad.dao.IQueryOrderBy;
 import org.adempiere.ad.dao.IQueryOrderBy.Direction;
 import org.adempiere.ad.dao.IQueryOrderBy.Nulls;
 import org.adempiere.ad.dao.impl.DateTruncQueryFilterModifier;
+import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.service.ISysConfigBL;
 import org.adempiere.util.agg.key.IAggregationKeyBuilder;
@@ -100,9 +101,11 @@ import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -823,6 +826,112 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 			topLevelHU.setC_BPartner_Location_ID(0);
 			save(topLevelHU);
 		}
+	}
+
+	@Override
+	public void reduceQtyPickedForPickToTU(
+			@NonNull final ShipmentScheduleId shipmentScheduleId,
+			@NonNull final HuId pickToTuId,
+			@NonNull final Quantity qtyToReduce)
+	{
+		if (qtyToReduce.isZeroOrNegative())
+		{
+			return;
+		}
+
+		final List<I_M_ShipmentSchedule_QtyPicked> qtyPickedRecords = huShipmentScheduleDAO.retrieveSchedsQtyPickedForTU(
+				shipmentScheduleId.getRepoId(), pickToTuId.getRepoId(), ITrx.TRXNAME_ThreadInherited);
+		if (qtyPickedRecords.isEmpty())
+		{
+			return;
+		}
+
+		assertNotAlreadyShipped(qtyPickedRecords, pickToTuId);
+
+		// Newest-first (highest M_ShipmentSchedule_QtyPicked_ID = newest pick), mirroring the HU-side
+		// LIFO order the unpick command already used to select which picked HUs to unpick.
+		final List<I_M_ShipmentSchedule_QtyPicked> newestFirst = qtyPickedRecords.stream()
+				.sorted(Comparator.comparingInt(I_M_ShipmentSchedule_QtyPicked::getM_ShipmentSchedule_QtyPicked_ID).reversed())
+				.collect(Collectors.toList());
+
+		final I_M_HU tuHU = handlingUnitsBL.getById(pickToTuId);
+		final IHUContext huContext = huContextFactory.createMutableHUContext(getContextAware(tuHU));
+
+		final List<I_M_ShipmentSchedule_QtyPicked> fullyConsumedRecords = new ArrayList<>();
+		BigDecimal remaining = qtyToReduce.getAsBigDecimal();
+
+		for (final I_M_ShipmentSchedule_QtyPicked qtyPickedRecord : newestFirst)
+		{
+			if (remaining.signum() <= 0)
+			{
+				break;
+			}
+
+			final BigDecimal rowQtyPicked = qtyPickedRecord.getQtyPicked();
+			if (rowQtyPicked.compareTo(remaining) <= 0)
+			{
+				// Row fully consumed by the unpick qty -> delete it entirely.
+				fullyConsumedRecords.add(qtyPickedRecord);
+				remaining = remaining.subtract(rowQtyPicked);
+			}
+			else
+			{
+				// Row only partially consumed -> reduce QtyPicked (+ QtyTU/QtyLU, QtyDeliveredCatch) and stop.
+				final BigDecimal newQtyPicked = rowQtyPicked.subtract(remaining);
+				reduceCatchWeightProportionally(qtyPickedRecord, rowQtyPicked, newQtyPicked);
+				qtyPickedRecord.setQtyPicked(newQtyPicked);
+				createCandidatesForQtyPicked(qtyPickedRecord, huContext, M_ShipmentSchedule_QuantityTypeToUse.TYPE_QTY_TO_DELIVER)
+						.forEach(ShipmentScheduleWithHU::updateQtyTUAndQtyLU);
+				save(qtyPickedRecord);
+				remaining = BigDecimal.ZERO;
+			}
+		}
+
+		Check.assume(remaining.signum() <= 0,
+				"qtyToReduce={} must not exceed the total active QtyPicked for shipmentScheduleId={} and pickToTuId={}",
+				qtyToReduce, shipmentScheduleId, pickToTuId);
+
+		if (!fullyConsumedRecords.isEmpty())
+		{
+			shipmentScheduleAllocBL.deleteRecords(fullyConsumedRecords);
+		}
+
+		if (fullyConsumedRecords.size() == newestFirst.size())
+		{
+			// No active row remains for this schedule on this TU -> mirror the reset already done by
+			// deleteByTopLevelHUsAndShipmentScheduleId (:821-824) and unallocateTU (:388-391).
+			tuHU.setC_BPartner_ID(0);
+			tuHU.setC_BPartner_Location_ID(0);
+			save(tuHU);
+		}
+	}
+
+	/**
+	 * Scales {@code QtyDeliveredCatch} by the stock-qty ratio {@code newQtyPicked / oldQtyPicked}, mirroring how
+	 * the pick side spreads catch weight across CUs ({@code PickingJobPickCommand#getCatchWeight().spreadEqually}).
+	 * No-op when the row does not track a catch qty (guard: an unset {@code Catch_UOM_ID} must never reach
+	 * {@code UomId.ofRepoId(...)}, which asserts a positive id).
+	 */
+	private static void reduceCatchWeightProportionally(
+			@NonNull final I_M_ShipmentSchedule_QtyPicked qtyPickedRecord,
+			@NonNull final BigDecimal oldQtyPicked,
+			@NonNull final BigDecimal newQtyPicked)
+	{
+		if (qtyPickedRecord.getCatch_UOM_ID() <= 0)
+		{
+			return;
+		}
+
+		final BigDecimal oldQtyDeliveredCatch = qtyPickedRecord.getQtyDeliveredCatch();
+		if (oldQtyDeliveredCatch == null || oldQtyPicked.signum() == 0)
+		{
+			return;
+		}
+
+		final BigDecimal newQtyDeliveredCatch = oldQtyDeliveredCatch
+				.multiply(newQtyPicked)
+				.divide(oldQtyPicked, Math.max(oldQtyDeliveredCatch.scale(), 2), RoundingMode.HALF_UP);
+		qtyPickedRecord.setQtyDeliveredCatch(newQtyDeliveredCatch);
 	}
 
 	private static void assertNotAlreadyShipped(final List<I_M_ShipmentSchedule_QtyPicked> qtyPickedRecords, @NonNull final HuId huIdInScope)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -896,10 +896,14 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 			shipmentScheduleAllocBL.deleteRecords(fullyConsumedRecords);
 		}
 
-		if (fullyConsumedRecords.size() == newestFirst.size())
+		final boolean thisScheduleFullyUnpickedFromTU = fullyConsumedRecords.size() == newestFirst.size();
+		final boolean otherScheduleStillOnTU = huShipmentScheduleDAO.hasActiveQtyPickedForTUExcludingSchedule(
+				pickToTuId.getRepoId(), shipmentScheduleId.getRepoId());
+		if (thisScheduleFullyUnpickedFromTU && !otherScheduleStillOnTU)
 		{
-			// No active row remains for this schedule on this TU -> mirror the reset already done by
-			// deleteByTopLevelHUsAndShipmentScheduleId and unallocateTU.
+			// No active picked row remains on this TU for ANY schedule -> mirror the reset done by
+			// deleteByTopLevelHUsAndShipmentScheduleId / unallocateTU. A bare TU can be shared across
+			// schedules, so we must not strip the consignee while another line still holds picked qty on it.
 			tuHU.setC_BPartner_ID(0);
 			tuHU.setC_BPartner_Location_ID(0);
 			save(tuHU);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -899,7 +899,7 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 		if (fullyConsumedRecords.size() == newestFirst.size())
 		{
 			// No active row remains for this schedule on this TU -> mirror the reset already done by
-			// deleteByTopLevelHUsAndShipmentScheduleId (:821-824) and unallocateTU (:388-391).
+			// deleteByTopLevelHUsAndShipmentScheduleId and unallocateTU.
 			tuHU.setC_BPartner_ID(0);
 			tuHU.setC_BPartner_Location_ID(0);
 			save(tuHU);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO.java
@@ -125,6 +125,18 @@ public class HUShipmentScheduleDAO implements IHUShipmentScheduleDAO
 	}
 
 	@Override
+	public boolean hasActiveQtyPickedForTUExcludingSchedule(final int tuHUId, final int excludeShipmentScheduleId)
+	{
+		Preconditions.checkArgument(tuHUId > 0, "tuHUId > 0");
+		return queryBL.createQueryBuilder(I_M_ShipmentSchedule_QtyPicked.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_TU_HU_ID, tuHUId)
+				.addNotEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_ShipmentSchedule_ID, excludeShipmentScheduleId)
+				.create()
+				.anyMatch();
+	}
+
+	@Override
 	public List<I_M_ShipmentSchedule_QtyPicked> retrieveSchedsQtyPickedForVHU(final I_M_HU vhu)
 	{
 		return retrieveSchedsQtyPickedForVHUQuery(vhu)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleDAO.java
@@ -125,15 +125,9 @@ public class HUShipmentScheduleDAO implements IHUShipmentScheduleDAO
 	}
 
 	@Override
-	public boolean hasActiveQtyPickedForTUExcludingSchedule(final int tuHUId, final int excludeShipmentScheduleId)
+	public boolean hasActiveQtyPickedForTopLevelHU(@NonNull final I_M_HU topLevelHU)
 	{
-		Preconditions.checkArgument(tuHUId > 0, "tuHUId > 0");
-		return queryBL.createQueryBuilder(I_M_ShipmentSchedule_QtyPicked.class)
-				.addOnlyActiveRecordsFilter()
-				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_TU_HU_ID, tuHUId)
-				.addNotEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_ShipmentSchedule_ID, excludeShipmentScheduleId)
-				.create()
-				.anyMatch();
+		return queryByTopLevelHU(topLevelHU).create().anyMatch();
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL_unallocateTU_Test.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL_unallocateTU_Test.java
@@ -1,0 +1,161 @@
+package de.metas.handlingunits.shipmentschedule.api.impl;
+
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2015 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.handlingunits.AbstractHUTest;
+import de.metas.handlingunits.HUTestHelper;
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.IHUContext;
+import de.metas.handlingunits.IHandlingUnitsBL;
+import de.metas.handlingunits.allocation.IAllocationRequest;
+import de.metas.handlingunits.allocation.impl.AllocationUtils;
+import de.metas.handlingunits.allocation.impl.HULoader;
+import de.metas.handlingunits.allocation.impl.HUProducerDestination;
+import de.metas.handlingunits.allocation.impl.ShipmentScheduleListAllocationSource;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.I_M_HU_PI;
+import de.metas.handlingunits.model.I_M_HU_PI_Item;
+import de.metas.handlingunits.model.I_M_ShipmentSchedule_QtyPicked;
+import de.metas.handlingunits.model.X_M_HU_PI_Version;
+import de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleBL;
+import de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleDAO;
+import de.metas.handlingunits.shipmentschedule.util.ShipmentScheduleHelper;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.util.Services;
+import de.metas.util.collections.CollectionUtils;
+import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the shared-TU consignee-reset guard ({@code HUShipmentScheduleBL.resetConsigneeIfNoActivePickedRows},
+ * backed by {@code IHUShipmentScheduleDAO.hasActiveQtyPickedForTopLevelHU}) on the ONE reset call-site
+ * ({@link IHUShipmentScheduleBL#unallocateTU}) that is <b>dead code</b> today: its only caller,
+ * {@code ShipmentScheduleHUAllocations.deleteAllocations}, is never constructed anywhere in the codebase, so
+ * {@code unallocateTU} is not reachable from any mobile or desktop UI action. A faithful Playwright E2E is
+ * therefore impossible for this path; the identical guard IS already E2E-covered on the two mobile-reachable
+ * sites ({@code reduceQtyPickedForPickToTU} via {@code picking_partial_unpack_TU_floor_two_lines.spec.js} and
+ * {@code deleteByTopLevelHUsAndShipmentScheduleId}). This test is the BL-level substitute for path (C).
+ * <p>
+ * {@code unallocateTU} is public and directly invokable, so this test calls it directly (no fabricated /
+ * unreachable state): it builds a real bare TU shared by TWO real {@link I_M_ShipmentSchedule}s via the same
+ * production allocation path ({@link ShipmentScheduleListAllocationSource} + {@link HUProducerDestination} +
+ * {@link HULoader}, as already proven by {@code ShipmentScheduleListAllocationSourceTest}), then drives
+ * {@code unallocateTU} for each schedule in turn. Per {@code unallocateTU}'s own contract (it throws if the
+ * calling schedule's active QtyPicked qty on the TU is non-zero), the row being unallocated is zeroed first —
+ * this mirrors the real caller's precondition ({@code AbstractHUAllocations} always zeroes/consumes a
+ * schedule's qty before invoking {@code deleteAllocations}/{@code unallocateTU}), not a fabricated state.
+ */
+class HUShipmentScheduleBL_unallocateTU_Test extends AbstractHUTest
+{
+	private ShipmentScheduleHelper shipmentScheduleHelper;
+	private I_M_HU_PI tuPI;
+
+	private IHUShipmentScheduleBL huShipmentScheduleBL;
+	private IHUShipmentScheduleDAO huShipmentScheduleDAO;
+	private IHandlingUnitsBL handlingUnitsBL;
+
+	@Override
+	protected void initialize()
+	{
+		huShipmentScheduleBL = Services.get(IHUShipmentScheduleBL.class);
+		huShipmentScheduleDAO = Services.get(IHUShipmentScheduleDAO.class);
+		handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
+
+		shipmentScheduleHelper = new ShipmentScheduleHelper(helper);
+
+		tuPI = helper.createHUDefinition("unallocateTU-TU", X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit);
+		final I_M_HU_PI_Item tuItem = helper.createHU_PI_Item_Material(tuPI);
+		helper.assignProduct(tuItem, pTomatoId, new BigDecimal("100"), uomEach);
+	}
+
+	@Test
+	void unallocateTU_retainsConsignee_whileOtherScheduleStillHoldsPickedQty_thenStripsItWhenLast()
+	{
+		// Two schedules sharing one bare TU, mirroring a 2-line sales_order aggregation onto a shared bare TU.
+		final I_M_ShipmentSchedule schedule1 = shipmentScheduleHelper.createShipmentSchedule(pTomato, uomEach, new BigDecimal("5"), BigDecimal.ZERO);
+		final I_M_ShipmentSchedule schedule2 = shipmentScheduleHelper.createShipmentSchedule(pTomato, uomEach, new BigDecimal("10"), BigDecimal.ZERO);
+
+		final ShipmentScheduleListAllocationSource source = new ShipmentScheduleListAllocationSource(Arrays.asList(schedule1, schedule2));
+		final HUProducerDestination destination = HUProducerDestination.of(tuPI);
+
+		final IHUContext huContext = helper.getHUContext();
+		final IAllocationRequest request = AllocationUtils.createQtyRequest(huContext, pTomato, new BigDecimal("12"), uomEach, helper.getTodayZonedDateTime());
+		HULoader.of(source, destination).load(request);
+
+		final List<I_M_HU> createdHUs = destination.getCreatedHUs();
+		assertThat(createdHUs).as("both schedules' picked qty must land on ONE shared bare TU").hasSize(1);
+		I_M_HU tuHU = createdHUs.get(0);
+		final HuId tuId = HuId.ofRepoId(tuHU.getM_HU_ID());
+
+		// Stamp the consignee on the shared TU, as the real pick flow does (setHUPartnerAndLocationFromSched) --
+		// this test targets only the reset GUARD, so the stamp is applied directly.
+		tuHU.setC_BPartner_ID(schedule1.getC_BPartner_ID());
+		tuHU.setC_BPartner_Location_ID(schedule1.getC_BPartner_Location_ID());
+		InterfaceWrapperHelper.save(tuHU);
+		assertThat(schedule1.getC_BPartner_ID()).as("test precondition: schedules share one customer").isEqualTo(schedule2.getC_BPartner_ID());
+
+		final String trxName = ITrx.TRXNAME_ThreadInherited;
+
+		// schedule1's own row must be zeroed before calling unallocateTU (its own contract: throws otherwise).
+		final I_M_ShipmentSchedule_QtyPicked row1 = CollectionUtils.singleElement(
+				huShipmentScheduleDAO.retrieveSchedsQtyPickedForTU(schedule1.getM_ShipmentSchedule_ID(), tuId.getRepoId(), trxName));
+		assertThat(row1.getQtyPicked()).as("schedule1's picked qty before zeroing").isGreaterThan(BigDecimal.ZERO);
+		row1.setQtyPicked(BigDecimal.ZERO);
+		InterfaceWrapperHelper.save(row1);
+
+		// unallocate schedule1 while schedule2 STILL holds an active (non-zero) picked row on the same TU.
+		huShipmentScheduleBL.unallocateTU(schedule1, tuHU, trxName);
+
+		tuHU = handlingUnitsBL.getById(tuId);
+		assertThat(tuHU.getC_BPartner_ID())
+				.as("consignee must be RETAINED: schedule2 still holds an active picked row on the shared TU")
+				.isEqualTo(schedule1.getC_BPartner_ID());
+		assertThat(tuHU.getC_BPartner_Location_ID())
+				.as("consignee location must be RETAINED: schedule2 still holds an active picked row on the shared TU")
+				.isEqualTo(schedule1.getC_BPartner_Location_ID());
+
+		// now zero + unallocate schedule2 (the LAST schedule holding an active row on the TU).
+		final I_M_ShipmentSchedule_QtyPicked row2 = CollectionUtils.singleElement(
+				huShipmentScheduleDAO.retrieveSchedsQtyPickedForTU(schedule2.getM_ShipmentSchedule_ID(), tuId.getRepoId(), trxName));
+		assertThat(row2.getQtyPicked()).as("schedule2's picked qty before zeroing").isGreaterThan(BigDecimal.ZERO);
+		row2.setQtyPicked(BigDecimal.ZERO);
+		InterfaceWrapperHelper.save(row2);
+
+		huShipmentScheduleBL.unallocateTU(schedule2, tuHU, trxName);
+
+		tuHU = handlingUnitsBL.getById(tuId);
+		assertThat(tuHU.getC_BPartner_ID())
+				.as("consignee must be STRIPPED: no schedule holds an active picked row on the TU anymore")
+				.isLessThanOrEqualTo(0);
+		assertThat(tuHU.getC_BPartner_Location_ID())
+				.as("consignee location must be STRIPPED: no schedule holds an active picked row on the TU anymore")
+				.isLessThanOrEqualTo(0);
+	}
+}

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 7 | 12 | 58% |
-| Picking | 74 | 78 | 95% |
+| Picking | 76 | 80 | 95% |
 | Distribution | 40 | 41 | 98% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
@@ -92,7 +92,8 @@
 | Partial unpack: mis-scan the product GTIN as the target HU → backend rejects (4xx), error toast, panel stays on SCAN_TARGET; scanning the correct target HU then commits | `picking/unpack/picking_partial_unpack.spec.js` |
 | Partial unpack to the floor from a pick-to-CU-into-TU package (bare TU target, no LU): skip the target scan → removed qty leaves the TU and reappears as re-pickable, rest stays packed, no orphaned/stuck CU in the TU, and the shipment schedule's picked qty (M_ShipmentSchedule_QtyPicked) is reduced accordingly; repeatable over 2 rounds | `picking/unpack/picking_partial_unpack_TU_floor.spec.js` |
 | Partial unpack to the floor spanning TWO separate picks of the same product into the same bare TU (2+2=4 packed): unpick 3 → the newest pick's schedule row is fully consumed and deleted, the older row is reduced to the remainder (1), no orphan row/CU | `picking/unpack/picking_partial_unpack_TU_floor_spanning_picks.spec.js` |
-| Partial unpack to the floor across TWO picking lines (two products) sharing the same bare TU: unpicking one line's qty reduces ONLY that line's shipment schedule, the other line's schedule is untouched (no cross-line bleed) | `picking/unpack/picking_partial_unpack_TU_floor_two_lines.spec.js` |
+| Partial unpack to the floor across TWO picking lines (two products) sharing the same bare TU: unpicking one line's qty reduces ONLY that line's shipment schedule, the other line's schedule is untouched (no cross-line bleed); fully unpicking one line while the other stays active RETAINS the shared TU's consignee (C_BPartner_ID/C_BPartner_Location_ID), fully unpicking the last one too CLEARS it | `picking/unpack/picking_partial_unpack_TU_floor_two_lines.spec.js` |
+| Unpick a whole line fully from its own TU under a shared LU (LU/TU-target unpick, not a bare-TU floor-reduce) RETAINS that TU's consignee (net-zero picked rows survive active and the consignee is re-stamped) and leaves the shared LU's consignee untouched throughout, without disturbing the other still-active line's TU/LU storage | `picking/unpack/picking_partial_unpack_LU_two_lines.spec.js` |
 | Scan invalid picking slot QR code → error shown | `picking/picking.spec.js` |
 | Line status indicator transitions draft → in-progress → complete as HUs are picked | `picking/picking.spec.js` |
 | Partial pick, allowCompletingPartialPickingJob = N → complete blocked | `picking/picking.spec.js` |
@@ -103,7 +104,7 @@
 | completeJobAutomatically=true, scan drop-to locator after pick → job auto-completed, removed from list | `picking/completeJobAutomatically.spec.js` |
 | ❌ Scan HU from wrong warehouse/locator → error shown | — |
 
-**19/20 — 95%**
+**20/21 — 95%**
 
 ### Order-based picking — filtering and facets
 
@@ -195,8 +196,9 @@
 | Catch-weight pick via EAN13 prefix 29 — wrong product → error | `picking/picking_catchWeight.spec.js` |
 | Catch-weight pick via custom QR code format | `picking/picking_catchWeight.spec.js` |
 | ShowLastPickedBestBeforeDateForLines = Y → last best-before date shown on picking line | `picking/picking_catchWeight.spec.js` |
+| Partial floor-unpick of a catch-weight pick from a bare TU: the remaining shipment schedule row's catch weight scales proportionally with the reduced qty | `picking/unpack/picking_partial_unpack_TU_floor_catchWeight.spec.js` |
 
-**10/10 — 100%**
+**11/11 — 100%**
 
 ### Order-based picking — special flows
 

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Login / Home | 8 | 11 | 73% |
 | Barcode Scanner Modes | 7 | 12 | 58% |
-| Picking | 72 | 76 | 95% |
+| Picking | 74 | 78 | 95% |
 | Distribution | 40 | 41 | 98% |
 | Manufacturing | 23 | 29 | 79% |
 | HU Manager | 14 | 16 | 88% |
@@ -91,6 +91,8 @@
 | Partial unpack: transient network failure on submit → error toast, panel stays on SCAN_TARGET; retry succeeds, net qty moved into target HU | `picking/unpack/picking_partial_unpack.spec.js` |
 | Partial unpack: mis-scan the product GTIN as the target HU → backend rejects (4xx), error toast, panel stays on SCAN_TARGET; scanning the correct target HU then commits | `picking/unpack/picking_partial_unpack.spec.js` |
 | Partial unpack to the floor from a pick-to-CU-into-TU package (bare TU target, no LU): skip the target scan → removed qty leaves the TU and reappears as re-pickable, rest stays packed, no orphaned/stuck CU in the TU, and the shipment schedule's picked qty (M_ShipmentSchedule_QtyPicked) is reduced accordingly; repeatable over 2 rounds | `picking/unpack/picking_partial_unpack_TU_floor.spec.js` |
+| Partial unpack to the floor spanning TWO separate picks of the same product into the same bare TU (2+2=4 packed): unpick 3 → the newest pick's schedule row is fully consumed and deleted, the older row is reduced to the remainder (1), no orphan row/CU | `picking/unpack/picking_partial_unpack_TU_floor_spanning_picks.spec.js` |
+| Partial unpack to the floor across TWO picking lines (two products) sharing the same bare TU: unpicking one line's qty reduces ONLY that line's shipment schedule, the other line's schedule is untouched (no cross-line bleed) | `picking/unpack/picking_partial_unpack_TU_floor_two_lines.spec.js` |
 | Scan invalid picking slot QR code → error shown | `picking/picking.spec.js` |
 | Line status indicator transitions draft → in-progress → complete as HUs are picked | `picking/picking.spec.js` |
 | Partial pick, allowCompletingPartialPickingJob = N → complete blocked | `picking/picking.spec.js` |
@@ -101,7 +103,7 @@
 | completeJobAutomatically=true, scan drop-to locator after pick → job auto-completed, removed from list | `picking/completeJobAutomatically.spec.js` |
 | ❌ Scan HU from wrong warehouse/locator → error shown | — |
 
-**17/18 — 94%**
+**19/20 — 95%**
 
 ### Order-based picking — filtering and facets
 

--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -90,7 +90,7 @@
 | Partial unpack: remove item to the floor by canceling/skipping the target-HU scan → removed qty leaves the pick, rest stays packed | `picking/unpack/picking_partial_unpack.spec.js` |
 | Partial unpack: transient network failure on submit → error toast, panel stays on SCAN_TARGET; retry succeeds, net qty moved into target HU | `picking/unpack/picking_partial_unpack.spec.js` |
 | Partial unpack: mis-scan the product GTIN as the target HU → backend rejects (4xx), error toast, panel stays on SCAN_TARGET; scanning the correct target HU then commits | `picking/unpack/picking_partial_unpack.spec.js` |
-| Partial unpack to the floor from a pick-to-CU-into-TU package (bare TU target, no LU): skip the target scan → removed qty leaves the TU and reappears as re-pickable, rest stays packed, no orphaned/stuck CU in the TU; repeatable over 2 rounds | `picking/unpack/picking_partial_unpack_TU_floor.spec.js` |
+| Partial unpack to the floor from a pick-to-CU-into-TU package (bare TU target, no LU): skip the target scan → removed qty leaves the TU and reappears as re-pickable, rest stays packed, no orphaned/stuck CU in the TU, and the shipment schedule's picked qty (M_ShipmentSchedule_QtyPicked) is reduced accordingly; repeatable over 2 rounds | `picking/unpack/picking_partial_unpack_TU_floor.spec.js` |
 | Scan invalid picking slot QR code → error shown | `picking/picking.spec.js` |
 | Line status indicator transitions draft → in-progress → complete as HUs are picked | `picking/picking.spec.js` |
 | Partial pick, allowCompletingPartialPickingJob = N → complete blocked | `picking/picking.spec.js` |

--- a/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_LU_two_lines.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_LU_two_lines.spec.js
@@ -1,0 +1,176 @@
+import { test } from "../../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobScreen } from "../../../utils/screens/picking/PickingJobScreen";
+import { Backend } from "../../../utils/screens/Backend";
+import { LoginScreen } from "../../../utils/screens/LoginScreen";
+
+// A valid, unique 14-digit GS1 GTIN per run (strict GTIN->product resolve, AD_Client_ID=METASFRESH).
+let _gtinSeq = 0;
+const uniqueGtin14 = () => {
+    const seq = `${(_gtinSeq++) % 100}`.padStart(2, '0');
+    const ts = `${Date.now()}`.slice(-11).padStart(11, '0');
+    return `9${seq}${ts}`;
+};
+const gs1GtinScan = (gtin14) => `01${gtin14}`;
+
+// TWO order lines (two products, two shipment schedules), each packed as a whole TU (piItemProduct set)
+// into its OWN TU, but BOTH TUs are nested under the SAME shared LU (sales_order aggregation sets one
+// LU pick target for the whole job). This exercises the mobile "Unpack item" LU/TU-target unpick path
+// (deleteByTopLevelHUsAndShipmentScheduleId), as opposed to the bare-TU floor-unpick reduce path covered
+// by picking_partial_unpack_TU_floor_two_lines.spec.js (path A).
+//
+// IMPORTANT — investigated and confirmed via direct DB/HU-code reading + live Backend.expect probes
+// (not guessed): unlike path A's bare TU (which is never physically detached — it stays the one shared
+// container the whole time), path B's PickingJobUnPickCommand.unpickWholeHUs ALWAYS extracts (detaches)
+// the picked-to node itself before HUShipmentScheduleBL.deleteByTopLevelHUsAndShipmentScheduleId /
+// resetConsigneeIfNoActivePickedRows ever run. For a whole-TU pick under an LU, the extracted/reset node
+// is the product's OWN TU (tu1/tu2) — NEVER the shared LU, which stays entirely out of scope for this
+// call site. Confirmed empirically: the shared LU's own C_BPartner_ID is untouched throughout (it never
+// clears). On the extracted TU itself, the consignee is RETAINED, not cleared: the deleted picked rows
+// net to zero but survive as active rows (pre-existing HU-transaction/allocation machinery), so the
+// reset guard's "no active picked rows" precondition never holds, and a deferred re-stamp
+// (addQtyPickedAndUpdateHU) re-applies the consignee to the TU regardless. So this spec asserts
+// retention on each line's own TU, and that the shared LU's consignee is never touched.
+const createMasterdata = async ({ gtinP1, gtinP2 }) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    // LU/TU target (not a bare TU): both lines' TUs nest under the SAME shared LU.
+                    pickTo: ['LU_TU'],
+                    allowCompletingPartialPickingJob: true,
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                "P1": { gtin: gtinP1, prices: [{ price: 1 }] },
+                "P2": { gtin: gtinP2, prices: [{ price: 1 }] },
+            },
+            packingInstructions: {
+                // Each product gets its OWN TU packing instruction, but both share the SAME LU name — the
+                // two physical TUs (tu1, tu2) end up as siblings nested under the SAME shared LU (lu1).
+                "PI1": { lu: "LU", qtyTUsPerLU: 20, tu: "TU1", product: "P1", qtyCUsPerTU: 4 },
+                "PI2": { lu: "LU", qtyTUsPerLU: 20, tu: "TU2", product: "P2", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', qty: 200 },
+                "HU2": { product: 'P2', warehouse: 'wh', qty: 200 },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [
+                        { product: 'P1', qty: 4, piItemProduct: 'TU1' },
+                        { product: 'P2', qty: 4, piItemProduct: 'TU2' },
+                    ]
+                }
+            },
+        }
+    });
+};
+
+const loginAndStartJob = async ({ masterdata }) => {
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    // Set the shared LU pick target ONCE, at job level — both lines pack their own TU into THIS LU.
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI1.luName });
+    return { pickingJobId };
+};
+
+// noinspection JSUnusedLocalSymbols
+test('Unpick a whole line fully from its own TU under a shared LU retains that TU\'s consignee and leaves the shared LU untouched, without disturbing the other still-active line', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Partial unpack by scanning a product GTIN');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata({ gtinP1: uniqueGtin14(), gtinP2: uniqueGtin14() });
+    const packedScanP1 = gs1GtinScan(masterdata.products.P1.gtin);
+    const packedScanP2 = gs1GtinScan(masterdata.products.P2.gtin);
+
+    const { pickingJobId } = await loginAndStartJob({ masterdata });
+
+    await test.step('Pick all 1 TU (4 PCE) of P1 into its own TU under the shared LU', async () => {
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '1' });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '1 TU', qtyPicked: '1 TU' });
+    });
+
+    await test.step('Pick all 1 TU (4 PCE) of P2 into its own TU under the SAME shared LU', async () => {
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU2.qrCode, expectQtyEntered: '1' });
+        await PickingJobScreen.expectLineButton({ index: 2, qtyToPick: '1 TU', qtyPicked: '1 TU' });
+
+        await Backend.expect({
+            title: 'after both picks: P1 (tu1) and P2 (tu2) each packed as their own TU, both nested under the SAME shared LU (lu1)',
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: '4 PCE', qtyTUs: 1, qtyLUs: 1, vhu: 'vhu1', tu: 'tu1', lu: 'lu1', processed: false, shipmentLineId: '-' }] },
+                        P2: { qtyPicked: [{ qtyPicked: '4 PCE', qtyTUs: 1, qtyLUs: 1, vhu: 'vhu2', tu: 'tu2', lu: 'lu1', processed: false, shipmentLineId: '-' }] },
+                    }
+                }
+            },
+            hus: {
+                lu1: { huStatus: 'S', storages: { P1: '4 PCE', P2: '4 PCE' }, bpartner: 'BP1' },
+                tu1: { huStatus: 'S', storages: { P1: '4 PCE' } },
+                tu2: { huStatus: 'S', storages: { P2: '4 PCE' } },
+            }
+        });
+    });
+
+    await test.step('Unpick ALL of P1 (its whole TU) to the floor — P1 drops to ZERO while P2 still has active qty nested under the shared LU', async () => {
+        await PickingJobScreen.unpickItemToFloor({ scannedCode: packedScanP1, expectDefaultQty: '4', qty: '4' });
+
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '1 TU', qtyPicked: '0 TU' });
+        // P2's line button is untouched by the P1 unpick.
+        await PickingJobScreen.expectLineButton({ index: 2, qtyToPick: '1 TU', qtyPicked: '1 TU' });
+
+        await Backend.expect({
+            title: 'after driving P1 to zero: P2 (tu2, under the same shared LU) is completely unaffected, the shared LU (lu1) keeps its consignee, and P1\'s own TU (tu1) RETAINS its consignee too',
+            hus: {
+                // Regression guard: unpicking P1 must not bleed into P2's own TU or its share of the LU.
+                // The shared LU's consignee stays 'BP1' — this delete/reset call site never targets the
+                // LU (it only ever operates on the extracted per-schedule TU), so it cannot be reachable
+                // to strip it here.
+                lu1: { huStatus: 'S', storages: { P1: '0 PCE', P2: '4 PCE' }, bpartner: 'BP1' },
+                tu2: { huStatus: 'S', storages: { P2: '4 PCE' } },
+                // tu1 is the node the delete/reset actually targets (the extracted per-schedule TU, not
+                // the shared LU): the deleted picked row nets to zero but survives active, so the guard's
+                // "no active rows" precondition never holds, and the deferred re-stamp re-applies BP1.
+                tu1: { bpartner: 'BP1' },
+            }
+        });
+    });
+
+    await test.step('Unpick ALL of P2 too — both lines empty', async () => {
+        await PickingJobScreen.unpickItemToFloor({ scannedCode: packedScanP2, expectDefaultQty: '4', qty: '4' });
+
+        await PickingJobScreen.expectLineButton({ index: 2, qtyToPick: '1 TU', qtyPicked: '0 TU' });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '1 TU', qtyPicked: '0 TU' });
+
+        await Backend.expect({
+            title: 'after driving P2 to zero too: P2\'s own TU (tu2) also RETAINS its consignee, and the shared LU (lu1) still has its consignee untouched',
+            hus: {
+                tu2: { bpartner: 'BP1' },
+                lu1: { bpartner: 'BP1' },
+            }
+        });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor.spec.js
@@ -131,6 +131,16 @@ test('Partial unpack to the floor from a pick-to-CU-into-TU package — repeatab
             title: 'round 1 after floor unpick: 3 PCE stays in the TU; unpicked 1 PCE dropped to the floor as an active standalone CU, no orphan left Picked in the TU',
             hus: {
                 tu1: { huStatus: 'S', storages: { P1: '3 PCE' } },
+            },
+            // The shipment schedule's picked qty must follow the unpick: 4 -> 3 PCE. The unpick deletes/reduces
+            // the M_ShipmentSchedule_QtyPicked recorded for this pick. (Max, danthermuat #30480: the HU detaches
+            // correctly but this row is NOT reduced — it stays at 4 PCE, so the schedule over-reports picked qty.)
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: '3 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] }
+                    }
+                }
             }
         });
 

--- a/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor.spec.js
@@ -132,9 +132,9 @@ test('Partial unpack to the floor from a pick-to-CU-into-TU package — repeatab
             hus: {
                 tu1: { huStatus: 'S', storages: { P1: '3 PCE' } },
             },
-            // The shipment schedule's picked qty must follow the unpick: 4 -> 3 PCE. The unpick deletes/reduces
-            // the M_ShipmentSchedule_QtyPicked recorded for this pick. (Max, danthermuat #30480: the HU detaches
-            // correctly but this row is NOT reduced — it stays at 4 PCE, so the schedule over-reports picked qty.)
+            // The shipment schedule's picked qty must follow the unpick: 4 -> 3 PCE. The unpick must
+            // reduce/delete the M_ShipmentSchedule_QtyPicked recorded for this pick — the known bug is that
+            // the HU detaches correctly but this row is NOT reduced (stays 4 PCE), over-reporting picked qty.
             pickings: {
                 [pickingJobId]: {
                     shipmentSchedules: {

--- a/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_catchWeight.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_catchWeight.spec.js
@@ -1,0 +1,150 @@
+import { test } from "../../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobScreen } from "../../../utils/screens/picking/PickingJobScreen";
+import { Backend } from "../../../utils/screens/Backend";
+import { LoginScreen } from "../../../utils/screens/LoginScreen";
+
+// A valid, unique 14-digit GS1 GTIN per run (strict GTIN->product resolve, AD_Client_ID=METASFRESH).
+let _gtinSeq = 0;
+const uniqueGtin14 = () => {
+    const seq = `${(_gtinSeq++) % 100}`.padStart(2, '0');
+    const ts = `${Date.now()}`.slice(-11).padStart(11, '0');
+    return `9${seq}${ts}`;
+};
+const gs1GtinScan = (gtin14) => `01${gtin14}`;
+
+// Same bare-TU (no LU) pick-to-CU structure as picking_partial_unpack_TU_floor.spec.js, but the product is
+// catch-weight (a manually-entered actual weight is recorded per pick, invoicing based on that weight
+// rather than the piece count). Partially floor-unpicking a catch-weight pick from a bare TU exercises
+// HUShipmentScheduleBL.reduceCatchWeightProportionally: the remaining QtyPicked row's catch weight must
+// scale down by the same ratio as the piece qty (newCatchWeight = oldCatchWeight * newQty/oldQty), not
+// just have its piece qty reduced while the weight is left stale.
+const createMasterdata = async ({ packedGtin }) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    // Bare TU target (no LU): the CU is packed directly into a top-level TU.
+                    pickTo: ['TU'],
+                    allowCompletingPartialPickingJob: true,
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                "P1": {
+                    gtin: packedGtin,
+                    uom: 'PCE',
+                    // Catch-weight product: KGM is the catch UOM (isCatchUOMForProduct), and invoicing is
+                    // based on the actually-entered catch weight rather than the PCE piece count.
+                    uomConversions: [{ from: 'PCE', to: 'KGM', multiplyRate: 0.10, isCatchUOMForProduct: true }],
+                    prices: [{ price: 5, uom: 'KGM', invoicableQtyBasedOn: 'CatchWeight' }],
+                },
+            },
+            packingInstructions: {
+                // The bare-TU pick target the CU is packed into (IFCO-like), capacity 100 CUs/TU, no LU.
+                "TU_PI": { tu: "IFCO", product: "P1", qtyCUsPerTU: 100 },
+                // A loose source HU holding the product to pick from.
+                "SRC": { cu: true, lu: "LU", qtyTUsPerLU: 1 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', qty: 1000, packingInstructions: 'SRC' },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    // No piItemProduct => the line is a CU (product) pick; the CU is packed into the TU target.
+                    lines: [{ product: 'P1', qty: 4 }]
+                }
+            },
+        }
+    });
+};
+
+const loginAndStartJob = async ({ masterdata }) => {
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    // A CU line (no piItemProduct) auto-navigates into the single line's PickLineScanScreen after the
+    // slot scan; step back up to the job screen (same as picking_partial_unpack_TU_floor.spec.js).
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode, expectNextScreen: 'PickLineScanScreen', gotoPickingJobScreen: true });
+    // Set a bare TU pick target (no LU) — the CU picks are packed into THIS TU.
+    await PickingJobScreen.setTargetTU({ tu: masterdata.packingInstructions.TU_PI.tuName });
+    return { pickingJobId };
+};
+
+// noinspection JSUnusedLocalSymbols
+test('Partial floor-unpick of a catch-weight pick from a bare TU scales the remaining catch weight proportionally', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Partial unpack by scanning a product GTIN');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata({ packedGtin: uniqueGtin14() });
+    const packedScan = gs1GtinScan(masterdata.products.P1.gtin);
+
+    const { pickingJobId } = await loginAndStartJob({ masterdata });
+
+    await test.step('Pick 4 PCE of P1 into the bare TU target with a manually-entered catch weight (0.44 kg, off the 0.1/PCE default ratio)', async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.qrCode,
+            switchToManualInput: true,
+            qtyEntered: '4',
+            catchWeight: '0.44',
+        });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyPicked: '4 Stk' });
+
+        await Backend.expect({
+            title: 'after pick: 4 PCE of P1 packed into the pick-to TU (tu1) with catch weight 0.440 KGM',
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: '4 PCE', catchWeight: '0.440 KGM', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] }
+                    }
+                }
+            },
+            hus: {
+                tu1: { huStatus: 'S', storages: { P1: '4 PCE' } },
+            }
+        });
+    });
+
+    // Unpick 1 PCE to the floor (partial — a boundary reduce, not a whole-HU delete): 3 PCE stays packed.
+    // HUShipmentScheduleBL.reduceQtyPickedForPickToTU must scale the remaining row's catch weight down by
+    // the SAME ratio as the piece qty (3/4), via reduceCatchWeightProportionally — NOT leave 0.440 KGM
+    // stale on a now-3-PCE row (which would silently over-report the remaining catch weight).
+    await test.step('Unpick 1 PCE to the floor — 3 PCE stays packed, the remaining catch weight scales 0.440 -> 0.330 KGM (x 3/4)', async () => {
+        await PickingJobScreen.unpickItemToFloor({ scannedCode: packedScan, expectDefaultQty: '4', qty: '1' });
+
+        await PickingJobScreen.expectLineButton({ index: 1, qtyPicked: '3 Stk' });
+
+        await Backend.expect({
+            title: 'after floor unpick: 3 PCE stays in the TU, remaining catch weight proportionally reduced 0.440 -> 0.330 KGM',
+            hus: {
+                tu1: { huStatus: 'S', storages: { P1: '3 PCE' } },
+            },
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: '3 PCE', catchWeight: '0.330 KGM', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] }
+                    }
+                }
+            }
+        });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_spanning_picks.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_spanning_picks.spec.js
@@ -1,0 +1,159 @@
+import { test } from "../../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobScreen } from "../../../utils/screens/picking/PickingJobScreen";
+import { Backend } from "../../../utils/screens/Backend";
+import { LoginScreen } from "../../../utils/screens/LoginScreen";
+
+// A valid, unique 14-digit GS1 GTIN per run (strict GTIN->product resolve, AD_Client_ID=METASFRESH).
+let _gtinSeq = 0;
+const uniqueGtin14 = () => {
+    const seq = `${(_gtinSeq++) % 100}`.padStart(2, '0');
+    const ts = `${Date.now()}`.slice(-11).padStart(11, '0');
+    return `9${seq}${ts}`;
+};
+const gs1GtinScan = (gtin14) => `01${gtin14}`;
+
+// Same bare-TU (no LU) pick-to-CU structure as picking_partial_unpack_TU_floor.spec.js, but the packed
+// qty is built from TWO SEPARATE pick actions into the SAME target TU (two M_ShipmentSchedule_QtyPicked
+// rows for one product on one TU, per PickingJobPickCommand — each pick into a bare TU records its own
+// row). This lets an unpick-to-floor qty CROSS both picks in a single unpick action.
+const createMasterdata = async ({ packedGtin }) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    // Bare TU target (no LU): the CU is packed directly into a top-level TU.
+                    pickTo: ['TU'],
+                    allowCompletingPartialPickingJob: true,
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                "P1": { gtin: packedGtin, prices: [{ price: 1 }] },
+            },
+            packingInstructions: {
+                // The bare-TU pick target the CUs are packed into (IFCO-like), capacity 100 CUs/TU, no LU.
+                "TU_PI": { tu: "IFCO", product: "P1", qtyCUsPerTU: 100 },
+                // A loose source HU holding the product to pick from.
+                "SRC": { cu: true, lu: "LU", qtyTUsPerLU: 1 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', qty: 1000, packingInstructions: 'SRC' },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    // No piItemProduct => the line is a CU (product) pick; the CU is packed into the TU target.
+                    lines: [{ product: 'P1', qty: 4 }]
+                }
+            },
+        }
+    });
+};
+
+const loginAndStartJob = async ({ masterdata }) => {
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    // A CU line (no piItemProduct) auto-navigates into the single line's PickLineScanScreen after the
+    // slot scan; step back up to the job screen.
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode, expectNextScreen: 'PickLineScanScreen', gotoPickingJobScreen: true });
+    // Set a bare TU pick target (no LU) — all pick actions below pack into THIS TU.
+    await PickingJobScreen.setTargetTU({ tu: masterdata.packingInstructions.TU_PI.tuName });
+    return { pickingJobId };
+};
+
+// noinspection JSUnusedLocalSymbols
+test('Unpick to the floor spanning two separate picks into the same bare TU reduces the shipment schedule qty across both picks', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Partial unpack by scanning a product GTIN');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata({ packedGtin: uniqueGtin14() });
+    const packedScan = gs1GtinScan(masterdata.products.P1.gtin);
+
+    const { pickingJobId } = await loginAndStartJob({ masterdata });
+
+    await test.step('First pick: 2 PCE of P1 into the bare TU target', async () => {
+        // The dialog's default offered qty is the full remaining-to-pick (4); we type 2 (a partial pick).
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, qtyEntered: 2, expectQtyEntered: '4' });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyPicked: '2 Stk' });
+        await Backend.expect({
+            title: 'after 1st pick: 2 PCE of P1 packed into the pick-to TU (tu1), one QtyPicked row',
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: '2 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] }
+                    }
+                }
+            },
+            hus: {
+                tu1: { huStatus: 'S', storages: { P1: '2 PCE' } },
+            }
+        });
+    });
+
+    await test.step('Second pick: another 2 PCE of P1 into the SAME bare TU (a second, independent pick step)', async () => {
+        // The remaining-to-pick default is now 2 (4 target - 2 already picked); type 2 again.
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, qtyEntered: 2, expectQtyEntered: '2' });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyPicked: '4 Stk' });
+        await Backend.expect({
+            title: 'after 2nd pick: 4 PCE of P1 packed into tu1, TWO QtyPicked rows of 2 PCE each (oldest first)',
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: {
+                            qtyPicked: [
+                                { qtyPicked: '2 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' },
+                                { qtyPicked: '2 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' },
+                            ]
+                        }
+                    }
+                }
+            },
+            hus: {
+                tu1: { huStatus: 'S', storages: { P1: '4 PCE' } },
+            }
+        });
+    });
+
+    await test.step('Unpick 3 PCE to the floor — crosses BOTH picks (2+2=4 packed, unpick 3 leaves 1)', async () => {
+        await PickingJobScreen.unpickItemToFloor({ scannedCode: packedScan, expectDefaultQty: '4', qty: '3' });
+
+        // The TU keeps the remainder (1 PCE); the qty-to-pick reappears (re-pickable).
+        await PickingJobScreen.expectLineButton({ index: 1, qtyPicked: '1 Stk' });
+        await Backend.expect({
+            title: 'after spanning floor unpick: 1 PCE stays in the TU (4-3), the newest pick row fully consumed and deleted, the older row reduced to 1 — no orphan row, no orphan CU',
+            hus: {
+                tu1: { huStatus: 'S', storages: { P1: '1 PCE' } },
+            },
+            // Newest-first reduce: the 2nd (newest) pick's row is fully consumed and deleted; the 1st
+            // (older) pick's row is partially reduced by the remaining 1 unit (2 -> 1). Exactly ONE
+            // QtyPicked row remains, holding the full packed-minus-unpicked qty.
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: '1 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] }
+                    }
+                }
+            }
+        });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_two_lines.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_two_lines.spec.js
@@ -190,24 +190,48 @@ test('Unpick to the floor on one of two picking lines reduces that line\'s shipm
         await PickingJobScreen.expectLineButton({ index: 2, qtyPicked: '1 Stk' });
 
         await Backend.expect({
-            title: 'after driving P1 to zero on the shared TU: P1 has no QtyPicked rows left, P2 schedule row is UNCHANGED at 1 PCE (no cross-line bleed from the to-zero guard)',
+            title: 'after driving P1 to zero on the shared TU: P1 has no QtyPicked rows left, P2 schedule row is UNCHANGED at 1 PCE, and the TU consignee is RETAINED (P2 still active on it)',
             hus: {
-                // The shared TU stays active (huStatus 'S') and keeps P2's storage untouched. Note: the
-                // production fix (IHUShipmentScheduleDAO.hasActiveQtyPickedForTUExcludingSchedule) also
-                // retains the TU's C_BPartner_ID/C_BPartner_Location_ID (consignee) whenever another
-                // schedule still has active rows on it — that retention is a backend-only side effect
-                // with no field in the frontendTesting HU-expectation schema (JsonHUExpectation has no
-                // bpartner/consignee key), so it cannot be asserted directly from this Playwright spec.
-                // It is covered by the guard itself and by the unaffected-P2 assertions here (the bug's
-                // symptom, if the guard regressed, would surface as P2's TU no longer resolving to the
-                // correct consignee downstream, e.g. on shipment generation).
-                tu1: { huStatus: 'S', storages: { P1: '0 PCE', P2: '1 PCE' } },
+                // The shared TU stays active (huStatus 'S') and keeps P2's storage untouched. The
+                // production guard (HUShipmentScheduleBL.resetConsigneeIfNoActivePickedRows, backed by
+                // IHUShipmentScheduleDAO.hasActiveQtyPickedForTopLevelHU) must RETAIN the TU's consignee
+                // (C_BPartner_ID/C_BPartner_Location_ID) here because P2 still has an active picked row on
+                // it — asserted directly via the `bpartner` HU-expectation field (not a proxy).
+                tu1: { huStatus: 'S', storages: { P1: '0 PCE', P2: '1 PCE' }, bpartner: 'BP1' },
             },
             pickings: {
                 [pickingJobId]: {
                     shipmentSchedules: {
                         P1: { qtyPicked: [] },
                         P2: { qtyPicked: [{ qtyPicked: '1 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] },
+                    }
+                }
+            }
+        });
+    });
+
+    // Now P2 becomes the LAST schedule holding picked qty on the shared TU. Driving it to zero too must
+    // FINALLY reset the TU's consignee (C_BPartner_ID/C_BPartner_Location_ID stripped) — no schedule is
+    // left active on it. Asserted directly via `consigneeCleared` (not a proxy).
+    await test.step('Unpick the remaining 1 PCE of P2 to the floor — P2 drops to ZERO too, no schedule left active on the shared TU', async () => {
+        await PickingJobScreen.unpickItemToFloor({ scannedCode: packedScanP2, expectDefaultQty: '1', qty: '1' });
+
+        await PickingJobScreen.expectLineButton({ index: 2, qtyPicked: '0 Stk' });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyPicked: '0 Stk' });
+
+        await Backend.expect({
+            title: 'after driving P2 to zero too: both schedules empty (the now-fully-drained TU is destroyed, per framework HU-lifecycle GC), the shared TU consignee is CLEARED (no schedule left active on it)',
+            hus: {
+                // The TU holds zero storage of both products at this point, so the framework destroys it
+                // (huStatus 'D') rather than leaving an empty active shell — unrelated to the consignee
+                // guard under test. `consigneeCleared` still asserts the guard's actual outcome directly.
+                tu1: { huStatus: 'D', consigneeCleared: true },
+            },
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [] },
+                        P2: { qtyPicked: [] },
                     }
                 }
             }

--- a/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_two_lines.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_two_lines.spec.js
@@ -1,0 +1,174 @@
+import { test } from "../../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobScreen } from "../../../utils/screens/picking/PickingJobScreen";
+import { Backend } from "../../../utils/screens/Backend";
+import { LoginScreen } from "../../../utils/screens/LoginScreen";
+
+// A valid, unique 14-digit GS1 GTIN per run (strict GTIN->product resolve, AD_Client_ID=METASFRESH).
+let _gtinSeq = 0;
+const uniqueGtin14 = () => {
+    const seq = `${(_gtinSeq++) % 100}`.padStart(2, '0');
+    const ts = `${Date.now()}`.slice(-11).padStart(11, '0');
+    return `9${seq}${ts}`;
+};
+const gs1GtinScan = (gtin14) => `01${gtin14}`;
+
+// Same bare-TU (no LU) pick-to-CU structure as picking_partial_unpack_TU_floor.spec.js, but with TWO
+// order lines (two products, two shipment schedules) sharing the SAME bare TU pick target. Verifies
+// that unpicking one line's qty to the floor reduces ONLY that line's M_ShipmentSchedule_QtyPicked,
+// leaving the other, independently-picked line untouched (no cross-line bleed).
+const createMasterdata = async ({ gtinP1, gtinP2 }) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    // Bare TU target (no LU): the CUs of BOTH lines are packed directly into the same
+                    // top-level TU (sales_order aggregation sets the pick target once, at job level).
+                    pickTo: ['TU'],
+                    allowCompletingPartialPickingJob: true,
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                "P1": { gtin: gtinP1, prices: [{ price: 1 }] },
+                "P2": { gtin: gtinP2, prices: [{ price: 1 }] },
+            },
+            packingInstructions: {
+                // The SAME bare-TU pick target ("IFCO") carries a distinct capacity item-product per
+                // product, so both order lines' CUs can be packed into the one physical TU.
+                "TU_PI_P1": { tu: "IFCO", product: "P1", qtyCUsPerTU: 100 },
+                "TU_PI_P2": { tu: "IFCO", product: "P2", qtyCUsPerTU: 100 },
+                // A loose source HU per product to pick from.
+                "SRC1": { cu: true, lu: "LU1", qtyTUsPerLU: 1 },
+                "SRC2": { cu: true, lu: "LU2", qtyTUsPerLU: 1 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', qty: 1000, packingInstructions: 'SRC1' },
+                "HU2": { product: 'P2', warehouse: 'wh', qty: 1000, packingInstructions: 'SRC2' },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    // Two CU (product) lines => two independent shipment schedules.
+                    lines: [
+                        { product: 'P1', qty: 4 },
+                        { product: 'P2', qty: 4 },
+                    ]
+                }
+            },
+        }
+    });
+};
+
+const loginAndStartJob = async ({ masterdata }) => {
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    // A CU line (no piItemProduct) auto-navigates into the first line's PickLineScanScreen after the
+    // slot scan (even with 2 lines); step back up to the job screen.
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode, expectNextScreen: 'PickLineScanScreen', gotoPickingJobScreen: true });
+    // Set the bare TU pick target (no LU) ONCE, at job level — both lines pack into THIS TU.
+    await PickingJobScreen.setTargetTU({ tu: masterdata.packingInstructions.TU_PI_P1.tuName });
+    return { pickingJobId };
+};
+
+// noinspection JSUnusedLocalSymbols
+test('Unpick to the floor on one of two picking lines reduces that line\'s shipment schedule qty only, the other line stays untouched', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Partial unpack by scanning a product GTIN');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata({ gtinP1: uniqueGtin14(), gtinP2: uniqueGtin14() });
+    const packedScanP1 = gs1GtinScan(masterdata.products.P1.gtin);
+    const packedScanP2 = gs1GtinScan(masterdata.products.P2.gtin);
+
+    const { pickingJobId } = await loginAndStartJob({ masterdata });
+
+    await test.step('Pick 3 PCE of P1 (line 1) into the shared bare TU', async () => {
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, qtyEntered: 3, expectQtyEntered: '4' });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyPicked: '3 Stk' });
+    });
+
+    await test.step('Pick 3 PCE of P2 (line 2) into the SAME shared bare TU', async () => {
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU2.qrCode, qtyEntered: 3, expectQtyEntered: '4' });
+        await PickingJobScreen.expectLineButton({ index: 2, qtyPicked: '3 Stk' });
+
+        await Backend.expect({
+            title: 'after both picks: 3 PCE of P1 + 3 PCE of P2 packed into the SAME TU (tu1), two independent schedule rows',
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: '3 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] },
+                        P2: { qtyPicked: [{ qtyPicked: '3 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] },
+                    }
+                }
+            },
+            hus: {
+                tu1: { huStatus: 'S', storages: { P1: '3 PCE', P2: '3 PCE' } },
+            }
+        });
+    });
+
+    await test.step('Unpick 2 PCE of P1 to the floor — must reduce ONLY the P1 schedule', async () => {
+        await PickingJobScreen.unpickItemToFloor({ scannedCode: packedScanP1, expectDefaultQty: '3', qty: '2' });
+
+        await PickingJobScreen.expectLineButton({ index: 1, qtyPicked: '1 Stk' });
+        // P2's line button is untouched by the P1 unpick.
+        await PickingJobScreen.expectLineButton({ index: 2, qtyPicked: '3 Stk' });
+
+        await Backend.expect({
+            title: 'after unpicking P1: P1 schedule reduced 3->1, P2 schedule UNCHANGED at 3 (no cross-line bleed)',
+            hus: {
+                tu1: { huStatus: 'S', storages: { P1: '1 PCE', P2: '3 PCE' } },
+            },
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: '1 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] },
+                        P2: { qtyPicked: [{ qtyPicked: '3 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] },
+                    }
+                }
+            }
+        });
+    });
+
+    await test.step('Unpick 2 PCE of P2 to the floor — must reduce ONLY the P2 schedule; P1 stays at its already-reduced qty', async () => {
+        await PickingJobScreen.unpickItemToFloor({ scannedCode: packedScanP2, expectDefaultQty: '3', qty: '2' });
+
+        await PickingJobScreen.expectLineButton({ index: 2, qtyPicked: '1 Stk' });
+        // P1's line button is untouched by the P2 unpick (stays at the qty from the previous step).
+        await PickingJobScreen.expectLineButton({ index: 1, qtyPicked: '1 Stk' });
+
+        await Backend.expect({
+            title: 'after unpicking P2: P2 schedule reduced 3->1, P1 schedule stays at 1 (no over/under-reduction, no bleed)',
+            hus: {
+                tu1: { huStatus: 'S', storages: { P1: '1 PCE', P2: '1 PCE' } },
+            },
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [{ qtyPicked: '1 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] },
+                        P2: { qtyPicked: [{ qtyPicked: '1 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] },
+                    }
+                }
+            }
+        });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_two_lines.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_two_lines.spec.js
@@ -18,7 +18,10 @@ const gs1GtinScan = (gtin14) => `01${gtin14}`;
 // Same bare-TU (no LU) pick-to-CU structure as picking_partial_unpack_TU_floor.spec.js, but with TWO
 // order lines (two products, two shipment schedules) sharing the SAME bare TU pick target. Verifies
 // that unpicking one line's qty to the floor reduces ONLY that line's M_ShipmentSchedule_QtyPicked,
-// leaving the other, independently-picked line untouched (no cross-line bleed).
+// leaving the other, independently-picked line untouched (no cross-line bleed). Also drives one line
+// (P1) fully to ZERO on the shared TU while the other (P2) still has active picked qty — the guarded
+// path where the shared bare TU's consignee reset must be skipped because another schedule is still
+// active on it (a bare TU is shared across schedules).
 const createMasterdata = async ({ gtinP1, gtinP2 }) => {
     return await Backend.createMasterdata({
         language: 'en_US',
@@ -165,6 +168,45 @@ test('Unpick to the floor on one of two picking lines reduces that line\'s shipm
                 [pickingJobId]: {
                     shipmentSchedules: {
                         P1: { qtyPicked: [{ qtyPicked: '1 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] },
+                        P2: { qtyPicked: [{ qtyPicked: '1 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] },
+                    }
+                }
+            }
+        });
+    });
+
+    // The shared bare TU is still carrying BOTH lines' picked qty at this point (P1=1, P2=1). Driving
+    // P1's remaining 1 PCE fully to the floor (P1 -> ZERO) is the case the shipment-schedule reset guard
+    // protects: on a bare TU shared across two schedules, fully unpicking ONE schedule's rows must NOT
+    // reset the TU's consignee (C_BPartner_ID/C_BPartner_Location_ID) while the OTHER schedule (P2) still
+    // holds active picked qty on the same TU. Before the guard, reaching zero on P1 unconditionally reset
+    // the TU's consignee, corrupting the still-active P2 pick sharing that TU.
+    await test.step('Unpick the remaining 1 PCE of P1 to the floor — P1 drops to ZERO while P2 still has active qty on the shared TU', async () => {
+        await PickingJobScreen.unpickItemToFloor({ scannedCode: packedScanP1, expectDefaultQty: '1', qty: '1' });
+
+        await PickingJobScreen.expectLineButton({ index: 1, qtyPicked: '0 Stk' });
+        // P2's line button (and its underlying schedule, asserted below) must be completely unaffected by
+        // P1 reaching zero on the shared TU — this is the guarded cross-line-bleed path.
+        await PickingJobScreen.expectLineButton({ index: 2, qtyPicked: '1 Stk' });
+
+        await Backend.expect({
+            title: 'after driving P1 to zero on the shared TU: P1 has no QtyPicked rows left, P2 schedule row is UNCHANGED at 1 PCE (no cross-line bleed from the to-zero guard)',
+            hus: {
+                // The shared TU stays active (huStatus 'S') and keeps P2's storage untouched. Note: the
+                // production fix (IHUShipmentScheduleDAO.hasActiveQtyPickedForTUExcludingSchedule) also
+                // retains the TU's C_BPartner_ID/C_BPartner_Location_ID (consignee) whenever another
+                // schedule still has active rows on it — that retention is a backend-only side effect
+                // with no field in the frontendTesting HU-expectation schema (JsonHUExpectation has no
+                // bpartner/consignee key), so it cannot be asserted directly from this Playwright spec.
+                // It is covered by the guard itself and by the unaffected-P2 assertions here (the bug's
+                // symptom, if the guard regressed, would surface as P2's TU no longer resolving to the
+                // correct consignee downstream, e.g. on shipment generation).
+                tu1: { huStatus: 'S', storages: { P1: '0 PCE', P2: '1 PCE' } },
+            },
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { qtyPicked: [] },
                         P2: { qtyPicked: [{ qtyPicked: '1 PCE', qtyTUs: 1, qtyLUs: 0, vhu: '-', tu: 'tu1', lu: '-', processed: false, shipmentLineId: '-' }] },
                     }
                 }


### PR DESCRIPTION
## Problem
In Mobile Packing, unpicking qty **to the floor** from a CU that was picked into a bare TU detaches the CU physically (HU correct) but did **not** reduce `M_ShipmentSchedule_QtyPicked` — the schedule kept the full picked qty, over-reporting what was actually picked.

## Root cause
The pick records the pick-to-**TU** on `M_ShipmentSchedule_QtyPicked` (`M_TU_HU_ID` set, `VHU_ID` null). On skip-to-floor unpick, the reversal looked up the schedule row by the extracted floor CU's HU id, which never matches the TU-keyed row, so the row was never reduced.

## Fix
- On skip-to-floor unpick, reduce the TU-keyed `M_ShipmentSchedule_QtyPicked` row(s) by the unpicked qty (newest-first, deleting a row once its qty reaches zero).
- Unified the shared-HU consignee reset behind one guard, `resetConsigneeIfNoActivePickedRows`: only reset a HU's BPartner/Location when no shipment schedule still holds an active picked row on it. Applied consistently across all reset call sites, replacing divergent per-site logic.
- De-twisted the unpick command dispatch for clarity.
- Catch-weight proportional-reduce behavior on unpick is preserved.

## Test coverage
- Mobile Playwright E2E: skip-to-floor unpick from a bare TU, covering consignee retained when another line still shares the TU vs. cleared when it was the last active line; multi-pick spanning; two independent lines; catch-weight scaling on unpick.
- Unit test covering the previously-dead reset-guard code path.

Verified: CI green at HEAD `cca743c879a` — https://github.com/metasfresh/metasfresh/actions/runs/29053345840 (all jobs, incl. the mobile E2E suite covering this fix, passed).
