### PR TITLE
HU org: derive M_HU.AD_Org_ID from locator warehouse at creation + repair migration

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_HU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_HU.java
@@ -21,6 +21,7 @@ import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
 import de.metas.logging.LogManager;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.compiere.model.I_M_Warehouse;
 
 @Interceptor(I_M_HU.class)
 public class M_HU
@@ -73,6 +74,24 @@ public class M_HU
 				}
 			}
 		}
+	}
+
+	/**
+	 * Sets the HU's {@code AD_Org_ID} from its locator's warehouse at creation time, so that a physical HU
+	 * always belongs to the org that owns its warehouse, regardless of the creating context's org.
+	 *
+	 * @param hu
+	 */
+	@ModelChange(timings = ModelValidator.TYPE_BEFORE_NEW)
+	public void setOrgFromWarehouse(@NonNull final I_M_HU hu)
+	{
+		final I_M_Warehouse warehouse = IHandlingUnitsBL.extractWarehouseOrNull(hu);
+		if (warehouse == null)
+		{
+			return; // no physical location => keep the context org
+		}
+
+		hu.setAD_Org_ID(warehouse.getAD_Org_ID());
 	}
 
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_CHANGE, ifColumnsChanged = I_M_HU.COLUMNNAME_HUStatus)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_HU.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_HU.java
@@ -77,8 +77,9 @@ public class M_HU
 	}
 
 	/**
-	 * Sets the HU's {@code AD_Org_ID} from its locator's warehouse at creation time, so that a physical HU
-	 * always belongs to the org that owns its warehouse, regardless of the creating context's org.
+	 * Sets the HU's {@code AD_Org_ID} from its locator's warehouse at creation time, when that warehouse has a
+	 * real org, so that a physical HU always belongs to the org that owns its warehouse, regardless of the
+	 * creating context's org.
 	 *
 	 * @param hu
 	 */
@@ -91,7 +92,17 @@ public class M_HU
 			return; // no physical location => keep the context org
 		}
 
-		hu.setAD_Org_ID(warehouse.getAD_Org_ID());
+		final int warehouseOrgId = warehouse.getAD_Org_ID();
+		if (warehouseOrgId <= 0)
+		{
+			// Warehouse itself carries no real org (0 = * / ANY). Stamping org 0 here would re-introduce the
+			// very org-0 physical HU this interceptor exists to prevent, so keep the context org instead —
+			// symmetric with the data-repair migration, which likewise only repairs HUs whose warehouse has a
+			// real org (w.ad_org_id > 0).
+			return;
+		}
+
+		hu.setAD_Org_ID(warehouseOrgId);
 	}
 
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_CHANGE, ifColumnsChanged = I_M_HU.COLUMNNAME_HUStatus)

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815330_sys_repair_M_HU_org_zero.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815330_sys_repair_M_HU_org_zero.sql
@@ -14,5 +14,4 @@ UPDATE m_hu hu
   JOIN m_warehouse w ON w.m_warehouse_id = l.m_warehouse_id
  WHERE hu.m_locator_id = l.m_locator_id
    AND hu.ad_org_id    = 0
-   AND hu.isactive     = 'Y'
    AND w.ad_org_id     > 0;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815330_sys_repair_M_HU_org_zero.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815330_sys_repair_M_HU_org_zero.sql
