### PR TITLE
ci: remove stale .testspace.yml paths-ignore entry — temporary_test202412_hotfix

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -6,7 +6,6 @@ on:
     paths-ignore:
       - '**/README.md'
       - '.mergify.yml'
-      - '.testspace.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What

Final Testspace cleanup on `temporary_test202412_hotfix`. This branch already had its Testspace steps removed and the feature/spec permalink + canonical `publish-test-reports` in place (`publish-test-reports` is byte-identical to `new_dawn_uat`). This PR removes the one remaining straggler:

- Drop the stale `- '.testspace.yml'` entry from the workflow `paths-ignore` (the file itself was already deleted).

## Why low-risk
Reporting-only, single-line workflow cleanup. 0 remaining `testspace` references; YAML valid; actionlint no new findings.
