### PR TITLE
Stock per week — take the MD_Stock_PerWeek_fn fast path for the order-line zoom into window 542159

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactory.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactory.java
@@ -1,5 +1,6 @@
 package de.metas.ui.web.material.stockperweek;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import de.metas.material.dispo.model.I_MD_Stock_PerWeek_V;
 import de.metas.security.IUserRolePermissions;
@@ -9,7 +10,9 @@ import de.metas.ui.web.base.model.I_T_WEBUI_ViewSelection;
 import de.metas.ui.web.document.filter.DocumentFilter;
 import de.metas.ui.web.document.filter.DocumentFilterList;
 import de.metas.ui.web.document.filter.DocumentFilterParam;
+import de.metas.ui.web.document.filter.sql.SqlDocumentFilterConverter;
 import de.metas.ui.web.document.filter.sql.SqlDocumentFilterConverterContext;
+import de.metas.ui.web.document.filter.sql.SqlDocumentFilterConverters;
 import de.metas.ui.web.view.AddRemoveChangedRowIdsCollector;
 import de.metas.ui.web.view.SqlViewRowIdsOrderedSelectionFactory;
 import de.metas.ui.web.view.ViewEvaluationCtx;
@@ -25,6 +28,7 @@ import de.metas.ui.web.window.datatypes.DocumentIdsSelection;
 import de.metas.ui.web.window.datatypes.WindowId;
 import de.metas.ui.web.window.model.DocumentQueryOrderBy;
 import de.metas.ui.web.window.model.DocumentQueryOrderByList;
+import de.metas.ui.web.window.model.sql.SqlOptions;
 import lombok.NonNull;
 import org.adempiere.ad.dao.QueryLimit;
 import org.adempiere.ad.expression.api.IStringExpressionWrapper;
