### PR TITLE
Shipment Schedule invalidation — dedupe accumulated segments (OOM fix)

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
@@ -46,6 +46,7 @@ import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.service.ITaskExecutorService;
+import org.adempiere.service.ISysConfigBL;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.I_C_OrderLine;
 import org.compiere.model.I_M_InOut;
@@ -64,12 +65,31 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidateBL
 {
+	/**
+	 * Int sysconfig bounding the invalidation-segment accumulator during a long-running batch: when the accumulator
+	 * ({@link ShipmentScheduleSegmentChangedProcessor}) reaches this size it flushes mid-batch (not only at
+	 * AFTER_COMMIT). A value {@code <= 0} disables the mid-batch flush. Default {@value #DEFAULT_SegmentFlushThreshold}.
+	 */
+	static final String SYSCONFIG_SegmentFlushThreshold = "de.metas.inoutcandidate.ShipmentScheduleSegmentFlushThreshold";
+	private static final int DEFAULT_SegmentFlushThreshold = 1000;
+
 	private final IShipmentSchedulePA shipmentSchedulePA = Services.get(IShipmentSchedulePA.class);
 	private final IShipmentScheduleInvalidateRepository invalidSchedulesRepo = Services.get(IShipmentScheduleInvalidateRepository.class);
 	private final IInOutDAO inOutDAO = Services.get(IInOutDAO.class);
 	protected final IShipmentScheduleAllocDAO shipmentScheduleAllocDAO = Services.get(IShipmentScheduleAllocDAO.class);
 	protected final IShipmentScheduleEffectiveBL shipmentScheduleEffectiveBL = Services.get(IShipmentScheduleEffectiveBL.class);
+	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	@NonNull private final PickingBOMService pickingBOMService;
+
+	/**
+	 * The mid-batch flush threshold for the invalidation-segment accumulator. Owned here (this BL owns the
+	 * invalidation concern and its collaborators); {@link ShipmentScheduleSegmentChangedProcessor} obtains it from
+	 * its owning BL rather than reaching into the {@link ISysConfigBL} registry itself.
+	 */
+	int getSegmentFlushThreshold()
+	{
+		return sysConfigBL.getIntValue(SYSCONFIG_SegmentFlushThreshold, DEFAULT_SegmentFlushThreshold);
+	}
 
 	private boolean isShipmentScheduleUpdaterRunning()
 	{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateRepository.java
@@ -414,7 +414,10 @@ public class ShipmentScheduleInvalidateRepository implements IShipmentScheduleIn
 		//
 		// Locators
 		// NOTE: same as for bPartners if no particular locator is specified, it means "all of them"
-		if (!segment.isAnyLocator())
+		// NOTE: guard with !isNoLocators() because a warehouse-derived segment now has an EMPTY locatorIds set
+		// (isAnyLocator() returns false for an empty set); without this guard the branch would fire with an empty
+		// list and DB.buildSqlList would produce a never-true predicate -> the segment would match NO schedule.
+		if (!segment.isNoLocators() && !segment.isAnyLocator())
 		{
 			final Set<Integer> locatorIds = segment.getLocatorIds();
 
@@ -425,6 +428,20 @@ public class ShipmentScheduleInvalidateRepository implements IShipmentScheduleIn
 					+ "\n\t\t loc." + I_M_Locator.COLUMNNAME_M_Warehouse_ID + "=" + warehouseColumnName
 					+ " AND " + DB.buildSqlList("loc." + I_M_Locator.COLUMNNAME_M_Locator_ID, locatorIds, sqlParams)
 					+ ")");
+		}
+
+		//
+		// Warehouses
+		// A warehouse-derived segment carries the warehouse identity directly (instead of enumerating all its
+		// locators). Matching by the schedule's effective warehouse column is equivalent to the old
+		// EXISTS(M_Locator WHERE M_Warehouse_ID = <sched wh> AND M_Locator_ID IN (all locators of wh)).
+		if (!segment.isAnyWarehouse())
+		{
+			final Set<Integer> warehouseIds = segment.getWarehouseIds();
+
+			final String warehouseColumnName = "COALESCE(" + ssAlias + I_M_ShipmentSchedule.COLUMNNAME_M_Warehouse_Override_ID + ", " + ssAlias + I_M_ShipmentSchedule.COLUMNNAME_M_Warehouse_ID + ")";
+			whereClause.append("\n\t AND ");
+			whereClause.append("(").append(DB.buildSqlList(warehouseColumnName, warehouseIds, sqlParams)).append(")");
 		}
 
 		//

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessor.java
@@ -2,7 +2,9 @@ package de.metas.inoutcandidate.invalidation.impl;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.trx.api.ITrxListenerManager.TrxEventTiming;
@@ -83,7 +85,7 @@ final class ShipmentScheduleSegmentChangedProcessor
 		return processor;
 	}
 
-	private final List<IShipmentScheduleSegment> segments = new ArrayList<>();
+	private final Set<IShipmentScheduleSegment> segments = new LinkedHashSet<>();
 	private final ShipmentScheduleInvalidateBL shipmentScheduleInvalidator;
 
 	private ShipmentScheduleSegmentChangedProcessor(@NonNull final ShipmentScheduleInvalidateBL shipmentScheduleInvalidator)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessor.java
@@ -11,9 +11,11 @@ import org.adempiere.ad.trx.api.ITrxListenerManager.TrxEventTiming;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.ad.trx.api.OnTrxMissingPolicy;
 import org.adempiere.service.ISysConfigBL;
+import org.slf4j.Logger;
 
 import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
 import de.metas.inoutcandidate.invalidation.segments.ImmutableShipmentScheduleSegment;
