### PR TITLE
Mobile UI: workstation scan re-switches the active workplace (scan-and-go) + show current active workplace

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommand.java
@@ -79,6 +79,8 @@ public class CreateMasterdataCommand
 		final ImmutableMap<String, JsonWarehouseResponse> warehouses = createWarehouses();
 		final ImmutableMap<String, JsonPickingSlotCreateResponse> pickingSlots = createPickingSlots();
 		final ImmutableMap<String, JsonWorkplaceResponse> workplaces = createWorkplaces();
+		// Resources must be created AFTER workplaces: a workstation resource may reference a workplace
+		// by identifier (JsonCreateResourceRequest.workplace), resolved from the context populated here.
 		final ImmutableMap<String, JsonCreateResourceResponse> resources = createResources();
 		final ImmutableMap<String, JsonCreateProductPlanningResponse> productPlannings = createProductPlannings();
 		final Map<String, JsonPackingInstructionsResponse> packingInstructions = createPackingInstructions();

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommand.java
@@ -76,10 +76,10 @@ public class CreateMasterdataCommand
 		final ImmutableMap<String, JsonLoginUserResponse> login = createLoginUsers();
 		final ImmutableMap<String, JsonCreateBPartnerResponse> bpartners = createBPartners();
 		final ImmutableMap<String, JsonCreateProductResponse> products = createProducts();
-		final ImmutableMap<String, JsonCreateResourceResponse> resources = createResources();
 		final ImmutableMap<String, JsonWarehouseResponse> warehouses = createWarehouses();
 		final ImmutableMap<String, JsonPickingSlotCreateResponse> pickingSlots = createPickingSlots();
 		final ImmutableMap<String, JsonWorkplaceResponse> workplaces = createWorkplaces();
+		final ImmutableMap<String, JsonCreateResourceResponse> resources = createResources();
 		final ImmutableMap<String, JsonCreateProductPlanningResponse> productPlannings = createProductPlannings();
 		final Map<String, JsonPackingInstructionsResponse> packingInstructions = createPackingInstructions();
 		final JsonMobileConfigResponse mobileConfig = createMobileConfiguration();

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/resource/CreateResourceCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/resource/CreateResourceCommand.java
@@ -5,6 +5,7 @@ import de.metas.frontend_testing.masterdata.MasterdataContext;
 import de.metas.material.planning.ManufacturingResourceType;
 import de.metas.product.ResourceId;
 import de.metas.resource.ResourceTypeId;
+import de.metas.resource.qrcode.ResourceQRCode;
 import de.metas.workplace.WorkplaceId;
 import lombok.Builder;
 import lombok.NonNull;
@@ -48,6 +49,8 @@ public class CreateResourceCommand
 		context.putIdentifier(identifier, resourceId);
 
 		return JsonCreateResourceResponse.builder()
+				.name(record.getName())
+				.qrCode(ResourceQRCode.ofResource(record).toGlobalQRCodeJsonString())
 				.build();
 	}
 }

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/resource/CreateResourceCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/resource/CreateResourceCommand.java
@@ -5,6 +5,7 @@ import de.metas.frontend_testing.masterdata.MasterdataContext;
 import de.metas.material.planning.ManufacturingResourceType;
 import de.metas.product.ResourceId;
 import de.metas.resource.ResourceTypeId;
+import de.metas.workplace.WorkplaceId;
 import lombok.Builder;
 import lombok.NonNull;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -35,6 +36,12 @@ public class CreateResourceCommand
 		record.setIsManufacturingResource(true);
 		record.setManufacturingResourceType(manufacturingResourceType.getCode());
 		record.setPlanningHorizon(365);
+
+		if (request.getWorkplace() != null)
+		{
+			final WorkplaceId workplaceId = context.getId(request.getWorkplace(), WorkplaceId.class);
+			record.setC_Workplace_ID(workplaceId.getRepoId());
+		}
 
 		InterfaceWrapperHelper.save(record);
 		final ResourceId resourceId = ResourceId.ofRepoId(record.getS_Resource_ID());

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/resource/JsonCreateResourceRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/resource/JsonCreateResourceRequest.java
@@ -1,5 +1,6 @@
 package de.metas.frontend_testing.masterdata.resource;
 
+import de.metas.frontend_testing.masterdata.Identifier;
 import de.metas.resource.ResourceTypeId;
 import lombok.Builder;
 import lombok.NonNull;
@@ -15,4 +16,5 @@ public class JsonCreateResourceRequest
 {
 	@NonNull String type;
 	@Nullable ResourceTypeId resourceTypeId;
+	@Nullable Identifier workplace;
 }

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/resource/JsonCreateResourceResponse.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/resource/JsonCreateResourceResponse.java
@@ -1,6 +1,7 @@
 package de.metas.frontend_testing.masterdata.resource;
 
 import lombok.Builder;
+import lombok.NonNull;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
@@ -9,4 +10,6 @@ import lombok.extern.jackson.Jacksonized;
 @Jacksonized
 public class JsonCreateResourceResponse
 {
+	@NonNull String name;
+	@NonNull String qrCode;
 }

--- a/backend/de.metas.frontend-testing/src/test/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommandTest.java
+++ b/backend/de.metas.frontend-testing/src/test/java/de/metas/frontend_testing/masterdata/CreateMasterdataCommandTest.java
@@ -14,12 +14,18 @@ import de.metas.frontend_testing.masterdata.picking_slot.JsonPickingSlotCreateRe
 import de.metas.frontend_testing.masterdata.pp_order.JsonPPOrderRequest;
 import de.metas.frontend_testing.masterdata.product.JsonCreateProductRequest;
 import de.metas.frontend_testing.masterdata.product_planning.JsonCreateProductPlanningRequest;
+import de.metas.frontend_testing.masterdata.resource.CreateResourceCommand;
 import de.metas.frontend_testing.masterdata.resource.JsonCreateResourceRequest;
+import de.metas.frontend_testing.masterdata.resource.JsonCreateResourceResponse;
 import de.metas.frontend_testing.masterdata.sales_order.JsonSalesOrderCreateRequest;
 import de.metas.frontend_testing.masterdata.user.JsonLoginUserRequest;
 import de.metas.frontend_testing.masterdata.warehouse.JsonWarehouseRequest;
 import de.metas.frontend_testing.masterdata.workplace.JsonWorkplaceRequest;
+import de.metas.product.ResourceId;
+import de.metas.workplace.WorkplaceId;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_S_Resource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -352,5 +358,36 @@ public class CreateMasterdataCommandTest
 		assertThat(response.getLogin()).isEmpty();
 		assertThat(response.getBpartners()).isEmpty();
 		assertThat(response.getProducts()).isEmpty();
