### PR TITLE
nShift: don't send the System user as the carrier shipment order receiver contact

### DIFF
--- a/backend/de.metas.shipper.gateway.commons/src/main/java/de/metas/shipper/gateway/commons/ShipperGatewayFacade.java
+++ b/backend/de.metas.shipper.gateway.commons/src/main/java/de/metas/shipper/gateway/commons/ShipperGatewayFacade.java
@@ -1,5 +1,6 @@
 package de.metas.shipper.gateway.commons;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
 import de.metas.async.AsyncBatchId;
@@ -177,7 +178,7 @@ public class ShipperGatewayFacade
 				.fromOrgId(mpackage.getAD_Org_ID())
 				.deliverToBPartnerId(mpackage.getC_BPartner_ID())
 				.deliverToBPartnerLocationId(mpackage.getC_BPartner_Location_ID())
-				.deliverToContactId(UserId.ofRepoIdOrNull(mpackage.getAD_User_ID()))
+				.deliverToContactId(toDeliverToContactId(mpackage.getAD_User_ID()))
 				.pickupDate(pickupDate)
 				.timeFrom(timeFrom)
 				.timeTo(timeTo)
@@ -187,6 +188,22 @@ public class ShipperGatewayFacade
 				.asyncBatchId(asyncBatchId)
 				.packageId(perPackageKey)
 				.build();
+	}
+
+	/**
+	 * Resolves the delivery-order receiver contact from an {@code M_Package.AD_User_ID}.
+	 * <p>
+	 * {@code AD_User_ID == 0} means the shipment carries <b>no</b> contact. It must NOT resolve to the
+	 * System user: {@link UserId#ofRepoIdOrNull(int)} maps {@code 0 -> UserId.SYSTEM}, and that (non-null)
+	 * System user then survives the {@code deliverContactId != null} guard in the draft-delivery-order
+	 * creators (e.g. {@code NShiftDraftDeliveryOrderCreator}), so the System user's name/phone/email are
+	 * sent as the carrier shipment order's receiver contact. Resolving to {@code null} instead lets the
+	 * delivery-order builder fall back to the delivery BPartner/location.
+	 */
+	@VisibleForTesting
+	static UserId toDeliverToContactId(final int adUserRepoId)
+	{
+		return UserId.ofRegularUserRepoIdOrNull(adUserRepoId);
 	}
 
 	/**

--- a/backend/de.metas.shipper.gateway.commons/src/test/java/de/metas/shipper/gateway/commons/ShipperGatewayFacadeTest.java
+++ b/backend/de.metas.shipper.gateway.commons/src/test/java/de/metas/shipper/gateway/commons/ShipperGatewayFacadeTest.java
@@ -1,0 +1,26 @@
+package de.metas.shipper.gateway.commons;
+
+import de.metas.user.UserId;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ShipperGatewayFacadeTest
+{
+	/**
+	 * A shipment with no contact has {@code M_Package.AD_User_ID == 0}. The resolved delivery-order
+	 * receiver contact id must be {@code null} (i.e. "no contact"), NOT {@link UserId#SYSTEM} — otherwise
+	 * the System user's name/phone/email are sent to the carrier as the shipment order's receiver contact.
+	 */
+	@Test
+	void toDeliverToContactId_isNull_whenPackageHasNoContact()
+	{
+		assertThat(ShipperGatewayFacade.toDeliverToContactId(0)).isNull();
+	}
+
+	@Test
+	void toDeliverToContactId_isTheUser_whenPackageHasRealContact()
+	{
+		assertThat(ShipperGatewayFacade.toDeliverToContactId(1234)).isEqualTo(UserId.ofRepoId(1234));
+	}
+}

