### PR TITLE
de.metas.cucumber: fix flaky DDOrderReplenishment_split per-locator assertion

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DD_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DD_Order_StepDef.java
@@ -98,10 +98,10 @@ import org.eevolution.model.X_DD_Order;
 import javax.annotation.Nullable;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.logging.LogManager;
+import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -850,18 +850,31 @@ public class DD_Order_StepDef
 		final PickingJobScheduleId jobScheduleId = rows.get(0)
 				.getAsIdentifier(I_DD_Order.COLUMNNAME_M_Picking_Job_Schedule_ID).lookupNotNullIdIn(pickingJobScheduleTable);
 
+		// Expected per-locator picture: the full source-locator SET, plus the expected QtyEntered for each row that
+		// specifies one (QtyEntered is an optional column).
 		final Map<LocatorId, DataTableRow> expectedBySourceLocator = new LinkedHashMap<>();
+		final Map<LocatorId, BigDecimal> expectedQtyBySourceLocator = new LinkedHashMap<>();
 		for (final DataTableRow row : rows)
 		{
 			final LocatorId sourceLocatorId = row.getAsIdentifier(I_DD_OrderLine.COLUMNNAME_M_Locator_ID).lookupNotNullIdIn(locatorTable);
 			expectedBySourceLocator.put(sourceLocatorId, row);
+			row.getAsOptionalBigDecimal(I_DD_OrderLine.COLUMNNAME_QtyEntered)
+					.ifPresent(qtyEntered -> expectedQtyBySourceLocator.put(sourceLocatorId, qtyEntered));
 		}
 
-		// Poll until the live DD_Orders' source-locator set EXACTLY matches the expected set, then validate each
-		// matched DD_Order's header + single line. Polling on the whole set (not row-by-row) avoids binding to a
-		// transient in-flight state where a void/create/update has only partially landed.
-		final Supplier<Boolean> exactSetReady = () -> liveSourceLocatorsForPickingJobSchedule(jobScheduleId).equals(expectedBySourceLocator.keySet());
-		StepDefUtil.tryAndWait(timeoutSec, 1000, exactSetReady, () -> logCurrentDDOrdersForPickingJobSchedule(jobScheduleId));
+		// Poll until the async reconcile has SETTLED, then validate each matched DD_Order's header + single line.
+		// "Settled" = the live source-locator set EXACTLY matches the expected set AND every expected per-locator
+		// QtyEntered matches the live line quantity. Polling on the whole picture (not row-by-row) avoids binding to
+		// a transient in-flight state where a void/create/update has only partially landed. QtyEntered is part of
+		// the gate because a demand change that keeps the SAME contributing locators (only the quantity changes)
+		// leaves the source-locator set unchanged: a set-only check is satisfied immediately by the stale pre-change
+		// DD_Orders and would race the async (event-bus) reconcile that updates the line quantity.
+		final Supplier<Boolean> reconcileSettled = () -> {
+			final Map<LocatorId, BigDecimal> liveQtyBySourceLocator = liveLineQtyBySourceLocatorForPickingJobSchedule(jobScheduleId);
+			return isPerLocatorReconcileSettled(expectedBySourceLocator.keySet(), expectedQtyBySourceLocator,
+					liveQtyBySourceLocator.keySet(), liveQtyBySourceLocator);
+		};
+		StepDefUtil.tryAndWait(timeoutSec, 1000, reconcileSettled, () -> logCurrentDDOrdersForPickingJobSchedule(jobScheduleId));
 
 		for (final Map.Entry<LocatorId, DataTableRow> entry : expectedBySourceLocator.entrySet())
 		{
@@ -877,11 +890,11 @@ public class DD_Order_StepDef
 	}
 
 	/**
-	 * Returns the set of source locators ({@code DD_OrderLine.M_Locator_ID}) of all live (non-voided) DD_Orders
-	 * linked to the given assignment. Each reconcile DD_Order has exactly one line, so this is the set of
-	 * contributing source locators.
+	 * Live per-locator picture: source {@code LocatorId} → the line's {@code QtyEntered}, for every live (non-voided)
+	 * DD_Order linked to the assignment. Each reconcile DD_Order has exactly one line, so the key set is the set of
+	 * contributing source locators and each value is that locator's current planned quantity.
 	 */
