### PR TITLE
Stock per week — product-only filter shows all warehouses; stop double-showing overdue backlog in the first week

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/material/stockperweek/StockPerWeek_atp.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/material/stockperweek/StockPerWeek_atp.feature
@@ -2,7 +2,7 @@
 @allure.label.epic:E0155_Material_Disposition
 @allure.label.feature:F19100
 @ghActions:run_on_executor6
-Feature: MD_Stock_PerWeek_V shows cumulative projected stock (QtyATP) and rolls overdue demand into the current week
+Feature: MD_Stock_PerWeek_V shows cumulative projected stock (QtyATP); overdue backlog stays in the projected stock, not in the movement columns
 
   Background:
     Given infrastructure and metasfresh are running
@@ -64,30 +64,30 @@ Feature: MD_Stock_PerWeek_V shows cumulative projected stock (QtyATP) and rolls 
   @from:cucumber
   @allure.label.epic:E0155_Material_Disposition
   @allure.label.feature:F19100
-  Scenario: Overdue DEMAND/SHIPMENT dated before the current week is rolled into the current week's QtyExpectedShipments
+  Scenario: Overdue DEMAND/SHIPMENT dated before the current week is NOT shown in the current week's movement columns (it stays in the projected stock)
 
-    # The view applies GREATEST(date_trunc('week', DateProjected), date_trunc('week', now()))
-    # so any DEMAND/SHIPMENT whose DateProjected falls in a past week still counts in the
-    # current-week row's QtyExpectedShipments — it is not silently dropped.
+    # Movement columns bucket by the candidate's ACTUAL week, so a DEMAND/SHIPMENT whose DateProjected
+    # falls in a past week does NOT appear in the current-week row's QtyExpectedShipments. The backlog
+    # is not lost: it is already reflected in the projected stock (QtyATPBegin / QtyATP), so it is shown
+    # once (in ATP), not twice (ATP + movement column).
     Given metasfresh contains M_Products:
       | Identifier          | M_Product_Category_ID    | C_UOM_ID.X12DE355 |
       | product_S25618_atp2 | standard_category_S25618 | PCE               |
 
-    # This DEMAND is dated 2 weeks in the past (WeekOffset=-2, within that past week) but must
-    # appear in the current-week (WeekOffset=0) row's QtyExpectedShipments via overdue rolling.
+    # This DEMAND is dated 2 weeks in the past (WeekOffset=-2, within that past week).
     And metasfresh initially has this MD_Candidate data relative to current week
       | Identifier           | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID        | WeekOffset | DayWithinWeek | Qty | ATP | M_Warehouse_ID |
       | overdue_S25618_atp2  | DEMAND            | SHIPMENT                  | product_S25618_atp2 | -2         | 3             | 7   | -7  | wh_S25618_atp  |
 
-    # The current-week row (WeekOffset=0) must show QtyExpectedShipments=7 for the overdue demand.
-    # QtyATP=-7: the STOCK candidate paired with this DEMAND is dated in the past week with
-    # Qty=ATP=-7. That date is before the current week+1 start, so it is the latest STOCK
-    # for this product/warehouse → QtyATP=-7.
-    # QtyATPBegin=-7: that same STOCK candidate is also dated before the current week's Monday
-    # (it is two weeks overdue), so it owns the as-of-start stock too.
+    # The current-week row (WeekOffset=0) shows QtyExpectedShipments=0: the overdue demand buckets into
+    # its own past week (outside the shown horizon), so it does not appear in the movement column.
+    # QtyATP=-7: the STOCK candidate paired with this DEMAND is dated in the past week with Qty=ATP=-7;
+    # it is the latest STOCK before the current week+1 start → QtyATP=-7.
+    # QtyATPBegin=-7: that same STOCK candidate is dated before the current week's Monday, so it owns the
+    # as-of-start stock — i.e. the projected balance already carries the backlog's effect (unchanged).
     Then after not more than 10s, MD_Stock_PerWeek_V contains:
       | M_Product_ID        | M_Warehouse_ID | WeekOffset | QtyATPBegin | QtyExpectedShipments | QtyExpectedReceipts | QtyATP |
