### PR TITLE
Port: ShipmentSchedule close_partially_shipped race fix → deep_tundra_release

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL.java
@@ -10,7 +10,6 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.bpartner.ShipmentAllocationBestBeforePolicy;
 import de.metas.bpartner.service.IBPartnerBL;
-import de.metas.common.util.CoalesceUtil;
 import de.metas.common.util.time.SystemTime;
 import de.metas.document.location.DocumentLocation;
 import de.metas.document.location.IDocumentLocationBL;
@@ -20,6 +19,7 @@ import de.metas.inout.IInOutBL;
 import de.metas.inout.IInOutDAO;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.inoutcandidate.api.ApplyShipmentScheduleChangesRequest;
+import de.metas.inoutcandidate.api.IShipmentScheduleAllocDAO;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleEffectiveBL;
 import de.metas.inoutcandidate.api.IShipmentSchedulePA;
@@ -150,7 +150,7 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 	static final AdMessageKey MSG_REACTIVATION_VOID_NOT_ALLOWED_BECAUSE_ALREADY_EXPORTED = AdMessageKey.of("salesorder.shipmentschedule.exported");
 	static final AdMessageKey MSG_REACTIVATION_VOID_NOT_ALLOWED_BECAUSE_SCHEDULED_FOR_PICKING = AdMessageKey.of("salesorder.shipmentschedule.cannotReactivateBecauseScheduledForPicking");
 
-	private static final String SYS_Config_M_ShipmentSchedule_Close_PartiallyShipped = "M_ShipmentSchedule_Close_PartiallyShipped";
+	static final String SYS_Config_M_ShipmentSchedule_Close_PartiallyShipped = "M_ShipmentSchedule_Close_PartiallyShipped";
 
 	private static final String SYSCONFIG_CAN_BE_EXPORTED_AFTER_SECONDS = "de.metas.inoutcandidate.M_ShipmentSchedule.canBeExportedAfterSeconds";
 	private static final String SYSCONFIG_CAN_BE_REEXPORTED_IF_QTYTODELIVER_IS_INCREASED = "de.metas.inoutcandidate.M_ShipmentSchedule.canBeExportedIfQtyToDeliverIsIncreased";
@@ -162,6 +162,7 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private final IAttributeSetInstanceBL attributeSetInstanceBL = Services.get(IAttributeSetInstanceBL.class);
 	private final IShipmentSchedulePA shipmentSchedulePA = Services.get(IShipmentSchedulePA.class);
+	private final IShipmentScheduleAllocDAO shipmentScheduleAllocDAO = Services.get(IShipmentScheduleAllocDAO.class);
 	private final IShipmentScheduleEffectiveBL shipmentScheduleEffectiveBL = Services.get(IShipmentScheduleEffectiveBL.class);
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	private final SpringContextHolder.Lazy<ProjectRepository> projectRepository = SpringContextHolder.lazyBean(ProjectRepository.class);
@@ -690,16 +691,11 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 			return;
 		}
 
-		// Sum up how much each schedule got delivered by THIS shipment (MovementQty), per schedule.
-		// Note on timing: this method runs synchronously at TIMING_AFTER_COMPLETE of the M_InOut, but the
-		// schedule's own QtyDelivered is only updated in a runAfterCommit hook (see
-		// M_InOut_Shipment.invalidateShipmentSchedulesForLines), i.e. AFTER this method. So at this point
-		// QtyDelivered does NOT yet reflect the current shipment - it only reflects deliveries from sibling
-		// shipments of the same order that were completed in earlier, already-committed transactions.
-		// We therefore add this shipment's just-shipped MovementQty on top of QtyDelivered below.
+		// This shipment's just-delivered qty per schedule. Its own lines are not yet Processed here, so the
+		// PROCESSED-only ledger read below excludes them and we add this qty on top (see the
+		// TIMING_AFTER_COMPLETE-runs-before-setProcessed gotcha in de.metas.inoutcandidate/CLAUDE.md).
 		final HashMap<ShipmentScheduleId, BigDecimal> qtyDeliveredByThisShipmentByScheduleId = new HashMap<>();
 		final HashSet<OrderId> orderIds = new HashSet<>();
