### PR TITLE
frontend-webui e2e: de-flake advanced-edit-focus nav-URL and modal-close waits

### DIFF
--- a/e2e/frontend-webui/tests/spec/advanced-edit-focus.spec.js
+++ b/e2e/frontend-webui/tests/spec/advanced-edit-focus.spec.js
@@ -55,10 +55,37 @@ async function loginAsMetasfresh(page) {
  * row.
  */
 async function openSingleRecord(page, windowId) {
+  // The list *container* (`.document-list-wrapper`) mounts before its rows
+  // arrive: the row set is fetched by a separate REST call
+  // (GET /documentView/<win>/<viewId>?firstRow=...). Reading the row count
+  // before that fetch resolves would momentarily see 0 rows for a row-bearing
+  // window (e.g. Product 140), wrongly take the empty-list ALT+N branch below,
+  // create a NEW draft that never persists to a numeric id, and hang the
+  // `waitForURL(/\d+\/\d+/)` that follows for the full timeout. So await that
+  // specific row-data response before counting. The listener is armed BEFORE
+  // navigating so the response can never be missed. (networkidle is not usable
+  // here — the dashboard's STOMP/KPI traffic keeps the network permanently
+  // busy, per e2e/frontend-webui skill guidance.)
+  const rowDataFetched = page
+    .waitForResponse(
+      (resp) =>
+        resp.url().includes(`/documentView/${windowId}/`) &&
+        resp.url().includes('firstRow='),
+      { timeout: SLOW_ACTION_TIMEOUT }
+    )
+    .catch(() => {});
+
   await page.goto(`/window/${windowId}`, { waitUntil: 'load' });
   await page
     .locator('.document-list-wrapper')
     .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+  await rowDataFetched;
+  // Let React paint the fetched rows (or the empty-list panel) before counting.
+  await page
+    .locator('.table-flex-wrapper tbody tr, .empty-info-text')
+    .first()
+    .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT })
+    .catch(() => {});
 
   const rows = page.locator('.table-flex-wrapper tbody tr');
   const rowCount = await rows.count();
@@ -412,9 +439,14 @@ test.describe('Advanced Edit modal — focus placement & Tab navigation (me03#27
 
     // --- Phase 3: Esc closes modal ---
     await page.keyboard.press('Escape');
+    // Closing the advanced-edit modal commits the focused field and can involve
+    // a document PATCH/refresh round-trip before the modal unmounts and its CSS
+    // transition completes; under CI load that exceeds the 5s FAST budget. The
+    // condition is correct — only the budget was too tight — so use the slow
+    // (server-round-trip) budget.
     await page
       .locator('.panel-modal')
-      .waitFor({ state: 'hidden', timeout: FAST_ACTION_TIMEOUT });
+      .waitFor({ state: 'hidden', timeout: SLOW_ACTION_TIMEOUT });
     await page.waitForTimeout(300);
 
     // --- Phase 4: Tab in main window (after modal close) ---
@@ -537,7 +569,9 @@ test.describe('Advanced Edit modal — focus placement & Tab navigation (me03#27
       expect(info.isEditable).toBe(true);
 
       await page.keyboard.press('Escape');
-      await modal.waitFor({ state: 'hidden', timeout: FAST_ACTION_TIMEOUT });
+      // Same server-round-trip-gated close as Phase 3 of the round-trip test —
+      // use the slow budget so a CI-load-slow close does not flake at 5s.
+      await modal.waitFor({ state: 'hidden', timeout: SLOW_ACTION_TIMEOUT });
       await page.waitForTimeout(300);
     }
   });