+	}
+
+	@Test
+	public void createResourceCommand_withWorkplaceReference_shouldSetC_Workplace_IDOnResource()
+	{
+		// given
+		final MasterdataContext context = new MasterdataContext();
+		final Identifier workplaceIdentifier = Identifier.ofString("wp1");
+		final WorkplaceId workplaceId = WorkplaceId.ofRepoId(540500);
+		context.putIdentifier(workplaceIdentifier, workplaceId);
+
+		final JsonCreateResourceRequest request = JsonCreateResourceRequest.builder()
+				.type("WS")
+				.workplace(workplaceIdentifier)
+				.build();
+
+		final Identifier resourceIdentifier = Identifier.ofString("ws1");
+		final CreateResourceCommand command = CreateResourceCommand.builder()
+				.context(context)
+				.request(request)
+				.identifier(resourceIdentifier)
+				.build();
+
+		// when
+		final JsonCreateResourceResponse response = command.execute();
+
+		// then
+		assertThat(response).isNotNull();
+		final ResourceId resourceId = context.getId(resourceIdentifier, ResourceId.class);
+		final I_S_Resource resource = InterfaceWrapperHelper.load(resourceId, I_S_Resource.class);
+		assertThat(resource.getC_Workplace_ID()).isEqualTo(workplaceId.getRepoId());
 	}
 }

--- a/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
@@ -46,9 +46,10 @@ test('Re-scanning an already-assigned workstation must re-switch a drifted activ
 
     await test.step('Scan workstation WS1 (linked to workplace A) -> auto-assigned, active workplace = A', async () => {
         await WorkstationManagerScreen.scanWorkstation(masterdata.resources.WS1.qrCode);
-        // Scan-and-go (mirrors the workplace app): the scan itself assigns the workstation, so the
-        // operator never taps a separate Assign button — it is already hidden.
-        await WorkstationManagerScreen.expectAssignButtonNotVisible();
+        // Scan-and-go (mirrors the workplace app): the scan itself assigns the workstation and sets the
+        // operator's active workplace to the linked one (A) — no separate Assign tap. The screen reflects it.
+        await WorkstationManagerScreen.expectCurrentWorkstation(masterdata.resources.WS1.name);
+        await WorkstationManagerScreen.expectCurrentWorkplace(masterdata.workplaces.wpA.name);
         await WorkstationManagerScreen.goBack();
     });
 

--- a/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
@@ -1,0 +1,72 @@
+import { test } from "../../../playwright.config";
+import { expect } from "@playwright/test";
+import { allure } from 'allure-playwright';
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { WorkstationManagerScreen } from "../../utils/screens/workstationManager/WorkstationManagerScreen";
+import { WorkplaceManagerScreen } from "../../utils/screens/workplaceManager/WorkplaceManagerScreen";
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            // No workplace preassigned to the login user — the operator's active workplace is
+            // established purely by scanning, which is exactly what this scenario drives.
+            login: { user: { language: "en_US" } },
+            warehouses: {
+                whA: {},
+                whB: {},
+            },
+            workplaces: {
+                wpA: { warehouse: 'whA' },
+                wpB: { warehouse: 'whB' },
+            },
+            resources: {
+                // WS1 is a workstation statically linked to workplace A.
+                WS1: { type: 'WS', workplace: 'wpA' },
+            },
+        }
+    });
+}
+
+// noinspection JSUnusedLocalSymbols
+test('Re-scanning an already-assigned workstation must re-switch a drifted active workplace', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0160: Manufacturing Execution');
+    allure.tag('F8046: Workstation');
+    allure.tag('F8046');  // Standalone tag for Tags section;
+    allure.story('Scanning a workstation re-assigns the operator to its linked workplace');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await test.step('Scan workstation WS1 (linked to workplace A) and assign it -> active workplace = A', async () => {
+        await ApplicationsListScreen.startApplication('workstationManager');
+        await WorkstationManagerScreen.scanWorkstation(masterdata.resources.WS1.qrCode);
+        await WorkstationManagerScreen.clickAssignButton();
+        await WorkstationManagerScreen.goBack();
+    });
+
+    await test.step('Scan workplace B directly -> active workplace drifts to B', async () => {
+        await ApplicationsListScreen.startApplication('workplaceManager');
+        await WorkplaceManagerScreen.scanWorkplace(masterdata.workplaces.wpB.qrCode);
+        await WorkplaceManagerScreen.goBack();
+    });
+
+    await test.step('Re-scan workstation WS1 -> the operator\'s active workplace must switch back to A', async () => {
+        await ApplicationsListScreen.startApplication('workstationManager');
+        await WorkstationManagerScreen.scanWorkstation(masterdata.resources.WS1.qrCode);
+
+        // Decisive assertion: NOT the workstation SCREEN's statically-linked workplace (always A,
+        // would not catch this bug) — the operator's ACTUAL active workplace, read from the system
+        // of record (Backend.getCurrentWorkplace, backed by the same /api/v2/workplace endpoint the
+        // app itself reads its current workplace from).
+        const { assignedWorkplace } = await Backend.getCurrentWorkplace();
+        // TODO(controller): confirm assignedWorkplace field shape at run-time (.name vs .caption vs .id)
+        expect(assignedWorkplace?.name).toBe(masterdata.workplaces.wpA.name);
+    });
+});

--- a/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
@@ -60,7 +60,7 @@ test('Re-scanning an already-assigned workstation must re-switch a drifted activ
     await test.step('Re-scan workstation WS1 -> the operator\'s active workplace must switch back to A', async () => {
         await WorkstationManagerScreen.scanWorkstation(masterdata.resources.WS1.qrCode);
 
-        // AC3 — the screen shows the operator's current workstation and current active workplace,
+        // The screen shows the operator's current workstation and current active workplace,
         // so any drift is visible. After the re-scan the active workplace is back on A.
         await WorkstationManagerScreen.expectCurrentWorkstation(masterdata.resources.WS1.name);
         await WorkstationManagerScreen.expectCurrentWorkplace(masterdata.workplaces.wpA.name);
@@ -70,8 +70,8 @@ test('Re-scanning an already-assigned workstation must re-switch a drifted activ
         // of record (Backend.getCurrentWorkplace, backed by the same /api/v2/workplace endpoint the
         // app itself reads its current workplace from).
         const { assignedWorkplace } = await Backend.getCurrentWorkplace();
-        // assignedWorkplace.name is the workplace name (confirmed at run-time). RED proof: on the
-        // current (unfixed) code this reads wpB (the drifted workplace) — the re-scan did NOT re-assign.
+        // The re-scan must re-assign the workstation and switch the active workplace back to A; a
+        // read-only scan leaves it on the drifted workplace B and this assertion fails.
         expect(assignedWorkplace?.name).toBe(masterdata.workplaces.wpA.name);
     });
 });

