### PR TITLE
mobile-webui e2e: guard the workflow-start bounce-to-home behaviour

### DIFF
--- a/e2e/mobile-webui/tests/spec/wfStartBounceHome.spec.js
+++ b/e2e/mobile-webui/tests/spec/wfStartBounceHome.spec.js
@@ -1,0 +1,323 @@
+/**
+ * TL;DR — Regression guard for the mobile-workflow "bounce-to-home" race at workflow start.
+ *
+ * The bug: starting a workflow from a launcher could drop the operator back on the home menu
+ * (ApplicationsListScreen) mid-start instead of landing on the job (WF-process) screen. Two
+ * independent races produced it:
+ *   - Race A (reducer): a stale POPULATE_LAUNCHERS_COMPLETE snapshot, fetched before the start
+ *     resolved, pruned the just-started wfProcess from the store.
+ *   - Race B (ApplicationLayout redirect-home guard): on React 17 / connected-react-router the
+ *     store update and the route change are not batched, so ApplicationLayout can mount on the job
+ *     route one render pass before the store selector observes the just-dispatched process; the
+ *     guard used to fire goHome() synchronously on that first pass. The guard now defers goHome()
+ *     one macrotask (setTimeout(...,0)) and cancels it in cleanup if the process becomes loaded
+ *     within the tick — so a real start no longer bounces, while a genuinely-absent process still
+ *     redirects.
+ *
+ * The three scenarios below are the end-to-end guard for that behaviour:
+ *   1. No-bounce on workflow start — the key regression guard. Covers BOTH a picking launcher and a
+ *      distribution launcher (the two launcher paths Race B protects). Goes RED if Race B (the
+ *      synchronous goHome) regresses.
+ *   2. Dead deep-link (cold navigate to a WF-process URL whose process is not in the store) still
+ *      redirects home — proves the deferred goHome still fires for a genuinely-absent process.
+ *   3. Reload while a job is open. Two real behaviours, one test:
+ *      (a) a PLAIN reload KEEPS the operator in the job — the redux store is persisted to
+ *          localStorage and re-hydrated on boot (intentional F5-resilience, mirroring the auth
+ *          token which is kept in a cookie), so the process is still loaded and the guard does not
+ *          fire; and
+ *      (b) when the re-hydrated store does NOT contain the process (localStorage evicted / private
+ *          mode / a fresh browser opening a bookmarked deep-link — the auth cookie still carries the
+ *          session), the boot-time guard still redirects home rather than hanging on a blank job
+ *          frame. This is the same dead-deep-link class as scenario 2, reached via the cold-boot path.
+ *
+ * NOTE on 3(a): a plain reload does NOT redirect home in this app (verified) because wfProcesses is
+ * persisted+re-hydrated. Forcing a redirect on a plain reload would require fabricating a state the
+ * real reload cannot produce; instead 3(b) clears the persisted store to model the genuine
+ * absent-process boot the guard actually protects.
+ *
+ *   4. Stale launchers refresh after start (Race A, deterministic) — reproduces the PRIMARY production
+ *      trigger with real network timing: a launchers-query issued before the start (so its snapshot
+ *      does not list the just-started process) whose response is delivered AFTER the start. Without
+ *      Race A's fix that stale snapshot prunes the just-started wfProcess and the operator bounces
+ *      home; with the fix the process is kept (its local update is newer than the request that fetched
+ *      the snapshot). The pre-start request timing is forced deterministically by holding the query's
+ *      response (Playwright route interception) — a faithful model of a slow/reordered response, not a
+ *      fabricated state. Scenarios 1–3 exercise the observable contract but do NOT reliably reproduce
+ *      this timing on a fast local stack (the natural race window rarely opens); scenario 4 is the
+ *      deterministic RED-provable guard of the reducer fix.
+ *
+ * Scenario 1 is the assertion that must NOT be weakened: land on #WFProcessScreen and NOT bounce to
+ * #ApplicationsListScreen. Scenarios 2 & 3(b) assert the preserved redirect-home behaviour survives
+ * the goHome deferral (the guard's genuine purpose); 3(a) locks in the job-survives-F5 resilience;
+ * scenario 4 deterministically guards the stale-launchers prune.
+ */
+
+import { test } from "../../playwright.config";
+import { expect } from '@playwright/test';
+import { allure } from 'allure-playwright';
+import { Backend } from "../utils/screens/Backend";
+import { LoginScreen } from "../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobsListFiltersScreen } from "../utils/screens/picking/PickingJobsListFiltersScreen";
+import { DistributionJobsListScreen } from "../utils/screens/distribution/DistributionJobsListScreen";
+import { FRONTEND_BASE_URL, FAST_ACTION_TIMEOUT, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from "../utils/common";
+
+// Container ids of the three screens this guard distinguishes. These mirror the private
+// containerElement() ids in the screen page objects (ApplicationsListScreen / PickingJobScreen /
+// DistributionJobScreen / *JobsListScreen) — keep in sync if a screen id ever changes.
+const HOME_MENU = '#ApplicationsListScreen';
+const WF_PROCESS_SCREEN = '#WFProcessScreen';
+
+const createPickingMasterdata = async () => Backend.createMasterdata({
+    language: "en_US",
+    request: {
+        login: { user: { language: "en_US" } },
+        mobileConfig: {
+            picking: {
+                aggregationType: "sales_order",
+                allowPickingAnyCustomer: true,
+                createShipmentPolicy: 'CL',
+                allowPickingAnyHU: true,
+                pickTo: ['LU_TU'],
+                allowCompletingPartialPickingJob: false,
+            }
+        },
+        bpartners: { "BP1": {} },
+        warehouses: { "wh": {} },
+        pickingSlots: { slot1: {} },
+        products: { "P1": { prices: [{ price: 1 }] } },
+        packingInstructions: {
+            "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "P1", qtyCUsPerTU: 4 },
+        },
+        handlingUnits: { "HU1": { product: 'P1', warehouse: 'wh', packingInstructions: 'PI' } },
+        salesOrders: {
+            "SO1": {
+                bpartner: 'BP1',
+                warehouse: 'wh',
+                datePromised: '2025-03-01T00:00:00.000+02:00',
+                lines: [{ product: 'P1', qty: 12, piItemProduct: 'TU' }]
+            }
+        },
+    }
+});
+
+const createDistributionMasterdata = async () => Backend.createMasterdata({
+    language: "en_US",
+    request: {
+        login: { user: { language: "en_US" } },
+        mobileConfig: { distribution: {} },
+        resources: { "plantId": { type: "PT" } },
+        products: { "P1": {} },
+        warehouses: {
+            "wh1": {},
+            "wh2": {},
+            "whInTransit": { inTransit: true },
+        },
+        packingInstructions: {
+            "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "P1", qtyCUsPerTU: 4 },
+        },
+        handlingUnits: { "HU1": { product: 'P1', warehouse: 'wh1', qty: 100 } },
+        distributionOrders: {
+            "DD1": {
+                warehouseFrom: "wh1",
+                warehouseTo: "wh2",
+                warehouseInTransit: "whInTransit",
+                plant: "plantId",
+                lines: [{ product: "P1", qtyEntered: 100 }],
+            }
+        },
+    }
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Workflow start from a PICKING launcher lands on the job screen and does NOT bounce to home', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Workflow start does not bounce to the home menu (picking launcher)');
+    allure.severity('critical');
+
+    const masterdata = await createPickingMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+
+    // Tap the launcher DIRECTLY (not via PickingJobsListScreen.startJob, whose tap-and-recover helper
+    // re-taps the launcher if the job screen does not appear — that recovery would paper over a
+    // bounce-to-home). We want the raw first-tap outcome so a Race-B regression is observed as-is.
+    const launcher = page.locator('.wflauncher-button').filter({ hasText: masterdata.salesOrders.SO1.documentNo });
+    await launcher.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+    await launcher.tap();
+
+    // The behaviour under guard: we land on the WF-process (job) screen and are NOT bounced to home.
+    await expect(page.locator(WF_PROCESS_SCREEN)).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+    await expect(page.locator(HOME_MENU)).toHaveCount(0);
+    expect(page.url()).toContain('/picking/wf/');
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Workflow start from a DISTRIBUTION launcher lands on the job screen and does NOT bounce to home', async ({ page }) => {
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
+    allure.tag('F5114');
+    allure.story('Workflow start does not bounce to the home menu (distribution launcher)');
+    allure.severity('critical');
+
+    const masterdata = await createDistributionMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
+
+    // Tap the launcher directly — same rationale as the picking scenario above.
+    const launcher = page.getByTestId(masterdata.distributionOrders.DD1.launcherTestId);
+    await launcher.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+    await launcher.tap();
+
+    await expect(page.locator(WF_PROCESS_SCREEN)).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+    await expect(page.locator(HOME_MENU)).toHaveCount(0);
+    expect(page.url()).toContain('/distribution/wf/');
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Dead deep-link to a WF-process URL (no loaded process) redirects to the home menu', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Redirect-home guard still fires for a genuinely-absent process (cold deep-link)');
+    allure.severity('critical');
+
+    // Log in first so the app is authenticated (the auth token is kept in a cookie, so it survives a
+    // cold navigation) and the store has NO wfProcess for the id we deep-link to.
+    const masterdata = await createPickingMasterdata();
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    // Navigate COLD to a picking WF-process URL whose process id is not (and never was) in the store.
+    const deadDeepLink = `${FRONTEND_BASE_URL}/picking/wf/NO-SUCH-WFPROCESS-999999999`;
+    await page.goto(deadDeepLink, { waitUntil: 'load' });
+
+    // The guard must redirect to the home menu (the deferred goHome still fires) — not hang on a blank frame.
+    await expect(page.locator(HOME_MENU)).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+    await expect(page.locator(WF_PROCESS_SCREEN)).toHaveCount(0);
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Reload while a job is open: plain reload keeps the job; a re-hydrated store without the process redirects home', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Reload behaviour: F5 keeps the job; a genuinely-absent process on cold boot redirects home');
+    allure.severity('critical');
+
+    const masterdata = await createPickingMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const launcher = page.locator('.wflauncher-button').filter({ hasText: masterdata.salesOrders.SO1.documentNo });
+    await launcher.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+    await launcher.tap();
+    await expect(page.locator(WF_PROCESS_SCREEN)).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+    const jobUrl = page.url();
+    expect(jobUrl).toContain('/picking/wf/');
+
+    // 3(a) — a PLAIN reload keeps the operator in the job (F5-resilience): the redux store is
+    // persisted to localStorage and re-hydrated on boot, so the process is still loaded and the guard
+    // does not fire. Locking this in protects the operator against losing their job on an accidental
+    // refresh.
+    await page.reload({ waitUntil: 'load' });
+    await expect(page.locator(WF_PROCESS_SCREEN)).toBeVisible({ timeout: VERY_SLOW_ACTION_TIMEOUT });
+    await expect(page.locator(HOME_MENU)).toHaveCount(0);
+    expect(page.url()).toBe(jobUrl);
+
+    // 3(b) — now model a cold boot where the re-hydrated store does NOT contain the process
+    // (localStorage evicted / private mode / a fresh browser opening a bookmarked deep-link). The auth
+    // token lives in a cookie, so the session survives; only the persisted redux store is gone. On the
+    // next reload the process is not loaded and the guard's (deferred) goHome must still redirect home
+    // — not hang on a blank job frame.
+    await page.evaluate(() => window.localStorage.clear());
+    await page.reload({ waitUntil: 'load' });
+    await expect(page.locator(HOME_MENU)).toBeVisible({ timeout: VERY_SLOW_ACTION_TIMEOUT });
+    await expect(page.locator(WF_PROCESS_SCREEN)).toHaveCount(0);
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Stale launchers refresh after start does not prune the just-started process nor bounce home', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Stale launchers snapshot (fetched before start, delivered after) does not delete the started process');
+    allure.severity('critical');
+
+    const masterdata = await createPickingMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+
+    // Arm a one-shot hold on the NEXT full launchers-list query (countOnly:false). We fetch its real
+    // (stale) snapshot NOW — before the job is started, so the snapshot does not list the process —
+    // and deliver it only AFTER the start. This is the exact production race (a launchers refresh
+    // issued before the start resolving after it), forced deterministically via a delayed response
+    // rather than left to chance. The filter screen's count query (countOnly:true) and the /facets
+    // endpoint are left untouched so the filter UI still works.
+    let armed = false;
+    let intercepted = false;
+    let markCaptured;
+    const staleCaptured = new Promise((resolve) => { markCaptured = resolve; });
+    let releaseHeld;
+    const held = new Promise((resolve) => { releaseHeld = resolve; });
+
+    await page.route('**/userWorkflows/launchers/query', async (route) => {
+        let body = {};
+        try { body = route.request().postDataJSON() ?? {}; } catch { /* no body */ }
+        if (!armed || intercepted || body.countOnly === true) {
+            return route.continue();
+        }
+        intercepted = true;
+        const staleResponse = await route.fetch(); // snapshot computed now, before the start
+        markCaptured();
+        await held;                                 // wait until the job has been started
+        await route.fulfill({ response: staleResponse });
+    });
+
+    // Trigger the held query by applying the document-number filter (the only sales order → the SO1
+    // launcher stays visible from the initial query while this filtered query is held). Do NOT wait
+    // for the list to settle (it cannot — the query is held on purpose).
+    armed = true;
+    await PickingJobsListScreen.clickFilterButton();
+    await PickingJobsListFiltersScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await staleCaptured;
+
+    // The SO1 launcher is still rendered (from the pre-filter query); start the job while the stale
+    // refresh is still in flight. We dispatch the click directly on the button rather than tap(): a
+    // foreground query shows a `.loading` overlay that would intercept a hit-tested tap, but that
+    // overlay is an artifact of using a filter query as the stale-refresh trigger — the production
+    // race is driven by a background refresh with no such overlay. The reducer path exercised
+    // (POPULATE_LAUNCHERS_COMPLETE pruning) is identical either way, so dispatching the click reaches
+    // the exact documented state (job started while a stale launchers snapshot is pending).
+    const launcher = page.locator('.wflauncher-button').filter({ hasText: masterdata.salesOrders.SO1.documentNo });
+    await launcher.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+    await launcher.dispatchEvent('click');
+    await expect(page.locator(WF_PROCESS_SCREEN)).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+
+    // Now deliver the stale snapshot. Its POPULATE_LAUNCHERS_COMPLETE must NOT delete the just-started
+    // process (its local update is newer than the request that fetched the snapshot), so we stay on
+    // the job screen and do not bounce home. Without the reducer fix this prunes the process and the
+    // redirect-home guard fires.
+    releaseHeld();
+    await page.waitForTimeout(FAST_ACTION_TIMEOUT);
+    await expect(page.locator(WF_PROCESS_SCREEN)).toBeVisible();
+    await expect(page.locator(HOME_MENU)).toHaveCount(0);
+    await page.unroute('**/userWorkflows/launchers/query');
+});

