### PR TITLE
mobile-webui: fix barcode scanner stuck in default mode on late settings load (flaky case 19)

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/BarcodeScannerComponent.modeSettingsRace.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/BarcodeScannerComponent.modeSettingsRace.test.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { combineReducers, createStore } from 'redux';
+import BarcodeScannerComponent from '../components/BarcodeScannerComponent';
+import { reducer as settingsReducer, putSettingsAction } from '../reducers/settings';
+
+// Reproduces the async-settings race behind flaky-test case 19
+// (barcode_scanner_modes.spec.js "manual mode — visible editable input rendered…").
+//
+// ApplicationRoot fetches the backend settings fire-and-forget in a useEffect AFTER login
+// (getSettings().then(putSettingsAction)); there is NO ordering guarantee that this resolves
+// before a scanner screen (e.g. HU Manager) mounts BarcodeScannerComponent. When the component
+// mounts BEFORE settings arrive, useBarcodeScannerModes returns its hook defaults → defaultMode
+// resolves to HARDWARE, and activeMode (a useState initialised from defaultMode) freezes there.
+// When settings later arrive with defaultMode=manual, activeMode must adopt the configured
+// default so the visible manual-entry input renders. Before the fix it stayed HARDWARE forever
+// → manual-entry-input never attached → SLOW_ACTION_TIMEOUT flake.
+
+const MANUAL_MODE_SETTINGS = {
+  'barcodeScanner.mode.hardware.enabled': 'Y',
+  'barcodeScanner.mode.camera.enabled': 'N',
+  'barcodeScanner.mode.manual.enabled': 'Y',
+  'barcodeScanner.defaultMode': 'manual',
+};
+
+const renderWithEmptySettings = () => {
+  const store = createStore(combineReducers({ settings: settingsReducer }));
+  render(
+    <Provider store={store}>
+      <BarcodeScannerComponent onResolvedResult={jest.fn()} />
+    </Provider>
+  );
+  return store;
+};
+
+describe('BarcodeScannerComponent — async settings race (flaky case 19)', () => {
+  it('adopts the configured manual defaultMode when settings arrive AFTER mount', () => {
+    const store = renderWithEmptySettings();
+
+    // Settings not loaded yet at mount → hook defaults → HARDWARE → no visible manual input.
+    expect(screen.queryByTestId('manual-entry-input')).not.toBeInTheDocument();
+
+    // Settings resolve late (ApplicationRoot's async getSettings) → defaultMode becomes manual.
+    act(() => {
+      store.dispatch(putSettingsAction(MANUAL_MODE_SETTINGS));
+    });
+
+    // The scanner must now switch to the configured manual mode and render the editable input.
+    expect(screen.getByTestId('manual-entry-input')).toBeInTheDocument();
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/BarcodeScannerComponent.modeSettingsRace.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/BarcodeScannerComponent.modeSettingsRace.test.js
@@ -1,10 +1,20 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { combineReducers, createStore } from 'redux';
 import BarcodeScannerComponent from '../components/BarcodeScannerComponent';
 import { reducer as settingsReducer, putSettingsAction } from '../reducers/settings';
+
+// ui_trace persists to IndexedDB / posts traces over the network, neither of which exists in
+// jsdom — a button click would otherwise leave an unhandled promise rejection. Mock it out
+// (same pattern as GetQuantityDialog.serialNo.test.js); traceFunction must stay pass-through.
+jest.mock('../utils/ui_trace', () => ({
+  putContext: jest.fn(),
+  trace: jest.fn(),
+  traceLogWarn: jest.fn(),
+  traceFunction: (fn) => fn,
+}));
 
 // Reproduces the async-settings race behind flaky-test case 19
 // (barcode_scanner_modes.spec.js "manual mode — visible editable input rendered…").
@@ -23,6 +33,13 @@ const MANUAL_MODE_SETTINGS = {
   'barcodeScanner.mode.camera.enabled': 'N',
   'barcodeScanner.mode.manual.enabled': 'Y',
   'barcodeScanner.defaultMode': 'manual',
+};
+
+const HARDWARE_MODE_SETTINGS = {
+  'barcodeScanner.mode.hardware.enabled': 'Y',
+  'barcodeScanner.mode.camera.enabled': 'N',
+  'barcodeScanner.mode.manual.enabled': 'Y',
+  'barcodeScanner.defaultMode': 'hardware',
 };
 
 const renderWithEmptySettings = () => {
@@ -48,6 +65,27 @@ describe('BarcodeScannerComponent — async settings race (flaky case 19)', () =
     });
 
     // The scanner must now switch to the configured manual mode and render the editable input.
+    expect(screen.getByTestId('manual-entry-input')).toBeInTheDocument();
+  });
+
+  it('does NOT revert an operator mode choice made during the settings-load window', () => {
+    // Mounts before settings arrive → boots in the default HARDWARE mode. The footer's "enter
+    // manually" button is live (gated only on mode.manual.enabled, default true), so the operator
+    // can switch to manual DURING the load window — a real path on a slow handheld network.
+    const store = renderWithEmptySettings();
+    expect(screen.queryByTestId('manual-entry-input')).not.toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('barcode-scanner-enter-manually'));
+    });
+    expect(screen.getByTestId('manual-entry-input')).toBeInTheDocument();
+
+    // Settings now arrive with a DIFFERENT configured default (hardware). The operator's explicit
+    // manual choice must survive — adopting the settings default here would silently yank them out
+    // of the manual input they are typing into.
+    act(() => {
+      store.dispatch(putSettingsAction(HARDWARE_MODE_SETTINGS));
+    });
     expect(screen.getByTestId('manual-entry-input')).toBeInTheDocument();
   });
 });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/BarcodeScannerComponent.modeSettingsRace.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/BarcodeScannerComponent.modeSettingsRace.test.js
