### PR TITLE
Merge: deep_tundra_release → new_dawn_uat (stock-per-week follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ nul
 docker-builds/e2e-tests/.env
 *.stackdump
 tmp/
+
+# graphify knowledge-graph output (per-module graph.json/graph.html, can be 5-30 MB each)
+graphify-out/

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/material/stockperweek/StockPerWeek_atp.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/material/stockperweek/StockPerWeek_atp.feature
@@ -2,7 +2,7 @@
 @allure.label.epic:E0155_Material_Disposition
 @allure.label.feature:F19100
 @ghActions:run_on_executor6
-Feature: MD_Stock_PerWeek_V shows cumulative projected stock (QtyATP) and rolls overdue demand into the current week
+Feature: MD_Stock_PerWeek_V shows cumulative projected stock (QtyATP); overdue backlog stays in the projected stock, not in the movement columns
 
   Background:
     Given infrastructure and metasfresh are running
@@ -64,30 +64,30 @@ Feature: MD_Stock_PerWeek_V shows cumulative projected stock (QtyATP) and rolls 
   @from:cucumber
   @allure.label.epic:E0155_Material_Disposition
   @allure.label.feature:F19100
-  Scenario: Overdue DEMAND/SHIPMENT dated before the current week is rolled into the current week's QtyExpectedShipments
+  Scenario: Overdue DEMAND/SHIPMENT dated before the current week is NOT shown in the current week's movement columns (it stays in the projected stock)
 
-    # The view applies GREATEST(date_trunc('week', DateProjected), date_trunc('week', now()))
-    # so any DEMAND/SHIPMENT whose DateProjected falls in a past week still counts in the
-    # current-week row's QtyExpectedShipments — it is not silently dropped.
+    # Movement columns bucket by the candidate's ACTUAL week, so a DEMAND/SHIPMENT whose DateProjected
+    # falls in a past week does NOT appear in the current-week row's QtyExpectedShipments. The backlog
+    # is not lost: it is already reflected in the projected stock (QtyATPBegin / QtyATP), so it is shown
+    # once (in ATP), not twice (ATP + movement column).
     Given metasfresh contains M_Products:
       | Identifier          | M_Product_Category_ID    | C_UOM_ID.X12DE355 |
       | product_S25618_atp2 | standard_category_S25618 | PCE               |
 
-    # This DEMAND is dated 2 weeks in the past (WeekOffset=-2, within that past week) but must
-    # appear in the current-week (WeekOffset=0) row's QtyExpectedShipments via overdue rolling.
+    # This DEMAND is dated 2 weeks in the past (WeekOffset=-2, within that past week).
     And metasfresh initially has this MD_Candidate data relative to current week
       | Identifier           | MD_Candidate_Type | MD_Candidate_BusinessCase | M_Product_ID        | WeekOffset | DayWithinWeek | Qty | ATP | M_Warehouse_ID |
       | overdue_S25618_atp2  | DEMAND            | SHIPMENT                  | product_S25618_atp2 | -2         | 3             | 7   | -7  | wh_S25618_atp  |
 
-    # The current-week row (WeekOffset=0) must show QtyExpectedShipments=7 for the overdue demand.
-    # QtyATP=-7: the STOCK candidate paired with this DEMAND is dated in the past week with
-    # Qty=ATP=-7. That date is before the current week+1 start, so it is the latest STOCK
-    # for this product/warehouse → QtyATP=-7.
-    # QtyATPBegin=-7: that same STOCK candidate is also dated before the current week's Monday
-    # (it is two weeks overdue), so it owns the as-of-start stock too.
+    # The current-week row (WeekOffset=0) shows QtyExpectedShipments=0: the overdue demand buckets into
+    # its own past week (outside the shown horizon), so it does not appear in the movement column.
+    # QtyATP=-7: the STOCK candidate paired with this DEMAND is dated in the past week with Qty=ATP=-7;
+    # it is the latest STOCK before the current week+1 start → QtyATP=-7.
+    # QtyATPBegin=-7: that same STOCK candidate is dated before the current week's Monday, so it owns the
+    # as-of-start stock — i.e. the projected balance already carries the backlog's effect (unchanged).
     Then after not more than 10s, MD_Stock_PerWeek_V contains:
       | M_Product_ID        | M_Warehouse_ID | WeekOffset | QtyATPBegin | QtyExpectedShipments | QtyExpectedReceipts | QtyATP |
-      | product_S25618_atp2 | wh_S25618_atp  | 0          | -7          | 7                    | 0                   | -7     |
+      | product_S25618_atp2 | wh_S25618_atp  | 0          | -7          | 0                    | 0                   | -7     |
 
   @Id:S30457_10
   @from:cucumber

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/ddl/de_metas_material/MD_Stock_PerWeek_V.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/ddl/de_metas_material/MD_Stock_PerWeek_V.sql
@@ -18,9 +18,9 @@
 --
 -- Horizon: current week .. current+N, where N = SysConfig
 --   'de.metas.material.stockperweek.HorizonWeeks' (default 12 => 13 rows).
--- Overdue activity (dated before the current week) is rolled into the current-week row
--- via GREATEST(week-of(DateProjected), current-week) so backlog is never hidden.
--- Only active, non-'simulated' candidates are considered.
+-- Overdue activity (dated before the current week) is NOT rolled into the current week's movement
+-- columns; it is already reflected in QtyATPBegin (the projected running balance), so backlog is
+-- shown once, not twice. Only active, non-'simulated' candidates are considered.
 --
 -- Aggregation defaults (DESIGN.md §7 — confirm with customer at UAT):
 --   * attributes : summed across StorageAttributesKey (latest STOCK per key, then SUM)

--- a/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5814630_sys_gh30457_MD_Stock_PerWeek_fn_first_week_hangover.sql
+++ b/backend/de.metas.material/dispo-service/src/main/sql/postgresql/system/75-material-dispo/5814630_sys_gh30457_MD_Stock_PerWeek_fn_first_week_hangover.sql
@@ -1,16 +1,9 @@
--- Function MD_Stock_PerWeek_fn — parameterized companion of MD_Stock_PerWeek_V (F19100
--- "Bestand pro Woche" / stock per week).
---
--- Same output shape/semantics as MD_Stock_PerWeek_V (see MD_Stock_PerWeek_V.sql for the full
--- column documentation), but the M_Product_ID / M_Warehouse_ID filter is pushed INTO the base
--- MD_Candidate scan instead of being applied after the view fully materializes. This lets the
--- planner use the partial index md_candidate_perweek_pw_idx (M_Product_ID, M_Warehouse_ID)
--- to answer a filtered "stock per week for this product/warehouse" read directly from the
--- index, instead of scanning/building the entire MD_Stock_PerWeek_V for every product and
--- warehouse and then throwing most of it away.
---
--- NULL parameters degrade to "no filter on that dimension" (fn(NULL, NULL) ~= the full view).
--- Output is byte-identical to MD_Stock_PerWeek_V for the same filter.
+-- MD_Stock_PerWeek_fn: stop double-showing overdue backlog in the first week.
+-- Overdue shipments/receipts (projected before the current week) are no longer rolled into the current
+-- week's Expected Shipments / Receipts columns (movement columns now bucket by the candidate's actual
+-- week). The backlog stays reflected in QtyATPBegin, which is the projected running balance and already
+-- accounts for it -- so it is shown once (in ATP), not twice. QtyATPBegin itself is unchanged. The view
+-- MD_Stock_PerWeek_V is fn(NULL,NULL) and inherits this behavior.
 
 CREATE OR REPLACE FUNCTION MD_Stock_PerWeek_fn(
     p_product_id   numeric DEFAULT NULL,   -- NULL = no product filter (degrades to full view)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactory.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactory.java
@@ -189,8 +189,10 @@ public class StockPerWeekSelectionFactory implements ViewRowIdsOrderedSelectionF
 						.append(", row_number() OVER (ORDER BY " + rowNumberOrderBySql + ")"
 								+ ", " + FUNCTION_ALIAS + "." + KEY_COLUMN
 								+ ", " + FUNCTION_ALIAS + "." + I_MD_Stock_PerWeek_V.COLUMNNAME_M_Product_ID
-								+ ", " + FUNCTION_ALIAS + "." + I_MD_Stock_PerWeek_V.COLUMNNAME_M_Warehouse_ID + "\n"
-								+ " FROM " + FUNCTION_NAME + "(?, ?) " + FUNCTION_ALIAS, productId, warehouseFnParam)
+								// IntKey3 = the applied warehouse filter (null for a product-only selection), not the
+								// per-row warehouse; readAppliedFilter re-parameterizes the page render with it.
+								+ ", CAST(? AS numeric)\n"
+								+ " FROM " + FUNCTION_NAME + "(?, ?) " + FUNCTION_ALIAS, warehouseFnParam, productId, warehouseFnParam)
 						.append("\n WHERE 1=1 ")
 						.wrap(securityRestrictionsWrapper(applySecurityRestrictions)));
 

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactoryTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/material/stockperweek/StockPerWeekSelectionFactoryTest.java
@@ -114,8 +114,8 @@ class StockPerWeekSelectionFactoryTest
 		// sourced from the function; product is the 1st fn param, warehouse (2nd) is NULL = all warehouses
 		assertThat(sqlText).contains("MD_Stock_PerWeek_fn(?, ?) fn");
 		assertThat(sql.getSqlParams()).containsSubsequence(PRODUCT_ID, null);
