### PR TITLE
CreateMissingShipmentSchedules — batch missing-schedule creation via bounded re-enqueued work packages

### DIFF
--- a/backend/de.metas.contracts/src/main/java/de/metas/contracts/inoutcandidate/SubscriptionShipmentScheduleHandler.java
+++ b/backend/de.metas.contracts/src/main/java/de/metas/contracts/inoutcandidate/SubscriptionShipmentScheduleHandler.java
@@ -25,6 +25,7 @@ import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.dao.impl.CompareQueryFilter.Operator;
 import org.adempiere.mm.attributes.api.IAttributeSetInstanceBL;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -146,7 +147,8 @@ public class SubscriptionShipmentScheduleHandler extends ShipmentScheduleHandler
 	@Override
 	public Iterator<?> retrieveModelsWithMissingCandidates(
 			final Properties ctx,
-			final String trxName)
+			final String trxName,
+			@NonNull final QueryLimit limit)
 	{
 		final int daysInAdvance = Services.get(ISysConfigBL.class).getIntValue(SYSCONFIG_CREATE_SHIPMENT_SCHEDULES_IN_ADVANCE_DAYS, 0, Env.getAD_Client_ID(ctx), Env.getAD_Org_ID(ctx));
 		final Timestamp eventDateMaximum = TimeUtil.addDays(SystemTime.asTimestamp(), daysInAdvance);
@@ -160,6 +162,9 @@ public class SubscriptionShipmentScheduleHandler extends ShipmentScheduleHandler
 				.create();
 
 		// Note: we used to also check if there is an active I_M_IolCandHandler_Log record referencing the C_SubscriptionProgress, but I don't see why.
+		// The query limit is pushed down here (not only enforced by the caller's processing budget) so that
+		// OPTION_GuaranteedIteratorRequired below only ever materializes a selection of up to `limit` rows instead of
+		// the whole missing-schedule backlog on every batch run.
 		return queryBL
 				.createQueryBuilder(I_C_SubscriptionProgress.class)
 				.addOnlyActiveRecordsFilter()
@@ -174,6 +179,7 @@ public class SubscriptionShipmentScheduleHandler extends ShipmentScheduleHandler
 						itemProductQuery)
 				.addOnlyContextClient(ctx)
 				.orderBy().addColumn(I_C_SubscriptionProgress.COLUMNNAME_C_SubscriptionProgress_ID).endOrderBy()
+				.setLimit(limit)
 				.create()
 				.setOption(IQuery.OPTION_GuaranteedIteratorRequired, true)
 				.setOption(IQuery.OPTION_IteratorBufferSize, 500)

--- a/backend/de.metas.contracts/src/test/java/de/metas/contracts/inoutcandidate/SubscriptionShipmentScheduleHandler_RetrieveModelsWithMissingCandidates_Tests.java
+++ b/backend/de.metas.contracts/src/test/java/de/metas/contracts/inoutcandidate/SubscriptionShipmentScheduleHandler_RetrieveModelsWithMissingCandidates_Tests.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import de.metas.common.util.time.SystemTime;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.service.ClientId;
 import org.adempiere.service.ISysConfigBL;
@@ -132,7 +133,7 @@ public class SubscriptionShipmentScheduleHandler_RetrieveModelsWithMissingCandid
 
 	private void assertOnlyFirstRecordIsReturned()
 	{
-		final List<? extends Object> result = IteratorUtils.asList(new SubscriptionShipmentScheduleHandler().retrieveModelsWithMissingCandidates(Env.getCtx(), ITrx.TRXNAME_ThreadInherited));
+		final List<? extends Object> result = IteratorUtils.asList(new SubscriptionShipmentScheduleHandler().retrieveModelsWithMissingCandidates(Env.getCtx(), ITrx.TRXNAME_ThreadInherited, QueryLimit.NO_LIMIT));
 
 		assertThat(result).hasSize(1);
 		assertThat(result.get(0)).isInstanceOf(I_C_SubscriptionProgress.class);
@@ -143,7 +144,7 @@ public class SubscriptionShipmentScheduleHandler_RetrieveModelsWithMissingCandid
 
 	private void assertBothRecordsAreReturned()
 	{
-		final List<? extends Object> secondResult = IteratorUtils.asList(new SubscriptionShipmentScheduleHandler().retrieveModelsWithMissingCandidates(Env.getCtx(), ITrx.TRXNAME_ThreadInherited));
+		final List<? extends Object> secondResult = IteratorUtils.asList(new SubscriptionShipmentScheduleHandler().retrieveModelsWithMissingCandidates(Env.getCtx(), ITrx.TRXNAME_ThreadInherited, QueryLimit.NO_LIMIT));
 		assertThat(secondResult).hasSize(2);
 
 		assertThat(secondResult).allSatisfy(r -> {

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workpackage/C_Queue_WorkPackage_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workpackage/C_Queue_WorkPackage_StepDef.java
@@ -24,7 +24,10 @@ package de.metas.cucumber.stepdefs.workpackage;
 
 import com.google.common.collect.ImmutableSet;
 import de.metas.async.QueueWorkPackageId;
+import de.metas.async.api.IQueueDAO;
 import de.metas.async.model.*;
+import de.metas.async.processor.IWorkpackageProcessorFactory;
+import de.metas.async.spi.IWorkpackageProcessor;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.DataTableUtil;
@@ -41,14 +44,19 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.IQueryFilter;
 import org.adempiere.ad.table.api.IADTableDAO;
+import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.IQuery;
 import org.compiere.model.I_AD_Table;
 
 import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -59,8 +67,11 @@ public class C_Queue_WorkPackage_StepDef
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	private final IADTableDAO tableDAO = Services.get(IADTableDAO.class);
+	private final IQueueDAO queueDAO = Services.get(IQueueDAO.class);
+	private final IWorkpackageProcessorFactory workpackageProcessorFactory = Services.get(IWorkpackageProcessorFactory.class);
 
 	private static final String MAIL_WP_PROCESSOR_INTERNAL_NAME = "MailWorkpackageProcessor";
+	private static final String WORKPACKAGE_PROCESSOR_CLASS_SUFFIX = "WorkpackageProcessor";
 
 	@NonNull private final C_Queue_Processor_StepDefData processorTable;
 	@NonNull private final C_Queue_WorkPackage_StepDefData workPackageTable;
@@ -343,5 +354,121 @@ public class C_Queue_WorkPackage_StepDef
 				.as("MailWorkpackageProcessor workpackage for %s did not reach state '%s' within %ss",
 						documentRef, expectedState, timeoutSec)
 				.isTrue();
+	}
+
+	/**
+	 * Directly instantiates (via the same {@link IWorkpackageProcessorFactory} the async framework itself uses to
+	 * turn a {@code C_Queue_PackageProcessor.Classname} into a runnable instance) and invokes the workpackage
+	 * processor identified by its short name (e.g. {@code CreateMissingShipmentSchedules} for
+	 * {@code CreateMissingShipmentSchedulesWorkpackageProcessor}), processing the OLDEST pending
+	 * {@code C_Queue_WorkPackage} for that processor and marking it {@code Processed=Y} on success — mirroring
+	 * what {@code WorkpackageProcessorTask} does for a single run.
+	 * <p>
+	 * In production, the background {@code QueueProcessorPlanner} thread polls for and runs due workpackages on
+	 * its own schedule; this step calls the processor directly, one workpackage at a time, so a scenario can
+	 * assert the outcome of exactly one run deterministically — waiting for the background poller would make the
+	 * "how many workpackages ran so far" boundary flaky and race-prone.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * When the next CreateMissingShipmentSchedules workpackage is processed
+	 * </pre>
+	 */
+	@And("^the next (.*) workpackage is processed$")
+	public void process_next_workpackage(@NonNull final String processorShortName)
+	{
+		final I_C_Queue_WorkPackage workPackage = retrieveOldestPendingWorkPackage(processorShortName)
+				.orElseThrow(() -> new AdempiereException("No pending C_Queue_WorkPackage found for processor")
+						.appendParametersToMessage()
+						.setParameter("processorShortName", processorShortName));
+
+		final Properties ctx = InterfaceWrapperHelper.getCtx(workPackage);
+		final IWorkpackageProcessor processor = workpackageProcessorFactory.getWorkpackageProcessor(ctx, workPackage.getC_Queue_PackageProcessor_ID());
+
+		final IWorkpackageProcessor.Result result = processor.processWorkPackage(workPackage, ITrx.TRXNAME_None);
+		assertThat(result)
+				.as("Result of processing C_Queue_WorkPackage_ID=%s with processor %s", workPackage.getC_Queue_WorkPackage_ID(), processorShortName)
+				.isEqualTo(IWorkpackageProcessor.Result.SUCCESS);
+
+		workPackage.setProcessed(true);
+		queueDAO.save(workPackage);
+	}
+
+	/**
+	 * Asserts how many {@code C_Queue_WorkPackage} rows are currently pending (not yet processed, not errored,
+	 * ready for processing) for the workpackage processor identified by its short name — i.e. how many runs of
+	 * that processor are still waiting to happen, whether because none has run yet or because a run re-enqueued
+	 * a follow-up workpackage for the remaining work.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then there is 1 pending "CreateMissingShipmentSchedules" workpackage
+	 * </pre>
+	 */
+	@And("^there (?:is|are) (\\d+) pending \"(.*)\" workpackages?$")
+	public void assert_pending_workpackage_count(final int expectedCount, @NonNull final String processorShortName)
+	{
+		final int actualCount = countPendingWorkPackages(processorShortName);
+		assertThat(actualCount)
+				.as("Number of pending C_Queue_WorkPackage for processor %s", processorShortName)
+				.isEqualTo(expectedCount);
+	}
+
+	private Optional<I_C_Queue_WorkPackage> retrieveOldestPendingWorkPackage(@NonNull final String processorShortName)
+	{
+		final ImmutableSet<Integer> packageProcessorIds = resolvePackageProcessorIds(processorShortName);
+		if (packageProcessorIds.isEmpty())
+		{
+			return Optional.empty();
+		}
+
+		return pendingWorkPackagesQuery(packageProcessorIds)
+				.orderBy(I_C_Queue_WorkPackage.COLUMNNAME_C_Queue_WorkPackage_ID)
+				.create()
+				.firstOptional(I_C_Queue_WorkPackage.class);
+	}
+
+	private int countPendingWorkPackages(@NonNull final String processorShortName)
+	{
+		final ImmutableSet<Integer> packageProcessorIds = resolvePackageProcessorIds(processorShortName);
+		if (packageProcessorIds.isEmpty())
+		{
+			return 0;
+		}
+
+		return pendingWorkPackagesQuery(packageProcessorIds)
+				.create()
+				.count();
+	}
+
+	private IQueryBuilder<I_C_Queue_WorkPackage> pendingWorkPackagesQuery(@NonNull final ImmutableSet<Integer> packageProcessorIds)
+	{
+		return queryBL.createQueryBuilder(I_C_Queue_WorkPackage.class)
+				.addInArrayFilter(I_C_Queue_WorkPackage.COLUMNNAME_C_Queue_PackageProcessor_ID, packageProcessorIds)
+				.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_Processed, false)
+				.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_IsError, false)
+				.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_IsReadyForProcessing, true);
+	}
+
+	/**
+	 * Resolves the {@code C_Queue_PackageProcessor_ID}s whose {@code Classname} simple name matches the given
+	 * short name (with a {@value WORKPACKAGE_PROCESSOR_CLASS_SUFFIX} suffix appended if not already present) —
+	 * e.g. {@code CreateMissingShipmentSchedules} resolves {@code CreateMissingShipmentSchedulesWorkpackageProcessor}.
+	 */
+	private ImmutableSet<Integer> resolvePackageProcessorIds(@NonNull final String processorShortName)
+	{
+		final String processorSimpleClassName = processorShortName.endsWith(WORKPACKAGE_PROCESSOR_CLASS_SUFFIX)
+				? processorShortName
+				: processorShortName + WORKPACKAGE_PROCESSOR_CLASS_SUFFIX;
+		final String classnameSuffix = "." + processorSimpleClassName;
+
+		return queryBL.createQueryBuilder(I_C_Queue_PackageProcessor.class)
+				.create()
+				.stream()
+				.filter(packageProcessor -> packageProcessor.getClassname() != null && packageProcessor.getClassname().endsWith(classnameSuffix))
+				.map(I_C_Queue_PackageProcessor::getC_Queue_PackageProcessor_ID)
+				.collect(ImmutableSet.toImmutableSet());
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workpackage/C_Queue_WorkPackage_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workpackage/C_Queue_WorkPackage_StepDef.java
@@ -361,8 +361,10 @@ public class C_Queue_WorkPackage_StepDef
 	 * turn a {@code C_Queue_PackageProcessor.Classname} into a runnable instance) and invokes the workpackage
 	 * processor identified by its short name (e.g. {@code CreateMissingShipmentSchedules} for
 	 * {@code CreateMissingShipmentSchedulesWorkpackageProcessor}), processing the OLDEST pending
