### PR TITLE
Outbound Emails: email template dropdown opens on first click + highlights applied template

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommand.java
@@ -63,6 +63,8 @@ import de.metas.frontend_testing.masterdata.user.LoginUserCommand;
 import de.metas.frontend_testing.masterdata.warehouse.JsonWarehouseRequest;
 import de.metas.frontend_testing.masterdata.warehouse.JsonWarehouseResponse;
 import de.metas.frontend_testing.masterdata.warehouse.WarehouseCommand;
+import de.metas.frontend_testing.masterdata.mailbox.CreateMailboxCommand;
+import de.metas.frontend_testing.masterdata.mailbox.JsonMailboxResponse;
 import de.metas.frontend_testing.masterdata.workplace.CreateWorkplaceCommand;
 import de.metas.frontend_testing.masterdata.workplace.JsonWorkplaceResponse;
 import de.metas.order.OrderId;
@@ -96,6 +98,7 @@ public class CreateMasterdataCommand
 
 		// IMPORTANT: the order is very important
 		final ImmutableMap<String, JsonLoginUserResponse> login = createLoginUsers();
+		final ImmutableMap<String, JsonMailboxResponse> mailboxes = createMailboxes();
 		final ImmutableMap<String, JsonCreateBPartnerResponse> bpartners = createBPartners();
 		final ImmutableMap<String, JsonCreateProductResponse> products = createProducts();
 		final ImmutableMap<String, JsonCreateResourceResponse> resources = createResources();
@@ -125,6 +128,7 @@ public class CreateMasterdataCommand
 				.previousSysconfigs(previousSysconfigs.isEmpty() ? null : previousSysconfigs)
 				.mobileConfig(mobileConfig)
 				.login(login)
+				.mailboxes(mailboxes.isEmpty() ? null : mailboxes)
 				.bpartners(bpartners)
 				.products(products)
 				.resources(resources)
@@ -265,6 +269,16 @@ public class CreateMasterdataCommand
 				.identifier(Identifier.ofString(identifier))
 				.build()
 				.execute();
+	}
+
+	private ImmutableMap<String, JsonMailboxResponse> createMailboxes()
+	{
+		if (request.getMailboxes() == null) {return ImmutableMap.of();}
+
+		return CreateMailboxCommand.builder()
+				.context(context)
+				.requests(request.getMailboxes())
+				.build().execute();
 	}
 
 	private ImmutableMap<String, JsonWorkplaceResponse> createWorkplaces()

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/JsonCreateMasterdataRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/JsonCreateMasterdataRequest.java
@@ -7,6 +7,7 @@ import de.metas.frontend_testing.masterdata.hu.JsonCreateHURequest;
 import de.metas.frontend_testing.masterdata.hu.JsonPackingInstructionsRequest;
 import de.metas.frontend_testing.masterdata.huQRCodes.JsonGenerateHUQRCodeRequest;
 import de.metas.frontend_testing.masterdata.inventory.JsonInventoryRequest;
+import de.metas.frontend_testing.masterdata.mailbox.JsonMailboxRequest;
 import de.metas.frontend_testing.masterdata.mobile_configuration.JsonMobileConfigRequest;
 import de.metas.frontend_testing.masterdata.picking_slot.JsonPickingSlotCreateRequest;
 import de.metas.frontend_testing.masterdata.pp_order.JsonPPOrderRequest;
@@ -42,6 +43,7 @@ public class JsonCreateMasterdataRequest
 
 	@Nullable JsonMobileConfigRequest mobileConfig;
 	@Nullable Map<String, JsonLoginUserRequest> login;
+	@Nullable Map<String, JsonMailboxRequest> mailboxes;
 	@Nullable Map<String, JsonCreateBPartnerRequest> bpartners;
 	@Nullable Map<String, JsonWorkplaceRequest> workplaces;
 	@Nullable Map<String, JsonWarehouseRequest> warehouses;

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/JsonCreateMasterdataResponse.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/JsonCreateMasterdataResponse.java
@@ -7,6 +7,7 @@ import de.metas.frontend_testing.masterdata.hu.JsonCreateHUResponse;
 import de.metas.frontend_testing.masterdata.hu.JsonPackingInstructionsResponse;
 import de.metas.frontend_testing.masterdata.huQRCodes.JsonGenerateHUQRCodeResponse;
 import de.metas.frontend_testing.masterdata.inventory.JsonInventoryResponse;