-      | product_S25618_atp2 | wh_S25618_atp  | 0          | -7          | 7                    | 0                   | -7     |
+      | product_S25618_atp2 | wh_S25618_atp  | 0          | -7          | 0                    | 0                   | -7     |
 
   @Id:S30457_10
   @from:cucumber

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/ddl/de_metas_material/MD_Stock_PerWeek_V.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/ddl/de_metas_material/MD_Stock_PerWeek_V.sql
@@ -18,9 +18,9 @@
 --
 -- Horizon: current week .. current+N, where N = SysConfig
 --   'de.metas.material.stockperweek.HorizonWeeks' (default 12 => 13 rows).
--- Overdue activity (dated before the current week) is rolled into the current-week row
--- via GREATEST(week-of(DateProjected), current-week) so backlog is never hidden.
--- Only active, non-'simulated' candidates are considered.
+-- Overdue activity (dated before the current week) is NOT rolled into the current week's movement
+-- columns; it is already reflected in QtyATPBegin (the projected running balance), so backlog is
+-- shown once, not twice. Only active, non-'simulated' candidates are considered.
 --
 -- Aggregation defaults (DESIGN.md §7 — confirm with customer at UAT):
 --   * attributes : summed across StorageAttributesKey (latest STOCK per key, then SUM)

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5814630_sys_gh30457_MD_Stock_PerWeek_fn_first_week_hangover.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5814630_sys_gh30457_MD_Stock_PerWeek_fn_first_week_hangover.sql
@@ -1,16 +1,9 @@
--- Function MD_Stock_PerWeek_fn — parameterized companion of MD_Stock_PerWeek_V (F19100
--- "Bestand pro Woche" / stock per week).
---
--- Same output shape/semantics as MD_Stock_PerWeek_V (see MD_Stock_PerWeek_V.sql for the full
--- column documentation), but the M_Product_ID / M_Warehouse_ID filter is pushed INTO the base
--- MD_Candidate scan instead of being applied after the view fully materializes. This lets the
--- planner use the partial index md_candidate_perweek_pw_idx (M_Product_ID, M_Warehouse_ID)
--- to answer a filtered "stock per week for this product/warehouse" read directly from the
--- index, instead of scanning/building the entire MD_Stock_PerWeek_V for every product and
--- warehouse and then throwing most of it away.
---
--- NULL parameters degrade to "no filter on that dimension" (fn(NULL, NULL) ~= the full view).
--- Output is byte-identical to MD_Stock_PerWeek_V for the same filter.
+-- MD_Stock_PerWeek_fn: stop double-showing overdue backlog in the first week.
+-- Overdue shipments/receipts (projected before the current week) are no longer rolled into the current
+-- week's Expected Shipments / Receipts columns (movement columns now bucket by the candidate's actual
+-- week). The backlog stays reflected in QtyATPBegin, which is the projected running balance and already
+-- accounts for it -- so it is shown once (in ATP), not twice. QtyATPBegin itself is unchanged. The view
+-- MD_Stock_PerWeek_V is fn(NULL,NULL) and inherits this behavior.
 
 CREATE OR REPLACE FUNCTION MD_Stock_PerWeek_fn(
     p_product_id   numeric DEFAULT NULL,   -- NULL = no product filter (degrades to full view)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactory.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactory.java
@@ -189,11 +189,8 @@ public class StockPerWeekSelectionFactory implements ViewRowIdsOrderedSelectionF
 						.append(", row_number() OVER (ORDER BY " + rowNumberOrderBySql + ")"
 								+ ", " + FUNCTION_ALIAS + "." + KEY_COLUMN
 								+ ", " + FUNCTION_ALIAS + "." + I_MD_Stock_PerWeek_V.COLUMNNAME_M_Product_ID
-								// IntKey3 = the applied WAREHOUSE FILTER (constant for the selection), NOT the per-row
-								// warehouse: readAppliedFilter re-parameterizes the page render with it. A product-only
-								// selection spans several warehouses, so this must be null (=warehouseFnParam) -> the render
-								// sources MD_Stock_PerWeek_fn(product, NULL) and its join back to the selection restores
-								// every warehouse. Persisting fn.M_Warehouse_ID here collapsed the render to one warehouse.
+								// IntKey3 = the applied warehouse filter (null for a product-only selection), not the
+								// per-row warehouse; readAppliedFilter re-parameterizes the page render with it.
 								+ ", CAST(? AS numeric)\n"
 								+ " FROM " + FUNCTION_NAME + "(?, ?) " + FUNCTION_ALIAS, warehouseFnParam, productId, warehouseFnParam)
 						.append("\n WHERE 1=1 ")

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactory.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactory.java
@@ -189,8 +189,13 @@ public class StockPerWeekSelectionFactory implements ViewRowIdsOrderedSelectionF
 						.append(", row_number() OVER (ORDER BY " + rowNumberOrderBySql + ")"
 								+ ", " + FUNCTION_ALIAS + "." + KEY_COLUMN
 								+ ", " + FUNCTION_ALIAS + "." + I_MD_Stock_PerWeek_V.COLUMNNAME_M_Product_ID
-								+ ", " + FUNCTION_ALIAS + "." + I_MD_Stock_PerWeek_V.COLUMNNAME_M_Warehouse_ID + "\n"
-								+ " FROM " + FUNCTION_NAME + "(?, ?) " + FUNCTION_ALIAS, productId, warehouseFnParam)
+								// IntKey3 = the applied WAREHOUSE FILTER (constant for the selection), NOT the per-row
+								// warehouse: readAppliedFilter re-parameterizes the page render with it. A product-only
+								// selection spans several warehouses, so this must be null (=warehouseFnParam) -> the render
+								// sources MD_Stock_PerWeek_fn(product, NULL) and its join back to the selection restores
+								// every warehouse. Persisting fn.M_Warehouse_ID here collapsed the render to one warehouse.
+								+ ", CAST(? AS numeric)\n"
+								+ " FROM " + FUNCTION_NAME + "(?, ?) " + FUNCTION_ALIAS, warehouseFnParam, productId, warehouseFnParam)
 						.append("\n WHERE 1=1 ")
 						.wrap(securityRestrictionsWrapper(applySecurityRestrictions)));
 

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactoryTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactoryTest.java
@@ -143,18 +143,17 @@ class StockPerWeekSelectionFactoryTest
 				DocumentFilter.equalsFilter("M_Warehouse_ID", warehouseId)));
 
 		assertThat(sql).isNotNull();
