### PR TITLE
ci(cucumber): copy allure-results out of the test container

### DIFF
--- a/backend/de.metas.cucumber/pom.xml
+++ b/backend/de.metas.cucumber/pom.xml
@@ -208,6 +208,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Allure reporting for Cucumber tests -->
+        <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-cucumber7-jvm</artifactId>
+            <version>2.25.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/RunCucumberTest.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/RunCucumberTest.java
@@ -41,7 +41,7 @@ import org.junit.platform.suite.api.Suite;
 @SelectPackages("de.metas.cucumber")
 @ConfigurationParameter(key = Constants.GLUE_PROPERTY_NAME, value = "de.metas.cucumber.stepdefs")
 @ConfigurationParameter(key = Constants.FILTER_TAGS_PROPERTY_NAME, value = "not @ignore")
-@ConfigurationParameter(key = Constants.PLUGIN_PROPERTY_NAME, value = "html:target/cucumber.html,json:target/cucumber.json,junit:target/cucumber-junit.xml,message:target/cucumber.message")
+@ConfigurationParameter(key = Constants.PLUGIN_PROPERTY_NAME, value = "html:target/cucumber.html,json:target/cucumber.json,junit:target/cucumber-junit.xml,message:target/cucumber.message,io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm")
 public class RunCucumberTest
 {
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/RunCucumberTest.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/RunCucumberTest.java
@@ -41,7 +41,7 @@ import org.junit.platform.suite.api.Suite;
 @SelectPackages("de.metas.cucumber")
 @ConfigurationParameter(key = Constants.GLUE_PROPERTY_NAME, value = "de.metas.cucumber.stepdefs")
 @ConfigurationParameter(key = Constants.FILTER_TAGS_PROPERTY_NAME, value = "not @ignore")
-@ConfigurationParameter(key = Constants.PLUGIN_PROPERTY_NAME, value = "html:target/cucumber.html,json:target/cucumber.json,junit:target/cucumber-junit.xml,message:target/cucumber.message,io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm")
+@ConfigurationParameter(key = Constants.PLUGIN_PROPERTY_NAME, value = "pretty,html:target/cucumber.html,json:target/cucumber.json,junit:target/cucumber-junit.xml,message:target/cucumber.message,io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm")
 public class RunCucumberTest
 {
 }

--- a/backend/de.metas.cucumber/src/test/resources/allure.properties
+++ b/backend/de.metas.cucumber/src/test/resources/allure.properties
@@ -1,0 +1,5 @@
+# Allure reporting configuration for Cucumber tests
+allure.results.directory=target/allure-results
+
+# Link template for GitHub issues
+allure.link.issue.pattern=https://github.com/metasfresh/metasfresh/issues/{}

--- a/backend/de.metas.cucumber/src/test/resources/allure/categories.json
+++ b/backend/de.metas.cucumber/src/test/resources/allure/categories.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "Database errors",
+    "messageRegex": ".*SQLException.*|.*database.*|.*PostgreSQL.*|.*constraint violation.*",
+    "matchedStatuses": ["failed", "broken"]
+  },
+  {
+    "name": "Timeout issues",
+    "messageRegex": ".*timeout.*|.*timed out.*|.*TimeoutException.*",
+    "matchedStatuses": ["failed", "broken"]
+  },
+  {
+    "name": "API errors",
+    "messageRegex": ".*REST.*|.*API.*|.*HTTP.*|.*status code.*|.*response.*",
+    "matchedStatuses": ["failed", "broken"]
+  },
+  {
+    "name": "Assertion failures",
+    "messageRegex": ".*AssertionError.*|.*Expected.*but.*|.*should be.*but was.*",
+    "matchedStatuses": ["failed"]
+  },
+  {
+    "name": "Infrastructure issues",
+    "messageRegex": ".*container.*|.*docker.*|.*connection refused.*|.*RabbitMQ.*",
+    "matchedStatuses": ["failed", "broken"]
+  }
+]

--- a/docker-builds/cucumber/entrypoint.sh
+++ b/docker-builds/cucumber/entrypoint.sh
@@ -56,3 +56,4 @@ echo "==================="
 
 cp target/*.xml /reports
 cp target/*.html /reports
+cp -r target/allure-results /reports/ 2>/dev/null || true


### PR DESCRIPTION
## What

The cucumber `entrypoint.sh` copied `target/*.xml` and `target/*.html` to `/reports` but **not** `target/allure-results`. So the `Extract Cucumber Allure results` step found nothing, the `cucumber-allure-results-*` artifact was never produced, and `cucumber-allure-report` skipped — cucumber Allure never reached `test-reports.metasfresh.com`.

This adds the one missing line (matching `new_dawn_uat`, which does publish cucumber Allure):
```
cp -r target/allure-results /reports/ 2>/dev/null || true
```

## Why now

Surfaced while verifying the Testspace-retirement / report-transport pilot (https://github.com/metasfresh/metasfresh/pull/25097): all other report types landed on the server, but `allure/cucumber` 404'd. Root cause was this missing copy-out, not the transport change.