### PR TITLE
Cache reset endpoint — make post-reset System.gc() opt-in (default off)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/cache/rest/CacheRestControllerTemplate.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/cache/rest/CacheRestControllerTemplate.java
@@ -62,12 +62,18 @@ public abstract class CacheRestControllerTemplate
 			Services.get(IUserRolePermissionsDAO.class).resetLocalCache();
 			response.addLog("user/role permissions: cache invalidated");
 		}
+		if (request.getValueAsBoolean("gc"))
 		{
-			System.gc();
+			invokeGc();
 			response.addLog("system: garbage collected");
 		}
 
 		return response;
+	}
+
+	protected void invokeGc()
+	{
+		System.gc();
 	}
 
 	protected void resetAdditional(@NonNull final JsonCacheResetResponse response, @NonNull final JsonCacheResetRequest request) {}

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/cache/rest/CacheRestControllerTemplateTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/cache/rest/CacheRestControllerTemplateTest.java
@@ -1,0 +1,82 @@
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2024 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cache.rest;
+
+import de.metas.security.IUserRolePermissionsDAO;
+import de.metas.util.Services;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CacheRestControllerTemplateTest
+{
+	private TestableCacheRestController controller;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		// reset() invalidates the user/role permissions cache; register a mock so the call is a no-op
+		Services.registerService(IUserRolePermissionsDAO.class, Mockito.mock(IUserRolePermissionsDAO.class));
+
+		controller = new TestableCacheRestController();
+	}
+
+	@Test
+	void gcParamAbsent_gcNotInvoked_andNotLogged()
+	{
+		final JsonCacheResetResponse response = controller.reset(new JsonCacheResetRequest());
+
+		assertThat(controller.gcInvocations).isZero();
+		assertThat(response.toString()).doesNotContain("garbage collected");
+	}
+
+	@Test
+	void gcParamTrue_gcInvokedOnce_andLogged()
+	{
+		final JsonCacheResetResponse response = controller.reset(new JsonCacheResetRequest().setValue("gc", true));
+
+		assertThat(controller.gcInvocations).isEqualTo(1);
+		assertThat(response.toString()).contains("garbage collected");
+	}
+
+	private static class TestableCacheRestController extends CacheRestControllerTemplate
+	{
+		int gcInvocations = 0;
+
+		@Override
+		protected void assertAuth()
+		{
+			// no-op for the unit test
+		}
+
+		@Override
+		protected void invokeGc()
+		{
+			gcInvocations++;
+		}
+	}
+}


### PR DESCRIPTION
## What

The cache-reset REST endpoint (`/cache/reset`, both GET and POST) unconditionally ran `System.gc()` as its final step. This change makes that post-reset garbage collection **opt-in**, gated behind a `gc` request parameter, and **defaults to OFF**.

- GET: `?gc=true`
- POST: `{"gc": true}` in the JSON body
- absent / any non-true value → no GC (new default)

## Why

An explicit `System.gc()` forces a full, stop-the-world garbage collection. On large heaps this can pause the JVM for a noticeable period, freezing all in-flight request threads during that window. Because the endpoint is a maintenance/ops action, that pause was being paid on every reset regardless of whether it was wanted.

Skipping the GC leaks nothing: `cacheMgt.reset()` already invalidates the caches and drops the references, so the freed memory becomes eligible for the next regular GC cycle anyway. Forcing an immediate full GC only changes *when* it happens, at the cost of a stop-the-world pause.

Passing `gc=true` (query param or JSON body) restores the previous behavior on demand.

## How

The `System.gc()` call (and its log line) is now wrapped in `if (request.getValueAsBoolean("gc"))`. An absent parameter converts to `false`, so the default is no GC.

A small overridable `invokeGc()` seam was introduced so the opt-in decision can be unit-tested without triggering a real full GC.

## Tests

New `CacheRestControllerTemplateTest`:
- `gcParamAbsent_gcNotInvoked_andNotLogged` — no `gc` param → GC not invoked, not logged.
- `gcParamTrue_gcInvokedOnce_andLogged` — `gc=true` → GC invoked once, logged.

Verified TDD RED (with unconditional GC the absent-param test failed: expected 0 invocations but got 1) then GREEN after adding the guard.