@@ -16,6 +16,10 @@ jest.mock('../utils/ui_trace', () => ({
   traceFunction: (fn) => fn,
 }));
 
+// beep() news up an AudioContext and calls navigator.vibrate — neither exists in jsdom, so a
+// completed scan would throw. Mock it (the scan-processing tests below drive a full scan cycle).
+jest.mock('../utils/audio', () => ({ beep: jest.fn() }));
+
 // Reproduces the async-settings race exercised by barcode_scanner_modes.spec.js
 // ("manual mode — visible editable input rendered…").
 //
@@ -111,5 +115,46 @@ describe('BarcodeScannerComponent — activeMode adoption on async settings load
       store.dispatch(putSettingsAction(MANUAL_MODE_SETTINGS));
     });
     expect(screen.queryByTestId('manual-entry-input')).not.toBeInTheDocument();
+  });
+
+  it('defers adoption while a scan is processing, then adopts once processing ends', async () => {
+    // Mounts before settings → boots HARDWARE. A scan is fired and is still in flight (slow
+    // network) when the settings finally arrive carrying a DIFFERENT default (manual). Flipping
+    // activeMode mid-scan would flicker the visible panel once; adoption must wait for a render
+    // where isProcessing is false, then apply.
+    let resolveScan;
+    const resolveScannedBarcode = jest.fn(() => new Promise((resolve) => (resolveScan = resolve)));
+    const store = createStore(combineReducers({ settings: settingsReducer }));
+    render(
+      <Provider store={store}>
+        <BarcodeScannerComponent onResolvedResult={jest.fn()} resolveScannedBarcode={resolveScannedBarcode} />
+      </Provider>
+    );
+
+    // Boots in HARDWARE mode: the offscreen scan input is present, no manual input.
+    const hardwareInput = screen.getByTestId('qrCode-input');
+    expect(screen.queryByTestId('manual-entry-input')).not.toBeInTheDocument();
+
+    // Fire a hardware scan → isProcessing becomes true and stays true (resolveScannedBarcode's
+    // promise is left pending). The offscreen input unmounts while processing.
+    act(() => {
+      hardwareInput.value = '12345';
+      fireEvent.keyUp(hardwareInput, { key: 'Enter' });
+    });
+    expect(resolveScannedBarcode).toHaveBeenCalled();
+    expect(screen.queryByTestId('qrCode-input')).not.toBeInTheDocument();
+
+    // Settings arrive mid-scan with defaultMode=manual. The guard must hold the mode on HARDWARE
+    // (no manual input) until the scan finishes — no mid-scan flip.
+    act(() => {
+      store.dispatch(putSettingsAction(MANUAL_MODE_SETTINGS));
+    });
+    expect(screen.queryByTestId('manual-entry-input')).not.toBeInTheDocument();
+
+    // Scan resolves → isProcessing flips false → the deferred adoption runs → manual mode shows.
+    await act(async () => {
+      resolveScan({ scannedBarcode: '12345', error: null });
+    });
+    expect(screen.getByTestId('manual-entry-input')).toBeInTheDocument();
   });
 });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/BarcodeScannerComponent.modeSettingsRace.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/BarcodeScannerComponent.modeSettingsRace.test.js