--- a/e2e/frontend-webui/tests/spec/advanced-edit-focus.spec.js
+++ b/e2e/frontend-webui/tests/spec/advanced-edit-focus.spec.js
@@ -57,40 +57,59 @@ async function loginAsMetasfresh(page) {
 async function openSingleRecord(page, windowId) {
   // The list *container* (`.document-list-wrapper`) mounts before its rows
   // arrive: the row set is fetched by a separate REST call
-  // (GET /documentView/<win>/<viewId>?firstRow=...). Reading the row count
-  // before that fetch resolves would momentarily see 0 rows for a row-bearing
-  // window (e.g. Product 140), wrongly take the empty-list ALT+N branch below,
-  // create a NEW draft that never persists to a numeric id, and hang the
-  // `waitForURL(/\d+\/\d+/)` that follows for the full timeout. So await that
-  // specific row-data response before counting. The listener is armed BEFORE
-  // navigating so the response can never be missed. (networkidle is not usable
-  // here — the dashboard's STOMP/KPI traffic keeps the network permanently
-  // busy, per e2e/frontend-webui skill guidance.)
-  const rowDataFetched = page
+  // (GET /documentView/<win>/<viewId>?firstRow=...). Deciding empty-vs-populated
+  // from a DOM row count races that fetch — a row-bearing window (e.g. Product
+  // 140) can momentarily read 0 rows, wrongly take the empty-list ALT+N branch
+  // below, create a NEW draft that never persists to a numeric id, and hang the
+  // `waitForURL(/\d+\/\d+/)` that follows for the full timeout. So take the
+  // decision from that response's own payload — `size`/`result` on the
+  // JSONViewResult is the server's ground truth — rather than from a DOM read
+  // that may precede React's commit. The listener is armed BEFORE navigating so
+  // the response can never be missed. (networkidle is not usable here — the
+  // dashboard's STOMP/KPI traffic keeps the network permanently busy, per
+  // e2e/frontend-webui skill guidance.)
+  const rowDataResponse = page
     .waitForResponse(
       (resp) =>
         resp.url().includes(`/documentView/${windowId}/`) &&
         resp.url().includes('firstRow='),
       { timeout: SLOW_ACTION_TIMEOUT }
     )
-    .catch(() => {});
+    .catch(() => null);
 
   await page.goto(`/window/${windowId}`, { waitUntil: 'load' });
   await page
     .locator('.document-list-wrapper')
     .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-  await rowDataFetched;
-  // Let React paint the fetched rows (or the empty-list panel) before counting.
-  await page
-    .locator('.table-flex-wrapper tbody tr, .empty-info-text')
-    .first()
-    .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT })
-    .catch(() => {});
+
+  const resp = await rowDataResponse;
+  // Only trust a 2xx body as ground truth — a non-2xx error response can carry
+  // a JSON body (e.g. Spring's {timestamp,status,error,path}) that parses fine
+  // but has no `size`/`result`, which would otherwise be misread as a confirmed
+  // empty view (wrong ALT+N branch) instead of falling through to the DOM check.
+  const body = resp && resp.ok() ? await resp.json().catch(() => null) : null;
+  // true = has rows, false = empty, null = payload unreadable (fall back to DOM).
+  const serverHasRows = body
+    ? (typeof body.size === 'number' ? body.size : body.result?.length ?? 0) > 0
+    : null;
 
   const rows = page.locator('.table-flex-wrapper tbody tr');
-  const rowCount = await rows.count();
+  let createNewRecord;
+  if (serverHasRows === true) {
+    // Row-bearing window: wait for the fetched row to actually commit to the
+    // DOM before opening it — deterministic, no race with React's render.
+    await rows
+      .first()
+      .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+    createNewRecord = false;
+  } else if (serverHasRows === false) {
+    createNewRecord = true;
+  } else {
+    // Payload unreadable — best-effort DOM count after the fetch resolved.
+    createNewRecord = (await rows.count()) === 0;
+  }
 
-  if (rowCount === 0) {
+  if (createNewRecord) {
     // Create a new record — ALT+N navigates to `/window/<id>/NEW` and persists
     // it, ending up on `/window/<id>/<new-id>` with a Drafted document.
     await page.keyboard.press('Alt+n');


### PR DESCRIPTION
## What

De-flake the `advanced-edit-focus.spec.js` frontend-webui Playwright spec. Two async-timing seams caused intermittent CI failures that passed on Playwright retry (a flaky retry still exits the shard non-zero).

## Root cause + fix (test-only)

Both root causes below are **hypotheses reasoned from the spec + frontend source** (the code paths were confirmed in the repo), **not yet reproduced at runtime** — these are load-dependent flakes that pass on Playwright retry, and local full-stack reproduction was unavailable on a contended shared host. CI is the verifying signal.

1. **nav-URL 20s timeout in `openSingleRecord`.** Hypothesis: the row count was read before the list's row-data fetch (`GET /documentView/<win>/<viewId>?firstRow=...`) resolved. On a slow/cold run a row-bearing window (Product 140) momentarily reads 0 rows, wrongly takes the empty-list `ALT+N` branch, creates a NEW draft that never persists to a numeric id, and hangs `waitForURL(/\d+\/\d+/)` for the full 20s. Fix: await that specific row-data response (listener armed before navigation), then wait for rows or the empty-list panel to paint, before counting. `networkidle` is deliberately not used (dashboard STOMP/KPI traffic never settles).

2. **modal-close 5s timeout.** Hypothesis: the `Escape` -> `.panel-modal` hidden waits used the 5s FAST budget, but closing the advanced-edit modal can involve a document PATCH/refresh round-trip before unmount + CSS transition, which under CI load exceeds 5s. The wait condition is correct, only the budget was too tight -> use the 20s slow budget (both occurrences).

## Scope

Test file only; no production code touched.