+import de.metas.frontend_testing.masterdata.mailbox.JsonMailboxResponse;
 import de.metas.frontend_testing.masterdata.mobile_configuration.JsonMobileConfigResponse;
 import de.metas.frontend_testing.masterdata.picking_slot.JsonPickingSlotCreateResponse;
 import de.metas.frontend_testing.masterdata.pp_order.JsonPPOrderResponse;
@@ -41,6 +42,7 @@ public class JsonCreateMasterdataResponse
 
 	@Nullable @JsonInclude(JsonInclude.Include.NON_EMPTY) JsonMobileConfigResponse mobileConfig;
 	@NonNull Map<String, JsonLoginUserResponse> login;
+	@Nullable @JsonInclude(JsonInclude.Include.NON_EMPTY) Map<String, JsonMailboxResponse> mailboxes;
 	@NonNull Map<String, JsonCreateBPartnerResponse> bpartners;
 	@NonNull Map<String, JsonCreateProductResponse> products;
 	@Nullable Map<String, JsonCreateResourceResponse> resources;

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mailbox/CreateMailboxCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mailbox/CreateMailboxCommand.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * otherwise. The generic e2e tenant ships neither, so the dialog cannot open. This command
  * get-or-creates BOTH:
  * <ul>
- *     <li>an {@code AD_MailBox} (SMTP, no authorization so the user-config merge passes), and</li>
+ *     <li>an {@code AD_MailBox} (SMTP, no authorization — no mail is sent), and</li>
  *     <li>a wildcard {@code AD_MailConfig} routing row referencing it (blank CustomType/DocBaseType).</li>
  * </ul>
  * Both are keyed on a stable value and reused if already present, so repeated runs against the
@@ -80,7 +80,9 @@ public class CreateMailboxCommand
 		mailbox.setType(X_AD_MailBox.TYPE_SMTP);
 		mailbox.setSMTPHost(request.getSmtpHost() != null ? request.getSmtpHost() : DEFAULT_SMTP_HOST);
 		mailbox.setSMTPPort(request.getSmtpPort() != null ? request.getSmtpPort() : DEFAULT_SMTP_PORT);
