### PR TITLE
externalsystem: one status row per export attempt

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_Config_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_Config_StepDef.java
@@ -432,8 +432,8 @@ public class ExternalSystem_Config_StepDef
 		if (readStatusColumn)
 		{
 			// Status_AD_Column_ID was removed from the model when the per-record status design was
-			// consolidated into ExternalSystem_ScriptedExportConversion_Status (a single-row-upsert table
-			// that carries the export lifecycle).  IsTriggerOnComplete is still required to tell the
+			// consolidated into ExternalSystem_ScriptedExportConversion_Status (one row per export
+			// attempt, carrying the export lifecycle).  IsTriggerOnComplete is still required to tell the
 			// complete-interceptor to start the export.
 			scriptedExportConversionConfig.setIsTriggerOnComplete(true);
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_ScriptedExportConversion_Status_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_ScriptedExportConversion_Status_StepDef.java
@@ -48,6 +48,7 @@ import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.table.api.IADTableDAO;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -79,10 +80,11 @@ public class ExternalSystem_ScriptedExportConversion_Status_StepDef
 	// ------------------------------------------------------------------
 
 	/**
-	 * Polls until the LATEST {@code ExternalSystem_ScriptedExportConversion_Status} row (newest by
-	 * Status_ID) for the given shipment + config combination reaches the expected {@code ExportStatus},
-	 * optionally asserting {@code IsResend} and the presence of an {@code AD_Issue_ID}. With per-attempt
-	 * history several rows may coexist for the same shipment + config; this checks the most recent one.
+	 * Polls until every expected {@code ExternalSystem_ScriptedExportConversion_Status} row is found.
+	 * Each data-table row describes ONE expected status row, matched NEWEST-FIRST by its {@code ExportStatus}
+	 * (the status tab's grid order). A single data row asserts the latest attempt; several data rows assert
+	 * that each attempt's data coexists — e.g. after a re-send, the Sent re-send attempt AND the retained
+	 * errored first attempt, each with its own {@code IsResend} / {@code HttpResponseCode} / {@code AD_Issue}.
 	 *
 	 * @cucumber.stepdef
 	 * @cucumber.columns
@@ -90,168 +92,113 @@ public class ExternalSystem_ScriptedExportConversion_Status_StepDef
 	 *   <b>ExternalSystem_Config_ScriptedExportConversion_ID</b> — (required, identifier-ref) config identifier<br>
 	 *   <b>ExportStatus</b> — (required) expected status code (P/U/D/S/E/I/N)<br>
 	 *   <b>IsResend</b> — (optional) expected IsResend flag (Y/N)<br>
-	 *   <b>HasAD_Issue</b> — (optional) Y if AD_Issue_ID must be &gt; 0<br>
+	 *   <b>HttpResponseCode</b> — (optional) expected HTTP response code; blank cell = not asserted<br>
+	 *   <b>HasAD_Issue</b> — (optional) Y if AD_Issue_ID must be &gt; 0, N if it must be 0<br>
 	 * @cucumber.depends StepDefData: M_InOut_StepDefData, ExternalSystem_Config_ScriptedExportConversion_StepDefData
 	 * @cucumber.example <pre>
 	 * Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
 	 *   | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | IsResend |
 	 *   | io_010     | scriptedCfg_es                                    | S            | N        |
+	 *
+	 * # several rows — the two attempts of a re-send coexist (newest-first):
+	 * Then after not more than 10s, ExternalSystem_ScriptedExportConversion_Status is found:
+	 *   | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | IsResend | HttpResponseCode | HasAD_Issue |
+	 *   | io_030     | scriptedCfg_es                                    | S            | Y        | 200              | N           |
+	 *   | io_030     | scriptedCfg_es                                    | E            | N        |                  | Y           |
 	 * </pre>
 	 */
 	@And("^after not more than (.*)s, ExternalSystem_ScriptedExportConversion_Status is found:$")
 	public void scriptedExportConversionStatusIsFound(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
 	{
-		final DataTableRow firstRow = DataTableRows.of(dataTable).getFirstRow();
-
-		final org.compiere.model.I_M_InOut inoutRecord = inoutTable.get(
-				firstRow.getAsIdentifier(org.compiere.model.I_M_InOut.COLUMNNAME_M_InOut_ID));
-		assertThat(inoutRecord).isNotNull();
-		final int inoutId = inoutRecord.getM_InOut_ID();
-
-		final ExternalSystemScriptedExportConversionConfig cfg = scriptedCfgTable.get(
-				firstRow.getAsIdentifier(I_ExternalSystem_Config_ScriptedExportConversion.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID));
-		assertThat(cfg).isNotNull();
-		final int cfgId = cfg.getId().getRepoId();
-
-		final String expectedStatus = firstRow.getAsString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExportStatus);
-		final String expectedIsResend = firstRow.getAsOptionalString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_IsResend).orElse(null);
-		final String expectedHasIssue = firstRow.getAsOptionalString("HasAD_Issue").orElse(null);
-
 		final int m_inout_table_id = tableDAO.retrieveTableId(org.compiere.model.I_M_InOut.Table_Name);
 
-		StepDefUtil.<I_ExternalSystem_ScriptedExportConversion_Status>tryAndWaitForItem()
+		// Resolve each data-table row to an expected status row (identifiers resolved once, up front).
+		final List<ExpectedStatusRow> expectedRows = new ArrayList<>();
+		for (final DataTableRow row : DataTableRows.of(dataTable).toList())
+		{
+			final org.compiere.model.I_M_InOut inoutRecord = inoutTable.get(
+					row.getAsIdentifier(org.compiere.model.I_M_InOut.COLUMNNAME_M_InOut_ID));
+			assertThat(inoutRecord).isNotNull();
+
+			final ExternalSystemScriptedExportConversionConfig cfg = scriptedCfgTable.get(
+					row.getAsIdentifier(I_ExternalSystem_Config_ScriptedExportConversion.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID));
+			assertThat(cfg).isNotNull();
+
+			expectedRows.add(new ExpectedStatusRow(
+					inoutRecord.getM_InOut_ID(),
+					cfg.getId().getRepoId(),
+					row.getAsString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExportStatus),
+					// blank cell for an optional column ⇒ that column is not asserted
+					row.getAsOptionalString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_IsResend).map(String::trim).filter(s -> !s.isEmpty()).orElse(null),
+					row.getAsOptionalString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_HttpResponseCode).map(String::trim).filter(s -> !s.isEmpty()).orElse(null),
+					row.getAsOptionalString("HasAD_Issue").map(String::trim).filter(s -> !s.isEmpty()).orElse(null)));
+		}
+
+		StepDefUtil.<Boolean>tryAndWaitForItem()
 				.maxWaitSeconds(timeoutSec)
 				.checkingIntervalMs(500L)
 				.workerFromOptionalSupplier(() -> {
-					final I_ExternalSystem_ScriptedExportConversion_Status statusRow = queryBL
-							.createQueryBuilder(I_ExternalSystem_ScriptedExportConversion_Status.class)
-							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_Table_ID, m_inout_table_id)
-							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_Record_ID, inoutId)
-							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID, cfgId)
-							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExportStatus, expectedStatus)
-							.orderByDescending(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID)
-							.create()
-							.first(I_ExternalSystem_ScriptedExportConversion_Status.class);
-
-					if (statusRow == null)
+					for (final ExpectedStatusRow expected : expectedRows)
 					{
-						return Optional.empty();
-					}
+						// newest-first by Status_ID (the grid order); match this expected attempt by its
+						// ExportStatus, so several coexisting attempts are each verified independently
+						final I_ExternalSystem_ScriptedExportConversion_Status statusRow = queryBL
+								.createQueryBuilder(I_ExternalSystem_ScriptedExportConversion_Status.class)
+								.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_Table_ID, m_inout_table_id)
+								.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_Record_ID, expected.inoutId)
+								.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID, expected.cfgId)
+								.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExportStatus, expected.exportStatus)
+								.orderByDescending(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID)
+								.create()
+								.first(I_ExternalSystem_ScriptedExportConversion_Status.class);
 