-	 * {@code C_Queue_WorkPackage} for that processor and marking it {@code Processed=Y} on success — mirroring
-	 * what {@code WorkpackageProcessorTask} does for a single run.
+	 * {@code C_Queue_WorkPackage} for that processor and marking it {@code Processed=Y} on success — the essential
+	 * effect of {@code WorkpackageProcessorTask} for a single run. (It deliberately does not replicate that task's
+	 * lock/error bookkeeping or lifecycle-event firing; this processor uses no queue-element locks, so for the
+	 * batching assertion only the created records and the {@code Processed} flag matter.)
 	 * <p>
 	 * In production, the background {@code QueueProcessorPlanner} thread polls for and runs due workpackages on
 	 * its own schedule; this step calls the processor directly, one workpackage at a time, so a scenario can
@@ -465,6 +467,7 @@ public class C_Queue_WorkPackage_StepDef
 		final String classnameSuffix = "." + processorSimpleClassName;
 
 		return queryBL.createQueryBuilder(I_C_Queue_PackageProcessor.class)
+				.addOnlyActiveRecordsFilter()
 				.create()
 				.stream()
 				.filter(packageProcessor -> packageProcessor.getClassname() != null && packageProcessor.getClassname().endsWith(classnameSuffix))

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/createMissingShipmentSchedulesBatching.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/createMissingShipmentSchedulesBatching.feature
@@ -1,0 +1,81 @@
+@from:cucumber
+@allure.label.epic:E0100_Sales
+@allure.label.feature:F00130_Shipment_Schedule
+@ghActions:run_on_executor7
+Feature: create missing shipment schedules in bounded batches
+## F00130: Shipment Schedule (Lieferdisposition)
+# A large backlog of missing shipment schedules is created in bounded batches per
+# workpackage run, re-enqueueing a follow-up workpackage for the remaining work,
+# instead of creating everything in one unbounded run.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2024-01-15T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config int value 2 for sys config de.metas.inoutcandidate.async.CreateMissingShipmentSchedulesWorkpackageProcessor.MaxToProcess
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_1       |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | SOTrx |
+      | pl_1       | ps_1                          | DE                        | EUR                 | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier |
+      | plv_1      | pl_1                      |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product_1  |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_1       | plv_1                             | product_1               | 10.0     | PCE               | Normal                        |
+    And metasfresh contains C_BPartners:
+      | Identifier | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | bpartner_1 | N            | Y              | ps_1                          |
+
+  @from:cucumber
+@allure.label.epic:E0100_Sales
+@allure.label.feature:F00130_Shipment_Schedule
+  @Id:S31050_TC1
+  Scenario: one workpackage run creates a bounded batch and re-enqueues the rest
+  _Given a sales order with 5 order lines is completed, enqueueing one CreateMissingShipmentSchedules workpackage
+  _And the MaxToProcess sysconfig for that processor is 2
+  _When the next CreateMissingShipmentSchedules workpackage is processed once
+  _Then exactly 2 shipment schedules exist for the order, and a follow-up workpackage is re-enqueued for the rest
+  _When the follow-up workpackage is processed until none remain
+  _Then all 5 shipment schedules exist for the order, and no CreateMissingShipmentSchedules workpackage is pending
+
+    Given metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | order_1    | true    | bpartner_1               | 2024-01-15  |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine_1 | order_1               | product_1               | 10         |
+      | orderLine_2 | order_1               | product_1               | 10         |
+      | orderLine_3 | order_1               | product_1               | 10         |
+      | orderLine_4 | order_1               | product_1               | 10         |
+      | orderLine_5 | order_1               | product_1               | 10         |
+
+    When the order identified by order_1 is completed
+
+    Then there is 1 pending "CreateMissingShipmentSchedules" workpackage
+
+    When the next CreateMissingShipmentSchedules workpackage is processed
+
+    Then after not more than 30s, M_ShipmentSchedules are found:
+      | Identifier         | C_OrderLine_ID.Identifier |
+      | shipmentSchedule_1 | orderLine_1               |
+      | shipmentSchedule_2 | orderLine_2               |
+    And there is 1 pending "CreateMissingShipmentSchedules" workpackage
+
+    When the next CreateMissingShipmentSchedules workpackage is processed
+    And the next CreateMissingShipmentSchedules workpackage is processed
+
+    Then after not more than 30s, M_ShipmentSchedules are found:
+      | Identifier         | C_OrderLine_ID.Identifier |
+      | shipmentSchedule_1 | orderLine_1               |
+      | shipmentSchedule_2 | orderLine_2               |
+      | shipmentSchedule_3 | orderLine_3               |
+      | shipmentSchedule_4 | orderLine_4               |
+      | shipmentSchedule_5 | orderLine_5               |
+    And there are 0 pending "CreateMissingShipmentSchedules" workpackages

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/createMissingShipmentSchedulesBatching.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/createMissingShipmentSchedulesBatching.feature
@@ -34,8 +34,8 @@ Feature: create missing shipment schedules in bounded batches
       | bpartner_1 | N            | Y              | ps_1                          |
 
   @from:cucumber
