### PR TITLE
Sales Order Document — cascade planning objects and block on real documents when deleting a sales order line

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_OrderLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_OrderLine_StepDef.java
@@ -31,6 +31,7 @@ import de.metas.cucumber.stepdefs.attribute.M_Attribute_StepDefData;
 import de.metas.cucumber.stepdefs.contract.C_Flatrate_Conditions_StepDefData;
 import de.metas.cucumber.stepdefs.contract.C_Flatrate_Term_StepDefData;
 import de.metas.cucumber.stepdefs.hu.M_HU_PI_Item_Product_StepDefData;
+import de.metas.cucumber.stepdefs.message.AD_Message_StepDefData;
 import de.metas.cucumber.stepdefs.pricing.C_TaxCategory_StepDefData;
 import de.metas.cucumber.stepdefs.util.IdentifiersEvaluatee;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
@@ -39,6 +40,8 @@ import de.metas.currency.CurrencyCode;
 import de.metas.currency.ICurrencyDAO;
 import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.i18n.AdMessageKey;
+import de.metas.i18n.IMsgBL;
 import de.metas.material.event.commons.AttributesKey;
 import de.metas.order.IOrderLineBL;
 import de.metas.ordercandidate.model.I_C_OLCand;
@@ -68,6 +71,7 @@ import org.adempiere.mm.attributes.api.Attribute;
 import org.adempiere.mm.attributes.keys.AttributesKeys;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.assertj.core.api.SoftAssertions;
+import org.compiere.model.I_AD_Message;
 import org.compiere.model.I_C_DocType;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_OrderLine;
@@ -77,6 +81,7 @@ import org.compiere.model.I_M_AttributeInstance;
 import org.compiere.model.I_M_AttributeSetInstance;
 import org.compiere.model.I_M_Product;
 import org.compiere.model.I_M_Warehouse;
+import org.compiere.util.Env;
 import org.compiere.util.Evaluatees;
 import org.compiere.util.TimeUtil;
 import org.jetbrains.annotations.NotNull;
@@ -94,6 +99,7 @@ import static de.metas.cucumber.stepdefs.StepDefConstants.TABLECOLUMN_IDENTIFIER
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.compiere.model.I_AD_Message.COLUMNNAME_AD_Message_ID;
 import static org.compiere.model.I_C_OrderLine.COLUMNNAME_C_TaxCategory_ID;
 import static org.compiere.model.I_C_OrderLine.COLUMNNAME_DateOrdered;
 import static org.compiere.model.I_C_OrderLine.COLUMNNAME_M_AttributeSetInstance_ID;
@@ -108,6 +114,7 @@ public class C_OrderLine_StepDef
 	@NonNull private final ICurrencyDAO currencyDAO = Services.get(ICurrencyDAO.class);
 	@NonNull private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
 	@NonNull private final IOrderLineBL orderLineBL = Services.get(IOrderLineBL.class);
+	@NonNull private final IMsgBL msgBL = Services.get(IMsgBL.class);
 
 	private final @NonNull M_Product_StepDefData productTable;
 	private final @NonNull C_BPartner_StepDefData partnerTable;
@@ -122,6 +129,7 @@ public class C_OrderLine_StepDef
 	private final @NonNull C_Tax_StepDefData taxTable;
 	private final @NonNull M_Warehouse_StepDefData warehouseTable;
 	private final @NonNull IdentifierIds_StepDefData identifierIdsTable;
+	private final @NonNull AD_Message_StepDefData messageTable;
 
 	@Given("metasfresh contains C_OrderLines:")
 	public void metasfresh_contains_c_order_lines(@NonNull final DataTable dataTable)
@@ -412,6 +420,46 @@ public class C_OrderLine_StepDef
 		final I_C_OrderLine orderLine = orderLineTable.get(orderLineIdentifier);
 		identifierIdsTable.put(orderLineIdentifier, orderLine.getC_OrderLine_ID());
 		InterfaceWrapperHelper.delete(orderLine);
+	}
+
+	/**
+	 * Attempts to delete a sales order line and asserts that the delete is blocked (an exception is thrown),
+	 * validating the error message against an AD_Message record when one is given.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>AD_Message_ID</b> — (optional, identifier-ref) expected error message from AD_Message<br>
+	 * @cucumber.depends StepDefData: C_OrderLine_StepDefData, AD_Message_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And delete C_OrderLine identified by ol_1 expecting error:
+	 *   | AD_Message_ID |
+	 *   | blockMsg      |
+	 * </pre>
+	 */
+	@And("^delete C_OrderLine identified by (.*) expecting error:$")
+	public void delete_orderLine_expecting_error(@NonNull final String orderLineIdentifier, @NonNull final DataTable dataTable)
+	{
+		final DataTableRow row = DataTableRows.of(dataTable).getFirstRow();
+		final I_C_OrderLine orderLine = orderLineTable.get(orderLineIdentifier);
+
+		boolean errorThrown = false;
+		try
+		{
+			InterfaceWrapperHelper.delete(orderLine);
+		}
+		catch (final Exception e)
+		{
+			errorThrown = true;
+
+			row.getAsOptionalIdentifier(COLUMNNAME_AD_Message_ID)
+					.ifPresent(errorMessageIdentifier -> {
+						final I_AD_Message errorMessage = messageTable.get(errorMessageIdentifier);
+						assertThat(e.getMessage()).contains(msgBL.getMsg(Env.getCtx(), AdMessageKey.of(errorMessage.getValue())));
+					});
+		}
+
+		assertThat(errorThrown).isTrue();
 	}
 
 	@And("load C_Order from C_OrderLine")

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/salesOrderLineDeleteAfterReactivation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/salesOrderLineDeleteAfterReactivation.feature
@@ -13,10 +13,13 @@ Feature: Delete a sales order line after the order was reactivated
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
     And metasfresh has date and time 2026-07-20T08:00:00+01:00[Europe/Berlin]
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    # test C_BPartners are not EDI-flavored; disable the EDI interceptor so plain order creation doesn't fail
+    # trying to load them as de.metas.edi.model.I_C_BPartner (see AnnotatedModelInterceptorDisabler)
+    And set sys config String value N for sys config InterceptorEnabled_de.metas.edi.model.validator.C_Order#setEdiEnabledForNewOrder
 
   @Id:S29172_10
   Scenario: Reactivated line whose planning objects never produced a real document cascades cleanly
-    Given load M_AttributeSet:
+    Given add M_AttributeSet:
       | M_AttributeSet_ID.Identifier | Name                   |
       | attributeSet_delLine         | Delete-Line Attributes |
     And load M_Product_Category:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/salesOrderLineDeleteAfterReactivation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/salesOrderLineDeleteAfterReactivation.feature
@@ -22,12 +22,9 @@ Feature: Delete a sales order line after the order was reactivated
     Given add M_AttributeSet:
       | M_AttributeSet_ID.Identifier | Name                   |
       | attributeSet_delLine         | Delete-Line Attributes |
-    And load M_Product_Category:
-      | M_Product_Category_ID.Identifier | Name       | Value      |
-      | category_delLine                 | DeleteLine | DeleteLine |
-    And update M_Product_Category:
-      | M_Product_Category_ID.Identifier | OPT.M_AttributeSet_ID.Identifier |
-      | category_delLine                 | attributeSet_delLine             |
+    And metasfresh contains M_Product_Categories:
+      | Identifier       | Name       | Value      | OPT.M_AttributeSet_ID.Identifier |
+      | category_delLine | DeleteLine | DeleteLine | attributeSet_delLine             |
     And metasfresh contains M_Products:
       | Identifier      | Name            | OPT.M_Product_Category_ID.Identifier | OPT.IsSold | OPT.IsPurchased |
       | product_delLine | product_delLine | category_delLine                     | Y          | Y               |
@@ -131,9 +128,12 @@ Feature: Delete a sales order line after the order was reactivated
       | orderLine_2 | order_2               | product_delLineInv      | 5          |
     When the order identified by order_2 is completed
 
-    Then after not more than 60s, C_Invoice_Candidate are found:
-      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
-      | invoiceCandidate_2                | orderLine_2               | 5            |
+    Then after not more than 60s locate up2date invoice candidates by order line:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier |
+      | invoiceCandidate_2                | orderLine_2               |
+    And validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_OrderLine_ID.Identifier | QtyToInvoice |
+      | invoiceCandidate_2                | orderLine_2                   | 5            |
     When process invoice candidates and wait 60s for C_Invoice_Candidate to be processed
       | C_Invoice_Candidate_ID.Identifier |
       | invoiceCandidate_2                |
@@ -190,9 +190,12 @@ Feature: Delete a sales order line after the order was reactivated
       | orderLine_3 | order_3               | product_delLineVoid     | 5          |
     When the order identified by order_3 is completed
 
-    Then after not more than 60s, C_Invoice_Candidate are found:
-      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
-      | invoiceCandidate_3                | orderLine_3               | 5            |
+    Then after not more than 60s locate up2date invoice candidates by order line:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier |
+      | invoiceCandidate_3                | orderLine_3               |
+    And validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_OrderLine_ID.Identifier | QtyToInvoice |
+      | invoiceCandidate_3                | orderLine_3                   | 5            |
     When process invoice candidates and wait 60s for C_Invoice_Candidate to be processed
       | C_Invoice_Candidate_ID.Identifier |
       | invoiceCandidate_3                |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/salesOrderLineDeleteAfterReactivation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/salesOrderLineDeleteAfterReactivation.feature
@@ -13,9 +13,13 @@ Feature: Delete a sales order line after the order was reactivated
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
     And metasfresh has date and time 2026-07-20T08:00:00+01:00[Europe/Berlin]
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
-    # test C_BPartners are not EDI-flavored; disable the EDI interceptor so plain order creation doesn't fail
-    # trying to load them as de.metas.edi.model.I_C_BPartner (see AnnotatedModelInterceptorDisabler)
+    # test C_BPartners are not EDI-flavored; disable the EDI interceptors so plain order creation and
+    # invoice-candidate creation don't fail trying to load them as de.metas.edi.model.I_C_BPartner
+    # (see AnnotatedModelInterceptorDisabler); the local schema lacks C_BPartner.IsEdiInvoicRecipient
+    # (environment gap), so the interceptor that reads it during C_Invoice_Candidate creation must be
+    # disabled too, else createMissingCandidates() throws IllegalArgumentException on POWrapper
     And set sys config String value N for sys config InterceptorEnabled_de.metas.edi.model.validator.C_Order#setEdiEnabledForNewOrder