@@ -16,8 +16,8 @@ jest.mock('../utils/ui_trace', () => ({
   traceFunction: (fn) => fn,
 }));
 
-// Reproduces the async-settings race behind flaky-test case 19
-// (barcode_scanner_modes.spec.js "manual mode — visible editable input rendered…").
+// Reproduces the async-settings race exercised by barcode_scanner_modes.spec.js
+// ("manual mode — visible editable input rendered…").
 //
 // ApplicationRoot fetches the backend settings fire-and-forget in a useEffect AFTER login
 // (getSettings().then(putSettingsAction)); there is NO ordering guarantee that this resolves
@@ -52,7 +52,7 @@ const renderWithEmptySettings = () => {
   return store;
 };
 
-describe('BarcodeScannerComponent — async settings race (flaky case 19)', () => {
+describe('BarcodeScannerComponent — activeMode adoption on async settings load', () => {
   it('adopts the configured manual defaultMode when settings arrive AFTER mount', () => {
     const store = renderWithEmptySettings();
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/BarcodeScannerComponent.modeSettingsRace.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/BarcodeScannerComponent.modeSettingsRace.test.js
@@ -88,4 +88,28 @@ describe('BarcodeScannerComponent — async settings race (flaky case 19)', () =
     });
     expect(screen.getByTestId('manual-entry-input')).toBeInTheDocument();
   });
+
+  it('does NOT override the operator even when they return to a mode equal to the pre-settings default', () => {
+    // Edge the flag guards but a value-equality check could not: operator goes manual and back to
+    // hardware (which equals the mount-time default) during the load window, then settings arrive
+    // with a DIFFERENT default (manual). The operator explicitly chose hardware — it must stick.
+    const store = renderWithEmptySettings();
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('barcode-scanner-enter-manually'));
+    });
+    expect(screen.getByTestId('manual-entry-input')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('barcode-scanner-back-to-scanner'));
+    });
+    expect(screen.queryByTestId('manual-entry-input')).not.toBeInTheDocument();
+
+    // Settings arrive with defaultMode=manual — but the operator deliberately went back to
+    // hardware, so no auto-switch to manual may happen.
+    act(() => {
+      store.dispatch(putSettingsAction(MANUAL_MODE_SETTINGS));
+    });
+    expect(screen.queryByTestId('manual-entry-input')).not.toBeInTheDocument();
+  });
 });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
@@ -24,47 +24,10 @@ const BarcodeScannerComponent = ({
     invisible,
   });
 
