### PR TITLE
test(cucumber): enable Allure results generation — modus_operandi_hotfix

### DIFF
--- a/.github/actions/generate-allure-report/action.yml
+++ b/.github/actions/generate-allure-report/action.yml
@@ -1,0 +1,144 @@
+name: 'Generate Allure Report'
+description: 'Validate allure results, generate HTML report with history support, and upload as artifact'
+
+inputs:
+  results-dir:
+    description: 'Path to allure-results directory (relative to repository root)'
+    required: true
+  output-dir:
+    description: 'Path to output the generated report (relative to repository root)'
+    required: true
+  artifact-name:
+    description: 'Name for the uploaded artifact'
+    required: true
+  retention-days:
+    description: 'Number of days to retain the artifact'
+    required: false
+    default: '1'
+  history-artifact-name:
+    description: 'Name of artifact containing previous history for trends (optional). If provided, enables trend charts.'
+    required: false
+    default: ''
+  report-title:
+    description: 'Title for the report (shown in Allure environment section)'
+    required: false
+    default: 'Test Report'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Allure CLI
+      uses: ./.github/actions/setup-allure
+
+    # Fix permissions on results dir (Docker may have created it as root)
+    - name: Fix results directory permissions
+      if: inputs.history-artifact-name != ''
+      shell: bash
+      run: |
+        if [ -d "${{ inputs.results-dir }}" ]; then
+          sudo chown -R $(id -u):$(id -g) "${{ inputs.results-dir }}"
+          echo "Fixed permissions on ${{ inputs.results-dir }}"
+        fi
+
+    # Download previous history from last successful run on same branch
+    - name: Download previous Allure history
+      if: inputs.history-artifact-name != ''
+      uses: dawidd6/action-download-artifact@v21
+      with:
+        name: ${{ inputs.history-artifact-name }}
+        path: ${{ inputs.results-dir }}/history
+        workflow_conclusion: ''
+        branch: ${{ github.ref_name }}
+        if_no_artifact_found: ignore
+        search_artifacts: true
+
+    - name: Validate and Generate Allure Report
+      shell: bash
+      env:
+        RESULTS_DIR: ${{ inputs.results-dir }}
+        OUTPUT_DIR: ${{ inputs.output-dir }}
+        REPORT_TITLE: ${{ inputs.report-title }}
+        GH_SERVER_URL: ${{ github.server_url }}
+        GH_REPOSITORY: ${{ github.repository }}
+        GH_RUN_ID: ${{ github.run_id }}
+        GH_RUN_NUMBER: ${{ github.run_number }}
+      run: |
+        echo "=== Checking $RESULTS_DIR directory ==="
+        if [ -d "$RESULTS_DIR" ]; then
+          echo "Directory exists. Contents:"
+          ls -la "$RESULTS_DIR/" || true
+          echo "JSON files count: $(find "$RESULTS_DIR" -name "*.json" -type f | wc -l)"
+        else
+          echo "ERROR: $RESULTS_DIR directory does not exist!"
+          echo "Contents of current directory:"
+          ls -la
+          exit 1
+        fi
+
+        RESULT_COUNT=$(find "$RESULTS_DIR" -name "*.json" -type f 2>/dev/null | wc -l)
+        if [ "$RESULT_COUNT" -eq 0 ]; then
+          echo "FATAL ERROR: $RESULTS_DIR contains no JSON files!"
+          echo "Directory contents:"
+          ls -la "$RESULTS_DIR/"
+          exit 1
+        fi
+
+        echo "Found $RESULT_COUNT JSON result files, proceeding with report generation"
+
+        # Check for history (enables trend charts)
+        if [ -d "$RESULTS_DIR/history" ]; then
+          HISTORY_COUNT=$(ls "$RESULTS_DIR/history" 2>/dev/null | wc -l)
+          echo "Found history directory with $HISTORY_COUNT files - trends will be available"
+        else
+          echo "No history directory found - trends will not be available (first run)"
+        fi
+
+        # Create/update environment.properties for Allure report metadata
+        # Use sudo in case directory was created by Docker with root permissions
+        if [ -f "$RESULTS_DIR/environment.properties" ]; then
+          # Append to existing file with newline (tests may have created it)
+          printf "\nReport.Name=%s\n" "$REPORT_TITLE" | sudo tee -a "$RESULTS_DIR/environment.properties" > /dev/null
+          echo "Appended Report.Name to existing environment.properties"
+        else
+          printf "Report.Name=%s\n" "$REPORT_TITLE" | sudo tee "$RESULTS_DIR/environment.properties" > /dev/null
+          echo "Created environment.properties with Report.Name=$REPORT_TITLE"
+        fi
+
+        # Create executor.json for CI build info in Allure report
+        BUILD_URL="${GH_SERVER_URL}/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}"
+        cat << EOF | sudo tee "$RESULTS_DIR/executor.json" > /dev/null
+        {
+          "name": "GitHub Actions",
+          "type": "github",
+          "buildName": "#${GH_RUN_NUMBER}",
+          "buildUrl": "${BUILD_URL}",
+          "reportName": "${REPORT_TITLE}"
+        }
+        EOF
+        sudo sed -i 's/^[[:space:]]*//' "$RESULTS_DIR/executor.json"
+        echo "Created executor.json with build #${GH_RUN_NUMBER}"
+
+        # Ensure output directory parent exists
+        mkdir -p "$(dirname "$OUTPUT_DIR")"
+
+        # Generate HTML report (Allure automatically uses history/ if present)
+        allure generate "$RESULTS_DIR" -o "$OUTPUT_DIR" --clean
+        echo "Allure report generated at: $OUTPUT_DIR"
+
+    - name: Upload Allure report artifact
+      uses: actions/upload-artifact@v6
+      if: success() || failure()
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.output-dir }}
+        retention-days: ${{ inputs.retention-days }}
+
+    # Upload history for next build (enables trends over time)
+    - name: Upload Allure history for trends
+      if: inputs.history-artifact-name != '' && (success() || failure())
+      uses: actions/upload-artifact@v6
+      with:
+        name: ${{ inputs.history-artifact-name }}
+        path: ${{ inputs.output-dir }}/history
+        retention-days: 30
+        overwrite: true

