### PR TITLE
Picking Job Schedule — chunk M_ShipmentSchedule_ID IN query to stay under the 32767 bind-param limit

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/job_schedule/repository/PickingJobScheduleRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/job_schedule/repository/PickingJobScheduleRepository.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Repository;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -53,6 +54,9 @@ public class PickingJobScheduleRepository
 	 * PostgreSQL/JDBC caps bind parameters at {@code Short.MAX_VALUE} (32767) — a 2-byte slot per parameter. This
 	 * constant caps the number of {@code M_ShipmentSchedule_ID} values folded into a single {@code IN (...)} filter,
 	 * with headroom below that hard limit (mirrors the rationale of {@code org.adempiere.ad.persistence.TableModelLoader.MAX_IDS_PER_QUERY}).
+	 * NOTE: this bounds only the {@code M_ShipmentSchedule_ID} IN-list. It does not budget for other bind parameters
+	 * in the same statement (e.g. a large {@code C_Workplace_ID}/exclude filter). No current caller combines those with
+	 * a near-cap shipment-schedule set; a future one would have to account for the combined bind-parameter count.
 	 */
 	@VisibleForTesting static final int MAX_SHIPMENT_SCHEDULE_IDS_PER_QUERY = 30000;
 
@@ -211,7 +215,7 @@ public class PickingJobScheduleRepository
 		// and snapshot-independent).
 		final Iterable<List<ShipmentScheduleId>> partitions = Iterables.partition(onlyShipmentScheduleIds, maxIdsPerChunk);
 		return Streams.stream(partitions)
-				.flatMap(chunk -> toSqlQuery(query, ImmutableSet.copyOf(chunk))
+				.flatMap(chunk -> toSqlQuery(query, chunk)
 						.stream()
 						.map(PickingJobScheduleRepository::fromRecord));
 	}
@@ -223,7 +227,7 @@ public class PickingJobScheduleRepository
 		return toSqlQuery(query, query.getOnlyShipmentScheduleIds()).anyMatch();
 	}
 
