### PR TITLE
Shipment Schedule invalidation — fix picking-BOM explode dropping warehouse scope

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
@@ -22,6 +22,7 @@ package de.metas.inoutcandidate.invalidation.impl;
  * #L%
  */
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import de.metas.inout.IInOutDAO;
@@ -323,7 +324,8 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 		}
 	}
 
-	private Stream<IShipmentScheduleSegment> explodeByPickingBOMs(final IShipmentScheduleSegment segment)
+	@VisibleForTesting
+	Stream<IShipmentScheduleSegment> explodeByPickingBOMs(final IShipmentScheduleSegment segment)
 	{
 		if (segment.isAnyProduct())
 		{
@@ -342,6 +344,7 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 				.productIds(ProductId.toRepoIds(pickingBOMProductIds))
 				.anyBPartner()
 				.locatorIds(segment.getLocatorIds())
+				.warehouseIds(segment.getWarehouseIds())
 				.build();
 
 		return Stream.of(segment, pickingBOMsSegment);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleSegmentChangedProcessor.java
@@ -16,7 +16,9 @@ import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
 import de.metas.inoutcandidate.invalidation.segments.ImmutableShipmentScheduleSegment;
 import de.metas.logging.LogManager;
 import de.metas.util.Services;
+import lombok.AccessLevel;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 /*
@@ -42,6 +44,7 @@ import lombok.ToString;
  */
 
 @ToString(of = "segments")
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 final class ShipmentScheduleSegmentChangedProcessor
 {
 	private static final Logger logger = LogManager.getLogger(ShipmentScheduleSegmentChangedProcessor.class);
@@ -96,7 +99,7 @@ final class ShipmentScheduleSegmentChangedProcessor
 	}
 
 	private final Set<IShipmentScheduleSegment> segments = new LinkedHashSet<>();
-	private final ShipmentScheduleInvalidateBL shipmentScheduleInvalidator;
+	@NonNull private final ShipmentScheduleInvalidateBL shipmentScheduleInvalidator;
 
 	/**
 	 * Mid-batch flush threshold, obtained from the owning {@link ShipmentScheduleInvalidateBL} by the factory when
@@ -105,14 +108,6 @@ final class ShipmentScheduleSegmentChangedProcessor
 	 * AFTER_COMMIT listener flushes then.
 	 */
 	private final int flushThreshold;
-
-	private ShipmentScheduleSegmentChangedProcessor(
-			@NonNull final ShipmentScheduleInvalidateBL shipmentScheduleInvalidator,
-			final int flushThreshold)
-	{
-		this.shipmentScheduleInvalidator = shipmentScheduleInvalidator;
-		this.flushThreshold = flushThreshold;
-	}
 
 	private void process()
 	{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/ImmutableShipmentScheduleSegment.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/ImmutableShipmentScheduleSegment.java
@@ -3,6 +3,7 @@ package de.metas.inoutcandidate.invalidation.segments;
 import java.util.Collections;
 import java.util.Set;
 
+import de.metas.util.Check;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Singular;
@@ -40,6 +41,14 @@ public class ImmutableShipmentScheduleSegment implements IShipmentScheduleSegmen
 			@NonNull @Singular final Set<Integer> warehouseIds,
 			@NonNull @Singular final Set<ShipmentScheduleAttributeSegment> attributes)
 	{
+		// Warehouse and locator scope are mutually exclusive: they become two AND-ed branches in the
+		// recompute WHERE clause ((warehouse IN ...) AND EXISTS(locator ...)) — an intersection that would
+		// silently UNDER-invalidate. Build a warehouse-scoped OR a locator-scoped segment, never both.
+		Check.assume(warehouseIds.isEmpty() || locatorIds.isEmpty(),
+				"warehouseIds and locatorIds must not both be set on a segment (they AND into an"
+						+ " under-invalidating intersection); warehouseIds={}, locatorIds={}",
+				warehouseIds, locatorIds);
+
 		this.productIds = Collections.unmodifiableSet(productIds);
 		this.bpartnerIds = Collections.unmodifiableSet(bpartnerIds);
 		this.billBPartnerIds = Collections.unmodifiableSet(billBPartnerIds);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/ImmutableShipmentScheduleSegment.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/ImmutableShipmentScheduleSegment.java
@@ -41,13 +41,7 @@ public class ImmutableShipmentScheduleSegment implements IShipmentScheduleSegmen
 			@NonNull @Singular final Set<Integer> warehouseIds,
 			@NonNull @Singular final Set<ShipmentScheduleAttributeSegment> attributes)
 	{
-		// Warehouse and locator scope are mutually exclusive: they become two AND-ed branches in the
-		// recompute WHERE clause ((warehouse IN ...) AND EXISTS(locator ...)) — an intersection that would
-		// silently UNDER-invalidate. Build a warehouse-scoped OR a locator-scoped segment, never both.
-		Check.assume(warehouseIds.isEmpty() || locatorIds.isEmpty(),
-				"warehouseIds and locatorIds must not both be set on a segment (they AND into an"
-						+ " under-invalidating intersection); warehouseIds={}, locatorIds={}",
-				warehouseIds, locatorIds);
+		assertWarehouseLocatorMutuallyExclusive(warehouseIds, locatorIds);
 
 		this.productIds = Collections.unmodifiableSet(productIds);
 		this.bpartnerIds = Collections.unmodifiableSet(bpartnerIds);
@@ -59,12 +53,28 @@ public class ImmutableShipmentScheduleSegment implements IShipmentScheduleSegmen
 
 	private ImmutableShipmentScheduleSegment(final IShipmentScheduleSegment from)
 	{
+		assertWarehouseLocatorMutuallyExclusive(from.getWarehouseIds(), from.getLocatorIds());
+
 		this.productIds = Collections.unmodifiableSet(from.getProductIds());
 		this.bpartnerIds = Collections.unmodifiableSet(from.getBpartnerIds());
 		this.billBPartnerIds = Collections.unmodifiableSet(from.getBillBPartnerIds());
 		this.locatorIds = Collections.unmodifiableSet(from.getLocatorIds());
 		this.warehouseIds = Collections.unmodifiableSet(from.getWarehouseIds());
 		this.attributes = Collections.unmodifiableSet(from.getAttributes());
+	}
+
+	/**
+	 * Warehouse and locator scope are mutually exclusive on a segment: they become two AND-ed branches in
+	 * the recompute WHERE clause ({@code (warehouse IN ...) AND EXISTS(locator ...)}) — an intersection that
+	 * would silently UNDER-invalidate. A segment is warehouse-scoped OR locator-scoped, never both. Enforced
+	 * here so it holds for EVERY construction path (the {@code @Builder} ctor and the {@code copyOf} ctor alike).
+	 */
+	private static void assertWarehouseLocatorMutuallyExclusive(final Set<Integer> warehouseIds, final Set<Integer> locatorIds)
+	{
+		Check.assume(warehouseIds.isEmpty() || locatorIds.isEmpty(),
+				"warehouseIds and locatorIds must not both be set on a segment (they AND into an"
+						+ " under-invalidating intersection); warehouseIds={}, locatorIds={}",
+				warehouseIds, locatorIds);
 	}
 
 	public static class ImmutableShipmentScheduleSegmentBuilder

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/ShipmentScheduleSegmentBuilder.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/ShipmentScheduleSegmentBuilder.java
@@ -23,6 +23,7 @@ package de.metas.inoutcandidate.invalidation.segments;
  */
 
 import de.metas.product.ProductId;
+import de.metas.util.Check;
 import lombok.NonNull;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.warehouse.WarehouseId;
@@ -46,6 +47,14 @@ public final class ShipmentScheduleSegmentBuilder
 
 	public ImmutableShipmentScheduleSegment build()
 	{
+		// warehouseId(...) and locatorId(...)/locator(...) are mutually exclusive on one builder (see warehouseId javadoc):
+		// they populate independent fields that become two AND-ed branches in the recompute WHERE clause
+		// ((warehouse IN ...) AND EXISTS(locator ...)) — an intersection that would silently UNDER-invalidate.
+		Check.assume(warehouseIds.isEmpty() || locatorIds.isEmpty(),
+				"warehouseId(...) and locatorId(...) must not both be set on the same segment builder"
+						+ " (they AND into an under-invalidating intersection); warehouseIds={}, locatorIds={}",
+				warehouseIds, locatorIds);
+
 		return ImmutableShipmentScheduleSegment.builder()
 				.productIds(productIds)
 				.locatorIds(locatorIds)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/ShipmentScheduleSegmentBuilder.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/segments/ShipmentScheduleSegmentBuilder.java
@@ -23,7 +23,6 @@ package de.metas.inoutcandidate.invalidation.segments;
  */
 
 import de.metas.product.ProductId;
-import de.metas.util.Check;
 import lombok.NonNull;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.warehouse.WarehouseId;
@@ -47,14 +46,9 @@ public final class ShipmentScheduleSegmentBuilder
 
 	public ImmutableShipmentScheduleSegment build()
 	{
-		// warehouseId(...) and locatorId(...)/locator(...) are mutually exclusive on one builder (see warehouseId javadoc):
-		// they populate independent fields that become two AND-ed branches in the recompute WHERE clause
-		// ((warehouse IN ...) AND EXISTS(locator ...)) — an intersection that would silently UNDER-invalidate.
-		Check.assume(warehouseIds.isEmpty() || locatorIds.isEmpty(),
-				"warehouseId(...) and locatorId(...) must not both be set on the same segment builder"
-						+ " (they AND into an under-invalidating intersection); warehouseIds={}, locatorIds={}",
-				warehouseIds, locatorIds);
-
+		// Note: the warehouse-vs-locator mutual-exclusivity invariant (see warehouseId(...) Javadoc) is
+		// enforced centrally in ImmutableShipmentScheduleSegment's constructor — the convergence point of
+		// every construction path — so it holds for direct ImmutableShipmentScheduleSegment.builder() callers too.
 		return ImmutableShipmentScheduleSegment.builder()
 				.productIds(productIds)
 				.locatorIds(locatorIds)

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
@@ -1,0 +1,105 @@
+package de.metas.inoutcandidate.invalidation.impl;
+
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableSetMultimap;
+import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
+import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleSegments;
+import de.metas.inoutcandidate.picking_bom.PickingBOMService;
+import de.metas.inoutcandidate.picking_bom.PickingBOMsReversedIndex;
+import de.metas.product.ProductId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.WarehouseId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression guard for {@link ShipmentScheduleInvalidateBL#explodeByPickingBOMs(IShipmentScheduleSegment)}.
+ * <p>
+ * Since the warehouse-identity model (a segment carries a {@code warehouseId} instead of enumerating the
+ * warehouse's locators), the {@code notifySegmentChangedFor*} callers build <b>warehouse-only</b> segments
+ * (empty {@code locatorIds}). When such a segment's product has a Picking-BOM parent, {@code explodeByPickingBOMs}
+ * must reconstruct the BOM-parent segment carrying the <b>same warehouse scope</b> — otherwise the reconstructed
+ * segment has both {@code locatorIds} and {@code warehouseIds} empty, is {@link IShipmentScheduleSegment#isInvalid()},
+ * and is silently dropped from the recompute WHERE clause: the BOM-parent product's shipment schedules in that
+ * warehouse are then never invalidated (silent invalidation loss).
+ */
+class ShipmentScheduleInvalidateBLTest
+{
+	private static final ProductId COMPONENT_PRODUCT_ID = ProductId.ofRepoId(1_000_001);
+	private static final ProductId BOM_PARENT_PRODUCT_ID = ProductId.ofRepoId(1_000_002);
+	private static final WarehouseId WAREHOUSE_ID = WarehouseId.ofRepoId(2_000_001);
+
+	private ShipmentScheduleInvalidateBL shipmentScheduleInvalidateBL;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		final PickingBOMService pickingBOMService = mock(PickingBOMService.class);
+		final PickingBOMsReversedIndex reversedIndex = PickingBOMsReversedIndex.ofBOMProductIdsByComponentId(
+				ImmutableSetMultimap.of(COMPONENT_PRODUCT_ID, BOM_PARENT_PRODUCT_ID));
+		when(pickingBOMService.getPickingBOMsReversedIndex()).thenReturn(reversedIndex);
+
+		shipmentScheduleInvalidateBL = new ShipmentScheduleInvalidateBL(pickingBOMService);
+	}
+
+	@Test
+	void explodeByPickingBOMs_warehouseDerivedSegment_bomParentSegmentKeepsWarehouseScope()
+	{
+		// A warehouse-derived source segment, exactly as createSegmentForShipmentSchedule builds it:
+		// warehouse identity set, no locators.
+		final IShipmentScheduleSegment warehouseSegment = ShipmentScheduleSegments.builder()
+				.bpartnerId(0)
+				.productId(COMPONENT_PRODUCT_ID)
+				.warehouseId(WAREHOUSE_ID)
+				.attributeSetInstanceId(0)
+				.build();
+
+		final List<IShipmentScheduleSegment> exploded = shipmentScheduleInvalidateBL
+				.explodeByPickingBOMs(warehouseSegment)
+				.collect(Collectors.toList());
+
+		// The BOM-parent segment (the exploded one carrying the BOM-parent product) must remain a VALID,
+		// warehouse-scoped segment — otherwise it is silently dropped and the BOM parent is never invalidated.
+		final IShipmentScheduleSegment bomParentSegment = exploded.stream()
+				.filter(s -> s.getProductIds().contains(BOM_PARENT_PRODUCT_ID.getRepoId()))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("expected an exploded segment for the picking-BOM parent product"));
+
+		assertThat(bomParentSegment.isInvalid())
+				.as("BOM-parent segment must not be invalid (both locatorIds and warehouseIds empty ⇒ dropped)")
+				.isFalse();
+		assertThat(bomParentSegment.getWarehouseIds())
+				.as("BOM-parent segment must inherit the source segment's warehouse scope")
+				.containsExactly(WAREHOUSE_ID.getRepoId());
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
@@ -56,6 +56,7 @@ class ShipmentScheduleInvalidateBLTest
 	private static final ProductId COMPONENT_PRODUCT_ID = ProductId.ofRepoId(1_000_001);
 	private static final ProductId BOM_PARENT_PRODUCT_ID = ProductId.ofRepoId(1_000_002);
 	private static final WarehouseId WAREHOUSE_ID = WarehouseId.ofRepoId(2_000_001);
+	private static final int LOCATOR_ID = 3_000_001;
 
 	private ShipmentScheduleInvalidateBL shipmentScheduleInvalidateBL;
 
@@ -101,5 +102,30 @@ class ShipmentScheduleInvalidateBLTest
 		assertThat(bomParentSegment.getWarehouseIds())
 				.as("BOM-parent segment must inherit the source segment's warehouse scope")
 				.containsExactly(WAREHOUSE_ID.getRepoId());
+	}
+
+	@Test
+	void explodeByPickingBOMs_locatorDerivedSegment_bomParentSegmentKeepsLocatorScope()
+	{
+		// Symmetrical guard for the locator-scoped branch (pre-existing behaviour): a locator-derived
+		// source segment must explode into a valid, locator-scoped BOM-parent segment.
+		final IShipmentScheduleSegment locatorSegment = ShipmentScheduleSegments.builder()
+				.bpartnerId(0)
+				.productId(COMPONENT_PRODUCT_ID)
+				.locatorId(LOCATOR_ID)
+				.attributeSetInstanceId(0)
+				.build();
+
+		final IShipmentScheduleSegment bomParentSegment = shipmentScheduleInvalidateBL
+				.explodeByPickingBOMs(locatorSegment)
+				.collect(Collectors.toList())
+				.stream()
+				.filter(s -> s.getProductIds().contains(BOM_PARENT_PRODUCT_ID.getRepoId()))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("expected an exploded segment for the picking-BOM parent product"));
+
+		assertThat(bomParentSegment.isInvalid()).isFalse();
+		assertThat(bomParentSegment.getLocatorIds()).containsExactly(LOCATOR_ID);
+		assertThat(bomParentSegment.getWarehouseIds()).isEmpty();
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
@@ -31,6 +31,7 @@ import de.metas.product.ProductId;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.warehouse.WarehouseId;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -73,59 +74,63 @@ class ShipmentScheduleInvalidateBLTest
 		shipmentScheduleInvalidateBL = new ShipmentScheduleInvalidateBL(pickingBOMService);
 	}
 
-	@Test
-	void explodeByPickingBOMs_warehouseDerivedSegment_bomParentSegmentKeepsWarehouseScope()
+	@Nested
+	class ExplodeByPickingBOMs
 	{
-		// A warehouse-derived source segment, exactly as createSegmentForShipmentSchedule builds it:
-		// warehouse identity set, no locators.
-		final IShipmentScheduleSegment warehouseSegment = ShipmentScheduleSegments.builder()
-				.bpartnerId(0)
-				.productId(COMPONENT_PRODUCT_ID)
-				.warehouseId(WAREHOUSE_ID)
-				.attributeSetInstanceId(0)
-				.build();
+		@Test
+		void warehouseDerivedSegment_bomParentSegmentKeepsWarehouseScope()
+		{
+			// A warehouse-derived source segment, exactly as createSegmentForShipmentSchedule builds it:
+			// warehouse identity set, no locators.
+			final IShipmentScheduleSegment warehouseSegment = ShipmentScheduleSegments.builder()
+					.bpartnerId(0)
+					.productId(COMPONENT_PRODUCT_ID)
+					.warehouseId(WAREHOUSE_ID)
+					.attributeSetInstanceId(0)
+					.build();
 
-		final List<IShipmentScheduleSegment> exploded = shipmentScheduleInvalidateBL
-				.explodeByPickingBOMs(warehouseSegment)
-				.collect(Collectors.toList());
+			final List<IShipmentScheduleSegment> exploded = shipmentScheduleInvalidateBL
+					.explodeByPickingBOMs(warehouseSegment)
+					.collect(Collectors.toList());
 
-		// The BOM-parent segment (the exploded one carrying the BOM-parent product) must remain a VALID,
-		// warehouse-scoped segment — otherwise it is silently dropped and the BOM parent is never invalidated.
-		final IShipmentScheduleSegment bomParentSegment = exploded.stream()
-				.filter(s -> s.getProductIds().contains(BOM_PARENT_PRODUCT_ID.getRepoId()))
-				.findFirst()
-				.orElseThrow(() -> new AssertionError("expected an exploded segment for the picking-BOM parent product"));
+			// The BOM-parent segment (the exploded one carrying the BOM-parent product) must remain a VALID,
+			// warehouse-scoped segment — otherwise it is silently dropped and the BOM parent is never invalidated.
+			final IShipmentScheduleSegment bomParentSegment = exploded.stream()
+					.filter(s -> s.getProductIds().contains(BOM_PARENT_PRODUCT_ID.getRepoId()))
+					.findFirst()
+					.orElseThrow(() -> new AssertionError("expected an exploded segment for the picking-BOM parent product"));
 
-		assertThat(bomParentSegment.isInvalid())
-				.as("BOM-parent segment must not be invalid (both locatorIds and warehouseIds empty ⇒ dropped)")
-				.isFalse();
-		assertThat(bomParentSegment.getWarehouseIds())
-				.as("BOM-parent segment must inherit the source segment's warehouse scope")
-				.containsExactly(WAREHOUSE_ID.getRepoId());
-	}
+			assertThat(bomParentSegment.isInvalid())
+					.as("BOM-parent segment must not be invalid (both locatorIds and warehouseIds empty ⇒ dropped)")
+					.isFalse();
+			assertThat(bomParentSegment.getWarehouseIds())
+					.as("BOM-parent segment must inherit the source segment's warehouse scope")
+					.containsExactly(WAREHOUSE_ID.getRepoId());
+		}
 
-	@Test
-	void explodeByPickingBOMs_locatorDerivedSegment_bomParentSegmentKeepsLocatorScope()
-	{
-		// Symmetrical guard for the locator-scoped branch (pre-existing behaviour): a locator-derived
-		// source segment must explode into a valid, locator-scoped BOM-parent segment.
-		final IShipmentScheduleSegment locatorSegment = ShipmentScheduleSegments.builder()
-				.bpartnerId(0)
-				.productId(COMPONENT_PRODUCT_ID)
-				.locatorId(LOCATOR_ID)
-				.attributeSetInstanceId(0)
-				.build();
+		@Test
+		void locatorDerivedSegment_bomParentSegmentKeepsLocatorScope()
+		{
+			// Symmetrical guard for the locator-scoped branch (pre-existing behaviour): a locator-derived
+			// source segment must explode into a valid, locator-scoped BOM-parent segment.
+			final IShipmentScheduleSegment locatorSegment = ShipmentScheduleSegments.builder()
+					.bpartnerId(0)
+					.productId(COMPONENT_PRODUCT_ID)
+					.locatorId(LOCATOR_ID)
+					.attributeSetInstanceId(0)
+					.build();
 
-		final IShipmentScheduleSegment bomParentSegment = shipmentScheduleInvalidateBL
-				.explodeByPickingBOMs(locatorSegment)
-				.collect(Collectors.toList())
-				.stream()
-				.filter(s -> s.getProductIds().contains(BOM_PARENT_PRODUCT_ID.getRepoId()))
-				.findFirst()
-				.orElseThrow(() -> new AssertionError("expected an exploded segment for the picking-BOM parent product"));
+			final IShipmentScheduleSegment bomParentSegment = shipmentScheduleInvalidateBL
+					.explodeByPickingBOMs(locatorSegment)
+					.collect(Collectors.toList())
+					.stream()
+					.filter(s -> s.getProductIds().contains(BOM_PARENT_PRODUCT_ID.getRepoId()))
+					.findFirst()
+					.orElseThrow(() -> new AssertionError("expected an exploded segment for the picking-BOM parent product"));
 
-		assertThat(bomParentSegment.isInvalid()).isFalse();
-		assertThat(bomParentSegment.getLocatorIds()).containsExactly(LOCATOR_ID);
-		assertThat(bomParentSegment.getWarehouseIds()).isEmpty();
+			assertThat(bomParentSegment.isInvalid()).isFalse();
+			assertThat(bomParentSegment.getLocatorIds()).containsExactly(LOCATOR_ID);
+			assertThat(bomParentSegment.getWarehouseIds()).isEmpty();
+		}
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/segments/ShipmentScheduleSegmentBuilderTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/segments/ShipmentScheduleSegmentBuilderTest.java
@@ -1,0 +1,79 @@
+package de.metas.inoutcandidate.invalidation.segments;
+
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import org.adempiere.warehouse.WarehouseId;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ShipmentScheduleSegmentBuilderTest
+{
+	private static final int PRODUCT_ID = 1_000_001;
+	private static final int LOCATOR_ID = 3_000_001;
+	private static final WarehouseId WAREHOUSE_ID = WarehouseId.ofRepoId(2_000_001);
+
+	@Test
+	void warehouseAndLocator_areMutuallyExclusive_onOneBuilder()
+	{
+		// Setting BOTH warehouse and locator on one builder would AND into an under-invalidating intersection
+		// in the recompute WHERE clause — build() must fail fast rather than silently under-invalidate.
+		assertThatThrownBy(() -> ShipmentScheduleSegments.builder()
+				.productId(PRODUCT_ID)
+				.anyBPartnerId()
+				.warehouseId(WAREHOUSE_ID)
+				.locatorId(LOCATOR_ID)
+				.build())
+				.isInstanceOf(RuntimeException.class)
+				.hasMessageContaining("must not both be set");
+	}
+
+	@Test
+	void warehouseOnlySegment_buildsAndIsValid()
+	{
+		final IShipmentScheduleSegment segment = ShipmentScheduleSegments.builder()
+				.productId(PRODUCT_ID)
+				.anyBPartnerId()
+				.warehouseId(WAREHOUSE_ID)
+				.build();
+
+		assertThat(segment.isInvalid()).isFalse();
+		assertThat(segment.getWarehouseIds()).containsExactly(WAREHOUSE_ID.getRepoId());
+		assertThat(segment.getLocatorIds()).isEmpty();
+	}
+
+	@Test
+	void locatorOnlySegment_buildsAndIsValid()
+	{
+		final IShipmentScheduleSegment segment = ShipmentScheduleSegments.builder()
+				.productId(PRODUCT_ID)
+				.anyBPartnerId()
+				.locatorId(LOCATOR_ID)
+				.build();
+
+		assertThat(segment.isInvalid()).isFalse();
+		assertThat(segment.getLocatorIds()).containsExactly(LOCATOR_ID);
+		assertThat(segment.getWarehouseIds()).isEmpty();
+	}
+}


### PR DESCRIPTION
## What

Follow-up correctness fix for the shipment-schedule invalidation change merged in https://github.com/metasfresh/metasfresh/pull/25179.

`ShipmentScheduleInvalidateBL.explodeByPickingBOMs` reconstructed the picking-BOM-parent invalidation segment copying only `locatorIds`. Since the warehouse-identity model, the `notifySegmentChanged*` callers build **warehouse-derived** segments (`warehouseIds` set, `locatorIds` empty), so the reconstructed BOM-parent segment ended up with **both** sets empty → `isInvalid()` → silently dropped from the recompute WHERE clause.

**Effect:** any warehouse-triggered invalidation of a product that has a picking-BOM parent never invalidated that parent's shipment schedules — a silent invalidation loss.

## Changes

- Copy `warehouseIds` alongside `locatorIds` when reconstructing the picking-BOM-parent segment.
- Enforce the warehouse/locator mutual-exclusivity invariant fail-fast in `ImmutableShipmentScheduleSegment`'s constructor — the convergence point of every segment construction path (the fluent `ShipmentScheduleSegmentBuilder` and direct `ImmutableShipmentScheduleSegment.builder()`/`copyOf` callers alike): warehouse- and locator-scope AND into an under-invalidating intersection, so a segment is warehouse-scoped or locator-scoped, never both.
- Convert `ShipmentScheduleSegmentChangedProcessor`'s field-assign-only constructor to `@RequiredArgsConstructor`.

## Tests

- `ShipmentScheduleInvalidateBLTest` — a warehouse-derived and a locator-derived segment whose product has a picking-BOM parent each explode into a valid, correctly-scoped BOM-parent segment (the warehouse case is RED before the fix, GREEN after).
- `ShipmentScheduleSegmentBuilderTest` — the mutual-exclusion guard rejects setting both dimensions; warehouse-only and locator-only segments build valid.
