### PR TITLE
cucumber: de-flake jobSchedule scheduled-for-picking settle

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_ScheduledForPickingSettleTest.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_ScheduledForPickingSettleTest.java
@@ -101,6 +101,35 @@ class M_ShipmentSchedule_ScheduledForPickingSettleTest
 				.isInstanceOf(AssertionError.class);
 	}
 
+	@Test
+	void prePickingExpectation_isNotGated_soUnsettledValidateDoesNotTimeOut()
+	{
+		// Line-61 style: the FIRST validate step expects the initial unsettled state (IsScheduledForPicking=N /
+		// QtyScheduledForPicking=0). QtyScheduledForPicking is nullable with no default, so pre-picking it is
+		// NULL in the DB; gating the poll on it would emit SQL `QtyScheduledForPicking = 0`, which never matches
+		// NULL, so the poll would time out even though nothing async is pending. The gate MUST NOT apply to the
+		// unsettled expectation. This locks the regression the first cut of the fix introduced.
+		assertThat(M_ShipmentSchedule_StepDef.shouldGateOnScheduledForPicking(false))
+				.as("gate on expected IsScheduledForPicking=N").isFalse();
+		assertThat(M_ShipmentSchedule_StepDef.shouldGateOnScheduledForPicking(null))
+				.as("gate on absent IsScheduledForPicking").isFalse();
+		assertThat(M_ShipmentSchedule_StepDef.shouldGateOnQtyScheduledForPicking(BigDecimal.ZERO))
+				.as("gate on expected QtyScheduledForPicking=0").isFalse();
+		assertThat(M_ShipmentSchedule_StepDef.shouldGateOnQtyScheduledForPicking(null))
+				.as("gate on absent QtyScheduledForPicking").isFalse();
+	}
+
+	@Test
+	void postPickingExpectation_isGatedOnSettledColumns()
+	{
+		// Line-68 style: the SECOND validate step expects the settled Y/3 state, so the poll must wait for the
+		// async reconcile to write it (this is the de-flake).
+		assertThat(M_ShipmentSchedule_StepDef.shouldGateOnScheduledForPicking(true))
+				.as("gate on expected IsScheduledForPicking=Y").isTrue();
+		assertThat(M_ShipmentSchedule_StepDef.shouldGateOnQtyScheduledForPicking(EXPECTED_QTY))
+				.as("gate on expected QtyScheduledForPicking=3").isTrue();
+	}
+
 	@Value
 	private static class PickingState
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_ScheduledForPickingSettleTest.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_ScheduledForPickingSettleTest.java
@@ -1,0 +1,114 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.shipmentschedule;
+
+import de.metas.cucumber.stepdefs.StepDefUtil;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Guards the {@code validate shipment schedules} step's picking-reconcile assertion against a transient
+ * stale read.
+ * <p>
+ * After {@code create or update picking job schedules}, the shipment schedule already exists (with its
+ * delivery quantities settled), but the async picking-job-schedule reconcile writes
+ * {@code IsScheduledForPicking=Y} / {@code QtyScheduledForPicking=<qty>} a moment later. A readiness
+ * poll that only checks the schedule's existence (or its delivery quantities) therefore returns before
+ * the picking columns are written, and the hard assertion then reads the stale {@code N} / {@code 0}.
+ * The fix gates the poll on the target picking-column values; these tests model that predicate over
+ * {@link #pickingReadSource(int)} and exercise the real
+ * {@link StepDefUtil#tryAndWait(long, long, java.util.function.Supplier)} used by the step.
+ */
+class M_ShipmentSchedule_ScheduledForPickingSettleTest
+{
+	private static final BigDecimal EXPECTED_QTY = new BigDecimal("3");
+
+	/**
+	 * Models the observed picking-reconcile state. The first {@code staleReads} reads return the
+	 * pre-reconcile state ({@code IsScheduledForPicking=false} / {@code QtyScheduledForPicking=0}); every
+	 * read after that returns the settled state ({@code true} / {@code 3}).
+	 * {@code staleReads = Integer.MAX_VALUE} models a reconcile that never happens (a genuine failure).
+	 */
+	private static Supplier<PickingState> pickingReadSource(final int staleReads)
+	{
+		final AtomicInteger reads = new AtomicInteger();
+		return () -> reads.getAndIncrement() < staleReads
+				? new PickingState(false, BigDecimal.ZERO)
+				: new PickingState(true, EXPECTED_QTY);
+	}
+
+	private static boolean isSettled(final PickingState state)
+	{
+		return state.isScheduledForPicking && state.qtyScheduledForPicking.compareTo(EXPECTED_QTY) == 0;
+	}
+
+	@Test
+	void singleImmediateRead_throwsOnTransientStalePickingRead()
+	{
+		// A single immediate read observes the pre-reconcile N/0 state and asserts Y/3 => AssertionError,
+		// the spurious failure this de-flake removes.
+		final Supplier<PickingState> source = pickingReadSource(1); // one transient stale read, then settled
+		final PickingState observed = source.get();
+		assertThatThrownBy(() -> {
+			assertThat(observed.isScheduledForPicking).as("IsScheduledForPicking").isEqualTo(true);
+			assertThat(observed.qtyScheduledForPicking).as("QtyScheduledForPicking").isEqualByComparingTo(EXPECTED_QTY);
+		}).isInstanceOf(AssertionError.class);
+	}
+
+	@Test
+	void boundedPoll_settlesOnEventualScheduledForPicking() throws InterruptedException
+	{
+		// The bounded readiness poll tolerates the transient N/0 reads and settles on Y/3.
+		final Supplier<PickingState> source = pickingReadSource(3); // a few stale reads, then settled
+		StepDefUtil.tryAndWait(10, 20, () -> isSettled(source.get()));
+		// no exception => the poll observed the settled picking columns
+	}
+
+	@Test
+	void boundedPoll_failsLoudWhenReconcileNeverHappens()
+	{
+		// Non-masking guarantee: a schedule whose picking reconcile never runs (a real failure) still
+		// fails on timeout rather than being silently swallowed.
+		final Supplier<PickingState> source = pickingReadSource(Integer.MAX_VALUE); // always N/0
+		assertThatThrownBy(() -> StepDefUtil.tryAndWait(1, 100, () -> isSettled(source.get())))
+				.isInstanceOf(AssertionError.class);
+	}
+
+	private static final class PickingState
+	{
+		private final boolean isScheduledForPicking;
+		private final BigDecimal qtyScheduledForPicking;
+
+		private PickingState(final boolean isScheduledForPicking, final BigDecimal qtyScheduledForPicking)
+		{
+			this.isScheduledForPicking = isScheduledForPicking;
+			this.qtyScheduledForPicking = qtyScheduledForPicking;
+		}
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_ScheduledForPickingSettleTest.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_ScheduledForPickingSettleTest.java
@@ -104,7 +104,7 @@ class M_ShipmentSchedule_ScheduledForPickingSettleTest
 	@Test
 	void prePickingExpectation_isNotGated_soUnsettledValidateDoesNotTimeOut()
 	{
-		// Line-61 style: the FIRST validate step expects the initial unsettled state (IsScheduledForPicking=N /
+		// A pre-picking validate step expects the initial unsettled state (IsScheduledForPicking=N /
 		// QtyScheduledForPicking=0). QtyScheduledForPicking is nullable with no default, so pre-picking it is
 		// NULL in the DB; gating the poll on it would emit SQL `QtyScheduledForPicking = 0`, which never matches
 		// NULL, so the poll would time out even though nothing async is pending. The gate MUST NOT apply to the
@@ -122,7 +122,7 @@ class M_ShipmentSchedule_ScheduledForPickingSettleTest
 	@Test
 	void postPickingExpectation_isGatedOnSettledColumns()
 	{
-		// Line-68 style: the SECOND validate step expects the settled Y/3 state, so the poll must wait for the
+		// A post-picking validate step expects the settled Y/3 state, so the poll must wait for the
 		// async reconcile to write it (this is the de-flake).
 		assertThat(M_ShipmentSchedule_StepDef.shouldGateOnScheduledForPicking(true))
 				.as("gate on expected IsScheduledForPicking=Y").isTrue();

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_ScheduledForPickingSettleTest.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_ScheduledForPickingSettleTest.java
@@ -23,6 +23,7 @@
 package de.metas.cucumber.stepdefs.shipmentschedule;
 
 import de.metas.cucumber.stepdefs.StepDefUtil;
+import lombok.Value;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -100,15 +101,10 @@ class M_ShipmentSchedule_ScheduledForPickingSettleTest
 				.isInstanceOf(AssertionError.class);
 	}
 
-	private static final class PickingState
+	@Value
+	private static class PickingState
 	{
-		private final boolean isScheduledForPicking;
-		private final BigDecimal qtyScheduledForPicking;
-
-		private PickingState(final boolean isScheduledForPicking, final BigDecimal qtyScheduledForPicking)
-		{
-			this.isScheduledForPicking = isScheduledForPicking;
-			this.qtyScheduledForPicking = qtyScheduledForPicking;
-		}
+		boolean isScheduledForPicking;
+		BigDecimal qtyScheduledForPicking;
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -768,6 +768,10 @@ public class M_ShipmentSchedule_StepDef
 		final BigDecimal qtyPicked = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_QtyPickList);
 		final BigDecimal qtyDelivered = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_QtyDelivered);
 		final BigDecimal qtyOnHand = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_QtyOnHand);
+		// Picking-reconcile columns: gate the poll on these so the assertion below reads them only once the
+		// async picking-job-schedule reconcile has settled (they are written after the schedule already exists).
+		final Boolean isScheduledForPicking = tableRow.getAsOptionalBoolean(I_M_ShipmentSchedule.COLUMNNAME_IsScheduledForPicking).toBooleanOrNull();
+		final BigDecimal qtyScheduledForPicking = tableRow.getAsOptionalBigDecimal(I_M_ShipmentSchedule.COLUMNNAME_QtyScheduledForPicking).orElse(null);
 		final Boolean isProcessed = DataTableUtil.extractBooleanForColumnNameOr(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_Processed, null);
 		final Boolean isClosed = DataTableUtil.extractBooleanForColumnNameOr(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_IsClosed, null);
 
@@ -793,6 +797,14 @@ public class M_ShipmentSchedule_StepDef
 			if (qtyOnHand != null)
 			{
 				queryBuilder.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_QtyOnHand, qtyOnHand);
+			}
+			if (isScheduledForPicking != null)
+			{
+				queryBuilder.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_IsScheduledForPicking, isScheduledForPicking);
+			}
+			if (qtyScheduledForPicking != null)
+			{
+				queryBuilder.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_QtyScheduledForPicking, qtyScheduledForPicking);
 			}
 			return queryBuilder
 					.create()

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -763,6 +763,28 @@ public class M_ShipmentSchedule_StepDef
 		saveRecord(shipmentScheduleRecord);
 	}
 