-					// optional IsResend assertion
-					if (expectedIsResend != null)
-					{
-						final boolean expectedIsResendBool = "Y".equals(expectedIsResend);
-						if (statusRow.isResend() != expectedIsResendBool)
+						if (statusRow == null)
+						{
+							return Optional.empty();
+						}
+						if (expected.isResend != null && "Y".equals(expected.isResend) != statusRow.isResend())
+						{
+							return Optional.empty();
+						}
+						if (expected.httpResponseCode != null && Integer.parseInt(expected.httpResponseCode) != statusRow.getHttpResponseCode())
+						{
+							return Optional.empty();
+						}
+						if (expected.hasIssue != null && "Y".equals(expected.hasIssue) != (statusRow.getAD_Issue_ID() > 0))
 						{
 							return Optional.empty();
 						}
 					}
-
-					// optional HasAD_Issue assertion
-					if ("Y".equals(expectedHasIssue) && statusRow.getAD_Issue_ID() <= 0)
-					{
-						return Optional.empty();
-					}
-
-					return Optional.of(statusRow);
+					return Optional.of(Boolean.TRUE);
 				})
 				.execute();
 	}
 
-	/**
-	 * Polls until the {@code ExternalSystem_ScriptedExportConversion_Status} rows for the given shipment
-	 * + config, ordered NEWEST-FIRST (exactly as the status tab's grid shows them), match the expected
-	 * data table row-for-row — count AND the actual per-row data. Because each export ATTEMPT (the
-	 * initial enqueue and every re-send) is its own row (per-attempt history) rather than a single
-	 * upserted row, this verifies the grid shows a faithful attempt log: e.g. after a re-send, the
-	 * Sent re-send attempt on top and the errored first attempt beneath it, each retaining its own data.
-	 *
-	 * @cucumber.stepdef
-	 * @cucumber.columns
-	 *   <b>ExportStatus</b> — (required) expected status code (P/U/D/S/E/I/N)<br>
-	 *   <b>IsResend</b> — (optional) expected IsResend flag (Y/N)<br>
-	 *   <b>HttpResponseCode</b> — (optional) expected HTTP response code; empty cell asserts none (0)<br>
-	 *   <b>HasAD_Issue</b> — (optional) Y if AD_Issue_ID must be &gt; 0, N if it must be 0<br>
-	 * @cucumber.depends StepDefData: M_InOut_StepDefData, ExternalSystem_Config_ScriptedExportConversion_StepDefData
-	 * @cucumber.example <pre>
-	 * And after not more than 10s, ExternalSystem_ScriptedExportConversion_Status rows for shipment io_030 and config scriptedCfg_es are (newest first):
-	 *   | ExportStatus | IsResend | HttpResponseCode | HasAD_Issue |
-	 *   | S            | Y        | 200              | N           |
-	 *   | E            | N        |                  | Y           |
-	 * </pre>
-	 */
-	@And("^after not more than (.*)s, ExternalSystem_ScriptedExportConversion_Status rows for shipment (.*) and config (.*) are \\(newest first\\):$")
-	public void scriptedExportConversionStatusRowsAre(
-			final int timeoutSec,
-			@NonNull final String inoutIdentifierStr,
-			@NonNull final String cfgIdentifierStr,
-			@NonNull final DataTable dataTable) throws InterruptedException
+	/** One expected status row, resolved from a data-table row (identifiers already resolved to repo ids). */
+	private static final class ExpectedStatusRow
 	{
-		final org.compiere.model.I_M_InOut inout = inoutTable.get(StepDefDataIdentifier.ofString(inoutIdentifierStr));
-		assertThat(inout).isNotNull();
-		final int inoutId = inout.getM_InOut_ID();
+		private final int inoutId;
+		private final int cfgId;
+		private final String exportStatus;
+		private final String isResend;
+		private final String httpResponseCode;
+		private final String hasIssue;
 
-		final ExternalSystemScriptedExportConversionConfig cfg = scriptedCfgTable.get(StepDefDataIdentifier.ofString(cfgIdentifierStr));
-		assertThat(cfg).isNotNull();
-		final int cfgId = cfg.getId().getRepoId();
-
-		final int m_inout_table_id = tableDAO.retrieveTableId(org.compiere.model.I_M_InOut.Table_Name);
-		final List<DataTableRow> expectedRows = DataTableRows.of(dataTable).toList();
-
-		StepDefUtil.<List<I_ExternalSystem_ScriptedExportConversion_Status>>tryAndWaitForItem()
-				.maxWaitSeconds(timeoutSec)
-				.checkingIntervalMs(500L)
-				.workerFromOptionalSupplier(() -> {
-					// newest-first — same ordering the status tab's grid uses (Updated/Status_ID DESC)
-					final List<I_ExternalSystem_ScriptedExportConversion_Status> actualRows = queryBL
-							.createQueryBuilder(I_ExternalSystem_ScriptedExportConversion_Status.class)
-							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_Table_ID, m_inout_table_id)
-							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_Record_ID, inoutId)
-							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID, cfgId)
-							.orderByDescending(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID)
-							.create()
-							.list(I_ExternalSystem_ScriptedExportConversion_Status.class);
-
-					if (actualRows.size() != expectedRows.size())
-					{
-						return Optional.empty();
-					}
-
-					for (int i = 0; i < expectedRows.size(); i++)
-					{
-						final DataTableRow expected = expectedRows.get(i);
-						final I_ExternalSystem_ScriptedExportConversion_Status actual = actualRows.get(i);
-
-						if (!expected.getAsString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExportStatus)
-								.equals(actual.getExportStatus()))
-						{
-							return Optional.empty();
-						}
-
-						// empty/blank cell for an optional column ⇒ that column is not asserted for this row
-						final String expectedIsResend = expected.getAsOptionalString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_IsResend).map(String::trim).filter(s -> !s.isEmpty()).orElse(null);
-						if (expectedIsResend != null && "Y".equals(expectedIsResend) != actual.isResend())
-						{
-							return Optional.empty();
-						}
-
-						final String expectedHttpCode = expected.getAsOptionalString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_HttpResponseCode).map(String::trim).filter(s -> !s.isEmpty()).orElse(null);
-						if (expectedHttpCode != null && Integer.parseInt(expectedHttpCode) != actual.getHttpResponseCode())
-						{
-							return Optional.empty();
-						}
-
-						final String expectedHasIssue = expected.getAsOptionalString("HasAD_Issue").map(String::trim).filter(s -> !s.isEmpty()).orElse(null);
-						if (expectedHasIssue != null && "Y".equals(expectedHasIssue) != (actual.getAD_Issue_ID() > 0))
-						{
-							return Optional.empty();
-						}
-					}
-
-					return Optional.of(actualRows);
-				})
-				.execute();
+		private ExpectedStatusRow(
+				final int inoutId,
+				final int cfgId,
+				@NonNull final String exportStatus,
+				final String isResend,
+				final String httpResponseCode,
+				final String hasIssue)
+		{
+			this.inoutId = inoutId;
+			this.cfgId = cfgId;
+			this.exportStatus = exportStatus;
+			this.isResend = isResend;
+			this.httpResponseCode = httpResponseCode;
+			this.hasIssue = hasIssue;
+		}
 	}
 
 	// ------------------------------------------------------------------

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_ScriptedExportConversion_Status_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_ScriptedExportConversion_Status_StepDef.java
@@ -60,8 +60,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * the {@code M_InOut_ReSend_ScriptedExportConversion} process invocation, and deactivating a
  * shipment's status row (the escape-hatch that releases a shipment blocked by an in-flight export).
  *