--- a/e2e/mobile-webui/tests/spec/wfStartBounceHome.spec.js
+++ b/e2e/mobile-webui/tests/spec/wfStartBounceHome.spec.js
@@ -14,10 +14,14 @@
  *     within the tick — so a real start no longer bounces, while a genuinely-absent process still
  *     redirects.
  *
- * The three scenarios below are the end-to-end guard for that behaviour:
- *   1. No-bounce on workflow start — the key regression guard. Covers BOTH a picking launcher and a
- *      distribution launcher (the two launcher paths Race B protects). Goes RED if Race B (the
- *      synchronous goHome) regresses.
+ * The scenarios below:
+ *   1. No-bounce on workflow start — the observable contract. Starting from a picking launcher and
+ *      from a distribution launcher lands on the WF-process screen and does NOT bounce to the home
+ *      menu. NOTE: this does NOT reliably reproduce the Race-B ordering hazard on a fast local stack
+ *      (verified: reverting the ApplicationLayout goHome-deferral alone did NOT turn this scenario
+ *      RED — that store-vs-router timing does not manifest in a plain launcher-start under test). So
+ *      scenario 1 is a contract guard, not a deterministic Race-B guard; the deterministic race
+ *      guard is scenario 4 (Race A). Race B's preserved behaviour is covered by scenarios 2 and 3(b).
  *   2. Dead deep-link (cold navigate to a WF-process URL whose process is not in the store) still
  *      redirects home — proves the deferred goHome still fires for a genuinely-absent process.
  *   3. Reload while a job is open. Two real behaviours, one test:
@@ -29,12 +33,6 @@
  *          mode / a fresh browser opening a bookmarked deep-link — the auth cookie still carries the
  *          session), the boot-time guard still redirects home rather than hanging on a blank job
  *          frame. This is the same dead-deep-link class as scenario 2, reached via the cold-boot path.
- *
- * NOTE on 3(a): a plain reload does NOT redirect home in this app (verified) because wfProcesses is
- * persisted+re-hydrated. Forcing a redirect on a plain reload would require fabricating a state the
- * real reload cannot produce; instead 3(b) clears the persisted store to model the genuine
- * absent-process boot the guard actually protects.
- *
  *   4. Stale launchers refresh after start (Race A, deterministic) — reproduces the PRIMARY production
  *      trigger with real network timing: a launchers-query issued before the start (so its snapshot
  *      does not list the just-started process) whose response is delivered AFTER the start. Without
@@ -42,14 +40,16 @@
  *      home; with the fix the process is kept (its local update is newer than the request that fetched
  *      the snapshot). The pre-start request timing is forced deterministically by holding the query's
  *      response (Playwright route interception) — a faithful model of a slow/reordered response, not a
- *      fabricated state. Scenarios 1–3 exercise the observable contract but do NOT reliably reproduce
- *      this timing on a fast local stack (the natural race window rarely opens); scenario 4 is the
- *      deterministic RED-provable guard of the reducer fix.
+ *      fabricated state. This is the RED-provable guard of the reducer fix (revert it → RED).
  *