@@ -1,0 +1,18 @@
+-- Repair physical HUs left with AD_Org_ID=0 (the * / ANY org).
+-- A physical HU lives in a locator -> warehouse -> exactly one real org, so AD_Org_ID=0 is corrupt: it makes
+-- MD_Stock_From_HUs_V emit an org-0 aggregate row for a real-org warehouse, which MD_Stock_Update_From_M_HUs
+-- cannot reconcile -> the whole stock-correction run fails. Set each such active HU's org to its locator's
+-- warehouse org. Idempotent: only touches active org-0 HUs whose warehouse carries a real org, so a re-run
+-- corrects nothing further.
+SELECT backup_table('m_hu', '_me03_30595_org_zero');
+
+UPDATE m_hu hu
+   SET ad_org_id = w.ad_org_id,
+       updated   = TO_TIMESTAMP('2026-07-22 07:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+       updatedby = 99
+  FROM m_locator l
+  JOIN m_warehouse w ON w.m_warehouse_id = l.m_warehouse_id
+ WHERE hu.m_locator_id = l.m_locator_id
+   AND hu.ad_org_id    = 0
+   AND hu.isactive     = 'Y'
+   AND w.ad_org_id     > 0;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815330_sys_repair_M_HU_org_zero.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815330_sys_repair_M_HU_org_zero.sql
@@ -4,7 +4,7 @@
 -- cannot reconcile -> the whole stock-correction run fails. Set each such active HU's org to its locator's
 -- warehouse org. Idempotent: only touches active org-0 HUs whose warehouse carries a real org, so a re-run
 -- corrects nothing further.
-SELECT backup_table('m_hu', '_me03_30595_org_zero');
+SELECT backup_table('m_hu', '_repair_org_zero');
 
 UPDATE m_hu hu
    SET ad_org_id = w.ad_org_id,

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815330_sys_repair_M_HU_org_zero.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815330_sys_repair_M_HU_org_zero.sql
@@ -1,8 +1,8 @@
 -- Repair physical HUs left with AD_Org_ID=0 (the * / ANY org).
 -- A physical HU lives in a locator -> warehouse -> exactly one real org, so AD_Org_ID=0 is corrupt: it makes
 -- MD_Stock_From_HUs_V emit an org-0 aggregate row for a real-org warehouse, which MD_Stock_Update_From_M_HUs
--- cannot reconcile -> the whole stock-correction run fails. Set each such active HU's org to its locator's
--- warehouse org. Idempotent: only touches active org-0 HUs whose warehouse carries a real org, so a re-run
+-- cannot reconcile -> the whole stock-correction run fails. Set each such HU's org to its locator's
+-- warehouse org. Idempotent: only touches org-0 HUs whose warehouse carries a real org, so a re-run
 -- corrects nothing further.
 SELECT backup_table('m_hu', '_repair_org_zero');
 

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUBuilderTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUBuilderTests.java
@@ -1,5 +1,6 @@
 package de.metas.handlingunits.impl;
 
+import de.metas.business.BusinessTestHelper;
 import de.metas.handlingunits.HUTestHelper;
 import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.IHandlingUnitsDAO;
@@ -12,8 +13,16 @@ import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
 import de.metas.handlingunits.model.X_M_HU_Item;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
+import de.metas.handlingunits.model.validator.M_HU;
+import de.metas.organization.OrgId;
 import de.metas.util.Services;
+import org.adempiere.ad.modelvalidator.IModelInterceptorRegistry;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.warehouse.LocatorId;
+import org.compiere.model.I_M_Locator;
+import org.compiere.model.I_M_Warehouse;
+import org.compiere.util.Env;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -256,5 +265,55 @@ public class HUBuilderTests
 		;
 		//@formatter:on
 		compressedHUExpectation.assertExpected(Collections.singletonList(luHU));
+	}
+
+	/**
+	 * A physical HU (top-level, real locator) shall get its {@code AD_Org_ID} from the locator's warehouse
+	 * at creation time, regardless of the creating context's org (AC1-AC3). If the context org already matches
+	 * the warehouse org, nothing changes (AC4, no-regression).
+	 */
+	@Test
+	public void huCreatedUnderOrgZeroContextGetsWarehouseOrg()
+	{
+		// Production wiring registers M_HU.INSTANCE as a model validator (see Main#registerInterceptors).
+		// HUTestHelper's "minimal" interceptor setup intentionally skips it (to avoid NPEs in unrelated tests),
+		// so register it here to exercise the real TYPE_BEFORE_NEW creation path.
+		Services.get(IModelInterceptorRegistry.class).addModelInterceptor(M_HU.INSTANCE);
+
+		// Fixture: a warehouse+locator that belongs to a real org R (the harness' helper.defaultWarehouse is org 0)
+		final OrgId orgR = AdempiereTestHelper.createOrgWithTimeZone("HuOrgFromWarehouseOrg");
+		assertThat(orgR.getRepoId()).isGreaterThan(0); // fixture sanity check
+
+		final I_M_Warehouse warehouseR = InterfaceWrapperHelper.newInstanceOutOfTrx(I_M_Warehouse.class);
+		warehouseR.setValue("WhOrgR");
+		warehouseR.setName("WhOrgR");
+		warehouseR.setIsIssueWarehouse(false);
+		warehouseR.setAD_Org_ID(orgR.getRepoId());
+		InterfaceWrapperHelper.save(warehouseR);
+		assertThat(warehouseR.getAD_Org_ID()).isEqualTo(orgR.getRepoId()); // fixture sanity check: R > 0
+
+		final I_M_Locator locatorR = BusinessTestHelper.createLocator("WhOrgR-default", warehouseR);
+		final LocatorId locatorIdR = LocatorId.ofRepoId(warehouseR.getM_Warehouse_ID(), locatorR.getM_Locator_ID());
+
+		// AC1-AC3: Set the creation context org to 0 and create a top-level HU at the real-org locator.
+		Env.setContext(helper.getCtx(), Env.CTXNAME_AD_Org_ID, 0);
+
+		final HUBuilder testeeOrgZero = new HUBuilder(huContext);
+		testeeOrgZero.setLocatorId(locatorIdR);
+		final I_M_HU resultOrgZero = testeeOrgZero.create(piLU_Version);
+
+		final I_M_HU reloadedOrgZero = InterfaceWrapperHelper.load(resultOrgZero.getM_HU_ID(), I_M_HU.class);
+		assertThat(reloadedOrgZero.getM_Locator_ID()).isEqualTo(locatorR.getM_Locator_ID()); // guard
+		assertThat(reloadedOrgZero.getAD_Org_ID()).isEqualTo(orgR.getRepoId());
+
+		// AC4 (no-regression): context org already == R => persisted org stays R
+		Env.setContext(helper.getCtx(), Env.CTXNAME_AD_Org_ID, orgR.getRepoId());
+
+		final HUBuilder testeeOrgR = new HUBuilder(huContext);
+		testeeOrgR.setLocatorId(locatorIdR);
+		final I_M_HU resultOrgR = testeeOrgR.create(piLU_Version);
+
+		final I_M_HU reloadedOrgR = InterfaceWrapperHelper.load(resultOrgR.getM_HU_ID(), I_M_HU.class);
+		assertThat(reloadedOrgR.getAD_Org_ID()).isEqualTo(orgR.getRepoId());
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUBuilderTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUBuilderTests.java
@@ -316,4 +316,69 @@ public class HUBuilderTests
 		final I_M_HU reloadedOrgR = InterfaceWrapperHelper.load(resultOrgR.getM_HU_ID(), I_M_HU.class);
 		assertThat(reloadedOrgR.getAD_Org_ID()).isEqualTo(orgR.getRepoId());
 	}