- * <p>The status table holds one row per (config, source-record) pair that is updated in place
- * as the export lifecycle progresses (Pending → Enqueued → Sent / Error / Invalid / DontSend).
+ * <p>The status table holds one row per export ATTEMPT: each enqueue / re-send inserts a fresh
+ * row (the per-attempt history), and the transitions of that attempt (Pending → Enqueued →
+ * Sent / Error / Invalid / DontSend) update its own row in place, correlated by AD_PInstance_ID.
  */
 @RequiredArgsConstructor
 public class ExternalSystem_ScriptedExportConversion_Status_StepDef
@@ -78,9 +79,10 @@ public class ExternalSystem_ScriptedExportConversion_Status_StepDef
 	// ------------------------------------------------------------------
 
 	/**
-	 * Polls until the single {@code ExternalSystem_ScriptedExportConversion_Status} row for the given
-	 * shipment + config combination reaches the expected {@code ExportStatus}, optionally asserting
-	 * {@code IsResend} and the presence of an {@code AD_Issue_ID}.
+	 * Polls until the LATEST {@code ExternalSystem_ScriptedExportConversion_Status} row (newest by
+	 * Status_ID) for the given shipment + config combination reaches the expected {@code ExportStatus},
+	 * optionally asserting {@code IsResend} and the presence of an {@code AD_Issue_ID}. With per-attempt
+	 * history several rows may coexist for the same shipment + config; this checks the most recent one.
 	 *
 	 * @cucumber.stepdef
 	 * @cucumber.columns
@@ -153,6 +155,53 @@ public class ExternalSystem_ScriptedExportConversion_Status_StepDef
 					}
 
 					return Optional.of(statusRow);
+				})
+				.execute();
+	}
+
+	/**
+	 * Polls until the NUMBER of {@code ExternalSystem_ScriptedExportConversion_Status} rows for the
+	 * given shipment + config equals the expected count. Because each export ATTEMPT (the initial
+	 * enqueue and every re-send) is its own row (per-attempt history) rather than a single upserted
+	 * row, a re-send GROWS this count. This is the observable that distinguishes per-attempt history
+	 * from the former single-row upsert.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns none (all args inline)
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData, ExternalSystem_Config_ScriptedExportConversion_StepDefData
+	 * @cucumber.example <pre>
+	 * Then after not more than 10s, ExternalSystem_ScriptedExportConversion_Status row count for shipment io_030 and config scriptedCfg_es is 2
+	 * </pre>
+	 */
+	@And("^after not more than (.*)s, ExternalSystem_ScriptedExportConversion_Status row count for shipment (.*) and config (.*) is (\\d+)$")
+	public void scriptedExportConversionStatusRowCountIs(
+			final int timeoutSec,
+			@NonNull final String inoutIdentifierStr,
+			@NonNull final String cfgIdentifierStr,
+			final int expectedCount) throws InterruptedException
+	{
+		final org.compiere.model.I_M_InOut inout = inoutTable.get(StepDefDataIdentifier.ofString(inoutIdentifierStr));
+		assertThat(inout).isNotNull();
+		final int inoutId = inout.getM_InOut_ID();
+
+		final ExternalSystemScriptedExportConversionConfig cfg = scriptedCfgTable.get(StepDefDataIdentifier.ofString(cfgIdentifierStr));
+		assertThat(cfg).isNotNull();
+		final int cfgId = cfg.getId().getRepoId();
+
+		final int m_inout_table_id = tableDAO.retrieveTableId(org.compiere.model.I_M_InOut.Table_Name);
+
+		StepDefUtil.<Long>tryAndWaitForItem()
+				.maxWaitSeconds(timeoutSec)
+				.checkingIntervalMs(500L)
+				.workerFromOptionalSupplier(() -> {
+					final long actual = queryBL
+							.createQueryBuilder(I_ExternalSystem_ScriptedExportConversion_Status.class)
+							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_Table_ID, m_inout_table_id)
+							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_Record_ID, inoutId)
+							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID, cfgId)
+							.create()
+							.count();
+					return actual == expectedCount ? Optional.of(actual) : Optional.empty();
 				})
 				.execute();
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_ScriptedExportConversion_Status_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_ScriptedExportConversion_Status_StepDef.java
@@ -160,25 +160,33 @@ public class ExternalSystem_ScriptedExportConversion_Status_StepDef
 	}
 
 	/**
-	 * Polls until the NUMBER of {@code ExternalSystem_ScriptedExportConversion_Status} rows for the
-	 * given shipment + config equals the expected count. Because each export ATTEMPT (the initial
-	 * enqueue and every re-send) is its own row (per-attempt history) rather than a single upserted
-	 * row, a re-send GROWS this count. This is the observable that distinguishes per-attempt history
-	 * from the former single-row upsert.
+	 * Polls until the {@code ExternalSystem_ScriptedExportConversion_Status} rows for the given shipment
+	 * + config, ordered NEWEST-FIRST (exactly as the status tab's grid shows them), match the expected
+	 * data table row-for-row — count AND the actual per-row data. Because each export ATTEMPT (the
+	 * initial enqueue and every re-send) is its own row (per-attempt history) rather than a single
+	 * upserted row, this verifies the grid shows a faithful attempt log: e.g. after a re-send, the
+	 * Sent re-send attempt on top and the errored first attempt beneath it, each retaining its own data.
 	 *
 	 * @cucumber.stepdef
-	 * @cucumber.columns none (all args inline)
+	 * @cucumber.columns
+	 *   <b>ExportStatus</b> — (required) expected status code (P/U/D/S/E/I/N)<br>
+	 *   <b>IsResend</b> — (optional) expected IsResend flag (Y/N)<br>
+	 *   <b>HttpResponseCode</b> — (optional) expected HTTP response code; empty cell asserts none (0)<br>
+	 *   <b>HasAD_Issue</b> — (optional) Y if AD_Issue_ID must be &gt; 0, N if it must be 0<br>
 	 * @cucumber.depends StepDefData: M_InOut_StepDefData, ExternalSystem_Config_ScriptedExportConversion_StepDefData
 	 * @cucumber.example <pre>
-	 * Then after not more than 10s, ExternalSystem_ScriptedExportConversion_Status row count for shipment io_030 and config scriptedCfg_es is 2
+	 * And after not more than 10s, ExternalSystem_ScriptedExportConversion_Status rows for shipment io_030 and config scriptedCfg_es are (newest first):
+	 *   | ExportStatus | IsResend | HttpResponseCode | HasAD_Issue |
+	 *   | S            | Y        | 200              | N           |
+	 *   | E            | N        |                  | Y           |
 	 * </pre>
 	 */