-		mailbox.setIsSmtpAuthorization(false); // no auth => findMailbox's user-config merge does not require SMTP credentials
+		mailbox.setIsSmtpAuthorization(false); // no SMTP auth (no mail is sent). NOTE: findMailbox still
+		// merges the sending user's config and asserts a non-empty SMTP username regardless of this flag,
+		// so the login user must carry EMailUser (set in LoginUserCommand) for the Email dialog to open.
 		mailbox.setIsStartTLS(false);
 		InterfaceWrapperHelper.save(mailbox);
 		return mailbox;

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mailbox/CreateMailboxCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mailbox/CreateMailboxCommand.java
@@ -1,0 +1,107 @@
+package de.metas.frontend_testing.masterdata.mailbox;
+
+import com.google.common.collect.ImmutableMap;
+import de.metas.frontend_testing.masterdata.MasterdataContext;
+import de.metas.util.Services;
+import de.metas.util.collections.CollectionUtils;
+import lombok.Builder;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.compiere.model.I_AD_MailBox;
+import org.compiere.model.I_AD_MailConfig;
+import org.compiere.model.X_AD_MailBox;
+
+import java.util.Map;
+
+/**
+ * Seeds a usable SMTP mailbox for the tenant so the WebUI email dialog can be opened.
+ * <p>
+ * {@code MailRestController.createNewEmail} asserts a resolvable mailbox via
+ * {@code MailService.findMailbox}, which resolves through {@code AD_MailConfig} routing rows
+ * (each pointing at an {@code AD_MailBox}) and falls back to the client's (empty) email config
+ * otherwise. The generic e2e tenant ships neither, so the dialog cannot open. This command
+ * get-or-creates BOTH:
+ * <ul>
+ *     <li>an {@code AD_MailBox} (SMTP, no authorization so the user-config merge passes), and</li>
+ *     <li>a wildcard {@code AD_MailConfig} routing row referencing it (blank CustomType/DocBaseType).</li>
+ * </ul>
+ * Both are keyed on a stable value and reused if already present, so repeated runs against the
+ * shared e2e DB never accumulate duplicates (which would also break {@code findMailbox}). No mail
+ * is actually sent.
+ */
+@Builder
+public class CreateMailboxCommand
+{
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	@NonNull private final MasterdataContext context;
+	@NonNull private final Map<String, JsonMailboxRequest> requests;
+
+	private static final String DEFAULT_EMAIL = "frontend-testing@metasfresh.com";
+	private static final String DEFAULT_SMTP_HOST = "localhost";
+	private static final int DEFAULT_SMTP_PORT = 587;
+
+	public ImmutableMap<String, JsonMailboxResponse> execute()
+	{
+		return CollectionUtils.mapValues(ImmutableMap.copyOf(requests), this::createMailbox);
+	}
+
+	private JsonMailboxResponse createMailbox(final String identifierStr, final JsonMailboxRequest request)
+	{
+		final ClientId clientId = MasterdataContext.CLIENT_ID;
+		final String email = request.getEmail() != null ? request.getEmail() : DEFAULT_EMAIL;
+
+		final I_AD_MailBox mailbox = getOrCreateMailbox(clientId, email, request);
+		getOrCreateRouting(clientId, mailbox.getAD_MailBox_ID());
+
+		return JsonMailboxResponse.builder()
+				.mailboxId(mailbox.getAD_MailBox_ID())
+				.email(email)
+				.build();
+	}
+
+	private I_AD_MailBox getOrCreateMailbox(@NonNull final ClientId clientId, @NonNull final String email, @NonNull final JsonMailboxRequest request)
+	{
+		final I_AD_MailBox existing = queryBL.createQueryBuilder(I_AD_MailBox.class)
+				.addEqualsFilter(I_AD_MailBox.COLUMNNAME_AD_Client_ID, clientId.getRepoId())
+				.addEqualsFilter(I_AD_MailBox.COLUMNNAME_EMail, email)
+				.create()
+				.firstOnlyOrNull(I_AD_MailBox.class);
+		if (existing != null)
+		{
+			return existing;
+		}
+
+		final I_AD_MailBox mailbox = InterfaceWrapperHelper.newInstance(I_AD_MailBox.class);
+		mailbox.setAD_Org_ID(0); // Any org
+		mailbox.setEMail(email);
+		mailbox.setType(X_AD_MailBox.TYPE_SMTP);
+		mailbox.setSMTPHost(request.getSmtpHost() != null ? request.getSmtpHost() : DEFAULT_SMTP_HOST);
+		mailbox.setSMTPPort(request.getSmtpPort() != null ? request.getSmtpPort() : DEFAULT_SMTP_PORT);
+		mailbox.setIsSmtpAuthorization(false); // no auth => findMailbox's user-config merge does not require SMTP credentials
+		mailbox.setIsStartTLS(false);
+		InterfaceWrapperHelper.save(mailbox);
+		return mailbox;
+	}
+
+	private void getOrCreateRouting(@NonNull final ClientId clientId, final int mailboxId)
+	{
+		final boolean exists = queryBL.createQueryBuilder(I_AD_MailConfig.class)
+				.addEqualsFilter(I_AD_MailConfig.COLUMNNAME_AD_Client_ID, clientId.getRepoId())
+				.addEqualsFilter(I_AD_MailConfig.COLUMNNAME_AD_MailBox_ID, mailboxId)
+				.create()
+				.anyMatch();
+		if (exists)
+		{
+			return;
+		}
+
+		final I_AD_MailConfig routing = InterfaceWrapperHelper.newInstance(I_AD_MailConfig.class);
+		routing.setAD_Org_ID(0); // Any org
+		routing.setAD_MailBox_ID(mailboxId);
+		// CustomType / DocBaseType left null => wildcard routing that matches any mailbox query for this client
+		InterfaceWrapperHelper.save(routing);
+	}
+}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mailbox/JsonMailboxRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mailbox/JsonMailboxRequest.java
@@ -1,0 +1,22 @@
+package de.metas.frontend_testing.masterdata.mailbox;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+import javax.annotation.Nullable;
+
+/**
+ * Requests a usable SMTP mailbox for the tenant so the WebUI email dialog can be opened
+ * (createEmail asserts a resolvable mailbox via MailService.findMailbox). All fields are
+ * optional; sensible testing defaults are used when omitted. No mail is actually sent.
+ */
+@Value
+@Builder
+@Jacksonized
+public class JsonMailboxRequest
+{
+	@Nullable String email;
+	@Nullable String smtpHost;
+	@Nullable Integer smtpPort;
+}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mailbox/JsonMailboxResponse.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mailbox/JsonMailboxResponse.java
@@ -1,0 +1,15 @@
+package de.metas.frontend_testing.masterdata.mailbox;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+@Value
+@Builder
+@Jacksonized
+public class JsonMailboxResponse
+{
+	int mailboxId;
+	@NonNull String email;
+}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/user/LoginUserCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/user/LoginUserCommand.java
@@ -65,6 +65,12 @@ public class LoginUserCommand
 		user.setFirstname(firstname);
 		user.setLastname(lastname);
 		user.setEMail(login + "@metasfresh.com");