+import de.metas.logging.LogManager;
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.ToString;
@@ -43,6 +45,8 @@ import lombok.ToString;
 @ToString(of = "segments")
 final class ShipmentScheduleSegmentChangedProcessor
 {
+	private static final Logger logger = LogManager.getLogger(ShipmentScheduleSegmentChangedProcessor.class);
+
 	private static final String TRX_PROPERTYNAME = ShipmentScheduleSegmentChangedProcessor.class.getName();
 
 	/**
@@ -119,9 +123,13 @@ final class ShipmentScheduleSegmentChangedProcessor
 		}
 
 		final List<IShipmentScheduleSegment> segmentsCopy = new ArrayList<>(segments);
-		segments.clear();
 
+		// Flag FIRST, clear AFTER: if flagging throws (it runs on a separate TRXNAME_None connection), the segments
+		// stay accumulated and are retried by the next flush (the AFTER_COMMIT listener) instead of being lost.
+		// flagSegmentForRecompute is idempotent (it only marks schedules as "needs recompute"), so a retry that
+		// re-flags an already-flagged schedule is a harmless no-op.
 		shipmentScheduleInvalidator.flagSegmentForRecompute(segmentsCopy);
+		segments.clear();
 	}
 
 	public void addSegment(final IShipmentScheduleSegment segment)
@@ -138,14 +146,26 @@ final class ShipmentScheduleSegmentChangedProcessor
 		// (the same OOM this class guards against). copyOf is a no-op for already-immutable segments.
 		this.segments.add(ImmutableShipmentScheduleSegment.copyOf(segment));
 
-		// Fix C — bound the accumulator during a long-running batch: flush mid-batch once it reaches the configured
-		// threshold, so memory stays bounded regardless of batch size / dedupe effectiveness (not only at AFTER_COMMIT).
-		// A threshold <= 0 disables the mid-batch flush. Safe mid-batch because the flush's matching SQL runs on its own
-		// connection (TRXNAME_None) and matches only COMMITTED schedules; the batch's own new schedules are flagged
-		// directly on the batch trx elsewhere, so these already-committed-targeting segments lose no invalidations.
+		// Bound the accumulator during a long-running batch: flush mid-batch once it reaches the configured threshold,
+		// so memory stays bounded regardless of batch size / dedupe effectiveness (not only at AFTER_COMMIT). A
+		// threshold <= 0 disables the mid-batch flush. Safe mid-batch because the flush's matching SQL runs on its own
+		// connection (TRXNAME_None) and matches only COMMITTED schedules; the batch's own new (uncommitted) schedules
+		// are flagged by id directly on the batch trx via ShipmentScheduleInvalidateBL.notifySegmentChangedForShipmentScheduleInclSched
+		// -> flagForRecompute, so these already-committed-targeting segments lose no invalidations.
+		//
+		// Best-effort: a mid-batch flush failure must NOT abort the enclosing business transaction (the AFTER_COMMIT
+		// flush historically ran post-commit and could never do so). process() flags-then-clears, so on failure the
+		// segments remain accumulated and are retried at commit.
 		if (flushThreshold > 0 && segments.size() >= flushThreshold)
 		{
-			process();
+			try
+			{
+				process();
+			}
+			catch (final RuntimeException ex)
+			{
+				logger.warn("Mid-batch invalidation-segment flush failed ({} segments retained for the AFTER_COMMIT retry)", segments.size(), ex);
+			}
 		}
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessor.java
@@ -10,7 +10,6 @@ import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.trx.api.ITrxListenerManager.TrxEventTiming;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.ad.trx.api.OnTrxMissingPolicy;
-import org.adempiere.service.ISysConfigBL;
 import org.slf4j.Logger;
 
 import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
@@ -49,14 +48,6 @@ final class ShipmentScheduleSegmentChangedProcessor
 
 	private static final String TRX_PROPERTYNAME = ShipmentScheduleSegmentChangedProcessor.class.getName();
 
-	/**
-	 * Int sysconfig bounding the invalidation-segment accumulator during a long-running batch: when the accumulator
-	 * reaches this size, it is flushed mid-batch (not only at AFTER_COMMIT). A value {@code <= 0} disables the
-	 * mid-batch flush (only the AFTER_COMMIT flush remains). Default {@value #DEFAULT_FlushThreshold}.
-	 */
-	static final String SYSCONFIG_FlushThreshold = "de.metas.inoutcandidate.ShipmentScheduleSegmentFlushThreshold";
-	private static final int DEFAULT_FlushThreshold = 1000;
-
 	public static ShipmentScheduleSegmentChangedProcessor getOrCreateIfThreadInheritedElseNull(
 			@NonNull final ShipmentScheduleInvalidateBL shipmentScheduleInvalidator)
 	{
@@ -77,9 +68,10 @@ final class ShipmentScheduleSegmentChangedProcessor
 		ShipmentScheduleSegmentChangedProcessor processor = trx.getProperty(TRX_PROPERTYNAME);
 		if (processor == null)
 		{
-			// Resolve the mid-batch flush threshold once here (the processor is created once per trx), so the
-			// constructor stays a pure value assignment and does not reach into the Services registry itself.
-			final int flushThreshold = Services.get(ISysConfigBL.class).getIntValue(SYSCONFIG_FlushThreshold, DEFAULT_FlushThreshold);
+			// The mid-batch flush threshold is owned by the invalidation BL (which owns the sysconfig read); the
+			// processor obtains it from there instead of reaching into the Services registry itself. Resolved once,
+			// here, because the processor is created exactly once per transaction.
+			final int flushThreshold = shipmentScheduleInvalidator.getSegmentFlushThreshold();
 
 			processor = new ShipmentScheduleSegmentChangedProcessor(shipmentScheduleInvalidator, flushThreshold);
 			trx.setProperty(TRX_PROPERTYNAME, processor);
@@ -107,9 +99,10 @@ final class ShipmentScheduleSegmentChangedProcessor
 	private final ShipmentScheduleInvalidateBL shipmentScheduleInvalidator;
 
 	/**
-	 * Mid-batch flush threshold, resolved once by the factory when this per-trx processor is created (the value is
-	 * stable for the lifetime of the batch, and reading it once bounds the per-{@link #addSegment} cost). A value
-	 * {@code <= 0} disables the mid-batch flush — only the AFTER_COMMIT listener flushes then.
+	 * Mid-batch flush threshold, obtained from the owning {@link ShipmentScheduleInvalidateBL} by the factory when
+	 * this per-trx processor is created (the value is stable for the lifetime of the batch, and reading it once
+	 * bounds the per-{@link #addSegment} cost). A value {@code <= 0} disables the mid-batch flush — only the
+	 * AFTER_COMMIT listener flushes then.
 	 */
 	private final int flushThreshold;
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessor.java
@@ -10,6 +10,7 @@ import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.ad.trx.api.ITrxListenerManager.TrxEventTiming;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.ad.trx.api.OnTrxMissingPolicy;
+import org.adempiere.service.ISysConfigBL;
 
 import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
 import de.metas.inoutcandidate.invalidation.segments.ImmutableShipmentScheduleSegment;
@@ -43,6 +44,14 @@ import lombok.ToString;
 final class ShipmentScheduleSegmentChangedProcessor
 {
 	private static final String TRX_PROPERTYNAME = ShipmentScheduleSegmentChangedProcessor.class.getName();
+
+	/**
+	 * Int sysconfig bounding the invalidation-segment accumulator during a long-running batch: when the accumulator
+	 * reaches this size, it is flushed mid-batch (not only at AFTER_COMMIT). A value {@code <= 0} disables the
+	 * mid-batch flush (only the AFTER_COMMIT flush remains). Default {@value #DEFAULT_FlushThreshold}.
+	 */
+	static final String SYSCONFIG_FlushThreshold = "de.metas.inoutcandidate.ShipmentScheduleSegmentFlushThreshold";
+	private static final int DEFAULT_FlushThreshold = 1000;
 
 	public static ShipmentScheduleSegmentChangedProcessor getOrCreateIfThreadInheritedElseNull(
 			@NonNull final ShipmentScheduleInvalidateBL shipmentScheduleInvalidator)
@@ -89,9 +98,17 @@ final class ShipmentScheduleSegmentChangedProcessor
 	private final Set<IShipmentScheduleSegment> segments = new LinkedHashSet<>();
 	private final ShipmentScheduleInvalidateBL shipmentScheduleInvalidator;
 
+	/**
+	 * Mid-batch flush threshold, resolved once when this per-trx processor is created (the value is stable for the
+	 * lifetime of the batch, and reading it once bounds the per-{@link #addSegment} cost). A value {@code <= 0}
+	 * disables the mid-batch flush — only the AFTER_COMMIT listener flushes then.
+	 */
+	private final int flushThreshold;
+
 	private ShipmentScheduleSegmentChangedProcessor(@NonNull final ShipmentScheduleInvalidateBL shipmentScheduleInvalidator)
 	{
 		this.shipmentScheduleInvalidator = shipmentScheduleInvalidator;
+		this.flushThreshold = Services.get(ISysConfigBL.class).getIntValue(SYSCONFIG_FlushThreshold, DEFAULT_FlushThreshold);
 	}
 
 	private void process()
@@ -120,6 +137,16 @@ final class ShipmentScheduleSegmentChangedProcessor
 		// fresh instance would be retained as distinct and the Set would degrade to list-like unbounded growth
 		// (the same OOM this class guards against). copyOf is a no-op for already-immutable segments.
 		this.segments.add(ImmutableShipmentScheduleSegment.copyOf(segment));
+
+		// Fix C — bound the accumulator during a long-running batch: flush mid-batch once it reaches the configured
+		// threshold, so memory stays bounded regardless of batch size / dedupe effectiveness (not only at AFTER_COMMIT).
+		// A threshold <= 0 disables the mid-batch flush. Safe mid-batch because the flush's matching SQL runs on its own
+		// connection (TRXNAME_None) and matches only COMMITTED schedules; the batch's own new schedules are flagged
+		// directly on the batch trx elsewhere, so these already-committed-targeting segments lose no invalidations.
+		if (flushThreshold > 0 && segments.size() >= flushThreshold)
+		{
+			process();
+		}
 	}
 
 	public void addSegments(final Collection<IShipmentScheduleSegment> segments)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessor.java
@@ -12,6 +12,7 @@ import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.ad.trx.api.OnTrxMissingPolicy;
 
 import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
+import de.metas.inoutcandidate.invalidation.segments.ImmutableShipmentScheduleSegment;
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.ToString;
@@ -113,7 +114,12 @@ final class ShipmentScheduleSegmentChangedProcessor
 			return;
 		}
 
-		this.segments.add(segment);
+		// Normalize to the value-based ImmutableShipmentScheduleSegment before adding, so the dedupe Set actually
+		// collapses logically-equal segments. Some IShipmentScheduleSegment implementations (e.g. the HU-derived
+		// ShipmentScheduleSegmentFromHU/-Storage/-Attribute) use identity equals/hashCode; without this copy each
+		// fresh instance would be retained as distinct and the Set would degrade to list-like unbounded growth
+		// (the same OOM this class guards against). copyOf is a no-op for already-immutable segments.
+		this.segments.add(ImmutableShipmentScheduleSegment.copyOf(segment));
 	}
 
 	public void addSegments(final Collection<IShipmentScheduleSegment> segments)
@@ -123,6 +129,9 @@ final class ShipmentScheduleSegmentChangedProcessor
 			return;
 		}
 