-@allure.label.epic:E0100_Sales
-@allure.label.feature:F00130_Shipment_Schedule
+  @allure.label.epic:E0100_Sales
+  @allure.label.feature:F00130_Shipment_Schedule
   @Id:S31050_TC1
   Scenario: one workpackage run creates a bounded batch and re-enqueues the rest
   _Given a sales order with 5 order lines is completed, enqueueing one CreateMissingShipmentSchedules workpackage

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/createMissingShipmentSchedulesBatching.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/createMissingShipmentSchedulesBatching.feature
@@ -40,9 +40,9 @@ Feature: create missing shipment schedules in bounded batches
   Scenario: one workpackage run creates a bounded batch and re-enqueues the rest
   _Given a sales order with 5 order lines is completed, enqueueing one CreateMissingShipmentSchedules workpackage
   _And the MaxToProcess sysconfig for that processor is 2
-  _When the next CreateMissingShipmentSchedules workpackage is processed once
+  _When the next CreateMissingShipmentSchedules workpackage is processed
   _Then exactly 2 shipment schedules exist for the order, and a follow-up workpackage is re-enqueued for the rest
-  _When the follow-up workpackage is processed until none remain
+  _When the two remaining follow-up workpackages are processed
   _Then all 5 shipment schedules exist for the order, and no CreateMissingShipmentSchedules workpackage is pending
 
     Given metasfresh contains C_Orders:

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/CreateMissingCandidatesResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/CreateMissingCandidatesResult.java
@@ -37,8 +37,11 @@ public class CreateMissingCandidatesResult
 	@NonNull Set<ShipmentScheduleId> createdShipmentScheduleIds;
 
 	/**
-	 * {@code true} if the given budget was exhausted while at least one more model was still available to process
-	 * (i.e. there is more work remaining and a follow-up run is needed to finish it).
+	 * {@code true} if the given budget was fully consumed (all handlers combined processed exactly {@code maxToProcess}
+	 * models), signalling that a follow-up run should be enqueued. Note this can be {@code true} with zero actual work
+	 * remaining in the rare case the backlog was an exact multiple of the budget — that follow-up run then finds and
+	 * processes nothing and reports {@code false}, so the re-enqueue chain terminates. Always {@code false} for an
+	 * unlimited ({@link org.adempiere.ad.dao.QueryLimit#NO_LIMIT}) budget.
 	 */
 	boolean limitReached;
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/CreateMissingCandidatesResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/CreateMissingCandidatesResult.java
@@ -1,0 +1,44 @@
+package de.metas.inoutcandidate.api;
+
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.inout.ShipmentScheduleId;
+import lombok.NonNull;
+import lombok.Value;
+
+import java.util.Set;
+
+/**
+ * Result of a (possibly budget-limited) {@link IShipmentScheduleHandlerBL#createMissingCandidates(java.util.Properties, org.adempiere.ad.dao.QueryLimit)} run.
+ */
+@Value
+public class CreateMissingCandidatesResult
+{
+	@NonNull Set<ShipmentScheduleId> createdShipmentScheduleIds;
+
+	/**
+	 * {@code true} if the given budget was exhausted while at least one more model was still available to process
+	 * (i.e. there is more work remaining and a follow-up run is needed to finish it).
+	 */
+	boolean limitReached;
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleHandlerBL.java
@@ -6,6 +6,7 @@ import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.inoutcandidate.spi.ModelWithoutShipmentScheduleVetoer;
 import de.metas.inoutcandidate.spi.ShipmentScheduleHandler;
 import de.metas.util.ISingletonService;
+import org.adempiere.ad.dao.QueryLimit;
 import org.compiere.model.I_C_OrderLine;
 
 import java.util.Properties;
@@ -51,8 +52,19 @@ public interface IShipmentScheduleHandlerBL extends ISingletonService
 
 	/**
 	 * Invokes all registered {@link ShipmentScheduleHandler}s to create missing InOut candidates.
+	 * <p>
+	 * Unlimited variant of {@link #createMissingCandidates(Properties, QueryLimit)}; delegates with {@link QueryLimit#NO_LIMIT}.
 	 */
 	Set<ShipmentScheduleId> createMissingCandidates(Properties ctx);
+
+	/**
+	 * Invokes all registered {@link ShipmentScheduleHandler}s to create missing InOut candidates, processing at most
+	 * {@code maxToProcess} models (created-or-vetoed, not schedules created) across all handlers combined.
+	 *
+	 * @param maxToProcess budget of models to process; use {@link QueryLimit#NO_LIMIT} for unlimited.
+	 * @return the created shipment schedule ids, plus whether the budget was exhausted with more work remaining.
+	 */
+	CreateMissingCandidatesResult createMissingCandidates(Properties ctx, QueryLimit maxToProcess);
 
 	/**
 	 * Invokes the given <code>sched</code>'s {@link ShipmentScheduleHandler} to get a {@link IDeliverRequest} instance.

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleHandlerBL.java
@@ -54,7 +54,11 @@ public interface IShipmentScheduleHandlerBL extends ISingletonService
 	 * Invokes all registered {@link ShipmentScheduleHandler}s to create missing InOut candidates.
 	 * <p>
 	 * Unlimited variant of {@link #createMissingCandidates(Properties, QueryLimit)}; delegates with {@link QueryLimit#NO_LIMIT}.
+	 *
+	 * @deprecated unbounded: processes the whole backlog in one go and can OOM on a large backlog. Use the bounded
+	 * {@link #createMissingCandidates(Properties, QueryLimit)} overload instead.
 	 */
+	@Deprecated
 	Set<ShipmentScheduleId> createMissingCandidates(Properties ctx);
 
 	/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
@@ -246,6 +246,11 @@ public class ShipmentScheduleHandlerBL implements IShipmentScheduleHandlerBL
 
 		private QueryLimit toQueryLimit()
 		{
+			// Guard the load-bearing invariant of the batching perf fix: QueryLimit.ofInt(<=0) silently resolves to
+			// NO_LIMIT (unbounded), which would reintroduce the whole-backlog OOM this class exists to prevent. Today
+			// invokeHandler is only reached while remaining>0 (createMissingCandidates breaks the loop on
+			// isLimitReached()), so this only fails loudly if a future change violates that.
+			Check.assume(unlimited || remaining > 0, "remaining budget must be > 0 when limited; remaining={}", remaining);
 			return unlimited ? QueryLimit.NO_LIMIT : QueryLimit.ofInt(remaining);
 		}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
@@ -142,6 +142,11 @@ public class ShipmentScheduleHandlerBL implements IShipmentScheduleHandlerBL
 		listeners.add(l);
 	}
 
