### PR TITLE
eInvoice — make C_BPartner.EInvoiceType mandatory in the UI when the partner is an e-invoice recipient

### DIFF
--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5814000_sys_EInvoice_TypeMandatoryWhenRecipient.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5814000_sys_EInvoice_TypeMandatoryWhenRecipient.sql
@@ -1,0 +1,18 @@
+-- Make C_BPartner.EInvoiceType mandatory in the UI whenever the partner is flagged as an
+-- e-invoice recipient (IsEInvoiceRecipeint='Y'). If the recipient flag is set but no type is
+-- chosen, invoice completion silently treats the partner as a non-e-invoice recipient, so no
+-- XRechnung/ZUGFeRD document is generated and no error is shown. This MandatoryLogic makes the
+-- field required in the UI. It is set on the AD_Column (not per field), so it applies to every
+-- window that shows EInvoiceType. UI-only guard by design (no server-side interceptor).
+--
+-- AFFECTED RECORD: AD_Column 591242 (C_BPartner.EInvoiceType), EntityType 'D'.
+-- Sets MandatoryLogic = @IsEInvoiceRecipeint/N@=Y (was empty). IsMandatory stays 'N'
+-- (conditionally mandatory via the logic expression; no NOT NULL / DDL change).
+
+-- 2026-07-15 12:00:00
+UPDATE AD_Column
+SET MandatoryLogic='@IsEInvoiceRecipeint/N@=Y',
+    Updated=TO_TIMESTAMP('2026-07-15 12:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy=100
+WHERE AD_Column_ID=591242
+;


### PR DESCRIPTION
## Problem

A `C_BPartner` can be flagged as an e-invoice recipient (`IsEInvoiceRecipeint='Y'`) **without** choosing an `EInvoiceType`. In that state, invoice completion resolves no e-invoice format and **silently generates no XRechnung/ZUGFeRD** — no error is shown, so the operator believes e-invoicing is active when nothing is produced.

## Change

Set `AD_Column.EInvoiceType.MandatoryLogic = @IsEInvoiceRecipeint/N@=Y` — the type field becomes required in the UI whenever the recipient flag is ticked. Set at the **column** level, so it applies in every window that shows the field (no per-field / per-window duplication). `IsMandatory` stays `N` (conditionally mandatory via the logic; no `NOT NULL`/DDL change).

Migration: `5814000_sys_EInvoice_TypeMandatoryWhenRecipient.sql`. No model regeneration (MandatoryLogic is not a generated-model column). No translations (logic expression, not a caption).

## Scope note

UI-only guard by design — no server-side interceptor. An API/import path could still persist the flag without a type; if that config is only ever set via the window, that is acceptable.

## Verification

- Migration applies cleanly; `AD_Column 591242` now carries the MandatoryLogic (`IsMandatory` still `N`).
- On the tab where both fields are placed, `EInvoiceType` + `IsEInvoiceRecipeint` are co-located, so the context variable resolves.
- Live "field renders mandatory on the redesigned BPartner windows" confirmation is a UAT step on the target instance.