-		this.segments.addAll(segments);
+		for (final IShipmentScheduleSegment segment : segments)
+		{
+			addSegment(segment);
+		}
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessor.java
@@ -77,7 +77,11 @@ final class ShipmentScheduleSegmentChangedProcessor
 		ShipmentScheduleSegmentChangedProcessor processor = trx.getProperty(TRX_PROPERTYNAME);
 		if (processor == null)
 		{
-			processor = new ShipmentScheduleSegmentChangedProcessor(shipmentScheduleInvalidator);
+			// Resolve the mid-batch flush threshold once here (the processor is created once per trx), so the
+			// constructor stays a pure value assignment and does not reach into the Services registry itself.
+			final int flushThreshold = Services.get(ISysConfigBL.class).getIntValue(SYSCONFIG_FlushThreshold, DEFAULT_FlushThreshold);
+
+			processor = new ShipmentScheduleSegmentChangedProcessor(shipmentScheduleInvalidator, flushThreshold);
 			trx.setProperty(TRX_PROPERTYNAME, processor);
 
 			// register our listener: we will actually fire the storage segment changed when the transaction is commited
@@ -103,16 +107,18 @@ final class ShipmentScheduleSegmentChangedProcessor
 	private final ShipmentScheduleInvalidateBL shipmentScheduleInvalidator;
 
 	/**
-	 * Mid-batch flush threshold, resolved once when this per-trx processor is created (the value is stable for the
-	 * lifetime of the batch, and reading it once bounds the per-{@link #addSegment} cost). A value {@code <= 0}
-	 * disables the mid-batch flush — only the AFTER_COMMIT listener flushes then.
+	 * Mid-batch flush threshold, resolved once by the factory when this per-trx processor is created (the value is
+	 * stable for the lifetime of the batch, and reading it once bounds the per-{@link #addSegment} cost). A value
+	 * {@code <= 0} disables the mid-batch flush — only the AFTER_COMMIT listener flushes then.
 	 */
 	private final int flushThreshold;
 
-	private ShipmentScheduleSegmentChangedProcessor(@NonNull final ShipmentScheduleInvalidateBL shipmentScheduleInvalidator)
+	private ShipmentScheduleSegmentChangedProcessor(
+			@NonNull final ShipmentScheduleInvalidateBL shipmentScheduleInvalidator,
+			final int flushThreshold)
 	{
 		this.shipmentScheduleInvalidator = shipmentScheduleInvalidator;
-		this.flushThreshold = Services.get(ISysConfigBL.class).getIntValue(SYSCONFIG_FlushThreshold, DEFAULT_FlushThreshold);
+		this.flushThreshold = flushThreshold;
 	}
 
 	private void process()

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/IShipmentScheduleSegment.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/IShipmentScheduleSegment.java
@@ -25,6 +25,7 @@ package de.metas.inoutcandidate.invalidation.segments;
 import de.metas.storage.IStorageQuery;
 import de.metas.storage.IStorageRecord;
 
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -106,7 +107,7 @@ public interface IShipmentScheduleSegment
 
 	default Set<Integer> getWarehouseIds()
 	{
-		return java.util.Collections.emptySet();
+		return Collections.emptySet();
 	}
 
 	default boolean isNoWarehouses()
@@ -115,6 +116,13 @@ public interface IShipmentScheduleSegment
 		return warehouseIds == null || warehouseIds.isEmpty();
 	}
 
+	/**
+	 * NOTE the deliberate divergence from the sibling {@link #isAnyLocator()}/{@link #isAnyBPartner()}/
+	 * {@link #isAnyProduct()}: those treat an EMPTY set as "not any" (false), whereas this treats empty as "any"
+	 * (true, i.e. "do not add a warehouse predicate"). Reason: most segments carry no warehouse id at all, and such a
+	 * segment must NOT contribute a warehouse filter. The locator branch of the recompute WHERE clause needs an
+	 * explicit {@code !isNoLocators()} guard precisely because {@code isAnyLocator()} does NOT collapse empty to "any".
+	 */
 	default boolean isAnyWarehouse()
 	{
 		final Set<Integer> warehouseIds = getWarehouseIds();

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/IShipmentScheduleSegment.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/IShipmentScheduleSegment.java
@@ -45,7 +45,7 @@ public interface IShipmentScheduleSegment
 
 	default boolean isInvalid()
 	{
-		return isNoProducts() || isNoLocators() || isNoBPartners();
+		return isNoProducts() || (isNoLocators() && isNoWarehouses()) || isNoBPartners();
 	}
 
 	Set<Integer> getProductIds();
@@ -102,6 +102,24 @@ public interface IShipmentScheduleSegment
 		return locatorIds != null
 				? locatorIds.contains(0) || locatorIds.contains(-1) || locatorIds.contains(ANY)
 				: false;
+	}
+
+	default Set<Integer> getWarehouseIds()
+	{
+		return java.util.Collections.emptySet();
+	}
+
+	default boolean isNoWarehouses()
+	{
+		final Set<Integer> warehouseIds = getWarehouseIds();
+		return warehouseIds == null || warehouseIds.isEmpty();
+	}
+
+	default boolean isAnyWarehouse()
+	{
+		final Set<Integer> warehouseIds = getWarehouseIds();
+		return warehouseIds == null || warehouseIds.isEmpty()
+				|| warehouseIds.contains(0) || warehouseIds.contains(-1) || warehouseIds.contains(ANY);
 	}
 
 	Set<ShipmentScheduleAttributeSegment> getAttributes();

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/ImmutableShipmentScheduleSegment.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/ImmutableShipmentScheduleSegment.java
@@ -28,6 +28,7 @@ public class ImmutableShipmentScheduleSegment implements IShipmentScheduleSegmen
 	Set<Integer> bpartnerIds;
 	Set<Integer> billBPartnerIds;
 	Set<Integer> locatorIds;