-  const [activeMode, setActiveMode] = useState(defaultMode);
-
-  // Set true the moment the operator explicitly picks a mode (footer HW/CAM toggle, footer
-  // "enter manually", or the ManualModePanel "back to scanner" button). Read by the async-settings
-  // adoption below so a deliberate operator choice made during the settings-load window is never
-  // overridden. NOT set by the internal auto-returns to the default mode (post-scan / camera
-  // cancel) — those are not operator mode selections.
-  const hasOperatorSelectedModeRef = useRef(false);
-  const selectMode = useCallback((mode) => {
-    hasOperatorSelectedModeRef.current = true;
-    setActiveMode(mode);
-  }, []);
-
-  // ── Async-settings default adoption ─────────────────────────────────────────────────────────
-  // Settings load asynchronously (ApplicationRoot fetches them fire-and-forget after login). If
-  // this scanner mounts BEFORE they arrive, useBarcodeScannerModes returns its hook defaults so
-  // defaultMode resolves to HARDWARE, and the useState initializer above freezes activeMode there
-  // — it would NOT pick up the configured default once settings resolve (e.g. defaultMode=manual),
-  // leaving the operator stuck in hardware mode with no visible manual input (flaky e2e case:
-  // barcode_scanner_modes.spec.js "manual mode — visible editable input rendered…").
-  //
-  // Adjust the state DURING RENDER (React's documented "adjust state when an input changes"
-  // pattern) rather than in a useEffect, so the switch happens before paint — on a handheld this
-  // avoids a one-frame flash of the wrong-mode scanner UI. Guarded so it fires exactly once, on
-  // the not-loaded→loaded transition.
-  //
-  // Adopt the configured default ONLY if the operator has NOT explicitly picked a mode during the
-  // load window (the footer's "enter manually" / toggle buttons are live before settings load) —
-  // otherwise a late settings arrival would silently revert the operator's own selection.
-  const isSettingsLoaded = useIsSettingsLoaded();
-  const [didAdoptSettingsDefault, setDidAdoptSettingsDefault] = useState(false);
-  if (isSettingsLoaded && !didAdoptSettingsDefault) {
-    setDidAdoptSettingsDefault(true);
-    if (!hasOperatorSelectedModeRef.current && activeMode !== defaultMode) {
-      setActiveMode(defaultMode);
-    }
-  }
-  // ─────────────────────────────────────────────────────────────────────────────────────────────
+  const [isProcessing, setProcessing] = useState(false);
+  const { activeMode, setActiveMode, selectMode } = useSettingsDefaultModeAdoption({ defaultMode, isProcessing });
 
   const scanningStatusRef = useRef({ running: false, done: false });