-		// product persisted into IntKey2 (what readAppliedFilter reads to route the page render through the fn)
-		assertThat(sqlText).contains(", fn.M_Product_ID, fn.M_Warehouse_ID");
+		// product persisted into IntKey2; IntKey3 = the (null, zoom) warehouse filter param -> render sources fn(product, NULL)
+		assertThat(sqlText).contains(", fn.M_Product_ID, CAST(? AS numeric)\n FROM MD_Stock_PerWeek_fn(?, ?) fn");
 		// the clause's residual warehouse-resolution + week floor are applied against the fn output, not dropped
 		assertThat(sqlText).contains("MD_getStockWarehouse");
 		assertThat(sqlText).contains("WeekStartDate >=");
@@ -143,9 +143,21 @@ class StockPerWeekSelectionFactoryTest
 				DocumentFilter.equalsFilter("M_Warehouse_ID", warehouseId)));
 
 		assertThat(sql).isNotNull();
-		assertThat(sql.getSql()).contains("MD_Stock_PerWeek_fn(?, ?) fn");
-		assertThat(sql.getSqlParams()).containsSubsequence(PRODUCT_ID, warehouseId);
+		assertThat(sql.getSql()).contains(", fn.M_Product_ID, CAST(? AS numeric)\n FROM MD_Stock_PerWeek_fn(?, ?) fn");
+		// IntKey3 persists the warehouse FILTER (=warehouseId), then product+warehouse are the two fn params
+		assertThat(sql.getSqlParams()).containsSubsequence(warehouseId, PRODUCT_ID, warehouseId);
 		assertThat(sql.getSql()).doesNotContain("\n AND (\n"); // direct facet => no residual WHERE