+	Set<Integer> warehouseIds;
 	Set<ShipmentScheduleAttributeSegment> attributes;
 
 	@Builder(toBuilder = true)
@@ -36,12 +37,14 @@ public class ImmutableShipmentScheduleSegment implements IShipmentScheduleSegmen
 			@NonNull @Singular final Set<Integer> bpartnerIds,
 			@NonNull @Singular final Set<Integer> billBPartnerIds,
 			@NonNull @Singular final Set<Integer> locatorIds,
+			@NonNull @Singular final Set<Integer> warehouseIds,
 			@NonNull @Singular final Set<ShipmentScheduleAttributeSegment> attributes)
 	{
 		this.productIds = Collections.unmodifiableSet(productIds);
 		this.bpartnerIds = Collections.unmodifiableSet(bpartnerIds);
 		this.billBPartnerIds = Collections.unmodifiableSet(billBPartnerIds);
 		this.locatorIds = Collections.unmodifiableSet(locatorIds);
+		this.warehouseIds = Collections.unmodifiableSet(warehouseIds);
 		this.attributes = Collections.unmodifiableSet(attributes);
 	}
 
@@ -51,6 +54,7 @@ public class ImmutableShipmentScheduleSegment implements IShipmentScheduleSegmen
 		this.bpartnerIds = Collections.unmodifiableSet(from.getBpartnerIds());
 		this.billBPartnerIds = Collections.unmodifiableSet(from.getBillBPartnerIds());
 		this.locatorIds = Collections.unmodifiableSet(from.getLocatorIds());
+		this.warehouseIds = Collections.unmodifiableSet(from.getWarehouseIds());
 		this.attributes = Collections.unmodifiableSet(from.getAttributes());
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/ShipmentScheduleSegmentBuilder.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/ShipmentScheduleSegmentBuilder.java
@@ -95,6 +95,15 @@ public final class ShipmentScheduleSegmentBuilder
 		return this;
 	}
 
