### PR TITLE
gh26253 Cost Revaluation MAI: post-merge review fixes (AD metadata + allure tag + E2E)

### DIFF
--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5814160_sys_gh26253_M_CostRevaluation_AD_metadata_fixes.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5814160_sys_gh26253_M_CostRevaluation_AD_metadata_fixes.sql
@@ -1,0 +1,27 @@
+-- gh26253 follow-up: correct AD metadata shipped with the Cost Revaluation "CopyFromCostElement" feature.
+-- (1) Make CopyFrom_M_CostElement_ID a zoom target, matching its sibling M_CostElement_ID on the same tab,
+--     so a Cost Element record can navigate to the Cost Revaluations that copy FROM it (the sibling already
+--     lets it see the ones that target it).
+-- (2) The en_US ref-list description of the CopyFromCostElement value referenced the label
+--     "Copy from cost element", but the actual en_US field label is "Source Cost Element".
+-- (3) The new AD_Element/AD_Field de_DE/de_CH translation rows were left IsTranslated='Y'; the metasfresh
+--     convention is that the German base-language rows carry IsTranslated='N' (en_US carries the translation).
+--     The companion AD_Ref_List_Trl rows already follow the convention.
+
+-- (1) Zoom target parity with the sibling M_CostElement_ID column (583869, already IsExcludeFromZoomTargets='N')
+UPDATE AD_Column SET IsExcludeFromZoomTargets='N', Updated=TO_TIMESTAMP('2026-07-16 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Column_ID=592962
+;
+
+-- (2) en_US ref-list description referenced the wrong label
+UPDATE AD_Ref_List_Trl SET Description='Cost is copied unchanged from the cost element selected under "Source Cost Element".', Updated=TO_TIMESTAMP('2026-07-16 10:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544318 AND AD_Language='en_US'
+;
+
+-- (3) de_DE/de_CH base-language rows => IsTranslated='N' (RevaluationSource=585099, CopyFrom_M_CostElement_ID=585100)
+UPDATE AD_Element_Trl SET IsTranslated='N', Updated=TO_TIMESTAMP('2026-07-16 10:00:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID IN (585099,585100) AND AD_Language IN ('de_DE','de_CH')
+;
+UPDATE AD_Field_Trl SET IsTranslated='N', Updated=TO_TIMESTAMP('2026-07-16 10:00:03','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID IN (781420,781421) AND AD_Language IN ('de_DE','de_CH')
+;

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
@@ -1,6 +1,7 @@
 @from:cucumber
 @allure.label.epic:E0226_Costing
 @allure.label.feature:F1500_Costing
+@allure.label.feature:F1514_Cost_Type_Moving_Average_Invoice
 @ghActions:run_on_executor6
 Feature: Switch to Moving Average Invoice
 ## F1500: Costing

--- a/e2e/frontend-webui/tests/spec/cost-revaluation-copyfrom-field.spec.js
+++ b/e2e/frontend-webui/tests/spec/cost-revaluation-copyfrom-field.spec.js
@@ -1,0 +1,145 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { LoginPage } from '../utils/pages/LoginPage';
+import { DashboardPage } from '../utils/pages/DashboardPage';
+import {
+  FRONTEND_BASE_URL,
+  SLOW_ACTION_TIMEOUT,
+  VERY_SLOW_ACTION_TIMEOUT,
+} from '../utils/common';
+
+/**
+ * Cost Revaluation window ("Kosten Neubewertung") — RevaluationSource / CopyFrom_M_CostElement_ID
+ * display + mandatory logic. AD_Window_ID = 541568, header tab AD_Tab_ID = 546464.
+ *
+ * The field `CopyFrom_M_CostElement_ID` carries:
+ *   - DisplayLogic   @RevaluationSource@=CopyFromCostElement   → shown ONLY when the source is
+ *                                                                 CopyFromCostElement
+ *   - MandatoryLogic @RevaluationSource@='CopyFromCostElement' → mandatory in that same state
+ * `RevaluationSource` is a List with values `Calculated` (default) and `CopyFromCostElement`.
+ *
+ * What is asserted (the core toggle):
+ *   1. NEW record, RevaluationSource = Calculated (default) → CopyFrom field NOT rendered.
+ *      (A DisplayLogic-hidden field is dropped from the DOM entirely — RawWidget renders nothing
+ *       when the field's `displayed !== true` — so the assertion is "wrapper absent", not "hidden".)
+ *   2. Set RevaluationSource = CopyFromCostElement → CopyFrom field becomes visible AND is marked
+ *      mandatory (empty mandatory List renders the language-invariant `.input-mandatory` marker).
+ *   3. Set RevaluationSource back to Calculated → CopyFrom field hides again.
+ *
+ * Language-independence: every selector/assertion uses language-invariant identifiers — the DB
+ * ColumnName (`.form-field-<Column>`), the ref-list VALUE as the option key
+ * (`[data-test-id^="<Value>"]`, since SelectionDropdown sets data-test-id = `${key}${caption}`),
+ * and the `.input-mandatory` structural class. Run in en_US + de_DE to prove it.
+ */
+
+const COST_REVALUATION_WINDOW_ID = 541568;
+
+// Language-invariant selectors — DB ColumnName based (RawWidget `.form-field-{ColumnName}` wrapper).
+const REVALUATION_SOURCE_WRAPPER = '.form-field-RevaluationSource';
+const REVALUATION_SOURCE_DROPDOWN = `${REVALUATION_SOURCE_WRAPPER} .input-dropdown-container`;
+const COPY_FROM_WRAPPER = '.form-field-CopyFrom_M_CostElement_ID';
+// Empty mandatory List/Lookup renders `.input-mandatory` (RawList / Lookup) — language-invariant.
+const COPY_FROM_MANDATORY = `${COPY_FROM_WRAPPER} .input-mandatory`;
+
+// SelectionDropdown option data-test-id = `${key}${caption}`; the List option key is the ref-list
+// VALUE, which is language-invariant (caption changes per language, the key prefix does not).
+const optionByKey = (key) => `.input-dropdown-list-option[data-test-id^="${key}"]`;
+
+const testCases = [
+  { language: 'en_US', label: 'English' },
+  { language: 'de_DE', label: 'German' },
+];
+
+// Open the RevaluationSource List and pick the option whose ref-list value === `valueKey`.
+async function selectRevaluationSource(page, valueKey) {
+  await page.locator(REVALUATION_SOURCE_DROPDOWN).click();
+  await page
+    .locator('.input-dropdown-list')
+    .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+  await page.locator(optionByKey(valueKey)).first().click();
+  await page
+    .locator('.input-dropdown-list')
+    .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+    .catch(() => {});
+}
+
+test.describe('Cost Revaluation window — CopyFrom_M_CostElement_ID display/mandatory logic', () => {
+  testCases.forEach(({ language, label }) => {
+    test(`CopyFrom field toggles with RevaluationSource (${label})`, async ({ page }) => {
+      allure.epic('E0226: Costing');
+      allure.tag('F1514: Cost Type Moving Average Invoice');
+      allure.tag('F1514'); // Standalone tag for Tags section
+      allure.story(
+        'Cost Revaluation — CopyFrom cost element shows and is mandatory only when source = CopyFromCostElement'
+      );
+      allure.severity('normal');
+      allure.description(`
+## Cost Revaluation — display/mandatory logic of CopyFrom_M_CostElement_ID
+
+Verifies, on a NEW Cost Revaluation record (AD_Window_ID = ${COST_REVALUATION_WINDOW_ID}), that
+\`CopyFrom_M_CostElement_ID\`:
+- is NOT displayed while RevaluationSource = Calculated (default),
+- becomes visible AND mandatory when RevaluationSource = CopyFromCostElement,
+- hides again when RevaluationSource is set back to Calculated.
+
+Language under test: ${language}.
+      `);
+
+      // 1. Provision a login user of the given language.
+      const masterdata = await Backend.createMasterdata({
+        request: { login: { user: { language } } },
+      });
+
+      await LoginPage.goto();
+      await LoginPage.login(masterdata.login.user);
+      await DashboardPage.expectVisible();
+
+      // 2. Open a NEW Cost Revaluation record directly in the detail form.
+      await page.goto(`${FRONTEND_BASE_URL}/window/${COST_REVALUATION_WINDOW_ID}/NEW`);
+      await page.waitForURL(
+        new RegExp(`/window/${COST_REVALUATION_WINDOW_ID}/\\d+`),
+        { timeout: VERY_SLOW_ACTION_TIMEOUT }
+      );
+      const recordId = page.url().split('/').pop().split('?')[0];
+      console.log(`[INFO] new M_CostRevaluation record id = ${recordId}`);
+
+      // The RevaluationSource List must be present (defaults to Calculated).
+      await page
+        .locator(REVALUATION_SOURCE_WRAPPER)
+        .waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
+
+      // 3. Default state (RevaluationSource = Calculated): CopyFrom field is NOT rendered.
+      await test.step('Default (Calculated): CopyFrom field is hidden', async () => {
+        // DisplayLogic-hidden fields are removed from the DOM (RawWidget renders nothing), so the
+        // wrapper must be absent — not merely not-visible.
+        await expect(page.locator(COPY_FROM_WRAPPER)).toHaveCount(0);
+      });
+
+      // 4. Set RevaluationSource = CopyFromCostElement → CopyFrom becomes visible AND mandatory.
+      await test.step('Set CopyFromCostElement: CopyFrom field shown and mandatory', async () => {
+        await selectRevaluationSource(page, 'CopyFromCostElement');
+
+        const copyFrom = page.locator(COPY_FROM_WRAPPER);
+        await copyFrom.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+        await expect(copyFrom).toBeVisible();
+
+        // Empty + mandatory → the language-invariant `.input-mandatory` marker is rendered.
+        await expect(page.locator(COPY_FROM_MANDATORY).first()).toBeVisible({
+          timeout: SLOW_ACTION_TIMEOUT,
+        });
+      });
+
+      // 5. Set RevaluationSource back to Calculated → CopyFrom hides again.
+      await test.step('Back to Calculated: CopyFrom field hides again', async () => {
+        await selectRevaluationSource(page, 'Calculated');
+        await expect(page.locator(COPY_FROM_WRAPPER)).toHaveCount(0, {
+          timeout: SLOW_ACTION_TIMEOUT,
+        });
+      });
+
+      console.log(`[PASS] Cost Revaluation CopyFrom display/mandatory toggle verified (${label})`);
+    });
+  });
+});


### PR DESCRIPTION
## What

Post-merge review fixes for the Cost Revaluation **CopyFromCostElement** (Switch-to-Moving-Average-Invoice) feature that shipped in #25142. All findings are non-blocking for the current rollout; grouped here as a small follow-up.

## Changes

- **Migration `5814160`** (AD metadata corrections):
  - `CopyFrom_M_CostElement_ID`: `IsExcludeFromZoomTargets='N'` — zoom-target parity with the sibling `M_CostElement_ID` column on the same tab (a Cost Element record can now navigate to the revaluations that copy *from* it).
  - `CopyFromCostElement` ref-list en_US description referenced the label *"Copy from cost element"*; the actual en_US field label is *"Source Cost Element"*.
  - `AD_Element_Trl`/`AD_Field_Trl` de_DE/de_CH `IsTranslated='N'` (base-language convention; en_US carries the translation).
- **`switchToMovingAverageInvoice.feature`**: added the issue's own Allure feature tag `@allure.label.feature:F1514_Cost_Type_Moving_Average_Invoice` (kept `F1500_Costing` for sibling-MAI consistency).
- **E2E**: Playwright test for the `RevaluationSource → CopyFrom_M_CostElement_ID` display/mandatory logic — _in progress_.

## Notes

- The costing skip-guard keys on `(acctSchema, element, product)` by design — one product-cost queue company-wide; no change.