+
+	/**
+	 * An org-0 warehouse ("*" / ANY) carries no real org. The interceptor shall then keep the creating
+	 * context's org rather than re-stamping the physical HU with org 0 (symmetric with the data-repair
+	 * migration, which likewise only repairs HUs whose warehouse has a real org).
+	 */
+	@Test
+	public void huCreatedAtOrgZeroWarehouseKeepsContextOrg()
+	{
+		// Production wiring registers M_HU.INSTANCE as a model validator (see Main#registerInterceptors).
+		// HUTestHelper's "minimal" interceptor setup intentionally skips it (to avoid NPEs in unrelated tests),
+		// so register it here to exercise the real TYPE_BEFORE_NEW creation path.
+		Services.get(IModelInterceptorRegistry.class).addModelInterceptor(M_HU.INSTANCE);
+
+		// Fixture: a warehouse+locator whose own AD_Org_ID is 0 ("*" / ANY)
+		final I_M_Warehouse warehouseOrgZero = InterfaceWrapperHelper.newInstanceOutOfTrx(I_M_Warehouse.class);
+		warehouseOrgZero.setValue("WhOrgZero");
+		warehouseOrgZero.setName("WhOrgZero");
+		warehouseOrgZero.setIsIssueWarehouse(false);
+		warehouseOrgZero.setAD_Org_ID(0);
+		InterfaceWrapperHelper.save(warehouseOrgZero);
+		assertThat(warehouseOrgZero.getAD_Org_ID()).isEqualTo(0); // fixture sanity check
+
+		final I_M_Locator locatorOrgZero = BusinessTestHelper.createLocator("WhOrgZero-default", warehouseOrgZero);
+		final LocatorId locatorIdOrgZero = LocatorId.ofRepoId(warehouseOrgZero.getM_Warehouse_ID(), locatorOrgZero.getM_Locator_ID());
+
+		// Set the creation context org to a real org R and create a top-level HU at the org-0-warehouse locator.
+		final OrgId orgR = AdempiereTestHelper.createOrgWithTimeZone("HuOrgZeroWarehouseContextOrg");
+		assertThat(orgR.getRepoId()).isGreaterThan(0); // fixture sanity check
+		Env.setContext(helper.getCtx(), Env.CTXNAME_AD_Org_ID, orgR.getRepoId());
+
+		final HUBuilder testee = new HUBuilder(huContext);
+		testee.setLocatorId(locatorIdOrgZero);
+		final I_M_HU result = testee.create(piLU_Version);
+
+		final I_M_HU reloaded = InterfaceWrapperHelper.load(result.getM_HU_ID(), I_M_HU.class);
+		assertThat(reloaded.getM_Locator_ID()).isEqualTo(locatorOrgZero.getM_Locator_ID()); // guard
+		assertThat(reloaded.getAD_Org_ID()).isEqualTo(orgR.getRepoId());
+	}
+
+	/**
+	 * An HU with no locator (no physical location) has no warehouse to derive an org from
+	 * ({@link IHandlingUnitsBL#extractWarehouseOrNull} returns null). The interceptor shall then keep the
+	 * creating context's org.
+	 */
+	@Test
+	public void huCreatedWithoutLocatorKeepsContextOrg()
+	{
+		// Production wiring registers M_HU.INSTANCE as a model validator (see Main#registerInterceptors).
+		// HUTestHelper's "minimal" interceptor setup intentionally skips it (to avoid NPEs in unrelated tests),
+		// so register it here to exercise the real TYPE_BEFORE_NEW creation path.
+		Services.get(IModelInterceptorRegistry.class).addModelInterceptor(M_HU.INSTANCE);
+
+		final OrgId orgR = AdempiereTestHelper.createOrgWithTimeZone("HuNoLocatorContextOrg");
+		assertThat(orgR.getRepoId()).isGreaterThan(0); // fixture sanity check
+		Env.setContext(helper.getCtx(), Env.CTXNAME_AD_Org_ID, orgR.getRepoId());
+
+		// no setLocatorId(..) call => M_Locator_ID stays 0 => extractWarehouseOrNull(hu) returns null
+		final HUBuilder testee = new HUBuilder(huContext);
+		final I_M_HU result = testee.create(piLU_Version);
+
+		final I_M_HU reloaded = InterfaceWrapperHelper.load(result.getM_HU_ID(), I_M_HU.class);
+		assertThat(reloaded.getM_Locator_ID()).isLessThanOrEqualTo(0); // guard: no physical location (LocatorId.toRepoId(null) == -1)
+		assertThat(reloaded.getAD_Org_ID()).isEqualTo(orgR.getRepoId());
+	}
 }

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUBuilderTests.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUBuilderTests.java
@@ -269,8 +269,8 @@ public class HUBuilderTests
 
 	/**
 	 * A physical HU (top-level, real locator) shall get its {@code AD_Org_ID} from the locator's warehouse
-	 * at creation time, regardless of the creating context's org (AC1-AC3). If the context org already matches
-	 * the warehouse org, nothing changes (AC4, no-regression).
+	 * at creation time, regardless of the creating context's org. If the context org already matches
+	 * the warehouse org, nothing changes (no-regression).
 	 */
 	@Test
 	public void huCreatedUnderOrgZeroContextGetsWarehouseOrg()
