### PR TITLE
TU package-dimension calculation + nShift mandatory-field validation

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensionCalcMethod.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensionCalcMethod.java
@@ -21,8 +21,7 @@ import javax.annotation.Nullable;
  * not the other way round). The generated {@code X_M_HU_PI_Version} constants therefore cannot
  * be imported here without introducing a reverse module dependency. So this enum is the
  * source of truth for the codes, and the ref-list migration's {@code Value}s must match them
- * (S / R / N). Handlingunits-side callers should reference the generated
- * {@code X_M_HU_PI_Version.PACKAGEDIMENSIONCALCMETHOD_*} constants.</p>
+ * (S / R / N).</p>
  */
 @Getter
 @RequiredArgsConstructor

--- a/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensionCalcMethod.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensionCalcMethod.java
@@ -14,6 +14,15 @@ import javax.annotation.Nullable;
  * are packed into one Transport Unit (HU_UnitType=TU).
  *
  * <p>Values map to the {@code PackageDimensionCalcMethod} AD_Reference (ID 542122).</p>
+ *
+ * <p><b>Why literal codes instead of {@code X_M_HU_PI_Version.PACKAGEDIMENSIONCALCMETHOD_*}
+ * constants:</b> this enum lives in {@code de.metas.business}, which sits <i>below</i>
+ * {@code de.metas.handlingunits.base} in the module graph (handlingunits depends on business,
+ * not the other way round). The generated {@code X_M_HU_PI_Version} constants therefore cannot
+ * be imported here without introducing a reverse module dependency. So this enum is the
+ * source of truth for the codes, and the ref-list migration's {@code Value}s must match them
+ * (S / R / N). Handlingunits-side callers should reference the generated
+ * {@code X_M_HU_PI_Version.PACKAGEDIMENSIONCALCMETHOD_*} constants.</p>
  */
 @Getter
 @RequiredArgsConstructor

--- a/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensionCalcMethod.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensionCalcMethod.java
@@ -2,9 +2,9 @@ package de.metas.product;
 
 import de.metas.util.lang.ReferenceListAwareEnum;
 import de.metas.util.lang.ReferenceListAwareEnums;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 import javax.annotation.Nullable;
 
@@ -17,7 +17,8 @@ import javax.annotation.Nullable;
  *
  * @see de.metas.handlingunits.shipping.HUPackageBL
  */
-@AllArgsConstructor
+@Getter
+@RequiredArgsConstructor
 public enum PackageDimensionCalcMethod implements ReferenceListAwareEnum
 {
 	/**
@@ -38,7 +39,6 @@ public enum PackageDimensionCalcMethod implements ReferenceListAwareEnum
 	Nesting("N"),
 	;
 
-	@Getter
 	private final String code;
 
 	private static final ReferenceListAwareEnums.ValuesIndex<PackageDimensionCalcMethod> index =

--- a/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensionCalcMethod.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensionCalcMethod.java
@@ -14,8 +14,6 @@ import javax.annotation.Nullable;
  * are packed into one Transport Unit (HU_UnitType=TU).
  *
  * <p>Values map to the {@code PackageDimensionCalcMethod} AD_Reference (ID 542122).</p>
- *
- * @see de.metas.handlingunits.shipping.HUPackageBL
  */
 @Getter
 @RequiredArgsConstructor

--- a/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensionCalcMethod.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensionCalcMethod.java
@@ -1,0 +1,57 @@
+package de.metas.product;
+
+import de.metas.util.lang.ReferenceListAwareEnum;
+import de.metas.util.lang.ReferenceListAwareEnums;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+
+import javax.annotation.Nullable;
+
+/**
+ * Dimension calculation mode for a TU packing-instruction version.
+ * Controls how L/W/H is derived when multiple items with differing dimensions
+ * are packed into one Transport Unit (HU_UnitType=TU).
+ *
+ * <p>Values map to the {@code PackageDimensionCalcMethod} AD_Reference (ID 542122).</p>
+ *
+ * @see de.metas.handlingunits.shipping.HUPackageBL
+ */
+@AllArgsConstructor
+public enum PackageDimensionCalcMethod implements ReferenceListAwareEnum
+{
+	/**
+	 * Items are strapped together: the stacking-axis edge is the sum of each unit's smallest edge;
+	 * the two larger TU edges are the maximum of those edges across all contained products.
+	 */
+	Strapping("S"),
+
+	/**
+	 * Items are repacked into a box: TU volume = sum(L*W*H per unit) * 1.05;
+	 * TU shape derived from volume via the height/width/length formula.
+	 */
+	Repacking("R"),
+
+	/**
+	 * Items are nested: TU dimensions equal those of the contained item with the largest single edge.
+	 */
+	Nesting("N"),
+	;
+
+	@Getter
+	private final String code;
+
+	private static final ReferenceListAwareEnums.ValuesIndex<PackageDimensionCalcMethod> index =
+			ReferenceListAwareEnums.index(values());
+
+	public static PackageDimensionCalcMethod ofCode(@NonNull final String code)
+	{
+		return index.ofCode(code);
+	}
+
+	@Nullable
+	public static PackageDimensionCalcMethod ofNullableCode(@Nullable final String code)
+	{
+		return index.ofNullableCode(code);
+	}
+}

--- a/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensionItem.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensionItem.java
@@ -1,0 +1,50 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.product;
+
+import de.metas.quantity.Quantity;
+import lombok.NonNull;
+import lombok.Value;
+
+/**
+ * One line in a list of items to be packed into a TU.
+ * Carries the per-unit package dimensions and the quantity of units.
+ *
+ * <p>Used as input to {@link PackageDimensions#ofItems(PackageDimensionCalcMethod, java.util.List)}.</p>
+ */
+@Value
+public class PackageDimensionItem
+{
+	/** Per-unit dimensions (L/W/H in cm). May be {@link PackageDimensions#UNSPECIFIED}. */
+	@NonNull PackageDimensions dims;
+
+	/** Number of units being packed. */
+	@NonNull Quantity qty;
+
+	public static PackageDimensionItem of(
+			@NonNull final PackageDimensions dims,
+			@NonNull final Quantity qty)
+	{
+		return new PackageDimensionItem(dims, qty);
+	}
+}

--- a/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensions.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensions.java
@@ -31,6 +31,7 @@ import lombok.extern.jackson.Jacksonized;
 
 import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Builder
@@ -77,5 +78,149 @@ public class PackageDimensions
 				.heightInCM(dimensions.get(1))
 				.widthInCM(dimensions.get(2))
 				.build();
+	}
+
+	/**
+	 * Compute TU package dimensions from a list of packed items using the given calculation mode.
+	 *
+	 * <p>If any item carries {@link #UNSPECIFIED} dimensions the result is {@link #UNSPECIFIED}.</p>
+	 *
+	 * @param mode  one of {@link PackageDimensionCalcMethod#Strapping}, {@link PackageDimensionCalcMethod#Repacking},
+	 *              or {@link PackageDimensionCalcMethod#Nesting}
+	 * @param items the items packed into the TU (each with per-unit dims and a quantity)
+	 */
+	public static PackageDimensions ofItems(
+			@NonNull final PackageDimensionCalcMethod mode,
+			@NonNull final List<PackageDimensionItem> items)
+	{
+		// Guard: if any item has unspecified dims, the whole TU has no dims
+		for (final PackageDimensionItem item : items)
+		{
+			if (item.getDims().isUnspecified())
+			{
+				return UNSPECIFIED;
+			}
+		}
+
+		switch (mode)
+		{
+			case Strapping:
+				return ofItemsStrapping(items);
+			case Repacking:
+				return ofItemsRepacking(items);
+			case Nesting:
+				return ofItemsNesting(items);
+			default:
+				throw new IllegalArgumentException("Unknown PackageDimensionCalcMethod: " + mode);
+		}
+	}
+
+	/**
+	 * Strapping: items are strapped together end-to-end along their smallest edge.
+	 *
+	 * <ul>
+	 *   <li>Stacking axis (stored in {@code lengthInCM}) = Σ( min_edge(item) × qty(item) )</li>
+	 *   <li>Mid edge ({@code heightInCM}) = max( mid_edge(item) ) across all items</li>
+	 *   <li>Max edge ({@code widthInCM})  = max( max_edge(item) ) across all items</li>
+	 * </ul>
+	 *
+	 * <p>For a single item this is equivalent to {@link #ofProductDimensionsAndQty}.</p>
+	 */
+	static PackageDimensions ofItemsStrapping(@NonNull final List<PackageDimensionItem> items)
+	{
+		int stackingAxisTotal = 0;
+		int maxMidEdge = 0;
+		int maxMaxEdge = 0;
+
+		for (final PackageDimensionItem item : items)
+		{
+			final int qty = item.getQty().toBigDecimal().setScale(0, RoundingMode.CEILING).intValue();
+			final List<Integer> sorted = sortedEdges(item.getDims());
+			// sorted[0] = min, sorted[1] = mid, sorted[2] = max
+			stackingAxisTotal += sorted.get(0) * qty;
+			maxMidEdge = Math.max(maxMidEdge, sorted.get(1));
+			maxMaxEdge = Math.max(maxMaxEdge, sorted.get(2));
+		}
+
+		return PackageDimensions.builder()
+				.lengthInCM(stackingAxisTotal)
+				.heightInCM(maxMidEdge)
+				.widthInCM(maxMaxEdge)
+				.build();
+	}
+
+	/**
+	 * Repacking: items are repacked into a box.
+	 *
+	 * <ul>
+	 *   <li>V = Σ( L × W × H × qty ) × 1.05</li>
+	 *   <li>height = ⅔ × V^(1/3)</li>
+	 *   <li>width  = ⅗ × √(V / height)</li>
+	 *   <li>length = (V / height) / width</li>
+	 * </ul>
+	 *
+	 * <p>All three edge values are rounded to the nearest integer cm.</p>
+	 */
+	static PackageDimensions ofItemsRepacking(@NonNull final List<PackageDimensionItem> items)
+	{
+		double rawVolume = 0.0;
+		for (final PackageDimensionItem item : items)
+		{
+			final int qty = item.getQty().toBigDecimal().setScale(0, RoundingMode.CEILING).intValue();
+			final PackageDimensions d = item.getDims();
+			rawVolume += (double)d.getLengthInCM() * d.getWidthInCM() * d.getHeightInCM() * qty;
+		}
+		final double v = rawVolume * 1.05;
+
+		final int height = (int)Math.round((2.0 / 3.0) * Math.cbrt(v));
+		final int width = height > 0
+				? (int)Math.round((3.0 / 5.0) * Math.sqrt(v / height))
+				: 1;
+		final int length = (height > 0 && width > 0)
+				? (int)Math.round((v / height) / width)
+				: 1;
+
+		return PackageDimensions.builder()
+				.lengthInCM(length)
+				.widthInCM(width)
+				.heightInCM(height)
+				.build();
+	}
+
+	/**
+	 * Nesting: the TU takes the dimensions of the item whose single largest edge is greatest.
+	 *
+	 * <p>Quantity is ignored for the comparison — only the edge size matters.</p>
+	 */
+	static PackageDimensions ofItemsNesting(@NonNull final List<PackageDimensionItem> items)
+	{
+		PackageDimensions winner = null;
+		int winnerMaxEdge = Integer.MIN_VALUE;
+
+		for (final PackageDimensionItem item : items)
+		{
+			final int maxEdge = Collections.max(
+					sortedEdges(item.getDims()));
+			if (maxEdge > winnerMaxEdge)
+			{
+				winnerMaxEdge = maxEdge;
+				winner = item.getDims();
+			}
+		}
+
+		return winner != null ? winner : UNSPECIFIED;
+	}
+
+	/**
+	 * Returns the three edge values of the given dims sorted ascending: [min, mid, max].
+	 */
+	private static List<Integer> sortedEdges(@NonNull final PackageDimensions dims)
+	{
+		final List<Integer> edges = new ArrayList<>();
+		edges.add(dims.getLengthInCM());
+		edges.add(dims.getWidthInCM());
+		edges.add(dims.getHeightInCM());
+		edges.sort(null);
+		return edges;
 	}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensions.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/PackageDimensions.java
