### PR TITLE
SalesOrderCandidate: explode compensation-group schema (trading-BOM) products into component order lines on OLCand→order processing

### DIFF
--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/shipping/JsonShipmentService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/shipping/JsonShipmentService.java
@@ -632,7 +632,7 @@ public class JsonShipmentService
 				.get(olCandId);
 
 		// This external-header/line-id lookup must resolve exactly ONE order line (-> one shipment schedule) for the
-		// one candidate. A compensation-group-schema/"Mischkarton" candidate explodes 1->N order lines during
+		// one candidate. A compensation-group-schema candidate explodes 1->N order lines during
 		// OLCand->order processing and cannot satisfy this 1:1 contract, so fail loud (mirrors the olCandIds.size()
 		// != 1 assertion above) instead of silently picking an arbitrary one of the N lines.
 		if (orderLineIds.size() != 1)

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/shipping/JsonShipmentService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/shipping/JsonShipmentService.java
@@ -628,13 +628,18 @@ public class JsonShipmentService
 
 		final OLCandId olCandId = CollectionUtils.singleElement(olCandIds);
 
-		final OrderLineId orderLineId = olCandDAO.retrieveOLCandIdToOrderLineId(ImmutableSet.of(olCandId))
+		final Set<OrderLineId> orderLineIds = olCandDAO.retrieveOLCandIdToOrderLineId(ImmutableSet.of(olCandId))
 				.get(olCandId);
 
-		if (orderLineId == null)
+		if (orderLineIds.isEmpty())
 		{
 			throw new AdempiereException("No orderLineId found for olCandId: " + olCandId);
 		}
+
+		// This external-header/line-id lookup resolves a single shipment schedule for one candidate; it is not
+		// the compensation-group-schema/"Mischkarton" explosion path (that runs during OLCand->order processing).
+		// For the 1:1 case there is exactly one order line; take the first to keep the single-schedule contract.
+		final OrderLineId orderLineId = orderLineIds.iterator().next();
 
 		final Optional<ShipmentScheduleId> shipmentScheduleId = Optional.ofNullable(shipmentSchedulePA.getShipmentScheduleIdByOrderLineId(orderLineId));
 

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/shipping/JsonShipmentService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/shipping/JsonShipmentService.java
@@ -631,14 +631,17 @@ public class JsonShipmentService
 		final Set<OrderLineId> orderLineIds = olCandDAO.retrieveOLCandIdToOrderLineId(ImmutableSet.of(olCandId))
 				.get(olCandId);
 
-		if (orderLineIds.isEmpty())
+		// This external-header/line-id lookup must resolve exactly ONE order line (-> one shipment schedule) for the
+		// one candidate. A compensation-group-schema/"Mischkarton" candidate explodes 1->N order lines during
+		// OLCand->order processing and cannot satisfy this 1:1 contract, so fail loud (mirrors the olCandIds.size()
+		// != 1 assertion above) instead of silently picking an arbitrary one of the N lines.
+		if (orderLineIds.size() != 1)
 		{
-			throw new AdempiereException("No orderLineId found for olCandId: " + olCandId);
+			throw new AdempiereException("Expected exactly 1 orderLineId for olCandId: " + olCandId
+					+ " but found " + orderLineIds.size()
+					+ " (candidate was likely exploded via a compensation-group schema)");
 		}
 
-		// This external-header/line-id lookup resolves a single shipment schedule for one candidate; it is not
-		// the compensation-group-schema/"Mischkarton" explosion path (that runs during OLCand->order processing).
-		// For the 1:1 case there is exactly one order line; take the first to keep the single-schedule contract.
 		final OrderLineId orderLineId = orderLineIds.iterator().next();
 
 		final Optional<ShipmentScheduleId> shipmentScheduleId = Optional.ofNullable(shipmentSchedulePA.getShipmentScheduleIdByOrderLineId(orderLineId));

--- a/backend/de.metas.business/src/main/java/de/metas/order/compensationGroup/OrderGroupRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/compensationGroup/OrderGroupRepository.java
@@ -666,6 +666,31 @@ public class OrderGroupRepository implements GroupRepository
 		delete(orderCompensationGroup);
 	}
 