@@ -295,7 +295,7 @@ public class HUBuilderTests
 		final I_M_Locator locatorR = BusinessTestHelper.createLocator("WhOrgR-default", warehouseR);
 		final LocatorId locatorIdR = LocatorId.ofRepoId(warehouseR.getM_Warehouse_ID(), locatorR.getM_Locator_ID());
 
-		// AC1-AC3: Set the creation context org to 0 and create a top-level HU at the real-org locator.
+		// Set the creation context org to 0 and create a top-level HU at the real-org locator.
 		Env.setContext(helper.getCtx(), Env.CTXNAME_AD_Org_ID, 0);
 
 		final HUBuilder testeeOrgZero = new HUBuilder(huContext);
@@ -306,7 +306,7 @@ public class HUBuilderTests
 		assertThat(reloadedOrgZero.getM_Locator_ID()).isEqualTo(locatorR.getM_Locator_ID()); // guard
 		assertThat(reloadedOrgZero.getAD_Org_ID()).isEqualTo(orgR.getRepoId());
 
-		// AC4 (no-regression): context org already == R => persisted org stays R
+		// No-regression: context org already == R => persisted org stays R
 		Env.setContext(helper.getCtx(), Env.CTXNAME_AD_Org_ID, orgR.getRepoId());
 
 		final HUBuilder testeeOrgR = new HUBuilder(huContext);