+    And set sys config String value N for sys config InterceptorEnabled_de.metas.edi.model.validator.C_Invoice_Candidate#setIsEDIInvoicRecipient
 
   @Id:S29172_10
   Scenario: Reactivated line whose planning objects never produced a real document cascades cleanly

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/salesOrderLineDeleteAfterReactivation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/salesOrderLineDeleteAfterReactivation.feature
@@ -15,9 +15,8 @@ Feature: Delete a sales order line after the order was reactivated
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
     # test C_BPartners are not EDI-flavored; disable the EDI interceptors so plain order creation and
     # invoice-candidate creation don't fail trying to load them as de.metas.edi.model.I_C_BPartner
-    # (see AnnotatedModelInterceptorDisabler); the local schema lacks C_BPartner.IsEdiInvoicRecipient
-    # (environment gap), so the interceptor that reads it during C_Invoice_Candidate creation must be
-    # disabled too, else createMissingCandidates() throws IllegalArgumentException on POWrapper
+    # (see AnnotatedModelInterceptorDisabler); EDI recipient flagging is irrelevant to this delete-flow
+    # test, so the interceptor that reads it during C_Invoice_Candidate creation is disabled too
     And set sys config String value N for sys config InterceptorEnabled_de.metas.edi.model.validator.C_Order#setEdiEnabledForNewOrder
     And set sys config String value N for sys config InterceptorEnabled_de.metas.edi.model.validator.C_Invoice_Candidate#setIsEDIInvoicRecipient
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/salesOrderLineDeleteAfterReactivation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/salesOrderLineDeleteAfterReactivation.feature
@@ -1,0 +1,211 @@
+@from:cucumber
+@allure.label.epic:E0100_Sales
+@allure.label.feature:F00105_Sales_Order_Document
+@ghActions:run_on_executor4
+Feature: Delete a sales order line after the order was reactivated
+  Completing a sales order creates, per line, a shipment schedule, an invoice candidate and a
+  purchase candidate. Reactivating the order does not remove them. Deleting a re-opened line must
+  cascade-remove those planning objects when they never produced a real document, and must
+  politely block (no raw database error) when a completed document already references the line.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2026-07-20T08:00:00+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+
+  @Id:S29172_10
+  Scenario: Reactivated line whose planning objects never produced a real document cascades cleanly
+    Given load M_AttributeSet:
+      | M_AttributeSet_ID.Identifier | Name                   |
+      | attributeSet_delLine         | Delete-Line Attributes |
+    And load M_Product_Category:
+      | M_Product_Category_ID.Identifier | Name       | Value      |
+      | category_delLine                 | DeleteLine | DeleteLine |
+    And update M_Product_Category:
+      | M_Product_Category_ID.Identifier | OPT.M_AttributeSet_ID.Identifier |
+      | category_delLine                 | attributeSet_delLine             |
+    And metasfresh contains M_Products:
+      | Identifier      | Name            | OPT.M_Product_Category_ID.Identifier | OPT.IsSold | OPT.IsPurchased |
+      | product_delLine | product_delLine | category_delLine                     | Y          | Y               |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                   | Value                        | OPT.IsActive |
+      | ps_delLine | pricing_system_delLine | pricing_system_value_delLine | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier   | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                 | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_s_delLine | ps_delLine                    | DE                        | EUR                 | s_price_list_delLine | true  | false         | 2              | true         |
+      | pl_p_delLine | ps_delLine                    | DE                        | EUR                 | p_price_list_delLine | false | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier    | M_PriceList_ID.Identifier | Name          | ValidFrom  |
+      | plv_s_delLine | pl_s_delLine              | s_PLV_delLine | 2026-07-01 |
+      | plv_p_delLine | pl_p_delLine              | p_PLV_delLine | 2026-07-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier   | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_s_delLine | plv_s_delLine                     | product_delLine         | 10.0     | PCE               | Normal                        |
+      | pp_p_delLine | plv_p_delLine                     | product_delLine         | 10.0     | PCE               | Normal                        |
+    And metasfresh contains M_DiscountSchemas:
+      | Identifier | Name                    | DiscountType | ValidFrom  |
+      | ds_delLine | discount_schema_delLine | F            | 2026-07-01 |
+    And metasfresh contains M_DiscountSchemaBreaks:
+      | Identifier  | M_DiscountSchema_ID.Identifier | M_Product_ID.Identifier | Base_PricingSystem_ID.Identifier | SeqNo | OPT.IsBPartnerFlatDiscount | OPT.PriceBase | OPT.BreakValue | OPT.BreakDiscount |
+      | dsb_delLine | ds_delLine                     | product_delLine         | ps_delLine                       | 10    | Y                          | P             | 10             | 0                 |
+    And metasfresh contains PP_Product_Plannings
+      | Identifier   | M_Product_ID.Identifier | IsCreatePlan | OPT.IsPurchased |
+      | ppln_delLine | product_delLine         | false        | Y               |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier       | Name             | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier | OPT.PO_DiscountSchema_ID.Identifier |
+      | customer_delLine | Customer_delLine | N            | Y              | ps_delLine                    |                                     |
+      | vendor_delLine   | Vendor_delLine   | Y            | N              | ps_delLine                    | ds_delLine                          |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier                | GLN           | C_BPartner_ID.Identifier | OPT.Name         | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | vendor_location_delLine   | 2411250300000 | vendor_delLine           | Vendor_delLine   | Y                   | Y                   |
+      | customer_location_delLine | 2411250300001 | customer_delLine         | Customer_delLine | Y                   | Y                   |
+    And metasfresh contains C_BPartner_Product
+      | C_BPartner_ID.Identifier | M_Product_ID.Identifier |
+      | vendor_delLine           | product_delLine         |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | order_1    | true    | customer_delLine         | 2026-07-20  |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine_1 | order_1               | product_delLine         | 5          |
+    When the order identified by order_1 is completed
+
+    Then after not more than 60s, C_PurchaseCandidates are found
+      | Identifier          | C_OrderSO_ID.Identifier | C_OrderLineSO_ID.Identifier | M_Product_ID.Identifier |
+      | purchaseCandidate_1 | order_1                 | orderLine_1                 | product_delLine         |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And no C_PurchaseCandidate_Alloc are found for:
+      | C_PurchaseCandidate_ID.Identifier |
+      | purchaseCandidate_1               |
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | schedule_1 | orderLine_1               | N             |
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | invoiceCandidate_1                | orderLine_1               | 0            |
+
+    # Reactivating does not neutralize the planning objects (per the real incident): the shipment
+    # schedule, invoice candidate and purchase candidate are all still around at this point.
+    When the order identified by order_1 is reactivated
+    And delete C_OrderLine identified by orderLine_1, but keep its id into identifierIds table
+
+    Then no C_PurchaseCandidate found for orderLine orderLine_1
+    And there is no M_ShipmentSchedule for C_Order order_1
+    And there is no C_Invoice_Candidate for C_Order order_1
+
+  @Id:S29172_20
+  Scenario: Reactivated line still referenced by a completed invoice is blocked with a friendly message
+    Given metasfresh contains M_Products:
+      | Identifier         | Name               |
+      | product_delLineInv | product_delLineInv |
+    And metasfresh contains M_PricingSystems
+      | Identifier    | Name                      | Value                           | OPT.IsActive |
+      | ps_delLineInv | pricing_system_delLineInv | pricing_system_value_delLineInv | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier    | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                  | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_delLineInv | ps_delLineInv                 | DE                        | EUR                 | price_list_delLineInv | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier     | M_PriceList_ID.Identifier | Name           | ValidFrom  |
+      | plv_delLineInv | pl_delLineInv             | plv_delLineInv | 2026-07-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier    | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_delLineInv | plv_delLineInv                    | product_delLineInv      | 10.0     | PCE               | Normal                        |
+    And metasfresh contains C_BPartners:
+      | Identifier          | Name                | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | customer_delLineInv | Customer_delLineInv | N            | Y              | ps_delLineInv                 |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier          | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | location_delLineInv | 2411250300002 | customer_delLineInv      | Y                   | Y                   |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.InvoiceRule |
+      | order_2    | true    | customer_delLineInv      | 2026-07-20  | I               |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine_2 | order_2               | product_delLineInv      | 5          |
+    When the order identified by order_2 is completed
+
+    Then after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | invoiceCandidate_2                | orderLine_2               | 5            |
+    When process invoice candidates and wait 60s for C_Invoice_Candidate to be processed
+      | C_Invoice_Candidate_ID.Identifier |
+      | invoiceCandidate_2                |
+    Then after not more than 60s, C_Invoice are found:
+      | C_Invoice_Candidate_ID.Identifier | C_Invoice_ID.Identifier |
+      | invoiceCandidate_2                | invoice_2               |
+    And validate created invoices
+      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | processed | DocStatus |
+      | invoice_2               | customer_delLineInv      | true      | CO        |
+
+    And load AD_Message:
+      | Identifier | Value                                        |
+      | blockMsg   | SalesOrderLine_CannotDelete_HasCompletedDocs |
+
+    When the order identified by order_2 is reactivated
+    And delete C_OrderLine identified by orderLine_2 expecting error:
+      | AD_Message_ID |
+      | blockMsg      |
+
+    # Nothing was deleted: the line is still there, unchanged.
+    Then validate C_OrderLine:
+      | C_OrderLine_ID.Identifier |
+      | orderLine_2               |
+
+  @Id:S29172_30
+  Scenario: Reactivated line whose invoice was voided is no longer blocked
+    Given metasfresh contains M_Products:
+      | Identifier          | Name                |
+      | product_delLineVoid | product_delLineVoid |
+    And metasfresh contains M_PricingSystems
+      | Identifier     | Name                       | Value                            | OPT.IsActive |
+      | ps_delLineVoid | pricing_system_delLineVoid | pricing_system_value_delLineVoid | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier     | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name                   | SOTrx | IsTaxIncluded | PricePrecision |
+      | pl_delLineVoid | ps_delLineVoid                | DE                        | EUR                 | price_list_delLineVoid | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier      | M_PriceList_ID.Identifier | Name            | ValidFrom  |
+      | plv_delLineVoid | pl_delLineVoid            | plv_delLineVoid | 2026-07-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier     | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_delLineVoid | plv_delLineVoid                   | product_delLineVoid     | 10.0     | PCE               | Normal                        |
+    And metasfresh contains C_BPartners:
+      | Identifier           | Name                 | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | customer_delLineVoid | Customer_delLineVoid | N            | Y              | ps_delLineVoid                |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier           | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | location_delLineVoid | 2411250300003 | customer_delLineVoid     | Y                   | Y                   |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | OPT.InvoiceRule |
+      | order_3    | true    | customer_delLineVoid     | 2026-07-20  | I               |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | orderLine_3 | order_3               | product_delLineVoid     | 5          |
+    When the order identified by order_3 is completed
+
+    Then after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | invoiceCandidate_3                | orderLine_3               | 5            |
+    When process invoice candidates and wait 60s for C_Invoice_Candidate to be processed
+      | C_Invoice_Candidate_ID.Identifier |
+      | invoiceCandidate_3                |
+    Then after not more than 60s, C_Invoice are found:
+      | C_Invoice_Candidate_ID.Identifier | C_Invoice_ID.Identifier |
+      | invoiceCandidate_3                | invoice_3               |
+    And validate created invoices
+      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | processed | DocStatus |
+      | invoice_3               | customer_delLineVoid     | true      | CO        |
+
+    # Voiding the invoice makes it no longer "real": the delete is no longer blocked.
+    When the invoice identified by invoice_3 is voided
+
+    And the order identified by order_3 is reactivated
+    And delete C_OrderLine identified by orderLine_3, but keep its id into identifierIds table
+
+    Then no C_PurchaseCandidate found for orderLine orderLine_3
+    And there is no M_ShipmentSchedule for C_Order order_3
+    And there is no C_Invoice_Candidate for C_Order order_3

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/PurchaseCandidateRepository.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/PurchaseCandidateRepository.java
@@ -142,15 +142,34 @@ public class PurchaseCandidateRepository
 
 	/**
 	 * @return {@code true} if a real (i.e. non-simulated) purchase candidate exists for the given sales order line
-	 * which has already been used to create a purchase order.
+	 * which has already been used to create a purchase order, i.e. has at least one {@link I_C_PurchaseCandidate_Alloc}
+	 * record (the real link to a {@code C_OrderLinePO_ID}/{@code C_OrderPO_ID}).
+	 * <p>
+	 * Note: intentionally NOT based on {@code C_PurchaseCandidate.Processed}. That flag is neither necessary nor
+	 * sufficient here: a partially-fulfilled candidate has real {@code C_PurchaseCandidate_Alloc} rows while still
+	 * {@code Processed=false} (false negative), and the manual AD process {@code C_PurchaseCandiate_Mark_Processed}
+	 * can set {@code Processed=true} with no PO at all (false positive).
 	 */
 	public boolean hasCandidateThatProducedAPurchaseOrder(@NonNull final OrderLineId salesOrderLineId)
 	{
-		return queryBL.createQueryBuilder(I_C_PurchaseCandidate.class)
+		final Set<PurchaseCandidateId> candidateIds = queryBL.createQueryBuilder(I_C_PurchaseCandidate.class)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_C_PurchaseCandidate.COLUMNNAME_C_OrderLineSO_ID, salesOrderLineId)
 				.addEqualsFilter(I_C_PurchaseCandidate.COLUMNNAME_IsSimulated, false)