@@ -40,6 +44,8 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /*
  * #%L
@@ -79,6 +85,8 @@ public class StockPerWeekSelectionFactory implements ViewRowIdsOrderedSelectionF
 	private static final String FUNCTION_SOURCE_RELATION_SQL = FUNCTION_NAME + "(?,?)";
 	private static final String KEY_COLUMN = I_MD_Stock_PerWeek_V.COLUMNNAME_MD_Stock_PerWeek_V_ID;
 	private static final String FUNCTION_ALIAS = "fn";
+	/** The order-line zoom clause always leads with a literal {@code M_Product_ID = <int>} (see zoom-slowpath diagnosis). */
+	private static final Pattern PRODUCT_LITERAL_PATTERN = Pattern.compile("\\bM_Product_ID\\s*=\\s*(\\d+)\\b");
 	/** Window's default sort, used when {@code orderBys} is empty. */
 	private static final ImmutableList<String> DEFAULT_ORDER_FIELD_NAMES = ImmutableList.of(
 			I_MD_Stock_PerWeek_V.COLUMNNAME_WeekStartDate,
@@ -103,14 +111,68 @@ public class StockPerWeekSelectionFactory implements ViewRowIdsOrderedSelectionF
 			final boolean applySecurityRestrictions,
 			final SqlDocumentFilterConverterContext context)
 	{
-		final Integer productId = extractFilterValue(filters, I_MD_Stock_PerWeek_V.COLUMNNAME_M_Product_ID);
-		if (productId == null)
+		final SqlAndParams sqlInsert = buildCreateSelectionSql(viewEvalCtx, viewId, filters, orderBys, applySecurityRestrictions, context);
+		if (sqlInsert == null)
 		{
-			// no single-product filter (absent / multi-value / range) => standard path (open-empty guard + warehouse/week-only filtering)
+			// no single-product filter (absent / multi-value / range / unrecognized zoom clause) => standard path (open-empty guard + warehouse/week-only filtering)
 			return delegate.createOrderedSelection(viewEvalCtx, viewId, filters, orderBys, applySecurityRestrictions, context);
 		}
 
-		final Integer warehouseId = extractFilterValue(filters, I_MD_Stock_PerWeek_V.COLUMNNAME_M_Warehouse_ID);
+		final long rowsCount = DB.executeUpdateAndThrowExceptionOnFail(
+				sqlInsert.getSql(), sqlInsert.getSqlParamsArray(), ITrx.TRXNAME_ThreadInherited);
+
+		return ViewRowIdsOrderedSelection.builder()
+				.viewId(viewId)
+				.size(rowsCount)
+				.orderBys(orderBys)
+				.queryLimit(QueryLimit.NO_LIMIT)
+				.build();
+	}
+
+	/**
+	 * Function-sourced INSERT into {@link I_T_WEBUI_ViewSelection} for a single-product view, or {@code null}
+	 * when no single product can be resolved (caller delegates to the standard path). Two fast paths feed one INSERT:
+	 * <ul>
+	 * <li><b>direct facet</b>: a top-level {@code M_Product_ID} (+ optional {@code M_Warehouse_ID}) {@code EQUAL}
+	 * param — both become {@code MD_Stock_PerWeek_fn} params, no residual WHERE.
+	 * <li><b>order-line zoom</b>: the product carried inside the zoom's opaque SQL-where filter (such params are
+	 * hidden from by-field-name lookup). The product parameterizes the function; that same clause's residual
+	 * {@code MD_getStockWarehouse(...)} warehouse-resolution and {@code WeekStartDate} floor — neither expressible
+	 * as a function param — are applied as the standard converted WHERE against the small function output.
+	 * </ul>
+	 */
+	@VisibleForTesting
+	@Nullable
+	SqlAndParams buildCreateSelectionSql(
+			final ViewEvaluationCtx viewEvalCtx,
+			final ViewId viewId,
+			final DocumentFilterList filters,
+			final DocumentQueryOrderByList orderBys,
+			final boolean applySecurityRestrictions,
+			final SqlDocumentFilterConverterContext context)
+	{
+		final int productId;
+		@Nullable final Integer warehouseFnParam;
+		@Nullable final SqlAndParams residualWhereClause;
+
+		final Integer directProductId = extractFilterValue(filters, I_MD_Stock_PerWeek_V.COLUMNNAME_M_Product_ID);
+		if (directProductId != null)
+		{
+			productId = directProductId;
+			warehouseFnParam = extractFilterValue(filters, I_MD_Stock_PerWeek_V.COLUMNNAME_M_Warehouse_ID);
+			residualWhereClause = null;
+		}
+		else
+		{
+			final Integer zoomProductId = extractProductIdFromSqlFilter(filters);
+			if (zoomProductId == null)
+			{
+				return null;
+			}
+			productId = zoomProductId;
+			warehouseFnParam = null; // all warehouses for the product; the residual WHERE narrows to the resolved one
+			residualWhereClause = buildResidualWhereClause(filters, context);
+		}
 
 		final String rowNumberOrderBySql = buildRowNumberOrderBySql(orderBys);
 
@@ -121,25 +183,23 @@ public class StockPerWeekSelectionFactory implements ViewRowIdsOrderedSelectionF
 						+ ", " + I_T_WEBUI_ViewSelection.COLUMNNAME_IntKey1
 						+ ", " + I_T_WEBUI_ViewSelection.COLUMNNAME_IntKey2
 						+ ", " + I_T_WEBUI_ViewSelection.COLUMNNAME_IntKey3 + ")\n")