+		// SMTP user/password are required for the WebUI Email dialog to open: MailService.findMailbox
+		// merges the sending user's email config into the mailbox, and SMTPConfig.mergeFrom asserts a
+		// non-empty username regardless of the mailbox's IsSmtpAuthorization. Without these the dialog
+		// (createEmail) fails with MailboxNotFoundException / "username is set".
+		user.setEMailUser(login + "@metasfresh.com");
+		user.setEMailUserPW(login);
 		user.setAD_Language(request.getLanguage());
 		user.setIsSystemUser(true);
 		user.setLogin(login);

--- a/e2e/frontend-webui/tests/spec/email-letter-dialog.spec.js
+++ b/e2e/frontend-webui/tests/spec/email-letter-dialog.spec.js
@@ -293,6 +293,12 @@ dialog opened only after the third click.
         login: {
           user: { language: 'en_US', firstname: 'first', lastname: 'last' },
         },
+        // Seed a tenant mailbox so the Email dialog can open (createEmail asserts a
+        // resolvable mailbox via MailService.findMailbox). Get-or-create, so it never
+        // accumulates duplicates in the shared e2e DB.
+        mailboxes: {
+          MB1: {},
+        },
         bpartners: {
           CUSTOMER1: {
             isVendor: false,
@@ -353,18 +359,9 @@ dialog opened only after the third click.
             .catch(() => false);
         }
       }
-      // The Email dialog only opens when the tenant has a mailbox configured
-      // (createEmail asserts a valid mailbox via MailService.findMailbox and the
-      // dialog auto-closes on failure). The generic e2e stack's tenant has no
-      // mailbox, so this scenario can only run where mail is configured (a real /
-      // customer instance, or once the masterdata API can seed a mailbox). Skip
-      // rather than fail there — AC1/AC3 are verified at UAT on the mail-configured
-      // instance. Where the dialog DOES open, the picker assertions below run as a
-      // full regression guard.
-      test.skip(
-        !emailVisible,
-        'Email dialog needs a configured mailbox (not present in the generic e2e stack)'
-      );
+      // The seeded tenant mailbox (masterdata `mailboxes`) makes createEmail resolve a
+      // mailbox via MailService.findMailbox, so the Email dialog opens.
+      expect(emailVisible, 'Email dialog must open (tenant mailbox is seeded)').toBe(true);
     });
 
     // === PRECONDITION: template picker rendered (>=1 template available) ===

--- a/e2e/frontend-webui/tests/spec/email-letter-dialog.spec.js
+++ b/e2e/frontend-webui/tests/spec/email-letter-dialog.spec.js
@@ -21,7 +21,9 @@ test.describe('Email & Letter Dialogs', () => {
   test('Email and Letter dialogs on Sales Order', async ({ page }) => {
     allure.epic('E0193: User Interface');
     allure.tag('F14010: Navigation');
+    allure.tag('F14010');
     allure.tag('F14100: Email & Letter');
+    allure.tag('F14100');
     allure.story('Email and Letter Composition');
     allure.severity('normal');
 
@@ -372,9 +374,14 @@ dialog opened only after the third click.
       // RED before fix: the list does not open on the first click (needed 3 clicks).
       // GREEN after fix: the list is visible after a single click.
       await expect(dropdownList).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+      // Stability re-check: the reported defect is a *transient* open (flash-then-
+      // ghost-close). A single retrying toBeVisible() can false-green on a millisecond
+      // flash, so re-assert after a settle delay that the dropdown STAYS open.
+      await page.waitForTimeout(600);
+      await expect(dropdownList).toBeVisible();
       await expect(
         page.locator('.input-dropdown-list .input-dropdown-list-option').first()
-      ).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+      ).toBeVisible();
 
       const screenshot = await page.screenshot();
       allure.attachment('Template dropdown after single click', screenshot, 'image/png');
@@ -392,6 +399,9 @@ dialog opened only after the third click.
       await picker.click();
       const dropdownList = page.locator('.input-dropdown-list');
       await expect(dropdownList).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+      // stays open on re-open too (AC3)
+      await page.waitForTimeout(600);
+      await expect(dropdownList).toBeVisible();
 
       // the applied template carries the selected marker class
       await expect(

--- a/e2e/frontend-webui/tests/spec/email-letter-dialog.spec.js
+++ b/e2e/frontend-webui/tests/spec/email-letter-dialog.spec.js
@@ -353,7 +353,18 @@ dialog opened only after the third click.
             .catch(() => false);
         }
       }
-      expect(emailVisible, 'Email dialog must open').toBe(true);
+      // The Email dialog only opens when the tenant has a mailbox configured
+      // (createEmail asserts a valid mailbox via MailService.findMailbox and the
+      // dialog auto-closes on failure). The generic e2e stack's tenant has no
+      // mailbox, so this scenario can only run where mail is configured (a real /
+      // customer instance, or once the masterdata API can seed a mailbox). Skip
+      // rather than fail there — AC1/AC3 are verified at UAT on the mail-configured
+      // instance. Where the dialog DOES open, the picker assertions below run as a
+      // full regression guard.
+      test.skip(
+        !emailVisible,
+        'Email dialog needs a configured mailbox (not present in the generic e2e stack)'
+      );
     });
 
     // === PRECONDITION: template picker rendered (>=1 template available) ===

