### PR TITLE
Mobile Packing: guard physical HU weight proportioning on catch-weight carve unpick

### DIFF
--- a/e2e/mobile-webui/TEST-COVERAGE.md
+++ b/e2e/mobile-webui/TEST-COVERAGE.md
@@ -196,7 +196,7 @@
 | Catch-weight pick via EAN13 prefix 29 — wrong product → error | `picking/picking_catchWeight.spec.js` |
 | Catch-weight pick via custom QR code format | `picking/picking_catchWeight.spec.js` |
 | ShowLastPickedBestBeforeDateForLines = Y → last best-before date shown on picking line | `picking/picking_catchWeight.spec.js` |
-| Partial floor-unpick of a catch-weight pick from a bare TU: the remaining shipment schedule row's catch weight scales proportionally with the reduced qty | `picking/unpack/picking_partial_unpack_TU_floor_catchWeight.spec.js` |
+| Partial floor-unpick of a catch-weight pick from a bare TU: the remaining shipment schedule row's catch weight AND the remaining CU's physical HU weight attributes (WeightNet/WeightGross) both scale proportionally with the reduced qty (0.440 → 0.330 for a 3/4 carve) | `picking/unpack/picking_partial_unpack_TU_floor_catchWeight.spec.js` |
 
 **11/11 — 100%**
 

--- a/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_catchWeight.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_catchWeight.spec.js
@@ -88,7 +88,7 @@ const loginAndStartJob = async ({ masterdata }) => {
 };
 
 // noinspection JSUnusedLocalSymbols
-test('Partial floor-unpick of a catch-weight pick from a bare TU scales the remaining catch weight proportionally', async ({ page }) => {
+test('Partial floor-unpick of a catch-weight pick from a bare TU scales the remaining catch weight and the physical HU weight attributes proportionally', async ({ page }) => {
     allure.epic('E0105: Picking');
     allure.tag('F00230: MobileUI Picking');
     allure.tag('F00230');
@@ -119,7 +119,15 @@ test('Partial floor-unpick of a catch-weight pick from a bare TU scales the rema
                 }
             },
             hus: {
-                tu1: { huStatus: 'S', storages: { P1: '4 PCE' } },
+                tu1: {
+                    huStatus: 'S',
+                    storages: { P1: '4 PCE' },
+                    // Physical HU weight attributes on the single picked CU (VHU) under the bare TU.
+                    // The manually-entered catch weight (0.44 KGM) is stored as the CU's measured
+                    // WeightNet; WeightGross follows it (tare 0, so gross == net). This is the source
+                    // of truth the schedule row's QtyDeliveredCatch was derived from at pick time.
+                    cus: [{ qty: '4 PCE', attributes: { WeightNet: '0.440', WeightGross: '0.440' } }],
+                },
             }
         });
     });
@@ -136,7 +144,16 @@ test('Partial floor-unpick of a catch-weight pick from a bare TU scales the rema
         await Backend.expect({
             title: 'after floor unpick: 3 PCE stays in the TU, remaining catch weight proportionally reduced 0.440 -> 0.330 KGM',
             hus: {
-                tu1: { huStatus: 'S', storages: { P1: '3 PCE' } },
+                tu1: {
+                    huStatus: 'S',
+                    storages: { P1: '3 PCE' },
+                    // The remaining CU's physical WeightNet/WeightGross must scale by the SAME 3/4 ratio
+                    // as the piece qty (0.440 -> 0.330), NOT stay stale at 0.440. The carved-out 1-PCE
+                    // floor CU carries the complementary 0.110 (0.440 x 1/4); 0.330 + 0.110 == 0.440
+                    // (conservation). WeightNet is redistributed by RedistributeQtyHUAttributeTransferStrategy
+                    // on the VHU-to-VHU split; WeightGross follows via the Net->Gross callout (tare 0).
+                    cus: [{ qty: '3 PCE', attributes: { WeightNet: '0.330', WeightGross: '0.330' } }],
+                },
             },
             pickings: {
                 [pickingJobId]: {


### PR DESCRIPTION
## What

Adds a regression test locking in that a **partial "unpick item to floor" carve** of a **catch-weight** product picked into a bare TU keeps the physical HU weight attributes consistent with quantity.

Extends `e2e/mobile-webui/tests/spec/picking/unpack/picking_partial_unpack_TU_floor_catchWeight.spec.js` to assert, before and after the carve, the remaining CU's `WeightNet` / `WeightGross` — they scale proportionally with the reduced qty and are conserved (e.g. `0.440 → 0.330` for a 3/4 remainder). Updates `TEST-COVERAGE.md` to match.

## Why

Follow-up to the merged catch-weight schedule fix at https://github.com/metasfresh/metasfresh/pull/25057 — a reviewer asked whether the *physical* HU weights (not just the shipment-schedule `QtyDeliveredCatch`) are proportioned on such a carve. Investigation against the running stack confirmed they already are: `WeightNet` is redistributed by the existing per-attribute transfer strategy on the produced split, and `WeightGross` follows via the Net→Gross callout, with weight conserved across the two resulting CUs. There was **no defect to fix**; this test captures and guards that correct behaviour so a future change can't silently regress it.

## Scope

Test-only. No production code, no migration.