-				.append("SELECT ?", viewId.getViewId())
-				.append(", row_number() OVER (ORDER BY " + rowNumberOrderBySql + ")"
-						+ ", " + FUNCTION_ALIAS + "." + KEY_COLUMN
-						+ ", " + FUNCTION_ALIAS + "." + I_MD_Stock_PerWeek_V.COLUMNNAME_M_Product_ID
-						+ ", " + FUNCTION_ALIAS + "." + I_MD_Stock_PerWeek_V.COLUMNNAME_M_Warehouse_ID + "\n"
-						+ " FROM " + FUNCTION_NAME + "(?, ?) " + FUNCTION_ALIAS, productId, warehouseId)
-				.append("\n WHERE 1=1 ")
-				.wrap(securityRestrictionsWrapper(applySecurityRestrictions));
+				.append(SqlAndParamsExpression.builder()
+						.append("SELECT ?", viewId.getViewId())
+						.append(", row_number() OVER (ORDER BY " + rowNumberOrderBySql + ")"
+								+ ", " + FUNCTION_ALIAS + "." + KEY_COLUMN
+								+ ", " + FUNCTION_ALIAS + "." + I_MD_Stock_PerWeek_V.COLUMNNAME_M_Product_ID
+								+ ", " + FUNCTION_ALIAS + "." + I_MD_Stock_PerWeek_V.COLUMNNAME_M_Warehouse_ID + "\n"
+								+ " FROM " + FUNCTION_NAME + "(?, ?) " + FUNCTION_ALIAS, productId, warehouseFnParam)
+						.append("\n WHERE 1=1 ")
+						.wrap(securityRestrictionsWrapper(applySecurityRestrictions)));
 
-		final SqlAndParams sqlAndParams = sqlInsert.build().evaluate(viewEvalCtx.toEvaluatee());
-		final long rowsCount = DB.executeUpdateAndThrowExceptionOnFail(
-				sqlAndParams.getSql(), sqlAndParams.getSqlParamsArray(), ITrx.TRXNAME_ThreadInherited);
+		if (residualWhereClause != null && !residualWhereClause.isEmpty())
+		{
+			// zoom: apply the clause's residual warehouse-resolution + week floor against the small function output
+			sqlInsert.append("\n AND (\n").append(residualWhereClause).append("\n)");
+		}
 
-		return ViewRowIdsOrderedSelection.builder()
-				.viewId(viewId)
-				.size(rowsCount)
-				.orderBys(orderBys)
-				.queryLimit(QueryLimit.NO_LIMIT)
-				.build();
+		return sqlInsert.build().evaluate(viewEvalCtx.toEvaluatee());
 	}
 
 	/** Same per-row client/org read-access filter the standard selection applies; the fn output carries AD_Client_ID/AD_Org_ID so it resolves against the fn alias. */