+	/**
+	 * Stores the warehouse identity (repo-id) on the segment. The recompute WHERE clause then matches by the
+	 * schedule's effective warehouse column directly, instead of enumerating every locator of the warehouse.
+	 * <p>
+	 * NOTE: {@code warehouseId(...)} and {@link #locatorId(int)}/{@link #locator(I_M_Locator)} are meant to be
+	 * MUTUALLY EXCLUSIVE on one builder. They populate independent fields that become two AND-ed branches in the
+	 * WHERE clause ({@code (warehouse IN ...) AND EXISTS(locator ...)}) — i.e. an intersection, which would
+	 * under-invalidate. Build a warehouse-scoped OR a locator-scoped segment, never both on the same builder.
+	 */
 	public ShipmentScheduleSegmentBuilder warehouseId(@NonNull final WarehouseId warehouseId)
 	{
 		warehouseIds.add(warehouseId.getRepoId());

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/ShipmentScheduleSegmentBuilder.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/ShipmentScheduleSegmentBuilder.java
@@ -23,17 +23,13 @@ package de.metas.inoutcandidate.invalidation.segments;
  */
 
 import de.metas.product.ProductId;
-import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
-import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
-import org.adempiere.warehouse.api.IWarehouseDAO;
 import org.compiere.model.I_M_Locator;
 
 import javax.annotation.Nullable;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public final class ShipmentScheduleSegmentBuilder
@@ -41,6 +37,7 @@ public final class ShipmentScheduleSegmentBuilder
 	private final Set<Integer> productIds = new HashSet<>();
 	private final Set<Integer> bpartnerIds = new HashSet<>();
 	private final Set<Integer> locatorIds = new HashSet<>();
+	private final Set<Integer> warehouseIds = new HashSet<>();
 	private final Set<ShipmentScheduleAttributeSegment> attributeSegments = new HashSet<>();
 
 	public ShipmentScheduleSegmentBuilder()
@@ -52,6 +49,7 @@ public final class ShipmentScheduleSegmentBuilder
 		return ImmutableShipmentScheduleSegment.builder()
 				.productIds(productIds)
 				.locatorIds(locatorIds)
+				.warehouseIds(warehouseIds)
 				.bpartnerIds(bpartnerIds)
 				.attributes(attributeSegments)
 				.build();
@@ -99,14 +97,7 @@ public final class ShipmentScheduleSegmentBuilder
 
 	public ShipmentScheduleSegmentBuilder warehouseId(@NonNull final WarehouseId warehouseId)
 	{
-		final IWarehouseDAO warehouseDAO = Services.get(IWarehouseDAO.class);
-
-		final List<LocatorId> locatorIds = warehouseDAO.getLocatorIds(warehouseId);
-		for (final LocatorId locatorId : locatorIds)
-		{
-			locatorId(locatorId.getRepoId());
-		}
-
+		warehouseIds.add(warehouseId.getRepoId());
 		return this;
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateRepositoryTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateRepositoryTest.java
@@ -1,0 +1,128 @@
+package de.metas.inoutcandidate.invalidation.impl;
+
+import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
+import de.metas.inoutcandidate.invalidation.segments.ImmutableShipmentScheduleSegment;
+import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleSegmentBuilder;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2024 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * Tests {@link ShipmentScheduleInvalidateRepository#buildShipmentScheduleWhereClause(String, IShipmentScheduleSegment, List)}
+ * for the warehouse-derived segment support (warehouse branch + empty-locator guard).
+ */
+public class ShipmentScheduleInvalidateRepositoryTest
+{
+	private static final String SS_ALIAS = I_M_ShipmentSchedule.Table_Name + ".";
+
+	/** effective warehouse column, mirroring the production builder */
+	private static final String WAREHOUSE_COLUMN =
+			"COALESCE(" + SS_ALIAS + I_M_ShipmentSchedule.COLUMNNAME_M_Warehouse_Override_ID
+					+ ", " + SS_ALIAS + I_M_ShipmentSchedule.COLUMNNAME_M_Warehouse_ID + ")";
+
+	/** the top-level warehouse predicate emitted by the warehouse branch for a single warehouse (DB.buildSqlList single value -> "col=?") */
+	private static final String WAREHOUSE_BRANCH_PREDICATE = "(" + WAREHOUSE_COLUMN + "=?)";
+
+	private static final String LOCATOR_SUBSELECT = "EXISTS (select 1 from " + org.compiere.model.I_M_Locator.Table_Name + " loc";
+
+	private ShipmentScheduleInvalidateRepository repository;
+	private Method buildShipmentScheduleWhereClause;
+
+	@BeforeEach
+	public void beforeEach() throws Exception
+	{
+		AdempiereTestHelper.get().init();
+
+		repository = new ShipmentScheduleInvalidateRepository();
+
+		buildShipmentScheduleWhereClause = ShipmentScheduleInvalidateRepository.class
+				.getDeclaredMethod("buildShipmentScheduleWhereClause", String.class, IShipmentScheduleSegment.class, List.class);
+		buildShipmentScheduleWhereClause.setAccessible(true);
+	}
+
+	private String buildWhereClause(final IShipmentScheduleSegment segment, final List<Object> sqlParams) throws Exception
+	{
+		return (String)buildShipmentScheduleWhereClause.invoke(repository, SS_ALIAS, segment, sqlParams);
+	}
+
+	@Test
+	public void warehouseSegment_matchesByEffectiveWarehouseColumn_andNoLocatorSubselect() throws Exception
+	{
+		// note: bpartnerId(2) is required so the segment is not "invalid" (see IShipmentScheduleSegment.isInvalid())
+		final ImmutableShipmentScheduleSegment segment = new ShipmentScheduleSegmentBuilder()
+				.productId(1)
+				.bpartnerId(2)
+				.warehouseId(WarehouseId.ofRepoId(50))
+				.build();
+
+		final List<Object> sqlParams = new ArrayList<>();
+		final String whereClause = buildWhereClause(segment, sqlParams);
+
+		assertThat(whereClause)
+				.as("warehouse-derived segment must match by the schedule's effective warehouse column")
+				.contains(WAREHOUSE_BRANCH_PREDICATE);
+		assertThat(whereClause)
+				.as("the product branch must still emit its predicate")
+				.contains(SS_ALIAS + I_M_ShipmentSchedule.COLUMNNAME_M_Product_ID + "=?");
+		assertThat(whereClause)
+				.as("warehouse-derived segment must NOT emit the M_Locator EXISTS sub-select")
+				.doesNotContain(LOCATOR_SUBSELECT);
+		assertThat(sqlParams)
+				.as("the warehouse repo-id must be collected as an SQL parameter")
+				.contains(50);
+	}
+
+	@Test
+	public void locatorSegment_stillUsesLocatorSubselect_andNoBareWarehousePredicate() throws Exception
+	{
+		final ImmutableShipmentScheduleSegment segment = new ShipmentScheduleSegmentBuilder()
+				.productId(1)
+				.bpartnerId(2)
+				.locatorId(555)
+				.build();
+
+		final List<Object> sqlParams = new ArrayList<>();
+		final String whereClause = buildWhereClause(segment, sqlParams);
+
+		assertThat(whereClause)
+				.as("locator segment must still use the M_Locator EXISTS sub-select")
+				.contains(LOCATOR_SUBSELECT)
+				.contains("loc." + org.compiere.model.I_M_Locator.COLUMNNAME_M_Locator_ID + "=?");
+		assertThat(whereClause)
+				.as("locator segment must NOT emit a top-level warehouse predicate (locator path unchanged)")
+				.doesNotContain(WAREHOUSE_BRANCH_PREDICATE);
+		assertThat(sqlParams)
+				.as("the locator repo-id must be collected as an SQL parameter")
+				.contains(555);
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessorTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessorTest.java
@@ -26,11 +26,8 @@ import com.google.common.collect.ImmutableSet;
 import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
 import de.metas.inoutcandidate.invalidation.segments.ImmutableShipmentScheduleSegment;
 import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleAttributeSegment;
-import de.metas.organization.OrgId;
 import de.metas.util.Services;
 import org.adempiere.ad.trx.api.ITrxManager;
-import org.adempiere.service.ClientId;
-import org.adempiere.service.ISysConfigBL;
 import org.adempiere.test.AdempiereTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Regression guard for {@link ShipmentScheduleSegmentChangedProcessor}'s segment accumulation.
@@ -203,14 +201,9 @@ class ShipmentScheduleSegmentChangedProcessorTest
 	@Test
 	void distinctSegmentsExceedingThreshold_areFlushedMidBatch_bounded()
 	{
-		// set a low, deterministic threshold at the SYSTEM level, which is what the 2-arg getIntValue(name, default) reads
-		Services.get(ISysConfigBL.class).setValue(
-				ShipmentScheduleSegmentChangedProcessor.SYSCONFIG_FlushThreshold,
-				FLUSH_THRESHOLD,
-				ClientId.SYSTEM,
-				OrgId.ANY);
-
 		final ShipmentScheduleInvalidateBL invalidator = mock(ShipmentScheduleInvalidateBL.class);
+		// The processor gets its flush threshold from the owning BL — stub a low, deterministic value directly on the mock.
+		when(invalidator.getSegmentFlushThreshold()).thenReturn(FLUSH_THRESHOLD);
 
 		final List<IShipmentScheduleSegment> distinctSegments = new ArrayList<>();
 		for (int i = 0; i < OVER_THRESHOLD_DISTINCT_COUNT; i++)

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessorTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessorTest.java
@@ -48,7 +48,8 @@ import static org.mockito.Mockito.verify;
  */
 class ShipmentScheduleSegmentChangedProcessorTest
 {
-	private static final int N = 1000;
+	private static final int REPEATED_ADD_COUNT = 1000;
+	private static final int DISTINCT_SEGMENT_COUNT = 1000;
 
 	@BeforeEach
 	void beforeEach()
@@ -57,20 +58,20 @@ class ShipmentScheduleSegmentChangedProcessorTest
 	}
 
 	/**
-	 * Adding the SAME segment value N times must be deduped down to a single distinct segment.
+	 * Adding {@value #REPEATED_ADD_COUNT} separately-constructed but value-equal segments must be deduped to a single
+	 * distinct segment.
 	 * <p>
-	 * FAILS on current ArrayList-based accumulator (retains all {@value #N}).
+	 * Each iteration builds a FRESH {@link ImmutableShipmentScheduleSegment} instance (not the same reference), so this
+	 * exercises the Lombok {@code @Value} equals/hashCode contract the Set-based accumulator relies on — mirroring the
+	 * real caller ({@code ShipmentScheduleInvalidateBL.notifySegmentsChanged}), which builds fresh equal instances per
+	 * invalidation event.
+	 * <p>
+	 * FAILS on the pre-fix ArrayList-based accumulator (retains all {@value #REPEATED_ADD_COUNT}).
 	 */
 	@Test
 	void sameSegmentAddedManyTimes_isDedupedToOne()
 	{
 		final ShipmentScheduleInvalidateBL invalidator = mock(ShipmentScheduleInvalidateBL.class);
-
-		final ImmutableShipmentScheduleSegment segment = ImmutableShipmentScheduleSegment.builder()
-				.productId(1)
-				.bpartnerId(2)
-				.locatorId(3)
-				.build();
 
 		Services.get(ITrxManager.class).runInThreadInheritedTrx(() -> {
 			final ShipmentScheduleSegmentChangedProcessor processor =
@@ -79,9 +80,14 @@ class ShipmentScheduleSegmentChangedProcessorTest
 					.as("processor must be created inside a thread-inherited trx")
 					.isNotNull();
 
-			for (int i = 0; i < N; i++)
+			for (int i = 0; i < REPEATED_ADD_COUNT; i++)
 			{
-				processor.addSegment(segment);
+				// fresh, independently-built instance each time — value-equal, NOT the same reference
+				processor.addSegment(ImmutableShipmentScheduleSegment.builder()
+						.productId(1)
+						.bpartnerId(2)
+						.locatorId(3)
+						.build());
 			}
 		});
 
@@ -90,12 +96,12 @@ class ShipmentScheduleSegmentChangedProcessorTest
 		verify(invalidator).flagSegmentForRecompute(captor.capture());
 
 		assertThat(captor.getValue())
-				.as("adding the same segment %d times must be deduped to a single distinct segment", N)
+				.as("adding %d value-equal segments must be deduped to a single distinct segment", REPEATED_ADD_COUNT)
 				.hasSize(1);
 	}
 
 	/**
-	 * N DISTINCT segment values must all be retained (proves dedupe, not truncation).
+	 * {@value #DISTINCT_SEGMENT_COUNT} DISTINCT segment values must all be retained (proves dedupe, not truncation).
 	 * <p>
 	 * PASSES on current code.
 	 */
@@ -105,7 +111,7 @@ class ShipmentScheduleSegmentChangedProcessorTest
 		final ShipmentScheduleInvalidateBL invalidator = mock(ShipmentScheduleInvalidateBL.class);
 
 		final List<IShipmentScheduleSegment> distinctSegments = new ArrayList<>();
-		for (int i = 0; i < N; i++)
+		for (int i = 0; i < DISTINCT_SEGMENT_COUNT; i++)
 		{
 			distinctSegments.add(ImmutableShipmentScheduleSegment.builder()
 					.productId(i)
@@ -129,7 +135,7 @@ class ShipmentScheduleSegmentChangedProcessorTest
 		verify(invalidator).flagSegmentForRecompute(captor.capture());
 
 		assertThat(captor.getValue())
-				.as("all %d distinct segments must be retained", N)
-				.hasSize(N);
+				.as("all %d distinct segments must be retained", DISTINCT_SEGMENT_COUNT)
+				.hasSize(DISTINCT_SEGMENT_COUNT);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessorTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessorTest.java
@@ -26,8 +26,11 @@ import com.google.common.collect.ImmutableSet;
 import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
 import de.metas.inoutcandidate.invalidation.segments.ImmutableShipmentScheduleSegment;
 import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleAttributeSegment;
+import de.metas.organization.OrgId;
 import de.metas.util.Services;
 import org.adempiere.ad.trx.api.ITrxManager;
+import org.adempiere.service.ClientId;
+import org.adempiere.service.ISysConfigBL;
 import org.adempiere.test.AdempiereTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +42,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -55,6 +59,11 @@ class ShipmentScheduleSegmentChangedProcessorTest
 {
 	private static final int REPEATED_ADD_COUNT = 1000;
 	private static final int DISTINCT_SEGMENT_COUNT = 1000;
+
+	/** Low, deterministic threshold so the mid-batch-flush test is fast and does not depend on the 1000 default. */
+	private static final int FLUSH_THRESHOLD = 10;
+	/** Distinct segments to add: > FLUSH_THRESHOLD so at least one mid-batch flush must fire before the trx commit. */
+	private static final int OVER_THRESHOLD_DISTINCT_COUNT = 25;
 
 	@BeforeEach
 	void beforeEach()
@@ -179,6 +188,80 @@ class ShipmentScheduleSegmentChangedProcessorTest
 		assertThat(captor.getValue())
 				.as("value-equal identity-based segments must be normalized and deduped to a single segment")
 				.hasSize(1);
+	}
+
+	/**
+	 * Fix C — threshold flush. Adding {@value #OVER_THRESHOLD_DISTINCT_COUNT} DISTINCT segments while the flush
+	 * threshold is {@value #FLUSH_THRESHOLD} must bound the accumulator: it flushes mid-batch when it reaches the
+	 * threshold, not only at AFTER_COMMIT. Asserts (a) MORE THAN ONE flush fired (≥1 mid-batch flush before commit),
+	 * (b) the UNION of all flushed segments equals the full distinct set (none lost, none duplicated), and (c) no
+	 * single flush exceeded the threshold size (memory stayed bounded).
+	 * <p>
+	 * FAILS on the pre-fix code: only the AFTER_COMMIT listener flushes, so there is exactly ONE invocation carrying
+	 * all {@value #OVER_THRESHOLD_DISTINCT_COUNT} segments — assertion (a) "more than one flush" fails.
+	 */
+	@Test
+	void distinctSegmentsExceedingThreshold_areFlushedMidBatch_bounded()
+	{
+		// set a low, deterministic threshold at the SYSTEM level, which is what the 2-arg getIntValue(name, default) reads
+		Services.get(ISysConfigBL.class).setValue(
+				ShipmentScheduleSegmentChangedProcessor.SYSCONFIG_FlushThreshold,
+				FLUSH_THRESHOLD,
+				ClientId.SYSTEM,
+				OrgId.ANY);
+
+		final ShipmentScheduleInvalidateBL invalidator = mock(ShipmentScheduleInvalidateBL.class);
+
+		final List<IShipmentScheduleSegment> distinctSegments = new ArrayList<>();
+		for (int i = 0; i < OVER_THRESHOLD_DISTINCT_COUNT; i++)
+		{
+			distinctSegments.add(ImmutableShipmentScheduleSegment.builder()
+					.productId(i)
+					.bpartnerId(2)
+					.locatorId(3)
+					.build());
+		}
+
+		Services.get(ITrxManager.class).runInThreadInheritedTrx(() -> {
+			final ShipmentScheduleSegmentChangedProcessor processor =
+					ShipmentScheduleSegmentChangedProcessor.getOrCreateIfThreadInheritedElseNull(invalidator);
+			assertThat(processor)
+					.as("processor must be created inside a thread-inherited trx")
+					.isNotNull();
+
+			// add one at a time so the accumulator can cross the threshold mid-batch
+			for (final IShipmentScheduleSegment segment : distinctSegments)
+			{
+				processor.addSegment(segment);
+			}
+		});
+
+		// capture EVERY flush: the mid-batch threshold flushes AND the final AFTER_COMMIT flush of the remainder
+		@SuppressWarnings("unchecked")
+		final ArgumentCaptor<Collection<IShipmentScheduleSegment>> captor = ArgumentCaptor.forClass(Collection.class);
+		verify(invalidator, atLeastOnce()).flagSegmentForRecompute(captor.capture());
+		final List<Collection<IShipmentScheduleSegment>> flushes = captor.getAllValues();
+
+		// (a) more than one flush → at least one mid-batch flush fired before the trx commit
+		assertThat(flushes.size())
+				.as("adding %d distinct segments with threshold %d must flush mid-batch (>1 flush), not only at commit",
+						OVER_THRESHOLD_DISTINCT_COUNT, FLUSH_THRESHOLD)
+				.isGreaterThan(1);
+
+		// (c) no single flush's batch exceeded the threshold size → memory stayed bounded
+		for (final Collection<IShipmentScheduleSegment> flush : flushes)
+		{
+			assertThat(flush.size())
+					.as("no single flush may exceed the threshold size %d", FLUSH_THRESHOLD)
+					.isLessThanOrEqualTo(FLUSH_THRESHOLD);
+		}
+
+		// (b) union of all flushed segments == the full distinct set (none lost, none duplicated)
+		final List<IShipmentScheduleSegment> union = new ArrayList<>();
+		flushes.forEach(union::addAll);
+		assertThat(union)
+				.as("union of all flushed segments must equal the full distinct set — none lost, none duplicated")
+				.containsExactlyInAnyOrderElementsOf(distinctSegments);
 	}
 
 	/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessorTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessorTest.java
@@ -191,7 +191,7 @@ class ShipmentScheduleSegmentChangedProcessorTest
 	}
 
 	/**
-	 * Fix C — threshold flush. Adding {@value #OVER_THRESHOLD_DISTINCT_COUNT} DISTINCT segments while the flush
+	 * Threshold flush. Adding {@value #OVER_THRESHOLD_DISTINCT_COUNT} DISTINCT segments while the flush
 	 * threshold is {@value #FLUSH_THRESHOLD} must bound the accumulator: it flushes mid-batch when it reaches the
 	 * threshold, not only at AFTER_COMMIT. Asserts (a) MORE THAN ONE flush fired (≥1 mid-batch flush before commit),
 	 * (b) the UNION of all flushed segments equals the full distinct set (none lost, none duplicated), and (c) no

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessorTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessorTest.java
@@ -22,8 +22,10 @@ package de.metas.inoutcandidate.invalidation.impl;
  * #L%
  */
 
+import com.google.common.collect.ImmutableSet;
 import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
 import de.metas.inoutcandidate.invalidation.segments.ImmutableShipmentScheduleSegment;
+import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleAttributeSegment;
 import de.metas.util.Services;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.test.AdempiereTestHelper;
@@ -34,17 +36,20 @@ import org.mockito.ArgumentCaptor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 /**
- * RED test proving that {@link ShipmentScheduleSegmentChangedProcessor} does NOT dedupe accumulated segments.
+ * Regression guard for {@link ShipmentScheduleSegmentChangedProcessor}'s segment accumulation.
  * <p>
- * The processor accumulates segments into a plain {@code ArrayList} and, on trx commit (AFTER_COMMIT listener),
- * flushes the whole list to {@link ShipmentScheduleInvalidateBL#flagSegmentForRecompute(Collection)}.
- * Feeding the same value N times should collapse to a single distinct segment, but the ArrayList keeps all N.
+ * The processor accumulates segments into a dedup {@link java.util.LinkedHashSet} and, on trx commit (AFTER_COMMIT
+ * listener), flushes them to {@link ShipmentScheduleInvalidateBL#flagSegmentForRecompute(Collection)}. These tests
+ * assert that (a) value-equal segments collapse to one, (b) distinct segments are all retained (dedupe, not
+ * truncation), and (c) identity-equals implementations (e.g. the HU-derived segments) are also deduped because the
+ * accumulator normalizes every segment to the value-based {@link ImmutableShipmentScheduleSegment} before adding.
  */
 class ShipmentScheduleSegmentChangedProcessorTest
 {
@@ -137,5 +142,76 @@ class ShipmentScheduleSegmentChangedProcessorTest
 		assertThat(captor.getValue())
 				.as("all %d distinct segments must be retained", DISTINCT_SEGMENT_COUNT)
 				.hasSize(DISTINCT_SEGMENT_COUNT);
+	}
+
+	/**
+	 * Identity-equals segment implementations must ALSO be deduped.
+	 * <p>
+	 * The HU-driven invalidation path ({@code M_HU_Storage}/{@code M_HU_Attribute}/{@code M_HU} changes) pushes
+	 * segment classes that use Object identity equals/hashCode straight into the accumulator (they do NOT go through
+	 * the value-based builder). The accumulator normalizes each segment to {@link ImmutableShipmentScheduleSegment}
+	 * before adding, so {@value #REPEATED_ADD_COUNT} freshly-constructed but value-equal identity segments must
+	 * collapse to one — otherwise this high-churn path would grow unbounded exactly like the pre-fix accumulator.
+	 */
+	@Test
+	void identityEqualsSegments_valueEqual_areDedupedToOne()
+	{
+		final ShipmentScheduleInvalidateBL invalidator = mock(ShipmentScheduleInvalidateBL.class);
+
+		Services.get(ITrxManager.class).runInThreadInheritedTrx(() -> {
+			final ShipmentScheduleSegmentChangedProcessor processor =
+					ShipmentScheduleSegmentChangedProcessor.getOrCreateIfThreadInheritedElseNull(invalidator);
+			assertThat(processor)
+					.as("processor must be created inside a thread-inherited trx")
+					.isNotNull();
+
+			for (int i = 0; i < REPEATED_ADD_COUNT; i++)
+			{
+				// fresh identity-equals instance each iteration, all value-equal
+				processor.addSegment(new IdentityEqualsSegment(1, 2, 3));
+			}
+		});
+
+		@SuppressWarnings("unchecked")
+		final ArgumentCaptor<Collection<IShipmentScheduleSegment>> captor = ArgumentCaptor.forClass(Collection.class);
+		verify(invalidator).flagSegmentForRecompute(captor.capture());
+
+		assertThat(captor.getValue())
+				.as("value-equal identity-based segments must be normalized and deduped to a single segment")
+				.hasSize(1);
+	}
+
+	/**
+	 * Minimal {@link IShipmentScheduleSegment} using Object (identity) equals/hashCode — models the HU-derived
+	 * segments ({@code ShipmentScheduleSegmentFromHU}/{@code -Storage}/{@code -Attribute}), none of which override
+	 * equals/hashCode.
+	 */
+	private static final class IdentityEqualsSegment implements IShipmentScheduleSegment
+	{
+		private final Set<Integer> productIds;
+		private final Set<Integer> bpartnerIds;
+		private final Set<Integer> locatorIds;
+
+		IdentityEqualsSegment(final int productId, final int bpartnerId, final int locatorId)
+		{
+			this.productIds = ImmutableSet.of(productId);
+			this.bpartnerIds = ImmutableSet.of(bpartnerId);
+			this.locatorIds = ImmutableSet.of(locatorId);
+		}
+
+		@Override
+		public Set<Integer> getProductIds() { return productIds; }
+
+		@Override
+		public Set<Integer> getBpartnerIds() { return bpartnerIds; }
+
+		@Override
+		public Set<Integer> getBillBPartnerIds() { return ImmutableSet.of(); }
+
+		@Override
+		public Set<Integer> getLocatorIds() { return locatorIds; }
+
+		@Override
+		public Set<ShipmentScheduleAttributeSegment> getAttributes() { return ImmutableSet.of(); }
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessorTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessorTest.java
@@ -1,0 +1,135 @@
+package de.metas.inoutcandidate.invalidation.impl;
+
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
+import de.metas.inoutcandidate.invalidation.segments.ImmutableShipmentScheduleSegment;
+import de.metas.util.Services;
+import org.adempiere.ad.trx.api.ITrxManager;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * RED test proving that {@link ShipmentScheduleSegmentChangedProcessor} does NOT dedupe accumulated segments.
+ * <p>
+ * The processor accumulates segments into a plain {@code ArrayList} and, on trx commit (AFTER_COMMIT listener),
+ * flushes the whole list to {@link ShipmentScheduleInvalidateBL#flagSegmentForRecompute(Collection)}.
+ * Feeding the same value N times should collapse to a single distinct segment, but the ArrayList keeps all N.
+ */
+class ShipmentScheduleSegmentChangedProcessorTest
+{
+	private static final int N = 1000;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+	}
+
+	/**
+	 * Adding the SAME segment value N times must be deduped down to a single distinct segment.
+	 * <p>
+	 * FAILS on current ArrayList-based accumulator (retains all {@value #N}).
+	 */
+	@Test
+	void sameSegmentAddedManyTimes_isDedupedToOne()
+	{
+		final ShipmentScheduleInvalidateBL invalidator = mock(ShipmentScheduleInvalidateBL.class);
+
+		final ImmutableShipmentScheduleSegment segment = ImmutableShipmentScheduleSegment.builder()
+				.productId(1)
+				.bpartnerId(2)
+				.locatorId(3)
+				.build();
+
+		Services.get(ITrxManager.class).runInThreadInheritedTrx(() -> {
+			final ShipmentScheduleSegmentChangedProcessor processor =
+					ShipmentScheduleSegmentChangedProcessor.getOrCreateIfThreadInheritedElseNull(invalidator);
+			assertThat(processor)
+					.as("processor must be created inside a thread-inherited trx")
+					.isNotNull();
+
+			for (int i = 0; i < N; i++)
+			{
+				processor.addSegment(segment);
+			}
+		});
+
+		@SuppressWarnings("unchecked")
+		final ArgumentCaptor<Collection<IShipmentScheduleSegment>> captor = ArgumentCaptor.forClass(Collection.class);
+		verify(invalidator).flagSegmentForRecompute(captor.capture());
+
+		assertThat(captor.getValue())
+				.as("adding the same segment %d times must be deduped to a single distinct segment", N)
+				.hasSize(1);
+	}
+
+	/**
+	 * N DISTINCT segment values must all be retained (proves dedupe, not truncation).
+	 * <p>
+	 * PASSES on current code.
+	 */
+	@Test
+	void distinctSegments_areAllRetained()
+	{
+		final ShipmentScheduleInvalidateBL invalidator = mock(ShipmentScheduleInvalidateBL.class);
+
+		final List<IShipmentScheduleSegment> distinctSegments = new ArrayList<>();
+		for (int i = 0; i < N; i++)
+		{
+			distinctSegments.add(ImmutableShipmentScheduleSegment.builder()
+					.productId(i)
+					.bpartnerId(2)
+					.locatorId(3)
+					.build());
+		}
+
+		Services.get(ITrxManager.class).runInThreadInheritedTrx(() -> {
+			final ShipmentScheduleSegmentChangedProcessor processor =
+					ShipmentScheduleSegmentChangedProcessor.getOrCreateIfThreadInheritedElseNull(invalidator);
+			assertThat(processor)
+					.as("processor must be created inside a thread-inherited trx")
+					.isNotNull();
+
+			processor.addSegments(distinctSegments);
+		});
+
+		@SuppressWarnings("unchecked")
+		final ArgumentCaptor<Collection<IShipmentScheduleSegment>> captor = ArgumentCaptor.forClass(Collection.class);
+		verify(invalidator).flagSegmentForRecompute(captor.capture());
+
+		assertThat(captor.getValue())
+				.as("all %d distinct segments must be retained", N)
+				.hasSize(N);
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/segments/ImmutableShipmentScheduleSegmentTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/segments/ImmutableShipmentScheduleSegmentTest.java
@@ -1,5 +1,6 @@
 package de.metas.inoutcandidate.invalidation.segments;
 
+import org.adempiere.warehouse.WarehouseId;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,5 +37,58 @@ public class ImmutableShipmentScheduleSegmentTest
 		assertThat(segment.getBpartnerIds()).isEmpty();
 		assertThat(segment.getLocatorIds()).isEmpty();
 		assertThat(segment.getProductIds()).isEmpty();
+	}
+
+	@Test
+	public void warehouseIdBuilder_carriesWarehouseIdentity_notEnumeratedLocators()
+	{
+		final int warehouseRepoId = 100;
+
+		final ImmutableShipmentScheduleSegment segment = new ShipmentScheduleSegmentBuilder()
+				.productId(1)
+				.bpartnerId(2)
+				.warehouseId(WarehouseId.ofRepoId(warehouseRepoId))
+				.build();
+
+		// the segment must carry the WAREHOUSE identity (as repo-id, mirroring locatorIds/productIds Set<Integer>) ...
+		assertThat(segment.getWarehouseIds()).containsExactly(warehouseRepoId);
+		// ... and must NOT have enumerated the warehouse's locators
+		assertThat(segment.getLocatorIds()).isEmpty();
+		assertThat(segment.isAnyWarehouse()).isFalse();
+	}
+
+	@Test
+	public void twoSegmentsFromSameWarehouseProductBPartner_areEqual()
+	{
+		final int warehouseRepoId = 100;
+
+		final ImmutableShipmentScheduleSegment segment1 = new ShipmentScheduleSegmentBuilder()
+				.productId(1)
+				.bpartnerId(2)
+				.warehouseId(WarehouseId.ofRepoId(warehouseRepoId))
+				.build();
+
+		final ImmutableShipmentScheduleSegment segment2 = new ShipmentScheduleSegmentBuilder()
+				.productId(1)
+				.bpartnerId(2)
+				.warehouseId(WarehouseId.ofRepoId(warehouseRepoId))
+				.build();
+
+		assertThat(segment1).isEqualTo(segment2);
+	}
+
+	@Test
+	public void locatorIdBuilder_keepsSingleLocator_withNoWarehouseIdentity()
+	{
+		final int locatorRepoId = 555;
+
+		final ImmutableShipmentScheduleSegment segment = new ShipmentScheduleSegmentBuilder()
+				.productId(1)
+				.bpartnerId(2)
+				.locatorId(locatorRepoId)
+				.build();
+
+		assertThat(segment.getLocatorIds()).contains(locatorRepoId);
+		assertThat(segment.getWarehouseIds()).isEmpty();
 	}
 }


### PR DESCRIPTION
## What

Fixes an app-server OOM / GC-death-spiral caused by the shipment-schedule invalidation-segment accumulator under heavy batch load.

**Root cause:** `ShipmentScheduleSegmentChangedProcessor` accumulated invalidation segments in a plain `ArrayList` on the batch transaction, flushed only at `AFTER_COMMIT`. When `CreateMissingShipmentSchedules` runs as one long-lived transaction, thousands of segments — the great majority identical, each holding an enumerated per-warehouse locator `Set` (multiple MB when a warehouse has tens of thousands of locators) — pile up until the heap is exhausted.

Confirmed via JVM heap-dump dominator-tree analysis (Eclipse MAT): a single batch transaction retained ~94% of the heap through this processor's `segments` list, the dominators being thousands of `ImmutableShipmentScheduleSegment` instances holding duplicate enumerated-locator sets.

## The fix — three complementary parts (all in `de.metas.swat.base`)

**A — Dedupe the accumulator.** `segments`: `ArrayList` → `LinkedHashSet`. `ImmutableShipmentScheduleSegment` is a Lombok `@Value` (value equals/hashCode), so equal segments collapse; insertion order is preserved. `addSegment` first normalizes each segment via the existing `ImmutableShipmentScheduleSegment.copyOf(...)`, so segment classes that use identity equals (the HU-derived `ShipmentScheduleSegmentFromHU/-Storage/-Attribute`, which reach the accumulator directly) are also deduped — otherwise the high-churn HU invalidation path would degrade to unbounded list-like growth.

**B — Warehouse identity instead of enumerated locators.** A warehouse-derived segment now carries the warehouse id (`getWarehouseIds()`) instead of a copy of every locator of that warehouse; the recompute WHERE clause matches `COALESCE(M_Warehouse_Override_ID, M_Warehouse_ID) IN (:warehouseIds)` — equivalent to the old `EXISTS(M_Locator …)` for warehouse-derived segments. Single-locator segments stay locator-granular. This shrinks each such segment from MB to a handful of ids.

**C — Threshold flush.** The accumulator flushes mid-batch once it reaches a configurable size (sysconfig `de.metas.inoutcandidate.ShipmentScheduleSegmentFlushThreshold`, default 1000; `<=0` disables), not only at `AFTER_COMMIT` — so a single non-committing batch transaction can no longer accumulate without bound. Safe because the flush's matching SQL runs on its own connection (`TRXNAME_None`) and matches only committed schedules.

## Behavior preserved (AC4)

The exact same set of shipment schedules is flagged for recompute as before — none missed, none spuriously added — regardless of the new flush timing and the warehouse-identity vs enumerated-locators representation.

**One intentional exception (a latent-bug fix, not strict preservation):** for a warehouse that has **zero** locators, the old path enumerated an empty locator set, which made the segment `isInvalid()` and silently matched no schedule — a latent under-invalidation. Matching by the warehouse column now correctly invalidates schedules in such a warehouse. This is safer (a superset — extra recompute is an idempotent no-op), affects only the pathological zero-locator case, and never *misses* an invalidation.

The mid-batch threshold flush is **best-effort**: `process()` flags-then-clears, and a mid-batch flush failure is caught + logged (segments retained for the AFTER_COMMIT retry) so it can never abort the enclosing business transaction — matching the historical post-commit semantics of the AFTER_COMMIT flush.

## Test

TDD throughout. `ShipmentScheduleSegmentChangedProcessorTest`: value-equal segments ×1000 → retained 1; 1000 distinct → retained 1000; identity-equals (HU-shaped) value-equal segments → deduped to 1; mid-batch threshold flush → multiple bounded flushes whose union equals the distinct set. `ImmutableShipmentScheduleSegmentTest`: warehouse segment carries `warehouseIds` and no locators; locator segment unchanged. `ShipmentScheduleInvalidateRepositoryTest`: warehouse-segment WHERE clause matches by warehouse column with no locator sub-select; locator-segment unchanged. Full `de.metas.swat.base` shipment-schedule/invalidation suite green (88 tests).