-
 		for (final I_M_InOutLine iolrecord : inOutDAO.retrieveLines(inoutRecord))
 		{
 			try (final MDCCloseable ignored = TableRecordMDC.putTableRecordReference(iolrecord))
@@ -718,11 +714,10 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 			}
 		}
 
-		// Close all not-yet-closed schedules of the involved orders that are NOT already fully delivered.
-		// A schedule that is already fully delivered must stay open, regardless of which shipment delivered
-		// it: whether by THIS shipment (its MovementQty is not yet in QtyDelivered - see above) or by a
-		// sibling shipment of the same order (multi-InOut split; its qty IS already in QtyDelivered).
-		// Only genuinely partially/unshipped schedules are closed here.
+		// Close every not-yet-closed schedule that is not fully delivered. Delivered = this shipment's qty
+		// (above) + the committed processed-line ledger of already-completed sibling M_InOuts
+		// (retrieveQtyDelivered). We intentionally do NOT read the schedule's own QtyDelivered: it is a
+		// deferred runAfterCommit recompute of that same ledger and lags here (the multi-InOut bug this fixes).
 		for (final OrderId orderId : orderIds)
 		{
 			final ImmutableSet<ShipmentScheduleId> allScheduleIds = shipmentSchedulePA.retrieveScheduleIdsByOrderId(orderId);
@@ -735,15 +730,13 @@ public class ShipmentScheduleBL implements IShipmentScheduleBL
 				}
 
 				final BigDecimal effectiveQtyOrdered = shipmentScheduleEffectiveBL.computeQtyOrdered(schedule);
-
-				final BigDecimal qtyDeliveredPersisted = CoalesceUtil.coalesce(schedule.getQtyDelivered(), BigDecimal.ZERO);
 				final BigDecimal qtyDeliveredThisShipment = qtyDeliveredByThisShipmentByScheduleId.getOrDefault(scheduleId, BigDecimal.ZERO);
-				final BigDecimal qtyDeliveredTotal = qtyDeliveredPersisted.add(qtyDeliveredThisShipment);
+				final BigDecimal qtyDelivered = qtyDeliveredThisShipment.add(shipmentScheduleAllocDAO.retrieveQtyDelivered(schedule));
 
-				if (qtyDeliveredTotal.compareTo(effectiveQtyOrdered) >= 0)
+				if (qtyDelivered.compareTo(effectiveQtyOrdered) >= 0)
 				{
-					logger.debug("Not closing shipment schedule {} - already fully delivered (qtyDeliveredTotal={} >= effectiveQtyOrdered={})",
-							scheduleId, qtyDeliveredTotal, effectiveQtyOrdered);
+					logger.debug("Not closing shipment schedule {} - already fully delivered (qtyDelivered={} >= effectiveQtyOrdered={})",
+							scheduleId, qtyDelivered, effectiveQtyOrdered);
 					continue;
 				}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL_closePartiallyShipped_Test.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleBL_closePartiallyShipped_Test.java
@@ -22,8 +22,10 @@ package de.metas.inoutcandidate.api.impl;
  * #L%
  */
 
+import de.metas.document.engine.DocStatus;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule_QtyPicked;
 import de.metas.organization.OrgId;
 import de.metas.util.Services;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -66,17 +68,22 @@ public class ShipmentScheduleBL_closePartiallyShipped_Test
 		shipmentScheduleBL = (ShipmentScheduleBL)Services.get(IShipmentScheduleBL.class);
 	}
 
