### PR TITLE
externalsystems: accept concrete command code in ScriptedImportConversion invoke (fix startup 500)

### DIFF
--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/process/InvokeScriptedImportConversionAction.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/process/InvokeScriptedImportConversionAction.java
@@ -120,10 +120,8 @@ public class InvokeScriptedImportConversionAction extends AlterExternalSystemSer
 	}
 
 	/**
-	 * Resolve the Start/Stop intent from {@code External_Request}. Two callers pass different codes here:
-	 * the manual "call" process passes a Start/Stop intent (AD_Reference 541998), while the generic
-	 * external-system infra (startup reconciler) and the {@code ExternalSystem_Service} enable/disable
-	 * commands pass the CONCRETE transport command (e.g. {@code enableSftpPolling}). Accept both.
+	 * The manual process passes a Start/Stop intent, but the generic infra + {@code ExternalSystem_Service}
+	 * enable/disable commands pass the CONCRETE transport command here — so accept both.
 	 */
 	@VisibleForTesting
 	static ScriptedImportConversionIntent resolveIntent(@NonNull final String externalRequest)

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/process/InvokeScriptedImportConversionAction.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/process/InvokeScriptedImportConversionAction.java
@@ -22,6 +22,7 @@
 
 package de.metas.externalsystem.process;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import de.metas.common.externalsystem.JsonExternalSystemName;
 import de.metas.common.externalsystem.JsonExternalSystemRequest;
@@ -40,11 +41,13 @@ import de.metas.externalsystem.scriptedimportconversion.ExternalSystemScriptedIm
 import de.metas.externalsystem.scriptedimportconversion.ExternalSystemScriptedImportConversionConfigId;
 import de.metas.externalsystem.scriptedimportconversion.ExternalSystemScriptedImportConversionService;
 import de.metas.externalsystem.scriptedimportconversion.ExternalSystemScriptedImportConversionService.ResolvedChildCommand;
+import de.metas.externalsystem.scriptedimportconversion.ScriptedImportConversionCommand;
 import de.metas.externalsystem.scriptedimportconversion.ScriptedImportConversionIntent;
 import de.metas.logging.LogManager;
 import de.metas.process.IProcessPreconditionsContext;
 import de.metas.process.PInstanceId;
 import de.metas.process.ProcessPreconditionsResolution;
+import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.SpringContextHolder;
 import org.slf4j.Logger;
@@ -74,7 +77,7 @@ public class InvokeScriptedImportConversionAction extends AlterExternalSystemSer
 	@Override
 	protected String doIt() throws Exception
 	{
-		final ScriptedImportConversionIntent intent = ScriptedImportConversionIntent.ofCode(externalRequest);
+		final ScriptedImportConversionIntent intent = resolveIntent(externalRequest);
 
 		final ImmutableList<ResolvedChildCommand> resolvedCommands = resolveChildCommands(intent);
 		if (resolvedCommands.isEmpty())
@@ -114,6 +117,36 @@ public class InvokeScriptedImportConversionAction extends AlterExternalSystemSer
 		}
 
 		return MSG_OK + " (" + succeeded + "/" + resolvedCommands.size() + ")";
+	}
+
+	/**
+	 * Resolve the Start/Stop intent from {@code External_Request}. Two callers pass different codes here:
+	 * the manual "call" process passes a Start/Stop intent (AD_Reference 541998), while the generic
+	 * external-system infra (startup reconciler) and the {@code ExternalSystem_Service} enable/disable
+	 * commands pass the CONCRETE transport command (e.g. {@code enableSftpPolling}). Accept both.
+	 */
+	@VisibleForTesting
+	static ScriptedImportConversionIntent resolveIntent(@NonNull final String externalRequest)
+	{
+		try
+		{
+			return ScriptedImportConversionIntent.ofCode(externalRequest);
+		}
+		catch (final AdempiereException intentNotFound)
+		{
+			try
+			{
+				return ScriptedImportConversionCommand.ofCode(externalRequest).getIntent();
+			}
+			catch (final AdempiereException commandNotFound)
+			{
+				throw new AdempiereException("No ScriptedImportConversion intent or command for External_Request")
+						.appendParametersToMessage()
+						.setParameter("External_Request", externalRequest)
+						.setParameter("acceptedIntents", "start, stop")
+						.setParameter("acceptedCommands", "enableRestAPI, disableRestAPI, enableSftpPolling, disableSftpPolling");
+			}
+		}
 	}
 
 	private ImmutableList<ResolvedChildCommand> resolveChildCommands(final ScriptedImportConversionIntent intent)

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedimportconversion/ScriptedImportConversionCommand.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedimportconversion/ScriptedImportConversionCommand.java
@@ -57,7 +57,6 @@ public enum ScriptedImportConversionCommand
 				.setParameter("code", value);
 	}
 