--- a/.github/actions/generate-allure-report/action.yml
+++ b/.github/actions/generate-allure-report/action.yml
@@ -126,7 +126,7 @@ runs:
         echo "Allure report generated at: $OUTPUT_DIR"
 
     - name: Upload Allure report artifact
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: ${{ inputs.artifact-name }}
@@ -136,7 +136,7 @@ runs:
     # Upload history for next build (enables trends over time)
     - name: Upload Allure history for trends
       if: inputs.history-artifact-name != '' && (success() || failure())
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.history-artifact-name }}
         path: ${{ inputs.output-dir }}/history

--- a/.github/actions/setup-allure/action.yml
+++ b/.github/actions/setup-allure/action.yml
@@ -1,0 +1,22 @@
+name: 'Setup Allure CLI'
+description: 'Install Allure command-line tool for report generation'
+runs:
+  using: 'composite'
+  steps:
+    - name: Install Allure CLI
+      shell: bash
+      run: |
+        # Extract version from package.json (single source of truth)
+        ALLURE_VERSION=$(jq -r '.devDependencies["allure-commandline"] | sub("^\\^"; "")' e2e/mobile-webui/package.json)
+
+        if [ -z "$ALLURE_VERSION" ] || [ "$ALLURE_VERSION" = "null" ]; then
+          echo "::error::Could not extract allure-commandline version from e2e/mobile-webui/package.json"
+          exit 1
+        fi
+
+        echo "Installing Allure CLI v${ALLURE_VERSION} (from e2e/mobile-webui/package.json)..."
+        wget -q "https://github.com/allure-framework/allure2/releases/download/${ALLURE_VERSION}/allure-${ALLURE_VERSION}.tgz" -O /tmp/allure.tgz
+        sudo tar -xzf /tmp/allure.tgz -C /opt/
+        sudo ln -sf "/opt/allure-${ALLURE_VERSION}/bin/allure" /usr/local/bin/allure
+        allure --version
+        echo "✓ Allure CLI installed successfully"

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -22,20 +22,12 @@ jobs:
       build-info-properties: ${{ steps.build-info-properties.outputs.content }}
       git-properties: ${{ steps.git-properties.outputs.content }}
       base-version-matrix: ${{ steps.base-version-matrix.outputs.matrix }}