- * Scenario 1 is the assertion that must NOT be weakened: land on #WFProcessScreen and NOT bounce to
- * #ApplicationsListScreen. Scenarios 2 & 3(b) assert the preserved redirect-home behaviour survives
- * the goHome deferral (the guard's genuine purpose); 3(a) locks in the job-survives-F5 resilience;
- * scenario 4 deterministically guards the stale-launchers prune.
+ * NOTE on 3(a): a plain reload does NOT redirect home in this app (verified) because wfProcesses is
+ * persisted+re-hydrated. Forcing a redirect on a plain reload would require fabricating a state the
+ * real reload cannot produce; instead 3(b) clears the persisted store to model the genuine
+ * absent-process boot the guard actually protects.
+ *
+ * No assertion here is to be weakened: scenario 1 must land on the WF-process screen AND not bounce
+ * to the home menu; scenarios 2 & 3(b) must redirect home; scenario 4 must keep the process on the
+ * job screen after the stale snapshot arrives.
  */
 
 import { test } from "../../playwright.config";
@@ -59,15 +59,10 @@ import { Backend } from "../utils/screens/Backend";
 import { LoginScreen } from "../utils/screens/LoginScreen";
 import { ApplicationsListScreen } from "../utils/screens/ApplicationsListScreen";
 import { PickingJobsListScreen } from "../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobScreen } from "../utils/screens/picking/PickingJobScreen";
 import { PickingJobsListFiltersScreen } from "../utils/screens/picking/PickingJobsListFiltersScreen";
 import { DistributionJobsListScreen } from "../utils/screens/distribution/DistributionJobsListScreen";
-import { FRONTEND_BASE_URL, FAST_ACTION_TIMEOUT, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from "../utils/common";
-
-// Container ids of the three screens this guard distinguishes. These mirror the private
-// containerElement() ids in the screen page objects (ApplicationsListScreen / PickingJobScreen /
-// DistributionJobScreen / *JobsListScreen) — keep in sync if a screen id ever changes.
-const HOME_MENU = '#ApplicationsListScreen';
-const WF_PROCESS_SCREEN = '#WFProcessScreen';
+import { FRONTEND_BASE_URL, VERY_SLOW_ACTION_TIMEOUT } from "../utils/common";
 
 const createPickingMasterdata = async () => Backend.createMasterdata({
     language: "en_US",
@@ -146,16 +141,12 @@ test('Workflow start from a PICKING launcher lands on the job screen and does NO
     await PickingJobsListScreen.waitForScreen();
     await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
 
-    // Tap the launcher DIRECTLY (not via PickingJobsListScreen.startJob, whose tap-and-recover helper
-    // re-taps the launcher if the job screen does not appear — that recovery would paper over a
-    // bounce-to-home). We want the raw first-tap outcome so a Race-B regression is observed as-is.
-    const launcher = page.locator('.wflauncher-button').filter({ hasText: masterdata.salesOrders.SO1.documentNo });
-    await launcher.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-    await launcher.tap();
-
-    // The behaviour under guard: we land on the WF-process (job) screen and are NOT bounced to home.
-    await expect(page.locator(WF_PROCESS_SCREEN)).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
-    await expect(page.locator(HOME_MENU)).toHaveCount(0);
+    // startJob({documentNo}) is a single launcher tap + PickingJobScreen.waitForScreen() (no retry),
+    // so a bounce-to-home surfaces as the job screen never arriving. It then leaves us on the job
+    // screen; assert we did NOT bounce to the home menu.
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.expectVisible();
+    await ApplicationsListScreen.expectNotDisplayed();
     expect(page.url()).toContain('/picking/wf/');
 });
 
@@ -175,13 +166,10 @@ test('Workflow start from a DISTRIBUTION launcher lands on the job screen and do
     await DistributionJobsListScreen.waitForScreen();
     await DistributionJobsListScreen.filterByFacetId({ facetId: masterdata.distributionOrders.DD1.warehouseFromFacetId });
 
-    // Tap the launcher directly — same rationale as the picking scenario above.
-    const launcher = page.getByTestId(masterdata.distributionOrders.DD1.launcherTestId);
-    await launcher.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-    await launcher.tap();
-
-    await expect(page.locator(WF_PROCESS_SCREEN)).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
-    await expect(page.locator(HOME_MENU)).toHaveCount(0);
+    // startJob({launcherTestId}) is a single launcher tap + DistributionJobScreen.waitForScreen()
+    // (no retry) — same rationale as the picking scenario.
+    await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+    await ApplicationsListScreen.expectNotDisplayed();
     expect(page.url()).toContain('/distribution/wf/');
 });
 
@@ -204,8 +192,8 @@ test('Dead deep-link to a WF-process URL (no loaded process) redirects to the ho
     await page.goto(deadDeepLink, { waitUntil: 'load' });
 
     // The guard must redirect to the home menu (the deferred goHome still fires) — not hang on a blank frame.
-    await expect(page.locator(HOME_MENU)).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
-    await expect(page.locator(WF_PROCESS_SCREEN)).toHaveCount(0);
+    await ApplicationsListScreen.expectVisible();
+    await PickingJobScreen.expectNotDisplayed();
 });
 
 // noinspection JSUnusedLocalSymbols
@@ -223,10 +211,8 @@ test('Reload while a job is open: plain reload keeps the job; a re-hydrated stor
     await ApplicationsListScreen.startApplication('picking');
     await PickingJobsListScreen.waitForScreen();
     await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
-    const launcher = page.locator('.wflauncher-button').filter({ hasText: masterdata.salesOrders.SO1.documentNo });
-    await launcher.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-    await launcher.tap();
-    await expect(page.locator(WF_PROCESS_SCREEN)).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.expectVisible();
     const jobUrl = page.url();
     expect(jobUrl).toContain('/picking/wf/');
 
@@ -235,8 +221,8 @@ test('Reload while a job is open: plain reload keeps the job; a re-hydrated stor
     // does not fire. Locking this in protects the operator against losing their job on an accidental
     // refresh.
     await page.reload({ waitUntil: 'load' });
-    await expect(page.locator(WF_PROCESS_SCREEN)).toBeVisible({ timeout: VERY_SLOW_ACTION_TIMEOUT });
-    await expect(page.locator(HOME_MENU)).toHaveCount(0);
+    await PickingJobScreen.expectVisible({ timeout: VERY_SLOW_ACTION_TIMEOUT });
+    await ApplicationsListScreen.expectNotDisplayed();
     expect(page.url()).toBe(jobUrl);
 
     // 3(b) — now model a cold boot where the re-hydrated store does NOT contain the process
@@ -246,8 +232,8 @@ test('Reload while a job is open: plain reload keeps the job; a re-hydrated stor
     // — not hang on a blank job frame.
     await page.evaluate(() => window.localStorage.clear());
     await page.reload({ waitUntil: 'load' });
-    await expect(page.locator(HOME_MENU)).toBeVisible({ timeout: VERY_SLOW_ACTION_TIMEOUT });
-    await expect(page.locator(WF_PROCESS_SCREEN)).toHaveCount(0);
+    await ApplicationsListScreen.expectVisible();
+    await PickingJobScreen.expectNotDisplayed();
 });
 
 // noinspection JSUnusedLocalSymbols
@@ -299,25 +285,20 @@ test('Stale launchers refresh after start does not prune the just-started proces
     await PickingJobsListFiltersScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
     await staleCaptured;
 
-    // The SO1 launcher is still rendered (from the pre-filter query); start the job while the stale
-    // refresh is still in flight. We dispatch the click directly on the button rather than tap(): a
-    // foreground query shows a `.loading` overlay that would intercept a hit-tested tap, but that
-    // overlay is an artifact of using a filter query as the stale-refresh trigger — the production
-    // race is driven by a background refresh with no such overlay. The reducer path exercised
-    // (POPULATE_LAUNCHERS_COMPLETE pruning) is identical either way, so dispatching the click reaches
-    // the exact documented state (job started while a stale launchers snapshot is pending).
-    const launcher = page.locator('.wflauncher-button').filter({ hasText: masterdata.salesOrders.SO1.documentNo });
-    await launcher.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-    await launcher.dispatchEvent('click');
-    await expect(page.locator(WF_PROCESS_SCREEN)).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+    // Start the job while the stale refresh is still in flight. A foreground query shows a `.loading`
+    // overlay that would intercept a hit-tested tap, but that overlay is an artifact of using a filter
+    // query as the stale-refresh trigger — the production race is driven by a background refresh with
+    // no such overlay. The reducer path exercised (POPULATE_LAUNCHERS_COMPLETE pruning) is identical
+    // either way, so a dispatched click reaches the exact documented state (job started while a stale
+    // launchers snapshot is pending).
+    await PickingJobsListScreen.startJobByDispatchClick({ documentNo: masterdata.salesOrders.SO1.documentNo });
 
     // Now deliver the stale snapshot. Its POPULATE_LAUNCHERS_COMPLETE must NOT delete the just-started
     // process (its local update is newer than the request that fetched the snapshot), so we stay on
     // the job screen and do not bounce home. Without the reducer fix this prunes the process and the
     // redirect-home guard fires.
     releaseHeld();
-    await page.waitForTimeout(FAST_ACTION_TIMEOUT);
-    await expect(page.locator(WF_PROCESS_SCREEN)).toBeVisible();
-    await expect(page.locator(HOME_MENU)).toHaveCount(0);
+    await PickingJobScreen.expectRemainsDisplayed();
+    await ApplicationsListScreen.expectNotDisplayed();
     await page.unroute('**/userWorkflows/launchers/query');
 });

--- a/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
@@ -20,6 +20,12 @@ export const ApplicationsListScreen = {
         await expect(containerElement()).toBeVisible();
     }),
 