@@ -263,6 +323,53 @@ public class StockPerWeekSelectionFactory implements ViewRowIdsOrderedSelectionF
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Product id of the order-line zoom, which delivers product/warehouse/week as one opaque SQL-where filter param
+	 * (hidden from {@link #extractFilterValue}'s by-field-name lookup). Scans the SQL-filter params for the
+	 * metas-controlled clause's leading literal {@code M_Product_ID = <int>}. Fail-closed — absent, non-literal
+	 * ({@code = ?}), or ambiguous (more than one distinct product) returns {@code null} so the caller keeps the safe
+	 * slow path (never guess a product).
+	 */
+	@Nullable
+	private static Integer extractProductIdFromSqlFilter(@NonNull final DocumentFilterList filters)
+	{
+		Integer found = null;
+		for (final DocumentFilter filter : filters.toList())
+		{
+			for (final DocumentFilterParam param : filter.getParameters())
+			{
+				final SqlAndParams sqlWhereClause = param.isSqlFilter() ? param.getSqlWhereClause() : null;
+				if (sqlWhereClause == null)
+				{
+					continue;
+				}
+				final Matcher matcher = PRODUCT_LITERAL_PATTERN.matcher(sqlWhereClause.getSql());
+				while (matcher.find())
+				{
+					final int productId = Integer.parseInt(matcher.group(1));
+					if (productId <= 0 || (found != null && found != productId))
+					{
+						return null; // malformed or ambiguous => slow path
+					}
+					found = productId;
+				}
+			}
+		}
+		return found;
+	}
+
+	/**
+	 * WHERE clause the standard (slow) path would apply for {@code filters}, aliased to the {@code MD_Stock_PerWeek_fn}
+	 * relation so the zoom clause's residual warehouse-resolution + week floor restrict the function output to exactly
+	 * the zoom's rows. Same converter the delegate uses, so the selection matches the view-filtered output.
+	 */
+	@Nullable
+	private SqlAndParams buildResidualWhereClause(@NonNull final DocumentFilterList filters, @NonNull final SqlDocumentFilterConverterContext context)
+	{
+		final SqlDocumentFilterConverter converter = SqlDocumentFilterConverters.createEntityBindingEffectiveConverter(sqlViewBinding);
+		return converter.getSql(filters, SqlOptions.usingTableAlias(FUNCTION_ALIAS), context).getWhereClause();
 	}
 
 	/**

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactory.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactory.java
@@ -85,8 +85,8 @@ public class StockPerWeekSelectionFactory implements ViewRowIdsOrderedSelectionF
 	private static final String FUNCTION_SOURCE_RELATION_SQL = FUNCTION_NAME + "(?,?)";
 	private static final String KEY_COLUMN = I_MD_Stock_PerWeek_V.COLUMNNAME_MD_Stock_PerWeek_V_ID;
 	private static final String FUNCTION_ALIAS = "fn";
-	/** The order-line zoom clause always leads with a literal {@code M_Product_ID = <int>} (see zoom-slowpath diagnosis). */
-	private static final Pattern PRODUCT_LITERAL_PATTERN = Pattern.compile("\\bM_Product_ID\\s*=\\s*(\\d+)\\b");
+	/** The order-line zoom clause carries an unqualified literal {@code M_Product_ID = <int>}; the negative lookbehind rejects table/alias-qualified references (e.g. {@code o.M_Product_ID}) so an incidental join predicate is never mistaken for the zoom's product. */
+	private static final Pattern PRODUCT_LITERAL_PATTERN = Pattern.compile("(?<![.\\w])M_Product_ID\\s*=\\s*(\\d+)\\b");
 	/** Window's default sort, used when {@code orderBys} is empty. */
 	private static final ImmutableList<String> DEFAULT_ORDER_FIELD_NAMES = ImmutableList.of(
 			I_MD_Stock_PerWeek_V.COLUMNNAME_WeekStartDate,
@@ -136,9 +136,10 @@ public class StockPerWeekSelectionFactory implements ViewRowIdsOrderedSelectionF
 	 * <li><b>direct facet</b>: a top-level {@code M_Product_ID} (+ optional {@code M_Warehouse_ID}) {@code EQUAL}
 	 * param — both become {@code MD_Stock_PerWeek_fn} params, no residual WHERE.
 	 * <li><b>order-line zoom</b>: the product carried inside the zoom's opaque SQL-where filter (such params are
-	 * hidden from by-field-name lookup). The product parameterizes the function; that same clause's residual
-	 * {@code MD_getStockWarehouse(...)} warehouse-resolution and {@code WeekStartDate} floor — neither expressible
-	 * as a function param — are applied as the standard converted WHERE against the small function output.
+	 * hidden from by-field-name lookup). The product parameterizes the function; the full clause is then applied as
+	 * the standard converted WHERE against the small function output — its {@code MD_getStockWarehouse(...)}
+	 * warehouse-resolution and {@code WeekStartDate} floor (neither expressible as a function param) do the narrowing,
+	 * while the clause's own {@code M_Product_ID} predicate is a harmless tautology against the product-scoped output.
 	 * </ul>
 	 */
 	@VisibleForTesting
@@ -195,7 +196,7 @@ public class StockPerWeekSelectionFactory implements ViewRowIdsOrderedSelectionF
 
 		if (residualWhereClause != null && !residualWhereClause.isEmpty())
 		{
-			// zoom: apply the clause's residual warehouse-resolution + week floor against the small function output
+			// zoom: apply the converted clause (warehouse-resolution + week floor; the product predicate is a redundant tautology) against the small function output
 			sqlInsert.append("\n AND (\n").append(residualWhereClause).append("\n)");
 		}
 
@@ -361,9 +362,10 @@ public class StockPerWeekSelectionFactory implements ViewRowIdsOrderedSelectionF
 	}
 
 	/**
-	 * WHERE clause the standard (slow) path would apply for {@code filters}, aliased to the {@code MD_Stock_PerWeek_fn}
-	 * relation so the zoom clause's residual warehouse-resolution + week floor restrict the function output to exactly
-	 * the zoom's rows. Same converter the delegate uses, so the selection matches the view-filtered output.
+	 * The full WHERE the standard (slow) path would apply for {@code filters}, converted against the
+	 * {@code MD_Stock_PerWeek_fn} relation (aliased as the view) so the zoom clause's warehouse-resolution + week floor
+	 * restrict the function output to exactly the zoom's rows. The product predicate is reapplied too but is a tautology
+	 * against the product-scoped function output. Same converter the delegate uses, so the selection matches the view.
 	 */
 	@Nullable
 	private SqlAndParams buildResidualWhereClause(@NonNull final DocumentFilterList filters, @NonNull final SqlDocumentFilterConverterContext context)

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactoryTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactoryTest.java
@@ -53,13 +53,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Covers {@link StockPerWeekSelectionFactory#buildCreateSelectionSql} — the layer that decides fast-vs-slow and
- * builds the fast-path SQL, without executing it (no DB). This is the faithful RED→GREEN layer for me03 #30457:
- * a full RelationType-driven zoom is not triggerable here (de.metas.cucumber, the only Postgres-backed suite,
- * has no ui.web.base classes; ui.web.base unit tests run on the in-memory POJO map with no SQL engine), so we
- * feed the <b>exact {@code DocumentFilterParam.ofSqlWhereClause(...)} the zoom provider emits</b> (see
- * {@code ai-work/30457/lifecycle/zoom-slowpath-diagnosis.md} §2) and assert the factory takes the
- * {@code MD_Stock_PerWeek_fn} fast path. Row-equivalence against the slow view output + the index-scan EXPLAIN
- * are verified separately against the live GDPR-scrambled stack (see the fix report).
+ * builds the fast-path SQL, without executing it (no DB). A full RelationType-driven zoom is not triggerable here
+ * (de.metas.cucumber, the only Postgres-backed suite, has no ui.web.base classes; ui.web.base unit tests run on the
+ * in-memory POJO map with no SQL engine), so we feed the <b>exact {@code DocumentFilterParam.ofSqlWhereClause(...)}
+ * the order-line zoom provider emits</b> and assert the factory takes the {@code MD_Stock_PerWeek_fn} fast path.
+ * Row-equivalence against the slow view output and the index-scan EXPLAIN are verified separately against a live
+ * stack, not here.
  * <p>
  * RED (before the fix): the zoom's SQL-where param is hidden from by-field-name lookup, so no product is
  * resolved and {@code buildCreateSelectionSql} returns {@code null} (slow delegate path) — the fast-path
@@ -91,7 +90,7 @@ class StockPerWeekSelectionFactoryTest
 		factory = new StockPerWeekSelectionFactory(minimalBinding());
 	}
 
