### PR TITLE
Manufacturing costing — CostDifference (negated) + cost-imbalance monitor window (PR1)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/I_PP_Order.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/I_PP_Order.java
@@ -383,6 +383,29 @@ public interface I_PP_Order
 	String COLUMNNAME_C_OrderLine_MTO_ID = "C_OrderLine_MTO_ID";
 
 	/**
+	 * Set Cost difference.
+	 *
+	 * <br>Type: Amount
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true
+	 * @deprecated Please don't use it because this is a virtual column
+	 */
+	@Deprecated
+	void setCostDifference (@Nullable BigDecimal CostDifference);
+
+	/**
+	 * Get Cost difference.
+	 *
+	 * <br>Type: Amount
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: true
+	 */
+	BigDecimal getCostDifference();
+
+	ModelColumn<I_PP_Order, Object> COLUMN_CostDifference = new ModelColumn<>(I_PP_Order.class, "CostDifference", null);
+	String COLUMNNAME_CostDifference = "CostDifference";
+
+	/**
 	 * Set Project.
 	 * Financial Project
 	 *
@@ -433,7 +456,7 @@ public interface I_PP_Order
 	 * Set UOM.
 	 * Unit of Measure
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
@@ -443,7 +466,7 @@ public interface I_PP_Order
 	 * Get UOM.
 	 * Unit of Measure
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Table
 	 * <br>Mandatory: true
 	 * <br>Virtual Column: false
 	 */
@@ -1030,29 +1053,6 @@ public interface I_PP_Order
 	String COLUMNNAME_IsSOTrx = "IsSOTrx";
 
 	/**
-	 * Set Cost difference.
-	 *
-	 * <br>Type: Amount
-	 * <br>Mandatory: false
-	 * <br>Virtual Column: true
-	 * @deprecated Please don't use it because this is a virtual column
-	 */
-	@Deprecated
-	void setKostendifferenz (@Nullable BigDecimal Kostendifferenz);
-
-	/**
-	 * Get Cost difference.
-	 *
-	 * <br>Type: Amount
-	 * <br>Mandatory: false
-	 * <br>Virtual Column: true
-	 */
-	BigDecimal getKostendifferenz();
-
-	ModelColumn<I_PP_Order, Object> COLUMN_Kostendifferenz = new ModelColumn<>(I_PP_Order.class, "Kostendifferenz", null);
-	String COLUMNNAME_Kostendifferenz = "Kostendifferenz";
-
-	/**
 	 * Set SeqNo..
 	 *
 	 * <br>Type: Integer
@@ -1124,7 +1124,7 @@ public interface I_PP_Order
 	/**
 	 * Set Packing Instruction.
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Table
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
@@ -1133,7 +1133,7 @@ public interface I_PP_Order
 	/**
 	 * Get Packing Instruction.
 	 *
-	 * <br>Type: TableDir
+	 * <br>Type: Table
 	 * <br>Mandatory: false
 	 * <br>Virtual Column: false
 	 */
@@ -1999,6 +1999,7 @@ public interface I_PP_Order
 
 	/**
 	 * Set Work Station.
+	 * The Workstation at which this manufacturing order is to be processed. In MobileUI Manufacturing, only orders whose Workstation matches the one scanned by the operator are shown.
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: false
@@ -2008,6 +2009,7 @@ public interface I_PP_Order
 
 	/**
 	 * Get Work Station.
+	 * The Workstation at which this manufacturing order is to be processed. In MobileUI Manufacturing, only orders whose Workstation matches the one scanned by the operator are shown.
 	 *
 	 * <br>Type: Search
 	 * <br>Mandatory: false

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/X_PP_Order.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/eevolution/model/X_PP_Order.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 public class X_PP_Order extends org.compiere.model.PO implements I_PP_Order, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 1478414169L;
+	private static final long serialVersionUID = -1908409784L;
 
     /** Standard Constructor */
     public X_PP_Order (final Properties ctx, final int PP_Order_ID, @Nullable final String trxName)
@@ -279,6 +279,18 @@ public class X_PP_Order extends org.compiere.model.PO implements I_PP_Order, org
 	public int getC_OrderLine_MTO_ID() 
 	{
 		return get_ValueAsInt(COLUMNNAME_C_OrderLine_MTO_ID);
+	}
+
+	@Override
+	public void setCostDifference (final @Nullable BigDecimal CostDifference)
+	{
+		throw new IllegalArgumentException ("CostDifference is virtual column");	}
+
+	@Override
+	public BigDecimal getCostDifference() 
+	{
+		final BigDecimal bd = get_ValueAsBigDecimal(COLUMNNAME_CostDifference);
+		return bd != null ? bd : BigDecimal.ZERO;
 	}
 
 	@Override
@@ -591,6 +603,10 @@ public class X_PP_Order extends org.compiere.model.PO implements I_PP_Order, org
 	public static final String DOCBASETYPE_RemittanceAdvice = "RMA";
 	/** BOM & Formula = BOM */
 	public static final String DOCBASETYPE_BOMFormula = "BOM";
+	/** Cost Revaluation = CRD */
+	public static final String DOCBASETYPE_CostRevaluation = "CRD";
+	/** AnalysisReport = QMA */
+	public static final String DOCBASETYPE_AnalysisReport = "QMA";
 	@Override
 	public void setDocBaseType (final @Nullable java.lang.String DocBaseType)
 	{
@@ -781,18 +797,6 @@ public class X_PP_Order extends org.compiere.model.PO implements I_PP_Order, org
 	public boolean isSOTrx() 
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsSOTrx);
-	}
-
-	@Override
-	public void setKostendifferenz (final @Nullable BigDecimal Kostendifferenz)
-	{
-		throw new IllegalArgumentException ("Kostendifferenz is virtual column");	}
-
-	@Override
-	public BigDecimal getKostendifferenz() 
-	{
-		final BigDecimal bd = get_ValueAsBigDecimal(COLUMNNAME_Kostendifferenz);
-		return bd != null ? bd : BigDecimal.ZERO;
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814670_gh30811_PP_Order_CostDifference.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814670_gh30811_PP_Order_CostDifference.sql
@@ -1,17 +1,12 @@
--- IDs allocated from idserver.metas.de on 2026-07-20:
---   AD_Element 585115 (CostDifference)
---   AD_Column  592970 (PP_Order.CostDifference)
---   AD_SQLColumn_SourceTableColumn 540223 (PP_Order.CostDifference <- PP_Order_Cost)
+-- Replaces the virtual column PP_Order.Kostendifferenz with PP_Order.CostDifference, which computes
+-- received-minus-issued (negative when more cost was issued than received). The German label stays
+-- "Kostendifferenz", en_US is "Cost difference". Being virtual, the column has no stored data: create
+-- it, repoint the existing header field (AD_Field 781320), drop the old objects.
 --
--- Renames the virtual column PP_Order.Kostendifferenz -> PP_Order.CostDifference and NEGATES its sign:
--- it now computes received-minus-issued, so the value is negative when more cost was issued than
--- received. Only the two coalesce(...) summands of the ColumnSQL are swapped.
---
--- The displayed German label stays "Kostendifferenz"; en_US is "Cost difference". The column is virtual
--- (ColumnSQL), so there is no stored data to copy: create the new column, rewire the existing header
--- field (AD_Field 781320) to it, then drop the now-unreferenced old objects.
+-- IDs allocated from idserver.metas.de: AD_Element 585115, AD_Column 592970,
+--   AD_SQLColumn_SourceTableColumn 540223
 
--- 1) New AD_Element CostDifference (German in base column; en_US override below).
+-- 1) AD_Element CostDifference (German in the base column, en_US override below).
 INSERT INTO AD_Element (AD_Client_ID,IsActive,CreatedBy,PrintName,EntityType,ColumnName,AD_Element_ID,AD_Org_ID,Name,UpdatedBy,Created,Updated)
 VALUES (0,'Y',100,'Kostendifferenz','D','CostDifference',585115 /*From ID Server*/,0,'Kostendifferenz',100,
         TO_TIMESTAMP('2026-07-20 10:00:00','YYYY-MM-DD HH24:MI:SS'),
@@ -25,7 +20,6 @@ WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Element_ID=585115
 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
 ;
 
--- de_DE / de_CH keep the base German text (mark as translated); en_US gets the English override.
 UPDATE AD_Element_Trl SET Name='Kostendifferenz', PrintName='Kostendifferenz', IsTranslated='Y',
        Updated=TO_TIMESTAMP('2026-07-20 10:00:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Element_ID=585115 AND AD_Language IN ('de_DE','de_CH')
@@ -36,9 +30,8 @@ UPDATE AD_Element_Trl SET Name='Cost difference', PrintName='Cost difference', I
 WHERE AD_Element_ID=585115 AND AD_Language='en_US'
 ;
 
--- 2) New virtual AD_Column CostDifference (AD_Reference 12 = Amount) with the NEGATED expression:
---    received (MR/CO/BY postcalculationamt) minus issued (MI -cumulatedqty * (cost + landed-cost)),
---    i.e. the two summands of the former Kostendifferenz expression swapped.
+-- 2) Virtual AD_Column CostDifference (AD_Reference 12 = Amount): received (MR/CO/BY) minus
+--    issued (MI), both read off the order's PP_Order_Cost rows.
 INSERT INTO AD_Column (AD_Reference_ID,IsKey,IsParent,IsTranslated,IsIdentifier,AD_Client_ID,IsActive,CreatedBy,
                         AD_Element_ID,IsUpdateable,IsSelectionColumn,IsSyncDatabase,IsAlwaysUpdateable,IsAllowLogging,
                         IsEncrypted,AD_Table_ID,ColumnSQL,ColumnName,AD_Column_ID,IsMandatory,AD_Org_ID,UpdatedBy,
@@ -72,9 +65,8 @@ WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=592970
 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
 ;
 
--- 3) Source table dependency: PP_Order.CostDifference reads pp_order_cost, correlated via
--- PP_Order_Cost.PP_Order_ID (AD_Column_ID=53551). Registering it lets the WebUI invalidate/refresh
--- the virtual column's cached value whenever a PP_Order_Cost row changes.
+-- 3) Source table dependency on PP_Order_Cost.PP_Order_ID (AD_Column 53551): lets the WebUI refresh
+-- the virtual column whenever a PP_Order_Cost row changes.
 INSERT INTO AD_SQLColumn_SourceTableColumn (AD_Client_ID,AD_Column_ID,AD_Org_ID,AD_SQLColumn_SourceTableColumn_ID,AD_Table_ID,Created,CreatedBy,FetchTargetRecordsMethod,IsActive,Link_Column_ID,Source_Column_ID,Source_Table_ID,Updated,UpdatedBy)
 VALUES (0,592970,0,540223 /*From ID Server*/,53027,
         TO_TIMESTAMP('2026-07-20 10:02:00','YYYY-MM-DD HH24:MI:SS'),100,
@@ -82,22 +74,17 @@ VALUES (0,592970,0,540223 /*From ID Server*/,53027,
         TO_TIMESTAMP('2026-07-20 10:02:00','YYYY-MM-DD HH24:MI:SS'),100)
 ;
 
--- 4) Rewire the existing Production Order header field (AD_Field 781320 on window 53009 / tab 53054,
--- UI element 652428) from the old Kostendifferenz column (592918) to the new CostDifference column
--- (592970). The field label continues to resolve from the column's element (585115), so the German
--- caption stays "Kostendifferenz" and en_US "Cost difference".
+-- 4) Repoint the Production Order header field (AD_Field 781320, window 53009 / tab 53054) from the
+-- old column 592918 to 592970. Its caption resolves from the column's element, so it is unchanged.
 UPDATE AD_Field SET AD_Column_ID=592970,
        Updated=TO_TIMESTAMP('2026-07-20 10:03:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Field_ID=781320
 ;
 
--- Propagate AD_Element 585115 translations (Name/Description/Help) onto AD_Column_Trl / AD_Field_Trl.
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585115);
 
--- 5) Drop the old objects, now fully unreferenced (field repointed above). The old column is
--- virtual (ColumnSQL) so there is no physical column to drop and no data to migrate. Dependency sweep
--- (views / functions / val-rules / other virtual ColumnSQL / EXP_FormatLine / other AD_Fields) was
--- empty: AD_Field 781320 (repointed) was the only referencer.
+-- 5) Drop the old objects. AD_Field 781320, repointed above, was their only referencer; the old
+-- column is virtual, so there is no physical column to drop.
 DELETE FROM AD_Element_Link                WHERE AD_Element_ID=585075;
 DELETE FROM AD_SQLColumn_SourceTableColumn WHERE AD_SQLColumn_SourceTableColumn_ID=540219;
 DELETE FROM AD_Column_Trl                  WHERE AD_Column_ID=592918;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814670_gh30811_PP_Order_CostDifference.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814670_gh30811_PP_Order_CostDifference.sql
@@ -3,16 +3,13 @@
 --   AD_Column  592970 (PP_Order.CostDifference)
 --   AD_SQLColumn_SourceTableColumn 540223 (PP_Order.CostDifference <- PP_Order_Cost)
 --
--- Renames the virtual column PP_Order.Kostendifferenz -> PP_Order.CostDifference and NEGATES its
--- sign. The former computed issued-minus-received (IN - OUT); this computes received-minus-issued
--- (OUT - IN), so the value is negative when more cost was issued than received and positive when
--- more was received than issued. Only the two coalesce(...) summands of the ColumnSQL are swapped;
--- the sub-selects are otherwise identical.
+-- Renames the virtual column PP_Order.Kostendifferenz -> PP_Order.CostDifference and NEGATES its sign:
+-- it now computes received-minus-issued, so the value is negative when more cost was issued than
+-- received. Only the two coalesce(...) summands of the ColumnSQL are swapped.
 --