-      skip-testspace: ${{ steps.skip-checks.outputs.skip-testspace }}
       skip-publish-reports: ${{ steps.skip-checks.outputs.skip-publish-reports }}
+      branch-sanitized-gh-pages: ${{ steps.sanitize-branch-gh-pages.outputs.value }}
     steps:
       - name: Determine skip flags
         id: skip-checks
-        env:
-          SKIP_TESTSPACE_VAR: ${{ vars.SKIP_TESTSPACE }}
         run: |
-          # Skip testspace for tmp-mergify/ branches or when SKIP_TESTSPACE var is set
-          if [[ "${{ github.ref_name }}" == tmp-mergify/* ]] || [[ "$SKIP_TESTSPACE_VAR" == "true" ]]; then
-            echo "skip-testspace=true" >> $GITHUB_OUTPUT
-          else
-            echo "skip-testspace=false" >> $GITHUB_OUTPUT
-          fi
           # Skip publish-reports for tmp-mergify/ branches only
           if [[ "${{ github.ref_name }}" == tmp-mergify/* ]]; then
             echo "skip-publish-reports=true" >> $GITHUB_OUTPUT
@@ -43,18 +35,19 @@ jobs:
             echo "skip-publish-reports=false" >> $GITHUB_OUTPUT
           fi
       - uses: actions/checkout@v4
-      - uses: testspace-com/setup-testspace@v1
-        continue-on-error: true  # testspace retired — never fail the build on it
-        if: steps.skip-checks.outputs.skip-testspace != 'true'
-        with:
-          domain: metasfresh
-          token: ${{ secrets.TESTSPACE_TOKEN }}
       - name: sanitize-ref-name
         id: sanitize
         env:
           GIT_REF: ${{ github.ref_name }}
         run: |
           echo "refname=$(echo ""$GIT_REF"" | sed -r 's/([^a-zA-Z0-9.]+)/-/g' | sed -r 's/(^-|-$)//g')" >> $GITHUB_OUTPUT
+      - name: sanitize-branch-for-gh-pages
+        id: sanitize-branch-gh-pages
+        env:
+          GIT_REF: ${{ github.ref_name }}
+        run: |
+          SANITIZED=$(echo "$GIT_REF" | tr '/' '-' | tr '_' '-' | tr -cd 'a-zA-Z0-9.-' | tr '[:upper:]' '[:lower:]' | sed 's/--*/-/g' | sed 's/^-*//' | sed 's/-*$//')
+          echo "value=${SANITIZED}" >> $GITHUB_OUTPUT
       - name: define-build-info-properties
         id: build-info-properties
         env:
@@ -98,16 +91,6 @@ jobs:
           echo '* find more information at https://github.com/metasfresh/metasfresh/tree/${{ github.ref_name }}/docker-builds/README.md' >> $GITHUB_STEP_SUMMARY
           echo '* artifacts will be created for tag `${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }}`' >> $GITHUB_STEP_SUMMARY
           echo '* BASE_VERSION for instances **without** customisations will be `${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }}-compat`' >> $GITHUB_STEP_SUMMARY
-          echo '* test results can be found after completion at https://metasfresh.testspace.com/projects/metasfresh:metasfresh/spaces/${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
-      - name: testspace push build infos
-        continue-on-error: true  # testspace retired — never fail the build on it
-        if: steps.skip-checks.outputs.skip-testspace != 'true'
-        run: |
-          touch github_run.txt
-          echo ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} >> github_run.txt
-          echo pipeline $PIPELINE_VERSION >> github_run.txt
-          echo ${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }} >> github_run.txt
-          testspace github_run.txt
 
   java:
     runs-on: ${{ vars.RUNNER_HEAVY }}