-	/** The exact single opaque SQL-where param the order-line RelationType zoom pushes in (diagnosis §2). */
+	/** The exact single opaque SQL-where param the order-line RelationType zoom pushes in. */
 	private static DocumentFilterList zoomFilter()
 	{
 		final String sqlWhere = "M_Product_ID = " + PRODUCT_ID
@@ -132,6 +131,21 @@ class StockPerWeekSelectionFactoryTest
 		assertThat(sql.getSql()).contains("MD_Stock_PerWeek_fn(?, ?) fn");
 		assertThat(sql.getSql()).doesNotContain("MD_getStockWarehouse");
 		assertThat(sql.getSql()).doesNotContain("\n AND (\n"); // no residual WHERE appended
+	}
+
+	@Test
+	void directProductAndWarehouseFacet_bothBecomeFunctionParams()
+	{
+		// product + warehouse EQUAL facets => both carried as the two fn params (warehouse non-null), no residual WHERE
+		final int warehouseId = 1_000_110;
+		final SqlAndParams sql = buildSql(DocumentFilterList.of(
+				DocumentFilter.equalsFilter("M_Product_ID", PRODUCT_ID),
+				DocumentFilter.equalsFilter("M_Warehouse_ID", warehouseId)));
+
+		assertThat(sql).isNotNull();
+		assertThat(sql.getSql()).contains("MD_Stock_PerWeek_fn(?, ?) fn");
+		assertThat(sql.getSqlParams()).containsSubsequence(PRODUCT_ID, warehouseId);
+		assertThat(sql.getSql()).doesNotContain("\n AND (\n"); // direct facet => no residual WHERE
 	}
 
 	@Test

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactoryTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactoryTest.java
@@ -1,0 +1,197 @@
+package de.metas.ui.web.material.stockperweek;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.organization.OrgId;
+import de.metas.security.RoleId;
+import de.metas.security.UserRolePermissionsKey;
+import de.metas.ui.web.document.filter.DocumentFilter;
+import de.metas.ui.web.document.filter.DocumentFilterList;
+import de.metas.ui.web.document.filter.DocumentFilterParam;
+import de.metas.ui.web.document.filter.sql.SqlDocumentFilterConverterContext;
+import de.metas.ui.web.view.ViewEvaluationCtx;
+import de.metas.ui.web.view.ViewId;
+import de.metas.ui.web.view.descriptor.SqlAndParams;
+import de.metas.ui.web.view.descriptor.SqlViewBinding;
+import de.metas.ui.web.view.descriptor.SqlViewRowFieldBinding;
+import de.metas.ui.web.window.datatypes.WindowId;
+import de.metas.ui.web.window.descriptor.DocumentFieldWidgetType;
+import de.metas.ui.web.window.descriptor.sql.SqlSelectValue;
+import de.metas.ui.web.window.model.DocumentQueryOrderByList;
+import de.metas.user.UserId;
+import org.adempiere.service.ClientId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * #%L
+ * de.metas.ui.web.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * Covers {@link StockPerWeekSelectionFactory#buildCreateSelectionSql} — the layer that decides fast-vs-slow and
+ * builds the fast-path SQL, without executing it (no DB). This is the faithful RED→GREEN layer for me03 #30457:
+ * a full RelationType-driven zoom is not triggerable here (de.metas.cucumber, the only Postgres-backed suite,
+ * has no ui.web.base classes; ui.web.base unit tests run on the in-memory POJO map with no SQL engine), so we
+ * feed the <b>exact {@code DocumentFilterParam.ofSqlWhereClause(...)} the zoom provider emits</b> (see
+ * {@code ai-work/30457/lifecycle/zoom-slowpath-diagnosis.md} §2) and assert the factory takes the
+ * {@code MD_Stock_PerWeek_fn} fast path. Row-equivalence against the slow view output + the index-scan EXPLAIN
+ * are verified separately against the live GDPR-scrambled stack (see the fix report).
+ * <p>
+ * RED (before the fix): the zoom's SQL-where param is hidden from by-field-name lookup, so no product is
+ * resolved and {@code buildCreateSelectionSql} returns {@code null} (slow delegate path) — the fast-path
+ * assertions fail. GREEN (after): the product is parsed out of the clause and the function fast path is built.
+ */
+class StockPerWeekSelectionFactoryTest
+{
+	private static final WindowId WINDOW_ID = StockPerWeekSelectionFactory.WINDOW_ID;
+	private static final int PRODUCT_ID = 1_000_042;
+	private static final int ORDER_ID = 5_000_007;
+
+	private ViewEvaluationCtx viewEvalCtx;
+	private StockPerWeekSelectionFactory factory;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		viewEvalCtx = ViewEvaluationCtx._builder()
+				.loggedUserId(Optional.of(UserId.METASFRESH))
+				.orgId(OrgId.ofRepoId(1000000))
+				.adLanguage("en_US")
+				.timeZone(ZoneId.of("Europe/Berlin"))
+				.permissionsKey(UserRolePermissionsKey.of(
+						RoleId.SYSTEM,
+						UserId.METASFRESH,
+						ClientId.SYSTEM,
+						LocalDate.of(2026, 3, 22)))
+				.build();
+		factory = new StockPerWeekSelectionFactory(minimalBinding());
+	}
+
+	/** The exact single opaque SQL-where param the order-line RelationType zoom pushes in (diagnosis §2). */
+	private static DocumentFilterList zoomFilter()
+	{
+		final String sqlWhere = "M_Product_ID = " + PRODUCT_ID
+				+ " AND M_Warehouse_ID = MD_getStockWarehouse( (SELECT o.M_Warehouse_ID FROM C_Order o WHERE o.C_Order_ID = " + ORDER_ID + ") )"
+				+ " AND WeekStartDate >= date_trunc('week', COALESCE( (SELECT o.PreparationDate FROM C_Order o WHERE o.C_Order_ID = " + ORDER_ID + "), now()))::date";
+		return DocumentFilterList.of(DocumentFilter.builder()
+				.setFilterId("MQuery-" + UUID.randomUUID())
+				.addParameter(DocumentFilterParam.ofSqlWhereClause(sqlWhere))
+				.build());
+	}
+
+	@Test
+	void orderLineZoom_sqlWhereFilter_takesFunctionFastPath_withResidualWhere()
+	{
+		final SqlAndParams sql = buildSql(zoomFilter());
+
+		// fast path used (RED before the fix: unrecognized zoom param => null => slow delegate path)
+		assertThat(sql).as("order-line zoom must take the MD_Stock_PerWeek_fn fast path").isNotNull();
+
+		final String sqlText = sql.getSql();
+		// sourced from the function; product is the 1st fn param, warehouse (2nd) is NULL = all warehouses
+		assertThat(sqlText).contains("MD_Stock_PerWeek_fn(?, ?) fn");
+		assertThat(sql.getSqlParams()).containsSubsequence(PRODUCT_ID, null);
+		// product persisted into IntKey2 (what readAppliedFilter reads to route the page render through the fn)
+		assertThat(sqlText).contains(", fn.M_Product_ID, fn.M_Warehouse_ID");
+		// the clause's residual warehouse-resolution + week floor are applied against the fn output, not dropped
+		assertThat(sqlText).contains("MD_getStockWarehouse");
+		assertThat(sqlText).contains("WeekStartDate >=");
+	}
+
+	@Test
+	void directProductEqualsFacet_takesFunctionFastPath_withoutResidualWhere()
+	{
+		// existing direct-filter fast path must stay intact: product+warehouse as the two fn params, WHERE 1=1
+		final SqlAndParams sql = buildSql(DocumentFilterList.of(DocumentFilter.equalsFilter("M_Product_ID", PRODUCT_ID)));
+
+		assertThat(sql).isNotNull();
+		assertThat(sql.getSql()).contains("MD_Stock_PerWeek_fn(?, ?) fn");
+		assertThat(sql.getSql()).doesNotContain("MD_getStockWarehouse");
+		assertThat(sql.getSql()).doesNotContain("\n AND (\n"); // no residual WHERE appended
+	}
+
+	@Test
+	void multiValueProductFacet_delegatesToSlowPath()
+	{
+		// IN_ARRAY facet (a single fn param can't carry N products) => slow delegate path preserved
+		final SqlAndParams sql = buildSql(DocumentFilterList.of(
+				DocumentFilter.inArrayFilter("prod", "M_Product_ID", ImmutableList.of(PRODUCT_ID, PRODUCT_ID + 1))));
+
+		assertThat(sql).isNull();
+	}
+
+	@Test
+	void ambiguousZoomClause_failsClosedToSlowPath()
+	{
+		// two distinct product literals => never guess a product => slow delegate path
+		final DocumentFilterList filters = DocumentFilterList.of(DocumentFilter.builder()
+				.setFilterId("MQuery-" + UUID.randomUUID())
+				.addParameter(DocumentFilterParam.ofSqlWhereClause(
+						"M_Product_ID = " + PRODUCT_ID + " OR M_Product_ID = " + (PRODUCT_ID + 1)))
+				.build());
+
+		assertThat(buildSql(filters)).isNull();
+	}
+
+	@Test
+	void noFilter_delegatesToSlowPath()
+	{
+		assertThat(buildSql(DocumentFilterList.EMPTY)).isNull();
+	}
+
+	private SqlAndParams buildSql(final DocumentFilterList filters)
+	{
+		return factory.buildCreateSelectionSql(
+				viewEvalCtx,
+				ViewId.random(WINDOW_ID),
+				filters,
+				DocumentQueryOrderByList.EMPTY,
+				false, // no security restrictions => no live permissions lookup needed in-test
+				SqlDocumentFilterConverterContext.builder().build());
+	}
+
+	private static SqlViewBinding minimalBinding()
+	{
+		final SqlViewRowFieldBinding keyField = SqlViewRowFieldBinding.builder()
+				.fieldName("MD_Stock_PerWeek_V_ID")
+				.widgetType(DocumentFieldWidgetType.Integer)
+				.sqlValueClass(Integer.class)
+				.keyColumn(true)
+				.fieldLoader((rs, adLanguage) -> null)
+				.sqlSelectValue(SqlSelectValue.builder()
+						.columnName("MD_Stock_PerWeek_V_ID")
+						.columnNameAlias("MD_Stock_PerWeek_V_ID")
+						.build())
+				.build();
+
+		return SqlViewBinding.builder()
+				.tableName("MD_Stock_PerWeek_V")
+				.field(keyField)
+				.displayFieldNames("MD_Stock_PerWeek_V_ID")
+				.build();
+	}
+}