+	private static void enableCloseIfPartiallyShipped(final OrgId orgId)
+	{
+		Services.get(ISysConfigBL.class).setValue(
+				ShipmentScheduleBL.SYS_Config_M_ShipmentSchedule_Close_PartiallyShipped,
+				true,
+				ClientId.METASFRESH,
+				orgId);
+	}
+
 	@Test
 	public void closePartiallyShipped_ShipmentSchedules_doesNotCloseScheduleAlreadyFullyDeliveredBySiblingInOut()
 	{
 		final OrgId orgId = OrgId.ANY;
 
 		// enable "close partially shipped schedules" for this org
-		Services.get(ISysConfigBL.class).setValue(
-				"M_ShipmentSchedule_Close_PartiallyShipped",
-				true,
-				ClientId.METASFRESH,
-				orgId);
+		enableCloseIfPartiallyShipped(orgId);
 
 		final I_C_Order order = newInstance(I_C_Order.class);
 		order.setIsSOTrx(true);
@@ -98,9 +105,30 @@ public class ShipmentScheduleBL_closePartiallyShipped_Test
 		scheduleFull.setRecord_ID(orderLineFull.getC_OrderLine_ID());
 		scheduleFull.setQtyOrdered(new BigDecimal("12"));
 		scheduleFull.setQtyOrdered_Calculated(new BigDecimal("12")); // effective QtyOrdered (no override)
-		scheduleFull.setQtyDelivered(new BigDecimal("12")); // fully delivered already, e.g. by a sibling InOut
+		scheduleFull.setQtyDelivered(new BigDecimal("12")); // recompute already landed (not read by the close decision)
 		scheduleFull.setIsClosed(false);
 		save(scheduleFull);
+
+		// the committed sibling delivery backing S_full: a completed M_InOut line (12) linked to S_full via
+		// M_ShipmentSchedule_QtyPicked - this is what the close decision actually reads (the processed-line ledger)
+		final I_M_InOut siblingInOut = newInstance(I_M_InOut.class);
+		siblingInOut.setAD_Org_ID(orgId.getRepoId());
+		siblingInOut.setIsSOTrx(true);
+		siblingInOut.setDocStatus(DocStatus.Completed.getCode());
+		save(siblingInOut);
+
+		final I_M_InOutLine siblingLineFull = newInstance(I_M_InOutLine.class);
+		siblingLineFull.setM_InOut(siblingInOut);
+		siblingLineFull.setC_OrderLine_ID(orderLineFull.getC_OrderLine_ID());
+		siblingLineFull.setMovementQty(new BigDecimal("12"));
+		siblingLineFull.setProcessed(true);
+		save(siblingLineFull);
+
+		final I_M_ShipmentSchedule_QtyPicked allocFull = newInstance(I_M_ShipmentSchedule_QtyPicked.class);
+		allocFull.setM_ShipmentSchedule_ID(scheduleFull.getM_ShipmentSchedule_ID());
+		allocFull.setM_InOutLine_ID(siblingLineFull.getM_InOutLine_ID());
+		allocFull.setQtyPicked(new BigDecimal("12"));
+		save(allocFull);
 
 		// S_partial: shipped by the CURRENT InOut with MovementQty=8 of 12 ordered (partial delivery).
 		// QtyDelivered is still 0 at TIMING_AFTER_COMPLETE - the QtyPicked->QtyDelivered shift for this
@@ -147,17 +175,125 @@ public class ShipmentScheduleBL_closePartiallyShipped_Test
 				.isTrue();
 	}
 
