### PR TITLE
Cost Revaluation MAI: cucumber multi-product batch scenario (TC6)

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
@@ -198,12 +198,12 @@ Feature: Switch to Moving Average Invoice
     #
     Given metasfresh contains M_Products:
       | Identifier |
-      | productA   |
-      | productB   |
+      | product1   |
+      | product2   |
     And update current costs
       | M_Product_ID | M_CostElement_ID | CurrentCostPrice |
-      | productA     | AveragePO        | 10 CHF           |
-      | productB     | AveragePO        | 20 CHF           |
+      | product1     | AveragePO        | 10 CHF           |
+      | product2     | AveragePO        | 20 CHF           |
     When metasfresh contains M_CostRevaluation:
       | Identifier | C_AcctSchema_ID | M_CostElement_ID     | RevaluationSource   | CopyFrom_M_CostElement_ID | EvaluationStartDate | DateAcct   |
       | switch     | acctSchema      | MovingAverageInvoice | CopyFromCostElement | AveragePO                 | 2025-12-31          | 2025-12-31 |
@@ -215,5 +215,5 @@ Feature: Switch to Moving Average Invoice
     #
     Then validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
-      | acctSchema      | productA     | MovingAverageInvoice | 10 CHF           | 0 PCE      | 0 CHF        |
-      | acctSchema      | productB     | MovingAverageInvoice | 20 CHF           | 0 PCE      | 0 CHF        |
+      | acctSchema      | product1     | MovingAverageInvoice | 10 CHF           | 0 PCE      | 0 CHF        |
+      | acctSchema      | product2     | MovingAverageInvoice | 20 CHF           | 0 PCE      | 0 CHF        |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
@@ -187,3 +187,33 @@ Feature: Switch to Moving Average Invoice
       | Identifier   | C_AcctSchema_ID | M_CostElement_ID | RevaluationSource   | CopyFrom_M_CostElement_ID | EvaluationStartDate | DateAcct   |
       | selfCopy     | acctSchema      | AveragePO        | CopyFromCostElement | AveragePO                 | 2025-12-31          | 2025-12-31 |
     Then create lines for cost revaluation selfCopy expecting error
+
+  @Id:S26253_TC6
+  Scenario: A single switch seeds every affected product's opening in one run, each at its own price
+    #
+    # The switch is company-wide: one CopyFromCostElement completion seeds the MovingAverageInvoice
+    # opening for every product that carries a source (AveragePO) cost — each at its OWN price — in a
+    # single run, not one product at a time. Two products with different source costs prove the batch
+    # seeds them independently and correctly in the same completion.
+    #
+    Given metasfresh contains M_Products:
+      | Identifier |
+      | productA   |
+      | productB   |
+    And update current costs
+      | M_Product_ID | M_CostElement_ID | CurrentCostPrice |
+      | productA     | AveragePO        | 10 CHF           |
+      | productB     | AveragePO        | 20 CHF           |
+    When metasfresh contains M_CostRevaluation:
+      | Identifier | C_AcctSchema_ID | M_CostElement_ID     | RevaluationSource   | CopyFrom_M_CostElement_ID | EvaluationStartDate | DateAcct   |
+      | switch     | acctSchema      | MovingAverageInvoice | CopyFromCostElement | AveragePO                 | 2025-12-31          | 2025-12-31 |
+    And create lines for cost revaluation switch
+    And the cost revaluation identified by switch is completed
+    #
+    # Both products' MovingAverageInvoice openings are seeded in the one completion, each carrying its
+    # own source price (10 / 20) with qty 0 — a valid MA base per product.
+    #
+    Then validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
+      | acctSchema      | productA     | MovingAverageInvoice | 10 CHF           | 0 PCE      | 0 CHF        |
+      | acctSchema      | productB     | MovingAverageInvoice | 20 CHF           | 0 PCE      | 0 CHF        |


### PR DESCRIPTION
## What

Adds cucumber scenario TC6 to `switchToMovingAverageInvoice.feature`: a single `CopyFromCostElement` switch (company-wide) seeds the Moving Average Invoice opening for every product carrying a source cost, each at its own price, in one completion. Two products with different source costs (10 / 20 CHF) prove the batch seeds them independently in the same run — the real production path, which the existing single-product scenarios (TC1–TC5) don't cover.

Test-only; uses existing step defs. Passed locally (TC6, ic114_4 stack).