-		assertThat(sql.getSql()).contains("MD_Stock_PerWeek_fn(?, ?) fn");
-		assertThat(sql.getSqlParams()).containsSubsequence(PRODUCT_ID, warehouseId);
+		assertThat(sql.getSql()).contains(", fn.M_Product_ID, CAST(? AS numeric)\n FROM MD_Stock_PerWeek_fn(?, ?) fn");
+		// IntKey3 persists the warehouse FILTER (=warehouseId), then product+warehouse are the two fn params
+		assertThat(sql.getSqlParams()).containsSubsequence(warehouseId, PRODUCT_ID, warehouseId);
 		assertThat(sql.getSql()).doesNotContain("\n AND (\n"); // direct facet => no residual WHERE
 	}
 
 	@Test
 	void productOnlyFacet_persistsNullWarehouseFilter_soRenderSpansAllWarehouses()
 	{
-		// A product-only selection legitimately spans several warehouses. IntKey3 must persist the (null)
-		// warehouse FILTER -- NOT the per-row fn.M_Warehouse_ID -- so readAppliedFilter re-parameterizes the
-		// page render as fn(product, NULL) and the page's join to the selection restores every warehouse.
-		// Persisting the per-row warehouse collapsed a product-only grid to a single warehouse.
+		// Product-only selection: IntKey3 persists the (null) warehouse filter, not the per-row warehouse,
+		// so the render sources fn(product, NULL) and its join to the selection restores every warehouse.
 		final SqlAndParams sql = buildSql(DocumentFilterList.of(DocumentFilter.equalsFilter("M_Product_ID", PRODUCT_ID)));
 
 		assertThat(sql).isNotNull();

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactoryTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactoryTest.java
@@ -114,8 +114,8 @@ class StockPerWeekSelectionFactoryTest
 		// sourced from the function; product is the 1st fn param, warehouse (2nd) is NULL = all warehouses
 		assertThat(sqlText).contains("MD_Stock_PerWeek_fn(?, ?) fn");
 		assertThat(sql.getSqlParams()).containsSubsequence(PRODUCT_ID, null);
-		// product persisted into IntKey2 (what readAppliedFilter reads to route the page render through the fn)
-		assertThat(sqlText).contains(", fn.M_Product_ID, fn.M_Warehouse_ID");
+		// product persisted into IntKey2; IntKey3 = the (null, zoom) warehouse filter param -> render sources fn(product, NULL)
+		assertThat(sqlText).contains(", fn.M_Product_ID, CAST(? AS numeric)\n FROM MD_Stock_PerWeek_fn(?, ?) fn");
 		// the clause's residual warehouse-resolution + week floor are applied against the fn output, not dropped
 		assertThat(sqlText).contains("MD_getStockWarehouse");
 		assertThat(sqlText).contains("WeekStartDate >=");
@@ -146,6 +146,19 @@ class StockPerWeekSelectionFactoryTest
 		assertThat(sql.getSql()).contains("MD_Stock_PerWeek_fn(?, ?) fn");
 		assertThat(sql.getSqlParams()).containsSubsequence(PRODUCT_ID, warehouseId);
 		assertThat(sql.getSql()).doesNotContain("\n AND (\n"); // direct facet => no residual WHERE
+	}
+
+	@Test
+	void productOnlyFacet_persistsNullWarehouseFilter_soRenderSpansAllWarehouses()
+	{
+		// A product-only selection legitimately spans several warehouses. IntKey3 must persist the (null)
+		// warehouse FILTER -- NOT the per-row fn.M_Warehouse_ID -- so readAppliedFilter re-parameterizes the
+		// page render as fn(product, NULL) and the page's join to the selection restores every warehouse.
+		// Persisting the per-row warehouse collapsed a product-only grid to a single warehouse.
+		final SqlAndParams sql = buildSql(DocumentFilterList.of(DocumentFilter.equalsFilter("M_Product_ID", PRODUCT_ID)));
+
+		assertThat(sql).isNotNull();
+		assertThat(sql.getSql()).contains(", fn.M_Product_ID, CAST(? AS numeric)\n FROM MD_Stock_PerWeek_fn(?, ?) fn");
 	}
 
 	@Test


