### PR TITLE
Port: product purchase/sales-gate client-org fix → deep_tundra_release

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/ProductLookupDescriptor.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/descriptor/sql/ProductLookupDescriptor.java
@@ -226,7 +226,7 @@ public class ProductLookupDescriptor implements LookupDescriptor, LookupDataSour
 
 		this.excludeBOMProducts = excludeBOMProducts;
 
-		ctxNamesNeededForQuery = ImmutableSet.of(param_C_BPartner_ID, param_M_PriceList_ID, param_PricingDate, param_AD_Org_ID);
+		ctxNamesNeededForQuery = ImmutableSet.of(param_C_BPartner_ID, param_M_PriceList_ID, param_PricingDate, param_AD_Org_ID, param_AD_Client_ID);
 
 		searchStringMinLength = adTablesRepo.getTypeaheadMinLength(org.compiere.model.I_M_Product.Table_Name);
 		this.isFallbackToBasePricelist = CoalesceUtil.coalesceNotNull(isFallbackToBasePricelist, Boolean.TRUE);
@@ -805,6 +805,7 @@ public class ProductLookupDescriptor implements LookupDescriptor, LookupDataSour
 		{
 			return;
 		}
+		// Resolve the enforcement gate from the request context's client/org.
 		final ClientId clientId = ClientId.ofRepoId(param_AD_Client_ID.getValueAsInteger(evalCtx));
 		final OrgId orgId = OrgId.ofRepoId(param_AD_Org_ID.getValueAsInteger(evalCtx));
 		if (!productBL.isPurchaseSalesEnforcementEnabled(clientId, orgId))


### PR DESCRIPTION
Back-port of the product purchase/sales-gate fix from `new_dawn_uat`.

**Source:** https://github.com/metasfresh/metasfresh/pull/24985 (squash commit https://github.com/metasfresh/metasfresh/commit/36a7fe84cfe) — "ProductLookupDescriptor: resolve IsSold/IsPurchased gate client/org from the request context".

The purchase/sales product-gate was silently disabled because the lookup descriptor read client/org from an evalCtx where the key was absent and fell back to `-1`. The fix adds `param_AD_Client_ID` to the query context set and resolves the enforcement gate's client/org from the request evalCtx. Real-bug fix (documented on the originating investigation), not a test flake.

File: `ProductLookupDescriptor.java`. No DDL / migration.