@@ -369,12 +352,6 @@ jobs:
     needs: [ init, frontend ]
     steps:
       - uses: actions/checkout@v4
-      - uses: testspace-com/setup-testspace@v1
-        continue-on-error: true  # testspace retired — never fail the build on it
-        if: needs.init.outputs.skip-testspace != 'true'
-        with:
-          domain: metasfresh
-          token: ${{ secrets.TESTSPACE_TOKEN }}
       - name: run-tests
         run: |
           docker buildx build \
@@ -383,14 +360,6 @@ jobs:
           --target test \
           --tag metas-frontend:test \
           .
-      - name: publish results
-        continue-on-error: true  # testspace retired — never fail the build on it
-        run: |
-          docker run --rm --volume "$(pwd)/jest:/reports" metas-frontend:test                                       # extracting test results from docker image
-          if [ "${{needs.init.outputs.skip-testspace}}" != "true" ]; then
-          find jest -type d -links 2 -exec testspace [{}]{}/*.xml \;                                                # upload all jest xml's to testspace 
-          testspace "[jest/frontend]jest/frontend/jest.log{$(cat jest/frontend/jest.exit-code):webui jest tests}"   # upload webui log with exit code
-          fi
       - name: assert success
         run: |
           if [ $(cat jest/frontend/jest.exit-code) != 0 ]; then tail -1000 jest/frontend/jest.log && exit 1; fi     # print frontend log and exit if frontend failed
@@ -979,12 +948,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: testspace-com/setup-testspace@v1
-        continue-on-error: true  # testspace retired — never fail the build on it
-        if: needs.init.outputs.skip-testspace != 'true'
-        with:
-          domain: metasfresh
-          token: ${{ secrets.TESTSPACE_TOKEN }}
       - name: prepare-settings
         env:
           METASFRESH_PACKAGES_READ_TOKEN: ${{ secrets.METASFRESH_PACKAGES_READ_TOKEN }}
@@ -1024,17 +987,6 @@ jobs:
           command: |
             docker push ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-floating }}
             docker push ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-floating }}-j14
-      - name: push-results
-        continue-on-error: true  # testspace retired — never fail the build on it
-        run: |
-          docker run --rm --volume "$(pwd)/junit:/reports" ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-fixed }}           # extracting java8 test results from docker image
-          docker run --rm --volume "$(pwd)/junit:/reports" ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-fixed }}-j14       # extracting java14 test results from docker image
-          if [ "${{needs.init.outputs.skip-testspace}}" != "true" ]; then
-          find junit -type d -links 2 -exec testspace [{}]{}/*.xml \;                                                           # upload all junit xml's to testspace 
-          testspace "[junit/commons]junit/commons/junit.log{$(awk '{ sum += $1 } END { print sum }' junit/commons/junit.exit-code junit/commons/junit.mvn.exit-code):java 8 commons junit tests}"     # upload commons log with combined exit code  
-          testspace "[junit/backend]junit/backend/junit.log{$(awk '{ sum += $1 } END { print sum }' junit/backend/junit.exit-code junit/backend/junit.mvn.exit-code):java 8 backend junit tests}"     # upload backend log with combined exit code 
-          testspace "[junit/camel]junit/camel/junit.log{$(awk '{ sum += $1 } END { print sum }' junit/camel/junit.exit-code junit/camel/junit.mvn.exit-code):java 14 camel junit tests}"              # upload camel log with combined exit code       
-          fi
       - name: assert success
         run: |
           if [ $(cat junit/commons/junit.exit-code) != 0 ] || [ $(cat junit/commons/junit.mvn.exit-code) != 0 ]; then tail -1000 junit/commons/junit.log && exit 1; fi      # print commons log and exit if commons failed
@@ -1139,12 +1091,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: testspace-com/setup-testspace@v1
-        continue-on-error: true  # testspace retired — never fail the build on it
-        if: needs.init.outputs.skip-testspace != 'true'
-        with:
-          domain: metasfresh
-          token: ${{ secrets.TESTSPACE_TOKEN }}
       - name: run-tests
         env:
           mfversion: ${{ needs.init.outputs.tag-fixed }}
@@ -1169,14 +1115,53 @@ jobs:
           docker commit metasfresh-db-1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postcucumber-${{ matrix.profile }}
           docker compose down
           cat cucumber.log | grep -q "BUILD SUCCESS" && echo "$?" > cucumber.mvn.exit-code || echo "$?" > cucumber.mvn.exit-code
-      - name: push-results
-        continue-on-error: true  # testspace retired — never fail the build on it
+      - name: Extract Cucumber Allure results
+        if: always()
         run: |
-          if [ "${{needs.init.outputs.skip-testspace}}" != "true" ]; then
-          testspace "[cucumber/${{ matrix.profile }}]cucumber/**/*.xml"
-          testspace "[cucumber/${{ matrix.profile }}]cucumber/*.html"                                                                                                                                                       
-          testspace "[cucumber/${{ matrix.profile }}]cucumber.log{$(awk '{ sum += $1 } END { print sum }' cucumber.exit-code cucumber.mvn.exit-code):cucumber tests}"
+          echo "=== Searching for Allure results ==="
+          # Fix permissions (Docker may have created files as root)
+          sudo chown -R $(id -u):$(id -g) docker-builds/cucumber/cucumber/ 2>/dev/null || true
+          mkdir -p cucumber-allure-results
+          FOUND_RESULTS=false
+      
+          # Customer repos run from docker-builds/cucumber/
+          for search_dir in \
+            "docker-builds/cucumber/cucumber/allure-results" \
+            "docker-builds/cucumber/cucumber/target/allure-results"; do
+            if [ -d "$search_dir" ]; then
+              echo "Found results in $search_dir"
+              cp -r "$search_dir"/. cucumber-allure-results/
+              FOUND_RESULTS=true
+              break
+            fi
+          done
+      
+          if [ "$FOUND_RESULTS" != "true" ]; then
+            echo "Searching for allure-results directory..."
+            ALLURE_DIR=$(find docker-builds/cucumber -name "allure-results" -type d 2>/dev/null | head -1)
+            if [ -n "$ALLURE_DIR" ]; then
+              echo "Found results in $ALLURE_DIR"
+              cp -r "$ALLURE_DIR"/. cucumber-allure-results/
+              FOUND_RESULTS=true
+            fi
           fi
