### PR TITLE
S_ExternalReference: per-org external-reference uniqueness (add AD_Org_ID to unique index)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalreference/S_ExternalReference_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalreference/S_ExternalReference_StepDef.java
@@ -156,7 +156,7 @@ public class S_ExternalReference_StepDef
 
 			// scope by org when provided, so the same external reference can be asserted independently per org
 			row.getAsOptionalIdentifier(I_S_ExternalReference.COLUMNNAME_AD_Org_ID)
-					.ifPresent(orgIdentifier -> queryBuilder.addEqualsFilter(I_S_ExternalReference.COLUMNNAME_AD_Org_ID, orgTable.getIdAsInt(orgIdentifier)));
+					.ifPresent(orgIdentifier -> queryBuilder.addEqualsFilter(I_S_ExternalReference.COLUMNNAME_AD_Org_ID, orgTable.getId(orgIdentifier)));
 
 			final I_S_ExternalReference externalRefRecord = queryBuilder
 					.create()

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalreference/S_ExternalReference_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalreference/S_ExternalReference_StepDef.java
@@ -98,7 +98,7 @@ import static org.compiere.model.I_M_Shipper.COLUMNNAME_M_Shipper_ID;
 @RequiredArgsConstructor
 public class S_ExternalReference_StepDef
 {
-	private final OrgId defaultOrgId = OrgId.ofRepoId(1000000);
+	private final OrgId defaultOrgId = OrgId.MAIN;
 
 	private final AD_User_StepDefData userTable;
 	private final S_ExternalReference_StepDefData externalRefTable;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalreference/S_ExternalReference_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalreference/S_ExternalReference_StepDef.java
@@ -66,6 +66,7 @@ import io.cucumber.java.en.Then;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.IQueryOrderBy;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -147,11 +148,17 @@ public class S_ExternalReference_StepDef
 			final String externalReference = row.getAsOptionalString("ExternalReference").map(DataTableUtil::nullToken2Null).orElse(null);
 			final String externalReferenceURL = row.getAsOptionalString("ExternalReferenceURL").map(DataTableUtil::nullToken2Null).orElse(null);
 
-			final I_S_ExternalReference externalRefRecord = queryBL.createQueryBuilder(I_S_ExternalReference.class)
+			final IQueryBuilder<I_S_ExternalReference> queryBuilder = queryBL.createQueryBuilder(I_S_ExternalReference.class)
 					.addEqualsFilter(I_S_ExternalReference.COLUMNNAME_ExternalSystem_ID, externalSystem.getId())
 					.addEqualsFilter(I_S_ExternalReference.COLUMNNAME_Type, type.getCode())
 					.addEqualsFilter(I_S_ExternalReference.COLUMNNAME_ExternalReference, externalReference)
-					.addEqualsFilter(I_S_ExternalReference.COLUMN_ExternalReferenceURL, externalReferenceURL)
+					.addEqualsFilter(I_S_ExternalReference.COLUMN_ExternalReferenceURL, externalReferenceURL);
+
+			// scope by org when provided, so the same external reference can be asserted independently per org
+			row.getAsOptionalIdentifier(I_S_ExternalReference.COLUMNNAME_AD_Org_ID)
+					.ifPresent(orgIdentifier -> queryBuilder.addEqualsFilter(I_S_ExternalReference.COLUMNNAME_AD_Org_ID, orgTable.getIdAsInt(orgIdentifier)));
+
+			final I_S_ExternalReference externalRefRecord = queryBuilder
 					.create()
 					.firstOnlyOrNull(I_S_ExternalReference.class);
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalreference/S_ExternalReference_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalreference/S_ExternalReference_StepDef.java
@@ -66,7 +66,6 @@ import io.cucumber.java.en.Then;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.dao.IQueryBL;
-import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.IQueryOrderBy;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
@@ -117,7 +116,7 @@ public class S_ExternalReference_StepDef
 
 	/**
 	 * Verifies that an {@code S_ExternalReference} record exists with the given field values,
-	 * and optionally asserts its {@code AD_Org_ID}.
+	 * scoped to a specific org.
 	 *
 	 * <p>Required columns:
 	 * <ul>
@@ -127,8 +126,9 @@ public class S_ExternalReference_StepDef
 	 *
 	 * <p>Optional columns (absent cell = not asserted):
 	 * {@code ExternalReference}, {@code ExternalReferenceURL},
-	 * {@code AD_Org_ID} – org identifier previously registered in {@link AD_Org_StepDefData}; asserts that
-	 * {@code S_ExternalReference.AD_Org_ID} matches the referenced org.
+	 * {@code AD_Org_ID} – org identifier previously registered in {@link AD_Org_StepDefData}; scopes the
+	 * lookup to that org (defaults to the main org when omitted). External references are unique per org,
+	 * so this lets the same reference be asserted independently for two different orgs.
 	 *
 	 * <p>Example:
 	 * <pre>
@@ -148,26 +148,18 @@ public class S_ExternalReference_StepDef
 			final String externalReference = row.getAsOptionalString("ExternalReference").map(DataTableUtil::nullToken2Null).orElse(null);
 			final String externalReferenceURL = row.getAsOptionalString("ExternalReferenceURL").map(DataTableUtil::nullToken2Null).orElse(null);
 
-			final IQueryBuilder<I_S_ExternalReference> queryBuilder = queryBL.createQueryBuilder(I_S_ExternalReference.class)
+			final I_S_ExternalReference externalRefRecord = queryBL.createQueryBuilder(I_S_ExternalReference.class)
 					.addEqualsFilter(I_S_ExternalReference.COLUMNNAME_ExternalSystem_ID, externalSystem.getId())
 					.addEqualsFilter(I_S_ExternalReference.COLUMNNAME_Type, type.getCode())
 					.addEqualsFilter(I_S_ExternalReference.COLUMNNAME_ExternalReference, externalReference)
-					.addEqualsFilter(I_S_ExternalReference.COLUMN_ExternalReferenceURL, externalReferenceURL);
-
-			// scope by org when provided, so the same external reference can be asserted independently per org
-			row.getAsOptionalIdentifier(I_S_ExternalReference.COLUMNNAME_AD_Org_ID)
-					.ifPresent(orgIdentifier -> queryBuilder.addEqualsFilter(I_S_ExternalReference.COLUMNNAME_AD_Org_ID, orgTable.getId(orgIdentifier)));
-
-			final I_S_ExternalReference externalRefRecord = queryBuilder
+					.addEqualsFilter(I_S_ExternalReference.COLUMN_ExternalReferenceURL, externalReferenceURL)
+					// scope by org so the same external reference can be asserted independently per org (defaults to the main org)
+					.addEqualsFilter(I_S_ExternalReference.COLUMNNAME_AD_Org_ID,
+							row.getAsOptionalIdentifier(I_S_ExternalReference.COLUMNNAME_AD_Org_ID).map(orgTable::getId).orElse(OrgId.MAIN))
 					.create()
 					.firstOnlyOrNull(I_S_ExternalReference.class);
 
 			assertThat(externalRefRecord).as("S_ExternalReference exists for externalReference=%s", externalReference).isNotNull();
-
-			row.getAsOptionalIdentifier(I_S_ExternalReference.COLUMNNAME_AD_Org_ID)
-					.ifPresent(orgIdentifier -> assertThat(externalRefRecord.getAD_Org_ID())
-							.as(I_S_ExternalReference.COLUMNNAME_AD_Org_ID)
-							.isEqualTo(orgTable.getIdAsInt(orgIdentifier)));
 		});
 	}
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/bpartnerV2OrgConsistency.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/bpartnerV2OrgConsistency.feature
@@ -10,6 +10,7 @@ Feature: BPartner v2 upsert places records in the path org
     And metasfresh contains AD_Org:
       | AD_Org_ID.Identifier | Name | Value |
       | org002               | 002  | 002   |
+      | org003               | 003  | 003   |
     And metasfresh contains External System
       | Name        | Value       |
       | Test System | Test_System |
@@ -19,6 +20,7 @@ Feature: BPartner v2 upsert places records in the path org
       | 002               | Test_System    | BPartner         |
       | 001-loc1          | Test_System    | BPartnerLocation |
       | 001-con1          | Test_System    | UserID           |
+      | shared            | Test_System    | BPartner         |
 
   @Id:S30934_TC1
   Scenario: PUT api/v2/bpartner/002 places C_BPartner and S_ExternalReference under org 002
@@ -183,3 +185,57 @@ Feature: BPartner v2 upsert places records in the path org
 """
     # GET by path org 001 should return not-found (org isolation)
     Then the metasfresh REST-API endpoint path 'api/v2/bpartner/001/ext-Test_System-001' receives a 'GET' request with the headers from context, expecting status='404'
+
+  @Id:S30934_TC4
+  Scenario: The same external reference may exist once per org (per-org uniqueness)
+    # External references are looked up per org, so the same external system + reference code must be
+    # usable independently by two different orgs. With an org-agnostic unique index the second org's
+    # write collided on the global key; the index includes AD_Org_ID so each org keeps its own row.
+    When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/bpartner/002' and fulfills with '201' status code
+    """
+{
+  "requestItems": [
+    {
+      "bpartnerIdentifier": "ext-Test_System-shared",
+      "bpartnerComposite": {
+        "bpartner": {
+          "name": "Shared Ref Org 002",
+          "language": "de"
+        }
+      }
+    }
+  ],
+  "syncAdvise": {
+    "ifNotExists": "CREATE",
+    "ifExists": "UPDATE_MERGE"
+  }
+}
+"""
+    # Same external reference (Test_System / shared / BPartner) under a DIFFERENT org must ALSO succeed
+    When a 'PUT' request with the below payload is sent to the metasfresh REST-API 'api/v2/bpartner/003' and fulfills with '201' status code
+    """
+{
+  "requestItems": [
+    {
+      "bpartnerIdentifier": "ext-Test_System-shared",
+      "bpartnerComposite": {
+        "bpartner": {
+          "name": "Shared Ref Org 003",
+          "language": "de"
+        }
+      }
+    }
+  ],
+  "syncAdvise": {
+    "ifNotExists": "CREATE",
+    "ifExists": "UPDATE_MERGE"
+  }
+}
+"""
+    # both external references persist, one per org
+    Then verify that S_ExternalReference was created
+      | ExternalSystem | Type     | ExternalReference | AD_Org_ID |
+      | Test_System    | BPartner | shared            | org002    |
+    And verify that S_ExternalReference was created
+      | ExternalSystem | Type     | ExternalReference | AD_Org_ID |
+      | Test_System    | BPartner | shared            | org003    |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/bpartnerV2OrgConsistency.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/bpartnerV2OrgConsistency.feature
@@ -200,7 +200,8 @@ Feature: BPartner v2 upsert places records in the path org
       "bpartnerComposite": {
         "bpartner": {
           "name": "Shared Ref Org 002",
-          "language": "de"
+          "language": "de",
+          "group": "Shared Ref Group 002"
         }
       }
     }
@@ -221,7 +222,8 @@ Feature: BPartner v2 upsert places records in the path org
       "bpartnerComposite": {
         "bpartner": {
           "name": "Shared Ref Org 003",
-          "language": "de"
+          "language": "de",
+          "group": "Shared Ref Group 003"
         }
       }
     }

--- a/backend/de.metas.externalreference/src/main/sql/postgresql/system/80-de.metas.externalreference/5815340_sys_gh30934_s_externalreference_uc_per_org.sql
+++ b/backend/de.metas.externalreference/src/main/sql/postgresql/system/80-de.metas.externalreference/5815340_sys_gh30934_s_externalreference_uc_per_org.sql
@@ -1,0 +1,25 @@
+-- Make S_ExternalReference uniqueness per-org, consistent with the org-scoped lookup.
+--
+-- The unique index on (ExternalReference, Type, ExternalSystem_ID) was org-agnostic (global), but
+-- ExternalReferenceRepository resolves references filtered by AD_Org_ID (the lookup is org-scoped).
+-- So two different orgs using the same external system + reference code collided on the global
+-- index even though the lookup treats them as distinct per org. Add AD_Org_ID to the index so the
+-- enforced uniqueness matches the (org-scoped) lookup: one external reference per org.
+--
+-- Loosening change: every row that satisfied the old (narrower) index still satisfies the new one,
+-- so no data migration / dedup is required.
+--
+-- The sibling index (Type, ExternalSystem_ID, Record_ID) is intentionally NOT changed: Record_ID is
+-- a metasfresh id that already belongs to exactly one org, so that index cannot collide across orgs.
+
+-- AD dictionary: add AD_Org_ID (SeqNo 40, tenant column last) to the index definition (AD_Index_Table 540525)
+INSERT INTO AD_Index_Column (AD_Client_ID,AD_Column_ID,AD_Index_Column_ID,AD_Index_Table_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,SeqNo,Updated,UpdatedBy)
+VALUES (0,570574,541534 /*From ID Server*/,540525,0,TO_TIMESTAMP('2026-07-22 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.externalreference','Y',40,TO_TIMESTAMP('2026-07-22 10:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- physical index: recreate including AD_Org_ID (tenant column last, per composite-index selectivity)
+DROP INDEX IF EXISTS idx_s_externalreference_externalsystem_type_externalreferenc
+;
+
+CREATE UNIQUE INDEX IDX_S_ExternalReference_ExternalSystem_Type_ExternalReferenc ON S_ExternalReference (ExternalReference,Type,ExternalSystem_ID,AD_Org_ID) WHERE S_ExternalReference.isActive='Y'
+;


### PR DESCRIPTION
## What

Make `S_ExternalReference` uniqueness **per-org**, aligning the enforced DB uniqueness with the org-scoped lookup.

`ExternalReferenceRepository` resolves external references filtered by `AD_Org_ID` (the lookup is org-scoped, `ExternalReferenceQuery.orgId` is `@NonNull`), but the unique index `idx_s_externalreference_externalsystem_type_externalreference` was **org-agnostic**: `UNIQUE(ExternalReference, Type, ExternalSystem_ID) WHERE isactive='Y'`. So two different orgs using the same external system + reference code collided on the global index even though the lookup treats them as distinct per org (the second org's write failed with a unique-constraint violation).

## Change

- Migration `5815340`: add `AD_Org_ID` (SeqNo 40, tenant column last) to the index — both the `AD_Index_Table` definition (`AD_Index_Column` row) and the physical index → `UNIQUE(ExternalReference, Type, ExternalSystem_ID, AD_Org_ID) WHERE isactive='Y'`. Loosening change: every row that satisfied the old narrower index still satisfies the new one, so no data migration/dedup is needed.
- The sibling index `(Type, ExternalSystem_ID, Record_ID)` is intentionally left unchanged — `Record_ID` is a metasfresh id that already belongs to exactly one org, so it cannot collide across orgs.
- Cucumber `bpartnerV2OrgConsistency.feature` TC4: the same external reference is created under two different orgs and both persist. The `verify that S_ExternalReference was created` step def is made org-aware (scopes the lookup by `AD_Org_ID` when provided) so per-org references can be asserted individually.

## Validation

Index-level RED→GREEN proven locally (transactional, rolled back): with the current global index the second cross-org insert fails with `duplicate key ... (externalreference, type, externalsystem_id)=(...)`; after the migration DDL both inserts succeed. End-to-end TC4 + compilation validated by CI.


