### PR TITLE
de-flake productMaturing: run maturing-candidate recompute synchronously (avoid async scheduler RUN_ONCE race)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_Candidate_StepDef.java
@@ -81,6 +81,7 @@ import org.compiere.model.IQuery;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_AttributeSetInstance;
 import org.compiere.model.I_M_Product;
+import org.adempiere.ad.trx.api.ITrxManager;
 import org.compiere.model.I_M_Warehouse;
 import org.compiere.model.I_S_Resource;
 import org.compiere.util.Env;
@@ -128,6 +129,8 @@ public class PP_Order_Candidate_StepDef
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	@NonNull
 	private final IMsgBL msgBL = Services.get(IMsgBL.class);
+	@NonNull
+	private final ITrxManager trxManager = Services.get(ITrxManager.class);
 
 	@NonNull
 	private final M_Product_StepDefData productTable;
@@ -183,6 +186,24 @@ public class PP_Order_Candidate_StepDef
 		DataTableRows.of(dataTable)
 				.setAdditionalRowIdentifierColumnName(COLUMNNAME_PP_Order_Candidate_ID)
 				.forEach(row -> validatePP_Order_Candidate(timeoutSec, row));
+	}
+
+	/**
+	 * Runs the maturing-candidate recompute <b>synchronously</b> in the calling thread's transaction.
+	 *
+	 * <p>Real-world trigger: the {@code PP_Order_Candidate_CreateMaturingCandidates} {@code AD_Process} is run
+	 * periodically by an {@code AD_Scheduler}; its {@code doIt} calls
+	 * {@link PPOrderCandidateService#recomputeMaturingCandidates()}. This step invokes that same service method
+	 * directly so the scenario is deterministic, instead of driving the async scheduler {@code RUN_ONCE}
+	 * event-bus path — that path lazily loads the scheduler's {@code AD_Process} on the async scheduler thread
+	 * via a PO bound to an already-closed {@code TrxRun} transaction, so it intermittently throws
+	 * "No transaction was found" in {@code Scheduler.doWork0}, leaves the maturing candidate uncreated, and
+	 * times out the poll below.</p>
+	 */
+	@When("the maturing candidates are created")
+	public void createMaturingCandidates()
+	{
+		trxManager.runInThreadInheritedTrx(() -> ppOrderCandidateService.recomputeMaturingCandidates());
 	}
 
 	/**

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_Candidate_StepDef.java
@@ -81,7 +81,6 @@ import org.compiere.model.IQuery;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_AttributeSetInstance;
 import org.compiere.model.I_M_Product;
-import org.adempiere.ad.trx.api.ITrxManager;
 import org.compiere.model.I_M_Warehouse;
 import org.compiere.model.I_S_Resource;
 import org.compiere.util.Env;
@@ -129,8 +128,6 @@ public class PP_Order_Candidate_StepDef
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	@NonNull
 	private final IMsgBL msgBL = Services.get(IMsgBL.class);
-	@NonNull
-	private final ITrxManager trxManager = Services.get(ITrxManager.class);
 
 	@NonNull
 	private final M_Product_StepDefData productTable;
@@ -186,24 +183,6 @@ public class PP_Order_Candidate_StepDef
 		DataTableRows.of(dataTable)
 				.setAdditionalRowIdentifierColumnName(COLUMNNAME_PP_Order_Candidate_ID)
 				.forEach(row -> validatePP_Order_Candidate(timeoutSec, row));
-	}
-
-	/**
-	 * Runs the maturing-candidate recompute <b>synchronously</b> in the calling thread's transaction.
-	 *
-	 * <p>Real-world trigger: the {@code PP_Order_Candidate_CreateMaturingCandidates} {@code AD_Process} is run
-	 * periodically by an {@code AD_Scheduler}; its {@code doIt} calls
-	 * {@link PPOrderCandidateService#recomputeMaturingCandidates()}. This step invokes that same service method
-	 * directly so the scenario is deterministic, instead of driving the async scheduler {@code RUN_ONCE}
-	 * event-bus path — that path lazily loads the scheduler's {@code AD_Process} on the async scheduler thread
-	 * via a PO bound to an already-closed {@code TrxRun} transaction, so it intermittently throws
-	 * "No transaction was found" in {@code Scheduler.doWork0}, leaves the maturing candidate uncreated, and
-	 * times out the poll below.</p>
-	 */
-	@When("the maturing candidates are created")
-	public void createMaturingCandidates()
-	{
-		trxManager.runInThreadInheritedTrx(() -> ppOrderCandidateService.recomputeMaturingCandidates());
 	}
 
 	/**

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
@@ -86,6 +86,10 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
+    # Intentionally kept as the scheduler trigger (not the generic "AD_Process ... is run" step used
+    # for CreateMaturingCandidates above): running AlreadyMaturedForOrdering synchronously only enqueues
+    # its selection — its close chain needs the scheduler's own async dispatch, so a synchronous run
+    # leaves the candidate unclosed (IsClosed never flips). Do not convert this line.
     And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_AlreadyMaturedForOrdering' is ran once
 
     And after not more than 60s, PP_Order_Candidates are found

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
@@ -86,10 +86,11 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    # Intentionally kept as the scheduler trigger (not the generic "AD_Process ... is run" step used
-    # for CreateMaturingCandidates above): running AlreadyMaturedForOrdering synchronously only enqueues
-    # its selection — its close chain needs the scheduler's own async dispatch, so a synchronous run
-    # leaves the candidate unclosed (IsClosed never flips). Do not convert this line.
+    # Intentionally NOT converted to the generic "AD_Process ... is run" step (unlike
+    # CreateMaturingCandidates above):
+    # - A synchronous run only enqueues its selection.
+    # - Its close chain needs the scheduler's own async RUN_ONCE dispatch to flip IsClosed.
+    # - Run synchronously, the candidate stays unclosed. Do not convert this line.
     And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_AlreadyMaturedForOrdering' is ran once
 
     And after not more than 60s, PP_Order_Candidates are found

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
@@ -78,7 +78,7 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the maturing candidates are created
 
     Then after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -151,7 +151,7 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the maturing candidates are created
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -163,7 +163,7 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the maturing candidates are created
 
     Then after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -206,7 +206,7 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the maturing candidates are created
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -218,6 +218,6 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the maturing candidates are created
 
     Then after not more than 60s, no PP_Order_Candidates are found for Issue_HU_ID: 'rawgood_hu_30'

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
@@ -78,7 +78,7 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And the maturing candidates are created
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     Then after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -86,7 +86,7 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_AlreadyMaturedForOrdering' is ran once
+    And the AD_Process with value 'PP_Order_Candidate_AlreadyMaturedForOrdering' is run
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -151,7 +151,7 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And the maturing candidates are created
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -163,7 +163,7 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And the maturing candidates are created
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     Then after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -206,7 +206,7 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And the maturing candidates are created
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -218,6 +218,6 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And the maturing candidates are created
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     Then after not more than 60s, no PP_Order_Candidates are found for Issue_HU_ID: 'rawgood_hu_30'

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
@@ -86,7 +86,7 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And the AD_Process with value 'PP_Order_Candidate_AlreadyMaturedForOrdering' is run
+    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_AlreadyMaturedForOrdering' is ran once
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |


### PR DESCRIPTION
## What

De-flakes `productMaturing.feature`. Converts **5 of the 6** `AD_Scheduler … is ran once` triggers — the 5× `PP_Order_Candidate_CreateMaturingCandidates` — to the existing generic step `And the AD_Process with value '<value>' is run` (`AD_Process_Run_StepDef`), which runs the process **synchronously** under the test client + WebUI role via `ProcessInfo.executeSync()`, removing the async scheduler trigger from the test path.

The 6th trigger, `PP_Order_Candidate_AlreadyMaturedForOrdering`, is **intentionally left on the scheduler path** (with an on-file rationale comment): running it synchronously only enqueues its selection — its close chain needs the scheduler's own async `RUN_ONCE` dispatch to flip `IsClosed`, so a synchronous run leaves the candidate unclosed and regresses the Happy-flow scenario. Converting it was tried and reverted for this reason.

No new step-def code; the feature file is the only change.

## Why

The scenarios intermittently failed: the `after not more than 60s, PP_Order_Candidates are found` poll timed out because the maturing candidate was **never created**.

**Verified:** the `cucumber-logs-flaky` + `junit-results-cucumber-flaky` artifacts of CI run https://github.com/metasfresh/metasfresh/actions/runs/29413684964 — both failing scenarios' polls ran the full 121 tries (`No item found for … PP_Order_Candidate`), and the log shows the scheduler run threw `AdempiereException: No transaction was found for TrxRun_…` at `org.compiere.server.Scheduler.doWork0` (via `X_AD_Scheduler.getAD_Process`) → `AdSchedulerManageRequestHandler.runOnce`; 2 such exceptions ↔ the 2 failing scenarios.

Root cause: `AD_Scheduler … is ran once` posts `RESTART`+`RUN_ONCE` to the scheduler event bus and returns; the run happens asynchronously on the scheduler thread, where `Scheduler.doWork0` lazily loads `m_model.getAD_Process()` via a PO bound to an already-closed `TrxRun_…` transaction → the load throws → the run aborts → no candidate → the poll times out. Intermittent because it depends on whether that transaction is still open when the async thread does the lazy load.

Running `CreateMaturingCandidates` synchronously via the generic step removes the async scheduler from that part of the test path, so the race cannot occur for the two tracked flaky scenarios. Business logic under test is unchanged (the step invokes the same process the scheduler's `doIt()` runs).

## Note

The underlying scheduler `RUN_ONCE`/`RESTART` transaction defect also affects the production "run scheduler now" / restart path and is tracked separately for a dedicated fix + refactor. This PR is test-only.

## Test

CI runs `productMaturing.feature`; with the async scheduler removed from the `CreateMaturingCandidates` triggers, the two previously-flaky scenarios (S0382_200 / S0382_300) are deterministic.
