### PR TITLE
EDI EPCIS ledger: record a fresh active row on re-send after deactivation

### DIFF
--- a/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/EpcisTransmittedSsccRepository.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/EpcisTransmittedSsccRepository.java
@@ -47,21 +47,26 @@ public class EpcisTransmittedSsccRepository
 
 	/**
 	 * Records that the given physical SSCC18 was transmitted to the given receiver config via the
-	 * given shipment. Idempotent: does nothing if a ledger row already exists for the
-	 * {@code (configId, sscc18)} pair — the pair the table's unique index is keyed on — regardless
-	 * of that row's {@code IsActive} state, since re-inserting would violate the unique index anyway.
+	 * given shipment. Idempotent per ACTIVE transmission: does nothing if an <b>active</b> ledger row
+	 * already exists for the {@code (configId, sscc18)} pair (that SSCC is currently transmitted).
+	 * Otherwise inserts a fresh active row — so after the deactivate-escape-hatch + a confirmed
+	 * re-send, a new active row is written (restoring the exactly-once guard), while the previously
+	 * deactivated rows remain as a per-transmission history. The table's partial unique index
+	 * (active-only) guarantees at most one active row per {@code (configId, sscc18)}.
 	 */
 	public void recordTransmittedIfAbsent(
 			@NonNull final ExternalSystemScriptedExportConversionConfigId configId,
 			@NonNull final InOutId inOutId,
 			@NonNull final String sscc18)
 	{
-		final int existingId = queryBL.createQueryBuilder(I_EDI_EPCIS_Transmitted_SSCC.class)
+		// ACTIVE-only: a deactivated (historical) row must NOT block recording a fresh transmission
+		final int existingActiveId = queryBL.createQueryBuilder(I_EDI_EPCIS_Transmitted_SSCC.class)
 				.addEqualsFilter(I_EDI_EPCIS_Transmitted_SSCC.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID, configId.getRepoId())
 				.addEqualsFilter(I_EDI_EPCIS_Transmitted_SSCC.COLUMNNAME_SSCC18, sscc18)
+				.addOnlyActiveRecordsFilter()
 				.create()
 				.firstIdOnly();
-		if (existingId > 0)
+		if (existingActiveId > 0)
 		{
 			return;
 		}

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5814340_sys_EDI_EPCIS_Transmitted_SSCC_partial_active_uq.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5814340_sys_EDI_EPCIS_Transmitted_SSCC_partial_active_uq.sql
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * de.metas.edi
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+-- EPCIS transmission ledger: make the (config, SSCC18) unique index ACTIVE-ONLY (partial).
+--
+-- WHY: deactivating a ledger row is the sanctioned escape-hatch to re-send an SSCC. The full unique
+-- index kept the deactivated row occupying the key, so recordTransmitted could neither reactivate it
+-- nor insert a fresh row after a re-send — leaving the SSCC with NO active ledger row. The exactly-once
+-- guard (get_epcis_events_json_fn / reverse guard) only matches active rows, so the NEXT send would
+-- re-transmit it → duplicate. Making the unique index partial (WHERE isactive='Y') keeps the invariant
+-- that matters — at most ONE ACTIVE row per (config, SSCC18) — while letting deactivated rows accumulate
+-- as a per-transmission history, so each confirmed (re)send inserts a fresh active row.
+DROP INDEX IF EXISTS edi_epcis_transmitted_sscc_uq;
+CREATE UNIQUE INDEX edi_epcis_transmitted_sscc_uq
+    ON public.edi_epcis_transmitted_sscc (externalsystem_config_scriptedexportconversion_id, sscc18)
+    WHERE isactive = 'Y';

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/EpcisTransmittedSsccRepositoryTest.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/EpcisTransmittedSsccRepositoryTest.java
@@ -1,0 +1,111 @@
+/*
+ * #%L
+ * de.metas.edi
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.edi.api.impl;
+
+import de.metas.esb.edi.model.I_EDI_EPCIS_Transmitted_SSCC;
+import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionConfigId;
+import de.metas.inout.InOutId;
+import de.metas.util.Services;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EpcisTransmittedSsccRepositoryTest
+{
+	private static final ExternalSystemScriptedExportConversionConfigId CONFIG_ID =
+			ExternalSystemScriptedExportConversionConfigId.ofRepoId(9999);
+	private static final String SSCC = "076105640006796324";
+
+	private EpcisTransmittedSsccRepository repository;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		repository = new EpcisTransmittedSsccRepository();
+	}
+
+	private List<I_EDI_EPCIS_Transmitted_SSCC> ledgerRows()
+	{
+		return Services.get(IQueryBL.class).createQueryBuilder(I_EDI_EPCIS_Transmitted_SSCC.class)
+				.addEqualsFilter(I_EDI_EPCIS_Transmitted_SSCC.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID, CONFIG_ID.getRepoId())
+				.addEqualsFilter(I_EDI_EPCIS_Transmitted_SSCC.COLUMNNAME_SSCC18, SSCC)
+				.create()
+				.list(I_EDI_EPCIS_Transmitted_SSCC.class);
+	}
+
+	@Test
+	void insertsActiveRow_whenNoneExists()
+	{
+		repository.recordTransmittedIfAbsent(CONFIG_ID, InOutId.ofRepoId(101), SSCC);
+
+		final List<I_EDI_EPCIS_Transmitted_SSCC> rows = ledgerRows();
+		assertThat(rows).hasSize(1);
+		assertThat(rows.get(0).isActive()).isTrue();
+		assertThat(rows.get(0).getM_InOut_ID()).isEqualTo(101);
+	}
+
+	@Test
+	void skips_whenAnActiveRowAlreadyExists()
+	{
+		repository.recordTransmittedIfAbsent(CONFIG_ID, InOutId.ofRepoId(101), SSCC);
+		repository.recordTransmittedIfAbsent(CONFIG_ID, InOutId.ofRepoId(102), SSCC);
+
+		final List<I_EDI_EPCIS_Transmitted_SSCC> rows = ledgerRows();
+		assertThat(rows).as("an active row already exists -> no second active row").hasSize(1);
+		assertThat(rows.get(0).getM_InOut_ID()).isEqualTo(101);
+	}
+
+	/**
+	 * The bug fix: after the deactivate-escape-hatch, a confirmed re-send must record a FRESH active
+	 * row (so the exactly-once guard is restored), while the deactivated row remains as history.
+	 * On the pre-fix code the existence check matched the deactivated row and returned early, so no
+	 * active row was written — leaving the SSCC re-transmittable (duplicate).
+	 */
+	@Test
+	void insertsFreshActiveRow_whenOnlyADeactivatedRowExists()
+	{
+		// first transmission
+		repository.recordTransmittedIfAbsent(CONFIG_ID, InOutId.ofRepoId(101), SSCC);
+		// escape-hatch: deactivate the ledger row (the WebUI action)
+		final I_EDI_EPCIS_Transmitted_SSCC existing = ledgerRows().get(0);
+		existing.setIsActive(false);
+		saveRecord(existing);
+
+		// confirmed re-send records the transmission again
+		repository.recordTransmittedIfAbsent(CONFIG_ID, InOutId.ofRepoId(102), SSCC);
+
+		final List<I_EDI_EPCIS_Transmitted_SSCC> rows = ledgerRows();
+		assertThat(rows).as("deactivated history row + a fresh active row").hasSize(2);
+		assertThat(rows).filteredOn(I_EDI_EPCIS_Transmitted_SSCC::isActive)
+				.as("exactly one ACTIVE row, carrying the re-sending shipment")
+				.hasSize(1)
+				.allSatisfy(r -> assertThat(r.getM_InOut_ID()).isEqualTo(102));
+	}
+}


### PR DESCRIPTION
Fixes a correctness hole in the exactly-once transmission ledger. Deactivating a ledger row is the sanctioned escape-hatch to re-send an SSCC, but recordTransmittedIfAbsent early-returned on ANY existing row (incl. a deactivated one) and never wrote a fresh row — so after deactivate+resend the SSCC had NO active ledger row, and the next send would re-transmit it (duplicate).

Fix: the existence check is now ACTIVE-only (a deactivated/historical row no longer blocks recording), and the (config, SSCC18) unique index becomes PARTIAL (WHERE isactive='Y') so a fresh active row can be inserted while deactivated rows remain as a per-transmission history — at most one active row per SSCC.

- Migration 5814340 (partial active-only unique index)
- EpcisTransmittedSsccRepository: active-only existence check
- Unit: EpcisTransmittedSsccRepositoryTest (RED->GREEN, 3/3); partial-index behaviour verified on a customer-faithful DB (active+inactive coexist; 2nd active rejected).