+	/**
+	 * The async-stale variant of the sibling-InOut case. When one order's picked lines ship via ≥2
+	 * separate {@code M_InOut} docs, each InOut's {@code QtyPicked→QtyDelivered} shift runs in its OWN
+	 * deferred {@code runAfterCommit} hook. So when a later sibling InOut completes and runs
+	 * {@code closePartiallyShipped}, a schedule fully shipped by an EARLIER sibling InOut can still have
+	 * {@code QtyDelivered=0} — its recompute has not landed yet. The committed truth is the sibling's
+	 * {@code M_InOutLine.MovementQty}; if the close trusts the stale {@code QtyDelivered} it wrongly
+	 * closes the fully-shipped schedule, which nothing ever reopens.
+	 */
+	@Test
+	public void closePartiallyShipped_ShipmentSchedules_doesNotCloseScheduleFullyDeliveredBySibling_whenQtyDeliveredNotYetRecomputed()
+	{
+		final OrgId orgId = OrgId.ANY;
+
+		enableCloseIfPartiallyShipped(orgId);
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setIsSOTrx(true);
+		save(order);
+
+		final int orderLineTableId = InterfaceWrapperHelper.getTableId(I_C_OrderLine.class);
+
+		// S_full: fully shipped (12/12) by a SIBLING, already-completed M_InOut, but QtyDelivered is
+		// still 0 because that sibling's QtyDelivered recompute has not landed yet (the race window).
+		final I_C_OrderLine orderLineFull = newInstance(I_C_OrderLine.class);
+		orderLineFull.setC_Order(order);
+		save(orderLineFull);
+
+		final I_M_ShipmentSchedule scheduleFull = newInstance(I_M_ShipmentSchedule.class);
+		scheduleFull.setAD_Org_ID(orgId.getRepoId());
+		scheduleFull.setC_Order_ID(order.getC_Order_ID());
+		scheduleFull.setC_OrderLine_ID(orderLineFull.getC_OrderLine_ID());
+		scheduleFull.setAD_Table_ID(orderLineTableId);
+		scheduleFull.setRecord_ID(orderLineFull.getC_OrderLine_ID());
+		scheduleFull.setQtyOrdered(new BigDecimal("12"));
+		scheduleFull.setQtyOrdered_Calculated(new BigDecimal("12"));
+		scheduleFull.setQtyDelivered(BigDecimal.ZERO); // stale: sibling's recompute not yet landed
+		scheduleFull.setIsClosed(false);
+		save(scheduleFull);
+
+		// the sibling shipment that already delivered S_full's 12 (completed, not a reversal)
+		final I_M_InOut siblingInOut = newInstance(I_M_InOut.class);
+		siblingInOut.setAD_Org_ID(orgId.getRepoId());
+		siblingInOut.setIsSOTrx(true);
+		siblingInOut.setDocStatus(DocStatus.Completed.getCode());
+		save(siblingInOut);
+
+		final I_M_InOutLine siblingLineFull = newInstance(I_M_InOutLine.class);
+		siblingLineFull.setM_InOut(siblingInOut);
+		siblingLineFull.setC_OrderLine_ID(orderLineFull.getC_OrderLine_ID());
+		siblingLineFull.setMovementQty(new BigDecimal("12"));
+		siblingLineFull.setProcessed(true);
+		save(siblingLineFull);
+
+		// the committed picking->shipment allocation binding S_full to the sibling shipment line
+		final I_M_ShipmentSchedule_QtyPicked allocFull = newInstance(I_M_ShipmentSchedule_QtyPicked.class);
+		allocFull.setM_ShipmentSchedule_ID(scheduleFull.getM_ShipmentSchedule_ID());
+		allocFull.setM_InOutLine_ID(siblingLineFull.getM_InOutLine_ID());
+		allocFull.setQtyPicked(new BigDecimal("12"));
+		save(allocFull);
+
+		// S_partial: shipped 8/12 by the CURRENT InOut (its QtyDelivered is 0 at close-time too)
+		final I_C_OrderLine orderLinePartial = newInstance(I_C_OrderLine.class);
+		orderLinePartial.setC_Order(order);
+		save(orderLinePartial);
+
+		final I_M_ShipmentSchedule schedulePartial = newInstance(I_M_ShipmentSchedule.class);
+		schedulePartial.setAD_Org_ID(orgId.getRepoId());
+		schedulePartial.setC_Order_ID(order.getC_Order_ID());
+		schedulePartial.setC_OrderLine_ID(orderLinePartial.getC_OrderLine_ID());
+		schedulePartial.setAD_Table_ID(orderLineTableId);
+		schedulePartial.setRecord_ID(orderLinePartial.getC_OrderLine_ID());
+		schedulePartial.setQtyOrdered(new BigDecimal("12"));
+		schedulePartial.setQtyOrdered_Calculated(new BigDecimal("12"));
+		schedulePartial.setQtyDelivered(BigDecimal.ZERO);
+		schedulePartial.setIsClosed(false);
+		save(schedulePartial);
+
+		final I_M_InOut currentInOut = newInstance(I_M_InOut.class);
+		currentInOut.setAD_Org_ID(orgId.getRepoId());
+		currentInOut.setIsSOTrx(true);
+		currentInOut.setDocStatus(DocStatus.Completed.getCode());
+		save(currentInOut);
+
+		final I_M_InOutLine currentLinePartial = newInstance(I_M_InOutLine.class);
+		currentLinePartial.setM_InOut(currentInOut);
+		currentLinePartial.setC_OrderLine_ID(orderLinePartial.getC_OrderLine_ID());
+		currentLinePartial.setMovementQty(new BigDecimal("8"));
+		// this InOut is completing NOW: its lines are not yet Processed at close-time (TIMING_AFTER_COMPLETE
+		// fires before setProcessed), so this delivery is counted via MovementQty, not the processed-line ledger
+		currentLinePartial.setProcessed(false);
+		save(currentLinePartial);
+
+		final I_M_ShipmentSchedule_QtyPicked allocPartial = newInstance(I_M_ShipmentSchedule_QtyPicked.class);
+		allocPartial.setM_ShipmentSchedule_ID(schedulePartial.getM_ShipmentSchedule_ID());
+		allocPartial.setM_InOutLine_ID(currentLinePartial.getM_InOutLine_ID());
+		allocPartial.setQtyPicked(new BigDecimal("8"));
+		save(allocPartial);
+
+		shipmentScheduleBL.closePartiallyShipped_ShipmentSchedules(currentInOut);
+
+		refresh(scheduleFull);
+		refresh(schedulePartial);
+
+		assertThat(scheduleFull.isClosed())
+				.as("S_full is fully delivered by a sibling InOut (committed in M_InOutLine, QtyDelivered not yet recomputed) and must stay open")
+				.isFalse();
+		assertThat(schedulePartial.isClosed())
+				.as("S_partial is not fully delivered => must be closed")
+				.isTrue();
+	}
+
 	@Test
 	public void closePartiallyShipped_ShipmentSchedules_closesCompletelyUnshippedSchedule()
 	{
 		final OrgId orgId = OrgId.ANY;
 
 		// enable "close partially shipped schedules" for this org
-		Services.get(ISysConfigBL.class).setValue(
-				"M_ShipmentSchedule_Close_PartiallyShipped",
-				true,
-				ClientId.METASFRESH,
-				orgId);
+		enableCloseIfPartiallyShipped(orgId);
 
 		final I_C_Order order = newInstance(I_C_Order.class);
 		order.setIsSOTrx(true);
@@ -227,11 +363,7 @@ public class ShipmentScheduleBL_closePartiallyShipped_Test
 		final OrgId orgId = OrgId.ANY;
 
 		// enable "close partially shipped schedules" for this org
-		Services.get(ISysConfigBL.class).setValue(
-				"M_ShipmentSchedule_Close_PartiallyShipped",
-				true,
-				ClientId.METASFRESH,
-				orgId);
+		enableCloseIfPartiallyShipped(orgId);
 
 		final I_C_Order order = newInstance(I_C_Order.class);
 		order.setIsSOTrx(true);


### PR DESCRIPTION
Back-port of the `close_partially_shipped` ShipmentSchedule race fix from `new_dawn_uat`.

**Source:** https://github.com/metasfresh/metasfresh/pull/25073 (squash commit https://github.com/metasfresh/metasfresh/commit/1f8726f1036) — "ShipmentSchedule: fix intermittent wrong-close of a fully-shipped schedule (multi-InOut split)".

The close decision now sums this-shipment qty + the committed delivery ledger (`retrieveQtyDelivered`) instead of reading the async-recomputed `QtyDelivered`, so a fully-shipped schedule split across multiple InOuts is no longer intermittently closed early. Behaviour is gated behind the existing sysconfig; default behaviour unchanged.

Files: `ShipmentScheduleBL.java` + its regression test. No DDL / migration.
