### PR TITLE
mobile-webui: don't bounce a just-started workflow to home (fix both the stale-launchers prune and the redirect-home guard races)

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/applicationRoot/ApplicationLayout.bounceHome.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/applicationRoot/ApplicationLayout.bounceHome.test.js
@@ -1,0 +1,132 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { combineReducers, createStore } from 'redux';
+
+import { ApplicationLayout } from '../../../containers/applicationRoot/ApplicationLayout';
+import wfProcesses from '../../../reducers/wfProcesses/index';
+import { updateWFProcess } from '../../../actions/WorkflowActions';
+
+// Race B — "bounce a just-started workflow to home".
+//
+// On a workflow-launcher tap, WFLauncherButton dispatches updateWFProcess and then navigates to the
+// job route in the same start-request `.then`. On React 17 / connected-react-router 6.9 /
+// react-redux 7.2 those updates are not batched, so ApplicationLayout can mount on the job route
+// one render pass BEFORE the store selector observes the just-dispatched process. The redirect-home
+// guard used to call history.goHome() synchronously on that first pass, dropping the operator on the
+// root menu mid-start (the flaky #WFProcessScreen timeout). The guard must tolerate the ordering:
+// only redirect home if the process is STILL not loaded after a tick.
+//
+// This test drives that ordering deterministically with a real store: ApplicationLayout mounts while
+// the process is absent (guard armed), then the just-started process arrives before the deferred tick
+// fires. It must NOT bounce home and must render the workflow screen.
+
+const WF_PROCESS_ID = 'picking-1000004';
+const SCREEN_ID = 'WFProcessScreen';
+
+const mockGoHome = jest.fn();
+jest.mock('../../../hooks/useMobileNavigation', () => ({
+  useMobileNavigation: () => ({
+    goHome: mockGoHome,
+    push: jest.fn(),
+    replace: jest.fn(),
+    goTo: jest.fn(),
+    goBack: jest.fn(),
+    go: jest.fn(),
+    goToFromLocation: jest.fn(),
+  }),
+}));
+
+// The job route carries a wfProcessId, so the redirect-home guard is armed.
+jest.mock('../../../hooks/useMobileLocation', () => ({
+  useMobileLocation: () => ({ wfProcessId: 'picking-1000004' }),
+}));
+
+jest.mock('../../../reducers/applications', () => ({
+  useApplicationInfo: () => ({ caption: 'Picking', iconClassNames: 'fas fa-box' }),
+}));
+
+jest.mock('../../../reducers/headers', () => ({
+  useNavigationInfoFromHeaders: () => ({
+    screenId: 'WFProcessScreen',
+    caption: 'Picking job',
+    homeLocation: { iconClassName: 'fas fa-home', location: '/' },
+  }),
+  useBackLocationFromHeaders: () => null,
+}));
+
+// Non-fullscreen layout (the real WF screens render the #WFProcessScreen container the e2e gate waits on).
+jest.mock('../../../apps', () => ({ isApplicationFullScreen: () => false }));
+
+jest.mock('../../../utils/ui_trace/useUITraceLocationChange', () => ({
+  useUITraceLocationChange: jest.fn(),
+}));
+jest.mock('../../../utils/ui_trace', () => ({
+  traceFunction: (fn) => fn,
+}));
+
+// Heavy children are irrelevant to the guard; stub them to trivial nodes.
+jest.mock('../../../containers/ViewHeader', () => ({ ViewHeader: () => null }));
+jest.mock('../../../components/ScreenToaster', () => () => null);
+jest.mock('../../../apps/picking/ShelfLifeConfirmDialogHost', () => () => null);
+
+describe('ApplicationLayout: a just-started workflow must not be bounced to home (Race B)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('does not call mockGoHome and renders the WF screen when the process is observed one tick later', () => {
+    // Store starts empty: the just-dispatched process is not yet observable on the job route.
+    const store = createStore(combineReducers({ wfProcesses }));
+
+    const WFScreen = () => <div data-testid="wf-screen-content">workflow content</div>;
+
+    // 1) ApplicationLayout mounts on the job route BEFORE the store observes the process.
+    render(
+      <Provider store={store}>
+        <ApplicationLayout applicationId="picking" Component={WFScreen} />
+      </Provider>
+    );
+
+    // 2) The just-started process becomes visible in the store (the start `.then` dispatch lands),
+    //    still within the same tick — before any deferred redirect could fire.
+    act(() => {
+      store.dispatch(updateWFProcess({ wfProcess: { id: WF_PROCESS_ID, activities: [] }, parent: null }));
+    });
+
+    // 3) Flush any pending timers (a deferred-but-cancelled mockGoHome must not fire).
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    // The operator stays on the job screen — no bounce home, screen rendered (not null).
+    expect(mockGoHome).not.toHaveBeenCalled();
+    expect(document.getElementById(SCREEN_ID)).not.toBeNull();
+    expect(document.querySelector('[data-testid="wf-screen-content"]')).not.toBeNull();
+  });
+
+  it('still redirects home for a genuinely absent process (dead deep-link / reload)', () => {
+    // The process never arrives — the guard must still bounce home once the deferred tick fires.
+    const store = createStore(combineReducers({ wfProcesses }));
+
+    const WFScreen = () => <div data-testid="wf-screen-content">workflow content</div>;
+
+    render(
+      <Provider store={store}>
+        <ApplicationLayout applicationId="picking" Component={WFScreen} />
+      </Provider>
+    );
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(mockGoHome).toHaveBeenCalledTimes(1);
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/reducers/wfProcesses/staleLaunchersDeletesStartedProcess.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/reducers/wfProcesses/staleLaunchersDeletesStartedProcess.test.js
@@ -1,0 +1,116 @@
+import reducer from '../../../reducers/wfProcesses/index';
+import { isWfProcessLoaded } from '../../../reducers/wfProcesses';
+import { updateWFProcess } from '../../../actions/WorkflowActions';
+import { POPULATE_LAUNCHERS_COMPLETE } from '../../../constants/LaunchersActionTypes';
+
+// A launchers refresh that was computed BEFORE a workflow is started can resolve AFTER the start's
+// UPDATE_WORKFLOW_PROCESS. The POPULATE_LAUNCHERS_COMPLETE reducer
+// (reducers/wfProcesses/workflow.js -> removeWFProcessesFromState) prunes wfProcesses that are not
+// in the snapshot. It must prune ONLY when the launchers snapshot was fetched strictly AFTER a
+// process was last updated locally; a snapshot that predates the start cannot be authoritative
+// about it. Otherwise ApplicationLayout sees isWfProcessLoaded===false and redirects the operator
+// to the home menu mid-flow (the observed job-start timeout landing on the root menu).
+//
+// updateWFProcess stamps `timestamp: Date.now()` in its action creator and populateLaunchersComplete
+// threads the launchers fetch-start time through as `requestTimestamp`. We drive Date.now() so the
+// two tests model the real ordering deterministically (no wall-clock flakiness).
+describe('wfProcesses: POPULATE_LAUNCHERS_COMPLETE prunes only genuinely stale processes', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('keeps the just-started wfProcess when a pre-start launchers snapshot resolves after the start', () => {
+    const wfProcessId = 'picking-1000004';
+
+    // The launchers refresh was ISSUED before the operator tapped the launcher.
+    const launchersFetchStartedAt = 1000;
+
+    // 1) Operator taps the launcher; startWorkflowRequest resolves and the app stores the process.
+    //    Its local update time (2000) is AFTER the launchers fetch was issued.
+    jest.spyOn(Date, 'now').mockReturnValue(2000);
+    let state = reducer(undefined, updateWFProcess({ wfProcess: { id: wfProcessId, activities: [] }, parent: null }));
+    expect(isWfProcessLoaded({ wfProcesses: state }, wfProcessId)).toBe(true);
+
+    // 2) The pre-start launchers refresh now completes. Its snapshot predates the start, so it does
+    //    NOT list wfProcessId as a startedWFProcessId — but it also predates the local update.
+    state = reducer(state, {
+      type: POPULATE_LAUNCHERS_COMPLETE,
+      payload: {
+        requestTimestamp: launchersFetchStartedAt,
+        applicationLaunchers: {
+          launchers: [
+            { startedWFProcessId: null },
+            { startedWFProcessId: 'picking-9999999' }, // some other, unrelated started job
+          ],
+        },
+      },
+    });
+
+    // The started process must survive — otherwise ApplicationLayout redirects the operator home
+    // mid-flow (the observed job-start timeout landing on the root menu).
+    expect(isWfProcessLoaded({ wfProcesses: state }, wfProcessId)).toBe(true);
+  });
+
+  it('still removes a process that is older than the launchers snapshot and absent from it (GC)', () => {
+    const wfProcessId = 'picking-1000004';
+
+    // 1) A process was stored at t=1000.
+    jest.spyOn(Date, 'now').mockReturnValue(1000);
+    let state = reducer(undefined, updateWFProcess({ wfProcess: { id: wfProcessId, activities: [] }, parent: null }));
+    expect(isWfProcessLoaded({ wfProcesses: state }, wfProcessId)).toBe(true);
+
+    // 2) A FRESH launchers refresh, issued at t=2000 (strictly after the process update), no longer
+    //    lists the process (it was finished/aborted server-side). It IS authoritative here.
+    state = reducer(state, {
+      type: POPULATE_LAUNCHERS_COMPLETE,
+      payload: {
+        requestTimestamp: 2000,
+        applicationLaunchers: {
+          launchers: [{ startedWFProcessId: 'picking-9999999' }],
+        },
+      },
+    });
+
+    // The legitimate garbage-collection must still happen: the fix must not just disable pruning.
+    expect(isWfProcessLoaded({ wfProcesses: state }, wfProcessId)).toBe(false);
+  });
+
+  it('keeps the process when its update time EQUALS the launchers fetch-start time (>= tie-break)', () => {
+    const wfProcessId = 'picking-1000004';
+
+    // Process update time and launchers fetch-start time are the same instant. The snapshot cannot
+    // be proven to postdate the start, so the tie must resolve to KEEP (workflow.js uses `>=`).
+    jest.spyOn(Date, 'now').mockReturnValue(1500);
+    let state = reducer(undefined, updateWFProcess({ wfProcess: { id: wfProcessId, activities: [] }, parent: null }));
+
+    state = reducer(state, {
+      type: POPULATE_LAUNCHERS_COMPLETE,
+      payload: {
+        requestTimestamp: 1500,
+        applicationLaunchers: { launchers: [{ startedWFProcessId: 'picking-9999999' }] },
+      },
+    });
+
+    expect(isWfProcessLoaded({ wfProcesses: state }, wfProcessId)).toBe(true);
+  });
+
+  it('keeps the process when the launchers snapshot carries no fetch-start time (conservative default)', () => {
+    const wfProcessId = 'picking-1000004';
+
+    // An older caller (or a cached snapshot) may complete with no requestTimestamp. With no way to
+    // prove the snapshot is authoritative, the reducer must default to KEEP rather than delete a
+    // possibly-live process.
+    jest.spyOn(Date, 'now').mockReturnValue(1000);
+    let state = reducer(undefined, updateWFProcess({ wfProcess: { id: wfProcessId, activities: [] }, parent: null }));
+
+    state = reducer(state, {
+      type: POPULATE_LAUNCHERS_COMPLETE,
+      payload: {
+        // requestTimestamp intentionally omitted (undefined)
+        applicationLaunchers: { launchers: [{ startedWFProcessId: 'picking-9999999' }] },
+      },
+    });
+
+    expect(isWfProcessLoaded({ wfProcesses: state }, wfProcessId)).toBe(true);
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/actions/LauncherActions.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/actions/LauncherActions.js
@@ -13,11 +13,13 @@ export const populateLaunchersStart = ({ applicationId, filterByQRCode }) => {
   };
 };
 
-export const populateLaunchersComplete = ({ applicationId, applicationLaunchers }) => {
+export const populateLaunchersComplete = ({ applicationId, applicationLaunchers, requestTimestamp }) => {
   //console.trace('populateLaunchersComplete', { applicationId, applicationLaunchers });
   return {
     type: POPULATE_LAUNCHERS_COMPLETE,
-    payload: { applicationId, applicationLaunchers },
+    // `requestTimestamp` is when this launchers snapshot was fetched (request issued). The
+    // wfProcesses reducer uses it to avoid pruning a process started after the request went out.
+    payload: { applicationId, applicationLaunchers, requestTimestamp },
   };
 };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/actions/WorkflowActions.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/actions/WorkflowActions.js
@@ -3,7 +3,11 @@ import { SET_ACTIVITY_PROCESSING, UPDATE_WORKFLOW_PROCESS } from '../constants/W
 export function updateWFProcess({ wfProcess, parent }) {
   return {
     type: UPDATE_WORKFLOW_PROCESS,
-    payload: { wfProcess, parent },
+    // `timestamp` records when this process was last updated locally. It is stamped here in the
+    // action creator (not in the reducer) so the reducer stays pure. It lets the
+    // POPULATE_LAUNCHERS_COMPLETE reducer tell a genuinely stale launchers snapshot from one that
+    // simply predates a just-started process (see reducers/wfProcesses/workflow.js).
+    payload: { wfProcess, parent, timestamp: Date.now() },
   };
 }
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/applicationRoot/ApplicationLayout.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/applicationRoot/ApplicationLayout.jsx
@@ -19,12 +19,26 @@ export const ApplicationLayout = ({ applicationId, Component }) => {
   const history = useMobileNavigation();
 
   //
-  // If the required process was not loaded, then redirect to home
+  // If the required process was not loaded, then redirect to home.
+  //
+  // A freshly-started workflow is dispatched to the store and navigated to in the same
+  // start-request `.then` (see WFLauncherButton). On React 17 / connected-react-router 6.9 /
+  // react-redux 7.2 the two updates are not batched, so ApplicationLayout can mount on the job
+  // route one render pass BEFORE the store selector observes the just-dispatched process — a
+  // store-vs-router ordering hazard. Bouncing home on that first pass drops the operator on the
+  // root menu mid-start (the observed job-start flake landing on the home menu).
+  //
+  // So defer goHome() one tick instead of firing it synchronously: if the process becomes visible
+  // within the tick, `redirectToHome` flips to false, this effect's cleanup cancels the pending
+  // goHome, and no bounce happens. A genuinely absent process (dead deep-link / page reload) stays
+  // not-loaded, the timer fires, and the operator is still redirected home as before.
   const redirectToHome = isWFProcessRequiredButNotLoaded();
   useEffect(() => {
-    if (redirectToHome) {
-      history.goHome();
+    if (!redirectToHome) {
+      return undefined;
     }
+    const timerId = setTimeout(() => history.goHome(), 0);
+    return () => clearTimeout(timerId);
   }, [redirectToHome]);
 
   const applicationInfo = useApplicationInfo({ applicationId });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/WFLauncherButton.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/WFLauncherButton.jsx
@@ -39,6 +39,12 @@ const WFLauncherButton = ({
 
     wfProcessPromise
       .then((wfProcess) => {
+        // NOTE: the store update and the navigation below are NOT batched on React 17 /
+        // connected-react-router 6.9 / react-redux 7.2, so ApplicationLayout can mount on the job
+        // route one render pass before this dispatched process is observable in the store. The
+        // redirect-home guard in ApplicationLayout tolerates that ordering (it defers goHome one
+        // tick); if this navigation is ever reworked to a root-cause fix (guarantee the store update
+        // is observable before navigating), that guard's deferral can be revisited.
         dispatch(updateWFProcess({ wfProcess, parent: null }));
         history.push(getWFProcessScreenLocation({ applicationId, wfProcessId: wfProcess.id }));
       })

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/useLaunchers.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/useLaunchers.js
@@ -22,15 +22,19 @@ export const useLaunchers = ({ applicationId, showFilterByQRCode, facets, filter
 
   //
   // Load application launchers
-  const onNewLaunchers = ({ applicationId, applicationLaunchers }) => {
-    dispatch(populateLaunchersComplete({ applicationId, applicationLaunchers }));
+  const onNewLaunchers = ({ applicationId, applicationLaunchers, requestTimestamp }) => {
+    dispatch(populateLaunchersComplete({ applicationId, applicationLaunchers, requestTimestamp }));
   };
   useEffect(() => {
     if (isEnabled) {
       setLoading(true);
+      // Capture WHEN the request is issued (not when it resolves): a launchers response is only
+      // authoritative about processes that existed when the request went out. Threading this into
+      // populateLaunchersComplete lets the wfProcesses reducer keep a process started after this.
+      const launchersFetchStartedAt = Date.now();
       getLaunchers({ applicationId, filterByQRCodeString, filters, facets })
         .then((applicationLaunchers) => {
-          onNewLaunchers({ applicationId, applicationLaunchers });
+          onNewLaunchers({ applicationId, applicationLaunchers, requestTimestamp: launchersFetchStartedAt });
         })
         .finally(() => setLoading(false));
     } else {
@@ -50,7 +54,9 @@ export const useLaunchers = ({ applicationId, showFilterByQRCode, facets, filter
     filters,
     facets,
     onWebsocketMessage: ({ applicationId, applicationLaunchers }) => {
-      onNewLaunchers({ applicationId, applicationLaunchers });
+      // A websocket push carries no request-issued time; it reflects current server state, so use
+      // receipt time. This preserves the pre-existing GC behaviour for pushed snapshots.
+      onNewLaunchers({ applicationId, applicationLaunchers, requestTimestamp: Date.now() });
     },
   });
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/wfProcesses/workflow.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/wfProcesses/workflow.js
@@ -7,7 +7,7 @@ import { mergeWFProcessToState, updateUserEditable } from './utils';
 export const workflowReducer = ({ draftState, action }) => {
   switch (action.type) {
     case workflowTypes.UPDATE_WORKFLOW_PROCESS: {
-      const { wfProcess: fromWFProcess, parent } = action.payload;
+      const { wfProcess: fromWFProcess, parent, timestamp } = action.payload;
 
       let draftWFProcess = draftState[fromWFProcess.id];
 
@@ -24,6 +24,13 @@ export const workflowReducer = ({ draftState, action }) => {
         parent,
       });
 
+      // Remember when this process was last updated locally so a launchers snapshot that predates
+      // the update cannot prune it (see POPULATE_LAUNCHERS_COMPLETE below). `timestamp` is stamped
+      // by the updateWFProcess action creator, keeping this reducer pure.
+      if (timestamp != null) {
+        draftState[fromWFProcess.id].updatedAt = timestamp;
+      }
+
       return draftState;
     }
 
@@ -39,11 +46,12 @@ export const workflowReducer = ({ draftState, action }) => {
     }
 
     case launcherTypes.POPULATE_LAUNCHERS_COMPLETE: {
-      const { applicationLaunchers } = action.payload;
+      const { applicationLaunchers, requestTimestamp } = action.payload;
 
       removeWFProcessesFromState({
         draftState,
         wfProcessIdsToKeep: extractStartedWFProcessIdsFromLaunchers(applicationLaunchers.launchers),
+        launchersFetchStartedAt: requestTimestamp,
       });
 
       return draftState;
@@ -64,12 +72,34 @@ const extractStartedWFProcessIdsFromLaunchers = (launchers) => {
   }, []);
 };
 
-const removeWFProcessesFromState = ({ draftState, wfProcessIdsToKeep }) => {
-  const wfProcessIdsInState = Object.keys(original(draftState));
+const removeWFProcessesFromState = ({ draftState, wfProcessIdsToKeep, launchersFetchStartedAt }) => {
+  const originalState = original(draftState);
+  const wfProcessIdsInState = Object.keys(originalState);
 
   wfProcessIdsInState.forEach((wfProcessIdInState) => {
-    if (!wfProcessIdsToKeep.includes(wfProcessIdInState)) {
-      delete draftState[wfProcessIdInState];
+    // Present in the snapshot => a live started job => keep.
+    if (wfProcessIdsToKeep.includes(wfProcessIdInState)) {
+      return;
     }
+
+    // Absent from the snapshot: prune ONLY when we can prove the snapshot is authoritative about
+    // this process, i.e. the launchers fetch was issued strictly AFTER the process was last updated
+    // locally. A launchers response cannot be authoritative about a process started after its
+    // request was issued, so a snapshot that predates (or is concurrent with) the local update must
+    // not delete the process — otherwise a pre-start refresh resolving after a start would bounce
+    // the operator home mid-flow. Conservative default: if either timestamp is unknown, KEEP.
+    // Residual risk (accepted): both stamps are wall-clock Date.now(), not monotonic, so a backward
+    // clock adjustment between them could invert this comparison — orders of magnitude rarer than
+    // the race being fixed.
+    const wfProcessUpdatedAt = originalState[wfProcessIdInState]?.updatedAt;
+    if (wfProcessUpdatedAt == null || launchersFetchStartedAt == null) {
+      return;
+    }
+    if (wfProcessUpdatedAt >= launchersFetchStartedAt) {
+      return;
+    }
+
+    // Older than the snapshot and absent from it => genuinely gone => prune (GC).
+    delete draftState[wfProcessIdInState];
   });
 };


### PR DESCRIPTION
## What

Fixes the mobile-webui race where starting a workflow (picking / distribution / HU-consolidation) can bounce the operator back to the home menu instead of opening the started job — the root cause of the flaky `#WFProcessScreen` timeouts on `hu_consolidation_grai.spec.js` / `trolley.spec.js`.

Two distinct races produce the same symptom; this PR fixes both.

## Race A — a stale launchers refresh deletes the freshly-started process (reducer)

**Root cause:** `reducers/wfProcesses/workflow.js` `POPULATE_LAUNCHERS_COMPLETE` → `removeWFProcessesFromState` deleted every `wfProcess` not present in the launchers snapshot's `startedWFProcessId` set. When a launchers refresh that was computed **before** a workflow start resolves **after** the start's `UPDATE_WORKFLOW_PROCESS`, its stale snapshot does not list the just-started process, so the reducer deleted it. `ApplicationLayout` then saw `isWfProcessLoaded === false` and redirected home.

Verified: reproduced deterministically by the reducer test `src/__tests__/reducers/wfProcesses/staleLaunchersDeletesStartedProcess.test.js` — after a pre-start `POPULATE_LAUNCHERS_COMPLETE`, `isWfProcessLoaded` returns `false` (process deleted) against the pre-fix reducer, `true` after the fix. Run: `CI=true yarn test --watchAll=false --testPathPattern=staleLaunchersDeletesStartedProcess`.

**Fix:** prune a process on `POPULATE_LAUNCHERS_COMPLETE` **only when the launchers snapshot was fetched strictly after that process was last updated locally**; otherwise keep it. `populateLaunchersStart` already stamps a timestamp; this threads the fetch-start time to `POPULATE_LAUNCHERS_COMPLETE` and stamps each `wfProcess`'s local update time in the `updateWFProcess` action creator (reducers stay pure). Conservative default: keep if either timestamp is missing. Legitimate GC (a genuinely-ended process older than the snapshot, absent from it) is preserved.

## Race B — the redirect-home guard bounces a just-started process (ApplicationLayout)

**Root cause:** on a launcher tap, `WFLauncherButton` dispatches `updateWFProcess` and then `history.push` to the job route in the same start-request `.then`. On React 17 / connected-react-router 6.9 / react-redux 7.2 those two updates are **not batched**, so `ApplicationLayout` can mount on the job route one render pass **before** the store selector `isWfProcessLoaded` observes the just-dispatched process — a store-vs-router ordering hazard. The redirect-home guard then called `history.goHome()` synchronously on that first pass, dropping the operator on the root menu mid-start. This is independent of Race A (no stale launchers refresh needed).

Verified: reproduced deterministically by the component test `src/__tests__/containers/applicationRoot/ApplicationLayout.bounceHome.test.js` — rendering `ApplicationLayout` on the job route with the process observed one tick after mount calls `goHome` exactly once against the pre-fix guard (RED), zero times after the fix (GREEN); the genuinely-absent-process case still calls `goHome` once. Run: `CI=true yarn test --watchAll=false --testPathPattern=ApplicationLayout.bounceHome`.

**Fix (guard tolerance):** defer `goHome()` one tick instead of firing it synchronously. If the process becomes observable within the tick, `redirectToHome` flips to false, the effect's cleanup cancels the pending `goHome`, and no bounce happens. A genuinely absent process (dead deep-link / page reload) stays not-loaded, the timer fires, and the operator is still redirected home as before — the guard's real purpose is preserved. A pointer comment at `WFLauncherButton`'s navigation documents where the ordering hazard originates. Chosen over batching the dispatch+push in `WFLauncherButton` (`unstable_batchedUpdates`) because the guard is the single chokepoint every redirect-home decision flows through, so it covers all navigation paths, not just this one launcher.

## Tests

- **Race A** — reducer unit tests reproduce the exact action sequence deterministically (pre-start snapshot resolving after a start → process kept), plus boundary cases (equal timestamps → keep; missing timestamp → keep) and the GC case (older + absent → pruned).
- **Race B** — new hermetic component test (jsdom + react-testing-library + a real `wfProcesses` store) renders `ApplicationLayout` on the job route with the unbatched ordering and asserts it does **not** call `goHome` and renders the `#WFProcessScreen` container; a companion case asserts a genuinely-absent process **is** still redirected home. RED against the pre-fix guard, GREEN after.
- Full mobile-webui Jest suite green (250 tests): `CI=true yarn test --watchAll=false`.
- The real end-to-end flow (tap launcher → land on and stay on the job screen) is covered by the existing Playwright specs this fix de-flakes; CI is the authoritative repeated-run verdict.
