### PR TITLE
cicd.yaml: adopt canonical Allure reporting + retire Testspace (vernal_mousse_release)

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -25,7 +25,6 @@ jobs:
       base-version-matrix: ${{ steps.base-version-matrix.outputs.matrix }}
       branch-sanitized-gh-pages: ${{ steps.sanitize-branch-gh-pages.outputs.value }}
       is-local: ${{ steps.detect-local.outputs.is-local }}
-      skip-testspace: ${{ steps.skip-checks.outputs.skip-testspace }}
       skip-publish-reports: ${{ steps.skip-checks.outputs.skip-publish-reports }}
     steps:
       - name: Detect local execution
@@ -40,15 +39,7 @@ jobs:
           fi
       - name: Determine skip flags
         id: skip-checks
-        env:
-          SKIP_TESTSPACE_VAR: ${{ vars.SKIP_TESTSPACE }}
         run: |
-          # Skip testspace for tmp-mergify/ branches or when SKIP_TESTSPACE var is set
-          if [[ "${{ github.ref_name }}" == tmp-mergify/* ]] || [[ "$SKIP_TESTSPACE_VAR" == "true" ]]; then
-            echo "skip-testspace=true" >> $GITHUB_OUTPUT
-          else
-            echo "skip-testspace=false" >> $GITHUB_OUTPUT
-          fi
           # Skip publish-reports for tmp-mergify/ branches only
           if [[ "${{ github.ref_name }}" == tmp-mergify/* ]]; then
             echo "skip-publish-reports=true" >> $GITHUB_OUTPUT
@@ -56,12 +47,6 @@ jobs:
             echo "skip-publish-reports=false" >> $GITHUB_OUTPUT
           fi
       - uses: actions/checkout@v6
-      - uses: testspace-com/setup-testspace@v1
-        continue-on-error: true  # testspace retired — never fail the build on it
-        if: env.ACT != 'true' && steps.skip-checks.outputs.skip-testspace != 'true'
-        with:
-          domain: metasfresh
-          token: ${{ secrets.TESTSPACE_TOKEN }}
       - name: sanitize-ref-name
         id: sanitize
         env:
@@ -118,18 +103,7 @@ jobs:
           echo '* find more information at https://github.com/metasfresh/metasfresh/tree/${{ github.ref_name }}/docker-builds/README.md' >> $GITHUB_STEP_SUMMARY
           echo '* artifacts will be created for tag `${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }}`' >> $GITHUB_STEP_SUMMARY
           echo '* BASE_VERSION for instances **without** customisations will be `${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }}-compat`' >> $GITHUB_STEP_SUMMARY
-          echo '* test results can be found after completion at https://metasfresh.testspace.com/projects/metasfresh:metasfresh/spaces/${{ github.ref_name }}' >> $GITHUB_STEP_SUMMARY
           echo '* Allure test reports: https://test-reports.metasfresh.com/branches/${{ steps.sanitize-branch-gh-pages.outputs.value }}/builds/${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }}/allure/' >> $GITHUB_STEP_SUMMARY
-      - name: testspace push build infos
-        if: env.ACT != 'true' && steps.skip-checks.outputs.skip-testspace != 'true'
-        continue-on-error: true  # Testspace may not have a space for this branch (e.g. merge-queue branches)
-        run: |
-          touch github_run.txt
-          echo ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} >> github_run.txt
-          echo pipeline $PIPELINE_VERSION >> github_run.txt
-          echo ${{ steps.build-info-properties.outputs.mfversion }}-${{ steps.sanitize.outputs.refname }}.${{ github.run_number }} >> github_run.txt
-          testspace github_run.txt
-
   # Fast migration CLI build - runs in parallel with java job
   # This enables db-images to start ~10 minutes earlier
   migration-cli:
@@ -494,12 +468,6 @@ jobs:
     needs: [ init, frontend ]
     steps:
       - uses: actions/checkout@v6
-      - uses: testspace-com/setup-testspace@v1
-        continue-on-error: true  # testspace retired — never fail the build on it
-        if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
-        with:
-          domain: metasfresh
-          token: ${{ secrets.TESTSPACE_TOKEN }}
       - name: run-tests
         run: |
           docker buildx build \
@@ -511,12 +479,6 @@ jobs:
       - name: extract results
         run: |
           docker run --rm --volume "$(pwd)/jest:/reports" metas-frontend:test                                       # extracting test results from docker image
-      - name: publish results to testspace
-        if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
-        continue-on-error: true  # Testspace may not have a space for this branch
-        run: |
-          find jest -type d -links 2 -exec testspace [{}]{}/*.xml \;                                                # upload all jest xml's to testspace
-          testspace "[jest/frontend]jest/frontend/jest.log{$(cat jest/frontend/jest.exit-code):webui jest tests}"   # upload webui log with exit code
       - name: upload jest junit results
         uses: actions/upload-artifact@v6
         if: always()
@@ -1280,12 +1242,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: testspace-com/setup-testspace@v1
-        continue-on-error: true  # testspace retired — never fail the build on it
-        if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
-        with:
-          domain: metasfresh
-          token: ${{ secrets.TESTSPACE_TOKEN }}
       - name: install-envsubst
         if: env.ACT == 'true'
         run: |
@@ -1344,14 +1300,6 @@ jobs:
         run: |
           docker run --rm --volume "$(pwd)/junit:/reports" ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-fixed }}           # extracting java8 test results from docker image
           docker run --rm --volume "$(pwd)/junit:/reports" ghcr.io/metasfresh/metas-junit:${{ needs.init.outputs.tag-fixed }}-j14       # extracting java14 test results from docker image
-      - name: push-results to testspace
-        if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
-        continue-on-error: true  # Testspace may not have a space for this branch
-        run: |
-          find junit -type d -links 2 -exec testspace [{}]{}/*.xml \;                                                           # upload all junit xml's to testspace
-          testspace "[junit/commons]junit/commons/junit.log{$(awk '{ sum += $1 } END { print sum }' junit/commons/junit.exit-code junit/commons/junit.mvn.exit-code):java 8 commons junit tests}"     # upload commons log with combined exit code
-          testspace "[junit/backend]junit/backend/junit.log{$(awk '{ sum += $1 } END { print sum }' junit/backend/junit.exit-code junit/backend/junit.mvn.exit-code):java 8 backend junit tests}"     # upload backend log with combined exit code
-          testspace "[junit/camel]junit/camel/junit.log{$(awk '{ sum += $1 } END { print sum }' junit/camel/junit.exit-code junit/camel/junit.mvn.exit-code):java 14 camel junit tests}"              # upload camel log with combined exit code
       - name: upload backend junit results
         uses: actions/upload-artifact@v6
         if: always()
@@ -1528,12 +1476,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: testspace-com/setup-testspace@v1
-        continue-on-error: true  # testspace retired — never fail the build on it
-        if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
-        with:
-          domain: metasfresh
-          token: ${{ secrets.TESTSPACE_TOKEN }}
       - name: run-tests
         env:
           mfversion: ${{ needs.init.outputs.tag-fixed }}
@@ -1558,14 +1500,6 @@ jobs:
           docker commit metasfresh-db-1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postcucumber-${{ matrix.profile }}
           docker compose down
           cat cucumber.log | grep -q "BUILD SUCCESS" && echo "$?" > cucumber.mvn.exit-code || echo "$?" > cucumber.mvn.exit-code
-      - name: push-results to testspace
-        if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
-        continue-on-error: true  # Testspace may not have a space for this branch
-        run: |
-          if [ "${{needs.init.outputs.skip-testspace}}" != "true" ]; then
-          testspace "[cucumber/${{ matrix.profile }}]cucumber/**/*.xml"
-          testspace "[cucumber/${{ matrix.profile }}]cucumber/*.html"
-          testspace "[cucumber/${{ matrix.profile }}]cucumber.log{$(awk '{ sum += $1 } END { print sum }' cucumber.exit-code cucumber.mvn.exit-code):cucumber tests}"
       - name: Extract Cucumber Allure results
         if: always()
         run: |
@@ -1886,12 +1820,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: testspace-com/setup-testspace@v1
-        continue-on-error: true  # testspace retired — never fail the build on it
-        if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
-        with:
-          domain: metasfresh
-          token: ${{ secrets.TESTSPACE_TOKEN }}
       - name: run test
         working-directory: docker-builds/e2e-tests/
         env:
@@ -1905,18 +1833,6 @@ jobs:
           docker compose --profile mobile logs --no-log-prefix db rabbitmq search app mobile > infra.log 2>&1 || true
           docker commit e2e-tests-db-1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postmobiletest
           docker compose --profile mobile down
-      - name: push-results to testspace
-        if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
-        continue-on-error: true  # Testspace may not have a space for this branch
-        working-directory: docker-builds/e2e-tests/
-        run: |
-          # Move test-results temporarily to avoid Testspace uploading large attachment files
-          mv test-results-mobile test-results-temp || true
-          testspace "[mobile/playwright]playwright-report-mobile/junit/results.xml"
-          # Move back for artifact upload
-          mv test-results-temp test-results-mobile || true
-
-      # ===== ALLURE REPORT GENERATION =====
       - name: Generate Allure Report for Mobile
         uses: ./.github/actions/generate-allure-report
         with:
@@ -2003,12 +1919,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: testspace-com/setup-testspace@v1
-        continue-on-error: true  # testspace retired — never fail the build on it
-        if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
-        with:
-          domain: metasfresh
-          token: ${{ secrets.TESTSPACE_TOKEN }}
       - name: run test
         working-directory: docker-builds/e2e-tests/
         env:
@@ -2023,17 +1933,6 @@ jobs:
           docker compose --profile frontend logs --no-log-prefix db rabbitmq search app webapi webui > infra.log 2>&1 || true
           docker commit e2e-tests-db-1 metasfresh/metas-db:${{ needs.init.outputs.tag-fixed }}-postfrontendtest-${{ matrix.shard_label }}
           docker compose --profile frontend down
-      - name: push-results to testspace
-        if: env.ACT != 'true' && needs.init.outputs.skip-testspace != 'true'
-        continue-on-error: true  # Testspace may not have a space for this branch
-        working-directory: docker-builds/e2e-tests/
-        run: |
-          # Move test-results temporarily to avoid Testspace uploading large attachment files
-          mv test-results-frontend test-results-temp || true
-          testspace "[frontend/playwright-${{ matrix.shard_label }}]playwright-report-frontend/junit/results.xml"
-          # Move back for artifact upload
-          mv test-results-temp test-results-frontend || true
-
       - name: Upload Allure results
         uses: actions/upload-artifact@v6
         if: always()
@@ -2143,6 +2042,8 @@ jobs:
       contents: read
       pull-requests: write # post Allure report links as PR comments
     steps:
+      - uses: actions/checkout@v6 # needed for .github/test-report-permalinks (generator + resolver page)
+
       - name: Check for report server secret
         id: check-secret
         run: |
@@ -2481,6 +2382,21 @@ jobs:
           print(f"Kept {len(data['builds'])} build(s), pruned {len(evicted)} old build(s)")
           PYEOF
 
+      - name: Generate feature/spec permalinks
+        if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true' && steps.inventory.outputs.count != '0'
+        continue-on-error: true
+        env:
+          BRANCH: ${{ needs.init.outputs.branch-sanitized-gh-pages }}
+          VERSION: ${{ needs.init.outputs.tag-fixed }}
+        run: |
+          DIR=.github/test-report-permalinks
+          # build the feature/spec -> uid map from the just-published build's trees (server-side)
+          ssh reports-server "python3 - '${BRANCH}' '${VERSION}'" < "$DIR/generate_permalinks.py"
+          # deploy the static resolver (identical content per branch)
+          ssh reports-server "cat > /var/www/test-reports/branches/${BRANCH}/permalink.js"   < "$DIR/permalink.js"
+          ssh reports-server "cat > /var/www/test-reports/branches/${BRANCH}/permalink.html" < "$DIR/permalink.html"
+          echo "Permalinks: https://test-reports.metasfresh.com/branches/${BRANCH}/permalink.html?feature=Fxxxx"
+
       - name: Update landing page
         if: steps.check-secret.outputs.available == 'true' && env.ACT != 'true' && steps.inventory.outputs.count != '0'
         run: |
@@ -2751,6 +2667,8 @@ jobs:
           | Report | Link |
           |--------|------|
           ${REPORT_LINKS}
+          **Permalinks** (build-stable, always newest): \`${BUILD_URL%/builds/*}/permalink.html?feature=Fxxxx\` · \`${BUILD_URL%/builds/*}/permalink.html?spec=spec/.../x.spec.js\`
+
           _Updated: $(date -u '+%Y-%m-%d %H:%M UTC')_"
 
           # Find existing comment with marker, update or create


### PR DESCRIPTION
Bring this `_release` branch's CI reporting in line with its `_hotfix` (the canonical config):

- Retire the decommissioned **Testspace** steps (setup + all `publish results to testspace` steps).
- Complete the **Allure** server-upload publish (`upload-report-to-server`, `cucumber-allure-report` job).
- Add the **feature/spec permalink** step + the permalink line in the PR report-link comment.

The branch's `cicd.yaml` had no `_release`-specific customization — it differed from its `_hotfix`
only by the retired Testspace blocks and the missing permalink pieces. Validated locally: the
workflow parses as valid YAML and carries all report jobs; no Testspace references remain.