+      
+          if [ "$FOUND_RESULTS" = true ]; then
+            echo "branch=${{ github.ref_name }}" >> cucumber-allure-results/environment.properties
+            echo "build=${{ needs.init.outputs.tag-fixed }}" >> cucumber-allure-results/environment.properties
+            JSON_COUNT=$(find cucumber-allure-results -name '*.json' -type f | wc -l)
+            echo "Allure results extracted: $JSON_COUNT JSON files for profile ${{ matrix.profile }}"
+          else
+            echo "No Allure results found for profile ${{ matrix.profile }}"
+          fi
+      - name: Upload Cucumber Allure results
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: cucumber-allure-results-${{ matrix.profile }}
+          path: cucumber-allure-results/
+          if-no-files-found: ignore
+          retention-days: 7
       - name: push-database-image metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postcucumber-${{ matrix.profile }}
         uses: nick-fields/retry@v3
         with:
@@ -1359,12 +1344,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: testspace-com/setup-testspace@v1
-        continue-on-error: true  # testspace retired — never fail the build on it
-        if: needs.init.outputs.skip-testspace != 'true'
-        with:
-          domain: metasfresh
-          token: ${{ secrets.TESTSPACE_TOKEN }}
       - name: run test
         working-directory: docker-builds/mobiletest/
         env:
@@ -1373,13 +1352,16 @@ jobs:
           docker compose up --abort-on-container-exit --exit-code-from playwright 2>&1 | tee playwright.log && echo "${PIPESTATUS[0]}" > playwright.exit-code
           docker commit mobiletest-db-1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postmobiletest
           docker compose down