-	@And("^after not more than (.*)s, ExternalSystem_ScriptedExportConversion_Status row count for shipment (.*) and config (.*) is (\\d+)$")
-	public void scriptedExportConversionStatusRowCountIs(
+	@And("^after not more than (.*)s, ExternalSystem_ScriptedExportConversion_Status rows for shipment (.*) and config (.*) are \\(newest first\\):$")
+	public void scriptedExportConversionStatusRowsAre(
 			final int timeoutSec,
 			@NonNull final String inoutIdentifierStr,
 			@NonNull final String cfgIdentifierStr,
-			final int expectedCount) throws InterruptedException
+			@NonNull final DataTable dataTable) throws InterruptedException
 	{
 		final org.compiere.model.I_M_InOut inout = inoutTable.get(StepDefDataIdentifier.ofString(inoutIdentifierStr));
 		assertThat(inout).isNotNull();
@@ -189,19 +197,59 @@ public class ExternalSystem_ScriptedExportConversion_Status_StepDef
 		final int cfgId = cfg.getId().getRepoId();
 
 		final int m_inout_table_id = tableDAO.retrieveTableId(org.compiere.model.I_M_InOut.Table_Name);
+		final List<DataTableRow> expectedRows = DataTableRows.of(dataTable).toList();
 
-		StepDefUtil.<Long>tryAndWaitForItem()
+		StepDefUtil.<List<I_ExternalSystem_ScriptedExportConversion_Status>>tryAndWaitForItem()
 				.maxWaitSeconds(timeoutSec)
 				.checkingIntervalMs(500L)
 				.workerFromOptionalSupplier(() -> {
-					final long actual = queryBL
+					// newest-first — same ordering the status tab's grid uses (Updated/Status_ID DESC)
+					final List<I_ExternalSystem_ScriptedExportConversion_Status> actualRows = queryBL
 							.createQueryBuilder(I_ExternalSystem_ScriptedExportConversion_Status.class)
 							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_Table_ID, m_inout_table_id)
 							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_Record_ID, inoutId)
 							.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_Config_ScriptedExportConversion_ID, cfgId)
+							.orderByDescending(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID)
 							.create()
-							.count();
-					return actual == expectedCount ? Optional.of(actual) : Optional.empty();
+							.list(I_ExternalSystem_ScriptedExportConversion_Status.class);
+
+					if (actualRows.size() != expectedRows.size())
+					{
+						return Optional.empty();
+					}
+
+					for (int i = 0; i < expectedRows.size(); i++)
+					{
+						final DataTableRow expected = expectedRows.get(i);
+						final I_ExternalSystem_ScriptedExportConversion_Status actual = actualRows.get(i);
+
+						if (!expected.getAsString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExportStatus)
+								.equals(actual.getExportStatus()))
+						{
+							return Optional.empty();
+						}
+
+						// empty/blank cell for an optional column ⇒ that column is not asserted for this row
+						final String expectedIsResend = expected.getAsOptionalString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_IsResend).map(String::trim).filter(s -> !s.isEmpty()).orElse(null);
+						if (expectedIsResend != null && "Y".equals(expectedIsResend) != actual.isResend())
+						{
+							return Optional.empty();
+						}
+
+						final String expectedHttpCode = expected.getAsOptionalString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_HttpResponseCode).map(String::trim).filter(s -> !s.isEmpty()).orElse(null);
+						if (expectedHttpCode != null && Integer.parseInt(expectedHttpCode) != actual.getHttpResponseCode())
+						{
+							return Optional.empty();
+						}
+
+						final String expectedHasIssue = expected.getAsOptionalString("HasAD_Issue").map(String::trim).filter(s -> !s.isEmpty()).orElse(null);
+						if (expectedHasIssue != null && "Y".equals(expectedHasIssue) != (actual.getAD_Issue_ID() > 0))
+						{
+							return Optional.empty();
+						}
+					}
+
+					return Optional.of(actualRows);
 				})
 				.execute();
 	}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
@@ -6,7 +6,7 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
 ## Verifies the ExternalSystem_ScriptedExportConversion_Status lifecycle for the EPCIS export config:
 ## (a) shipment completed → invocation enqueued → /ok callback → status row Sent + roll-up M_InOut.EPCIS_ExportStatus=Sent
 ## (b) same path but /error callback → status row Error + AD_Issue_ID linked + roll-up Error
-## (c) re-send of an errored shipment → status row flipped to Pending+IsResend=Y (single-row upsert) → Sent via /ok
+## (c) re-send of an errored shipment → a NEW Pending+IsResend=Y attempt row (per-attempt history, prior attempt kept) → Sent via /ok
 
   Background:
     Given infrastructure and metasfresh are running

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
@@ -160,7 +160,7 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
   @allure.label.epic:E0292_EDI
   @allure.label.feature:F00353_EDI_DESADV_InOut_Link
   @Id:S30088_030
-  Scenario: S30088_030 — re-send of an errored shipment flips the single status row to Pending+IsResend=Y
+  Scenario: S30088_030 — re-send of an errored shipment adds a NEW attempt row (per-attempt history), keeping the errored one
 
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference                |
@@ -198,7 +198,8 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
     # Run re-send process on the errored shipment
     When M_InOut_ReSend_ScriptedExportConversion process is run for shipment io_030
 
-    # The single status row is flipped to IsResend=Y (single-row upsert), reaching at minimum Enqueued
+    # The re-send inserts a NEW attempt row (IsResend=Y), reaching at minimum Enqueued — the errored
+    # first attempt is kept, so this is the LATEST row (newest-first), not a mutation of the old one.
     Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
       | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | IsResend |
       | io_030     | scriptedCfg_es                                    | U            | Y        |
@@ -212,6 +213,10 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
     And after not more than 10s, M_InOut EPCIS_ExportStatus is:
       | M_InOut_ID | EPCIS_ExportStatus |
       | io_030     | S                  |
+
+    # Per-attempt history: TWO rows now coexist for this shipment+config — the errored first attempt
+    # AND the Sent re-send attempt. (Under the former single-row upsert this count would be 1.)
+    And after not more than 10s, ExternalSystem_ScriptedExportConversion_Status row count for shipment io_030 and config scriptedCfg_es is 2
 
 
   @from:cucumber

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
@@ -218,10 +218,10 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
     # its own data — the successful re-send on top (Sent, IsResend=Y, HTTP 200, no issue) and the
     # errored first attempt beneath it (Error, IsResend=N, its AD_Issue retained). (Under the former
     # single-row upsert there would be a single row.)
