### PR TITLE
mobile-webui e2e: gate close_partially_shipped shipment-close read on async drain (fix flake)

### DIFF
--- a/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/close_partially_shipped.spec.js
@@ -124,40 +124,57 @@ test('Sysconfig M_ShipmentSchedule_Close_PartiallyShipped: partial and unshipped
         await PickingJobScreen.complete();
     });
 
-    await test.step("Assert shipment schedules: P2 and P3 should be closed", async () => {
+    // Completing the job enqueues shipment generation + M_ShipmentSchedule_Close_PartiallyShipped
+    // close-processing on an async workpackage (a separate thread/transaction). Reading P1's IsClosed
+    // right after complete() races that work: the fully-shipped line P1 passes through a transient,
+    // committed "closed" state while the workpackage runs, before it settles back to open. So the
+    // final IsClosed assertions must be gated on the async work having landed first, not fired
+    // immediately. The backend `expect` polls up to 60s for isClosed:true and for processed lines, so
+    // asserting "P2 + P3 are closed and every picked line is processed" first blocks until the
+    // workpackage has finished; only then do we assert P1 is (and stays) open.
+    const p1PickedLine = {
+        qtyPicked: "12 PCE",
+        qtyTUs: 3,
+        qtyLUs: 1,
+        vhu: 'vhu1',
+        tu: 'tu1',
+        lu: 'lu1',
+        processed: true,
+        shipmentLineId: 'shipmentLineId1',
+    };
+    const p2PickedLine = {
+        qtyPicked: "8 PCE",
+        qtyTUs: 2,
+        qtyLUs: 1,
+        vhu: 'vhu2',
+        tu: 'tu2',
+        lu: 'lu2',
+        processed: true,
+        shipmentLineId: 'shipmentLineId2',
+    };
+
+    await test.step("Wait until the shipment processing has completed (P2 + P3 closed, lines processed)", async () => {
         await Backend.expect({
             pickings: {
                 [pickingJobId]: {
                     shipmentSchedules: {
-                        P1: {
-                            isClosed: false,
-                            qtyPicked: [{
-                                qtyPicked: "12 PCE",
-                                qtyTUs: 3,
-                                qtyLUs: 1,
-                                vhu: 'vhu1',
-                                tu: 'tu1',
-                                lu: 'lu1',
-                                processed: true,
-                                shipmentLineId: 'shipmentLineId1',
-                            }]
-                        },
-                        P2: {
-                            isClosed: true,
-                            qtyPicked: [{
-                                qtyPicked: "8 PCE",
-                                qtyTUs: 2,
-                                qtyLUs: 1,
-                                vhu: 'vhu2',
-                                tu: 'tu2',
-                                lu: 'lu2',
-                                processed: true,
-                                shipmentLineId: 'shipmentLineId2',
-                            }]
-                        },
-                        P3: {
-                            isClosed: true,
-                        },
+                        P1: { qtyPicked: [p1PickedLine] },
+                        P2: { isClosed: true, qtyPicked: [p2PickedLine] },
+                        P3: { isClosed: true },
+                    }
+                }
+            },
+        });
+    });
+
+    await test.step("Assert final state: P1 stays open (fully shipped), P2 + P3 are closed", async () => {
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        P1: { isClosed: false, qtyPicked: [p1PickedLine] },
+                        P2: { isClosed: true, qtyPicked: [p2PickedLine] },
+                        P3: { isClosed: true },
                     }
                 }
             },


### PR DESCRIPTION
## What

Fix an intermittent flake in the mobile-webui Playwright spec `close_partially_shipped.spec.js` — an **async-commit read race**, not a product regression.

## Root cause

The spec completes a picking job (`createShipmentPolicy=CO`, sysconfig `M_ShipmentSchedule_Close_PartiallyShipped=Y`) and then asserts, in a single `Backend.expect`, that the fully-shipped line **P1 stays open** (`isClosed:false`) while the partially-shipped **P2** and unshipped **P3** close (`isClosed:true`).

Completing the job enqueues shipment generation + `Close_PartiallyShipped` close-processing on an **async workpackage** (a separate thread/transaction). The fully-shipped line P1 passes through a transient, committed *closed* state while that workpackage runs, before it settles back to open. In the backend assert command, the `isClosed:true` path polls up to 60s (so P2/P3 are race-immune), but the `isClosed:false` path returns immediately on the loaded snapshot — so reading P1 before the async work lands can catch it transiently closed and fail with `Expected IsClosed to be <false> but was <true>`.

**Changing-failure signature** (test-artifact tell): the same CI run failed on one attempt and passed on the adjacent attempt with identical code.

## Fix

Test-side only, **no assertion weakened**. Gate the final read on the async work having landed: first assert P2/P3 are closed and every picked line is processed (this blocks until the workpackage has finished), then assert P1 is — and stays — open. The final assertions are byte-for-byte the same as before; only a drain step is prepended.

## Validation

Local full-stack reproduction is unavailable on this shared build host (a co-tenant e2e-stack occupies the fixed e2e ports; `mf-docker-e2e.sh` is single-stack-per-host and a second full stack risks OOM-ing the co-tenant). Validated via CI (the mobile-test job runs the real two-JVM app+webapi topology in isolation); flake-confidence via fresh full runs.