--- a/backend/de.metas.shipper.gateway.commons/src/test/java/de/metas/shipper/gateway/commons/ShipperGatewayFacadeTest.java
+++ b/backend/de.metas.shipper.gateway.commons/src/test/java/de/metas/shipper/gateway/commons/ShipperGatewayFacadeTest.java
@@ -1,26 +1,31 @@
 package de.metas.shipper.gateway.commons;
 
 import de.metas.user.UserId;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ShipperGatewayFacadeTest
 {
-	/**
-	 * A shipment with no contact has {@code M_Package.AD_User_ID == 0}. The resolved delivery-order
-	 * receiver contact id must be {@code null} (i.e. "no contact"), NOT {@link UserId#SYSTEM} — otherwise
-	 * the System user's name/phone/email are sent to the carrier as the shipment order's receiver contact.
-	 */
-	@Test
-	void toDeliverToContactId_isNull_whenPackageHasNoContact()
+	@Nested
+	class ToDeliverToContactId
 	{
-		assertThat(ShipperGatewayFacade.toDeliverToContactId(0)).isNull();
-	}
+		/**
+		 * A shipment with no contact has {@code M_Package.AD_User_ID == 0}. The resolved delivery-order
+		 * receiver contact id must be {@code null} (i.e. "no contact"), NOT {@link UserId#SYSTEM} — otherwise
+		 * the System user's name/phone/email are sent to the carrier as the shipment order's receiver contact.
+		 */
+		@Test
+		void isNull_whenPackageHasNoContact()
+		{
+			assertThat(ShipperGatewayFacade.toDeliverToContactId(0)).isNull();
+		}
 
-	@Test
-	void toDeliverToContactId_isTheUser_whenPackageHasRealContact()
-	{
-		assertThat(ShipperGatewayFacade.toDeliverToContactId(1234)).isEqualTo(UserId.ofRepoId(1234));
+		@Test
+		void isTheUser_whenPackageHasRealContact()
+		{
+			assertThat(ShipperGatewayFacade.toDeliverToContactId(1234)).isEqualTo(UserId.ofRepoId(1234));
+		}
 	}
 }


### PR DESCRIPTION
## Problem

For an nShift shipment with **no contact** (`M_InOut.AD_User_ID = 0`, propagated to `M_Package.AD_User_ID`), the **System user** was sent to nShift as the carrier shipment order's **receiver contact** (`Receiver_ContactName/Phone/Email`).

## Root cause

`ShipperGatewayFacade` resolved the delivery-order receiver contact with `UserId.ofRepoIdOrNull(mpackage.getAD_User_ID())`. `ofRepoIdOrNull(0)` does **not** return `null` — it special-cases `0` and returns `UserId.SYSTEM`. That non-null System user then survived the `deliverContactId != null` guard in `NShiftDraftDeliveryOrderCreator`, so `DeliveryOrderUtil.getContactPerson` copied the System user's name/phone/email into the receiver contact.

**Verified** (RED test on the resolution seam, `mvn -pl de.metas.shipper.gateway.commons -Dtest=ShipperGatewayFacadeTest test`): before the fix, `toDeliverToContactId(0)` returned `UserId(repoId=0)` (i.e. `UserId.SYSTEM`) instead of `null` — `expected: null but was: UserId(repoId=0)`. After the fix it returns `null`.

## Fix

Resolve via `UserId.ofRegularUserRepoIdOrNull` (the non-deprecated method; `0`/system → `null`). With `null`, the existing guard in the draft-delivery-order creators falls back to the delivery **BPartner + location** contact — the correct "default ship-to" receiver — instead of the System user.

Extracted `ShipperGatewayFacade.toDeliverToContactId(int)` as a `@VisibleForTesting` seam carrying the guard rationale.

Behavior change (nShift ship path only):
- **no contact** (`AD_User_ID = 0`) → before: System user's name/phone/email; after: delivery partner name + delivery location phone/email.
- **real contact** (`AD_User_ID > 0`) → unchanged.

## Test

`ShipperGatewayFacadeTest` — RED→GREEN: `toDeliverToContactId(0)` must be `null` (was `UserId(repoId=0)`), a real user id passes through unchanged.
