### PR TITLE
#30899 GL Journal Import: prefer C_ValidCombination with no partner on org 0 when multiple match

### DIFF
--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/impexp/GLJournalImportProcess.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/impexp/GLJournalImportProcess.java
@@ -436,13 +436,27 @@ public class GLJournalImportProcess extends SimpleImportProcessTemplate<I_I_GLJo
 
 	private AccountDimension newMinimalAccountDimension(final I_I_GLJournal importRecord, final int accountId)
 	{
+		// All optional segments are set to 0 so AccountDAO produces IS NULL filters for each,
+		// ensuring the lookup matches only the most generic C_ValidCombination entry (org=0, no partner/product/etc.).
 		return AccountDimension.builder()
 				.setAcctSchemaId(AcctSchemaId.ofRepoIdOrNull(importRecord.getC_AcctSchema_ID()))
 				.setAD_Client_ID(importRecord.getAD_Client_ID())
-				.setAD_Org_ID(0)  // chart-of-accounts entries live at system org (0); produces AD_Org_ID=0 filter
+				.setAD_Org_ID(0)
 				.setC_ElementValue_ID(accountId)
-				.setC_BPartner_ID(0)  // no partner; produces C_BPartner_ID IS NULL filter
-				.setM_Product_ID(0)   // no product; produces M_Product_ID IS NULL filter
+				.setC_SubAcct_ID(0)
+				.setM_Product_ID(0)
+				.setC_BPartner_ID(0)
+				.setAD_OrgTrx_ID(0)
+				.setC_LocFrom_ID(0)
+				.setC_LocTo_ID(0)
+				.setC_SalesRegion_ID(null)
+				.setC_Project_ID(0)
+				.setC_Campaign_ID(0)
+				.setC_Activity_ID(0)
+				.setUser1_ID(0)
+				.setUser2_ID(0)
+				.setUserElement1_ID(0)
+				.setUserElement2_ID(0)
 				.build();
 	}
 

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/impexp/GLJournalImportProcess.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/impexp/GLJournalImportProcess.java
@@ -436,8 +436,9 @@ public class GLJournalImportProcess extends SimpleImportProcessTemplate<I_I_GLJo
 
 	private AccountDimension newMinimalAccountDimension(final I_I_GLJournal importRecord, final int accountId)
 	{
-		// All optional segments are set to 0 so AccountDAO produces IS NULL filters for each,
-		// ensuring the lookup matches only the most generic C_ValidCombination entry (org=0, no partner/product/etc.).
+		// All optional segments are set to produce IS NULL filters in AccountDAO (integer segments to 0;
+		// SalesRegion to null, which maps to -1 via toRepoId — also IS NULL in AccountDAO).
+		// This ensures the lookup matches only the most generic C_ValidCombination entry (org=0, no partner/product/etc.).
 		return AccountDimension.builder()
 				.setAcctSchemaId(AcctSchemaId.ofRepoIdOrNull(importRecord.getC_AcctSchema_ID()))
 				.setAD_Client_ID(importRecord.getAD_Client_ID())

--- a/backend/de.metas.acct.base/src/main/java/de/metas/acct/impexp/GLJournalImportProcess.java
+++ b/backend/de.metas.acct.base/src/main/java/de/metas/acct/impexp/GLJournalImportProcess.java
@@ -439,8 +439,10 @@ public class GLJournalImportProcess extends SimpleImportProcessTemplate<I_I_GLJo
 		return AccountDimension.builder()
 				.setAcctSchemaId(AcctSchemaId.ofRepoIdOrNull(importRecord.getC_AcctSchema_ID()))
 				.setAD_Client_ID(importRecord.getAD_Client_ID())
-				.setAD_Org_ID(importRecord.getAD_Org_ID())
+				.setAD_Org_ID(0)  // chart-of-accounts entries live at system org (0); produces AD_Org_ID=0 filter
 				.setC_ElementValue_ID(accountId)
+				.setC_BPartner_ID(0)  // no partner; produces C_BPartner_ID IS NULL filter
+				.setM_Product_ID(0)   // no product; produces M_Product_ID IS NULL filter
 				.build();
 	}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/acct/api/impl/AccountDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/acct/api/impl/AccountDAO.java
