### PR TITLE
ci: remove stale .testspace.yml paths-ignore entry — new_dawn_uat

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -6,7 +6,6 @@ on:
     paths-ignore:
       - '**/README.md'
       - '.mergify.yml'
-      - '.testspace.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What

Final Testspace cleanup on the canonical `new_dawn_uat` branch. Its Testspace steps were already retired (via the auto-ported Tier A branch merges) and it already carries the feature/spec permalink + canonical `publish-test-reports`. This PR drops the one remaining straggler:

- Remove the stale `- '.testspace.yml'` entry from the workflow `paths-ignore` (the file itself is already deleted).

## Why low-risk
Reporting-only, single-line workflow cleanup. 0 remaining `testspace` references; YAML valid; actionlint no new findings.