+	/**
+	 * Deletes the {@code C_Order_CompensationGroup} <b>header</b> row for the given {@link GroupId}, if it still exists.
+	 * <p>
+	 * Intended for rolling back a compensation group whose {@code C_OrderLine}s have <b>already</b> been deleted, so the
+	 * header is the last row left and (being a {@code DEFERRABLE INITIALLY DEFERRED} FK to {@code C_Order}) would abort
+	 * the whole transaction at COMMIT if left orphaned. Unlike {@link #destroyGroup(Group)}, this does NOT need a
+	 * rebuildable {@link Group} and does NOT reject compensation-line groups — the lines are gone, only the header
+	 * remains. Idempotent: a no-op if the header is already gone.
+	 */
+	public void deleteGroupById(@NonNull final GroupId groupId)
+	{
+		assertOrderGroupId(groupId);
+
+		final I_C_Order_CompensationGroup groupRecord = queryBL
+				.createQueryBuilder(I_C_Order_CompensationGroup.class)
+				.addEqualsFilter(I_C_Order_CompensationGroup.COLUMNNAME_C_Order_CompensationGroup_ID, groupId.getOrderCompensationGroupId())
+				.create()
+				.firstOnlyOrNull(I_C_Order_CompensationGroup.class);
+
+		if (groupRecord != null)
+		{
+			delete(groupRecord);
+		}
+	}
+
 	private I_C_Order_CompensationGroup retrieveGroupRecord(final GroupId groupId)
 	{
 		assertOrderGroupId(groupId);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/contract/C_Flatrate_Conditions_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/contract/C_Flatrate_Conditions_StepDef.java
@@ -107,7 +107,7 @@ public class C_Flatrate_Conditions_StepDef
 	 * <pre>
 	 * And metasfresh contains C_Flatrate_Conditions:
 	 *   | Name         | Type_Conditions | REST.Context.C_Flatrate_Conditions_ID |
-	 *   | mischkartonFC | Subscription    | flatrateConditionsId                  |
+	 *   | flatrateConditions | Subscription    | flatrateConditionsId                  |
 	 * </pre>
 	 */
 	@Given("metasfresh contains C_Flatrate_Conditions:")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/contract/C_Flatrate_Conditions_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/contract/C_Flatrate_Conditions_StepDef.java
@@ -46,6 +46,7 @@ import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Given;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_C_UOM;
@@ -70,41 +71,20 @@ import static de.metas.contracts.model.I_C_Flatrate_Conditions.COLUMNNAME_Type_F
 import static de.metas.cucumber.stepdefs.StepDefConstants.TABLECOLUMN_IDENTIFIER;
 import static org.assertj.core.api.Assertions.*;
 
+@RequiredArgsConstructor
 public class C_Flatrate_Conditions_StepDef
 {
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
-	private final C_HierarchyCommissionSettings_StepDefData hierarchyCommissionSettingsTable;
-	private final C_LicenseFeeSettings_StepDefData licenseFeeSettingsTable;
-	private final C_Customer_Trade_Margin_StepDefData customerTradeMarginTable;
-	private final C_MediatedCommissionSettings_StepDefData mediatedCommissionSettingsTable;
-	private final C_Flatrate_Conditions_StepDefData conditionsTable;
-	private final M_PricingSystem_StepDefData pricingSysTable;
-	private final M_Product_StepDefData productTable;
-	private final C_UOM_StepDefData uomTable;
-	private final TestContext testContext;
-
-	public C_Flatrate_Conditions_StepDef(
-			@NonNull final C_HierarchyCommissionSettings_StepDefData hierarchyCommissionSettingsTable,
-			@NonNull final C_LicenseFeeSettings_StepDefData licenseFeeSettingsTable,
-			@NonNull final C_Customer_Trade_Margin_StepDefData customerTradeMarginTable,
-			@NonNull final C_MediatedCommissionSettings_StepDefData mediatedCommissionSettingsTable,
-			@NonNull final C_Flatrate_Conditions_StepDefData conditionsTable,
-			@NonNull final M_PricingSystem_StepDefData pricingSysTable,
-			@NonNull final M_Product_StepDefData productTable,
-			@NonNull final C_UOM_StepDefData uomTable,
-			@NonNull final TestContext testContext)
-	{
-		this.hierarchyCommissionSettingsTable = hierarchyCommissionSettingsTable;
-		this.licenseFeeSettingsTable = licenseFeeSettingsTable;
-		this.customerTradeMarginTable = customerTradeMarginTable;
-		this.mediatedCommissionSettingsTable = mediatedCommissionSettingsTable;
-		this.conditionsTable = conditionsTable;
-		this.pricingSysTable = pricingSysTable;
-		this.productTable = productTable;
-		this.uomTable = uomTable;
-		this.testContext = testContext;
-	}
+	private final @NonNull C_HierarchyCommissionSettings_StepDefData hierarchyCommissionSettingsTable;
+	private final @NonNull C_LicenseFeeSettings_StepDefData licenseFeeSettingsTable;
+	private final @NonNull C_Customer_Trade_Margin_StepDefData customerTradeMarginTable;
+	private final @NonNull C_MediatedCommissionSettings_StepDefData mediatedCommissionSettingsTable;
+	private final @NonNull C_Flatrate_Conditions_StepDefData conditionsTable;
+	private final @NonNull M_PricingSystem_StepDefData pricingSysTable;
+	private final @NonNull M_Product_StepDefData productTable;
+	private final @NonNull C_UOM_StepDefData uomTable;
+	private final @NonNull TestContext testContext;
 
 	/**
 	 * Creates (or upserts by {@code Name}) {@link I_C_Flatrate_Conditions} records used to set up flatrate/contract

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/contract/C_Flatrate_Conditions_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/contract/C_Flatrate_Conditions_StepDef.java
@@ -37,6 +37,7 @@ import de.metas.cucumber.stepdefs.contract.commission.hierarchy.C_HierarchyCommi
 import de.metas.cucumber.stepdefs.contract.commission.licensefee.C_LicenseFeeSettings_StepDefData;
 import de.metas.cucumber.stepdefs.contract.commission.margin.C_Customer_Trade_Margin_StepDefData;
 import de.metas.cucumber.stepdefs.contract.commission.mediated.C_MediatedCommissionSettings_StepDefData;
+import de.metas.cucumber.stepdefs.context.TestContext;
 import de.metas.cucumber.stepdefs.pricing.M_PricingSystem_StepDefData;
 import de.metas.cucumber.stepdefs.uom.C_UOM_StepDefData;
 import de.metas.order.InvoiceRule;
@@ -81,6 +82,7 @@ public class C_Flatrate_Conditions_StepDef
 	private final M_PricingSystem_StepDefData pricingSysTable;
 	private final M_Product_StepDefData productTable;
 	private final C_UOM_StepDefData uomTable;
+	private final TestContext testContext;
 
 	public C_Flatrate_Conditions_StepDef(
 			@NonNull final C_HierarchyCommissionSettings_StepDefData hierarchyCommissionSettingsTable,
@@ -90,7 +92,8 @@ public class C_Flatrate_Conditions_StepDef
 			@NonNull final C_Flatrate_Conditions_StepDefData conditionsTable,
 			@NonNull final M_PricingSystem_StepDefData pricingSysTable,
 			@NonNull final M_Product_StepDefData productTable,
-			@NonNull final C_UOM_StepDefData uomTable)
+			@NonNull final C_UOM_StepDefData uomTable,
+			@NonNull final TestContext testContext)
 	{
 		this.hierarchyCommissionSettingsTable = hierarchyCommissionSettingsTable;
 		this.licenseFeeSettingsTable = licenseFeeSettingsTable;
@@ -100,8 +103,33 @@ public class C_Flatrate_Conditions_StepDef
 		this.pricingSysTable = pricingSysTable;
 		this.productTable = productTable;
 		this.uomTable = uomTable;
+		this.testContext = testContext;
 	}
 
+	/**
+	 * Creates (or upserts by {@code Name}) {@link I_C_Flatrate_Conditions} records used to set up flatrate/contract
+	 * conditions for a scenario.
+	 * <p>
+	 * DataTable columns:
+	 * <ul>
+	 *     <li>{@code Name} (required) — the conditions' name (also the upsert key)</li>
+	 *     <li>{@code Type_Conditions} (required) — the conditions type code</li>
+	 *     <li>{@code OPT.Type_Flatrate}, {@code OPT.M_Product_Flatrate_ID.Identifier},
+	 *         {@code OPT.C_HierarchyCommissionSettings_ID.Identifier}, {@code OPT.C_LicenseFeeSettings_ID.Identifier},
+	 *         {@code OPT.C_Customer_Trade_Margin_ID.Identifier}, {@code OPT.C_MediatedCommissionSettings_ID.Identifier},
+	 *         {@code OPT.DocStatus} (default Completed), {@code OPT.InvoiceRule} (default AfterDelivery),
+	 *         {@code OPT.C_UOM_ID.Identifier}, {@code OPT.M_PricingSystem_ID.Identifier},
+	 *         {@code OPT.OnFlatrateTermExtend} (all optional)</li>
+	 *     <li>{@code REST.Context.C_Flatrate_Conditions_ID} (optional) — when present, its cell value is used as a
+	 *         REST-context variable name that is set to the created {@code C_Flatrate_Conditions_ID}, so that a later
+	 *         REST payload can reference the dynamically-allocated id via {@code @<name>@}</li>
+	 * </ul>
+	 * <pre>
+	 * And metasfresh contains C_Flatrate_Conditions:
+	 *   | Name         | Type_Conditions | REST.Context.C_Flatrate_Conditions_ID |
+	 *   | mischkartonFC | Subscription    | flatrateConditionsId                  |
+	 * </pre>
+	 */
 	@Given("metasfresh contains C_Flatrate_Conditions:")
 	public void metasfresh_contains_c_flatrate_conditions(@NonNull final DataTable dataTable)
 	{
@@ -216,6 +244,14 @@ public class C_Flatrate_Conditions_StepDef
 			final String conditionsIdentifier = DataTableUtil.extractStringForColumnName(tableRow, TABLECOLUMN_IDENTIFIER);
 
 			conditionsTable.put(conditionsIdentifier, flatrateConditions);
+
+			// Expose the freshly-allocated C_Flatrate_Conditions_ID as a REST-context variable so a later REST
+			// payload can reference it (the id is dynamic in a fresh cucumber DB and cannot be hardcoded).
+			final String restContextVariableName = DataTableUtil.extractStringOrNullForColumnName(tableRow, "REST.Context." + I_C_Flatrate_Conditions.COLUMNNAME_C_Flatrate_Conditions_ID);
+			if (Check.isNotBlank(restContextVariableName))
+			{
+				testContext.setVariable(restContextVariableName, flatrateConditions.getC_Flatrate_Conditions_ID());
+			}
 		}
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_SchemaLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_SchemaLine_StepDef.java
@@ -70,7 +70,7 @@ public class C_CompensationGroup_SchemaLine_StepDef
 	 * <pre>
 	 * And metasfresh contains C_CompensationGroup_SchemaLine:
 	 *   | Identifier          | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | OPT.CompleteOrderDiscount | OPT.SeqNo |
-	 *   | mischkartonDiscount | mischkartonSchema                        | discountProduct         | 10                        | 30        |
+	 *   | schemaDiscount | compGroupSchema                        | discountProduct         | 10                        | 30        |
 	 * </pre>
 	 */
 	@Given("metasfresh contains C_CompensationGroup_SchemaLine:")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_SchemaLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_SchemaLine_StepDef.java
@@ -1,0 +1,103 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.order;
+
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.M_Product_StepDefData;
+import de.metas.order.model.I_C_CompensationGroup_Schema;
+import de.metas.order.model.I_C_CompensationGroup_SchemaLine;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.compiere.model.I_M_Product;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+
+/**
+ * Step definitions for creating {@link I_C_CompensationGroup_SchemaLine} records.
+ * <p>
+ * A schema line is the <b>compensation</b> (e.g. discount / surcharge) counterpart of a
+ * {@link de.metas.order.model.I_C_CompensationGroup_Schema_TemplateLine}: while a template line adds a
+ * regular product line to the generated compensation group, a schema line adds a compensation line
+ * (tracked on the order line via {@code IsGroupCompensationLine=Y}). It is read by
+ * {@code GroupTemplateRepository.retrieveCompensationLines}; the compensation type / amount type default
+ * from the referenced product (Discount / Percent), and {@code CompleteOrderDiscount} supplies the discount
+ * percentage. Leaving {@code Type} unset yields an always-matching compensation line.
+ */
+@RequiredArgsConstructor
+public class C_CompensationGroup_SchemaLine_StepDef
+{
+	private final @NonNull C_CompensationGroup_Schema_StepDefData schemaTable;
+	private final @NonNull C_CompensationGroup_SchemaLine_StepDefData schemaLineTable;
+	private final @NonNull M_Product_StepDefData productTable;
+
+	/**
+	 * Creates {@link I_C_CompensationGroup_SchemaLine} records that add a compensation (discount / surcharge)
+	 * line to a compensation-group schema.
+	 * <p>
+	 * DataTable columns:
+	 * <ul>
+	 *     <li>{@code Identifier} (required) — identifier for later reference</li>
+	 *     <li>{@code C_CompensationGroup_Schema_ID} (required) — identifier of the parent schema</li>
+	 *     <li>{@code M_Product_ID} (required) — identifier of the compensation product (its GroupCompensationType /
+	 *         GroupCompensationAmtType default to Discount / Percent)</li>
+	 *     <li>{@code OPT.CompleteOrderDiscount} (optional) — the whole-order discount percentage (e.g. {@code 10})</li>
+	 *     <li>{@code OPT.SeqNo} (optional) — sequence number for ordering</li>
+	 *     <li>{@code OPT.Type} (optional) — matcher type; leave unset for an always-matching line</li>
+	 * </ul>
+	 * <pre>
+	 * And metasfresh contains C_CompensationGroup_SchemaLine:
+	 *   | Identifier          | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | OPT.CompleteOrderDiscount | OPT.SeqNo |
+	 *   | mischkartonDiscount | mischkartonSchema                        | discountProduct         | 10                        | 30        |
+	 * </pre>
+	 */
+	@Given("metasfresh contains C_CompensationGroup_SchemaLine:")
+	public void createSchemaLines(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final I_C_CompensationGroup_Schema schema = row.getAsIdentifier(I_C_CompensationGroup_SchemaLine.COLUMNNAME_C_CompensationGroup_Schema_ID)
+					.lookupNotNullIn(schemaTable);
+
+			final I_M_Product product = row.getAsIdentifier(I_C_CompensationGroup_SchemaLine.COLUMNNAME_M_Product_ID)
+					.lookupNotNullIn(productTable);
+
+			final I_C_CompensationGroup_SchemaLine record = newInstance(I_C_CompensationGroup_SchemaLine.class);
+			record.setAD_Org_ID(schema.getAD_Org_ID());
+			record.setC_CompensationGroup_Schema_ID(schema.getC_CompensationGroup_Schema_ID());
+			record.setM_Product_ID(product.getM_Product_ID());
+
+			row.getAsOptionalBigDecimal(I_C_CompensationGroup_SchemaLine.COLUMNNAME_CompleteOrderDiscount)
+					.ifPresent(record::setCompleteOrderDiscount);
+			row.getAsOptionalInt(I_C_CompensationGroup_SchemaLine.COLUMNNAME_SeqNo)
+					.ifPresent(record::setSeqNo);
+			row.getAsOptionalString(I_C_CompensationGroup_SchemaLine.COLUMNNAME_Type)
+					.ifPresent(record::setType);
+
+			saveRecord(record);
+
+			schemaLineTable.putOrReplace(row.getAsIdentifier(), record);
+		});
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_SchemaLine_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_CompensationGroup_SchemaLine_StepDefData.java
@@ -1,0 +1,35 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.order;
+
+import de.metas.cucumber.stepdefs.StepDefData;
+import de.metas.order.model.I_C_CompensationGroup_SchemaLine;
+
+/** StepDefData holder for {@link I_C_CompensationGroup_SchemaLine} records, auto-discovered by PicoContainer. */
+public class C_CompensationGroup_SchemaLine_StepDefData extends StepDefData<I_C_CompensationGroup_SchemaLine>
+{
+	public C_CompensationGroup_SchemaLine_StepDefData()
+	{
+		super(I_C_CompensationGroup_SchemaLine.class);
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
@@ -332,12 +332,13 @@ public class C_OrderLine_StepDef
 	 * <p>
 	 * Required DataTable columns: {@code C_Order_ID.Identifier}, {@code M_Product_ID.Identifier}, {@code QtyOrdered}.
 	 * All other columns are optional per-row assertions handled by {@code validateOrderLine} — among them
-	 * {@code OPT.C_Flatrate_Conditions_ID.Identifier} (the threaded contract conditions) and
-	 * {@code OPT.IsGroupCompensationLine} (asserts a compensation/discount line, {@code IsGroupCompensationLine=Y}).
+	 * {@code OPT.C_Flatrate_Conditions_ID.Identifier} (the threaded contract conditions),
+	 * {@code OPT.IsGroupCompensationLine} (asserts a compensation/discount line, {@code IsGroupCompensationLine=Y}) and
+	 * {@code OPT.GroupCompensationPercentage} (the compensation line's discount/surcharge percentage).
 	 * <pre>
 	 * And validate the created order lines
-	 *   | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | OPT.IsGroupCompensationLine |
-	 *   | orderLine_discount        | order_1               | discountProduct         | 0          | true                        |
+	 *   | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | OPT.IsGroupCompensationLine | OPT.GroupCompensationPercentage |
+	 *   | orderLine_discount        | order_1               | discountProduct         | 1          | true                        | 10                              |
 	 * </pre>
 	 */
 	@And("validate the created order lines")
@@ -529,6 +530,9 @@ public class C_OrderLine_StepDef
 
 		row.getAsOptionalBoolean(I_C_OrderLine.COLUMNNAME_IsGroupCompensationLine)
 				.ifPresent(isGroupCompensationLine -> softly.assertThat(orderLine.isGroupCompensationLine()).as("IsGroupCompensationLine").isEqualTo(isGroupCompensationLine));
+
+		row.getAsOptionalBigDecimal(I_C_OrderLine.COLUMNNAME_GroupCompensationPercentage)
+				.ifPresent(groupCompensationPercentage -> softly.assertThat(orderLine.getGroupCompensationPercentage()).as("GroupCompensationPercentage").isEqualByComparingTo(groupCompensationPercentage));
 
 		final String bPartnerQtyItemCapacity = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_BPartner_QtyItemCapacity);
 		if (Check.isNotBlank(bPartnerQtyItemCapacity))

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_OrderLine_StepDef.java
@@ -326,6 +326,20 @@ public class C_OrderLine_StepDef
 		}
 	}
 
+	/**
+	 * Validates order lines by locating each one via ({@code C_Order_ID}, {@code M_Product_ID}, {@code QtyOrdered}) and
+	 * asserting the remaining columns.
+	 * <p>
+	 * Required DataTable columns: {@code C_Order_ID.Identifier}, {@code M_Product_ID.Identifier}, {@code QtyOrdered}.
+	 * All other columns are optional per-row assertions handled by {@code validateOrderLine} — among them
+	 * {@code OPT.C_Flatrate_Conditions_ID.Identifier} (the threaded contract conditions) and
+	 * {@code OPT.IsGroupCompensationLine} (asserts a compensation/discount line, {@code IsGroupCompensationLine=Y}).
+	 * <pre>
+	 * And validate the created order lines
+	 *   | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | OPT.IsGroupCompensationLine |
+	 *   | orderLine_discount        | order_1               | discountProduct         | 0          | true                        |
+	 * </pre>
+	 */
 	@And("validate the created order lines")
 	public void validate_created_order_lines(@NonNull final DataTable table)
 	{
@@ -512,6 +526,9 @@ public class C_OrderLine_StepDef
 			final boolean isManualPrice = StringUtils.toBoolean(isManualPriceStr);
 			softly.assertThat(orderLine.isManualPrice()).isEqualTo(isManualPrice);
 		}
+
+		row.getAsOptionalBoolean(I_C_OrderLine.COLUMNNAME_IsGroupCompensationLine)
+				.ifPresent(isGroupCompensationLine -> softly.assertThat(orderLine.isGroupCompensationLine()).as("IsGroupCompensationLine").isEqualTo(isGroupCompensationLine));
 
 		final String bPartnerQtyItemCapacity = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + I_C_OrderLine.COLUMNNAME_BPartner_QtyItemCapacity);
 		if (Check.isNotBlank(bPartnerQtyItemCapacity))

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/product/M_Product_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/product/M_Product_StepDef.java
@@ -115,12 +115,12 @@ public class M_Product_StepDef
 	 *     <li>{@code OPT.C_CompensationGroup_Schema_ID.Identifier} (optional) — identifier of a
 	 *         {@link I_C_CompensationGroup_Schema} (created via
 	 *         "metasfresh contains C_CompensationGroup_Schema:") linking the product to its
-	 *         "Mischkarton" (mixed carton) compensation-group schema.</li>
+	 *         compensation-group schema.</li>
 	 * </ul>
 	 * <pre>{@code
 	 * Given metasfresh contains M_Products:
 	 *   | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
-	 *   | mischkartonProduct | mischkartonProduct | mischkartonSchema                            |
+	 *   | schemaProduct | schemaProduct | compGroupSchema                            |
 	 * }</pre>
 	 */
 	@Given("metasfresh contains M_Products:")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/product/M_Product_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/product/M_Product_StepDef.java
@@ -33,10 +33,12 @@ import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.ValueAndName;
 import de.metas.cucumber.stepdefs.attribute.M_AttributeSet_StepDefData;
 import de.metas.cucumber.stepdefs.context.TestContext;
+import de.metas.cucumber.stepdefs.order.C_CompensationGroup_Schema_StepDefData;
 import de.metas.cucumber.stepdefs.org.AD_Org_StepDefData;
 import de.metas.cucumber.stepdefs.productCategory.M_Product_Category_StepDefData;
 import de.metas.externalreference.ExternalIdentifier;
 import de.metas.handlingunits.ClearanceStatus;
+import de.metas.order.model.I_C_CompensationGroup_Schema;
 import de.metas.organization.OrgId;
 import de.metas.product.IProductDAO;
 import de.metas.product.ProductCategoryId;
@@ -92,6 +94,7 @@ public class M_Product_StepDef
 	@NonNull private final C_BPartner_StepDefData bpartnerTable;
 	@NonNull private final M_Product_Category_StepDefData productCategoryTable;
 	@NonNull private final AD_Org_StepDefData orgTable;
+	@NonNull private final C_CompensationGroup_Schema_StepDefData compensationGroupSchemaTable;
 	@NonNull private final TestContext restTestContext;
 
 	@NonNull private final IProductDAO productDAO = Services.get(IProductDAO.class);
@@ -100,6 +103,17 @@ public class M_Product_StepDef
 	@NonNull private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
 	@NonNull private final ExternalIdentifierProductLookupService productLookupService = SpringContextHolder.instance.getBean(ExternalIdentifierProductLookupService.class);
 
+	/**
+	 * Creates (or updates, if a matching {@code Value} already exists) {@link I_M_Product} records.
+	 * <p>
+	 * DataTable columns include (non-exhaustive; see {@link #createM_Product(DataTableRow)}):
+	 * <ul>
+	 *     <li>{@code OPT.C_CompensationGroup_Schema_ID.Identifier} (optional) — identifier of a
+	 *         {@link I_C_CompensationGroup_Schema} (created via
+	 *         "metasfresh contains C_CompensationGroup_Schema:") to link as the product's
+	 *         "Mischkarton" (mixed carton) compensation-group schema.</li>
+	 * </ul>
+	 */
 	@Given("metasfresh contains M_Products:")
 	public void metasfresh_contains_m_product(@NonNull final io.cucumber.datatable.DataTable dataTable)
 	{
@@ -323,6 +337,10 @@ public class M_Product_StepDef
 			final AttributeSetId attributeSetId = attributeSetTable.getId(asIdentifier);
 			productRecord.setM_AttributeSet_ID(attributeSetId.getRepoId());
 		}
+
+		tableRow.getAsOptionalIdentifier(I_M_Product.COLUMNNAME_C_CompensationGroup_Schema_ID)
+				.map(identifier -> identifier.lookupNotNullIn(compensationGroupSchemaTable))
+				.ifPresent((I_C_CompensationGroup_Schema schema) -> productRecord.setC_CompensationGroup_Schema_ID(schema.getC_CompensationGroup_Schema_ID()));
 
 		InterfaceWrapperHelper.saveRecord(productRecord);
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/product/M_Product_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/product/M_Product_StepDef.java
@@ -106,13 +106,22 @@ public class M_Product_StepDef
 	/**
 	 * Creates (or updates, if a matching {@code Value} already exists) {@link I_M_Product} records.
 	 * <p>
-	 * DataTable columns include (non-exhaustive; see {@link #createM_Product(DataTableRow)}):
+	 * Frequently used DataTable columns (full handling is in {@link #createM_Product(DataTableRow)}):
 	 * <ul>
+	 *     <li>{@code Identifier} (required) — identifier for later reference.</li>
+	 *     <li>{@code Name} / {@code Value} (optional) — auto-generated unique when omitted.</li>
+	 *     <li>{@code OPT.M_Product_Category_ID.Identifier}, {@code OPT.C_UOM_ID.X12DE355},
+	 *         {@code OPT.M_AttributeSetInstance_ID.Identifier} — the common optional links.</li>
 	 *     <li>{@code OPT.C_CompensationGroup_Schema_ID.Identifier} (optional) — identifier of a
 	 *         {@link I_C_CompensationGroup_Schema} (created via
-	 *         "metasfresh contains C_CompensationGroup_Schema:") to link as the product's
+	 *         "metasfresh contains C_CompensationGroup_Schema:") linking the product to its
 	 *         "Mischkarton" (mixed carton) compensation-group schema.</li>
 	 * </ul>
+	 * <pre>{@code
+	 * Given metasfresh contains M_Products:
+	 *   | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
+	 *   | mischkartonProduct | mischkartonProduct | mischkartonSchema                            |
+	 * }</pre>
 	 */
 	@Given("metasfresh contains M_Products:")
 	public void metasfresh_contains_m_product(@NonNull final io.cucumber.datatable.DataTable dataTable)
@@ -340,7 +349,7 @@ public class M_Product_StepDef
 
 		tableRow.getAsOptionalIdentifier(I_M_Product.COLUMNNAME_C_CompensationGroup_Schema_ID)
 				.map(identifier -> identifier.lookupNotNullIn(compensationGroupSchemaTable))
-				.ifPresent((I_C_CompensationGroup_Schema schema) -> productRecord.setC_CompensationGroup_Schema_ID(schema.getC_CompensationGroup_Schema_ID()));
+				.ifPresent(schema -> productRecord.setC_CompensationGroup_Schema_ID(schema.getC_CompensationGroup_Schema_ID()));
 
 		InterfaceWrapperHelper.saveRecord(productRecord);
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
@@ -433,9 +433,9 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
       | order_comp            |
 
     # the order carries the 2 regular component lines (IsGroupCompensationLine=N) plus the compensation/discount line
-    # (IsGroupCompensationLine=Y, QtyOrdered=0 as it is a percentage whole-order discount)
+    # the schema's percentage whole-order discount materialises as a compensation line (IsGroupCompensationLine=Y, QtyOrdered=1)
     And validate the created order lines
       | C_OrderLine_ID.Identifier  | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | OPT.IsGroupCompensationLine | processed |
       | orderLine_comp_subProductA | order_comp            | subProductA             | 4          | false                       | true      |
       | orderLine_comp_subProductB | order_comp            | subProductB             | 6          | false                       | true      |
-      | orderLine_comp_discount    | order_comp            | discountProduct         | 0          | true                        | true      |
+      | orderLine_comp_discount    | order_comp            | discountProduct         | 1          | true                        | true      |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
@@ -16,14 +16,14 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
   @Id:S28977_TC1
   Scenario: OLCand for a Mischkarton (compensation-group-schema) product explodes into its component order lines
     Given metasfresh contains M_PricingSystems
-      | Identifier          | Name                | Value               | OPT.IsActive |
-      | ps_mischkarton28977 | ps_mischkarton28977 | ps_mischkarton28977 | true         |
+      | Identifier     | Name           |
+      | ps_mischkarton | ps_mischkarton |
     And metasfresh contains M_PriceLists
-      | Identifier          | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
-      | pl_mischkarton28977 | ps_mischkarton28977           | DE                        | EUR                 | pl_mischkarton28977 | true  | false         | 2              | true         |
+      | Identifier     | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name           | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_mischkarton | ps_mischkarton                | DE                        | EUR                 | pl_mischkarton | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
-      | Identifier           | M_PriceList_ID.Identifier | Name                 | ValidFrom  |
-      | plv_mischkarton28977 | pl_mischkarton28977       | plv_mischkarton28977 | 2026-07-01 |
+      | Identifier      | M_PriceList_ID.Identifier | Name            | ValidFrom  |
+      | plv_mischkarton | pl_mischkarton            | plv_mischkarton | 2026-07-01 |
 
     # the two sub-article products that make up the Mischkarton; created first so the schema's template lines can reference them
     And metasfresh contains M_Products:
@@ -47,16 +47,14 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
     # all three products need a price: the carton itself (to price the incoming OLCand) and both sub-articles (the exploded component lines must be priced)
     And metasfresh contains M_ProductPrices
       | Identifier            | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | pp_mischkartonProduct | plv_mischkarton28977              | mischkartonProduct      | 15.00    | PCE               | Normal                        |
-      | pp_subProductA        | plv_mischkarton28977              | subProductA             | 5.00     | PCE               | Normal                        |
-      | pp_subProductB        | plv_mischkarton28977              | subProductB             | 3.00     | PCE               | Normal                        |
+      | pp_mischkartonProduct | plv_mischkarton                   | mischkartonProduct      | 15.00    | PCE               | Normal                        |
+      | pp_subProductA        | plv_mischkarton                   | subProductA             | 5.00     | PCE               | Normal                        |
+      | pp_subProductB        | plv_mischkarton                   | subProductB             | 3.00     | PCE               | Normal                        |
 
+    # the C_BPartners step auto-creates the default location (with the given GLN, IsShipTo + IsBillToDefault) under the C_BPartner_Location_ID identifier
     And metasfresh contains C_BPartners:
       | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
-      | mischkartonCustomer | mischkartonCustomer | Y              | N            | ps_mischkarton28977           | mischkartonCustomerLocation | 4009900001234 |
-    And metasfresh contains C_BPartner_Locations:
-      | Identifier                  | GLN           | C_BPartner_ID.Identifier |
-      | mischkartonCustomerLocation | 4009900001234 | mischkartonCustomer      |
+      | mischkartonCustomer | mischkartonCustomer | Y              | N            | ps_mischkarton                | mischkartonCustomerLocation | 4009900001234 |
 
     # a single OLCand for 2 Mischkarton units
     When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
@@ -108,11 +106,11 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
       | order_1               |
 
     And validate the created orders
-      | C_Order_ID.Identifier | externalId       | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | poReference      | processed | DocStatus |
+      | C_Order_ID.Identifier | OPT.ExternalId   | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | POReference      | processed | DocStatus |
       | order_1               | mischkarton28977 | mischkartonCustomer      | mischkartonCustomerLocation       | 2026-07-20  | SOO         | EUR          | mischkarton28977 | true      | CO        |
 
-    # the point of this test: the Mischkarton line must have exploded into its two component lines (qty scaled by the OLCand qty of 2),
-    # NOT a single un-exploded line for mischkartonProduct. Today's processing does not explode it, so this assertion is RED.
+    # the ordered Mischkarton must resolve to its schema's two component article lines (quantities scaled by the ordered number of cartons: 2×2=4 and 3×2=6),
+    # matching what the sales-order window produces for the same product and quantity
     And validate the created order lines
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | DateOrdered | M_Product_ID.Identifier | qtydelivered | QtyOrdered | qtyinvoiced | price | discount | currencyCode | processed |
       | orderLine_1_subProductA   | order_1               | 2026-07-20  | subProductA             | 0            | 4          | 0           | 5     | 0        | EUR          | true      |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
@@ -158,6 +158,10 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
     And metasfresh contains C_BPartners:
       | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
       | mischkartonCustomer | mischkartonCustomer | Y              | N            | ps_mischkarton                | mischkartonCustomerLocation | 4009900001234 |
+    # explicit ship-to/bill-to location so the shipment-header C_BPartner_Location_ID assertion resolves the identifier reliably (registered in the step-def data)
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier                  | GLN           | C_BPartner_ID.Identifier | OPT.IsShipTo | OPT.IsBillTo |
+      | mischkartonCustomerLocation | 4009900001234 | mischkartonCustomer      | true         | true         |
 
     When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
   """

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
@@ -323,9 +323,9 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
 
     # both exploded component lines must carry the candidate's contract conditions (C2 threading)
     And validate the created order lines
-      | C_OrderLine_ID.Identifier   | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | OPT.C_Flatrate_Conditions_ID.Identifier | processed |
-      | orderLine_flatrate_subProdA | order_flatrate        | subProductA             | 4          | mischkartonFlatrate                     | true      |
-      | orderLine_flatrate_subProdB | order_flatrate        | subProductB             | 6          | mischkartonFlatrate                     | true      |
+      | C_OrderLine_ID.Identifier      | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | OPT.C_Flatrate_Conditions_ID.Identifier | processed |
+      | orderLine_flatrate_subProductA | order_flatrate        | subProductA             | 4          | mischkartonFlatrate                     | true      |
+      | orderLine_flatrate_subProductB | order_flatrate        | subProductB             | 6          | mischkartonFlatrate                     | true      |
 
   @from:cucumber
   @allure.label.epic:E0100_Sales
@@ -433,9 +433,10 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
       | order_comp            |
 
     # the order carries the 2 regular component lines (IsGroupCompensationLine=N) plus the compensation/discount line
-    # the schema's percentage whole-order discount materialises as a compensation line (IsGroupCompensationLine=Y, QtyOrdered=1)
+    # the schema's 10% whole-order discount materialises as a compensation line (IsGroupCompensationLine=Y, QtyOrdered=1,
+    # GroupCompensationPercentage=10 — the discount % carried from the schema line's CompleteOrderDiscount)
     And validate the created order lines
-      | C_OrderLine_ID.Identifier  | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | OPT.IsGroupCompensationLine | processed |
-      | orderLine_comp_subProductA | order_comp            | subProductA             | 4          | false                       | true      |
-      | orderLine_comp_subProductB | order_comp            | subProductB             | 6          | false                       | true      |
-      | orderLine_comp_discount    | order_comp            | discountProduct         | 1          | true                        | true      |
+      | C_OrderLine_ID.Identifier  | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | OPT.IsGroupCompensationLine | OPT.GroupCompensationPercentage | processed |
+      | orderLine_comp_subProductA | order_comp            | subProductA             | 4          | false                       |                                 | true      |
+      | orderLine_comp_subProductB | order_comp            | subProductB             | 6          | false                       |                                 | true      |
+      | orderLine_comp_discount    | order_comp            | discountProduct         | 1          | true                        | 10                              | true      |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
@@ -16,14 +16,14 @@ Feature: Explode a compensation-group-schema product into its component order li
   @Id:S28977_TC1
   Scenario: OLCand for a compensation-group-schema product explodes into its component order lines
     Given metasfresh contains M_PricingSystems
-      | Identifier     | Name           |
-      | ps_schema | ps_schema |
+      | Identifier | Name      |
+      | ps_schema  | ps_schema |
     And metasfresh contains M_PriceLists
-      | Identifier     | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name           | SOTrx | IsTaxIncluded | PricePrecision |
-      | pl_schema | ps_schema                | DE                        | EUR                 | pl_schema | true  | false         | 2              |
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name      | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_schema  | ps_schema                     | DE                        | EUR                 | pl_schema | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
-      | Identifier      | M_PriceList_ID.Identifier | Name            | ValidFrom  |
-      | plv_schema | pl_schema            | plv_schema | 2026-07-01 |
+      | Identifier | M_PriceList_ID.Identifier | Name       | ValidFrom  |
+      | plv_schema | pl_schema                 | plv_schema | 2026-07-01 |
 
     # the two sub-article products that make up the compensation group; created first so the schema's template lines can reference them
     And metasfresh contains M_Products:
@@ -32,29 +32,29 @@ Feature: Explode a compensation-group-schema product into its component order li
       | subProductB | subProductB |
 
     And metasfresh contains C_CompensationGroup_Schema:
-      | Identifier        | Name              |
+      | Identifier      | Name            |
       | compGroupSchema | compGroupSchema |
     And metasfresh contains C_CompensationGroup_Schema_TemplateLine:
-      | Identifier             | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
-      | schemaTemplateLineA | compGroupSchema                        | subProductA             | 2   | PCE      | 10    |
-      | schemaTemplateLineB | compGroupSchema                        | subProductB             | 3   | PCE      | 20    |
+      | Identifier          | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
+      | schemaTemplateLineA | compGroupSchema                          | subProductA             | 2   | PCE      | 10    |
+      | schemaTemplateLineB | compGroupSchema                          | subProductB             | 3   | PCE      | 20    |
 
     # the compensation-group-schema product itself, linked to the schema
     And metasfresh contains M_Products:
-      | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
-      | schemaProduct | schemaProduct | compGroupSchema                            |
+      | Identifier    | Name          | OPT.C_CompensationGroup_Schema_ID.Identifier |
+      | schemaProduct | schemaProduct | compGroupSchema                              |
 
     # all three products need a price: the schema product itself (to price the incoming OLCand) and both sub-articles (the exploded component lines must be priced)
     And metasfresh contains M_ProductPrices
-      | Identifier            | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | pp_schemaProduct | plv_schema                   | schemaProduct      | 15.00    | PCE               | Normal                        |
-      | pp_subProductA        | plv_schema                   | subProductA             | 5.00     | PCE               | Normal                        |
-      | pp_subProductB        | plv_schema                   | subProductB             | 3.00     | PCE               | Normal                        |
+      | Identifier       | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_schemaProduct | plv_schema                        | schemaProduct           | 15.00    | PCE               | Normal                        |
+      | pp_subProductA   | plv_schema                        | subProductA             | 5.00     | PCE               | Normal                        |
+      | pp_subProductB   | plv_schema                        | subProductB             | 3.00     | PCE               | Normal                        |
 
     # the C_BPartners step auto-creates the default location (with the given GLN, IsShipTo + IsBillToDefault) under the C_BPartner_Location_ID identifier
     And metasfresh contains C_BPartners:
-      | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
-      | customer | customer | Y              | N            | ps_schema                | customerLocation | 4009900001234 |
+      | Identifier | Name     | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID | GLN           |
+      | customer   | customer | Y              | N            | ps_schema                     | customerLocation           | 4009900001234 |
 
     # a single OLCand for 2 units of the schema product
     When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
@@ -106,8 +106,8 @@ Feature: Explode a compensation-group-schema product into its component order li
       | order_1               |
 
     And validate the created orders
-      | C_Order_ID.Identifier | OPT.ExternalId   | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | POReference      | processed | DocStatus |
-      | order_1               | schemaExplosion | customer      | customerLocation       | 2026-07-20  | SOO         | EUR          | schemaExplosion | true      | CO        |
+      | C_Order_ID.Identifier | OPT.ExternalId  | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | POReference     | processed | DocStatus |
+      | order_1               | schemaExplosion | customer                 | customerLocation                  | 2026-07-20  | SOO         | EUR          | schemaExplosion | true      | CO        |
 
     # the ordered schema product must resolve to its schema's two component article lines (quantities scaled by the ordered quantity 2: 2×2=4 and 3×2=6),
     # matching what the sales-order window produces for the same product and quantity
@@ -123,14 +123,14 @@ Feature: Explode a compensation-group-schema product into its component order li
   @Id:S28977_TC2
   Scenario: A shipment generated from a schema-exploded OLCand contains a line for each component product
     Given metasfresh contains M_PricingSystems
-      | Identifier     | Name           |
-      | ps_schema | ps_schema |
+      | Identifier | Name      |
+      | ps_schema  | ps_schema |
     And metasfresh contains M_PriceLists
-      | Identifier     | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name           | SOTrx | IsTaxIncluded | PricePrecision |
-      | pl_schema | ps_schema                | DE                        | EUR                 | pl_schema | true  | false         | 2              |
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name      | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_schema  | ps_schema                     | DE                        | EUR                 | pl_schema | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
-      | Identifier      | M_PriceList_ID.Identifier | Name            | ValidFrom  |
-      | plv_schema | pl_schema            | plv_schema | 2026-07-01 |
+      | Identifier | M_PriceList_ID.Identifier | Name       | ValidFrom  |
+      | plv_schema | pl_schema                 | plv_schema | 2026-07-01 |
 
     And metasfresh contains M_Products:
       | Identifier  | Name        |
@@ -138,30 +138,30 @@ Feature: Explode a compensation-group-schema product into its component order li
       | subProductB | subProductB |
 
     And metasfresh contains C_CompensationGroup_Schema:
-      | Identifier        | Name              |
+      | Identifier      | Name            |
       | compGroupSchema | compGroupSchema |
     And metasfresh contains C_CompensationGroup_Schema_TemplateLine:
-      | Identifier             | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
-      | schemaTemplateLineA | compGroupSchema                        | subProductA             | 2   | PCE      | 10    |
-      | schemaTemplateLineB | compGroupSchema                        | subProductB             | 3   | PCE      | 20    |
+      | Identifier          | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
+      | schemaTemplateLineA | compGroupSchema                          | subProductA             | 2   | PCE      | 10    |
+      | schemaTemplateLineB | compGroupSchema                          | subProductB             | 3   | PCE      | 20    |
 
     And metasfresh contains M_Products:
-      | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
-      | schemaProduct | schemaProduct | compGroupSchema                            |
+      | Identifier    | Name          | OPT.C_CompensationGroup_Schema_ID.Identifier |
+      | schemaProduct | schemaProduct | compGroupSchema                              |
 
     And metasfresh contains M_ProductPrices
-      | Identifier            | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | pp_schemaProduct | plv_schema                   | schemaProduct      | 15.00    | PCE               | Normal                        |
-      | pp_subProductA        | plv_schema                   | subProductA             | 5.00     | PCE               | Normal                        |
-      | pp_subProductB        | plv_schema                   | subProductB             | 3.00     | PCE               | Normal                        |
+      | Identifier       | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_schemaProduct | plv_schema                        | schemaProduct           | 15.00    | PCE               | Normal                        |
+      | pp_subProductA   | plv_schema                        | subProductA             | 5.00     | PCE               | Normal                        |
+      | pp_subProductB   | plv_schema                        | subProductB             | 3.00     | PCE               | Normal                        |
 
     And metasfresh contains C_BPartners:
-      | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
-      | customer | customer | Y              | N            | ps_schema                | customerLocation | 4009900001234 |
+      | Identifier | Name     | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID | GLN           |
+      | customer   | customer | Y              | N            | ps_schema                     | customerLocation           | 4009900001234 |
     # explicit ship-to/bill-to location so the shipment-header C_BPartner_Location_ID assertion resolves the identifier reliably (registered in the step-def data)
     And metasfresh contains C_BPartner_Locations:
-      | Identifier                  | GLN           | C_BPartner_ID.Identifier | OPT.IsShipTo | OPT.IsBillTo |
-      | customerLocation | 4009900001234 | customer      | true         | true         |
+      | Identifier       | GLN           | C_BPartner_ID.Identifier | OPT.IsShipTo | OPT.IsBillTo |
+      | customerLocation | 4009900001234 | customer                 | true         | true         |
 
     When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
   """
@@ -214,8 +214,8 @@ Feature: Explode a compensation-group-schema product into its component order li
       | order_ship            | shipment_ship         |
 
     And validate the created shipments
-      | M_InOut_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | poreference           | processed | DocStatus |
-      | shipment_ship         | customer      | customerLocation       | 2026-07-20  | schemaExplosion_ship | true      | CO        |
+      | M_InOut_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | poreference          | processed | DocStatus |
+      | shipment_ship         | customer                 | customerLocation                  | 2026-07-20  | schemaExplosion_ship | true      | CO        |
 
     # the shipment must carry ONE line per exploded component product, with the scaled quantities (2x2=4, 3x2=6)
     And validate the created shipment lines
@@ -230,14 +230,14 @@ Feature: Explode a compensation-group-schema product into its component order li
   @Id:S28977_TC3
   Scenario: A flatrate-linked OLCand threads its contract conditions onto the exploded component order lines
     Given metasfresh contains M_PricingSystems
-      | Identifier     | Name           |
-      | ps_schema | ps_schema |
+      | Identifier | Name      |
+      | ps_schema  | ps_schema |
     And metasfresh contains M_PriceLists
-      | Identifier     | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name           | SOTrx | IsTaxIncluded | PricePrecision |
-      | pl_schema | ps_schema                | DE                        | EUR                 | pl_schema | true  | false         | 2              |
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name      | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_schema  | ps_schema                     | DE                        | EUR                 | pl_schema | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
-      | Identifier      | M_PriceList_ID.Identifier | Name            | ValidFrom  |
-      | plv_schema | pl_schema            | plv_schema | 2026-07-01 |
+      | Identifier | M_PriceList_ID.Identifier | Name       | ValidFrom  |
+      | plv_schema | pl_schema                 | plv_schema | 2026-07-01 |
 
     And metasfresh contains M_Products:
       | Identifier  | Name        |
@@ -245,22 +245,22 @@ Feature: Explode a compensation-group-schema product into its component order li
       | subProductB | subProductB |
 
     And metasfresh contains C_CompensationGroup_Schema:
-      | Identifier        | Name              |
+      | Identifier      | Name            |
       | compGroupSchema | compGroupSchema |
     And metasfresh contains C_CompensationGroup_Schema_TemplateLine:
-      | Identifier             | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
-      | schemaTemplateLineA | compGroupSchema                        | subProductA             | 2   | PCE      | 10    |
-      | schemaTemplateLineB | compGroupSchema                        | subProductB             | 3   | PCE      | 20    |
+      | Identifier          | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
+      | schemaTemplateLineA | compGroupSchema                          | subProductA             | 2   | PCE      | 10    |
+      | schemaTemplateLineB | compGroupSchema                          | subProductB             | 3   | PCE      | 20    |
 
     And metasfresh contains M_Products:
-      | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
-      | schemaProduct | schemaProduct | compGroupSchema                            |
+      | Identifier    | Name          | OPT.C_CompensationGroup_Schema_ID.Identifier |
+      | schemaProduct | schemaProduct | compGroupSchema                              |
 
     And metasfresh contains M_ProductPrices
-      | Identifier            | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | pp_schemaProduct | plv_schema                   | schemaProduct      | 15.00    | PCE               | Normal                        |
-      | pp_subProductA        | plv_schema                   | subProductA             | 5.00     | PCE               | Normal                        |
-      | pp_subProductB        | plv_schema                   | subProductB             | 3.00     | PCE               | Normal                        |
+      | Identifier       | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_schemaProduct | plv_schema                        | schemaProduct           | 15.00    | PCE               | Normal                        |
+      | pp_subProductA   | plv_schema                        | subProductA             | 5.00     | PCE               | Normal                        |
+      | pp_subProductB   | plv_schema                        | subProductB             | 3.00     | PCE               | Normal                        |
 
     # the contract conditions the incoming candidate carries; its (dynamically-allocated) id is exposed as the REST
     # context variable 'flatrateConditionsId' so the candidate payload below can reference it via @flatrateConditionsId@.
@@ -269,12 +269,12 @@ Feature: Explode a compensation-group-schema product into its component order li
     # (that path is gated on TYPE_CONDITIONS_Subscription in SubscriptionBL.isSubscription) and so does not drag in a
     # full subscription/transition contract setup that is orthogonal to the OLCand-explosion threading.
     And metasfresh contains C_Flatrate_Conditions:
-      | Identifier          | Name                | Type_Conditions | REST.Context.C_Flatrate_Conditions_ID |
+      | Identifier     | Name           | Type_Conditions | REST.Context.C_Flatrate_Conditions_ID |
       | schemaFlatrate | schemaFlatrate | FlatFee         | flatrateConditionsId                  |
 
     And metasfresh contains C_BPartners:
-      | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
-      | customer | customer | Y              | N            | ps_schema                | customerLocation | 4009900001234 |
+      | Identifier | Name     | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID | GLN           |
+      | customer   | customer | Y              | N            | ps_schema                     | customerLocation           | 4009900001234 |
 
     When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
   """
@@ -328,8 +328,8 @@ Feature: Explode a compensation-group-schema product into its component order li
     # both exploded component lines must carry the candidate's contract conditions (C2 threading)
     And validate the created order lines
       | C_OrderLine_ID.Identifier      | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | OPT.C_Flatrate_Conditions_ID.Identifier | processed |
-      | orderLine_flatrate_subProductA | order_flatrate        | subProductA             | 4          | schemaFlatrate                     | true      |
-      | orderLine_flatrate_subProductB | order_flatrate        | subProductB             | 6          | schemaFlatrate                     | true      |
+      | orderLine_flatrate_subProductA | order_flatrate        | subProductA             | 4          | schemaFlatrate                          | true      |
+      | orderLine_flatrate_subProductB | order_flatrate        | subProductB             | 6          | schemaFlatrate                          | true      |
 
   @from:cucumber
   @allure.label.epic:E0100_Sales
@@ -338,14 +338,14 @@ Feature: Explode a compensation-group-schema product into its component order li
   @Id:S28977_TC4
   Scenario: A compensation-group schema with a compensation line explodes into its regular component lines plus the compensation (discount) line
     Given metasfresh contains M_PricingSystems
-      | Identifier     | Name           |
-      | ps_schema | ps_schema |
+      | Identifier | Name      |
+      | ps_schema  | ps_schema |
     And metasfresh contains M_PriceLists
-      | Identifier     | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name           | SOTrx | IsTaxIncluded | PricePrecision |
-      | pl_schema | ps_schema                | DE                        | EUR                 | pl_schema | true  | false         | 2              |
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name      | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_schema  | ps_schema                     | DE                        | EUR                 | pl_schema | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
-      | Identifier      | M_PriceList_ID.Identifier | Name            | ValidFrom  |
-      | plv_schema | pl_schema            | plv_schema | 2026-07-01 |
+      | Identifier | M_PriceList_ID.Identifier | Name       | ValidFrom  |
+      | plv_schema | pl_schema                 | plv_schema | 2026-07-01 |
 
     And metasfresh contains M_Products:
       | Identifier  | Name        |
@@ -359,34 +359,34 @@ Feature: Explode a compensation-group-schema product into its component order li
       | discountProduct | discountProduct |
 
     And metasfresh contains C_CompensationGroup_Schema:
-      | Identifier        | Name              |
+      | Identifier      | Name            |
       | compGroupSchema | compGroupSchema |
     And metasfresh contains C_CompensationGroup_Schema_TemplateLine:
-      | Identifier             | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
-      | schemaTemplateLineA | compGroupSchema                        | subProductA             | 2   | PCE      | 10    |
-      | schemaTemplateLineB | compGroupSchema                        | subProductB             | 3   | PCE      | 20    |
+      | Identifier          | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
+      | schemaTemplateLineA | compGroupSchema                          | subProductA             | 2   | PCE      | 10    |
+      | schemaTemplateLineB | compGroupSchema                          | subProductB             | 3   | PCE      | 20    |
     # the schema's compensation line: an always-matching whole-order discount of 10%
     And metasfresh contains C_CompensationGroup_SchemaLine:
-      | Identifier          | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | OPT.CompleteOrderDiscount | OPT.SeqNo |
-      | schemaDiscount | compGroupSchema                        | discountProduct         | 10                        | 30        |
+      | Identifier     | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | OPT.CompleteOrderDiscount | OPT.SeqNo |
+      | schemaDiscount | compGroupSchema                          | discountProduct         | 10                        | 30        |
 
     And metasfresh contains M_Products:
-      | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
-      | schemaProduct | schemaProduct | compGroupSchema                            |
+      | Identifier    | Name          | OPT.C_CompensationGroup_Schema_ID.Identifier |
+      | schemaProduct | schemaProduct | compGroupSchema                              |
 
     # the compensation product is a real M_Product (M_Product_ID is mandatory on the schema line), so it must be on
     # the price list like any ordered product — order completion prices every line, including the compensation line.
     # Its PriceStd is irrelevant to the discount amount (the line is a percentage whole-order discount), hence 0.
     And metasfresh contains M_ProductPrices
-      | Identifier            | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | pp_schemaProduct | plv_schema                   | schemaProduct      | 15.00    | PCE               | Normal                        |
-      | pp_subProductA        | plv_schema                   | subProductA             | 5.00     | PCE               | Normal                        |
-      | pp_subProductB        | plv_schema                   | subProductB             | 3.00     | PCE               | Normal                        |
-      | pp_discountProduct    | plv_schema                   | discountProduct         | 0.00     | PCE               | Normal                        |
+      | Identifier         | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_schemaProduct   | plv_schema                        | schemaProduct           | 15.00    | PCE               | Normal                        |
+      | pp_subProductA     | plv_schema                        | subProductA             | 5.00     | PCE               | Normal                        |
+      | pp_subProductB     | plv_schema                        | subProductB             | 3.00     | PCE               | Normal                        |
+      | pp_discountProduct | plv_schema                        | discountProduct         | 0.00     | PCE               | Normal                        |
 
     And metasfresh contains C_BPartners:
-      | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
-      | customer | customer | Y              | N            | ps_schema                | customerLocation | 4009900001234 |
+      | Identifier | Name     | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID | GLN           |
+      | customer   | customer | Y              | N            | ps_schema                     | customerLocation           | 4009900001234 |
 
     When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
   """

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
@@ -1,0 +1,119 @@
+@from:cucumber
+@allure.label.epic:E0100_Sales
+@allure.label.feature:F00122_Sales_Order_Candidate_to_Order
+@ghActions:run_on_executor3
+Feature: Explode a Mischkarton compensation-group-schema product into its component order lines when processing an order candidate to an order
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2026-07-20T09:00:00+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+
+  @from:cucumber
+  @allure.label.epic:E0100_Sales
+  @allure.label.feature:F00122_Sales_Order_Candidate_to_Order
+  @Id:S28977_TC1
+  Scenario: OLCand for a Mischkarton (compensation-group-schema) product explodes into its component order lines
+    Given metasfresh contains M_PricingSystems
+      | Identifier          | Name                | Value               | OPT.IsActive |
+      | ps_mischkarton28977 | ps_mischkarton28977 | ps_mischkarton28977 | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier          | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_mischkarton28977 | ps_mischkarton28977           | DE                        | EUR                 | pl_mischkarton28977 | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier           | M_PriceList_ID.Identifier | Name                 | ValidFrom  |
+      | plv_mischkarton28977 | pl_mischkarton28977       | plv_mischkarton28977 | 2026-07-01 |
+
+    # the two sub-article products that make up the Mischkarton; created first so the schema's template lines can reference them
+    And metasfresh contains M_Products:
+      | Identifier  | Name        |
+      | subProductA | subProductA |
+      | subProductB | subProductB |
+
+    And metasfresh contains C_CompensationGroup_Schema:
+      | Identifier        | Name              |
+      | mischkartonSchema | mischkartonSchema |
+    And metasfresh contains C_CompensationGroup_Schema_TemplateLine:
+      | Identifier             | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
+      | mischkartonSchemaLineA | mischkartonSchema                        | subProductA             | 2   | PCE      | 10    |
+      | mischkartonSchemaLineB | mischkartonSchema                        | subProductB             | 3   | PCE      | 20    |
+
+    # the Mischkarton (mixed carton) product itself, linked to the schema
+    And metasfresh contains M_Products:
+      | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
+      | mischkartonProduct | mischkartonProduct | mischkartonSchema                            |
+
+    # all three products need a price: the carton itself (to price the incoming OLCand) and both sub-articles (the exploded component lines must be priced)
+    And metasfresh contains M_ProductPrices
+      | Identifier            | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_mischkartonProduct | plv_mischkarton28977              | mischkartonProduct      | 15.00    | PCE               | Normal                        |
+      | pp_subProductA        | plv_mischkarton28977              | subProductA             | 5.00     | PCE               | Normal                        |
+      | pp_subProductB        | plv_mischkarton28977              | subProductB             | 3.00     | PCE               | Normal                        |
+
+    And metasfresh contains C_BPartners:
+      | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
+      | mischkartonCustomer | mischkartonCustomer | Y              | N            | ps_mischkarton28977           | mischkartonCustomerLocation | 4009900001234 |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier                  | GLN           | C_BPartner_ID.Identifier |
+      | mischkartonCustomerLocation | 4009900001234 | mischkartonCustomer      |
+
+    # a single OLCand for 2 Mischkarton units
+    When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
+  """
+{
+    "requests": [
+        {
+            "orgCode": "001",
+            "externalHeaderId": "mischkarton28977",
+            "externalLineId": "mischkarton28977_0",
+            "externalSystemCode": "Shopware6",
+            "dataSource": "int-Shopware",
+            "bpartner": {
+                "bpartnerIdentifier": "gln-4009900001234",
+                "bpartnerLocationIdentifier": "gln-4009900001234"
+            },
+            "dateRequired": "2026-08-01",
+            "dateOrdered": "2026-07-20",
+            "orderDocType": "SalesOrder",
+            "paymentTerm": "val-1000002",
+            "productIdentifier": "val-mischkartonProduct",
+            "qty": 2,
+            "currencyCode": "EUR",
+            "discount": 0,
+            "poReference": "mischkarton28977",
+            "deliveryViaRule": "S",
+            "deliveryRule": "F"
+        }
+    ]
+}
+"""
+
+    Then process metasfresh response JsonOLCandCreateBulkResponse
+      | C_OLCand_ID.Identifier |
+      | olCand_1               |
+
+    When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/process' and fulfills with '200' status code
+"""
+{
+    "externalHeaderId": "mischkarton28977",
+    "externalSystemCode": "Shopware6",
+    "ship": false,
+    "invoice": false,
+    "closeOrder": false
+}
+"""
+    Then process metasfresh response
+      | C_Order_ID.Identifier |
+      | order_1               |
+
+    And validate the created orders
+      | C_Order_ID.Identifier | externalId       | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | poReference      | processed | DocStatus |
+      | order_1               | mischkarton28977 | mischkartonCustomer      | mischkartonCustomerLocation       | 2026-07-20  | SOO         | EUR          | mischkarton28977 | true      | CO        |
+
+    # the point of this test: the Mischkarton line must have exploded into its two component lines (qty scaled by the OLCand qty of 2),
+    # NOT a single un-exploded line for mischkartonProduct. Today's processing does not explode it, so this assertion is RED.
+    And validate the created order lines
+      | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | DateOrdered | M_Product_ID.Identifier | qtydelivered | QtyOrdered | qtyinvoiced | price | discount | currencyCode | processed |
+      | orderLine_1_subProductA   | order_1               | 2026-07-20  | subProductA             | 0            | 4          | 0           | 5     | 0        | EUR          | true      |
+      | orderLine_1_subProductB   | order_1               | 2026-07-20  | subProductB             | 0            | 6          | 0           | 3     | 0        | EUR          | true      |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
@@ -259,10 +259,14 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
       | pp_subProductB        | plv_mischkarton                   | subProductB             | 3.00     | PCE               | Normal                        |
 
     # the contract conditions the incoming candidate carries; its (dynamically-allocated) id is exposed as the REST
-    # context variable 'flatrateConditionsId' so the candidate payload below can reference it via @flatrateConditionsId@
+    # context variable 'flatrateConditionsId' so the candidate payload below can reference it via @flatrateConditionsId@.
+    # Type_Conditions=FlatFee (not Subscription): the exploded order lines must still carry C_Flatrate_Conditions_ID
+    # (the behaviour under test), but a non-subscription type does not spawn a C_Flatrate_Term on order completion
+    # (that path is gated on TYPE_CONDITIONS_Subscription in SubscriptionBL.isSubscription) and so does not drag in a
+    # full subscription/transition contract setup that is orthogonal to the OLCand-explosion threading.
     And metasfresh contains C_Flatrate_Conditions:
       | Identifier          | Name                | Type_Conditions | REST.Context.C_Flatrate_Conditions_ID |
-      | mischkartonFlatrate | mischkartonFlatrate | Subscr          | flatrateConditionsId                  |
+      | mischkartonFlatrate | mischkartonFlatrate | FlatFee         | flatrateConditionsId                  |
 
     And metasfresh contains C_BPartners:
       | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
@@ -366,11 +370,15 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
       | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
       | mischkartonProduct | mischkartonProduct | mischkartonSchema                            |
 
+    # the compensation product is a real M_Product (M_Product_ID is mandatory on the schema line), so it must be on
+    # the price list like any ordered product — order completion prices every line, including the compensation line.
+    # Its PriceStd is irrelevant to the discount amount (the line is a percentage whole-order discount), hence 0.
     And metasfresh contains M_ProductPrices
       | Identifier            | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
       | pp_mischkartonProduct | plv_mischkarton                   | mischkartonProduct      | 15.00    | PCE               | Normal                        |
       | pp_subProductA        | plv_mischkarton                   | subProductA             | 5.00     | PCE               | Normal                        |
       | pp_subProductB        | plv_mischkarton                   | subProductB             | 3.00     | PCE               | Normal                        |
+      | pp_discountProduct    | plv_mischkarton                   | discountProduct         | 0.00     | PCE               | Normal                        |
 
     And metasfresh contains C_BPartners:
       | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
@@ -115,3 +115,319 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | DateOrdered | M_Product_ID.Identifier | qtydelivered | QtyOrdered | qtyinvoiced | price | discount | currencyCode | processed |
       | orderLine_1_subProductA   | order_1               | 2026-07-20  | subProductA             | 0            | 4          | 0           | 5     | 0        | EUR          | true      |
       | orderLine_1_subProductB   | order_1               | 2026-07-20  | subProductB             | 0            | 6          | 0           | 3     | 0        | EUR          | true      |
+
+  @from:cucumber
+  @allure.label.epic:E0100_Sales
+  @allure.label.feature:F00122_Sales_Order_Candidate_to_Order
+  @ghActions:run_on_executor3
+  @Id:S28977_TC2
+  Scenario: A shipment generated from a schema-exploded Mischkarton OLCand contains a line for each component product
+    Given metasfresh contains M_PricingSystems
+      | Identifier     | Name           |
+      | ps_mischkarton | ps_mischkarton |
+    And metasfresh contains M_PriceLists
+      | Identifier     | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name           | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_mischkarton | ps_mischkarton                | DE                        | EUR                 | pl_mischkarton | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier      | M_PriceList_ID.Identifier | Name            | ValidFrom  |
+      | plv_mischkarton | pl_mischkarton            | plv_mischkarton | 2026-07-01 |
+
+    And metasfresh contains M_Products:
+      | Identifier  | Name        |
+      | subProductA | subProductA |
+      | subProductB | subProductB |
+
+    And metasfresh contains C_CompensationGroup_Schema:
+      | Identifier        | Name              |
+      | mischkartonSchema | mischkartonSchema |
+    And metasfresh contains C_CompensationGroup_Schema_TemplateLine:
+      | Identifier             | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
+      | mischkartonSchemaLineA | mischkartonSchema                        | subProductA             | 2   | PCE      | 10    |
+      | mischkartonSchemaLineB | mischkartonSchema                        | subProductB             | 3   | PCE      | 20    |
+
+    And metasfresh contains M_Products:
+      | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
+      | mischkartonProduct | mischkartonProduct | mischkartonSchema                            |
+
+    And metasfresh contains M_ProductPrices
+      | Identifier            | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_mischkartonProduct | plv_mischkarton                   | mischkartonProduct      | 15.00    | PCE               | Normal                        |
+      | pp_subProductA        | plv_mischkarton                   | subProductA             | 5.00     | PCE               | Normal                        |
+      | pp_subProductB        | plv_mischkarton                   | subProductB             | 3.00     | PCE               | Normal                        |
+
+    And metasfresh contains C_BPartners:
+      | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
+      | mischkartonCustomer | mischkartonCustomer | Y              | N            | ps_mischkarton                | mischkartonCustomerLocation | 4009900001234 |
+
+    When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
+  """
+{
+    "requests": [
+        {
+            "orgCode": "001",
+            "externalHeaderId": "mischkarton28977_ship",
+            "externalLineId": "mischkarton28977_ship_0",
+            "externalSystemCode": "Shopware6",
+            "dataSource": "int-Shopware",
+            "bpartner": {
+                "bpartnerIdentifier": "gln-4009900001234",
+                "bpartnerLocationIdentifier": "gln-4009900001234"
+            },
+            "dateRequired": "2026-08-01",
+            "dateOrdered": "2026-07-20",
+            "orderDocType": "SalesOrder",
+            "paymentTerm": "val-1000002",
+            "productIdentifier": "val-mischkartonProduct",
+            "qty": 2,
+            "currencyCode": "EUR",
+            "discount": 0,
+            "poReference": "mischkarton28977_ship",
+            "deliveryViaRule": "S",
+            "deliveryRule": "F"
+        }
+    ]
+}
+"""
+
+    Then process metasfresh response JsonOLCandCreateBulkResponse
+      | C_OLCand_ID.Identifier |
+      | olCand_ship            |
+
+    # process the Mischkarton candidate AND generate the shipment in one step (ship=true), exercising the widened
+    # 1->N OLCand-to-order-line mapping all the way through shipment generation
+    When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/process' and fulfills with '200' status code
+"""
+{
+    "externalHeaderId": "mischkarton28977_ship",
+    "externalSystemCode": "Shopware6",
+    "ship": true,
+    "invoice": false,
+    "closeOrder": false
+}
+"""
+    Then process metasfresh response
+      | C_Order_ID.Identifier | M_InOut_ID.Identifier |
+      | order_ship            | shipment_ship         |
+
+    And validate the created shipments
+      | M_InOut_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | poreference           | processed | DocStatus |
+      | shipment_ship         | mischkartonCustomer      | mischkartonCustomerLocation       | 2026-07-20  | mischkarton28977_ship | true      | CO        |
+
+    # the shipment must carry ONE line per exploded component product, with the scaled quantities (2x2=4, 3x2=6)
+    And validate the created shipment lines
+      | M_InOutLine_ID.Identifier | M_InOut_ID.Identifier | M_Product_ID.Identifier | movementqty | processed |
+      | shipmentLine_subProductA  | shipment_ship         | subProductA             | 4           | true      |
+      | shipmentLine_subProductB  | shipment_ship         | subProductB             | 6           | true      |
+
+  @from:cucumber
+  @allure.label.epic:E0100_Sales
+  @allure.label.feature:F00122_Sales_Order_Candidate_to_Order
+  @ghActions:run_on_executor3
+  @Id:S28977_TC3
+  Scenario: A flatrate-linked Mischkarton OLCand threads its contract conditions onto the exploded component order lines
+    Given metasfresh contains M_PricingSystems
+      | Identifier     | Name           |
+      | ps_mischkarton | ps_mischkarton |
+    And metasfresh contains M_PriceLists
+      | Identifier     | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name           | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_mischkarton | ps_mischkarton                | DE                        | EUR                 | pl_mischkarton | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier      | M_PriceList_ID.Identifier | Name            | ValidFrom  |
+      | plv_mischkarton | pl_mischkarton            | plv_mischkarton | 2026-07-01 |
+
+    And metasfresh contains M_Products:
+      | Identifier  | Name        |
+      | subProductA | subProductA |
+      | subProductB | subProductB |
+
+    And metasfresh contains C_CompensationGroup_Schema:
+      | Identifier        | Name              |
+      | mischkartonSchema | mischkartonSchema |
+    And metasfresh contains C_CompensationGroup_Schema_TemplateLine:
+      | Identifier             | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
+      | mischkartonSchemaLineA | mischkartonSchema                        | subProductA             | 2   | PCE      | 10    |
+      | mischkartonSchemaLineB | mischkartonSchema                        | subProductB             | 3   | PCE      | 20    |
+
+    And metasfresh contains M_Products:
+      | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
+      | mischkartonProduct | mischkartonProduct | mischkartonSchema                            |
+
+    And metasfresh contains M_ProductPrices
+      | Identifier            | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_mischkartonProduct | plv_mischkarton                   | mischkartonProduct      | 15.00    | PCE               | Normal                        |
+      | pp_subProductA        | plv_mischkarton                   | subProductA             | 5.00     | PCE               | Normal                        |
+      | pp_subProductB        | plv_mischkarton                   | subProductB             | 3.00     | PCE               | Normal                        |
+
+    # the contract conditions the incoming candidate carries; its (dynamically-allocated) id is exposed as the REST
+    # context variable 'flatrateConditionsId' so the candidate payload below can reference it via @flatrateConditionsId@
+    And metasfresh contains C_Flatrate_Conditions:
+      | Identifier          | Name                | Type_Conditions | REST.Context.C_Flatrate_Conditions_ID |
+      | mischkartonFlatrate | mischkartonFlatrate | Subscr          | flatrateConditionsId                  |
+
+    And metasfresh contains C_BPartners:
+      | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
+      | mischkartonCustomer | mischkartonCustomer | Y              | N            | ps_mischkarton                | mischkartonCustomerLocation | 4009900001234 |
+
+    When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
+  """
+{
+    "requests": [
+        {
+            "orgCode": "001",
+            "externalHeaderId": "mischkarton28977_flatrate",
+            "externalLineId": "mischkarton28977_flatrate_0",
+            "externalSystemCode": "Shopware6",
+            "dataSource": "int-Shopware",
+            "bpartner": {
+                "bpartnerIdentifier": "gln-4009900001234",
+                "bpartnerLocationIdentifier": "gln-4009900001234"
+            },
+            "dateRequired": "2026-08-01",
+            "dateOrdered": "2026-07-20",
+            "orderDocType": "SalesOrder",
+            "paymentTerm": "val-1000002",
+            "productIdentifier": "val-mischkartonProduct",
+            "qty": 2,
+            "currencyCode": "EUR",
+            "discount": 0,
+            "flatrateConditionsId": @flatrateConditionsId@,
+            "poReference": "mischkarton28977_flatrate",
+            "deliveryViaRule": "S",
+            "deliveryRule": "F"
+        }
+    ]
+}
+"""
+
+    Then process metasfresh response JsonOLCandCreateBulkResponse
+      | C_OLCand_ID.Identifier |
+      | olCand_flatrate        |
+
+    When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/process' and fulfills with '200' status code
+"""
+{
+    "externalHeaderId": "mischkarton28977_flatrate",
+    "externalSystemCode": "Shopware6",
+    "ship": false,
+    "invoice": false,
+    "closeOrder": false
+}
+"""
+    Then process metasfresh response
+      | C_Order_ID.Identifier |
+      | order_flatrate        |
+
+    # both exploded component lines must carry the candidate's contract conditions (C2 threading)
+    And validate the created order lines
+      | C_OrderLine_ID.Identifier   | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | OPT.C_Flatrate_Conditions_ID.Identifier | processed |
+      | orderLine_flatrate_subProdA | order_flatrate        | subProductA             | 4          | mischkartonFlatrate                     | true      |
+      | orderLine_flatrate_subProdB | order_flatrate        | subProductB             | 6          | mischkartonFlatrate                     | true      |
+
+  @from:cucumber
+  @allure.label.epic:E0100_Sales
+  @allure.label.feature:F00122_Sales_Order_Candidate_to_Order
+  @ghActions:run_on_executor3
+  @Id:S28977_TC4
+  Scenario: A Mischkarton schema with a compensation line explodes into its regular component lines plus the compensation (discount) line
+    Given metasfresh contains M_PricingSystems
+      | Identifier     | Name           |
+      | ps_mischkarton | ps_mischkarton |
+    And metasfresh contains M_PriceLists
+      | Identifier     | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name           | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_mischkarton | ps_mischkarton                | DE                        | EUR                 | pl_mischkarton | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier      | M_PriceList_ID.Identifier | Name            | ValidFrom  |
+      | plv_mischkarton | pl_mischkarton            | plv_mischkarton | 2026-07-01 |
+
+    And metasfresh contains M_Products:
+      | Identifier  | Name        |
+      | subProductA | subProductA |
+      | subProductB | subProductB |
+
+    # a dedicated discount product used only as the schema's compensation line (no price list entry needed: the
+    # compensation line is created with a manual price of 0)
+    And metasfresh contains M_Products:
+      | Identifier      | Name            |
+      | discountProduct | discountProduct |
+
+    And metasfresh contains C_CompensationGroup_Schema:
+      | Identifier        | Name              |
+      | mischkartonSchema | mischkartonSchema |
+    And metasfresh contains C_CompensationGroup_Schema_TemplateLine:
+      | Identifier             | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
+      | mischkartonSchemaLineA | mischkartonSchema                        | subProductA             | 2   | PCE      | 10    |
+      | mischkartonSchemaLineB | mischkartonSchema                        | subProductB             | 3   | PCE      | 20    |
+    # the schema's compensation line: an always-matching whole-order discount of 10%
+    And metasfresh contains C_CompensationGroup_SchemaLine:
+      | Identifier          | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | OPT.CompleteOrderDiscount | OPT.SeqNo |
+      | mischkartonDiscount | mischkartonSchema                        | discountProduct         | 10                        | 30        |
+
+    And metasfresh contains M_Products:
+      | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
+      | mischkartonProduct | mischkartonProduct | mischkartonSchema                            |
+
+    And metasfresh contains M_ProductPrices
+      | Identifier            | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_mischkartonProduct | plv_mischkarton                   | mischkartonProduct      | 15.00    | PCE               | Normal                        |
+      | pp_subProductA        | plv_mischkarton                   | subProductA             | 5.00     | PCE               | Normal                        |
+      | pp_subProductB        | plv_mischkarton                   | subProductB             | 3.00     | PCE               | Normal                        |
+
+    And metasfresh contains C_BPartners:
+      | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
+      | mischkartonCustomer | mischkartonCustomer | Y              | N            | ps_mischkarton                | mischkartonCustomerLocation | 4009900001234 |
+
+    When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
+  """
+{
+    "requests": [
+        {
+            "orgCode": "001",
+            "externalHeaderId": "mischkarton28977_comp",
+            "externalLineId": "mischkarton28977_comp_0",
+            "externalSystemCode": "Shopware6",
+            "dataSource": "int-Shopware",
+            "bpartner": {
+                "bpartnerIdentifier": "gln-4009900001234",
+                "bpartnerLocationIdentifier": "gln-4009900001234"
+            },
+            "dateRequired": "2026-08-01",
+            "dateOrdered": "2026-07-20",
+            "orderDocType": "SalesOrder",
+            "paymentTerm": "val-1000002",
+            "productIdentifier": "val-mischkartonProduct",
+            "qty": 2,
+            "currencyCode": "EUR",
+            "discount": 0,
+            "poReference": "mischkarton28977_comp",
+            "deliveryViaRule": "S",
+            "deliveryRule": "F"
+        }
+    ]
+}
+"""
+
+    Then process metasfresh response JsonOLCandCreateBulkResponse
+      | C_OLCand_ID.Identifier |
+      | olCand_comp            |
+
+    When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/process' and fulfills with '200' status code
+"""
+{
+    "externalHeaderId": "mischkarton28977_comp",
+    "externalSystemCode": "Shopware6",
+    "ship": false,
+    "invoice": false,
+    "closeOrder": false
+}
+"""
+    Then process metasfresh response
+      | C_Order_ID.Identifier |
+      | order_comp            |
+
+    # the order carries the 2 regular component lines (IsGroupCompensationLine=N) plus the compensation/discount line
+    # (IsGroupCompensationLine=Y, QtyOrdered=0 as it is a percentage whole-order discount)
+    And validate the created order lines
+      | C_OrderLine_ID.Identifier  | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | OPT.IsGroupCompensationLine | processed |
+      | orderLine_comp_subProductA | order_comp            | subProductA             | 4          | false                       | true      |
+      | orderLine_comp_subProductB | order_comp            | subProductB             | 6          | false                       | true      |
+      | orderLine_comp_discount    | order_comp            | discountProduct         | 0          | true                        | true      |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/automateOrderCand/explodeCompensationSchemaOnOLCandProcessing.feature
@@ -2,7 +2,7 @@
 @allure.label.epic:E0100_Sales
 @allure.label.feature:F00122_Sales_Order_Candidate_to_Order
 @ghActions:run_on_executor3
-Feature: Explode a Mischkarton compensation-group-schema product into its component order lines when processing an order candidate to an order
+Feature: Explode a compensation-group-schema product into its component order lines when processing an order candidate to an order
 
   Background:
     Given infrastructure and metasfresh are running
@@ -14,18 +14,18 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
   @allure.label.epic:E0100_Sales
   @allure.label.feature:F00122_Sales_Order_Candidate_to_Order
   @Id:S28977_TC1
-  Scenario: OLCand for a Mischkarton (compensation-group-schema) product explodes into its component order lines
+  Scenario: OLCand for a compensation-group-schema product explodes into its component order lines
     Given metasfresh contains M_PricingSystems
       | Identifier     | Name           |
-      | ps_mischkarton | ps_mischkarton |
+      | ps_schema | ps_schema |
     And metasfresh contains M_PriceLists
       | Identifier     | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name           | SOTrx | IsTaxIncluded | PricePrecision |
-      | pl_mischkarton | ps_mischkarton                | DE                        | EUR                 | pl_mischkarton | true  | false         | 2              |
+      | pl_schema | ps_schema                | DE                        | EUR                 | pl_schema | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
       | Identifier      | M_PriceList_ID.Identifier | Name            | ValidFrom  |
-      | plv_mischkarton | pl_mischkarton            | plv_mischkarton | 2026-07-01 |
+      | plv_schema | pl_schema            | plv_schema | 2026-07-01 |
 
-    # the two sub-article products that make up the Mischkarton; created first so the schema's template lines can reference them
+    # the two sub-article products that make up the compensation group; created first so the schema's template lines can reference them
     And metasfresh contains M_Products:
       | Identifier  | Name        |
       | subProductA | subProductA |
@@ -33,38 +33,38 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
 
     And metasfresh contains C_CompensationGroup_Schema:
       | Identifier        | Name              |
-      | mischkartonSchema | mischkartonSchema |
+      | compGroupSchema | compGroupSchema |
     And metasfresh contains C_CompensationGroup_Schema_TemplateLine:
       | Identifier             | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
-      | mischkartonSchemaLineA | mischkartonSchema                        | subProductA             | 2   | PCE      | 10    |
-      | mischkartonSchemaLineB | mischkartonSchema                        | subProductB             | 3   | PCE      | 20    |
+      | schemaTemplateLineA | compGroupSchema                        | subProductA             | 2   | PCE      | 10    |
+      | schemaTemplateLineB | compGroupSchema                        | subProductB             | 3   | PCE      | 20    |
 
-    # the Mischkarton (mixed carton) product itself, linked to the schema
+    # the compensation-group-schema product itself, linked to the schema
     And metasfresh contains M_Products:
       | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
-      | mischkartonProduct | mischkartonProduct | mischkartonSchema                            |
+      | schemaProduct | schemaProduct | compGroupSchema                            |
 
-    # all three products need a price: the carton itself (to price the incoming OLCand) and both sub-articles (the exploded component lines must be priced)
+    # all three products need a price: the schema product itself (to price the incoming OLCand) and both sub-articles (the exploded component lines must be priced)
     And metasfresh contains M_ProductPrices
       | Identifier            | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | pp_mischkartonProduct | plv_mischkarton                   | mischkartonProduct      | 15.00    | PCE               | Normal                        |
-      | pp_subProductA        | plv_mischkarton                   | subProductA             | 5.00     | PCE               | Normal                        |
-      | pp_subProductB        | plv_mischkarton                   | subProductB             | 3.00     | PCE               | Normal                        |
+      | pp_schemaProduct | plv_schema                   | schemaProduct      | 15.00    | PCE               | Normal                        |
+      | pp_subProductA        | plv_schema                   | subProductA             | 5.00     | PCE               | Normal                        |
+      | pp_subProductB        | plv_schema                   | subProductB             | 3.00     | PCE               | Normal                        |
 
     # the C_BPartners step auto-creates the default location (with the given GLN, IsShipTo + IsBillToDefault) under the C_BPartner_Location_ID identifier
     And metasfresh contains C_BPartners:
       | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
-      | mischkartonCustomer | mischkartonCustomer | Y              | N            | ps_mischkarton                | mischkartonCustomerLocation | 4009900001234 |
+      | customer | customer | Y              | N            | ps_schema                | customerLocation | 4009900001234 |
 
-    # a single OLCand for 2 Mischkarton units
+    # a single OLCand for 2 units of the schema product
     When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
   """
 {
     "requests": [
         {
             "orgCode": "001",
-            "externalHeaderId": "mischkarton28977",
-            "externalLineId": "mischkarton28977_0",
+            "externalHeaderId": "schemaExplosion",
+            "externalLineId": "schemaExplosion_0",
             "externalSystemCode": "Shopware6",
             "dataSource": "int-Shopware",
             "bpartner": {
@@ -75,11 +75,11 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
             "dateOrdered": "2026-07-20",
             "orderDocType": "SalesOrder",
             "paymentTerm": "val-1000002",
-            "productIdentifier": "val-mischkartonProduct",
+            "productIdentifier": "val-schemaProduct",
             "qty": 2,
             "currencyCode": "EUR",
             "discount": 0,
-            "poReference": "mischkarton28977",
+            "poReference": "schemaExplosion",
             "deliveryViaRule": "S",
             "deliveryRule": "F"
         }
@@ -94,7 +94,7 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
     When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/process' and fulfills with '200' status code
 """
 {
-    "externalHeaderId": "mischkarton28977",
+    "externalHeaderId": "schemaExplosion",
     "externalSystemCode": "Shopware6",
     "ship": false,
     "invoice": false,
@@ -107,9 +107,9 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
 
     And validate the created orders
       | C_Order_ID.Identifier | OPT.ExternalId   | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | DocBaseType | currencyCode | POReference      | processed | DocStatus |
-      | order_1               | mischkarton28977 | mischkartonCustomer      | mischkartonCustomerLocation       | 2026-07-20  | SOO         | EUR          | mischkarton28977 | true      | CO        |
+      | order_1               | schemaExplosion | customer      | customerLocation       | 2026-07-20  | SOO         | EUR          | schemaExplosion | true      | CO        |
 
-    # the ordered Mischkarton must resolve to its schema's two component article lines (quantities scaled by the ordered number of cartons: 2×2=4 and 3×2=6),
+    # the ordered schema product must resolve to its schema's two component article lines (quantities scaled by the ordered quantity 2: 2×2=4 and 3×2=6),
     # matching what the sales-order window produces for the same product and quantity
     And validate the created order lines
       | C_OrderLine_ID.Identifier | C_Order_ID.Identifier | DateOrdered | M_Product_ID.Identifier | qtydelivered | QtyOrdered | qtyinvoiced | price | discount | currencyCode | processed |
@@ -121,16 +121,16 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
   @allure.label.feature:F00122_Sales_Order_Candidate_to_Order
   @ghActions:run_on_executor3
   @Id:S28977_TC2
-  Scenario: A shipment generated from a schema-exploded Mischkarton OLCand contains a line for each component product
+  Scenario: A shipment generated from a schema-exploded OLCand contains a line for each component product
     Given metasfresh contains M_PricingSystems
       | Identifier     | Name           |
-      | ps_mischkarton | ps_mischkarton |
+      | ps_schema | ps_schema |
     And metasfresh contains M_PriceLists
       | Identifier     | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name           | SOTrx | IsTaxIncluded | PricePrecision |
-      | pl_mischkarton | ps_mischkarton                | DE                        | EUR                 | pl_mischkarton | true  | false         | 2              |
+      | pl_schema | ps_schema                | DE                        | EUR                 | pl_schema | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
       | Identifier      | M_PriceList_ID.Identifier | Name            | ValidFrom  |
-      | plv_mischkarton | pl_mischkarton            | plv_mischkarton | 2026-07-01 |
+      | plv_schema | pl_schema            | plv_schema | 2026-07-01 |
 
     And metasfresh contains M_Products:
       | Identifier  | Name        |
@@ -139,29 +139,29 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
 
     And metasfresh contains C_CompensationGroup_Schema:
       | Identifier        | Name              |
-      | mischkartonSchema | mischkartonSchema |
+      | compGroupSchema | compGroupSchema |
     And metasfresh contains C_CompensationGroup_Schema_TemplateLine:
       | Identifier             | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
-      | mischkartonSchemaLineA | mischkartonSchema                        | subProductA             | 2   | PCE      | 10    |
-      | mischkartonSchemaLineB | mischkartonSchema                        | subProductB             | 3   | PCE      | 20    |
+      | schemaTemplateLineA | compGroupSchema                        | subProductA             | 2   | PCE      | 10    |
+      | schemaTemplateLineB | compGroupSchema                        | subProductB             | 3   | PCE      | 20    |
 
     And metasfresh contains M_Products:
       | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
-      | mischkartonProduct | mischkartonProduct | mischkartonSchema                            |
+      | schemaProduct | schemaProduct | compGroupSchema                            |
 
     And metasfresh contains M_ProductPrices
       | Identifier            | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | pp_mischkartonProduct | plv_mischkarton                   | mischkartonProduct      | 15.00    | PCE               | Normal                        |
-      | pp_subProductA        | plv_mischkarton                   | subProductA             | 5.00     | PCE               | Normal                        |
-      | pp_subProductB        | plv_mischkarton                   | subProductB             | 3.00     | PCE               | Normal                        |
+      | pp_schemaProduct | plv_schema                   | schemaProduct      | 15.00    | PCE               | Normal                        |
+      | pp_subProductA        | plv_schema                   | subProductA             | 5.00     | PCE               | Normal                        |
+      | pp_subProductB        | plv_schema                   | subProductB             | 3.00     | PCE               | Normal                        |
 
     And metasfresh contains C_BPartners:
       | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
-      | mischkartonCustomer | mischkartonCustomer | Y              | N            | ps_mischkarton                | mischkartonCustomerLocation | 4009900001234 |
+      | customer | customer | Y              | N            | ps_schema                | customerLocation | 4009900001234 |
     # explicit ship-to/bill-to location so the shipment-header C_BPartner_Location_ID assertion resolves the identifier reliably (registered in the step-def data)
     And metasfresh contains C_BPartner_Locations:
       | Identifier                  | GLN           | C_BPartner_ID.Identifier | OPT.IsShipTo | OPT.IsBillTo |
-      | mischkartonCustomerLocation | 4009900001234 | mischkartonCustomer      | true         | true         |
+      | customerLocation | 4009900001234 | customer      | true         | true         |
 
     When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
   """
@@ -169,8 +169,8 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
     "requests": [
         {
             "orgCode": "001",
-            "externalHeaderId": "mischkarton28977_ship",
-            "externalLineId": "mischkarton28977_ship_0",
+            "externalHeaderId": "schemaExplosion_ship",
+            "externalLineId": "schemaExplosion_ship_0",
             "externalSystemCode": "Shopware6",
             "dataSource": "int-Shopware",
             "bpartner": {
@@ -181,11 +181,11 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
             "dateOrdered": "2026-07-20",
             "orderDocType": "SalesOrder",
             "paymentTerm": "val-1000002",
-            "productIdentifier": "val-mischkartonProduct",
+            "productIdentifier": "val-schemaProduct",
             "qty": 2,
             "currencyCode": "EUR",
             "discount": 0,
-            "poReference": "mischkarton28977_ship",
+            "poReference": "schemaExplosion_ship",
             "deliveryViaRule": "S",
             "deliveryRule": "F"
         }
@@ -197,12 +197,12 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
       | C_OLCand_ID.Identifier |
       | olCand_ship            |
 
-    # process the Mischkarton candidate AND generate the shipment in one step (ship=true), exercising the widened
+    # process the compensation-group-schema candidate AND generate the shipment in one step (ship=true), exercising the widened
     # 1->N OLCand-to-order-line mapping all the way through shipment generation
     When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/process' and fulfills with '200' status code
 """
 {
-    "externalHeaderId": "mischkarton28977_ship",
+    "externalHeaderId": "schemaExplosion_ship",
     "externalSystemCode": "Shopware6",
     "ship": true,
     "invoice": false,
@@ -215,7 +215,7 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
 
     And validate the created shipments
       | M_InOut_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | DateOrdered | poreference           | processed | DocStatus |
-      | shipment_ship         | mischkartonCustomer      | mischkartonCustomerLocation       | 2026-07-20  | mischkarton28977_ship | true      | CO        |
+      | shipment_ship         | customer      | customerLocation       | 2026-07-20  | schemaExplosion_ship | true      | CO        |
 
     # the shipment must carry ONE line per exploded component product, with the scaled quantities (2x2=4, 3x2=6)
     And validate the created shipment lines
@@ -228,16 +228,16 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
   @allure.label.feature:F00122_Sales_Order_Candidate_to_Order
   @ghActions:run_on_executor3
   @Id:S28977_TC3
-  Scenario: A flatrate-linked Mischkarton OLCand threads its contract conditions onto the exploded component order lines
+  Scenario: A flatrate-linked OLCand threads its contract conditions onto the exploded component order lines
     Given metasfresh contains M_PricingSystems
       | Identifier     | Name           |
-      | ps_mischkarton | ps_mischkarton |
+      | ps_schema | ps_schema |
     And metasfresh contains M_PriceLists
       | Identifier     | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name           | SOTrx | IsTaxIncluded | PricePrecision |
-      | pl_mischkarton | ps_mischkarton                | DE                        | EUR                 | pl_mischkarton | true  | false         | 2              |
+      | pl_schema | ps_schema                | DE                        | EUR                 | pl_schema | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
       | Identifier      | M_PriceList_ID.Identifier | Name            | ValidFrom  |
-      | plv_mischkarton | pl_mischkarton            | plv_mischkarton | 2026-07-01 |
+      | plv_schema | pl_schema            | plv_schema | 2026-07-01 |
 
     And metasfresh contains M_Products:
       | Identifier  | Name        |
@@ -246,21 +246,21 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
 
     And metasfresh contains C_CompensationGroup_Schema:
       | Identifier        | Name              |
-      | mischkartonSchema | mischkartonSchema |
+      | compGroupSchema | compGroupSchema |
     And metasfresh contains C_CompensationGroup_Schema_TemplateLine:
       | Identifier             | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
-      | mischkartonSchemaLineA | mischkartonSchema                        | subProductA             | 2   | PCE      | 10    |
-      | mischkartonSchemaLineB | mischkartonSchema                        | subProductB             | 3   | PCE      | 20    |
+      | schemaTemplateLineA | compGroupSchema                        | subProductA             | 2   | PCE      | 10    |
+      | schemaTemplateLineB | compGroupSchema                        | subProductB             | 3   | PCE      | 20    |
 
     And metasfresh contains M_Products:
       | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
-      | mischkartonProduct | mischkartonProduct | mischkartonSchema                            |
+      | schemaProduct | schemaProduct | compGroupSchema                            |
 
     And metasfresh contains M_ProductPrices
       | Identifier            | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | pp_mischkartonProduct | plv_mischkarton                   | mischkartonProduct      | 15.00    | PCE               | Normal                        |
-      | pp_subProductA        | plv_mischkarton                   | subProductA             | 5.00     | PCE               | Normal                        |
-      | pp_subProductB        | plv_mischkarton                   | subProductB             | 3.00     | PCE               | Normal                        |
+      | pp_schemaProduct | plv_schema                   | schemaProduct      | 15.00    | PCE               | Normal                        |
+      | pp_subProductA        | plv_schema                   | subProductA             | 5.00     | PCE               | Normal                        |
+      | pp_subProductB        | plv_schema                   | subProductB             | 3.00     | PCE               | Normal                        |
 
     # the contract conditions the incoming candidate carries; its (dynamically-allocated) id is exposed as the REST
     # context variable 'flatrateConditionsId' so the candidate payload below can reference it via @flatrateConditionsId@.
@@ -270,11 +270,11 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
     # full subscription/transition contract setup that is orthogonal to the OLCand-explosion threading.
     And metasfresh contains C_Flatrate_Conditions:
       | Identifier          | Name                | Type_Conditions | REST.Context.C_Flatrate_Conditions_ID |
-      | mischkartonFlatrate | mischkartonFlatrate | FlatFee         | flatrateConditionsId                  |
+      | schemaFlatrate | schemaFlatrate | FlatFee         | flatrateConditionsId                  |
 
     And metasfresh contains C_BPartners:
       | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
-      | mischkartonCustomer | mischkartonCustomer | Y              | N            | ps_mischkarton                | mischkartonCustomerLocation | 4009900001234 |
+      | customer | customer | Y              | N            | ps_schema                | customerLocation | 4009900001234 |
 
     When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
   """
@@ -282,8 +282,8 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
     "requests": [
         {
             "orgCode": "001",
-            "externalHeaderId": "mischkarton28977_flatrate",
-            "externalLineId": "mischkarton28977_flatrate_0",
+            "externalHeaderId": "schemaExplosion_flatrate",
+            "externalLineId": "schemaExplosion_flatrate_0",
             "externalSystemCode": "Shopware6",
             "dataSource": "int-Shopware",
             "bpartner": {
@@ -294,12 +294,12 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
             "dateOrdered": "2026-07-20",
             "orderDocType": "SalesOrder",
             "paymentTerm": "val-1000002",
-            "productIdentifier": "val-mischkartonProduct",
+            "productIdentifier": "val-schemaProduct",
             "qty": 2,
             "currencyCode": "EUR",
             "discount": 0,
             "flatrateConditionsId": @flatrateConditionsId@,
-            "poReference": "mischkarton28977_flatrate",
+            "poReference": "schemaExplosion_flatrate",
             "deliveryViaRule": "S",
             "deliveryRule": "F"
         }
@@ -314,7 +314,7 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
     When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/process' and fulfills with '200' status code
 """
 {
-    "externalHeaderId": "mischkarton28977_flatrate",
+    "externalHeaderId": "schemaExplosion_flatrate",
     "externalSystemCode": "Shopware6",
     "ship": false,
     "invoice": false,
@@ -328,24 +328,24 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
     # both exploded component lines must carry the candidate's contract conditions (C2 threading)
     And validate the created order lines
       | C_OrderLine_ID.Identifier      | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | OPT.C_Flatrate_Conditions_ID.Identifier | processed |
-      | orderLine_flatrate_subProductA | order_flatrate        | subProductA             | 4          | mischkartonFlatrate                     | true      |
-      | orderLine_flatrate_subProductB | order_flatrate        | subProductB             | 6          | mischkartonFlatrate                     | true      |
+      | orderLine_flatrate_subProductA | order_flatrate        | subProductA             | 4          | schemaFlatrate                     | true      |
+      | orderLine_flatrate_subProductB | order_flatrate        | subProductB             | 6          | schemaFlatrate                     | true      |
 
   @from:cucumber
   @allure.label.epic:E0100_Sales
   @allure.label.feature:F00122_Sales_Order_Candidate_to_Order
   @ghActions:run_on_executor3
   @Id:S28977_TC4
-  Scenario: A Mischkarton schema with a compensation line explodes into its regular component lines plus the compensation (discount) line
+  Scenario: A compensation-group schema with a compensation line explodes into its regular component lines plus the compensation (discount) line
     Given metasfresh contains M_PricingSystems
       | Identifier     | Name           |
-      | ps_mischkarton | ps_mischkarton |
+      | ps_schema | ps_schema |
     And metasfresh contains M_PriceLists
       | Identifier     | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name           | SOTrx | IsTaxIncluded | PricePrecision |
-      | pl_mischkarton | ps_mischkarton                | DE                        | EUR                 | pl_mischkarton | true  | false         | 2              |
+      | pl_schema | ps_schema                | DE                        | EUR                 | pl_schema | true  | false         | 2              |
     And metasfresh contains M_PriceList_Versions
       | Identifier      | M_PriceList_ID.Identifier | Name            | ValidFrom  |
-      | plv_mischkarton | pl_mischkarton            | plv_mischkarton | 2026-07-01 |
+      | plv_schema | pl_schema            | plv_schema | 2026-07-01 |
 
     And metasfresh contains M_Products:
       | Identifier  | Name        |
@@ -360,33 +360,33 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
 
     And metasfresh contains C_CompensationGroup_Schema:
       | Identifier        | Name              |
-      | mischkartonSchema | mischkartonSchema |
+      | compGroupSchema | compGroupSchema |
     And metasfresh contains C_CompensationGroup_Schema_TemplateLine:
       | Identifier             | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | Qty | C_UOM_ID | SeqNo |
-      | mischkartonSchemaLineA | mischkartonSchema                        | subProductA             | 2   | PCE      | 10    |
-      | mischkartonSchemaLineB | mischkartonSchema                        | subProductB             | 3   | PCE      | 20    |
+      | schemaTemplateLineA | compGroupSchema                        | subProductA             | 2   | PCE      | 10    |
+      | schemaTemplateLineB | compGroupSchema                        | subProductB             | 3   | PCE      | 20    |
     # the schema's compensation line: an always-matching whole-order discount of 10%
     And metasfresh contains C_CompensationGroup_SchemaLine:
       | Identifier          | C_CompensationGroup_Schema_ID.Identifier | M_Product_ID.Identifier | OPT.CompleteOrderDiscount | OPT.SeqNo |
-      | mischkartonDiscount | mischkartonSchema                        | discountProduct         | 10                        | 30        |
+      | schemaDiscount | compGroupSchema                        | discountProduct         | 10                        | 30        |
 
     And metasfresh contains M_Products:
       | Identifier         | Name               | OPT.C_CompensationGroup_Schema_ID.Identifier |
-      | mischkartonProduct | mischkartonProduct | mischkartonSchema                            |
+      | schemaProduct | schemaProduct | compGroupSchema                            |
 
     # the compensation product is a real M_Product (M_Product_ID is mandatory on the schema line), so it must be on
     # the price list like any ordered product — order completion prices every line, including the compensation line.
     # Its PriceStd is irrelevant to the discount amount (the line is a percentage whole-order discount), hence 0.
     And metasfresh contains M_ProductPrices
       | Identifier            | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
-      | pp_mischkartonProduct | plv_mischkarton                   | mischkartonProduct      | 15.00    | PCE               | Normal                        |
-      | pp_subProductA        | plv_mischkarton                   | subProductA             | 5.00     | PCE               | Normal                        |
-      | pp_subProductB        | plv_mischkarton                   | subProductB             | 3.00     | PCE               | Normal                        |
-      | pp_discountProduct    | plv_mischkarton                   | discountProduct         | 0.00     | PCE               | Normal                        |
+      | pp_schemaProduct | plv_schema                   | schemaProduct      | 15.00    | PCE               | Normal                        |
+      | pp_subProductA        | plv_schema                   | subProductA             | 5.00     | PCE               | Normal                        |
+      | pp_subProductB        | plv_schema                   | subProductB             | 3.00     | PCE               | Normal                        |
+      | pp_discountProduct    | plv_schema                   | discountProduct         | 0.00     | PCE               | Normal                        |
 
     And metasfresh contains C_BPartners:
       | Identifier          | Name                | OPT.IsCustomer | OPT.IsVendor | M_PricingSystem_ID.Identifier | OPT.C_BPartner_Location_ID  | GLN           |
-      | mischkartonCustomer | mischkartonCustomer | Y              | N            | ps_mischkarton                | mischkartonCustomerLocation | 4009900001234 |
+      | customer | customer | Y              | N            | ps_schema                | customerLocation | 4009900001234 |
 
     When a 'POST' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/bulk' and fulfills with '201' status code
   """
@@ -394,8 +394,8 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
     "requests": [
         {
             "orgCode": "001",
-            "externalHeaderId": "mischkarton28977_comp",
-            "externalLineId": "mischkarton28977_comp_0",
+            "externalHeaderId": "schemaExplosion_comp",
+            "externalLineId": "schemaExplosion_comp_0",
             "externalSystemCode": "Shopware6",
             "dataSource": "int-Shopware",
             "bpartner": {
@@ -406,11 +406,11 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
             "dateOrdered": "2026-07-20",
             "orderDocType": "SalesOrder",
             "paymentTerm": "val-1000002",
-            "productIdentifier": "val-mischkartonProduct",
+            "productIdentifier": "val-schemaProduct",
             "qty": 2,
             "currencyCode": "EUR",
             "discount": 0,
-            "poReference": "mischkarton28977_comp",
+            "poReference": "schemaExplosion_comp",
             "deliveryViaRule": "S",
             "deliveryRule": "F"
         }
@@ -425,7 +425,7 @@ Feature: Explode a Mischkarton compensation-group-schema product into its compon
     When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/orders/sales/candidates/process' and fulfills with '200' status code
 """
 {
-    "externalHeaderId": "mischkarton28977_comp",
+    "externalHeaderId": "schemaExplosion_comp",
     "externalSystemCode": "Shopware6",
     "ship": false,
     "invoice": false,

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/ShipmentService.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import de.metas.async.AsyncBatchId;
 import de.metas.async.api.IAsyncBatchBL;
 import de.metas.async.service.AsyncBatchService;
@@ -452,9 +453,9 @@ public class ShipmentService implements IShipmentService
 			@NonNull final Set<OLCandId> olCandIds,
 			@NonNull final AsyncBatchId asyncBatchId)
 	{
-		final Map<OLCandId, OrderLineId> olCandId2OrderLineId = olCandDAO.retrieveOLCandIdToOrderLineId(olCandIds);
+		final ImmutableSetMultimap<OLCandId, OrderLineId> olCandId2OrderLineId = olCandDAO.retrieveOLCandIdToOrderLineId(olCandIds);
 
-		if (olCandId2OrderLineId == null || olCandId2OrderLineId.isEmpty())
+		if (olCandId2OrderLineId.isEmpty())
 		{
 			return QtyToDeliverMap.EMPTY;
 		}
@@ -463,7 +464,7 @@ public class ShipmentService implements IShipmentService
 
 		final ImmutableMap.Builder<ShipmentScheduleId, StockQtyAndUOMQty> scheduleId2QtyShipped = ImmutableMap.builder();
 
-		for (final Map.Entry<OLCandId, OrderLineId> olCand2OrderLineEntry : olCandId2OrderLineId.entrySet())
+		for (final Map.Entry<OLCandId, OrderLineId> olCand2OrderLineEntry : olCandId2OrderLineId.entries())
 		{
 			final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule = shipmentScheduleBL.getByOrderLineId(olCand2OrderLineEntry.getValue());
 

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/IOLCandDAO.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/IOLCandDAO.java
@@ -23,6 +23,7 @@ package de.metas.ordercandidate.api;
  */
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSetMultimap;
 import de.metas.async.AsyncBatchId;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.order.OrderId;
@@ -75,7 +76,7 @@ public interface IOLCandDAO extends ISingletonService
 
 	I_C_OLCand retrieveByIds(OLCandId olCandId);
 	
-	Map<OLCandId, OrderLineId> retrieveOLCandIdToOrderLineId(Set<OLCandId> olCandIds);
+	ImmutableSetMultimap<OLCandId, OrderLineId> retrieveOLCandIdToOrderLineId(Set<OLCandId> olCandIds);
 
 	boolean isAnyRecordProcessed(@NonNull Set<OLCandId> olCandIds);
 

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
@@ -524,8 +524,8 @@ class OLCandOrderFactory
 
 	private void addOLCand0(@NonNull final OLCand candidate)
 	{
-		// If the candidate's product carries a compensation-group schema ("Mischkarton" / trading-BOM),
-		// explode it into the schema's component order lines instead of creating a single carton line
+		// If the candidate's product carries a compensation-group schema (trading-BOM),
+		// explode it into the schema's component order lines instead of creating a single un-exploded line
 		// (mirrors what the sales-order window / Quick-Input does).
 		if (tryExplodeCompensationGroupSchema(candidate))
 		{
@@ -653,12 +653,12 @@ class OLCandOrderFactory
 	}
 
 	/**
-	 * If the candidate's product has a compensation-group schema (a "Mischkarton" / trading-BOM) and the candidate is
-	 * NOT already part of an explicit OLCand group, explode the ordered carton qty into the schema's component order
+	 * If the candidate's product has a compensation-group schema (a trading-BOM) and the candidate is
+	 * NOT already part of an explicit OLCand group, explode the ordered qty into the schema's component order
 	 * lines (regular + compensation) using the same business API the sales-order window / Quick-Input uses, and link
-	 * the carton candidate to each generated regular line via {@code C_Order_Line_Alloc}.
+	 * the candidate to each generated regular line via {@code C_Order_Line_Alloc}.
 	 *
-	 * @return {@code true} if the candidate was handled by schema explosion (caller must NOT create a plain carton
+	 * @return {@code true} if the candidate was handled by schema explosion (caller must NOT create a plain order
 	 * line); {@code false} otherwise (caller proceeds with the plain-line flow).
 	 */
 	private boolean tryExplodeCompensationGroupSchema(@NonNull final OLCand candidate)
@@ -683,17 +683,17 @@ class OLCandOrderFactory
 			return false;
 		}
 
-		// Make sure the order exists (without creating a stray carton order line).
+		// Make sure the order exists (without creating a stray order line).
 		if (order == null)
 		{
 			order = newOrder(candidate);
 		}
 		final OrderId orderId = OrderId.ofRepoId(order.getC_Order_ID());
 
-		// The ordered number of cartons scales the schema's template-line quantities.
-		// M5: cartonQty is passed as the pure group qty-multiplier with NO UOM conversion, matching
+		// The ordered quantity scales the schema's template-line quantities.
+		// M5: orderedQty is passed as the pure group qty-multiplier with NO UOM conversion, matching
 		// OrderLineQuickInputProcessor. This assumes candidate.getQty() is already expressed in the schema
-		// product's own stocking (counting) UOM (i.e. a count of cartons); a UOM other than that would scale
+		// product's own stocking (counting) UOM; a UOM other than that would scale
 		// every exploded component quantity wrongly. Guard the assumption instead of silently trusting the
 		// (REST/EDI) caller: fail loud if the candidate qty UOM differs from the schema product's stocking UOM.
 		final UomId candidateQtyUomId = candidate.getQty().getUomId();
@@ -708,9 +708,9 @@ class OLCandOrderFactory
 					.setParameter("C_OLCand_ID", candidate.getId())
 					.appendParametersToMessage();
 		}
-		final BigDecimal cartonQty = candidate.getQty().toBigDecimal();
+		final BigDecimal orderedQty = candidate.getQty().toBigDecimal();
 
-		// C2: thread the carton candidate's flatrate/contract conditions into createGroup. This is how the
+		// C2: thread the candidate's flatrate/contract conditions into createGroup. This is how the
 		// exploded component lines get their C_Flatrate_Conditions_ID: OrderGroupRepository.createRegularLineFromTemplate
 		// sets it from the request's newContractConditionsId (and the same id also drives which template regular
 		// lines match). This is the Quick-Input mechanism; the OLCand listener path (FlatrateOLCandListener) is
@@ -719,7 +719,7 @@ class OLCandOrderFactory
 
 		final Group group = orderGroupsRepository.prepareNewGroup()
 				.groupTemplate(groupTemplateRepository.getById(groupTemplateId))
-				.qty(cartonQty)
+				.qty(orderedQty)
 				.createGroup(orderId, flatrateConditionsId);
 
 		// Track the created compensation-group header so onCompensationGroupFailure can delete it during rollback.
@@ -728,7 +728,7 @@ class OLCandOrderFactory
 		compensationGroupIds.add(group.getGroupId());
 
 		// H3: we deliberately do NOT fire olCandListeners.onOrderLineCreated for the generated component lines.
-		// HU packing-instruction (OLCandPIIPListener) is product-specific and must not be copied from the carton
+		// HU packing-instruction (OLCandPIIPListener) is product-specific and must not be copied from the schema-product
 		// candidate onto its differing-product component lines; flatrate conditions are instead threaded via
 		// createGroup's conditions parameter (above).
 		//
@@ -745,7 +745,7 @@ class OLCandOrderFactory
 			final I_C_OrderLine componentOrderLine = InterfaceWrapperHelper.load(generatedLineId, I_C_OrderLine.class);
 
 			// H4: the generated group lines otherwise inherit warehouse/org from the order header only. Mirror the
-			// plain path (see addOLCand0) and align them with THIS candidate, so a later Mischkarton candidate
+			// plain path (see addOLCand0) and align them with THIS candidate, so a later compensation-group-schema candidate
 			// aggregated into the same order (different warehouse/org) does not silently diverge from its own values.
 			componentOrderLine.setM_Warehouse_ID(WarehouseId.toRepoId(candidate.getWarehouseId()));
 			componentOrderLine.setM_Warehouse_Dest_ID(WarehouseId.toRepoId(candidate.getWarehouseDestId()));

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
@@ -683,7 +683,21 @@ class OLCandOrderFactory
 		// The ordered number of cartons scales the schema's template-line quantities.
 		// M5: cartonQty is passed as the pure group qty-multiplier with NO UOM conversion, matching
 		// OrderLineQuickInputProcessor. This assumes candidate.getQty() is already expressed in the schema
-		// product's own counting UOM (i.e. a count of cartons); a UOM other than that would scale wrongly.
+		// product's own stocking (counting) UOM (i.e. a count of cartons); a UOM other than that would scale
+		// every exploded component quantity wrongly. Guard the assumption instead of silently trusting the
+		// (REST/EDI) caller: fail loud if the candidate qty UOM differs from the schema product's stocking UOM.
+		final UomId candidateQtyUomId = candidate.getQty().getUomId();
+		final UomId schemaProductStockUomId = productBL.getStockUOMId(productId);
+		if (!UomId.equals(candidateQtyUomId, schemaProductStockUomId))
+		{
+			throw new AdempiereException("OLCand qty UOM does not match the compensation-group-schema product's"
+					+ " stocking UOM; the exploded component quantities would be mis-scaled")
+					.setParameter("productId", productId)
+					.setParameter("candidateQtyUomId", candidateQtyUomId)
+					.setParameter("schemaProductStockUomId", schemaProductStockUomId)
+					.setParameter("C_OLCand_ID", candidate.getId())
+					.appendParametersToMessage();
+		}
 		final BigDecimal cartonQty = candidate.getQty().toBigDecimal();
 
 		// C2: thread the carton candidate's flatrate/contract conditions into createGroup. This is how the

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
@@ -31,6 +31,7 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.service.BPartnerInfo;
 import de.metas.bpartner.service.IBPartnerDAO;
 import de.metas.common.util.CoalesceUtil;
+import de.metas.contracts.ConditionsId;
 import de.metas.currency.CurrencyPrecision;
 import de.metas.currency.ICurrencyDAO;
 import de.metas.document.DocTypeId;
@@ -58,7 +59,6 @@ import de.metas.order.OrderLineId;
 import de.metas.order.compensationGroup.Group;
 import de.metas.order.compensationGroup.GroupCompensationAmtType;
 import de.metas.order.compensationGroup.GroupCompensationType;
-import de.metas.order.compensationGroup.GroupRegularLine;
 import de.metas.order.compensationGroup.GroupRepository;
 import de.metas.order.compensationGroup.GroupTemplate;
 import de.metas.order.compensationGroup.GroupTemplateId;
@@ -88,6 +88,7 @@ import de.metas.util.ILoggable;
 import de.metas.util.Loggables;
 import de.metas.util.Services;
 import de.metas.util.lang.Percent;
+import de.metas.util.lang.RepoIdAware;
 import lombok.Builder;
 import lombok.NonNull;
 import org.adempiere.ad.trx.api.ITrx;
@@ -680,17 +681,49 @@ class OLCandOrderFactory
 		final OrderId orderId = OrderId.ofRepoId(order.getC_Order_ID());
 
 		// The ordered number of cartons scales the schema's template-line quantities.
+		// M5: cartonQty is passed as the pure group qty-multiplier with NO UOM conversion, matching
+		// OrderLineQuickInputProcessor. This assumes candidate.getQty() is already expressed in the schema
+		// product's own counting UOM (i.e. a count of cartons); a UOM other than that would scale wrongly.
 		final BigDecimal cartonQty = candidate.getQty().toBigDecimal();
+
+		// C2: thread the carton candidate's flatrate/contract conditions into createGroup. This is how the
+		// exploded component lines get their C_Flatrate_Conditions_ID: OrderGroupRepository.createRegularLineFromTemplate
+		// sets it from the request's newContractConditionsId (and the same id also drives which template regular
+		// lines match). This is the Quick-Input mechanism; the OLCand listener path (FlatrateOLCandListener) is
+		// deliberately NOT used for generated lines (see below).
+		final ConditionsId flatrateConditionsId = ConditionsId.ofRepoIdOrNull(candidate.getFlatrateConditionsId());
 
 		final Group group = orderGroupsRepository.prepareNewGroup()
 				.groupTemplate(groupTemplateRepository.getById(groupTemplateId))
 				.qty(cartonQty)
-				.createGroup(orderId, /* C_Flatrate_Conditions_ID */ null);
+				.createGroup(orderId, flatrateConditionsId);
 
-		// Preserve the OLCand -> order traceability: allocate the carton candidate to each generated regular component line.
-		for (final GroupRegularLine regularLine : group.getRegularLines())
+		// H3: we deliberately do NOT fire olCandListeners.onOrderLineCreated for the generated component lines.
+		// HU packing-instruction (OLCandPIIPListener) is product-specific and must not be copied from the carton
+		// candidate onto its differing-product component lines; flatrate conditions are instead threaded via
+		// createGroup's conditions parameter (above).
+		//
+		// C1: createGroup persists real C_OrderLine rows for BOTH the regular AND the compensation lines of the
+		// group. Track every one of them in `orderLines` (and allocate the candidate to each) so that a later
+		// rollback in onCompensationGroupFailure (deleteAll(orderLines) + delete(order)) does not leave an
+		// untracked compensation line still FK-referencing C_Order and make delete(order) fail.
+		final List<RepoIdAware> generatedLineIds = new ArrayList<>();
+		group.getRegularLines().forEach(regularLine -> generatedLineIds.add(regularLine.getRepoId()));
+		group.getCompensationLines().forEach(compensationLine -> generatedLineIds.add(compensationLine.getRepoId()));
+
+		for (final RepoIdAware generatedLineId : generatedLineIds)
 		{
-			final I_C_OrderLine componentOrderLine = InterfaceWrapperHelper.load(regularLine.getRepoId(), I_C_OrderLine.class);
+			final I_C_OrderLine componentOrderLine = InterfaceWrapperHelper.load(generatedLineId, I_C_OrderLine.class);
+
+			// H4: the generated group lines otherwise inherit warehouse/org from the order header only. Mirror the
+			// plain path (see addOLCand0) and align them with THIS candidate, so a later Mischkarton candidate
+			// aggregated into the same order (different warehouse/org) does not silently diverge from its own values.
+			componentOrderLine.setM_Warehouse_ID(WarehouseId.toRepoId(candidate.getWarehouseId()));
+			componentOrderLine.setM_Warehouse_Dest_ID(WarehouseId.toRepoId(candidate.getWarehouseDestId()));
+			componentOrderLine.setAD_Org_ID(candidate.getAD_Org_ID());
+			InterfaceWrapperHelper.save(componentOrderLine);
+
+			// Preserve the OLCand -> order traceability and cover the line for rollback.
 			createOla(candidate, componentOrderLine);
 			orderLines.put(componentOrderLine.getC_OrderLine_ID(), componentOrderLine);
 		}

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
@@ -52,12 +52,17 @@ import de.metas.order.IOrderBL;
 import de.metas.order.IOrderDAO;
 import de.metas.order.IOrderLineBL;
 import de.metas.order.InvoiceRule;
+import de.metas.order.OrderId;
 import de.metas.order.OrderLineGroup;
 import de.metas.order.OrderLineId;
+import de.metas.order.compensationGroup.Group;
 import de.metas.order.compensationGroup.GroupCompensationAmtType;
 import de.metas.order.compensationGroup.GroupCompensationType;
+import de.metas.order.compensationGroup.GroupRegularLine;
 import de.metas.order.compensationGroup.GroupRepository;
 import de.metas.order.compensationGroup.GroupTemplate;
+import de.metas.order.compensationGroup.GroupTemplateId;
+import de.metas.order.compensationGroup.GroupTemplateRepository;
 import de.metas.order.compensationGroup.OrderGroupRepository;
 import de.metas.order.location.adapter.OrderDocumentLocationAdapterFactory;
 import de.metas.ordercandidate.model.I_C_OLCand;
@@ -154,6 +159,7 @@ class OLCandOrderFactory
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 
 	private final OrderGroupRepository orderGroupsRepository = SpringContextHolder.instance.getBean(OrderGroupRepository.class);
+	private final GroupTemplateRepository groupTemplateRepository = SpringContextHolder.instance.getBean(GroupTemplateRepository.class);
 	private final OLCandValidatorService olCandValidatorService = SpringContextHolder.instance.getBean(OLCandValidatorService.class);
 
 	private static final AdMessageKey MSG_OL_CAND_PROCESSOR_PROCESSING_ERROR_DESC_1P = AdMessageKey.of("OLCandProcessor.ProcessingError_Desc");
@@ -507,6 +513,14 @@ class OLCandOrderFactory
 
 	private void addOLCand0(@NonNull final OLCand candidate)
 	{
+		// If the candidate's product carries a compensation-group schema ("Mischkarton" / trading-BOM),
+		// explode it into the schema's component order lines instead of creating a single carton line
+		// (mirrors what the sales-order window / Quick-Input does).
+		if (tryExplodeCompensationGroupSchema(candidate))
+		{
+			return;
+		}
+
 		final boolean isNewOrderLine;
 		if (currentOrderLine == null)
 		{
@@ -625,6 +639,64 @@ class OLCandOrderFactory
 		//
 		orderLines.put(currentOrderLine.getC_OrderLine_ID(), currentOrderLine);
 		candidates.add(candidate);
+	}
+
+	/**
+	 * If the candidate's product has a compensation-group schema (a "Mischkarton" / trading-BOM) and the candidate is
+	 * NOT already part of an explicit OLCand group, explode the ordered carton qty into the schema's component order
+	 * lines (regular + compensation) using the same business API the sales-order window / Quick-Input uses, and link
+	 * the carton candidate to each generated regular line via {@code C_Order_Line_Alloc}.
+	 *
+	 * @return {@code true} if the candidate was handled by schema explosion (caller must NOT create a plain carton
+	 * line); {@code false} otherwise (caller proceeds with the plain-line flow).
+	 */
+	private boolean tryExplodeCompensationGroupSchema(@NonNull final OLCand candidate)
+	{
+		// Guard (b): leave candidates that already belong to an explicit CompensationGroupKey group to the existing grouping path.
+		final OrderLineGroup orderLineGroup = candidate.getOrderLineGroup();
+		if (orderLineGroup != null && !Check.isBlank(orderLineGroup.getGroupKey()))
+		{
+			return false;
+		}
+
+		// Guard (a): the product must carry a compensation-group schema.
+		final int productRepoId = candidate.getM_Product_ID();
+		if (productRepoId <= 0)
+		{
+			return false;
+		}
+		final ProductId productId = ProductId.ofRepoId(productRepoId);
+		final GroupTemplateId groupTemplateId = productDAO.getGroupTemplateIdByProductId(productId).orElse(null);
+		if (groupTemplateId == null)
+		{
+			return false;
+		}
+
+		// Make sure the order exists (without creating a stray carton order line).
+		if (order == null)
+		{
+			order = newOrder(candidate);
+		}
+		final OrderId orderId = OrderId.ofRepoId(order.getC_Order_ID());
+
+		// The ordered number of cartons scales the schema's template-line quantities.
+		final BigDecimal cartonQty = candidate.getQty().toBigDecimal();
+
+		final Group group = orderGroupsRepository.prepareNewGroup()
+				.groupTemplate(groupTemplateRepository.getById(groupTemplateId))
+				.qty(cartonQty)
+				.createGroup(orderId, /* C_Flatrate_Conditions_ID */ null);
+
+		// Preserve the OLCand -> order traceability: allocate the carton candidate to each generated regular component line.
+		for (final GroupRegularLine regularLine : group.getRegularLines())
+		{
+			final I_C_OrderLine componentOrderLine = InterfaceWrapperHelper.load(regularLine.getRepoId(), I_C_OrderLine.class);
+			createOla(candidate, componentOrderLine);
+			orderLines.put(componentOrderLine.getC_OrderLine_ID(), componentOrderLine);
+		}
+
+		candidates.add(candidate);
+		return true;
 	}
 
 	private I_C_OrderLine newOrderLine(@NonNull final OLCand candToProcess)

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/OLCandOrderFactory.java
@@ -59,6 +59,7 @@ import de.metas.order.OrderLineId;
 import de.metas.order.compensationGroup.Group;
 import de.metas.order.compensationGroup.GroupCompensationAmtType;
 import de.metas.order.compensationGroup.GroupCompensationType;
+import de.metas.order.compensationGroup.GroupId;
 import de.metas.order.compensationGroup.GroupRepository;
 import de.metas.order.compensationGroup.GroupTemplate;
 import de.metas.order.compensationGroup.GroupTemplateId;
@@ -183,6 +184,8 @@ class OLCandOrderFactory
 	private I_C_OrderLine currentOrderLine = null;
 	private final Map<Integer, I_C_OrderLine> orderLines = new LinkedHashMap<>();
 	private final List<OLCand> candidates = new ArrayList<>();
+	// Compensation-group headers created via schema explosion (tryExplodeCompensationGroupSchema); rolled back in onCompensationGroupFailure.
+	private final List<GroupId> compensationGroupIds = new ArrayList<>();
 	private final ListMultimap<String, OrderLineId> groupsToOrderLines = ArrayListMultimap.create();
 	private final Map<OrderLineId, OrderLineGroup> primaryOrderLineToGroup = new HashMap<>();
 
@@ -394,6 +397,13 @@ class OLCandOrderFactory
 	{
 		deleteAll(allocations);
 		deleteAll(orderLines.values());
+		// Delete any compensation-group headers created by schema explosion BEFORE delete(order): their order lines are
+		// already gone (above), so each header is the last, FK-orphaned row and its deferred C_Order FK would abort the
+		// transaction at COMMIT otherwise. deleteGroupById is idempotent, so a header already removed elsewhere is fine.
+		for (final GroupId compensationGroupId : compensationGroupIds)
+		{
+			orderGroupsRepository.deleteGroupById(compensationGroupId);
+		}
 		delete(order);
 
 		for (final OLCand candidate : candidates)
@@ -711,6 +721,11 @@ class OLCandOrderFactory
 				.groupTemplate(groupTemplateRepository.getById(groupTemplateId))
 				.qty(cartonQty)
 				.createGroup(orderId, flatrateConditionsId);
+
+		// Track the created compensation-group header so onCompensationGroupFailure can delete it during rollback.
+		// Its C_Order_CompensationGroup->C_Order FK is DEFERRABLE INITIALLY DEFERRED: an orphaned header (left after
+		// the order+lines are deleted) would otherwise abort the whole transaction at COMMIT.
+		compensationGroupIds.add(group.getGroupId());
 
 		// H3: we deliberately do NOT fire olCandListeners.onOrderLineCreated for the generated component lines.
 		// HU packing-instruction (OLCandPIIPListener) is product-specific and must not be copied from the carton

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandDAO.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandDAO.java
@@ -24,6 +24,7 @@ package de.metas.ordercandidate.api.impl;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import de.metas.async.AsyncBatchId;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.order.IOrderDAO;
@@ -227,18 +228,20 @@ public class OLCandDAO implements IOLCandDAO
 	}
 
 	@NonNull
-	public Map<OLCandId, OrderLineId> retrieveOLCandIdToOrderLineId(@NonNull final Set<OLCandId> olCandIds)
+	public ImmutableSetMultimap<OLCandId, OrderLineId> retrieveOLCandIdToOrderLineId(@NonNull final Set<OLCandId> olCandIds)
 	{
 		if (olCandIds.isEmpty())
 		{
-			return ImmutableMap.of();
+			return ImmutableSetMultimap.of();
 		}
 
+		// A single C_OLCand can be allocated to N C_OrderLines (e.g. a compensation-group-schema/"Mischkarton"
+		// product exploded into its component order lines), so this must be a multimap.
 		return queryBL.createQueryBuilder(I_C_Order_Line_Alloc.class)
 				.addInArrayFilter(I_C_Order_Line_Alloc.COLUMNNAME_C_OLCand_ID, olCandIds)
 				.create()
 				.stream()
-				.collect(ImmutableMap.toImmutableMap(
+				.collect(ImmutableSetMultimap.toImmutableSetMultimap(
 						olAlloc -> OLCandId.ofRepoId(olAlloc.getC_OLCand_ID()),
 						olAlloc -> OrderLineId.ofRepoId(olAlloc.getC_OrderLine_ID())
 				));

--- a/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandDAO.java
+++ b/backend/de.metas.salescandidate.base/src/main/java/de/metas/ordercandidate/api/impl/OLCandDAO.java
@@ -235,7 +235,7 @@ public class OLCandDAO implements IOLCandDAO
 			return ImmutableSetMultimap.of();
 		}
 
-		// A single C_OLCand can be allocated to N C_OrderLines (e.g. a compensation-group-schema/"Mischkarton"
+		// A single C_OLCand can be allocated to N C_OrderLines (e.g. a compensation-group-schema
 		// product exploded into its component order lines), so this must be a multimap.
 		return queryBL.createQueryBuilder(I_C_Order_Line_Alloc.class)
 				.addInArrayFilter(I_C_Order_Line_Alloc.COLUMNNAME_C_OLCand_ID, olCandIds)

--- a/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandOrderFactoryTest.java
+++ b/backend/de.metas.salescandidate.base/src/test/java/de/metas/ordercandidate/api/OLCandOrderFactoryTest.java
@@ -35,6 +35,7 @@ import de.metas.location.CountryId;
 import de.metas.location.LocationId;
 import de.metas.order.BPartnerOrderParamsRepository;
 import de.metas.order.compensationGroup.GroupCompensationLineCreateRequestFactory;
+import de.metas.order.compensationGroup.GroupTemplateRepository;
 import de.metas.order.compensationGroup.OrderGroupRepository;
 import de.metas.order.location.adapter.OrderDocumentLocationAdapterFactory;
 import de.metas.ordercandidate.api.impl.OLCandBL;
@@ -90,6 +91,8 @@ class OLCandOrderFactoryTest
 				new GroupCompensationLineCreateRequestFactory(),
 				Optional.empty()
 		));
+
+		SpringContextHolder.registerJUnitBean(new GroupTemplateRepository(Optional.empty()));
 
 		SpringContextHolder.registerJUnitBean(new OLCandValidatorService(new OLCandSPIRegistry(Optional.empty(), Optional.empty(), Optional.empty())));
 


### PR DESCRIPTION
## What

When an order candidate (`C_OLCand`) is processed into a sales order, a product that carries a **compensation-group schema** (a "trading BOM" / mixed-carton product) is now **exploded into the schema's component order lines automatically**, scaled by the ordered quantity — matching exactly what the sales-order window already produces for the same product. Previously such a candidate produced a single, un-exploded line, so the order (and everything downstream — picking, shipment) was missing the individual articles that make up the carton.

Scope: only the candidate→order conversion (the path EDI ORDERS uses). Direct sales-order-window entry already worked and is unchanged.

## How

- `OLCandOrderFactory.addOLCand0`: when the candidate's product has a compensation-group schema **and** the candidate is not already part of an explicit compensation group, generate the group from the schema template (`OrderGroupRepository.prepareNewGroup().groupTemplate(...).qty(cartonQty).createGroup(orderId, conditionsId)`) instead of a single plain line — the same production mechanism the sales-order-window Quick-Input uses. The explicit-`CompensationGroupKey` grouping path is untouched.
- The carton candidate is allocated (`C_Order_Line_Alloc`) to each generated line, so `IOLCandDAO.retrieveOLCandIdToOrderLineId` is widened to a `Multimap` (one candidate → N order lines); its call sites (shipment generation + the REST shipment lookup) are updated, with the single-schedule REST lookup asserting cardinality rather than silently picking one.
- Robustness: the compensation-group header is rolled back on a processing failure; flatrate/contract conditions are threaded onto the exploded lines; per-line warehouse/org follow the originating candidate; the ordered-qty UOM is guarded against silent mis-scaling.

## Tests (cucumber, integration)

New feature `explodeCompensationSchemaOnOLCandProcessing.feature` exercising the EDI-style REST bulk-candidate + process path:
- explosion into the schema's component lines with quantity scaling;
- a shipment generated off an exploded candidate contains a line per component (exercises the 1→N allocation end-to-end);
- a flatrate-linked candidate threads its contract conditions onto the exploded lines;
- a schema with a compensation/discount line produces the discount compensation line.

Plus a new `metasfresh contains C_CompensationGroup_SchemaLine:` step-def. All scenarios verified green locally against a faithful DB.
