### PR TITLE
mobile-webui e2e: de-flake the camera-mode toggle test (stub getUserMedia)

### DIFF
--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -406,12 +406,9 @@ test.describe('Modes', () => {
         await allure.story('Barcode scanning modes');
         await allure.severity('critical');
 
-        // Inject a deterministic blank-canvas camera double BEFORE the app loads, so the camera-mode
-        // panel never tears down: getUserMedia() resolves (no NotReadableError) and the flat grey feed
-        // gives ZXing nothing to false-positive on. Without this, Chromium's synthetic fake-media feed
-        // intermittently rejects/false-positives → onCancel → mode reverts to hardware → the
-        // `.camera-mode-panel` wrapper unmounts → expectCameraModeActive() flakes on a 20s timeout.
-        // (See BarcodeScannerComponent.stubCameraStream for the full mechanism.)
+        // Must run BEFORE login so the getUserMedia stub is installed before the app's first camera
+        // request. Stabilises this camera-toggle test against a flaky panel teardown — mechanism in
+        // BarcodeScannerComponent.stubCameraStream.
         await BarcodeScannerComponent.stubCameraStream();
 
         const masterdata = await createLoginMasterdata({

--- a/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
+++ b/e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js
@@ -406,6 +406,14 @@ test.describe('Modes', () => {
         await allure.story('Barcode scanning modes');
         await allure.severity('critical');
 
+        // Inject a deterministic blank-canvas camera double BEFORE the app loads, so the camera-mode
+        // panel never tears down: getUserMedia() resolves (no NotReadableError) and the flat grey feed
+        // gives ZXing nothing to false-positive on. Without this, Chromium's synthetic fake-media feed
+        // intermittently rejects/false-positives → onCancel → mode reverts to hardware → the
+        // `.camera-mode-panel` wrapper unmounts → expectCameraModeActive() flakes on a 20s timeout.
+        // (See BarcodeScannerComponent.stubCameraStream for the full mechanism.)
+        await BarcodeScannerComponent.stubCameraStream();
+
         const masterdata = await createLoginMasterdata({
             extraSysconfigs: modeSysconfigs({
                 hardwareEnabled: 'Y',

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -302,11 +302,28 @@ export const BarcodeScannerComponent = {
     stubCameraStream: async () => await test.step(`${NAME} - Stub getUserMedia (blank deterministic stream)`, async () => {
         await page.addInitScript(() => {
             const makeBlankStream = () => {
-                const c = document.createElement('canvas'); c.width = 640; c.height = 480;
+                const c = document.createElement('canvas');
+                c.width = 640;
+                c.height = 480;
                 const ctx = c.getContext('2d');
-                const paint = () => { ctx.fillStyle = '#808080'; ctx.fillRect(0, 0, c.width, c.height); };
-                paint(); setInterval(paint, 100);
-                return c.captureStream(10);
+                const paint = () => {
+                    ctx.fillStyle = '#808080';
+                    ctx.fillRect(0, 0, c.width, c.height);
+                };
+                paint();
+                const intervalId = setInterval(paint, 100);
+                const stream = c.captureStream(10);
+                // Stop the repaint loop when the video track is stopped (CameraModePanel's cleanup
+                // calls track.stop()), so a test that toggles the camera on/off repeatedly does not
+                // leak one live setInterval per toggle. captureStream tracks don't auto-clear it.
+                stream.getVideoTracks().forEach((track) => {
+                    const originalStop = track.stop.bind(track);
+                    track.stop = () => {
+                        clearInterval(intervalId);
+                        originalStop();
+                    };
+                });
+                return stream;
             };
             if (navigator.mediaDevices) {
                 navigator.mediaDevices.getUserMedia = () => Promise.resolve(makeBlankStream());

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -286,6 +286,36 @@ export const BarcodeScannerComponent = {
         await expect(page.locator('.camera-mode-panel')).toHaveCount(1, { timeout: SLOW_ACTION_TIMEOUT });
     }),
 
+    // Injects a deterministic blank-canvas camera double so the camera-mode toggle test is stable.
+    // WHY: CameraModePanel.startCamera() calls getUserMedia()/codeReader.decodeFromVideoDevice(); when
+    // that rejects, onCancel fires → setActiveMode(defaultMode=hardware) → the `.camera-mode-panel`
+    // wrapper unmounts, so expectCameraModeActive() times out. Chromium's synthetic fake-media feed
+    // (--use-fake-device-for-media-stream) is decodable + flicker-prone, so ZXing intermittently
+    // false-positives a barcode (or a transient NotReadableError surfaces) → reject → mode reverts →
+    // 20s flake. This stub replaces getUserMedia with a constant grey 640x480 canvas stream: it never
+    // rejects (panel stays mounted) and, being a flat single colour, gives ZXing nothing to decode
+    // (no false-positive teardown). enumerateDevices is stubbed too so the camera enumerates cleanly.
+    // MUST be called BEFORE the app loads (before LoginScreen.login) — page.addInitScript runs on every
+    // document creation, so it is in place when the frontend first requests the camera.
+    // Keeps BOTH hardware and camera modes enabled — it makes the real camera path deterministic
+    // rather than disabling it, so the hw↔camera toggle under test is still exercised end to end.
+    stubCameraStream: async () => await test.step(`${NAME} - Stub getUserMedia (blank deterministic stream)`, async () => {
+        await page.addInitScript(() => {
+            const makeBlankStream = () => {
+                const c = document.createElement('canvas'); c.width = 640; c.height = 480;
+                const ctx = c.getContext('2d');
+                const paint = () => { ctx.fillStyle = '#808080'; ctx.fillRect(0, 0, c.width, c.height); };
+                paint(); setInterval(paint, 100);
+                return c.captureStream(10);
+            };
+            if (navigator.mediaDevices) {
+                navigator.mediaDevices.getUserMedia = () => Promise.resolve(makeBlankStream());
+                navigator.mediaDevices.enumerateDevices = () => Promise.resolve(
+                    [{ kind: 'videoinput', deviceId: 'fake-cam', label: 'Fake Camera', groupId: 'g', toJSON() { return this; } }]);
+            }
+        });
+    }),
+
     // Clicks a footer button by its testId (e.g. 'barcode-scanner-toggle-hw-camera',
     // 'barcode-scanner-enter-manually', 'barcode-scanner-back-to-scanner').
     clickFooterButton: async (testId) => await test.step(`${NAME} - Click footer button '${testId}'`, async () => {


### PR DESCRIPTION
## What

De-flakes the mobile-webui Playwright E2E scenario `camera toggle — clicking hw/camera toggle activates camera mode` (`e2e/mobile-webui/tests/spec/barcode_scanner_modes.spec.js:403`). Test-side only — no production code changes.

## Flake mechanism

`expectCameraModeActive()` asserts `.camera-mode-panel` has count 1. `CameraModePanel.startCamera()` calls `codeReader.decodeFromVideoDevice()` (which calls `getUserMedia`). When that **rejects**, the panel's `catch` fires `onCancel()` → `setActiveMode(defaultMode=hardware)` → the `.camera-mode-panel` wrapper **unmounts**.

The panel mounts synchronously on the toggle tap, then the async `getUserMedia` outcome resolves ~100 ms later. So the assertion is a race between its first poll and that ~100 ms teardown:

- getUserMedia **resolves** → panel stays mounted → pass.
- getUserMedia **rejects** → panel torn down ~100 ms after mount → if the assertion's first poll lands after teardown (CI under load), it waits out the full 20 s `SLOW_ACTION_TIMEOUT` → **flake**.

Chromium's synthetic fake-media feed (`--use-fake-device-for-media-stream`, already present) is decodable + flicker-prone, so ZXing intermittently false-positives a barcode or a transient `NotReadableError` surfaces → reject → the flaky teardown. The `--use-fake-*` flags being present is not the issue (that was a separate earlier fix).

## Fix (test-side)

New `BarcodeScannerComponent.stubCameraStream()` helper injects, via `page.addInitScript` **before app load**, a deterministic blank grey 640×480 canvas stream:

- `getUserMedia` always **resolves** → panel never tears down.
- the flat single-colour feed gives ZXing nothing to decode → no false-positive teardown.

Called at the start of the affected test, before login. **Both** hardware and camera modes stay enabled — the real hw↔camera toggle is still exercised end to end; the assertion is not weakened.

## Local RED/GREEN evidence

Ran against a local mobile-webui E2E stack (CI images `metasfresh/*:5.175-new-dawn-uat.40349`, offset ports), `--project="Mobile Chrome"`.

An instrumented probe confirmed the mechanism: on reject, `.camera-mode-panel` count goes 1→0 by ~100 ms and stays 0; with the blank stream it stays 1 at every sample (0–4000 ms).

Because the local machine's first poll wins the race, a plain reject isn't a deterministic RED — so the RED forces the first poll to land after teardown (temporary 1 s wait before the assertion, modeling CI scheduling delay; not committed):

- **RED** (getUserMedia rejects + delayed poll), `--repeat-each=5`: **5/5 FAIL**, each a 20 s timeout — `expect(locator('.camera-mode-panel')).toHaveCount(1)` Received 0. Exact CI flake signature.
- **GREEN-A** (blank stream + the *same* delayed poll), `--repeat-each=20`: **20/20 PASS** — apples-to-apples, fix flips the identical condition from all-fail to all-pass.
- **GREEN-B** (committed artifact: blank stream, no wait), `--repeat-each=20`: **20/20 PASS**.

Full file run: all tests pass except a pre-existing, unrelated failure in `#input-text HTML: type=text, inputMode=none, readOnly absent` (`:76`) that fails 3/3 on the pristine tree too (image-vs-source skew in the preloaded mobile image; independent of this change).
