### PR TITLE
cucumber: de-flake reversedShipmentClearsBPartner MD_Stock wait (path 2.8)

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/reversedShipmentClearsBPartner.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/reversedShipmentClearsBPartner.feature
@@ -1053,7 +1053,10 @@ Feature: reversed shipment clears HU C_BPartner_ID
     And M_HU_Storage are validated
       | Identifier | M_HU_ID.Identifier | M_Product_ID.Identifier | Qty |
       | hu_s_1     | hu_1               | p_1                     | 10  |
-    And after not more than 60 seconds metasfresh has MD_Stock data
+    # The shipment reversal (RC) fires async stock events (delete+create) that must
+    # propagate through RabbitMQ before MD_Stock reaches its final value. Use 120s for
+    # CI headroom (mirrors the 120s post-reversal MD_Stock wait earlier in this feature).
+    And after not more than 120 seconds metasfresh has MD_Stock data
       | M_Product_ID.Identifier | QtyOnHand |
       | p_1                     | 10        |
 


### PR DESCRIPTION
## Flaky test fix

`reversedShipmentClearsBPartner.feature:1056` — step "after not more than 60 seconds metasfresh has MD_Stock data" (scenario *path 2.8: shipment reversal then inventory adjustment then re-ship*) intermittently fails on CI with:

```
AssertionFailedError: the given supplier didn't succeed within the 60 seconds timeout (121 tries)
```

accompanied by `DeadlockRetryPolicy` retries in material-dispo.

### Root cause (test-side timing, not a product defect)
The step sits immediately after a shipment reversal (`RC`, line 1047). A reversal fires async stock events (delete+create) that must propagate through RabbitMQ before `MD_Stock.QtyOnHand` settles back to 10. Under CI contention (profile5 parallel load + deadlock-retry latency) that async settle can exceed the 60s poll budget, so the poll times out. The poll itself is correct — it already gates on the exact target value (`QtyOnHand == 10`) and exits the instant it settles; it just needs more headroom.

Observed on two independent, structurally-unrelated PRs (same feature:line): #25183 (frontend-only diff) and #25162 (DD-replenishment).

### Fix (test-only)
Raise the post-reversal MD_Stock wait from 60s to **120s**, matching the precedent already set at line 365 of this same feature for the same reversal->RabbitMQ->MD_Stock pattern ("Use 120s for CI headroom"). No assertion weakened (still asserts `QtyOnHand == 10` exactly), no sleep added (poll exits as soon as the value settles).

### Validation
Timing flake is **not locally reproducible** on an idle stack (async settle is sub-second locally; both 60s and 120s pass) — the RED only manifests under CI contention. The authoritative GREEN signal is this PR's CI.

**Sibling observation:** five other post-reversal MD_Stock waits in this feature (lines ~100, 216, 256, 492, 614) are still at 60s and share the identical pattern; only line 1056 has recurring CI evidence, so this PR fixes only that line.