### PR DESCRIPTION
Follow-up to https://github.com/metasfresh/metasfresh/pull/25167.

## Problem

The order-line **zoom** into the "Bestand pro Woche" window (`MD_Stock_PerWeek_V`, window 542159) was still slow. The zoom delivers product + warehouse + week as **one opaque** `DocumentFilterParam.ofSqlWhereClause(...)`; that param is hidden from the by-field-name lookup the fast path uses, so the selection fell back to materializing the full ~785k-row view.

## Change (`StockPerWeekSelectionFactory`)

- Parse the literal `M_Product_ID = <int>` out of the zoom's opaque SQL-where clause and source the selection from `MD_Stock_PerWeek_fn(product, NULL)` (indexed `MD_Candidate` scan) instead of the view.
- Re-apply the clause's warehouse-resolution (`MD_getStockWarehouse(...)`) + `WeekStartDate` floor as the standard converted WHERE against the small function output, so the result is row-equivalent to the slow view path.
- **Fail-closed**: absent / non-literal (`= ?`) / alias-qualified (`o.M_Product_ID`) / ambiguous (multiple distinct products) → keep the safe slow path; never guess a product.
- The pre-existing direct-facet fast path and the multi-value guard are unchanged.

## Testing

- New `StockPerWeekSelectionFactoryTest` (unit, DB-free): 6 cases — order-line zoom takes the fn fast path with residual WHERE; direct product facet; direct product+warehouse facet; multi-value facet → slow path; ambiguous zoom clause → fail-closed; no filter → slow path. RED→GREEN proven on the SQL-builder that feeds the exact `ofSqlWhereClause` shape the zoom emits.
- Row-equivalence vs. the slow view output and the index-scan `EXPLAIN` were verified against a live GDPR-scrambled stack.
