### PR TITLE
Merge: soft_panda_hotfix → soft_panda_release (EPCIS grid-editable IsActive fix)

### DIFF
--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5814640_sys_EPCIS_StatusTab_IsActive_GridEditable.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5814640_sys_EPCIS_StatusTab_IsActive_GridEditable.sql
@@ -1,0 +1,23 @@
+-- Make the EPCIS-Exportstatus tab's IsActive switch editable in the GRID.
+-- (ExternalSystem_ScriptedExportConversion_Status, AD_Tab 549295, on the Lieferung / M_InOut window 169)
+--
+-- Prior migrations delivered the escape-hatch (deactivate a stuck in-flight status row to release the
+-- shipment) only partway for the WebUI grid:
+--   * 5813870 added the editable IsActive AD_Field (781730) + AD_UI_Element (652656) and set the tab
+--     IsReadOnly='N';
+--   * 5814320 set AD_Column.IsAlwaysUpdateable='Y' so the field survives the processed-parent readonly
+--     lock (DocumentReadonly) in the SINGLE-ROW form.
+-- But the field stays non-editable in the GRID: LayoutFactory#computeViewEditorRenderMode defaults any
+-- widget that is not Amount/CostPrice/Quantity to ViewEditorRenderMode.NEVER when the AD_UI_Element has
+-- no ViewEditMode set. IsActive is a YesNo Switch, and 5813870 left ViewEditMode empty on 652656, so the
+-- grid renders "viewEditorRenderMode":"never" and the switch cannot be toggled inline.
+--
+-- Fix: set ViewEditMode='D' (ON_DEMAND) on the IsActive element so the switch is editable on demand in
+-- the grid; it composes with the existing IsAlwaysUpdateable='Y' so the backend PATCH accepts the toggle
+-- on the processed-parent row. 'D' matches the existing grid-editable AD_UI_Element convention.
+UPDATE AD_UI_Element
+SET    ViewEditMode = 'D',
+       Updated = TO_TIMESTAMP('2026-07-20 12:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy = 100
+WHERE  AD_UI_Element_ID = 652656
+  AND  COALESCE(ViewEditMode, '') <> 'D'
+;

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemConfigRepoTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemConfigRepoTest.java
@@ -38,6 +38,7 @@ import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConve
 import de.metas.externalsystem.model.I_ExternalSystem_Endpoint;
 import de.metas.externalsystem.model.I_ExternalSystem_Config_Alberta;
 import de.metas.externalsystem.model.I_ExternalSystem_Config_GRSSignum;
+import de.metas.externalsystem.model.I_ExternalSystem_Config_ProCareManagement;
 import de.metas.externalsystem.model.I_ExternalSystem_Config_LeichMehl;
 import de.metas.externalsystem.model.I_ExternalSystem_Config_RabbitMQ_HTTP;
 import de.metas.externalsystem.model.I_ExternalSystem_Config_Shopware6;
@@ -54,6 +55,7 @@ import de.metas.externalsystem.woocommerce.ExternalSystemWooCommerceConfigId;
 import de.metas.pricing.PriceListId;
 import org.adempiere.ad.wrapper.POJOLookupMap;
 import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_AD_Org;
 import org.compiere.model.I_C_UOM;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -1031,6 +1033,115 @@ class ExternalSystemConfigRepoTest
 		assertThat(result)
 				.extracting(config -> config.getId().getRepoId())
 				.containsExactly(validParent.getExternalSystem_Config_ID());
+	}
+
+	// The resilience filter was added to all readers; guard each of the previously-untested ones with
+	// a positive test (a correctly-parented config is still returned — catches a wrong expected-type
+	// argument that would filter everything out) and a mismatch test (a wrong-typed parent is skipped,
+	// not a 500).
+
+	@Test
+	void getActiveByType_woo_returnsValidConfig()
+	{
+		final I_ExternalSystem_Config parentRecord = ExternalSystemConfigTestUtil.createI_ExternalSystem_ConfigBuilder()
+				.type(WOO.getValue())
+				.build();
+
+		final I_ExternalSystem_Config_WooCommerce child = newInstance(I_ExternalSystem_Config_WooCommerce.class);
+		child.setExternalSystemValue("woo-value");
+		child.setExternalSystem_Config_ID(parentRecord.getExternalSystem_Config_ID());
+		saveRecord(child);
+
+		assertThat(externalSystemConfigRepo.getActiveByType(WOO))
+				.extracting(config -> config.getId().getRepoId())
+				.containsExactly(parentRecord.getExternalSystem_Config_ID());
+	}
+
+	@Test
+	void getActiveByType_woo_skipsConfigWithMismatchedParentType()
+	{
+		final I_ExternalSystem_Config eddysonParent = ExternalSystemConfigTestUtil.createI_ExternalSystem_ConfigBuilder()
+				.type("eddyson")
+				.build();
+
+		final I_ExternalSystem_Config_WooCommerce child = newInstance(I_ExternalSystem_Config_WooCommerce.class);
+		child.setExternalSystemValue("woo-value");
+		child.setExternalSystem_Config_ID(eddysonParent.getExternalSystem_Config_ID());
+		saveRecord(child);
+
+		assertThat(externalSystemConfigRepo.getActiveByType(WOO)).isEmpty();
+	}
+
+	@Test
+	void getActiveByType_grs_returnsValidConfig()
+	{
+		final I_ExternalSystem_Config parentRecord = ExternalSystemConfigTestUtil.createI_ExternalSystem_ConfigBuilder()
+				.type(ExternalSystemType.GRSSignum.getValue())
+				.build();
+
+		ExternalSystemConfigTestUtil.createGrsConfigBuilder()
+				.externalSystemConfigId(parentRecord.getExternalSystem_Config_ID())
+				.value("grs-value")
+				.syncBPartnersToRestEndpoint(true)
+				.build();
+
+		assertThat(externalSystemConfigRepo.getActiveByType(ExternalSystemType.GRSSignum))
+				.extracting(config -> config.getId().getRepoId())
+				.containsExactly(parentRecord.getExternalSystem_Config_ID());
+	}
+
+	@Test
+	void getActiveByType_grs_skipsConfigWithMismatchedParentType()
+	{
+		final I_ExternalSystem_Config eddysonParent = ExternalSystemConfigTestUtil.createI_ExternalSystem_ConfigBuilder()
+				.type("eddyson")
+				.build();
+
+		ExternalSystemConfigTestUtil.createGrsConfigBuilder()
+				.externalSystemConfigId(eddysonParent.getExternalSystem_Config_ID())
+				.value("grs-value")
+				.syncBPartnersToRestEndpoint(true)
+				.build();
+
+		assertThat(externalSystemConfigRepo.getActiveByType(ExternalSystemType.GRSSignum)).isEmpty();
+	}
+
+	@Test
+	void getActiveByType_pcm_returnsValidConfig()
+	{
+		// PCM's config build requires a regular (non-zero) AD_Org_ID.
+		final I_AD_Org org = newInstance(I_AD_Org.class);
+		saveRecord(org);
+
+		final I_ExternalSystem_Config parentRecord = ExternalSystemConfigTestUtil.createI_ExternalSystem_ConfigBuilder()
+				.type(ExternalSystemType.ProCareManagement.getValue())
+				.build();
+
+		final I_ExternalSystem_Config_ProCareManagement child = newInstance(I_ExternalSystem_Config_ProCareManagement.class);
+		child.setAD_Org_ID(org.getAD_Org_ID());
+		child.setExternalSystemValue("pcm-value");
+		child.setExternalSystem_Config_ID(parentRecord.getExternalSystem_Config_ID());
+		saveRecord(child);
+
+		assertThat(externalSystemConfigRepo.getActiveByType(ExternalSystemType.ProCareManagement))
+				.extracting(config -> config.getId().getRepoId())
+				.containsExactly(parentRecord.getExternalSystem_Config_ID());
+	}
+
+	@Test
+	void getActiveByType_pcm_skipsConfigWithMismatchedParentType()
+	{
+		final I_ExternalSystem_Config eddysonParent = ExternalSystemConfigTestUtil.createI_ExternalSystem_ConfigBuilder()
+				.type("eddyson")
+				.build();
+
+		// no AD_Org_ID needed: the resilience filter skips this row before the PCM config is built.
+		final I_ExternalSystem_Config_ProCareManagement child = newInstance(I_ExternalSystem_Config_ProCareManagement.class);
+		child.setExternalSystemValue("pcm-value");
+		child.setExternalSystem_Config_ID(eddysonParent.getExternalSystem_Config_ID());
+		saveRecord(child);
+
+		assertThat(externalSystemConfigRepo.getActiveByType(ExternalSystemType.ProCareManagement)).isEmpty();
 	}
 }
 


### PR DESCRIPTION
Propagation merge `soft_panda_hotfix → soft_panda_release` (merge-commit, not squash).

Carries the EPCIS-Exportstatus **grid-editable IsActive** fix (#25248, migration `5814640`) onto the
release line so it can be deployed to **spavettirelease**. `soft_panda_hotfix` was exactly 1 commit
ahead of `soft_panda_release` (this fix); the merge is **clean** and brings only the new migration file
`5814640_sys_EPCIS_StatusTab_IsActive_GridEditable.sql`.

Migration is an additive `AD_UI_Element` metadata `UPDATE` (sets `ViewEditMode='D'` on element 652656) —
no view/function/DDL-object redefinition, so no whole-object regression risk.