+	/**
+	 * Whether the readiness poll should wait for {@code IsScheduledForPicking} to reach the expected value.
+	 * Only the settled state ({@code Y}) is awaited: the pre-picking {@code N} is the column default and is
+	 * present from the start, so gating on it would add no readiness value (and, paired with the nullable
+	 * {@code QtyScheduledForPicking}, would break the poll — see {@link #shouldGateOnQtyScheduledForPicking}).
+	 */
+	static boolean shouldGateOnScheduledForPicking(final Boolean expectedIsScheduledForPicking)
+	{
+		return Boolean.TRUE.equals(expectedIsScheduledForPicking);
+	}
+
+	/**
+	 * Whether the readiness poll should wait for {@code QtyScheduledForPicking} to reach the expected value.
+	 * Only a settled non-zero qty is awaited: {@code QtyScheduledForPicking} is nullable with no default, so
+	 * pre-picking it is NULL in the DB; gating on the expected {@code 0} would emit SQL
+	 * {@code QtyScheduledForPicking = 0}, which never matches NULL, so the poll would time out.
+	 */
+	static boolean shouldGateOnQtyScheduledForPicking(final BigDecimal expectedQtyScheduledForPicking)
+	{
+		return expectedQtyScheduledForPicking != null && expectedQtyScheduledForPicking.signum() != 0;
+	}
+
 	private void validateShipmentSchedule(final int timeoutSec, @NonNull final DataTableRow tableRow) throws InterruptedException
 	{
 		final BigDecimal qtyOrdered = DataTableUtil.extractBigDecimalOrNullForColumnName(tableRow, "OPT." + I_M_ShipmentSchedule.COLUMNNAME_QtyOrdered);
@@ -802,11 +824,17 @@ public class M_ShipmentSchedule_StepDef
 			{
 				queryBuilder.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_QtyOnHand, qtyOnHand);
 			}