--- The displayed German label STAYS "Kostendifferenz" (base language) and en_US is "Cost difference";
--- only the technical ColumnName changes to CostDifference. The column is virtual (ColumnSQL) so
--- there is no stored data to copy; the migration creates the new virtual column, rewires the
--- existing header field (AD_Field 781320) to it, then drops the now-unreferenced old objects.
+-- The displayed German label stays "Kostendifferenz"; en_US is "Cost difference". The column is virtual
+-- (ColumnSQL), so there is no stored data to copy: create the new column, rewire the existing header
+-- field (AD_Field 781320) to it, then drop the now-unreferenced old objects.
 
 -- 1) New AD_Element CostDifference (German in base column; en_US override below).
 INSERT INTO AD_Element (AD_Client_ID,IsActive,CreatedBy,PrintName,EntityType,ColumnName,AD_Element_ID,AD_Org_ID,Name,UpdatedBy,Created,Updated)

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814670_gh30811_PP_Order_CostDifference.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814670_gh30811_PP_Order_CostDifference.sql
@@ -1,0 +1,109 @@
+-- IDs allocated from idserver.metas.de on 2026-07-20:
+--   AD_Element 585115 (CostDifference)
+--   AD_Column  592970 (PP_Order.CostDifference)
+--   AD_SQLColumn_SourceTableColumn 540223 (PP_Order.CostDifference <- PP_Order_Cost)
+--
+-- Renames the virtual column PP_Order.Kostendifferenz -> PP_Order.CostDifference and NEGATES its
+-- sign. The former computed issued-minus-received (IN - OUT); this computes received-minus-issued
+-- (OUT - IN), so the value is negative when more cost was issued than received and positive when
+-- more was received than issued. Only the two coalesce(...) summands of the ColumnSQL are swapped;
+-- the sub-selects are otherwise identical.
+--
+-- The displayed German label STAYS "Kostendifferenz" (base language) and en_US is "Cost difference";
+-- only the technical ColumnName changes to CostDifference. The column is virtual (ColumnSQL) so
+-- there is no stored data to copy; the migration creates the new virtual column, rewires the
+-- existing header field (AD_Field 781320) to it, then drops the now-unreferenced old objects.
+
+-- 1) New AD_Element CostDifference (German in base column; en_US override below).
+INSERT INTO AD_Element (AD_Client_ID,IsActive,CreatedBy,PrintName,EntityType,ColumnName,AD_Element_ID,AD_Org_ID,Name,UpdatedBy,Created,Updated)
+VALUES (0,'Y',100,'Kostendifferenz','D','CostDifference',585115 /*From ID Server*/,0,'Kostendifferenz',100,
+        TO_TIMESTAMP('2026-07-20 10:00:00','YYYY-MM-DD HH24:MI:SS'),
+        TO_TIMESTAMP('2026-07-20 10:00:00','YYYY-MM-DD HH24:MI:SS'))
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, PO_Name,PO_PrintName,PrintName,PO_Description,PO_Help,Help,Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Element_ID, t.PO_Name,t.PO_PrintName,t.PrintName,t.PO_Description,t.PO_Help,t.Help,t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Element_ID=585115
+AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- de_DE / de_CH keep the base German text (mark as translated); en_US gets the English override.
+UPDATE AD_Element_Trl SET Name='Kostendifferenz', PrintName='Kostendifferenz', IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-07-20 10:00:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585115 AND AD_Language IN ('de_DE','de_CH')
+;
+
+UPDATE AD_Element_Trl SET Name='Cost difference', PrintName='Cost difference', IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-07-20 10:00:18','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585115 AND AD_Language='en_US'
+;
+
+-- 2) New virtual AD_Column CostDifference (AD_Reference 12 = Amount) with the NEGATED expression:
+--    received (MR/CO/BY postcalculationamt) minus issued (MI -cumulatedqty * (cost + landed-cost)),
+--    i.e. the two summands of the former Kostendifferenz expression swapped.
+INSERT INTO AD_Column (AD_Reference_ID,IsKey,IsParent,IsTranslated,IsIdentifier,AD_Client_ID,IsActive,CreatedBy,
+                        AD_Element_ID,IsUpdateable,IsSelectionColumn,IsSyncDatabase,IsAlwaysUpdateable,IsAllowLogging,
+                        IsEncrypted,AD_Table_ID,ColumnSQL,ColumnName,AD_Column_ID,IsMandatory,AD_Org_ID,UpdatedBy,
+                        Name,EntityType,FieldLength,Version,SeqNo,PersonalDataCategory,IsCalculated,Created,Updated)
+VALUES (12,'N','N','N','N',0,'Y',100,
+        585115 /*From ID Server*/,'N','N','N','N','Y',
+        'N',53027,
+        '(coalesce((select sum(oc.postcalculationamt)
+   from pp_order_cost oc
+   join c_acctschema acs on acs.c_acctschema_id = oc.c_acctschema_id
+    and acs.c_acctschema_id = (select ci.c_acctschema1_id from ad_clientinfo ci where ci.ad_client_id = PP_Order.AD_Client_ID)
+   join m_costelement ce on ce.m_costelement_id = oc.m_costelement_id and ce.costingmethod = acs.costingmethod
+   where oc.pp_order_id = PP_Order.PP_Order_ID and oc.pp_order_cost_trxtype in (''MR'',''CO'',''BY'')), 0)
+ -
+ coalesce((select sum(-oc.cumulatedqty * (coalesce(oc.currentcostprice,0) + coalesce(oc.currentcostpricell,0)))
+   from pp_order_cost oc
+   join c_acctschema acs on acs.c_acctschema_id = oc.c_acctschema_id
+    and acs.c_acctschema_id = (select ci.c_acctschema1_id from ad_clientinfo ci where ci.ad_client_id = PP_Order.AD_Client_ID)
+   join m_costelement ce on ce.m_costelement_id = oc.m_costelement_id and ce.costingmethod = acs.costingmethod
+   where oc.pp_order_id = PP_Order.PP_Order_ID and oc.pp_order_cost_trxtype = ''MI''), 0)
+)','CostDifference',592970 /*From ID Server*/,'N',0,100,
+        'Kostendifferenz','D',14,0,0,'NP','Y',
+        TO_TIMESTAMP('2026-07-20 10:01:00','YYYY-MM-DD HH24:MI:SS'),
+        TO_TIMESTAMP('2026-07-20 10:01:00','YYYY-MM-DD HH24:MI:SS'))
+;
+
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Column_ID=592970
+AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 3) Source table dependency: PP_Order.CostDifference reads pp_order_cost, correlated via
+-- PP_Order_Cost.PP_Order_ID (AD_Column_ID=53551). Registering it lets the WebUI invalidate/refresh
+-- the virtual column's cached value whenever a PP_Order_Cost row changes.
+INSERT INTO AD_SQLColumn_SourceTableColumn (AD_Client_ID,AD_Column_ID,AD_Org_ID,AD_SQLColumn_SourceTableColumn_ID,AD_Table_ID,Created,CreatedBy,FetchTargetRecordsMethod,IsActive,Link_Column_ID,Source_Column_ID,Source_Table_ID,Updated,UpdatedBy)
+VALUES (0,592970,0,540223 /*From ID Server*/,53027,
+        TO_TIMESTAMP('2026-07-20 10:02:00','YYYY-MM-DD HH24:MI:SS'),100,
+        'L','Y',53551,53551,53024,
+        TO_TIMESTAMP('2026-07-20 10:02:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 4) Rewire the existing Production Order header field (AD_Field 781320 on window 53009 / tab 53054,
+-- UI element 652428) from the old Kostendifferenz column (592918) to the new CostDifference column
+-- (592970). The field label continues to resolve from the column's element (585115), so the German
+-- caption stays "Kostendifferenz" and en_US "Cost difference".
+UPDATE AD_Field SET AD_Column_ID=592970,
+       Updated=TO_TIMESTAMP('2026-07-20 10:03:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=781320
+;
+
+-- Propagate AD_Element 585115 translations (Name/Description/Help) onto AD_Column_Trl / AD_Field_Trl.
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585115);
+
+-- 5) Drop the old objects, now fully unreferenced (field repointed above). The old column is
+-- virtual (ColumnSQL) so there is no physical column to drop and no data to migrate. Dependency sweep
+-- (views / functions / val-rules / other virtual ColumnSQL / EXP_FormatLine / other AD_Fields) was
+-- empty: AD_Field 781320 (repointed) was the only referencer.
+DELETE FROM AD_Element_Link                WHERE AD_Element_ID=585075;
+DELETE FROM AD_SQLColumn_SourceTableColumn WHERE AD_SQLColumn_SourceTableColumn_ID=540219;
+DELETE FROM AD_Column_Trl                  WHERE AD_Column_ID=592918;
+DELETE FROM AD_Column                      WHERE AD_Column_ID=592918;
+DELETE FROM AD_Element_Trl                 WHERE AD_Element_ID=585075;
+DELETE FROM AD_Element                     WHERE AD_Element_ID=585075;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814680_sys_gh30811_PP_Order_CostImbalance_Window.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814680_sys_gh30811_PP_Order_CostImbalance_Window.sql
@@ -11,9 +11,7 @@
 --   AD_UI_Element 652680..652692 (13, same order as the fields)
 --   AD_Menu    542348
 
--- ===========================================================================
 -- 1) Window caption element: DE base, EN override
--- ===========================================================================
 INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, EntityType, Name, PrintName, Description)
 VALUES (585116 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-20 14:00:00','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-20 14:00:00','YYYY-MM-DD HH24:MI:SS'), 100, 'D', 'Kostenüberwachung Fertigung', 'Kostenüberwachung Fertigung', 'Fertigungsaufträge, die abgeschlossen aber noch nicht geschlossen sind, mit Kostendifferenz')
 ;
@@ -39,9 +37,7 @@ UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-20 14:
 WHERE AD_Element_ID=585116 AND AD_Language='de_CH'
 ;
 
--- ===========================================================================
 -- 2) AD_Window
--- ===========================================================================
 INSERT INTO AD_Window (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Window_ID,Created,CreatedBy,EntityType,IsActive,IsBetaFunctionality,IsDefault,IsEnableRemoteCacheInvalidation,IsExcludeFromZoomTargets,IsOneInstanceOnly,IsOverrideInMenu,IsSOTrx,Name,Processing,Updated,UpdatedBy,WindowType,WinHeight,WinWidth,ZoomIntoPriority)
 VALUES (0,585116 /*From ID Server*/,0,542175 /*From ID Server*/,TO_TIMESTAMP('2026-07-20 14:00:20','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','N','N','N','N','N','N','N','Kostenüberwachung Fertigung','N',TO_TIMESTAMP('2026-07-20 14:00:20','YYYY-MM-DD HH24:MI:SS'),100,'M',0,0,100)
 ;
@@ -61,9 +57,7 @@ DELETE FROM AD_Element_Link WHERE AD_Window_ID=542175
 select AD_Element_Link_Create_Missing_Window(542175)
 ;
 
--- ===========================================================================
 -- 3) Tab caption element: DE base, EN override
--- ===========================================================================
 INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, EntityType, Name, PrintName, Description)
 VALUES (585117 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-20 14:00:25','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-20 14:00:25','YYYY-MM-DD HH24:MI:SS'), 100, 'D', 'Fertigungsaufträge', 'Fertigungsaufträge', 'Fertigungsaufträge mit Status abgeschlossen, die noch nicht geschlossen sind')
 ;
@@ -89,9 +83,7 @@ UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-20 14:
 WHERE AD_Element_ID=585117 AND AD_Language='de_CH'
 ;
 
--- ===========================================================================
 -- 4) AD_Tab (TabLevel=0, over PP_Order, read-only, DocStatus='CO')
--- ===========================================================================
 INSERT INTO AD_Tab (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Tab_ID,AD_Table_ID,AD_Window_ID,AllowQuickInput,Created,CreatedBy,EntityType,HasTree,ImportFields,IncludedTabNewRecordInputMode,IsActive,IsAdvancedTab,IsAutodetectDefaultDateFilter,IsGenericZoomTarget,IsGridModeOnly,IsInsertRecord,IsReadOnly,IsRefreshAllOnActivate,IsRefreshViewOnChangeEvents,IsSearchCollapsed,IsSingleRow,IsSortTab,IsTranslationTab,Name,Processing,SeqNo,TabLevel,Updated,UpdatedBy,WhereClause)
 VALUES (0,585117 /*From ID Server*/,0,549352 /*From ID Server*/,53027,542175,'N',TO_TIMESTAMP('2026-07-20 14:00:45','YYYY-MM-DD HH24:MI:SS'),100,'D','N','N','A','Y','N','Y','N','N','N','Y','N','N','Y','Y','N','N','Fertigungsaufträge','N',10,0,TO_TIMESTAMP('2026-07-20 14:00:45','YYYY-MM-DD HH24:MI:SS'),100,'DocStatus=''CO''')
 ;
@@ -111,11 +103,9 @@ DELETE FROM AD_Element_Link WHERE AD_Tab_ID=549352
 select AD_Element_Link_Create_Missing_Tab(549352)
 ;
 
--- ===========================================================================
 -- 5) AD_Field rows, reusing the existing column elements (no new AD_Elements
 --    for standard PP_Order columns). Grid order matches the review workflow;
 --    C_UOM_ID is added next to the quantities for UOM adjacency.
--- ===========================================================================
 
 -- 5.1 IsActive (flags group, form only, not displayed in grid)
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
@@ -325,9 +315,7 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID=781761
 select AD_Element_Link_Create_Missing_Field(781761)
 ;
 
--- ===========================================================================
 -- 6) Layout: 1 section, 2 columns (left/right), 4 element groups
--- ===========================================================================
 INSERT INTO AD_UI_Section (AD_Client_ID,AD_Org_ID,AD_Tab_ID,AD_UI_Section_ID,Created,CreatedBy,IsActive,SeqNo,Updated,UpdatedBy,Value)
 VALUES (0,0,549352,547860 /*From ID Server*/,TO_TIMESTAMP('2026-07-20 14:01:55','YYYY-MM-DD HH24:MI:SS'),100,'Y',10,TO_TIMESTAMP('2026-07-20 14:01:55','YYYY-MM-DD HH24:MI:SS'),100,'main')
 ;
@@ -363,66 +351,62 @@ INSERT INTO AD_UI_ElementGroup (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_Ele
 VALUES (0,0,549605,555517 /*From ID Server*/,TO_TIMESTAMP('2026-07-20 14:02:25','YYYY-MM-DD HH24:MI:SS'),100,'Y','default',20,NULL,TO_TIMESTAMP('2026-07-20 14:02:25','YYYY-MM-DD HH24:MI:SS'),100)
 ;
 
--- ===========================================================================
 -- 7) AD_UI_Element rows (one per field). All are grid-displayed except IsActive.
--- ===========================================================================
 