-      - name: push-results
-        continue-on-error: true  # testspace retired — never fail the build on it
-        working-directory: docker-builds/mobiletest/
-        run: |
-          if [ "${{needs.init.outputs.skip-testspace}}" != "true" ]; then
-          testspace "[mobile/playwright]playwright-report/junit/results.xml"
-          fi
+      - name: Generate Allure Report for Mobile
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/generate-allure-report
+        with:
+          results-dir: docker-builds/mobiletest/allure-results
+          output-dir: mobile-allure-report
+          artifact-name: allure-report-mobile-webui
+          history-artifact-name: allure-history-mobile-webui
+          report-title: 'Playwright (Mobile WebUI)'
       - name: push-image metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postmobiletest
         uses: nick-fields/retry@v3
         with:
@@ -1402,6 +1384,46 @@ jobs:
           path: docker-builds/mobiletest/playwright-report/
           retention-days: 30
 
+
+  cucumber-allure-report:
+    name: Generate Cucumber Allure Report
+    runs-on: ubuntu-latest
+    needs: [ init, cucumber-run ]
+    if: always()
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download all Cucumber Allure results
+        uses: actions/download-artifact@v6
+        with:
+          pattern: cucumber-allure-results-*
+          path: all-cucumber-results/
+          merge-multiple: true
+
+      - name: Check if results exist
+        id: check_results
+        run: |
+          if [ -d "all-cucumber-results" ] && [ "$(ls -A all-cucumber-results 2>/dev/null)" ]; then
+            echo "has_results=true" >> $GITHUB_OUTPUT
+            echo "JSON files: $(find all-cucumber-results -name '*.json' -type f | wc -l)"
+          else
+            echo "has_results=false" >> $GITHUB_OUTPUT
+            echo "No Allure results found - skipping report generation"
+          fi
+
+      - name: Generate combined Allure report
+        if: steps.check_results.outputs.has_results == 'true'
+        uses: ./.github/actions/generate-allure-report
+        with:
+          results-dir: all-cucumber-results
+          output-dir: cucumber-allure-report
+          artifact-name: allure-report-cucumber
+          retention-days: 30
+          history-artifact-name: allure-history-cucumber
+          report-title: 'Cucumber BDD'
 
   publish-test-reports:
     name: publish test reports

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1126,8 +1126,8 @@ jobs:
       
           # Customer repos run from docker-builds/cucumber/
           for search_dir in \
-            "docker-builds/cucumber/cucumber/allure-results" \
-            "docker-builds/cucumber/cucumber/target/allure-results"; do
+            "cucumber/allure-results" \
+            "cucumber/target/allure-results"; do
             if [ -d "$search_dir" ]; then
               echo "Found results in $search_dir"
               cp -r "$search_dir"/. cucumber-allure-results/
@@ -1138,7 +1138,7 @@ jobs:
       
           if [ "$FOUND_RESULTS" != "true" ]; then
             echo "Searching for allure-results directory..."
-            ALLURE_DIR=$(find docker-builds/cucumber -name "allure-results" -type d 2>/dev/null | head -1)
+            ALLURE_DIR=$(find cucumber -name "allure-results" -type d 2>/dev/null | head -1)
             if [ -n "$ALLURE_DIR" ]; then
               echo "Found results in $ALLURE_DIR"
               cp -r "$ALLURE_DIR"/. cucumber-allure-results/
@@ -1156,7 +1156,7 @@ jobs:
           fi
       - name: Upload Cucumber Allure results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v4
         with:
           name: cucumber-allure-results-${{ matrix.profile }}
           path: cucumber-allure-results/
@@ -1352,16 +1352,6 @@ jobs:
           docker compose up --abort-on-container-exit --exit-code-from playwright 2>&1 | tee playwright.log && echo "${PIPESTATUS[0]}" > playwright.exit-code
           docker commit mobiletest-db-1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postmobiletest
           docker compose down
