### PR TITLE
Untrack accidental Claude-config symlinks (REVIEW.md, docs/manual, docs/documentation-naming.md)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,1 +1,0 @@
-/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/REVIEW.md

--- a/docs/documentation-naming.md
+++ b/docs/documentation-naming.md
@@ -1,1 +1,0 @@
-/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/docs/documentation-naming.md

--- a/docs/manual
+++ b/docs/manual
@@ -1,1 +1,0 @@
-/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/docs/manual


### PR DESCRIPTION
## What

Remove three paths from version control in the `new_dawn_uat` branch:

- `REVIEW.md`
- `docs/documentation-naming.md`
- `docs/manual`

All three are tracked as **symlinks** (git mode `120000`) whose target is an absolute, per-developer path:

```
/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/...
```

They are machine-local Claude-config links created by `install-claude-config.sh` and were committed by accident. They should never be version-controlled.

## Why

On Windows clones (`core.symlinks=false`) git cannot materialize a committed symlink, so it writes each one as a **plain text file containing the target path**. As a result `install-claude-config.sh`:

- does not recognize them as symlinks (`[ -L ]` is false), so it prompts to back up + replace **on every run**, and
- after it creates a real native symlink, leaves those paths **permanently dirty** in `git status`.

Any `git checkout`/`reset`/`restore` restores the tracked plain-text version, so the installer prompt recurs indefinitely.

## Notes

- No `.gitignore` change is required: all three are already covered by existing rules (`**/REVIEW.md` and `/docs/`). They only persisted because ignore rules do not apply to already-tracked paths. Once untracked, git will not re-add them.
- This removes the paths going forward. The blobs still exist in history; scrubbing them from history would require rewriting published history and is intentionally out of scope here.
- The same three paths may be present on other base branches (they arrived here via a merge). Propagation, if wanted, can be handled separately.
