### PR TITLE
Available-for-Sales — port retrieve_available_for_sales perf rewrite to intensive_care_hotfix

### DIFF
--- a/backend/de.metas.material/cockpit/src/main/sql/postgresql/system/75-material-cockpit/5805670_sys_retrieve_available_for_sales_perf.sql
+++ b/backend/de.metas.material/cockpit/src/main/sql/postgresql/system/75-material-cockpit/5805670_sys_retrieve_available_for_sales_perf.sql
@@ -1,3 +1,19 @@
+-- Source DDL: backend/de.metas.material/cockpit/src/main/sql/postgresql/ddl/functions/de_metas_material/Retrieve_available_for_Sales.sql
+--
+-- Performance rewrite of de_metas_material.retrieve_available_for_sales (Available-for-Sales,
+-- gh#5108). The previous body read from de_metas_material.MD_ShipmentQty_V and applied the
+-- look-behind / look-ahead date filters on top of the view. Because the view FULL-OUTER-JOINs
+-- the order-line side and the shipment-schedule side, and the filter contained
+-- "... OR SalesOrderLastUpdated IS NULL", Postgres could not push the date filters down: for a
+-- high-runner product it materialised the product's ENTIRE C_OrderLine history (150k+ rows) and
+-- only then discarded almost all of it -> several seconds per order-line entry.
+--
+-- The view's two demand sides are disjoint (the order-line side excludes lines that already have
+-- a shipment schedule; the schedule side is the schedules), so the join is effectively a
+-- concatenation. We inline both sides as separate branches and push the date filters INTO each
+-- source, so the look-behind prunes order lines (via the existing C_OrderLine(Updated, M_Product_ID)
+-- index) before any join. Output semantics are unchanged.
+
 SELECT db_drop_functions('*.retrieve_available_for_sales')
 ;
 
@@ -23,20 +39,6 @@ CREATE FUNCTION de_metas_material.retrieve_available_for_sales(
             )
 AS
 $BODY$
--- Performance rewrite: the previous implementation read from
--- de_metas_material.MD_ShipmentQty_V and applied the look-behind / look-ahead date filters
--- on top of the view. Because the view FULL-OUTER-JOINs the order-line side and the
--- shipment-schedule side, and the filter contained "... OR SalesOrderLastUpdated IS NULL",
--- Postgres could not push the date filters down: for a high-runner product it built the
--- product's ENTIRE C_OrderLine history (150k+ rows) and only then discarded almost all of
--- it -> several seconds per order-line entry (the Available-for-Sales calc, gh#5108).
---
--- The view's two demand sides are disjoint (the order-line side excludes lines that already
--- have a shipment schedule; the schedule side is the schedules), so the join is effectively a
--- concatenation. We inline both sides as separate branches and push the date filters INTO each
--- source, so the look-behind prunes order lines (using the existing
--- C_OrderLine(Updated, M_Product_ID) index) before any join. Result on a 2.2M-shipment-schedule
--- / 150k-order-line instance: ~7.6 s -> sub-second. Output semantics are unchanged.
 SELECT p_QueryNo,
        p_M_Product_ID,
        final.AttributesKey,


### PR DESCRIPTION
## Available-for-Sales — port `retrieve_available_for_sales` perf rewrite to `intensive_care_hotfix`

Ports the perf rewrite of `de_metas_material.retrieve_available_for_sales` onto `intensive_care_hotfix`.

- Source PR: https://github.com/metasfresh/metasfresh/pull/24361
- Original issue: https://github.com/metasfresh/metasfresh/issues/5108

### Problem
The previous implementation read from `de_metas_material.MD_ShipmentQty_V` and applied the look-behind / look-ahead date filters on top of the view. The view FULL-OUTER-JOINs the order-line demand side and the shipment-schedule side, and the filter carried `... OR SalesOrderLastUpdated IS NULL`, which blocked predicate push-down. For a high-runner product Postgres materialised the product's entire `C_OrderLine` history before discarding almost all of it — several seconds per Available-for-Sales entry.

### Fix
Inline the view's two disjoint demand sides as separate `UNION ALL` branches and push the look-behind / look-ahead date filters into each source, so the look-behind prunes order lines via the existing `C_OrderLine(Updated, M_Product_ID)` index before any join. Output semantics are unchanged.

### Impact
- **Semantics**: output verified identical to the old function (0 diff across 51 products on real data, per the original change). Regression guard is `availableForSales.feature` (`@ghActions:run_on_executor4` → profile4), which drives the real function.
- **Performance**: measured on a large production instance (2.2M shipment schedules / 150k+ order lines), a high-runner product — **~154 ms → ~68 ms (≈2.2×, roughly −55% buffers)**.

### Files
- `backend/de.metas.material/cockpit/.../Retrieve_available_for_Sales.sql` — function DDL rewrite
- `backend/de.metas.material/cockpit/.../5805670_sys_retrieve_available_for_sales_perf.sql` — migration (same id as the source change, so a later branch merge deduplicates it)

### Not in scope
The residual `M_ShipmentSchedule(Processed='N')` scan (a separate partial-index lever) is a follow-up, not part of this port.
