### PR TITLE
cicd.yaml: remove duplicate 'permissions' blocks (frontend + junit) — fixes HTTP 422 / 0 jobs

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -396,8 +396,6 @@ jobs:
     permissions:
       packages: write
     needs: init
-    permissions:
-      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v4
@@ -1320,8 +1318,6 @@ jobs:
     permissions:
       packages: write
     needs: [ init, java ]
-    permissions:
-      packages: write
     steps:
       - uses: actions/checkout@v6
       - uses: docker/login-action@v4


### PR DESCRIPTION
## What

Fixes a pre-existing invalid-YAML defect in this branch's `.github/workflows/cicd.yaml` that blocked **all** CI on `mighty_pegasus_hotfix` (GitHub rejected the workflow with HTTP 422 → 0 jobs).

## Root cause

A merge artifact left **two identical `permissions:` mapping keys** (one before and one after `needs:`) in both the `frontend` and `junit` jobs. Duplicate mapping keys are invalid YAML, so the workflow could not be parsed/dispatched.

## Fix

Remove the redundant post-`needs:` `permissions: {packages: write}` copy in each of the two jobs (4 lines). Each job keeps a single `permissions: {packages: write}` — matching the exact form every other metasfresh branch already has (`new_dawn_uat`, `deep_tundra_release`, and the other customer families all have the clean 7 `permissions:` blocks; this branch had 9).

Verified locally: YAML now parses with no duplicate keys; `permissions:` count is back to 7; a `workflow_dispatch` on the fixed branch is now **accepted** (no 422).

Not introduced by any recent change on this branch — a stale merge artifact specific to `mighty_pegasus_hotfix` (no other branch has it).