+    // Assert the home menu is NOT displayed — used to prove a workflow start did not bounce the
+    // operator back to the root menu.
+    expectNotDisplayed: async () => await test.step(`${NAME} - Expect NOT to be displayed`, async () => {
+        await expect(containerElement()).toHaveCount(0);
+    }),
+
     expectLogoutButtonReachable: async () => await test.step(`${NAME} - Expect logout button reachable by scrolling`, async () => {
         const logoutButton = page.locator('#logout-button');
         await expect(logoutButton).toBeVisible();

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
@@ -27,6 +27,25 @@ export const PickingJobScreen = {
         await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
+    expectVisible: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await step(`${NAME} - Expect to be displayed`, async () => {
+        await expect(containerElement()).toBeVisible({ timeout });
+    }),
+
+    // Assert the WF-process (job) screen is NOT displayed — used to prove a redirect away from the job
+    // (e.g. the redirect-home guard sending a dead deep-link back to the menu).
+    expectNotDisplayed: async () => await step(`${NAME} - Expect NOT to be displayed`, async () => {
+        await expect(containerElement()).toHaveCount(0);
+    }),
+
+    // Assert the job screen is STILL displayed after a settle window — used to prove the operator was
+    // NOT bounced away by a delayed/asynchronous event (e.g. a stale launchers refresh landing after
+    // the job started). There is no natural "visible" event to await for a non-event, so this settles
+    // for `settleTimeout` before asserting.
+    expectRemainsDisplayed: async ({ settleTimeout = FAST_ACTION_TIMEOUT } = {}) => await step(`${NAME} - Expect to remain displayed after ${settleTimeout}ms`, async () => {
+        await page.waitForTimeout(settleTimeout);
+        await expect(containerElement()).toBeVisible();
+    }),
+
     getPickingJobId: async () => {
         const currentUrl = await page.url();
 

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
@@ -116,6 +116,17 @@ export const PickingJobsListScreen = {
         }
     },
 
+    // Start a job by dispatching the click event directly on the launcher (by document number),
+    // bypassing hit-testing. Use ONLY when a foreground `.loading` overlay would intercept a normal
+    // tap yet the launcher itself is the intended target — e.g. a test that deliberately holds a
+    // launchers refresh in flight while starting the job. Waits for the job (WF-process) screen.
+    startJobByDispatchClick: async ({ documentNo }) => await test.step(`${NAME} - Start job by dispatched click (documentNo ${documentNo})`, async () => {
+        const launcher = locateJobButtons({ documentNo });
+        await launcher.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+        await launcher.dispatchEvent('click');
+        await PickingJobScreen.waitForScreen();
+    }),
+
     expectJobButtons: async (expectationsArray) => await test.step(`${NAME} - Expect ${expectationsArray.length} job buttons`, async () => {
         await test.step(`Wait for all expected buttons to be attached`, async () => {
             for (const expectation of expectationsArray) {


### PR DESCRIPTION
## What

Test-only PR. Adds `e2e/mobile-webui/tests/spec/wfStartBounceHome.spec.js`, an end-to-end regression guard for the mobile workflow-start "bounce-to-home" fix (https://github.com/metasfresh/metasfresh/pull/25183).

No production code changes — verify with `git diff --stat origin/new_dawn_uat...HEAD`.

## Scenarios

1. **No-bounce on workflow start** (the key guard) — starting a workflow from a **picking** launcher and from a **distribution** launcher lands on `#WFProcessScreen` and does NOT bounce to the home menu.
2. **Dead deep-link** — a cold navigation to a WF-process URL whose process is not in the store redirects to the home menu (the redirect-home guard's genuine purpose, preserved by the deferred `goHome`).
3. **Reload while a job is open** — (a) a plain reload keeps the job (the redux store is persisted to localStorage and re-hydrated on boot — intentional F5-resilience); (b) when the re-hydrated store is missing the process (storage evicted / fresh browser opening a bookmarked deep-link — the auth cookie keeps the session), the boot-time guard still redirects home.
4. **Stale launchers refresh after start** (deterministic RED-provable guard for the reducer fix) — a launchers snapshot fetched before the start, delivered after it, must NOT prune the just-started process. Reproduced deterministically via a held launchers-query response (a faithful model of a slow/reordered response). Reverting the reducer fix turns this test RED.

## Validation

Run locally against a `new_dawn_uat` app stack + mobile-webui frontend from source:

- All 5 tests: **100/100 passed** with `--repeat-each=20` (no flake).
- Scenario 4: **GREEN** on fixed code; **RED** when the reducer fix is reverted (the just-started process is pruned → bounce home).
- Reverting only the `ApplicationLayout` redirect-home deferral did not reproduce a bounce in the plain launcher-start flow (that ordering hazard does not manifest under test); the primary production trigger is the stale-launchers prune, which scenario 4 guards deterministically.

The mobile-webui e2e suite auto-discovers this spec (no CI matrix change needed).