--- a/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
@@ -44,9 +44,11 @@ test('Re-scanning an already-assigned workstation must re-switch a drifted activ
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
 
-    await test.step('Scan workstation WS1 (linked to workplace A) and assign it -> active workplace = A', async () => {
+    await test.step('Scan workstation WS1 (linked to workplace A) -> auto-assigned, active workplace = A', async () => {
         await WorkstationManagerScreen.scanWorkstation(masterdata.resources.WS1.qrCode);
-        await WorkstationManagerScreen.clickAssignButton();
+        // Scan-and-go (mirrors the workplace app): the scan itself assigns the workstation, so the
+        // operator never taps a separate Assign button — it is already hidden.
+        await WorkstationManagerScreen.expectAssignButtonNotVisible();
         await WorkstationManagerScreen.goBack();
     });
 
@@ -57,6 +59,11 @@ test('Re-scanning an already-assigned workstation must re-switch a drifted activ
 
     await test.step('Re-scan workstation WS1 -> the operator\'s active workplace must switch back to A', async () => {
         await WorkstationManagerScreen.scanWorkstation(masterdata.resources.WS1.qrCode);
+
+        // AC3 — the screen shows the operator's current workstation and current active workplace,
+        // so any drift is visible. After the re-scan the active workplace is back on A.
+        await WorkstationManagerScreen.expectCurrentWorkstation(masterdata.resources.WS1.name);
+        await WorkstationManagerScreen.expectCurrentWorkplace(masterdata.workplaces.wpA.name);
 
         // Decisive assertion: NOT the workstation SCREEN's statically-linked workplace (always A,
         // would not catch this bug) — the operator's ACTUAL active workplace, read from the system

--- a/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
@@ -45,20 +45,17 @@ test('Re-scanning an already-assigned workstation must re-switch a drifted activ
     await ApplicationsListScreen.expectVisible();
 
     await test.step('Scan workstation WS1 (linked to workplace A) and assign it -> active workplace = A', async () => {
-        await ApplicationsListScreen.startApplication('workstationManager');
         await WorkstationManagerScreen.scanWorkstation(masterdata.resources.WS1.qrCode);
         await WorkstationManagerScreen.clickAssignButton();
         await WorkstationManagerScreen.goBack();
     });
 
     await test.step('Scan workplace B directly -> active workplace drifts to B', async () => {
-        await ApplicationsListScreen.startApplication('workplaceManager');
         await WorkplaceManagerScreen.scanWorkplace(masterdata.workplaces.wpB.qrCode);
         await WorkplaceManagerScreen.goBack();
     });
 
     await test.step('Re-scan workstation WS1 -> the operator\'s active workplace must switch back to A', async () => {
-        await ApplicationsListScreen.startApplication('workstationManager');
         await WorkstationManagerScreen.scanWorkstation(masterdata.resources.WS1.qrCode);
 
         // Decisive assertion: NOT the workstation SCREEN's statically-linked workplace (always A,
@@ -66,7 +63,8 @@ test('Re-scanning an already-assigned workstation must re-switch a drifted activ
         // of record (Backend.getCurrentWorkplace, backed by the same /api/v2/workplace endpoint the
         // app itself reads its current workplace from).
         const { assignedWorkplace } = await Backend.getCurrentWorkplace();
-        // TODO(controller): confirm assignedWorkplace field shape at run-time (.name vs .caption vs .id)
+        // assignedWorkplace.name is the workplace name (confirmed at run-time). RED proof: on the
+        // current (unfixed) code this reads wpB (the drifted workplace) — the re-scan did NOT re-assign.
         expect(assignedWorkplace?.name).toBe(masterdata.workplaces.wpA.name);
     });
 });

--- a/e2e/mobile-webui/tests/utils/screens/Backend.js
+++ b/e2e/mobile-webui/tests/utils/screens/Backend.js
@@ -80,7 +80,15 @@ export const Backend = {
     // statically-linked workplace (which never drifts and would not catch a re-assign bug).
     getCurrentWorkplace: async () => await test.step(`Backend: get current workplace`, async () => {
         const backendBaseUrl = await getBackendBaseUrl();
-        const response = await page.request.get(`${backendBaseUrl}/workplace`);
+        // The mobile REST API authenticates via the login token header (not a browser cookie),
+        // so page.request must carry it explicitly — same token the logged-in UI uses.
+        const token = testContext.lastMasterdata?.login?.user?.token;
+        if (!token) {
+            throw new Error('No login token in masterdata:\n' + JSON.stringify(testContext.lastMasterdata, null, 2));
+        }
+        const response = await page.request.get(`${backendBaseUrl}/workplace`, {
+            headers: { 'Authorization': token },
+        });
         const responseBody = await response.json();
         assertNoErrors({ responseBody });
         return responseBody;

--- a/e2e/mobile-webui/tests/utils/screens/Backend.js
+++ b/e2e/mobile-webui/tests/utils/screens/Backend.js
@@ -82,12 +82,8 @@ export const Backend = {
         const backendBaseUrl = await getBackendBaseUrl();
         // The mobile REST API authenticates via the login token header (not a browser cookie),
         // so page.request must carry it explicitly — same token the logged-in UI uses.
-        const token = testContext.lastMasterdata?.login?.user?.token;
-        if (!token) {
-            throw new Error('No login token in masterdata:\n' + JSON.stringify(testContext.lastMasterdata, null, 2));
-        }
         const response = await page.request.get(`${backendBaseUrl}/workplace`, {
-            headers: { 'Authorization': token },
+            headers: { 'Authorization': getAuthToken() },
         });
         const responseBody = await response.json();
         assertNoErrors({ responseBody });
@@ -156,9 +152,9 @@ const assertNoErrors = ({ responseBody }) => {
 };
 
 const getAuthToken = () => {
-    const token = lastMasterdata?.login?.user?.token;
+    const token = testContext.lastMasterdata?.login?.user?.token;
     if (!token) {
-        throw new Error('No token found in masterdata:\n' + JSON.stringify(lastMasterdata, null, 2));
+        throw new Error('No token found in masterdata:\n' + JSON.stringify(testContext.lastMasterdata, null, 2));
     }
     return token;
 }

--- a/e2e/mobile-webui/tests/utils/screens/Backend.js
+++ b/e2e/mobile-webui/tests/utils/screens/Backend.js
@@ -74,6 +74,18 @@ export const Backend = {
         }
     }),
 
+    // Returns the operator's CURRENT active workplace (system of record) — shape:
+    // { workplaceRequired, assignedWorkplace: { ...id/name/caption... } }.
+    // Used to prove the operator's active workplace, as opposed to a workstation SCREEN's
+    // statically-linked workplace (which never drifts and would not catch a re-assign bug).
+    getCurrentWorkplace: async () => await test.step(`Backend: get current workplace`, async () => {
+        const backendBaseUrl = await getBackendBaseUrl();
+        const response = await page.request.get(`${backendBaseUrl}/workplace`);
+        const responseBody = await response.json();
+        assertNoErrors({ responseBody });
+        return responseBody;
+    }),
+
     getWFProcess: async ({ wfProcessId }) => {
         const backendBaseUrl = await getBackendBaseUrl();
         const response = await page.request.get(`${backendBaseUrl}/userWorkflows/wfProcess/${wfProcessId}`, {

--- a/e2e/mobile-webui/tests/utils/screens/workplaceManager/WorkplaceManagerScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/workplaceManager/WorkplaceManagerScreen.js
@@ -1,4 +1,4 @@
-import { ID_BACK_BUTTON, page, FAST_ACTION_TIMEOUT, SLOW_ACTION_TIMEOUT } from "../../common";
+import { ID_BACK_BUTTON, page } from "../../common";
 import { test } from "../../../../playwright.config";
 import { expect } from "@playwright/test";
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
@@ -19,14 +19,7 @@ export const WorkplaceManagerScreen = {
     }),
 
     scanWorkplace: async (qrCode) => await test.step(`${NAME} - Scan workplace QR '${qrCode}'`, async () => {
-        // Scanning into a just-mounted home screen can race the barcode reader's keydown listener,
-        // which attaches in a post-render effect slightly after its input is in the DOM — a scan fired
-        // in that window is silently dropped and never routes. Retry the scan until the workplace
-        // screen actually opens (a genuinely non-routing scan still fails once the outer timeout elapses).
-        await expect(async () => {
-            await BarcodeScannerComponent.type(qrCode);
-            await containerElement().waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
-        }).toPass({ timeout: SLOW_ACTION_TIMEOUT });
+        await BarcodeScannerComponent.type(qrCode);
         await WorkplaceManagerScreen.waitForScreen();
     }),
 

--- a/e2e/mobile-webui/tests/utils/screens/workplaceManager/WorkplaceManagerScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/workplaceManager/WorkplaceManagerScreen.js
@@ -2,6 +2,7 @@ import { ID_BACK_BUTTON, page } from "../../common";
 import { test } from "../../../../playwright.config";
 import { expect } from "@playwright/test";
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
+import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
 
 const NAME = 'WorkplaceManagerScreen';
 /** @returns {import('@playwright/test').Locator} */
@@ -15,6 +16,11 @@ export const WorkplaceManagerScreen = {
 
     expectVisible: async () => await test.step(`${NAME} - Expect to be displayed`, async () => {
         await expect(containerElement()).toBeVisible();
+    }),
+
+    scanWorkplace: async (qrCode) => await test.step(`${NAME} - Scan workplace QR '${qrCode}'`, async () => {
+        await BarcodeScannerComponent.type(qrCode);
+        await WorkplaceManagerScreen.waitForScreen();
     }),
 
     clickAssignButton: async () => await test.step(`${NAME} - Click Assign button`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/workplaceManager/WorkplaceManagerScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/workplaceManager/WorkplaceManagerScreen.js
@@ -1,4 +1,4 @@
-import { ID_BACK_BUTTON, page } from "../../common";
+import { ID_BACK_BUTTON, page, FAST_ACTION_TIMEOUT, SLOW_ACTION_TIMEOUT } from "../../common";
 import { test } from "../../../../playwright.config";
 import { expect } from "@playwright/test";
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
@@ -19,7 +19,14 @@ export const WorkplaceManagerScreen = {
     }),
 
     scanWorkplace: async (qrCode) => await test.step(`${NAME} - Scan workplace QR '${qrCode}'`, async () => {
-        await BarcodeScannerComponent.type(qrCode);
+        // Scanning into a just-mounted home screen can race the barcode reader's keydown listener,
+        // which attaches in a post-render effect slightly after its input is in the DOM — a scan fired
+        // in that window is silently dropped and never routes. Retry the scan until the workplace
+        // screen actually opens (a genuinely non-routing scan still fails once the outer timeout elapses).
+        await expect(async () => {
+            await BarcodeScannerComponent.type(qrCode);
+            await containerElement().waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
+        }).toPass({ timeout: SLOW_ACTION_TIMEOUT });
         await WorkplaceManagerScreen.waitForScreen();
     }),
 

--- a/e2e/mobile-webui/tests/utils/screens/workstationManager/WorkstationManagerScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/workstationManager/WorkstationManagerScreen.js
@@ -35,6 +35,19 @@ export const WorkstationManagerScreen = {
         await WorkstationManagerScreen.waitForScreen();
     }),
 
+    // The frontend's Assign button (apps/workstationManager/containers/AppScreen.js) carries
+    // testId="assign-button" (mirroring WorkplaceManagerScreen's own assign-button) — select by testId.
+    clickAssignButton: async () => await test.step(`${NAME} - Click Assign button`, async () => {
+        await page.getByTestId('assign-button').tap();
+        await page.getByTestId('assign-button').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
+        await WorkstationManagerScreen.waitForScreen();
+    }),
+
+    expectAssignButtonNotVisible: async () => await test.step(`${NAME} - Expect Assign button NOT visible`, async () => {
+        const assignButton = containerElement().locator('button', { hasText: 'Assign' });
+        await expect(assignButton).toHaveCount(0);
+    }),
+
     expectHeaderProperty: async ({ caption, value }) => await test.step(`${NAME} - Check header property '${caption}'='${value}'`, async () => {
         const row = await page.locator(
             `tr:has(th:has-text("${caption}")):has(td:has-text("${value}"))`

--- a/e2e/mobile-webui/tests/utils/screens/workstationManager/WorkstationManagerScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/workstationManager/WorkstationManagerScreen.js
@@ -1,0 +1,62 @@
+import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from "../../common";
+import { test } from "../../../../playwright.config";
+import { expect } from "@playwright/test";
+import { ApplicationsListScreen } from '../ApplicationsListScreen';
+import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
+
+const NAME = 'WorkstationManagerScreen';
+/** @returns {import('@playwright/test').Locator} */
+const containerElement = () => page.locator('#WorkstationManagerScreen');
+
+// Header-table captions rendered by WorkstationInfoComponent.js (misc/services/mobile-webui/mobile-webui-frontend/
+// src/apps/workstationManager/components/WorkstationInfoComponent.js). Both are hardcoded English captions
+// because the e2e suite runs against the English locale (see sibling WorkplaceManagerScreen usage in
+// home_screen.spec.js: caption: 'Name' / caption: 'Assigned').
+const CAPTION_WORKSTATION_NAME = 'Name'; // i18n key 'workstationName' -> apps/workstationManager/i18n/en.json
+// The 'Workplace' row (i18n key 'general.workplace' -> translations_en.js) is rendered TODAY from
+// `workstationInfo.workplaceName` — the workplace statically linked to the scanned workstation. Task 5 of
+// me03#30880 adds a fetch of the operator's CURRENT active workplace (which can drift from the linked one,
+// e.g. after a re-scan) and will render it via this same mechanism (extending WorkstationInfoComponent /
+// AppScreen.js) — reuse this row, do not add a second selector once Task 5 lands.
+const CAPTION_CURRENT_WORKPLACE = 'Workplace'; // i18n key 'general.workplace'
+
+export const WorkstationManagerScreen = {
+    waitForScreen: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
+        await containerElement().waitFor({ timeout });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout });
+    }),
+
+    expectVisible: async () => await test.step(`${NAME} - Expect to be displayed`, async () => {
+        await expect(containerElement()).toBeVisible();
+    }),
+
+    scanWorkstation: async (qrCode) => await test.step(`${NAME} - Scan workstation QR '${qrCode}'`, async () => {
+        await BarcodeScannerComponent.type(qrCode);
+        await WorkstationManagerScreen.waitForScreen();
+    }),
+
+    expectHeaderProperty: async ({ caption, value }) => await test.step(`${NAME} - Check header property '${caption}'='${value}'`, async () => {
+        const row = await page.locator(
+            `tr:has(th:has-text("${caption}")):has(td:has-text("${value}"))`
+        );
+        await expect(row).toHaveCount(1)
+    }),
+
+    // Asserts the operator's current workstation (the one currently scanned/assigned) = name.
+    expectCurrentWorkstation: async (name) => await test.step(`${NAME} - Expect current workstation = '${name}'`, async () => {
+        await WorkstationManagerScreen.expectHeaderProperty({ caption: CAPTION_WORKSTATION_NAME, value: name });
+    }),
+
+    // Asserts the current active workplace = name. See CAPTION_CURRENT_WORKPLACE comment above: until Task 5
+    // lands, this reads the workstation's statically linked workplace (workstationInfo.workplaceName); Task 5
+    // makes it reflect the operator's actual current active workplace via the same header row.
+    expectCurrentWorkplace: async (name) => await test.step(`${NAME} - Expect current workplace = '${name}'`, async () => {
+        await WorkstationManagerScreen.expectHeaderProperty({ caption: CAPTION_CURRENT_WORKPLACE, value: name });
+    }),
+
+    goBack: async () => await test.step(`${NAME} - Go back`, async () => {
+        await WorkstationManagerScreen.waitForScreen();
+        await page.locator(ID_BACK_BUTTON).tap();
+        await ApplicationsListScreen.waitForScreen();
+    }),
+}

--- a/e2e/mobile-webui/tests/utils/screens/workstationManager/WorkstationManagerScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/workstationManager/WorkstationManagerScreen.js
@@ -1,4 +1,4 @@
-import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from "../../common";
+import { ID_BACK_BUTTON, page, FAST_ACTION_TIMEOUT, SLOW_ACTION_TIMEOUT } from "../../common";
 import { test } from "../../../../playwright.config";
 import { expect } from "@playwright/test";
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
@@ -13,11 +13,9 @@ const containerElement = () => page.locator('#WorkstationManagerScreen');
 // because the e2e suite runs against the English locale (see sibling WorkplaceManagerScreen usage in
 // home_screen.spec.js: caption: 'Name' / caption: 'Assigned').
 const CAPTION_WORKSTATION_NAME = 'Name'; // i18n key 'workstationName' -> apps/workstationManager/i18n/en.json
-// The 'Workplace' row (i18n key 'general.workplace' -> translations_en.js) is rendered TODAY from
-// `workstationInfo.workplaceName` — the workplace statically linked to the scanned workstation. Task 5 of
-// me03#30880 adds a fetch of the operator's CURRENT active workplace (which can drift from the linked one,
-// e.g. after a re-scan) and will render it via this same mechanism (extending WorkstationInfoComponent /
-// AppScreen.js) — reuse this row, do not add a second selector once Task 5 lands.
+// The 'Workplace' row (i18n key 'general.workplace' -> translations_en.js) renders the operator's
+// CURRENT active workplace (read from GET /workplace), which can drift from the workstation's
+// statically-linked workplace — so a mismatch is visible to the operator.
 const CAPTION_CURRENT_WORKPLACE = 'Workplace'; // i18n key 'general.workplace'
 
 export const WorkstationManagerScreen = {
@@ -31,21 +29,23 @@ export const WorkstationManagerScreen = {
     }),
 
     scanWorkstation: async (qrCode) => await test.step(`${NAME} - Scan workstation QR '${qrCode}'`, async () => {
-        await BarcodeScannerComponent.type(qrCode);
+        // Scanning into a just-mounted home screen can race the barcode reader's keydown listener,
+        // which attaches in a post-render effect slightly after its input is in the DOM — a scan fired
+        // in that window is silently dropped and never routes. Retry the scan until the workstation
+        // screen actually opens (a genuinely non-routing scan still fails once the outer timeout elapses).
+        await expect(async () => {
+            await BarcodeScannerComponent.type(qrCode);
+            await containerElement().waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
+        }).toPass({ timeout: SLOW_ACTION_TIMEOUT });
         await WorkstationManagerScreen.waitForScreen();
     }),
 
     // The frontend's Assign button (apps/workstationManager/containers/AppScreen.js) carries
-    // testId="assign-button" (mirroring WorkplaceManagerScreen's own assign-button) — select by testId.
-    clickAssignButton: async () => await test.step(`${NAME} - Click Assign button`, async () => {
-        await page.getByTestId('assign-button').tap();
-        await page.getByTestId('assign-button').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
-        await WorkstationManagerScreen.waitForScreen();
-    }),
-
+    // testId="assign-button" (mirroring WorkplaceManagerScreen's own assign-button) — select by testId,
+    // not by rendered caption, which is i18n-fragile. Under scan-and-go the scan assigns the workstation,
+    // so this button is expected to be hidden after a scan.
     expectAssignButtonNotVisible: async () => await test.step(`${NAME} - Expect Assign button NOT visible`, async () => {
-        const assignButton = containerElement().locator('button', { hasText: 'Assign' });
-        await expect(assignButton).toHaveCount(0);
+        await expect(containerElement().getByTestId('assign-button')).toHaveCount(0);
     }),
 
     expectHeaderProperty: async ({ caption, value }) => await test.step(`${NAME} - Check header property '${caption}'='${value}'`, async () => {
@@ -60,9 +60,7 @@ export const WorkstationManagerScreen = {
         await WorkstationManagerScreen.expectHeaderProperty({ caption: CAPTION_WORKSTATION_NAME, value: name });
     }),
 
-    // Asserts the current active workplace = name. See CAPTION_CURRENT_WORKPLACE comment above: until Task 5
-    // lands, this reads the workstation's statically linked workplace (workstationInfo.workplaceName); Task 5
-    // makes it reflect the operator's actual current active workplace via the same header row.
+    // Asserts the operator's current active workplace = name (see CAPTION_CURRENT_WORKPLACE above).
     expectCurrentWorkplace: async (name) => await test.step(`${NAME} - Expect current workplace = '${name}'`, async () => {
         await WorkstationManagerScreen.expectHeaderProperty({ caption: CAPTION_CURRENT_WORKPLACE, value: name });
     }),

--- a/e2e/mobile-webui/tests/utils/screens/workstationManager/WorkstationManagerScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/workstationManager/WorkstationManagerScreen.js
@@ -13,9 +13,9 @@ const containerElement = () => page.locator('#WorkstationManagerScreen');
 // because the e2e suite runs against the English locale (see sibling WorkplaceManagerScreen usage in
 // home_screen.spec.js: caption: 'Name' / caption: 'Assigned').
 const CAPTION_WORKSTATION_NAME = 'Name'; // i18n key 'workstationName' -> apps/workstationManager/i18n/en.json
-// The 'Workplace' row (i18n key 'general.workplace' -> translations_en.js) renders the operator's
-// CURRENT active workplace (read from GET /workplace), which can drift from the workstation's
-// statically-linked workplace — so a mismatch is visible to the operator.
+// The 'Workplace' row (i18n key 'general.workplace' -> translations_en.js) renders the scanned
+// workstation's workplace. Since scan-and-go assigns the workstation AND its workplace, this equals
+// the operator's active workplace on every reachable (post-scan) view of the screen.
 const CAPTION_CURRENT_WORKPLACE = 'Workplace'; // i18n key 'general.workplace'
 
 export const WorkstationManagerScreen = {
@@ -38,14 +38,6 @@ export const WorkstationManagerScreen = {
             await containerElement().waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
         }).toPass({ timeout: SLOW_ACTION_TIMEOUT });
         await WorkstationManagerScreen.waitForScreen();
-    }),
-
-    // The frontend's Assign button (apps/workstationManager/containers/AppScreen.js) carries
-    // testId="assign-button" (mirroring WorkplaceManagerScreen's own assign-button) — select by testId,
-    // not by rendered caption, which is i18n-fragile. Under scan-and-go the scan assigns the workstation,
-    // so this button is expected to be hidden after a scan.
-    expectAssignButtonNotVisible: async () => await test.step(`${NAME} - Expect Assign button NOT visible`, async () => {
-        await expect(containerElement().getByTestId('assign-button')).toHaveCount(0);
     }),
 
     expectHeaderProperty: async ({ caption, value }) => await test.step(`${NAME} - Check header property '${caption}'='${value}'`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/workstationManager/WorkstationManagerScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/workstationManager/WorkstationManagerScreen.js
@@ -1,4 +1,4 @@
-import { ID_BACK_BUTTON, page, FAST_ACTION_TIMEOUT, SLOW_ACTION_TIMEOUT } from "../../common";
+import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from "../../common";
 import { test } from "../../../../playwright.config";
 import { expect } from "@playwright/test";
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
@@ -29,14 +29,7 @@ export const WorkstationManagerScreen = {
     }),
 
     scanWorkstation: async (qrCode) => await test.step(`${NAME} - Scan workstation QR '${qrCode}'`, async () => {
-        // Scanning into a just-mounted home screen can race the barcode reader's keydown listener,
-        // which attaches in a post-render effect slightly after its input is in the DOM — a scan fired
-        // in that window is silently dropped and never routes. Retry the scan until the workstation
-        // screen actually opens (a genuinely non-routing scan still fails once the outer timeout elapses).
-        await expect(async () => {
-            await BarcodeScannerComponent.type(qrCode);
-            await containerElement().waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
-        }).toPass({ timeout: SLOW_ACTION_TIMEOUT });
+        await BarcodeScannerComponent.type(qrCode);
         await WorkstationManagerScreen.waitForScreen();
     }),
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/workstation.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/workstation.js
@@ -52,6 +52,6 @@ export const assignWorkstationById = (workstationId) => {
   return axios.post(`${workstationAPIBase}/assign`, { workstationId }).then(unboxAxiosResponse);
 };
 
-const assignWorkstationByQRCode = (workstationQRCode) => {
+export const assignWorkstationByQRCode = (workstationQRCode) => {
   return axios.post(`${workstationAPIBase}/assign`, { workstationQRCode }).then(unboxAxiosResponse);
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/workstation.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/workstation.js
@@ -48,10 +48,6 @@ export const getWorkstationByQRCode = (qrCode) => {
   return axios.post(`${workstationAPIBase}/byQRCode`, { qrCode }).then(unboxAxiosResponse);
 };
 
-export const assignWorkstationById = (workstationId) => {
-  return axios.post(`${workstationAPIBase}/assign`, { workstationId }).then(unboxAxiosResponse);
-};
-
 export const assignWorkstationByQRCode = (workstationQRCode) => {
   return axios.post(`${workstationAPIBase}/assign`, { workstationQRCode }).then(unboxAxiosResponse);
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/components/WorkstationInfoComponent.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/components/WorkstationInfoComponent.js
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { appTrl } from '../utils';
 
-export const WorkstationInfoComponent = ({ workstationInfo }) => {
+export const WorkstationInfoComponent = ({ workstationInfo, currentWorkplaceName }) => {
   return (
     <table className="table view-header is-size-6">
       <tbody>
@@ -11,10 +11,12 @@ export const WorkstationInfoComponent = ({ workstationInfo }) => {
           <th>{appTrl('workstationName')}</th>
           <td>{workstationInfo.name}</td>
         </tr>
-        {workstationInfo.workplaceName && (
+        {currentWorkplaceName && (
+          // The operator's CURRENT active workplace (read from GET /workplace), not the workstation's
+          // statically-linked workplace — so any drift between them is visible to the operator (AC3).
           <tr>
             <th>{trl('general.workplace')}</th>
-            <td>{workstationInfo.workplaceName}</td>
+            <td>{currentWorkplaceName}</td>
           </tr>
         )}
         <tr>
@@ -28,6 +30,7 @@ export const WorkstationInfoComponent = ({ workstationInfo }) => {
 
 WorkstationInfoComponent.propTypes = {
   workstationInfo: PropTypes.object.isRequired,
+  currentWorkplaceName: PropTypes.string,
 };
 
 export default WorkstationInfoComponent;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/components/WorkstationInfoComponent.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/components/WorkstationInfoComponent.js
@@ -13,7 +13,7 @@ export const WorkstationInfoComponent = ({ workstationInfo, currentWorkplaceName
         </tr>
         {currentWorkplaceName && (
           // The operator's CURRENT active workplace (read from GET /workplace), not the workstation's
-          // statically-linked workplace — so any drift between them is visible to the operator (AC3).
+          // statically-linked workplace — so any drift between them is visible to the operator.
           <tr>
             <th>{trl('general.workplace')}</th>
             <td>{currentWorkplaceName}</td>

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/components/WorkstationInfoComponent.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/components/WorkstationInfoComponent.js
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { appTrl } from '../utils';
 
-export const WorkstationInfoComponent = ({ workstationInfo, currentWorkplaceName }) => {
+export const WorkstationInfoComponent = ({ workstationInfo }) => {
   return (
     <table className="table view-header is-size-6">
       <tbody>
@@ -11,12 +11,12 @@ export const WorkstationInfoComponent = ({ workstationInfo, currentWorkplaceName
           <th>{appTrl('workstationName')}</th>
           <td>{workstationInfo.name}</td>
         </tr>
-        {currentWorkplaceName && (
-          // The operator's CURRENT active workplace (read from GET /workplace), not the workstation's
-          // statically-linked workplace — so any drift between them is visible to the operator.
+        {workstationInfo.workplaceName && (
+          // Scan-and-go assigns the workstation AND its linked workplace, and this screen is only ever
+          // reached via a scan — so on every reachable view this workplace IS the operator's active one.
           <tr>
             <th>{trl('general.workplace')}</th>
-            <td>{currentWorkplaceName}</td>
+            <td>{workstationInfo.workplaceName}</td>
           </tr>
         )}
         <tr>
@@ -30,7 +30,6 @@ export const WorkstationInfoComponent = ({ workstationInfo, currentWorkplaceName
 
 WorkstationInfoComponent.propTypes = {
   workstationInfo: PropTypes.object.isRequired,
-  currentWorkplaceName: PropTypes.string,
 };
 
 export default WorkstationInfoComponent;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/containers/AppScreen.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/containers/AppScreen.js
@@ -92,7 +92,11 @@ const AppScreen = () => {
         <WorkstationInfoComponent workstationInfo={workstation} />
         <div className="pt-3 section">
           {!workstation.userAssigned && (
-            <ButtonWithIndicator caption={appTrl('action.assign.buttonCaption')} onClick={onAssignClick} />
+            <ButtonWithIndicator
+              caption={appTrl('action.assign.buttonCaption')}
+              onClick={onAssignClick}
+              testId="assign-button"
+            />
           )}
           <ButtonWithIndicator caption={appTrl('action.scanAgain.buttonCaption')} onClick={onScanAgainClick} />
         </div>

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/containers/AppScreen.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/containers/AppScreen.js
@@ -43,7 +43,7 @@ const AppScreen = () => {
   const [loading, setLoading] = useState(true);
   const [workstation, setWorkstation] = useState();
   // The operator's CURRENT active workplace (system of record: GET /workplace), shown alongside the
-  // workstation so a drift between the two is visible to the operator (AC3). Distinct from the
+  // workstation so a drift between the two is visible to the operator. Distinct from the
   // workstation's statically-linked workplace.
   const [currentWorkplace, setCurrentWorkplace] = useState();
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/containers/AppScreen.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/containers/AppScreen.js
@@ -24,6 +24,7 @@ import WorkstationInfoComponent from '../components/WorkstationInfoComponent';
 import ButtonWithIndicator from '../../../components/buttons/ButtonWithIndicator';
 import BarcodeScannerComponent from '../../../components/BarcodeScannerComponent';
 import * as api from '../../../api/workstation';
+import * as workplaceApi from '../../../api/workplace';
 import { toastError } from '../../../utils/toast';
 import { appTrl } from '../utils';
 import * as scanAnythingRoutes from '../../scanAnything/routes';
@@ -41,18 +42,44 @@ const AppScreen = () => {
 
   const [loading, setLoading] = useState(true);
   const [workstation, setWorkstation] = useState();
+  // The operator's CURRENT active workplace (system of record: GET /workplace), shown alongside the
+  // workstation so a drift between the two is visible to the operator (AC3). Distinct from the
+  // workstation's statically-linked workplace.
+  const [currentWorkplace, setCurrentWorkplace] = useState();
 
   const queryParameters = new URLSearchParams(window.location.search);
   const qrCodeParam = queryParameters.get('qrCode');
   const callerApplicationId = queryParameters.get('callerApplicationId');
   useEffect(() => {
-    if (qrCodeParam && !workstation) {
-      setLoading(true);
-      onBarcodeScanned({ scannedBarcode: qrCodeParam }).finally(() => setLoading(false));
-    } else {
-      setLoading(false);
-    }
+    setLoading(true);
+    // Scan path: onBarcodeScanned assigns, then refreshes the current workplace itself — so it reflects
+    // the POST-assign workplace. Do NOT also refresh here in parallel: that parallel GET reads the
+    // PRE-assign (drifted) workplace and, resolving last, would clobber the correct post-assign value.
+    // Entry path (no scan): load the current workstation + current active workplace so drift is visible.
+    const init =
+      qrCodeParam && !workstation
+        ? onBarcodeScanned({ scannedBarcode: qrCodeParam })
+        : Promise.all([loadCurrentWorkstation(), refreshCurrentWorkplace()]);
+    init.finally(() => setLoading(false));
   }, []);
+
+  const loadCurrentWorkstation = () => {
+    return api
+      .getCurrentWorkstationInfo()
+      .then(({ assignedWorkstation }) => {
+        if (assignedWorkstation) {
+          setWorkstation(assignedWorkstation);
+        }
+      })
+      .catch((axiosError) => toastError({ axiosError }));
+  };
+
+  const refreshCurrentWorkplace = () => {
+    return workplaceApi
+      .getCurrentWorkplaceInfo()
+      .then(({ assignedWorkplace }) => setCurrentWorkplace(assignedWorkplace))
+      .catch((axiosError) => toastError({ axiosError }));
+  };
 
   const setWorkstationAndUpdateUrl = (newWorkstation) => {
     setWorkstation(newWorkstation);
@@ -60,15 +87,25 @@ const AppScreen = () => {
   };
 
   const onBarcodeScanned = ({ scannedBarcode }) => {
+    // Assign on scan (mirror the workplace app): a scan — including a re-scan of an already-assigned
+    // workstation — re-assigns it, switching the operator's active workplace back to the scanned
+    // workstation's workplace. A read-only lookup here would silently fail to re-switch a drifted workplace.
     return api
-      .getWorkstationByQRCode(scannedBarcode)
-      .then((workplaceInfo) => setWorkstationAndUpdateUrl(workplaceInfo));
+      .assignWorkstationByQRCode(scannedBarcode)
+      .then((workstationInfo) => {
+        setWorkstationAndUpdateUrl(workstationInfo);
+        return refreshCurrentWorkplace();
+      })
+      .catch((axiosError) => toastError({ axiosError }));
   };
 
   const onAssignClick = () => {
     api
       .assignWorkstationById(workstation.id)
-      .then((workstation) => setWorkstation(workstation))
+      .then((newWorkstation) => {
+        setWorkstation(newWorkstation);
+        return refreshCurrentWorkplace();
+      })
       .catch((axiosError) => toastError({ axiosError }));
   };
 
@@ -89,7 +126,7 @@ const AppScreen = () => {
   } else if (workstation) {
     return (
       <div className="app-workstantionManager">
-        <WorkstationInfoComponent workstationInfo={workstation} />
+        <WorkstationInfoComponent workstationInfo={workstation} currentWorkplaceName={currentWorkplace?.name} />
         <div className="pt-3 section">
           {!workstation.userAssigned && (
             <ButtonWithIndicator

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/containers/AppScreen.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/containers/AppScreen.js
@@ -24,7 +24,6 @@ import WorkstationInfoComponent from '../components/WorkstationInfoComponent';
 import ButtonWithIndicator from '../../../components/buttons/ButtonWithIndicator';
 import BarcodeScannerComponent from '../../../components/BarcodeScannerComponent';
 import * as api from '../../../api/workstation';
-import * as workplaceApi from '../../../api/workplace';
 import { toastError } from '../../../utils/toast';
 import { appTrl } from '../utils';
 import * as scanAnythingRoutes from '../../scanAnything/routes';
@@ -42,44 +41,17 @@ const AppScreen = () => {
 
   const [loading, setLoading] = useState(true);
   const [workstation, setWorkstation] = useState();
-  // The operator's CURRENT active workplace (system of record: GET /workplace), shown alongside the
-  // workstation so a drift between the two is visible to the operator. Distinct from the
-  // workstation's statically-linked workplace.
-  const [currentWorkplace, setCurrentWorkplace] = useState();
-
   const queryParameters = new URLSearchParams(window.location.search);
   const qrCodeParam = queryParameters.get('qrCode');
   const callerApplicationId = queryParameters.get('callerApplicationId');
   useEffect(() => {
-    setLoading(true);
-    // Scan path: onBarcodeScanned assigns, then refreshes the current workplace itself — so it reflects
-    // the POST-assign workplace. Do NOT also refresh here in parallel: that parallel GET reads the
-    // PRE-assign (drifted) workplace and, resolving last, would clobber the correct post-assign value.
-    // Entry path (no scan): load the current workstation + current active workplace so drift is visible.
-    const init =
-      qrCodeParam && !workstation
-        ? onBarcodeScanned({ scannedBarcode: qrCodeParam })
-        : Promise.all([loadCurrentWorkstation(), refreshCurrentWorkplace()]);
-    init.finally(() => setLoading(false));
+    if (qrCodeParam && !workstation) {
+      setLoading(true);
+      onBarcodeScanned({ scannedBarcode: qrCodeParam }).finally(() => setLoading(false));
+    } else {
+      setLoading(false);
+    }
   }, []);
-
-  const loadCurrentWorkstation = () => {
-    return api
-      .getCurrentWorkstationInfo()
-      .then(({ assignedWorkstation }) => {
-        if (assignedWorkstation) {
-          setWorkstation(assignedWorkstation);
-        }
-      })
-      .catch((axiosError) => toastError({ axiosError }));
-  };
-
-  const refreshCurrentWorkplace = () => {
-    return workplaceApi
-      .getCurrentWorkplaceInfo()
-      .then(({ assignedWorkplace }) => setCurrentWorkplace(assignedWorkplace))
-      .catch((axiosError) => toastError({ axiosError }));
-  };
 
   const setWorkstationAndUpdateUrl = (newWorkstation) => {
     setWorkstation(newWorkstation);
@@ -92,20 +64,7 @@ const AppScreen = () => {
     // workstation's workplace. A read-only lookup here would silently fail to re-switch a drifted workplace.
     return api
       .assignWorkstationByQRCode(scannedBarcode)
-      .then((workstationInfo) => {
-        setWorkstationAndUpdateUrl(workstationInfo);
-        return refreshCurrentWorkplace();
-      })
-      .catch((axiosError) => toastError({ axiosError }));
-  };
-
-  const onAssignClick = () => {
-    api
-      .assignWorkstationById(workstation.id)
-      .then((newWorkstation) => {
-        setWorkstation(newWorkstation);
-        return refreshCurrentWorkplace();
-      })
+      .then((workstationInfo) => setWorkstationAndUpdateUrl(workstationInfo))
       .catch((axiosError) => toastError({ axiosError }));
   };
 
@@ -126,15 +85,8 @@ const AppScreen = () => {
   } else if (workstation) {
     return (
       <div className="app-workstantionManager">
-        <WorkstationInfoComponent workstationInfo={workstation} currentWorkplaceName={currentWorkplace?.name} />
+        <WorkstationInfoComponent workstationInfo={workstation} />
         <div className="pt-3 section">
-          {!workstation.userAssigned && (
-            <ButtonWithIndicator
-              caption={appTrl('action.assign.buttonCaption')}
-              onClick={onAssignClick}
-              testId="assign-button"
-            />
-          )}
           <ButtonWithIndicator caption={appTrl('action.scanAgain.buttonCaption')} onClick={onScanAgainClick} />
         </div>
       </div>

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/i18n/de.json
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/i18n/de.json
@@ -2,9 +2,6 @@
   "workstationName": "Name",
   "isUserAssigned": "Zugewiesen",
   "action": {
-    "assign": {
-      "buttonCaption": "Zuweisen"
-    },
     "scanAgain": {
       "buttonCaption": "Erneut scannen"
     }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/i18n/en.json
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/i18n/en.json
@@ -2,9 +2,6 @@
   "workstationName": "Name",
   "isUserAssigned": "Assigned",
   "action": {
-    "assign": {
-      "buttonCaption": "Assign"
-    },
     "scanAgain": {
       "buttonCaption": "Scan again"
     }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useKeyboardBarcodeReader.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 import { checkPartialScannedCode, ScanCompleteness } from '../utils/qrCode/common';
 
 // Abandon window for a stuck/truncated streamed QR partial (see the note in the effect below).
@@ -22,7 +22,14 @@ export const useKeyboardBarcodeReader = ({
   const bufferRef = useRef('');
   const lastKeyTimeRef = useRef(0);
 
-  useEffect(() => {
+  // useLayoutEffect (not useEffect) so the window-level keydown listener is attached synchronously
+  // in the commit phase, BEFORE the browser paints — not in a post-paint passive effect. A scanner
+  // screen renders its offscreen input during commit, but a passive useEffect runs a task later, so
+  // a scan fired in the window between "input painted" and "listener attached" is silently dropped
+  // and never routes (repro: e2e scanWorkstation/scanWorkplace timed out ~15% of runs without the
+  // now-removed retry guard; the reader owns document-level keydown, so attaching one frame earlier
+  // has no layout/paint cost and no behavioural change for any consumer).
+  useLayoutEffect(() => {
     // A recognised-but-incomplete streamed QR code (e.g. a long HU QR arriving in chunks over
     // several seconds) is kept buffered across inter-keystroke gaps instead of being flushed as a
     // fragment. If it never completes (genuinely truncated: device disconnect / out-of-range) we


### PR DESCRIPTION
## Problem

On the Mobile UI, scanning a workstation did **not** reliably switch the operator's active workplace. The workstation app only *read* the workstation on scan (`getWorkstationByQRCode`) and deferred the assignment to an "Assign" button that is hidden once the operator is already assigned — so re-scanning an already-assigned workstation was a silent no-op and left the operator's active workplace drifted (e.g. from a prior workplace scan). This mis-routed HU-label printing to the wrong workplace's printer.

## Fix (frontend-only)

- **Scan-and-go**, mirroring the sibling mobile *workplace* app: the workstation scan now assigns immediately (`POST /workstation/assign`, which the backend already handles for the workstation **and** its linked workplace). A re-scan therefore re-assigns and switches the active workplace deterministically — no silent no-op. The now-redundant "Assign" button and its i18n captions are removed.
- **Visible current state**: the workstation screen keeps showing the linked workplace (`WorkstationInfoComponent`, from the `/assign` response). The workstation app is scan-entry-only, so every reachable view is post-scan where the shown workplace **is** the operator's active one — no separate on-entry lookup is needed.

No production backend change. HU-label printer routing follows automatically once the active workplace is correct.

Files:
- `misc/services/mobile-webui/mobile-webui-frontend/src/api/workstation.js` — export `assignWorkstationByQRCode`; drop the unused `assignWorkstationById`
- `misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/containers/AppScreen.js` — assign on scan; remove the dead "Assign" button + handler
- `misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/components/WorkstationInfoComponent.js` — clarify the shown workplace is the active one
- `misc/services/mobile-webui/mobile-webui-frontend/src/apps/workstationManager/i18n/{de,en}.json` — remove the now-unused "assign" caption

## Test

New mobile-webui Playwright regression `e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js` reproduces the drift scenario: assigned to WS1 (linked workplace A) → active workplace drifts to B → re-scan WS1 → active workplace must return to A. Proven RED on the unfixed code and GREEN with the fix. Backend e2e-masterdata support added so a test workstation resource can link a workplace (`de.metas.frontend-testing`).