-			if (isScheduledForPicking != null)
+			// Only gate the poll on the picking columns once the async picking-job-schedule reconcile is
+			// expected to have SETTLED them (IsScheduledForPicking=Y / QtyScheduledForPicking>0). The initial
+			// pre-picking state is IsScheduledForPicking=N (the column default) with QtyScheduledForPicking NULL
+			// (the column is nullable, no default); gating on that unsettled N/0 expectation would never match
+			// (SQL `QtyScheduledForPicking = 0` does not match a NULL value) and the poll would time out even
+			// though nothing async is pending.
+			if (shouldGateOnScheduledForPicking(isScheduledForPicking))
 			{
-				queryBuilder.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_IsScheduledForPicking, isScheduledForPicking);
+				queryBuilder.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_IsScheduledForPicking, true);
 			}
-			if (qtyScheduledForPicking != null)
+			if (shouldGateOnQtyScheduledForPicking(qtyScheduledForPicking))
 			{
 				queryBuilder.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_QtyScheduledForPicking, qtyScheduledForPicking);
 			}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -380,6 +380,10 @@ public class M_ShipmentSchedule_StepDef
 	 *   <b>QtyOnHand</b> — (optional) expected on-hand quantity<br>
 	 *   <b>Processed</b> — (optional) true/false<br>
 	 *   <b>IsClosed</b> — (optional) true/false<br>