@@ -21,8 +21,6 @@ import org.compiere.model.I_C_ValidCombination;
 import org.compiere.model.MAccount;
 import org.compiere.util.Env;
 
-import java.util.Comparator;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -148,19 +146,7 @@ public class AccountDAO implements IAccountDAO
 			}
 		}
 
-		final List<I_C_ValidCombination> matches = queryBuilder.create().list(I_C_ValidCombination.class);
-		if (matches.isEmpty())
-		{
-			return null;
-		}
-		// When multiple combinations match (e.g. minimal dimension with no BPartner/Org filters),
-		// prefer the one with no partner assigned on org 0 — the most "generic" entry.
-		final I_C_ValidCombination existingAccount = matches.stream()
-				.min(Comparator
-						.comparingInt((I_C_ValidCombination vc) -> vc.getC_BPartner_ID() == 0 ? 0 : 1)
-						.thenComparingInt(vc -> vc.getAD_Org_ID() == 0 ? 0 : 1)
-						.thenComparingInt(I_C_ValidCombination::getC_ValidCombination_ID))
-				.orElseThrow();
+		final I_C_ValidCombination existingAccount = queryBuilder.create().firstOnly(I_C_ValidCombination.class);
 		return LegacyAdapters.convertToPO(existingAccount);
 	}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/acct/api/impl/AccountDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/acct/api/impl/AccountDAO.java
@@ -21,6 +21,8 @@ import org.compiere.model.I_C_ValidCombination;
 import org.compiere.model.MAccount;
 import org.compiere.util.Env;
 
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -146,7 +148,19 @@ public class AccountDAO implements IAccountDAO
 			}
 		}
 
-		final I_C_ValidCombination existingAccount = queryBuilder.create().firstOnly(I_C_ValidCombination.class);
+		final List<I_C_ValidCombination> matches = queryBuilder.create().list(I_C_ValidCombination.class);
+		if (matches.isEmpty())
+		{
+			return null;
+		}
+		// When multiple combinations match (e.g. minimal dimension with no BPartner/Org filters),
+		// prefer the one with no partner assigned on org 0 — the most "generic" entry.
+		final I_C_ValidCombination existingAccount = matches.stream()
+				.min(Comparator
+						.comparingInt((I_C_ValidCombination vc) -> vc.getC_BPartner_ID() == 0 ? 0 : 1)
+						.thenComparingInt(vc -> vc.getAD_Org_ID() == 0 ? 0 : 1)
+						.thenComparingInt(I_C_ValidCombination::getC_ValidCombination_ID))
+				.orElseThrow();
 		return LegacyAdapters.convertToPO(existingAccount);
 	}
 


### PR DESCRIPTION
## Problem

In GL Journal Import, `newMinimalAccountDimension` builds an `AccountDimension` with only Client, Org, and Account segments set. The other segments (BPartner, Product, etc.) are absent from the map, so `getSegmentValue()` returns `null` for them.

In `AccountDAO.retrieveAccount()`, `null` values match neither `instanceof String` nor `instanceof Integer`, so **no filter is added** for those segments. The query can therefore return multiple `C_ValidCombination` rows (with any BPartner, any Product, etc.). The old `.firstOnly()` threw an exception on multiple results.

## Fix

In `GLJournalImportProcess.newMinimalAccountDimension`, explicitly set:

- `AD_Org_ID = 0` — valid combinations for the chart of accounts live at system org
- `C_BPartner_ID = 0` — no partner (produces `IS NULL` filter in query)
- `M_Product_ID = 0` — no product (produces `IS NULL` filter in query)

This makes the lookup precise and deterministic without changing the general `AccountDAO` behaviour.