+	}
+
+	@Test
+	void productOnlyFacet_persistsNullWarehouseFilter_soRenderSpansAllWarehouses()
+	{
+		// Product-only selection: IntKey3 persists the (null) warehouse filter, not the per-row warehouse,
+		// so the render sources fn(product, NULL) and its join to the selection restores every warehouse.
+		final SqlAndParams sql = buildSql(DocumentFilterList.of(DocumentFilter.equalsFilter("M_Product_ID", PRODUCT_ID)));
+
+		assertThat(sql).isNotNull();
+		assertThat(sql.getSql()).contains(", fn.M_Product_ID, CAST(? AS numeric)\n FROM MD_Stock_PerWeek_fn(?, ?) fn");
 	}
 
 	@Test

--- a/e2e/frontend-webui/tests/spec/stock-per-week-standalone.spec.js
+++ b/e2e/frontend-webui/tests/spec/stock-per-week-standalone.spec.js
@@ -162,3 +162,112 @@ testCases.forEach(({ language, label }) => {
     });
   });
 });
+
+/**
+ * Product-only filter must show EVERY warehouse the product has stock/demand in — driven through the
+ * UI (the real filter panel → grid), so the recorded video shows the actual behavior.
+ *
+ * Regression guard: the selection factory persists the applied warehouse FILTER (null for a
+ * product-only filter), not the per-row warehouse, so the page render sources
+ * MD_Stock_PerWeek_fn(product, NULL) and restores every warehouse. A prior defect collapsed a
+ * product-only grid to one arbitrary warehouse.
+ *
+ * Setup: one product with an open sales-order line in EACH of two warehouses → Material Disposition
+ * creates candidates for the product in both → the product-filtered grid must span both warehouses.
+ *
+ * UI note (verified against the live window 542159 DOM): M_Product_ID is an IsSelectionColumn, so it
+ * lives in the combined "Default" filter panel — NOT a per-column facet button. There is no
+ * `filter-button-facet-M_Product_ID`. The real interaction is: open the Default panel (the generic
+ * "Filter" toggle in `.filters-not-frequent`), type into the Product lookup input
+ * (`.form-field-M_Product_ID input.input-field`), pick the option (`option-<M_Product_ID>` in the
+ * lookup dropdown), then Apply (`filter-apply-button`).
+ */
+test.describe('Stock per Week — product-only filter spans all warehouses', () => {
+  test('Filtering by product only shows rows from every warehouse the product is in', async ({ page }) => {
+    allure.epic('E0155: Material Disposition');
+    allure.tag('F19100: Stock per week');
+    allure.tag('F19100');
+    allure.story('Product-only filter shows all warehouses (not just one)');
+    allure.severity('critical');
+
+    test.setTimeout(300000); // SO completion + async dispo + UI filter retries
+
+    const masterdata = await Backend.createMasterdata({
+      request: {
+        login: { user: { language: 'de_DE', firstname: 'spw', lastname: 'multiwh' } },
+        bpartners: { CUSTOMER1: { isVendor: false, isCustomer: true, isSoPriceList: true, name: 'Customer' } },
+        products: { P1: { name: 'SPW_MULTIWH', type: 'Item', prices: [{ price: 30.0, currencyCode: 'EUR' }] } },
+        warehouses: { whA: {}, whB: {} },
+        salesOrders: {
+          SO_A: { bpartner: 'CUSTOMER1', warehouse: 'whA', datePromised: new Date().toISOString(), lines: [{ product: 'P1', qty: 5 }] },
+          SO_B: { bpartner: 'CUSTOMER1', warehouse: 'whB', datePromised: new Date().toISOString(), lines: [{ product: 'P1', qty: 7 }] },
+        },
+      },
+    });
+    allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+    const productId = masterdata.products.P1.id;
+    const productName = masterdata.products.P1.productName || 'SPW_MULTIWH';
+    expect(productId, 'seeded product must expose its M_Product_ID').toBeTruthy();
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+    await DashboardPage.expectVisible();
+
+    // Material Disposition materializes candidates asynchronously; give it a head start.
+    await page.waitForTimeout(12000);
+
+    // Open the window (standalone → empty) then apply the product filter via the Default filter panel,
+    // retrying to absorb async dispo. Read the warehouse the grid actually shows per row.
+    const distinctWarehouses = new Set();
+    for (let attempt = 1; attempt <= 8; attempt++) {
+      await page.goto(`${FRONTEND_BASE_URL}/window/${STOCK_PER_WEEK_WINDOW_ID}`);
+      await page.locator('.document-list-wrapper, .document-list').first()
+        .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await page.locator('.indicator-pending').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+
+      // 1) open the combined "Default" filter panel (product is a selection column, not a facet)
+      const filterToggle = page.locator('.filters-not-frequent button.toggle-filters').first();
+      await filterToggle.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await filterToggle.click();
+      const filterPanel = page.locator('.filter-menu.filter-widget');
+      await filterPanel.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+      // 2) type the product name into the Product lookup (scoped to the panel) and pick the exact option
+      //    (option-<M_Product_ID>). Gate on the option becoming visible rather than a fixed sleep — the
+      //    lookup typeahead is async and can be slower than a flat timeout under CI load. Selecting by
+      //    exact M_Product_ID (not caption text) avoids picking a stale same-named product, since this
+      //    test seeds real masterdata with no teardown.
+      const prodInput = filterPanel.locator('.form-field-M_Product_ID input.input-field').first();
+      await prodInput.click();
+      await prodInput.fill(String(productName));
+      const productOption = page
+        .locator(`.input-dropdown-list [data-testid="option-${productId}"]`)
+        .first();
+      await productOption.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await productOption.click();
+
+      // 3) apply the product-only filter
+      await filterPanel.getByTestId('filter-apply-button').click();
+      await page.waitForTimeout(3000);
+      await page.locator('.indicator-pending').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+
+      const cells = await page.locator('table tbody tr [data-cy="cell-M_Warehouse_ID"]').allTextContents();
+      cells.map((c) => c.trim()).filter(Boolean).forEach((w) => distinctWarehouses.add(w));
+      console.log(`[INFO] attempt ${attempt}: distinct warehouses in grid = ${[...distinctWarehouses].join(' | ')}`);
+
+      if (distinctWarehouses.size >= 2) break;
+      distinctWarehouses.clear();
+      await page.waitForTimeout(10000); // let dispo catch up, then re-open + re-filter
+    }
+
+    allure.attachment('Filtered grid (product only)', await page.screenshot({ fullPage: true }), 'image/png');
+    allure.attachment('Distinct warehouses shown', JSON.stringify([...distinctWarehouses]), 'application/json');
+
+    expect(
+      distinctWarehouses.size,
+      'product-only filter must show rows for BOTH warehouses the product is stocked in (must not collapse to one)'
+    ).toBeGreaterThanOrEqual(2);
+
+    console.log('[PASS] Stock-per-week product-only filter spans all warehouses');
+  });
+});


### PR DESCRIPTION
Forward merge-through **`deep_tundra_release` → `new_dawn_uat`** — up-propagation of the F19100 Stock-per-week follow-up.

Carries the 3 commits on `deep_tundra_release` not yet on `new_dawn_uat`:
- https://github.com/metasfresh/metasfresh/pull/25258 — product-only filter shows all warehouses + stop double-showing overdue backlog (Problem 1 + Problem 2)
- https://github.com/metasfresh/metasfresh/pull/25268 — gitignore `graphify-out/`
- https://github.com/metasfresh/metasfresh/pull/25264 — E2E: product-only filter spans all warehouses (test-only)

The prior auto-port chain (run 29893579221) failed on a `.gitignore` conflict; this is the manual merge-through resolving it.

**Conflict resolved:** `.gitignore` — pure union (kept both `new_dawn_uat`'s Claude-config-links block and `deep_tundra_release`'s `graphify-out/` ignore).

**Migration note:** the diff includes `5814630_…_MD_Stock_PerWeek_fn_first_week_hangover.sql` + the `MD_Stock_PerWeek_fn` DDL ref — this PR needs the DDL-regression sign-off and a human merge (merge-commit, not squash).
