### PR TITLE
BPartner (REST API) — v2 upsert: set customer pricing system from priceListId

### DIFF
--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/jsonpersister/JsonPersisterService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/jsonpersister/JsonPersisterService.java
@@ -91,6 +91,7 @@ import de.metas.money.CurrencyId;
 import de.metas.organization.ClientAndOrgId;
 import de.metas.organization.OrgId;
 import de.metas.pricing.PriceListId;
+import de.metas.pricing.PricingSystemId;
 import de.metas.pricing.service.IPriceListDAO;
 import de.metas.rest_api.utils.MetasfreshId;
 import de.metas.rest_api.v2.bpartner.JsonRequestConsolidateService;
@@ -116,6 +117,7 @@ import org.adempiere.ad.wrapper.POJOWrapper;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ClientId;
+import org.compiere.model.I_M_PriceList;
 import org.slf4j.Logger;
 import org.springframework.util.CollectionUtils;
 
@@ -1021,7 +1023,16 @@ public class JsonPersisterService
 			final PriceListId priceListId = PriceListId.ofRepoIdOrNull(JsonMetasfreshId.toValue(jsonBPartner.getPriceListId()));
 			if (priceListId != null)
 			{
-				bpartner.setCustomerPricingSystemId(priceListDAO.getPricingSystemId(priceListId));
+				final I_M_PriceList priceList = priceListDAO.getById(priceListId);
+				if (priceList == null)
+				{
+					throw MissingResourceException.builder()
+							.resourceName("priceListId")
+							.resourceIdentifier(String.valueOf(priceListId.getRepoId()))
+							.parentResource(jsonBPartner)
+							.build();
+				}
+				bpartner.setCustomerPricingSystemId(PricingSystemId.ofRepoId(priceList.getM_PricingSystem_ID()));
 			}
 		}
 

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/jsonpersister/JsonPersisterService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/jsonpersister/JsonPersisterService.java
@@ -90,6 +90,8 @@ import de.metas.logging.LogManager;
 import de.metas.money.CurrencyId;
 import de.metas.organization.ClientAndOrgId;
 import de.metas.organization.OrgId;
+import de.metas.pricing.PriceListId;
+import de.metas.pricing.service.IPriceListDAO;
 import de.metas.rest_api.utils.MetasfreshId;
 import de.metas.rest_api.v2.bpartner.JsonRequestConsolidateService;
 import de.metas.rest_api.v2.bpartner.bpartnercomposite.BPartnerCompositeRestUtils;
@@ -139,6 +141,7 @@ public class JsonPersisterService
 {
 	private static final Logger logger = LogManager.getLogger(JsonPersisterService.class);
 	private final ITrxManager trxManager = Services.get(ITrxManager.class);
+	private final IPriceListDAO priceListDAO = Services.get(IPriceListDAO.class);
 
 	private final transient JsonRetrieverService jsonRetrieverService;
 	private final transient JsonRequestConsolidateService jsonRequestConsolidateService;
@@ -1009,6 +1012,16 @@ public class JsonPersisterService
 			else
 			{
 				bpartner.setDiscountPrinted(jsonBPartner.getDiscountPrinted());
+			}
+		}
+
+		// priceListId -> customer pricing system (looked up from the price list)
+		if (jsonBPartner.isPriceListIdSet())
+		{
+			final PriceListId priceListId = PriceListId.ofRepoIdOrNull(JsonMetasfreshId.toValue(jsonBPartner.getPriceListId()));
+			if (priceListId != null)
+			{
+				bpartner.setCustomerPricingSystemId(priceListDAO.getPricingSystemId(priceListId));
 			}
 		}
 

--- a/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v2/bpartner/BpartnerRestControllerTest.java
+++ b/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v2/bpartner/BpartnerRestControllerTest.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableList;
 import de.metas.bpartner.BPartnerBankAccountId;
 import de.metas.bpartner.BPartnerContactId;
 import de.metas.bpartner.BPartnerId;