### PR DESCRIPTION
## Problem

A physical Handling Unit lives in a locator → warehouse → exactly one real org, yet an `M_HU`'s `AD_Org_ID` is never tied to that physical location: a new HU inherits its org from the creation **context**. Any HU-creating flow running under an org-0 (`*`/ANY) context therefore leaves a physical HU with `AD_Org_ID=0`, even though its warehouse belongs to a real org.

Such org-0 HUs break stock reconciliation: `MD_Stock_From_HUs_V` groups HU stock by `hu.AD_Org_ID` while taking the warehouse from the locator, so an org-0 HU produces an org-0 aggregate row for a real-org warehouse that reconciles against no `MD_Stock` row. `MD_Stock_Update_From_M_HUs` then tries to create an `MD_Stock` row / fire a stock event for org 0, and the whole run fails.

## Fix

**Enforce the invariant at the single source (creation):** a new `@ModelChange(BEFORE_NEW)` interceptor on `M_HU` derives `AD_Org_ID` from the HU's locator → warehouse org. No locator ⇒ context org is left untouched (such HUs are not physical stock in the view). This covers every creation flow (`HUBuilder` and any `newInstance(I_M_HU.class)`), not one call site.

**Repair existing corrupt rows:** an idempotent system migration sets `AD_Org_ID` to the locator's warehouse org for every active `M_HU` currently at `AD_Org_ID=0` whose warehouse has a real org. Touches only such rows; a re-run corrects nothing further.

Scope is **creation-time only** — no re-derivation on locator change (cross-org HU movements do not occur).

## Verification

- TDD unit test `HUBuilderTests#huCreatedUnderOrgZeroContextGetsWarehouseOrg` (RED→GREEN): an HU built under an org-0 context at a real-org locator gets the warehouse org; no-regression case (context org already correct) unchanged. Existing HU suite green.
- Migration applied against a local customer-faithful DB (applies cleanly, registered, idempotent); repair logic verified on a synthetic org-0 HU (org 0 → warehouse org; second run 0 rows).
- End-to-end verification that the stock-update process completes on corrected data is a manual UAT on the target instance after merge-up.