-	/** The enable/disable transport commands map back to the Start/Stop intent the generic infra reasons in. */
 	@NonNull
 	public ScriptedImportConversionIntent getIntent()
 	{

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedimportconversion/ScriptedImportConversionCommand.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedimportconversion/ScriptedImportConversionCommand.java
@@ -42,6 +42,40 @@ public enum ScriptedImportConversionCommand
 	@Getter
 	private final String value;
 
+	@NonNull
+	public static ScriptedImportConversionCommand ofCode(@NonNull final String value)
+	{
+		for (final ScriptedImportConversionCommand command : values())
+		{
+			if (command.value.equals(value))
+			{
+				return command;
+			}
+		}
+		throw new AdempiereException("No ScriptedImportConversionCommand for code")
+				.appendParametersToMessage()
+				.setParameter("code", value);
+	}
+
+	/** The enable/disable transport commands map back to the Start/Stop intent the generic infra reasons in. */
+	@NonNull
+	public ScriptedImportConversionIntent getIntent()
+	{
+		switch (this)
+		{
+			case EnableRestAPI:
+			case EnableSftpPolling:
+				return ScriptedImportConversionIntent.Start;
+			case DisableRestAPI:
+			case DisableSftpPolling:
+				return ScriptedImportConversionIntent.Stop;
+			default:
+				throw new AdempiereException("Unhandled ScriptedImportConversionCommand")
+						.appendParametersToMessage()
+						.setParameter("command", this);
+		}
+	}
+
 	/**
 	 * Derive the concrete command from the user's Start/Stop intent and the child's endpoint
 	 * transport. A parent config may have both REST and SFTP children, so this is resolved per child.

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/process/InvokeScriptedImportConversionActionTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/process/InvokeScriptedImportConversionActionTest.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.process;
+
+import de.metas.externalsystem.scriptedimportconversion.ScriptedImportConversionIntent;
+import org.adempiere.exceptions.AdempiereException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InvokeScriptedImportConversionActionTest
+{
+	@Test
+	void resolveIntent_startStopIntentCodes_areAccepted()
+	{
+		// the manual "call" process (AD_Process 585512, External_Request = AD_Reference 541998) passes the intent code
+		assertThat(InvokeScriptedImportConversionAction.resolveIntent("start")).isEqualTo(ScriptedImportConversionIntent.Start);
+		assertThat(InvokeScriptedImportConversionAction.resolveIntent("stop")).isEqualTo(ScriptedImportConversionIntent.Stop);
+	}
+
+	@Test
+	void resolveIntent_concreteEnableCommands_mapToStart()
+	{
+		// the generic external-system infra (startup reconciler) + ExternalSystem_Service EnableCommand pass the
+		// CONCRETE command code as {externalRequest}; the enable variants must resolve to the Start intent
+		assertThat(InvokeScriptedImportConversionAction.resolveIntent("enableRestAPI")).isEqualTo(ScriptedImportConversionIntent.Start);
+		assertThat(InvokeScriptedImportConversionAction.resolveIntent("enableSftpPolling")).isEqualTo(ScriptedImportConversionIntent.Start);
+	}
+
+	@Test
+	void resolveIntent_concreteDisableCommands_mapToStop()
+	{
+		assertThat(InvokeScriptedImportConversionAction.resolveIntent("disableRestAPI")).isEqualTo(ScriptedImportConversionIntent.Stop);
+		assertThat(InvokeScriptedImportConversionAction.resolveIntent("disableSftpPolling")).isEqualTo(ScriptedImportConversionIntent.Stop);
+	}
+
+	@Test
+	void resolveIntent_unknownCode_throwsClearError()
+	{
+		assertThatThrownBy(() -> InvokeScriptedImportConversionAction.resolveIntent("bogus"))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("bogus");
+	}
+}

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedimportconversion/ScriptedImportConversionCommandTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedimportconversion/ScriptedImportConversionCommandTest.java
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedimportconversion;
+
+import org.adempiere.exceptions.AdempiereException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ScriptedImportConversionCommandTest
+{
+	@Test
+	void ofCode_matchesByWireValue()
+	{
+		assertThat(ScriptedImportConversionCommand.ofCode("enableRestAPI")).isEqualTo(ScriptedImportConversionCommand.EnableRestAPI);
+		assertThat(ScriptedImportConversionCommand.ofCode("disableRestAPI")).isEqualTo(ScriptedImportConversionCommand.DisableRestAPI);
+		assertThat(ScriptedImportConversionCommand.ofCode("enableSftpPolling")).isEqualTo(ScriptedImportConversionCommand.EnableSftpPolling);
+		assertThat(ScriptedImportConversionCommand.ofCode("disableSftpPolling")).isEqualTo(ScriptedImportConversionCommand.DisableSftpPolling);
+	}
+
+	@Test
+	void ofCode_unknown_throwsClearError()
+	{
+		assertThatThrownBy(() -> ScriptedImportConversionCommand.ofCode("start"))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("start");
+	}
+
+	@Test
+	void getIntent_enableMapsToStart_disableMapsToStop()
+	{
+		assertThat(ScriptedImportConversionCommand.EnableRestAPI.getIntent()).isEqualTo(ScriptedImportConversionIntent.Start);
+		assertThat(ScriptedImportConversionCommand.EnableSftpPolling.getIntent()).isEqualTo(ScriptedImportConversionIntent.Start);
+		assertThat(ScriptedImportConversionCommand.DisableRestAPI.getIntent()).isEqualTo(ScriptedImportConversionIntent.Stop);
+		assertThat(ScriptedImportConversionCommand.DisableSftpPolling.getIntent()).isEqualTo(ScriptedImportConversionIntent.Stop);
+	}
+}


### PR DESCRIPTION
## Problem
The generic external-system invoke path `POST /api/v2/externalsystem/invoke/{type}/{configValue}/{externalRequest}` passes the CONCRETE transport command as `{externalRequest}`:
- the startup camel reconciler (`ExternalSystemRestAPIHandler` -> `ExternalSystemRouteBuilder`), and
- the `ExternalSystem_Service` Enable/Disable commands (`enableSftpPolling` / `disableSftpPolling` / `enableRestAPI` / `disableRestAPI`).

`InvokeScriptedImportConversionAction.doIt()` only accepted a Start/Stop **intent** code (`ScriptedImportConversionIntent.ofCode`), so a concrete command threw `AdempiereException: No ScriptedImportConversionIntent for code` on app/camel startup -> HTTP 500. Regression from the intent/command split.

## Fix
Resolve the intent leniently so BOTH an intent code and a concrete command code work:
- `ScriptedImportConversionCommand.ofCode(String)` + `getIntent()` (enable -> Start, disable -> Stop).
- `InvokeScriptedImportConversionAction.resolveIntent(...)`: try the intent code, else fall back to the concrete command's intent; if neither matches, throw a clear error listing accepted values. Per-child command derivation (`ofIntentAndTransport`) is unchanged.

No migration, camel, or generic-base-action changes.

## Tests
- `InvokeScriptedImportConversionActionTest` (four tests) - `resolveIntent` accepts start/stop and the four concrete commands, rejects garbage.
- `ScriptedImportConversionCommandTest` (three tests) - `ofCode` / `getIntent`.
- RED confirmed: both test classes fail to compile against the unfixed code (methods absent). GREEN after fix.
- Full `de.metas.externalsystem` suite: 150 tests, 0 failures/errors/skipped.
