### PR TITLE
Untrack accidental Claude-config symlinks (REVIEW.md, docs/manual, docs/documentation-naming.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,8 @@ act_output_*.txt
 nul
 
 /mcp-scripts/**/*
+
+# Claude-config links (created by install-claude-config.sh; must not be tracked)
+/REVIEW.md
+/docs/documentation-naming.md
+/docs/manual

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,1 +1,0 @@
-/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/REVIEW.md

--- a/docs/documentation-naming.md
+++ b/docs/documentation-naming.md
@@ -1,1 +1,0 @@
-/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/docs/documentation-naming.md

--- a/docs/manual
+++ b/docs/manual
@@ -1,1 +1,0 @@
-/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/docs/manual


### PR DESCRIPTION
## What

Remove three accidentally-committed Claude-config symlinks:

- `REVIEW.md`
- `docs/documentation-naming.md`
- `docs/manual`

All three are tracked as **symlinks** (git mode `120000`) targeting an absolute, per-developer path:

```
/home/tobi/work/mf15-ai-dev-support/claude/metasfresh/...
```

They are machine-local links created by `install-claude-config.sh` and were committed by accident. They should never be version-controlled.

## Why

On Windows clones (`core.symlinks=false`) git cannot materialize a committed symlink, so it writes each one as a plain text file containing the target path. `install-claude-config.sh` then does not recognize them as symlinks, prompts to back up + replace **on every run**, and leaves those paths **permanently dirty** in `git status`.

This `intensive_care` branch group is the source from which the same three entries reached `new_dawn_uat` (removed there in #25076).

## Notes

- Unlike `new_dawn_uat`, this branch group has no `**/REVIEW.md` / `/docs/` ignore rules, so this PR also adds a small `.gitignore` block for the three specific paths to stop them being re-added. (A narrow, anchored block — it does not touch the real `docs/architecture/…` content.)
- This removes the paths going forward; the blobs remain in history (scrubbing history would require rewriting published history and is out of scope).