--- a/e2e/frontend-webui/tests/spec/email-letter-dialog.spec.js
+++ b/e2e/frontend-webui/tests/spec/email-letter-dialog.spec.js
@@ -263,4 +263,142 @@ Tests the email and letter composition panels:
 
     console.log('Email & Letter dialog test completed');
   });
+
+  test('Email template picker opens on the first click', async ({ page }) => {
+    allure.epic('E0193: User Interface');
+    allure.tag('F00580: Outbound Emails');
+    allure.tag('F00580');
+    allure.story('Email template picker');
+    allure.severity('normal');
+
+    allure.description(`
+## Email template picker — first-click open
+
+Reproduces and guards the defect where the email-template dropdown in the Email
+dialog opened only after the third click.
+
+1. Open the Email dialog on a Sales Order.
+2. Single-click the template picker.
+3. Assert the template list is visible after ONE click (RED before fix, GREEN after).
+4. Re-open and assert the applied template is highlighted.
+    `);
+
+    test.setTimeout(180000); // 3 minutes
+
+    // === CREATE TEST DATA ===
+    const masterdata = await Backend.createMasterdata({
+      request: {
+        login: {
+          user: { language: 'en_US', firstname: 'first', lastname: 'last' },
+        },
+        bpartners: {
+          CUSTOMER1: {
+            isVendor: false,
+            isCustomer: true,
+            isSoPriceList: true,
+            name: 'Customer',
+          },
+        },
+        products: {
+          Product1: {
+            name: 'PROD',
+            type: 'Item',
+            prices: [{ price: 15.0, currencyCode: 'EUR' }],
+          },
+        },
+      },
+    });
+
+    // === LOGIN ===
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await DashboardPage.expectVisible();
+
+    // === CREATE SALES ORDER WITH CUSTOMER ===
+    await SalesOrderPage.goto();
+    await SalesOrderPage.clickNew();
+    await SalesOrderPage.selectCustomer(masterdata.bpartners.CUSTOMER1.bpartnerCode);
+    await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+    await page.waitForTimeout(2000);
+
+    // === OPEN EMAIL DIALOG (Alt+K, SubHeader fallback) ===
+    await test.step('Open Email dialog', async () => {
+      await page.locator('body').click();
+      await page.waitForTimeout(200);
+      await page.keyboard.press('Alt+K');
+      await page.waitForTimeout(1500);
+
+      let emailVisible = await page
+        .locator('.panel-email')
+        .first()
+        .waitFor({ state: 'visible', timeout: 5000 })
+        .then(() => true)
+        .catch(() => false);
+
+      if (!emailVisible) {
+        // Fallback: open via SubHeader mail icon
+        await page.keyboard.press('Alt+1');
+        await page.waitForTimeout(500);
+        const emailIcon = page.locator('.subheader-container .meta-icon-mail').first();
+        if (await emailIcon.isVisible().catch(() => false)) {
+          await emailIcon.click();
+          await page.waitForTimeout(1500);
+          emailVisible = await page
+            .locator('.panel-email')
+            .first()
+            .waitFor({ state: 'visible', timeout: 5000 })
+            .then(() => true)
+            .catch(() => false);
+        }
+      }
+      expect(emailVisible, 'Email dialog must open').toBe(true);
+    });
+
+    // === PRECONDITION: template picker rendered (>=1 template available) ===
+    // The picker only renders when GET /mail/templates returns >=1 AD_BoilerPlate.
+    // The standard preloaded DB ships a readable boilerplate for the WEBUI role,
+    // so the picker is present.
+    const picker = page.locator('.email-templates .input-dropdown-container').first();
+    await picker.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+    // === AC1: single click opens the dropdown list ===
+    await test.step('Single click opens the template dropdown', async () => {
+      const dropdownList = page.locator('.input-dropdown-list');
+      // sanity: closed before the click
+      expect(await dropdownList.isVisible().catch(() => false)).toBe(false);
+
+      await picker.click(); // exactly ONE click
+
+      // RED before fix: the list does not open on the first click (needed 3 clicks).
+      // GREEN after fix: the list is visible after a single click.
+      await expect(dropdownList).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+      await expect(
+        page.locator('.input-dropdown-list .input-dropdown-list-option').first()
+      ).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+
+      const screenshot = await page.screenshot();
+      allure.attachment('Template dropdown after single click', screenshot, 'image/png');
+    });
+
+    // === AC2: applied template is highlighted on re-open (where feasible) ===
+    await test.step('Applied template is highlighted on re-open', async () => {
+      const firstOption = page
+        .locator('.input-dropdown-list .input-dropdown-list-option')
+        .first();
+      await firstOption.click();
+      await page.waitForTimeout(1000);
+
+      // re-open on the first click
+      await picker.click();
+      const dropdownList = page.locator('.input-dropdown-list');
+      await expect(dropdownList).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+
+      // the applied template carries the selected marker class
+      await expect(
+        page.locator('.input-dropdown-list .input-dropdown-list-option-key-on')
+      ).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+    });
+
+    console.log('Email template picker first-click test completed');
+  });
 });

