### PR TITLE
async poll — skip empty re-fetch + use idx_queue_workpackage_polling

### DIFF
--- a/backend/de.metas.async/pom.xml
+++ b/backend/de.metas.async/pom.xml
@@ -56,6 +56,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>${mockito.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/backend/de.metas.async/src/main/java/de/metas/async/processor/impl/planner/QueueProcessorPlanner.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/processor/impl/planner/QueueProcessorPlanner.java
@@ -293,6 +293,12 @@ public abstract class QueueProcessorPlanner implements Runnable
 			final int lockedCount = query.updateDirectly(workPackageUpdater);
 			logger.debug("Locked {} workpackages for queueProcessor {} with queueProcessorId={}", lockedCount, queueProcessor.getName(), queueProcessor.getQueueProcessorId());
 
+			if (lockedCount == 0)
+			{
+				// nothing claimed => nothing this processor could re-fetch; skip the (otherwise wasted) re-fetch query
+				continue;
+			}
+
 			// Execute query - returns successfully locked rows only
 			final List<I_C_Queue_WorkPackage> workPackages = queryBL.createQueryBuilder(I_C_Queue_WorkPackage.class)
 					.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_LockedAt, now)

--- a/backend/de.metas.async/src/main/java/de/metas/async/processor/impl/planner/QueueProcessorPlanner.java
+++ b/backend/de.metas.async/src/main/java/de/metas/async/processor/impl/planner/QueueProcessorPlanner.java
@@ -303,6 +303,9 @@ public abstract class QueueProcessorPlanner implements Runnable
 			final List<I_C_Queue_WorkPackage> workPackages = queryBL.createQueryBuilder(I_C_Queue_WorkPackage.class)
 					.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_LockedAt, now)
 					.addInArrayFilter(I_C_Queue_WorkPackage.COLUMNNAME_C_Queue_PackageProcessor_ID, queueProcessor.getAssignedPackageProcessorIds())
+					.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_Processed, false)
+					.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_IsError, false)
+					.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_IsReadyForProcessing, true)
 					.orderBy(I_C_Queue_WorkPackage.COLUMNNAME_C_Queue_WorkPackage_ID)
 					.list();
 

--- a/backend/de.metas.async/src/test/java/de/metas/async/processor/impl/planner/QueueProcessorPlanner_PollGuardTest.java
+++ b/backend/de.metas.async/src/test/java/de/metas/async/processor/impl/planner/QueueProcessorPlanner_PollGuardTest.java
@@ -78,6 +78,38 @@ public class QueueProcessorPlanner_PollGuardTest extends QueueProcessorTestBase
 	}
 
 	@Test