+	 *   <b>IsScheduledForPicking</b> — (optional) true/false; also gates the readiness poll, so the step waits
+	 *     for the async picking-job-schedule reconcile to write this value before asserting<br>
+	 *   <b>QtyScheduledForPicking</b> — (optional) expected qty scheduled for picking; also gates the readiness
+	 *     poll (see IsScheduledForPicking)<br>
 	 *   <b>PreparationDate</b> — (optional) expected per-line base preparation date, as a plain calendar date
 	 *     (e.g. {@code 2022-08-10}) compared in the order's time zone<br>
 	 *   <b>DeliveryDate</b> — (optional) expected per-line delivery date (the line's promised delivery date),

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -824,12 +824,7 @@ public class M_ShipmentSchedule_StepDef
 			{
 				queryBuilder.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_QtyOnHand, qtyOnHand);
 			}
-			// Only gate the poll on the picking columns once the async picking-job-schedule reconcile is
-			// expected to have SETTLED them (IsScheduledForPicking=Y / QtyScheduledForPicking>0). The initial
-			// pre-picking state is IsScheduledForPicking=N (the column default) with QtyScheduledForPicking NULL
-			// (the column is nullable, no default); gating on that unsettled N/0 expectation would never match
-			// (SQL `QtyScheduledForPicking = 0` does not match a NULL value) and the poll would time out even
-			// though nothing async is pending.
+			// Gate only on the SETTLED picking state; see shouldGateOn* for why the unsettled N/0 must not gate.
 			if (shouldGateOnScheduledForPicking(isScheduledForPicking))
 			{
 				queryBuilder.addEqualsFilter(I_M_ShipmentSchedule.COLUMNNAME_IsScheduledForPicking, true);


### PR DESCRIPTION
## What

De-flake the second `validate shipment schedules` assertion in `jobSchedule.feature:68` (Scenario `@Id:S0271_010 Schedule & check`) and the `autoJobSchedule.feature` scenarios.

## Why

After `create or update picking job schedules`, the shipment schedule already exists (delivery quantities settled), but the async picking-job-schedule reconcile writes `IsScheduledForPicking=Y` / `QtyScheduledForPicking=<qty>` a moment later. The step's readiness poll (`StepDefUtil.tryAndWait`) only gated on the schedule's existence and its delivery quantities, so it returned before the picking columns were written; the hard soft-assert then intermittently read the stale `IsScheduledForPicking=N` / `QtyScheduledForPicking=0`.

Observed as a pre-existing `new_dawn_uat` flake on an unrelated frontend-only PR's cucumber run (structurally impossible to be caused there).

## Change (test-only)

- `M_ShipmentSchedule_StepDef.validateShipmentSchedule`: gate the poll additionally on the target `IsScheduledForPicking` / `QtyScheduledForPicking` values when the row specifies them, mirroring the existing `QtyToDeliver` / `QtyOnHand` gate. Non-masking — a schedule whose reconcile never settles still times out and fails loud.
- New deterministic seam test `M_ShipmentSchedule_ScheduledForPickingSettleTest`: single immediate read throws on the transient stale `N`/`0` (the spurious failure); bounded poll settles on `Y`/`3`; stuck-at-`N`/`0` fails loud.

## Evidence

Deterministic seam test GREEN locally (JDK 8 toolchain, offline against the workspace local repo): `Tests run: 3, Failures: 0, Errors: 0` — `M_ShipmentSchedule_ScheduledForPickingSettleTest`. Module test-compiles clean.

## Notes

Feature present on all four tracked branches; down-ports are future low-priority follow-ups (not propagated here).