-  const [isProcessing, setProcessing] = useState(false);
   const { trackDuplicateScan } = useDuplicateScansGuard({ scanDuplicatesIntervalMillis });
 
   const validateScannedBarcodeAndForward0 = async ({ scannedBarcode, onStart, onSuccess, onError, onFinally }) => {
@@ -206,6 +169,52 @@ BarcodeScannerComponent.defaultProps = {
 };
 
 export default BarcodeScannerComponent;
+
+//
+//
+//
+//
+//
+
+// Owns activeMode and adopts the configured default mode when settings arrive late.
+//
+// Why: settings load async after login. If the scanner mounts first, defaultMode resolves to the
+// hook default (HARDWARE) and activeMode freezes there — so a manual-default workplace would stay
+// stuck on hardware with no visible input until the screen is left and re-entered.
+//
+// Fix: when settings first arrive, adopt their default once. Three guards:
+//   - once only, on the not-loaded → loaded transition (didAdoptSettingsDefault);
+//   - not while a scan is processing — flipping mid-scan flickers the panel, so we skip and let a
+//     later, calm render (isProcessing=false) do it;
+//   - not if the operator already picked a mode (hasOperatorSelectedModeRef) — their choice wins
+//     over a late settings arrival; internal auto-returns to default (post-scan, camera cancel)
+//     go through setActiveMode directly and do NOT count as an operator choice.
+//
+// Adopting during render (React's "adjust state on prop change" pattern) lands the switch before
+// paint, avoiding a one-frame flash of the wrong panel.
+//
+// Returns: activeMode + setActiveMode (raw, for internal auto-returns) + selectMode (operator
+// picks, which set the guard).
+const useSettingsDefaultModeAdoption = ({ defaultMode, isProcessing }) => {
+  const [activeMode, setActiveMode] = useState(defaultMode);
+
+  const hasOperatorSelectedModeRef = useRef(false);
+  const selectMode = useCallback((mode) => {
+    hasOperatorSelectedModeRef.current = true;
+    setActiveMode(mode);
+  }, []);
+
+  const isSettingsLoaded = useIsSettingsLoaded();
+  const [didAdoptSettingsDefault, setDidAdoptSettingsDefault] = useState(false);
+  if (isSettingsLoaded && !isProcessing && !didAdoptSettingsDefault) {
+    setDidAdoptSettingsDefault(true);
+    if (!hasOperatorSelectedModeRef.current && activeMode !== defaultMode) {
+      setActiveMode(defaultMode);
+    }
+  }
+
+  return { activeMode, setActiveMode, selectMode };
+};
 
 //
 //

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { toastError, toastErrorFromObj } from '../utils/toast';
-import { useAreSettingsLoaded, useNumber, usePositiveNumberSetting } from '../reducers/settings';
+import { useIsSettingsLoaded, useNumber, usePositiveNumberSetting } from '../reducers/settings';
 import { beep } from '../utils/audio';
 import * as uiTrace from '../utils/ui_trace';
 import Spinner from './Spinner';
@@ -26,23 +26,33 @@ const BarcodeScannerComponent = ({
 
   const [activeMode, setActiveMode] = useState(defaultMode);
 
+  // ── Async-settings default adoption ─────────────────────────────────────────────────────────
   // Settings load asynchronously (ApplicationRoot fetches them fire-and-forget after login). If
   // this scanner mounts BEFORE they arrive, useBarcodeScannerModes returns its hook defaults so
   // defaultMode resolves to HARDWARE, and the useState initializer above freezes activeMode there
   // — it would NOT pick up the configured default once settings resolve (e.g. defaultMode=manual),
   // leaving the operator stuck in hardware mode with no visible manual input (flaky e2e case:
-  // barcode_scanner_modes.spec.js "manual mode — visible editable input rendered…"). Adopt
-  // defaultMode ONCE, when settings first load, so a late arrival still lands on the configured
-  // mode. One-shot (guarded by the ref, not a plain [defaultMode] sync) so a subsequent operator
-  // mode toggle is never stomped by a settings re-emit.
-  const settingsLoaded = useAreSettingsLoaded();
-  const adoptedSettingsDefaultRef = useRef(false);
-  useEffect(() => {
-    if (settingsLoaded && !adoptedSettingsDefaultRef.current) {
-      adoptedSettingsDefaultRef.current = true;
+  // barcode_scanner_modes.spec.js "manual mode — visible editable input rendered…").
+  //
+  // Adjust the state DURING RENDER (React's documented "adjust state when an input changes"
+  // pattern) rather than in a useEffect, so the switch happens before paint — on a handheld this
+  // avoids a one-frame flash of the wrong-mode scanner UI. Guarded so it fires exactly once, on
+  // the not-loaded→loaded transition.
+  //
+  // Adopt the configured default ONLY if the operator has NOT already picked a mode during the
+  // load window: activeMode must still equal the pre-settings default captured at mount. The
+  // footer's "enter manually" / mode buttons are live before settings load, so without this guard
+  // a late settings arrival would silently revert the operator's own selection.
+  const isSettingsLoaded = useIsSettingsLoaded();
+  const initialDefaultModeRef = useRef(defaultMode);
+  const [didAdoptSettingsDefault, setDidAdoptSettingsDefault] = useState(false);
+  if (isSettingsLoaded && !didAdoptSettingsDefault) {
+    setDidAdoptSettingsDefault(true);
+    if (activeMode === initialDefaultModeRef.current && activeMode !== defaultMode) {
       setActiveMode(defaultMode);
     }
-  }, [settingsLoaded, defaultMode]);
+  }
+  // ─────────────────────────────────────────────────────────────────────────────────────────────
 
   const scanningStatusRef = useRef({ running: false, done: false });
   const [isProcessing, setProcessing] = useState(false);

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { toastError, toastErrorFromObj } from '../utils/toast';
-import { useNumber, usePositiveNumberSetting } from '../reducers/settings';
+import { useAreSettingsLoaded, useNumber, usePositiveNumberSetting } from '../reducers/settings';
 import { beep } from '../utils/audio';
 import * as uiTrace from '../utils/ui_trace';
 import Spinner from './Spinner';
@@ -25,6 +25,24 @@ const BarcodeScannerComponent = ({
   });
 
   const [activeMode, setActiveMode] = useState(defaultMode);
+
+  // Settings load asynchronously (ApplicationRoot fetches them fire-and-forget after login). If
+  // this scanner mounts BEFORE they arrive, useBarcodeScannerModes returns its hook defaults so
+  // defaultMode resolves to HARDWARE, and the useState initializer above freezes activeMode there
+  // — it would NOT pick up the configured default once settings resolve (e.g. defaultMode=manual),
+  // leaving the operator stuck in hardware mode with no visible manual input (flaky e2e case:
+  // barcode_scanner_modes.spec.js "manual mode — visible editable input rendered…"). Adopt
+  // defaultMode ONCE, when settings first load, so a late arrival still lands on the configured
+  // mode. One-shot (guarded by the ref, not a plain [defaultMode] sync) so a subsequent operator
+  // mode toggle is never stomped by a settings re-emit.
+  const settingsLoaded = useAreSettingsLoaded();
+  const adoptedSettingsDefaultRef = useRef(false);
+  useEffect(() => {
+    if (settingsLoaded && !adoptedSettingsDefaultRef.current) {
+      adoptedSettingsDefaultRef.current = true;
+      setActiveMode(defaultMode);
+    }
+  }, [settingsLoaded, defaultMode]);
 
   const scanningStatusRef = useRef({ running: false, done: false });
   const [isProcessing, setProcessing] = useState(false);

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScannerComponent.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { toastError, toastErrorFromObj } from '../utils/toast';
 import { useIsSettingsLoaded, useNumber, usePositiveNumberSetting } from '../reducers/settings';
 import { beep } from '../utils/audio';
@@ -26,6 +26,17 @@ const BarcodeScannerComponent = ({
 
   const [activeMode, setActiveMode] = useState(defaultMode);
 
+  // Set true the moment the operator explicitly picks a mode (footer HW/CAM toggle, footer
+  // "enter manually", or the ManualModePanel "back to scanner" button). Read by the async-settings
+  // adoption below so a deliberate operator choice made during the settings-load window is never
+  // overridden. NOT set by the internal auto-returns to the default mode (post-scan / camera
+  // cancel) — those are not operator mode selections.
+  const hasOperatorSelectedModeRef = useRef(false);
+  const selectMode = useCallback((mode) => {
+    hasOperatorSelectedModeRef.current = true;
+    setActiveMode(mode);
+  }, []);
+
   // ── Async-settings default adoption ─────────────────────────────────────────────────────────
   // Settings load asynchronously (ApplicationRoot fetches them fire-and-forget after login). If
   // this scanner mounts BEFORE they arrive, useBarcodeScannerModes returns its hook defaults so
@@ -39,16 +50,14 @@ const BarcodeScannerComponent = ({
   // avoids a one-frame flash of the wrong-mode scanner UI. Guarded so it fires exactly once, on
   // the not-loaded→loaded transition.
   //
-  // Adopt the configured default ONLY if the operator has NOT already picked a mode during the
-  // load window: activeMode must still equal the pre-settings default captured at mount. The
-  // footer's "enter manually" / mode buttons are live before settings load, so without this guard
-  // a late settings arrival would silently revert the operator's own selection.
+  // Adopt the configured default ONLY if the operator has NOT explicitly picked a mode during the
+  // load window (the footer's "enter manually" / toggle buttons are live before settings load) —
+  // otherwise a late settings arrival would silently revert the operator's own selection.
   const isSettingsLoaded = useIsSettingsLoaded();
-  const initialDefaultModeRef = useRef(defaultMode);
   const [didAdoptSettingsDefault, setDidAdoptSettingsDefault] = useState(false);
   if (isSettingsLoaded && !didAdoptSettingsDefault) {
     setDidAdoptSettingsDefault(true);
-    if (activeMode === initialDefaultModeRef.current && activeMode !== defaultMode) {
+    if (!hasOperatorSelectedModeRef.current && activeMode !== defaultMode) {
       setActiveMode(defaultMode);
     }
   }
@@ -157,7 +166,7 @@ const BarcodeScannerComponent = ({
         <ManualModePanel
           isProcessing={isProcessing}
           enabledModes={enabledModes}
-          onModeSelected={setActiveMode}
+          onModeSelected={selectMode}
           onBarcodeScanned={({ scannedBarcode, onSuccess, onError }) =>
             validateScannedBarcodeAndForward({
               scannedBarcode,
@@ -178,7 +187,7 @@ const BarcodeScannerComponent = ({
         />
       )}
       {!invisible && (
-        <BarcodeScannerFooter activeMode={activeMode} enabledModes={enabledModes} onModeSelected={setActiveMode} />
+        <BarcodeScannerFooter activeMode={activeMode} enabledModes={enabledModes} onModeSelected={selectMode} />
       )}
     </div>
   );

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/settings.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/settings.js
@@ -39,6 +39,14 @@ export const useSetting = (name) => {
   return useSelector((state) => getSettingFromState(state, name));
 };
 
+// True once the backend settings response has been stored (SETTING_PUT dispatched). Lets a
+// component tell "settings not fetched yet" (all values undefined → hook defaults) apart from
+// "settings loaded, this key is genuinely absent" — needed to adopt a settings-derived default
+// exactly once, when settings first arrive.
+export const useAreSettingsLoaded = () => {
+  return useSelector((state) => state?.settings?.backend != null);
+};
+
 const getSettingFromState = (state, name) => {
   //console.log('getSettingFromState', { name, value, state });
   return state?.settings?.backend?.[name];

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/settings.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/settings.js
@@ -43,7 +43,7 @@ export const useSetting = (name) => {
 // component tell "settings not fetched yet" (all values undefined → hook defaults) apart from
 // "settings loaded, this key is genuinely absent" — needed to adopt a settings-derived default
 // exactly once, when settings first arrive.
-export const useAreSettingsLoaded = () => {
+export const useIsSettingsLoaded = () => {
   return useSelector((state) => state?.settings?.backend != null);
 };
 


### PR DESCRIPTION
## What

Fixes flaky test **case 19** (flaky-test registry) — `barcode_scanner_modes.spec.js` "manual mode — visible editable input rendered…" intermittently timing out on `expect(manual-entry-input).toBeAttached()`.

## Root cause (production defect, not a test artifact)

`BarcodeScannerComponent` initialised `activeMode` from `defaultMode` via `useState` only. `defaultMode` is derived from backend settings, which `ApplicationRoot` fetches **fire-and-forget** (`getSettings().then(putSettingsAction)`) after login — with no ordering guarantee vs. when a scanner screen mounts the component.

When the component mounts **before** settings resolve, `useBarcodeScannerModes` returns hook defaults (`defaultMode=HARDWARE`) and the `useState` initializer freezes `activeMode` at HARDWARE. When settings later arrive (`defaultMode=manual`), `activeMode` never re-syncs -> `ManualModePanel` never mounts -> `manual-entry-input` never attaches -> `SLOW_ACTION_TIMEOUT`. The lucky ordering (settings resolve first) passes, which is why it "clears on re-run".

This is also a latent real-world defect: on a slow network an operator can be stuck in the wrong scanner mode until reload.

## Fix

Adopt `defaultMode` **once**, when settings first load — extracted into a dedicated hook `useSettingsDefaultModeAdoption({ defaultMode, isProcessing })` (defined in the same file, just below the component). It:
- adopts the settings-derived default only **once** (a one-shot latch, keyed off a new `useIsSettingsLoaded()` selector), then never again;
- **never overrides a mode the operator already chose** (an operator-interaction ref, set only by explicit mode selection);
- **defers adoption while a scan is processing** (`!isProcessing`) so a late settings arrival can never flip `activeMode` mid-scan (which would flicker the panel) — the pending adoption applies on the first calm render instead.

## Tests

- Deterministic component tests in `BarcodeScannerComponent.modeSettingsRace.test.js` covering: adoption after mount-before-settings, operator choice not overridden by a settings re-emit, and (new) adoption deferred while a scan is processing — each RED→GREEN.
- Full mobile-webui frontend unit suite: 254 passed / 23 suites. Lint clean.

Verified (independent review, HEAD https://github.com/metasfresh/metasfresh/commit/e8fdfd938a8b003277ceb6c6b983ac26965b0567): reverting only the `!isProcessing` guard and running `react-scripts test --watchAll=false BarcodeScannerComponent.modeSettingsRace.test.js` fails exactly the "defers adoption while a scan is processing" case (1 failed / 3 passed); restoring it -> 4 passed. This runtime RED→GREEN confirms the guard behaviour, not merely the presence of the code.

Base: `new_dawn_uat`. Down-ports to the hotfix/release branch groups noted as future low-priority; NOT propagated here.