-	private Set<LocatorId> liveSourceLocatorsForPickingJobSchedule(@NonNull final PickingJobScheduleId jobScheduleId)
+	private Map<LocatorId, BigDecimal> liveLineQtyBySourceLocatorForPickingJobSchedule(@NonNull final PickingJobScheduleId jobScheduleId)
 	{
 		// Collect the live DD_Order ids, then fetch all their lines in a single batched query (no per-DD_Order query).
 		final List<DDOrderId> liveDDOrderIds = queryBL.createQueryBuilder(I_DD_Order.class)
@@ -892,7 +905,7 @@ public class DD_Order_StepDef
 				.map(ddOrder -> DDOrderId.ofRepoId(ddOrder.getDD_Order_ID()))
 				.collect(java.util.stream.Collectors.toList());
 
-		final Set<LocatorId> sourceLocatorIds = new LinkedHashSet<>();
+		final Map<LocatorId, BigDecimal> qtyBySourceLocator = new LinkedHashMap<>();
 		ddOrderLowLevelDAO.streamLinesByDDOrderIds(liveDDOrderIds)
 				.forEach(line -> {
 					// Resolve the source LocatorId from the locator record (authoritative warehouse), not the
@@ -900,10 +913,39 @@ public class DD_Order_StepDef
 					final LocatorId sourceLocatorId = LocatorId.ofRecordOrNull(warehouseDAO.getLocatorByRepoId(line.getM_Locator_ID()));
 					if (sourceLocatorId != null)
 					{
-						sourceLocatorIds.add(sourceLocatorId);
+						qtyBySourceLocator.put(sourceLocatorId, line.getQtyEntered());
 					}
 				});
-		return sourceLocatorIds;
+		return qtyBySourceLocator;
+	}
+
+	/**
+	 * Readiness predicate for {@link #validatePerLocatorDDOrdersLinkedToPickingJobSchedule}: the async reconcile has
+	 * settled iff the live source-locator set exactly matches the expected set AND every expected per-locator
+	 * {@code QtyEntered} equals the live line quantity. Including the quantity is essential — a demand change that
+	 * keeps the same contributing locators (only the quantity changes) leaves the source-locator set unchanged, so a
+	 * set-only check would report "ready" immediately against the stale pre-change DD_Orders and race the async
+	 * reconcile that updates the line quantity. Pure/stateless so it can be unit-tested without a DB.
+	 */
+	static boolean isPerLocatorReconcileSettled(
+			@NonNull final Set<LocatorId> expectedLocators,
+			@NonNull final Map<LocatorId, BigDecimal> expectedQtyByLocator,
+			@NonNull final Set<LocatorId> liveLocators,
+			@NonNull final Map<LocatorId, BigDecimal> liveQtyByLocator)
+	{
+		if (!liveLocators.equals(expectedLocators))
+		{
+			return false;
+		}
+		for (final Map.Entry<LocatorId, BigDecimal> expected : expectedQtyByLocator.entrySet())
+		{
+			final BigDecimal liveQty = liveQtyByLocator.get(expected.getKey());
+			if (liveQty == null || liveQty.compareTo(expected.getValue()) != 0)
+			{
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Nullable

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DD_Order_StepDef_ReconcileSettledTest.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/distributionorder/DD_Order_StepDef_ReconcileSettledTest.java
@@ -1,0 +1,147 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.distributionorder;
+
+import org.adempiere.warehouse.LocatorId;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link DD_Order_StepDef#isPerLocatorReconcileSettled(Set, Map, Set, Map)} — the readiness gate of
+ * the "per-locator DD_Orders linked to picking job schedule are found" assertion step.
+ * <p>
+ * When a demand change keeps the SAME contributing locators and only changes the quantity, the source-locator set is
+ * unchanged, so a set-only readiness check reports "ready" immediately against the stale pre-change DD_Orders and
+ * races the asynchronous reconcile — the assertion then intermittently reads the pre-change {@code QtyEntered}.
+ * {@link DD_Order_StepDef#isPerLocatorReconcileSettled} gates on the per-locator quantity too, so it only reports
+ * ready once the reconcile has settled the line quantity.
+ */
+class DD_Order_StepDef_ReconcileSettledTest
+{
+	private static final LocatorId locatorA = LocatorId.ofRepoId(100, 10);
+	private static final LocatorId locatorB = LocatorId.ofRepoId(100, 20);
+
+	private static BigDecimal bd(final String v)
+	{
+		return new BigDecimal(v);
+	}
+
+	private static Set<LocatorId> set(final LocatorId... ids)
+	{
+		return new LinkedHashSet<>(Arrays.asList(ids));
+	}
+
+	/**
+	 * The defect this fix targets: same contributing locators, only the quantity lowered (15→12 ⇒ locatorB 5→2).
+	 * The live DD_Orders still show the stale pre-change quantity (locatorB=5) while the async reconcile is in
+	 * flight. A set-only check would pass here (set {A,B} matches) and let the hard assertion read the stale 5 —
+	 * must NOT be ready until locatorB settles to 2.
+	 */
+	@Test
+	void staleQuantity_sameLocatorSet_isNotReady()
+	{
+		final Map<LocatorId, BigDecimal> expectedQty = new LinkedHashMap<>();
+		expectedQty.put(locatorA, bd("10"));
+		expectedQty.put(locatorB, bd("2"));
+
+		final Map<LocatorId, BigDecimal> liveQty = new LinkedHashMap<>();
+		liveQty.put(locatorA, bd("10"));
+		liveQty.put(locatorB, bd("5")); // stale: reconcile not yet applied
+
+		assertThat(DD_Order_StepDef.isPerLocatorReconcileSettled(
+				set(locatorA, locatorB), expectedQty, liveQty.keySet(), liveQty))
+				.as("stale per-locator quantity (same locator set) must NOT be reported as settled")
+				.isFalse();
+	}
+
+	/** Once the reconcile has settled the quantity (locatorB=2), the gate reports ready. */
+	@Test
+	void settledQuantity_sameLocatorSet_isReady()
+	{
+		final Map<LocatorId, BigDecimal> expectedQty = new LinkedHashMap<>();
+		expectedQty.put(locatorA, bd("10"));
+		expectedQty.put(locatorB, bd("2"));
+
+		final Map<LocatorId, BigDecimal> liveQty = new LinkedHashMap<>();
+		liveQty.put(locatorA, bd("10"));
+		liveQty.put(locatorB, bd("2"));
+
+		assertThat(DD_Order_StepDef.isPerLocatorReconcileSettled(
+				set(locatorA, locatorB), expectedQty, liveQty.keySet(), liveQty))
+				.as("settled per-locator quantity must be reported as settled")
+				.isTrue();
+	}
+
+	/** Quantity comparison ignores scale (2 vs 2.00), matching the hard assertion's isEqualByComparingTo. */
+	@Test
+	void settledQuantity_differentScale_isReady()
+	{
+		final Map<LocatorId, BigDecimal> expectedQty = new LinkedHashMap<>();
+		expectedQty.put(locatorB, bd("2"));
+		final Map<LocatorId, BigDecimal> liveQty = new LinkedHashMap<>();
+		liveQty.put(locatorB, bd("2.000"));
+
+		assertThat(DD_Order_StepDef.isPerLocatorReconcileSettled(
+				set(locatorB), expectedQty, liveQty.keySet(), liveQty))
+				.isTrue();
+	}
+
+	/** A locator that drops out (void) / joins (create) changes the SET — the gate waits for the set to match. */
+	@Test
+	void locatorSetMismatch_isNotReady()
+	{
+		final Map<LocatorId, BigDecimal> expectedQty = new LinkedHashMap<>();
+		expectedQty.put(locatorA, bd("10"));
+		final Map<LocatorId, BigDecimal> liveQty = new LinkedHashMap<>();
+		liveQty.put(locatorA, bd("10"));
+		liveQty.put(locatorB, bd("5")); // locatorB still present live, but not expected
+
+		assertThat(DD_Order_StepDef.isPerLocatorReconcileSettled(
+				set(locatorA), expectedQty, liveQty.keySet(), liveQty))
+				.as("a live locator set that differs from expected must NOT be reported as settled")
+				.isFalse();
+	}
+
+	/** No QtyEntered expectations (optional column omitted) ⇒ the gate is set-only, preserving prior behaviour. */
+	@Test
+	void noQuantityExpectations_gatesOnSetOnly()
+	{
+		final Map<LocatorId, BigDecimal> noQty = new LinkedHashMap<>();
+		final Map<LocatorId, BigDecimal> liveQty = new LinkedHashMap<>();
+		liveQty.put(locatorA, bd("10"));
+		liveQty.put(locatorB, bd("5"));
+
+		assertThat(DD_Order_StepDef.isPerLocatorReconcileSettled(
+				set(locatorA, locatorB), noQty, liveQty.keySet(), liveQty))
+				.as("with no quantity expectations, a matching locator set is settled")
+				.isTrue();
+	}
+}


### PR DESCRIPTION
## What

Ports the flaky-test fix for `DDOrderReplenishment_split.feature` (intermittent `QtyEntered 5 vs 2`) to this customer line, which independently carries the same scenario + the unfixed readiness predicate.

Cherry-pick of the reviewed+merged fix https://github.com/metasfresh/metasfresh/pull/25160.

## Fix (test-only)

The `…per-locator DD_Orders linked to picking job schedule are found` step gated its poll only on the source-locator SET, which is invariant under a qty-only demand change (same locators, only the quantity changes) — so the poll returned immediately against the stale pre-change DD_Orders and the hard `QtyEntered` assertion raced the async reconcile. Now the poll also waits for each expected per-locator `QtyEntered` to settle, via the extracted `DD_Order_StepDef.isPerLocatorReconcileSettled(...)` + a deterministic unit test. No production code changed.