### PR DESCRIPTION
Follow-up to the "Bestand pro Woche" / stock-per-week feature (window 542159), fixing two issues found in UAT.

## 1. Product-only filter collapsed to a single warehouse

Filtering the standalone window by **product only** (a product stocked in several warehouses) showed rows for just one warehouse; filtering by each warehouse explicitly worked.

Cause: the selection persisted `IntKey3 = fn.M_Warehouse_ID` (the per-row warehouse). `StockPerWeekViewDataRepository` re-parameterizes the page render as `MD_Stock_PerWeek_fn(product, warehouse)` from `readAppliedFilter` (which reads one row via `LIMIT 1`), so a product-only selection — legitimately spanning several warehouses — collapsed the render to one arbitrary warehouse.

Fix: persist `IntKey3` = the applied **warehouse filter** (constant for the selection; `NULL` when product-only), not the per-row warehouse. The render then sources `MD_Stock_PerWeek_fn(product, NULL)` and its join back to the persisted selection (by the synthetic key) restores every warehouse. Product+warehouse and the order-line zoom are unchanged.

## 2. Overdue backlog was double-shown in the first week

For the current week, overdue activity (dated before this week) was rolled into **both** `QtyATPBegin` (the projected running balance, which already accounts for it) **and** the Expected Shipments / Receipts columns — showing the same backlog twice.

Fix: the movement columns now bucket by the candidate's **actual** week, so overdue activity falls outside the shown horizon and no longer appears in the current week's Expected Shipments/Receipts. `QtyATPBegin` is **unchanged** (it correctly still reflects the backlog). Later weeks are unaffected. Delivered as migration `5814630` redefining `MD_Stock_PerWeek_fn`; the view `MD_Stock_PerWeek_V` = `fn(NULL,NULL)` inherits the behavior.

## Tests
- Unit: regression asserting the selection persists the warehouse **filter** (not the per-row warehouse) so the render spans all warehouses.
- Cucumber `StockPerWeek_atp`: the overdue-shipment scenario updated from the old roll-in (`QtyExpectedShipments = 7`) to the new behavior (`= 0`, `QtyATPBegin` unchanged at `-7`).
