### PR TITLE
externalsystem: tolerate configs with inconsistent parent/child type (status 500 + type-change crash)

### DIFF
--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemConfigRepo.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemConfigRepo.java
@@ -274,6 +274,18 @@ public class ExternalSystemConfigRepo
 		{
 			return getScriptedImportConversionConfigByParentId(id);
 		}
+		else if (externalSystemType.isScriptedExportConversion())
+		{
+			// ScriptedExportConversion is modelled 0..many per parent (not a single Optional),
+			// so it has no getXxxByParentId branch above; resolve it explicitly here. Returning
+			// the first child (if any) is enough for every caller — the type-change interceptor
+			// only needs "does a child of this type still exist?" (must NOT fall through to the
+			// empty catch-all below, which would let the parent be re-typed and orphan the rows).
+			return externalSystemScriptedExportConversionRepository.getByParentConfigId(id)
+					.stream()
+					.findFirst()
+					.map(child -> (IExternalSystemChildConfig)child);
+		}
 		// No per-parent child-config table for this type (e.g. a custom/other external-system
 		// type). Return empty rather than throwing: callers ask "is there a child of this type
 		// under this parent?" and the honest answer is "no". Throwing here made the
@@ -1198,6 +1210,8 @@ public class ExternalSystemConfigRepo
 		final I_ExternalSystem_Config parent = InterfaceWrapperHelper.load(externalSystemConfigId, I_ExternalSystem_Config.class);
 		if (parent == null)
 		{
+			logger.warn("Skipping {} config whose parent ExternalSystem_Config_ID={} no longer exists (orphaned child)",
+					expectedType, externalSystemConfigId);
 			return false;
 		}
 

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemConfigRepo.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemConfigRepo.java
@@ -649,7 +649,6 @@ public class ExternalSystemConfigRepo
 				.create()
 				.stream()
 				.filter(config -> isParentConfigOfType(config.getExternalSystem_Config_ID(), ExternalSystemType.Alberta))
-				.filter(config -> isParentConfigOfType(config.getExternalSystem_Config_ID(), ExternalSystemType.RabbitMQ))
 				.map(this::getExternalSystemParentConfig)
 				.collect(ImmutableList.toImmutableList());
 	}
@@ -908,6 +907,7 @@ public class ExternalSystemConfigRepo
 				.addOnlyActiveRecordsFilter()
 				.create()
 				.stream()
+				.filter(config -> isParentConfigOfType(config.getExternalSystem_Config_ID(), ExternalSystemType.RabbitMQ))
 				.map(this::getExternalSystemParentConfig)
 				.collect(ImmutableList.toImmutableList());
 	}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemConfigRepo.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemConfigRepo.java
@@ -648,6 +648,8 @@ public class ExternalSystemConfigRepo
 				.addOnlyActiveRecordsFilter()
 				.create()
 				.stream()
+				.filter(config -> isParentConfigOfType(config.getExternalSystem_Config_ID(), ExternalSystemType.Alberta))
+				.filter(config -> isParentConfigOfType(config.getExternalSystem_Config_ID(), ExternalSystemType.RabbitMQ))
 				.map(this::getExternalSystemParentConfig)
 				.collect(ImmutableList.toImmutableList());
 	}
@@ -709,6 +711,7 @@ public class ExternalSystemConfigRepo
 				.addOnlyActiveRecordsFilter()
 				.create()
 				.stream()
+				.filter(config -> isParentConfigOfType(config.getExternalSystem_Config_ID(), ExternalSystemType.WOO))
 				.map(this::getExternalSystemParentConfig)
 				.collect(ImmutableList.toImmutableList());
 	}
@@ -893,6 +896,7 @@ public class ExternalSystemConfigRepo
 				.addOnlyActiveRecordsFilter()
 				.create()
 				.stream()
+				.filter(config -> isParentConfigOfType(config.getExternalSystem_Config_ID(), ExternalSystemType.GRSSignum))
 				.map(this::getExternalSystemParentConfig)
 				.collect(ImmutableList.toImmutableList());
 	}
@@ -992,6 +996,7 @@ public class ExternalSystemConfigRepo
 				.addOnlyActiveRecordsFilter()
 				.create()
 				.stream()
+				.filter(config -> isParentConfigOfType(config.getExternalSystem_Config_ID(), ExternalSystemType.LeichUndMehl))
 				.map(this::getExternalSystemParentConfig)
 				.collect(ImmutableList.toImmutableList());
 	}
@@ -1180,6 +1185,7 @@ public class ExternalSystemConfigRepo
 				.addOnlyActiveRecordsFilter()
 				.create()
 				.stream()
