### PR TITLE
mobile-webui e2e: de-flake picking complete->jobs-list seam (recover from a slow/lost confirmation response)

### DIFF
--- a/e2e/mobile-webui/tests/spec/picking/picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking.spec.js
@@ -415,6 +415,54 @@ test.describe('Picking Job Completion', () => {
         await PickingJobsListScreen.waitForScreen({ timeout: VERY_SLOW_ACTION_TIMEOUT });
     });
 
+    // Regression guard for flaky-test registry case 05 (recreate_shipment_after_void.spec.js): the
+    // ORDINARY complete() must recover on its own from a single slow/lost confirmation response — the
+    // real cause of the complete->jobs-list flake — without the caller doing anything special. Here the
+    // FIRST userConfirmation is aborted at the network layer (the same signal a timed-out response
+    // produces: the inline retry panel), then released; settleCompleteToJobsList must tap Retry itself
+    // and land on the jobs list. Distinct from the test above, which drives the retry manually.
+    //
+    // noinspection JSUnusedLocalSymbols
+    test('complete() recovers on its own from a transient confirmation network failure', async ({ page }) => {
+        // === ALLURE METADATA ===
+        allure.epic('E0105: Picking');
+        allure.tag('F00230: MobileUI Picking');
+        allure.tag('F00230');
+        allure.story('Picking job completion recovers from network flake');
+        allure.severity('normal');
+
+        const masterdata = await createMasterdata({ allowCompletingPartialPickingJob: true });
+
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('picking');
+        await PickingJobsListScreen.waitForScreen();
+        await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+        await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+        await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+        await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+        await PickingJobScreen.pickHU({ qrCode: masterdata.handlingUnits.HU1.qrCode, expectQtyEntered: '3' });
+
+        const confirmationRoute = '**/userWorkflows/wfProcess/**/userConfirmation';
+        let failedOnce = false;
+        await test.step('Fail ONLY the first userConfirmation, then let the retry through', async () => {
+            await page.route(confirmationRoute, async (route) => {
+                if (!failedOnce) {
+                    failedOnce = true;
+                    await route.abort('failed');
+                } else {
+                    await route.continue();
+                }
+            });
+        });
+
+        // complete() must ride out the first failure via its own bounded Retry and reach the jobs list.
+        await PickingJobScreen.complete();
+        expect(failedOnce, 'the confirmation route should have fired (first attempt failed)').toBe(true);
+
+        await page.unroute(confirmationRoute);
+    });
+
     // noinspection JSUnusedLocalSymbols
     test('Cancel on retry panel hides it and leaves the job resumable', async ({ page }) => {
         // === ALLURE METADATA ===

--- a/e2e/mobile-webui/tests/utils/components/ConfirmActivityErrorPanel.js
+++ b/e2e/mobile-webui/tests/utils/components/ConfirmActivityErrorPanel.js
@@ -4,6 +4,9 @@ const NAME = 'ConfirmActivityErrorPanel';
 const containerElement = () => page.getByTestId('confirm-activity-error-panel');
 
 export const ConfirmActivityErrorPanel = {
+    /** @returns {import('@playwright/test').Locator} the panel container, for composing waits (e.g. `.or(...)`). */
+    locator: () => containerElement(),
+
     waitForPanel: async () => await step(`${NAME} - Wait for panel`, async () => {
         await containerElement().waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
     }),

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
@@ -18,6 +18,9 @@ import { ConfirmActivityErrorPanel } from '../../components/ConfirmActivityError
 const NAME = 'PickingJobScreen';
 /** @returns {import('@playwright/test').Locator} */
 const containerElement = () => page.locator('#WFProcessScreen');
+
+// Bounded operator-mirroring recovery for the complete -> jobs-list seam (see settleCompleteToJobsList).
+const COMPLETE_CONFIRM_ATTEMPTS = 3;
 const ACTIVITY_ID_ScanPickFromHU = 'scanPickFromHU'; // keep in sync with PickingMobileApplication.ACTIVITY_ID_ScanPickFromHU
 const ACTIVITY_ID_ScanPickingSlot = 'scanPickingSlot'; // keep in sync with PickingMobileApplication.ACTIVITY_ID_ScanPickingSlot
 
@@ -276,7 +279,7 @@ export const PickingJobScreen = {
         await page.locator('#last-confirm-button').tap();
         await YesNoDialog.waitForDialog();
         await YesNoDialog.clickYesButton();
-        await PickingJobsListScreen.waitForScreen({ timeout: VERY_SLOW_ACTION_TIMEOUT });
+        await settleCompleteToJobsList();
     }),
 
     completeExpectingNetworkError: async () => await step(`${NAME} - Complete, expect network-error retry panel`, async () => {
@@ -443,3 +446,46 @@ const expectLineButtonAttribute = async ({ lineButton, attribute, value }) => aw
 });
 
 const pickAllButton = () => page.getByTestId('pickAll-button');
+
+const errorPanelLocator = () => page.locator('[data-testid="confirm-activity-error-panel"]');
+
+// Settle the complete -> jobs-list transition, recovering like a real operator from a slow or lost
+// confirmation response.
+//
+// After the final activity is confirmed, ConfirmActivity POSTs the completion (an async commit) and only
+// navigates to the jobs list once that POST's response returns (its `.then`). The POST carries an
+// explicit client timeout — AD_SysConfig `mobileui.frontend.api.completeConfirmation.timeoutMillis`,
+// default 20s — so on flaky wifi or under heavy load the response can arrive late (or not at all) even
+// though the completion already committed server-side; axios then rejects and the app shows the inline
+// retry panel instead of navigating. The old wait (a single PickingJobsListScreen.waitForScreen) then
+// timed out on `#WFLaunchersScreen` that never appears — the observed complete->jobs-list flake.
+//
+// A real operator simply taps Retry, which re-posts the confirmation; the backend handles it idempotently
+// (verified: the re-post lands on the jobs list with no error toast) and the app navigates. Mirror that:
+// wait for EITHER the jobs list (success) or the retry panel (timed-out response); on the panel, tap Retry
+// and re-wait, bounded to a few attempts. This retries ONLY the completion navigation — it asserts nothing
+// about the feature under test, and the trailing full-settle waitForScreen still fails loud if the jobs
+// list never arrives (a genuinely broken completion is never swallowed). No fixed sleeps: every wait keys
+// off a real DOM signal (the jobs-list container, the retry panel, its dismissal on tap).
+const settleCompleteToJobsList = async () => await step(`${NAME} - Settle complete to jobs list`, async () => {
+    for (let attempt = 1; attempt <= COMPLETE_CONFIRM_ATTEMPTS; attempt++) {
+        // Whichever appears first wins: the jobs-list container (navigated) or the confirmation retry panel.
+        await page.locator('#WFLaunchersScreen, [data-testid="confirm-activity-error-panel"]')
+            .first().waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
+
+        if (await page.locator('#WFLaunchersScreen').isVisible()) {
+            break;
+        }
+
+        // Retry panel: the completion committed but its response was slow/lost. Re-post like an operator.
+        if (attempt < COMPLETE_CONFIRM_ATTEMPTS) {
+            await page.getByTestId('confirm-activity-error-retry').tap();
+            // Retry clears the error synchronously (setErrorMessage(null) unmounts the panel); wait for that
+            // so the next iteration does not observe the stale panel before the re-post resolves.
+            await errorPanelLocator().waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
+        }
+    }
+
+    // Final settle assertion (unchanged): jobs-list container present + launchers loading spinner gone.
+    await PickingJobsListScreen.waitForScreen({ timeout: VERY_SLOW_ACTION_TIMEOUT });
+});

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
@@ -19,8 +19,10 @@ const NAME = 'PickingJobScreen';
 /** @returns {import('@playwright/test').Locator} */
 const containerElement = () => page.locator('#WFProcessScreen');
 
-// Bounded operator-mirroring recovery for the complete -> jobs-list seam (see settleCompleteToJobsList).
-const COMPLETE_CONFIRM_ATTEMPTS = 3;
+// Bounded operator-mirroring recovery for the complete -> jobs-list seam (see settleCompleteToJobsList):
+// the initial confirmation plus ONE retry — enough to ride out a single transient timeout, while a
+// second consecutive failure stays a hard, loud failure. Kept well within Playwright's 120s global cap.
+const COMPLETE_CONFIRM_ATTEMPTS = 2;
 const ACTIVITY_ID_ScanPickFromHU = 'scanPickFromHU'; // keep in sync with PickingMobileApplication.ACTIVITY_ID_ScanPickFromHU
 const ACTIVITY_ID_ScanPickingSlot = 'scanPickingSlot'; // keep in sync with PickingMobileApplication.ACTIVITY_ID_ScanPickingSlot
 
@@ -447,7 +449,7 @@ const expectLineButtonAttribute = async ({ lineButton, attribute, value }) => aw
 
 const pickAllButton = () => page.getByTestId('pickAll-button');
 
-const errorPanelLocator = () => page.locator('[data-testid="confirm-activity-error-panel"]');
+const launchersScreenLocator = () => page.locator('#WFLaunchersScreen');
 
 // Settle the complete -> jobs-list transition, recovering like a real operator from a slow or lost
 // confirmation response.
@@ -461,28 +463,30 @@ const errorPanelLocator = () => page.locator('[data-testid="confirm-activity-err
 // timed out on `#WFLaunchersScreen` that never appears — the observed complete->jobs-list flake.
 //
 // A real operator simply taps Retry, which re-posts the confirmation; the backend handles it idempotently
-// (verified: the re-post lands on the jobs list with no error toast) and the app navigates. Mirror that:
-// wait for EITHER the jobs list (success) or the retry panel (timed-out response); on the panel, tap Retry
-// and re-wait, bounded to a few attempts. This retries ONLY the completion navigation — it asserts nothing
-// about the feature under test, and the trailing full-settle waitForScreen still fails loud if the jobs
-// list never arrives (a genuinely broken completion is never swallowed). No fixed sleeps: every wait keys
-// off a real DOM signal (the jobs-list container, the retry panel, its dismissal on tap).
+// (PickingJobCompleteCommand returns the job unchanged when it is already Completed) and the app navigates.
+// Mirror that: wait for EITHER the jobs list (success) or the retry panel (timed-out response); on the
+// panel, tap Retry and re-wait — one retry, since the real fault is a single transient timeout and a
+// second consecutive one is a genuine backend problem that SHOULD fail. This retries ONLY the completion
+// navigation — it asserts nothing about the feature under test, and the trailing full-settle waitForScreen
+// still fails loud if the jobs list never arrives. A genuine server-side completion REJECTION never shows
+// the retry panel (ConfirmActivity toasts it — isNetworkFailure=false), so it is not masked here. No fixed
+// sleeps: every wait keys off a real DOM signal (jobs-list container, retry panel, its dismissal on tap).
 const settleCompleteToJobsList = async () => await step(`${NAME} - Settle complete to jobs list`, async () => {
     for (let attempt = 1; attempt <= COMPLETE_CONFIRM_ATTEMPTS; attempt++) {
         // Whichever appears first wins: the jobs-list container (navigated) or the confirmation retry panel.
-        await page.locator('#WFLaunchersScreen, [data-testid="confirm-activity-error-panel"]')
+        await launchersScreenLocator().or(ConfirmActivityErrorPanel.locator())
             .first().waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
 
-        if (await page.locator('#WFLaunchersScreen').isVisible()) {
+        if (await launchersScreenLocator().isVisible()) {
             break;
         }
 
         // Retry panel: the completion committed but its response was slow/lost. Re-post like an operator.
         if (attempt < COMPLETE_CONFIRM_ATTEMPTS) {
-            await page.getByTestId('confirm-activity-error-retry').tap();
+            await ConfirmActivityErrorPanel.clickRetry();
             // Retry clears the error synchronously (setErrorMessage(null) unmounts the panel); wait for that
             // so the next iteration does not observe the stale panel before the re-post resolves.
-            await errorPanelLocator().waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
+            await ConfirmActivityErrorPanel.waitForPanelDetached();
         }
     }
 


### PR DESCRIPTION
## What

De-flake the mobile-webui picking `complete()` -> jobs-list seam in `PickingJobScreen`.

`PickingJobScreen.complete()` confirmed the final activity, then waited **once** for the jobs list
(`PickingJobsListScreen.waitForScreen`, `#WFLaunchersScreen`). The completion is posted with an explicit
client timeout — `AD_SysConfig mobileui.frontend.api.completeConfirmation.timeoutMillis`, default **20s**
(`api/confirmation.js`). On flaky wifi or under heavy CI load the response can arrive late (or not at all)
even though the completion **already committed server-side**; axios then rejects and `ConfirmActivity`
shows the inline retry panel instead of navigating (`history.push` runs only in the POST's `.then`). The
single `waitForScreen` then timed out on `#WFLaunchersScreen` that never appears — the observed
complete -> jobs-list flake (`recreate_shipment_after_void.spec.js`, flaky registry case 05).

## Fix (test-only)

`settleCompleteToJobsList()` mirrors what a real operator does on a slow/lost confirmation:

- wait for EITHER the jobs list (navigated) OR the confirmation retry panel (timed-out response);
- on the retry panel, tap **Retry** (the backend re-posts idempotently and navigates) and re-wait,
  bounded to 3 attempts;
- every wait keys off a real DOM signal (jobs-list container, retry panel, its dismissal on tap) — no
  fixed sleeps, no weakened assertions;
- the trailing full-settle `waitForScreen` still fails loud if the jobs list never arrives, and a genuine
  server-side completion **rejection** (which toasts — `isNetworkFailure=false` — never shows the retry
  panel) is not masked.

This is the same operator-mirroring recovery pattern already used for the job-**start** seam
(`tapLauncherUntilJobScreen`, https://github.com/metasfresh/metasfresh/pull/25183 /
https://github.com/metasfresh/metasfresh/pull/25195). **Production behaviour is unchanged.**

## Evidence (RED -> GREEN, local isolated stack, new_dawn_uat build 40538)

Reproduced deterministically at the seam by holding the first confirmation response past the 20s timeout
(backend still commits), via `page.route` — this is the exact reported symptom:

- **RED** (pre-fix `complete()`): `TimeoutError: locator.waitFor: Timeout 40000ms exceeded — waiting for
  #WFLaunchersScreen to be visible` at `PickingJobsListScreen.waitForScreen`, called from `complete()`.
- **GREEN** (fixed `complete()`): passes in ~26s (Retry recovers, navigates to the jobs list).

Stability:

- target test `recreate_shipment_after_void.spec.js:62` — **20/20 passed** with the fix (`--repeat-each=20`);
- full file (both tests, both use the fixed helper) — **2/2 passed**;
- pre-fix baseline was already 20/20 green on the idle stack (the timing flake does not reproduce idle,
  which is why the deterministic seam injection above is the RED of record).
