### PR TITLE
Karottenabrechnung — read archived HU attributes for destroyed HUs (fix no-invoice-candidates)

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/IHUAttributesDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/IHUAttributesDAO.java
@@ -33,12 +33,18 @@ public interface IHUAttributesDAO extends ISingletonService
 
 	/**
 	 * Load the given <code>hu</code>'s attributes, ordered by their <code>M_HU_PI_Attribute</code>'s <code>SeqNo</code> (see {@link HUAttributesBySeqNoComparator}).
+	 * <p>
+	 * Returns active attribute rows only, EXCEPT for a <b>destroyed</b> HU: the HU-attribute archival job deactivates
+	 * all attributes of a destroyed HU, so for a destroyed HU the archived (inactive) rows are returned intentionally
+	 * (rather than an empty set), so destroyed-HU attribute consumers keep working as before the job existed.
 	 *
 	 * @return sorted HU attributes
 	 */
 	HUAndPIAttributes retrieveAttributesOrdered(I_M_HU hu);
 
 	/**
+	 * Active attribute rows only, EXCEPT for a destroyed HU (see {@link #retrieveAttributesOrdered(I_M_HU)}).
+	 *
 	 * @return the attribute or <code>null</code>
 	 */
 	@Nullable

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/impl/HUAttributesDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/impl/HUAttributesDAO.java
@@ -3,13 +3,13 @@ package de.metas.handlingunits.attribute.impl;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.IHUStatusBL;
 import de.metas.handlingunits.attribute.HUAndPIAttributes;
 import de.metas.handlingunits.attribute.IHUAttributesDAO;
 import de.metas.handlingunits.attribute.IHUPIAttributesDAO;
 import de.metas.handlingunits.attribute.PIAttributes;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_Attribute;