--- a/e2e/frontend-webui/tests/utils/Backend.js
+++ b/e2e/frontend-webui/tests/utils/Backend.js
@@ -1,6 +1,10 @@
 import { test, testContext } from '../../playwright.config';
 import { getPage } from './common';
 
+// The webapi node (mailbox/cache endpoints live here), distinct from the app-node testing API.
+const WEBAPI_BASE_URL =
+  process.env.WEBAPI_BASE_URL || 'http://localhost:8080/rest/api';
+
 /**
  * Backend API client for interacting with /rest/api/v2/frontendTesting endpoints.
  * Used to create test master data and validate expectations.
@@ -37,6 +41,25 @@ export const Backend = {
 
       const responseBody = await response.json();
       assertNoErrors({ responseBody });
+
+      // Mailboxes are created on the app node (:8282). MailService.findMailbox runs on
+      // the webapi node (:8080) with its own MailboxRepository caches (AD_MailBox /
+      // AD_MailConfig). A prior findMailbox call (e.g. an earlier test opening the Email
+      // dialog) may have primed those caches empty, so the cross-JVM invalidation isn't
+      // guaranteed to have arrived. Reset them synchronously so the freshly-seeded
+      // mailbox is visible before the Email dialog is opened.
+      if (request.mailboxes) {
+        for (const tableName of ['AD_MailBox', 'AD_MailConfig']) {
+          const resetResponse = await page.request.get(
+            `${WEBAPI_BASE_URL}/cache/resetByTable?tableName=${tableName}`
+          );
+          if (!resetResponse.ok()) {
+            throw Error(
+              `Failed resetting webapi cache for ${tableName}: HTTP ${resetResponse.status()}`
+            );
+          }
+        }
+      }
 
       console.log('Created master data:', JSON.stringify(responseBody, null, 2));
 

--- a/frontend/src/__tests__/components/widget/List/SimpleList.test.js
+++ b/frontend/src/__tests__/components/widget/List/SimpleList.test.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import SimpleList from '../../../../components/widget/List/SimpleList';
+import { RawList0 as RawListBare } from '../../../../components/widget/List/RawList';
+import fixtures from '../../../../../test_setup/fixtures/raw_list.json';
+
+// dev-note: RawList0's TetherComponent reads `this.inputContainerElement.offsetWidth`
+// and the dropdown reads `dropdown.offsetWidth`; shim it like RawList.test.js does.
+RawListBare.prototype.dropdown = { offsetWidth: 100 };
+
+describe('SimpleList component', () => {
+  it('updates the inner RawList highlighted/selected option when `selected` prop changes but `list` reference stays the same', () => {
+    // NOTE: same `list` array reference is reused for both mount and setProps,
+    // so `listHash` (computed via useMemo(() => uuidv4(), [list])) will NOT change.
+    const list = fixtures.data1.listData;
+    const itemA = list[0]; // { key: '2000284', caption: 'Divers' }
+    const itemB = list[1]; // { key: '2000838', caption: 'Lagerkonferenz' }
+
+    const wrapper = mount(
+      <SimpleList list={list} selected={itemA} onSelect={jest.fn()} />
+    );
+
+    const rawListInstances = wrapper.find('RawList0');
+    expect(rawListInstances.length).toBe(1);
+
+    expect(rawListInstances.instance().state.selected).toEqual(itemA);
+
+    wrapper.setProps({ selected: itemB });
+    wrapper.update();
+
+    // dev-note (bug AC2): `listHash` is memoized on `[list]` only (SimpleList.js line 21),
+    // so when `selected` changes but `list` keeps the same reference, RawList's
+    // componentDidUpdate never re-runs setSelectedValue (gated on listHash change),
+    // leaving the dropdown's highlighted option (state.selected) stale at itemA
+    // instead of reflecting the new itemB.
+    const updatedRawListInstance = wrapper.find('RawList0').instance();
+    expect(updatedRawListInstance.state.selected).toEqual(itemB);
+  });
+});

--- a/frontend/src/__tests__/components/widget/List/SimpleList.test.js
+++ b/frontend/src/__tests__/components/widget/List/SimpleList.test.js
@@ -29,12 +29,59 @@ describe('SimpleList component', () => {
     wrapper.setProps({ selected: itemB });
     wrapper.update();
 
-    // dev-note (bug AC2): `listHash` is memoized on `[list]` only (SimpleList.js line 21),
-    // so when `selected` changes but `list` keeps the same reference, RawList's
-    // componentDidUpdate never re-runs setSelectedValue (gated on listHash change),
-    // leaving the dropdown's highlighted option (state.selected) stale at itemA
-    // instead of reflecting the new itemB.
+    // AC2: because `listHash` now depends on `selected?.key`, changing `selected` to a
+    // different-key item (same `list` ref) regenerates the hash, so RawList's
+    // componentDidUpdate re-runs setSelectedValue and the highlighted option updates.
     const updatedRawListInstance = wrapper.find('RawList0').instance();
     expect(updatedRawListInstance.state.selected).toEqual(itemB);
+  });
+
+  // Blast-radius guard for the shared consumers (SimulationsDropDown / ResourcesDropDown),
+  // which rebuild `selected` as a fresh object literal on every (e.g. websocket-driven)
+  // render: the hash must stay STABLE when only `selected`'s identity changes but its key
+  // does not — otherwise an open dropdown would reorder/reload under the user's cursor.
+  it('does NOT regenerate listHash when `selected` changes identity but keeps the same key', () => {
+    const list = fixtures.data1.listData;
+    const itemA = list[0];
+    const wrapper = mount(
+      <SimpleList list={list} selected={itemA} onSelect={jest.fn()} />
+    );
+    const hashBefore = wrapper.find('RawList0').prop('listHash');
+
+    const sameKeyNewIdentity = { ...itemA }; // new object, same key — the calendar pattern
+    expect(sameKeyNewIdentity).not.toBe(itemA);
+    wrapper.setProps({ selected: sameKeyNewIdentity });
+    wrapper.update();
+
+    expect(wrapper.find('RawList0').prop('listHash')).toBe(hashBefore);
+  });
+
+  it('regenerates listHash when the `selected` key changes (re-highlight the applied entry)', () => {
+    const list = fixtures.data1.listData;
+    const wrapper = mount(
+      <SimpleList list={list} selected={list[0]} onSelect={jest.fn()} />
+    );
+    const hashBefore = wrapper.find('RawList0').prop('listHash');
+
+    wrapper.setProps({ selected: list[1] }); // different key
+    wrapper.update();
+
+    expect(wrapper.find('RawList0').prop('listHash')).not.toBe(hashBefore);
+  });
+
+  it('starts unfocused by default (shared consumers unchanged) and focused only when keepFocused is set', () => {
+    const list = fixtures.data1.listData;
+
+    const dflt = mount(
+      <SimpleList list={list} selected={list[0]} onSelect={jest.fn()} />
+    );
+    // calendar dropdowns pass no keepFocused → identical to the previous useState(false)
+    expect(dflt.find('RawList0').prop('isFocused')).toBe(false);
+
+    const kept = mount(
+      <SimpleList list={list} selected={list[0]} onSelect={jest.fn()} keepFocused />
+    );
+    // the email picker opts in → starts focused so it opens on the first click
+    expect(kept.find('RawList0').prop('isFocused')).toBe(true);
   });
 });

--- a/frontend/src/components/email/NewEmail.js
+++ b/frontend/src/components/email/NewEmail.js
@@ -86,6 +86,7 @@ const NewEmail = ({ windowId, docId, handleCloseEmail }) => {
                   list={availableTemplates}
                   onSelect={onTemplateChanged}
                   selected={appliedTemplate}
+                  keepFocused
                 />
               </div>
             )}

--- a/frontend/src/components/widget/List/SimpleList.js
+++ b/frontend/src/components/widget/List/SimpleList.js
@@ -14,11 +14,22 @@ const SimpleList = ({
   onSelect,
   onOpenDropdown,
   className,
+  keepFocused = false,
 }) => {
-  const [isFocused, setIsFocused] = useState(false);
+  // Start focused (opt-in) so the first click only has to toggle the dropdown open
+  // instead of focusing AND toggling in the same tick (which otherwise races the
+  // click-outside handler and swallows the first open). Mirrors the sibling Letter
+  // picker, which is driven with a persistent focused state and opens on first click.
+  const [isFocused, setIsFocused] = useState(keepFocused);
   const [isToggled, setIsToggled] = useState(false);
 
-  const listHash = useMemo(() => uuidv4(), [list]);
+  // Recompute the hash when the list OR the selected entry's key changes, so RawList's
+  // componentDidUpdate re-runs setSelectedValue and re-highlights the applied entry
+  // (it gates on listHash !== prevListHash). Depend on `selected?.key` (value), NOT the
+  // `selected` object identity: consumers that build `selected` as a fresh object literal
+  // each render would otherwise regenerate the hash on every unrelated re-render and
+  // reorder an open dropdown under the cursor.
+  const listHash = useMemo(() => uuidv4(), [list, selected?.key]);
 
   return (
     <RawList
@@ -46,6 +57,7 @@ SimpleList.propTypes = {
   onSelect: PropTypes.func.isRequired,
   onOpenDropdown: PropTypes.func,
   className: PropTypes.string,
+  keepFocused: PropTypes.bool,
 };
 
 export default SimpleList;


### PR DESCRIPTION
## What

The email-template dropdown in the Email dialog opened only after the third click, and did not reflect the currently-applied template. This fixes both so the picker behaves like a normal dropdown: opens on the first click, highlights the applied template, and re-opens reliably — matching the already-correct Letter dialog.

## Why

The picker is `SimpleList` (a wrapper around the shared `RawList`). Two defects:

1. **First-click open.** `SimpleList` started unfocused (`isFocused: useState(false)`), so the first click had to focus *and* toggle the dropdown in the same tick, which raced the click-outside handler and swallowed the open. The sibling Letter picker (`NewLetter`) drives `RawList` with a persistent focused state (`listFocused: true`) and opens on the first click.
2. **Applied template not highlighted.** `listHash` was memoized on `[list]` only, so when `selected` changed but the list reference stayed the same, `RawList.componentDidUpdate` never re-ran `setSelectedValue` (it gates on `listHash !== prevListHash`).

## How

Confined to `SimpleList` + its email caller — the shared `RawList` is untouched:

- `SimpleList`: new **opt-in** prop `keepFocused` (default `false`) → `useState(keepFocused)` for `isFocused`, mirroring `NewLetter`'s persistent focused state. `NewEmail` passes `keepFocused`; the calendar consumers (`SimulationsDropDown`, `ResourcesDropDown`) do **not**, so their behaviour is unchanged (no focus-steal on mount).
- `SimpleList`: add `selected` to the `listHash` `useMemo` deps so the applied entry is re-highlighted.
- `RawList.js` deliberately **not** changed — in particular the `RawList.js:151-155` focus guard (kept removed for the GL-Journal/SAP batch-entry case) is **not** reintroduced.

## Tests

- **jest** `frontend/src/__tests__/components/widget/List/SimpleList.test.js` — fails before the fix (stale highlighted selection), passes after. Full frontend jest suite green (324 tests), lint 0 errors.
- **Playwright** `e2e/frontend-webui/tests/spec/email-letter-dialog.spec.js` — new "Email template picker opens on the first click": opens the Email dialog on a Sales Order, single-clicks the picker, asserts the list opens *and stays open* (settle-delay re-check to avoid a flash false-green), then re-opens and asserts the applied template is highlighted. Uses the standard preloaded boilerplate (readable by the WEBUI role) — no seeding needed.

### Test infra — mailbox seeding so the picker E2E runs in CI

The Email dialog only opens when the tenant has a mailbox configured (`createEmail` asserts `MailService.findMailbox`; `NewEmail` auto-closes on failure), and the generic e2e tenant ships none. So this PR extends the **frontend-testing masterdata API** with a `mailboxes` section (`CreateMailboxCommand`): it **get-or-creates** an `AD_MailBox` (SMTP, no auth) + a wildcard `AD_MailConfig` routing for the tenant — keyed on a stable email/client, so the shared e2e DB never accumulates duplicate mailbox rows (which would also break `findMailbox`). No mail is sent. With that, the picker E2E opens the dialog and asserts first-click-open **in CI**. (Product fix stays frontend-only; this is test infrastructure.)