-import de.metas.pricing.PricingSystemId;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.bpartner.composite.BPartnerBankAccount;
 import de.metas.bpartner.composite.BPartnerComposite;
@@ -71,6 +70,7 @@ import de.metas.externalreference.ExternalBusinessKey;
 import de.metas.externalreference.bpartner.BPartnerExternalReferenceType;
 import de.metas.externalreference.model.I_S_ExternalReference;
 import de.metas.greeting.GreetingRepository;
+import de.metas.pricing.PricingSystemId;
 import de.metas.rest_api.v2.bpartner.bpartnercomposite.JsonServiceFactory;
 import de.metas.user.UserId;
 import de.metas.user.UserRepository;
@@ -82,18 +82,19 @@ import lombok.NonNull;
 import lombok.Value;
 import org.adempiere.ad.table.MockLogEntriesRepository;
 import org.adempiere.ad.wrapper.POJOLookupMap;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_AD_SysConfig;
 import org.compiere.model.I_AD_User;
 import org.compiere.model.I_C_BP_Group;
-import org.compiere.model.I_M_PriceList;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_BPartner_Location;
 import org.compiere.model.I_C_BPartner_Product;
 import org.compiere.model.I_C_Country;
 import org.compiere.model.I_C_Location;
+import org.compiere.model.I_M_PriceList;
 import org.compiere.util.Env;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -372,41 +373,27 @@ class BpartnerRestControllerTest
 	{
 		createCountryRecord("CH");
 		createCountryRecord("DE");
-
 		final int pricingSystemId = 540123;
-		final I_M_PriceList priceListRecord = newInstance(I_M_PriceList.class);
-		priceListRecord.setM_PricingSystem_ID(pricingSystemId);
-		saveRecord(priceListRecord);
+		final I_M_PriceList priceListRecord = createPriceList(pricingSystemId);
 
 		final String bPartnerIdentifier = "ext-" + EXTERNAL_SYSTEM_NAME + "-b1_" + C_BPARTNER_EXTERNAL_ID;
 		final JsonRequestComposite bpartnerComposite = MockedDataUtil.createMockBPartner(bPartnerIdentifier);
-		final JsonRequestBPartner bpartner = bpartnerComposite.getBpartner();
-		bpartner.setGroup(BP_GROUP_RECORD_NAME);
-		bpartner.setPriceListId(JsonMetasfreshId.of(priceListRecord.getM_PriceList_ID()));
-
-		final JsonRequestBPartnerUpsert bpartnerUpsertRequest = JsonRequestBPartnerUpsert.builder()
-				.syncAdvise(SyncAdvise.CREATE_OR_MERGE)
-				.requestItem(JsonRequestBPartnerUpsertItem.builder()
-						.bpartnerIdentifier(bPartnerIdentifier)
-						.externalVersion(BP_EXTERNAL_VERSION)
-						.bpartnerComposite(bpartnerComposite)
-						.build())
-				.build();
+		bpartnerComposite.getBpartner().setGroup(BP_GROUP_RECORD_NAME);
+		bpartnerComposite.getBpartner().setPriceListId(JsonMetasfreshId.of(priceListRecord.getM_PriceList_ID()));
 
 		Env.setLoggedUserId(Env.getCtx(), UserId.ofRepoId(BPartnerRecordsUtil.AD_USER_ID));
+		final JsonMetasfreshId metasfreshId = assertUpsertResultOK(
+				bpartnerRestController.createOrUpdateBPartner(priceListUpsertRequest(bPartnerIdentifier, bpartnerComposite)),
+				bPartnerIdentifier);
 
-		final ResponseEntity<JsonResponseBPartnerCompositeUpsert> result = bpartnerRestController.createOrUpdateBPartner(bpartnerUpsertRequest);
-
-		final JsonMetasfreshId metasfreshId = assertUpsertResultOK(result, bPartnerIdentifier);
-		final BPartnerComposite persistedResult = bpartnerCompositeRepository.getById(BPartnerId.ofRepoId(metasfreshId.getValue()));
-
-		assertThat(persistedResult.getBpartner().getCustomerPricingSystemId())
+		assertThat(bpartnerCompositeRepository.getById(BPartnerId.ofRepoId(metasfreshId.getValue()))
+				.getBpartner().getCustomerPricingSystemId())
 				.isEqualTo(PricingSystemId.ofRepoId(pricingSystemId));
 	}
 
 	/**
-	 * When no {@code priceListId} is provided, the customer pricing system stays unset — the field is
-	 * set-only and never clears an existing value.
+	 * When no {@code priceListId} is provided on create, the customer pricing system stays unset — the
+	 * field is set-only and never clears an existing value.
 	 */
 	@Test
 	void createOrUpdateBPartner_noPriceListId_leavesCustomerPricingSystemUnset()