-import de.metas.handlingunits.model.X_M_HU;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
@@ -26,6 +26,7 @@ import java.util.Optional;
 public final class HUAttributesDAO implements IHUAttributesDAO
 {
 	public static final HUAttributesDAO instance = new HUAttributesDAO();
+	private static final IHUStatusBL huStatusBL = Services.get(IHUStatusBL.class);
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 	private HUAttributesDAO()
@@ -149,7 +150,7 @@ public final class HUAttributesDAO implements IHUAttributesDAO
 	 */
 	private static IQueryBuilder<I_M_HU_Attribute> addActiveRecordsFilterUnlessDestroyed(final IQueryBuilder<I_M_HU_Attribute> queryBuilder, final I_M_HU hu)
 	{
-		if (!X_M_HU.HUSTATUS_Destroyed.equals(hu.getHUStatus()))
+		if (!huStatusBL.isStatusDestroyed(hu))
 		{
 			queryBuilder.addOnlyActiveRecordsFilter();
 		}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/impl/HUAttributesDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/impl/HUAttributesDAO.java
@@ -94,10 +94,8 @@ public final class HUAttributesDAO implements IHUAttributesDAO
 		// NOTE: don't cache on this level. Caching is handled on upper levels
 
 		// there are only some dozen attributes at most, so i think it'S fine to order them after loading
-		final IQueryBuilder<I_M_HU_Attribute> queryBuilder = queryBL.createQueryBuilder(I_M_HU_Attribute.class, hu)
-				.addEqualsFilter(I_M_HU_Attribute.COLUMNNAME_M_HU_ID, hu.getM_HU_ID());
-		addActiveRecordsFilterUnlessDestroyed(queryBuilder, hu);
-		final List<I_M_HU_Attribute> huAttributes = queryBuilder
+		final List<I_M_HU_Attribute> huAttributes = addActiveRecordsFilterUnlessDestroyed(queryBL.createQueryBuilder(I_M_HU_Attribute.class, hu), hu)
+				.addEqualsFilter(I_M_HU_Attribute.COLUMNNAME_M_HU_ID, hu.getM_HU_ID())
 				.create()
 				.stream()
 				.collect(ImmutableList.toImmutableList());
@@ -124,11 +122,9 @@ public final class HUAttributesDAO implements IHUAttributesDAO
 
 	private List<I_M_HU_Attribute> retrieveAttributes(final I_M_HU hu, @NonNull final AttributeId attributeId)
 	{
-		final IQueryBuilder<I_M_HU_Attribute> queryBuilder = queryBL.createQueryBuilder(I_M_HU_Attribute.class, hu)
+		final List<I_M_HU_Attribute> huAttributes = addActiveRecordsFilterUnlessDestroyed(queryBL.createQueryBuilder(I_M_HU_Attribute.class, hu), hu)
 				.addEqualsFilter(I_M_HU_Attribute.COLUMNNAME_M_HU_ID, hu.getM_HU_ID())
-				.addEqualsFilter(I_M_HU_Attribute.COLUMNNAME_M_Attribute_ID, attributeId);
-		addActiveRecordsFilterUnlessDestroyed(queryBuilder, hu);
-		final List<I_M_HU_Attribute> huAttributes = queryBuilder
+				.addEqualsFilter(I_M_HU_Attribute.COLUMNNAME_M_Attribute_ID, attributeId)
 				.create()
 				.list(I_M_HU_Attribute.class);
 
@@ -149,14 +145,15 @@ public final class HUAttributesDAO implements IHUAttributesDAO
 	 * HU_ReceiptInOutLine_ID link), breaking destroyed-HU attribute consumers such as the
 	 * material-tracking receipt-line lookup. A destroyed HU's attributes are uniformly the archived
 	 * set, so dropping the active filter for it reads exactly that set. Live HUs keep the active-only
-	 * filter (and the M_HU_Attribute active partial index it relies on).
+	 * filter (unchanged behaviour).
 	 */
-	private static void addActiveRecordsFilterUnlessDestroyed(final IQueryBuilder<I_M_HU_Attribute> queryBuilder, final I_M_HU hu)
+	private static IQueryBuilder<I_M_HU_Attribute> addActiveRecordsFilterUnlessDestroyed(final IQueryBuilder<I_M_HU_Attribute> queryBuilder, final I_M_HU hu)
 	{
 		if (!X_M_HU.HUSTATUS_Destroyed.equals(hu.getHUStatus()))
 		{
 			queryBuilder.addOnlyActiveRecordsFilter();
 		}
+		return queryBuilder;
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/impl/HUAttributesDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/attribute/impl/HUAttributesDAO.java
@@ -9,9 +9,11 @@ import de.metas.handlingunits.attribute.IHUPIAttributesDAO;
 import de.metas.handlingunits.attribute.PIAttributes;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_Attribute;
+import de.metas.handlingunits.model.X_M_HU;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.AttributeId;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -92,9 +94,10 @@ public final class HUAttributesDAO implements IHUAttributesDAO
 		// NOTE: don't cache on this level. Caching is handled on upper levels
 
 		// there are only some dozen attributes at most, so i think it'S fine to order them after loading
-		final List<I_M_HU_Attribute> huAttributes = queryBL.createQueryBuilder(I_M_HU_Attribute.class, hu)
-				.addOnlyActiveRecordsFilter()
-				.addEqualsFilter(I_M_HU_Attribute.COLUMNNAME_M_HU_ID, hu.getM_HU_ID())
+		final IQueryBuilder<I_M_HU_Attribute> queryBuilder = queryBL.createQueryBuilder(I_M_HU_Attribute.class, hu)
+				.addEqualsFilter(I_M_HU_Attribute.COLUMNNAME_M_HU_ID, hu.getM_HU_ID());
+		addActiveRecordsFilterUnlessDestroyed(queryBuilder, hu);
+		final List<I_M_HU_Attribute> huAttributes = queryBuilder
 				.create()
 				.stream()
 				.collect(ImmutableList.toImmutableList());
@@ -121,10 +124,11 @@ public final class HUAttributesDAO implements IHUAttributesDAO
 
 	private List<I_M_HU_Attribute> retrieveAttributes(final I_M_HU hu, @NonNull final AttributeId attributeId)
 	{
-		final List<I_M_HU_Attribute> huAttributes = queryBL.createQueryBuilder(I_M_HU_Attribute.class, hu)
-				.addOnlyActiveRecordsFilter()
+		final IQueryBuilder<I_M_HU_Attribute> queryBuilder = queryBL.createQueryBuilder(I_M_HU_Attribute.class, hu)
 				.addEqualsFilter(I_M_HU_Attribute.COLUMNNAME_M_HU_ID, hu.getM_HU_ID())
-				.addEqualsFilter(I_M_HU_Attribute.COLUMNNAME_M_Attribute_ID, attributeId)
+				.addEqualsFilter(I_M_HU_Attribute.COLUMNNAME_M_Attribute_ID, attributeId);
+		addActiveRecordsFilterUnlessDestroyed(queryBuilder, hu);
+		final List<I_M_HU_Attribute> huAttributes = queryBuilder
 				.create()
 				.list(I_M_HU_Attribute.class);
 
@@ -135,6 +139,24 @@ public final class HUAttributesDAO implements IHUAttributesDAO
 		}
 
 		return huAttributes;
+	}
+
+	/**
+	 * Restricts the query to active attribute rows, EXCEPT for a destroyed HU.
+	 * <p>
+	 * The HU-attribute archival job sets M_HU_Attribute.IsActive='N' on ALL attributes of a destroyed
+	 * HU. Filtering active-only would then hide every attribute of a destroyed HU (e.g. its
+	 * HU_ReceiptInOutLine_ID link), breaking destroyed-HU attribute consumers such as the
+	 * material-tracking receipt-line lookup. A destroyed HU's attributes are uniformly the archived
+	 * set, so dropping the active filter for it reads exactly that set. Live HUs keep the active-only
+	 * filter (and the M_HU_Attribute active partial index it relies on).
+	 */
+	private static void addActiveRecordsFilterUnlessDestroyed(final IQueryBuilder<I_M_HU_Attribute> queryBuilder, final I_M_HU hu)
+	{
+		if (!X_M_HU.HUSTATUS_Destroyed.equals(hu.getHUStatus()))
+		{
+			queryBuilder.addOnlyActiveRecordsFilter();
+		}
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/materialtracking/spi/impl/PPOrderMInOutLineRetrievalServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/materialtracking/spi/impl/PPOrderMInOutLineRetrievalServiceTest.java
@@ -7,13 +7,21 @@ import de.metas.handlingunits.HUDocumentSelectTestHelper;
 import de.metas.handlingunits.IHUAssignmentBL;
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.IHandlingUnitsDAO;
+import de.metas.handlingunits.attribute.HUAndPIAttributes;
+import de.metas.handlingunits.attribute.HUAttributeConstants;
+import de.metas.handlingunits.attribute.impl.HUAttributesDAO;
 import de.metas.handlingunits.attribute.impl.SaveDecoupledHUAttributesDAO;
 import de.metas.handlingunits.inout.impl.ReceiptInOutLineHUAssignmentListener;
 import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.I_M_HU_Attribute;
+import de.metas.handlingunits.model.X_M_HU;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
 import de.metas.util.collections.CollectionUtils;
+import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.mm.attributes.AttributeId;
+import org.adempiere.mm.attributes.api.IAttributeDAO;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
@@ -175,6 +183,97 @@ public class PPOrderMInOutLineRetrievalServiceTest
 		assertThat(provideIssuedInOutLinesSalad).hasSize(1);
 		assertThat(provideIssuedInOutLinesSalad.get(0)).isEqualTo(completedLines.get(1)); // expecting the completed salad line
 
+	}
+
+	/**
+	 * A destroyed HU's attribute rows may all be deactivated (IsActive='N') by the HU-attribute
+	 * archival job. The HU-attribute read-path must still return those archived rows for a destroyed
+	 * HU, otherwise its HU_ReceiptInOutLine_ID link is unreadable and quality invoicing finds no
+	 * receipt (no invoice candidates).
+	 * <p>
+	 * Asserted at the DAO read methods with a COLD read (HUAttributesDAO.instance, no cache): the
+	 * SaveDecoupledHUAttributesDAO runtime wrapper warms a sticky per-HU read cache on assignment that
+	 * flush() never evicts, so an end-to-end read through it cannot observe a later DB-level
+	 * deactivation in this in-memory harness (the definitive runtime confirmation is a live
+	 * re-invoice on the running stack). Both fixed read methods are exercised here:
+	 * {@code retrieveAttributesOrdered} (the runtime whole-HU load) and {@code retrieveAttribute} ->
+	 * {@code retrieveAttributes} (the point lookup).
+	 */
+	@Test
+	public void test_destroyedHU_deactivatedReceiptAttribute_readReturnsArchivedRow()
+	{
+		final IAttributeDAO attributeDAO = Services.get(IAttributeDAO.class);
+
+		final List<I_M_InOutLine> completedLines = createReceiptInOutLines(IDocument.STATUS_Completed);
+		final I_M_InOutLine completedTomatoLine = completedLines.get(0);
+		final I_M_HU tomatoHU = createLU(helper.pTomatoProductId, new BigDecimal("30"));
+
+		// assigning the HU to the receipt line sets its HU_ReceiptInOutLine_ID attribute (via the listener)
+		createAssignments(completedTomatoLine, tomatoHU);
+
+		final AttributeId receiptAttrId = attributeDAO.getAttributeIdByCode(HUAttributeConstants.ATTR_ReceiptInOutLine_ID);
+
+		// sanity: while the HU is active, the attribute is set and readable
+		final I_M_HU_Attribute activeRead = HUAttributesDAO.instance.retrieveAttribute(tomatoHU, receiptAttrId);
+		assertThat(activeRead).isNotNull();
+		assertThat(activeRead.getValueNumber().intValue()).isEqualTo(completedTomatoLine.getM_InOutLine_ID());
+
+		// simulate the archival job: HU destroyed + its HU_ReceiptInOutLine_ID attribute row deactivated
+		tomatoHU.setHUStatus(X_M_HU.HUSTATUS_Destroyed);
+		InterfaceWrapperHelper.save(tomatoHU);
+		deactivateHuAttribute(tomatoHU, receiptAttrId);
+
+		// point-lookup path (retrieveAttribute -> retrieveAttributes)
+		final I_M_HU_Attribute pointLookup = HUAttributesDAO.instance.retrieveAttribute(tomatoHU, receiptAttrId);
+		assertThat(pointLookup)
+				.as("retrieveAttribute must return the archived HU_ReceiptInOutLine_ID for a destroyed HU")
+				.isNotNull();
+		assertThat(pointLookup.getValueNumber().intValue()).isEqualTo(completedTomatoLine.getM_InOutLine_ID());
+
+		// runtime whole-HU load path (retrieveAttributesOrdered)
+		final HUAndPIAttributes ordered = HUAttributesDAO.instance.retrieveAttributesOrdered(tomatoHU);
+		assertThat(ordered.getHuAttributes())
+				.as("retrieveAttributesOrdered must include the archived HU_ReceiptInOutLine_ID for a destroyed HU")
+				.anyMatch(attr -> attr.getM_Attribute_ID() == receiptAttrId.getRepoId());
+	}
+
+	/**
+	 * For a NON-destroyed (live) HU the active-records filter is preserved, so a deactivated attribute
+	 * stays invisible (the archival performance win is not given back for live HUs).
+	 */
+	@Test
+	public void test_activeHU_deactivatedReceiptAttribute_stillFilteredOut()
+	{
+		final IAttributeDAO attributeDAO = Services.get(IAttributeDAO.class);
+
+		final List<I_M_InOutLine> completedLines = createReceiptInOutLines(IDocument.STATUS_Completed);
+		final I_M_HU tomatoHU = createLU(helper.pTomatoProductId, new BigDecimal("30"));
+		createAssignments(completedLines.get(0), tomatoHU);
+
+		final AttributeId receiptAttrId = attributeDAO.getAttributeIdByCode(HUAttributeConstants.ATTR_ReceiptInOutLine_ID);
+
+		// HU stays active (assignment leaves it HUSTATUS_Active); deactivate the attribute row only
+		deactivateHuAttribute(tomatoHU, receiptAttrId);
+
+		assertThat(HUAttributesDAO.instance.retrieveAttribute(tomatoHU, receiptAttrId))
+				.as("a deactivated attribute must stay invisible for a live (non-destroyed) HU")
+				.isNull();
+	}
+
+	/**
+	 * Deactivates the given HU's attribute row directly in the DB (as the archival job does), loading a
+	 * fresh instance via the query layer so the SaveDecoupled read cache is bypassed.
+	 */
+	private void deactivateHuAttribute(final I_M_HU hu, final AttributeId attributeId)
+	{
+		final IQueryBL queryBL = Services.get(IQueryBL.class);
+		final I_M_HU_Attribute attr = queryBL.createQueryBuilder(I_M_HU_Attribute.class)
+				.addEqualsFilter(I_M_HU_Attribute.COLUMNNAME_M_HU_ID, hu.getM_HU_ID())
+				.addEqualsFilter(I_M_HU_Attribute.COLUMNNAME_M_Attribute_ID, attributeId)
+				.create()
+				.firstOnlyNotNull(I_M_HU_Attribute.class);
+		attr.setIsActive(false);
+		InterfaceWrapperHelper.save(attr);
 	}
 
 	private void createAssignments(


### PR DESCRIPTION
## What
For a destroyed HU, the HU-attribute read-path now returns its archived (inactive) attribute rows, so destroyed-HU attribute consumers — notably the material-tracking receipt-line lookup used by quality invoicing — keep working after the HU-attribute archival job deactivates those attributes.

## Why
A weekly HU-attribute archival job sets `M_HU_Attribute.IsActive='N'` on all attributes of a destroyed HU. Sample HUs issued to a quality-inspection PP_Order are destroyed after issue, so their `HU_ReceiptInOutLine_ID` attribute — the only link from an issued sample HU back to its material receipt — got deactivated. The quality-invoicing read-path resolved that link through an active-records-only query, found no receipt, no price-list version, and created no invoice candidates (silently).

## How
Gate `.addOnlyActiveRecordsFilter()` behind `!isDestroyed(hu)` (`X_M_HU.HUSTATUS_Destroyed`) in both `HUAttributesDAO` read methods — `retrieveAttributesOrdered` (runtime whole-HU load) and `retrieveAttributes` (point lookup) — via a shared helper. A destroyed HU's attributes are uniformly the archived set (the archival job is the sole deactivator), so dropping the filter reads exactly that set. Live HUs keep active-only reads (and the active partial index they use); the archival job itself is unchanged, so its performance win is preserved.

## Test
New regression test in `PPOrderMInOutLineRetrievalServiceTest`: a destroyed HU whose `HU_ReceiptInOutLine_ID` attribute row is deactivated is read back via the DAO methods — RED before the fix (active filter hides it), GREEN after. An active-HU control asserts the active filter is preserved for live (non-destroyed) HUs. Assertions are at the DAO read methods with a cold read, because the decoupled HU-attribute DAO warms a sticky per-HU read cache that prevents an end-to-end assertion in the in-memory harness; the definitive runtime confirmation is a live re-invoice of the affected orders after deploy.