+				.filter(config -> isParentConfigOfType(config.getExternalSystem_Config_ID(), ExternalSystemType.ProCareManagement))
 				.map(this::getExternalSystemParentConfig)
 				.collect(ImmutableList.toImmutableList());
 	}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemConfigRepo.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemConfigRepo.java
@@ -97,10 +97,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import de.metas.logging.LogManager;
+import org.slf4j.Logger;
+
 @Repository
 @RequiredArgsConstructor
 public class ExternalSystemConfigRepo
 {
+	private static final Logger logger = LogManager.getLogger(ExternalSystemConfigRepo.class);
+
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 	@NonNull private final TaxCategoryDAO taxCategoryDAO;
@@ -269,7 +274,13 @@ public class ExternalSystemConfigRepo
 		{
 			return getScriptedImportConversionConfigByParentId(id);
 		}
-		throw Check.fail("Unsupported IExternalSystemChildConfigId.type={}", externalSystemType);
+		// No per-parent child-config table for this type (e.g. a custom/other external-system
+		// type). Return empty rather than throwing: callers ask "is there a child of this type
+		// under this parent?" and the honest answer is "no". Throwing here made the
+		// ExternalSystem_Config type-change interceptor crash on such a parent instead of
+		// letting the user correct the data.
+		logger.debug("getChildByParentIdAndType: no child-config lookup for type={}, id={} -> empty", externalSystemType, id);
+		return Optional.empty();
 	}
 
 	@NonNull
@@ -1168,7 +1179,35 @@ public class ExternalSystemConfigRepo
 				.addOnlyActiveRecordsFilter()
 				.create()
 				.stream()
+				.filter(config -> isParentConfigOfType(config.getExternalSystem_Config_ID(), ExternalSystemType.ScriptedImportConversion))
 				.map(this::getExternalSystemParentConfig)
 				.collect(ImmutableList.toImmutableList());
+	}
+
+	/**
+	 * True if the parent {@code ExternalSystem_Config}'s type equals {@code expectedType}.
+	 * Guards the whole-table status readers ({@link #getActiveByType(ExternalSystemType)}): a
+	 * child config whose parent was re-typed, or that was created under a wrong-typed parent
+	 * (e.g. a scripted-import config placed under a custom external system), is inconsistent
+	 * data. Skipping it (logged) keeps one bad row from throwing out of
+	 * {@link ExternalSystemParentConfig}'s constructor and 500-ing the entire external-system
+	 * status endpoint.
+	 */
+	private boolean isParentConfigOfType(final int externalSystemConfigId, @NonNull final ExternalSystemType expectedType)
+	{
+		final I_ExternalSystem_Config parent = InterfaceWrapperHelper.load(externalSystemConfigId, I_ExternalSystem_Config.class);
+		if (parent == null)
+		{
+			return false;
+		}
+
+		final ExternalSystemType parentType = externalSystemRepository.getById(ExternalSystemId.ofRepoId(parent.getExternalSystem_ID())).getType();
+		final boolean matches = expectedType.equals(parentType);
+		if (!matches)
+		{
+			logger.warn("Skipping inconsistent {} config under ExternalSystem_Config_ID={} whose parent is of type {} (expected {})",
+					expectedType, externalSystemConfigId, parentType, expectedType);
+		}
+		return matches;
 	}
 }

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemConfigRepoTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemConfigRepoTest.java
@@ -955,6 +955,48 @@ class ExternalSystemConfigRepoTest
 	}
 
 	@Test