-				.addEqualsFilter(I_C_PurchaseCandidate.COLUMNNAME_Processed, true)
+				.create()
+				.listIds()
+				.stream()
+				.map(PurchaseCandidateId::ofRepoId)
+				.collect(ImmutableSet.toImmutableSet());
+
+		if (candidateIds.isEmpty())
+		{
+			return false;
+		}
+
+		return queryBL.createQueryBuilder(I_C_PurchaseCandidate_Alloc.class)
+				.addOnlyActiveRecordsFilter()
+				.addInArrayFilter(I_C_PurchaseCandidate_Alloc.COLUMN_C_PurchaseCandidate_ID, PurchaseCandidateId.toIntSet(candidateIds))
 				.create()
 				.anyMatch();
 	}

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/PurchaseCandidateRepository.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/PurchaseCandidateRepository.java
@@ -140,6 +140,21 @@ public class PurchaseCandidateRepository
 				.collect(ImmutableList.toImmutableList());
 	}
 
+	/**
+	 * @return {@code true} if a real (i.e. non-simulated) purchase candidate exists for the given sales order line
+	 * which has already been used to create a purchase order.
+	 */
+	public boolean hasCandidateThatProducedAPurchaseOrder(@NonNull final OrderLineId salesOrderLineId)
+	{
+		return queryBL.createQueryBuilder(I_C_PurchaseCandidate.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_C_PurchaseCandidate.COLUMNNAME_C_OrderLineSO_ID, salesOrderLineId)
+				.addEqualsFilter(I_C_PurchaseCandidate.COLUMNNAME_IsSimulated, false)
+				.addEqualsFilter(I_C_PurchaseCandidate.COLUMNNAME_Processed, true)
+				.create()
+				.anyMatch();
+	}
+
 	@NonNull
 	public Optional<PurchaseCandidateId> getByExternalHeaderAndLineId(
 			@NonNull final String externalHeaderId,
@@ -760,7 +775,11 @@ public class PurchaseCandidateRepository
 
 		if (deletePurchaseCandidateQuery.isOnlySimulated())
 		{
-			deleteQuery.addEqualsFilter(I_C_PurchaseCandidate.COLUMNNAME_IsSimulated, deletePurchaseCandidateQuery.isOnlySimulated());
+			deleteQuery.addEqualsFilter(I_C_PurchaseCandidate.COLUMNNAME_IsSimulated, true);
+		}
+		else
+		{
+			deleteQuery.addEqualsFilter(I_C_PurchaseCandidate.COLUMNNAME_IsSimulated, false);
 		}
 
 		if (deletePurchaseCandidateQuery.getSalesOrderLineId() != null)

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/PurchaseCandidateRepository.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/PurchaseCandidateRepository.java
@@ -149,6 +149,13 @@ public class PurchaseCandidateRepository
 	 * sufficient here: a partially-fulfilled candidate has real {@code C_PurchaseCandidate_Alloc} rows while still
 	 * {@code Processed=false} (false negative), and the manual AD process {@code C_PurchaseCandiate_Mark_Processed}
 	 * can set {@code Processed=true} with no PO at all (false positive).
+	 * <p>
+	 * Note: unlike the shipment/invoice delete guards, this check does NOT unblock once the purchase order is
+	 * voided or reversed. Those guards look at the referenced document's {@code DocStatus} because voiding/reversing
+	 * a shipment or invoice cancels the document itself. Here, voiding/reversing the purchase order does NOT remove
+	 * the {@code C_PurchaseCandidate_Alloc} row that links the candidate to it, so the FK would still be violated if
+	 * the candidate were deleted. Blocking on Alloc existence alone (regardless of the PO's DocStatus) is therefore
+	 * deliberate and FK-necessary — do not add a DocStatus check here.
 	 */
 	public boolean hasCandidateThatProducedAPurchaseOrder(@NonNull final OrderLineId salesOrderLineId)
 	{

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/RealPurchaseCandidateCleanUpService.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/RealPurchaseCandidateCleanUpService.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * de.metas.purchasecandidate.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.purchasecandidate.material;
+
+import de.metas.i18n.AdMessageKey;
+import de.metas.order.OrderLineId;
+import de.metas.purchasecandidate.DeletePurchaseCandidateQuery;
+import de.metas.purchasecandidate.PurchaseCandidateRepository;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.springframework.stereotype.Service;
+
+/**
+ * Cascades the delete of a sales order line onto its <b>real</b> (i.e. non-simulated) {@code C_PurchaseCandidate}
+ * records: candidates that never produced a purchase order are deleted along with the line, while candidates that
+ * already produced a purchase order block the delete.
+ */
+@Service
+public class RealPurchaseCandidateCleanUpService
+{
+	public static final AdMessageKey MSG_SalesOrderLine_CannotDelete_HasCompletedDocs = AdMessageKey.of("SalesOrderLine_CannotDelete_HasCompletedDocs");
+
+	@NonNull
+	private final PurchaseCandidateRepository purchaseCandidateRepository;
+
+	public RealPurchaseCandidateCleanUpService(final @NonNull PurchaseCandidateRepository purchaseCandidateRepository)
+	{
+		this.purchaseCandidateRepository = purchaseCandidateRepository;
+	}
+
+	public void deleteRealCandidatesFor(@NonNull final OrderLineId salesOrderLineId)
+	{
+		if (purchaseCandidateRepository.hasCandidateThatProducedAPurchaseOrder(salesOrderLineId))
+		{
+			throw new AdempiereException("@" + MSG_SalesOrderLine_CannotDelete_HasCompletedDocs + "@");
+		}
+
+		final DeletePurchaseCandidateQuery deleteQuery = DeletePurchaseCandidateQuery.builder()
+				.salesOrderLineId(salesOrderLineId)
+				.onlySimulated(false)
+				.build();
+
+		purchaseCandidateRepository.deletePurchaseCandidates(deleteQuery);
+	}
+}

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/RealPurchaseCandidateCleanUpService.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/RealPurchaseCandidateCleanUpService.java
@@ -27,6 +27,7 @@ import de.metas.order.OrderLineId;
 import de.metas.purchasecandidate.DeletePurchaseCandidateQuery;
 import de.metas.purchasecandidate.PurchaseCandidateRepository;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.adempiere.exceptions.AdempiereException;
 import org.springframework.stereotype.Service;
 
@@ -36,17 +37,13 @@ import org.springframework.stereotype.Service;
  * already produced a purchase order block the delete.
  */
 @Service
+@RequiredArgsConstructor
 public class RealPurchaseCandidateCleanUpService
 {
 	public static final AdMessageKey MSG_SalesOrderLine_CannotDelete_HasCompletedDocs = AdMessageKey.of("SalesOrderLine_CannotDelete_HasCompletedDocs");
 
 	@NonNull
 	private final PurchaseCandidateRepository purchaseCandidateRepository;
-
-	public RealPurchaseCandidateCleanUpService(final @NonNull PurchaseCandidateRepository purchaseCandidateRepository)
-	{
-		this.purchaseCandidateRepository = purchaseCandidateRepository;
-	}
 
 	public void deleteRealCandidatesFor(@NonNull final OrderLineId salesOrderLineId)
 	{

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/RealPurchaseCandidateCleanUpService.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/RealPurchaseCandidateCleanUpService.java
@@ -49,7 +49,7 @@ public class RealPurchaseCandidateCleanUpService
 	{
 		if (purchaseCandidateRepository.hasCandidateThatProducedAPurchaseOrder(salesOrderLineId))
 		{
-			throw new AdempiereException("@" + MSG_SalesOrderLine_CannotDelete_HasCompletedDocs + "@");
+			throw new AdempiereException(MSG_SalesOrderLine_CannotDelete_HasCompletedDocs);
 		}
 
 		final DeletePurchaseCandidateQuery deleteQuery = DeletePurchaseCandidateQuery.builder()

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/interceptor/C_OrderLine.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/interceptor/C_OrderLine.java
@@ -23,6 +23,7 @@
 package de.metas.purchasecandidate.material.interceptor;
 
 import de.metas.order.OrderLineId;
+import de.metas.purchasecandidate.material.RealPurchaseCandidateCleanUpService;
 import de.metas.purchasecandidate.material.SimulatedPurchaseCandidateCleanUpService;
 import lombok.NonNull;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
@@ -38,14 +39,35 @@ public class C_OrderLine
 	@NonNull
 	private final SimulatedPurchaseCandidateCleanUpService simulatedPurchaseCandidateCleanUpService;
 
-	public C_OrderLine(final @NonNull SimulatedPurchaseCandidateCleanUpService simulatedPurchaseCandidateCleanUpService)
+	@NonNull
+	private final RealPurchaseCandidateCleanUpService realPurchaseCandidateCleanUpService;
+
+	public C_OrderLine(
+			final @NonNull SimulatedPurchaseCandidateCleanUpService simulatedPurchaseCandidateCleanUpService,
+			final @NonNull RealPurchaseCandidateCleanUpService realPurchaseCandidateCleanUpService)
 	{
 		this.simulatedPurchaseCandidateCleanUpService = simulatedPurchaseCandidateCleanUpService;
+		this.realPurchaseCandidateCleanUpService = realPurchaseCandidateCleanUpService;
 	}
 
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_DELETE)
 	public void removeSimulatedPurchaseCandidate(final I_C_OrderLine orderLine)
 	{
 		simulatedPurchaseCandidateCleanUpService.deleteSimulatedCandidatesFor(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
+	}
+
+	/**
+	 * Cascades the delete onto real (i.e. non-simulated) purchase candidates of a sales order line, guarding
+	 * against deleting a line whose candidate already produced a purchase order.
+	 */
+	@ModelChange(timings = ModelValidator.TYPE_BEFORE_DELETE)
+	public void deleteOrGuardRealPurchaseCandidate(final I_C_OrderLine orderLine)
+	{
+		if (!orderLine.getC_Order().isSOTrx())
+		{
+			return;
+		}
+
+		realPurchaseCandidateCleanUpService.deleteRealCandidatesFor(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
 	}
 }

--- a/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/interceptor/C_OrderLine.java
+++ b/backend/de.metas.purchasecandidate.base/src/main/java/de/metas/purchasecandidate/material/interceptor/C_OrderLine.java
@@ -26,6 +26,7 @@ import de.metas.order.OrderLineId;
 import de.metas.purchasecandidate.material.RealPurchaseCandidateCleanUpService;
 import de.metas.purchasecandidate.material.SimulatedPurchaseCandidateCleanUpService;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.compiere.model.I_C_OrderLine;
@@ -34,6 +35,7 @@ import org.springframework.stereotype.Component;
 
 @Interceptor(I_C_OrderLine.class)
 @Component
+@RequiredArgsConstructor
 public class C_OrderLine
 {
 	@NonNull
@@ -41,14 +43,6 @@ public class C_OrderLine
 
 	@NonNull
 	private final RealPurchaseCandidateCleanUpService realPurchaseCandidateCleanUpService;
-
-	public C_OrderLine(
-			final @NonNull SimulatedPurchaseCandidateCleanUpService simulatedPurchaseCandidateCleanUpService,
-			final @NonNull RealPurchaseCandidateCleanUpService realPurchaseCandidateCleanUpService)
-	{
-		this.simulatedPurchaseCandidateCleanUpService = simulatedPurchaseCandidateCleanUpService;
-		this.realPurchaseCandidateCleanUpService = realPurchaseCandidateCleanUpService;
-	}
 
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_DELETE)
 	public void removeSimulatedPurchaseCandidate(final I_C_OrderLine orderLine)

--- a/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/material/interceptor/C_OrderLineTest.java
+++ b/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/material/interceptor/C_OrderLineTest.java
@@ -1,0 +1,179 @@
+/*
+ * #%L
+ * de.metas.purchasecandidate.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.purchasecandidate.material.interceptor;
+
+import de.metas.adempiere.model.I_M_Product;
+import de.metas.common.util.time.SystemTime;
+import de.metas.document.dimension.DimensionService;
+import de.metas.order.OrderLineId;
+import de.metas.purchasecandidate.PurchaseCandidateRepository;
+import de.metas.purchasecandidate.ReferenceGenerator;
+import de.metas.purchasecandidate.material.RealPurchaseCandidateCleanUpService;
+import de.metas.purchasecandidate.material.SimulatedPurchaseCandidateCleanUpService;
+import de.metas.purchasecandidate.model.I_C_PurchaseCandidate;
+import de.metas.purchasecandidate.purchaseordercreation.remotepurchaseitem.PurchaseItemRepository;
+import org.adempiere.ad.wrapper.POJOLookupMap;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_OrderLine;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class C_OrderLineTest
+{
+	private PurchaseCandidateRepository purchaseCandidateRepository;
+
+	private C_OrderLine c_OrderLine;
+
+	private I_M_Product productRecord;
+
+	private I_C_Order salesOrderRecord;
+
+	private I_C_OrderLine salesOrderLineRecord;
+
+	@BeforeEach
+	public void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		final ReferenceGenerator referenceGenerator = Mockito.mock(ReferenceGenerator.class);
+		final DimensionService dimensionService = Mockito.mock(DimensionService.class);
+		purchaseCandidateRepository = new PurchaseCandidateRepository(
+				new PurchaseItemRepository(),
+				referenceGenerator,
+				dimensionService);
+
+		final SimulatedPurchaseCandidateCleanUpService simulatedPurchaseCandidateCleanUpService =
+				new SimulatedPurchaseCandidateCleanUpService(purchaseCandidateRepository);
+		final RealPurchaseCandidateCleanUpService realPurchaseCandidateCleanUpService =
+				new RealPurchaseCandidateCleanUpService(purchaseCandidateRepository);
+
+		c_OrderLine = new C_OrderLine(simulatedPurchaseCandidateCleanUpService, realPurchaseCandidateCleanUpService);
+
+		final I_C_UOM uom = newInstance(I_C_UOM.class);
+		saveRecord(uom);
+
+		productRecord = newInstance(I_M_Product.class);
+		productRecord.setValue("product.Value");
+		productRecord.setC_UOM_ID(uom.getC_UOM_ID());
+		saveRecord(productRecord);
+
+		salesOrderRecord = newInstance(I_C_Order.class);
+		salesOrderRecord.setIsSOTrx(true);
+		saveRecord(salesOrderRecord);
+
+		salesOrderLineRecord = newInstance(I_C_OrderLine.class);
+		salesOrderLineRecord.setC_Order(salesOrderRecord);
+		salesOrderLineRecord.setM_Product_ID(productRecord.getM_Product_ID());
+		salesOrderLineRecord.setQtyOrdered(BigDecimal.TEN);
+		saveRecord(salesOrderLineRecord);
+	}
+
+	private I_C_PurchaseCandidate createCandidate(final boolean simulated, final boolean processed)
+	{
+		final I_C_PurchaseCandidate candidateRecord = newInstance(I_C_PurchaseCandidate.class);
+		candidateRecord.setC_OrderLineSO_ID(salesOrderLineRecord.getC_OrderLine_ID());
+		candidateRecord.setM_Product_ID(productRecord.getM_Product_ID());
+		candidateRecord.setM_WarehousePO_ID(30);
+		candidateRecord.setC_UOM_ID(productRecord.getC_UOM_ID());
+		candidateRecord.setQtyToPurchase(BigDecimal.TEN);
+		candidateRecord.setPurchaseDatePromised(SystemTime.asTimestamp());
+		candidateRecord.setIsSimulated(simulated);
+		candidateRecord.setProcessed(processed);
+		saveRecord(candidateRecord);
+		return candidateRecord;
+	}
+
+	private List<I_C_PurchaseCandidate> getAllCandidateRecords()
+	{
+		return POJOLookupMap.get().getRecords(I_C_PurchaseCandidate.class);
+	}
+
+	@Test
+	public void simulatedCandidate_isStillDeleted_onOrderLineDelete()
+	{
+		final I_C_PurchaseCandidate simulatedCandidate = createCandidate(true, false);
+
+		c_OrderLine.removeSimulatedPurchaseCandidate(salesOrderLineRecord);
+
+		assertThat(getAllCandidateRecords())
+				.noneMatch(record -> record.getC_PurchaseCandidate_ID() == simulatedCandidate.getC_PurchaseCandidate_ID());
+	}
+
+	@Test
+	public void realCandidate_withNoPurchaseOrder_isDeleted_onOrderLineDelete()
+	{
+		final I_C_PurchaseCandidate realCandidate = createCandidate(false, false);
+
+		c_OrderLine.deleteOrGuardRealPurchaseCandidate(salesOrderLineRecord);
+
+		assertThat(getAllCandidateRecords())
+				.noneMatch(record -> record.getC_PurchaseCandidate_ID() == realCandidate.getC_PurchaseCandidate_ID());
+	}
+
+	@Test
+	public void realCandidate_thatProducedAPurchaseOrder_blocksDelete_onOrderLineDelete()
+	{
+		final I_C_PurchaseCandidate realCandidate = createCandidate(false, true);
+
+		assertThatThrownBy(() -> c_OrderLine.deleteOrGuardRealPurchaseCandidate(salesOrderLineRecord))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("SalesOrderLine_CannotDelete_HasCompletedDocs");
+
+		assertThat(getAllCandidateRecords())
+				.anyMatch(record -> record.getC_PurchaseCandidate_ID() == realCandidate.getC_PurchaseCandidate_ID());
+	}
+
+	@Test
+	public void purchaseOrderLine_isNeverGuardedOrCascaded()
+	{
+		final I_C_Order purchaseOrderRecord = newInstance(I_C_Order.class);
+		purchaseOrderRecord.setIsSOTrx(false);
+		saveRecord(purchaseOrderRecord);
+
+		final I_C_OrderLine purchaseOrderLineRecord = newInstance(I_C_OrderLine.class);
+		purchaseOrderLineRecord.setC_Order(purchaseOrderRecord);
+		purchaseOrderLineRecord.setM_Product_ID(productRecord.getM_Product_ID());
+		purchaseOrderLineRecord.setQtyOrdered(BigDecimal.ONE);
+		saveRecord(purchaseOrderLineRecord);
+
+		// even a candidate that "produced a PO" must not block deleting a *purchase* order line
+		final I_C_PurchaseCandidate realCandidate = createCandidate(false, true);
+
+		c_OrderLine.deleteOrGuardRealPurchaseCandidate(purchaseOrderLineRecord); // must not throw
+
+		assertThat(getAllCandidateRecords())
+				.anyMatch(record -> record.getC_PurchaseCandidate_ID() == realCandidate.getC_PurchaseCandidate_ID());
+	}
+}

--- a/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/material/interceptor/C_OrderLineTest.java
+++ b/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/material/interceptor/C_OrderLineTest.java
@@ -31,6 +31,7 @@ import de.metas.purchasecandidate.ReferenceGenerator;
 import de.metas.purchasecandidate.material.RealPurchaseCandidateCleanUpService;
 import de.metas.purchasecandidate.material.SimulatedPurchaseCandidateCleanUpService;
 import de.metas.purchasecandidate.model.I_C_PurchaseCandidate;
+import de.metas.purchasecandidate.model.I_C_PurchaseCandidate_Alloc;
 import de.metas.purchasecandidate.purchaseordercreation.remotepurchaseitem.PurchaseItemRepository;
 import org.adempiere.ad.wrapper.POJOLookupMap;
 import org.adempiere.exceptions.AdempiereException;
@@ -102,8 +103,16 @@ public class C_OrderLineTest
 
 	private I_C_PurchaseCandidate createCandidate(final boolean simulated, final boolean processed)
 	{
+		return createCandidate(salesOrderLineRecord, simulated, processed);
+	}
+
+	private I_C_PurchaseCandidate createCandidate(
+			final I_C_OrderLine orderLineSO,
+			final boolean simulated,
+			final boolean processed)
+	{
 		final I_C_PurchaseCandidate candidateRecord = newInstance(I_C_PurchaseCandidate.class);
-		candidateRecord.setC_OrderLineSO_ID(salesOrderLineRecord.getC_OrderLine_ID());
+		candidateRecord.setC_OrderLineSO_ID(orderLineSO.getC_OrderLine_ID());
 		candidateRecord.setM_Product_ID(productRecord.getM_Product_ID());
 		candidateRecord.setM_WarehousePO_ID(30);
 		candidateRecord.setC_UOM_ID(productRecord.getC_UOM_ID());
@@ -113,6 +122,36 @@ public class C_OrderLineTest
 		candidateRecord.setProcessed(processed);
 		saveRecord(candidateRecord);
 		return candidateRecord;
+	}
+
+	/**
+	 * Creates a purchase order + purchase order line, representing the PO that a purchase candidate produced.
+	 */
+	private I_C_OrderLine createPurchaseOrderLine()
+	{
+		final I_C_Order purchaseOrderRecord = newInstance(I_C_Order.class);
+		purchaseOrderRecord.setIsSOTrx(false);
+		saveRecord(purchaseOrderRecord);
+
+		final I_C_OrderLine purchaseOrderLineRecord = newInstance(I_C_OrderLine.class);
+		purchaseOrderLineRecord.setC_Order(purchaseOrderRecord);
+		purchaseOrderLineRecord.setM_Product_ID(productRecord.getM_Product_ID());
+		purchaseOrderLineRecord.setQtyOrdered(BigDecimal.ONE);
+		saveRecord(purchaseOrderLineRecord);
+		return purchaseOrderLineRecord;
+	}
+
+	/**
+	 * Creates the {@code C_PurchaseCandidate_Alloc} record that is the real, ground-truth link between a purchase
+	 * candidate and the purchase order line it produced.
+	 */
+	private void createAlloc(final I_C_PurchaseCandidate candidate, final I_C_OrderLine purchaseOrderLineRecord)
+	{
+		final I_C_PurchaseCandidate_Alloc allocRecord = newInstance(I_C_PurchaseCandidate_Alloc.class);
+		allocRecord.setC_PurchaseCandidate_ID(candidate.getC_PurchaseCandidate_ID());
+		allocRecord.setC_OrderLinePO_ID(purchaseOrderLineRecord.getC_OrderLine_ID());
+		allocRecord.setC_OrderPO_ID(purchaseOrderLineRecord.getC_Order_ID());
+		saveRecord(allocRecord);
 	}
 
 	private List<I_C_PurchaseCandidate> getAllCandidateRecords()
@@ -146,6 +185,27 @@ public class C_OrderLineTest
 	public void realCandidate_thatProducedAPurchaseOrder_blocksDelete_onOrderLineDelete()
 	{
 		final I_C_PurchaseCandidate realCandidate = createCandidate(false, true);
+		createAlloc(realCandidate, createPurchaseOrderLine());
+
+		assertThatThrownBy(() -> c_OrderLine.deleteOrGuardRealPurchaseCandidate(salesOrderLineRecord))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("SalesOrderLine_CannotDelete_HasCompletedDocs");
+
+		assertThat(getAllCandidateRecords())
+				.anyMatch(record -> record.getC_PurchaseCandidate_ID() == realCandidate.getC_PurchaseCandidate_ID());
+	}
+
+	/**
+	 * A candidate that is only partially fulfilled has a real {@code C_PurchaseCandidate_Alloc} row (the true link
+	 * to the PO it produced) while still {@code Processed=false}. The guard must be based on the {@code Alloc}
+	 * ground truth, not on {@code Processed} -- otherwise it would miss this case (false negative) and the
+	 * candidate would be hard-deleted while the {@code Alloc} row still FK-references it.
+	 */
+	@Test
+	public void realCandidate_partiallyFulfilled_blocksDelete_onOrderLineDelete()
+	{
+		final I_C_PurchaseCandidate realCandidate = createCandidate(false, false);
+		createAlloc(realCandidate, createPurchaseOrderLine());
 
 		assertThatThrownBy(() -> c_OrderLine.deleteOrGuardRealPurchaseCandidate(salesOrderLineRecord))
 				.isInstanceOf(AdempiereException.class)
@@ -158,18 +218,12 @@ public class C_OrderLineTest
 	@Test
 	public void purchaseOrderLine_isNeverGuardedOrCascaded()
 	{
-		final I_C_Order purchaseOrderRecord = newInstance(I_C_Order.class);
-		purchaseOrderRecord.setIsSOTrx(false);
-		saveRecord(purchaseOrderRecord);
+		final I_C_OrderLine purchaseOrderLineRecord = createPurchaseOrderLine();
 
-		final I_C_OrderLine purchaseOrderLineRecord = newInstance(I_C_OrderLine.class);
-		purchaseOrderLineRecord.setC_Order(purchaseOrderRecord);
-		purchaseOrderLineRecord.setM_Product_ID(productRecord.getM_Product_ID());
-		purchaseOrderLineRecord.setQtyOrdered(BigDecimal.ONE);
-		saveRecord(purchaseOrderLineRecord);
-
-		// even a candidate that "produced a PO" must not block deleting a *purchase* order line
-		final I_C_PurchaseCandidate realCandidate = createCandidate(false, true);
+		// the candidate genuinely references the *purchase* order line under test (C_OrderLineSO_ID) and has
+		// actually produced a PO (real Alloc row) -- if the isSOTrx gate were removed, this would block the delete
+		final I_C_PurchaseCandidate realCandidate = createCandidate(purchaseOrderLineRecord, false, false);
+		createAlloc(realCandidate, createPurchaseOrderLine());
 
 		c_OrderLine.deleteOrGuardRealPurchaseCandidate(purchaseOrderLineRecord); // must not throw
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentSchedulePA.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentSchedulePA.java
@@ -116,6 +116,13 @@ public interface IShipmentSchedulePA extends ISingletonService
 
 	void deleteAllForReference(TableRecordReference referencedRecord);
 
+	/**
+	 * Cascades the delete of a sales order line onto its {@link I_M_ShipmentSchedule}: a schedule with no active
+	 * allocation to a non-voided/reversed inout is deleted along with the line, while a schedule that already has
+	 * a real shipment blocks the delete.
+	 */
+	void deleteOrGuardForOrderLine(@NonNull OrderLineId orderLineId);
+
 	Set<ProductId> getProductIdsByShipmentScheduleIds(Collection<ShipmentScheduleId> shipmentScheduleIds);
 
 	void save(I_M_ShipmentSchedule record);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA.java
@@ -69,12 +69,12 @@ public class ShipmentSchedulePA implements IShipmentSchedulePA
 	public static final AdMessageKey MSG_SalesOrderLine_CannotDelete_HasCompletedDocs = AdMessageKey.of("SalesOrderLine_CannotDelete_HasCompletedDocs");
 
 	/**
-	 * DocStatuses of an {@code M_InOut} that do NOT count as "a real shipment" blocking the sales order line delete
-	 * (AC3): a voided or reversed inout never blocks.
+	 * DocStatuses of an {@code M_InOut} that do NOT count as "a real shipment" blocking the sales order line delete:
+	 * a voided or reversed inout never blocks.
 	 */
-	private static final ImmutableSet<String> NON_BLOCKING_INOUT_DOCSTATUSES = ImmutableSet.of(
-			DocStatus.Voided.getCode(),
-			DocStatus.Reversed.getCode());
+	private static final ImmutableSet<DocStatus> NON_BLOCKING_INOUT_DOCSTATUSES = ImmutableSet.of(
+			DocStatus.Voided,
+			DocStatus.Reversed);
 
 	/**
 	 * When mass cache invalidation, above this threshold we will invalidate ALL shipment schedule records instead of particular IDS
@@ -610,14 +610,14 @@ public class ShipmentSchedulePA implements IShipmentSchedulePA
 	{
 		if (hasActiveShipmentToNonVoidedInOut(orderLineId))
 		{
-			throw new AdempiereException("@" + MSG_SalesOrderLine_CannotDelete_HasCompletedDocs + "@");
+			throw new AdempiereException(MSG_SalesOrderLine_CannotDelete_HasCompletedDocs);
 		}
 
 		deleteAllForReference(TableRecordReference.of(InterfaceWrapperHelper.getTableId(I_C_OrderLine.class), orderLineId.getRepoId()));
 	}
 
 	/**
-	 * Block predicate (AC2/AC3): the schedule for this order line has at least one active allocation
+	 * Block predicate: the schedule for this order line has at least one active allocation
 	 * ({@code M_ShipmentSchedule_QtyPicked}, or the direct {@code M_InOutLine.C_OrderLine_ID} link used for manually
 	 * created shipments) to an {@code M_InOutLine} whose parent {@code M_InOut} is NOT voided/reversed.
 	 */

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA.java
@@ -7,6 +7,8 @@ import com.google.common.collect.Maps;
 import de.metas.bpartner.BPartnerId;
 import de.metas.cache.CacheMgt;
 import de.metas.cache.model.CacheInvalidateMultiRequest;
+import de.metas.document.engine.DocStatus;
+import de.metas.i18n.AdMessageKey;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.inout.model.I_M_InOutLine;
 import de.metas.inoutcandidate.api.IShipmentScheduleAllocDAO;
@@ -15,6 +17,7 @@ import de.metas.inoutcandidate.api.OlAndSched;
 import de.metas.inoutcandidate.exportaudit.APIExportStatus;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateRepository;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule_QtyPicked;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.logging.LogManager;
@@ -62,6 +65,16 @@ public class ShipmentSchedulePA implements IShipmentSchedulePA
 {
 	private final static Logger logger = LogManager.getLogger(ShipmentSchedulePA.class);
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	public static final AdMessageKey MSG_SalesOrderLine_CannotDelete_HasCompletedDocs = AdMessageKey.of("SalesOrderLine_CannotDelete_HasCompletedDocs");
+
+	/**
+	 * DocStatuses of an {@code M_InOut} that do NOT count as "a real shipment" blocking the sales order line delete
+	 * (AC3): a voided or reversed inout never blocks.
+	 */
+	private static final ImmutableSet<String> NON_BLOCKING_INOUT_DOCSTATUSES = ImmutableSet.of(
+			DocStatus.Voided.getCode(),
+			DocStatus.Reversed.getCode());
 
 	/**
 	 * When mass cache invalidation, above this threshold we will invalidate ALL shipment schedule records instead of particular IDS
@@ -590,6 +603,67 @@ public class ShipmentSchedulePA implements IShipmentSchedulePA
 				.delete(); // don't "deleteDirectly". we need model interceptors to fire
 
 		logger.debug("Deleted {} M_ShipmentSchedule records for referencedRecord={}", deletedCount, referencedRecord);
+	}
+
+	@Override
+	public void deleteOrGuardForOrderLine(@NonNull final OrderLineId orderLineId)
+	{
+		if (hasActiveShipmentToNonVoidedInOut(orderLineId))
+		{
+			throw new AdempiereException("@" + MSG_SalesOrderLine_CannotDelete_HasCompletedDocs + "@");
+		}
+
+		deleteAllForReference(TableRecordReference.of(InterfaceWrapperHelper.getTableId(I_C_OrderLine.class), orderLineId.getRepoId()));
+	}
+
+	/**
+	 * Block predicate (AC2/AC3): the schedule for this order line has at least one active allocation
+	 * ({@code M_ShipmentSchedule_QtyPicked}, or the direct {@code M_InOutLine.C_OrderLine_ID} link used for manually
+	 * created shipments) to an {@code M_InOutLine} whose parent {@code M_InOut} is NOT voided/reversed.
+	 */
+	private boolean hasActiveShipmentToNonVoidedInOut(@NonNull final OrderLineId orderLineId)
+	{
+		final ImmutableSet<Integer> inOutLineIds = ImmutableSet.<Integer>builder()
+				.addAll(retrieveInOutLineIdsFromQtyPicked(orderLineId))
+				.addAll(retrieveInOutLineIdsFromDirectOrderLineLink(orderLineId))
+				.build();
+
+		if (inOutLineIds.isEmpty())
+		{
+			return false;
+		}
+
+		return queryBL.createQueryBuilder(org.compiere.model.I_M_InOutLine.class)
+				.addInArrayFilter(org.compiere.model.I_M_InOutLine.COLUMNNAME_M_InOutLine_ID, inOutLineIds)
+				.andCollect(org.compiere.model.I_M_InOutLine.COLUMN_M_InOut_ID)
+				.addNotInArrayFilter(org.compiere.model.I_M_InOut.COLUMNNAME_DocStatus, NON_BLOCKING_INOUT_DOCSTATUSES)
+				.create()
+				.anyMatch();
+	}
+
+	private Set<Integer> retrieveInOutLineIdsFromQtyPicked(@NonNull final OrderLineId orderLineId)
+	{
+		final ShipmentScheduleId shipmentScheduleId = getShipmentScheduleIdByOrderLineId(orderLineId);
+		if (shipmentScheduleId == null)
+		{
+			return ImmutableSet.of();
+		}
+
+		return ImmutableSet.copyOf(queryBL.createQueryBuilder(I_M_ShipmentSchedule_QtyPicked.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_ShipmentSchedule_ID, shipmentScheduleId)
+				.addNotNull(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_InOutLine_ID)
+				.create()
+				.listDistinct(I_M_ShipmentSchedule_QtyPicked.COLUMNNAME_M_InOutLine_ID, Integer.class));
+	}
+
+	private Set<Integer> retrieveInOutLineIdsFromDirectOrderLineLink(@NonNull final OrderLineId orderLineId)
+	{
+		return ImmutableSet.copyOf(queryBL.createQueryBuilder(org.compiere.model.I_M_InOutLine.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(org.compiere.model.I_M_InOutLine.COLUMNNAME_C_OrderLine_ID, orderLineId)
+				.create()
+				.listDistinct(org.compiere.model.I_M_InOutLine.COLUMNNAME_M_InOutLine_ID, Integer.class));
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_OrderLine_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/C_OrderLine_ShipmentSchedule.java
@@ -22,7 +22,9 @@ package de.metas.inoutcandidate.modelvalidator;
  * #L%
  */
 
+import de.metas.inoutcandidate.api.IShipmentSchedulePA;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
+import de.metas.order.OrderLineId;
 import de.metas.util.Services;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.ad.modelvalidator.annotations.Validator;
@@ -59,5 +61,20 @@ public class C_OrderLine_ShipmentSchedule
 			shipmentScheduleInvalidateBL.invalidateJustForOrderLine(ol);
 			shipmentScheduleInvalidateBL.notifySegmentChangedForOrderLine(ol);
 		});
+	}
+
+	/**
+	 * Cascades the delete onto the {@code M_ShipmentSchedule} of a sales order line, guarding against deleting a
+	 * line whose schedule already has a real shipment (an active allocation to a non-voided/reversed inout).
+	 */
+	@ModelChange(timings = ModelValidator.TYPE_BEFORE_DELETE)
+	public void deleteOrGuardShipmentSchedules(final I_C_OrderLine ol)
+	{
+		if (!ol.getC_Order().isSOTrx())
+		{
+			return;
+		}
+
+		Services.get(IShipmentSchedulePA.class).deleteOrGuardForOrderLine(OrderLineId.ofRepoId(ol.getC_OrderLine_ID()));
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandDAO.java
@@ -217,6 +217,13 @@ public interface IInvoiceCandDAO extends ISingletonService
 	int deleteAllReferencingInvoiceCandidates(Object model);
 
 	/**
+	 * Same as {@link #deleteAllReferencingInvoiceCandidates(Object)}, but first checks whether any of the referencing
+	 * invoice candidates already has an invoice line on a non-voided/reversed {@code C_Invoice}; if so, the delete is
+	 * blocked (nothing is deleted) instead of proceeding.
+	 */
+	void deleteOrGuardReferencingInvoiceCandidates(Object model);
+
+	/**
 	 * Updates <code>dateInvoiced</code> of candidates from selection.
 	 *
 	 * @param dateInvoiced new value to be set.

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandDAO.java
@@ -18,6 +18,7 @@ import de.metas.currency.ICurrencyBL;
 import de.metas.document.DocTypeId;
 import de.metas.document.engine.DocStatus;
 import de.metas.document.engine.IDocument;
+import de.metas.i18n.AdMessageKey;
 import de.metas.inout.IInOutDAO;
 import de.metas.inout.InOutId;
 import de.metas.invoice.InvoiceId;
@@ -140,6 +141,8 @@ import static org.adempiere.model.InterfaceWrapperHelper.delete;
 
 public class InvoiceCandDAO implements IInvoiceCandDAO
 {
+	public static final AdMessageKey MSG_SalesOrderLine_CannotDelete_HasCompletedDocs = AdMessageKey.of("SalesOrderLine_CannotDelete_HasCompletedDocs");
+
 	private final transient Logger logger = InvoiceCandidate_Constants.getLogger(InvoiceCandDAO.class);
 
 	private final transient IOrgDAO orgDAO = Services.get(IOrgDAO.class);
@@ -245,19 +248,9 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 	@Override
 	public int deleteAllReferencingInvoiceCandidates(@NonNull final Object model)
 	{
-		final String tableName = InterfaceWrapperHelper.getModelTableName(model);
-		final int tableId = Services.get(IADTableDAO.class).retrieveTableId(tableName);
-
-		final int recordId = InterfaceWrapperHelper.getId(model);
-
 		// i could do all this with "stream", but i find "old-school" easier to debug
 		int deleteCount = 0;
-		final List<I_C_Invoice_Candidate> icRecordsToDelete = queryBL
-				.createQueryBuilder(I_C_Invoice_Candidate.class)
-				.addEqualsFilter(I_C_Invoice_Candidate.COLUMNNAME_AD_Table_ID, tableId)
-				.addEqualsFilter(I_C_Invoice_Candidate.COLUMNNAME_Record_ID, recordId)
-				.create()
-				.list();
+		final List<I_C_Invoice_Candidate> icRecordsToDelete = retrieveIcRecordsReferencing(model);
 		for (final I_C_Invoice_Candidate icRecordToDelete : icRecordsToDelete)
 		{
 			setProcessedToFalseIfIcNotNeeded(icRecordToDelete);
@@ -266,6 +259,48 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 		}
 
 		return deleteCount;
+	}
+
+	@Override
+	public void deleteOrGuardReferencingInvoiceCandidates(@NonNull final Object model)
+	{
+		final List<I_C_Invoice_Candidate> icRecords = retrieveIcRecordsReferencing(model);
+
+		final boolean blockedByRealInvoice = icRecords.stream().anyMatch(this::hasNonVoidedInvoiceLine);
+		if (blockedByRealInvoice)
+		{
+			throw new AdempiereException(MSG_SalesOrderLine_CannotDelete_HasCompletedDocs);
+		}
+
+		deleteAllReferencingInvoiceCandidates(model);
+	}
+
+	private List<I_C_Invoice_Candidate> retrieveIcRecordsReferencing(@NonNull final Object model)
+	{
+		final String tableName = InterfaceWrapperHelper.getModelTableName(model);
+		final int tableId = Services.get(IADTableDAO.class).retrieveTableId(tableName);
+
+		final int recordId = InterfaceWrapperHelper.getId(model);
+
+		return queryBL
+				.createQueryBuilder(I_C_Invoice_Candidate.class)
+				.addEqualsFilter(I_C_Invoice_Candidate.COLUMNNAME_AD_Table_ID, tableId)
+				.addEqualsFilter(I_C_Invoice_Candidate.COLUMNNAME_Record_ID, recordId)
+				.create()
+				.list();
+	}
+
+	/**
+	 * Block predicate: {@code ic} has at least one {@link I_C_Invoice_Line_Alloc}-linked {@code C_InvoiceLine} whose
+	 * parent {@code C_Invoice} is NOT voided/reversed. A voided/reversed invoice's lines stay active -- voiding zeroes
+	 * out their amounts but never deactivates them (see {@code MInvoice#voidIt}/{@code #reverseCorrectIt}) -- so
+	 * {@link #retrieveIlForIc} alone does not exclude them; the parent invoice's {@code DocStatus} must be checked.
+	 */
+	private boolean hasNonVoidedInvoiceLine(@NonNull final I_C_Invoice_Candidate ic)
+	{
+		return retrieveIlForIc(ic)
+				.stream()
+				.anyMatch(invoiceLine -> !DocStatus.ofCode(invoiceLine.getC_Invoice().getDocStatus()).isReversedOrVoided());
 	}
 
 	/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/C_OrderLine.java
@@ -24,9 +24,21 @@ public class C_OrderLine
 		Services.get(IInvoiceCandidateHandlerBL.class).invalidateCandidatesFor(ol);
 	}
 
+	/**
+	 * Cascades the delete onto the {@code C_Invoice_Candidate}s of an order line, guarding against deleting a
+	 * sales order line whose candidate already has an invoice line on a non-voided/reversed invoice.
+	 */
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_DELETE)
 	public void deleteInvoiceCandidates(final I_C_OrderLine ol)
 	{
-		Services.get(IInvoiceCandDAO.class).deleteAllReferencingInvoiceCandidates(ol);
+		final IInvoiceCandDAO invoiceCandDAO = Services.get(IInvoiceCandDAO.class);
+		if (ol.getC_Order().isSOTrx())
+		{
+			invoiceCandDAO.deleteOrGuardReferencingInvoiceCandidates(ol);
+		}
+		else
+		{
+			invoiceCandDAO.deleteAllReferencingInvoiceCandidates(ol);
+		}
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.order/5814660_sys_gh29172_AD_Message_SalesOrderLine_CannotDelete_HasCompletedDocs.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.order/5814660_sys_gh29172_AD_Message_SalesOrderLine_CannotDelete_HasCompletedDocs.sql
@@ -1,0 +1,31 @@
+-- AD_Message thrown by the C_OrderLine TYPE_BEFORE_DELETE guards (de.metas.purchasecandidate.base,
+-- de.metas.swat.base) when a sales order line still has a real downstream document
+-- (a purchase candidate that produced a PO, a shipment schedule allocated to a non-voided inout,
+-- or an invoice candidate with invoice lines).
+
+-- 1. the message (base text = German)
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545776 /*From ID Server*/,0,TO_TIMESTAMP('2026-07-20 14:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Die Auftragszeile kann nicht gelöscht werden, weil sie noch von einem abgeschlossenen Beleg (Rechnung, Lieferung oder Bestellung) referenziert wird. Stornieren Sie zuerst diesen Beleg.','E',TO_TIMESTAMP('2026-07-20 14:00:00','YYYY-MM-DD HH24:MI:SS'),100,'SalesOrderLine_CannotDelete_HasCompletedDocs')
+;
+
+-- 2. short ErrorCode
+UPDATE AD_Message SET ErrorCode='SALES_ORDERLINE_CANNOT_DELETE', Updated=TO_TIMESTAMP('2026-07-20 14:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Message_ID=545776
+;
+
+-- 3. seed AD_Message_Trl for ALL active system languages with the base (DE) text, IsTranslated='N'
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545776
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- 4. en_US override (the real English text) + IsTranslated='Y'
+UPDATE AD_Message_Trl SET MsgText='Cannot delete the order line because it is still referenced by a completed document (invoice, shipment, or purchase order). Void or reverse that document first.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-07-20 14:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545776
+;
+
+-- 5. flip de_DE + de_CH to IsTranslated='Y' (their text already equals the DE base)
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-07-20 14:00:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545776
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-07-20 14:00:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545776
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/modelvalidator/C_OrderLine_ShipmentScheduleTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/modelvalidator/C_OrderLine_ShipmentScheduleTest.java
@@ -1,0 +1,172 @@
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.inoutcandidate.modelvalidator;
+
+import de.metas.document.engine.DocStatus;
+import de.metas.inout.model.I_M_InOut;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule_QtyPicked;
+import org.adempiere.ad.wrapper.POJOLookupMap;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_OrderLine;
+import org.compiere.model.I_M_InOutLine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests the {@code TYPE_BEFORE_DELETE} guarded cascade of {@link C_OrderLine_ShipmentSchedule} onto
+ * {@link I_M_ShipmentSchedule} records: a schedule with no real shipment yet is deleted along with its sales order
+ * line, while a schedule with an active allocation to a non-voided/reversed inout blocks the delete.
+ */
+public class C_OrderLine_ShipmentScheduleTest
+{
+	private C_OrderLine_ShipmentSchedule c_OrderLine_ShipmentSchedule;
+
+	private I_C_OrderLine salesOrderLineRecord;
+
+	@BeforeEach
+	public void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		c_OrderLine_ShipmentSchedule = new C_OrderLine_ShipmentSchedule();
+
+		final I_C_Order salesOrderRecord = newInstance(I_C_Order.class);
+		salesOrderRecord.setIsSOTrx(true);
+		saveRecord(salesOrderRecord);
+
+		salesOrderLineRecord = newInstance(I_C_OrderLine.class);
+		salesOrderLineRecord.setC_Order(salesOrderRecord);
+		saveRecord(salesOrderLineRecord);
+	}
+
+	private I_M_ShipmentSchedule createShipmentScheduleFor(final I_C_OrderLine orderLine)
+	{
+		final I_M_ShipmentSchedule sched = newInstance(I_M_ShipmentSchedule.class);
+		sched.setAD_Table_ID(InterfaceWrapperHelper.getTableId(I_C_OrderLine.class));
+		sched.setRecord_ID(orderLine.getC_OrderLine_ID());
+		saveRecord(sched);
+		return sched;
+	}
+
+	/**
+	 * Creates an {@code M_InOut} + {@code M_InOutLine} + an active {@code M_ShipmentSchedule_QtyPicked} allocation
+	 * linking the given schedule to that inout line -- i.e. a "real shipment" for the schedule.
+	 */
+	private void createActiveAllocation(final I_M_ShipmentSchedule sched, final String inOutDocStatus)
+	{
+		final I_M_InOut inOutRecord = newInstance(I_M_InOut.class);
+		inOutRecord.setDocStatus(inOutDocStatus);
+		saveRecord(inOutRecord);
+
+		final I_M_InOutLine inOutLineRecord = newInstance(I_M_InOutLine.class);
+		inOutLineRecord.setM_InOut_ID(inOutRecord.getM_InOut_ID());
+		saveRecord(inOutLineRecord);
+
+		final I_M_ShipmentSchedule_QtyPicked qtyPickedRecord = newInstance(I_M_ShipmentSchedule_QtyPicked.class);
+		qtyPickedRecord.setM_ShipmentSchedule_ID(sched.getM_ShipmentSchedule_ID());
+		qtyPickedRecord.setM_InOutLine_ID(inOutLineRecord.getM_InOutLine_ID());
+		saveRecord(qtyPickedRecord);
+	}
+
+	private boolean shipmentScheduleStillExists(final I_M_ShipmentSchedule sched)
+	{
+		return POJOLookupMap.get().getRecords(I_M_ShipmentSchedule.class)
+				.stream()
+				.anyMatch(record -> record.getM_ShipmentSchedule_ID() == sched.getM_ShipmentSchedule_ID());
+	}
+
+	@Test
+	public void schedule_withNoAlloc_isDeleted_onOrderLineDelete()
+	{
+		final I_M_ShipmentSchedule sched = createShipmentScheduleFor(salesOrderLineRecord);
+
+		c_OrderLine_ShipmentSchedule.deleteOrGuardShipmentSchedules(salesOrderLineRecord);
+
+		assertThat(shipmentScheduleStillExists(sched)).isFalse();
+	}
+
+	@Test
+	public void schedule_withActiveAllocToNonVoidedInOut_blocksDelete_onOrderLineDelete()
+	{
+		final I_M_ShipmentSchedule sched = createShipmentScheduleFor(salesOrderLineRecord);
+		createActiveAllocation(sched, DocStatus.Completed.getCode());
+
+		assertThatThrownBy(() -> c_OrderLine_ShipmentSchedule.deleteOrGuardShipmentSchedules(salesOrderLineRecord))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("SalesOrderLine_CannotDelete_HasCompletedDocs");
+
+		assertThat(shipmentScheduleStillExists(sched)).isTrue();
+	}
+
+	@Test
+	public void schedule_withAllocOnlyToVoidedInOut_isDeleted_onOrderLineDelete()
+	{
+		final I_M_ShipmentSchedule sched = createShipmentScheduleFor(salesOrderLineRecord);
+		createActiveAllocation(sched, DocStatus.Voided.getCode());
+
+		c_OrderLine_ShipmentSchedule.deleteOrGuardShipmentSchedules(salesOrderLineRecord); // must not throw
+
+		assertThat(shipmentScheduleStillExists(sched)).isFalse();
+	}
+
+	@Test
+	public void schedule_withAllocOnlyToReversedInOut_isDeleted_onOrderLineDelete()
+	{
+		final I_M_ShipmentSchedule sched = createShipmentScheduleFor(salesOrderLineRecord);
+		createActiveAllocation(sched, DocStatus.Reversed.getCode());
+
+		c_OrderLine_ShipmentSchedule.deleteOrGuardShipmentSchedules(salesOrderLineRecord); // must not throw
+
+		assertThat(shipmentScheduleStillExists(sched)).isFalse();
+	}
+
+	@Test
+	public void purchaseOrderLine_isNeverGuardedOrCascaded()
+	{
+		final I_C_Order purchaseOrderRecord = newInstance(I_C_Order.class);
+		purchaseOrderRecord.setIsSOTrx(false);
+		saveRecord(purchaseOrderRecord);
+
+		final I_C_OrderLine purchaseOrderLineRecord = newInstance(I_C_OrderLine.class);
+		purchaseOrderLineRecord.setC_Order(purchaseOrderRecord);
+		saveRecord(purchaseOrderLineRecord);
+
+		// the schedule genuinely references the *purchase* order line under test and has an active alloc to a
+		// non-voided inout -- if the isSOTrx gate were removed, this would block the delete
+		final I_M_ShipmentSchedule sched = createShipmentScheduleFor(purchaseOrderLineRecord);
+		createActiveAllocation(sched, DocStatus.Completed.getCode());
+
+		c_OrderLine_ShipmentSchedule.deleteOrGuardShipmentSchedules(purchaseOrderLineRecord); // must not throw
+
+		assertThat(shipmentScheduleStillExists(sched)).isTrue();
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/modelvalidator/C_OrderLine_ShipmentScheduleTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/modelvalidator/C_OrderLine_ShipmentScheduleTest.java
@@ -149,6 +149,35 @@ public class C_OrderLine_ShipmentScheduleTest
 		assertThat(shipmentScheduleStillExists(sched)).isFalse();
 	}
 
+	/**
+	 * Creates an active {@code M_InOut} + {@code M_InOutLine} whose {@code C_OrderLine_ID} points directly at the
+	 * given order line, with NO {@code M_ShipmentSchedule_QtyPicked} row -- i.e. the manually-created-shipment case.
+	 */
+	private void createDirectOrderLineLink(final I_C_OrderLine orderLine, final String inOutDocStatus)
+	{
+		final I_M_InOut inOutRecord = newInstance(I_M_InOut.class);
+		inOutRecord.setDocStatus(inOutDocStatus);
+		saveRecord(inOutRecord);
+
+		final I_M_InOutLine inOutLineRecord = newInstance(I_M_InOutLine.class);
+		inOutLineRecord.setM_InOut_ID(inOutRecord.getM_InOut_ID());
+		inOutLineRecord.setC_OrderLine_ID(orderLine.getC_OrderLine_ID());
+		saveRecord(inOutLineRecord);
+	}
+
+	@Test
+	public void schedule_withDirectInOutLineLinkToNonVoidedInOut_blocksDelete_onOrderLineDelete()
+	{
+		final I_M_ShipmentSchedule sched = createShipmentScheduleFor(salesOrderLineRecord);
+		createDirectOrderLineLink(salesOrderLineRecord, DocStatus.Completed.getCode());
+
+		assertThatThrownBy(() -> c_OrderLine_ShipmentSchedule.deleteOrGuardShipmentSchedules(salesOrderLineRecord))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("SalesOrderLine_CannotDelete_HasCompletedDocs");
+
+		assertThat(shipmentScheduleStillExists(sched)).isTrue();
+	}
+
 	@Test
 	public void purchaseOrderLine_isNeverGuardedOrCascaded()
 	{

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/modelvalidator/InvoiceCand_OrderLineDeleteTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/modelvalidator/InvoiceCand_OrderLineDeleteTest.java
@@ -1,0 +1,172 @@
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.invoicecandidate.modelvalidator;
+
+import de.metas.document.engine.DocStatus;
+import de.metas.interfaces.I_C_OrderLine;
+import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
+import de.metas.invoicecandidate.model.I_C_Invoice_Line_Alloc;
+import org.adempiere.ad.wrapper.POJOLookupMap;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_Invoice;
+import org.compiere.model.I_C_InvoiceLine;
+import org.compiere.model.I_C_Order;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests the {@code TYPE_BEFORE_DELETE} guarded cascade of {@link C_OrderLine} (invoicecandidate) onto
+ * {@link I_C_Invoice_Candidate} records: a candidate with no invoice line yet is deleted along with its sales order
+ * line, while a candidate with an invoice line on a non-voided/reversed invoice blocks the delete.
+ */
+public class InvoiceCand_OrderLineDeleteTest
+{
+	private C_OrderLine c_OrderLine;
+
+	private I_C_OrderLine salesOrderLineRecord;
+
+	@BeforeEach
+	public void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		c_OrderLine = new C_OrderLine();
+
+		final I_C_Order salesOrderRecord = newInstance(I_C_Order.class);
+		salesOrderRecord.setIsSOTrx(true);
+		saveRecord(salesOrderRecord);
+
+		salesOrderLineRecord = newInstance(I_C_OrderLine.class);
+		salesOrderLineRecord.setC_Order_ID(salesOrderRecord.getC_Order_ID());
+		saveRecord(salesOrderLineRecord);
+	}
+
+	private I_C_Invoice_Candidate createInvoiceCandidateFor(final org.compiere.model.I_C_OrderLine orderLine)
+	{
+		final I_C_Invoice_Candidate ic = newInstance(I_C_Invoice_Candidate.class);
+		ic.setAD_Table_ID(InterfaceWrapperHelper.getTableId(org.compiere.model.I_C_OrderLine.class));
+		ic.setRecord_ID(orderLine.getC_OrderLine_ID());
+		saveRecord(ic);
+		return ic;
+	}
+
+	/**
+	 * Creates a {@code C_Invoice} + {@code C_InvoiceLine} + an active {@code C_Invoice_Line_Alloc} linking the given
+	 * candidate to that invoice line -- i.e. a "real invoice" for the candidate.
+	 */
+	private void createInvoiceLineAlloc(final I_C_Invoice_Candidate ic, final String invoiceDocStatus)
+	{
+		final I_C_Invoice invoiceRecord = newInstance(I_C_Invoice.class);
+		invoiceRecord.setDocStatus(invoiceDocStatus);
+		saveRecord(invoiceRecord);
+
+		final I_C_InvoiceLine invoiceLineRecord = newInstance(I_C_InvoiceLine.class);
+		invoiceLineRecord.setC_Invoice_ID(invoiceRecord.getC_Invoice_ID());
+		saveRecord(invoiceLineRecord);
+
+		final I_C_Invoice_Line_Alloc allocRecord = newInstance(I_C_Invoice_Line_Alloc.class);
+		allocRecord.setC_Invoice_Candidate_ID(ic.getC_Invoice_Candidate_ID());
+		allocRecord.setC_InvoiceLine_ID(invoiceLineRecord.getC_InvoiceLine_ID());
+		saveRecord(allocRecord);
+	}
+
+	private boolean invoiceCandidateStillExists(final I_C_Invoice_Candidate ic)
+	{
+		return POJOLookupMap.get().getRecords(I_C_Invoice_Candidate.class)
+				.stream()
+				.anyMatch(record -> record.getC_Invoice_Candidate_ID() == ic.getC_Invoice_Candidate_ID());
+	}
+
+	@Test
+	public void ic_withNoInvoiceLine_isDeleted_onOrderLineDelete()
+	{
+		final I_C_Invoice_Candidate ic = createInvoiceCandidateFor(salesOrderLineRecord);
+
+		c_OrderLine.deleteInvoiceCandidates(salesOrderLineRecord);
+
+		assertThat(invoiceCandidateStillExists(ic)).isFalse();
+	}
+
+	@Test
+	public void ic_withInvoiceLineOnNonVoidedInvoice_blocksDelete_onOrderLineDelete()
+	{
+		final I_C_Invoice_Candidate ic = createInvoiceCandidateFor(salesOrderLineRecord);
+		createInvoiceLineAlloc(ic, DocStatus.Completed.getCode());
+
+		assertThatThrownBy(() -> c_OrderLine.deleteInvoiceCandidates(salesOrderLineRecord))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("SalesOrderLine_CannotDelete_HasCompletedDocs");
+
+		assertThat(invoiceCandidateStillExists(ic)).isTrue();
+	}
+
+	@Test
+	public void ic_withInvoiceLineOnlyOnVoidedInvoice_isDeleted_onOrderLineDelete()
+	{
+		final I_C_Invoice_Candidate ic = createInvoiceCandidateFor(salesOrderLineRecord);
+		createInvoiceLineAlloc(ic, DocStatus.Voided.getCode());
+
+		c_OrderLine.deleteInvoiceCandidates(salesOrderLineRecord); // must not throw
+
+		assertThat(invoiceCandidateStillExists(ic)).isFalse();
+	}
+
+	@Test
+	public void ic_withInvoiceLineOnlyOnReversedInvoice_isDeleted_onOrderLineDelete()
+	{
+		final I_C_Invoice_Candidate ic = createInvoiceCandidateFor(salesOrderLineRecord);
+		createInvoiceLineAlloc(ic, DocStatus.Reversed.getCode());
+
+		c_OrderLine.deleteInvoiceCandidates(salesOrderLineRecord); // must not throw
+
+		assertThat(invoiceCandidateStillExists(ic)).isFalse();
+	}
+
+	@Test
+	public void purchaseOrderLine_isNeverGuarded()
+	{
+		final I_C_Order purchaseOrderRecord = newInstance(I_C_Order.class);
+		purchaseOrderRecord.setIsSOTrx(false);
+		saveRecord(purchaseOrderRecord);
+
+		final I_C_OrderLine purchaseOrderLineRecord = newInstance(I_C_OrderLine.class);
+		purchaseOrderLineRecord.setC_Order_ID(purchaseOrderRecord.getC_Order_ID());
+		saveRecord(purchaseOrderLineRecord);
+
+		// the candidate genuinely references the *purchase* order line under test and has an invoice line on a
+		// non-voided invoice -- if the isSOTrx gate were removed, this would block the delete
+		final I_C_Invoice_Candidate ic = createInvoiceCandidateFor(purchaseOrderLineRecord);
+		createInvoiceLineAlloc(ic, DocStatus.Completed.getCode());
+
+		c_OrderLine.deleteInvoiceCandidates(purchaseOrderLineRecord); // must not throw, unconditional delete
+
+		assertThat(invoiceCandidateStillExists(ic)).isFalse();
+	}
+}


### PR DESCRIPTION
## Problem

Deleting a sales-order line — typically after the order was reactivated — could fail with a raw database foreign-key stacktrace. On completion the system auto-creates per-line planning objects (shipment schedule, invoice candidate, purchase candidate); reactivation does not remove them, and the line-delete path only cascaded *simulated* purchase candidates and merely *invalidated* shipment schedules. A real purchase candidate then violated the `NOT NULL` FK on `C_PurchaseCandidate.C_OrderLineSO_ID`. The only remedy was manual SQL.

## Change

On `C_OrderLine` `TYPE_BEFORE_DELETE`, gated to sales lines (`C_Order.IsSOTrx = Y`; purchase-order behaviour unchanged):

- **Purchase candidate** — cascade-delete real (non-simulated) candidates for the line; block if the candidate produced a purchase order (has a `C_PurchaseCandidate_Alloc` row).
- **Shipment schedule** — cascade-delete (previously only invalidated); block if it has an active allocation to a non-Voided/Reversed shipment (via `M_ShipmentSchedule_QtyPicked` or a direct `M_InOutLine.C_OrderLine_ID` link).
- **Invoice candidate** — the previously *unconditional* delete now blocks when the candidate has an invoice line on a non-Voided/Reversed `C_Invoice`.

When a real downstream document exists, the delete is blocked with a friendly translated message (new `AD_Message` `SalesOrderLine_CannotDelete_HasCompletedDocs`, EN + DE) instead of a raw FK error. Voided/reversed documents do not block. All three guards check before deleting and run in the delete's transaction, so any block rolls back cleanly regardless of interceptor order.

## Notes

- No DB-schema / FK-constraint changes.
- Tests: JUnit per guard (no-doc → cascade, real-doc → block, voided/reversed → cascade, PO-line → never guarded); a cucumber end-to-end feature covering the cascade-clean, block-on-invoice, and voided-unblocks flows.
