### PR TITLE
gitignore graphify-out/ knowledge-graph output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ nul
 docker-builds/e2e-tests/.env
 *.stackdump
 tmp/
+
+# graphify knowledge-graph output (per-module graph.json/graph.html, can be 5-30 MB each)
+graphify-out/


### PR DESCRIPTION
## What

Add `graphify-out/` to `.gitignore`.

The graphify code-knowledge-graph tool writes per-module `graph.json` / `graph.html`
artifacts (5–30 MB each) into `graphify-out/` directories inside the source tree.
This ignores them repo-wide so the large generated artifacts are never accidentally committed.

## Scope

`.gitignore` only — one 3-line addition. No code, no functional change.