--- IsActive -> flags group, form only
+-- IsActive
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
 VALUES (0,781749,0,549352,555516,652680 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:02:30','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','N','N','Aktiv',10,0,0,TO_TIMESTAMP('2026-07-20 14:02:30','YYYY-MM-DD HH24:MI:SS'),100)
 ;
--- DocumentNo -> primary group, grid col 1
+-- DocumentNo
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
 VALUES (0,781750,0,549352,555514,652681 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:02:35','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Nr.',10,10,0,TO_TIMESTAMP('2026-07-20 14:02:35','YYYY-MM-DD HH24:MI:SS'),100)
 ;
--- C_DocType_ID -> primary group, grid col 2
+-- C_DocType_ID
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
 VALUES (0,781751,0,549352,555514,652682 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:02:40','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Belegart',20,20,0,TO_TIMESTAMP('2026-07-20 14:02:40','YYYY-MM-DD HH24:MI:SS'),100)
 ;
--- M_Product_ID -> primary group, grid col 3
+-- M_Product_ID
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
 VALUES (0,781752,0,549352,555514,652683 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:02:45','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Produkt',30,30,0,TO_TIMESTAMP('2026-07-20 14:02:45','YYYY-MM-DD HH24:MI:SS'),100)
 ;
--- CostDifference -> primary group (prominent), grid col 10
+-- CostDifference
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
 VALUES (0,781753,0,549352,555514,652684 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:02:50','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Kostendifferenz',40,100,0,TO_TIMESTAMP('2026-07-20 14:02:50','YYYY-MM-DD HH24:MI:SS'),100)
 ;
--- QtyOrdered -> secondary group, grid col 4
+-- QtyOrdered
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
 VALUES (0,781754,0,549352,555515,652685 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:02:55','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Bestellt/ Beauftragt',10,40,0,TO_TIMESTAMP('2026-07-20 14:02:55','YYYY-MM-DD HH24:MI:SS'),100)
 ;
--- QtyDelivered -> secondary group, grid col 5
+-- QtyDelivered
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
 VALUES (0,781755,0,549352,555515,652686 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:03:00','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Gelieferte Menge',20,50,0,TO_TIMESTAMP('2026-07-20 14:03:00','YYYY-MM-DD HH24:MI:SS'),100)
 ;
--- C_UOM_ID -> secondary group, grid col 6 (adjacent to the quantities)
+-- C_UOM_ID
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
 VALUES (0,781756,0,549352,555515,652687 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:03:05','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Maßeinheit',30,60,0,TO_TIMESTAMP('2026-07-20 14:03:05','YYYY-MM-DD HH24:MI:SS'),100)
 ;
--- DatePromised -> secondary group, grid col 7
+-- DatePromised
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
 VALUES (0,781757,0,549352,555515,652688 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:03:10','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Zugesagter Termin',40,70,0,TO_TIMESTAMP('2026-07-20 14:03:10','YYYY-MM-DD HH24:MI:SS'),100)
 ;
--- DateFinishSchedule -> secondary group, grid col 8
+-- DateFinishSchedule
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
 VALUES (0,781758,0,549352,555515,652689 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:03:15','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Datum Fertigstellung geplant',50,80,0,TO_TIMESTAMP('2026-07-20 14:03:15','YYYY-MM-DD HH24:MI:SS'),100)
 ;
--- M_Warehouse_ID -> secondary group, grid col 9
+-- M_Warehouse_ID
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
 VALUES (0,781759,0,549352,555515,652690 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:03:20','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Lager',60,90,0,TO_TIMESTAMP('2026-07-20 14:03:20','YYYY-MM-DD HH24:MI:SS'),100)
 ;
--- DocStatus -> flags group, grid col 11 (near-last)
+-- DocStatus
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
 VALUES (0,781760,0,549352,555516,652691 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:03:25','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Belegstatus',20,110,0,TO_TIMESTAMP('2026-07-20 14:03:25','YYYY-MM-DD HH24:MI:SS'),100)
 ;
--- AD_Org_ID -> org group, grid col 12 (last)
+-- AD_Org_ID
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
 VALUES (0,781761,0,549352,555517,652692 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:03:30','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Sektion',10,120,0,TO_TIMESTAMP('2026-07-20 14:03:30','YYYY-MM-DD HH24:MI:SS'),100)
 ;
 
--- ===========================================================================
 -- 8) Menu: reuse the window caption element for the menu label
--- ===========================================================================
 INSERT INTO AD_Menu (Action,AD_Client_ID,AD_Element_ID,AD_Menu_ID,AD_Org_ID,AD_Window_ID,Created,CreatedBy,EntityType,InternalName,IsActive,IsCreateNew,IsReadOnly,IsSOTrx,IsSummary,Name,Updated,UpdatedBy)
 VALUES ('W',0,585116,542348 /*From ID Server*/,0,542175,TO_TIMESTAMP('2026-07-20 14:03:35','YYYY-MM-DD HH24:MI:SS'),100,'D','PP_Order_CostImbalance','Y','N','Y','N','N','Kostenüberwachung Fertigung',TO_TIMESTAMP('2026-07-20 14:03:35','YYYY-MM-DD HH24:MI:SS'),100)
 ;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814680_sys_gh30811_PP_Order_CostImbalance_Window.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814680_sys_gh30811_PP_Order_CostImbalance_Window.sql
@@ -1,15 +1,10 @@
--- New read-only monitor window over PP_Order (table 53027): lists manufacturing orders
--- that are completed but not closed (DocStatus='CO'), surfacing the CostDifference
--- virtual column (AD_Column 592970) so a controller can review the WIP cost imbalance
--- before running the later distribution step.
--- IDs allocated from idserver.metas.de:
---   AD_Element 585116 (window caption), 585117 (tab caption)
---   AD_Window  542175
---   AD_Tab     549352
---   AD_Field   781749..781761 (13 fields)
---   AD_UI_Section 547860, AD_UI_Column 549604/549605, AD_UI_ElementGroup 555514..555517
---   AD_UI_Element 652680..652692 (13, same order as the fields)
---   AD_Menu    542348
+-- Read-only monitor window over PP_Order (table 53027): completed-but-not-closed orders
+-- (DocStatus='CO') with the CostDifference virtual column (AD_Column 592970), so a controller can
+-- review the WIP cost imbalance before running the distribution step.
+--
+-- IDs allocated from idserver.metas.de: AD_Element 585116/585117, AD_Window 542175, AD_Tab 549352,
+--   AD_Field 781749..781761, AD_UI_Section 547860, AD_UI_Column 549604/549605,
+--   AD_UI_ElementGroup 555514..555517, AD_UI_Element 652680..652692 (field order), AD_Menu 542348
 
 -- 1) Window caption element: DE base, EN override
 INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, EntityType, Name, PrintName, Description)
@@ -103,11 +98,9 @@ DELETE FROM AD_Element_Link WHERE AD_Tab_ID=549352
 select AD_Element_Link_Create_Missing_Tab(549352)
 ;
 
--- 5) AD_Field rows, reusing the existing column elements (no new AD_Elements
---    for standard PP_Order columns). Grid order matches the review workflow;
---    C_UOM_ID is added next to the quantities for UOM adjacency.
+-- 5) AD_Field rows, reusing the existing column elements.
 
--- 5.1 IsActive (flags group, form only, not displayed in grid)
+-- 5.1 IsActive
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
 VALUES (0,53649,781749 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:00:50','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','N','N','N','N','N','N','Aktiv',10,0,TO_TIMESTAMP('2026-07-20 14:00:50','YYYY-MM-DD HH24:MI:SS'),100)
 ;
@@ -123,7 +116,7 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID=781749
 select AD_Element_Link_Create_Missing_Field(781749)
 ;
 
--- 5.2 DocumentNo (primary group, first grid column)
+-- 5.2 DocumentNo
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
 VALUES (0,53621,781750 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:00:55','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Nr.',10,10,TO_TIMESTAMP('2026-07-20 14:00:55','YYYY-MM-DD HH24:MI:SS'),100)
 ;
@@ -139,7 +132,7 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID=781750
 select AD_Element_Link_Create_Missing_Field(781750)
 ;
 
--- 5.3 C_DocType_ID (primary group)
+-- 5.3 C_DocType_ID
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
 VALUES (0,53629,781751 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Belegart',20,20,TO_TIMESTAMP('2026-07-20 14:01:00','YYYY-MM-DD HH24:MI:SS'),100)
 ;
@@ -155,7 +148,7 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID=781751
 select AD_Element_Link_Create_Missing_Field(781751)
 ;
 
--- 5.4 M_Product_ID (primary group)
+-- 5.4 M_Product_ID
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
 VALUES (0,53623,781752 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:05','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Produkt',30,30,TO_TIMESTAMP('2026-07-20 14:01:05','YYYY-MM-DD HH24:MI:SS'),100)
 ;
@@ -171,7 +164,7 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID=781752
 select AD_Element_Link_Create_Missing_Field(781752)
 ;
 
--- 5.5 CostDifference (primary group, prominent; the key column being surfaced)
+-- 5.5 CostDifference
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
 VALUES (0,592970,781753 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:10','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Kostendifferenz',40,100,TO_TIMESTAMP('2026-07-20 14:01:10','YYYY-MM-DD HH24:MI:SS'),100)
 ;
@@ -187,7 +180,7 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID=781753
 select AD_Element_Link_Create_Missing_Field(781753)
 ;
 
--- 5.6 QtyOrdered (secondary group)
+-- 5.6 QtyOrdered
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
 VALUES (0,53670,781754 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:15','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Bestellt/ Beauftragt',10,40,TO_TIMESTAMP('2026-07-20 14:01:15','YYYY-MM-DD HH24:MI:SS'),100)
 ;
@@ -203,7 +196,7 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID=781754
 select AD_Element_Link_Create_Missing_Field(781754)
 ;
 
--- 5.7 QtyDelivered (secondary group)
+-- 5.7 QtyDelivered
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
 VALUES (0,53668,781755 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:20','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Gelieferte Menge',20,50,TO_TIMESTAMP('2026-07-20 14:01:20','YYYY-MM-DD HH24:MI:SS'),100)
 ;
@@ -219,7 +212,7 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID=781755
 select AD_Element_Link_Create_Missing_Field(781755)
 ;
 
--- 5.8 C_UOM_ID (secondary group; adjacent to the quantities above for UOM display)
+-- 5.8 C_UOM_ID
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
 VALUES (0,53632,781756 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:25','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Maßeinheit',30,60,TO_TIMESTAMP('2026-07-20 14:01:25','YYYY-MM-DD HH24:MI:SS'),100)
 ;
@@ -235,7 +228,7 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID=781756
 select AD_Element_Link_Create_Missing_Field(781756)
 ;
 
--- 5.9 DatePromised (secondary group)
+-- 5.9 DatePromised
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
 VALUES (0,53641,781757 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:30','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Zugesagter Termin',40,70,TO_TIMESTAMP('2026-07-20 14:01:30','YYYY-MM-DD HH24:MI:SS'),100)
 ;
@@ -251,7 +244,7 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID=781757
 select AD_Element_Link_Create_Missing_Field(781757)
 ;
 
--- 5.10 DateFinishSchedule (secondary group; drives the tab's default sort, most recent first)
+-- 5.10 DateFinishSchedule (drives the tab's default sort)
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,SortNo,Updated,UpdatedBy)
 VALUES (0,53639,781758 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:35','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Datum Fertigstellung geplant',50,80,-1,TO_TIMESTAMP('2026-07-20 14:01:35','YYYY-MM-DD HH24:MI:SS'),100)
 ;
@@ -267,7 +260,7 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID=781758
 select AD_Element_Link_Create_Missing_Field(781758)
 ;
 
--- 5.11 M_Warehouse_ID (secondary group)
+-- 5.11 M_Warehouse_ID
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
 VALUES (0,53624,781759 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:40','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Lager',60,90,TO_TIMESTAMP('2026-07-20 14:01:40','YYYY-MM-DD HH24:MI:SS'),100)
 ;
@@ -283,7 +276,7 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID=781759
 select AD_Element_Link_Create_Missing_Field(781759)
 ;
 
--- 5.12 DocStatus (flags group; shown as a column even though the tab's WhereClause already scopes to CO)
+-- 5.12 DocStatus (kept as a grid column although the tab is already scoped to CO)
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
 VALUES (0,53646,781760 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:45','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Belegstatus',20,110,TO_TIMESTAMP('2026-07-20 14:01:45','YYYY-MM-DD HH24:MI:SS'),100)
 ;
@@ -299,7 +292,7 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID=781760
 select AD_Element_Link_Create_Missing_Field(781760)
 ;
 
--- 5.13 AD_Org_ID (org group; last field, last grid column per the org-last rule)
+-- 5.13 AD_Org_ID (last, per the org-last layout rule)
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
 VALUES (0,53683,781761 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:50','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Sektion',10,120,TO_TIMESTAMP('2026-07-20 14:01:50','YYYY-MM-DD HH24:MI:SS'),100)
 ;
@@ -351,7 +344,7 @@ INSERT INTO AD_UI_ElementGroup (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_Ele
 VALUES (0,0,549605,555517 /*From ID Server*/,TO_TIMESTAMP('2026-07-20 14:02:25','YYYY-MM-DD HH24:MI:SS'),100,'Y','default',20,NULL,TO_TIMESTAMP('2026-07-20 14:02:25','YYYY-MM-DD HH24:MI:SS'),100)
 ;
 
--- 7) AD_UI_Element rows (one per field). All are grid-displayed except IsActive.
+-- 7) AD_UI_Element rows, one per field; all grid-displayed except IsActive.
 
 -- IsActive
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814680_sys_gh30811_PP_Order_CostImbalance_Window.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814680_sys_gh30811_PP_Order_CostImbalance_Window.sql
@@ -1,0 +1,443 @@
+-- New read-only monitor window over PP_Order (table 53027): lists manufacturing orders
+-- that are completed but not closed (DocStatus='CO'), surfacing the CostDifference
+-- virtual column (AD_Column 592970) so a controller can review the WIP cost imbalance
+-- before running the later distribution step.
+-- IDs allocated from idserver.metas.de:
+--   AD_Element 585116 (window caption), 585117 (tab caption)
+--   AD_Window  542175
+--   AD_Tab     549352
+--   AD_Field   781749..781761 (13 fields)
+--   AD_UI_Section 547860, AD_UI_Column 549604/549605, AD_UI_ElementGroup 555514..555517
+--   AD_UI_Element 652680..652692 (13, same order as the fields)
+--   AD_Menu    542348
+
+-- ===========================================================================
+-- 1) Window caption element: DE base, EN override
+-- ===========================================================================
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, EntityType, Name, PrintName, Description)
+VALUES (585116 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-20 14:00:00','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-20 14:00:00','YYYY-MM-DD HH24:MI:SS'), 100, 'D', 'Kostenüberwachung Fertigung', 'Kostenüberwachung Fertigung', 'Fertigungsaufträge, die abgeschlossen aber noch nicht geschlossen sind, mit Kostendifferenz')
+;
+
+INSERT INTO AD_Element_Trl (AD_Element_ID, AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Name, PrintName, Description, IsTranslated)
+SELECT t.AD_Element_ID, l.AD_Language, t.AD_Client_ID, t.AD_Org_ID, 'Y', t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, t.Name, t.PrintName, t.Description, 'N'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Element_ID=585116
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+UPDATE AD_Element_Trl SET Name='Manufacturing cost monitoring', PrintName='Manufacturing cost monitoring',
+    Description='Manufacturing orders that are completed but not closed, showing the cost difference',
+    IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-20 14:00:05','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585116 AND AD_Language='en_US'
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-20 14:00:10','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585116 AND AD_Language='de_DE'
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-20 14:00:15','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585116 AND AD_Language='de_CH'
+;
+
+-- ===========================================================================
+-- 2) AD_Window
+-- ===========================================================================
+INSERT INTO AD_Window (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Window_ID,Created,CreatedBy,EntityType,IsActive,IsBetaFunctionality,IsDefault,IsEnableRemoteCacheInvalidation,IsExcludeFromZoomTargets,IsOneInstanceOnly,IsOverrideInMenu,IsSOTrx,Name,Processing,Updated,UpdatedBy,WindowType,WinHeight,WinWidth,ZoomIntoPriority)
+VALUES (0,585116 /*From ID Server*/,0,542175 /*From ID Server*/,TO_TIMESTAMP('2026-07-20 14:00:20','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','N','N','N','N','N','N','N','Kostenüberwachung Fertigung','N',TO_TIMESTAMP('2026-07-20 14:00:20','YYYY-MM-DD HH24:MI:SS'),100,'M',0,0,100)
+;
+
+INSERT INTO AD_Window_Trl (AD_Language,AD_Window_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Window_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Window t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Window_ID=542175
+  AND NOT EXISTS (SELECT 1 FROM AD_Window_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Window_ID=t.AD_Window_ID)
+;
+
+select update_window_translation_from_ad_element(585116)
+;
+
+DELETE FROM AD_Element_Link WHERE AD_Window_ID=542175
+;
+select AD_Element_Link_Create_Missing_Window(542175)
+;
+
+-- ===========================================================================
+-- 3) Tab caption element: DE base, EN override
+-- ===========================================================================
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, EntityType, Name, PrintName, Description)
+VALUES (585117 /*From ID Server*/, 0, 0, 'Y', TO_TIMESTAMP('2026-07-20 14:00:25','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-20 14:00:25','YYYY-MM-DD HH24:MI:SS'), 100, 'D', 'Fertigungsaufträge', 'Fertigungsaufträge', 'Fertigungsaufträge mit Status abgeschlossen, die noch nicht geschlossen sind')
+;
+
+INSERT INTO AD_Element_Trl (AD_Element_ID, AD_Language, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy, Name, PrintName, Description, IsTranslated)
+SELECT t.AD_Element_ID, l.AD_Language, t.AD_Client_ID, t.AD_Org_ID, 'Y', t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, t.Name, t.PrintName, t.Description, 'N'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Element_ID=585117
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+UPDATE AD_Element_Trl SET Name='Manufacturing orders', PrintName='Manufacturing orders',
+    Description='Manufacturing orders with document status Completed that are not yet closed',
+    IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-20 14:00:30','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585117 AND AD_Language='en_US'
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-20 14:00:35','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585117 AND AD_Language='de_DE'
+;
+
+UPDATE AD_Element_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-20 14:00:40','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585117 AND AD_Language='de_CH'
+;
+
+-- ===========================================================================
+-- 4) AD_Tab (TabLevel=0, over PP_Order, read-only, DocStatus='CO')
+-- ===========================================================================
+INSERT INTO AD_Tab (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Tab_ID,AD_Table_ID,AD_Window_ID,AllowQuickInput,Created,CreatedBy,EntityType,HasTree,ImportFields,IncludedTabNewRecordInputMode,IsActive,IsAdvancedTab,IsAutodetectDefaultDateFilter,IsGenericZoomTarget,IsGridModeOnly,IsInsertRecord,IsReadOnly,IsRefreshAllOnActivate,IsRefreshViewOnChangeEvents,IsSearchCollapsed,IsSingleRow,IsSortTab,IsTranslationTab,Name,Processing,SeqNo,TabLevel,Updated,UpdatedBy,WhereClause)
+VALUES (0,585117 /*From ID Server*/,0,549352 /*From ID Server*/,53027,542175,'N',TO_TIMESTAMP('2026-07-20 14:00:45','YYYY-MM-DD HH24:MI:SS'),100,'D','N','N','A','Y','N','Y','N','N','N','Y','N','N','Y','Y','N','N','Fertigungsaufträge','N',10,0,TO_TIMESTAMP('2026-07-20 14:00:45','YYYY-MM-DD HH24:MI:SS'),100,'DocStatus=''CO''')
+;
+
+INSERT INTO AD_Tab_Trl (AD_Language,AD_Tab_ID, CommitWarning,Description,Help,Name,QuickInput_CloseButton_Caption,QuickInput_OpenButton_Caption, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Tab_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.QuickInput_CloseButton_Caption,t.QuickInput_OpenButton_Caption, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Tab t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Tab_ID=549352
+  AND NOT EXISTS (SELECT 1 FROM AD_Tab_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Tab_ID=t.AD_Tab_ID)
+;
+
+select update_tab_translation_from_ad_element(585117)
+;
+
+DELETE FROM AD_Element_Link WHERE AD_Tab_ID=549352
+;
+select AD_Element_Link_Create_Missing_Tab(549352)
+;
+
+-- ===========================================================================
+-- 5) AD_Field rows, reusing the existing column elements (no new AD_Elements
+--    for standard PP_Order columns). Grid order matches the review workflow;
+--    C_UOM_ID is added next to the quantities for UOM adjacency.
+-- ===========================================================================
+
+-- 5.1 IsActive (flags group, form only, not displayed in grid)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,53649,781749 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:00:50','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','N','N','N','N','N','N','Aktiv',10,0,TO_TIMESTAMP('2026-07-20 14:00:50','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781749
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+select update_FieldTranslation_From_AD_Name_Element(348)
+;
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781749
+;
+select AD_Element_Link_Create_Missing_Field(781749)
+;
+
+-- 5.2 DocumentNo (primary group, first grid column)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,53621,781750 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:00:55','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Nr.',10,10,TO_TIMESTAMP('2026-07-20 14:00:55','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781750
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+select update_FieldTranslation_From_AD_Name_Element(290)
+;
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781750
+;
+select AD_Element_Link_Create_Missing_Field(781750)
+;
+
+-- 5.3 C_DocType_ID (primary group)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,53629,781751 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Belegart',20,20,TO_TIMESTAMP('2026-07-20 14:01:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781751
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+select update_FieldTranslation_From_AD_Name_Element(196)
+;
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781751
+;
+select AD_Element_Link_Create_Missing_Field(781751)
+;
+
+-- 5.4 M_Product_ID (primary group)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,53623,781752 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:05','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Produkt',30,30,TO_TIMESTAMP('2026-07-20 14:01:05','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781752
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+select update_FieldTranslation_From_AD_Name_Element(454)
+;
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781752
+;
+select AD_Element_Link_Create_Missing_Field(781752)
+;
+
+-- 5.5 CostDifference (primary group, prominent; the key column being surfaced)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,592970,781753 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:10','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Kostendifferenz',40,100,TO_TIMESTAMP('2026-07-20 14:01:10','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781753
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+select update_FieldTranslation_From_AD_Name_Element(585115)
+;
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781753
+;
+select AD_Element_Link_Create_Missing_Field(781753)
+;
+
+-- 5.6 QtyOrdered (secondary group)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,53670,781754 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:15','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Bestellt/ Beauftragt',10,40,TO_TIMESTAMP('2026-07-20 14:01:15','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781754
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+select update_FieldTranslation_From_AD_Name_Element(531)
+;
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781754
+;
+select AD_Element_Link_Create_Missing_Field(781754)
+;
+
+-- 5.7 QtyDelivered (secondary group)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,53668,781755 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:20','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Gelieferte Menge',20,50,TO_TIMESTAMP('2026-07-20 14:01:20','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781755
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+select update_FieldTranslation_From_AD_Name_Element(528)
+;
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781755
+;
+select AD_Element_Link_Create_Missing_Field(781755)
+;
+
+-- 5.8 C_UOM_ID (secondary group; adjacent to the quantities above for UOM display)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,53632,781756 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:25','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Maßeinheit',30,60,TO_TIMESTAMP('2026-07-20 14:01:25','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781756
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+select update_FieldTranslation_From_AD_Name_Element(215)
+;
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781756
+;
+select AD_Element_Link_Create_Missing_Field(781756)
+;
+
+-- 5.9 DatePromised (secondary group)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,53641,781757 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:30','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Zugesagter Termin',40,70,TO_TIMESTAMP('2026-07-20 14:01:30','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781757
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+select update_FieldTranslation_From_AD_Name_Element(269)
+;
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781757
+;
+select AD_Element_Link_Create_Missing_Field(781757)
+;
+
+-- 5.10 DateFinishSchedule (secondary group; drives the tab's default sort, most recent first)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,SortNo,Updated,UpdatedBy)
+VALUES (0,53639,781758 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:35','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Datum Fertigstellung geplant',50,80,-1,TO_TIMESTAMP('2026-07-20 14:01:35','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781758
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+select update_FieldTranslation_From_AD_Name_Element(53278)
+;
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781758
+;
+select AD_Element_Link_Create_Missing_Field(781758)
+;
+
+-- 5.11 M_Warehouse_ID (secondary group)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,53624,781759 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:40','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Lager',60,90,TO_TIMESTAMP('2026-07-20 14:01:40','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781759
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+select update_FieldTranslation_From_AD_Name_Element(459)
+;
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781759
+;
+select AD_Element_Link_Create_Missing_Field(781759)
+;
+
+-- 5.12 DocStatus (flags group; shown as a column even though the tab's WhereClause already scopes to CO)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,53646,781760 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:45','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Belegstatus',20,110,TO_TIMESTAMP('2026-07-20 14:01:45','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781760
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+select update_FieldTranslation_From_AD_Name_Element(289)
+;
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781760
+;
+select AD_Element_Link_Create_Missing_Field(781760)
+;
+
+-- 5.13 AD_Org_ID (org group; last field, last grid column per the org-last rule)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,53683,781761 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-07-20 14:01:50','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','Y','N','N','N','N','N','Sektion',10,120,TO_TIMESTAMP('2026-07-20 14:01:50','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=781761
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+select update_FieldTranslation_From_AD_Name_Element(113)
+;
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781761
+;
+select AD_Element_Link_Create_Missing_Field(781761)
+;
+
+-- ===========================================================================
+-- 6) Layout: 1 section, 2 columns (left/right), 4 element groups
+-- ===========================================================================
+INSERT INTO AD_UI_Section (AD_Client_ID,AD_Org_ID,AD_Tab_ID,AD_UI_Section_ID,Created,CreatedBy,IsActive,SeqNo,Updated,UpdatedBy,Value)
+VALUES (0,0,549352,547860 /*From ID Server*/,TO_TIMESTAMP('2026-07-20 14:01:55','YYYY-MM-DD HH24:MI:SS'),100,'Y',10,TO_TIMESTAMP('2026-07-20 14:01:55','YYYY-MM-DD HH24:MI:SS'),100,'main')
+;
+INSERT INTO AD_UI_Section_Trl (AD_Language,AD_UI_Section_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_UI_Section_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_UI_Section t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_UI_Section_ID=547860
+  AND NOT EXISTS (SELECT 1 FROM AD_UI_Section_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_UI_Section_ID=t.AD_UI_Section_ID)
+;
+
+-- Left column
+INSERT INTO AD_UI_Column (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_Section_ID,Created,CreatedBy,IsActive,SeqNo,Updated,UpdatedBy)
+VALUES (0,0,549604 /*From ID Server*/,547860,TO_TIMESTAMP('2026-07-20 14:02:00','YYYY-MM-DD HH24:MI:SS'),100,'Y',10,TO_TIMESTAMP('2026-07-20 14:02:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- Right column
+INSERT INTO AD_UI_Column (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_Section_ID,Created,CreatedBy,IsActive,SeqNo,Updated,UpdatedBy)
+VALUES (0,0,549605 /*From ID Server*/,547860,TO_TIMESTAMP('2026-07-20 14:02:05','YYYY-MM-DD HH24:MI:SS'),100,'Y',20,TO_TIMESTAMP('2026-07-20 14:02:05','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- Left column, group 1 (primary): DocumentNo, C_DocType_ID, M_Product_ID, CostDifference
+INSERT INTO AD_UI_ElementGroup (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_ElementGroup_ID,Created,CreatedBy,IsActive,Name,SeqNo,UIStyle,Updated,UpdatedBy)
+VALUES (0,0,549604,555514 /*From ID Server*/,TO_TIMESTAMP('2026-07-20 14:02:10','YYYY-MM-DD HH24:MI:SS'),100,'Y','default',10,'primary',TO_TIMESTAMP('2026-07-20 14:02:10','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- Left column, group 2: quantities/dates/warehouse
+INSERT INTO AD_UI_ElementGroup (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_ElementGroup_ID,Created,CreatedBy,IsActive,Name,SeqNo,UIStyle,Updated,UpdatedBy)
+VALUES (0,0,549604,555515 /*From ID Server*/,TO_TIMESTAMP('2026-07-20 14:02:15','YYYY-MM-DD HH24:MI:SS'),100,'Y','default',20,NULL,TO_TIMESTAMP('2026-07-20 14:02:15','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- Right column, group 1: flags (IsActive first, then DocStatus)
+INSERT INTO AD_UI_ElementGroup (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_ElementGroup_ID,Created,CreatedBy,IsActive,Name,SeqNo,UIStyle,Updated,UpdatedBy)
+VALUES (0,0,549605,555516 /*From ID Server*/,TO_TIMESTAMP('2026-07-20 14:02:20','YYYY-MM-DD HH24:MI:SS'),100,'Y','flags',10,NULL,TO_TIMESTAMP('2026-07-20 14:02:20','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- Right column, group 2: org (last)
+INSERT INTO AD_UI_ElementGroup (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_ElementGroup_ID,Created,CreatedBy,IsActive,Name,SeqNo,UIStyle,Updated,UpdatedBy)
+VALUES (0,0,549605,555517 /*From ID Server*/,TO_TIMESTAMP('2026-07-20 14:02:25','YYYY-MM-DD HH24:MI:SS'),100,'Y','default',20,NULL,TO_TIMESTAMP('2026-07-20 14:02:25','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- ===========================================================================
+-- 7) AD_UI_Element rows (one per field). All are grid-displayed except IsActive.
+-- ===========================================================================
+
+-- IsActive -> flags group, form only
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781749,0,549352,555516,652680 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:02:30','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','N','N','Aktiv',10,0,0,TO_TIMESTAMP('2026-07-20 14:02:30','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- DocumentNo -> primary group, grid col 1
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781750,0,549352,555514,652681 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:02:35','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Nr.',10,10,0,TO_TIMESTAMP('2026-07-20 14:02:35','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- C_DocType_ID -> primary group, grid col 2
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781751,0,549352,555514,652682 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:02:40','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Belegart',20,20,0,TO_TIMESTAMP('2026-07-20 14:02:40','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- M_Product_ID -> primary group, grid col 3
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781752,0,549352,555514,652683 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:02:45','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Produkt',30,30,0,TO_TIMESTAMP('2026-07-20 14:02:45','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- CostDifference -> primary group (prominent), grid col 10
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781753,0,549352,555514,652684 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:02:50','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Kostendifferenz',40,100,0,TO_TIMESTAMP('2026-07-20 14:02:50','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- QtyOrdered -> secondary group, grid col 4
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781754,0,549352,555515,652685 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:02:55','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Bestellt/ Beauftragt',10,40,0,TO_TIMESTAMP('2026-07-20 14:02:55','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- QtyDelivered -> secondary group, grid col 5
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781755,0,549352,555515,652686 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:03:00','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Gelieferte Menge',20,50,0,TO_TIMESTAMP('2026-07-20 14:03:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- C_UOM_ID -> secondary group, grid col 6 (adjacent to the quantities)
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781756,0,549352,555515,652687 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:03:05','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Maßeinheit',30,60,0,TO_TIMESTAMP('2026-07-20 14:03:05','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- DatePromised -> secondary group, grid col 7
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781757,0,549352,555515,652688 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:03:10','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Zugesagter Termin',40,70,0,TO_TIMESTAMP('2026-07-20 14:03:10','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- DateFinishSchedule -> secondary group, grid col 8
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781758,0,549352,555515,652689 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:03:15','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Datum Fertigstellung geplant',50,80,0,TO_TIMESTAMP('2026-07-20 14:03:15','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- M_Warehouse_ID -> secondary group, grid col 9
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781759,0,549352,555515,652690 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:03:20','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Lager',60,90,0,TO_TIMESTAMP('2026-07-20 14:03:20','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- DocStatus -> flags group, grid col 11 (near-last)
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781760,0,549352,555516,652691 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:03:25','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Belegstatus',20,110,0,TO_TIMESTAMP('2026-07-20 14:03:25','YYYY-MM-DD HH24:MI:SS'),100)
+;
+-- AD_Org_ID -> org group, grid col 12 (last)
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781761,0,549352,555517,652692 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-20 14:03:30','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Sektion',10,120,0,TO_TIMESTAMP('2026-07-20 14:03:30','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- ===========================================================================
+-- 8) Menu: reuse the window caption element for the menu label
+-- ===========================================================================
+INSERT INTO AD_Menu (Action,AD_Client_ID,AD_Element_ID,AD_Menu_ID,AD_Org_ID,AD_Window_ID,Created,CreatedBy,EntityType,InternalName,IsActive,IsCreateNew,IsReadOnly,IsSOTrx,IsSummary,Name,Updated,UpdatedBy)
+VALUES ('W',0,585116,542348 /*From ID Server*/,0,542175,TO_TIMESTAMP('2026-07-20 14:03:35','YYYY-MM-DD HH24:MI:SS'),100,'D','PP_Order_CostImbalance','Y','N','Y','N','N','Kostenüberwachung Fertigung',TO_TIMESTAMP('2026-07-20 14:03:35','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Menu_Trl (AD_Language,AD_Menu_ID, Description,Name,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Menu_ID, t.Description,t.Name,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Menu t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Menu_ID=542348
+  AND NOT EXISTS (SELECT 1 FROM AD_Menu_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Menu_ID=t.AD_Menu_ID)
+;
+select update_menu_translation_from_ad_element(585116)
+;
+
+-- Tree placement: under "Produktion" (Node_ID 1000014), next free SeqNo in that folder
+INSERT INTO AD_TreeNodeMM (AD_Client_ID,AD_Org_ID, IsActive,Created,CreatedBy,Updated,UpdatedBy, AD_Tree_ID, Node_ID, Parent_ID, SeqNo)
+SELECT t.AD_Client_ID,0, 'Y', TO_TIMESTAMP('2026-07-20 14:03:40','YYYY-MM-DD HH24:MI:SS'), 100, TO_TIMESTAMP('2026-07-20 14:03:40','YYYY-MM-DD HH24:MI:SS'), 100, t.AD_Tree_ID, 542348, 1000014, 7
+FROM AD_Tree t
+WHERE t.AD_Client_ID=0 AND t.IsActive='Y' AND t.IsAllNodes='Y' AND t.AD_Table_ID=116
+  AND NOT EXISTS (SELECT 1 FROM AD_TreeNodeMM e WHERE e.AD_Tree_ID=t.AD_Tree_ID AND e.Node_ID=542348)
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814690_sys_gh30811_PP_Order_CostImbalance_Window_ExcludeZoomTarget.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814690_sys_gh30811_PP_Order_CostImbalance_Window_ExcludeZoomTarget.sql
@@ -1,8 +1,6 @@
--- The PP_Order cost-imbalance monitor window (542175) is a narrow, read-only,
--- DocStatus-filtered reporting view over PP_Order. Two other windows already
--- expose PP_Order at TabLevel=0 as general-purpose zoom targets (53009, 540328);
--- excluding this monitor from auto-discovered zoom targets avoids it competing
--- with those in a Related-Documents panel for anything with an FK into PP_Order.
+-- Two windows already expose PP_Order at TabLevel=0 as general-purpose zoom targets (53009, 540328).
+-- Excluding this narrow, DocStatus-filtered monitor keeps it from competing with them in a
+-- Related-Documents panel.
 UPDATE AD_Window
 SET IsExcludeFromZoomTargets='Y', Updated=TO_TIMESTAMP('2026-07-20 14:05:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Window_ID=542175

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814690_sys_gh30811_PP_Order_CostImbalance_Window_ExcludeZoomTarget.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814690_sys_gh30811_PP_Order_CostImbalance_Window_ExcludeZoomTarget.sql
@@ -1,0 +1,9 @@
+-- The PP_Order cost-imbalance monitor window (542175) is a narrow, read-only,
+-- DocStatus-filtered reporting view over PP_Order. Two other windows already
+-- expose PP_Order at TabLevel=0 as general-purpose zoom targets (53009, 540328);
+-- excluding this monitor from auto-discovered zoom targets avoids it competing
+-- with those in a Related-Documents panel for anything with an FK into PP_Order.
+UPDATE AD_Window
+SET IsExcludeFromZoomTargets='Y', Updated=TO_TIMESTAMP('2026-07-20 14:05:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Window_ID=542175
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814720_sys_gh30811_PP_Order_CostImbalance_Window_GridOrder.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814720_sys_gh30811_PP_Order_CostImbalance_Window_GridOrder.sql
@@ -1,10 +1,6 @@
--- Surface CostDifference prominently in the cost-imbalance monitor grid.
--- The window exists to let a controller scan completed-not-closed orders for their WIP cost
--- imbalance, so the CostDifference column must sit near the front of the grid — not after the
--- quantity/date/warehouse columns. Move its grid position from SeqNoGrid=100 to 35, right after
--- M_Product_ID (30) and before QtyOrdered (40), matching its form position (4th). Form order
--- (SeqNo) and the other columns are unchanged. AD_UI_Element has no _Trl and no propagation
--- dependency, so a direct UPDATE is correct.
+-- CostDifference is the column the cost-imbalance monitor exists for, so it belongs near the front of
+-- the grid: move it from SeqNoGrid=100 to 35, between M_Product_ID (30) and QtyOrdered (40). Form order
+-- and the other columns are unchanged.
 UPDATE AD_UI_Element SET SeqNoGrid=35,
        Updated=TO_TIMESTAMP('2026-07-20 23:49:54','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_UI_Element_ID=652684

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814720_sys_gh30811_PP_Order_CostImbalance_Window_GridOrder.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814720_sys_gh30811_PP_Order_CostImbalance_Window_GridOrder.sql
@@ -1,6 +1,5 @@
 -- CostDifference is the column the cost-imbalance monitor exists for, so it belongs near the front of
--- the grid: move it from SeqNoGrid=100 to 35, between M_Product_ID (30) and QtyOrdered (40). Form order
--- and the other columns are unchanged.
+-- the grid: between M_Product_ID (30) and QtyOrdered (40).
 UPDATE AD_UI_Element SET SeqNoGrid=35,
        Updated=TO_TIMESTAMP('2026-07-20 23:49:54','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_UI_Element_ID=652684

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814720_sys_gh30811_PP_Order_CostImbalance_Window_GridOrder.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814720_sys_gh30811_PP_Order_CostImbalance_Window_GridOrder.sql
@@ -1,0 +1,11 @@
+-- Surface CostDifference prominently in the cost-imbalance monitor grid.
+-- The window exists to let a controller scan completed-not-closed orders for their WIP cost
+-- imbalance, so the CostDifference column must sit near the front of the grid — not after the
+-- quantity/date/warehouse columns. Move its grid position from SeqNoGrid=100 to 35, right after
+-- M_Product_ID (30) and before QtyOrdered (40), matching its form position (4th). Form order
+-- (SeqNo) and the other columns are unchanged. AD_UI_Element has no _Trl and no propagation
+-- dependency, so a direct UPDATE is correct.
+UPDATE AD_UI_Element SET SeqNoGrid=35,
+       Updated=TO_TIMESTAMP('2026-07-20 10:10:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_UI_Element_ID=652684
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814720_sys_gh30811_PP_Order_CostImbalance_Window_GridOrder.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814720_sys_gh30811_PP_Order_CostImbalance_Window_GridOrder.sql
@@ -6,6 +6,6 @@
 -- (SeqNo) and the other columns are unchanged. AD_UI_Element has no _Trl and no propagation
 -- dependency, so a direct UPDATE is correct.
 UPDATE AD_UI_Element SET SeqNoGrid=35,
-       Updated=TO_TIMESTAMP('2026-07-20 10:10:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+       Updated=TO_TIMESTAMP('2026-07-20 23:49:54','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_UI_Element_ID=652684
 ;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814990_sys_gh30811_PP_Order_CostImbalance_Window_GridOrder_Field.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814990_sys_gh30811_PP_Order_CostImbalance_Window_GridOrder_Field.sql
@@ -1,6 +1,5 @@
--- The cost-imbalance monitor tab (AD_Tab 549352) has a persisted AD_UI_Section, so both grid orderings
--- are live: the WebUI reads AD_UI_Element.SeqNoGrid, the Swing client reads AD_Field.SeqNoGrid. Mirror
--- CostDifference's grid position onto the AD_Field layer (slot 35 is free: 30=M_Product_ID, 40=QtyOrdered).
+-- Both grid orderings are live on this tab: the WebUI reads AD_UI_Element.SeqNoGrid, the Swing client
+-- reads AD_Field.SeqNoGrid. Mirror CostDifference's grid position onto the AD_Field layer.
 
 UPDATE AD_Field SET SeqNoGrid=35,
        Updated=TO_TIMESTAMP('2026-07-21 00:40:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814990_sys_gh30811_PP_Order_CostImbalance_Window_GridOrder_Field.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814990_sys_gh30811_PP_Order_CostImbalance_Window_GridOrder_Field.sql
@@ -1,11 +1,6 @@
--- Mirror the CostDifference grid-column position onto the AD_Field layer.
---
--- The cost-imbalance monitor tab (AD_Tab 549352) has a persisted AD_UI_Section, so both grid
--- orderings are live: the WebUI reads AD_UI_Element.SeqNoGrid, the legacy Swing client reads
--- AD_Field.SeqNoGrid. An earlier fix moved the CostDifference AD_UI_Element (652684) to
--- SeqNoGrid=35 (right after M_Product_ID) for the WebUI, but left the sibling AD_Field (781753)
--- at 100, so the Swing client still rendered CostDifference last. Set AD_Field.SeqNoGrid=35 to
--- match (slot 35 is free on the AD_Field layer: siblings are 30=M_Product_ID, 40=QtyOrdered).
+-- The cost-imbalance monitor tab (AD_Tab 549352) has a persisted AD_UI_Section, so both grid orderings
+-- are live: the WebUI reads AD_UI_Element.SeqNoGrid, the Swing client reads AD_Field.SeqNoGrid. Mirror
+-- CostDifference's grid position onto the AD_Field layer (slot 35 is free: 30=M_Product_ID, 40=QtyOrdered).
 
 UPDATE AD_Field SET SeqNoGrid=35,
        Updated=TO_TIMESTAMP('2026-07-21 00:40:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814990_sys_gh30811_PP_Order_CostImbalance_Window_GridOrder_Field.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5814990_sys_gh30811_PP_Order_CostImbalance_Window_GridOrder_Field.sql
@@ -1,0 +1,13 @@
+-- Mirror the CostDifference grid-column position onto the AD_Field layer.
+--
+-- The cost-imbalance monitor tab (AD_Tab 549352) has a persisted AD_UI_Section, so both grid
+-- orderings are live: the WebUI reads AD_UI_Element.SeqNoGrid, the legacy Swing client reads
+-- AD_Field.SeqNoGrid. An earlier fix moved the CostDifference AD_UI_Element (652684) to
+-- SeqNoGrid=35 (right after M_Product_ID) for the WebUI, but left the sibling AD_Field (781753)
+-- at 100, so the Swing client still rendered CostDifference last. Set AD_Field.SeqNoGrid=35 to
+-- match (slot 35 is free on the AD_Field layer: siblings are 30=M_Product_ID, 40=QtyOrdered).
+
+UPDATE AD_Field SET SeqNoGrid=35,
+       Updated=TO_TIMESTAMP('2026-07-21 00:40:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Field_ID=781753
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820560_gh30811_PP_Order_CostDifference_NetDistributed.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820560_gh30811_PP_Order_CostDifference_NetDistributed.sql
@@ -1,0 +1,41 @@
+-- Nets already-distributed amounts out of the virtual column PP_Order.CostDifference (AD_Column 592970).
+--
+-- The column shows the order's WIP cost imbalance as received-minus-issued. Once a controller discharges
+-- that imbalance, the order must stop reporting it, otherwise the cost-imbalance monitor keeps listing
+-- orders that have already been dealt with.
+--
+-- The discharged amount is the MAIN leg of the cost details of the order's cost-difference-distribution
+-- collectors, which carries issued-minus-received - the exact negation of what the first two summands
+-- produce, so a fully discharged order reads 0. Reversing such a collector stores the negated legs under
+-- the same collector type, so the sum cancels itself and the column reports the gross imbalance again.
+--
+-- The third summand contributes nothing until cost-difference-distribution collectors exist.
+
+UPDATE AD_Column SET ColumnSQL=
+'(coalesce((select sum(oc.postcalculationamt)
+   from pp_order_cost oc
+   join c_acctschema acs on acs.c_acctschema_id = oc.c_acctschema_id
+    and acs.c_acctschema_id = (select ci.c_acctschema1_id from ad_clientinfo ci where ci.ad_client_id = PP_Order.AD_Client_ID)
+   join m_costelement ce on ce.m_costelement_id = oc.m_costelement_id and ce.costingmethod = acs.costingmethod
+   where oc.pp_order_id = PP_Order.PP_Order_ID and oc.pp_order_cost_trxtype in (''MR'',''CO'',''BY'')), 0)
+ -
+ coalesce((select sum(-oc.cumulatedqty * (coalesce(oc.currentcostprice,0) + coalesce(oc.currentcostpricell,0)))
+   from pp_order_cost oc
+   join c_acctschema acs on acs.c_acctschema_id = oc.c_acctschema_id
+    and acs.c_acctschema_id = (select ci.c_acctschema1_id from ad_clientinfo ci where ci.ad_client_id = PP_Order.AD_Client_ID)
+   join m_costelement ce on ce.m_costelement_id = oc.m_costelement_id and ce.costingmethod = acs.costingmethod
+   where oc.pp_order_id = PP_Order.PP_Order_ID and oc.pp_order_cost_trxtype = ''MI''), 0)
+ +
+ coalesce((select sum(cd.amt)
+   from m_costdetail cd
+   join pp_cost_collector cc on cc.pp_cost_collector_id = cd.pp_cost_collector_id
+   join c_acctschema acs on acs.c_acctschema_id = cd.c_acctschema_id
+    and acs.c_acctschema_id = (select ci.c_acctschema1_id from ad_clientinfo ci where ci.ad_client_id = PP_Order.AD_Client_ID)
+   join m_costelement ce on ce.m_costelement_id = cd.m_costelement_id and ce.costingmethod = acs.costingmethod
+   where cc.pp_order_id = PP_Order.PP_Order_ID
+     and cc.costcollectortype = ''170''
+     and cd.m_costdetail_type = ''M''), 0)
+)',
+    Updated=TO_TIMESTAMP('2026-08-27 09:30:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Column_ID=592970
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820560_gh30811_PP_Order_CostDifference_NetDistributed.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820560_gh30811_PP_Order_CostDifference_NetDistributed.sql
@@ -1,15 +1,10 @@
--- Nets already-distributed amounts out of the virtual column PP_Order.CostDifference (AD_Column 592970).
+-- Nets already-discharged amounts out of PP_Order.CostDifference (AD_Column 592970), so the cost-imbalance
+-- monitor stops listing orders a controller has already dealt with.
 --
--- The column shows the order's WIP cost imbalance as received-minus-issued. Once a controller discharges
--- that imbalance, the order must stop reporting it, otherwise the cost-imbalance monitor keeps listing
--- orders that have already been dealt with.
---
--- The discharged amount is the MAIN leg of the cost details of the order's cost-difference-distribution
--- collectors, which carries issued-minus-received - the exact negation of what the first two summands
--- produce, so a fully discharged order reads 0. Reversing such a collector stores the negated legs under
--- the same collector type, so the sum cancels itself and the column reports the gross imbalance again.
---
--- The third summand contributes nothing until cost-difference-distribution collectors exist.
+-- The discharged amount is the MAIN cost detail of the order's cost-difference-distribution collectors
+-- (type 170), carrying issued-minus-received, so a fully discharged order reads 0. Reversing such a
+-- collector stores the negated legs under the same type, so the sum cancels and the gross imbalance
+-- is reported again.
 
 UPDATE AD_Column SET ColumnSQL=
 '(coalesce((select sum(oc.postcalculationamt)

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820570_gh30811_PP_Cost_Collector_PP_Order_ID_index.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820570_gh30811_PP_Cost_Collector_PP_Order_ID_index.sql
@@ -1,8 +1,13 @@
 -- PP_Cost_Collector carries only its primary key and a partial index for unposted rows, so a "collectors of
--- this order" lookup otherwise scans the whole table. The virtual column PP_Order.CostDifference does one such
--- lookup per row it renders, which makes a grid over completed orders scan that table once per line.
+-- this order" lookup otherwise scans the whole table. The Kostensammler tab of the production-order window
+-- (AD_Tab 53053) does exactly that lookup every time an order is opened, and the cost-collector creation in the
+-- post-calculation action does it again per run.
 --
 -- PP_Order_ID is highly selective - an order has a handful of collectors out of tens of thousands - so a plain
 -- btree turns each of those scans into a two-row index lookup.
+--
+-- Measured on a customer-flavored local stack while PP_Order.CostDifference still joined PP_Cost_Collector:
+-- ~1.4 s/page before, sub-second after. That summand has since been dropped from the column (see 5820790),
+-- so the column itself no longer touches this table; the index is kept for the lookups named above.
 
 CREATE INDEX IF NOT EXISTS PP_Cost_Collector_PP_Order_ID ON PP_Cost_Collector (PP_Order_ID);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820570_gh30811_PP_Cost_Collector_PP_Order_ID_index.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820570_gh30811_PP_Cost_Collector_PP_Order_ID_index.sql
@@ -1,13 +1,6 @@
--- PP_Cost_Collector carries only its primary key and a partial index for unposted rows, so a "collectors of
--- this order" lookup otherwise scans the whole table. The Kostensammler tab of the production-order window
--- (AD_Tab 53053) does exactly that lookup every time an order is opened, and the cost-collector creation in the
--- post-calculation action does it again per run.
---
--- PP_Order_ID is highly selective - an order has a handful of collectors out of tens of thousands - so a plain
--- btree turns each of those scans into a two-row index lookup.
---
--- Measured on a customer-flavored local stack while PP_Order.CostDifference still joined PP_Cost_Collector:
--- ~1.4 s/page before, sub-second after. That summand has since been dropped from the column (see 5820790),
--- so the column itself no longer touches this table; the index is kept for the lookups named above.
+-- PP_Cost_Collector has only its primary key and a partial index for unposted rows, so a "collectors of
+-- this order" lookup scans the whole table. The Kostensammler tab of the production-order window
+-- (AD_Tab 53053) does that lookup on every order open, and the post-calculation action once per run.
+-- PP_Order_ID is highly selective, so a plain btree turns those scans into index lookups.
 
 CREATE INDEX IF NOT EXISTS PP_Cost_Collector_PP_Order_ID ON PP_Cost_Collector (PP_Order_ID);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820570_gh30811_PP_Cost_Collector_PP_Order_ID_index.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820570_gh30811_PP_Cost_Collector_PP_Order_ID_index.sql
@@ -1,0 +1,8 @@
+-- PP_Cost_Collector carries only its primary key and a partial index for unposted rows, so a "collectors of
+-- this order" lookup otherwise scans the whole table. The virtual column PP_Order.CostDifference does one such
+-- lookup per row it renders, which makes a grid over completed orders scan that table once per line.
+--
+-- PP_Order_ID is highly selective - an order has a handful of collectors out of tens of thousands - so a plain
+-- btree turns each of those scans into a two-row index lookup.
+
+CREATE INDEX IF NOT EXISTS PP_Cost_Collector_PP_Order_ID ON PP_Cost_Collector (PP_Order_ID);

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820720_sys_gh30811_PP_Order_CostImbalance_Window_ClientField_DateFinishSchedule_Trl.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820720_sys_gh30811_PP_Order_CostImbalance_Window_ClientField_DateFinishSchedule_Trl.sql
@@ -1,0 +1,56 @@
+-- Review follow-up to 5814680_sys_gh30811_PP_Order_CostImbalance_Window.sql (already released,
+-- therefore immutable). Two corrections to the manufacturing cost-monitoring window (542175):
+--
+-- 1) The bottom-right org/client element group (AD_UI_ElementGroup 555517) only carried AD_Org_ID.
+--    The standard layout requires AD_Org_ID first, then AD_Client_ID. AD_Client_ID is added to the
+--    form only -- it must never become a grid column, so IsDisplayedGrid='N' on both the AD_Field
+--    and the AD_UI_Element.
+--
+-- 2) AD_Element 53278 (DateFinishSchedule) carried the raw column name as its de_DE / de_CH
+--    Name and PrintName, so every window that shows that column rendered "DateFinishSchedule"
+--    to German users (windows 53009, 53064 and the new 542175). The German text is written into
+--    the element translations and cascaded, which also repairs the base AD_Element row (de_DE is
+--    the base language) and every AD_Column / AD_Field that resolves its caption from it.
+--
+-- IDs allocated from idserver.metas.de:
+--   AD_Field      783023 (PP_Order.AD_Client_ID on tab 549352)
+--   AD_UI_Element 653672 (AD_Client_ID in element group 555517)
+
+-- 1) AD_Client_ID field on tab 549352.
+--    AD_Column 53680 = PP_Order.AD_Client_ID, backed by AD_Element 102 ("Mandant").
+--    SeqNo 20 places it directly after AD_Org_ID (SeqNo 10) in the org/client group.
+--    SeqNoGrid 0 + IsDisplayedGrid 'N' keep it out of the grid, matching how the same script
+--    treats the other form-only field (IsActive).
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
+VALUES (0,53680,783023 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-08-27 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','N','N','N','N','N','N','Mandant',20,0,TO_TIMESTAMP('2026-08-27 10:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Field_ID=783023
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+select update_FieldTranslation_From_AD_Name_Element(102)
+;
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=783023
+;
+select AD_Element_Link_Create_Missing_Field(783023)
+;
+
+-- AD_UI_Element for the new field: same group 555517, right after AD_Org_ID, form only.
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,783023,0,549352,555517,653672 /*From ID Server*/,'F',TO_TIMESTAMP('2026-08-27 10:00:05','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','N','N','Mandant',20,0,0,TO_TIMESTAMP('2026-08-27 10:00:05','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2) AD_Element 53278 (DateFinishSchedule): supply the German caption for the German languages.
+UPDATE AD_Element_Trl SET Name='Datum Fertigstellung geplant', PrintName='Datum Fertigstellung geplant',
+    IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-27 10:00:10','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=53278 AND AD_Language='de_DE'
+;
+UPDATE AD_Element_Trl SET Name='Datum Fertigstellung geplant', PrintName='Datum Fertigstellung geplant',
+    IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-27 10:00:15','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=53278 AND AD_Language='de_CH'
+;
+-- Cascade into AD_Element (base language), AD_Column_Trl and AD_Field_Trl, so windows 53009,
+-- 53064 and 542175 all show the translated caption.
+select update_TRL_Tables_On_AD_Element_TRL_Update(53278)
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820720_sys_gh30811_PP_Order_CostImbalance_Window_ClientField_DateFinishSchedule_Trl.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820720_sys_gh30811_PP_Order_CostImbalance_Window_ClientField_DateFinishSchedule_Trl.sql
@@ -1,26 +1,14 @@
--- Review follow-up to 5814680_sys_gh30811_PP_Order_CostImbalance_Window.sql (already released,
--- therefore immutable). Two corrections to the manufacturing cost-monitoring window (542175):
+-- Two corrections to the manufacturing cost-monitoring window (542175), whose own script (5814680) is
+-- already released and therefore immutable:
+--   1) the org/client element group (AD_UI_ElementGroup 555517) carried only AD_Org_ID; the standard
+--      layout wants AD_Org_ID first, then AD_Client_ID, form-only (never a grid column);
+--   2) AD_Element 53278 (DateFinishSchedule) carried the raw column name as its German Name/PrintName,
+--      so German users saw "DateFinishSchedule" in every window showing that column.
 --
--- 1) The bottom-right org/client element group (AD_UI_ElementGroup 555517) only carried AD_Org_ID.
---    The standard layout requires AD_Org_ID first, then AD_Client_ID. AD_Client_ID is added to the
---    form only -- it must never become a grid column, so IsDisplayedGrid='N' on both the AD_Field
---    and the AD_UI_Element.
---
--- 2) AD_Element 53278 (DateFinishSchedule) carried the raw column name as its de_DE / de_CH
---    Name and PrintName, so every window that shows that column rendered "DateFinishSchedule"
---    to German users (windows 53009, 53064 and the new 542175). The German text is written into
---    the element translations and cascaded, which also repairs the base AD_Element row (de_DE is
---    the base language) and every AD_Column / AD_Field that resolves its caption from it.
---
--- IDs allocated from idserver.metas.de:
---   AD_Field      783023 (PP_Order.AD_Client_ID on tab 549352)
---   AD_UI_Element 653672 (AD_Client_ID in element group 555517)
+-- IDs allocated from idserver.metas.de: AD_Field 783023, AD_UI_Element 653672
 
--- 1) AD_Client_ID field on tab 549352.
---    AD_Column 53680 = PP_Order.AD_Client_ID, backed by AD_Element 102 ("Mandant").
---    SeqNo 20 places it directly after AD_Org_ID (SeqNo 10) in the org/client group.
---    SeqNoGrid 0 + IsDisplayedGrid 'N' keep it out of the grid, matching how the same script
---    treats the other form-only field (IsActive).
+-- 1) AD_Client_ID (AD_Column 53680, AD_Element 102) on tab 549352: SeqNo 20 places it right after
+--    AD_Org_ID; SeqNoGrid 0 + IsDisplayedGrid 'N' keep it out of the grid, as for IsActive.
 INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,Updated,UpdatedBy)
 VALUES (0,53680,783023 /*From ID Server*/,0,549352,TO_TIMESTAMP('2026-08-27 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Y','N','N','N','N','N','N','Mandant',20,0,TO_TIMESTAMP('2026-08-27 10:00:00','YYYY-MM-DD HH24:MI:SS'),100)
 ;
@@ -36,12 +24,11 @@ DELETE FROM AD_Element_Link WHERE AD_Field_ID=783023
 select AD_Element_Link_Create_Missing_Field(783023)
 ;
 
--- AD_UI_Element for the new field: same group 555517, right after AD_Org_ID, form only.
 INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
 VALUES (0,783023,0,549352,555517,653672 /*From ID Server*/,'F',TO_TIMESTAMP('2026-08-27 10:00:05','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','N','N','Mandant',20,0,0,TO_TIMESTAMP('2026-08-27 10:00:05','YYYY-MM-DD HH24:MI:SS'),100)
 ;
 
--- 2) AD_Element 53278 (DateFinishSchedule): supply the German caption for the German languages.
+-- 2) AD_Element 53278 (DateFinishSchedule): supply the German caption.
 UPDATE AD_Element_Trl SET Name='Datum Fertigstellung geplant', PrintName='Datum Fertigstellung geplant',
     IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-27 10:00:10','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Element_ID=53278 AND AD_Language='de_DE'
@@ -50,7 +37,6 @@ UPDATE AD_Element_Trl SET Name='Datum Fertigstellung geplant', PrintName='Datum 
     IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-27 10:00:15','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
 WHERE AD_Element_ID=53278 AND AD_Language='de_CH'
 ;
--- Cascade into AD_Element (base language), AD_Column_Trl and AD_Field_Trl, so windows 53009,
--- 53064 and 542175 all show the translated caption.
+-- Cascades into AD_Element (de_DE is the base language), AD_Column_Trl and AD_Field_Trl.
 select update_TRL_Tables_On_AD_Element_TRL_Update(53278)
 ;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820790_gh30811_PP_Order_CostDifference_ReceivedFromCumulatedAmt.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820790_gh30811_PP_Order_CostDifference_ReceivedFromCumulatedAmt.sql
@@ -1,27 +1,12 @@
--- gh30811 Manufacturing costing — PP_Order.CostDifference (AD_Column 592970) now reads received-minus-issued
--- straight off the order's PP_Order_Cost rows.
+-- PP_Order.CostDifference (AD_Column 592970): received minus issued, off the order's PP_Order_Cost rows.
 --
--- Supersedes the expression set by 5814670 / 5820560. Two changes:
+-- Received reads cumulatedamt, not postcalculationamt: post-calculation distributes the order's total
+-- INPUT cost over its outputs, so on the main-product line postcalculationamt holds the ISSUED total.
+-- Discharging a residual accumulates onto that same main-product line, so a discharged order already
+-- reads 0 without netting M_CostDetail on top.
 --
--- 1. The "received" summand moves from postcalculationamt to cumulatedamt on the MR / CO / BY lines.
---    postcalculationamt is written by PPOrderCosts.updatePostCalculationAmountsForCostElement, which
---    distributes the order's total INPUT cost over its outputs — so on the main-product line it holds the
---    ISSUED total, the very figure the second summand already computes from the MaterialIssue lines.
---    Reading it as "received" is therefore wrong. The amount actually received out of the order is
---    cumulatedamt, which is correct on the MR line both before and after the post-calculation fixes.
---
--- 2. The netting of already-distributed amounts out of M_CostDetail (the third summand added by 5820560)
---    is dropped. Discharging an order's residual accumulates it onto the main product's PP_Order_Cost line
---    itself, and reversing the distribution takes it back off, so the first two summands already read zero
---    for a discharged order. Keeping the M_CostDetail summand on top would count the discharge twice and
---    leave a fully discharged order reporting its residual with the opposite sign.
---
--- Verified on a customer-flavored local stack: an order receiving 25 against 10 issued reads 15, one
--- receiving 5 against 10 issued reads -5, and a fully discharged order reads 0.
---
--- Known scope limit: the distribution discharges only the main-product line, so an order carrying
--- co-products or by-products does not net to zero after discharging. Same limit as the expression this
--- supersedes; out of scope here.
+-- Scope limit: only the main-product line is discharged, so orders carrying co-/by-products do not
+-- net to zero.
 
 UPDATE AD_Column SET ColumnSQL=
 '(coalesce((select sum(oc.cumulatedamt)

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820790_gh30811_PP_Order_CostDifference_ReceivedFromCumulatedAmt.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820790_gh30811_PP_Order_CostDifference_ReceivedFromCumulatedAmt.sql
@@ -1,0 +1,43 @@
+-- gh30811 Manufacturing costing — PP_Order.CostDifference (AD_Column 592970) now reads received-minus-issued
+-- straight off the order's PP_Order_Cost rows.
+--
+-- Supersedes the expression set by 5814670 / 5820560. Two changes:
+--
+-- 1. The "received" summand moves from postcalculationamt to cumulatedamt on the MR / CO / BY lines.
+--    postcalculationamt is written by PPOrderCosts.updatePostCalculationAmountsForCostElement, which
+--    distributes the order's total INPUT cost over its outputs — so on the main-product line it holds the
+--    ISSUED total, the very figure the second summand already computes from the MaterialIssue lines.
+--    Reading it as "received" is therefore wrong. The amount actually received out of the order is
+--    cumulatedamt, which is correct on the MR line both before and after the post-calculation fixes.
+--
+-- 2. The netting of already-distributed amounts out of M_CostDetail (the third summand added by 5820560)
+--    is dropped. Discharging an order's residual accumulates it onto the main product's PP_Order_Cost line
+--    itself, and reversing the distribution takes it back off, so the first two summands already read zero
+--    for a discharged order. Keeping the M_CostDetail summand on top would count the discharge twice and
+--    leave a fully discharged order reporting its residual with the opposite sign.
+--
+-- Verified on a customer-flavored local stack: an order receiving 25 against 10 issued reads 15, one
+-- receiving 5 against 10 issued reads -5, and a fully discharged order reads 0.
+--
+-- Known scope limit: the distribution discharges only the main-product line, so an order carrying
+-- co-products or by-products does not net to zero after discharging. Same limit as the expression this
+-- supersedes; out of scope here.
+
+UPDATE AD_Column SET ColumnSQL=
+'(coalesce((select sum(oc.cumulatedamt)
+   from pp_order_cost oc
+   join c_acctschema acs on acs.c_acctschema_id = oc.c_acctschema_id
+    and acs.c_acctschema_id = (select ci.c_acctschema1_id from ad_clientinfo ci where ci.ad_client_id = PP_Order.AD_Client_ID)
+   join m_costelement ce on ce.m_costelement_id = oc.m_costelement_id and ce.costingmethod = acs.costingmethod
+   where oc.pp_order_id = PP_Order.PP_Order_ID and oc.pp_order_cost_trxtype in (''MR'',''CO'',''BY'')), 0)
+ -
+ coalesce((select sum(-oc.cumulatedqty * (coalesce(oc.currentcostprice,0) + coalesce(oc.currentcostpricell,0)))
+   from pp_order_cost oc
+   join c_acctschema acs on acs.c_acctschema_id = oc.c_acctschema_id
+    and acs.c_acctschema_id = (select ci.c_acctschema1_id from ad_clientinfo ci where ci.ad_client_id = PP_Order.AD_Client_ID)
+   join m_costelement ce on ce.m_costelement_id = oc.m_costelement_id and ce.costingmethod = acs.costingmethod
+   where oc.pp_order_id = PP_Order.PP_Order_ID and oc.pp_order_cost_trxtype = ''MI''), 0)
+)',
+    Updated=TO_TIMESTAMP('2026-08-27 15:05:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Column_ID=592970
+;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
@@ -196,6 +196,8 @@ public class PP_Order_StepDef
 	 *   | Identifier | CostDifference |
 	 *   | ppOrder    | 15             |
 	 * </pre>
+	 * @see de.metas.cucumber.stepdefs.costing.PP_Order_Cost_StepDef for asserting the individual PP_Order_Cost rows that CostDifference aggregates
+	 * @see PP_Cost_Collector_StepDef for asserting the cost collectors that produce those PP_Order_Cost rows
 	 */
 	@And("^after not more than (.*)s, PP_Orders are found$")
 	public void validatePP_Order(

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
@@ -188,7 +188,7 @@ public class PP_Order_StepDef
 	 *   <b>M_AttributeSetInstance_ID</b> — (optional, identifier-ref) expected ASI, compared by attributes-key<br>
 	 *   <b>M_HU_PI_Item_Product_ID</b> — (optional, identifier-ref) expected packing item-product<br>
 	 *   <b>DocStatus</b> — (optional) expected document status<br>
-	 *   <b>CostDifference</b> — (optional) expected value of the virtual PP_Order.CostDifference column: received (MR/CO/BY) minus issued (MI), summed across all PP_Order_Cost rows of this order — positive when received exceeds issued, negative when issued exceeds received<br>
+	 *   <b>CostDifference</b> — (optional) expected value of the virtual PP_Order.CostDifference column: received (MR/CO/BY) minus issued (MI) over the order's PP_Order_Cost rows<br>
 	 * @cucumber.depends StepDefData: PP_Order_StepDefData
 	 * @cucumber.example
 	 * <pre>

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
@@ -176,7 +176,7 @@ public class PP_Order_StepDef
 	/**
 	 * @cucumber.stepdef
 	 * @cucumber.columns
-	 *   <b>Identifier</b> — (optional) alias of an already-created PP_Order; when given, the order is looked up directly instead of by the criteria columns below<br>
+	 *   <b>Identifier</b> — (optional) alias of an already-created PP_Order; looked up directly instead of by the criteria columns below<br>
 	 *   <b>M_Product_ID</b> — (optional, identifier-ref) main product<br>
 	 *   <b>PP_Product_BOM_ID</b> — (optional, identifier-ref) BOM used by the order<br>
 	 *   <b>PP_Product_Planning_ID</b> — (optional, identifier-ref) product planning record<br>
@@ -188,7 +188,7 @@ public class PP_Order_StepDef
 	 *   <b>M_AttributeSetInstance_ID</b> — (optional, identifier-ref) expected ASI, compared by attributes-key<br>
 	 *   <b>M_HU_PI_Item_Product_ID</b> — (optional, identifier-ref) expected packing item-product<br>
 	 *   <b>DocStatus</b> — (optional) expected document status<br>
-	 *   <b>CostDifference</b> — (optional) expected value of the virtual PP_Order.CostDifference column: received (MR/CO/BY) minus issued (MI) over the order's PP_Order_Cost rows<br>
+	 *   <b>CostDifference</b> — (optional) expected received (MR/CO/BY) minus issued (MI) over the order's PP_Order_Cost rows<br>
 	 * @cucumber.depends StepDefData: PP_Order_StepDefData
 	 * @cucumber.example
 	 * <pre>
@@ -196,8 +196,7 @@ public class PP_Order_StepDef
 	 *   | Identifier | CostDifference |
 	 *   | ppOrder    | 15             |
 	 * </pre>
-	 * @see de.metas.cucumber.stepdefs.costing.PP_Order_Cost_StepDef for asserting the individual PP_Order_Cost rows that CostDifference aggregates
-	 * @see PP_Cost_Collector_StepDef for asserting the cost collectors that produce those PP_Order_Cost rows
+	 * @see de.metas.cucumber.stepdefs.costing.PP_Order_Cost_StepDef for the individual rows CostDifference aggregates
 	 */
 	@And("^after not more than (.*)s, PP_Orders are found$")
 	public void validatePP_Order(

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
@@ -173,6 +173,30 @@ public class PP_Order_StepDef
 		this.warehouseTable = warehouseTable;
 	}
 
+	/**
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>Identifier</b> — (optional) alias of an already-created PP_Order; when given, the order is looked up directly instead of by the criteria columns below<br>
+	 *   <b>M_Product_ID</b> — (optional, identifier-ref) main product<br>
+	 *   <b>PP_Product_BOM_ID</b> — (optional, identifier-ref) BOM used by the order<br>
+	 *   <b>PP_Product_Planning_ID</b> — (optional, identifier-ref) product planning record<br>
+	 *   <b>S_Resource_ID</b> — (optional, identifier-ref or raw ID) plant resource<br>
+	 *   <b>QtyEntered</b> — (optional) expected entered quantity with UOM<br>
+	 *   <b>QtyOrdered</b> — (optional) expected ordered quantity<br>
+	 *   <b>DatePromised</b> — (optional) expected/lookup promised date<br>
+	 *   <b>C_BPartner_ID</b> — (optional, identifier-ref) BPartner<br>
+	 *   <b>M_AttributeSetInstance_ID</b> — (optional, identifier-ref) expected ASI, compared by attributes-key<br>
+	 *   <b>M_HU_PI_Item_Product_ID</b> — (optional, identifier-ref) expected packing item-product<br>
+	 *   <b>DocStatus</b> — (optional) expected document status<br>
+	 *   <b>CostDifference</b> — (optional) expected value of the virtual PP_Order.CostDifference column: received (MR/CO/BY) minus issued (MI), summed across all PP_Order_Cost rows of this order — positive when received exceeds issued, negative when issued exceeds received<br>
+	 * @cucumber.depends StepDefData: PP_Order_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And after not more than 60s, PP_Orders are found
+	 *   | Identifier | CostDifference |
+	 *   | ppOrder    | 15             |
+	 * </pre>
+	 */
 	@And("^after not more than (.*)s, PP_Orders are found$")
 	public void validatePP_Order(
 			final int timeoutSec,
@@ -550,6 +574,9 @@ public class PP_Order_StepDef
 
 		row.getAsOptionalEnum(I_PP_Order.COLUMNNAME_DocStatus, DocStatus.class)
 				.ifPresent(docStatus -> softly.assertThat(actual.getDocStatus()).as("DocStatus").isEqualTo(docStatus.getCode()));
+
+		row.getAsOptionalBigDecimal(I_PP_Order.COLUMNNAME_CostDifference)
+				.ifPresent(costDifference -> softly.assertThat(actual.getCostDifference()).as("CostDifference").isEqualByComparingTo(costDifference));
 
 		softly.assertAll();
 	}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
@@ -166,7 +166,7 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
       | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowLine.Identifier | WorkflowReceivingTargetValues.Identifier |
       | mfgWorkflow                | receiptActivity             | receiptLine             | receivingTargetValues                    |
 
-    # Issue the component to the production order (at its own actual cost, different from finProd's cost)
+    # Issue the component to the production order
     And create JsonManufacturingOrderEvent and store it in context as request payload:
       | Event   | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowStep.Identifier | WorkflowStepQRCode.Identifier |
       | IssueTo | mfgWorkflow                | issueActivity               | issueStep               | issueQRCode                   |
@@ -194,8 +194,7 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
       | PP_Order_ID.Identifier | M_Product_ID.Identifier | M_CostElement_ID | PP_Order_Cost_TrxType | CurrentCostPrice |
       | ppOrder                | finProd                 | AveragePO        | MR                    | 25 CHF           |
 
-    # Order-level CostDifference = received (finProd MR, 25) minus issued (compProd MI, 10) = 15:
-    # positive, because received exceeds issued.
+    # CostDifference = received (finProd MR, 25) minus issued (compProd MI, 10) = 15.
     And after not more than 60s, PP_Orders are found
       | Identifier | CostDifference |
       | ppOrder    | 15             |
@@ -209,9 +208,8 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
   @from:cucumber
   @Id:S30811_TC2
   Scenario: Finished good is received below its component cost
-    # finProd's own standing AveragePO cost (5 CHF/PCE) is lower than the 1:1 BOM rollup
-    # from compProd (10 CHF/PCE). The receipt posts at finProd's own current cost, so more
-    # was issued (compProd) than received (finProd): CostDifference must be negative.
+    # finProd's own standing AveragePO cost (5 CHF/PCE) is lower than the 1:1 BOM rollup from compProd
+    # (10 CHF/PCE), and the receipt posts at finProd's own cost, so CostDifference must be negative.
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 | CostPrice | M_HU_ID |
       | finInventory   | finInventoryLine   | 2024-03-20   | 540008         | finProd      | 0       | 10       | PCE          | 5         | finHU   |
@@ -241,7 +239,7 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
       | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowLine.Identifier | WorkflowReceivingTargetValues.Identifier |
       | mfgWorkflow                | receiptActivity             | receiptLine             | receivingTargetValues                    |
 
-    # Issue the component to the production order (at its own actual cost, different from finProd's cost)
+    # Issue the component to the production order
     And create JsonManufacturingOrderEvent and store it in context as request payload:
       | Event   | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowStep.Identifier | WorkflowStepQRCode.Identifier |
       | IssueTo | mfgWorkflow                | issueActivity               | issueStep               | issueQRCode                   |
@@ -264,8 +262,7 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
       | PP_Order_ID.Identifier | M_Product_ID.Identifier | M_CostElement_ID | PP_Order_Cost_TrxType | CurrentCostPrice |
       | ppOrder                | finProd                 | AveragePO        | MR                    | 5 CHF            |
 
-    # Order-level CostDifference = received (finProd MR, 5) minus issued (compProd MI, 10) = -5:
-    # negative, because issued exceeds received.
+    # CostDifference = received (finProd MR, 5) minus issued (compProd MI, 10) = -5.
     And after not more than 60s, PP_Orders are found
       | Identifier | CostDifference |
       | ppOrder    | -5             |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
@@ -208,8 +208,8 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
   @from:cucumber
   @Id:S30811_TC2
   Scenario: Finished good is received below its component cost
-    # finProd's own standing AveragePO cost (5 CHF/PCE) is lower than the 1:1 BOM rollup from compProd
-    # (10 CHF/PCE), and the receipt posts at finProd's own cost, so CostDifference must be negative.
+    # finProd's own AveragePO cost (5 CHF/PCE) is below the 1:1 BOM rollup from compProd (10 CHF/PCE),
+    # and the receipt posts at finProd's own cost, so CostDifference is negative.
     And metasfresh contains single line completed inventories
       | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 | CostPrice | M_HU_ID |
       | finInventory   | finInventoryLine   | 2024-03-20   | 540008         | finProd      | 0       | 10       | PCE          | 5         | finHU   |
@@ -257,7 +257,6 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
 
     And Wait until documents receiptCostCollector are posted
 
-    # The PP_Order_Cost row for the main product must carry the same current cost price.
     And PP_Order_Cost are found:
       | PP_Order_ID.Identifier | M_Product_ID.Identifier | M_CostElement_ID | PP_Order_Cost_TrxType | CurrentCostPrice |
       | ppOrder                | finProd                 | AveragePO        | MR                    | 5 CHF            |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/manufacturingCostCollectorPosting.feature
@@ -132,6 +132,7 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
       | receiptCostCollector | P_WIP_Acct            | finProd      | 0         | 10        |
 
   @from:cucumber
+  @Id:S30811_TC1
   Scenario: Finished good is received at its current cost price
     # finProd already has its own standing AveragePO cost (25 CHF/PCE), higher than the
     # 1:1 BOM rollup from compProd (10 CHF/PCE). The receipt must post at finProd's own
@@ -193,8 +194,84 @@ Feature: Manufacturing cost collector posting - component issue vs material rece
       | PP_Order_ID.Identifier | M_Product_ID.Identifier | M_CostElement_ID | PP_Order_Cost_TrxType | CurrentCostPrice |
       | ppOrder                | finProd                 | AveragePO        | MR                    | 25 CHF           |
 
+    # Order-level CostDifference = received (finProd MR, 25) minus issued (compProd MI, 10) = 15:
+    # positive, because received exceeds issued.
+    And after not more than 60s, PP_Orders are found
+      | Identifier | CostDifference |
+      | ppOrder    | 15             |
+
     # Receipt posts at finProd's own current cost (25), not at the 10 CHF BOM rollup.
     And Fact_Acct records are matching
       | Record_ID            | AccountConceptualName | M_Product_ID | AmtAcctDr | AmtAcctCr |
       | receiptCostCollector | P_Asset_Acct          | finProd      | 25        | 0         |
       | receiptCostCollector | P_WIP_Acct            | finProd      | 0         | 25        |
+
+  @from:cucumber
+  @Id:S30811_TC2
+  Scenario: Finished good is received below its component cost
+    # finProd's own standing AveragePO cost (5 CHF/PCE) is lower than the 1:1 BOM rollup
+    # from compProd (10 CHF/PCE). The receipt posts at finProd's own current cost, so more
+    # was issued (compProd) than received (finProd): CostDifference must be negative.
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 | CostPrice | M_HU_ID |
+      | finInventory   | finInventoryLine   | 2024-03-20   | 540008         | finProd      | 0       | 10       | PCE          | 5         | finHU   |
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
+      | acctSchema      | finProd      | AveragePO        | 5 CHF            | 10 PCE     |
+
+    And create PP_Order:
+      | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument | OPT.PP_Product_Planning_ID.Identifier |
+      | ppOrder                | MOP         | finProd                 | 1          | testResource             | 2024-03-26T23:59:00.00Z | 2024-03-26T23:59:00.00Z | 2024-03-26T23:59:00.00Z | Y                | prodPlan                              |
+    And after not more than 60s, PP_Order_BomLines are found
+      | PP_Order_BOMLine_ID.Identifier | PP_Order_ID.Identifier | M_Product_ID.Identifier | QtyRequiered | IsQtyPercentage | C_UOM_ID.X12DE355 | ComponentType |
+      | ppOrderBomLine                 | ppOrder                | compProd                | 1            | false           | PCE               | CO            |
+    When complete planning for PP_Order:
+      | PP_Order_ID.Identifier |
+      | ppOrder                |
+
+    And create JsonWFProcessStartRequest for manufacturing and store it in context as request payload:
+      | PP_Order_ID.Identifier |
+      | ppOrder                |
+    And the metasfresh REST-API endpoint path 'api/v2/userWorkflows/wfProcess/start' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    And process response and extract manufacturing step and issueTo HU manufacturing candidate:
+      | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowStep.Identifier | WorkflowStepQRCode.Identifier |
+      | mfgWorkflow                | issueActivity               | issueStep               | issueQRCode                   |
+    And process response and extract manufacturing line and receiving target values:
+      | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowLine.Identifier | WorkflowReceivingTargetValues.Identifier |
+      | mfgWorkflow                | receiptActivity             | receiptLine             | receivingTargetValues                    |
+
+    # Issue the component to the production order (at its own actual cost, different from finProd's cost)
+    And create JsonManufacturingOrderEvent and store it in context as request payload:
+      | Event   | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowStep.Identifier | WorkflowStepQRCode.Identifier |
+      | IssueTo | mfgWorkflow                | issueActivity               | issueStep               | issueQRCode                   |
+    And the metasfresh REST-API endpoint path 'api/v2/manufacturing/event' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    # Receive the finished good
+    And create JsonManufacturingOrderEvent and store it in context as request payload:
+      | Event       | WorkflowProcess.Identifier | WorkflowActivity.Identifier | WorkflowLine.Identifier | WorkflowReceivingTargetValues.Identifier |
+      | ReceiveFrom | mfgWorkflow                | receiptActivity             | receiptLine             | receivingTargetValues                    |
+    And the metasfresh REST-API endpoint path 'api/v2/manufacturing/event' receives a 'POST' request with the payload from context and responds with '200' status code
+
+    And after not more than 60s, PP_Cost_Collector are found:
+      | PP_Cost_Collector_ID.Identifier | PP_Order_ID.Identifier | M_Product_ID.Identifier | MovementQty | DocStatus |
+      | receiptCostCollector            | ppOrder                | finProd                 | 1           | CO        |
+
+    And Wait until documents receiptCostCollector are posted
+
+    # The PP_Order_Cost row for the main product must carry the same current cost price.
+    And PP_Order_Cost are found:
+      | PP_Order_ID.Identifier | M_Product_ID.Identifier | M_CostElement_ID | PP_Order_Cost_TrxType | CurrentCostPrice |
+      | ppOrder                | finProd                 | AveragePO        | MR                    | 5 CHF            |
+
+    # Order-level CostDifference = received (finProd MR, 5) minus issued (compProd MI, 10) = -5:
+    # negative, because issued exceeds received.
+    And after not more than 60s, PP_Orders are found
+      | Identifier | CostDifference |
+      | ppOrder    | -5             |
+
+    # Receipt posts at finProd's own current cost (5).
+    And Fact_Acct records are matching
+      | Record_ID            | AccountConceptualName | M_Product_ID | AmtAcctDr | AmtAcctCr |
+      | receiptCostCollector | P_Asset_Acct          | finProd      | 5         | 0         |
+      | receiptCostCollector | P_WIP_Acct            | finProd      | 0         | 5         |

--- a/e2e/frontend-webui/tests/spec/mfg-config-translations.spec.js
+++ b/e2e/frontend-webui/tests/spec/mfg-config-translations.spec.js
@@ -9,10 +9,6 @@ import { MasterWindowPage } from '../utils/pages/MasterWindowPage';
 // MobileUI Manufacturing Configuration window ID
 const MFG_CONFIG_WINDOW_ID = 541788;
 
-// Manufacturing cost-imbalance monitor window ("Kostenüberwachung Fertigung")
-// Read-only window over PP_Order (DocStatus='CO') surfacing the CostDifference column.
-const COST_IMBALANCE_WINDOW_ID = 542175;
-
 test.describe('MobileUI MFG Config Translations', () => {
   //
   // TC-E1: German field names
@@ -81,75 +77,5 @@ test.describe('MobileUI MFG Config Translations', () => {
 
     // Verify English translations are present
     expect(allHeaderText).toContain('Allow Issuing Any HU');
-  });
-});
-
-test.describe('Manufacturing cost-imbalance monitor window', () => {
-  //
-  // The window's AD_Tab has WhereClause="DocStatus='CO'" over PP_Order and surfaces the
-  // CostDifference virtual column. This test seeds a real completed manufacturing order via
-  // the frontendTesting masterdata API (which always drives the PP_Order to DocStatus='CO' on
-  // creation) and asserts it renders in the grid with the CostDifference column.
-  //
-  test('Completed manufacturing order appears with the CostDifference column', async ({ page }) => {
-    allure.epic('E0226: Costing');
-    allure.tag('F1500: Costing');
-    allure.tag('F1500');
-    allure.story('Cost-imbalance monitor window renders completed (CO) PP_Orders with CostDifference');
-    allure.severity('normal');
-    allure.description(
-      "Verifies the cost-imbalance monitor window (read-only monitor over PP_Order, WhereClause " +
-        "DocStatus='CO') in successful action: a seeded completed manufacturing order appears in " +
-        'the grid, proving the DocStatus filter, and the CostDifference grid column renders for that row.'
-    );
-
-    const masterdata = await Backend.createMasterdata({
-      request: {
-        login: { user: { language: 'en_US' } },
-        warehouses: { wh: {} },
-        products: {
-          Component1: {},
-          FinishedGood: {
-            bom: { lines: [{ product: 'Component1', qty: 1 }] },
-          },
-        },
-        manufacturingOrders: {
-          PP1: {
-            warehouse: 'wh',
-            product: 'FinishedGood',
-            qty: 5,
-            datePromised: new Date().toISOString(),
-          },
-        },
-      },
-    });
-
-    const documentNo = masterdata.manufacturingOrders.PP1.documentNo;
-    expect(documentNo).toBeTruthy();
-
-    await LoginPage.goto();
-    await LoginPage.login(masterdata.login.user);
-    await DashboardPage.expectVisible();
-
-    await MasterWindowPage.goto(COST_IMBALANCE_WINDOW_ID);
-    await MasterWindowPage.expectWindowLoaded();
-    await MasterWindowPage.waitForTableData();
-
-    // The CostDifference grid column header is present (language-independent ColumnName selector).
-    const costDifferenceColumn = page.locator('th[data-testid="column-CostDifference"]');
-    expect(await costDifferenceColumn.count()).toBeGreaterThan(0);
-
-    // The seeded CO order appears in the grid, proving the tab's DocStatus='CO' WhereClause
-    // filter let it through (a Drafted/InProgress order would not show up here).
-    const row = page.locator('tr').filter({ hasText: documentNo });
-    expect(await row.count()).toBeGreaterThan(0);
-
-    // That row renders a CostDifference cell (value correctness is covered by a cucumber test;
-    // here we only need the column to be wired to the row, per the window-design-rules
-    // verification recipe for a new grid column).
-    const costDifferenceCell = row.first().locator('[data-cy="cell-CostDifference"]');
-    expect(await costDifferenceCell.count()).toBeGreaterThan(0);
-
-    console.log(`Manufacturing order ${documentNo} rendered in cost-imbalance monitor with CostDifference column`);
   });
 });

--- a/e2e/frontend-webui/tests/spec/mfg-config-translations.spec.js
+++ b/e2e/frontend-webui/tests/spec/mfg-config-translations.spec.js
@@ -9,6 +9,10 @@ import { MasterWindowPage } from '../utils/pages/MasterWindowPage';
 // MobileUI Manufacturing Configuration window ID
 const MFG_CONFIG_WINDOW_ID = 541788;
 
+// Manufacturing cost-imbalance monitor window ("Kostenüberwachung Fertigung")
+// Read-only window over PP_Order (DocStatus='CO') surfacing the CostDifference column.
+const COST_IMBALANCE_WINDOW_ID = 542175;
+
 test.describe('MobileUI MFG Config Translations', () => {
   //
   // TC-E1: German field names
@@ -77,5 +81,75 @@ test.describe('MobileUI MFG Config Translations', () => {
 
     // Verify English translations are present
     expect(allHeaderText).toContain('Allow Issuing Any HU');
+  });
+});
+
+test.describe('Manufacturing cost-imbalance monitor window', () => {
+  //
+  // The window's AD_Tab has WhereClause="DocStatus='CO'" over PP_Order and surfaces the
+  // CostDifference virtual column. This test seeds a real completed manufacturing order via
+  // the frontendTesting masterdata API (which always drives the PP_Order to DocStatus='CO' on
+  // creation) and asserts it renders in the grid with the CostDifference column.
+  //
+  test('Completed manufacturing order appears with the CostDifference column', async ({ page }) => {
+    allure.epic('E0226: Costing');
+    allure.tag('F1500: Costing');
+    allure.tag('F1500');
+    allure.story('Cost-imbalance monitor window renders completed (CO) PP_Orders with CostDifference');
+    allure.severity('normal');
+    allure.description(
+      "Verifies the cost-imbalance monitor window (read-only monitor over PP_Order, WhereClause " +
+        "DocStatus='CO') in successful action: a seeded completed manufacturing order appears in " +
+        'the grid, proving the DocStatus filter, and the CostDifference grid column renders for that row.'
+    );
+
+    const masterdata = await Backend.createMasterdata({
+      request: {
+        login: { user: { language: 'en_US' } },
+        warehouses: { wh: {} },
+        products: {
+          Component1: {},
+          FinishedGood: {
+            bom: { lines: [{ product: 'Component1', qty: 1 }] },
+          },
+        },
+        manufacturingOrders: {
+          PP1: {
+            warehouse: 'wh',
+            product: 'FinishedGood',
+            qty: 5,
+            datePromised: new Date().toISOString(),
+          },
+        },
+      },
+    });
+
+    const documentNo = masterdata.manufacturingOrders.PP1.documentNo;
+    expect(documentNo).toBeTruthy();
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await DashboardPage.expectVisible();
+
+    await MasterWindowPage.goto(COST_IMBALANCE_WINDOW_ID);
+    await MasterWindowPage.expectWindowLoaded();
+    await MasterWindowPage.waitForTableData();
+
+    // The CostDifference grid column header is present (language-independent ColumnName selector).
+    const costDifferenceColumn = page.locator('th[data-testid="column-CostDifference"]');
+    expect(await costDifferenceColumn.count()).toBeGreaterThan(0);
+
+    // The seeded CO order appears in the grid, proving the tab's DocStatus='CO' WhereClause
+    // filter let it through (a Drafted/InProgress order would not show up here).
+    const row = page.locator('tr').filter({ hasText: documentNo });
+    expect(await row.count()).toBeGreaterThan(0);
+
+    // That row renders a CostDifference cell (value correctness is covered by a cucumber test;
+    // here we only need the column to be wired to the row, per the window-design-rules
+    // verification recipe for a new grid column).
+    const costDifferenceCell = row.first().locator('[data-cy="cell-CostDifference"]');
+    expect(await costDifferenceCell.count()).toBeGreaterThan(0);
+
+    console.log(`Manufacturing order ${documentNo} rendered in cost-imbalance monitor with CostDifference column`);
   });
 });

--- a/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
+++ b/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
@@ -6,17 +6,9 @@ import { LoginPage } from '../utils/pages/LoginPage';
 import { DashboardPage } from '../utils/pages/DashboardPage';
 import { MasterWindowPage } from '../utils/pages/MasterWindowPage';
 
-// Manufacturing cost-imbalance monitor window ("Kostenüberwachung Fertigung")
-// Read-only window over PP_Order (DocStatus='CO') surfacing the CostDifference column.
 const COST_IMBALANCE_WINDOW_ID = 542175;
 
 test.describe('Manufacturing cost-imbalance monitor window', () => {
-  //
-  // The window's AD_Tab has WhereClause="DocStatus='CO'" over PP_Order and surfaces the
-  // CostDifference virtual column. This test seeds a real completed manufacturing order via
-  // the frontendTesting masterdata API (which always drives the PP_Order to DocStatus='CO' on
-  // creation) and asserts it renders in the grid with the CostDifference column.
-  //
   test('Completed manufacturing order appears with the CostDifference column', async ({ page }) => {
     allure.epic('E0226: Costing');
     allure.tag('F1500: Costing');
@@ -61,18 +53,15 @@ test.describe('Manufacturing cost-imbalance monitor window', () => {
     await MasterWindowPage.expectWindowLoaded();
     await MasterWindowPage.waitForTableData();
 
-    // The CostDifference grid column header is present (language-independent ColumnName selector).
+    // Selecting on ColumnName keeps the assertion language-independent.
     const costDifferenceColumn = page.locator('th[data-testid="column-CostDifference"]');
     expect(await costDifferenceColumn.count()).toBeGreaterThan(0);
 
-    // The seeded CO order appears in the grid, proving the tab's DocStatus='CO' WhereClause
-    // filter let it through (a Drafted/InProgress order would not show up here).
+    // The seeded order is completed, so the tab's DocStatus='CO' filter must let it through.
     const row = page.locator('tr').filter({ hasText: documentNo });
     expect(await row.count()).toBeGreaterThan(0);
 
-    // That row renders a CostDifference cell (value correctness is covered by a cucumber test;
-    // here we only need the column to be wired to the row, per the window-design-rules
-    // verification recipe for a new grid column).
+    // Only the wiring is checked here; the value itself is covered by a cucumber scenario.
     const costDifferenceCell = row.first().locator('[data-cy="cell-CostDifference"]');
     expect(await costDifferenceCell.count()).toBeGreaterThan(0);
 

--- a/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
+++ b/e2e/frontend-webui/tests/spec/mfg-cost-imbalance-monitor.spec.js
@@ -1,0 +1,81 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { LoginPage } from '../utils/pages/LoginPage';
+import { DashboardPage } from '../utils/pages/DashboardPage';
+import { MasterWindowPage } from '../utils/pages/MasterWindowPage';
+
+// Manufacturing cost-imbalance monitor window ("Kostenüberwachung Fertigung")
+// Read-only window over PP_Order (DocStatus='CO') surfacing the CostDifference column.
+const COST_IMBALANCE_WINDOW_ID = 542175;
+
+test.describe('Manufacturing cost-imbalance monitor window', () => {
+  //
+  // The window's AD_Tab has WhereClause="DocStatus='CO'" over PP_Order and surfaces the
+  // CostDifference virtual column. This test seeds a real completed manufacturing order via
+  // the frontendTesting masterdata API (which always drives the PP_Order to DocStatus='CO' on
+  // creation) and asserts it renders in the grid with the CostDifference column.
+  //
+  test('Completed manufacturing order appears with the CostDifference column', async ({ page }) => {
+    allure.epic('E0226: Costing');
+    allure.tag('F1500: Costing');
+    allure.tag('F1500');
+    allure.story('Cost-imbalance monitor window renders completed (CO) PP_Orders with CostDifference');
+    allure.severity('normal');
+    allure.description(
+      "Verifies the cost-imbalance monitor window (read-only monitor over PP_Order, WhereClause " +
+        "DocStatus='CO') in successful action: a seeded completed manufacturing order appears in " +
+        'the grid, proving the DocStatus filter, and the CostDifference grid column renders for that row.'
+    );
+
+    const masterdata = await Backend.createMasterdata({
+      request: {
+        login: { user: { language: 'en_US' } },
+        warehouses: { wh: {} },
+        products: {
+          Component1: {},
+          FinishedGood: {
+            bom: { lines: [{ product: 'Component1', qty: 1 }] },
+          },
+        },
+        manufacturingOrders: {
+          PP1: {
+            warehouse: 'wh',
+            product: 'FinishedGood',
+            qty: 5,
+            datePromised: new Date().toISOString(),
+          },
+        },
+      },
+    });
+
+    const documentNo = masterdata.manufacturingOrders.PP1.documentNo;
+    expect(documentNo).toBeTruthy();
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await DashboardPage.expectVisible();
+
+    await MasterWindowPage.goto(COST_IMBALANCE_WINDOW_ID);
+    await MasterWindowPage.expectWindowLoaded();
+    await MasterWindowPage.waitForTableData();
+
+    // The CostDifference grid column header is present (language-independent ColumnName selector).
+    const costDifferenceColumn = page.locator('th[data-testid="column-CostDifference"]');
+    expect(await costDifferenceColumn.count()).toBeGreaterThan(0);
+
+    // The seeded CO order appears in the grid, proving the tab's DocStatus='CO' WhereClause
+    // filter let it through (a Drafted/InProgress order would not show up here).
+    const row = page.locator('tr').filter({ hasText: documentNo });
+    expect(await row.count()).toBeGreaterThan(0);
+
+    // That row renders a CostDifference cell (value correctness is covered by a cucumber test;
+    // here we only need the column to be wired to the row, per the window-design-rules
+    // verification recipe for a new grid column).
+    const costDifferenceCell = row.first().locator('[data-cy="cell-CostDifference"]');
+    expect(await costDifferenceCell.count()).toBeGreaterThan(0);
+
+    console.log(`Manufacturing order ${documentNo} rendered in cost-imbalance monitor with CostDifference column`);
+  });
+});

--- a/e2e/frontend-webui/tests/utils/pages/DashboardPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/DashboardPage.js
@@ -23,17 +23,13 @@ export class DashboardPage {
           timeout: SLOW_ACTION_TIMEOUT,
         });
 
-      // Wait for network to settle. Best-effort only: the dashboard's STOMP/websocket
-      // + KPI polling keep the network permanently active, so networkidle can never
-      // settle on a real backend. The .app-content/.dashboard visibility wait above is
-      // the deterministic load signal; don't let this extra grace period gate the test.
+      // Best-effort grace period only: the dashboard's STOMP and KPI polling keep the network
+      // permanently active, so networkidle never settles. The visibility wait above is the real signal.
       await page
         .waitForLoadState('networkidle', {
           timeout: SLOW_ACTION_TIMEOUT,
         })
-        .catch(() => {
-          // Ignore timeout - dashboard keeps background network activity (STOMP, polling)
-        });
+        .catch(() => {});
     });
   }
 

--- a/e2e/frontend-webui/tests/utils/pages/DashboardPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/DashboardPage.js
@@ -23,10 +23,17 @@ export class DashboardPage {
           timeout: SLOW_ACTION_TIMEOUT,
         });
 
-      // Wait for network to settle
-      await page.waitForLoadState('networkidle', {
-        timeout: SLOW_ACTION_TIMEOUT,
-      });
+      // Wait for network to settle. Best-effort only: the dashboard's STOMP/websocket
+      // + KPI polling keep the network permanently active, so networkidle can never
+      // settle on a real backend. The .app-content/.dashboard visibility wait above is
+      // the deterministic load signal; don't let this extra grace period gate the test.
+      await page
+        .waitForLoadState('networkidle', {
+          timeout: SLOW_ACTION_TIMEOUT,
+        })
+        .catch(() => {
+          // Ignore timeout - dashboard keeps background network activity (STOMP, polling)
+        });
     });
   }
 


### PR DESCRIPTION
## Manufacturing costing — WIP cost-imbalance review (PR1)

First staged PR of the manufacturing cost-imbalance review feature.

### What this delivers
1. **`PP_Order.CostDifference`** — renames the former virtual `Kostendifferenz` column to `CostDifference` and **negates its sign**, so the value is **negative when more cost was issued than received** and positive when more was received. Virtual `ColumnSQL`, so no stored data. German UI label stays **"Kostendifferenz"**; en_US is **"Cost difference"**. `I_/X_PP_Order` regenerated.
2. **Cost-imbalance monitor window** — a new read-only `AD_Window` over `PP_Order` filtered to `DocStatus='CO'` (completed but not closed), surfacing `CostDifference` prominently in the grid so a controller can review the imbalance before the (later PR) post-calculation action. Grid leads with DocumentNo → DocType → Product → **CostDifference**; org last; client excluded from the grid.
3. **Cucumber coverage** — two scenarios on the real manufacturing issue→receive flow asserting `CostDifference` for both signs (received > issued → +15; received < issued → −5), consistent with the `Fact_Acct` postings asserted in the same scenarios.
4. **The expression reads the received amount from `PP_Order_Cost.cumulatedamt`** (`5820790`, superseding what `5814670` and `5820560` set). It previously took that summand from `postcalculationamt`, which is written by `PPOrderCosts.updatePostCalculationAmountsForCostElement` to distribute the order's total **input** cost over its outputs — so on the main-product line it holds the **issued** total, the same figure the second summand already derives from the `MaterialIssue` lines. `cumulatedamt` is the amount actually received out of the order, and is correct on that line independently of the post-calculation fixes shipped in the sibling PR.
5. **Index on `PP_Cost_Collector(PP_Order_ID)`** (`5820570`) — the expression fans out over an order's cost collectors on every rendered row. Measured on a customer-flavored local stack: ~1.4 s/page before, sub-second after. Built non-`CONCURRENTLY` because the migration tool runs each script inside a transaction; safe here given the table size and that the build happens at rollout.

`5820790` also drops the netting of already-distributed amounts out of `M_CostDetail` that `5820560` had added. The later PR discharges an order's residual by accumulating it onto the main product's `PP_Order_Cost` line, so the first two summands already read zero for a discharged order; keeping the `M_CostDetail` summand on top would count the discharge twice and report the residual with the opposite sign.

### Verification
- Migrations applied cleanly and DB-verified on a customer-flavored local stack (rename + field repoint + old-object drop; new window/tab/UI chain/menu; grid order; the new index and the final expression).
- The expression was evaluated against eight real orders on that stack: 25 received / 10 issued reads **15**, 5 received / 10 issued reads **−5**, and a fully discharged order reads **0** — including orders created before the sibling PR's post-calculation fixes existed, which is what makes this expression safe to ship here on its own.
- Rendering rule-checked via the window-designer against the live DB.
- Reviewed (whole-branch); findings applied.

### Known limitation
The later PR's discharge touches only the main-product line, so an order carrying co-products or by-products does not net to zero after discharging. Same limit as the expression this supersedes.

### Scope / follow-ups
- The post-calculation action + new cost-collector type, and the two catch-weight issue-flow bugs, follow in later staged PRs.