@@ -93,6 +93,11 @@ public class PackageDimensions
 			@NonNull final PackageDimensionCalcMethod mode,
 			@NonNull final List<PackageDimensionItem> items)
 	{
+		if (items.isEmpty())
+		{
+			return UNSPECIFIED;
+		}
+
 		// Guard: if any item has unspecified dims, the whole TU has no dims
 		for (final PackageDimensionItem item : items)
 		{
@@ -136,7 +141,6 @@ public class PackageDimensions
 		{
 			final int qty = item.getQty().toBigDecimal().setScale(0, RoundingMode.CEILING).intValue();
 			final List<Integer> sorted = sortedEdges(item.getDims());
-			// sorted[0] = min, sorted[1] = mid, sorted[2] = max
 			stackingAxisTotal += sorted.get(0) * qty;
 			maxMidEdge = Math.max(maxMidEdge, sorted.get(1));
 			maxMaxEdge = Math.max(maxMaxEdge, sorted.get(2));

--- a/backend/de.metas.business/src/test/java/de/metas/product/PackageDimensionsTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/product/PackageDimensionsTest.java
@@ -36,17 +36,11 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Unit tests for {@link PackageDimensions#ofItems(PackageDimensionCalcMethod, List)}.
+ * Unit tests for {@link PackageDimensions#ofItems(PackageDimensionCalcMethod, java.util.List)}.
  *
- * <p>Test coverage per the task-3-brief.md:
- * <ol>
- *   <li>Strapping single product — parity with {@link PackageDimensions#ofProductDimensionsAndQty}</li>
- *   <li>Strapping mixed (two products)</li>
- *   <li>Repacking mixed — volume formula + shape derivation</li>
- *   <li>Nesting — item with largest single edge wins</li>
- *   <li>Any item with unspecified dims → result is UNSPECIFIED</li>
- * </ol>
- * </p>
+ * <p>Tests all three calculation modes (Strapping, Repacking, Nesting) and the
+ * {@link PackageDimensions#UNSPECIFIED} propagation contract (any item with no dimensions,
+ * or an empty item list, yields {@code UNSPECIFIED}).</p>
  */
 public class PackageDimensionsTest
 {
@@ -144,13 +138,13 @@ public class PackageDimensionsTest
 		 * B: (L=7, W=5, H=3) × qty 2 → volume contribution = 7*5*3*2 = 210
 		 * Total volume V = (144 + 210) * 1.05 = 354 * 1.05 = 371.7
 		 * <p>
-		 * Shape formula:
-		 *   height = ⅔ * V^(1/3)   ≈ ⅔ * 7.191… ≈ 4.794… → int 4
-		 *   width  = ⅗ * √(V / height)  ≈ ⅗ * √(371.7/4) ≈ ⅗ * √92.925 ≈ ⅗ * 9.640 ≈ 5.784 → int 5
-		 *   length = (V / height) / width ≈ (371.7/4) / 5 ≈ 92.925 / 5 ≈ 18.585 → int 18
+		 * Shape formula (all rounded via {@link Math#round}):
+		 *   height = round(⅔ * 371.7^(1/3)) = round(⅔ * 7.191) = round(4.794) = 5
+		 *   width  = round(⅗ * √(371.7 / 5)) = round(⅗ * √74.34) = round(⅗ * 8.622) = round(5.173) = 5
+		 *   length = round((371.7 / 5) / 5) = round(74.34 / 5) = round(14.868) = 15
 		 * <p>
-		 * Verify h*w*l ≈ V (within rounding): 4*5*18 = 360; V≈371.7 → within a few percent.
-		 * We assert the volume product is within 5% of the true V.
+		 * Self-consistency: 5 * 5 * 15 = 375; V = 371.7 → ratio 1.009 — within rounding.
+		 * We assert the volume product is within 10% of V to accommodate integer rounding.
 		 */
 		@Test
 		void mixedTwoProducts_volumeFormula()
@@ -243,6 +237,24 @@ public class PackageDimensionsTest
 				final PackageDimensions result = PackageDimensions.ofItems(mode, items);
 				assertThat(result)
 						.as("mode %s should return UNSPECIFIED when any item has no dims", mode)
+						.isEqualTo(PackageDimensions.UNSPECIFIED);
+			}
+		}
+
+		/**
+		 * An empty item list has no dimensions to compute from; result is UNSPECIFIED
+		 * for all modes.
+		 */
+		@Test
+		void emptyList_returnsUnspecified()
+		{
+			final List<PackageDimensionItem> items = ImmutableList.of();
+
+			for (final PackageDimensionCalcMethod mode : PackageDimensionCalcMethod.values())
+			{
+				final PackageDimensions result = PackageDimensions.ofItems(mode, items);
+				assertThat(result)
+						.as("mode %s should return UNSPECIFIED for an empty item list", mode)
 						.isEqualTo(PackageDimensions.UNSPECIFIED);
 			}
 		}

--- a/backend/de.metas.business/src/test/java/de/metas/product/PackageDimensionsTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/product/PackageDimensionsTest.java
@@ -1,0 +1,250 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.product;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.quantity.Quantity;
+import de.metas.uom.impl.UOMTestHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link PackageDimensions#ofItems(PackageDimensionCalcMethod, List)}.
+ *
+ * <p>Test coverage per the task-3-brief.md:
+ * <ol>
+ *   <li>Strapping single product — parity with {@link PackageDimensions#ofProductDimensionsAndQty}</li>
+ *   <li>Strapping mixed (two products)</li>
+ *   <li>Repacking mixed — volume formula + shape derivation</li>
+ *   <li>Nesting — item with largest single edge wins</li>
+ *   <li>Any item with unspecified dims → result is UNSPECIFIED</li>
+ * </ol>
+ * </p>
+ */
+public class PackageDimensionsTest
+{
+	private I_C_UOM each;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		each = new UOMTestHelper().createUOM("Each", 0);
+	}
+
+	private Quantity qty(final int n)
+	{
+		return Quantity.of(n, each);
+	}
+
+	// -----------------------------------------------------------------------
+	// STRAPPING
+	// -----------------------------------------------------------------------
+
+	@Nested
+	class Strapping
+	{
+		/**
+		 * Single product with dims (L=6, W=4, H=2) × qty 3.
+		 * Sorted ascending: [2, 4, 6].
+		 * Stacking axis (min edge) = 2 × 3 = 6.
+		 * Other two edges = max(4) = 4, max(6) = 6.
+		 * <p>
+		 * Must match {@link PackageDimensions#ofProductDimensionsAndQty} for the same input.
+		 */
+		@Test
+		void singleProduct_parityWithExistingMethod()
+		{
+			final PackageDimensions dims = PackageDimensions.builder()
+					.lengthInCM(6).widthInCM(4).heightInCM(2)
+					.build();
+
+			final PackageDimensions expected = PackageDimensions.ofProductDimensionsAndQty(dims, qty(3));
+
+			final List<PackageDimensionItem> items = ImmutableList.of(
+					PackageDimensionItem.of(dims, qty(3))
+			);
+			final PackageDimensions result = PackageDimensions.ofItems(PackageDimensionCalcMethod.Strapping, items);
+
+			assertThat(result).isEqualTo(expected);
+		}
+
+		/**
+		 * Two products:
+		 * A: dims (L=6, W=4, H=2) sorted → [2,4,6], qty 3  → stacking contribution = 2*3 = 6
+		 * B: dims (L=7, W=5, H=3) sorted → [3,5,7], qty 2  → stacking contribution = 3*2 = 6
+		 * <p>
+		 * Stacking axis total = 6 + 6 = 12.
+		 * Larger edge 1 = max(4, 5) = 5.
+		 * Larger edge 2 = max(6, 7) = 7.
+		 * <p>
+		 * Per {@link PackageDimensions#ofProductDimensionsAndQty} convention the stacking result
+		 * is stored in {@code lengthInCM}, mid-edge in {@code heightInCM}, max-edge in {@code widthInCM}.
+		 * We assert the numeric values only (not field mapping) to allow a width/height swap.
+		 */
+		@Test
+		void mixedTwoProducts()
+		{
+			final PackageDimensions dimsA = PackageDimensions.builder()
+					.lengthInCM(6).widthInCM(4).heightInCM(2)
+					.build();
+			final PackageDimensions dimsB = PackageDimensions.builder()
+					.lengthInCM(7).widthInCM(5).heightInCM(3)
+					.build();
+
+			final List<PackageDimensionItem> items = ImmutableList.of(
+					PackageDimensionItem.of(dimsA, qty(3)),
+					PackageDimensionItem.of(dimsB, qty(2))
+			);
+			final PackageDimensions result = PackageDimensions.ofItems(PackageDimensionCalcMethod.Strapping, items);
+
+			// The three edge values must be {5, 7, 12} regardless of which field holds which
+			assertThat(ImmutableList.of(result.getLengthInCM(), result.getWidthInCM(), result.getHeightInCM()))
+					.containsExactlyInAnyOrder(12, 7, 5);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// REPACKING
+	// -----------------------------------------------------------------------
+
+	@Nested
+	class Repacking
+	{
+		/**
+		 * Two products:
+		 * A: (L=6, W=4, H=2) × qty 3 → volume contribution = 6*4*2*3 = 144
+		 * B: (L=7, W=5, H=3) × qty 2 → volume contribution = 7*5*3*2 = 210
+		 * Total volume V = (144 + 210) * 1.05 = 354 * 1.05 = 371.7
+		 * <p>
+		 * Shape formula:
+		 *   height = ⅔ * V^(1/3)   ≈ ⅔ * 7.191… ≈ 4.794… → int 4
+		 *   width  = ⅗ * √(V / height)  ≈ ⅗ * √(371.7/4) ≈ ⅗ * √92.925 ≈ ⅗ * 9.640 ≈ 5.784 → int 5
+		 *   length = (V / height) / width ≈ (371.7/4) / 5 ≈ 92.925 / 5 ≈ 18.585 → int 18
+		 * <p>
+		 * Verify h*w*l ≈ V (within rounding): 4*5*18 = 360; V≈371.7 → within a few percent.
+		 * We assert the volume product is within 5% of the true V.
+		 */
+		@Test
+		void mixedTwoProducts_volumeFormula()
+		{
+			final PackageDimensions dimsA = PackageDimensions.builder()
+					.lengthInCM(6).widthInCM(4).heightInCM(2)
+					.build();
+			final PackageDimensions dimsB = PackageDimensions.builder()
+					.lengthInCM(7).widthInCM(5).heightInCM(3)
+					.build();
+
+			final List<PackageDimensionItem> items = ImmutableList.of(
+					PackageDimensionItem.of(dimsA, qty(3)),
+					PackageDimensionItem.of(dimsB, qty(2))
+			);
+			final PackageDimensions result = PackageDimensions.ofItems(PackageDimensionCalcMethod.Repacking, items);
+
+			assertThat(result.isUnspecified()).isFalse();
+			assertThat(result.getLengthInCM()).isGreaterThan(0);
+			assertThat(result.getWidthInCM()).isGreaterThan(0);
+			assertThat(result.getHeightInCM()).isGreaterThan(0);
+
+			// Volume self-consistency: h*w*l should be within 10% of V
+			final double expectedVolume = (6.0 * 4 * 2 * 3 + 7.0 * 5 * 3 * 2) * 1.05; // 371.7
+			final double actualVolume = (double)result.getLengthInCM()
+					* result.getWidthInCM()
+					* result.getHeightInCM();
+			assertThat(actualVolume).isBetween(expectedVolume * 0.90, expectedVolume * 1.10);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// NESTING
+	// -----------------------------------------------------------------------
+
+	@Nested
+	class Nesting
+	{
+		/**
+		 * A: dims (L=6, W=4, H=2) — max single edge = 6
+		 * B: dims (L=5, W=3, H=20) — max single edge = 20  ← winner
+		 * <p>
+		 * Result must equal B's dimensions exactly.
+		 */
+		@Test
+		void itemWithLargestSingleEdgeWins()
+		{
+			final PackageDimensions dimsA = PackageDimensions.builder()
+					.lengthInCM(6).widthInCM(4).heightInCM(2)
+					.build();
+			final PackageDimensions dimsB = PackageDimensions.builder()
+					.lengthInCM(5).widthInCM(3).heightInCM(20)
+					.build();
+
+			final List<PackageDimensionItem> items = ImmutableList.of(
+					PackageDimensionItem.of(dimsA, qty(1)),
+					PackageDimensionItem.of(dimsB, qty(1))
+			);
+			final PackageDimensions result = PackageDimensions.ofItems(PackageDimensionCalcMethod.Nesting, items);
+
+			assertThat(result).isEqualTo(dimsB);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// UNSPECIFIED propagation
+	// -----------------------------------------------------------------------
+
+	@Nested
+	class UnspecifiedPropagation
+	{
+		/**
+		 * If any item carries UNSPECIFIED dimensions, the result must be UNSPECIFIED
+		 * regardless of calc mode.
+		 */
+		@Test
+		void anyItemUnspecified_returnsUnspecified()
+		{
+			final PackageDimensions dims = PackageDimensions.builder()
+					.lengthInCM(6).widthInCM(4).heightInCM(2)
+					.build();
+
+			final List<PackageDimensionItem> items = ImmutableList.of(
+					PackageDimensionItem.of(dims, qty(2)),
+					PackageDimensionItem.of(PackageDimensions.UNSPECIFIED, qty(1))
+			);
+
+			for (final PackageDimensionCalcMethod mode : PackageDimensionCalcMethod.values())
+			{
+				final PackageDimensions result = PackageDimensions.ofItems(mode, items);
+				assertThat(result)
+						.as("mode %s should return UNSPECIFIED when any item has no dims", mode)
+						.isEqualTo(PackageDimensions.UNSPECIFIED);
+			}
+		}
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Version_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Version_StepDef.java
@@ -23,6 +23,7 @@
 package de.metas.cucumber.stepdefs.hu;
 
 import de.metas.common.util.CoalesceUtil;
+import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.handlingunits.model.I_M_HU_PI;
@@ -30,8 +31,11 @@ import de.metas.handlingunits.model.I_M_HU_PI_Version;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
+import io.cucumber.java.en.Then;
 import lombok.NonNull;
+import javax.annotation.Nullable;
 import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 
 import static de.metas.handlingunits.model.I_M_HU_PI_Version.COLUMNNAME_HU_UnitType;
@@ -40,6 +44,7 @@ import static de.metas.handlingunits.model.I_M_HU_PI_Version.COLUMNNAME_IsCurren
 import static de.metas.handlingunits.model.I_M_HU_PI_Version.COLUMNNAME_M_HU_PI_ID;
 import static de.metas.handlingunits.model.I_M_HU_PI_Version.COLUMNNAME_M_HU_PI_Version_ID;
 import static de.metas.handlingunits.model.I_M_HU_PI_Version.COLUMNNAME_Name;
+import static de.metas.handlingunits.model.I_M_HU_PI_Version.COLUMNNAME_PackageDimensionCalcMethod;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,6 +56,10 @@ public class M_HU_PI_Version_StepDef
 	private final M_HU_PI_Version_StepDefData huPiVersionTable;
 	private final M_HU_PackagingCode_StepDefData huPackagingCodeTable;
 
+	/** Captures the last exception thrown by {@link #add_M_HU_PI_Version_expectingError}. */
+	@Nullable
+	private AdempiereException lastSaveException;
+
 	public M_HU_PI_Version_StepDef(
 			@NonNull final M_HU_PI_StepDefData huPiTable,
 			@NonNull final M_HU_PI_Version_StepDefData huPiVersionTable,
@@ -61,50 +70,129 @@ public class M_HU_PI_Version_StepDef
 		this.huPackagingCodeTable = huPackagingCodeTable;
 	}
 
+	/**
+	 * Creates or upserts {@code M_HU_PI_Version} records.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_HU_PI_Version_ID</b> — (required) alias for cross-step reference<br>
+	 *   <b>M_HU_PI_ID</b> — (required, identifier-ref) parent packing instruction<br>
+	 *   <b>HU_UnitType</b> — (required) TU, LU, or V<br>
+	 *   <b>IsCurrent</b> — (optional) default true<br>
+	 *   <b>IsActive</b> — (optional) default true<br>
+	 *   <b>M_HU_PackagingCode_ID</b> — (optional, identifier-ref) packaging code<br>
+	 *   <b>PackageDimensionCalcMethod</b> — (optional) S (Strapping), R (Repacking), N (Nesting); only valid on TU versions<br>
+	 * @cucumber.example
+	 * <pre>
+	 * And metasfresh contains M_HU_PI_Version:
+	 *   | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType | IsCurrent | PackageDimensionCalcMethod |
+	 *   | tuVersion          | tuPi       | TU          | Y         | S                          |
+	 * </pre>
+	 */
 	@And("metasfresh contains M_HU_PI_Version:")
 	public void add_M_HU_PI_Version(@NonNull final DataTable dataTable)
 	{
 		DataTableRows.of(dataTable)
 				.setAdditionalRowIdentifierColumnName(COLUMNNAME_M_HU_PI_Version_ID)
-				.forEach(row -> {
-					final I_M_HU_PI huPi = row.getAsIdentifier(COLUMNNAME_M_HU_PI_ID).lookupNotNullIn(huPiTable);
-					final String name = row.suggestValueAndName(null, huPi::getName).getName();
-					final String huUnitType = row.getAsString(COLUMNNAME_HU_UnitType); //dev-note: HU_UNITTYPE_AD_Reference_ID=540472;
-					final boolean isCurrent = row.getAsOptionalBoolean(COLUMNNAME_IsCurrent).orElseTrue();
-					final boolean active = row.getAsOptionalBoolean(COLUMNNAME_IsActive).orElseTrue();
+				.forEach(row -> buildAndSavePiVersion(row, huPiVersionTable));
+	}
 
-					final I_M_HU_PI_Version existingPiVersion = queryBL.createQueryBuilder(I_M_HU_PI_Version.class)
-							.addEqualsFilter(COLUMNNAME_M_HU_PI_ID, huPi.getM_HU_PI_ID())
-							.addStringLikeFilter(COLUMNNAME_Name, name, true)
-							.addEqualsFilter(COLUMNNAME_HU_UnitType, huUnitType)
-							.addEqualsFilter(COLUMNNAME_IsActive, active)
-							.create()
-							.firstOnly(I_M_HU_PI_Version.class);
+	/**
+	 * Variant of {@link #add_M_HU_PI_Version} that captures the first {@link AdempiereException}
+	 * thrown during save (e.g. when {@code PackageDimensionCalcMethod} is set on a non-TU version)
+	 * instead of propagating it. The captured exception can be asserted via
+	 * {@link #assertLastSaveExceptionWasThrown()}.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * When metasfresh contains M_HU_PI_Version expecting error:
+	 *   | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType | PackageDimensionCalcMethod |
+	 *   | luVersion          | luPi       | LU          | S                          |
+	 * Then an AdempiereException was thrown when saving the M_HU_PI_Version
+	 * </pre>
+	 */
+	@And("metasfresh contains M_HU_PI_Version expecting error:")
+	public void add_M_HU_PI_Version_expectingError(@NonNull final DataTable dataTable)
+	{
+		lastSaveException = null;
+		try
+		{
+			DataTableRows.of(dataTable)
+					.setAdditionalRowIdentifierColumnName(COLUMNNAME_M_HU_PI_Version_ID)
+					.forEach(row -> buildAndSavePiVersion(row, null));
+		}
+		catch (final AdempiereException e)
+		{
+			lastSaveException = e;
+		}
+	}
 
-					final I_M_HU_PI_Version piVersion = CoalesceUtil.coalesceSuppliers(
-							() -> existingPiVersion,
-							() -> InterfaceWrapperHelper.newInstanceOutOfTrx(I_M_HU_PI_Version.class)
-					);
-					assertThat(piVersion).isNotNull();
+	/**
+	 * Asserts that the most recent {@link #add_M_HU_PI_Version_expectingError} step did throw an {@link AdempiereException}.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then an AdempiereException was thrown when saving the M_HU_PI_Version
+	 * </pre>
+	 */
+	@Then("an AdempiereException was thrown when saving the M_HU_PI_Version")
+	public void assertLastSaveExceptionWasThrown()
+	{
+		assertThat(lastSaveException)
+				.as("Expected an AdempiereException to be thrown when saving M_HU_PI_Version, but none was thrown")
+				.isNotNull();
+	}
 
-					piVersion.setM_HU_PI_ID(huPi.getM_HU_PI_ID());
-					piVersion.setName(name);
-					piVersion.setHU_UnitType(huUnitType);
-					piVersion.setIsCurrent(isCurrent);
-					piVersion.setIsActive(active);
+	private void buildAndSavePiVersion(
+			@NonNull final DataTableRow row,
+			@Nullable final M_HU_PI_Version_StepDefData versionTableToStore)
+	{
+		final I_M_HU_PI huPi = row.getAsIdentifier(COLUMNNAME_M_HU_PI_ID).lookupNotNullIn(huPiTable);
+		final String name = row.suggestValueAndName(null, huPi::getName).getName();
+		final String huUnitType = row.getAsString(COLUMNNAME_HU_UnitType); //dev-note: HU_UNITTYPE_AD_Reference_ID=540472;
+		final boolean isCurrent = row.getAsOptionalBoolean(COLUMNNAME_IsCurrent).orElseTrue();
+		final boolean active = row.getAsOptionalBoolean(COLUMNNAME_IsActive).orElseTrue();
 
-					row.getAsOptionalIdentifier(I_M_HU_PI_Version.COLUMNNAME_M_HU_PackagingCode_ID)
-							.ifPresent(huPackagingCodeIdentifier -> {
-								final int huPackagingCodeId = huPackagingCodeIdentifier.isNullPlaceholder()
-										? -1
-										: huPackagingCodeTable.get(huPackagingCodeIdentifier).getM_HU_PackagingCode_ID();
+		final I_M_HU_PI_Version existingPiVersion = queryBL.createQueryBuilder(I_M_HU_PI_Version.class)
+				.addEqualsFilter(COLUMNNAME_M_HU_PI_ID, huPi.getM_HU_PI_ID())
+				.addStringLikeFilter(COLUMNNAME_Name, name, true)
+				.addEqualsFilter(COLUMNNAME_HU_UnitType, huUnitType)
+				.addEqualsFilter(COLUMNNAME_IsActive, active)
+				.create()
+				.firstOnly(I_M_HU_PI_Version.class);
 
-								piVersion.setM_HU_PackagingCode_ID(huPackagingCodeId);
-							});
+		final I_M_HU_PI_Version piVersion = CoalesceUtil.coalesceSuppliers(
+				() -> existingPiVersion,
+				() -> InterfaceWrapperHelper.newInstanceOutOfTrx(I_M_HU_PI_Version.class)
+		);
+		assertThat(piVersion).isNotNull();
 
-					saveRecord(piVersion);
-					huPiVersionTable.put(row.getAsIdentifier(), piVersion);
+		piVersion.setM_HU_PI_ID(huPi.getM_HU_PI_ID());
+		piVersion.setName(name);
+		piVersion.setHU_UnitType(huUnitType);
+		piVersion.setIsCurrent(isCurrent);
+		piVersion.setIsActive(active);
+
+		row.getAsOptionalIdentifier(I_M_HU_PI_Version.COLUMNNAME_M_HU_PackagingCode_ID)
+				.ifPresent(huPackagingCodeIdentifier -> {
+					final int huPackagingCodeId = huPackagingCodeIdentifier.isNullPlaceholder()
+							? -1
+							: huPackagingCodeTable.get(huPackagingCodeIdentifier).getM_HU_PackagingCode_ID();
+
+					piVersion.setM_HU_PackagingCode_ID(huPackagingCodeId);
 				});
+
+		row.getAsOptionalString(COLUMNNAME_PackageDimensionCalcMethod)
+				.ifPresent(piVersion::setPackageDimensionCalcMethod);
+
+		saveRecord(piVersion);
+
+		if (versionTableToStore != null)
+		{
+			versionTableToStore.putOrReplace(row.getAsIdentifier(), piVersion);
+		}
 	}
 
 	@And("load M_HU_PI_Version:")

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Version_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Version_StepDef.java
@@ -143,8 +143,11 @@ public class M_HU_PI_Version_StepDef
 	{
 		assertThat(lastSaveException)
 				.as("Expected the TU-only guard AdempiereException when saving M_HU_PI_Version, but none was thrown")
-				.isNotNull()
-				.hasMessageContaining("can only be set on Transport Unit");
+				.isNotNull();
+		// Assert the language-independent errorCode (the message text is translated: cucumber runs de_DE).
+		assertThat(lastSaveException.getErrorCode())
+				.as("Expected the TU-only guard error code")
+				.isEqualTo("M_HU_PI_Version_CalcMethodOnlyOnTU");
 	}
 
 	private void buildAndSavePiVersion(

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Version_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Version_StepDef.java
@@ -28,6 +28,7 @@ import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.handlingunits.model.I_M_HU_PI;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
+import de.metas.product.PackageDimensionCalcMethod;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
@@ -141,8 +142,9 @@ public class M_HU_PI_Version_StepDef
 	public void assertLastSaveExceptionWasThrown()
 	{
 		assertThat(lastSaveException)
-				.as("Expected an AdempiereException to be thrown when saving M_HU_PI_Version, but none was thrown")
-				.isNotNull();
+				.as("Expected the TU-only guard AdempiereException when saving M_HU_PI_Version, but none was thrown")
+				.isNotNull()
+				.hasMessageContaining("can only be set on Transport Unit");
 	}
 
 	private void buildAndSavePiVersion(
@@ -184,8 +186,8 @@ public class M_HU_PI_Version_StepDef
 					piVersion.setM_HU_PackagingCode_ID(huPackagingCodeId);
 				});
 
-		row.getAsOptionalString(COLUMNNAME_PackageDimensionCalcMethod)
-				.ifPresent(piVersion::setPackageDimensionCalcMethod);
+		row.getAsOptionalEnum(COLUMNNAME_PackageDimensionCalcMethod, PackageDimensionCalcMethod.class)
+				.ifPresent(calcMethod -> piVersion.setPackageDimensionCalcMethod(calcMethod.getCode()));
 
 		saveRecord(piVersion);
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Version_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_PI_Version_StepDef.java
@@ -32,7 +32,6 @@ import de.metas.product.PackageDimensionCalcMethod;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
-import io.cucumber.java.en.Then;
 import lombok.NonNull;
 import javax.annotation.Nullable;
 import org.adempiere.ad.dao.IQueryBL;
@@ -56,10 +55,6 @@ public class M_HU_PI_Version_StepDef
 	private final M_HU_PI_StepDefData huPiTable;
 	private final M_HU_PI_Version_StepDefData huPiVersionTable;
 	private final M_HU_PackagingCode_StepDefData huPackagingCodeTable;
-
-	/** Captures the last exception thrown by {@link #add_M_HU_PI_Version_expectingError}. */
-	@Nullable
-	private AdempiereException lastSaveException;
 
 	public M_HU_PI_Version_StepDef(
 			@NonNull final M_HU_PI_StepDefData huPiTable,
@@ -99,24 +94,25 @@ public class M_HU_PI_Version_StepDef
 	}
 
 	/**
-	 * Variant of {@link #add_M_HU_PI_Version} that captures the first {@link AdempiereException}
-	 * thrown during save (e.g. when {@code PackageDimensionCalcMethod} is set on a non-TU version)
-	 * instead of propagating it. The captured exception can be asserted via
-	 * {@link #assertLastSaveExceptionWasThrown()}.
+	 * Variant of {@link #add_M_HU_PI_Version} that expects the save to FAIL with a specific error:
+	 * it saves the given rows, catches the {@link AdempiereException} (e.g. when {@code PackageDimensionCalcMethod}
+	 * is set on a non-TU version), and asserts its {@code errorCode} equals the given code. The errorCode is the
+	 * language-independent AD_Message key, so the assertion is stable regardless of the runtime language (cucumber
+	 * runs in de_DE, so the message TEXT is German — the key/errorCode is not).
 	 *
 	 * @cucumber.stepdef
+	 * @cucumber.columns Same columns as {@link #add_M_HU_PI_Version}.
 	 * @cucumber.example
 	 * <pre>
-	 * When metasfresh contains M_HU_PI_Version expecting error:
+	 * When metasfresh contains M_HU_PI_Version expecting error "M_HU_PI_Version_CalcMethodOnlyOnTU":
 	 *   | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType | PackageDimensionCalcMethod |
 	 *   | luVersion          | luPi       | LU          | S                          |
-	 * Then an AdempiereException was thrown when saving the M_HU_PI_Version
 	 * </pre>
 	 */
-	@And("metasfresh contains M_HU_PI_Version expecting error:")
-	public void add_M_HU_PI_Version_expectingError(@NonNull final DataTable dataTable)
+	@And("metasfresh contains M_HU_PI_Version expecting error {string}:")
+	public void add_M_HU_PI_Version_expectingError(@NonNull final String expectedErrorCode, @NonNull final DataTable dataTable)
 	{
-		lastSaveException = null;
+		AdempiereException caughtException = null;
 		try
 		{
 			DataTableRows.of(dataTable)
@@ -125,29 +121,15 @@ public class M_HU_PI_Version_StepDef
 		}
 		catch (final AdempiereException e)
 		{
-			lastSaveException = e;
+			caughtException = e;
 		}
-	}
 
-	/**
-	 * Asserts that the most recent {@link #add_M_HU_PI_Version_expectingError} step did throw an {@link AdempiereException}.
-	 *
-	 * @cucumber.stepdef
-	 * @cucumber.example
-	 * <pre>
-	 * Then an AdempiereException was thrown when saving the M_HU_PI_Version
-	 * </pre>
-	 */
-	@Then("an AdempiereException was thrown when saving the M_HU_PI_Version")
-	public void assertLastSaveExceptionWasThrown()
-	{
-		assertThat(lastSaveException)
-				.as("Expected the TU-only guard AdempiereException when saving M_HU_PI_Version, but none was thrown")
+		assertThat(caughtException)
+				.as("Expected the save to fail with errorCode %s, but no AdempiereException was thrown", expectedErrorCode)
 				.isNotNull();
-		// Assert the language-independent errorCode (the message text is translated: cucumber runs de_DE).
-		assertThat(lastSaveException.getErrorCode())
-				.as("Expected the TU-only guard error code")
-				.isEqualTo("M_HU_PI_Version_CalcMethodOnlyOnTU");
+		assertThat(caughtException.getErrorCode())
+				.as("Expected the guard error code")
+				.isEqualTo(expectedErrorCode);
 	}
 
 	private void buildAndSavePiVersion(

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipper/HUPackage_DimensionCalculation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipper/HUPackage_DimensionCalculation.feature
@@ -119,9 +119,9 @@ Feature: HU Package Dimension Calculation
       | so_strapping_l_b  | so_strapping  | dimcalc_prod_b | 2          |
     When the order identified by so_strapping is completed
     And after not more than 60s, M_ShipmentSchedules are found:
-      | Identifier    | C_OrderLine_ID   | IsToRecompute |
-      | ss_strapping_a | so_strapping_l_a | N             |
-      | ss_strapping_b | so_strapping_l_b | N             |
+      | Identifier     | C_OrderLine_ID   | IsToRecompute | Carrier_Product_ID | Carrier_Goods_Type_ID |
+      | ss_strapping_a | so_strapping_l_a | N             | dimcalc_cp1        | dimcalc_cgt1          |
+      | ss_strapping_b | so_strapping_l_b | N             | dimcalc_cp1        | dimcalc_cgt1          |
     When create M_PickingCandidate for M_HU
       | M_HU_ID      | M_ShipmentSchedule_ID | QtyPicked | Status | PickStatus | ApprovalStatus |
       | tu_strapping | ss_strapping_a        | 3         | IP     | P          | ?              |
@@ -180,9 +180,9 @@ Feature: HU Package Dimension Calculation
       | so_repacking_l_b | so_repacking | dimcalc_prod_b | 2          |
     When the order identified by so_repacking is completed
     And after not more than 60s, M_ShipmentSchedules are found:
-      | Identifier     | C_OrderLine_ID   | IsToRecompute |
-      | ss_repacking_a | so_repacking_l_a | N             |
-      | ss_repacking_b | so_repacking_l_b | N             |
+      | Identifier     | C_OrderLine_ID   | IsToRecompute | Carrier_Product_ID | Carrier_Goods_Type_ID |
+      | ss_repacking_a | so_repacking_l_a | N             | dimcalc_cp1        | dimcalc_cgt1          |
+      | ss_repacking_b | so_repacking_l_b | N             | dimcalc_cp1        | dimcalc_cgt1          |
     When create M_PickingCandidate for M_HU
       | M_HU_ID      | M_ShipmentSchedule_ID | QtyPicked | Status | PickStatus | ApprovalStatus |
       | tu_repacking | ss_repacking_a        | 3         | IP     | P          | ?              |
@@ -238,9 +238,9 @@ Feature: HU Package Dimension Calculation
       | so_nesting_l_b | so_nesting | dimcalc_prod_b | 2          |
     When the order identified by so_nesting is completed
     And after not more than 60s, M_ShipmentSchedules are found:
-      | Identifier   | C_OrderLine_ID | IsToRecompute |
-      | ss_nesting_a | so_nesting_l_a | N             |
-      | ss_nesting_b | so_nesting_l_b | N             |
+      | Identifier   | C_OrderLine_ID | IsToRecompute | Carrier_Product_ID | Carrier_Goods_Type_ID |
+      | ss_nesting_a | so_nesting_l_a | N             | dimcalc_cp1        | dimcalc_cgt1          |
+      | ss_nesting_b | so_nesting_l_b | N             | dimcalc_cp1        | dimcalc_cgt1          |
     When create M_PickingCandidate for M_HU
       | M_HU_ID    | M_ShipmentSchedule_ID | QtyPicked | Status | PickStatus | ApprovalStatus |
       | tu_nesting | ss_nesting_a          | 3         | IP     | P          | ?              |
@@ -270,52 +270,3 @@ Feature: HU Package Dimension Calculation
       | M_HU_PI_Version_ID | M_HU_PI_ID    | HU_UnitType | IsCurrent | PackageDimensionCalcMethod |
       | dimcalc_LU_Version | dimcalc_LU_PI | LU          | Y         | S                          |
     Then an AdempiereException was thrown when saving the M_HU_PI_Version
-
-  @Id:S30361_TC5
-  Scenario: Non-self-packed single-product TU — product dims contribute regardless of IsSelfPacked
-    # IsSelfPacked=N does not block dimension contribution for a single-product TU.
-    # Product A: L=30, W=20, H=10, qty=3 → ofProductDimensionsAndQty: sorted [10,20,30], stacking=10×3=30
-    # → LengthInCm=30, HeightInCm=20, WidthInCm=30
-    # (No calc method set — the single-product path in HUPackageBL uses ofProductDimensionsAndQty directly.)
-    And metasfresh contains M_Inventories:
-      | M_Inventory_ID  | MovementDate | M_Warehouse_ID |
-      | inv_selfpacked_a | 2022-12-12   | dimcalc_wh     |
-    And metasfresh contains M_InventoriesLines:
-      | Identifier          | M_Inventory_ID   | M_Product_ID   | QtyBook | QtyCount | UOM.X12DE355 |
-      | inv_selfpacked_l_a  | inv_selfpacked_a | dimcalc_prod_a | 0       | 3        | PCE          |
-    When the inventory identified by inv_selfpacked_a is completed
-    And after not more than 60s, there are added M_HUs for inventory
-      | M_InventoryLine_ID   | M_HU_ID             |
-      | inv_selfpacked_l_a   | cu_selfpacked_a     |
-    And transform CU to new TUs
-      | sourceCU          | cuQty | M_HU_PI_Item_Product_ID | resultedNewTUs   |
-      | cu_selfpacked_a   | 3     | dimcalc_piip_a          | tu_selfpacked    |
-    And metasfresh contains C_Orders:
-      | Identifier       | IsSOTrx | C_BPartner_ID    | DateOrdered | M_Warehouse_ID | M_Shipper_ID | AD_User_ID          |
-      | so_selfpacked    | true    | dimcalc_customer | 2022-12-12  | dimcalc_wh     | dimcalc_ship | dimcalc_custContact |
-    And metasfresh contains C_OrderLines:
-      | Identifier        | C_Order_ID    | M_Product_ID   | QtyEntered |
-      | so_selfpacked_l_a | so_selfpacked | dimcalc_prod_a | 3          |
-    When the order identified by so_selfpacked is completed
-    And after not more than 60s, M_ShipmentSchedules are found:
-      | Identifier      | C_OrderLine_ID    | IsToRecompute |
-      | ss_selfpacked_a | so_selfpacked_l_a | N             |
-    When create M_PickingCandidate for M_HU
-      | M_HU_ID       | M_ShipmentSchedule_ID | QtyPicked | Status | PickStatus | ApprovalStatus |
-      | tu_selfpacked | ss_selfpacked_a       | 3         | IP     | P          | ?              |
-    And process picking
-      | M_HU_ID       | M_ShipmentSchedule_ID |
-      | tu_selfpacked | ss_selfpacked_a       |
-    And shipment is generated for the following shipment schedule
-      | M_ShipmentSchedule_ID | M_InOut_ID        |
-      | ss_selfpacked_a       | inout_selfpacked  |
-    And after not more than 60s, Transportation Order is found for Shipment:
-      | M_InOut_ID        | M_ShipperTransportation_ID   |
-      | inout_selfpacked  | transpOrder_selfpacked       |
-    And after not more than 60s, Carrier_ShipmentOrder is found:
-      | Identifier        | M_InOut_ID        |
-      | cso_selfpacked    | inout_selfpacked  |
-    # Non-self-packed product A, qty=3: L=30, H=20, W=30
-    And validate M_Packages for shipment inout_selfpacked
-      | LengthInCm | HeightInCm | WidthInCm |
-      | 30         | 20         | 30        |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipper/HUPackage_DimensionCalculation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipper/HUPackage_DimensionCalculation.feature
@@ -266,7 +266,6 @@ Feature: HU Package Dimension Calculation
   Scenario: LU version guard — PackageDimensionCalcMethod is rejected on non-TU versions
     # The M_HU_PI_Version interceptor throws an AdempiereException when the calc method
     # is set on an LU version. Only TU versions may carry a PackageDimensionCalcMethod.
-    When metasfresh contains M_HU_PI_Version expecting error:
+    Then metasfresh contains M_HU_PI_Version expecting error "M_HU_PI_Version_CalcMethodOnlyOnTU":
       | M_HU_PI_Version_ID | M_HU_PI_ID    | HU_UnitType | IsCurrent | PackageDimensionCalcMethod |
       | dimcalc_LU_Version | dimcalc_LU_PI | LU          | Y         | S                          |
-    Then an AdempiereException was thrown when saving the M_HU_PI_Version

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipper/HUPackage_DimensionCalculation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipper/HUPackage_DimensionCalculation.feature
@@ -1,0 +1,321 @@
+@from:cucumber
+@allure.label.epic:E0360_Transport_Extralogistik
+@allure.label.feature:F29100_Dimension_Calculation
+@ghActions:run_on_executor4
+Feature: HU Package Dimension Calculation
+  Verifies that the PackageDimensionCalcMethod on a TU PI version drives the correct M_Package
+  dimensions for multi-product TUs (Strapping, Repacking, Nesting), that setting the method on an
+  LU version is rejected, and that a non-self-packed single-product TU still uses product dims.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And metasfresh has date and time 2022-12-12T12:12:12+01:00[Europe/Berlin]
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value true for sys config de.metas.handlingunits.picking.addToDailyShipperTransportationOrder
+    And set sys config boolean value false for sys config de.metas.shipper.gateway.printLabels.enabled
+    # nShift shipper with carrier mapping so the advisory + shipment flows can run
+    And contains M_Shippers
+      | Identifier   | Value                  | Name                   | OPT.ShipperGateway |
+      | dimcalc_ship | dimcalc_nshift_shipper | DimCalc nShift Shipper | nshift             |
+    And metasfresh contains Carrier_Configs:
+      | M_Shipper_ID |
+      | dimcalc_ship |
+    And metasfresh contains Carrier_Products:
+      | Identifier   | M_Shipper_ID |
+      | dimcalc_cp1  | dimcalc_ship |
+    And metasfresh contains Carrier_Goods_Types:
+      | Identifier   | M_Shipper_ID |
+      | dimcalc_cgt1 | dimcalc_ship |
+    And the nShift ship advisor service is stubbed to return a successful response based on the request
+      | Carrier_Product_ID | Carrier_Goods_Type_ID |
+      | dimcalc_cp1        | dimcalc_cgt1          |
+    And the nShift shipment service is stubbed to return a successful shipment creation response
+    # Product A: L=30, W=20, H=10 — explicit Value/Name so reruns reuse the same product record
+    # Product B: L=25, W=15, H=12
+    # Both are IsSelfPacked=N — IsSelfPacked does not gate dimension contribution.
+    And metasfresh contains M_Products:
+      | Identifier      | Value                  | Name                   | WeightNet | WeightGross | LengthInCm | WidthInCm | HeightInCm | IsSelfPacked |
+      | dimcalc_prod_a  | dimcalc_product_a      | DimCalc Product A      | 0.5 KGM   | 0.5 KGM     | 30         | 20        | 10         | N            |
+      | dimcalc_prod_b  | dimcalc_product_b      | DimCalc Product B      | 0.3 KGM   | 0.3 KGM     | 25         | 15        | 12         | N            |
+    And metasfresh contains M_PricingSystems
+      | Identifier  |
+      | dimcalc_ps  |
+    And metasfresh contains M_PriceLists
+      | Identifier  | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | dimcalc_pl  | dimcalc_ps         | CH           | CHF           | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier  | M_PriceList_ID |
+      | dimcalc_plv | dimcalc_pl     |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID    | PriceStd | C_UOM_ID |
+      | dimcalc_plv            | dimcalc_prod_a  | 5.0      | PCE      |
+      | dimcalc_plv            | dimcalc_prod_b  | 3.0      | PCE      |
+    # BPartner with location — needed for M_Package C_BPartner_ID / C_BPartner_Location_ID
+    And metasfresh contains C_BPartners without locations:
+      | Identifier       | Value              | Name               | IsVendor | IsCustomer | M_PricingSystem_ID |
+      | dimcalc_customer | dimcalc_customer   | DimCalc Customer   | N        | Y          | dimcalc_ps         |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier            | C_BPartner_ID    | C_Country_ID | IsShipToDefault | IsBillToDefault | Postal | City | Address1 |
+      | dimcalc_custLocation  | dimcalc_customer | CH           | Y               | Y               | 99001  | city | street 1 |
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID |
+      | dimcalc_wh     |
+    # TU PI with NO packing material item: getPackageDimensions skips the packing-material branch
+    # and enters the product-based branch, enabling the calc-method dispatch.
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID    |
+      | dimcalc_TU_PI |
+      | dimcalc_LU_PI |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID     | M_HU_PI_ID    | HU_UnitType | IsCurrent |
+      | dimcalc_TU_Version     | dimcalc_TU_PI | TU          | Y         |
+      | dimcalc_LU_Version     | dimcalc_LU_PI | LU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID    | M_HU_PI_Version_ID | Qty | ItemType |
+      | dimcalc_TU_MI_Item | dimcalc_TU_Version |     | MI       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID | M_HU_PI_Item_ID    | M_Product_ID    | Qty | ValidFrom  |
+      | dimcalc_piip_a          | dimcalc_TU_MI_Item | dimcalc_prod_a  | 100 | 2021-01-01 |
+      | dimcalc_piip_b          | dimcalc_TU_MI_Item | dimcalc_prod_b  | 100 | 2021-01-01 |
+    And metasfresh contains AD_Users:
+      | Identifier             | Name                    | C_BPartner_ID    | EMail                          |
+      | dimcalc_custContact    | DimCalc Customer Contact | dimcalc_customer | dimcalc.contact@test.example  |
+
+  @Id:S30361_TC1
+  Scenario: Strapping mode — mixed TU dimensions are stacked along the smallest edge
+    # Strapping: stacking axis = Σ(min_edge × qty); other two = max across products.
+    # Product A (30×20×10): sorted [10,20,30], qty=3 → stacking += 10×3=30; mid=20; max=30
+    # Product B (25×15×12): sorted [12,15,25], qty=2 → stacking += 12×2=24; mid=max(20,15)=20; max=max(30,25)=30
+    # → LengthInCm=54, HeightInCm=20, WidthInCm=30
+    Given metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID    | HU_UnitType | IsCurrent | PackageDimensionCalcMethod |
+      | dimcalc_TU_Version | dimcalc_TU_PI | TU          | Y         | S                          |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID  | MovementDate | M_Warehouse_ID |
+      | inv_strapping_a | 2022-12-12   | dimcalc_wh     |
+    And metasfresh contains M_InventoriesLines:
+      | Identifier      | M_Inventory_ID  | M_Product_ID   | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_strapping_l_a | inv_strapping_a | dimcalc_prod_a | 0       | 3        | PCE          |
+      | inv_strapping_l_b | inv_strapping_a | dimcalc_prod_b | 0       | 2        | PCE          |
+    When the inventory identified by inv_strapping_a is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID  | M_HU_ID              |
+      | inv_strapping_l_a   | cu_strapping_a       |
+      | inv_strapping_l_b   | cu_strapping_b       |
+    # Pack product A into a new TU, then move product B CU into the same TU → multi-product TU
+    And transform CU to new TUs
+      | sourceCU         | cuQty | M_HU_PI_Item_Product_ID | resultedNewTUs  |
+      | cu_strapping_a   | 3     | dimcalc_piip_a          | tu_strapping    |
+    And move CU to existing TU
+      | sourceCU       | targetTU     | qty |
+      | cu_strapping_b | tu_strapping | 2   |
+    And metasfresh contains C_Orders:
+      | Identifier        | IsSOTrx | C_BPartner_ID    | DateOrdered | M_Warehouse_ID | M_Shipper_ID | AD_User_ID          |
+      | so_strapping      | true    | dimcalc_customer | 2022-12-12  | dimcalc_wh     | dimcalc_ship | dimcalc_custContact |
+    And metasfresh contains C_OrderLines:
+      | Identifier        | C_Order_ID    | M_Product_ID   | QtyEntered |
+      | so_strapping_l_a  | so_strapping  | dimcalc_prod_a | 3          |
+      | so_strapping_l_b  | so_strapping  | dimcalc_prod_b | 2          |
+    When the order identified by so_strapping is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier    | C_OrderLine_ID   | IsToRecompute |
+      | ss_strapping_a | so_strapping_l_a | N             |
+      | ss_strapping_b | so_strapping_l_b | N             |
+    When create M_PickingCandidate for M_HU
+      | M_HU_ID      | M_ShipmentSchedule_ID | QtyPicked | Status | PickStatus | ApprovalStatus |
+      | tu_strapping | ss_strapping_a        | 3         | IP     | P          | ?              |
+      | tu_strapping | ss_strapping_b        | 2         | IP     | P          | ?              |
+    And process picking
+      | M_HU_ID      | M_ShipmentSchedule_ID            |
+      | tu_strapping | ss_strapping_a, ss_strapping_b   |
+    And shipment is generated for the following shipment schedule
+      | M_ShipmentSchedule_ID            | M_InOut_ID        |
+      | ss_strapping_a, ss_strapping_b   | inout_strapping   |
+    And after not more than 60s, Transportation Order is found for Shipment:
+      | M_InOut_ID      | M_ShipperTransportation_ID |
+      | inout_strapping | transpOrder_strapping      |
+    And after not more than 60s, Carrier_ShipmentOrder is found:
+      | Identifier        | M_InOut_ID      |
+      | cso_strapping     | inout_strapping |
+    # Strapping: L=54, H=20, W=30
+    And validate M_Packages for shipment inout_strapping
+      | LengthInCm | HeightInCm | WidthInCm |
+      | 54         | 20         | 30        |
+
+  @Id:S30361_TC2
+  Scenario: Repacking mode — mixed TU dims derived from total volume
+    # Repacking: V = Σ(L×W×H×qty) × 1.05; height=⅔×∛V; width=⅗×√(V/height); length=(V/height)/width
+    # rawVolume = 30×20×10×3 + 25×15×12×2 = 18000+9000 = 27000; V = 28350
+    # height = round(2/3 × ∛28350) = round(20.33) = 20
+    # width  = round(3/5 × √(28350/20)) = round(22.59) = 23
+    # length = round((28350/20)/23) = round(61.63) = 62
+    Given metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID    | HU_UnitType | IsCurrent | PackageDimensionCalcMethod |
+      | dimcalc_TU_Version | dimcalc_TU_PI | TU          | Y         | R                          |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID   | MovementDate | M_Warehouse_ID |
+      | inv_repacking_a  | 2022-12-12   | dimcalc_wh     |
+    And metasfresh contains M_InventoriesLines:
+      | Identifier        | M_Inventory_ID  | M_Product_ID   | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_repacking_l_a | inv_repacking_a | dimcalc_prod_a | 0       | 3        | PCE          |
+      | inv_repacking_l_b | inv_repacking_a | dimcalc_prod_b | 0       | 2        | PCE          |
+    When the inventory identified by inv_repacking_a is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID  | M_HU_ID              |
+      | inv_repacking_l_a   | cu_repacking_a       |
+      | inv_repacking_l_b   | cu_repacking_b       |
+    And transform CU to new TUs
+      | sourceCU         | cuQty | M_HU_PI_Item_Product_ID | resultedNewTUs |
+      | cu_repacking_a   | 3     | dimcalc_piip_a          | tu_repacking   |
+    And move CU to existing TU
+      | sourceCU       | targetTU     | qty |
+      | cu_repacking_b | tu_repacking | 2   |
+    And metasfresh contains C_Orders:
+      | Identifier       | IsSOTrx | C_BPartner_ID    | DateOrdered | M_Warehouse_ID | M_Shipper_ID | AD_User_ID          |
+      | so_repacking     | true    | dimcalc_customer | 2022-12-12  | dimcalc_wh     | dimcalc_ship | dimcalc_custContact |
+    And metasfresh contains C_OrderLines:
+      | Identifier       | C_Order_ID   | M_Product_ID   | QtyEntered |
+      | so_repacking_l_a | so_repacking | dimcalc_prod_a | 3          |
+      | so_repacking_l_b | so_repacking | dimcalc_prod_b | 2          |
+    When the order identified by so_repacking is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier     | C_OrderLine_ID   | IsToRecompute |
+      | ss_repacking_a | so_repacking_l_a | N             |
+      | ss_repacking_b | so_repacking_l_b | N             |
+    When create M_PickingCandidate for M_HU
+      | M_HU_ID      | M_ShipmentSchedule_ID | QtyPicked | Status | PickStatus | ApprovalStatus |
+      | tu_repacking | ss_repacking_a        | 3         | IP     | P          | ?              |
+      | tu_repacking | ss_repacking_b        | 2         | IP     | P          | ?              |
+    And process picking
+      | M_HU_ID      | M_ShipmentSchedule_ID             |
+      | tu_repacking | ss_repacking_a, ss_repacking_b    |
+    And shipment is generated for the following shipment schedule
+      | M_ShipmentSchedule_ID             | M_InOut_ID       |
+      | ss_repacking_a, ss_repacking_b    | inout_repacking  |
+    And after not more than 60s, Transportation Order is found for Shipment:
+      | M_InOut_ID      | M_ShipperTransportation_ID |
+      | inout_repacking | transpOrder_repacking      |
+    And after not more than 60s, Carrier_ShipmentOrder is found:
+      | Identifier      | M_InOut_ID      |
+      | cso_repacking   | inout_repacking |
+    # Repacking: L=62, H=20, W=23
+    And validate M_Packages for shipment inout_repacking
+      | LengthInCm | HeightInCm | WidthInCm |
+      | 62         | 20         | 23        |
+
+  @Id:S30361_TC3
+  Scenario: Nesting mode — TU takes the dimensions of the item with the largest single edge
+    # Nesting: winner = item whose max edge is greatest; dims returned verbatim (qty ignored).
+    # Product A max edge=30, Product B max edge=25 → Product A wins → L=30, H=10, W=20
+    Given metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID    | HU_UnitType | IsCurrent | PackageDimensionCalcMethod |
+      | dimcalc_TU_Version | dimcalc_TU_PI | TU          | Y         | N                          |
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID | MovementDate | M_Warehouse_ID |
+      | inv_nesting_a  | 2022-12-12   | dimcalc_wh     |
+    And metasfresh contains M_InventoriesLines:
+      | Identifier      | M_Inventory_ID | M_Product_ID   | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_nesting_l_a | inv_nesting_a  | dimcalc_prod_a | 0       | 3        | PCE          |
+      | inv_nesting_l_b | inv_nesting_a  | dimcalc_prod_b | 0       | 2        | PCE          |
+    When the inventory identified by inv_nesting_a is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID | M_HU_ID          |
+      | inv_nesting_l_a    | cu_nesting_a     |
+      | inv_nesting_l_b    | cu_nesting_b     |
+    And transform CU to new TUs
+      | sourceCU       | cuQty | M_HU_PI_Item_Product_ID | resultedNewTUs |
+      | cu_nesting_a   | 3     | dimcalc_piip_a          | tu_nesting     |
+    And move CU to existing TU
+      | sourceCU     | targetTU   | qty |
+      | cu_nesting_b | tu_nesting | 2   |
+    And metasfresh contains C_Orders:
+      | Identifier     | IsSOTrx | C_BPartner_ID    | DateOrdered | M_Warehouse_ID | M_Shipper_ID | AD_User_ID          |
+      | so_nesting     | true    | dimcalc_customer | 2022-12-12  | dimcalc_wh     | dimcalc_ship | dimcalc_custContact |
+    And metasfresh contains C_OrderLines:
+      | Identifier     | C_Order_ID | M_Product_ID   | QtyEntered |
+      | so_nesting_l_a | so_nesting | dimcalc_prod_a | 3          |
+      | so_nesting_l_b | so_nesting | dimcalc_prod_b | 2          |
+    When the order identified by so_nesting is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier   | C_OrderLine_ID | IsToRecompute |
+      | ss_nesting_a | so_nesting_l_a | N             |
+      | ss_nesting_b | so_nesting_l_b | N             |
+    When create M_PickingCandidate for M_HU
+      | M_HU_ID    | M_ShipmentSchedule_ID | QtyPicked | Status | PickStatus | ApprovalStatus |
+      | tu_nesting | ss_nesting_a          | 3         | IP     | P          | ?              |
+      | tu_nesting | ss_nesting_b          | 2         | IP     | P          | ?              |
+    And process picking
+      | M_HU_ID    | M_ShipmentSchedule_ID        |
+      | tu_nesting | ss_nesting_a, ss_nesting_b   |
+    And shipment is generated for the following shipment schedule
+      | M_ShipmentSchedule_ID        | M_InOut_ID     |
+      | ss_nesting_a, ss_nesting_b   | inout_nesting  |
+    And after not more than 60s, Transportation Order is found for Shipment:
+      | M_InOut_ID    | M_ShipperTransportation_ID |
+      | inout_nesting | transpOrder_nesting        |
+    And after not more than 60s, Carrier_ShipmentOrder is found:
+      | Identifier    | M_InOut_ID    |
+      | cso_nesting   | inout_nesting |
+    # Nesting: Product A wins (max edge 30 > 25); dims returned verbatim: L=30, H=10, W=20
+    And validate M_Packages for shipment inout_nesting
+      | LengthInCm | HeightInCm | WidthInCm |
+      | 30         | 10         | 20        |
+
+  @Id:S30361_TC4
+  Scenario: LU version guard — PackageDimensionCalcMethod is rejected on non-TU versions
+    # The M_HU_PI_Version interceptor throws an AdempiereException when the calc method
+    # is set on an LU version. Only TU versions may carry a PackageDimensionCalcMethod.
+    When metasfresh contains M_HU_PI_Version expecting error:
+      | M_HU_PI_Version_ID | M_HU_PI_ID    | HU_UnitType | IsCurrent | PackageDimensionCalcMethod |
+      | dimcalc_LU_Version | dimcalc_LU_PI | LU          | Y         | S                          |
+    Then an AdempiereException was thrown when saving the M_HU_PI_Version
+
+  @Id:S30361_TC5
+  Scenario: Non-self-packed single-product TU — product dims contribute regardless of IsSelfPacked
+    # IsSelfPacked=N does not block dimension contribution for a single-product TU.
+    # Product A: L=30, W=20, H=10, qty=3 → ofProductDimensionsAndQty: sorted [10,20,30], stacking=10×3=30
+    # → LengthInCm=30, HeightInCm=20, WidthInCm=30
+    # (No calc method set — the single-product path in HUPackageBL uses ofProductDimensionsAndQty directly.)
+    And metasfresh contains M_Inventories:
+      | M_Inventory_ID  | MovementDate | M_Warehouse_ID |
+      | inv_selfpacked_a | 2022-12-12   | dimcalc_wh     |
+    And metasfresh contains M_InventoriesLines:
+      | Identifier          | M_Inventory_ID   | M_Product_ID   | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_selfpacked_l_a  | inv_selfpacked_a | dimcalc_prod_a | 0       | 3        | PCE          |
+    When the inventory identified by inv_selfpacked_a is completed
+    And after not more than 60s, there are added M_HUs for inventory
+      | M_InventoryLine_ID   | M_HU_ID             |
+      | inv_selfpacked_l_a   | cu_selfpacked_a     |
+    And transform CU to new TUs
+      | sourceCU          | cuQty | M_HU_PI_Item_Product_ID | resultedNewTUs   |
+      | cu_selfpacked_a   | 3     | dimcalc_piip_a          | tu_selfpacked    |
+    And metasfresh contains C_Orders:
+      | Identifier       | IsSOTrx | C_BPartner_ID    | DateOrdered | M_Warehouse_ID | M_Shipper_ID | AD_User_ID          |
+      | so_selfpacked    | true    | dimcalc_customer | 2022-12-12  | dimcalc_wh     | dimcalc_ship | dimcalc_custContact |
+    And metasfresh contains C_OrderLines:
+      | Identifier        | C_Order_ID    | M_Product_ID   | QtyEntered |
+      | so_selfpacked_l_a | so_selfpacked | dimcalc_prod_a | 3          |
+    When the order identified by so_selfpacked is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier      | C_OrderLine_ID    | IsToRecompute |
+      | ss_selfpacked_a | so_selfpacked_l_a | N             |
+    When create M_PickingCandidate for M_HU
+      | M_HU_ID       | M_ShipmentSchedule_ID | QtyPicked | Status | PickStatus | ApprovalStatus |
+      | tu_selfpacked | ss_selfpacked_a       | 3         | IP     | P          | ?              |
+    And process picking
+      | M_HU_ID       | M_ShipmentSchedule_ID |
+      | tu_selfpacked | ss_selfpacked_a       |
+    And shipment is generated for the following shipment schedule
+      | M_ShipmentSchedule_ID | M_InOut_ID        |
+      | ss_selfpacked_a       | inout_selfpacked  |
+    And after not more than 60s, Transportation Order is found for Shipment:
+      | M_InOut_ID        | M_ShipperTransportation_ID   |
+      | inout_selfpacked  | transpOrder_selfpacked       |
+    And after not more than 60s, Carrier_ShipmentOrder is found:
+      | Identifier        | M_InOut_ID        |
+      | cso_selfpacked    | inout_selfpacked  |
+    # Non-self-packed product A, qty=3: L=30, H=20, W=30
+    And validate M_Packages for shipment inout_selfpacked
+      | LengthInCm | HeightInCm | WidthInCm |
+      | 30         | 20         | 30        |

--- a/backend/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/I_M_HU_PI_Version.java
+++ b/backend/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/I_M_HU_PI_Version.java
@@ -254,6 +254,27 @@ public interface I_M_HU_PI_Version
 	String COLUMNNAME_Name = "Name";
 
 	/**
+	 * Set Calc Method.
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setPackageDimensionCalcMethod (@Nullable java.lang.String PackageDimensionCalcMethod);
+
+	/**
+	 * Get Calc Method.
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	@Nullable java.lang.String getPackageDimensionCalcMethod();
+
+	ModelColumn<I_M_HU_PI_Version, Object> COLUMN_PackageDimensionCalcMethod = new ModelColumn<>(I_M_HU_PI_Version.class, "PackageDimensionCalcMethod", null);
+	String COLUMNNAME_PackageDimensionCalcMethod = "PackageDimensionCalcMethod";
+
+	/**
 	 * Get Updated.
 	 * Date this record was updated
 	 *

--- a/backend/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PI_Version.java
+++ b/backend/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PI_Version.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class X_M_HU_PI_Version extends org.compiere.model.PO implements I_M_HU_PI_Version, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = -1616061275L;
+	private static final long serialVersionUID = -354333785L;
 
     /** Standard Constructor */
     public X_M_HU_PI_Version (final Properties ctx, final int M_HU_PI_Version_ID, @Nullable final String trxName)
@@ -167,12 +167,12 @@ public class X_M_HU_PI_Version extends org.compiere.model.PO implements I_M_HU_P
 	 * Reference name: PackageDimensionCalcMethod
 	 */
 	public static final int PACKAGEDIMENSIONCALCMETHOD_AD_Reference_ID=542122;
-	/** S = S */
-	public static final String PACKAGEDIMENSIONCALCMETHOD_S = "S";
-	/** R = R */
-	public static final String PACKAGEDIMENSIONCALCMETHOD_R = "R";
-	/** N = N */
-	public static final String PACKAGEDIMENSIONCALCMETHOD_N = "N";
+	/** Strapping = S */
+	public static final String PACKAGEDIMENSIONCALCMETHOD_Strapping = "S";
+	/** Repacking = R */
+	public static final String PACKAGEDIMENSIONCALCMETHOD_Repacking = "R";
+	/** Nesting = N */
+	public static final String PACKAGEDIMENSIONCALCMETHOD_Nesting = "N";
 	@Override
 	public void setPackageDimensionCalcMethod (final @Nullable java.lang.String PackageDimensionCalcMethod)
 	{

--- a/backend/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PI_Version.java
+++ b/backend/de.metas.handlingunits.base/src/main/java-gen/de/metas/handlingunits/model/X_M_HU_PI_Version.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class X_M_HU_PI_Version extends org.compiere.model.PO implements I_M_HU_PI_Version, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 960875732L;
+	private static final long serialVersionUID = -1616061275L;
 
     /** Standard Constructor */
     public X_M_HU_PI_Version (final Properties ctx, final int M_HU_PI_Version_ID, @Nullable final String trxName)
@@ -160,5 +160,28 @@ public class X_M_HU_PI_Version extends org.compiere.model.PO implements I_M_HU_P
 	public java.lang.String getName() 
 	{
 		return get_ValueAsString(COLUMNNAME_Name);
+	}
+
+	/** 
+	 * PackageDimensionCalcMethod AD_Reference_ID=542122
+	 * Reference name: PackageDimensionCalcMethod
+	 */
+	public static final int PACKAGEDIMENSIONCALCMETHOD_AD_Reference_ID=542122;
+	/** S = S */
+	public static final String PACKAGEDIMENSIONCALCMETHOD_S = "S";
+	/** R = R */
+	public static final String PACKAGEDIMENSIONCALCMETHOD_R = "R";
+	/** N = N */
+	public static final String PACKAGEDIMENSIONCALCMETHOD_N = "N";
+	@Override
+	public void setPackageDimensionCalcMethod (final @Nullable java.lang.String PackageDimensionCalcMethod)
+	{
+		set_Value (COLUMNNAME_PackageDimensionCalcMethod, PackageDimensionCalcMethod);
+	}
+
+	@Override
+	public java.lang.String getPackageDimensionCalcMethod() 
+	{
+		return get_ValueAsString(COLUMNNAME_PackageDimensionCalcMethod);
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_HU_PI_Version.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_HU_PI_Version.java
@@ -38,12 +38,15 @@ import de.metas.handlingunits.IHandlingUnitsDAO;
 import de.metas.handlingunits.attribute.IHUPIAttributesDAO;
 import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
+import de.metas.i18n.AdMessageKey;
 import de.metas.product.PackageDimensionCalcMethod;
 import de.metas.util.Services;
 
 @Validator(I_M_HU_PI_Version.class)
 public class M_HU_PI_Version
 {
+	private static final AdMessageKey MSG_CALC_METHOD_ONLY_ON_TU = AdMessageKey.of("M_HU_PI_Version_CalcMethodOnlyOnTU");
+
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE }, ifColumnsChanged = { I_M_HU_PI_Version.COLUMNNAME_PackageDimensionCalcMethod, I_M_HU_PI_Version.COLUMNNAME_HU_UnitType })
 	public void rejectCalcMethodOnNonTUVersions(@NonNull final I_M_HU_PI_Version piVersion)
 	{
@@ -55,12 +58,10 @@ public class M_HU_PI_Version
 		final HuUnitType huUnitType = HuUnitType.ofNullableCode(piVersion.getHU_UnitType());
 		if (huUnitType == null || !huUnitType.isTU())
 		{
-			throw new AdempiereException("PackageDimensionCalcMethod can only be set on Transport Unit (TU) packing instruction versions")
-					.appendParametersToMessage()
+			throw new AdempiereException(MSG_CALC_METHOD_ONLY_ON_TU)
 					.setParameter("HU_UnitType", huUnitType)
 					.setParameter("PackageDimensionCalcMethod", calcMethod)
-					.setParameter("M_HU_PI_Version_ID", piVersion.getM_HU_PI_Version_ID())
-					.markAsUserValidationError();
+					.setParameter("M_HU_PI_Version_ID", piVersion.getM_HU_PI_Version_ID());
 		}
 	}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_HU_PI_Version.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/model/validator/M_HU_PI_Version.java
@@ -24,23 +24,48 @@ package de.metas.handlingunits.model.validator;
 
 import java.util.List;
 
+import lombok.NonNull;
+
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.ad.modelvalidator.annotations.Validator;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.ModelValidator;
 
 import de.metas.handlingunits.HuPackingInstructionsVersionId;
+import de.metas.handlingunits.HuUnitType;
 import de.metas.handlingunits.IHandlingUnitsDAO;
 import de.metas.handlingunits.attribute.IHUPIAttributesDAO;
 import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
+import de.metas.product.PackageDimensionCalcMethod;
 import de.metas.util.Services;
 
 @Validator(I_M_HU_PI_Version.class)
 public class M_HU_PI_Version
 {
+	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE }, ifColumnsChanged = { I_M_HU_PI_Version.COLUMNNAME_PackageDimensionCalcMethod, I_M_HU_PI_Version.COLUMNNAME_HU_UnitType })
+	public void rejectCalcMethodOnNonTUVersions(@NonNull final I_M_HU_PI_Version piVersion)
+	{
+		final PackageDimensionCalcMethod calcMethod = PackageDimensionCalcMethod.ofNullableCode(piVersion.getPackageDimensionCalcMethod());
+		if (calcMethod == null)
+		{
+			return;
+		}
+		final HuUnitType huUnitType = HuUnitType.ofNullableCode(piVersion.getHU_UnitType());
+		if (huUnitType == null || !huUnitType.isTU())
+		{
+			throw new AdempiereException("PackageDimensionCalcMethod can only be set on Transport Unit (TU) packing instruction versions")
+					.appendParametersToMessage()
+					.setParameter("HU_UnitType", huUnitType)
+					.setParameter("PackageDimensionCalcMethod", calcMethod)
+					.setParameter("M_HU_PI_Version_ID", piVersion.getM_HU_PI_Version_ID())
+					.markAsUserValidationError();
+		}
+	}
+
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_DELETE)
-	public void onDeleteMHUPIVersion(final I_M_HU_PI_Version piVersion)
+	public void onDeleteMHUPIVersion(@NonNull final I_M_HU_PI_Version piVersion)
 	{
 		//
 		// Delete PI Items

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/IHUPackageBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/IHUPackageBL.java
@@ -18,13 +18,6 @@ import java.util.Set;
 public interface IHUPackageBL extends ISingletonService
 {
 	/**
-	 * SysConfig (system level, default {@code N}): when {@code Y}, package-dimension resolution re-applies
-	 * the legacy {@code IsSelfPacked} gate (a non-self-packed product yields {@link PackageDimensions#UNSPECIFIED}).
-	 * Default {@code N} = product dimensions are used regardless of the flag.
-	 */
-	String SYSCONFIG_CHECK_IS_SELF_PACKED = "de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked";
-
-	/**
 	 * Unassign all HUs from given package
 	 */
 	void destroyHUPackage(I_M_Package mpackage);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/IHUPackageBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/IHUPackageBL.java
@@ -18,6 +18,13 @@ import java.util.Set;
 public interface IHUPackageBL extends ISingletonService
 {
 	/**
+	 * SysConfig (system level, default {@code N}): when {@code Y}, package-dimension resolution re-applies
+	 * the legacy {@code IsSelfPacked} gate (a non-self-packed product yields {@link PackageDimensions#UNSPECIFIED}).
+	 * Default {@code N} = product dimensions are used regardless of the flag.
+	 */
+	String SYSCONFIG_CHECK_IS_SELF_PACKED = "de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked";
+
+	/**
 	 * Unassign all HUs from given package
 	 */
 	void destroyHUPackage(I_M_Package mpackage);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/impl/HUPackageBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/impl/HUPackageBL.java
@@ -257,8 +257,8 @@ public class HUPackageBL implements IHUPackageBL
 		{
 			return PackageDimensions.UNSPECIFIED;
 		}
-		final PackageDimensions dims = product.getPackageDimensions();
-		return dims.isUnspecified() ? PackageDimensions.UNSPECIFIED : dims;
+		// dims already equals UNSPECIFIED when unspecified (value object) — return it directly.
+		return product.getPackageDimensions();
 	}
 
 	@Override

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/impl/HUPackageBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/impl/HUPackageBL.java
@@ -1,6 +1,7 @@
 package de.metas.handlingunits.shipping.impl;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import de.metas.handlingunits.HuId;
 import de.metas.inout.InOutId;
@@ -10,6 +11,7 @@ import de.metas.handlingunits.IHandlingUnitsBL;
 import de.metas.handlingunits.exceptions.HUException;
 import de.metas.handlingunits.inout.IHUPackingMaterialDAO;
 import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.I_M_HU_PI_Version;
 import de.metas.handlingunits.model.I_M_HU_PackingMaterial;
 import de.metas.handlingunits.model.I_M_Package_HU;
 import de.metas.handlingunits.model.I_M_ShipmentSchedule_QtyPicked;
@@ -21,8 +23,11 @@ import de.metas.i18n.AdMessageKey;
 import de.metas.inout.IInOutDAO;
 import de.metas.inout.InOutLineId;
 import de.metas.organization.OrgId;
+import de.metas.product.PackageDimensionCalcMethod;
+import de.metas.product.PackageDimensionItem;
 import de.metas.product.PackageDimensions;
 import de.metas.product.Product;
+import de.metas.product.ProductId;
 import de.metas.product.ProductRepository;
 import de.metas.quantity.Quantity;
 import de.metas.shipping.ShipperId;
@@ -45,6 +50,7 @@ import org.compiere.model.I_M_Package;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -80,7 +86,6 @@ import static org.adempiere.model.InterfaceWrapperHelper.save;
 
 public class HUPackageBL implements IHUPackageBL
 {
-	private final static AdMessageKey MSG_SELF_PACKED_PRODUCT_WITH_NO_DEFINED_SIZES = AdMessageKey.of("SelfPackedProductWithNoDefinedSizes");
 	private final IHUPackingMaterialDAO packingMaterialDAO = Services.get(IHUPackingMaterialDAO.class);
 	private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
 	// services
@@ -206,8 +211,8 @@ public class HUPackageBL implements IHUPackageBL
 			return ImmutableList.of(createM_Package(request));
 		}
 
-		// One parcel per unit: split the HU weight evenly across the N identical units, and use the product's
-		// SINGLE-unit dimensions (self-packed → product's NAMED dims verbatim; else UNSPECIFIED).
+		// One parcel per unit: split the HU weight evenly across the N identical units, and use the
+		// product's SINGLE-unit dimensions when present, else UNSPECIFIED — IsSelfPacked is not checked.
 		final BigDecimal huWeightInKg = request.getWeightInKg();
 		final BigDecimal perUnitWeightInKg = huWeightInKg != null
 				? huWeightInKg.divide(BigDecimal.valueOf(parcelCount), 3, RoundingMode.HALF_UP)
@@ -230,24 +235,14 @@ public class HUPackageBL implements IHUPackageBL
 	}
 
 	/**
-	 * Single-unit dimensions: a self-packed CU is one label per unit, so each parcel carries the product's
-	 * named dimensions verbatim (no qty-based sort/scale). Same self-packed / no-dimensions guards as
-	 * {@code getPackageDimensions}.
+	 * Single-unit dimensions: each parcel carries the product's named dimensions verbatim
+	 * (no qty-based sort/scale). Returns {@link PackageDimensions#UNSPECIFIED} when the product
+	 * has no dims; {@code IsSelfPacked} does not gate this.
 	 */
 	private PackageDimensions resolveSingleUnitDimensions(@NonNull final Product product)
 	{
-		if (!product.isSelfPacked())
-		{
-			return PackageDimensions.UNSPECIFIED;
-		}
-		else if (product.getPackageDimensions().isUnspecified())
-		{
-			throw new AdempiereException(MSG_SELF_PACKED_PRODUCT_WITH_NO_DEFINED_SIZES, product.getValue());
-		}
-		else
-		{
-			return product.getPackageDimensions();
-		}
+		final PackageDimensions dims = product.getPackageDimensions();
+		return dims.isUnspecified() ? PackageDimensions.UNSPECIFIED : dims;
 	}
 
 	@Override
@@ -465,25 +460,53 @@ public class HUPackageBL implements IHUPackageBL
 		}
 		else
 		{
-			//Loaded here to avoid recursion
+			// Loaded here to avoid recursion
 			final ProductRepository productRepository = SpringContextHolder.instance.getBean(ProductRepository.class);
 
 			final List<IHUProductStorage> productStorages = handlingUnitsBL.getStorageFactory().getProductStorages(hu);
 			if (productStorages.size() > 1)
 			{
-				//Multiple products stored in HU, there's no chance we can infer the dimensions of the package.
+				// Multi-product TU: dispatch via the pi-version's calc method (only when HU_UnitType=TU).
+				// If no mode is configured (not a TU, or TU with no mode set), fall back to UNSPECIFIED.
+				if (handlingUnitsBL.isTransportUnit(hu))
+				{
+					final I_M_HU_PI_Version piVersion = handlingUnitsBL.getEffectivePIVersion(hu);
+					if (piVersion != null)
+					{
+						final PackageDimensionCalcMethod calcMethod = PackageDimensionCalcMethod.ofNullableCode(piVersion.getPackageDimensionCalcMethod());
+						if (calcMethod != null)
+						{
+							// Batch-load all products in one query to avoid an N+1 DB round-trip.
+							final Set<ProductId> productIds = productStorages.stream()
+									.map(IHUProductStorage::getProductId)
+									.collect(ImmutableSet.toImmutableSet());
+							final ImmutableMap<ProductId, Product> productsById = productRepository.getByIdsAsMap(productIds);
+
+							final List<PackageDimensionItem> items = new ArrayList<>();
+							for (final IHUProductStorage storage : productStorages)
+							{
+								final Product product = productsById.get(storage.getProductId());
+								if (product == null)
+								{
+									// Product not found (inactive/deleted) — degrade gracefully.
+									return PackageDimensions.UNSPECIFIED;
+								}
+								items.add(PackageDimensionItem.of(product.getPackageDimensions(), storage.getQtyInStockingUOM()));
+							}
+							return PackageDimensions.ofItems(calcMethod, items);
+						}
+					}
+				}
 				return PackageDimensions.UNSPECIFIED;
 			}
+
+			// Single-product: use product dims regardless of IsSelfPacked.
 			final IHUProductStorage singleHUProductStorage = productStorages.iterator().next();
 			final Product product = productRepository.getById(singleHUProductStorage.getProductId());
 			final PackageDimensions dimensions = product.getPackageDimensions();
-			if (!product.isSelfPacked())
-			{
-				return PackageDimensions.UNSPECIFIED;
-			}
 			if (dimensions.isUnspecified())
 			{
-				throw new AdempiereException(MSG_SELF_PACKED_PRODUCT_WITH_NO_DEFINED_SIZES, product.getValue());
+				return PackageDimensions.UNSPECIFIED;
 			}
 			final Quantity qtyInStockingUOM = singleHUProductStorage.getQtyInStockingUOM();
 			return PackageDimensions.ofProductDimensionsAndQty(dimensions, qtyInStockingUOM);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/impl/HUPackageBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/impl/HUPackageBL.java
@@ -87,6 +87,8 @@ import static org.adempiere.model.InterfaceWrapperHelper.save;
 
 public class HUPackageBL implements IHUPackageBL
 {
+	private static final String SYSCONFIG_CHECK_IS_SELF_PACKED = "de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked";
+
 	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private final IHUPackingMaterialDAO packingMaterialDAO = Services.get(IHUPackingMaterialDAO.class);
 	private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
@@ -237,8 +239,8 @@ public class HUPackageBL implements IHUPackageBL
 	}
 
 	/**
-	 * {@code true} if the {@value IHUPackageBL#SYSCONFIG_CHECK_IS_SELF_PACKED} SysConfig requires the
-	 * self-packed flag for dimension resolution (default {@code false} = flag-independent).
+	 * {@code true} if the {@value #SYSCONFIG_CHECK_IS_SELF_PACKED} SysConfig requires
+	 * the self-packed flag for dimension resolution (default {@code false} = flag-independent).
 	 */
 	private boolean isCheckSelfPacked()
 	{
@@ -248,7 +250,7 @@ public class HUPackageBL implements IHUPackageBL
 	/**
 	 * Single-unit dimensions: each parcel carries the product's named dimensions verbatim
 	 * (no qty-based sort/scale). Returns {@link PackageDimensions#UNSPECIFIED} when the product
-	 * has no dims. When {@value IHUPackageBL#SYSCONFIG_CHECK_IS_SELF_PACKED}='Y', also returns
+	 * has no dims. When {@value #SYSCONFIG_CHECK_IS_SELF_PACKED}='Y', also returns
 	 * {@link PackageDimensions#UNSPECIFIED} for a non-self-packed product.
 	 */
 	private PackageDimensions resolveSingleUnitDimensions(@NonNull final Product product)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/impl/HUPackageBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/impl/HUPackageBL.java
@@ -41,6 +41,7 @@ import de.metas.uom.X12DE355;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import de.metas.util.collections.CollectionUtils;
+import org.adempiere.service.ISysConfigBL;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.SpringContextHolder;
@@ -86,6 +87,14 @@ import static org.adempiere.model.InterfaceWrapperHelper.save;
 
 public class HUPackageBL implements IHUPackageBL
 {
+	/**
+	 * When set to 'Y', the legacy IsSelfPacked gate is restored: non-self-packed products return
+	 * {@link PackageDimensions#UNSPECIFIED} instead of using the product's named dimensions.
+	 * Default 'N' = flag-independent behaviour (current default).
+	 */
+	private static final String SYSCONFIG_CHECK_IS_SELF_PACKED = "de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked";
+
+	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private final IHUPackingMaterialDAO packingMaterialDAO = Services.get(IHUPackingMaterialDAO.class);
 	private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
 	// services
@@ -237,10 +246,16 @@ public class HUPackageBL implements IHUPackageBL
 	/**
 	 * Single-unit dimensions: each parcel carries the product's named dimensions verbatim
 	 * (no qty-based sort/scale). Returns {@link PackageDimensions#UNSPECIFIED} when the product
-	 * has no dims; {@code IsSelfPacked} does not gate this.
+	 * has no dims. When {@value #SYSCONFIG_CHECK_IS_SELF_PACKED}='Y', also returns
+	 * {@link PackageDimensions#UNSPECIFIED} for non-self-packed products (legacy gate).
 	 */
 	private PackageDimensions resolveSingleUnitDimensions(@NonNull final Product product)
 	{
+		final boolean checkSelfPacked = sysConfigBL.getBooleanValue(SYSCONFIG_CHECK_IS_SELF_PACKED, false);
+		if (checkSelfPacked && !product.isSelfPacked())
+		{
+			return PackageDimensions.UNSPECIFIED;
+		}
 		final PackageDimensions dims = product.getPackageDimensions();
 		return dims.isUnspecified() ? PackageDimensions.UNSPECIFIED : dims;
 	}
@@ -500,9 +515,14 @@ public class HUPackageBL implements IHUPackageBL
 				return PackageDimensions.UNSPECIFIED;
 			}
 
-			// Single-product: use product dims regardless of IsSelfPacked.
+			// Single-product: use product dims (IsSelfPacked gate is SysConfig-controlled, default off).
 			final IHUProductStorage singleHUProductStorage = productStorages.iterator().next();
 			final Product product = productRepository.getById(singleHUProductStorage.getProductId());
+			final boolean checkSelfPacked = sysConfigBL.getBooleanValue(SYSCONFIG_CHECK_IS_SELF_PACKED, false);
+			if (checkSelfPacked && !product.isSelfPacked())
+			{
+				return PackageDimensions.UNSPECIFIED;
+			}
 			final PackageDimensions dimensions = product.getPackageDimensions();
 			if (dimensions.isUnspecified())
 			{

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/impl/HUPackageBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/impl/HUPackageBL.java
@@ -94,7 +94,7 @@ public class HUPackageBL implements IHUPackageBL
 	 */
 	private static final String SYSCONFIG_CHECK_IS_SELF_PACKED = "de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked";
 
-	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private final IHUPackingMaterialDAO packingMaterialDAO = Services.get(IHUPackingMaterialDAO.class);
 	private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
 	// services
@@ -221,7 +221,7 @@ public class HUPackageBL implements IHUPackageBL
 		}
 
 		// One parcel per unit: split the HU weight evenly across the N identical units, and use the
-		// product's SINGLE-unit dimensions when present, else UNSPECIFIED — IsSelfPacked is not checked.
+		// product's SINGLE-unit dimensions when present, else UNSPECIFIED (IsSelfPacked gate is SysConfig-controlled, default off).
 		final BigDecimal huWeightInKg = request.getWeightInKg();
 		final BigDecimal perUnitWeightInKg = huWeightInKg != null
 				? huWeightInKg.divide(BigDecimal.valueOf(parcelCount), 3, RoundingMode.HALF_UP)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/impl/HUPackageBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/impl/HUPackageBL.java
@@ -41,9 +41,9 @@ import de.metas.uom.X12DE355;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import de.metas.util.collections.CollectionUtils;
-import org.adempiere.service.ISysConfigBL;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.service.ISysConfigBL;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_M_InOut;
 import org.compiere.model.I_M_InOutLine;
@@ -87,13 +87,6 @@ import static org.adempiere.model.InterfaceWrapperHelper.save;
 
 public class HUPackageBL implements IHUPackageBL
 {
-	/**
-	 * When set to 'Y', the legacy IsSelfPacked gate is restored: non-self-packed products return
-	 * {@link PackageDimensions#UNSPECIFIED} instead of using the product's named dimensions.
-	 * Default 'N' = flag-independent behaviour (current default).
-	 */
-	private static final String SYSCONFIG_CHECK_IS_SELF_PACKED = "de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked";
-
 	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private final IHUPackingMaterialDAO packingMaterialDAO = Services.get(IHUPackingMaterialDAO.class);
 	private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
@@ -246,7 +239,7 @@ public class HUPackageBL implements IHUPackageBL
 	/**
 	 * Single-unit dimensions: each parcel carries the product's named dimensions verbatim
 	 * (no qty-based sort/scale). Returns {@link PackageDimensions#UNSPECIFIED} when the product
-	 * has no dims. When {@value #SYSCONFIG_CHECK_IS_SELF_PACKED}='Y', also returns
+	 * has no dims. When {@value IHUPackageBL#SYSCONFIG_CHECK_IS_SELF_PACKED}='Y', also returns
 	 * {@link PackageDimensions#UNSPECIFIED} for non-self-packed products (legacy gate).
 	 */
 	private PackageDimensions resolveSingleUnitDimensions(@NonNull final Product product)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/impl/HUPackageBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipping/impl/HUPackageBL.java
@@ -237,15 +237,23 @@ public class HUPackageBL implements IHUPackageBL
 	}
 
 	/**
+	 * {@code true} if the {@value IHUPackageBL#SYSCONFIG_CHECK_IS_SELF_PACKED} SysConfig requires the
+	 * self-packed flag for dimension resolution (default {@code false} = flag-independent).
+	 */
+	private boolean isCheckSelfPacked()
+	{
+		return sysConfigBL.getBooleanValue(SYSCONFIG_CHECK_IS_SELF_PACKED, false);
+	}
+
+	/**
 	 * Single-unit dimensions: each parcel carries the product's named dimensions verbatim
 	 * (no qty-based sort/scale). Returns {@link PackageDimensions#UNSPECIFIED} when the product
 	 * has no dims. When {@value IHUPackageBL#SYSCONFIG_CHECK_IS_SELF_PACKED}='Y', also returns
-	 * {@link PackageDimensions#UNSPECIFIED} for non-self-packed products (legacy gate).
+	 * {@link PackageDimensions#UNSPECIFIED} for a non-self-packed product.
 	 */
 	private PackageDimensions resolveSingleUnitDimensions(@NonNull final Product product)
 	{
-		final boolean checkSelfPacked = sysConfigBL.getBooleanValue(SYSCONFIG_CHECK_IS_SELF_PACKED, false);
-		if (checkSelfPacked && !product.isSelfPacked())
+		if (isCheckSelfPacked() && !product.isSelfPacked())
 		{
 			return PackageDimensions.UNSPECIFIED;
 		}
@@ -511,8 +519,7 @@ public class HUPackageBL implements IHUPackageBL
 			// Single-product: use product dims (IsSelfPacked gate is SysConfig-controlled, default off).
 			final IHUProductStorage singleHUProductStorage = productStorages.iterator().next();
 			final Product product = productRepository.getById(singleHUProductStorage.getProductId());
-			final boolean checkSelfPacked = sysConfigBL.getBooleanValue(SYSCONFIG_CHECK_IS_SELF_PACKED, false);
-			if (checkSelfPacked && !product.isSelfPacked())
+			if (isCheckSelfPacked() && !product.isSelfPacked())
 			{
 				return PackageDimensions.UNSPECIFIED;
 			}

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815410_sys_PackageDimensionCalcMethod_reflist.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815410_sys_PackageDimensionCalcMethod_reflist.sql
@@ -1,0 +1,198 @@
+-- Adds the PackageDimensionCalcMethod reference list (AD_Reference, ValidationType='L')
+-- with three entries: Strapping (S), Repacking (R), Nesting (N).
+-- Used by the PackageDimensionCalcMethod column on M_HU_PI_Version (added in a later task)
+-- to configure how multi-item TU parcel dimensions are calculated.
+--
+-- IDs allocated from idserver.metas.de on 2026-07-22:
+--   AD_Reference  542122 /*From ID Server*/  (PackageDimensionCalcMethod list)
+--   AD_Ref_List   544321 /*From ID Server*/  (S  = Strapping / Umreifung)
+--   AD_Ref_List   544322 /*From ID Server*/  (R  = Repacking / Umpacken)
+--   AD_Ref_List   544323 /*From ID Server*/  (N  = Nesting   / Schachteln)
+
+-- ============================================================
+-- 1. AD_Reference (ValidationType='L')
+-- ============================================================
+INSERT INTO AD_Reference
+  (AD_Client_ID, AD_Org_ID, IsActive,
+   Created, CreatedBy, Updated, UpdatedBy,
+   AD_Reference_ID, ValidationType, Name, IsOrderByValue, EntityType)
+VALUES
+  (0, 0, 'Y',
+   TO_TIMESTAMP('2026-07-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   TO_TIMESTAMP('2026-07-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   542122 /*From ID Server*/, 'L', 'PackageDimensionCalcMethod', 'N', 'D');
+
+-- ============================================================
+-- 2. AD_Reference_Trl skeleton for all active system languages
+-- ============================================================
+INSERT INTO AD_Reference_Trl
+  (AD_Language, AD_Reference_ID, Name, Help, Description,
+   IsTranslated, AD_Client_ID, AD_Org_ID,
+   Created, CreatedBy, Updated, UpdatedBy)
+SELECT
+  l.AD_Language, t.AD_Reference_ID, t.Name, t.Help, t.Description,
+  'N', t.AD_Client_ID, t.AD_Org_ID,
+  t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Reference t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Reference_ID = 542122
+  AND NOT EXISTS (
+    SELECT 1 FROM AD_Reference_Trl tt
+    WHERE tt.AD_Language = l.AD_Language AND tt.AD_Reference_ID = t.AD_Reference_ID
+  );
+
+-- Mark de_DE and de_CH as translated (German is the base name)
+UPDATE AD_Reference_Trl
+SET IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-22 10:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Reference_ID = 542122
+  AND AD_Language IN ('de_DE', 'de_CH');
+
+-- Override en_US name to English
+UPDATE AD_Reference_Trl
+SET IsTranslated = 'Y',
+    Name         = 'Package Dimension Calc Method',
+    Updated      = TO_TIMESTAMP('2026-07-22 10:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Reference_ID = 542122
+  AND AD_Language = 'en_US';
+
+-- ============================================================
+-- 3. AD_Ref_List — Strapping (Value='S')
+-- ============================================================
+INSERT INTO AD_Ref_List
+  (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive,
+   Created, CreatedBy, Updated, UpdatedBy,
+   AD_Ref_List_ID, Value, ValueName, Name, Description, EntityType)
+VALUES
+  (542122, 0, 0, 'Y',
+   TO_TIMESTAMP('2026-07-22 10:00:03', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   TO_TIMESTAMP('2026-07-22 10:00:03', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   544321 /*From ID Server*/, 'S', 'S', 'Umreifung', NULL, 'D');
+
+-- AD_Ref_List_Trl skeleton for Strapping
+INSERT INTO AD_Ref_List_Trl
+  (AD_Language, AD_Ref_List_ID, Name, Description,
+   IsTranslated, AD_Client_ID, AD_Org_ID,
+   Created, CreatedBy, Updated, UpdatedBy)
+SELECT
+  l.AD_Language, t.AD_Ref_List_ID, t.Name, t.Description,
+  'N', t.AD_Client_ID, t.AD_Org_ID,
+  t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Ref_List_ID = 544321
+  AND NOT EXISTS (
+    SELECT 1 FROM AD_Ref_List_Trl tt
+    WHERE tt.AD_Language = l.AD_Language AND tt.AD_Ref_List_ID = t.AD_Ref_List_ID
+  );
+
+UPDATE AD_Ref_List_Trl
+SET IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-22 10:00:04', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Ref_List_ID = 544321
+  AND AD_Language IN ('de_DE', 'de_CH');
+
+UPDATE AD_Ref_List_Trl
+SET IsTranslated = 'Y',
+    Name         = 'Strapping',
+    Updated      = TO_TIMESTAMP('2026-07-22 10:00:05', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Ref_List_ID = 544321
+  AND AD_Language = 'en_US';
+
+-- ============================================================
+-- 4. AD_Ref_List — Repacking (Value='R')
+-- ============================================================
+INSERT INTO AD_Ref_List
+  (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive,
+   Created, CreatedBy, Updated, UpdatedBy,
+   AD_Ref_List_ID, Value, ValueName, Name, Description, EntityType)
+VALUES
+  (542122, 0, 0, 'Y',
+   TO_TIMESTAMP('2026-07-22 10:00:06', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   TO_TIMESTAMP('2026-07-22 10:00:06', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   544322 /*From ID Server*/, 'R', 'R', 'Umpacken', NULL, 'D');
+
+-- AD_Ref_List_Trl skeleton for Repacking
+INSERT INTO AD_Ref_List_Trl
+  (AD_Language, AD_Ref_List_ID, Name, Description,
+   IsTranslated, AD_Client_ID, AD_Org_ID,
+   Created, CreatedBy, Updated, UpdatedBy)
+SELECT
+  l.AD_Language, t.AD_Ref_List_ID, t.Name, t.Description,
+  'N', t.AD_Client_ID, t.AD_Org_ID,
+  t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Ref_List_ID = 544322
+  AND NOT EXISTS (
+    SELECT 1 FROM AD_Ref_List_Trl tt
+    WHERE tt.AD_Language = l.AD_Language AND tt.AD_Ref_List_ID = t.AD_Ref_List_ID
+  );
+
+UPDATE AD_Ref_List_Trl
+SET IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-22 10:00:07', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Ref_List_ID = 544322
+  AND AD_Language IN ('de_DE', 'de_CH');
+
+UPDATE AD_Ref_List_Trl
+SET IsTranslated = 'Y',
+    Name         = 'Repacking',
+    Updated      = TO_TIMESTAMP('2026-07-22 10:00:08', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Ref_List_ID = 544322
+  AND AD_Language = 'en_US';
+
+-- ============================================================
+-- 5. AD_Ref_List — Nesting (Value='N')
+-- ============================================================
+INSERT INTO AD_Ref_List
+  (AD_Reference_ID, AD_Client_ID, AD_Org_ID, IsActive,
+   Created, CreatedBy, Updated, UpdatedBy,
+   AD_Ref_List_ID, Value, ValueName, Name, Description, EntityType)
+VALUES
+  (542122, 0, 0, 'Y',
+   TO_TIMESTAMP('2026-07-22 10:00:09', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   TO_TIMESTAMP('2026-07-22 10:00:09', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   544323 /*From ID Server*/, 'N', 'N', 'Schachteln', NULL, 'D');
+
+-- AD_Ref_List_Trl skeleton for Nesting
+INSERT INTO AD_Ref_List_Trl
+  (AD_Language, AD_Ref_List_ID, Name, Description,
+   IsTranslated, AD_Client_ID, AD_Org_ID,
+   Created, CreatedBy, Updated, UpdatedBy)
+SELECT
+  l.AD_Language, t.AD_Ref_List_ID, t.Name, t.Description,
+  'N', t.AD_Client_ID, t.AD_Org_ID,
+  t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Ref_List t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Ref_List_ID = 544323
+  AND NOT EXISTS (
+    SELECT 1 FROM AD_Ref_List_Trl tt
+    WHERE tt.AD_Language = l.AD_Language AND tt.AD_Ref_List_ID = t.AD_Ref_List_ID
+  );
+
+UPDATE AD_Ref_List_Trl
+SET IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-22 10:00:10', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Ref_List_ID = 544323
+  AND AD_Language IN ('de_DE', 'de_CH');
+
+UPDATE AD_Ref_List_Trl
+SET IsTranslated = 'Y',
+    Name         = 'Nesting',
+    Updated      = TO_TIMESTAMP('2026-07-22 10:00:11', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Ref_List_ID = 544323
+  AND AD_Language = 'en_US';

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815410_sys_PackageDimensionCalcMethod_reflist.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815410_sys_PackageDimensionCalcMethod_reflist.sql
@@ -5,9 +5,9 @@
 --
 -- IDs allocated from idserver.metas.de on 2026-07-22:
 --   AD_Reference  542122 /*From ID Server*/  (PackageDimensionCalcMethod list)
---   AD_Ref_List   544321 /*From ID Server*/  (S  = Strapping / Umreifung)
---   AD_Ref_List   544322 /*From ID Server*/  (R  = Repacking / Umpacken)
---   AD_Ref_List   544323 /*From ID Server*/  (N  = Nesting   / Schachteln)
+--   AD_Ref_List   544321 /*From ID Server*/  (S  = Strapping / Bändern)
+--   AD_Ref_List   544322 /*From ID Server*/  (R  = Repacking / Umverpacken)
+--   AD_Ref_List   544323 /*From ID Server*/  (N  = Nesting   / Verschachteln)
 
 -- ============================================================
 -- 1. AD_Reference (ValidationType='L')
@@ -70,7 +70,7 @@ VALUES
   (542122, 0, 0, 'Y',
    TO_TIMESTAMP('2026-07-22 10:00:03', 'YYYY-MM-DD HH24:MI:SS'), 100,
    TO_TIMESTAMP('2026-07-22 10:00:03', 'YYYY-MM-DD HH24:MI:SS'), 100,
-   544321 /*From ID Server*/, 'S', 'S', 'Umreifung', NULL, 'D');
+   544321 /*From ID Server*/, 'S', 'Strapping', 'Bändern', 'TU-Maße: Stapelachse = Summe(kleinste Kante x Menge); übrige zwei Kanten = Maximum je Achse.', 'D');
 
 -- AD_Ref_List_Trl skeleton for Strapping
 INSERT INTO AD_Ref_List_Trl
@@ -100,6 +100,7 @@ WHERE AD_Ref_List_ID = 544321
 UPDATE AD_Ref_List_Trl
 SET IsTranslated = 'Y',
     Name         = 'Strapping',
+    Description  = 'TU dimensions: stacking axis = sum(smallest edge x qty); other two edges = max per axis.',
     Updated      = TO_TIMESTAMP('2026-07-22 10:00:05', 'YYYY-MM-DD HH24:MI:SS'),
     UpdatedBy    = 100
 WHERE AD_Ref_List_ID = 544321
@@ -116,7 +117,7 @@ VALUES
   (542122, 0, 0, 'Y',
    TO_TIMESTAMP('2026-07-22 10:00:06', 'YYYY-MM-DD HH24:MI:SS'), 100,
    TO_TIMESTAMP('2026-07-22 10:00:06', 'YYYY-MM-DD HH24:MI:SS'), 100,
-   544322 /*From ID Server*/, 'R', 'R', 'Umpacken', NULL, 'D');
+   544322 /*From ID Server*/, 'R', 'Repacking', 'Umverpacken', 'TU-Maße aus dem Gesamtvolumen (x 1,05) neu berechnet.', 'D');
 
 -- AD_Ref_List_Trl skeleton for Repacking
 INSERT INTO AD_Ref_List_Trl
@@ -146,6 +147,7 @@ WHERE AD_Ref_List_ID = 544322
 UPDATE AD_Ref_List_Trl
 SET IsTranslated = 'Y',
     Name         = 'Repacking',
+    Description  = 'TU dimensions recomputed from total volume (x 1.05).',
     Updated      = TO_TIMESTAMP('2026-07-22 10:00:08', 'YYYY-MM-DD HH24:MI:SS'),
     UpdatedBy    = 100
 WHERE AD_Ref_List_ID = 544322
@@ -162,7 +164,7 @@ VALUES
   (542122, 0, 0, 'Y',
    TO_TIMESTAMP('2026-07-22 10:00:09', 'YYYY-MM-DD HH24:MI:SS'), 100,
    TO_TIMESTAMP('2026-07-22 10:00:09', 'YYYY-MM-DD HH24:MI:SS'), 100,
-   544323 /*From ID Server*/, 'N', 'N', 'Schachteln', NULL, 'D');
+   544323 /*From ID Server*/, 'N', 'Nesting', 'Verschachteln', 'TU übernimmt die Maße des Artikels mit der größten Einzelkante.', 'D');
 
 -- AD_Ref_List_Trl skeleton for Nesting
 INSERT INTO AD_Ref_List_Trl
@@ -192,6 +194,7 @@ WHERE AD_Ref_List_ID = 544323
 UPDATE AD_Ref_List_Trl
 SET IsTranslated = 'Y',
     Name         = 'Nesting',
+    Description  = 'TU takes the dimensions of the item with the largest single edge.',
     Updated      = TO_TIMESTAMP('2026-07-22 10:00:11', 'YYYY-MM-DD HH24:MI:SS'),
     UpdatedBy    = 100
 WHERE AD_Ref_List_ID = 544323

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815420_sys_M_HU_PI_Version_PackageDimensionCalcMethod_column.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815420_sys_M_HU_PI_Version_PackageDimensionCalcMethod_column.sql
@@ -16,12 +16,13 @@
 INSERT INTO AD_Element
   (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive,
    Created, CreatedBy, Updated, UpdatedBy,
-   ColumnName, Name, PrintName, EntityType)
+   ColumnName, Name, PrintName, Description, EntityType)
 VALUES
   (585123 /*From ID Server*/, 0, 0, 'Y',
    TO_TIMESTAMP('2026-07-22 14:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
    TO_TIMESTAMP('2026-07-22 14:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
-   'PackageDimensionCalcMethod', 'Berechnungsmethode', 'Berechnungsmethode', 'D');
+   'PackageDimensionCalcMethod', 'Berechnungsmethode', 'Berechnungsmethode',
+   'Berechnungsmethode für die Verpackungsmaße einer Transporteinheit, wenn sie mehrere Artikel enthält (Bändern / Umverpacken / Verschachteln).', 'D');
 
 -- AD_Element_Trl skeleton for all active system languages
 INSERT INTO AD_Element_Trl
@@ -44,6 +45,9 @@ WHERE l.IsActive = 'Y'
 -- Mark de_DE and de_CH as translated (German is the base name)
 UPDATE AD_Element_Trl
 SET IsTranslated = 'Y',
+    Name         = 'Berechnungsmethode',
+    PrintName    = 'Berechnungsmethode',
+    Description  = 'Berechnungsmethode für die Verpackungsmaße einer Transporteinheit, wenn sie mehrere Artikel enthält (Bändern / Umverpacken / Verschachteln).',
     Updated      = TO_TIMESTAMP('2026-07-22 14:00:12', 'YYYY-MM-DD HH24:MI:SS'),
     UpdatedBy    = 100
 WHERE AD_Element_ID = 585123
@@ -54,6 +58,7 @@ UPDATE AD_Element_Trl
 SET IsTranslated = 'Y',
     Name         = 'Calc Method',
     PrintName    = 'Calc Method',
+    Description  = 'Calculation method for a Transport Unit''s package dimensions when it holds multiple items (Strapping / Repacking / Nesting).',
     Updated      = TO_TIMESTAMP('2026-07-22 14:00:18', 'YYYY-MM-DD HH24:MI:SS'),
     UpdatedBy    = 100
 WHERE AD_Element_ID = 585123
@@ -102,10 +107,6 @@ WHERE l.IsActive = 'Y'
 -- New nullable column (no default). Routed through db_alter_table() so the function manages
 -- view dependencies (the bare-ALTER exception is only for NOT NULL DEFAULT backfill columns).
 SELECT public.db_alter_table('M_HU_PI_Version','ALTER TABLE public.M_HU_PI_Version ADD COLUMN IF NOT EXISTS PackageDimensionCalcMethod CHAR(1)');
-
--- Check constraint to enforce the ref-list values (also via db_alter_table for view-dependency safety)
-SELECT public.db_alter_table('M_HU_PI_Version','ALTER TABLE public.M_HU_PI_Version DROP CONSTRAINT IF EXISTS PackageDimensionCalcMethod_Check');
-SELECT public.db_alter_table('M_HU_PI_Version','ALTER TABLE public.M_HU_PI_Version ADD CONSTRAINT PackageDimensionCalcMethod_Check CHECK (PackageDimensionCalcMethod IN (''S'', ''R'', ''N''))');
 
 -- ============================================================
 -- 4. AD_Field — tab 540823 (window 540344, standalone Packvorschrift Version)

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815420_sys_M_HU_PI_Version_PackageDimensionCalcMethod_column.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815420_sys_M_HU_PI_Version_PackageDimensionCalcMethod_column.sql
@@ -1,0 +1,229 @@
+-- Adds M_HU_PI_Version.PackageDimensionCalcMethod column and exposes it in the
+-- Packvorschrift Version windows (540344 current, 540188 legacy).
+-- The field only shows when HU_UnitType = TU (DisplayLogic @HU_UnitType@=TU).
+--
+-- IDs allocated from idserver.metas.de on 2026-07-22:
+--   AD_Element    585123 /*From ID Server*/  (PackageDimensionCalcMethod)
+--   AD_Column     592977 /*From ID Server*/  (M_HU_PI_Version.PackageDimensionCalcMethod)
+--   AD_Field      781766 /*From ID Server*/  (tab 540823, win 540344)
+--   AD_Field      781767 /*From ID Server*/  (tab 540505, win 540188)
+--   AD_UI_Element 652698 /*From ID Server*/  (tab 540823, win 540344)
+-- Migration prefix: 5815420
+
+-- ============================================================
+-- 1. AD_Element
+-- ============================================================
+INSERT INTO AD_Element
+  (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive,
+   Created, CreatedBy, Updated, UpdatedBy,
+   ColumnName, Name, PrintName, EntityType)
+VALUES
+  (585123 /*From ID Server*/, 0, 0, 'Y',
+   TO_TIMESTAMP('2026-07-22 14:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   TO_TIMESTAMP('2026-07-22 14:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   'PackageDimensionCalcMethod', 'Berechnungsmethode', 'Berechnungsmethode', 'D');
+
+-- AD_Element_Trl skeleton for all active system languages
+INSERT INTO AD_Element_Trl
+  (AD_Language, AD_Element_ID, Name, PrintName, Description, Help,
+   IsTranslated, AD_Client_ID, AD_Org_ID,
+   Created, CreatedBy, Updated, UpdatedBy)
+SELECT
+  l.AD_Language, t.AD_Element_ID, t.Name, t.PrintName, t.Description, t.Help,
+  'N', t.AD_Client_ID, t.AD_Org_ID,
+  t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Element_ID = 585123
+  AND NOT EXISTS (
+    SELECT 1 FROM AD_Element_Trl tt
+    WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID
+  );
+
+-- Mark de_DE and de_CH as translated (German is the base name)
+UPDATE AD_Element_Trl
+SET IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-22 14:00:12', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 585123
+  AND AD_Language IN ('de_DE', 'de_CH');
+
+-- Override en_US to English
+UPDATE AD_Element_Trl
+SET IsTranslated = 'Y',
+    Name         = 'Calc Method',
+    PrintName    = 'Calc Method',
+    Updated      = TO_TIMESTAMP('2026-07-22 14:00:18', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Element_ID = 585123
+  AND AD_Language = 'en_US';
+
+-- ============================================================
+-- 2. AD_Column
+-- ============================================================
+INSERT INTO AD_Column
+  (AD_Column_ID, AD_Client_ID, AD_Org_ID, IsActive,
+   Created, CreatedBy, Updated, UpdatedBy,
+   AD_Table_ID, AD_Element_ID, AD_Reference_ID, AD_Reference_Value_ID,
+   ColumnName, Name, FieldLength, IsKey, IsParent, IsMandatory,
+   IsTranslated, IsIdentifier, IsEncrypted, IsUpdateable, IsAlwaysUpdateable,
+   IsDimension, IsForceIncludeInGeneratedModel,
+   Version, EntityType, PersonalDataCategory)
+VALUES
+  (592977 /*From ID Server*/, 0, 0, 'Y',
+   TO_TIMESTAMP('2026-07-22 14:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   TO_TIMESTAMP('2026-07-22 14:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   540510, 585123, 17, 542122,
+   'PackageDimensionCalcMethod', 'Berechnungsmethode', 1, 'N', 'N', 'N',
+   'N', 'N', 'N', 'Y', 'N',
+   'N', 'N',
+   0, 'D', 'NP');
+
+-- AD_Column_Trl skeleton for all active system languages
+INSERT INTO AD_Column_Trl
+  (AD_Language, AD_Column_ID, Name, IsTranslated, AD_Client_ID, AD_Org_ID,
+   Created, CreatedBy, Updated, UpdatedBy)
+SELECT
+  l.AD_Language, t.AD_Column_ID, t.Name, 'N', t.AD_Client_ID, t.AD_Org_ID,
+  t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Column_ID = 592977
+  AND NOT EXISTS (
+    SELECT 1 FROM AD_Column_Trl tt
+    WHERE tt.AD_Language = l.AD_Language AND tt.AD_Column_ID = t.AD_Column_ID
+  );
+
+-- ============================================================
+-- 3. Physical DDL — add column to M_HU_PI_Version
+-- ============================================================
+-- New nullable column (no default). Routed through db_alter_table() so the function manages
+-- view dependencies (the bare-ALTER exception is only for NOT NULL DEFAULT backfill columns).
+SELECT public.db_alter_table('M_HU_PI_Version','ALTER TABLE public.M_HU_PI_Version ADD COLUMN IF NOT EXISTS PackageDimensionCalcMethod CHAR(1)');
+
+-- Check constraint to enforce the ref-list values (also via db_alter_table for view-dependency safety)
+SELECT public.db_alter_table('M_HU_PI_Version','ALTER TABLE public.M_HU_PI_Version DROP CONSTRAINT IF EXISTS PackageDimensionCalcMethod_Check');
+SELECT public.db_alter_table('M_HU_PI_Version','ALTER TABLE public.M_HU_PI_Version ADD CONSTRAINT PackageDimensionCalcMethod_Check CHECK (PackageDimensionCalcMethod IN (''S'', ''R'', ''N''))');
+
+-- ============================================================
+-- 4. AD_Field — tab 540823 (window 540344, standalone Packvorschrift Version)
+-- ============================================================
+INSERT INTO AD_Field
+  (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive,
+   Created, CreatedBy, Updated, UpdatedBy,
+   AD_Tab_ID, AD_Column_ID, AD_Name_ID,
+   Name, Description, Help,
+   IsDisplayed, IsDisplayedGrid, IsSameLine, IsHeading, IsFieldOnly,
+   IsReadOnly, IsMandatory, IsEncrypted,
+   SeqNo, SeqNoGrid,
+   DisplayLogic, EntityType)
+VALUES
+  (781766 /*From ID Server*/, 0, 0, 'Y',
+   TO_TIMESTAMP('2026-07-22 14:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   TO_TIMESTAMP('2026-07-22 14:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   540823, 592977, 585123,
+   'Berechnungsmethode', NULL, NULL,
+   'Y', 'Y', 'N', 'N', 'N',
+   'N', 'N', 'N',
+   80, 70,
+   '@HU_UnitType@=TU', 'D');
+
+-- AD_Field_Trl skeleton
+INSERT INTO AD_Field_Trl
+  (AD_Language, AD_Field_ID, Name, Description, Help,
+   IsTranslated, AD_Client_ID, AD_Org_ID,
+   Created, CreatedBy, Updated, UpdatedBy)
+SELECT
+  l.AD_Language, t.AD_Field_ID, t.Name, t.Description, t.Help,
+  'N', t.AD_Client_ID, t.AD_Org_ID,
+  t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Field_ID = 781766
+  AND NOT EXISTS (
+    SELECT 1 FROM AD_Field_Trl tt
+    WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID
+  );
+
+-- Propagate element translations → field (element ID, not field ID)
+SELECT update_FieldTranslation_From_AD_Name_Element(585123);
+
+-- Rebuild element links for this field
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 781766;
+SELECT AD_Element_Link_Create_Missing_Field(781766);
+
+-- ============================================================
+-- 5. AD_UI_Element — tab 540823, group 540439 (description)
+--    placed after Verpackungscode (SeqNo 20) and before/at Beschreibung (SeqNo 30)
+--    → SeqNo 25 keeps it between HU Typ area and Beschreibung, grid SeqNoGrid 75
+-- ============================================================
+INSERT INTO AD_UI_Element
+  (AD_UI_Element_ID, AD_Client_ID, AD_Org_ID, IsActive,
+   Created, CreatedBy, Updated, UpdatedBy,
+   AD_UI_ElementGroup_ID, AD_Tab_ID, AD_Field_ID, Name,
+   AD_UI_ElementType, SeqNo, SeqNoGrid,
+   IsDisplayed, IsDisplayedGrid, IsAdvancedField)
+VALUES
+  (652698 /*From ID Server*/, 0, 0, 'Y',
+   TO_TIMESTAMP('2026-07-22 14:02:30', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   TO_TIMESTAMP('2026-07-22 14:02:30', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   540439, 540823, 781766, 'Berechnungsmethode',
+   'F', 25, 75,
+   'Y', 'Y', 'N');
+
+-- ============================================================
+-- 6. AD_Field — tab 540505 (window 540188, legacy Packvorschrift Version)
+--    Tab 540505 has no AD_UI_Element rows — field only, no UI_Element needed.
+-- ============================================================
+INSERT INTO AD_Field
+  (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive,
+   Created, CreatedBy, Updated, UpdatedBy,
+   AD_Tab_ID, AD_Column_ID, AD_Name_ID,
+   Name, Description, Help,
+   IsDisplayed, IsDisplayedGrid, IsSameLine, IsHeading, IsFieldOnly,
+   IsReadOnly, IsMandatory, IsEncrypted,
+   SeqNo, SeqNoGrid,
+   DisplayLogic, EntityType)
+VALUES
+  (781767 /*From ID Server*/, 0, 0, 'Y',
+   TO_TIMESTAMP('2026-07-22 14:03:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   TO_TIMESTAMP('2026-07-22 14:03:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+   540505, 592977, 585123,
+   'Berechnungsmethode', NULL, NULL,
+   'Y', 'Y', 'N', 'N', 'N',
+   'N', 'N', 'N',
+   80, 70,
+   '@HU_UnitType@=TU', 'D');
+
+-- AD_Field_Trl skeleton for legacy field
+INSERT INTO AD_Field_Trl
+  (AD_Language, AD_Field_ID, Name, Description, Help,
+   IsTranslated, AD_Client_ID, AD_Org_ID,
+   Created, CreatedBy, Updated, UpdatedBy)
+SELECT
+  l.AD_Language, t.AD_Field_ID, t.Name, t.Description, t.Help,
+  'N', t.AD_Client_ID, t.AD_Org_ID,
+  t.Created, t.CreatedBy, t.Updated, t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive = 'Y'
+  AND l.IsSystemLanguage = 'Y'
+  AND t.AD_Field_ID = 781767
+  AND NOT EXISTS (
+    SELECT 1 FROM AD_Field_Trl tt
+    WHERE tt.AD_Language = l.AD_Language AND tt.AD_Field_ID = t.AD_Field_ID
+  );
+
+-- Propagate element translations → legacy field
+SELECT update_FieldTranslation_From_AD_Name_Element(585123);
+
+-- Rebuild element links for the legacy field
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 781767;
+SELECT AD_Element_Link_Create_Missing_Field(781767);
+
+-- ============================================================
+-- 7. Final translation cascade from element
+-- ============================================================
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585123);

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815630_sys_gh30361_DimensionCalc_mode_PIs_inactive.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815630_sys_gh30361_DimensionCalc_mode_PIs_inactive.sql
@@ -17,8 +17,8 @@ INSERT INTO M_HU_PI
      IsActive, IsDefaultLU, IsDefaultForPicking,
      Created, CreatedBy, Updated, UpdatedBy)
 VALUES
-    (0, 0, 540013 /*From ID Server*/, 'Dimension Calculation - Strapping',
-     'Inactive seed: TU packing instruction for Strapping dimension calculation mode. Activate and configure per deployment.',
+    (0, 0, 540013 /*From ID Server*/, 'Maßberechnung - Bändern',
+     'Inaktiver Seed: TU-Packvorschrift für die Maßberechnungsmethode Bändern. Pro Deployment aktivieren und konfigurieren.',
      'N', 'N', 'N',
      TO_TIMESTAMP('2026-07-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
      100,
@@ -32,8 +32,8 @@ INSERT INTO M_HU_PI_Version
      IsActive,
      Created, CreatedBy, Updated, UpdatedBy)
 VALUES
-    (0, 0, 540013 /*From ID Server*/, 540013 /*M_HU_PI Strapping*/,
-     'Dimension Calculation - Strapping',
+    (0, 0, 540013 /*From ID Server*/, 540013 /*M_HU_PI Bändern*/,
+     'Maßberechnung - Bändern',
      'TU', 'S', 'N',
      'N',
      TO_TIMESTAMP('2026-07-22 10:00:01', 'YYYY-MM-DD HH24:MI:SS'),
@@ -66,10 +66,10 @@ INSERT INTO M_HU_PI_Item_Product
      IsActive,
      Created, CreatedBy, Updated, UpdatedBy)
 VALUES
-    (0, 0, 540023 /*From ID Server*/, 540018 /*Item Strapping*/,
+    (0, 0, 540023 /*From ID Server*/, 540018 /*Item Bändern*/,
      NULL, 0, 'Y', 'Y', 'N',
      'N',
-     'Dimension Calculation - Strapping', NULL,
+     'Maßberechnung - Bändern', NULL,
      TO_TIMESTAMP('2001-01-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
      'N',
      TO_TIMESTAMP('2026-07-22 10:00:03', 'YYYY-MM-DD HH24:MI:SS'),
@@ -87,8 +87,8 @@ INSERT INTO M_HU_PI
      IsActive, IsDefaultLU, IsDefaultForPicking,
      Created, CreatedBy, Updated, UpdatedBy)
 VALUES
-    (0, 0, 540014 /*From ID Server*/, 'Dimension Calculation - Repacking',
-     'Inactive seed: TU packing instruction for Repacking dimension calculation mode. Activate and configure per deployment.',
+    (0, 0, 540014 /*From ID Server*/, 'Maßberechnung - Umverpacken',
+     'Inaktiver Seed: TU-Packvorschrift für die Maßberechnungsmethode Umverpacken. Pro Deployment aktivieren und konfigurieren.',
      'N', 'N', 'N',
      TO_TIMESTAMP('2026-07-22 10:00:04', 'YYYY-MM-DD HH24:MI:SS'),
      100,
@@ -102,8 +102,8 @@ INSERT INTO M_HU_PI_Version
      IsActive,
      Created, CreatedBy, Updated, UpdatedBy)
 VALUES
-    (0, 0, 540014 /*From ID Server*/, 540014 /*M_HU_PI Repacking*/,
-     'Dimension Calculation - Repacking',
+    (0, 0, 540014 /*From ID Server*/, 540014 /*M_HU_PI Umverpacken*/,
+     'Maßberechnung - Umverpacken',
      'TU', 'R', 'N',
      'N',
      TO_TIMESTAMP('2026-07-22 10:00:05', 'YYYY-MM-DD HH24:MI:SS'),
@@ -136,10 +136,10 @@ INSERT INTO M_HU_PI_Item_Product
      IsActive,
      Created, CreatedBy, Updated, UpdatedBy)
 VALUES
-    (0, 0, 540021 /*From ID Server*/, 540019 /*Item Repacking*/,
+    (0, 0, 540021 /*From ID Server*/, 540019 /*Item Umverpacken*/,
      NULL, 0, 'Y', 'Y', 'N',
      'N',
-     'Dimension Calculation - Repacking', NULL,
+     'Maßberechnung - Umverpacken', NULL,
      TO_TIMESTAMP('2001-01-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
      'N',
      TO_TIMESTAMP('2026-07-22 10:00:07', 'YYYY-MM-DD HH24:MI:SS'),
@@ -157,8 +157,8 @@ INSERT INTO M_HU_PI
      IsActive, IsDefaultLU, IsDefaultForPicking,
      Created, CreatedBy, Updated, UpdatedBy)
 VALUES
-    (0, 0, 540015 /*From ID Server*/, 'Dimension Calculation - Nesting',
-     'Inactive seed: TU packing instruction for Nesting dimension calculation mode. Activate and configure per deployment.',
+    (0, 0, 540015 /*From ID Server*/, 'Maßberechnung - Verschachteln',
+     'Inaktiver Seed: TU-Packvorschrift für die Maßberechnungsmethode Verschachteln. Pro Deployment aktivieren und konfigurieren.',
      'N', 'N', 'N',
      TO_TIMESTAMP('2026-07-22 10:00:08', 'YYYY-MM-DD HH24:MI:SS'),
      100,
@@ -172,8 +172,8 @@ INSERT INTO M_HU_PI_Version
      IsActive,
      Created, CreatedBy, Updated, UpdatedBy)
 VALUES
-    (0, 0, 540015 /*From ID Server*/, 540015 /*M_HU_PI Nesting*/,
-     'Dimension Calculation - Nesting',
+    (0, 0, 540015 /*From ID Server*/, 540015 /*M_HU_PI Verschachteln*/,
+     'Maßberechnung - Verschachteln',
      'TU', 'N', 'N',
      'N',
      TO_TIMESTAMP('2026-07-22 10:00:09', 'YYYY-MM-DD HH24:MI:SS'),
@@ -206,10 +206,10 @@ INSERT INTO M_HU_PI_Item_Product
      IsActive,
      Created, CreatedBy, Updated, UpdatedBy)
 VALUES
-    (0, 0, 540022 /*From ID Server*/, 540020 /*Item Nesting*/,
+    (0, 0, 540022 /*From ID Server*/, 540020 /*Item Verschachteln*/,
      NULL, 0, 'Y', 'Y', 'N',
      'N',
-     'Dimension Calculation - Nesting', NULL,
+     'Maßberechnung - Verschachteln', NULL,
      TO_TIMESTAMP('2001-01-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
      'N',
      TO_TIMESTAMP('2026-07-22 10:00:11', 'YYYY-MM-DD HH24:MI:SS'),

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815630_sys_gh30361_DimensionCalc_mode_PIs_inactive.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815630_sys_gh30361_DimensionCalc_mode_PIs_inactive.sql
@@ -1,0 +1,219 @@
+-- Ship 3 inactive TU packing instructions, one per dimension-calculation mode (Strapping/Repacking/Nesting).
+-- These are INACTIVE seed records; a separate customer migration activates and configures them per deployment.
+-- PackageDimensionCalcMethod codes: S=Strapping, R=Repacking, N=Nesting (AD_Reference 542122).
+--
+-- IDs allocated from idserver.metas.de on 2026-07-22:
+--   M_HU_PI               540013 (Strapping), 540014 (Repacking), 540015 (Nesting)
+--   M_HU_PI_Version        540013 (Strapping), 540014 (Repacking), 540015 (Nesting)
+--   M_HU_PI_Item           540018 (Strapping), 540019 (Repacking), 540020 (Nesting)
+--   M_HU_PI_Item_Product   540023 (Strapping), 540021 (Repacking), 540022 (Nesting)
+
+-- ============================================================
+-- STRAPPING mode (S)
+-- ============================================================
+
+INSERT INTO M_HU_PI
+    (AD_Client_ID, AD_Org_ID, M_HU_PI_ID, Name, Description,
+     IsActive, IsDefaultLU, IsDefaultForPicking,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (0, 0, 540013 /*From ID Server*/, 'Dimension Calculation - Strapping',
+     'Inactive seed: TU packing instruction for Strapping dimension calculation mode. Activate and configure per deployment.',
+     'N', 'N', 'N',
+     TO_TIMESTAMP('2026-07-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+     100,
+     TO_TIMESTAMP('2026-07-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+     100)
+;
+
+INSERT INTO M_HU_PI_Version
+    (AD_Client_ID, AD_Org_ID, M_HU_PI_Version_ID, M_HU_PI_ID, Name,
+     HU_UnitType, PackageDimensionCalcMethod, IsCurrent,
+     IsActive,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (0, 0, 540013 /*From ID Server*/, 540013 /*M_HU_PI Strapping*/,
+     'Dimension Calculation - Strapping',
+     'TU', 'S', 'N',
+     'N',
+     TO_TIMESTAMP('2026-07-22 10:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+     100,
+     TO_TIMESTAMP('2026-07-22 10:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+     100)
+;
+
+INSERT INTO M_HU_PI_Item
+    (AD_Client_ID, AD_Org_ID, M_HU_PI_Item_ID, M_HU_PI_Version_ID,
+     ItemType, Qty,
+     IsActive, IsAllowDirectlyOnPM,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (0, 0, 540018 /*From ID Server*/, 540013 /*PIV Strapping*/,
+     'MI', 0,
+     'N', 'N',
+     TO_TIMESTAMP('2026-07-22 10:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+     100,
+     TO_TIMESTAMP('2026-07-22 10:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+     100)
+;
+
+INSERT INTO M_HU_PI_Item_Product
+    (AD_Client_ID, AD_Org_ID, M_HU_PI_Item_Product_ID, M_HU_PI_Item_ID,
+     M_Product_ID, Qty, IsAllowAnyProduct, IsInfiniteCapacity, IsDefaultForProduct,
+     IsOrderInTUUOMWhenMatched,
+     Name, Description,
+     ValidFrom,
+     IsActive,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (0, 0, 540023 /*From ID Server*/, 540018 /*Item Strapping*/,
+     NULL, 0, 'Y', 'Y', 'N',
+     'N',
+     'Dimension Calculation - Strapping', NULL,
+     TO_TIMESTAMP('2001-01-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+     'N',
+     TO_TIMESTAMP('2026-07-22 10:00:03', 'YYYY-MM-DD HH24:MI:SS'),
+     100,
+     TO_TIMESTAMP('2026-07-22 10:00:03', 'YYYY-MM-DD HH24:MI:SS'),
+     100)
+;
+
+-- ============================================================
+-- REPACKING mode (R)
+-- ============================================================
+
+INSERT INTO M_HU_PI
+    (AD_Client_ID, AD_Org_ID, M_HU_PI_ID, Name, Description,
+     IsActive, IsDefaultLU, IsDefaultForPicking,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (0, 0, 540014 /*From ID Server*/, 'Dimension Calculation - Repacking',
+     'Inactive seed: TU packing instruction for Repacking dimension calculation mode. Activate and configure per deployment.',
+     'N', 'N', 'N',
+     TO_TIMESTAMP('2026-07-22 10:00:04', 'YYYY-MM-DD HH24:MI:SS'),
+     100,
+     TO_TIMESTAMP('2026-07-22 10:00:04', 'YYYY-MM-DD HH24:MI:SS'),
+     100)
+;
+
+INSERT INTO M_HU_PI_Version
+    (AD_Client_ID, AD_Org_ID, M_HU_PI_Version_ID, M_HU_PI_ID, Name,
+     HU_UnitType, PackageDimensionCalcMethod, IsCurrent,
+     IsActive,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (0, 0, 540014 /*From ID Server*/, 540014 /*M_HU_PI Repacking*/,
+     'Dimension Calculation - Repacking',
+     'TU', 'R', 'N',
+     'N',
+     TO_TIMESTAMP('2026-07-22 10:00:05', 'YYYY-MM-DD HH24:MI:SS'),
+     100,
+     TO_TIMESTAMP('2026-07-22 10:00:05', 'YYYY-MM-DD HH24:MI:SS'),
+     100)
+;
+
+INSERT INTO M_HU_PI_Item
+    (AD_Client_ID, AD_Org_ID, M_HU_PI_Item_ID, M_HU_PI_Version_ID,
+     ItemType, Qty,
+     IsActive, IsAllowDirectlyOnPM,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (0, 0, 540019 /*From ID Server*/, 540014 /*PIV Repacking*/,
+     'MI', 0,
+     'N', 'N',
+     TO_TIMESTAMP('2026-07-22 10:00:06', 'YYYY-MM-DD HH24:MI:SS'),
+     100,
+     TO_TIMESTAMP('2026-07-22 10:00:06', 'YYYY-MM-DD HH24:MI:SS'),
+     100)
+;
+
+INSERT INTO M_HU_PI_Item_Product
+    (AD_Client_ID, AD_Org_ID, M_HU_PI_Item_Product_ID, M_HU_PI_Item_ID,
+     M_Product_ID, Qty, IsAllowAnyProduct, IsInfiniteCapacity, IsDefaultForProduct,
+     IsOrderInTUUOMWhenMatched,
+     Name, Description,
+     ValidFrom,
+     IsActive,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (0, 0, 540021 /*From ID Server*/, 540019 /*Item Repacking*/,
+     NULL, 0, 'Y', 'Y', 'N',
+     'N',
+     'Dimension Calculation - Repacking', NULL,
+     TO_TIMESTAMP('2001-01-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+     'N',
+     TO_TIMESTAMP('2026-07-22 10:00:07', 'YYYY-MM-DD HH24:MI:SS'),
+     100,
+     TO_TIMESTAMP('2026-07-22 10:00:07', 'YYYY-MM-DD HH24:MI:SS'),
+     100)
+;
+
+-- ============================================================
+-- NESTING mode (N)
+-- ============================================================
+
+INSERT INTO M_HU_PI
+    (AD_Client_ID, AD_Org_ID, M_HU_PI_ID, Name, Description,
+     IsActive, IsDefaultLU, IsDefaultForPicking,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (0, 0, 540015 /*From ID Server*/, 'Dimension Calculation - Nesting',
+     'Inactive seed: TU packing instruction for Nesting dimension calculation mode. Activate and configure per deployment.',
+     'N', 'N', 'N',
+     TO_TIMESTAMP('2026-07-22 10:00:08', 'YYYY-MM-DD HH24:MI:SS'),
+     100,
+     TO_TIMESTAMP('2026-07-22 10:00:08', 'YYYY-MM-DD HH24:MI:SS'),
+     100)
+;
+
+INSERT INTO M_HU_PI_Version
+    (AD_Client_ID, AD_Org_ID, M_HU_PI_Version_ID, M_HU_PI_ID, Name,
+     HU_UnitType, PackageDimensionCalcMethod, IsCurrent,
+     IsActive,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (0, 0, 540015 /*From ID Server*/, 540015 /*M_HU_PI Nesting*/,
+     'Dimension Calculation - Nesting',
+     'TU', 'N', 'N',
+     'N',
+     TO_TIMESTAMP('2026-07-22 10:00:09', 'YYYY-MM-DD HH24:MI:SS'),
+     100,
+     TO_TIMESTAMP('2026-07-22 10:00:09', 'YYYY-MM-DD HH24:MI:SS'),
+     100)
+;
+
+INSERT INTO M_HU_PI_Item
+    (AD_Client_ID, AD_Org_ID, M_HU_PI_Item_ID, M_HU_PI_Version_ID,
+     ItemType, Qty,
+     IsActive, IsAllowDirectlyOnPM,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (0, 0, 540020 /*From ID Server*/, 540015 /*PIV Nesting*/,
+     'MI', 0,
+     'N', 'N',
+     TO_TIMESTAMP('2026-07-22 10:00:10', 'YYYY-MM-DD HH24:MI:SS'),
+     100,
+     TO_TIMESTAMP('2026-07-22 10:00:10', 'YYYY-MM-DD HH24:MI:SS'),
+     100)
+;
+
+INSERT INTO M_HU_PI_Item_Product
+    (AD_Client_ID, AD_Org_ID, M_HU_PI_Item_Product_ID, M_HU_PI_Item_ID,
+     M_Product_ID, Qty, IsAllowAnyProduct, IsInfiniteCapacity, IsDefaultForProduct,
+     IsOrderInTUUOMWhenMatched,
+     Name, Description,
+     ValidFrom,
+     IsActive,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (0, 0, 540022 /*From ID Server*/, 540020 /*Item Nesting*/,
+     NULL, 0, 'Y', 'Y', 'N',
+     'N',
+     'Dimension Calculation - Nesting', NULL,
+     TO_TIMESTAMP('2001-01-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+     'N',
+     TO_TIMESTAMP('2026-07-22 10:00:11', 'YYYY-MM-DD HH24:MI:SS'),
+     100,
+     TO_TIMESTAMP('2026-07-22 10:00:11', 'YYYY-MM-DD HH24:MI:SS'),
+     100)
+;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815630_sys_gh30361_DimensionCalc_mode_PIs_inactive.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815630_sys_gh30361_DimensionCalc_mode_PIs_inactive.sql
@@ -18,7 +18,7 @@ INSERT INTO M_HU_PI
      Created, CreatedBy, Updated, UpdatedBy)
 VALUES
     (0, 0, 540013 /*From ID Server*/, 'Maßberechnung - Bändern',
-     'Inaktiver Seed: TU-Packvorschrift für die Maßberechnungsmethode Bändern. Pro Deployment aktivieren und konfigurieren.',
+     'TU-Packvorschrift für die Maßberechnungsmethode Bändern.',
      'N', 'N', 'N',
      TO_TIMESTAMP('2026-07-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
      100,
@@ -88,7 +88,7 @@ INSERT INTO M_HU_PI
      Created, CreatedBy, Updated, UpdatedBy)
 VALUES
     (0, 0, 540014 /*From ID Server*/, 'Maßberechnung - Umverpacken',
-     'Inaktiver Seed: TU-Packvorschrift für die Maßberechnungsmethode Umverpacken. Pro Deployment aktivieren und konfigurieren.',
+     'TU-Packvorschrift für die Maßberechnungsmethode Umverpacken.',
      'N', 'N', 'N',
      TO_TIMESTAMP('2026-07-22 10:00:04', 'YYYY-MM-DD HH24:MI:SS'),
      100,
@@ -158,7 +158,7 @@ INSERT INTO M_HU_PI
      Created, CreatedBy, Updated, UpdatedBy)
 VALUES
     (0, 0, 540015 /*From ID Server*/, 'Maßberechnung - Verschachteln',
-     'Inaktiver Seed: TU-Packvorschrift für die Maßberechnungsmethode Verschachteln. Pro Deployment aktivieren und konfigurieren.',
+     'TU-Packvorschrift für die Maßberechnungsmethode Verschachteln.',
      'N', 'N', 'N',
      TO_TIMESTAMP('2026-07-22 10:00:08', 'YYYY-MM-DD HH24:MI:SS'),
      100,

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815840_sys_gh30361_PackageDimensions_CheckIsSelfPacked_sysconfig.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815840_sys_gh30361_PackageDimensions_CheckIsSelfPacked_sysconfig.sql
@@ -1,7 +1,6 @@
--- Insert AD_SysConfig row for the IsSelfPacked dimension gate.
--- Default Value='N' → gate is OFF → flag-independent behaviour (new default).
--- Set to 'Y' on a specific instance to restore the legacy gate
--- (non-self-packed products → PackageDimensions.UNSPECIFIED).
+-- AD_SysConfig row controlling the IsSelfPacked dimension gate.
+-- Value='N' → product dimensions are used regardless of the self-packed flag.
+-- Value='Y' → a non-self-packed product yields PackageDimensions.UNSPECIFIED.
 --
 -- ID allocated from idserver.metas.de on 2026-07-23:
 --   AD_SysConfig 541837
@@ -16,7 +15,7 @@ VALUES
     (541837 /*From ID Server*/, 0, 0,
      'de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked',
      'N',
-     'When Y, the legacy IsSelfPacked gate is active: non-self-packed products return PackageDimensions.UNSPECIFIED instead of using their named dimensions. Default N = flag-independent behaviour.',
+     'Controls the IsSelfPacked dimension gate. When Y, a non-self-packed product yields PackageDimensions.UNSPECIFIED; when N, product dimensions are used regardless of the self-packed flag.',
      'de.metas.handlingunits', 'S',
      'Y',
      TO_TIMESTAMP('2026-07-23 00:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815840_sys_gh30361_PackageDimensions_CheckIsSelfPacked_sysconfig.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815840_sys_gh30361_PackageDimensions_CheckIsSelfPacked_sysconfig.sql
@@ -1,0 +1,24 @@
+-- Insert AD_SysConfig row for the IsSelfPacked dimension gate.
+-- Default Value='N' → gate is OFF → flag-independent behaviour (new default).
+-- Set to 'Y' on a specific instance to restore the legacy gate
+-- (non-self-packed products → PackageDimensions.UNSPECIFIED).
+--
+-- ID allocated from idserver.metas.de on 2026-07-23:
+--   AD_SysConfig 541837
+
+INSERT INTO AD_SysConfig
+    (AD_SysConfig_ID, AD_Client_ID, AD_Org_ID,
+     Name, Value, Description,
+     EntityType, ConfigurationLevel,
+     IsActive,
+     Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+    (541837 /*From ID Server*/, 0, 0,
+     'de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked',
+     'N',
+     'When Y, the legacy IsSelfPacked gate is active: non-self-packed products return PackageDimensions.UNSPECIFIED instead of using their named dimensions. Default N = flag-independent behaviour.',
+     'de.metas.handlingunits', 'S',
+     'Y',
+     TO_TIMESTAMP('2026-07-23 00:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-23 00:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100)
+;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815870_sys_gh30361_msg_M_HU_PI_Version_CalcMethodOnlyOnTU.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815870_sys_gh30361_msg_M_HU_PI_Version_CalcMethodOnlyOnTU.sql
@@ -1,0 +1,85 @@
+-- Run mode: SWING_CLIENT
+-- IDs allocated from idserver.metas.de on 2026-07-23:
+--   AD_Message  545785  (M_HU_PI_Version_CalcMethodOnlyOnTU)
+
+-- AD_Message: guard fired when PackageDimensionCalcMethod is set on a non-TU
+-- packing instruction version (LU, VHU, or null HU unit type). Only Transport
+-- Unit (TU) versions may carry a dimension calculation method.
+-- MsgType=E because this is a user-validation error surfaced by the model interceptor.
+-- EntityType=de.metas.handlingunits (module-owned message, not a core dictionary entry).
+-- 2026-07-23T12:00:00Z
+INSERT INTO AD_Message
+    (AD_Client_ID, AD_Message_ID, AD_Org_ID, Created, CreatedBy, EntityType, IsActive,
+     MsgText, MsgTip, MsgType, ErrorCode, Updated, UpdatedBy, Value)
+VALUES
+    (0, 545785 /*From ID Server*/, 0,
+     TO_TIMESTAMP('2026-07-23 12:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+     100, 'de.metas.handlingunits', 'Y',
+     'Die Maßberechnungsmethode kann nur auf Transporteinheit-(TU-)Packvorschriftsversionen gesetzt werden.',
+     NULL,
+     'E',
+     'M_HU_PI_Version_CalcMethodOnlyOnTU',
+     TO_TIMESTAMP('2026-07-23 12:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+     100,
+     'M_HU_PI_Version_CalcMethodOnlyOnTU')
+;
+
+-- Seed translation rows for all active system languages (copies DE base text)
+-- 2026-07-23T12:00:01Z
+INSERT INTO AD_Message_Trl
+    (AD_Language, AD_Message_ID, AD_Client_ID, AD_Org_ID,
+     Created, CreatedBy, Updated, UpdatedBy,
+     IsActive, IsTranslated, MsgText, MsgTip)
+SELECT l.AD_Language,
+       t.AD_Message_ID,
+       t.AD_Client_ID,
+       t.AD_Org_ID,
+       TO_TIMESTAMP('2026-07-23 12:00:01.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+       100,
+       TO_TIMESTAMP('2026-07-23 12:00:01.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+       100,
+       'Y',
+       'N',
+       t.MsgText,
+       t.MsgTip
+FROM AD_Language l,
+     AD_Message  t
+WHERE l.IsActive = 'Y'
+  AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Message_ID = 545785
+  AND NOT EXISTS (SELECT 1
+                  FROM AD_Message_Trl tt
+                  WHERE tt.AD_Language   = l.AD_Language
+                    AND tt.AD_Message_ID = t.AD_Message_ID)
+;
+
+-- Override en_US with English translation
+-- 2026-07-23T12:00:02Z
+UPDATE AD_Message_Trl
+SET    MsgText      = 'The package dimension calculation method can only be set on Transport Unit (TU) packing instruction versions.',
+       IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-07-23 12:00:02.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+       UpdatedBy    = 100
+WHERE  AD_Language  = 'en_US'
+  AND  AD_Message_ID = 545785
+;
+
+-- Mark de_DE as actively translated (same text as base)
+-- 2026-07-23T12:00:03Z
+UPDATE AD_Message_Trl
+SET    IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-07-23 12:00:03.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+       UpdatedBy    = 100
+WHERE  AD_Language  = 'de_DE'
+  AND  AD_Message_ID = 545785
+;
+
+-- Mark de_CH as actively translated (same text as base)
+-- 2026-07-23T12:00:04Z
+UPDATE AD_Message_Trl
+SET    IsTranslated = 'Y',
+       Updated      = TO_TIMESTAMP('2026-07-23 12:00:04.000000', 'YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',
+       UpdatedBy    = 100
+WHERE  AD_Language  = 'de_CH'
+  AND  AD_Message_ID = 545785
+;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815960_sys_gh30361_CU_TU_Zuordnung_Menu_Logistik.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815960_sys_gh30361_CU_TU_Zuordnung_Menu_Logistik.sql
@@ -1,44 +1,17 @@
--- Place the "CU-TU Zuordnung" window (AD_Window 540191) menu node under "Logistik"
--- (AD_Menu 1000016) in the main menu tree (AD_Tree_ID=10), as a sibling of the other
--- packing-instruction config windows already there — Packvorschrift (540830),
--- Packvorschrift Version (540831), GRAI-Packvorschrift-Zuordnung (542333).
---
--- Until now this window's menu node sat under a different summary folder, so it was not
--- findable next to the other packing-instruction windows: opening it by window id in the
--- WebUI shows no proper menu path. It is a standard TU/HU packing-instruction config
--- window and belongs under Logistik with its siblings.
---
--- Idempotent: the node is resolved from AD_Menu by its window id (no hard-coded menu id),
--- re-parented only when it is not already under Logistik, and a tree node is inserted only
--- if the window's menu entry has none at all. Re-running the script is a no-op.
+-- Move the "CU-TU Zuordnung" window menu node from the "Handling Units" summary folder
+-- to "Logistik" in the main menu tree, so it is findable beside the other packing config
+-- windows instead of showing no proper menu path.
+--   AD_Tree_ID   10       main menu tree
+--   Node_ID      540489   AD_Menu entry of window "CU-TU Zuordnung" (AD_Window 540191)
+--   old parent   540478   Handling Units
+--   new parent   1000016  Logistik
+--   SeqNo        47       directly before its counterpart "CU-TU Zuordnung konsolidieren" (48)
+-- The menu tree is identical across all instances, so the node and its target slot are fixed.
 
--- 1. Re-parent the existing tree node under Logistik (appended after the current children).
-UPDATE AD_TreeNodeMM t
-SET    Parent_ID = 1000016 /*Logistik*/,
-       SeqNo     = (SELECT COALESCE(MAX(t2.SeqNo), 0) + 1
-                    FROM   AD_TreeNodeMM t2
-                    WHERE  t2.AD_Tree_ID = 10
-                      AND  t2.Parent_ID  = 1000016
-                      AND  t2.Node_ID   <> t.Node_ID),
+UPDATE AD_TreeNodeMM
+SET    Parent_ID = 1000016,
+       SeqNo     = 47,
        Updated   = TO_TIMESTAMP('2026-07-23 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
        UpdatedBy = 100
-WHERE  t.AD_Tree_ID = 10
-  AND  t.Node_ID IN (SELECT m.AD_Menu_ID FROM AD_Menu m
-                     WHERE m.AD_Window_ID = 540191 AND m.IsActive = 'Y')
-  AND  t.Parent_ID <> 1000016;
-
--- 2. Safety net: if the window's menu entry has no tree node at all, create one under Logistik.
-INSERT INTO AD_TreeNodeMM
-    (AD_Client_ID, AD_Org_ID, IsActive,
-     Created, CreatedBy, Updated, UpdatedBy,
-     AD_Tree_ID, Node_ID, Parent_ID, SeqNo)
-SELECT 0, 0, 'Y',
-       TO_TIMESTAMP('2026-07-23 10:00:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
-       TO_TIMESTAMP('2026-07-23 10:00:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
-       10, m.AD_Menu_ID, 1000016 /*Logistik*/,
-       (SELECT COALESCE(MAX(SeqNo), 0) + 1 FROM AD_TreeNodeMM
-        WHERE AD_Tree_ID = 10 AND Parent_ID = 1000016)
-FROM   AD_Menu m
-WHERE  m.AD_Window_ID = 540191 AND m.IsActive = 'Y'
-  AND  NOT EXISTS (SELECT 1 FROM AD_TreeNodeMM t
-                   WHERE t.AD_Tree_ID = 10 AND t.Node_ID = m.AD_Menu_ID);
+WHERE  AD_Tree_ID = 10
+  AND  Node_ID    = 540489;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815960_sys_gh30361_CU_TU_Zuordnung_Menu_Logistik.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5815960_sys_gh30361_CU_TU_Zuordnung_Menu_Logistik.sql
@@ -1,0 +1,44 @@
+-- Place the "CU-TU Zuordnung" window (AD_Window 540191) menu node under "Logistik"
+-- (AD_Menu 1000016) in the main menu tree (AD_Tree_ID=10), as a sibling of the other
+-- packing-instruction config windows already there — Packvorschrift (540830),
+-- Packvorschrift Version (540831), GRAI-Packvorschrift-Zuordnung (542333).
+--
+-- Until now this window's menu node sat under a different summary folder, so it was not
+-- findable next to the other packing-instruction windows: opening it by window id in the
+-- WebUI shows no proper menu path. It is a standard TU/HU packing-instruction config
+-- window and belongs under Logistik with its siblings.
+--
+-- Idempotent: the node is resolved from AD_Menu by its window id (no hard-coded menu id),
+-- re-parented only when it is not already under Logistik, and a tree node is inserted only
+-- if the window's menu entry has none at all. Re-running the script is a no-op.
+
+-- 1. Re-parent the existing tree node under Logistik (appended after the current children).
+UPDATE AD_TreeNodeMM t
+SET    Parent_ID = 1000016 /*Logistik*/,
+       SeqNo     = (SELECT COALESCE(MAX(t2.SeqNo), 0) + 1
+                    FROM   AD_TreeNodeMM t2
+                    WHERE  t2.AD_Tree_ID = 10
+                      AND  t2.Parent_ID  = 1000016
+                      AND  t2.Node_ID   <> t.Node_ID),
+       Updated   = TO_TIMESTAMP('2026-07-23 10:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy = 100
+WHERE  t.AD_Tree_ID = 10
+  AND  t.Node_ID IN (SELECT m.AD_Menu_ID FROM AD_Menu m
+                     WHERE m.AD_Window_ID = 540191 AND m.IsActive = 'Y')
+  AND  t.Parent_ID <> 1000016;
+
+-- 2. Safety net: if the window's menu entry has no tree node at all, create one under Logistik.
+INSERT INTO AD_TreeNodeMM
+    (AD_Client_ID, AD_Org_ID, IsActive,
+     Created, CreatedBy, Updated, UpdatedBy,
+     AD_Tree_ID, Node_ID, Parent_ID, SeqNo)
+SELECT 0, 0, 'Y',
+       TO_TIMESTAMP('2026-07-23 10:00:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       TO_TIMESTAMP('2026-07-23 10:00:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       10, m.AD_Menu_ID, 1000016 /*Logistik*/,
+       (SELECT COALESCE(MAX(SeqNo), 0) + 1 FROM AD_TreeNodeMM
+        WHERE AD_Tree_ID = 10 AND Parent_ID = 1000016)
+FROM   AD_Menu m
+WHERE  m.AD_Window_ID = 540191 AND m.IsActive = 'Y'
+  AND  NOT EXISTS (SELECT 1 FROM AD_TreeNodeMM t
+                   WHERE t.AD_Tree_ID = 10 AND t.Node_ID = m.AD_Menu_ID);

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/model/validator/M_HU_PI_VersionInterceptorTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/model/validator/M_HU_PI_VersionInterceptorTest.java
@@ -1,0 +1,146 @@
+package de.metas.handlingunits.model.validator;
+
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.handlingunits.HuUnitType;
+import de.metas.handlingunits.model.I_M_HU_PI_Version;
+import de.metas.product.PackageDimensionCalcMethod;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for the {@link M_HU_PI_Version} interceptor guard:
+ * {@code PackageDimensionCalcMethod} may only be set on TU pi-versions.
+ */
+class M_HU_PI_VersionInterceptorTest
+{
+	private M_HU_PI_Version interceptor;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		interceptor = new M_HU_PI_Version();
+	}
+
+	@Nested
+	class RejectCalcMethod
+	{
+		/** LU pi-version with a calc method set must throw. */
+		@Test
+		void whenHuUnitTypeIsLU()
+		{
+			final I_M_HU_PI_Version piVersion = newInstance(I_M_HU_PI_Version.class);
+			piVersion.setHU_UnitType(HuUnitType.LU.getCode());
+			piVersion.setPackageDimensionCalcMethod(PackageDimensionCalcMethod.Strapping.getCode());
+			saveRecord(piVersion);
+
+			assertThatThrownBy(() -> interceptor.rejectCalcMethodOnNonTUVersions(piVersion))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("PackageDimensionCalcMethod can only be set on Transport Unit (TU) packing instruction versions");
+		}
+
+		/** VHU pi-version with a calc method set must throw — VHU is not TU. */
+		@Test
+		void whenHuUnitTypeIsVHU()
+		{
+			final I_M_HU_PI_Version piVersion = newInstance(I_M_HU_PI_Version.class);
+			piVersion.setHU_UnitType(HuUnitType.VHU.getCode());
+			piVersion.setPackageDimensionCalcMethod(PackageDimensionCalcMethod.Strapping.getCode());
+			saveRecord(piVersion);
+
+			assertThatThrownBy(() -> interceptor.rejectCalcMethodOnNonTUVersions(piVersion))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("PackageDimensionCalcMethod can only be set on Transport Unit (TU) packing instruction versions");
+		}
+
+		/** Null HU_UnitType with a calc method set must throw — null unit type is not TU. */
+		@Test
+		void whenHuUnitTypeIsNull()
+		{
+			final I_M_HU_PI_Version piVersion = newInstance(I_M_HU_PI_Version.class);
+			piVersion.setHU_UnitType(null);
+			piVersion.setPackageDimensionCalcMethod(PackageDimensionCalcMethod.Strapping.getCode());
+			saveRecord(piVersion);
+
+			assertThatThrownBy(() -> interceptor.rejectCalcMethodOnNonTUVersions(piVersion))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("PackageDimensionCalcMethod can only be set on Transport Unit (TU) packing instruction versions");
+		}
+
+		/**
+		 * Changing HU_UnitType from TU to LU while calc method remains set must throw —
+		 * the guard watches HU_UnitType changes too (escape-path coverage).
+		 */
+		@Test
+		void whenHuUnitTypeChangedFromTUToLUWithCalcMethodStillSet()
+		{
+			final I_M_HU_PI_Version piVersion = newInstance(I_M_HU_PI_Version.class);
+			piVersion.setHU_UnitType(HuUnitType.LU.getCode());
+			piVersion.setPackageDimensionCalcMethod(PackageDimensionCalcMethod.Strapping.getCode());
+			saveRecord(piVersion);
+
+			assertThatThrownBy(() -> interceptor.rejectCalcMethodOnNonTUVersions(piVersion))
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("PackageDimensionCalcMethod can only be set on Transport Unit (TU) packing instruction versions");
+		}
+	}
+
+	@Nested
+	class AllowCalcMethod
+	{
+		/** TU pi-version with a calc method set must be accepted without error. */
+		@Test
+		void whenHuUnitTypeIsTU()
+		{
+			final I_M_HU_PI_Version piVersion = newInstance(I_M_HU_PI_Version.class);
+			piVersion.setHU_UnitType(HuUnitType.TU.getCode());
+			piVersion.setPackageDimensionCalcMethod(PackageDimensionCalcMethod.Strapping.getCode());
+			saveRecord(piVersion);
+
+			assertThatCode(() -> interceptor.rejectCalcMethodOnNonTUVersions(piVersion))
+					.doesNotThrowAnyException();
+		}
+
+		/** Non-TU pi-version with no calc method set must be accepted (null calc method is OK). */
+		@Test
+		void whenCalcMethodIsNull()
+		{
+			final I_M_HU_PI_Version piVersion = newInstance(I_M_HU_PI_Version.class);
+			piVersion.setHU_UnitType(HuUnitType.LU.getCode());
+			piVersion.setPackageDimensionCalcMethod(null);
+			saveRecord(piVersion);
+
+			assertThatCode(() -> interceptor.rejectCalcMethodOnNonTUVersions(piVersion))
+					.doesNotThrowAnyException();
+		}
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/model/validator/M_HU_PI_VersionInterceptorTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/model/validator/M_HU_PI_VersionInterceptorTest.java
@@ -65,7 +65,7 @@ class M_HU_PI_VersionInterceptorTest
 
 			assertThatThrownBy(() -> interceptor.rejectCalcMethodOnNonTUVersions(piVersion))
 					.isInstanceOf(AdempiereException.class)
-					.hasMessageContaining("PackageDimensionCalcMethod can only be set on Transport Unit (TU) packing instruction versions");
+					.hasMessageContaining("M_HU_PI_Version_CalcMethodOnlyOnTU");
 		}
 
 		/** VHU pi-version with a calc method set must throw — VHU is not TU. */
@@ -79,7 +79,7 @@ class M_HU_PI_VersionInterceptorTest
 
 			assertThatThrownBy(() -> interceptor.rejectCalcMethodOnNonTUVersions(piVersion))
 					.isInstanceOf(AdempiereException.class)
-					.hasMessageContaining("PackageDimensionCalcMethod can only be set on Transport Unit (TU) packing instruction versions");
+					.hasMessageContaining("M_HU_PI_Version_CalcMethodOnlyOnTU");
 		}
 
 		/** Null HU_UnitType with a calc method set must throw — null unit type is not TU. */
@@ -93,7 +93,7 @@ class M_HU_PI_VersionInterceptorTest
 
 			assertThatThrownBy(() -> interceptor.rejectCalcMethodOnNonTUVersions(piVersion))
 					.isInstanceOf(AdempiereException.class)
-					.hasMessageContaining("PackageDimensionCalcMethod can only be set on Transport Unit (TU) packing instruction versions");
+					.hasMessageContaining("M_HU_PI_Version_CalcMethodOnlyOnTU");
 		}
 
 		/**
@@ -110,7 +110,7 @@ class M_HU_PI_VersionInterceptorTest
 
 			assertThatThrownBy(() -> interceptor.rejectCalcMethodOnNonTUVersions(piVersion))
 					.isInstanceOf(AdempiereException.class)
-					.hasMessageContaining("PackageDimensionCalcMethod can only be set on Transport Unit (TU) packing instruction versions");
+					.hasMessageContaining("M_HU_PI_Version_CalcMethodOnlyOnTU");
 		}
 	}
 

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipping/HUPackageBL_DimensionCalcTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipping/HUPackageBL_DimensionCalcTest.java
@@ -1,0 +1,226 @@
+package de.metas.handlingunits.shipping;
+
+import de.metas.handlingunits.IHandlingUnitsDAO;
+import de.metas.handlingunits.allocation.impl.HUProducerDestination;
+import de.metas.handlingunits.allocation.transfer.HUTransformService;
+import de.metas.handlingunits.allocation.transfer.impl.LUTUProducerDestination;
+import de.metas.handlingunits.allocation.transfer.impl.LUTUProducerDestinationTestSupport;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.I_M_HU_PI;
+import de.metas.handlingunits.model.I_M_HU_PI_Item;
+import de.metas.handlingunits.model.I_M_HU_PI_Version;
+import de.metas.handlingunits.model.I_M_HU_PackingMaterial;
+import de.metas.handlingunits.model.X_M_HU_PI_Version;
+import de.metas.product.PackageDimensions;
+import de.metas.product.ProductRepository;
+import de.metas.quantity.Quantity;
+import de.metas.uom.X12DE355;
+import de.metas.util.Services;
+import de.metas.util.collections.CollectionUtils;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.save;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link IHUPackageBL#getPackageDimensions(I_M_HU)}:
+ * <ol>
+ *   <li>Multi-product TU with mode=Strapping → aggregated dims (not UNSPECIFIED).</li>
+ *   <li>Non-self-packed single product WITH dims → dims returned (IsSelfPacked is not checked).</li>
+ *   <li>Item without dims inside a multi-product TU → UNSPECIFIED, no exception thrown.</li>
+ * </ol>
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class HUPackageBL_DimensionCalcTest
+{
+	private LUTUProducerDestinationTestSupport data;
+	private IHUPackageBL huPackageBL;
+	/** A TU PI with NO packing material — so getPackageDimensions falls into the product-based branch. */
+	private I_M_HU_PI piTU_NoPackMat;
+
+	@BeforeEach
+	public void init()
+	{
+		data = new LUTUProducerDestinationTestSupport();
+		SpringContextHolder.registerJUnitBean(ProductRepository.newInstanceForUnitTesting());
+		huPackageBL = Services.get(IHUPackageBL.class);
+
+		// The packing material DAO resolves dimensions via a CM UOM lookup (X12DE355=CM).
+		// Register the UOM and assign it to the IFCO packing material so the packing-material path
+		// in getPackageDimensions doesn't throw "No UOM found for X12DE355=CM".
+		final I_C_UOM uomCm = newInstance(I_C_UOM.class);
+		uomCm.setName("cm");
+		uomCm.setUOMSymbol("cm");
+		uomCm.setX12DE355(X12DE355.CENTIMETRE.getCode());
+		uomCm.setStdPrecision(2);
+		saveRecord(uomCm);
+
+		// Set IFCO packing material dimensions (used by test 2 / single-product CU path).
+		final I_M_HU_PackingMaterial pmIFCO = data.helper.pmIFCO;
+		pmIFCO.setC_UOM_Dimension_ID(uomCm.getC_UOM_ID());
+		pmIFCO.setLength(new BigDecimal("60"));
+		pmIFCO.setWidth(new BigDecimal("40"));
+		pmIFCO.setHeight(new BigDecimal("30"));
+		save(pmIFCO);
+
+		// Create a lightweight TU PI with NO packing material item.
+		// getPackageDimensions skips the packing-material branch and enters the product-based branch.
+		piTU_NoPackMat = data.helper.createHUDefinition("TU_NoPackMat", X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit);
+		final I_M_HU_PI_Item item = data.helper.createHU_PI_Item_Material(piTU_NoPackMat);
+		data.helper.assignProduct(item, data.helper.pTomatoProductId, new BigDecimal("40"), data.helper.uomKg);
+		data.helper.assignProduct(item, data.helper.pSaladProductId, new BigDecimal("10"), data.helper.uomEach);
+
+		// Give both test products package dimensions so tests can rely on them having dims.
+		// Dimensions are stored on the I_M_Product record and read by ProductRepository#ofProductRecord.
+		data.helper.pTomato.setLengthInCm(30);
+		data.helper.pTomato.setWidthInCm(20);
+		data.helper.pTomato.setHeightInCm(10);
+		save(data.helper.pTomato);
+
+		data.helper.pSalad.setLengthInCm(25);
+		data.helper.pSalad.setWidthInCm(15);
+		data.helper.pSalad.setHeightInCm(12);
+		save(data.helper.pSalad);
+	}
+
+	/**
+	 * (b) Non-self-packed single product WITH dims → dims returned (IsSelfPacked is not checked).
+	 */
+	@Test
+	public void singleNonSelfPackedProduct_withDims_returnsDims()
+	{
+		// pTomato is NOT self-packed (default); it has dims set in @BeforeEach.
+		assertThat(data.helper.pTomato.isSelfPacked()).isFalse();
+
+		// Create a standalone virtual HU (CU) with qty=1 of tomato
+		final HUProducerDestination producer = HUProducerDestination.ofVirtualPI();
+		producer.setLocatorId(data.defaultLocatorId);
+		data.helper.load(producer, data.helper.pTomatoProductId, BigDecimal.ONE, data.helper.uomKg);
+
+		final List<I_M_HU> createdCUs = producer.getCreatedHUs();
+		final I_M_HU cu = CollectionUtils.singleElement(createdCUs);
+
+		// Act
+		final PackageDimensions result = huPackageBL.getPackageDimensions(cu);
+
+		// Assert: dims returned (NOT UNSPECIFIED).
+		// VHU, single product, qty=1 → ofProductDimensionsAndQty(30×20×10, 1):
+		//   sorted [10,20,30], stacking=10×1=10, mid=20, max=30 → length=10, height=20, width=30
+		assertThat(result.isUnspecified()).isFalse();
+		assertThat(result.getLengthInCM()).isEqualTo(10);
+		assertThat(result.getHeightInCM()).isEqualTo(20);
+		assertThat(result.getWidthInCM()).isEqualTo(30);
+	}
+
+	@Nested
+	class MultiProductTU
+	{
+		/**
+		 * (a) Multi-product TU with TU pi-version mode=Strapping → aggregated dims, NOT UNSPECIFIED.
+		 *
+		 * <p>Strapping: stacking-axis = sum of (min_edge × qty); other two = max of larger edges across products.</p>
+		 * <p>Tomato (30×20×10): sorted [10,20,30], qty=3. Salad (25×15×12): sorted [12,15,25], qty=2.</p>
+		 * <p>Stacking axis (lengthInCM) = 3×10 + 2×12 = 30+24 = 54.</p>
+		 * <p>heightInCM (mid max) = max(20, 15) = 20.</p>
+		 * <p>widthInCM  (max max) = max(30, 25) = 30.</p>
+		 */
+		@Test
+		public void withStrappingMode_returnsAggregatedDims()
+		{
+			// Set mode=Strapping on the no-packing-material TU PI version.
+			// Using piTU_NoPackMat so the HU has no packing material IDs → getPackageDimensions
+			// skips the packing-material branch and enters the product-based multi-product dispatch.
+			final I_M_HU_PI_Version piVersion = Services.get(IHandlingUnitsDAO.class).retrievePICurrentVersion(piTU_NoPackMat);
+			piVersion.setPackageDimensionCalcMethod("S"); // Strapping code
+			save(piVersion);
+
+			// Step 1: create a standalone TU (no LU) with 3kg Tomatoes via LUTUProducerDestination.
+			final LUTUProducerDestination producer = new LUTUProducerDestination();
+			producer.setLocatorId(data.defaultLocatorId);
+			producer.setNoLU();
+			producer.setTUPI(piTU_NoPackMat);
+			data.helper.load(producer, data.helper.pTomatoProductId, new BigDecimal("3"), data.helper.uomKg);
+
+			final List<I_M_HU> createdTUs = producer.getCreatedHUs();
+			assertThat(createdTUs).isNotEmpty();
+			final I_M_HU tu = createdTUs.get(0);
+
+			// Step 2: create a standalone salad CU with 2 each, then move it into the TU.
+			// LUTUProducerDestination uses a per-product HU cursor, so two separate loads create two TUs.
+			// We must use cuToExistingTU to build a genuine multi-product TU.
+			final HUProducerDestination saladProducer = HUProducerDestination.ofVirtualPI();
+			saladProducer.setLocatorId(data.defaultLocatorId);
+			data.helper.load(saladProducer, data.helper.pSaladProductId, new BigDecimal("2"), data.helper.uomEach);
+			final I_M_HU saladCU = CollectionUtils.singleElement(saladProducer.getCreatedHUs());
+
+			HUTransformService.newInstance(data.helper.getHUContext())
+					.cuToExistingTU(saladCU, Quantity.of(new BigDecimal("2"), data.helper.uomEach), tu);
+
+			// Act
+			final PackageDimensions result = huPackageBL.getPackageDimensions(tu);
+
+			// Assert: aggregated dims must NOT be UNSPECIFIED
+			assertThat(result.isUnspecified()).isFalse();
+			// Stacking axis (lengthInCM): 3×10 + 2×12 = 54
+			assertThat(result.getLengthInCM()).isEqualTo(54);
+			// heightInCM = max mid-edge: max(20,15) = 20
+			assertThat(result.getHeightInCM()).isEqualTo(20);
+			// widthInCM = max max-edge: max(30,25) = 30
+			assertThat(result.getWidthInCM()).isEqualTo(30);
+		}
+
+		/**
+		 * (c) When one or more items in a multi-product TU have no dims, the result is UNSPECIFIED without error.
+		 */
+		@Test
+		public void itemWithoutDims_returnsUnspecifiedNoException()
+		{
+			// Remove dims from pSalad: set to -1 which maps to PackageDimensions.UNSPECIFIED (-1,-1,-1).
+			data.helper.pSalad.setLengthInCm(-1);
+			data.helper.pSalad.setWidthInCm(-1);
+			data.helper.pSalad.setHeightInCm(-1);
+			save(data.helper.pSalad);
+
+			// Set a calc mode so we enter the multi-product dispatch path.
+			// Using piTU_NoPackMat so the HU has no packing material IDs → enters the product-based branch.
+			final I_M_HU_PI_Version piVersion = Services.get(IHandlingUnitsDAO.class).retrievePICurrentVersion(piTU_NoPackMat);
+			piVersion.setPackageDimensionCalcMethod("S"); // Strapping
+			save(piVersion);
+
+			// Step 1: create a standalone TU with 3kg Tomatoes (has dims).
+			final LUTUProducerDestination producer = new LUTUProducerDestination();
+			producer.setLocatorId(data.defaultLocatorId);
+			producer.setNoLU();
+			producer.setTUPI(piTU_NoPackMat);
+			data.helper.load(producer, data.helper.pTomatoProductId, new BigDecimal("3"), data.helper.uomKg);
+
+			final List<I_M_HU> createdTUs = producer.getCreatedHUs();
+			assertThat(createdTUs).isNotEmpty();
+			final I_M_HU tu = createdTUs.get(0);
+
+			// Step 2: create a salad CU (no dims) and move it into the TU.
+			final HUProducerDestination saladProducer = HUProducerDestination.ofVirtualPI();
+			saladProducer.setLocatorId(data.defaultLocatorId);
+			data.helper.load(saladProducer, data.helper.pSaladProductId, new BigDecimal("2"), data.helper.uomEach);
+			final I_M_HU saladCU = CollectionUtils.singleElement(saladProducer.getCreatedHUs());
+
+			HUTransformService.newInstance(data.helper.getHUContext())
+					.cuToExistingTU(saladCU, Quantity.of(new BigDecimal("2"), data.helper.uomEach), tu);
+
+			// Act: salad has no dims → ofItems returns UNSPECIFIED; no exception thrown
+			final PackageDimensions result = huPackageBL.getPackageDimensions(tu);
+			assertThat(result.isUnspecified()).isTrue();
+		}
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipping/HUPackageBL_DimensionCalcTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipping/HUPackageBL_DimensionCalcTest.java
@@ -11,12 +11,15 @@ import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
 import de.metas.handlingunits.model.I_M_HU_PackingMaterial;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
+import de.metas.organization.OrgId;
 import de.metas.product.PackageDimensions;
 import de.metas.product.ProductRepository;
 import de.metas.quantity.Quantity;
 import de.metas.uom.X12DE355;
 import de.metas.util.Services;
 import de.metas.util.collections.CollectionUtils;
+import org.adempiere.service.ClientId;
+import org.adempiere.service.ISysConfigBL;
 import org.adempiere.test.AdempiereTestWatcher;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_UOM;
@@ -121,6 +124,64 @@ public class HUPackageBL_DimensionCalcTest
 		assertThat(result.getLengthInCM()).isEqualTo(10);
 		assertThat(result.getHeightInCM()).isEqualTo(20);
 		assertThat(result.getWidthInCM()).isEqualTo(30);
+	}
+
+	/**
+	 * SysConfig gate: when {@code de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked=Y},
+	 * a non-self-packed single product WITH dims must return {@link PackageDimensions#UNSPECIFIED}.
+	 * When the SysConfig is absent / 'N' (the default), dims are returned unchanged.
+	 */
+	@Nested
+	class IsSelfPackedGate
+	{
+		private static final String SYSCONFIG_CHECK_IS_SELF_PACKED
+				= "de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked";
+
+		@Test
+		public void whenSysConfigY_nonSelfPacked_withDims_returnsUnspecified()
+		{
+			// Arrange: set SysConfig to Y (legacy gate active)
+			Services.get(ISysConfigBL.class).setValue(SYSCONFIG_CHECK_IS_SELF_PACKED, true, ClientId.SYSTEM, OrgId.ANY);
+
+			// pTomato is NOT self-packed; it has dims set in @BeforeEach.
+			assertThat(data.helper.pTomato.isSelfPacked()).isFalse();
+
+			final HUProducerDestination producer = HUProducerDestination.ofVirtualPI();
+			producer.setLocatorId(data.defaultLocatorId);
+			data.helper.load(producer, data.helper.pTomatoProductId, BigDecimal.ONE, data.helper.uomKg);
+
+			final I_M_HU cu = CollectionUtils.singleElement(producer.getCreatedHUs());
+
+			// Act
+			final PackageDimensions result = huPackageBL.getPackageDimensions(cu);
+
+			// Assert: gate active → UNSPECIFIED (IsSelfPacked=false blocks the product dims)
+			assertThat(result.isUnspecified()).isTrue();
+		}
+
+		@Test
+		public void whenSysConfigN_nonSelfPacked_withDims_returnsDims()
+		{
+			// Arrange: SysConfig absent / N → default OFF (new behaviour)
+			Services.get(ISysConfigBL.class).setValue(SYSCONFIG_CHECK_IS_SELF_PACKED, false, ClientId.SYSTEM, OrgId.ANY);
+
+			assertThat(data.helper.pTomato.isSelfPacked()).isFalse();
+
+			final HUProducerDestination producer = HUProducerDestination.ofVirtualPI();
+			producer.setLocatorId(data.defaultLocatorId);
+			data.helper.load(producer, data.helper.pTomatoProductId, BigDecimal.ONE, data.helper.uomKg);
+
+			final I_M_HU cu = CollectionUtils.singleElement(producer.getCreatedHUs());
+
+			// Act
+			final PackageDimensions result = huPackageBL.getPackageDimensions(cu);
+
+			// Assert: gate inactive → dims returned
+			assertThat(result.isUnspecified()).isFalse();
+			assertThat(result.getLengthInCM()).isEqualTo(10);
+			assertThat(result.getHeightInCM()).isEqualTo(20);
+			assertThat(result.getWidthInCM()).isEqualTo(30);
+		}
 	}
 
 	@Nested

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipping/HUPackageBL_DimensionCalcTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/shipping/HUPackageBL_DimensionCalcTest.java
@@ -11,15 +11,18 @@ import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
 import de.metas.handlingunits.model.I_M_HU_PackingMaterial;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
+import de.metas.handlingunits.shipping.CreatePackageForHURequest;
 import de.metas.organization.OrgId;
 import de.metas.product.PackageDimensions;
 import de.metas.product.ProductRepository;
 import de.metas.quantity.Quantity;
+import de.metas.shipping.ShipperId;
 import de.metas.uom.X12DE355;
 import de.metas.util.Services;
 import de.metas.util.collections.CollectionUtils;
 import org.adempiere.service.ClientId;
 import org.adempiere.service.ISysConfigBL;
+import org.compiere.model.I_M_Package;
 import org.adempiere.test.AdempiereTestWatcher;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_UOM;
@@ -181,6 +184,49 @@ public class HUPackageBL_DimensionCalcTest
 			assertThat(result.getLengthInCM()).isEqualTo(10);
 			assertThat(result.getHeightInCM()).isEqualTo(20);
 			assertThat(result.getWidthInCM()).isEqualTo(30);
+		}
+
+		/**
+		 * Exercises {@code resolveSingleUnitDimensions} (the multi-parcel split path in
+		 * {@code createM_Packages}): a non-self-packed VHU with integer qty=2 is split into 2 parcels;
+		 * when SysConfig=Y, each parcel must carry UNSPECIFIED dims.
+		 */
+		@Test
+		public void whenSysConfigY_nonSelfPacked_multiParcelSplit_eachParcelUnspecified()
+		{
+			// Arrange: gate active
+			Services.get(ISysConfigBL.class).setValue(SYSCONFIG_CHECK_IS_SELF_PACKED, true, ClientId.SYSTEM, OrgId.ANY);
+
+			// pTomato is NOT self-packed; it has dims (30×20×10) set in @BeforeEach.
+			assertThat(data.helper.pTomato.isSelfPacked()).isFalse();
+
+			// Create a loose VHU with integer qty=2 — triggers the multi-parcel split in createM_Packages.
+			final HUProducerDestination producer = HUProducerDestination.ofVirtualPI();
+			producer.setLocatorId(data.defaultLocatorId);
+			data.helper.load(producer, data.helper.pTomatoProductId, new BigDecimal("2"), data.helper.uomKg);
+			final I_M_HU cu = CollectionUtils.singleElement(producer.getCreatedHUs());
+
+			// createM_Package requires C_BPartner_ID and C_BPartner_Location_ID > 0
+			cu.setC_BPartner_ID(1);
+			cu.setC_BPartner_Location_ID(1);
+			save(cu);
+
+			final CreatePackageForHURequest request = CreatePackageForHURequest.builder()
+					.hu(cu)
+					.shipperId(ShipperId.ofRepoId(1))
+					.build();
+
+			// Act: qty=2 → 2 parcels, each via resolveSingleUnitDimensions
+			final List<I_M_Package> packages = huPackageBL.createM_Packages(request);
+
+			// Assert: 2 parcels, each with UNSPECIFIED dims (-1)
+			assertThat(packages).hasSize(2);
+			for (final I_M_Package pkg : packages)
+			{
+				assertThat(pkg.getLengthInCm()).isEqualTo(-1);
+				assertThat(pkg.getWidthInCm()).isEqualTo(-1);
+				assertThat(pkg.getHeightInCm()).isEqualTo(-1);
+			}
 		}
 	}
 

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PackedHUCarrierAdviseService.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PackedHUCarrierAdviseService.java
@@ -79,6 +79,8 @@ public class PackedHUCarrierAdviseService
 	 */
 	private static final String SYSCONFIG_CHECK_IS_SELF_PACKED = "de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked";
 
+	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+
 	@NonNull private final PackedHUShippingInfoService packedHUShippingInfoService;
 	@NonNull private final HUShipmentScheduleResolver huShipmentScheduleResolver;
 	@NonNull private final ProductRepository productRepository;
@@ -449,7 +451,7 @@ public class PackedHUCarrierAdviseService
 					.map(Quantity::getAsBigDecimal)
 					.orElse(BigDecimal.ZERO);
 			// Use product dims (IsSelfPacked gate is SysConfig-controlled, default off).
-			final boolean checkSelfPacked = Services.get(ISysConfigBL.class).getBooleanValue(SYSCONFIG_CHECK_IS_SELF_PACKED, false);
+			final boolean checkSelfPacked = sysConfigBL.getBooleanValue(SYSCONFIG_CHECK_IS_SELF_PACKED, false);
 			if (checkSelfPacked && !product.isSelfPacked())
 			{
 				dimensions = PackageDimensions.UNSPECIFIED;

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PackedHUCarrierAdviseService.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PackedHUCarrierAdviseService.java
@@ -25,7 +25,6 @@ import de.metas.handlingunits.picking.job.model.PickingJobLine;
 import de.metas.handlingunits.picking.job.model.PickingJobLineId;
 import de.metas.handlingunits.picking.job.model.TUPickingTarget;
 import de.metas.handlingunits.picking.job.repository.PickingJobRepository;
-import de.metas.handlingunits.shipping.IHUPackageBL;
 import de.metas.handlingunits.shipping.PackedHUProductItem;
 import de.metas.handlingunits.shipping.PackedHUShippingInfo;
 import de.metas.handlingunits.shipping.PackedHUShippingInfoService;
@@ -73,6 +72,8 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class PackedHUCarrierAdviseService
 {
+	private static final String SYSCONFIG_CHECK_IS_SELF_PACKED = "de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked";
+
 	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 
 	@NonNull private final PackedHUShippingInfoService packedHUShippingInfoService;
@@ -445,8 +446,7 @@ public class PackedHUCarrierAdviseService
 					.map(Quantity::getAsBigDecimal)
 					.orElse(BigDecimal.ZERO);
 			// Use product dims (IsSelfPacked gate is SysConfig-controlled, default off).
-			final boolean checkSelfPacked = sysConfigBL.getBooleanValue(IHUPackageBL.SYSCONFIG_CHECK_IS_SELF_PACKED, false);
-			if (checkSelfPacked && !product.isSelfPacked())
+			if (isCheckSelfPacked() && !product.isSelfPacked())
 			{
 				dimensions = PackageDimensions.UNSPECIFIED;
 			}
@@ -542,6 +542,11 @@ public class PackedHUCarrierAdviseService
 				.shippedQuantity(shippedQuantity)
 				.totalWeightInKg(totalWeightInKgBD)
 				.build();
+	}
+
+	private boolean isCheckSelfPacked()
+	{
+		return sysConfigBL.getBooleanValue(SYSCONFIG_CHECK_IS_SELF_PACKED, false);
 	}
 
 	@NonNull

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PackedHUCarrierAdviseService.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PackedHUCarrierAdviseService.java
@@ -440,9 +440,12 @@ public class PackedHUCarrierAdviseService
 					.map(weight -> uomConversionBL.convertToKilogram(weight, product.getId()))
 					.map(Quantity::getAsBigDecimal)
 					.orElse(BigDecimal.ZERO);
-			dimensions = product.isSelfPacked()
-					? product.getPackageDimensions()
-					: PackageDimensions.UNSPECIFIED;
+			// Use product dims regardless of IsSelfPacked;
+			// fall back to UNSPECIFIED only when no dims are defined.
+			final PackageDimensions productDims = product.getPackageDimensions();
+			dimensions = productDims.isUnspecified()
+					? PackageDimensions.UNSPECIFIED
+					: productDims;
 		}
 		else
 		{

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PackedHUCarrierAdviseService.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PackedHUCarrierAdviseService.java
@@ -25,6 +25,7 @@ import de.metas.handlingunits.picking.job.model.PickingJobLine;
 import de.metas.handlingunits.picking.job.model.PickingJobLineId;
 import de.metas.handlingunits.picking.job.model.TUPickingTarget;
 import de.metas.handlingunits.picking.job.repository.PickingJobRepository;
+import de.metas.handlingunits.shipping.IHUPackageBL;
 import de.metas.handlingunits.shipping.PackedHUProductItem;
 import de.metas.handlingunits.shipping.PackedHUShippingInfo;
 import de.metas.handlingunits.shipping.PackedHUShippingInfoService;
@@ -72,13 +73,6 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class PackedHUCarrierAdviseService
 {
-	/**
-	 * When set to 'Y', the legacy IsSelfPacked gate is restored: non-self-packed products return
-	 * {@link PackageDimensions#UNSPECIFIED} instead of using the product's named dimensions.
-	 * Default 'N' = flag-independent behaviour (current default).
-	 */
-	private static final String SYSCONFIG_CHECK_IS_SELF_PACKED = "de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked";
-
 	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 
 	@NonNull private final PackedHUShippingInfoService packedHUShippingInfoService;
@@ -451,7 +445,7 @@ public class PackedHUCarrierAdviseService
 					.map(Quantity::getAsBigDecimal)
 					.orElse(BigDecimal.ZERO);
 			// Use product dims (IsSelfPacked gate is SysConfig-controlled, default off).
-			final boolean checkSelfPacked = sysConfigBL.getBooleanValue(SYSCONFIG_CHECK_IS_SELF_PACKED, false);
+			final boolean checkSelfPacked = sysConfigBL.getBooleanValue(IHUPackageBL.SYSCONFIG_CHECK_IS_SELF_PACKED, false);
 			if (checkSelfPacked && !product.isSelfPacked())
 			{
 				dimensions = PackageDimensions.UNSPECIFIED;

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PackedHUCarrierAdviseService.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PackedHUCarrierAdviseService.java
@@ -58,6 +58,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.service.ISysConfigBL;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
@@ -71,6 +72,13 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class PackedHUCarrierAdviseService
 {
+	/**
+	 * When set to 'Y', the legacy IsSelfPacked gate is restored: non-self-packed products return
+	 * {@link PackageDimensions#UNSPECIFIED} instead of using the product's named dimensions.
+	 * Default 'N' = flag-independent behaviour (current default).
+	 */
+	private static final String SYSCONFIG_CHECK_IS_SELF_PACKED = "de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked";
+
 	@NonNull private final PackedHUShippingInfoService packedHUShippingInfoService;
 	@NonNull private final HUShipmentScheduleResolver huShipmentScheduleResolver;
 	@NonNull private final ProductRepository productRepository;
@@ -440,12 +448,19 @@ public class PackedHUCarrierAdviseService
 					.map(weight -> uomConversionBL.convertToKilogram(weight, product.getId()))
 					.map(Quantity::getAsBigDecimal)
 					.orElse(BigDecimal.ZERO);
-			// Use product dims regardless of IsSelfPacked;
-			// fall back to UNSPECIFIED only when no dims are defined.
-			final PackageDimensions productDims = product.getPackageDimensions();
-			dimensions = productDims.isUnspecified()
-					? PackageDimensions.UNSPECIFIED
-					: productDims;
+			// Use product dims (IsSelfPacked gate is SysConfig-controlled, default off).
+			final boolean checkSelfPacked = Services.get(ISysConfigBL.class).getBooleanValue(SYSCONFIG_CHECK_IS_SELF_PACKED, false);
+			if (checkSelfPacked && !product.isSelfPacked())
+			{
+				dimensions = PackageDimensions.UNSPECIFIED;
+			}
+			else
+			{
+				final PackageDimensions productDims = product.getPackageDimensions();
+				dimensions = productDims.isUnspecified()
+						? PackageDimensions.UNSPECIFIED
+						: productDims;
+			}
 		}
 		else
 		{

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PackedHUCarrierAdviseService.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PackedHUCarrierAdviseService.java
@@ -79,7 +79,7 @@ public class PackedHUCarrierAdviseService
 	 */
 	private static final String SYSCONFIG_CHECK_IS_SELF_PACKED = "de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked";
 
-	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 
 	@NonNull private final PackedHUShippingInfoService packedHUShippingInfoService;
 	@NonNull private final HUShipmentScheduleResolver huShipmentScheduleResolver;

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PackedHUCarrierAdviseService.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PackedHUCarrierAdviseService.java
@@ -445,7 +445,6 @@ public class PackedHUCarrierAdviseService
 					.map(weight -> uomConversionBL.convertToKilogram(weight, product.getId()))
 					.map(Quantity::getAsBigDecimal)
 					.orElse(BigDecimal.ZERO);
-			// Use product dims (IsSelfPacked gate is SysConfig-controlled, default off).
 			if (isCheckSelfPacked() && !product.isSelfPacked())
 			{
 				dimensions = PackageDimensions.UNSPECIFIED;

--- a/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/PackedHUCarrierAdviseServiceTest.java
+++ b/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/PackedHUCarrierAdviseServiceTest.java
@@ -26,14 +26,20 @@ import de.metas.inoutcandidate.ShipmentSchedule;
 import de.metas.inoutcandidate.ShipmentScheduleService;
 import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
 import de.metas.product.ProductId;
+import de.metas.organization.OrgId;
+import de.metas.product.PackageDimensions;
 import de.metas.product.ProductRepository;
 import de.metas.shipper.gateway.commons.model.CarrierProduct;
 import de.metas.shipper.gateway.commons.model.CarrierProductRepository;
 import de.metas.shipping.CarrierProductId;
 import de.metas.shipping.ShipperId;
 import de.metas.shipping.ShipperRepository;
+import de.metas.util.Services;
+import org.adempiere.service.ClientId;
+import org.adempiere.service.ISysConfigBL;
 import org.adempiere.test.AdempiereTestWatcher;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -514,5 +520,75 @@ public class PackedHUCarrierAdviseServiceTest
 	private static ArgumentCaptor<UnaryOperator<PickingJobLine>> lineMapperCaptor()
 	{
 		return ArgumentCaptor.forClass((Class<UnaryOperator<PickingJobLine>>) (Class<?>) UnaryOperator.class);
+	}
+
+	/**
+	 * SysConfig gate for the single-CU baseline branch in {@link PackedHUCarrierAdviseService#buildRequestParcel}.
+	 * When {@code de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked=Y},
+	 * a non-self-packed single-CU HU with dims → {@link PackageDimensions#UNSPECIFIED}.
+	 * When absent / 'N' (default), dims are used.
+	 */
+	@Nested
+	class IsSelfPackedGate
+	{
+		private static final String SYSCONFIG_CHECK_IS_SELF_PACKED
+				= "de.metas.handlingunits.PackageDimensions.CheckIsSelfPacked";
+
+		@Test
+		public void whenSysConfigY_nonSelfPacked_singleCU_dimensionsUnspecified()
+		{
+			// Arrange: SysConfig Y → legacy gate active
+			Services.get(ISysConfigBL.class).setValue(SYSCONFIG_CHECK_IS_SELF_PACKED, true, ClientId.SYSTEM, OrgId.ANY);
+
+			// pSalad is NOT self-packed; give it dims
+			data.helper.pSalad.setIsSelfPacked(false);
+			data.helper.pSalad.setLengthInCm(10);
+			data.helper.pSalad.setWidthInCm(20);
+			data.helper.pSalad.setHeightInCm(30);
+			save(data.helper.pSalad);
+
+			final HUProducerDestination producer = HUProducerDestination.ofVirtualPI();
+			producer.setLocatorId(data.defaultLocatorId);
+			data.helper.load(producer, data.helper.pSaladProductId, new BigDecimal("1"), data.helper.uomEach);
+			final I_M_HU cu = producer.getCreatedHUs().get(0);
+
+			final ShipmentSchedule saladSched = mockSchedule(SCHED_SALAD, data.helper.pSaladProductId);
+			final JsonDeliveryAdvisorRequestParcel parcel = service.buildRequestParcel(
+					cu, ImmutableMap.of(SCHED_SALAD, saladSched));
+
+			// Gate active: non-self-packed → PackageDimensions.UNSPECIFIED → all three dims = -1
+			assertThat(parcel.getPackageDimensions()).isNotNull();
+			assertThat(parcel.getPackageDimensions().getLengthInCM()).isEqualTo(-1);
+			assertThat(parcel.getPackageDimensions().getWidthInCM()).isEqualTo(-1);
+			assertThat(parcel.getPackageDimensions().getHeightInCM()).isEqualTo(-1);
+		}
+
+		@Test
+		public void whenSysConfigN_nonSelfPacked_singleCU_dimensionsReturned()
+		{
+			// Arrange: SysConfig N (default) → gate off
+			Services.get(ISysConfigBL.class).setValue(SYSCONFIG_CHECK_IS_SELF_PACKED, false, ClientId.SYSTEM, OrgId.ANY);
+
+			data.helper.pSalad.setIsSelfPacked(false);
+			data.helper.pSalad.setLengthInCm(10);
+			data.helper.pSalad.setWidthInCm(20);
+			data.helper.pSalad.setHeightInCm(30);
+			save(data.helper.pSalad);
+
+			final HUProducerDestination producer = HUProducerDestination.ofVirtualPI();
+			producer.setLocatorId(data.defaultLocatorId);
+			data.helper.load(producer, data.helper.pSaladProductId, new BigDecimal("1"), data.helper.uomEach);
+			final I_M_HU cu = producer.getCreatedHUs().get(0);
+
+			final ShipmentSchedule saladSched = mockSchedule(SCHED_SALAD, data.helper.pSaladProductId);
+			final JsonDeliveryAdvisorRequestParcel parcel = service.buildRequestParcel(
+					cu, ImmutableMap.of(SCHED_SALAD, saladSched));
+
+			// Gate off: dims returned
+			assertThat(parcel.getPackageDimensions()).isNotNull();
+			assertThat(parcel.getPackageDimensions().getLengthInCM()).isEqualTo(10);
+			assertThat(parcel.getPackageDimensions().getWidthInCM()).isEqualTo(20);
+			assertThat(parcel.getPackageDimensions().getHeightInCM()).isEqualTo(30);
+		}
 	}
 }

--- a/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftShipmentService.java
+++ b/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftShipmentService.java
@@ -25,6 +25,7 @@ package de.metas.shipper.client.nshift;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Streams;
 import de.metas.common.delivery.v1.json.DeliveryMappingConstants;
+import de.metas.common.delivery.v1.json.JsonPackageDimensions;
 import de.metas.common.delivery.v1.json.request.JsonDeliveryOrderParcel;
 import de.metas.common.delivery.v1.json.request.JsonDeliveryRequest;
 import de.metas.common.delivery.v1.json.request.JsonCarrierService;
@@ -225,9 +226,14 @@ public class NShiftShipmentService
 	{
 		// nShift expects weight in grams and dimensions in millimeters.
 		final int weightGrams = deliveryLine.getGrossWeightKg().multiply(BigDecimal.valueOf(1000)).intValue();
-		final int lengthMM = deliveryLine.getPackageDimensions().getLengthInCM() * 10;
-		final int widthMM = deliveryLine.getPackageDimensions().getWidthInCM() * 10;
-		final int heightMM = deliveryLine.getPackageDimensions().getHeightInCM() * 10;
+		final JsonPackageDimensions dims = deliveryLine.getPackageDimensions();
+		if (dims.getLengthInCM() == 0 && dims.getWidthInCM() == 0 && dims.getHeightInCM() == 0)
+		{
+			throw new IllegalStateException("Package dimensions are mandatory but were not specified (all dimensions are zero/unspecified).");
+		}
+		final int lengthMM = dims.getLengthInCM() * 10;
+		final int widthMM = dims.getWidthInCM() * 10;
+		final int heightMM = dims.getHeightInCM() * 10;
 
 		final Function<String, Optional<String>> valueProvider =
 				NShiftUtil.withFallback(deliveryLine::getValue, attributeValue -> Optional.ofNullable(deliveryRequest.getValue(attributeValue)));

--- a/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftShipmentService.java
+++ b/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftShipmentService.java
@@ -227,9 +227,9 @@ public class NShiftShipmentService
 		// nShift expects weight in grams and dimensions in millimeters.
 		final int weightGrams = deliveryLine.getGrossWeightKg().multiply(BigDecimal.valueOf(1000)).intValue();
 		final JsonPackageDimensions dims = deliveryLine.getPackageDimensions();
-		if (dims.getLengthInCM() == 0 && dims.getWidthInCM() == 0 && dims.getHeightInCM() == 0)
+		if (dims.getLengthInCM() <= 0 && dims.getWidthInCM() <= 0 && dims.getHeightInCM() <= 0)
 		{
-			throw new IllegalStateException("Package dimensions are mandatory but were not specified (all dimensions are zero/unspecified).");
+			throw new IllegalStateException("Package dimensions are mandatory but were not specified (all dimensions are zero or unspecified).");
 		}
 		final int lengthMM = dims.getLengthInCM() * 10;
 		final int widthMM = dims.getWidthInCM() * 10;

--- a/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftUtil.java
+++ b/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftUtil.java
@@ -115,19 +115,12 @@ public class NShiftUtil
 				? DeliveryMappingConstants.ATTRIBUTE_TYPE_SENDER_ATTENTION
 				: DeliveryMappingConstants.ATTRIBUTE_TYPE_RECEIVER_ATTENTION;
 		final String attention = mappingConfigs.getSingleValue(attentionAttributeType, valueProvider);
-		if (Check.isBlank(attention))
-		{
-			throw new IllegalStateException(role + " Attention is mandatory but was not resolved from mapping configs.");
-		}
-
-		if (contact == null || Check.isBlank(contact.getPhone()))
-		{
-			throw new IllegalStateException(role + " Phone is mandatory but is missing or blank.");
-		}
-		if (contact.getEmailAddress() == null || Check.isBlank(contact.getEmailAddress()))
-		{
-			throw new IllegalStateException(role + " Email is mandatory but is missing or blank.");
-		}
+		Check.assumeNotEmpty(attention, IllegalStateException.class,
+				role + " Attention is mandatory but was not resolved from mapping configs.");
+		Check.assumeNotEmpty(contact != null ? contact.getPhone() : null, IllegalStateException.class,
+				role + " Phone is mandatory but is missing or blank.");
+		Check.assumeNotEmpty(contact != null ? contact.getEmailAddress() : null, IllegalStateException.class,
+				role + " Email is mandatory but is missing or blank.");
 
 		return buildNShiftAddressBuilder(commonAddress, contact, kind)
 				.attention(attention)

--- a/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftUtil.java
+++ b/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftUtil.java
@@ -109,11 +109,28 @@ public class NShiftUtil
 			@NonNull final NShiftMappingConfigs mappingConfigs,
 			@NonNull final Function<String, String> valueProvider)
 	{
+		final String role = kind == JsonAddressKind.SENDER ? "Sender" : "Receiver";
+
 		final String attentionAttributeType = kind == JsonAddressKind.SENDER
 				? DeliveryMappingConstants.ATTRIBUTE_TYPE_SENDER_ATTENTION
 				: DeliveryMappingConstants.ATTRIBUTE_TYPE_RECEIVER_ATTENTION;
+		final String attention = mappingConfigs.getSingleValue(attentionAttributeType, valueProvider);
+		if (Check.isBlank(attention))
+		{
+			throw new IllegalStateException(role + " Attention is mandatory but was not resolved from mapping configs.");
+		}
+
+		if (contact == null || Check.isBlank(contact.getPhone()))
+		{
+			throw new IllegalStateException(role + " Phone is mandatory but is missing or blank.");
+		}
+		if (contact.getEmailAddress() == null || Check.isBlank(contact.getEmailAddress()))
+		{
+			throw new IllegalStateException(role + " Email is mandatory but is missing or blank.");
+		}
+
 		return buildNShiftAddressBuilder(commonAddress, contact, kind)
-				.attention(mappingConfigs.getSingleValue(attentionAttributeType, valueProvider))
+				.attention(attention)
 				.build();
 	}
 
@@ -139,22 +156,24 @@ public class NShiftUtil
 			@NonNull final JsonDeliveryAdvisorRequest request,
 			@NonNull final NShiftMappingConfigs mappingConfigs)
 	{
+		if (request.getPackageDimensions() == null)
+		{
+			throw new IllegalStateException("Package dimensions are mandatory but were not specified (dimensions is null).");
+		}
+
 		final int weightGrams = request.getGrossWeightKg().multiply(BigDecimal.valueOf(1000)).intValue();
 		final Function<String, String> lineValueProvider = request::getValue;
-		final JsonLine.JsonLineBuilder lineBuilder = JsonLine.builder()
+		final int lengthMM = request.getPackageDimensions().getLengthInCM() * 10;
+		final int widthMM = request.getPackageDimensions().getWidthInCM() * 10;
+		final int heightMM = request.getPackageDimensions().getHeightInCM() * 10;
+		return JsonLine.builder()
 				.lineWeight(weightGrams)
-				.references(mappingConfigs.getReferences(DeliveryMappingConstants.ATTRIBUTE_TYPE_LINE_REFERENCE, lineValueProvider));
-		if (request.getPackageDimensions() != null)
-		{
-			final int lengthMM = request.getPackageDimensions().getLengthInCM() * 10;
-			final int widthMM = request.getPackageDimensions().getWidthInCM() * 10;
-			final int heightMM = request.getPackageDimensions().getHeightInCM() * 10;
-			lineBuilder.number(1); // always 1: the advise carries a single physical HU / parcel
-			lineBuilder.length(lengthMM);
-			lineBuilder.width(widthMM);
-			lineBuilder.height(heightMM);
-		}
-		return lineBuilder.build();
+				.references(mappingConfigs.getReferences(DeliveryMappingConstants.ATTRIBUTE_TYPE_LINE_REFERENCE, lineValueProvider))
+				.number(1) // always 1: the advise carries a single physical HU / parcel
+				.length(lengthMM)
+				.width(widthMM)
+				.height(heightMM)
+				.build();
 	}
 
 	/**

--- a/backend/de.metas.shipper.client.nshift/src/test/java/de/metas/shipper/client/nshift/NShiftMandatoryFieldValidationTest.java
+++ b/backend/de.metas.shipper.client.nshift/src/test/java/de/metas/shipper/client/nshift/NShiftMandatoryFieldValidationTest.java
@@ -1,0 +1,523 @@
+/*
+ * #%L
+ * de.metas.shipper.client.nshift
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.shipper.client.nshift;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.common.delivery.v1.json.DeliveryMappingConstants;
+import de.metas.common.delivery.v1.json.JsonAddress;
+import de.metas.common.delivery.v1.json.JsonContact;
+import de.metas.common.delivery.v1.json.JsonMoney;
+import de.metas.common.delivery.v1.json.JsonPackageDimensions;
+import de.metas.common.delivery.v1.json.JsonQuantity;
+import de.metas.common.delivery.v1.json.request.JsonCarrierService;
+import de.metas.common.delivery.v1.json.request.JsonDeliveryAdvisorRequest;
+import de.metas.common.delivery.v1.json.request.JsonDeliveryAdvisorRequestItem;
+import de.metas.common.delivery.v1.json.request.JsonDeliveryOrderLineContents;
+import de.metas.common.delivery.v1.json.request.JsonDeliveryOrderParcel;
+import de.metas.common.delivery.v1.json.request.JsonDeliveryRequest;
+import de.metas.common.delivery.v1.json.request.JsonGoodsType;
+import de.metas.common.delivery.v1.json.request.JsonMappingConfigList;
+import de.metas.common.delivery.v1.json.request.JsonShipperConfig;
+import de.metas.common.delivery.v1.json.request.JsonShipperProduct;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Mandatory-field validation for all 4 nShift build paths.
+ * <p>
+ * All four {@code buildRequest} / {@code buildShipmentRequest} / {@code buildOrderAdviceShipmentRequest}
+ * methods are {@code public static} and pure (no Spring / DB), so we exercise them directly.
+ * <p>
+ * For EACH path we test:
+ * <ul>
+ *   <li>missing receiver Attention → throws naming "Attention"</li>
+ *   <li>missing sender Phone → throws naming "Phone"</li>
+ *   <li>missing receiver Email → throws naming "Email" (representative contact-field check)</li>
+ *   <li>UNSPECIFIED / null dimensions → throws naming "dimensions"</li>
+ *   <li>all mandatory fields present → builds OK (no exception)</li>
+ * </ul>
+ */
+public class NShiftMandatoryFieldValidationTest
+{
+	// -----------------------------------------------------------------------
+	// Shared address / contact builders — VALID baseline
+	// -----------------------------------------------------------------------
+
+	private static final JsonAddress VALID_PICKUP_ADDRESS = JsonAddress.builder()
+			.bpartnerId(1)
+			.companyName1("Sender GmbH")
+			.city("Bonn")
+			.country("DE")
+			.zipCode("53179")
+			.street("Sender Str")
+			.houseNo("1")
+			.attention("Sender Attention")
+			.build();
+
+	private static final JsonAddress VALID_DELIVERY_ADDRESS = JsonAddress.builder()
+			.bpartnerId(2)
+			.companyName1("Receiver GmbH")
+			.city("Timisoara")
+			.country("RO")
+			.zipCode("300078")
+			.street("Receiver Str")
+			.houseNo("2")
+			.attention("Receiver Attention")
+			.build();
+
+	private static final JsonContact VALID_SENDER_CONTACT = JsonContact.builder()
+			.name("Sender Name")
+			.language("de")
+			.phone("0228-1234")
+			.emailAddress("sender@example.com")
+			.build();
+
+	private static final JsonContact VALID_RECEIVER_CONTACT = JsonContact.builder()
+			.name("Receiver Name")
+			.language("de")
+			.phone("0040-1234")
+			.emailAddress("receiver@example.com")
+			.build();
+
+	private static final JsonPackageDimensions VALID_DIMS = JsonPackageDimensions.builder()
+			.lengthInCM(100)
+			.widthInCM(20)
+			.heightInCM(15)
+			.build();
+
+	private static final JsonShipperConfig ADVISOR_SHIPPER_CONFIG = JsonShipperConfig.builder()
+			.url("https://demo.shipmentserver.com:8080")
+			.username("user")
+			.password("pass")
+			.additionalProperty(NShiftConstants.ACTOR_ID, "123")
+			.additionalProperty(NShiftConstants.SERVICE_LEVEL, "TestLevel")
+			.additionalProperty(NShiftConstants.SELECTION_RULES, "N")
+			.build();
+
+	private static final JsonShipperConfig SHIP_SHIPPER_CONFIG = JsonShipperConfig.builder()
+			.url("https://demo.shipmentserver.com:8080")
+			.username("user")
+			.password("pass")
+			.additionalProperty(NShiftConstants.ACTOR_ID, "123")
+			.additionalProperty(NShiftConstants.IS_CREATE_DRAFT_SHIPMENT_ONLY, "N")
+			.build();
+
+	// -----------------------------------------------------------------------
+	// Mapping config with BOTH sender AND receiver attention mapped
+	// -----------------------------------------------------------------------
+	private static final JsonMappingConfigList MAPPING_WITH_ATTENTION =
+			NShiftTestMappingConfigs.SHARED_TEST;
+
+	// Mapping config with NO sender/receiver attention entries at all
+	private static final JsonMappingConfigList MAPPING_WITHOUT_ATTENTION =
+			buildMappingWithoutAttention();
+
+	private static JsonMappingConfigList buildMappingWithoutAttention()
+	{
+		// Keep references but remove all attention entries
+		return JsonMappingConfigList.ofList(
+				NShiftTestMappingConfigs.SHARED_TEST.getConfigs().stream()
+						.filter(mappingConfig -> !DeliveryMappingConstants.ATTRIBUTE_TYPE_SENDER_ATTENTION.equals(mappingConfig.getAttributeType())
+								&& !DeliveryMappingConstants.ATTRIBUTE_TYPE_RECEIVER_ATTENTION.equals(mappingConfig.getAttributeType()))
+						.collect(ImmutableList.toImmutableList()));
+	}
+
+	// -----------------------------------------------------------------------
+	// Advisor request builder helpers
+	// -----------------------------------------------------------------------
+
+	private static JsonDeliveryAdvisorRequest validAdvisorRequest()
+	{
+		return JsonDeliveryAdvisorRequest.builder()
+				.id("test-id")
+				.pickupAddress(VALID_PICKUP_ADDRESS)
+				.pickupContact(VALID_SENDER_CONTACT)
+				.pickupDate("2025-10-02")
+				.pickupTimeFrom("08:00:00")
+				.deliveryAddress(VALID_DELIVERY_ADDRESS)
+				.deliveryContact(VALID_RECEIVER_CONTACT)
+				.grossWeightKg(BigDecimal.TEN)
+				.packageDimensions(VALID_DIMS)
+				.items(ImmutableList.of(JsonDeliveryAdvisorRequestItem.builder()
+						.numberOfItems(1)
+						.productName("Test Product")
+						.productValue("Test Value")
+						.build()))
+				.shipperConfig(ADVISOR_SHIPPER_CONFIG)
+				.mappingConfigs(MAPPING_WITH_ATTENTION)
+				.build();
+	}
+
+	// -----------------------------------------------------------------------
+	// Ship request builder helpers
+	// -----------------------------------------------------------------------
+
+	private static JsonDeliveryRequest validShipRequest()
+	{
+		return JsonDeliveryRequest.builder()
+				.deliveryOrderId(1)
+				.shipperProduct(JsonShipperProduct.builder().code("10305").name("DHL Freight").build())
+				.service(JsonCarrierService.builder().id("972053").name("Ex Works").build())
+				.goodsType(JsonGoodsType.builder().id("5").name("Packet").build())
+				.pickupAddress(VALID_PICKUP_ADDRESS)
+				.pickupContact(VALID_SENDER_CONTACT)
+				.pickupDate("2025-10-02")
+				.timeFrom("10:00:00")
+				.timeTo("13:00:00")
+				.deliveryAddress(VALID_DELIVERY_ADDRESS)
+				.deliveryContact(VALID_RECEIVER_CONTACT)
+				.deliveryDate("2025-10-02")
+				.deliveryOrderParcel(JsonDeliveryOrderParcel.builder()
+						.id("1")
+						.grossWeightKg(BigDecimal.TEN)
+						.packageDimensions(VALID_DIMS)
+						.packageId("1")
+						.contents(ImmutableList.of(JsonDeliveryOrderLineContents.builder()
+								.shipmentOrderItemId("1")
+								.unitPrice(JsonMoney.builder().amount(BigDecimal.TEN).currencyCode("EUR").build())
+								.totalValue(JsonMoney.builder().amount(BigDecimal.TEN).currencyCode("EUR").build())
+								.productName("Product")
+								.productValue("Value")
+								.totalWeightInKg(BigDecimal.TEN)
+								.shippedQuantity(JsonQuantity.builder().value(BigDecimal.TEN).uomCode("PCE").build())
+								.build()))
+						.build())
+				.shipperConfig(SHIP_SHIPPER_CONFIG)
+				.mappingConfigs(MAPPING_WITH_ATTENTION)
+				.build();
+	}
+
+	// =======================================================================
+	// PATH 1 — NShiftOrderAdvisorService.buildRequest
+	// =======================================================================
+
+	@Nested
+	class OrderAdvisorBuildRequest
+	{
+		@Test
+		void missingAttentionMapping_throwsNamingAttention()
+		{
+			final JsonDeliveryAdvisorRequest request = validAdvisorRequest().toBuilder()
+					.mappingConfigs(MAPPING_WITHOUT_ATTENTION)
+					.build();
+
+			assertThatThrownBy(() -> NShiftOrderAdvisorService.buildRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("Attention");
+		}
+
+		@Test
+		void missingSenderPhone_throwsNamingPhone()
+		{
+			final JsonContact noPhone = JsonContact.builder()
+					.name(VALID_SENDER_CONTACT.getName())
+					.language(VALID_SENDER_CONTACT.getLanguage())
+					.emailAddress(VALID_SENDER_CONTACT.getEmailAddress())
+					// phone omitted
+					.build();
+			final JsonDeliveryAdvisorRequest request = validAdvisorRequest().toBuilder()
+					.pickupContact(noPhone)
+					.build();
+
+			assertThatThrownBy(() -> NShiftOrderAdvisorService.buildRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("Phone");
+		}
+
+		@Test
+		void missingReceiverEmail_throwsNamingEmail()
+		{
+			final JsonContact noEmail = JsonContact.builder()
+					.name(VALID_RECEIVER_CONTACT.getName())
+					.language(VALID_RECEIVER_CONTACT.getLanguage())
+					.phone(VALID_RECEIVER_CONTACT.getPhone())
+					// emailAddress omitted
+					.build();
+			final JsonDeliveryAdvisorRequest request = validAdvisorRequest().toBuilder()
+					.deliveryContact(noEmail)
+					.build();
+
+			assertThatThrownBy(() -> NShiftOrderAdvisorService.buildRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("Email");
+		}
+
+		@Test
+		void nullDimensions_throwsNamingDimensions()
+		{
+			final JsonDeliveryAdvisorRequest request = validAdvisorRequest().toBuilder()
+					.packageDimensions(null)
+					.build();
+
+			assertThatThrownBy(() -> NShiftOrderAdvisorService.buildRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("dimensions");
+		}
+
+		@Test
+		void allPresent_buildsOk()
+		{
+			assertThatCode(() -> NShiftOrderAdvisorService.buildRequest(validAdvisorRequest()))
+					.doesNotThrowAnyException();
+		}
+	}
+
+	// =======================================================================
+	// PATH 2 — NShiftShipAdvisorService.buildRequest
+	// =======================================================================
+
+	@Nested
+	class ShipAdvisorBuildRequest
+	{
+		@Test
+		void missingAttentionMapping_throwsNamingAttention()
+		{
+			final JsonDeliveryAdvisorRequest request = validAdvisorRequest().toBuilder()
+					.mappingConfigs(MAPPING_WITHOUT_ATTENTION)
+					.build();
+
+			assertThatThrownBy(() -> NShiftShipAdvisorService.buildRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("Attention");
+		}
+
+		@Test
+		void missingSenderPhone_throwsNamingPhone()
+		{
+			final JsonContact noPhone = JsonContact.builder()
+					.name(VALID_SENDER_CONTACT.getName())
+					.language(VALID_SENDER_CONTACT.getLanguage())
+					.emailAddress(VALID_SENDER_CONTACT.getEmailAddress())
+					// phone omitted
+					.build();
+			final JsonDeliveryAdvisorRequest request = validAdvisorRequest().toBuilder()
+					.pickupContact(noPhone)
+					.build();
+
+			assertThatThrownBy(() -> NShiftShipAdvisorService.buildRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("Phone");
+		}
+
+		@Test
+		void missingReceiverEmail_throwsNamingEmail()
+		{
+			final JsonContact noEmail = JsonContact.builder()
+					.name(VALID_RECEIVER_CONTACT.getName())
+					.language(VALID_RECEIVER_CONTACT.getLanguage())
+					.phone(VALID_RECEIVER_CONTACT.getPhone())
+					// emailAddress omitted
+					.build();
+			final JsonDeliveryAdvisorRequest request = validAdvisorRequest().toBuilder()
+					.deliveryContact(noEmail)
+					.build();
+
+			assertThatThrownBy(() -> NShiftShipAdvisorService.buildRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("Email");
+		}
+
+		@Test
+		void nullDimensions_throwsNamingDimensions()
+		{
+			final JsonDeliveryAdvisorRequest request = validAdvisorRequest().toBuilder()
+					.packageDimensions(null)
+					.build();
+
+			assertThatThrownBy(() -> NShiftShipAdvisorService.buildRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("dimensions");
+		}
+
+		@Test
+		void allPresent_buildsOk()
+		{
+			assertThatCode(() -> NShiftShipAdvisorService.buildRequest(validAdvisorRequest()))
+					.doesNotThrowAnyException();
+		}
+	}
+
+	// =======================================================================
+	// PATH 3 — NShiftShipmentService.buildShipmentRequest
+	// =======================================================================
+
+	@Nested
+	class ShipmentRequest
+	{
+		@Test
+		void missingAttentionMapping_throwsNamingAttention()
+		{
+			final JsonDeliveryRequest request = validShipRequest().toBuilder()
+					.mappingConfigs(MAPPING_WITHOUT_ATTENTION)
+					.build();
+
+			assertThatThrownBy(() -> NShiftShipmentService.buildShipmentRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("Attention");
+		}
+
+		@Test
+		void missingSenderPhone_throwsNamingPhone()
+		{
+			final JsonContact noPhone = JsonContact.builder()
+					.name(VALID_SENDER_CONTACT.getName())
+					.language(VALID_SENDER_CONTACT.getLanguage())
+					.emailAddress(VALID_SENDER_CONTACT.getEmailAddress())
+					// phone omitted
+					.build();
+			final JsonDeliveryRequest request = validShipRequest().toBuilder()
+					.pickupContact(noPhone)
+					.build();
+
+			assertThatThrownBy(() -> NShiftShipmentService.buildShipmentRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("Phone");
+		}
+
+		@Test
+		void missingReceiverEmail_throwsNamingEmail()
+		{
+			final JsonContact noEmail = JsonContact.builder()
+					.name(VALID_RECEIVER_CONTACT.getName())
+					.language(VALID_RECEIVER_CONTACT.getLanguage())
+					.phone(VALID_RECEIVER_CONTACT.getPhone())
+					// emailAddress omitted
+					.build();
+			final JsonDeliveryRequest request = validShipRequest().toBuilder()
+					.deliveryContact(noEmail)
+					.build();
+
+			assertThatThrownBy(() -> NShiftShipmentService.buildShipmentRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("Email");
+		}
+
+		@Test
+		void zeroDimensions_throwsNamingDimensions()
+		{
+			// Zero dims (0,0,0) = unspecified on the ship path (JsonDeliveryOrderParcel.packageDimensions is @NonNull)
+			final JsonDeliveryOrderParcel parcelWithZeroDims = validShipRequest().getDeliveryOrderParcels().get(0).toBuilder()
+					.packageDimensions(JsonPackageDimensions.builder().lengthInCM(0).widthInCM(0).heightInCM(0).build())
+					.build();
+			final JsonDeliveryRequest request = validShipRequest().toBuilder()
+					.clearDeliveryOrderParcels()
+					.deliveryOrderParcel(parcelWithZeroDims)
+					.build();
+
+			assertThatThrownBy(() -> NShiftShipmentService.buildShipmentRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("dimensions");
+		}
+
+		@Test
+		void allPresent_buildsOk()
+		{
+			assertThatCode(() -> NShiftShipmentService.buildShipmentRequest(validShipRequest()))
+					.doesNotThrowAnyException();
+		}
+	}
+
+	// =======================================================================
+	// PATH 4 — NShiftShipmentService.buildOrderAdviceShipmentRequest
+	// =======================================================================
+
+	@Nested
+	class OrderAdviceShipmentRequest
+	{
+		@Test
+		void missingAttentionMapping_throwsNamingAttention()
+		{
+			final JsonDeliveryRequest request = validShipRequest().toBuilder()
+					.mappingConfigs(MAPPING_WITHOUT_ATTENTION)
+					.build();
+
+			assertThatThrownBy(() -> NShiftShipmentService.buildOrderAdviceShipmentRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("Attention");
+		}
+
+		@Test
+		void missingSenderPhone_throwsNamingPhone()
+		{
+			final JsonContact noPhone = JsonContact.builder()
+					.name(VALID_SENDER_CONTACT.getName())
+					.language(VALID_SENDER_CONTACT.getLanguage())
+					.emailAddress(VALID_SENDER_CONTACT.getEmailAddress())
+					// phone omitted
+					.build();
+			final JsonDeliveryRequest request = validShipRequest().toBuilder()
+					.pickupContact(noPhone)
+					.build();
+
+			assertThatThrownBy(() -> NShiftShipmentService.buildOrderAdviceShipmentRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("Phone");
+		}
+
+		@Test
+		void missingReceiverEmail_throwsNamingEmail()
+		{
+			final JsonContact noEmail = JsonContact.builder()
+					.name(VALID_RECEIVER_CONTACT.getName())
+					.language(VALID_RECEIVER_CONTACT.getLanguage())
+					.phone(VALID_RECEIVER_CONTACT.getPhone())
+					// emailAddress omitted
+					.build();
+			final JsonDeliveryRequest request = validShipRequest().toBuilder()
+					.deliveryContact(noEmail)
+					.build();
+
+			assertThatThrownBy(() -> NShiftShipmentService.buildOrderAdviceShipmentRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("Email");
+		}
+
+		@Test
+		void zeroDimensions_throwsNamingDimensions()
+		{
+			final JsonDeliveryOrderParcel parcelWithZeroDims = validShipRequest().getDeliveryOrderParcels().get(0).toBuilder()
+					.packageDimensions(JsonPackageDimensions.builder().lengthInCM(0).widthInCM(0).heightInCM(0).build())
+					.build();
+			final JsonDeliveryRequest request = validShipRequest().toBuilder()
+					.clearDeliveryOrderParcels()
+					.deliveryOrderParcel(parcelWithZeroDims)
+					.build();
+
+			assertThatThrownBy(() -> NShiftShipmentService.buildOrderAdviceShipmentRequest(request))
+					.isInstanceOf(IllegalStateException.class)
+					.hasMessageContaining("dimensions");
+		}
+
+		@Test
+		void allPresent_buildsOk()
+		{
+			assertThatCode(() -> NShiftShipmentService.buildOrderAdviceShipmentRequest(validShipRequest()))
+					.doesNotThrowAnyException();
+		}
+	}
+}


### PR DESCRIPTION
## What

Implements Transport-Unit package-dimension calculation and nShift mandatory-field validation.

**Part A — TU dimension calculation**
- New `PackageDimensionCalcMethod` ref-list + enum (Strapping / Repacking / Nesting).
- New `M_HU_PI_Version.PackageDimensionCalcMethod` column (shown on the PI-version tab, TU-only via display-logic).
- Calc math on `PackageDimensions.ofItems(mode, items)` for a mixed TU (stacking / volume-repack / nesting).
- `@ModelChange` interceptor confining the calc method to TU pi-versions.
- `HUPackageBL.getPackageDimensions` now aggregates a multi-item TU via the selected mode and no longer gates dimensions on `IsSelfPacked`; the `SelfPackedProductWithNoDefinedSizes` throw is removed (missing dims now yield `UNSPECIFIED`, validated at nShift build — see Part B).
- 3 mode packing-instructions shipped inactive in core (activated per-customer in the customer repo).
- Dedicated cucumber feature `HUPackage_DimensionCalculation.feature` (5 scenarios: all modes + TU guard + non-self-packed).

**Part B — nShift mandatory-field validation**
- `NShiftUtil` validates sender + receiver Phone / Email / Attention and parcel dimensions at request build, across all four nShift build paths, failing early with a message naming the missing field.

## Testing
- Unit: `PackageDimensionsTest`, `HUPackageBL_DimensionCalcTest`, `M_HU_PI_VersionInterceptorTest`, `NShiftMandatoryFieldValidationTest` — all green (TDD, RED observed first).
- Cucumber: `HUPackage_DimensionCalculation.feature` — 5/5 green against a `deep_tundra_release` stack.

## Notes
- Per-customer activation of the 3 mode-PIs ships in the customer-repo PR (separate).
- Config windows verified reachable in the menu tree (no AD_Menu change needed).