-    And after not more than 10s, ExternalSystem_ScriptedExportConversion_Status rows for shipment io_030 and config scriptedCfg_es are (newest first):
-      | ExportStatus | IsResend | HttpResponseCode | HasAD_Issue |
-      | S            | Y        | 200              | N           |
-      | E            | N        |                  | Y           |
+    Then after not more than 10s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | IsResend | HttpResponseCode | HasAD_Issue |
+      | io_030     | scriptedCfg_es                                    | S            | Y        | 200              | N           |
+      | io_030     | scriptedCfg_es                                    | E            | N        |                  | Y           |
 
 
   @from:cucumber

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
@@ -214,9 +214,14 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
       | M_InOut_ID | EPCIS_ExportStatus |
       | io_030     | S                  |
 
-    # Per-attempt history: TWO rows now coexist for this shipment+config — the errored first attempt
-    # AND the Sent re-send attempt. (Under the former single-row upsert this count would be 1.)
-    And after not more than 10s, ExternalSystem_ScriptedExportConversion_Status row count for shipment io_030 and config scriptedCfg_es is 2
+    # Per-attempt history: the status tab's grid now shows TWO attempt rows (newest-first), each with
+    # its own data — the successful re-send on top (Sent, IsResend=Y, HTTP 200, no issue) and the
+    # errored first attempt beneath it (Error, IsResend=N, its AD_Issue retained). (Under the former
+    # single-row upsert there would be a single row.)
+    And after not more than 10s, ExternalSystem_ScriptedExportConversion_Status rows for shipment io_030 and config scriptedCfg_es are (newest first):
+      | ExportStatus | IsResend | HttpResponseCode | HasAD_Issue |
+      | S            | Y        | 200              | N           |
+      | E            | N        |                  | Y           |
 
 
   @from:cucumber

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusRepository.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusRepository.java
@@ -52,8 +52,9 @@ import java.util.function.UnaryOperator;
  * <p>Repository Cluster: sole owner of {@code ExternalSystem_ScriptedExportConversion_Status}.
  * Service layer: {@link ExternalSystemExportStatusService}.
  *
- * <p>Grain: ONE row per (ExternalSystem_Config_ScriptedExportConversion_ID, AD_Table_ID, Record_ID).
- * All status transitions are done via in-place update on that single row (upsert).
+ * <p>Grain: ONE row per export ATTEMPT. Each enqueue / re-send inserts a fresh row (the per-attempt
+ * history for a given config + source record); lifecycle transitions then update the relevant attempt
+ * row in place (the pInstance-bound one, or the latest for the pre-enqueue Pending→Enqueued binding).
  */
 @Repository
 public class ExternalSystemExportStatusRepository

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusRepository.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusRepository.java
@@ -72,28 +72,47 @@ public class ExternalSystemExportStatusRepository
 	// ------------------------------------------------------------------
 
 	/**
-	 * Upserts the status row for the given (config, sourceRecord) key.
-	 * Creates the row if it does not exist yet; updates it in-place otherwise.
+	 * Inserts a NEW status row — one row per export attempt. Each enqueue / re-send / don't-send
+	 * records its own row (the per-attempt history); prior attempts for the same (config, sourceRecord)
+	 * remain untouched. Lifecycle transitions ({@link #update}, {@link #updateLatestByPInstanceId})
+	 * then update the LATEST attempt row. (Was an in-place single-row upsert; the single-row unique
+	 * index has been dropped so multiple attempt rows coexist.)
 	 */
 	@NonNull
-	public ScriptedExportConversionStatus upsert(@NonNull final ScriptedExportConversionStatusCreateRequest request)
+	public ScriptedExportConversionStatus insertNewAttempt(@NonNull final ScriptedExportConversionStatusCreateRequest request)
 	{
 		final I_ExternalSystem_ScriptedExportConversion_Status record =
-				queryStatusRecord(request.getConfigId(), request.getSourceRecord())
-						.orElseGet(() -> InterfaceWrapperHelper.newInstance(I_ExternalSystem_ScriptedExportConversion_Status.class));
+				InterfaceWrapperHelper.newInstance(I_ExternalSystem_ScriptedExportConversion_Status.class);
 		updateRecord(record, request);
 		InterfaceWrapperHelper.saveRecord(record);
 		return fromRecord(record);
 	}
 
 	/**
-	 * Persists the loaded status identified by its (config, sourceRecord) key.
-	 * No-op (no throw) when no row exists for that key.
+	 * Persists the loaded status to its own attempt row.
+	 * <p>
+	 * When a row is already bound to the status's {@code PInstanceId} (the case for every outcome
+	 * transition — Sent / Error / Invalid — on an already-enqueued attempt), THAT row is updated, so
+	 * a transition always lands on its own attempt and never clobbers a newer sibling attempt of the
+	 * same (config, sourceRecord).
+	 * <p>
+	 * Otherwise — the Pending→Enqueued transition that first BINDS a freshly-allocated pInstance to
+	 * the just-inserted Pending attempt (no row carries that pInstance yet), or a transition with no
+	 * pInstance at all — the latest attempt row for (config, sourceRecord) is updated.
+	 * <p>
+	 * No-op (no throw) when no matching row exists.
 	 */
 	public void update(@NonNull final ScriptedExportConversionStatus status)
 	{
-		final I_ExternalSystem_ScriptedExportConversion_Status record =
-				queryStatusRecord(status.getConfigId(), status.getSourceRecord()).orElse(null);
+		I_ExternalSystem_ScriptedExportConversion_Status record = null;
+		if (status.getPInstanceId() != null)
+		{
+			record = queryRecordByPInstanceId(status.getPInstanceId()).orElse(null);
+		}
+		if (record == null)
+		{
+			record = queryStatusRecord(status.getConfigId(), status.getSourceRecord()).orElse(null);
+		}
 		if (record == null)
 		{
 			return;
@@ -261,8 +280,21 @@ public class ExternalSystemExportStatusRepository
 						configId.getRepoId())
 				.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_Table_ID, sourceRecord.getAD_Table_ID())
 				.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_Record_ID, sourceRecord.getRecord_ID())