-	private IQuery<I_M_Picking_Job_Schedule> toSqlQuery(@NonNull final PickingJobScheduleQuery query, @NonNull final ImmutableSet<ShipmentScheduleId> shipmentScheduleIds)
+	private IQuery<I_M_Picking_Job_Schedule> toSqlQuery(@NonNull final PickingJobScheduleQuery query, @NonNull final Collection<ShipmentScheduleId> shipmentScheduleIds)
 	{
 		if (query.isAny())
 		{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/job_schedule/repository/PickingJobScheduleRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/picking/job_schedule/repository/PickingJobScheduleRepository.java
@@ -2,6 +2,9 @@ package de.metas.picking.job_schedule.repository;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Streams;
 import de.metas.i18n.AdMessageKey;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.inoutcandidate.model.I_M_Picking_Job_Schedule;
@@ -45,6 +48,13 @@ public class PickingJobScheduleRepository
 {
 	@NonNull private static final AdMessageKey UPDATE_OF_PROCESSED_NOT_ALLOWED = AdMessageKey.of("UPDATE_OF_PROCESSED_NOT_ALLOWED");
 	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	/**
+	 * PostgreSQL/JDBC caps bind parameters at {@code Short.MAX_VALUE} (32767) — a 2-byte slot per parameter. This
+	 * constant caps the number of {@code M_ShipmentSchedule_ID} values folded into a single {@code IN (...)} filter,
+	 * with headroom below that hard limit (mirrors the rationale of {@code org.adempiere.ad.persistence.TableModelLoader.MAX_IDS_PER_QUERY}).
+	 */
+	@VisibleForTesting static final int MAX_SHIPMENT_SCHEDULE_IDS_PER_QUERY = 30000;
 
 	@VisibleForTesting
 	public static PickingJobScheduleRepository newInstanceForUnitTesting()
@@ -182,17 +192,38 @@ public class PickingJobScheduleRepository
 
 	public Stream<PickingJobSchedule> stream(@NonNull final PickingJobScheduleQuery query)
 	{
-		return toSqlQuery(query)
-				.stream()
-				.map(PickingJobScheduleRepository::fromRecord);
+		return stream(query, MAX_SHIPMENT_SCHEDULE_IDS_PER_QUERY);
+	}
+
+	@VisibleForTesting
+	Stream<PickingJobSchedule> stream(@NonNull final PickingJobScheduleQuery query, final int maxIdsPerChunk)
+	{
+		final ImmutableSet<ShipmentScheduleId> onlyShipmentScheduleIds = query.getOnlyShipmentScheduleIds();
+		if (onlyShipmentScheduleIds.size() <= maxIdsPerChunk)
+		{
+			return toSqlQuery(query, onlyShipmentScheduleIds)
+					.stream()
+					.map(PickingJobScheduleRepository::fromRecord);
+		}
+
+		// Each chunk is a separate statement, so under READ COMMITTED there is no cross-chunk MVCC snapshot consistency for id
+		// sets > MAX_SHIPMENT_SCHEDULE_IDS_PER_QUERY. Acceptable here: callers group the result by M_ShipmentSchedule_ID (order-
+		// and snapshot-independent).
+		final Iterable<List<ShipmentScheduleId>> partitions = Iterables.partition(onlyShipmentScheduleIds, maxIdsPerChunk);
+		return Streams.stream(partitions)
+				.flatMap(chunk -> toSqlQuery(query, ImmutableSet.copyOf(chunk))
+						.stream()
+						.map(PickingJobScheduleRepository::fromRecord));
 	}
 
 	public boolean anyMatch(@NonNull final PickingJobScheduleQuery query)
 	{
-		return toSqlQuery(query).anyMatch();
+		// Not chunked: the only caller passes a single id. If a caller ever needs a large set here, chunk it as stream() does
+		// (see the deferred unbounded-parameter audit).
+		return toSqlQuery(query, query.getOnlyShipmentScheduleIds()).anyMatch();
 	}
 
-	private IQuery<I_M_Picking_Job_Schedule> toSqlQuery(@NonNull final PickingJobScheduleQuery query)
+	private IQuery<I_M_Picking_Job_Schedule> toSqlQuery(@NonNull final PickingJobScheduleQuery query, @NonNull final ImmutableSet<ShipmentScheduleId> shipmentScheduleIds)
 	{
 		if (query.isAny())
 		{
@@ -214,9 +245,9 @@ public class PickingJobScheduleRepository
 			queryBuilder.addNotInArrayFilter(I_M_Picking_Job_Schedule.COLUMNNAME_M_Picking_Job_Schedule_ID, query.getExcludeJobScheduleIds());
 		}
 
-		if (!query.getOnlyShipmentScheduleIds().isEmpty())
+		if (!shipmentScheduleIds.isEmpty())
 		{
-			queryBuilder.addInArrayFilter(I_M_Picking_Job_Schedule.COLUMNNAME_M_ShipmentSchedule_ID, query.getOnlyShipmentScheduleIds());
+			queryBuilder.addInArrayFilter(I_M_Picking_Job_Schedule.COLUMNNAME_M_ShipmentSchedule_ID, shipmentScheduleIds);
 		}
 
 		if (query.getIsProcessed() != null)

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/picking/job_schedule/repository/PickingJobScheduleRepositoryChunkingTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/picking/job_schedule/repository/PickingJobScheduleRepositoryChunkingTest.java
@@ -1,0 +1,173 @@
+package de.metas.picking.job_schedule.repository;
+
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import com.google.common.collect.ImmutableList;
+import de.metas.business.BusinessTestHelper;
+import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.model.I_M_Picking_Job_Schedule;
+import de.metas.picking.api.PickingJobScheduleId;
+import de.metas.picking.job_schedule.model.PickingJobSchedule;
+import de.metas.picking.job_schedule.model.PickingJobScheduleQuery;
+import de.metas.uom.UomId;
+import lombok.NonNull;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_C_Workplace;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the {@code M_ShipmentSchedule_ID IN (...)} bind-parameter overflow fix: {@link PickingJobScheduleRepository}
+ * must not fold an unbounded {@code onlyShipmentScheduleIds} set into a single {@code IN (?,?,...)}, which overflows
+ * the PostgreSQL/JDBC 2-byte bind-parameter limit (max 32767) once the set exceeds that many entries. The chunking
+ * overload {@code stream(query, maxIdsPerChunk)} partitions the set to stay under the cap; this test drives that
+ * overload directly (with a tiny cap) rather than reproducing >32767 rows.
+ */
+class PickingJobScheduleRepositoryChunkingTest
+{
+	private static final BigDecimal QTY_TO_PICK = new BigDecimal("10");
+
+	private UomId uomId;
+	private int workplaceRepoId;
+
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		final I_C_UOM uom = BusinessTestHelper.createUOM("Ea");
+		uomId = UomId.ofRepoId(uom.getC_UOM_ID());
+
+		final I_C_Workplace workplace = InterfaceWrapperHelper.newInstance(I_C_Workplace.class);
+		workplace.setName("TestWorkplace");
+		InterfaceWrapperHelper.saveRecord(workplace);
+		workplaceRepoId = workplace.getC_Workplace_ID();
+	}
+
+	private I_M_Picking_Job_Schedule createJobScheduleRecord(@NonNull final ShipmentScheduleId shipmentScheduleId)
+	{
+		final I_M_Picking_Job_Schedule record = InterfaceWrapperHelper.newInstance(I_M_Picking_Job_Schedule.class);
+		record.setM_ShipmentSchedule_ID(shipmentScheduleId.getRepoId());
+		record.setC_Workplace_ID(workplaceRepoId);
+		record.setC_UOM_ID(uomId.getRepoId());
+		record.setQtyToPick(QTY_TO_PICK);
+		record.setProcessed(false);
+		InterfaceWrapperHelper.saveRecord(record);
+		return record;
+	}
+
+	private static Map<ShipmentScheduleId, Set<PickingJobSchedule>> groupByShipmentScheduleId(@NonNull final List<PickingJobSchedule> schedules)
+	{
+		return schedules.stream()
+				.collect(Collectors.groupingBy(PickingJobSchedule::getShipmentScheduleId, Collectors.toSet()));
+	}
+
+	/**
+	 * TC1 (AC1/AC2): ~5 shipment-schedule ids, one of them with 2 job-schedule rows (the rest with 1 each) — the
+	 * chunked stream (chunk size 2, well below the 5-id/6-row total) must return exactly the same rows and the
+	 * same per-shipment-schedule grouping as an oversized single-chunk call (10 000): no loss, no duplication.
+	 */
+	@Test
+	void stream_chunked_isEquivalentToUnchunked()
+	{
+		final ImmutableList<ShipmentScheduleId> shipmentScheduleIds = ImmutableList.of(
+				ShipmentScheduleId.ofRepoId(500001),
+				ShipmentScheduleId.ofRepoId(500002),
+				ShipmentScheduleId.ofRepoId(500003),
+				ShipmentScheduleId.ofRepoId(500004),
+				ShipmentScheduleId.ofRepoId(500005));
+
+		// first shipment schedule gets two job-schedule rows, to also exercise multi-row grouping
+		createJobScheduleRecord(shipmentScheduleIds.get(0));
+		createJobScheduleRecord(shipmentScheduleIds.get(0));
+		for (int i = 1; i < shipmentScheduleIds.size(); i++)
+		{
+			createJobScheduleRecord(shipmentScheduleIds.get(i));
+		}
+
+		final PickingJobScheduleQuery query = PickingJobScheduleQuery.builder()
+				.onlyShipmentScheduleIds(shipmentScheduleIds)
+				.build();
+
+		final PickingJobScheduleRepository repo = PickingJobScheduleRepository.newInstanceForUnitTesting();
+
+		final List<PickingJobSchedule> chunked = repo.stream(query, 2).collect(Collectors.toList());
+		final List<PickingJobSchedule> unchunked = repo.stream(query, 10_000).collect(Collectors.toList());
+
+		final Set<PickingJobScheduleId> chunkedIds = chunked.stream().map(PickingJobSchedule::getId).collect(Collectors.toSet());
+		final Set<PickingJobScheduleId> unchunkedIds = unchunked.stream().map(PickingJobSchedule::getId).collect(Collectors.toSet());
+
+		assertThat(chunked).as("no duplication in the chunked result").hasSize(chunkedIds.size());
+		assertThat(unchunked).as("no duplication in the unchunked result").hasSize(unchunkedIds.size());
+		assertThat(chunkedIds).as("chunked result must contain exactly the same rows as the unchunked result (no loss, no duplication)").isEqualTo(unchunkedIds);
+
+		assertThat(groupByShipmentScheduleId(chunked))
+				.as("grouping by shipment-schedule id must match between chunked and unchunked results")
+				.isEqualTo(groupByShipmentScheduleId(unchunked));
+	}
+
+	/** TC2 (AC4): the chunk-size cap must stay strictly positive and within the JDBC 2-byte bind-param limit. */
+	@Test
+	void maxShipmentScheduleIdsPerQuery_staysUnderJdbc2ByteParamLimit()
+	{
+		assertThat(PickingJobScheduleRepository.MAX_SHIPMENT_SCHEDULE_IDS_PER_QUERY)
+				.isGreaterThan(0)
+				.isLessThanOrEqualTo(32767);
+	}
+
+	/** TC3 (AC3): a shipment-schedule-id set at or below the cap takes the fast path — identical to the plain (unchunked) query. */
+	@Test
+	void stream_withSetSizeAtOrBelowCap_isEquivalentToPlainQuery()
+	{
+		final ImmutableList<ShipmentScheduleId> shipmentScheduleIds = ImmutableList.of(
+				ShipmentScheduleId.ofRepoId(600001),
+				ShipmentScheduleId.ofRepoId(600002),
+				ShipmentScheduleId.ofRepoId(600003));
+
+		for (final ShipmentScheduleId shipmentScheduleId : shipmentScheduleIds)
+		{
+			createJobScheduleRecord(shipmentScheduleId);
+		}
+
+		final PickingJobScheduleQuery query = PickingJobScheduleQuery.builder()
+				.onlyShipmentScheduleIds(shipmentScheduleIds)
+				.build();
+
+		final PickingJobScheduleRepository repo = PickingJobScheduleRepository.newInstanceForUnitTesting();
+
+		final List<PickingJobSchedule> capped = repo.stream(query, 10_000).collect(Collectors.toList());
+		final List<PickingJobSchedule> plain = repo.stream(query).collect(Collectors.toList());
+
+		assertThat(capped).as("fast-path equivalence: cap far above set size behaves like the plain query").containsExactlyElementsOf(plain);
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/picking/job_schedule/repository/PickingJobScheduleRepositoryChunkingTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/picking/job_schedule/repository/PickingJobScheduleRepositoryChunkingTest.java
@@ -93,7 +93,7 @@ class PickingJobScheduleRepositoryChunkingTest
 	}
 
 	/**
-	 * TC1 (AC1/AC2): ~5 shipment-schedule ids, one of them with 2 job-schedule rows (the rest with 1 each) — the
+	 * ~5 shipment-schedule ids, one of them with 2 job-schedule rows (the rest with 1 each) — the
 	 * chunked stream (chunk size 2, well below the 5-id/6-row total) must return exactly the same rows and the
 	 * same per-shipment-schedule grouping as an oversized single-chunk call (10 000): no loss, no duplication.
 	 */
@@ -136,7 +136,7 @@ class PickingJobScheduleRepositoryChunkingTest
 				.isEqualTo(groupByShipmentScheduleId(unchunked));
 	}
 
-	/** TC2 (AC4): the chunk-size cap must stay strictly positive and within the JDBC 2-byte bind-param limit. */
+	/** The chunk-size cap must stay strictly positive and within the JDBC 2-byte bind-param limit. */
 	@Test
 	void maxShipmentScheduleIdsPerQuery_staysUnderJdbc2ByteParamLimit()
 	{
@@ -145,7 +145,7 @@ class PickingJobScheduleRepositoryChunkingTest
 				.isLessThanOrEqualTo(32767);
 	}
 
-	/** TC3 (AC3): a shipment-schedule-id set at or below the cap takes the fast path — identical to the plain (unchunked) query. */
+	/** A shipment-schedule-id set at or below the cap takes the fast path — identical to the plain (unchunked) query. */
 	@Test
 	void stream_withSetSizeAtOrBelowCap_isEquivalentToPlainQuery()
 	{


### PR DESCRIPTION
## Problem
The `UpdateInvalidShipmentSchedules` async work package recomputes a batch of shipment schedules. `ShipmentScheduleUpdater.updateFromPickingJobSchedules` collects **all** shipment-schedule IDs of the batch and calls `PickingJobScheduleRepository.stream(...onlyShipmentScheduleIds(ids))`, which renders them as a single `M_ShipmentSchedule_ID IN (?,?,…)` — one bind parameter per ID.

When a batch holds more shipment schedules than the PostgreSQL/JDBC 2-byte bind-parameter limit (**32767**; 33589 observed), the statement fails and the whole work package aborts:

```
org.postgresql.util.PSQLException: An I/O error occurred while sending to the backend.
Caused by: java.io.IOException: Tried to send an out-of-range integer as a 2-byte value: 33589
```

## Fix
Chunk the `M_ShipmentSchedule_ID` `IN`-filter at the repository (root), so it can never emit an over-limit `IN` for any caller:

- New cap `MAX_SHIPMENT_SCHEDULE_IDS_PER_QUERY = 30000` (headroom below 32767), mirroring the in-house precedent `org.adempiere.ad.persistence.TableModelLoader.MAX_IDS_PER_QUERY`.
- When the ID set exceeds the cap, `Iterables.partition` it and merge the per-chunk results; each ID lands in exactly one chunk, so the result set and grouping-by-`M_ShipmentSchedule_ID` are unchanged (no loss / no duplication).
- The common small-set case (`≤ cap`, incl. empty / other-filter-only) runs exactly one query as before — fast path unchanged.

## Tests
`PickingJobScheduleRepositoryChunkingTest`:
- chunked path (small cap) returns exactly the same rows and grouping as a single-query run;
- cap invariant (`0 < cap ≤ 32767`), so a future off-by-one can't reintroduce the overflow;
- fast-path equivalence for a `≤ cap` set.

Module unit tests pass (`Tests run: 3` for the new class; 65/65 across the picking / shipment-schedule regression sweep).

_Note: general audit of other unbounded-parameter query sites is intentionally out of scope for this change._