+	/**
+	 * @deprecated unbounded: processes the whole backlog in one go and can OOM on a large backlog. Use the bounded
+	 * {@link #createMissingCandidates(Properties, QueryLimit)} overload instead.
+	 */
+	@Deprecated
 	@Override
 	public Set<ShipmentScheduleId> createMissingCandidates(@NonNull final Properties ctx)
 	{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +67,10 @@ public class ShipmentScheduleHandlerBL implements IShipmentScheduleHandlerBL
 	private final IMsgBL msgBL = Services.get(IMsgBL.class);
 	private final IADTableDAO adTableDAO = Services.get(IADTableDAO.class);
 
-	private final Map<String, ShipmentScheduleHandler> tableName2Handler = new HashMap<>();
+	// LinkedHashMap (not HashMap): when a bounded budget is threaded across handlers (see createMissingCandidates),
+	// the budget is consumed in this map's iteration order, so that order must be deterministic (= handler registration
+	// order) rather than incidental hash-bucket order.
+	private final Map<String, ShipmentScheduleHandler> tableName2Handler = new LinkedHashMap<>();
 
 	private final Map<String, List<ModelWithoutShipmentScheduleVetoer>> tableName2Listeners = new HashMap<>();
 
@@ -149,8 +153,13 @@ public class ShipmentScheduleHandlerBL implements IShipmentScheduleHandlerBL
 	{
 		final LinkedHashSet<ShipmentScheduleId> result = new LinkedHashSet<>();
 
-		// Budget of models to process (created-or-vetoed), threaded across all handlers.
-		final Budget budget = new Budget(maxToProcess.toIntOr(Integer.MAX_VALUE));
+		// Budget of models to process (created-or-vetoed), threaded across all handlers in registration order.
+		// NOTE: this drains handlers sequentially in that order; an earlier handler with a full backlog can therefore
+		// use up the whole budget before a later one gets a turn. That is acceptable here because the processor
+		// re-enqueues follow-up work packages until nothing remains, so every handler is eventually served across
+		// successive runs. If strict per-run fairness across handlers is ever required, distribute the budget
+		// (e.g. round-robin) instead of draining in order.
+		final Budget budget = new Budget(maxToProcess.toIntOrInfinit());
 
 		for (final String tableName : tableName2Handler.keySet())
 		{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
@@ -164,14 +164,13 @@ public class ShipmentScheduleHandlerBL implements IShipmentScheduleHandlerBL
 		// re-enqueues follow-up work packages until nothing remains, so every handler is eventually served across
 		// successive runs. If strict per-run fairness across handlers is ever required, distribute the budget
 		// (e.g. round-robin) instead of draining in order.
-		final Budget budget = new Budget(maxToProcess.toIntOrInfinit());
+		final Budget budget = new Budget(maxToProcess);
 
 		for (final String tableName : tableName2Handler.keySet())
 		{
 			if (budget.isLimitReached())
 			{
-				// Budget already exhausted by a previous handler and there is still work left (see Budget javadoc);
-				// don't even start the next handler's iterator.
+				// Budget already fully consumed by a previous handler; don't even start the next handler's iterator.
 				break;
 			}
 
@@ -198,13 +197,17 @@ public class ShipmentScheduleHandlerBL implements IShipmentScheduleHandlerBL
 
 		final LinkedHashSet<ShipmentScheduleId> result = new LinkedHashSet<>();
 
-		final Iterator<?> missingCandidateModels = handler.retrieveModelsWithMissingCandidates(ctx, ITrx.TRXNAME_ThreadInherited);
+		// Retrieve only up to the CURRENT remaining budget: pushing the limit into the retrieve itself (instead of
+		// merely capping how many of an unlimited result we process) avoids materializing the whole missing-candidates
+		// backlog -- which OPTION_GuaranteedIteratorRequired otherwise selects in full, tens of thousands of rows on
+		// every batch run -- see OrderLineShipmentScheduleHandler#retrieveModelsWithMissingCandidates.
+		final Iterator<?> missingCandidateModels = handler.retrieveModelsWithMissingCandidates(ctx, ITrx.TRXNAME_ThreadInherited, budget.toQueryLimit());
 		while (missingCandidateModels.hasNext())
 		{
 			if (!budget.hasRemaining())
 			{
-				// the iterator still has a next model, but we ran out of budget => there is more work remaining
-				budget.setLimitReached();
+				// Defensive only: with the limited retrieve above, the iterator should never yield more than the
+				// budget that was passed to it.
 				break;
 			}
 
@@ -221,36 +224,57 @@ public class ShipmentScheduleHandlerBL implements IShipmentScheduleHandlerBL
 
 	/**
 	 * Mutable budget of models (created-or-vetoed) still allowed to be processed, shared across all handlers invoked
-	 * by a single {@link #createMissingCandidates(Properties, QueryLimit)} call.
+	 * by a single {@link #createMissingCandidates(Properties, QueryLimit)} call. Also hands out the CURRENT remaining
+	 * budget as a {@link QueryLimit} so each handler's retrieve fetches only up to what this run can still process
+	 * (see {@link #invokeHandler(Properties, ShipmentScheduleHandler, Budget)}).
 	 */
 	private static final class Budget
 	{
+		private final boolean unlimited;
 		private int remaining;
-		private boolean limitReached;
 
-		private Budget(final int remaining)
+		private Budget(@NonNull final QueryLimit maxToProcess)
 		{
-			this.remaining = remaining;
+			this.unlimited = maxToProcess.isNoLimit();
+			this.remaining = maxToProcess.toIntOrInfinit();
 		}
 
 		private boolean hasRemaining()
 		{
-			return remaining > 0;
+			return unlimited || remaining > 0;
+		}
+
+		private QueryLimit toQueryLimit()
+		{
+			return unlimited ? QueryLimit.NO_LIMIT : QueryLimit.ofInt(remaining);
 		}
 
 		private void consumeOne()
 		{
-			remaining--;
+			if (!unlimited)
+			{
+				remaining--;
+			}
 		}
 
-		private void setLimitReached()
-		{
-			limitReached = true;
-		}
-
+		/**
+		 * {@code true} iff the combined budget was fully consumed across all handlers in this run (i.e. {@code remaining==0}).
+		 * <p>
+		 * With the per-handler retrieve now capped to the remaining budget (see {@link #toQueryLimit()}), an iterator can
+		 * no longer signal "more work exists" via a leftover {@code hasNext()} -- the query itself never returns more than
+		 * the budget allows. So budget-exhaustion is the only remaining signal that a follow-up run may be needed.
+		 * <p>
+		 * Never {@code true} for an unlimited budget ({@link QueryLimit#NO_LIMIT}) -- that variant always means
+		 * "process everything in one go".
+		 * <p>
+		 * Note: when the backlog is an exact multiple of {@code maxToProcess}, this causes exactly ONE extra follow-up
+		 * run that finds and processes 0 models (a fresh {@code Budget} whose {@code remaining} then stays at the full
+		 * {@code maxToProcess}) -- that run's own {@link #isLimitReached()} correctly reports {@code false}, so the
+		 * re-enqueue chain terminates.
+		 */
 		private boolean isLimitReached()
 		{
-			return limitReached;
+			return !unlimited && remaining <= 0;
 		}
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
@@ -2,10 +2,12 @@ package de.metas.inoutcandidate.api.impl;
 
 import ch.qos.logback.classic.Level;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import de.metas.cache.CCache;
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.IMsgBL;
 import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.api.CreateMissingCandidatesResult;
 import de.metas.inoutcandidate.api.IDeliverRequest;
 import de.metas.inoutcandidate.api.IShipmentScheduleHandlerBL;
 import de.metas.inoutcandidate.model.I_M_IolCandHandler;
@@ -21,6 +23,7 @@ import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
@@ -138,22 +141,40 @@ public class ShipmentScheduleHandlerBL implements IShipmentScheduleHandlerBL
 	@Override
 	public Set<ShipmentScheduleId> createMissingCandidates(@NonNull final Properties ctx)
 	{
+		return createMissingCandidates(ctx, QueryLimit.NO_LIMIT).getCreatedShipmentScheduleIds();
+	}
+
+	@Override
+	public CreateMissingCandidatesResult createMissingCandidates(@NonNull final Properties ctx, @NonNull final QueryLimit maxToProcess)
+	{
 		final LinkedHashSet<ShipmentScheduleId> result = new LinkedHashSet<>();
+
+		// Budget of models to process (created-or-vetoed), threaded across all handlers.
+		final Budget budget = new Budget(maxToProcess.toIntOr(Integer.MAX_VALUE));
 
 		for (final String tableName : tableName2Handler.keySet())
 		{
+			if (budget.isLimitReached())
+			{
+				// Budget already exhausted by a previous handler and there is still work left (see Budget javadoc);
+				// don't even start the next handler's iterator.
+				break;
+			}
+
 			final ShipmentScheduleHandler handler = tableName2Handler.get(tableName);
 			try (final MDCCloseable ignored = MDC.putCloseable("ShipmentScheduleHandler.className", handler.getClass().getName()))
 			{
-				result.addAll(invokeHandler(ctx, handler));
+				result.addAll(invokeHandler(ctx, handler, budget));
 			}
 		}
-		return result;
+
+		return new CreateMissingCandidatesResult(ImmutableSet.copyOf(result), budget.isLimitReached());
 	}
 
 	private LinkedHashSet<ShipmentScheduleId> invokeHandler(
 			@NonNull final Properties ctx,
-			@NonNull final ShipmentScheduleHandler handler)
+			@NonNull final ShipmentScheduleHandler handler,
+			@NonNull final Budget budget)
 	{
 		final String handlerClassName = handler.getClass().getName();
 
@@ -166,14 +187,57 @@ public class ShipmentScheduleHandlerBL implements IShipmentScheduleHandlerBL
 		final Iterator<?> missingCandidateModels = handler.retrieveModelsWithMissingCandidates(ctx, ITrx.TRXNAME_ThreadInherited);
 		while (missingCandidateModels.hasNext())
 		{
+			if (!budget.hasRemaining())
+			{
+				// the iterator still has a next model, but we ran out of budget => there is more work remaining
+				budget.setLimitReached();
+				break;
+			}
+
 			final Object model = missingCandidateModels.next();
 			try (final MDCCloseable ignored = TableRecordMDC.putTableRecordReference(model))
 			{
 				result.addAll(invokeHandlerForModel(ctx, handler, handlerRecord, model));
 			}
+			budget.consumeOne();
 		}
 		Loggables.withLogger(logger, Level.DEBUG).addLog("ShipmentScheduleHandler {} created {} shipment schedules", handler, result.size());
 		return result;
+	}
+
+	/**
+	 * Mutable budget of models (created-or-vetoed) still allowed to be processed, shared across all handlers invoked
+	 * by a single {@link #createMissingCandidates(Properties, QueryLimit)} call.
+	 */
+	private static final class Budget
+	{
+		private int remaining;
+		private boolean limitReached;
+
+		private Budget(final int remaining)
+		{
+			this.remaining = remaining;
+		}
+
+		private boolean hasRemaining()
+		{
+			return remaining > 0;
+		}
+
+		private void consumeOne()
+		{
+			remaining--;
+		}
+
+		private void setLimitReached()
+		{
+			limitReached = true;
+		}
+
+		private boolean isLimitReached()
+		{
+			return limitReached;
+		}
 	}
 
 	private LinkedHashSet<ShipmentScheduleId> invokeHandlerForModel(

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/async/CreateMissingShipmentSchedulesWorkpackageProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/async/CreateMissingShipmentSchedulesWorkpackageProcessor.java
@@ -31,7 +31,7 @@ import de.metas.async.api.IWorkPackageQueue;
 import de.metas.async.model.I_C_Queue_WorkPackage;
 import de.metas.async.processor.IWorkPackageQueueFactory;
 import de.metas.async.spi.WorkpackageProcessorAdapter;
-import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.api.CreateMissingCandidatesResult;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleHandlerBL;
 import de.metas.inoutcandidate.api.IShipmentSchedulePA;
@@ -42,14 +42,17 @@ import de.metas.util.ILoggable;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.ad.dao.QueryLimit;
+import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ISysConfigBL;
 import org.adempiere.util.lang.IContextAware;
 import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Properties;
-import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Workpackage used to create missing shipment schedules.
@@ -59,6 +62,9 @@ import java.util.Set;
 public class CreateMissingShipmentSchedulesWorkpackageProcessor extends WorkpackageProcessorAdapter
 {
 	private static final Logger logger = LogManager.getLogger(CreateMissingShipmentSchedulesWorkpackageProcessor.class);
+
+	private static final String SYSCONFIG_MaxToProcess = "de.metas.inoutcandidate.async.CreateMissingShipmentSchedulesWorkpackageProcessor.MaxToProcess";
+	private static final int DEFAULT_MaxToProcess = 500;
 
 	public static void scheduleIfNotPostponed(final IContextAware ctxAware)
 	{
@@ -125,26 +131,76 @@ public class CreateMissingShipmentSchedulesWorkpackageProcessor extends Workpack
 
 	// services
 	private final transient IShipmentScheduleHandlerBL inOutCandHandlerBL = Services.get(IShipmentScheduleHandlerBL.class);
+	private final transient ITrxManager trxManager = Services.get(ITrxManager.class);
+	private final transient ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 
 	@Override
-	public Result processWorkPackage(@NonNull final I_C_Queue_WorkPackage workpackage, final String localTrxName_NOTUSED)
+	public final boolean isRunInTransaction()
 	{
+		return false; // run out of transaction; we bound our own batch to an explicit, short-lived trx below instead
+	}
+
+	@Override
+	public Result processWorkPackage(@NonNull final I_C_Queue_WorkPackage workpackage, final String localTrxName)
+	{
+		trxManager.assertTrxNameNull(localTrxName);
+
 		final Properties ctx = InterfaceWrapperHelper.getCtx(workpackage);
+		final QueryLimit maxToProcess = QueryLimit.ofInt(getMaxToProcess());
 
-		final Set<ShipmentScheduleId> shipmentScheduleIds = inOutCandHandlerBL.createMissingCandidates(ctx);
+		// Create+invalidate one bounded batch of missing shipment schedules in its own transaction. Justification for
+		// runInNewTrx (see the "runInNewTrx is a hack" gotcha): we deliberately want a SHORT, bounded transaction here
+		// instead of one unbounded transaction for the whole backlog (which OOMs on a large backlog) -- that is the
+		// whole point of this processor's batching.
+		final AtomicReference<CreateMissingCandidatesResult> resultHolder = new AtomicReference<>();
+		trxManager.runInNewTrx(() -> {
+			final CreateMissingCandidatesResult result = inOutCandHandlerBL.createMissingCandidates(ctx, maxToProcess);
+			resultHolder.set(result);
 
-		// After shipment schedules where created, invalidate them because we want to make sure they are up2date.
-		final IShipmentScheduleInvalidateBL invalidSchedulesService = Services.get(IShipmentScheduleInvalidateBL.class);
-		final IShipmentSchedulePA shipmentScheduleDAO = Services.get(IShipmentSchedulePA.class);
+			// After shipment schedules where created, invalidate them because we want to make sure they are up2date.
+			final IShipmentScheduleInvalidateBL invalidSchedulesService = Services.get(IShipmentScheduleInvalidateBL.class);
+			final IShipmentSchedulePA shipmentScheduleDAO = Services.get(IShipmentSchedulePA.class);
 
-		final Collection<I_M_ShipmentSchedule> scheduleRecords = shipmentScheduleDAO.getByIds(shipmentScheduleIds).values();
-		for (final I_M_ShipmentSchedule scheduleRecord : scheduleRecords)
+			final Collection<I_M_ShipmentSchedule> scheduleRecords = shipmentScheduleDAO.getByIds(result.getCreatedShipmentScheduleIds()).values();
+			for (final I_M_ShipmentSchedule scheduleRecord : scheduleRecords)
+			{
+				invalidSchedulesService.notifySegmentChangedForShipmentScheduleInclSched(scheduleRecord);
+			}
+		});
+		final CreateMissingCandidatesResult result = resultHolder.get();
+
+		Loggables.addLog("Created " + result.getCreatedShipmentScheduleIds().size() + " candidates");
+
+		if (result.isLimitReached())
 		{
-			invalidSchedulesService.notifySegmentChangedForShipmentScheduleInclSched(scheduleRecord);
+			enqueueFollowUpWorkpackage(ctx, workpackage);
 		}
 
-		Loggables.addLog("Created " + shipmentScheduleIds.size() + " candidates");
 		return Result.SUCCESS;
 	}
 
+	private int getMaxToProcess()
+	{
+		return sysConfigBL.getIntValue(SYSCONFIG_MaxToProcess, DEFAULT_MaxToProcess);
+	}
+
+	/**
+	 * Enqueues a fresh workpackage (carrying over the current one's async batch) to create the shipment schedules that
+	 * remained after this run's bounded batch. Enqueues it directly instead of going through {@link #scheduleIfNotPostponed},
+	 * because that method's dedup guard (skip if &gt;1 processable workpackage already queued) does not apply here: we
+	 * KNOW there is more work left for this exact run and must not skip it.
+	 */
+	private void enqueueFollowUpWorkpackage(@NonNull final Properties ctx, @NonNull final I_C_Queue_WorkPackage workpackage)
+	{
+		final AsyncBatchId asyncBatchId = AsyncBatchId.ofRepoIdOrNull(workpackage.getC_Async_Batch_ID());
+
+		final IWorkPackageQueueFactory workPackageQueueFactory = Services.get(IWorkPackageQueueFactory.class);
+		workPackageQueueFactory
+				.getQueueForEnqueuing(ctx, CreateMissingShipmentSchedulesWorkpackageProcessor.class)
+				.newWorkPackage()
+				.setAsyncBatchId(asyncBatchId)
+				.buildAndEnqueue();
+
+		Loggables.addLog("Limit reached; enqueued a follow-up workpackage to create the remaining missing shipment schedules");
+	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/async/CreateMissingShipmentSchedulesWorkpackageProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/async/CreateMissingShipmentSchedulesWorkpackageProcessor.java
@@ -134,6 +134,7 @@ public class CreateMissingShipmentSchedulesWorkpackageProcessor extends Workpack
 	private final transient ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private final transient IShipmentScheduleInvalidateBL invalidSchedulesService = Services.get(IShipmentScheduleInvalidateBL.class);
 	private final transient IShipmentSchedulePA shipmentScheduleDAO = Services.get(IShipmentSchedulePA.class);
+	private final transient IWorkPackageQueueFactory workPackageQueueFactory = Services.get(IWorkPackageQueueFactory.class);
 
 	@Override
 	public final boolean isRunInTransaction()
@@ -150,29 +151,15 @@ public class CreateMissingShipmentSchedulesWorkpackageProcessor extends Workpack
 		final QueryLimit maxToProcess = QueryLimit.ofInt(getMaxToProcess());
 
 		// Create+invalidate one bounded batch of missing shipment schedules in its own transaction.
-		// Why callInNewTrx here: this processor runs out-of-transaction (isRunInTransaction()==false), so there is NO
-		// ambient trx; we deliberately open ONE short, bounded transaction per batch instead of a single unbounded
-		// transaction for the whole backlog (which OOMs on a large backlog) -- that bounded batching is the whole point
-		// of this processor. The two effects (create + by-id invalidation) MUST share this one transaction (see the
-		// notifySegmentChangedForShipmentScheduleInclSched call below).
+		// Why callInThreadInheritedTrx here: this processor runs out-of-transaction (isRunInTransaction()==false), so
+		// there is NO ambient trx; callInThreadInheritedTrx then starts a new trx (and commits/closes it) -- giving us
+		// ONE short, bounded transaction per batch instead of a single unbounded transaction for the whole backlog
+		// (which OOMs on a large backlog) -- that bounded batching is the whole point of this processor. The two
+		// effects (create + by-id invalidation) MUST share this one transaction (see processOneBatch below).
 		// This is NOT removable: the batching design requires exactly one bounded, atomic trx per batch; removing it
 		// would either restore the unbounded-single-trx OOM, or split creation and by-id flagging across transactions
 		// and break the same-trx invalidation invariant documented in de/metas/inoutcandidate/CLAUDE.md.
-		final CreateMissingCandidatesResult result = trxManager.callInNewTrx(() -> {
-			final CreateMissingCandidatesResult batchResult = inOutCandHandlerBL.createMissingCandidates(ctx, maxToProcess);
-
-			// After shipment schedules were created, invalidate them (by id, in THIS same batch trx) because we want to
-			// make sure they are up2date. By-id flagging in the creating transaction is mandatory: the segment-based
-			// invalidation channel flushes on TRXNAME_None and cannot see this transaction's uncommitted inserts
-			// (invariant: de/metas/inoutcandidate/CLAUDE.md).
-			final Collection<I_M_ShipmentSchedule> scheduleRecords = shipmentScheduleDAO.getByIds(batchResult.getCreatedShipmentScheduleIds()).values();
-			for (final I_M_ShipmentSchedule scheduleRecord : scheduleRecords)
-			{
-				invalidSchedulesService.notifySegmentChangedForShipmentScheduleInclSched(scheduleRecord);
-			}
-
-			return batchResult;
-		});
+		final CreateMissingCandidatesResult result = trxManager.callInThreadInheritedTrx(() -> processOneBatch(ctx, maxToProcess));
 
 		Loggables.addLog("Created " + result.getCreatedShipmentScheduleIds().size() + " candidates");
 
@@ -190,6 +177,28 @@ public class CreateMissingShipmentSchedulesWorkpackageProcessor extends Workpack
 	}
 
 	/**
+	 * Creates one bounded batch of missing shipment schedules and, in the same (batch) transaction, invalidates them
+	 * by id. See the invocation site in {@link #processWorkPackage(I_C_Queue_WorkPackage, String)} for why both effects
+	 * must share that one transaction.
+	 */
+	private CreateMissingCandidatesResult processOneBatch(@NonNull final Properties ctx, @NonNull final QueryLimit maxToProcess)
+	{
+		final CreateMissingCandidatesResult batchResult = inOutCandHandlerBL.createMissingCandidates(ctx, maxToProcess);
+
+		// After shipment schedules were created, invalidate them (by id, in THIS same batch trx) because we want to
+		// make sure they are up2date. By-id flagging in the creating transaction is mandatory: the segment-based
+		// invalidation channel flushes on TRXNAME_None and cannot see this transaction's uncommitted inserts
+		// (invariant: de/metas/inoutcandidate/CLAUDE.md).
+		final Collection<I_M_ShipmentSchedule> scheduleRecords = shipmentScheduleDAO.getByIds(batchResult.getCreatedShipmentScheduleIds()).values();
+		for (final I_M_ShipmentSchedule scheduleRecord : scheduleRecords)
+		{
+			invalidSchedulesService.notifySegmentChangedForShipmentScheduleInclSched(scheduleRecord);
+		}
+
+		return batchResult;
+	}
+
+	/**
 	 * Enqueues a fresh workpackage (carrying over the current one's async batch) to create the shipment schedules that
 	 * remained after this run's bounded batch. Enqueues it directly instead of going through {@link #scheduleIfNotPostponed},
 	 * because that method's dedup guard (skip if &gt;1 processable workpackage already queued) does not apply here: we
@@ -200,9 +209,8 @@ public class CreateMissingShipmentSchedulesWorkpackageProcessor extends Workpack
 		final AsyncBatchId asyncBatchId = AsyncBatchId.ofRepoIdOrNull(workpackage.getC_Async_Batch_ID());
 
 		// Deliberately NOT bound to any trx (unlike _scheduleIfNotPostponed, which does bindToTrxName): this run's batch
-		// already committed inside the callInNewTrx above, so there is nothing left to defer the follow-up's readiness to
-		// -- it must become ready-for-processing immediately.
-		final IWorkPackageQueueFactory workPackageQueueFactory = Services.get(IWorkPackageQueueFactory.class);
+		// already committed inside the callInThreadInheritedTrx above, so there is nothing left to defer the follow-up's
+		// readiness to -- it must become ready-for-processing immediately.
 		workPackageQueueFactory
 				.getQueueForEnqueuing(ctx, CreateMissingShipmentSchedulesWorkpackageProcessor.class)
 				.newWorkPackage()

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/async/CreateMissingShipmentSchedulesWorkpackageProcessor.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/async/CreateMissingShipmentSchedulesWorkpackageProcessor.java
@@ -52,7 +52,6 @@ import org.slf4j.Logger;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Workpackage used to create missing shipment schedules.
@@ -133,6 +132,8 @@ public class CreateMissingShipmentSchedulesWorkpackageProcessor extends Workpack
 	private final transient IShipmentScheduleHandlerBL inOutCandHandlerBL = Services.get(IShipmentScheduleHandlerBL.class);
 	private final transient ITrxManager trxManager = Services.get(ITrxManager.class);
 	private final transient ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+	private final transient IShipmentScheduleInvalidateBL invalidSchedulesService = Services.get(IShipmentScheduleInvalidateBL.class);
+	private final transient IShipmentSchedulePA shipmentScheduleDAO = Services.get(IShipmentSchedulePA.class);
 
 	@Override
 	public final boolean isRunInTransaction()
@@ -148,26 +149,30 @@ public class CreateMissingShipmentSchedulesWorkpackageProcessor extends Workpack
 		final Properties ctx = InterfaceWrapperHelper.getCtx(workpackage);
 		final QueryLimit maxToProcess = QueryLimit.ofInt(getMaxToProcess());
 
-		// Create+invalidate one bounded batch of missing shipment schedules in its own transaction. Justification for
-		// runInNewTrx (see the "runInNewTrx is a hack" gotcha): we deliberately want a SHORT, bounded transaction here
-		// instead of one unbounded transaction for the whole backlog (which OOMs on a large backlog) -- that is the
-		// whole point of this processor's batching.
-		final AtomicReference<CreateMissingCandidatesResult> resultHolder = new AtomicReference<>();
-		trxManager.runInNewTrx(() -> {
-			final CreateMissingCandidatesResult result = inOutCandHandlerBL.createMissingCandidates(ctx, maxToProcess);
-			resultHolder.set(result);
+		// Create+invalidate one bounded batch of missing shipment schedules in its own transaction.
+		// Why callInNewTrx here: this processor runs out-of-transaction (isRunInTransaction()==false), so there is NO
+		// ambient trx; we deliberately open ONE short, bounded transaction per batch instead of a single unbounded
+		// transaction for the whole backlog (which OOMs on a large backlog) -- that bounded batching is the whole point
+		// of this processor. The two effects (create + by-id invalidation) MUST share this one transaction (see the
+		// notifySegmentChangedForShipmentScheduleInclSched call below).
+		// This is NOT removable: the batching design requires exactly one bounded, atomic trx per batch; removing it
+		// would either restore the unbounded-single-trx OOM, or split creation and by-id flagging across transactions
+		// and break the same-trx invalidation invariant documented in de/metas/inoutcandidate/CLAUDE.md.
+		final CreateMissingCandidatesResult result = trxManager.callInNewTrx(() -> {
+			final CreateMissingCandidatesResult batchResult = inOutCandHandlerBL.createMissingCandidates(ctx, maxToProcess);
 
-			// After shipment schedules where created, invalidate them because we want to make sure they are up2date.
-			final IShipmentScheduleInvalidateBL invalidSchedulesService = Services.get(IShipmentScheduleInvalidateBL.class);
-			final IShipmentSchedulePA shipmentScheduleDAO = Services.get(IShipmentSchedulePA.class);
-
-			final Collection<I_M_ShipmentSchedule> scheduleRecords = shipmentScheduleDAO.getByIds(result.getCreatedShipmentScheduleIds()).values();
+			// After shipment schedules were created, invalidate them (by id, in THIS same batch trx) because we want to
+			// make sure they are up2date. By-id flagging in the creating transaction is mandatory: the segment-based
+			// invalidation channel flushes on TRXNAME_None and cannot see this transaction's uncommitted inserts
+			// (invariant: de/metas/inoutcandidate/CLAUDE.md).
+			final Collection<I_M_ShipmentSchedule> scheduleRecords = shipmentScheduleDAO.getByIds(batchResult.getCreatedShipmentScheduleIds()).values();
 			for (final I_M_ShipmentSchedule scheduleRecord : scheduleRecords)
 			{
 				invalidSchedulesService.notifySegmentChangedForShipmentScheduleInclSched(scheduleRecord);
 			}
+
+			return batchResult;
 		});
-		final CreateMissingCandidatesResult result = resultHolder.get();
 
 		Loggables.addLog("Created " + result.getCreatedShipmentScheduleIds().size() + " candidates");
 
@@ -194,6 +199,9 @@ public class CreateMissingShipmentSchedulesWorkpackageProcessor extends Workpack
 	{
 		final AsyncBatchId asyncBatchId = AsyncBatchId.ofRepoIdOrNull(workpackage.getC_Async_Batch_ID());
 
+		// Deliberately NOT bound to any trx (unlike _scheduleIfNotPostponed, which does bindToTrxName): this run's batch
+		// already committed inside the callInNewTrx above, so there is nothing left to defer the follow-up's readiness to
+		// -- it must become ready-for-processing immediately.
 		final IWorkPackageQueueFactory workPackageQueueFactory = Services.get(IWorkPackageQueueFactory.class);
 		workPackageQueueFactory
 				.getQueueForEnqueuing(ctx, CreateMissingShipmentSchedulesWorkpackageProcessor.class)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule.java
@@ -120,7 +120,7 @@ public class M_ShipmentSchedule
 
 	/**
 	 * If a shipment schedule is deleted, then this method makes sure that all {@link I_M_IolCandHandler_Log} records which refer to the same record as the schedule are also deleted.<br>
-	 * Otherwise, that referenced record would never be considered again by {@link de.metas.inoutcandidate.spi.ShipmentScheduleHandler#retrieveModelsWithMissingCandidates(Properties, String)}.
+	 * Otherwise, that referenced record would never be considered again by {@link de.metas.inoutcandidate.spi.ShipmentScheduleHandler#retrieveModelsWithMissingCandidates(Properties, String, org.adempiere.ad.dao.QueryLimit)}.
 	 *
 	 * Task 08288
 	 */

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/ShipmentScheduleHandler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/ShipmentScheduleHandler.java
@@ -15,6 +15,7 @@ import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.AttributeId;
 import de.metas.organization.OrgId;
@@ -111,8 +112,12 @@ public abstract class ShipmentScheduleHandler
 	 * <li>The framework will create a {@link I_M_IolCandHandler_Log} record for every object returned by this method.</li>
 	 * <li>Implementors should check for <code>I_M_IolCandHandler_Log</code> to make sure that they don't repeatedly return records are then vetoed by some {@link ModelWithoutShipmentScheduleVetoer}</li>
 	 * </ul>
+	 *
+	 * @param limit budget of models still allowed to be processed in the current run; implementors MUST apply this as
+	 * a query limit so that they don't materialize the whole (potentially huge) backlog. Use {@link org.adempiere.ad.dao.QueryLimit#NO_LIMIT}
+	 * to retrieve everything in one go.
 	 */
-	public abstract Iterator<?> retrieveModelsWithMissingCandidates(Properties ctx, String trxName);
+	public abstract Iterator<?> retrieveModelsWithMissingCandidates(Properties ctx, String trxName, QueryLimit limit);
 
 	/**
 	 * Creates missing candidates for the given model.

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/inoutcandidate/OrderLineShipmentScheduleHandler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/inoutcandidate/OrderLineShipmentScheduleHandler.java
@@ -38,6 +38,7 @@ import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.dao.impl.TypedSqlQueryFilter;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
@@ -349,7 +350,8 @@ public class OrderLineShipmentScheduleHandler extends ShipmentScheduleHandler
 	@Override
 	public Iterator<?> retrieveModelsWithMissingCandidates(
 			final Properties ctx,
-			final String trxName)
+			final String trxName,
+			@NonNull final QueryLimit limit)
 	{
 		// task 08896: don't use the where clause with all those INs.
 		// Its performance can turn catastrophic for large numbers or orderlines and orders.
@@ -358,12 +360,16 @@ public class OrderLineShipmentScheduleHandler extends ShipmentScheduleHandler
 		final String wc = " C_OrderLine_ID IN ( select C_OrderLine_ID from C_OrderLine_ID_With_Missing_ShipmentSchedule_v ) ";
 		final TypedSqlQueryFilter<I_C_OrderLine> orderLinesFilter = TypedSqlQueryFilter.of(wc);
 
+		// Note: the query limit is pushed down here (not only enforced by the caller's processing budget) so that
+		// OPTION_GuaranteedIteratorRequired below only ever materializes a selection of up to `limit` rows instead of
+		// the whole (potentially huge, tens-of-thousands rows) missing-schedule backlog on every batch run.
 		return queryBL
 				.createQueryBuilder(I_C_OrderLine.class)
 				.addOnlyActiveRecordsFilter()
 				.filter(orderLinesFilter)
 				.addOnlyContextClient(ctx)
 				.orderBy().addColumn(I_C_OrderLine.COLUMNNAME_C_OrderLine_ID).endOrderBy()
+				.setLimit(limit)
 				.create()
 				.setOption(IQuery.OPTION_GuaranteedIteratorRequired, true)
 				.setOption(IQuery.OPTION_IteratorBufferSize, 500)

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL_createMissingCandidates_Test.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL_createMissingCandidates_Test.java
@@ -1,0 +1,270 @@
+package de.metas.inoutcandidate.api.impl;
+
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableList;
+import de.metas.inoutcandidate.api.CreateMissingCandidatesResult;
+import de.metas.inoutcandidate.api.IDeliverRequest;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.inoutcandidate.spi.ShipmentScheduleHandler;
+import org.adempiere.ad.dao.QueryLimit;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_OrderLine;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.adempiere.model.InterfaceWrapperHelper.getId;
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers {@link ShipmentScheduleHandlerBL#createMissingCandidates(Properties, QueryLimit)} -- the bounded batching
+ * entry point plus the cross-handler {@code Budget} it threads across all registered {@link ShipmentScheduleHandler}s.
+ */
+class ShipmentScheduleHandlerBL_createMissingCandidates_Test
+{
+	private ShipmentScheduleHandlerBL shipmentScheduleHandlerBL;
+	private Properties ctx;
+
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+		shipmentScheduleHandlerBL = new ShipmentScheduleHandlerBL();
+		ctx = Env.getCtx();
+	}
+
+	@Test
+	void boundedBatch_processesExactlyTheLimit_andReportsLimitReached()
+	{
+		final TestHandler handler = new TestHandler(I_C_OrderLine.Table_Name);
+		handler.addMissingModels(5, I_C_OrderLine.class);
+		shipmentScheduleHandlerBL.registerHandler(handler);
+
+		final CreateMissingCandidatesResult result = shipmentScheduleHandlerBL.createMissingCandidates(ctx, QueryLimit.ofInt(3));
+
+		assertThat(handler.createCandidatesForCallCount).isEqualTo(3);
+		assertThat(result.getCreatedShipmentScheduleIds()).hasSize(3);
+		assertThat(result.isLimitReached()).isTrue();
+		// the 3 unprocessed models remain missing for a follow-up run
+		assertThat(handler.remainingMissingCount()).isEqualTo(2);
+	}
+
+	@Test
+	void exactMultiple_processesAll_limitReached_thenFollowUpRunFindsNothing()
+	{
+		final TestHandler handler = new TestHandler(I_C_OrderLine.Table_Name);
+		handler.addMissingModels(3, I_C_OrderLine.class);
+		shipmentScheduleHandlerBL.registerHandler(handler);
+
+		// first run: budget == backlog size exactly
+		final CreateMissingCandidatesResult firstResult = shipmentScheduleHandlerBL.createMissingCandidates(ctx, QueryLimit.ofInt(3));
+
+		assertThat(handler.createCandidatesForCallCount).isEqualTo(3);
+		assertThat(firstResult.getCreatedShipmentScheduleIds()).hasSize(3);
+		assertThat(firstResult.isLimitReached())
+				.as("budget was fully consumed by the exact-size backlog -- a follow-up run must be enqueued")
+				.isTrue();
+		assertThat(handler.remainingMissingCount()).isZero();
+
+		// follow-up run: nothing left to process -- must terminate the re-enqueue chain
+		final CreateMissingCandidatesResult followUpResult = shipmentScheduleHandlerBL.createMissingCandidates(ctx, QueryLimit.ofInt(3));
+
+		assertThat(handler.createCandidatesForCallCount)
+				.as("no further model was processed in the follow-up run")
+				.isEqualTo(3);
+		assertThat(followUpResult.getCreatedShipmentScheduleIds()).isEmpty();
+		assertThat(followUpResult.isLimitReached())
+				.as("an empty run must report false, or the re-enqueue chain would never terminate")
+				.isFalse();
+	}
+
+	@Test
+	void noLimit_processesEverything_andNeverReportsLimitReached()
+	{
+		final TestHandler handler = new TestHandler(I_C_OrderLine.Table_Name);
+		handler.addMissingModels(7, I_C_OrderLine.class);
+		shipmentScheduleHandlerBL.registerHandler(handler);
+
+		final CreateMissingCandidatesResult result = shipmentScheduleHandlerBL.createMissingCandidates(ctx, QueryLimit.NO_LIMIT);
+
+		assertThat(handler.createCandidatesForCallCount).isEqualTo(7);
+		assertThat(result.getCreatedShipmentScheduleIds()).hasSize(7);
+		assertThat(result.isLimitReached()).isFalse();
+		assertThat(handler.remainingMissingCount()).isZero();
+	}
+
+	@Test
+	void crossHandlerBudget_isThreadedInRegistrationOrder_andSpillsOverIntoTheSecondHandler()
+	{
+		final TestHandler firstHandler = new TestHandler(I_C_OrderLine.Table_Name);
+		firstHandler.addMissingModels(2, I_C_OrderLine.class);
+		final TestHandler secondHandler = new TestHandler(I_C_Order.Table_Name);
+		secondHandler.addMissingModels(4, I_C_Order.class);
+
+		// registration order matters: budget drains handlers in this order
+		shipmentScheduleHandlerBL.registerHandler(firstHandler);
+		shipmentScheduleHandlerBL.registerHandler(secondHandler);
+
+		// budget=5: first handler's 2 models fully drain (using up 2), remaining 3 spill into the second handler
+		final CreateMissingCandidatesResult result = shipmentScheduleHandlerBL.createMissingCandidates(ctx, QueryLimit.ofInt(5));
+
+		assertThat(firstHandler.createCandidatesForCallCount).isEqualTo(2);
+		assertThat(firstHandler.remainingMissingCount()).isZero();
+
+		assertThat(secondHandler.retrieveWasCalled).isTrue();
+		assertThat(secondHandler.lastLimitPassed).isEqualTo(QueryLimit.ofInt(3));
+		assertThat(secondHandler.createCandidatesForCallCount).isEqualTo(3);
+		assertThat(secondHandler.remainingMissingCount()).isEqualTo(1);
+
+		assertThat(result.getCreatedShipmentScheduleIds()).hasSize(5);
+		assertThat(result.isLimitReached()).isTrue();
+	}
+
+	@Test
+	void crossHandlerBudget_exhaustedByFirstHandler_secondHandlerIsNeverOpened()
+	{
+		final TestHandler firstHandler = new TestHandler(I_C_OrderLine.Table_Name);
+		firstHandler.addMissingModels(5, I_C_OrderLine.class);
+		final TestHandler secondHandler = new TestHandler(I_C_Order.Table_Name);
+		secondHandler.addMissingModels(4, I_C_Order.class);
+
+		shipmentScheduleHandlerBL.registerHandler(firstHandler);
+		shipmentScheduleHandlerBL.registerHandler(secondHandler);
+
+		// budget=3: fully consumed by the first handler alone
+		final CreateMissingCandidatesResult result = shipmentScheduleHandlerBL.createMissingCandidates(ctx, QueryLimit.ofInt(3));
+
+		assertThat(firstHandler.createCandidatesForCallCount).isEqualTo(3);
+		assertThat(firstHandler.remainingMissingCount()).isEqualTo(2);
+
+		assertThat(secondHandler.retrieveWasCalled)
+				.as("budget was already exhausted by the first handler; the second handler's iterator must never be opened")
+				.isFalse();
+		assertThat(secondHandler.createCandidatesForCallCount).isZero();
+
+		assertThat(result.getCreatedShipmentScheduleIds()).hasSize(3);
+		assertThat(result.isLimitReached()).isTrue();
+	}
+
+	/**
+	 * Test double for {@link ShipmentScheduleHandler}: models "missing a candidate" are tracked as an ordered map of
+	 * (id -> model). {@link #retrieveModelsWithMissingCandidates} returns only up to the given {@code limit} of the
+	 * still-missing models (in insertion order), mirroring how a real handler's bounded query behaves. Once
+	 * {@link #createCandidatesFor} is invoked for a model, it is removed from the missing set -- so a follow-up
+	 * {@code retrieveModelsWithMissingCandidates} call correctly no longer returns it.
+	 */
+	private static class TestHandler extends ShipmentScheduleHandler
+	{
+		private final String tableName;
+		private final Map<Integer, Object> missingModelsById = new LinkedHashMap<>();
+
+		int createCandidatesForCallCount = 0;
+		boolean retrieveWasCalled = false;
+		QueryLimit lastLimitPassed;
+
+		TestHandler(final String tableName)
+		{
+			this.tableName = tableName;
+		}
+
+		void addMissingModels(final int count, final Class<?> modelClass)
+		{
+			for (int i = 0; i < count; i++)
+			{
+				final Object model = newInstance(modelClass);
+				saveRecord(model);
+				missingModelsById.put(getId(model), model);
+			}
+		}
+
+		int remainingMissingCount()
+		{
+			return missingModelsById.size();
+		}
+
+		@Override
+		public Iterator<?> retrieveModelsWithMissingCandidates(final Properties ctx, final String trxName, final QueryLimit limit)
+		{
+			retrieveWasCalled = true;
+			lastLimitPassed = limit;
+
+			final int max = limit.toIntOrInfinit();
+			final List<Object> result = new ArrayList<>();
+			for (final Object model : missingModelsById.values())
+			{
+				if (result.size() >= max)
+				{
+					break;
+				}
+				result.add(model);
+			}
+			return result.iterator();
+		}
+
+		@Override
+		public List<I_M_ShipmentSchedule> createCandidatesFor(final Object model)
+		{
+			createCandidatesForCallCount++;
+			missingModelsById.remove(getId(model));
+
+			// unsaved on purpose: the framework (ShipmentScheduleHandlerBL.invokeHandlerForModel) saves it
+			final I_M_ShipmentSchedule newSched = newInstance(I_M_ShipmentSchedule.class);
+			return ImmutableList.of(newSched);
+		}
+
+		@Override
+		public void updateShipmentScheduleFromReferencedRecord(final I_M_ShipmentSchedule shipmentSchedule)
+		{
+			// not exercised by these tests
+		}
+
+		@Override
+		public void invalidateCandidatesFor(final Object model)
+		{
+			// not exercised by these tests
+		}
+
+		@Override
+		public String getSourceTable()
+		{
+			return tableName;
+		}
+
+		@Override
+		public IDeliverRequest createDeliverRequest(final I_M_ShipmentSchedule sched, final I_C_OrderLine salesOrderLine)
+		{
+			throw new UnsupportedOperationException("not exercised by these tests");
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`CreateMissingShipmentSchedulesWorkpackageProcessor` created ALL missing shipment schedules in a single unbounded transaction, and its handler retrieve materialized a guaranteed-iterator selection over the ENTIRE missing-order-line backlog. On a large backlog this holds one long-running transaction and exhausts heap (`OutOfMemoryError`), stalling the async work-package queue.

## Change

Process missing order lines in **bounded, re-enqueued batches** (mirrors `UpdateInvalidInvoiceCandidatesWorkpackageProcessor`):

- Processor runs **out of transaction** (`isRunInTransaction() = false`).
- Each run processes at most `MaxToProcess` models inside one short batch run via `trxManager.callInThreadInheritedTrx(() -> processOneBatch(...))` (starts + commits/closes a new trx when none is inherited). Batch size via sysconfig `de.metas.inoutcandidate.async.CreateMissingShipmentSchedulesWorkpackageProcessor.MaxToProcess` (code default 500).
- When work remains, it enqueues a follow-up work package (carrying the `AsyncBatchId`); draining the chain creates all missing schedules.
- `IShipmentScheduleHandlerBL.createMissingCandidates(ctx, QueryLimit)` returns `CreateMissingCandidatesResult { createdShipmentScheduleIds, limitReached }`. The no-arg overload is now `@Deprecated` (delegates unlimited — unchanged behaviour; the unbounded path can OOM on a large backlog).
- **The batch limit is pushed down into the retrieve**: `ShipmentScheduleHandler#retrieveModelsWithMissingCandidates(ctx, trxName, QueryLimit)` now applies `.setLimit(limit)` (`OrderLineShipmentScheduleHandler`, `SubscriptionShipmentScheduleHandler`), so each batch materializes at most `limit` rows instead of the whole backlog. ORDER BY is preserved → deterministic first-N → forward progress.

## Result

- No single transaction spans the whole backlog, and the retrieve no longer buffers the entire backlog → no OOM, no multi-hour transaction.
- `getByIds` runs on a bounded (≤ limit) id set — no unbounded IN-clause.
- End result identical to the unbounded run: same schedules created, none missed or duplicated. `limitReached` uses budget-exhaustion; an exact-multiple-of-batch backlog causes at most one extra empty follow-up run, which terminates.

## Tests

- New cucumber scenario `createMissingShipmentSchedulesBatching.feature`: with `MaxToProcess = 2` and a 5-line sales order, one processor run creates exactly 2 schedules and re-enqueues a follow-up WP; draining creates all 5 with no pending WP left. A deterministic single-work-package-run step drives the processor directly to avoid background-drain flakiness.
- Unit tests for `createMissingCandidates(ctx, QueryLimit)` / the `Budget` cross-handler logic (bounded path, exact-multiple edge, NO_LIMIT, cross-handler threading).
- Existing `CreateMissingShipmentSchedulesWorkpackageProcessorTest` unchanged and green.

## Notes

- A manual, admin-triggered path (`M_ShipmentSchedule_Update` → `ShipmentScheduleUpdater`) still calls the deprecated unbounded overload; it is not the automated feed that caused the incident and is documented for a possible follow-up.

## Known limitation

A single order line that throws during creation rolls back its **entire batch transaction** (every creation in that run, up to `MaxToProcess`, is undone) and the work package errors — halting the re-enqueue chain at that batch until the offending line is corrected. No infinite loop; blast radius is one batch, and the drain resumes once the poison line is fixed. Still strictly better than the previous whole-backlog single-transaction failure. To be addressed separately.