-      - name: Generate Allure Report for Mobile
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/generate-allure-report
-        with:
-          results-dir: docker-builds/mobiletest/allure-results
-          output-dir: mobile-allure-report
-          artifact-name: allure-report-mobile-webui
-          history-artifact-name: allure-history-mobile-webui
-          report-title: 'Playwright (Mobile WebUI)'
       - name: push-image metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postmobiletest
         uses: nick-fields/retry@v3
         with:
@@ -1394,10 +1384,10 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Download all Cucumber Allure results
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v4
         with:
           pattern: cucumber-allure-results-*
           path: all-cucumber-results/
@@ -1428,7 +1418,7 @@ jobs:
   publish-test-reports:
     name: publish test reports
     runs-on: ${{ vars.RUNNER_LIGHT }}
-    needs: [ init, cucumber-run, mobile_test ]
+    needs: [ init, cucumber-run, mobile_test, cucumber-allure-report ]
     if: always() && needs.init.result == 'success' && needs.init.outputs.skip-publish-reports != 'true'
     permissions:
       actions: write    # trigger reports-cleanup workflow when disk space is low

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1423,6 +1423,7 @@ jobs:
     permissions:
       actions: write    # trigger reports-cleanup workflow when disk space is low
       contents: read
+      pull-requests: write    # post Allure report links as a PR comment
     steps:
       - name: Check for report server secret
         id: check-secret
@@ -1793,6 +1794,47 @@ jobs:
           for report_type in ${{ steps.inventory.outputs.reports }}; do
             echo "| ${report_type} | [Open report](${BASE_URL}/${report_type}/) |" >> $GITHUB_STEP_SUMMARY
           done