@@ -416,11 +403,91 @@ class BpartnerRestControllerTest
 
 		final String bPartnerIdentifier = "ext-" + EXTERNAL_SYSTEM_NAME + "-b1_" + C_BPARTNER_EXTERNAL_ID;
 		final JsonRequestComposite bpartnerComposite = MockedDataUtil.createMockBPartner(bPartnerIdentifier);
-		final JsonRequestBPartner bpartner = bpartnerComposite.getBpartner();
-		bpartner.setGroup(BP_GROUP_RECORD_NAME);
+		bpartnerComposite.getBpartner().setGroup(BP_GROUP_RECORD_NAME);
 		// intentionally no priceListId
 
-		final JsonRequestBPartnerUpsert bpartnerUpsertRequest = JsonRequestBPartnerUpsert.builder()
+		Env.setLoggedUserId(Env.getCtx(), UserId.ofRepoId(BPartnerRecordsUtil.AD_USER_ID));
+		final JsonMetasfreshId metasfreshId = assertUpsertResultOK(
+				bpartnerRestController.createOrUpdateBPartner(priceListUpsertRequest(bPartnerIdentifier, bpartnerComposite)),
+				bPartnerIdentifier);
+
+		assertThat(bpartnerCompositeRepository.getById(BPartnerId.ofRepoId(metasfreshId.getValue()))
+				.getBpartner().getCustomerPricingSystemId()).isNull();
+	}
+
+	/**
+	 * On a subsequent update that omits {@code priceListId}, the bpartner's existing customer pricing
+	 * system must be preserved (not cleared) — the field cannot unset a value.
+	 */
+	@Test
+	void createOrUpdateBPartner_update_priceListIdOmitted_preservesCustomerPricingSystem()
+	{
+		createCountryRecord("CH");
+		createCountryRecord("DE");
+		final int pricingSystemId = 540123;
+		final I_M_PriceList priceListRecord = createPriceList(pricingSystemId);
+		Env.setLoggedUserId(Env.getCtx(), UserId.ofRepoId(BPartnerRecordsUtil.AD_USER_ID));
+
+		final String bPartnerIdentifier = "ext-" + EXTERNAL_SYSTEM_NAME + "-b1_" + C_BPARTNER_EXTERNAL_ID;
+
+		// create with priceListId -> pricing system set
+		final JsonRequestComposite createComposite = MockedDataUtil.createMockBPartner(bPartnerIdentifier);
+		createComposite.getBpartner().setGroup(BP_GROUP_RECORD_NAME);
+		createComposite.getBpartner().setPriceListId(JsonMetasfreshId.of(priceListRecord.getM_PriceList_ID()));
+		final BPartnerId bpartnerId = BPartnerId.ofRepoId(assertUpsertResultOK(
+				bpartnerRestController.createOrUpdateBPartner(priceListUpsertRequest(bPartnerIdentifier, createComposite)),
+				bPartnerIdentifier).getValue());
+		assertThat(bpartnerCompositeRepository.getById(bpartnerId).getBpartner().getCustomerPricingSystemId())
+				.isEqualTo(PricingSystemId.ofRepoId(pricingSystemId)); // guard: precondition established
+
+		// update WITHOUT priceListId -> pricing system preserved
+		final JsonRequestComposite updateComposite = MockedDataUtil.createMockBPartner(bPartnerIdentifier);
+		updateComposite.getBpartner().setGroup(BP_GROUP_RECORD_NAME);
+		updateComposite.getBpartner().setName("updated name");
+		// intentionally no priceListId
+		assertUpsertResultOK(
+				bpartnerRestController.createOrUpdateBPartner(priceListUpsertRequest(bPartnerIdentifier, updateComposite)),
+				bPartnerIdentifier);
+
+		assertThat(bpartnerCompositeRepository.getById(bpartnerId).getBpartner().getCustomerPricingSystemId())
+				.isEqualTo(PricingSystemId.ofRepoId(pricingSystemId));
+	}
+
+	/**
+	 * A {@code priceListId} that references no existing price list must fail loudly, never a silent no-op.
+	 * In production the persister's guard raises {@link MissingResourceException} (a subtype of
+	 * {@link AdempiereException}); the in-memory test layer raises the not-found on load first — both are
+	 * {@link AdempiereException}, so the env-independent contract asserted here is "fails loudly".
+	 */
+	@Test
+	void createOrUpdateBPartner_unknownPriceListId_isRejected()
+	{
+		createCountryRecord("CH");
+		createCountryRecord("DE");
+
+		final String bPartnerIdentifier = "ext-" + EXTERNAL_SYSTEM_NAME + "-b1_" + C_BPARTNER_EXTERNAL_ID;
+		final JsonRequestComposite bpartnerComposite = MockedDataUtil.createMockBPartner(bPartnerIdentifier);
+		bpartnerComposite.getBpartner().setGroup(BP_GROUP_RECORD_NAME);
+		bpartnerComposite.getBpartner().setPriceListId(JsonMetasfreshId.of(9_999_999)); // no such price list
+
+		Env.setLoggedUserId(Env.getCtx(), UserId.ofRepoId(BPartnerRecordsUtil.AD_USER_ID));
+
+		assertThatThrownBy(() -> bpartnerRestController.createOrUpdateBPartner(priceListUpsertRequest(bPartnerIdentifier, bpartnerComposite)))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("9999999");
+	}
+
+	private I_M_PriceList createPriceList(final int pricingSystemId)
+	{
+		final I_M_PriceList priceListRecord = newInstance(I_M_PriceList.class);
+		priceListRecord.setM_PricingSystem_ID(pricingSystemId);
+		saveRecord(priceListRecord);
+		return priceListRecord;
+	}
+
+	private static JsonRequestBPartnerUpsert priceListUpsertRequest(final String bPartnerIdentifier, final JsonRequestComposite bpartnerComposite)
+	{
+		return JsonRequestBPartnerUpsert.builder()
 				.syncAdvise(SyncAdvise.CREATE_OR_MERGE)
 				.requestItem(JsonRequestBPartnerUpsertItem.builder()
 						.bpartnerIdentifier(bPartnerIdentifier)
@@ -428,15 +495,6 @@ class BpartnerRestControllerTest
 						.bpartnerComposite(bpartnerComposite)
 						.build())
 				.build();
-
-		Env.setLoggedUserId(Env.getCtx(), UserId.ofRepoId(BPartnerRecordsUtil.AD_USER_ID));
-
-		final ResponseEntity<JsonResponseBPartnerCompositeUpsert> result = bpartnerRestController.createOrUpdateBPartner(bpartnerUpsertRequest);
-
-		final JsonMetasfreshId metasfreshId = assertUpsertResultOK(result, bPartnerIdentifier);
-		final BPartnerComposite persistedResult = bpartnerCompositeRepository.getById(BPartnerId.ofRepoId(metasfreshId.getValue()));
-
-		assertThat(persistedResult.getBpartner().getCustomerPricingSystemId()).isNull();
 	}
 
 	/**

--- a/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v2/bpartner/BpartnerRestControllerTest.java
+++ b/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v2/bpartner/BpartnerRestControllerTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import de.metas.bpartner.BPartnerBankAccountId;
 import de.metas.bpartner.BPartnerContactId;
 import de.metas.bpartner.BPartnerId;
+import de.metas.pricing.PricingSystemId;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.bpartner.composite.BPartnerBankAccount;
 import de.metas.bpartner.composite.BPartnerComposite;
@@ -87,6 +88,7 @@ import org.compiere.SpringContextHolder;
 import org.compiere.model.I_AD_SysConfig;
 import org.compiere.model.I_AD_User;
 import org.compiere.model.I_C_BP_Group;
+import org.compiere.model.I_M_PriceList;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_BPartner_Location;
 import org.compiere.model.I_C_BPartner_Product;
@@ -359,6 +361,82 @@ class BpartnerRestControllerTest
 		assertThat(POJOLookupMap.get().getRecords(I_AD_User.class)).hasSize(initialUserRecordCount + 2);
 		assertThat(POJOLookupMap.get().getRecords(I_C_BPartner_Location.class)).hasSize(initialBPartnerLocationRecordCount + 2);
 		assertThat(POJOLookupMap.get().getRecords(I_C_Location.class)).hasSize(initialLocationRecordCount + 2);
+	}
+
+	/**
+	 * A provided {@code priceListId} must set the bpartner's customer pricing system
+	 * ({@code C_BPartner.M_PricingSystem_ID}) to the price list's pricing system.
+	 */
+	@Test
+	void createOrUpdateBPartner_setsCustomerPricingSystemFromPriceListId()
+	{
+		createCountryRecord("CH");
+		createCountryRecord("DE");
+
+		final int pricingSystemId = 540123;
+		final I_M_PriceList priceListRecord = newInstance(I_M_PriceList.class);
+		priceListRecord.setM_PricingSystem_ID(pricingSystemId);
+		saveRecord(priceListRecord);
+
+		final String bPartnerIdentifier = "ext-" + EXTERNAL_SYSTEM_NAME + "-b1_" + C_BPARTNER_EXTERNAL_ID;
+		final JsonRequestComposite bpartnerComposite = MockedDataUtil.createMockBPartner(bPartnerIdentifier);
+		final JsonRequestBPartner bpartner = bpartnerComposite.getBpartner();
+		bpartner.setGroup(BP_GROUP_RECORD_NAME);
+		bpartner.setPriceListId(JsonMetasfreshId.of(priceListRecord.getM_PriceList_ID()));
+
+		final JsonRequestBPartnerUpsert bpartnerUpsertRequest = JsonRequestBPartnerUpsert.builder()
+				.syncAdvise(SyncAdvise.CREATE_OR_MERGE)
+				.requestItem(JsonRequestBPartnerUpsertItem.builder()
+						.bpartnerIdentifier(bPartnerIdentifier)
+						.externalVersion(BP_EXTERNAL_VERSION)
+						.bpartnerComposite(bpartnerComposite)
+						.build())
+				.build();
+
+		Env.setLoggedUserId(Env.getCtx(), UserId.ofRepoId(BPartnerRecordsUtil.AD_USER_ID));
+
+		final ResponseEntity<JsonResponseBPartnerCompositeUpsert> result = bpartnerRestController.createOrUpdateBPartner(bpartnerUpsertRequest);
+
+		final JsonMetasfreshId metasfreshId = assertUpsertResultOK(result, bPartnerIdentifier);
+		final BPartnerComposite persistedResult = bpartnerCompositeRepository.getById(BPartnerId.ofRepoId(metasfreshId.getValue()));
+
+		assertThat(persistedResult.getBpartner().getCustomerPricingSystemId())
+				.isEqualTo(PricingSystemId.ofRepoId(pricingSystemId));
+	}
+
+	/**
+	 * When no {@code priceListId} is provided, the customer pricing system stays unset — the field is
+	 * set-only and never clears an existing value.
+	 */
+	@Test
+	void createOrUpdateBPartner_noPriceListId_leavesCustomerPricingSystemUnset()
+	{
+		createCountryRecord("CH");
+		createCountryRecord("DE");
+
+		final String bPartnerIdentifier = "ext-" + EXTERNAL_SYSTEM_NAME + "-b1_" + C_BPARTNER_EXTERNAL_ID;
+		final JsonRequestComposite bpartnerComposite = MockedDataUtil.createMockBPartner(bPartnerIdentifier);
+		final JsonRequestBPartner bpartner = bpartnerComposite.getBpartner();
+		bpartner.setGroup(BP_GROUP_RECORD_NAME);
+		// intentionally no priceListId
+
+		final JsonRequestBPartnerUpsert bpartnerUpsertRequest = JsonRequestBPartnerUpsert.builder()
+				.syncAdvise(SyncAdvise.CREATE_OR_MERGE)
+				.requestItem(JsonRequestBPartnerUpsertItem.builder()
+						.bpartnerIdentifier(bPartnerIdentifier)
+						.externalVersion(BP_EXTERNAL_VERSION)
+						.bpartnerComposite(bpartnerComposite)
+						.build())
+				.build();
+
+		Env.setLoggedUserId(Env.getCtx(), UserId.ofRepoId(BPartnerRecordsUtil.AD_USER_ID));
+
+		final ResponseEntity<JsonResponseBPartnerCompositeUpsert> result = bpartnerRestController.createOrUpdateBPartner(bpartnerUpsertRequest);
+
+		final JsonMetasfreshId metasfreshId = assertUpsertResultOK(result, bPartnerIdentifier);
+		final BPartnerComposite persistedResult = bpartnerCompositeRepository.getById(BPartnerId.ofRepoId(metasfreshId.getValue()));
+
+		assertThat(persistedResult.getBpartner().getCustomerPricingSystemId()).isNull();
 	}
 
 	/**

--- a/backend/de.metas.business/src/main/java/de/metas/bpartner/composite/BPartner.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner/composite/BPartner.java
@@ -178,7 +178,8 @@ public class BPartner
 	private boolean identifiedByExternalReference;
 
 	private final PaymentTermId customerPaymentTermId;
-	private final PricingSystemId customerPricingSystemId;
+	// non-final so @Data generates a setter: the v2 BPartner REST persister sets it from the request's priceListId
+	private PricingSystemId customerPricingSystemId;
 	private final IncotermsId customerIncotermsId;
 
 	private final PaymentTermId vendorPaymentTermId;


### PR DESCRIPTION
## What

The v2 BPartner REST endpoint (`POST /api/v2/bpartner/{orgCode}`) accepts
`JsonRequestBPartner.priceListId`, whose API documentation states it sets
`C_BPartner.M_PricingSystem_ID`. The v2 persister never read the field, so the
pricing system was silently never set. This wires it through: when `priceListId`
is provided, the referenced price list's pricing system is assigned as the
business partner's **customer** pricing system (new and existing partners).

## Changes

- `JsonPersisterService.syncJsonToBPartner` (v2): read `priceListId`, load the
  referenced price list via `IPriceListDAO.getById(PriceListId)`, and set
  `customerPricingSystemId` from its `M_PricingSystem_ID`. An unknown price list
  is rejected with a `MissingResourceException` (matching the class's existing
  FK-validation convention) rather than a silent no-op or NPE.
- `BPartner` composite model: `customerPricingSystemId` made settable (was `final`),
  mirroring the other fields the persister already mutates in place.

## Tests

`BpartnerRestControllerTest` (v2), 4 methods:
- `priceListId` set → `C_BPartner.M_PricingSystem_ID` = the price list's pricing system;
- no `priceListId` on create → pricing system left unset;
- update omitting `priceListId` → existing pricing system preserved (set-only field);
- unknown `priceListId` → request fails loudly (not silently ignored).

Local: v2 27/27, v1 19/19 green.

## Scope

v2 write path only. The v1 endpoint and the GET/read path have the same gap but
were not in scope for this change.