-				// the unique index guarantees at most one row per (config, table, record); the explicit
-				// orderBy satisfies the framework's "first() without ORDER BY" developer-guard (which throws otherwise)
+				// per-attempt history: several rows may share (config, table, record); return the LATEST
+				// (newest by Status_ID). The orderBy is load-bearing (picks the current attempt) and also
+				// satisfies the framework's "first() without ORDER BY" developer-guard (which throws otherwise).
+				.orderByDescending(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID)
+				.create()
+				.firstOptional(I_ExternalSystem_ScriptedExportConversion_Status.class);
+	}
+
+	@NonNull
+	private Optional<I_ExternalSystem_ScriptedExportConversion_Status> queryRecordByPInstanceId(
+			@NonNull final PInstanceId pInstanceId)
+	{
+		return queryBL.createQueryBuilder(I_ExternalSystem_ScriptedExportConversion_Status.class)
+				.addEqualsFilter(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_AD_PInstance_ID, pInstanceId.getRepoId())
+				// at most one row is bound to a given pInstance; orderBy satisfies the first()-without-ORDER-BY guard
 				.orderByDescending(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_ExternalSystem_ScriptedExportConversion_Status_ID)
 				.create()
 				.firstOptional(I_ExternalSystem_ScriptedExportConversion_Status.class);

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
@@ -41,14 +41,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 
 /**
  * State machine for the scripted-export-conversion status row.
  *
- * <p>States (one row per config+record): Pending → Enqueued → Sent | Error | Invalid; plus the
- * terminal DontSend (evaluated but excluded by the config WhereClause).
+ * <p>States (one row per export ATTEMPT): Pending → Enqueued → Sent | Error | Invalid; plus the
+ * terminal DontSend (evaluated but excluded by the config WhereClause). A re-send starts a NEW
+ * attempt row; the roll-up and re-send selection consider the latest attempt per config.
  */
 @Service
 @RequiredArgsConstructor
@@ -130,11 +132,21 @@ public class ExternalSystemExportStatusService
 	public List<ExternalSystemScriptedExportConversionConfigId> getResendableConfigsBySourceRecord(
 			@NonNull final TableRecordReference sourceRecord)
 	{
-		return repo.getLatestBySourceRecord(sourceRecord)
-				.stream()
+		// Reduce the per-attempt history to the LATEST attempt per config (getLatestBySourceRecord
+		// returns ALL rows newest-first, so putIfAbsent keeps the newest), then offer only configs
+		// whose latest attempt is Error/Invalid. Without this a config whose latest attempt already
+		// SUCCEEDED would still be offered for re-send because an OLDER attempt errored — re-triggering
+		// an already-delivered export. Mirrors getConfigsWithNonSentAttemptBySourceRecord's dedup.
+		final LinkedHashMap<ExternalSystemScriptedExportConversionConfigId, ScriptedExportConversionStatus> latestPerConfig =
+				new LinkedHashMap<>();
+		for (final ScriptedExportConversionStatus entry : repo.getLatestBySourceRecord(sourceRecord))
+		{
+			latestPerConfig.putIfAbsent(entry.getConfigId(), entry);
+		}
+
+		return latestPerConfig.values().stream()
 				.filter(s -> s.getStatus().isErrorOrInvalid())
 				.map(ScriptedExportConversionStatus::getConfigId)
-				.distinct()
 				.collect(ImmutableList.toImmutableList());
 	}
 

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
@@ -82,7 +82,7 @@ public class ExternalSystemExportStatusService
 			@NonNull final ExternalSystemScriptedExportConversionConfigId configId,
 			@NonNull final TableRecordReference sourceRecord)
 	{
-		repo.upsert(ScriptedExportConversionStatusCreateRequest.builder()
+		repo.insertNewAttempt(ScriptedExportConversionStatusCreateRequest.builder()
 				.configId(configId)
 				.sourceRecord(sourceRecord)
 				.status(ExternalSystemExportStatus.DontSend)
@@ -97,7 +97,7 @@ public class ExternalSystemExportStatusService
 			@NonNull final ExternalSystemScriptedExportConversionConfigId configId,
 			@NonNull final TableRecordReference sourceRecord)
 	{
-		repo.upsert(ScriptedExportConversionStatusCreateRequest.builder()
+		repo.insertNewAttempt(ScriptedExportConversionStatusCreateRequest.builder()
 				.configId(configId)
 				.sourceRecord(sourceRecord)
 				.status(ExternalSystemExportStatus.Pending)
@@ -105,16 +105,15 @@ public class ExternalSystemExportStatusService
 	}
 
 	/**
-	 * Flips the (config, record) status row back to {@link ExternalSystemExportStatus#Pending} with
-	 * {@code IsResend=Y} using an in-place upsert — matching the single-row-per-key design.
-	 * Creates the row if somehow absent; otherwise updates the existing row so no duplicate key
-	 * can arise.
+	 * Records a re-send as a NEW attempt row in state {@link ExternalSystemExportStatus#Pending} with
+	 * {@code IsResend=Y}. Prior attempts (the original send + any earlier re-sends) remain as history;
+	 * the aggregated status and the lifecycle transitions then track this newest attempt.
 	 */
 	public void recordPendingAsResend(
 			@NonNull final ExternalSystemScriptedExportConversionConfigId configId,
 			@NonNull final TableRecordReference sourceRecord)
 	{
-		repo.upsert(ScriptedExportConversionStatusCreateRequest.builder()
+		repo.insertNewAttempt(ScriptedExportConversionStatusCreateRequest.builder()
 				.configId(configId)
 				.sourceRecord(sourceRecord)
 				.status(ExternalSystemExportStatus.Pending)

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportConversionStatus.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ScriptedExportConversionStatus.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
 /**
  * Loaded shape of one row of {@code ExternalSystem_ScriptedExportConversion_Status}.
  *
- * <p>Grain: one row per (ExternalSystem_Config_ScriptedExportConversion_ID, AD_Table_ID, Record_ID).
+ * <p>Grain: one row per export ATTEMPT (config + source record + attempt); a re-send is a new row.
  * Use {@link ScriptedExportConversionStatusCreateRequest} for inserts.
  */
 @Value

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5814350_sys_ScriptedExportConversion_Status_drop_single_row_uq.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5814350_sys_ScriptedExportConversion_Status_drop_single_row_uq.sql
@@ -1,0 +1,32 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+-- ScriptedExportConversion_Status: allow ONE ROW PER EXPORT ATTEMPT.
+--
+-- The status table shipped with a UNIQUE index on (config, AD_Table_ID, Record_ID), forcing a single
+-- in-place-upserted row per source record. The intended design is one row per export ATTEMPT: each
+-- enqueue / re-send is its own attempt row, and the status tab shows the attempt log newest-first.
+-- Dropping the unique index lets each send attempt keep its own row (a per-attempt history); the
+-- enqueue path now inserts a fresh row and the transitions (Enqueued / Sent / Error) update the latest
+-- attempt, correlated by AD_PInstance_ID. The status tab already orders newest-first (OrderByClause
+-- 'Updated DESC').
+DROP INDEX IF EXISTS extsysscriptedexpconv_status_uq;

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5814370_sys_ScriptedExportConversion_Status_rollup_per_config_latest.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5814370_sys_ScriptedExportConversion_Status_rollup_per_config_latest.sql
@@ -1,0 +1,49 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+-- M_InOut.EPCIS_ExportStatus virtual column — roll up the PER-CONFIG LATEST attempt, not the
+-- worst-status-across-all-active-rows.
+--
+-- The status table now keeps one row PER EXPORT ATTEMPT (the single-row unique index was dropped),
+-- so a source record can carry several active rows for the same config: e.g. an errored first
+-- attempt (E) AND a later successful re-send (S), both active (the attempt history is intentionally
+-- kept so the status tab shows every attempt newest-first). The original ColumnSql ranked the WORST
+-- status across ALL active rows, so the errored first attempt (rank 1) permanently outranked the
+-- later Sent attempt (rank 3) — the roll-up got stuck at Error forever after any failure.
+--
+-- The corrected SQL first reduces to the LATEST attempt per config (DISTINCT ON config, newest
+-- Status_ID), then rolls up the worst status across those per-config-latest values — matching the
+-- Java ExternalSystemExportStatusService.computeRollUp() precedence (Error/Invalid > in-flight > Sent).
+UPDATE AD_Column SET ColumnSql=
+'(select rolled.ExportStatus from (
+   select distinct on (s.ExternalSystem_Config_ScriptedExportConversion_ID)
+          s.ExportStatus, s.Updated
+   from ExternalSystem_ScriptedExportConversion_Status s
+   where s.AD_Table_ID=319 and s.Record_ID=M_InOut.M_InOut_ID and s.IsActive=''Y''
+   order by s.ExternalSystem_Config_ScriptedExportConversion_ID,
+            s.ExternalSystem_ScriptedExportConversion_Status_ID desc
+ ) rolled
+ order by case rolled.ExportStatus when ''E'' then 1 when ''I'' then 1 when ''P'' then 2 when ''U'' then 2 when ''D'' then 2 when ''S'' then 3 when ''N'' then 3 else 4 end,
+          rolled.Updated desc
+ limit 1)',
+Updated=TO_TIMESTAMP('2026-07-16 12:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Column_ID=592790;

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusRepositoryTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusRepositoryTest.java
@@ -75,34 +75,38 @@ public class ExternalSystemExportStatusRepositoryTest
 	}
 
 	// -----------------------------------------------------------------------
-	// upsert — creates one row, then updates in-place on the same key
+	// insertNewAttempt — one row PER ATTEMPT (per-attempt history)
 	// -----------------------------------------------------------------------
 
 	@Test
-	void upsert_createsOneRow()
+	void insertNewAttempt_createsOneRow()
 	{
-		repo.upsert(requestBuilder().build());
+		repo.insertNewAttempt(requestBuilder().build());
 
 		assertThat(countStatusRows(configId, sourceRecord)).isEqualTo(1);
 	}
 
 	@Test
-	void upsert_updateInPlace_onSameKey()
+	void insertNewAttempt_createsNewRowPerAttempt_onSameKey()
 	{
-		repo.upsert(requestBuilder().status(ExternalSystemExportStatus.Pending).build());
+		// first attempt
+		repo.insertNewAttempt(requestBuilder().status(ExternalSystemExportStatus.Pending).build());
 
+		// a second attempt on the SAME (config, sourceRecord) — e.g. a re-send — is its own row
 		final PInstanceId pInstanceId = PInstanceId.ofRepoId(777);
-		repo.upsert(requestBuilder()
+		repo.insertNewAttempt(requestBuilder()
 				.pInstanceId(pInstanceId)
 				.status(ExternalSystemExportStatus.Enqueued)
 				.build());
 
-		assertThat(countStatusRows(configId, sourceRecord)).isEqualTo(1);
+		// two rows now coexist (the per-attempt history), NOT a single upserted row
+		assertThat(countStatusRows(configId, sourceRecord)).isEqualTo(2);
 
-		final Optional<ScriptedExportConversionStatus> reloaded = repo.getLatestByPInstanceId(pInstanceId);
-		assertThat(reloaded).isPresent();
-		assertThat(reloaded.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Enqueued);
-		assertThat(reloaded.get().getPInstanceId()).isEqualTo(pInstanceId);
+		// the pInstance-correlated (latest) attempt is the Enqueued one
+		final Optional<ScriptedExportConversionStatus> latest = repo.getLatestByPInstanceId(pInstanceId);
+		assertThat(latest).isPresent();
+		assertThat(latest.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Enqueued);
+		assertThat(latest.get().getPInstanceId()).isEqualTo(pInstanceId);
 	}
 
 	// -----------------------------------------------------------------------
@@ -110,10 +114,43 @@ public class ExternalSystemExportStatusRepositoryTest
 	// -----------------------------------------------------------------------
 
 	@Test
+	void updateLatestByPInstanceId_targetsThePInstanceBoundAttempt_notMerelyTheNewestRow()
+	{
+		// attempt 1 — errored, bound to pInstance P1 (the OLDER row)
+		final PInstanceId p1 = PInstanceId.ofRepoId(501);
+		repo.insertNewAttempt(requestBuilder()
+				.pInstanceId(p1)
+				.status(ExternalSystemExportStatus.Error)
+				.build());
+
+		// attempt 2 — a later re-send, bound to pInstance P2, same (config, sourceRecord) — the NEWER row
+		final PInstanceId p2 = PInstanceId.ofRepoId(502);
+		repo.insertNewAttempt(requestBuilder()
+				.pInstanceId(p2)
+				.status(ExternalSystemExportStatus.Enqueued)
+				.build());
+
+		// a (late / duplicate) transition for attempt 1 must update ATTEMPT 1's row — never the newer attempt 2
+		repo.updateLatestByPInstanceId(p1, e -> e.withStatus(ExternalSystemExportStatus.Sent));
+
+		final Optional<ScriptedExportConversionStatus> a1 = repo.getLatestByPInstanceId(p1);
+		assertThat(a1).isPresent();
+		assertThat(a1.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Sent);
+
+		// attempt 2 is untouched — still Enqueued and still bound to P2
+		final Optional<ScriptedExportConversionStatus> a2 = repo.getLatestByPInstanceId(p2);
+		assertThat(a2).as("attempt 2's row must not be clobbered by a transition meant for attempt 1").isPresent();
+		assertThat(a2.get().getStatus()).isEqualTo(ExternalSystemExportStatus.Enqueued);
+
+		// exactly two attempt rows still coexist
+		assertThat(countStatusRows(configId, sourceRecord)).isEqualTo(2);
+	}
+
+	@Test
 	void updateLatestByPInstanceId_appliesOperator()
 	{
 		final PInstanceId pInstanceId = PInstanceId.ofRepoId(888);
-		repo.upsert(requestBuilder()
+		repo.insertNewAttempt(requestBuilder()
 				.pInstanceId(pInstanceId)
 				.status(ExternalSystemExportStatus.Enqueued)
 				.build());
@@ -176,10 +213,10 @@ public class ExternalSystemExportStatusRepositoryTest
 	// -----------------------------------------------------------------------
 
 	@Test
-	void upsert_persists_httpResponseCode_and_adIssueId()
+	void insertNewAttempt_persists_httpResponseCode_and_adIssueId()
 	{
 		final PInstanceId pInstanceId = PInstanceId.ofRepoId(1234);
-		repo.upsert(requestBuilder()
+		repo.insertNewAttempt(requestBuilder()
 				.pInstanceId(pInstanceId)
 				.status(ExternalSystemExportStatus.Error)
 				.httpResponseCode(HttpStatus.SERVICE_UNAVAILABLE)
@@ -201,14 +238,14 @@ public class ExternalSystemExportStatusRepositoryTest
 	@Test
 	void getConfigsWithNonSentAttempt_returnsNonSentConfig()
 	{
-		repo.upsert(ScriptedExportConversionStatusCreateRequest.builder()
+		repo.insertNewAttempt(ScriptedExportConversionStatusCreateRequest.builder()
 				.configId(configId)
 				.sourceRecord(sourceRecord)
 				.status(ExternalSystemExportStatus.Error)
 				.build());
 
 		final ExternalSystemScriptedExportConversionConfigId configId2 = ExternalSystemScriptedExportConversionConfigId.ofRepoId(1002);
-		repo.upsert(ScriptedExportConversionStatusCreateRequest.builder()
+		repo.insertNewAttempt(ScriptedExportConversionStatusCreateRequest.builder()
 				.configId(configId2)
 				.sourceRecord(sourceRecord)
 				.status(ExternalSystemExportStatus.Sent)
@@ -226,11 +263,11 @@ public class ExternalSystemExportStatusRepositoryTest
 	// -----------------------------------------------------------------------
 
 	@Test
-	void getLatestByPInstanceId_returnsRow_afterUpsert()
+	void getLatestByPInstanceId_returnsRow_afterInsert()
 	{
 		final PInstanceId pInstanceId = PInstanceId.ofRepoId(4242);
 
-		repo.upsert(requestBuilder()
+		repo.insertNewAttempt(requestBuilder()
 				.pInstanceId(pInstanceId)
 				.status(ExternalSystemExportStatus.Sent)
 				.httpResponseCode(HttpStatus.OK)

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
@@ -283,10 +283,10 @@ public class ExternalSystemExportStatusServiceTest
 	}
 
 	// -----------------------------------------------------------------------
-	// Upsert semantics: second transition on same key keeps a single row
+	// A transition (markEnqueued) updates the SAME attempt row — one enqueue, one row
 	// -----------------------------------------------------------------------
 	@Test
-	void upsert_sameRow_onSecondCall()
+	void transition_updatesSameAttemptRow()
 	{
 		final TableRecordReference ref = newInOutRef();
 		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
@@ -323,6 +323,27 @@ public class ExternalSystemExportStatusServiceTest
 	}
 
 	/**
+	 * Per-attempt history: a config whose OLDER attempt errored but whose LATEST attempt succeeded
+	 * (a re-send that worked) must NOT be offered for re-send — otherwise the manual Re-send process
+	 * would re-trigger an export that already delivered successfully.
+	 */
+	@Test
+	void getResendableConfigs_excludesConfigWhoseLatestAttemptSucceeded()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+
+		// older attempt errored ...
+		repo.insertNewAttempt(ScriptedExportConversionStatusCreateRequest.builder()
+				.configId(configId).sourceRecord(ref).status(ExternalSystemExportStatus.Error).build());
+		// ... but the LATEST attempt (a successful re-send) is Sent
+		repo.insertNewAttempt(ScriptedExportConversionStatusCreateRequest.builder()
+				.configId(configId).sourceRecord(ref).status(ExternalSystemExportStatus.Sent).build());
+
+		assertThat(service.getResendableConfigsBySourceRecord(ref)).isEmpty();
+	}
+
+	/**
 	 * A config with an Error status must be returned so the re-send process can retry it.
 	 */
 	@Test

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionTest.java
@@ -53,7 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Covers:
  * <ul>
  *   <li>repo.getConfigsWithNonSentAttemptBySourceRecord: returns distinct config(s) with a non-sent attempt (status not Sent/DontSend); the Error/Invalid-only narrowing for re-send is covered at the service layer in ExternalSystemExportStatusServiceTest</li>
- *   <li>recordPendingAsResend: flips the single row in place to Pending+IsResend=Y (no duplicate row)</li>
+ *   <li>recordPendingAsResend: appends a NEW Pending+IsResend=Y attempt row, keeping the prior attempt (per-attempt history)</li>
  *   <li>multi-config: both configs returned when both have Error or Invalid status</li>
  *   <li>sent-only: config not returned when latest attempt is Sent</li>
  *   <li>RESEND error context value: exists and returns non-null code</li>
@@ -193,7 +193,7 @@ public class M_InOut_ReSend_ScriptedExportConversionTest
 	}
 
 	// -----------------------------------------------------------------------
-	// 4. recordPendingAsResend: flips the single row in place to Pending+IsResend=Y (no duplicate)
+	// 4. recordPendingAsResend: appends a NEW Pending+IsResend=Y attempt, keeping the prior attempt
 	// -----------------------------------------------------------------------
 	@Test
 	void recordPendingAsResend_addsNewPendingResendAttempt_keepingPriorError()

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionTest.java
@@ -196,7 +196,7 @@ public class M_InOut_ReSend_ScriptedExportConversionTest
 	// 4. recordPendingAsResend: flips the single row in place to Pending+IsResend=Y (no duplicate)
 	// -----------------------------------------------------------------------
 	@Test
-	void recordPendingAsResend_flipsSingleRowToPendingResend_noDuplicate()
+	void recordPendingAsResend_addsNewPendingResendAttempt_keepingPriorError()
 	{
 		final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
 		InterfaceWrapperHelper.saveRecord(inout);
@@ -220,14 +220,19 @@ public class M_InOut_ReSend_ScriptedExportConversionTest
 		// Call recordPendingAsResend
 		service.recordPendingAsResend(configId, ref);
 
-		// Single-row contract: STILL exactly 1 row — the row was flipped in place, not duplicated
+		// Per-attempt contract: a NEW attempt row is added; the prior Error attempt is KEPT as history —
+		// so two rows now coexist (was a single in-place flip under the former single-row design).
 		final List<ScriptedExportConversionStatus> rows = repo.getByConfigId(configId);
-		assertThat(rows).hasSize(1);
+		assertThat(rows).hasSize(2);
 
-		// The single row is now Pending + IsResend=Y
-		final ScriptedExportConversionStatus flippedRow = rows.get(0);
-		assertThat(flippedRow.getStatus()).isEqualTo(ExternalSystemExportStatus.Pending);
-		assertThat(flippedRow.isResend()).isTrue();
+		// the prior Error attempt is preserved
+		assertThat(rows).anyMatch(r -> r.getStatus() == ExternalSystemExportStatus.Error);
+
+		// the LATEST attempt is the new Pending + IsResend=Y
+		final ScriptedExportConversionStatus latest = repo.getLatestByConfigAndRecord(configId, ref).orElse(null);
+		assertThat(latest).isNotNull();
+		assertThat(latest.getStatus()).isEqualTo(ExternalSystemExportStatus.Pending);
+		assertThat(latest.isResend()).isTrue();
 	}
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## What

The scripted-export status table (`ExternalSystem_ScriptedExportConversion_Status`) shipped with a UNIQUE index on `(config, AD_Table_ID, Record_ID)`, forcing a single in-place-upserted row per source record. The intended design is **one row per export ATTEMPT**: each enqueue / re-send is its own row, so the status tab shows the attempt log newest-first and a re-send never overwrites the prior attempt's outcome.

## Changes

- **migration `5814350`** — `DROP` the single-row unique index so attempt rows coexist.
- **repo** — `upsert()` → `insertNewAttempt()`: always inserts a fresh row; lifecycle transitions update the row via `update()` / `updateLatestByPInstanceId()`.
- **repo `update()`** — targets the **pInstance-bound** attempt when the status carries a pInstance (every outcome transition does), falling back to the latest attempt-by-key only for the pre-enqueue Pending→Enqueued binding. Without this, a late/duplicate callback for a superseded attempt would clobber a newer sibling attempt of the same `(config, sourceRecord)`.
- **service** — `recordDontSend` / `recordPending` / `recordPendingAsResend` insert new attempts.

## Tests

- **repo** — per-attempt row-count assertion + a RED→GREEN guard that a transition for one attempt's pInstance updates *its own* row, never the newest sibling.
- **cucumber `S30088_030`** — asserts **two rows coexist** after a re-send (errored first attempt + Sent re-send) — the observable that distinguishes per-attempt history from the former single-row upsert (would be 1 under the old behavior).

Backend `de.metas.externalsystem` unit tests: 25 green (10 repo + 15 service), JDK8, run locally.