+	void getActiveByType_alberta_returnsValidConfig()
+	{
+		// Guard against the resilience filter using the wrong expected type (which would filter
+		// out every valid config for that reader): a correctly-parented Alberta config must be returned.
+		final I_ExternalSystem_Config parentRecord = ExternalSystemConfigTestUtil.createI_ExternalSystem_ConfigBuilder()
+				.type(Alberta.getValue())
+				.build();
+
+		final I_ExternalSystem_Config_Alberta child = newInstance(I_ExternalSystem_Config_Alberta.class);
+		child.setApiKey("apiKey");
+		child.setBaseURL("baseUrl");
+		child.setTenant("tenant");
+		child.setExternalSystemValue("alberta-value");
+		child.setExternalSystem_Config_ID(parentRecord.getExternalSystem_Config_ID());
+		saveRecord(child);
+
+		// when / then
+		final ImmutableList<ExternalSystemParentConfig> result = externalSystemConfigRepo.getActiveByType(Alberta);
+		assertThat(result)
+				.extracting(config -> config.getId().getRepoId())
+				.containsExactly(parentRecord.getExternalSystem_Config_ID());
+	}
+
+	@Test
+	void getActiveByType_rabbitMQ_skipsConfigWithMismatchedParentType()
+	{
+		// Guard that the RabbitMQ reader also filters (it was missing the filter): a RabbitMQ child
+		// under a wrong-typed parent must be skipped, not 500 the status endpoint.
+		final I_ExternalSystem_Config eddysonParent = ExternalSystemConfigTestUtil.createI_ExternalSystem_ConfigBuilder()
+				.type("eddyson")
+				.build();
+		ExternalSystemConfigTestUtil.createRabbitMQConfigBuilder()
+				.externalSystemConfigId(eddysonParent.getExternalSystem_Config_ID())
+				.value("rabbit-value")
+				.isSyncBPartnerToRabbitMQ(false)
+				.build();
+
+		// when / then: skipped (not returned), no throw
+		assertThat(externalSystemConfigRepo.getActiveByType(RabbitMQ)).isEmpty();
+	}
+
+	@Test
 	void getActiveByType_scriptedImportConversion_skipsConfigWithMismatchedParentType()
 	{
 		// given: a VALID scripted-import config under a scripted-import-typed parent ...

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemConfigRepoTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemConfigRepoTest.java
@@ -34,6 +34,8 @@ import de.metas.externalsystem.ExternalSystemParentConfigId;
 import de.metas.externalsystem.IExternalSystemChildConfig;
 import de.metas.externalsystem.model.I_ExternalSystem_Config;
 import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedImportConversion;
+import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion;
+import de.metas.externalsystem.model.I_ExternalSystem_Endpoint;
 import de.metas.externalsystem.model.I_ExternalSystem_Config_Alberta;
 import de.metas.externalsystem.model.I_ExternalSystem_Config_GRSSignum;
 import de.metas.externalsystem.model.I_ExternalSystem_Config_LeichMehl;
@@ -917,6 +919,39 @@ class ExternalSystemConfigRepoTest
 		// then: no child of that type -> empty (must NOT throw "Unsupported type", which would
 		// crash the ExternalSystem_Config type-change interceptor).
 		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void getChildByParentIdAndType_scriptedExportConversion_withChild_returnsPresent()
+	{
+		// Regression guard: ScriptedExportConversion DOES have a per-parent child table (modelled
+		// 0..many), so the lookup must find its child rather than fall through to the empty
+		// catch-all — otherwise the type-change interceptor would let a scripted-export parent be
+		// re-typed and silently orphan its child rows.
+		final I_ExternalSystem_Config parentRecord = ExternalSystemConfigTestUtil.createI_ExternalSystem_ConfigBuilder()
+				.type(ExternalSystemType.ScriptedExportConversion.getValue())
+				.build();
+
+		final I_ExternalSystem_Endpoint endpoint = newInstance(I_ExternalSystem_Endpoint.class);
+		endpoint.setValue("export-endpoint");
+		saveRecord(endpoint);
+
+		final I_ExternalSystem_Config_ScriptedExportConversion child = newInstance(I_ExternalSystem_Config_ScriptedExportConversion.class);
+		child.setExternalSystem_Config_ID(parentRecord.getExternalSystem_Config_ID());
+		child.setExternalSystem_Endpoint_ID(endpoint.getExternalSystem_Endpoint_ID());
+		child.setExternalSystemValue("export-orders");
+		child.setScriptIdentifier("echo");
+		child.setAD_Table_ID(318);
+		child.setWhereClause("1=1");
+		saveRecord(child);
+
+		// when
+		final Optional<IExternalSystemChildConfig> result = externalSystemConfigRepo.getChildByParentIdAndType(
+				ExternalSystemParentConfigId.ofRepoId(parentRecord.getExternalSystem_Config_ID()),
+				ExternalSystemType.ScriptedExportConversion);
+
+		// then
+		assertThat(result).isPresent();
 	}
 
 	@Test

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemConfigRepoTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemConfigRepoTest.java
@@ -29,7 +29,11 @@ import de.metas.externalsystem.alberta.ExternalSystemAlbertaConfigId;
 import de.metas.externalsystem.grssignum.ExternalSystemGRSSignumConfigId;
 import de.metas.externalsystem.leichmehl.ExternalSystemLeichMehlConfigId;
 import de.metas.externalsystem.leichmehl.PLUType;
+import de.metas.externalsystem.ExternalSystemType;
+import de.metas.externalsystem.ExternalSystemParentConfigId;
+import de.metas.externalsystem.IExternalSystemChildConfig;
 import de.metas.externalsystem.model.I_ExternalSystem_Config;
+import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedImportConversion;
 import de.metas.externalsystem.model.I_ExternalSystem_Config_Alberta;
 import de.metas.externalsystem.model.I_ExternalSystem_Config_GRSSignum;
 import de.metas.externalsystem.model.I_ExternalSystem_Config_LeichMehl;
@@ -894,6 +898,62 @@ class ExternalSystemConfigRepoTest
 
 		// then
 		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void getChildByParentIdAndType_unhandledParentType_returnsEmpty()
+	{
+		// given: a parent config of a custom external-system type ("eddyson") that has no
+		// per-parent child-config table.
+		final I_ExternalSystem_Config parentRecord = ExternalSystemConfigTestUtil.createI_ExternalSystem_ConfigBuilder()
+				.type("eddyson")
+				.build();
+
+		// when
+		final Optional<IExternalSystemChildConfig> result = externalSystemConfigRepo.getChildByParentIdAndType(
+				ExternalSystemParentConfigId.ofRepoId(parentRecord.getExternalSystem_Config_ID()),
+				ExternalSystemType.ofValue("eddyson"));
+
+		// then: no child of that type -> empty (must NOT throw "Unsupported type", which would
+		// crash the ExternalSystem_Config type-change interceptor).
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	void getActiveByType_scriptedImportConversion_skipsConfigWithMismatchedParentType()
+	{
+		// given: a VALID scripted-import config under a scripted-import-typed parent ...
+		final I_ExternalSystem_Config validParent = ExternalSystemConfigTestUtil.createI_ExternalSystem_ConfigBuilder()
+				.type(ExternalSystemType.ScriptedImportConversion.getValue())
+				.build();
+		final I_ExternalSystem_Config_ScriptedImportConversion validChild = newInstance(I_ExternalSystem_Config_ScriptedImportConversion.class);
+		validChild.setExternalSystem_Config_ID(validParent.getExternalSystem_Config_ID());
+		validChild.setExternalSystemValue("valid-orders");
+		validChild.setScriptIdentifier("echo");
+		validChild.setEndpointName("valid-orders-endpoint");
+		validChild.setAD_User_Import_ID(100);
+		saveRecord(validChild);
+
+		// ... and an INCONSISTENT scripted-import config created under a wrong-typed ("eddyson") parent.
+		final I_ExternalSystem_Config eddysonParent = ExternalSystemConfigTestUtil.createI_ExternalSystem_ConfigBuilder()
+				.type("eddyson")
+				.build();
+		final I_ExternalSystem_Config_ScriptedImportConversion mismatchedChild = newInstance(I_ExternalSystem_Config_ScriptedImportConversion.class);
+		mismatchedChild.setExternalSystem_Config_ID(eddysonParent.getExternalSystem_Config_ID());
+		mismatchedChild.setExternalSystemValue("ORDERS");
+		mismatchedChild.setScriptIdentifier("echo");
+		mismatchedChild.setEndpointName("orders-endpoint");
+		mismatchedChild.setAD_User_Import_ID(100);
+		saveRecord(mismatchedChild);
+
+		// when
+		final ImmutableList<ExternalSystemParentConfig> result = externalSystemConfigRepo.getActiveByType(ExternalSystemType.ScriptedImportConversion);
+
+		// then: the mismatched config is skipped (not returned) and does NOT 500 the whole
+		// status endpoint; only the valid config is returned.
+		assertThat(result)
+				.extracting(config -> config.getId().getRepoId())
+				.containsExactly(validParent.getExternalSystem_Config_ID());
 	}
 }
 


### PR DESCRIPTION
### Problem

When a scripted-import config exists under a parent external system whose type has no
per-parent child-config table (e.g. a custom external-system type), two failures occur:

1. **The external-system status endpoint returns 500 for the whole system.**
   `ExternalSystemConfigRepo.getActiveByType` → `getAllByScriptedImportConversion` builds an
   `ExternalSystemParentConfig` for **every** scripted-import config, and that constructor
   throws when the parent type ≠ child type. One inconsistent config blinded the entire
   external-system status page.

2. **The config's type can no longer be changed (so the data can't be corrected in the UI).**
   The `ExternalSystem_Config` `@ModelChange` interceptor calls
   `getChildByParentIdAndType(oldType)`, which threw `Check.fail("Unsupported …type=…")` for a
   type with no child-config table.

### Fix

- `getChildByParentIdAndType` returns `Optional.empty()` for a type with no per-parent
  child-config table, instead of throwing — the honest "no child of that type", which also
  unblocks the type-change interceptor.
- `getAllByScriptedImportConversion` skips configs whose parent type doesn't match (logged
  `warn`) instead of throwing, so one inconsistent row can't 500 the whole status endpoint.

### Tests

New unit tests in `ExternalSystemConfigRepoTest` reproduce both failures (RED before the fix,
GREEN after). Full `de.metas.externalsystem` module suite green (123 tests).
