### PR TITLE
[DOES NOT FIX - gated on production] qtyReservation_orderReactivation.feature:121 flake

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_orderReactivation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/qtyReservation/qtyReservation_orderReactivation.feature
@@ -114,6 +114,18 @@ Feature: Qty Reservation — reconcile reservation to ordered qty on order react
     And update C_OrderLine:
       | C_OrderLine_ID.Identifier | OPT.QtyEntered | OPT.QtyOrdered |
       | orderLine                 | 75             | 75             |
+
+    # Let the reactivation's + line-reduction's async processing settle before re-completing:
+    # drain the material queue and wait for the shipment-schedule recompute to finish, so the
+    # completion's synchronous reservation-reconcile (BEFORE_COMPLETE) does not race — and deadlock
+    # against — a still-in-flight shipment-schedule recompute. Without this gate the re-completion's
+    # `UPDATE C_OrderLine` deadlocks with the async worker's `UPDATE M_ShipmentSchedule` on the same
+    # order line; the completion transaction is rolled back and the reservation is left un-shrunk at 100.
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And after not more than 60s, shipment schedule is recomputed
+      | M_ShipmentSchedule_ID |
+      | shipmentSchedule      |
+
     And the order identified by order is completed
 
     # Reconcile assertion: the reservation is shrunk to the new ordered qty,


### PR DESCRIPTION
## Status: this test-side change does NOT fix the flake — do NOT merge

me03 https://github.com/metasfresh/me03/issues/31020 case 8. This PR added a settle gate (drain material queue + wait shipment-schedule recompute) before the order re-completion, mirroring the scenario's existing post-reversal gate.

CI re-ran the fixed feature and it failed IDENTICALLY:
- run https://github.com/metasfresh/metasfresh/actions/runs/29639776421 (profile5): `[M_QtyReservation[1000007].Qty] expected: 75 Stk but was: 100 Stk`, 121 tries / 60s timeout — the exact case-8 symptom, on the gated feature.
- In that run the gate executed and there was NO deadlock, no exception, no retry — yet the reservation was still un-shrunk (Qty=100, QtyDelivered=0, active).

## Why it is not test-side fixable

The reservation shrink runs as a single synchronous side-effect at C_Order TIMING_BEFORE_COMPLETE (reconcileQtyReservations -> ReconcileQtyReservationsCommand). It is one-shot: if it does not persist a shrink at that instant, nothing re-applies it.

- Original failing run (pre-gate, https://github.com/metasfresh/metasfresh/actions/runs/29578897317): a DB deadlock (UPDATE C_OrderLine in the completion vs an async UPDATE M_ShipmentSchedule) rolled back the completion; DeadlockRetryPolicy retried the whole completion but the shrink still did not end up persisted.
- Gated run (this PR): no deadlock at all, and the shipment-schedule recompute path only READS M_QtyReservation (no concurrent writer of Qty), yet reconcile still produced no shrink. Given the captured reservation was active with Qty=100, QtyDelivered=0, the only input that makes the deterministic reconcile a no-op is QtyOrdered >= 100 at BEFORE_COMPLETE — a CI-load-dependent timing/ordering effect around when the reactivated order's QtyOrdered settles relative to the one-shot reconcile. It does not reproduce on an idle local stack.

A test-side settle gate cannot deterministically close this: the reactivate->reduce->re-complete sequence inherently churns async shipment-schedule / material-dispo recompute that races the completion, and the reconcile has no idempotent re-application.

## Recommendation

Gate case 8 on a production robustness fix to reconcile-on-complete (make it idempotent / re-applied after a completion retry, ensure QtyOrdered is settled before it runs, or move it off the fragile one-shot BEFORE_COMPLETE path). Do NOT merge this PR.
