### PR TITLE
InArrayQueryFilter — render oversized IN lists inline to stay under the JDBC 32767 bind-param limit

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/DB.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/util/DB.java
@@ -1906,6 +1906,13 @@ public class DB
 		{
 			return TO_STRING(DisplayType.toBooleanString((Boolean)param));
 		}
+		else if (param instanceof Number)
+		{
+			// Long/Short/Byte/AtomicInteger/Double/... — the JDBC '?' bind path accepts any Number, so inline rendering
+			// must too (else switching a large IN list to inline would reject a type that used to bind). Integer and
+			// BigDecimal are handled by their specific branches above; this covers the rest.
+			return param.toString();
+		}
 		else
 		{
 			throw new DBException("Unknown parameter type: " + param + " (" + param.getClass() + ")");

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/dao/impl/InArrayQueryFilter.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/dao/impl/InArrayQueryFilter.java
@@ -38,8 +38,11 @@ import static org.adempiere.ad.dao.impl.CompareQueryFilter.normalizeValue;
  * NOTES:
  * <ul>
  * <li>NULL case is covered (i.e. if one of your values is NULL, the built SQL will contain an "ColumnName IS NULL" check
- * <li>maximum values list length is not checked and we rely on database. However in PostgreSQL there is no limit (see
- * <a href="http://stackoverflow.com/questions/1009706/postgresql-max-number-of-parameters-in-in-clause">...</a>)
+ * <li>PostgreSQL allows an unlimited number of values in an {@code IN (...)} list, BUT the wire protocol caps
+ * <b>bind parameters</b> at {@value #MAX_BIND_PARAMS_BEFORE_EMBED_HARD_LIMIT} (a signed 2-byte count) per statement.
+ * Rendering one {@code ?} per value overflows that cap once a list exceeds it ("out-of-range integer as a 2-byte
+ * value"). To stay safe for any list size, a list larger than {@link #MAX_BIND_PARAMS_BEFORE_EMBED} is rendered
+ * <b>inline</b> (no bind parameters) instead of as {@code ?} placeholders — see {@link #buildSql()}.
  * </ul>
  *
  * @param <T>
@@ -50,6 +53,25 @@ public final class InArrayQueryFilter<T> implements IQueryFilter<T>, ISqlQueryFi
 {
 	static final String SQL_TRUE = "1=1";
 	static final String SQL_FALSE = "1=0";
+
+	/**
+	 * The PostgreSQL/JDBC hard cap on bind parameters per statement (a signed 2-byte count). Rendering one {@code ?}
+	 * per value overflows this once an {@code IN (...)} list exceeds it ("out-of-range integer as a 2-byte value").
+	 */
+	@VisibleForTesting
+	static final int MAX_BIND_PARAMS_BEFORE_EMBED_HARD_LIMIT = 32767;
+
+	/**
+	 * Above this many values, an {@code IN (...)} list is rendered inline (values embedded via {@link DB#TO_SQL(Object)})
+	 * instead of as {@code ?} bind parameters, so it cannot overflow {@link #MAX_BIND_PARAMS_BEFORE_EMBED_HARD_LIMIT}.
+	 * Kept below that hard cap with headroom for the other bind parameters in the same statement; smaller lists keep
+	 * the {@code ?} form, which is plan-cacheable (the common case).
+	 * <p>
+	 * NOTE: this bounds a single IN filter. A statement combining several near-threshold IN filters could still exceed
+	 * the per-statement cap; such a query should bind the list as an array ({@code = ANY(?)}) instead.
+	 */
+	@VisibleForTesting
+	static final int MAX_BIND_PARAMS_BEFORE_EMBED = 30000;
 
 	private final String columnName;
 	@Nullable private final List<Object> values;
@@ -216,6 +238,11 @@ public final class InArrayQueryFilter<T> implements IQueryFilter<T>, ISqlQueryFi
 			return;
 		}
 
+		// Render values inline (no bind parameters) when explicitly requested, OR automatically once the list is large
+		// enough that one '?' per value would overflow the JDBC 2-byte bind-parameter cap. values.size() is a safe upper
+		// bound on the bind-param count (nulls don't bind), so this never under-embeds.
+		final boolean embed = embedSqlParams || (values != null && values.size() > MAX_BIND_PARAMS_BEFORE_EMBED);
+
 		if (values == null || values.isEmpty())
 		{
 			sqlWhereClause = defaultReturnWhenEmpty ? SQL_TRUE : SQL_FALSE;
@@ -229,7 +256,7 @@ public final class InArrayQueryFilter<T> implements IQueryFilter<T>, ISqlQueryFi
 				sqlWhereClause = columnName + " IS NULL";
 				sqlParams = ImmutableList.of();
 			}
-			else if (embedSqlParams)
+			else if (embed)
 			{
 				sqlWhereClause = columnName + "=" + DB.TO_SQL(value);
 				sqlParams = ImmutableList.of();
@@ -268,7 +295,7 @@ public final class InArrayQueryFilter<T> implements IQueryFilter<T>, ISqlQueryFi
 					sqlWhereClauseBuilt.append(columnName).append(" IN (");
 				}
 
-				if (embedSqlParams)
+				if (embed)
 				{
 					sqlWhereClauseBuilt.append(DB.TO_SQL(value));
 				}

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/dao/impl/InArrayQueryFilterTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/dao/impl/InArrayQueryFilterTest.java
@@ -226,6 +226,48 @@ public class InArrayQueryFilterTest
 		assertThat(filter1).isEqualTo(filter2);
 	}
 
+	/**
+	 * A list larger than the JDBC 2-byte bind-parameter cap (32767) must not be rendered as one {@code ?} per value,
+	 * or the statement overflows ("out-of-range integer as a 2-byte value"). Above the embed threshold the values are
+	 * rendered inline instead, so there are zero bind parameters and the overflow is impossible.
+	 */
+	@Test
+	public void test_oversizedList_rendersInline_withoutBindParams()
+	{
+		final List<Object> values = new ArrayList<>();
+		for (int i = 1; i <= InArrayQueryFilter.MAX_BIND_PARAMS_BEFORE_EMBED + 1; i++)
+		{
+			values.add(i);
+		}
+
+		final InArrayQueryFilter<I_Test> filter = new InArrayQueryFilter<>("MyColumnName", values);
+
+		assertThat(filter.getSqlParams(ctx)).isEmpty();
+		assertThat(filter.getSql())
+				.startsWith("MyColumnName IN (1,2,3,")
+				.doesNotContain("?")
+				.endsWith(")");
+	}
+
+	/** The common (small) case stays on the plan-cacheable {@code ?} bind-parameter path. */
+	@Test
+	public void test_smallList_usesBindParams()
+	{
+		final InArrayQueryFilter<I_Test> filter = new InArrayQueryFilter<>("MyColumnName", 1, 2, 3);
+
+		assertThat(filter.getSql()).isEqualTo("MyColumnName IN (?,?,?)");
+		assertThat(filter.getSqlParams(ctx)).containsExactly(1, 2, 3);
+	}
+
+	/** The embed threshold must stay strictly within the JDBC 2-byte bind-parameter cap, or the overflow it guards returns. */
+	@Test
+	public void test_embedThreshold_staysWithinJdbcBindParamCap()
+	{
+		assertThat(InArrayQueryFilter.MAX_BIND_PARAMS_BEFORE_EMBED)
+				.isGreaterThan(0)
+				.isLessThanOrEqualTo(32767);
+	}
+
 	private void assertDefaultReturnWhenEmpty(final boolean defaultReturnWhenEmpty, final List<Object> params)
 	{
 		final String columnName = "MyColumnName";

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/dao/impl/InArrayQueryFilterTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/dao/impl/InArrayQueryFilterTest.java
@@ -249,6 +249,48 @@ public class InArrayQueryFilterTest
 				.endsWith(")");
 	}
 
+	/**
+	 * Regression guard: the {@code ?} bind path accepts any type the JDBC driver handles (e.g. {@code Long}); the inline
+	 * path must too, or switching a large list to inline would reject a type that used to work. An oversized {@code Long}
+	 * list must render inline without throwing.
+	 */
+	@Test
+	public void test_oversizedList_ofLongs_rendersInline_withoutThrowing()
+	{
+		final List<Object> values = new ArrayList<>();
+		for (long i = 1; i <= InArrayQueryFilter.MAX_BIND_PARAMS_BEFORE_EMBED + 1; i++)
+		{
+			values.add(i); // autoboxed to Long
+		}
+
+		final InArrayQueryFilter<I_Test> filter = new InArrayQueryFilter<>("MyColumnName", values);
+
+		assertThat(filter.getSqlParams(ctx)).isEmpty();
+		assertThat(filter.getSql())
+				.startsWith("MyColumnName IN (1,2,3,")
+				.doesNotContain("?");
+	}
+
+	/** An oversized list mixing NULLs still renders the "IN (...) OR IS NULL" shape inline, with zero bind parameters. */
+	@Test
+	public void test_oversizedList_withNulls_rendersInline()
+	{
+		final List<Object> values = new ArrayList<>();
+		for (int i = 1; i <= InArrayQueryFilter.MAX_BIND_PARAMS_BEFORE_EMBED + 1; i++)
+		{
+			values.add(i);
+		}
+		values.add(null);
+
+		final InArrayQueryFilter<I_Test> filter = new InArrayQueryFilter<>("MyColumnName", values);
+
+		assertThat(filter.getSqlParams(ctx)).isEmpty();
+		assertThat(filter.getSql())
+				.startsWith("(MyColumnName IN (1,2,3,")
+				.doesNotContain("?")
+				.endsWith("MyColumnName IS NULL)");
+	}
+
 	/** The common (small) case stays on the plan-cacheable {@code ?} bind-parameter path. */
 	@Test
 	public void test_smallList_usesBindParams()


### PR DESCRIPTION
## Problem
`IQueryBuilder.addInArrayFilter` / `addNotInArrayFilter` render `col IN (?,?,…)` — one JDBC bind parameter per value. PostgreSQL's wire protocol caps bind parameters at 32767 (a signed 2-byte count) per statement, so a data-volume-driven list overflows with `Tried to send an out-of-range integer as a 2-byte value`. Both methods build the same shared `InArrayQueryFilter`, so this affects all of its ~547 call sites.

## Fix
`InArrayQueryFilter.buildSql()` now renders the values **inline** (via the existing `embedSqlParams` path, `DB.TO_SQL`) automatically once a list exceeds `MAX_BIND_PARAMS_BEFORE_EMBED` (30000, headroom below 32767) — producing zero bind parameters for oversized lists, so the overflow is impossible. Small lists keep the `?` form unchanged (plan-cacheable — the common case). Covers both `IN` and `NOT IN` (same filter class); NULL handling (`… IS NULL`) is preserved.

`DB.TO_SQL` gains a general `Number` branch so inline rendering accepts every value type the `?` bind path did (e.g. `Long`), matching the prior behavior for lists in the 30001–32767 range.

_Note: this bounds a single IN filter; a statement combining several near-threshold IN filters could still exceed the per-statement cap — such a query should bind the list as an array (`= ANY(?)`), a fuller future improvement._

## Tests
`InArrayQueryFilterTest` (13/13 green): oversized list renders inline with zero bind params; oversized `Long` list renders without throwing (regression guard); oversized NULL-mixed list renders `(… IN (…) OR … IS NULL)` inline; small list keeps `?`; cap invariant `≤ 32767`.