+
+      - name: Post report link on PR
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true' && steps.inventory.outputs.count != '0'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          VERSION: ${{ needs.init.outputs.tag-fixed }}
+        run: |
+          PR=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "${{ github.ref_name }}" --json number --jq '.[0].number')
+          if [ -z "$PR" ]; then
+            echo "No open PR for branch ${{ github.ref_name }} — skipping comment"
+            exit 0
+          fi
+
+          BASE_URL="https://test-reports.metasfresh.com/branches/${BRANCH}/builds/${VERSION}/allure"
+          REPORT_LINKS=""
+          for report_type in ${{ steps.inventory.outputs.reports }}; do
+            REPORT_LINKS="${REPORT_LINKS}| ${report_type} | [Open report](${BASE_URL}/${report_type}/) |"$'\n'
+          done
+
+          MARKER="<!-- allure-reports -->"
+          BODY="${MARKER}
+          ### 📊 Test Reports
+
+          **Build:** \`${VERSION}\`
+
+          | Report | Link |
+          |--------|------|
+          ${REPORT_LINKS}
+          _Updated: $(date -u '+%Y-%m-%d %H:%M UTC')_"
+
+          # Find existing comment with the marker, update in place or create
+          COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" --paginate --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" -X PATCH -f body="$BODY" --silent
+            echo "Updated existing comment ${COMMENT_ID} on PR #${PR}"
+          else
+            gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body "$BODY"
+            echo "Posted new comment on PR #${PR}"
+          fi
 
       - name: Cleanup SSH
         if: always() && steps.check-secret.outputs.available == 'true'

--- a/backend/de.metas.cucumber/pom.xml
+++ b/backend/de.metas.cucumber/pom.xml
@@ -208,6 +208,15 @@
             <scope>test</scope>
         </dependency>
 
+    
+        <!-- Allure reporting for Cucumber tests -->
+        <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-cucumber7-jvm</artifactId>
+            <version>2.25.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/RunCucumberTest.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/RunCucumberTest.java
@@ -41,7 +41,7 @@ import org.junit.platform.suite.api.Suite;
 @SelectPackages("de.metas.cucumber")
 @ConfigurationParameter(key = Constants.GLUE_PROPERTY_NAME, value = "de.metas.cucumber.stepdefs")
 @ConfigurationParameter(key = Constants.FILTER_TAGS_PROPERTY_NAME, value = "not @ignore")
-@ConfigurationParameter(key = Constants.PLUGIN_PROPERTY_NAME, value = "html:target/cucumber.html,json:target/cucumber.json,junit:target/cucumber-junit.xml,message:target/cucumber.message")
+@ConfigurationParameter(key = Constants.PLUGIN_PROPERTY_NAME, value = "pretty,html:target/cucumber.html,json:target/cucumber.json,junit:target/cucumber-junit.xml,message:target/cucumber.message,io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm")
 public class RunCucumberTest
 {
 }

--- a/backend/de.metas.cucumber/src/test/resources/allure.properties
+++ b/backend/de.metas.cucumber/src/test/resources/allure.properties
@@ -1,0 +1,5 @@
+# Allure reporting configuration for Cucumber tests
+allure.results.directory=target/allure-results
+
+# Link template for GitHub issues
+allure.link.issue.pattern=https://github.com/metasfresh/metasfresh/issues/{}

--- a/backend/de.metas.cucumber/src/test/resources/allure/categories.json
+++ b/backend/de.metas.cucumber/src/test/resources/allure/categories.json
@@ -1,0 +1,27 @@
+[
+  {
+    "name": "Database errors",
+    "messageRegex": ".*SQLException.*|.*database.*|.*PostgreSQL.*|.*constraint violation.*",
+    "matchedStatuses": ["failed", "broken"]
+  },
+  {
+    "name": "Timeout issues",
+    "messageRegex": ".*timeout.*|.*timed out.*|.*TimeoutException.*",
+    "matchedStatuses": ["failed", "broken"]
+  },
+  {
+    "name": "API errors",
+    "messageRegex": ".*REST.*|.*API.*|.*HTTP.*|.*status code.*|.*response.*",
+    "matchedStatuses": ["failed", "broken"]
+  },
+  {
+    "name": "Assertion failures",
+    "messageRegex": ".*AssertionError.*|.*Expected.*but.*|.*should be.*but was.*",
+    "matchedStatuses": ["failed"]
+  },
+  {
+    "name": "Infrastructure issues",
+    "messageRegex": ".*container.*|.*docker.*|.*connection refused.*|.*RabbitMQ.*",
+    "matchedStatuses": ["failed", "broken"]
+  }
+]

--- a/docker-builds/cucumber/entrypoint.sh
+++ b/docker-builds/cucumber/entrypoint.sh
@@ -56,3 +56,4 @@ echo "==================="
 
 cp target/*.xml /reports
 cp target/*.html /reports
+cp -r target/allure-results /reports/ 2>/dev/null || true

--- a/e2e/mobile-webui/package.json
+++ b/e2e/mobile-webui/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mobile-webui-frontend-testing",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "devDependencies": {
+    "@playwright/test": "^1.50.1",
+    "@types/node": "^22.13.1",
+    "allure-commandline": "^2.32.1",
+    "allure-js-commons": "^3.4.3",
+    "allure-playwright": "^3.4.3"
+  },
+  "scripts": {
+    "test": "npx playwright test",
+    "allure:generate": "npx allure generate allure-results --clean -o allure-report",
+    "allure:open": "npx allure open allure-report",
+    "allure:serve": "npx allure serve allure-results"
+  }
+}


### PR DESCRIPTION
Enables cucumber Allure on the `modus_operandi_hotfix` line so its `metas-cucumber` base image emits `target/allure-results`. Without the adapter, cucumber produces no allure-results and downstream Allure reporting stays empty.

Same change as the merged keen_hawk fix (https://github.com/metasfresh/metasfresh/pull/25145):
- `pom.xml`: `io.qameta.allure:allure-cucumber7-jvm:2.25.0` (test scope)
- `RunCucumberTest`: register `AllureCucumber7Jvm` + `pretty` in the cucumber plugin list
- `allure.properties` + `allure/categories.json` (from new_dawn_uat)
- `docker-builds/cucumber/entrypoint.sh`: copy `target/allure-results` to `/reports`

Compile-inert (dependency + annotation string + verbatim resources + shell line); CI is the authoritative compile.
