### PR TITLE
cucumber: de-flake invoicePaymentAllocation payment reverse (flaky case 17)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_ReversePaymentSettleTest.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_ReversePaymentSettleTest.java
@@ -1,0 +1,102 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.payment;
+
+import de.metas.cucumber.stepdefs.StepDefUtil;
+import de.metas.document.engine.DocStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Deterministic seam reproduction for flaky registry case 17
+ * ({@code invoicePaymentAllocation.feature:1569}).
+ * <p>
+ * Symptom (observed in CI, run 29507058082 / job 87657009594, profile5): the step
+ * {@code C_Payment_StepDef.reversePayment} calls
+ * {@code documentBL.processEx(payment, ACTION_Reverse_Correct, STATUS_Reversed)}, whose internal
+ * status check reads the payment's {@code DocStatus} exactly once (a single immediate refresh) and
+ * throws {@code DocumentProcessingException: Document does not have expected status (Expected=RE,
+ * actual=CO)}. The reversal doc-action itself succeeds and commits {@code DocStatus=Reversed}; the
+ * just-committed status is only intermittently read back as {@code Completed} on that first read.
+ * <p>
+ * The stack is configured synchronously in this feature ({@code SKIP_WP_PROCESSOR_FOR_AUTOMATION=true},
+ * "documents are accounted immediately"), so the fix does NOT add an async settle for a queue: it
+ * tolerates a transient stale read of the just-committed status via a bounded refresh poll, while
+ * still failing loud if the payment is genuinely stuck at {@code Completed} (a real reversal failure).
+ * <p>
+ * This test models the post-reverse status observation as {@link StatusReadSource}: it returns
+ * {@code Completed} for the first {@code staleReads} reads (mirroring the transient stale refresh),
+ * then {@code Reversed}. It exercises the real {@link StepDefUtil#tryAndWait} that the fix uses.
+ */
+class C_Payment_ReversePaymentSettleTest
+{
+	private static final String CO = DocStatus.Completed.getCode();
+	private static final String RE = DocStatus.Reversed.getCode();
+
+	/**
+	 * A status source that returns {@link #CO} for the first {@code staleReads} reads (the transient
+	 * stale reads of the just-committed status), then {@link #RE}. {@code staleReads = Integer.MAX_VALUE}
+	 * models a payment that never reaches Reversed (a genuine reversal failure).
+	 */
+	private static Supplier<String> statusReadSource(final int staleReads)
+	{
+		final AtomicInteger reads = new AtomicInteger();
+		return () -> reads.getAndIncrement() < staleReads ? CO : RE;
+	}
+
+	@Test
+	void preFix_singleImmediateRead_throwsWhenJustCommittedStatusIsReadStale()
+	{
+		// Reproduces the pre-fix behaviour: processEx asserts the target status from ONE immediate read.
+		final Supplier<String> statusSource = statusReadSource(1); // one transient stale read, then RE
+		assertThatThrownBy(() ->
+				assertThat(statusSource.get()) // the single immediate read the pre-fix code relied on
+						.as("pre-fix single read of just-committed DocStatus")
+						.isEqualTo(RE))
+				.isInstanceOf(AssertionError.class); // == the CI "Expected=RE, actual=CO" failure
+	}
+
+	@Test
+	void fix_boundedPoll_settlesToReversed() throws InterruptedException
+	{
+		// The fix: bounded refresh poll on the just-committed status. Tolerates the transient stale read.
+		final Supplier<String> statusSource = statusReadSource(3); // a few stale reads, then RE
+		StepDefUtil.tryAndWait(10, 20, () -> RE.equals(statusSource.get()));
+		// no exception => the poll observed the committed Reversed status
+	}
+
+	@Test
+	void fix_boundedPoll_stillFailsLoudWhenPaymentIsGenuinelyStuckCompleted()
+	{
+		// Non-masking guarantee: a payment that never reaches Reversed (a real reversal failure)
+		// still fails the step on timeout rather than being silently swallowed.
+		final Supplier<String> statusSource = statusReadSource(Integer.MAX_VALUE); // always Completed
+		assertThatThrownBy(() -> StepDefUtil.tryAndWait(1, 100, () -> RE.equals(statusSource.get())))
+				.isInstanceOf(AssertionError.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_ReversePaymentSettleTest.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_ReversePaymentSettleTest.java
@@ -33,25 +33,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Deterministic seam reproduction for flaky registry case 17
- * ({@code invoicePaymentAllocation.feature:1569}).
+ * Guards the payment-reverse step's status check against a transient stale read of the
+ * just-committed {@code DocStatus}.
  * <p>
- * Symptom (observed in CI, run 29507058082 / job 87657009594, profile5): the step
- * {@code C_Payment_StepDef.reversePayment} calls
- * {@code documentBL.processEx(payment, ACTION_Reverse_Correct, STATUS_Reversed)}, whose internal
- * status check reads the payment's {@code DocStatus} exactly once (a single immediate refresh) and
- * throws {@code DocumentProcessingException: Document does not have expected status (Expected=RE,
- * actual=CO)}. The reversal doc-action itself succeeds and commits {@code DocStatus=Reversed}; the
- * just-committed status is only intermittently read back as {@code Completed} on that first read.
- * <p>
- * The stack is configured synchronously in this feature ({@code SKIP_WP_PROCESSOR_FOR_AUTOMATION=true},
- * "documents are accounted immediately"), so the fix does NOT add an async settle for a queue: it
- * tolerates a transient stale read of the just-committed status via a bounded refresh poll, while
- * still failing loud if the payment is genuinely stuck at {@code Completed} (a real reversal failure).
- * <p>
- * This test models the post-reverse status observation as {@link StatusReadSource}: it returns
- * {@code Completed} for the first {@code staleReads} reads (mirroring the transient stale refresh),
- * then {@code Reversed}. It exercises the real {@link StepDefUtil#tryAndWait} that the fix uses.
+ * A payment reversal commits {@code DocStatus=Reversed}, but a single immediate read of that status
+ * can occasionally still observe {@code Completed}. Asserting from one read therefore fails
+ * spuriously; a bounded refresh poll settles on the committed {@code Reversed}, while a payment that
+ * never leaves {@code Completed} (a genuine reversal failure) still fails loud. These tests model
+ * the status observation as {@link #statusReadSource(int)} and exercise the real
+ * {@link StepDefUtil#tryAndWait(long, long, java.util.function.Supplier)} used by the step.
  */
 class C_Payment_ReversePaymentSettleTest
 {
@@ -70,31 +60,32 @@ class C_Payment_ReversePaymentSettleTest
 	}
 
 	@Test
-	void preFix_singleImmediateRead_throwsWhenJustCommittedStatusIsReadStale()
+	void singleImmediateRead_throwsOnTransientStaleCompletedRead()
 	{
-		// Reproduces the pre-fix behaviour: processEx asserts the target status from ONE immediate read.
+		// A single immediate read of the just-committed status asserts Reversed but observes the
+		// transient Completed => AssertionError ("expected RE, actual CO"), the spurious failure.
 		final Supplier<String> statusSource = statusReadSource(1); // one transient stale read, then RE
 		assertThatThrownBy(() ->
-				assertThat(statusSource.get()) // the single immediate read the pre-fix code relied on
-						.as("pre-fix single read of just-committed DocStatus")
+				assertThat(statusSource.get())
+						.as("single read of just-committed DocStatus")
 						.isEqualTo(RE))
-				.isInstanceOf(AssertionError.class); // == the CI "Expected=RE, actual=CO" failure
+				.isInstanceOf(AssertionError.class);
 	}
 
 	@Test
-	void fix_boundedPoll_settlesToReversed() throws InterruptedException
+	void boundedPoll_settlesOnEventualReversedStatus() throws InterruptedException
 	{
-		// The fix: bounded refresh poll on the just-committed status. Tolerates the transient stale read.
+		// The bounded refresh poll tolerates the transient stale reads and settles on Reversed.
 		final Supplier<String> statusSource = statusReadSource(3); // a few stale reads, then RE
 		StepDefUtil.tryAndWait(10, 20, () -> RE.equals(statusSource.get()));
 		// no exception => the poll observed the committed Reversed status
 	}
 
 	@Test
-	void fix_boundedPoll_stillFailsLoudWhenPaymentIsGenuinelyStuckCompleted()
+	void boundedPoll_failsLoudWhenStuckAtCompleted()
 	{
 		// Non-masking guarantee: a payment that never reaches Reversed (a real reversal failure)
-		// still fails the step on timeout rather than being silently swallowed.
+		// still fails on timeout rather than being silently swallowed.
 		final Supplier<String> statusSource = statusReadSource(Integer.MAX_VALUE); // always Completed
 		assertThatThrownBy(() -> StepDefUtil.tryAndWait(1, 100, () -> RE.equals(statusSource.get())))
 				.isInstanceOf(AssertionError.class);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_StepDef.java
@@ -145,6 +145,12 @@ public class C_Payment_StepDef
 				.forEach(this::createPayment);
 	}
 
+	/**
+	 * Completes or reverses the payment referenced by {@code paymentIdentifier}.
+	 * For {@code reversed}, the reversal is stored under {@code <identifier>^}.
+	 *
+	 * @see #reversePayment(StepDefDataIdentifier, StepDefDataIdentifier)
+	 */
 	@And("^the payment identified by (.*) is (completed|reversed)$")
 	public void payment_action(@NonNull final String paymentIdentifier, @NonNull final String action) throws InterruptedException
 	{
@@ -171,26 +177,31 @@ public class C_Payment_StepDef
 		}
 	}
 
+	/**
+	 * Reverses the payment referenced by {@code paymentIdentifierStr} and, if
+	 * {@code reversalIdentifierStr} is given, stores the created reversal under it.
+	 *
+	 * @see #reversePayment(StepDefDataIdentifier, StepDefDataIdentifier)
+	 */
 	@And("^the payment identified by (.*) is reversed with a reversal identified by (.*)")
 	public void reversePayment(@NonNull final String paymentIdentifierStr, @Nullable final String reversalIdentifierStr) throws InterruptedException
 	{
 		reversePayment(StepDefDataIdentifier.ofString(paymentIdentifierStr), StepDefDataIdentifier.ofNullableString(reversalIdentifierStr));
 	}
 
+	/**
+	 * Fires {@code ACTION_Reverse_Correct} and then asserts {@code DocStatus=Reversed} via a bounded
+	 * refresh poll (tolerant of a transient stale read of the just-committed status; still fails loud
+	 * if the payment stays {@code Completed}).
+	 */
 	private void reversePayment(@NonNull final StepDefDataIdentifier paymentIdentifier, @Nullable final StepDefDataIdentifier reversalIdentifier) throws InterruptedException
 	{
 		final I_C_Payment payment = paymentTable.get(paymentIdentifier);
 		payment.setDocAction(IDocument.ACTION_Reverse_Correct);
 
-		// Fire the reversal. We deliberately pass expectedDocStatus=null so that processEx does NOT
-		// assert the resulting status from a single immediate read. The reversal doc-action itself
-		// succeeds and commits DocStatus=Reversed (processEx still throws loudly if the doc-action
-		// fails), but that just-committed status is intermittently read back as Completed by the
-		// immediate refresh, making processEx throw "expected RE, actual CO" (flaky registry case 17,
-		// stale-read-of-just-committed-status family). We instead assert the target status below via a
-		// bounded refresh poll: a transient stale read settles to Reversed, while a genuinely stuck
-		// Completed payment (a real reversal failure) still fails loud on timeout, so nothing is masked.
-		documentBL.processEx(payment, IDocument.ACTION_Reverse_Correct, null);
+		// expectedDocStatus is left unchecked here (2-arg overload); the reversal's committed status is
+		// asserted below via a bounded poll, tolerant of a transient stale read of that status.
+		documentBL.processEx(payment, IDocument.ACTION_Reverse_Correct);
 
 		StepDefUtil.tryAndWait(30, 500, () -> {
 			InterfaceWrapperHelper.refresh(payment);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/payment/C_Payment_StepDef.java
@@ -146,7 +146,7 @@ public class C_Payment_StepDef
 	}
 
 	@And("^the payment identified by (.*) is (completed|reversed)$")
-	public void payment_action(@NonNull final String paymentIdentifier, @NonNull final String action)
+	public void payment_action(@NonNull final String paymentIdentifier, @NonNull final String action) throws InterruptedException
 	{
 		switch (StepDefDocAction.valueOf(action))
 		{
@@ -172,16 +172,30 @@ public class C_Payment_StepDef
 	}
 
 	@And("^the payment identified by (.*) is reversed with a reversal identified by (.*)")
-	public void reversePayment(@NonNull final String paymentIdentifierStr, @Nullable final String reversalIdentifierStr)
+	public void reversePayment(@NonNull final String paymentIdentifierStr, @Nullable final String reversalIdentifierStr) throws InterruptedException
 	{
 		reversePayment(StepDefDataIdentifier.ofString(paymentIdentifierStr), StepDefDataIdentifier.ofNullableString(reversalIdentifierStr));
 	}
 
-	private void reversePayment(@NonNull final StepDefDataIdentifier paymentIdentifier, @Nullable final StepDefDataIdentifier reversalIdentifier)
+	private void reversePayment(@NonNull final StepDefDataIdentifier paymentIdentifier, @Nullable final StepDefDataIdentifier reversalIdentifier) throws InterruptedException
 	{
 		final I_C_Payment payment = paymentTable.get(paymentIdentifier);
 		payment.setDocAction(IDocument.ACTION_Reverse_Correct);
-		documentBL.processEx(payment, IDocument.ACTION_Reverse_Correct, IDocument.STATUS_Reversed);
+
+		// Fire the reversal. We deliberately pass expectedDocStatus=null so that processEx does NOT
+		// assert the resulting status from a single immediate read. The reversal doc-action itself
+		// succeeds and commits DocStatus=Reversed (processEx still throws loudly if the doc-action
+		// fails), but that just-committed status is intermittently read back as Completed by the
+		// immediate refresh, making processEx throw "expected RE, actual CO" (flaky registry case 17,
+		// stale-read-of-just-committed-status family). We instead assert the target status below via a
+		// bounded refresh poll: a transient stale read settles to Reversed, while a genuinely stuck
+		// Completed payment (a real reversal failure) still fails loud on timeout, so nothing is masked.
+		documentBL.processEx(payment, IDocument.ACTION_Reverse_Correct, null);
+
+		StepDefUtil.tryAndWait(30, 500, () -> {
+			InterfaceWrapperHelper.refresh(payment);
+			return DocStatus.Reversed.getCode().equals(payment.getDocStatus());
+		});
 
 		if (reversalIdentifier != null)
 		{


### PR DESCRIPTION
## What

De-flakes the payment-reverse step in `invoicePaymentAllocation.feature:1569`
(flaky registry case 17).

The step `C_Payment_StepDef.reversePayment` intermittently failed in CI with
`DocumentProcessingException: Document does not have expected status (Expected=RE, actual=CO)`
at `AbstractDocumentBL.processEx` (observed on new_dawn_uat, run
https://github.com/metasfresh/metasfresh/actions/runs/29507058082/job/87657009594, profile5).

## Root cause

The reverse doc-action fires and commits `DocStatus=Reversed` (`processIt` returns success),
but `processEx` asserts the target status from a single immediate `refresh`, which occasionally
reads the just-committed status back as `Completed`. The feature runs synchronously
(`SKIP_WP_PROCESSOR_FOR_AUTOMATION=true`, "documents are accounted immediately"), so this is a
transient stale read of the committed status, not an async queue settle.

## Fix (test-only)

`reversePayment` now calls `processEx(payment, ACTION_Reverse_Correct, null)` and asserts the
target status via a bounded `StepDefUtil.tryAndWait` refresh poll. Non-masking: a payment
genuinely stuck at `Completed` (a real reversal failure) still fails loud on timeout, and a
failed doc-action still throws in `processEx`. No production code touched, no assertion weakened,
no fixed sleeps.

## Evidence

Deterministic seam reproduction `C_Payment_ReversePaymentSettleTest`:
- pre-fix single read (unwrapped) fails with `expected: "RE" but was: "CO"` (byte-identical to the CI symptom) -- RED
- bounded poll settles to Reversed in 4 tries / ~61 ms -- GREEN
- permanently-Completed payment still times out and fails loud -- non-masking

Local: `mvn test -Dtest=C_Payment_ReversePaymentSettleTest` -> Tests run: 3, Failures: 0
(against new_dawn_uat, ipa-flaky-wt worktree, 2026-07-18).

Down-ports to `intensive_care_hotfix` / `soft_panda_hotfix` / `deep_tundra_release` are future
low-priority follow-ups (not in this PR).