+	public void refetch_still_returns_claimed_package_with_predicates()
+	{
+		final I_C_Queue_PackageProcessor packageProcessorDef = helper.createPackageProcessor(ctx, StaticMockedWorkpackageProcessor.class);
+		final I_C_Queue_Processor queueProcessorDef = helper.createQueueProcessor(StaticMockedWorkpackageProcessor.class.getName(), 1, 1000);
+		helper.assignPackageProcessor(queueProcessorDef, packageProcessorDef);
+
+		final IWorkPackageQueue workpackageQueue = Services.get(IWorkPackageQueueFactory.class).getQueueForEnqueuing(ctx, StaticMockedWorkpackageProcessor.class);
+
+		final List<I_C_Queue_WorkPackage> workpackages = helper.createAndEnqueueWorkpackages(workpackageQueue, 1, true); // markReadyForProcessing=true
+		final I_C_Queue_WorkPackage workpackage = workpackages.get(0);
+
+		final MockedWorkpackageProcessor workpackageProcessor = StaticMockedWorkpackageProcessor.getMockedWorkpackageProcessor();
+		workpackageProcessor.setDefaultResult(Result.SUCCESS);
+
+		final IQueueProcessor processor = helper.newSynchronousQueueProcessor(workpackageQueue);
+		SynchronousProcessorPlanner.executeNow(processor);
+
+		// the just-claimed row (Processed='N', IsError='N', IsReadyForProcessing='Y' at claim time) must still be
+		// returned by the re-fetch (and thus processed) even after the new predicates are added to that query
+		final List<I_C_Queue_WorkPackage> processedWorkpackages = workpackageProcessor.getProcessedWorkpackages();
+		assertThat(processedWorkpackages)
+				.extracting(I_C_Queue_WorkPackage::getC_Queue_WorkPackage_ID)
+				.containsExactly(workpackage.getC_Queue_WorkPackage_ID());
+
+		InterfaceWrapperHelper.refresh(workpackage);
+		assertThat(workpackage.isProcessed()).as("workpackage shall be processed").isTrue();
+		assertThat(workpackage.isError()).as("workpackage shall not be in error").isFalse();
+
+		helper.assertNothingLocked();
+	}
+
+	@Test
 	public void ready_packages_processed_exactly_once_in_priority_order()
 	{
 		final I_C_Queue_PackageProcessor packageProcessorDef = helper.createPackageProcessor(ctx, StaticMockedWorkpackageProcessor.class);

--- a/backend/de.metas.async/src/test/java/de/metas/async/processor/impl/planner/QueueProcessorPlanner_PollGuardTest.java
+++ b/backend/de.metas.async/src/test/java/de/metas/async/processor/impl/planner/QueueProcessorPlanner_PollGuardTest.java
@@ -1,0 +1,124 @@
+/*
+ * #%L
+ * de.metas.async
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.async.processor.impl.planner;
+
+import de.metas.async.QueueProcessorTestBase;
+import de.metas.async.api.IWorkPackageQueue;
+import de.metas.async.model.I_C_Queue_PackageProcessor;
+import de.metas.async.model.I_C_Queue_Processor;
+import de.metas.async.model.I_C_Queue_WorkPackage;
+import de.metas.async.model.X_C_Queue_WorkPackage;
+import de.metas.async.processor.IQueueProcessor;
+import de.metas.async.processor.IWorkPackageQueueFactory;
+import de.metas.async.processor.impl.MockedWorkpackageProcessor;
+import de.metas.async.processor.impl.StaticMockedWorkpackageProcessor;
+import de.metas.async.spi.IWorkpackageProcessor.Result;
+import de.metas.util.Services;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * The async poll re-fetch used to run on every poll tick, even when the claim
+ * ({@code query.updateDirectly(...)}) locked nothing. This test proves the {@code lockedCount == 0} guard skips
+ * that re-fetch, and the sibling test proves the guard does not change behaviour for a productive poll.
+ */
+public class QueueProcessorPlanner_PollGuardTest extends QueueProcessorTestBase
+{
+	@Test
+	public void refetch_is_skipped_when_nothing_claimed()
+	{
+		final I_C_Queue_PackageProcessor packageProcessorDef = helper.createPackageProcessor(ctx, StaticMockedWorkpackageProcessor.class);
+		final I_C_Queue_Processor queueProcessorDef = helper.createQueueProcessor(StaticMockedWorkpackageProcessor.class.getName(), 1, 1000);
+		helper.assignPackageProcessor(queueProcessorDef, packageProcessorDef);
+
+		final IWorkPackageQueue workpackageQueue = Services.get(IWorkPackageQueueFactory.class).getQueueForEnqueuing(ctx, StaticMockedWorkpackageProcessor.class);
+		// note: NO workpackages enqueued -> the claim (updateDirectly) will lock 0 rows
+
+		// register a spy wrapping the real IQueryBL, BEFORE the planner is constructed, so the planner's own
+		// `queryBL` field (a plain `Services.get(IQueryBL.class)` eager field) picks up the spy. Pre-existing
+		// singletons (e.g. the queue DAO) already hold the real instance and are unaffected, so this only
+		// observes calls made by the planner itself.
+		final IQueryBL realQueryBL = Services.get(IQueryBL.class);
+		final IQueryBL queryBLSpy = Mockito.spy(realQueryBL);
+		Services.registerService(IQueryBL.class, queryBLSpy);
+
+		final IQueueProcessor processor = helper.newSynchronousQueueProcessor(workpackageQueue);
+		SynchronousProcessorPlanner.executeNow(processor);
+
+		// the re-fetch builder must never be invoked when nothing was claimed
+		verify(queryBLSpy, never()).createQueryBuilder(I_C_Queue_WorkPackage.class);
+	}
+
+	@Test
+	public void ready_packages_processed_exactly_once_in_priority_order()
+	{
+		final I_C_Queue_PackageProcessor packageProcessorDef = helper.createPackageProcessor(ctx, StaticMockedWorkpackageProcessor.class);
+		final I_C_Queue_Processor queueProcessorDef = helper.createQueueProcessor(StaticMockedWorkpackageProcessor.class.getName(), 1, 1000);
+		helper.assignPackageProcessor(queueProcessorDef, packageProcessorDef);
+
+		final IWorkPackageQueue workpackageQueue = Services.get(IWorkPackageQueueFactory.class).getQueueForEnqueuing(ctx, StaticMockedWorkpackageProcessor.class);
+
+		final List<I_C_Queue_WorkPackage> workpackages = helper.createAndEnqueueWorkpackages(workpackageQueue, 3, true); // markReadyForProcessing=true
+
+		// assign distinct priorities, out of creation order, so processing order proves priority-based ordering
+		workpackages.get(0).setPriority(X_C_Queue_WorkPackage.PRIORITY_Low);
+		InterfaceWrapperHelper.save(workpackages.get(0));
+		workpackages.get(1).setPriority(X_C_Queue_WorkPackage.PRIORITY_Urgent);
+		InterfaceWrapperHelper.save(workpackages.get(1));
+		workpackages.get(2).setPriority(X_C_Queue_WorkPackage.PRIORITY_Medium);
+		InterfaceWrapperHelper.save(workpackages.get(2));
+
+		final MockedWorkpackageProcessor workpackageProcessor = StaticMockedWorkpackageProcessor.getMockedWorkpackageProcessor();
+		workpackageProcessor.setDefaultResult(Result.SUCCESS);
+
+		final IQueueProcessor processor = helper.newSynchronousQueueProcessor(workpackageQueue);
+		SynchronousProcessorPlanner.executeNow(processor);
+
+		final List<I_C_Queue_WorkPackage> processedWorkpackages = workpackageProcessor.getProcessedWorkpackages();
+
+		// exactly once each (MockedWorkpackageProcessor itself asserts no double-processing), and in Priority order
+		assertThat(processedWorkpackages)
+				.extracting(I_C_Queue_WorkPackage::getC_Queue_WorkPackage_ID)
+				.containsExactly(
+						workpackages.get(1).getC_Queue_WorkPackage_ID(), // Urgent = "1"
+						workpackages.get(2).getC_Queue_WorkPackage_ID(), // Medium = "5"
+						workpackages.get(0).getC_Queue_WorkPackage_ID()); // Low = "7"
+
+		for (final I_C_Queue_WorkPackage wp : workpackages)
+		{
+			InterfaceWrapperHelper.refresh(wp);
+			assertThat(wp.isProcessed()).as("wp %s shall be processed", wp.getC_Queue_WorkPackage_ID()).isTrue();
+			assertThat(wp.isError()).as("wp %s shall not be in error", wp.getC_Queue_WorkPackage_ID()).isFalse();
+		}
+
+		helper.assertNothingLocked();
+	}
+}


### PR DESCRIPTION
## What

Two surgical edits in `QueueProcessorPlanner.pollAndLockWorkPackages()` (`de.metas.async`) that stop the async work-package poll from dominating DB CPU. No persistence-core change, no migration, no new index.

1. **Guard** — `if (lockedCount == 0) { continue; }` after the claim UPDATE: skips the re-fetch SELECT when the claim locked nothing (~97% of poll ticks fleet-wide).
2. **Index reuse** — add `Processed='N' / IsError='N' / IsReadyForProcessing='Y'` to the re-fetch builder so it uses the already-deployed partial index `idx_queue_workpackage_polling` instead of a Parallel Seq Scan of `C_Queue_WorkPackage`.

## Why

Live read-only diagnostics on 3 PROD instances (2026-07-10/11) proved the re-fetch-after-claim SELECT is **88–98% of total DB time** fleet-wide (spavetti: 97.59%), because no index matched its WHERE and it seq-scanned the 245 MB / 711k-row table on every tick. 96.5–97.7% of those polls return 0 rows. On spavetti the guard alone removes ~94.6% of total DB CPU; guard + index removes essentially all of the re-fetch cost.

Root cause is a production-latent defect in the recent `LockedAt` poll-and-lock scheme — affects any high-throughput instance, not just sp80.

## Behaviour

Output-identical: each work package still claimed exactly once, in `Priority, C_Queue_WorkPackage_ID` order. The claim query always sets `Processed='N'/IsReadyForProcessing='Y'/IsError='N'`, so the three new re-fetch predicates are an exact subset of the claim predicates — a just-claimed row can never be dropped.

## Tests

New `QueueProcessorPlanner_PollGuardTest` (de.metas.async): RED→GREEN guard test (re-fetch skipped on zero-lock), a parity test (exactly-once + priority order), and a correctness test (just-claimed row still returned with the new predicates). Full `de.metas.async` unit suite green. No existing test weakened.

Live `EXPLAIN` (index-reuse proof) and post-rollout `pg_stat_statements` (DB-time collapse) are the human-run verification steps.

Issue: https://github.com/metasfresh/me03/issues/30639
