### PR TITLE
Advance Payment no LC: proforma allocation without Letter-of-Credit + transport-order BL/ETA date follow-up

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/invoice/proforma/ProformaOrderAllocateCommand.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/proforma/ProformaOrderAllocateCommand.java
@@ -29,7 +29,6 @@ import de.metas.invoice.service.IInvoiceBL;
 import de.metas.order.IOrderBL;
 import de.metas.order.OrderId;
 import de.metas.order.paymentschedule.steps.letter_of_credit.OrderPayScheduleLCStepService;
-import de.metas.payment.paymentterm.PaymentTerm;
 import de.metas.payment.paymentterm.PaymentTermBreak;
 import de.metas.payment.paymentterm.PaymentTermId;
 import de.metas.payment.paymentterm.PaymentTermService;
@@ -42,16 +41,17 @@ import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.I_C_Invoice;
 import org.compiere.model.I_C_Order;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Builder
 class ProformaOrderAllocateCommand
 {
-	private static final AdMessageKey MSG_NoLCBreakInOrder            = AdMessageKey.of("de.metas.invoice.proforma.NoLCBreakInOrder");
-	private static final AdMessageKey MSG_MultipleLCBreaksUnsupported = AdMessageKey.of("de.metas.invoice.proforma.MultipleLCBreaksUnsupported");
-	private static final AdMessageKey MSG_CurrencyMismatch            = AdMessageKey.of("de.metas.invoice.proforma.CurrencyMismatch");
-	private static final AdMessageKey MSG_VendorMismatch              = AdMessageKey.of("de.metas.invoice.proforma.VendorMismatch");
+	private static final AdMessageKey MSG_MultipleLCBreaksUnsupported      = AdMessageKey.of("de.metas.invoice.proforma.MultipleLCBreaksUnsupported");
+	private static final AdMessageKey MSG_MultipleAdvanceBreaksUnsupported = AdMessageKey.of("de.metas.invoice.proforma.MultipleAdvanceBreaksUnsupported");
+	private static final AdMessageKey MSG_CurrencyMismatch                 = AdMessageKey.of("de.metas.invoice.proforma.CurrencyMismatch");
+	private static final AdMessageKey MSG_VendorMismatch                   = AdMessageKey.of("de.metas.invoice.proforma.VendorMismatch");
 
 	@NonNull private final ITrxManager trxManager = Services.get(ITrxManager.class);
 	@NonNull private final IInvoiceBL invoiceBL = Services.get(IInvoiceBL.class);
@@ -100,9 +100,16 @@ class ProformaOrderAllocateCommand
 	 * <ol>
 	 *   <li>Currency match: proforma and order must share the same currency.</li>
 	 *   <li>Vendor (BPartner) match: proforma and order must have the same bill-to partner.</li>
-	 *   <li>No LC break: order payment term must have at least one Letter-of-Credit break.</li>
-	 *   <li>Multiple LC breaks: order payment term must have exactly one LC break (iter 2 limitation).</li>
+	 *   <li>Multiple LC breaks: order payment term must have at most one LC break (only one LC break per term is currently supported).</li>
+	 *   <li>Multiple advance breaks: a payment term with no LC break must have at most one advance
+	 *       (non-material-receipt) break.</li>
 	 * </ol>
+	 * <p>
+	 * Note on the prepaid target: the step a proforma payment settles is the Letter-of-Credit or the
+	 * order-date (advance) break (see {@link de.metas.order.paymentschedule.core.OrderPayScheduleLine#isPrepaidLine()}).
+	 * A term whose only non-material-receipt break is an invoice-date break has no prepaid step: allocation
+	 * still records the proforma↔order link, but the proforma payment marks no pay-schedule line paid, since
+	 * an invoice-date break is a regular post-invoice term rather than an up-front advance.
 	 *
 	 * @throws AdempiereException with a translated user-facing message on any violation
 	 */
@@ -128,29 +135,35 @@ class ProformaOrderAllocateCommand
 					.markAsUserValidationError();
 		}
 
-		// LC-break count — 0 breaks → reject; >1 break → reject (iter 2 limitation)
+		// LC-break count — >1 LC break → reject (only one LC break per term is currently supported); a term
+		// with no LC break is allowed, as long as it does not have more than one advance (non-material-receipt) break.
 		final PaymentTermId paymentTermId = PaymentTermId.ofRepoIdOrNull(order.getC_PaymentTerm_ID());
-		if (paymentTermId == null)
-		{
-			throw new AdempiereException(MSG_NoLCBreakInOrder, order.getDocumentNo())
-					.markAsUserValidationError();
-		}
+		final List<PaymentTermBreak> breaks = paymentTermId != null
+				? paymentTermService.getById(paymentTermId).getSortedBreaks()
+				: Collections.emptyList();
 
-		final PaymentTerm paymentTerm = paymentTermService.getById(paymentTermId);
-		final List<PaymentTermBreak> lcBreaks = paymentTerm.getSortedBreaks()
+		final List<PaymentTermBreak> lcBreaks = breaks
 				.stream()
 				.filter(PaymentTermBreak::isLetterOfCredit)
 				.collect(Collectors.toList());
 
-		if (lcBreaks.isEmpty())
-		{
-			throw new AdempiereException(MSG_NoLCBreakInOrder, order.getDocumentNo())
-					.markAsUserValidationError();
-		}
 		if (lcBreaks.size() > 1)
 		{
 			throw new AdempiereException(MSG_MultipleLCBreaksUnsupported, order.getDocumentNo())
 					.markAsUserValidationError();
+		}
+		else if (lcBreaks.isEmpty())
+		{
+			final List<PaymentTermBreak> advanceBreaks = breaks
+					.stream()
+					.filter(paymentTermBreak -> !paymentTermBreak.getReferenceDateType().isMaterialReceiptDate())
+					.collect(Collectors.toList());
+
+			if (advanceBreaks.size() > 1)
+			{
+				throw new AdempiereException(MSG_MultipleAdvanceBreaksUnsupported, order.getDocumentNo())
+						.markAsUserValidationError();
+			}
 		}
 	}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/core/OrderPaySchedule.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/core/OrderPaySchedule.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 public class OrderPaySchedule
 {
 	private static final AdMessageKey MSG_MultipleLCBreaksUnsupported = AdMessageKey.of("de.metas.invoice.proforma.MultipleLCBreaksUnsupported");
+	private static final AdMessageKey MSG_MultipleAdvanceBreaksUnsupported = AdMessageKey.of("de.metas.invoice.proforma.MultipleAdvanceBreaksUnsupported");
 
 	@NonNull @Getter OrderId orderId;
 	@NonNull private final ArrayList<OrderPayScheduleLine> lines;
@@ -122,7 +123,9 @@ public class OrderPaySchedule
 
 		for (final OrderPayScheduleLine line : lines)
 		{
-			if (line.getStatus().isPending())
+			// A still-Pending line is (re)computed as usual; an unsettled Awaiting_Pay material-receipt line
+			// is additionally refreshed so a post-completion BL/ETA correction still reaches it.
+			if (line.getStatus().isPending() || line.isUnsettledAwaitingPayMaterialReceipt())
 			{
 				final PaymentTermBreak termBreak = paymentTerm.getBreakById(line.getPaymentTermBreakId());
 				final OrderPayScheduleLineContext dueDateAndStatus = context.computeLineContext(termBreak);
@@ -158,6 +161,32 @@ public class OrderPaySchedule
 		else
 		{
 			return Optional.of(lcLines.get(0));
+		}
+	}
+
+	/**
+	 * The single prepaid line of the payment term — the one step settled up front via a proforma
+	 * ({@link OrderPayScheduleLine#isPrepaidLine()}: a Letter-of-Credit or an order-date/advance break).
+	 * Callers resolve the LC line first via {@link #getSingleLCLine()} and only fall through to here for
+	 * the no-LC case, so on a schedule carrying both an LC and an OD break this counts both as prepaid
+	 * and fails loud — that misuse never happens on the guarded caller path.
+	 */
+	public Optional<OrderPayScheduleLine> getSinglePrepaidLine()
+	{
+		final ImmutableList<OrderPayScheduleLine> prepaidLines = lines.stream()
+				.filter(OrderPayScheduleLine::isPrepaidLine)
+				.collect(ImmutableList.toImmutableList());
+		if (prepaidLines.isEmpty())
+		{
+			return Optional.empty();  // no prepaid break in payment term — no-op
+		}
+		else if (prepaidLines.size() > 1)
+		{
+			throw new AdempiereException(MSG_MultipleAdvanceBreaksUnsupported, orderId);
+		}
+		else
+		{
+			return Optional.of(prepaidLines.get(0));
 		}
 	}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/core/OrderPayScheduleLine.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/core/OrderPayScheduleLine.java
@@ -124,6 +124,15 @@ public class OrderPayScheduleLine
 
 	public boolean isLetterOfCreditDate() {return referenceDateType.isLetterOfCreditDate();}
 
+	public boolean isMaterialReceiptDate() {return referenceDateType.isMaterialReceiptDate();}
+
+	/**
+	 * True for a prepaid step — one settled up front via a proforma, before delivery: a Letter-of-Credit
+	 * or an order-date (advance) break. An invoice-date break is a regular post-invoice term (not prepaid);
+	 * a material-receipt (BL/ETA) break is delivery-driven (not prepaid).
+	 */
+	public boolean isPrepaidLine() {return isLetterOfCreditDate() || referenceDateType.isOrderDate();}
+
 	/**
 	 * True if this line is linked to a committed downstream document — a goods receipt ({@code inoutId})
 	 * or a matched invoice ({@code invoiceId}). Such a link reflects real activity that a reactivate
@@ -131,6 +140,21 @@ public class OrderPayScheduleLine
 	 * reference date was known at completion carries no such link.
 	 */
 	public boolean isLinkedToDownstreamDocument() {return inoutId != null || invoiceId != null;}
+
+	/**
+	 * True for a material-receipt (BL/ETA) line the generic recompute may still refresh on a later
+	 * reference-date correction: {@code Awaiting_Pay} (a Transport Order completed it, so no longer
+	 * {@code Pending}), not yet paid, and not linked to a committed downstream document. LC/OD lines are
+	 * out via {@code isMaterialReceiptDate()} (an LC line is refreshed only by the LC step service);
+	 * {@code !isPaid()} guards a legacy row whose status and {@code isPaid} column have drifted apart.
+	 */
+	public boolean isUnsettledAwaitingPayMaterialReceipt()
+	{
+		return isMaterialReceiptDate()
+				&& status == OrderPayScheduleStatus.Awaiting_Pay
+				&& !isPaid()
+				&& !isLinkedToDownstreamDocument();
+	}
 
 	public void applyAndProcess(@NonNull final OrderPayScheduleLineContext context)
 	{

--- a/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/steps/letter_of_credit/OrderPayScheduleLCStepService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/steps/letter_of_credit/OrderPayScheduleLCStepService.java
@@ -109,8 +109,8 @@ public class OrderPayScheduleLCStepService
 		final OrderPaySchedule schedule = orderPayScheduleService.getByOrderId(orderId).orElse(null);
 		if (schedule == null) {return;} // no pay-schedule at all — no-op
 
-		final OrderPayScheduleLine lcStep = schedule.getSingleLCLine().orElse(null);
-		if (lcStep == null) {return;} // no LC break in payment term — no-op
+		final OrderPayScheduleLine target = schedule.getSingleLCLine().orElseGet(() -> schedule.getSinglePrepaidLine().orElse(null));
+		if (target == null) {return;} // no LC break and no single prepaid line in payment term — no-op
 
 		//
 		// Proforma invoice
@@ -127,9 +127,12 @@ public class OrderPayScheduleLCStepService
 		if (proforma == null)
 		{
 			// No proforma allocation — reset to Pending
-			schedule.markAsPending(lcStep.getIdNotNull());
+			schedule.markAsPending(target.getIdNotNull());
 			orderPayScheduleService.save(schedule);
-			clearLCDateOnOrder(orderId);
+			if (target.isLetterOfCreditDate())
+			{
+				clearLCDateOnOrder(orderId);
+			}
 			return;
 		}
 
@@ -149,7 +152,7 @@ public class OrderPayScheduleLCStepService
 		{
 			// Payment completed → Paid
 			schedule.applyAndProcess(
-					lcStep.getIdNotNull(),
+					target.getIdNotNull(),
 					OrderPayScheduleLineContext.paid()
 							.referenceDate(proforma.getDateInvoiced())
 							.dueDate(proforma.getDueDate())
@@ -161,7 +164,7 @@ public class OrderPayScheduleLCStepService
 		{
 			// Payment absent, drafted, or reversed → Awaiting_Pay
 			schedule.applyAndProcess(
-					lcStep.getIdNotNull(),
+					target.getIdNotNull(),
 					OrderPayScheduleLineContext.awaitingPayment()
 							.referenceDate(proforma.getDateInvoiced())
 							.dueDate(proforma.getDueDate())
@@ -171,7 +174,10 @@ public class OrderPayScheduleLCStepService
 		}
 
 		orderPayScheduleService.save(schedule);
-		stampLCDateOnOrder(orderId, proforma);
+		if (target.isLetterOfCreditDate())
+		{
+			stampLCDateOnOrder(orderId, proforma);
+		}
 	}
 
 	private void clearLCDateOnOrder(@NonNull final OrderId orderId)

--- a/backend/de.metas.business/src/main/java/de/metas/payment/paymentterm/ReferenceDateType.java
+++ b/backend/de.metas.business/src/main/java/de/metas/payment/paymentterm/ReferenceDateType.java
@@ -46,5 +46,7 @@ public enum ReferenceDateType implements ReferenceListAwareEnum
 
 	public boolean isLetterOfCreditDate() {return this == LetterOfCreditDate;}
 
+	public boolean isOrderDate() {return this == OrderDate;}
+
 	public boolean isMaterialReceiptDate() {return this == BillOfLadingDate || this == ETADate;}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/shipping/model/validator/M_ShipperTransportation.java
+++ b/backend/de.metas.business/src/main/java/de/metas/shipping/model/validator/M_ShipperTransportation.java
@@ -23,6 +23,7 @@ package de.metas.shipping.model.validator;
  */
 
 import de.metas.copy_with_details.CopyRecordFactory;
+import de.metas.document.engine.DocStatus;
 import de.metas.order.IOrderBL;
 import de.metas.shipping.api.IShipperTransportationDAO;
 import de.metas.shipping.model.I_M_ShipperTransportation;
@@ -33,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.callout.spi.IProgramaticCalloutProvider;
 import org.adempiere.ad.modelvalidator.annotations.DocValidate;
 import org.adempiere.ad.modelvalidator.annotations.Init;
+import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.ad.modelvalidator.annotations.Validator;
 import org.compiere.model.ModelValidator;
 
@@ -55,10 +57,31 @@ public class M_ShipperTransportation
 	@DocValidate(timings = { ModelValidator.TIMING_AFTER_COMPLETE })
 	public void syncOrderDates(final I_M_ShipperTransportation transportOrder)
 	{
-		if (transportOrder.getETA() != null || transportOrder.getBLDate() != null)
+		propagateDatesToOrders(transportOrder);
+	}
+
+	@ModelChange(timings = { ModelValidator.TYPE_AFTER_CHANGE },
+			ifColumnsChanged = { I_M_ShipperTransportation.COLUMNNAME_BLDate, I_M_ShipperTransportation.COLUMNNAME_ETA })
+	public void syncOrderDatesOnEdit(final I_M_ShipperTransportation transportOrder)
+	{
+		final DocStatus docStatus = DocStatus.ofCode(transportOrder.getDocStatus());
+		if (!docStatus.isCompletedOrClosed())
 		{
-			shipperTransportationDAO.retrieveOrderIds(ShipperTransportationId.ofRepoId(transportOrder.getM_ShipperTransportation_ID()))
-					.forEach(orderId -> orderBL.syncDatesFromTransportOrder(orderId, transportOrder));
+			return; // tentative draft/in-progress transport-order dates must not drive the purchase order's due date
 		}
+
+		propagateDatesToOrders(transportOrder);
+	}
+
+	/** Push the transport order's BL/ETA dates onto every linked purchase order's pay-schedule due dates (no-op when neither date is set). */
+	private void propagateDatesToOrders(@NonNull final I_M_ShipperTransportation transportOrder)
+	{
+		if (transportOrder.getETA() == null && transportOrder.getBLDate() == null)
+		{
+			return;
+		}
+
+		shipperTransportationDAO.retrieveOrderIds(ShipperTransportationId.ofRepoId(transportOrder.getM_ShipperTransportation_ID()))
+				.forEach(orderId -> orderBL.syncDatesFromTransportOrder(orderId, transportOrder));
 	}
 }

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5815170_sys_AdvancePaymentNoLC_MultipleAdvanceBreaksUnsupported.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5815170_sys_AdvancePaymentNoLC_MultipleAdvanceBreaksUnsupported.sql
@@ -1,0 +1,21 @@
+-- AD_Message for advance payment without Letter of Credit validation.
+-- Triggered when an order has multiple advance-payment breaks but no LC break.
+
+INSERT INTO AD_Message (AD_Message_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                        Value, MsgText, MsgType, EntityType)
+VALUES
+  (545778 /*From ID Server*/, 0, 0, 'Y', '2026-07-21 12:00', 0, '2026-07-21 12:00', 0,
+   'de.metas.invoice.proforma.MultipleAdvanceBreaksUnsupported',
+   'Order {0} has more than one advance payment break without a Letter of Credit; this is not supported.',
+   'E', 'D')
+;
+
+UPDATE AD_Message SET ErrorCode='MultipleAdvanceBreaksUnsupported', Updated='2026-07-21 12:00', UpdatedBy=0 WHERE AD_Message_ID=545778 /*From ID Server*/;
+
+-- DE translation
+INSERT INTO AD_Message_Trl (AD_Message_ID, AD_Language, MsgText, IsTranslated, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy)
+VALUES
+  (545778 /*From ID Server*/, 'de_DE',
+   'Bestellung {0} hat mehrere Zahlungsfortschrittsmeilensteine ohne Letter of Credit; dies wird nicht unterstützt.',
+   'Y', 0, 0, 'Y', '2026-07-21 12:00', 0, '2026-07-21 12:00', 0)
+;

--- a/backend/de.metas.business/src/test/java/de/metas/invoice/proforma/ProformaOrderAllocServiceTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/invoice/proforma/ProformaOrderAllocServiceTest.java
@@ -22,30 +22,39 @@
 
 package de.metas.invoice.proforma;
 
+import de.metas.bpartner.BPartnerId;
 import de.metas.invoice.InvoiceId;
 import de.metas.order.IOrderBL;
 import de.metas.order.OrderId;
 import de.metas.order.paymentschedule.steps.letter_of_credit.OrderPayScheduleLCStepService;
 import de.metas.payment.api.IPaymentDAO;
+import de.metas.payment.paymentterm.PaymentTermId;
 import de.metas.payment.paymentterm.PaymentTermService;
+import de.metas.payment.paymentterm.ReferenceDateType;
 import de.metas.pricing.tax.ProductTaxCategoryRepository;
 import de.metas.pricing.tax.ProductTaxCategoryService;
 import de.metas.util.Services;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.test.AdempiereTestHelper;
 import org.compiere.SpringContextHolder;
+import org.compiere.model.I_C_DocType;
 import org.compiere.model.I_C_Invoice;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_Payment;
+import org.compiere.model.I_C_PaymentTerm;
+import org.compiere.model.I_C_PaymentTerm_Break;
 import org.compiere.model.I_C_Proforma_Order_Alloc;
+import org.compiere.model.X_C_DocType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -151,6 +160,119 @@ class ProformaOrderAllocServiceTest
 		assertThat(repository.getByInvoiceId(invoiceId)).hasSize(2);
 	}
 
+	/**
+	 * A purchase payment term with NO Letter-of-Credit break — only an {@code OD}
+	 * (order-date/advance) break and a {@code BL} (bill-of-lading/material-receipt) break — must be
+	 * a valid allocation target: allocate must not reject a no-LC payment term.
+	 */
+	@Test
+	void allocate_noLcBreak_succeeds()
+	{
+		// Synthetic vendor ID: not validated, only used for matching with mocked getEffectiveBillPartnerId.
+		final BPartnerId vendorId = BPartnerId.ofRepoId(1000000);
+		final int currencyId = 318; // EUR
+
+		final PaymentTermId paymentTermId = createNoLcPaymentTerm();
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setIsSOTrx(false);
+		// Kept for fixture realism; the vendor match is driven by the mock below.
+		order.setC_BPartner_ID(vendorId.getRepoId());
+		order.setC_Currency_ID(currencyId);
+		order.setC_PaymentTerm_ID(paymentTermId.getRepoId());
+		order.setDocumentNo("PO-no-lc");
+		saveRecord(order);
+		final OrderId orderId = OrderId.ofRepoId(order.getC_Order_ID());
+
+		// Override the class-level IOrderBL mock (registered in beforeEach for the deallocate-guard path only)
+		// with stubs matching THIS order/vendor, so validate() sees the real fixture instead of the generic stub.
+		final IOrderBL orderBL = mock(IOrderBL.class);
+		when(orderBL.getById(orderId)).thenReturn(order);
+		when(orderBL.getEffectiveBillPartnerId(order)).thenReturn(vendorId);
+		Services.registerService(IOrderBL.class, orderBL);
+
+		final InvoiceId invoiceId = createProformaInvoice(vendorId, currencyId);
+
+		// No-LC payment terms are a valid allocation target — allocate must not reject them.
+		assertThatCode(() -> service.allocate(invoiceId, orderId))
+				.as("allocate must succeed for a no-LC (OD+BL only) payment term")
+				.doesNotThrowAnyException();
+
+		assertThat(repository.getByOrderId(orderId)).hasSize(1);
+	}
+
+	/**
+	 * A purchase payment term with NO Letter-of-Credit break and TWO non-material-receipt (advance)
+	 * breaks — {@code OD} 10% + {@code Invoice} 90% — must be rejected: allocate throws
+	 * {@code MSG_MultipleAdvanceBreaksUnsupported} and no allocation row is created.
+	 */
+	@Test
+	void allocate_multipleAdvanceBreaksNoLc_throws()
+	{
+		final BPartnerId vendorId = BPartnerId.ofRepoId(1000001);
+		final int currencyId = 318; // EUR
+
+		final PaymentTermId paymentTermId = createMultipleAdvanceBreaksNoLcPaymentTerm();
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setIsSOTrx(false);
+		order.setC_BPartner_ID(vendorId.getRepoId());
+		order.setC_Currency_ID(currencyId);
+		order.setC_PaymentTerm_ID(paymentTermId.getRepoId());
+		order.setDocumentNo("PO-multi-advance");
+		saveRecord(order);
+		final OrderId orderId = OrderId.ofRepoId(order.getC_Order_ID());
+
+		final IOrderBL orderBL = mock(IOrderBL.class);
+		when(orderBL.getById(orderId)).thenReturn(order);
+		when(orderBL.getEffectiveBillPartnerId(order)).thenReturn(vendorId);
+		Services.registerService(IOrderBL.class, orderBL);
+
+		final InvoiceId invoiceId = createProformaInvoice(vendorId, currencyId);
+
+		assertThatThrownBy(() -> service.allocate(invoiceId, orderId))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("MultipleAdvanceBreaksUnsupported");
+
+		assertThat(repository.getByOrderId(orderId)).isEmpty();
+	}
+
+	/**
+	 * A purchase payment term WITH a single Letter-of-Credit break ({@code BL} 50% + {@code LC} 50%)
+	 * must remain a valid allocation target — confirms the gate rewrite (no-LC handling added) left the
+	 * pre-existing LC allocation leg intact.
+	 */
+	@Test
+	void allocate_singleLcBreak_succeeds()
+	{
+		final BPartnerId vendorId = BPartnerId.ofRepoId(1000002);
+		final int currencyId = 318; // EUR
+
+		final PaymentTermId paymentTermId = createSingleLcPaymentTerm();
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setIsSOTrx(false);
+		order.setC_BPartner_ID(vendorId.getRepoId());
+		order.setC_Currency_ID(currencyId);
+		order.setC_PaymentTerm_ID(paymentTermId.getRepoId());
+		order.setDocumentNo("PO-single-lc");
+		saveRecord(order);
+		final OrderId orderId = OrderId.ofRepoId(order.getC_Order_ID());
+
+		final IOrderBL orderBL = mock(IOrderBL.class);
+		when(orderBL.getById(orderId)).thenReturn(order);
+		when(orderBL.getEffectiveBillPartnerId(order)).thenReturn(vendorId);
+		Services.registerService(IOrderBL.class, orderBL);
+
+		final InvoiceId invoiceId = createProformaInvoice(vendorId, currencyId);
+
+		assertThatCode(() -> service.allocate(invoiceId, orderId))
+				.as("allocate must succeed for a payment term with a single LC break")
+				.doesNotThrowAnyException();
+
+		assertThat(repository.getByOrderId(orderId)).hasSize(1);
+	}
+
 	// -----------------------------------------------------------------------
 	// Fixture helpers
 	// -----------------------------------------------------------------------
@@ -167,6 +289,100 @@ class ProformaOrderAllocServiceTest
 		final I_C_Invoice invoice = newInstance(I_C_Invoice.class);
 		saveRecord(invoice);
 		return InvoiceId.ofRepoId(invoice.getC_Invoice_ID());
+	}
+
+	/**
+	 * Purchase-proforma-invoice (APF) variant of {@link #createProformaInvoice()} — sets the
+	 * {@code C_DocType} (DocBaseType=APF) plus vendor/currency, needed to pass
+	 * {@code ProformaOrderAllocateCommand.validate}'s {@code isPurchaseProforma}/currency/vendor checks.
+	 */
+	private InvoiceId createProformaInvoice(final BPartnerId vendorId, final int currencyId)
+	{
+		final I_C_DocType docType = newInstance(I_C_DocType.class);
+		docType.setDocBaseType(X_C_DocType.DOCBASETYPE_APProFormaInvoice);
+		saveRecord(docType);
+
+		final I_C_Invoice invoice = newInstance(I_C_Invoice.class);
+		invoice.setC_DocType_ID(docType.getC_DocType_ID());
+		invoice.setC_BPartner_ID(vendorId.getRepoId());
+		invoice.setC_Currency_ID(currencyId);
+		saveRecord(invoice);
+		return InvoiceId.ofRepoId(invoice.getC_Invoice_ID());
+	}
+
+	/**
+	 * OrderDate/no-LC variant of a payment term: two breaks, {@code OD} 10% (advance) + {@code BL} 90%
+	 * (material receipt) — no Letter-of-Credit break at all.
+	 */
+	private PaymentTermId createNoLcPaymentTerm()
+	{
+		final I_C_PaymentTerm paymentTermRecord = newInstance(I_C_PaymentTerm.class);
+		paymentTermRecord.setValue("no-lc-test");
+		paymentTermRecord.setName("No-LC test payment term");
+		paymentTermRecord.setDiscount(BigDecimal.ZERO);
+		paymentTermRecord.setDiscount2(BigDecimal.ZERO);
+		saveRecord(paymentTermRecord);
+		final PaymentTermId paymentTermId = PaymentTermId.ofRepoId(paymentTermRecord.getC_PaymentTerm_ID());
+
+		createPaymentTermBreak(paymentTermId, ReferenceDateType.OrderDate, 10, 10);
+		createPaymentTermBreak(paymentTermId, ReferenceDateType.BillOfLadingDate, 90, 20);
+
+		return paymentTermId;
+	}
+
+	/**
+	 * No-LC variant with TWO non-material-receipt breaks: {@code OD} 10% (advance) + {@code Invoice} 90%
+	 * (also advance, since only {@code BL}/{@code ETA} count as material-receipt) — no LC, no BL/ETA.
+	 */
+	private PaymentTermId createMultipleAdvanceBreaksNoLcPaymentTerm()
+	{
+		final I_C_PaymentTerm paymentTermRecord = newInstance(I_C_PaymentTerm.class);
+		paymentTermRecord.setValue("multi-advance-test");
+		paymentTermRecord.setName("Multiple-advance-breaks test payment term");
+		paymentTermRecord.setDiscount(BigDecimal.ZERO);
+		paymentTermRecord.setDiscount2(BigDecimal.ZERO);
+		saveRecord(paymentTermRecord);
+		final PaymentTermId paymentTermId = PaymentTermId.ofRepoId(paymentTermRecord.getC_PaymentTerm_ID());
+
+		createPaymentTermBreak(paymentTermId, ReferenceDateType.OrderDate, 10, 10);
+		createPaymentTermBreak(paymentTermId, ReferenceDateType.InvoiceDate, 90, 20);
+
+		return paymentTermId;
+	}
+
+	/**
+	 * Single-LC variant: {@code BL} 50% (material receipt) + {@code LC} 50% (Letter-of-Credit) — exactly
+	 * one LC break, a valid allocation target.
+	 */
+	private PaymentTermId createSingleLcPaymentTerm()
+	{
+		final I_C_PaymentTerm paymentTermRecord = newInstance(I_C_PaymentTerm.class);
+		paymentTermRecord.setValue("single-lc-test");
+		paymentTermRecord.setName("Single-LC test payment term");
+		paymentTermRecord.setDiscount(BigDecimal.ZERO);
+		paymentTermRecord.setDiscount2(BigDecimal.ZERO);
+		saveRecord(paymentTermRecord);
+		final PaymentTermId paymentTermId = PaymentTermId.ofRepoId(paymentTermRecord.getC_PaymentTerm_ID());
+
+		createPaymentTermBreak(paymentTermId, ReferenceDateType.BillOfLadingDate, 50, 10);
+		createPaymentTermBreak(paymentTermId, ReferenceDateType.LetterOfCreditDate, 50, 20);
+
+		return paymentTermId;
+	}
+
+	private void createPaymentTermBreak(
+			final PaymentTermId paymentTermId,
+			final ReferenceDateType referenceDateType,
+			final int percent,
+			final int seqNo)
+	{
+		final I_C_PaymentTerm_Break breakRecord = newInstance(I_C_PaymentTerm_Break.class);
+		breakRecord.setC_PaymentTerm_ID(paymentTermId.getRepoId());
+		breakRecord.setReferenceDateType(referenceDateType.getCode());
+		breakRecord.setPercent(percent);
+		breakRecord.setSeqNo(seqNo);
+		breakRecord.setOffsetDays(0);
+		saveRecord(breakRecord);
 	}
 
 	private void createAlloc(final InvoiceId invoiceId, final OrderId orderId)

--- a/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/core/OrderPayScheduleGetSinglePrepaidLineTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/core/OrderPayScheduleGetSinglePrepaidLineTest.java
@@ -1,0 +1,169 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.order.paymentschedule.core;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.money.CurrencyId;
+import de.metas.money.Money;
+import de.metas.order.OrderId;
+import de.metas.payment.paymentterm.PaymentTermBreakId;
+import de.metas.payment.paymentterm.ReferenceDateType;
+import de.metas.util.lang.Percent;
+import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link OrderPaySchedule#getSinglePrepaidLine()} — finding the single prepaid
+ * ({@link OrderPayScheduleLine#isPrepaidLine()}: Letter-of-Credit or order-date/advance) break of a
+ * payment term, analogous to {@link OrderPaySchedule#getSingleLCLine()}.
+ */
+class OrderPayScheduleGetSinglePrepaidLineTest
+{
+	private static final OrderId ORDER_ID = OrderId.ofRepoId(1001);
+	private static final CurrencyId EUR = CurrencyId.ofRepoId(102);
+	private static final LocalDate DUE_DATE = LocalDate.of(2026, 4, 30);
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+	}
+
+	private OrderPayScheduleLine newLine(final int breakId, @NonNull final ReferenceDateType referenceDateType)
+	{
+		return OrderPayScheduleLine.builder()
+				.id(OrderPayScheduleId.ofRepoId(2000 + breakId))
+				.orderId(ORDER_ID)
+				.paymentTermBreakId(PaymentTermBreakId.ofRepoId(3001, breakId))
+				.referenceDateType(referenceDateType)
+				.percent(Percent.of(100))
+				.offsetDays(0)
+				.status(OrderPayScheduleStatus.Pending)
+				.dueDate(DUE_DATE)
+				.dueAmount(Money.of(BigDecimal.valueOf(1000), EUR))
+				.build();
+	}
+
+	private OrderPaySchedule schedule(final OrderPayScheduleLine... lines)
+	{
+		return OrderPaySchedule.ofList(ORDER_ID, ImmutableList.copyOf(lines));
+	}
+
+	@Test
+	void getSinglePrepaidLine_singleOrderDateLine_returnsIt()
+	{
+		final OrderPayScheduleLine prepaidLine = newLine(100, ReferenceDateType.OrderDate);
+		final OrderPayScheduleLine materialReceiptLine = newLine(101, ReferenceDateType.BillOfLadingDate);
+
+		final OrderPaySchedule paySchedule = schedule(prepaidLine, materialReceiptLine);
+
+		assertThat(paySchedule.getSinglePrepaidLine()).contains(prepaidLine);
+	}
+
+	@Test
+	void getSinglePrepaidLine_singleLcLine_returnsIt()
+	{
+		// An LC line IS a prepaid line: with one LC break + one material-receipt break the LC line is returned.
+		final OrderPayScheduleLine lcLine = newLine(100, ReferenceDateType.LetterOfCreditDate);
+		final OrderPayScheduleLine materialReceiptLine = newLine(101, ReferenceDateType.BillOfLadingDate);
+
+		final OrderPaySchedule paySchedule = schedule(lcLine, materialReceiptLine);
+
+		assertThat(paySchedule.getSinglePrepaidLine()).contains(lcLine);
+	}
+
+	@Test
+	void getSinglePrepaidLine_onlyMaterialReceiptLines_returnsEmpty()
+	{
+		final OrderPayScheduleLine materialReceiptLine1 = newLine(100, ReferenceDateType.BillOfLadingDate);
+		final OrderPayScheduleLine materialReceiptLine2 = newLine(101, ReferenceDateType.ETADate);
+
+		final OrderPaySchedule paySchedule = schedule(materialReceiptLine1, materialReceiptLine2);
+
+		assertThat(paySchedule.getSinglePrepaidLine()).isEmpty();
+	}
+
+	@Test
+	void getSinglePrepaidLine_soleInvoiceDateNoOrderDateNoLc_returnsEmpty()
+	{
+		// A term whose only non-material-receipt break is an invoice-date break has NO prepaid step —
+		// an invoice-date break is a regular post-invoice term — so the proforma settles nothing here.
+		final OrderPayScheduleLine materialReceiptLine = newLine(100, ReferenceDateType.BillOfLadingDate);
+		final OrderPayScheduleLine invoiceDateLine = newLine(101, ReferenceDateType.InvoiceDate);
+
+		final OrderPaySchedule paySchedule = schedule(materialReceiptLine, invoiceDateLine);
+
+		assertThat(paySchedule.getSinglePrepaidLine()).isEmpty();
+	}
+
+	@Test
+	void getSinglePrepaidLine_invoiceDateAndOrderDate_ignoresInvoiceDate()
+	{
+		// An invoice-date break is a regular post-invoice term, not prepaid: with one OD (prepaid) break
+		// + one Invoice break the method returns the OD line and does NOT count the Invoice line.
+		final OrderPayScheduleLine orderDateLine = newLine(100, ReferenceDateType.OrderDate);
+		final OrderPayScheduleLine invoiceDateLine = newLine(101, ReferenceDateType.InvoiceDate);
+
+		final OrderPaySchedule paySchedule = schedule(orderDateLine, invoiceDateLine);
+
+		assertThat(paySchedule.getSinglePrepaidLine()).contains(orderDateLine);
+	}
+
+	@Test
+	void getSinglePrepaidLine_twoOrderDateLines_throws()
+	{
+		final OrderPayScheduleLine prepaidLine1 = newLine(100, ReferenceDateType.OrderDate);
+		final OrderPayScheduleLine prepaidLine2 = newLine(101, ReferenceDateType.OrderDate);
+
+		final OrderPaySchedule paySchedule = schedule(prepaidLine1, prepaidLine2);
+
+		assertThatThrownBy(paySchedule::getSinglePrepaidLine)
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("MultipleAdvanceBreaksUnsupported");
+	}
+
+	@Test
+	void getSinglePrepaidLine_lcAndOrderDate_throws()
+	{
+		// Both LC and OD are prepaid. The guarded caller resolves LC first (getSingleLCLine) and only falls
+		// through to getSinglePrepaidLine for the no-LC case, so this misuse never happens on that path —
+		// but called directly on a term carrying both, it correctly fails loud rather than silently pick one.
+		final OrderPayScheduleLine lcLine = newLine(100, ReferenceDateType.LetterOfCreditDate);
+		final OrderPayScheduleLine orderDateLine = newLine(101, ReferenceDateType.OrderDate);
+
+		final OrderPaySchedule paySchedule = schedule(lcLine, orderDateLine);
+
+		assertThatThrownBy(paySchedule::getSinglePrepaidLine)
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("MultipleAdvanceBreaksUnsupported");
+	}
+}

--- a/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/core/OrderPayScheduleUpdateStatusFromContextTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/core/OrderPayScheduleUpdateStatusFromContextTest.java
@@ -1,0 +1,298 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.order.paymentschedule.core;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.currency.CurrencyPrecision;
+import de.metas.inout.InOutId;
+import de.metas.money.CurrencyId;
+import de.metas.money.Money;
+import de.metas.order.OrderId;
+import de.metas.organization.OrgId;
+import de.metas.payment.paymentterm.PaymentTerm;
+import de.metas.payment.paymentterm.PaymentTermBreak;
+import de.metas.payment.paymentterm.PaymentTermBreakId;
+import de.metas.payment.paymentterm.PaymentTermId;
+import de.metas.payment.paymentterm.ReferenceDateType;
+import de.metas.util.lang.Percent;
+import de.metas.util.lang.SeqNo;
+import org.adempiere.service.ClientId;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link OrderPaySchedule#updateStatusFromContext(OrderSchedulingContext)} — the recompute
+ * must refresh an unsettled {@code Awaiting_Pay} material-receipt (BL/ETA) line on a reference-date
+ * change, while leaving an {@code Awaiting_Pay} LC line untouched (that line stays on the dedicated
+ * LC step service path).
+ */
+class OrderPayScheduleUpdateStatusFromContextTest
+{
+	private static final PaymentTermId PT_ID = PaymentTermId.ofRepoId(5002);
+	private static final PaymentTermBreakId BL_BREAK_ID = PaymentTermBreakId.ofRepoId(PT_ID.getRepoId(), 5020);
+	private static final PaymentTermBreakId LC_BREAK_ID = PaymentTermBreakId.ofRepoId(PT_ID.getRepoId(), 5021);
+	private static final CurrencyId EUR = CurrencyId.ofRepoId(102);
+	private static final OrderId ORDER_ID = OrderId.ofRepoId(7002);
+
+	private static final LocalDate OLD_BL_DATE = LocalDate.of(2026, 3, 1);
+	private static final LocalDate NEW_BL_DATE = LocalDate.of(2026, 3, 15); // corrected BL date
+	private static final LocalDate LC_DATE = LocalDate.of(2026, 2, 1); // LC line's stored value, must stay untouched
+	private static final LocalDate NEW_LC_CONTEXT_DATE = LocalDate.of(2026, 2, 20); // context-only change; must never reach the LC line
+
+	private static final PaymentTermBreakId ETA_BREAK_ID = PaymentTermBreakId.ofRepoId(PT_ID.getRepoId(), 5022);
+	private static final LocalDate OLD_ETA_DATE = LocalDate.of(2026, 4, 1);
+	private static final LocalDate NEW_ETA_DATE = LocalDate.of(2026, 4, 15); // corrected ETA date
+
+	private PaymentTerm newPaymentTerm()
+	{
+		final PaymentTermBreak blBreak = PaymentTermBreak.builder()
+				.id(BL_BREAK_ID)
+				.referenceDateType(ReferenceDateType.BillOfLadingDate)
+				.percent(Percent.of("50"))
+				.seqNo(SeqNo.ofInt(10))
+				.offsetDays(0)
+				.build();
+
+		final PaymentTermBreak lcBreak = PaymentTermBreak.builder()
+				.id(LC_BREAK_ID)
+				.referenceDateType(ReferenceDateType.LetterOfCreditDate)
+				.percent(Percent.of("50"))
+				.seqNo(SeqNo.ofInt(20))
+				.offsetDays(0)
+				.build();
+
+		return PaymentTerm.builder()
+				.id(PT_ID)
+				.clientId(ClientId.SYSTEM)
+				.orgId(OrgId.ANY)
+				.value("pt_bl_lc")
+				.name("pt_bl_lc (BL 50% + LC 50%)")
+				.breaks(ImmutableList.of(blBreak, lcBreak))
+				.paySchedules(ImmutableList.of())
+				.build();
+	}
+
+	private PaymentTerm newPaymentTermWithETA()
+	{
+		final PaymentTermBreak etaBreak = PaymentTermBreak.builder()
+				.id(ETA_BREAK_ID)
+				.referenceDateType(ReferenceDateType.ETADate)
+				.percent(Percent.of("50"))
+				.seqNo(SeqNo.ofInt(10))
+				.offsetDays(0)
+				.build();
+
+		final PaymentTermBreak lcBreak = PaymentTermBreak.builder()
+				.id(LC_BREAK_ID)
+				.referenceDateType(ReferenceDateType.LetterOfCreditDate)
+				.percent(Percent.of("50"))
+				.seqNo(SeqNo.ofInt(20))
+				.offsetDays(0)
+				.build();
+
+		return PaymentTerm.builder()
+				.id(PT_ID)
+				.clientId(ClientId.SYSTEM)
+				.orgId(OrgId.ANY)
+				.value("pt_eta_lc")
+				.name("pt_eta_lc (ETA 50% + LC 50%)")
+				.breaks(ImmutableList.of(etaBreak, lcBreak))
+				.paySchedules(ImmutableList.of())
+				.build();
+	}
+
+	private OrderPayScheduleLine newAwaitingPayLine(
+			final PaymentTermBreakId breakId,
+			final ReferenceDateType referenceDateType,
+			final LocalDate referenceDate)
+	{
+		return OrderPayScheduleLine.builder()
+				.id(OrderPayScheduleId.ofRepoId(breakId.getRepoId()))
+				.orderId(ORDER_ID)
+				.paymentTermBreakId(breakId)
+				.referenceDateType(referenceDateType)
+				.percent(Percent.of("50"))
+				.offsetDays(0)
+				.status(OrderPayScheduleStatus.Awaiting_Pay)
+				.isPaid(false)
+				.referenceDate(referenceDate)
+				.dueDate(referenceDate)
+				.dueAmount(Money.of(BigDecimal.valueOf(5000), EUR))
+				.invoiceId(null)
+				.inoutId(null)
+				.build();
+	}
+
+	/**
+	 * After a Transport Order completes, the BL line is already {@code Awaiting_Pay}. A later BL-date
+	 * correction must still refresh its due date (unsettled: not paid, no invoice, no receipt linked
+	 * yet). The LC line, also {@code Awaiting_Pay}, must stay byte-behavior-identical — it is refreshed
+	 * only via the dedicated LC step service, never by this generic recompute.
+	 */
+	@Test
+	void blLineRefreshed_lcLineUntouched_onBLDateCorrection()
+	{
+		final OrderPayScheduleLine blLine = newAwaitingPayLine(BL_BREAK_ID, ReferenceDateType.BillOfLadingDate, OLD_BL_DATE);
+		final OrderPayScheduleLine lcLine = newAwaitingPayLine(LC_BREAK_ID, ReferenceDateType.LetterOfCreditDate, LC_DATE);
+
+		final OrderPaySchedule paySchedule = OrderPaySchedule.ofList(ORDER_ID, ImmutableList.of(blLine, lcLine));
+
+		final OrderSchedulingContext context = OrderSchedulingContext.builder()
+				.orderId(ORDER_ID)
+				.billOfLadingDate(NEW_BL_DATE) // corrected
+				.letterOfCreditDate(NEW_LC_CONTEXT_DATE) // also changed in the context; must not reach the LC line
+				.grandTotal(Money.of(BigDecimal.valueOf(10000), EUR))
+				.precision(CurrencyPrecision.TWO)
+				.paymentTerm(newPaymentTerm())
+				.build();
+
+		paySchedule.updateStatusFromContext(context);
+
+		assertThat(blLine.getStatus()).isEqualTo(OrderPayScheduleStatus.Awaiting_Pay);
+		assertThat(blLine.isPaid()).isFalse();
+		assertThat(blLine.getDueDate()).as("BL line dueDate refreshed to corrected BL date").isEqualTo(NEW_BL_DATE);
+		assertThat(blLine.getReferenceDate()).isEqualTo(NEW_BL_DATE);
+
+		assertThat(lcLine.getStatus()).isEqualTo(OrderPayScheduleStatus.Awaiting_Pay);
+		assertThat(lcLine.isPaid()).isFalse();
+		assertThat(lcLine.getDueDate()).as("LC line dueDate must stay at its OLD value, ignoring the changed context LC date").isEqualTo(LC_DATE);
+		assertThat(lcLine.getReferenceDate()).as("LC line referenceDate must stay at its OLD value, ignoring the changed context LC date").isEqualTo(LC_DATE);
+	}
+
+	/**
+	 * Same recompute path as {@link #blLineRefreshed_lcLineUntouched_onBLDateCorrection()}, but for the
+	 * other material-receipt reference type: an unsettled {@code Awaiting_Pay} {@code ETA} line must also
+	 * refresh its due date on an ETA reference-date correction, proving the refresh gate
+	 * ({@code isMaterialReceiptDate()}) covers ETA, not just BL.
+	 */
+	@Test
+	void etaLineRefreshed_onETADateCorrection()
+	{
+		final OrderPayScheduleLine etaLine = newAwaitingPayLine(ETA_BREAK_ID, ReferenceDateType.ETADate, OLD_ETA_DATE);
+		final OrderPayScheduleLine lcLine = newAwaitingPayLine(LC_BREAK_ID, ReferenceDateType.LetterOfCreditDate, LC_DATE);
+
+		final OrderPaySchedule paySchedule = OrderPaySchedule.ofList(ORDER_ID, ImmutableList.of(etaLine, lcLine));
+
+		final OrderSchedulingContext context = OrderSchedulingContext.builder()
+				.orderId(ORDER_ID)
+				.ETADate(NEW_ETA_DATE) // corrected
+				.letterOfCreditDate(NEW_LC_CONTEXT_DATE) // also changed in the context; must not reach the LC line
+				.grandTotal(Money.of(BigDecimal.valueOf(10000), EUR))
+				.precision(CurrencyPrecision.TWO)
+				.paymentTerm(newPaymentTermWithETA())
+				.build();
+
+		paySchedule.updateStatusFromContext(context);
+
+		assertThat(etaLine.getStatus()).isEqualTo(OrderPayScheduleStatus.Awaiting_Pay);
+		assertThat(etaLine.isPaid()).isFalse();
+		assertThat(etaLine.getDueDate()).as("ETA line dueDate refreshed to corrected ETA date").isEqualTo(NEW_ETA_DATE);
+		assertThat(etaLine.getReferenceDate()).isEqualTo(NEW_ETA_DATE);
+
+		assertThat(lcLine.getStatus()).isEqualTo(OrderPayScheduleStatus.Awaiting_Pay);
+		assertThat(lcLine.isPaid()).isFalse();
+		assertThat(lcLine.getDueDate()).as("LC line dueDate must stay at its OLD value, ignoring the changed context LC date").isEqualTo(LC_DATE);
+		assertThat(lcLine.getReferenceDate()).as("LC line referenceDate must stay at its OLD value, ignoring the changed context LC date").isEqualTo(LC_DATE);
+	}
+
+	/**
+	 * The refresh gate excludes an already-paid line: an {@code Awaiting_Pay} BL line whose {@code isPaid}
+	 * has drifted to true (hand-edited/legacy row) must NOT be re-dated by a later BL-date correction —
+	 * the {@code !isPaid()} guard keeps it untouched.
+	 */
+	@Test
+	void paidMaterialReceiptLine_notRefreshed_onBLDateCorrection()
+	{
+		final OrderPayScheduleLine paidBlLine = OrderPayScheduleLine.builder()
+				.id(OrderPayScheduleId.ofRepoId(BL_BREAK_ID.getRepoId()))
+				.orderId(ORDER_ID)
+				.paymentTermBreakId(BL_BREAK_ID)
+				.referenceDateType(ReferenceDateType.BillOfLadingDate)
+				.percent(Percent.of("50"))
+				.offsetDays(0)
+				.status(OrderPayScheduleStatus.Awaiting_Pay)
+				.isPaid(true) // drifted: Awaiting_Pay yet already paid
+				.referenceDate(OLD_BL_DATE)
+				.dueDate(OLD_BL_DATE)
+				.dueAmount(Money.of(BigDecimal.valueOf(5000), EUR))
+				.build();
+
+		final OrderPaySchedule paySchedule = OrderPaySchedule.ofList(ORDER_ID, ImmutableList.of(paidBlLine));
+
+		final OrderSchedulingContext context = OrderSchedulingContext.builder()
+				.orderId(ORDER_ID)
+				.billOfLadingDate(NEW_BL_DATE) // corrected
+				.grandTotal(Money.of(BigDecimal.valueOf(10000), EUR))
+				.precision(CurrencyPrecision.TWO)
+				.paymentTerm(newPaymentTerm())
+				.build();
+
+		paySchedule.updateStatusFromContext(context);
+
+		assertThat(paidBlLine.getDueDate()).as("a paid line must NOT be refreshed by a later BL-date correction").isEqualTo(OLD_BL_DATE);
+		assertThat(paidBlLine.getReferenceDate()).isEqualTo(OLD_BL_DATE);
+	}
+
+	/**
+	 * The refresh gate excludes a line already linked to a committed downstream document: an
+	 * {@code Awaiting_Pay} BL line whose goods receipt ({@code inoutId}) is set must NOT be re-dated by a
+	 * later BL-date correction — the {@code !isLinkedToDownstreamDocument()} guard keeps it untouched.
+	 */
+	@Test
+	void downstreamLinkedMaterialReceiptLine_notRefreshed_onBLDateCorrection()
+	{
+		final OrderPayScheduleLine linkedBlLine = OrderPayScheduleLine.builder()
+				.id(OrderPayScheduleId.ofRepoId(BL_BREAK_ID.getRepoId()))
+				.orderId(ORDER_ID)
+				.paymentTermBreakId(BL_BREAK_ID)
+				.referenceDateType(ReferenceDateType.BillOfLadingDate)
+				.percent(Percent.of("50"))
+				.offsetDays(0)
+				.status(OrderPayScheduleStatus.Awaiting_Pay)
+				.isPaid(false)
+				.referenceDate(OLD_BL_DATE)
+				.dueDate(OLD_BL_DATE)
+				.dueAmount(Money.of(BigDecimal.valueOf(5000), EUR))
+				.inoutId(InOutId.ofRepoId(900001)) // goods receipt already matched
+				.build();
+
+		final OrderPaySchedule paySchedule = OrderPaySchedule.ofList(ORDER_ID, ImmutableList.of(linkedBlLine));
+
+		final OrderSchedulingContext context = OrderSchedulingContext.builder()
+				.orderId(ORDER_ID)
+				.billOfLadingDate(NEW_BL_DATE) // corrected
+				.grandTotal(Money.of(BigDecimal.valueOf(10000), EUR))
+				.precision(CurrencyPrecision.TWO)
+				.paymentTerm(newPaymentTerm())
+				.build();
+
+		paySchedule.updateStatusFromContext(context);
+
+		assertThat(linkedBlLine.getDueDate()).as("a downstream-linked line must NOT be refreshed by a later BL-date correction").isEqualTo(OLD_BL_DATE);
+		assertThat(linkedBlLine.getReferenceDate()).isEqualTo(OLD_BL_DATE);
+	}
+}

--- a/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/service/OrderPayScheduleLCServiceTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/service/OrderPayScheduleLCServiceTest.java
@@ -49,6 +49,7 @@ import java.time.LocalDate;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Property-based JUnit for {@link OrderPayScheduleLCStepService}.
@@ -333,6 +334,73 @@ class OrderPayScheduleLCServiceTest
 	}
 
 	// -----------------------------------------------------------------------
+	// No-LC payment terms (no Letter-of-Credit break)
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A payment term with a single {@code OD} advance break + a {@code BL} break (no LC break
+	 * at all). Once the proforma is allocated and its payment completes, the OD (advance) line must
+	 * reach {@code Paid} with {@code DueAmt_Actual == proforma GrandTotal}; {@code C_Order.LC_Date}
+	 * must stay null (no LC break to stamp); the BL line must be untouched.
+	 * <p>
+	 * Verifies that the recompute step correctly handles no-LC advance breaks.
+	 */
+	@Test
+	void noLc_advanceLine_completedPayment_yields_Paid()
+	{
+		final OrderId orderId = createOrder();
+		createAdvancePayScheduleLine(orderId, X_C_OrderPaySchedule.STATUS_Pending_Ref);
+		createMaterialReceiptPayScheduleLine(orderId, X_C_OrderPaySchedule.STATUS_Pending_Ref);
+
+		final Timestamp invoiceDate = TimeUtil.asTimestamp(LocalDate.of(2026, 7, 1));
+		final int proformaInvoiceId = createProformaInvoice(invoiceDate);
+		createAlloc(orderId, proformaInvoiceId);
+		createPayment(proformaInvoiceId, X_C_Payment.DOCSTATUS_Completed);
+
+		service.recomputeLCStep(orderId);
+
+		final I_C_OrderPaySchedule odLine = findLineByReferenceDateType(orderId, ReferenceDateType.OrderDate);
+		assertThat(odLine.getStatus())
+				.as("no-LC advance (OD) line must reach Paid once the proforma payment completes")
+				.isEqualTo(X_C_OrderPaySchedule.STATUS_Paid);
+		assertThat(odLine.getDueAmt_Actual()).isEqualByComparingTo(PROFORMA_GRAND_TOTAL);
+
+		final I_C_Order order = findOrder(orderId);
+		assertThat(order.getLC_Date())
+				.as("no LC break in this payment term — LC_Date must stay null")
+				.isNull();
+
+		final I_C_OrderPaySchedule blLine = findLineByReferenceDateType(orderId, ReferenceDateType.BillOfLadingDate);
+		assertThat(blLine.getStatus())
+				.as("BL line is untouched by the recompute step")
+				.isEqualTo(X_C_OrderPaySchedule.STATUS_Pending_Ref);
+	}
+
+	/**
+	 * A payment term with only a {@code BL} (material-receipt) break — no advance line, no LC
+	 * line at all. Paying the proforma must not mark any line {@code Paid} and must not throw.
+	 */
+	@Test
+	void noLc_noAdvanceLine_paysNothing()
+	{
+		final OrderId orderId = createOrder();
+		createMaterialReceiptPayScheduleLine(orderId, X_C_OrderPaySchedule.STATUS_Pending_Ref);
+
+		final int proformaInvoiceId = createProformaInvoice(TimeUtil.asTimestamp(LocalDate.of(2026, 7, 2)));
+		createAlloc(orderId, proformaInvoiceId);
+		createPayment(proformaInvoiceId, X_C_Payment.DOCSTATUS_Completed);
+
+		assertThatCode(() -> service.recomputeLCStep(orderId))
+				.as("no exception even though there is no advance/LC line to pay")
+				.doesNotThrowAnyException();
+
+		final I_C_OrderPaySchedule blLine = findLineByReferenceDateType(orderId, ReferenceDateType.BillOfLadingDate);
+		assertThat(blLine.getStatus())
+				.as("no advance/LC line present — nothing should be marked Paid")
+				.isNotEqualTo(X_C_OrderPaySchedule.STATUS_Paid);
+	}
+
+	// -----------------------------------------------------------------------
 	// Fixture helpers
 	// -----------------------------------------------------------------------
 
@@ -359,6 +427,36 @@ class OrderPayScheduleLCServiceTest
 	 */
 	private void createLCPayScheduleLine(final OrderId orderId, final String initialStatus)
 	{
+		createPayScheduleLine(orderId, ReferenceDateType.LetterOfCreditDate, 100, initialStatus);
+	}
+
+	/**
+	 * OrderDate/no-LC variant: the {@code OD} advance break of a no-LC payment term.
+	 */
+	private void createAdvancePayScheduleLine(final OrderId orderId, final String initialStatus)
+	{
+		createPayScheduleLine(orderId, ReferenceDateType.OrderDate, 10, initialStatus);
+	}
+
+	/**
+	 * The {@code BL} (bill-of-lading) material-receipt break of a no-LC payment term.
+	 */
+	private void createMaterialReceiptPayScheduleLine(final OrderId orderId, final String initialStatus)
+	{
+		createPayScheduleLine(orderId, ReferenceDateType.BillOfLadingDate, 90, initialStatus);
+	}
+
+	/**
+	 * Creates one pay-schedule line of the given {@link ReferenceDateType} for the given order.
+	 * Uses a synthetic {@code C_PaymentTerm_ID} and {@code C_PaymentTerm_Break_ID} (just non-zero ints —
+	 * the service does not validate them, only uses {@code ReferenceDateType}).
+	 */
+	private void createPayScheduleLine(
+			final OrderId orderId,
+			final ReferenceDateType referenceDateType,
+			final int percent,
+			final String initialStatus)
+	{
 		final int payTermId = PAYMENT_TERM_ID_COUNTER++;
 		final int payTermBreakId = PAYMENT_TERM_ID_COUNTER++;
 		final int currencyId = 318; // EUR
@@ -367,11 +465,11 @@ class OrderPayScheduleLCServiceTest
 		schedule.setC_Order_ID(orderId.getRepoId());
 		schedule.setC_PaymentTerm_ID(payTermId);
 		schedule.setC_PaymentTerm_Break_ID(payTermBreakId);
-		schedule.setReferenceDateType(ReferenceDateType.LetterOfCreditDate.getCode());
+		schedule.setReferenceDateType(referenceDateType.getCode());
 		schedule.setDueAmt(PROFORMA_GRAND_TOTAL);
 		schedule.setC_Currency_ID(currencyId);
 		schedule.setDueDate(TimeUtil.asTimestamp(LocalDate.of(2026, 6, 1)));
-		schedule.setPercent(100);
+		schedule.setPercent(percent);
 		schedule.setOffsetDays(0);
 		schedule.setSeqNo(10);
 		schedule.setStatus(initialStatus);
@@ -429,11 +527,19 @@ class OrderPayScheduleLCServiceTest
 
 	private I_C_OrderPaySchedule findLCLine(final OrderId orderId)
 	{
-		// reload all pay-schedule lines for the order and find the LC one
+		return findLineByReferenceDateType(orderId, ReferenceDateType.LetterOfCreditDate);
+	}
+
+	/**
+	 * Reloads all pay-schedule lines for the order and returns the one matching the given
+	 * {@link ReferenceDateType} (e.g. the OD advance line or the BL material-receipt line).
+	 */
+	private I_C_OrderPaySchedule findLineByReferenceDateType(final OrderId orderId, final ReferenceDateType referenceDateType)
+	{
 		return de.metas.util.Services.get(org.adempiere.ad.dao.IQueryBL.class)
 				.createQueryBuilder(I_C_OrderPaySchedule.class)
 				.addEqualsFilter(I_C_OrderPaySchedule.COLUMNNAME_C_Order_ID, orderId)
-				.addEqualsFilter(I_C_OrderPaySchedule.COLUMNNAME_ReferenceDateType, ReferenceDateType.LetterOfCreditDate.getCode())
+				.addEqualsFilter(I_C_OrderPaySchedule.COLUMNNAME_ReferenceDateType, referenceDateType)
 				.create()
 				.firstOnlyNotNull(I_C_OrderPaySchedule.class);
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Proforma_Order_Alloc_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Proforma_Order_Alloc_StepDef.java
@@ -60,7 +60,8 @@ public class C_Proforma_Order_Alloc_StepDef
 	 * <p>Preconditions (enforced by the service):
 	 * <ul>
 	 *   <li>The invoice must be a completed Purchase Proforma (APF).</li>
-	 *   <li>The order must have exactly one LC break in its payment term.</li>
+	 *   <li>The order's payment term must have at most one LC break; a no-LC term is allowed as long as
+	 *       it has at most one advance (non-material-receipt) break.</li>
 	 *   <li>Currency and vendor must match between invoice and order.</li>
 	 * </ul>
 	 *

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderComplexPaymentTerm.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderComplexPaymentTerm.feature
@@ -245,3 +245,255 @@ Feature: Purchase order with complex payment term
       | C_PaymentTerm_Break_ID | DueDate    | DueAmt | Status |
       | PTB31                  | 2025-10-10 | 25.58  | WP     |
       | PTB32                  | 2025-04-01 | 76.72  | WP     |
+
+
+  @from:cucumber
+@allure.label.epic:E0140_Purchasing
+@allure.label.feature:F00600_Purchase_Order
+@allure.label.feature:F00994_Multiple_Levels_of_Payment
+@F00600
+@Id:S30954_1
+  Scenario: BL date entered after transport order completion recomputes the shipping line
+    When metasfresh contains C_PaymentTerm
+      | Identifier |
+      | pt_PO_4    |
+    And metasfresh contains C_PaymentTerm_Break
+      | Identifier | C_PaymentTerm_ID | Percent | OffsetDays | ReferenceDateType | SeqNo |
+      | PTB41      | pt_PO_4          | 10      | 1          | OD                | 10    |
+      | PTB42      | pt_PO_4          | 90      | 5          | BL                | 20    |
+    And validate C_PaymentTerm:
+      | Identifier | IsComplex | IsValid |
+      | pt_PO_4    | Y         | Y       |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po4        | N       | vendor        | 2025-10-09  | POO         | wh             | pt_PO_4          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | po4_l1     | po4        | product      | 10         |
+    And the order identified by po4 is completed
+    Then the order identified by po4 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueDate    | DueAmt | Status |
+      | PTB41                  | 2025-10-10 | 10.23  | WP     |
+      | PTB42                  | 9999-12-01 | 92.07  | PR     |
+
+    And metasfresh contains Transport Order
+      | Identifier      | M_Shipper_ID | Shipper_BPartner_ID | Shipper_Location_ID |
+      | shipperTransp_2 | shipper_DHL  | shipper             | shipperLocation     |
+    And metasfresh contains M_Package
+      | Identifier | M_Shipper_ID |
+      | Pckg2      | shipper_DHL  |
+    And metasfresh contains M_ShippingPackage
+      | Identifier | C_Order_ID | M_ShipperTransportation_ID | M_Package_ID | C_BPartner_Location_ID |
+      | shPckg2    | po4        | shipperTransp_2            | Pckg2        | shipperLocation        |
+    And the transport order identified by shipperTransp_2 is completed
+    Then the order identified by po4 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueDate    | DueAmt | Status |
+      | PTB41                  | 2025-10-10 | 10.23  | WP     |
+      | PTB42                  | 9999-12-01 | 92.07  | PR     |
+
+    And update transport order
+      | M_ShipperTransportation_ID | BLDate     |
+      | shipperTransp_2            | 2025-10-20 |
+    Then the order identified by po4 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueDate    | DueAmt | Status |
+      | PTB41                  | 2025-10-10 | 10.23  | WP     |
+      | PTB42                  | 2025-10-25 | 92.07  | WP     |
+
+
+  @from:cucumber
+@allure.label.epic:E0140_Purchasing
+@allure.label.feature:F00600_Purchase_Order
+@allure.label.feature:F00994_Multiple_Levels_of_Payment
+@F00600
+@Id:S30954_2
+  Scenario: BL date corrected after transport order completion recomputes the shipping line
+    When metasfresh contains C_PaymentTerm
+      | Identifier |
+      | pt_PO_5    |
+    And metasfresh contains C_PaymentTerm_Break
+      | Identifier | C_PaymentTerm_ID | Percent | OffsetDays | ReferenceDateType | SeqNo |
+      | PTB51      | pt_PO_5          | 10      | 1          | OD                | 10    |
+      | PTB52      | pt_PO_5          | 90      | 5          | BL                | 20    |
+    And validate C_PaymentTerm:
+      | Identifier | IsComplex | IsValid |
+      | pt_PO_5    | Y         | Y       |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po5        | N       | vendor        | 2025-10-09  | POO         | wh             | pt_PO_5          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | po5_l1     | po5        | product      | 10         |
+    And the order identified by po5 is completed
+    Then the order identified by po5 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueDate    | DueAmt | Status |
+      | PTB51                  | 2025-10-10 | 10.23  | WP     |
+      | PTB52                  | 9999-12-01 | 92.07  | PR     |
+
+    And metasfresh contains Transport Order
+      | Identifier      | M_Shipper_ID | Shipper_BPartner_ID | Shipper_Location_ID |
+      | shipperTransp_3 | shipper_DHL  | shipper             | shipperLocation     |
+    And metasfresh contains M_Package
+      | Identifier | M_Shipper_ID |
+      | Pckg3      | shipper_DHL  |
+    And metasfresh contains M_ShippingPackage
+      | Identifier | C_Order_ID | M_ShipperTransportation_ID | M_Package_ID | C_BPartner_Location_ID |
+      | shPckg3    | po5        | shipperTransp_3            | Pckg3        | shipperLocation        |
+    And update transport order
+      | M_ShipperTransportation_ID | BLDate     |
+      | shipperTransp_3            | 2025-10-15 |
+    And the transport order identified by shipperTransp_3 is completed
+    Then the order identified by po5 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueDate    | DueAmt | Status |
+      | PTB51                  | 2025-10-10 | 10.23  | WP     |
+      | PTB52                  | 2025-10-20 | 92.07  | WP     |
+
+    And update transport order
+      | M_ShipperTransportation_ID | BLDate     |
+      | shipperTransp_3            | 2025-10-22 |
+    Then the order identified by po5 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueDate    | DueAmt | Status |
+      | PTB51                  | 2025-10-10 | 10.23  | WP     |
+      | PTB52                  | 2025-10-27 | 92.07  | WP     |
+
+
+  @from:cucumber
+@allure.label.epic:E0140_Purchasing
+@allure.label.feature:F00600_Purchase_Order
+@allure.label.feature:F00994_Multiple_Levels_of_Payment
+@F00600
+@Id:S30954_3
+  Scenario: Draft transport order does not propagate its BL date to the shipping line
+    When metasfresh contains C_PaymentTerm
+      | Identifier |
+      | pt_PO_6    |
+    And metasfresh contains C_PaymentTerm_Break
+      | Identifier | C_PaymentTerm_ID | Percent | OffsetDays | ReferenceDateType | SeqNo |
+      | PTB61      | pt_PO_6          | 10      | 1          | OD                | 10    |
+      | PTB62      | pt_PO_6          | 90      | 5          | BL                | 20    |
+    And validate C_PaymentTerm:
+      | Identifier | IsComplex | IsValid |
+      | pt_PO_6    | Y         | Y       |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po6        | N       | vendor        | 2025-10-09  | POO         | wh             | pt_PO_6          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | po6_l1     | po6        | product      | 10         |
+    And the order identified by po6 is completed
+    Then the order identified by po6 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueDate    | DueAmt | Status |
+      | PTB61                  | 2025-10-10 | 10.23  | WP     |
+      | PTB62                  | 9999-12-01 | 92.07  | PR     |
+
+    And metasfresh contains Transport Order
+      | Identifier      | M_Shipper_ID | Shipper_BPartner_ID | Shipper_Location_ID |
+      | shipperTransp_4 | shipper_DHL  | shipper             | shipperLocation     |
+    And metasfresh contains M_Package
+      | Identifier | M_Shipper_ID |
+      | Pckg4      | shipper_DHL  |
+    And metasfresh contains M_ShippingPackage
+      | Identifier | C_Order_ID | M_ShipperTransportation_ID | M_Package_ID | C_BPartner_Location_ID |
+      | shPckg4    | po6        | shipperTransp_4            | Pckg4        | shipperLocation        |
+    And update transport order
+      | M_ShipperTransportation_ID | BLDate     |
+      | shipperTransp_4            | 2025-10-18 |
+    Then the order identified by po6 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueDate    | DueAmt | Status |
+      | PTB61                  | 2025-10-10 | 10.23  | WP     |
+      | PTB62                  | 9999-12-01 | 92.07  | PR     |
+
+    And the transport order identified by shipperTransp_4 is completed
+    Then the order identified by po6 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueDate    | DueAmt | Status |
+      | PTB61                  | 2025-10-10 | 10.23  | WP     |
+      | PTB62                  | 2025-10-23 | 92.07  | WP     |
+
+
+  @from:cucumber
+@allure.label.epic:E0140_Purchasing
+@allure.label.feature:F00600_Purchase_Order
+@allure.label.feature:F00994_Multiple_Levels_of_Payment
+@F00600
+@Id:S30954_4
+  Scenario: Advance paid via a proforma marks the order-date step Paid on a no-LC payment term
+    # No-Letter-of-Credit purchase term: OD 10% (order-date advance) + BL 90% (bill-of-lading material receipt).
+    # The procurement worker pays the 10% advance up front via a purchase proforma invoice.
+    # Advance step (OD) state walk: Awaiting_Pay (order completed) -> Paid (proforma allocated + paid).
+    # BL step stays Pending throughout - the bill-of-lading date is not yet known (no goods receipt).
+    When metasfresh contains C_PaymentTerm
+      | Identifier   |
+      | pt_PO_7      |
+      | pt_immediate |
+    And metasfresh contains C_PaymentTerm_Break
+      | Identifier | C_PaymentTerm_ID | Percent | OffsetDays | ReferenceDateType | SeqNo |
+      | PTB71      | pt_PO_7          | 10      | 1          | OD                | 10    |
+      | PTB72      | pt_PO_7          | 90      | 5          | BL                | 20    |
+    And validate C_PaymentTerm:
+      | Identifier | IsComplex | IsValid |
+      | pt_PO_7    | Y         | Y       |
+
+    And metasfresh contains organization bank accounts
+      | Identifier      | C_Currency_ID |
+      | org_CHF_account | CHF           |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po7        | N       | vendor        | 2025-10-09  | POO         | wh             | pt_PO_7          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | po7_l1     | po7        | product      | 10         |
+    And the order identified by po7 is completed
+
+    # Order completed: OD step is Awaiting_Pay (order date is known); BL step is Pending (BL date unknown).
+    Then the order identified by po7 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueAmt | DueAmt_Actual | DueDate    | Status |
+      | PTB71                  | 10.23  | null          | 2025-10-10 | WP     |
+      | PTB72                  | 92.07  | null          | 9999-12-01 | PR     |
+
+    # Vendor sends a proforma for the 10% advance (1 PCE at 9.98 CHF net -> 10.23 CHF incl. 2.5% tax).
+    And metasfresh contains C_Invoice:
+      | Identifier     | C_BPartner_ID | C_DocTypeTarget_ID.Name       | DateInvoiced | IsSOTrx | C_Currency_ID | C_PaymentTerm_ID |
+      | advanceInvoice | vendor        | Proforma-Rechnung (Lieferant) | 2025-10-10   | false   | CHF           | pt_immediate     |
+    And metasfresh contains C_InvoiceLines
+      | Identifier       | C_Invoice_ID   | M_Product_ID | QtyInvoiced | Price |
+      | advanceInvoiceL1 | advanceInvoice | product      | 1 PCE       | 9.98  |
+    And the invoice identified by advanceInvoice is completed
+
+    # A completed but unpaid proforma does not change the pay schedule.
+    And validate created invoices
+      | Identifier     | IsPaid |
+      | advanceInvoice | N      |
+    Then the order identified by po7 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueAmt | DueAmt_Actual | DueDate    | Status |
+      | PTB71                  | 10.23  | null          | 2025-10-10 | WP     |
+      | PTB72                  | 92.07  | null          | 9999-12-01 | PR     |
+
+    # Allocate the proforma to the order: the OD step captures the actual proforma amount (DueAmt_Actual).
+    And I allocate proforma 'advanceInvoice' to order 'po7'
+    Then the order identified by po7 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueAmt | DueAmt_Actual | DueDate    | Status |
+      | PTB71                  | 10.23  | 10.23         | 2025-10-10 | WP     |
+      | PTB72                  | 92.07  | null          | 9999-12-01 | PR     |
+
+    # Pay the proforma in full (Proforma_Invoice_ID + IsPrepayment=Y). Completion marks the OD step Paid.
+    And metasfresh contains C_Payment
+      | Identifier     | C_BPartner_ID | PayAmt    | IsReceipt | C_BP_BankAccount_ID | Proforma_Invoice_ID |
+      | advancePayment | vendor        | 10.23 CHF | false     | org_CHF_account     | advanceInvoice      |
+    And the payment identified by advancePayment is completed
+    Then validate payments
+      | C_Payment_ID.Identifier | IsPrepayment | C_Invoice_ID | Proforma_Invoice_ID | PayAmt |
+      | advancePayment          | Y            | null         | advanceInvoice      | 10.23  |
+
+    # The proforma flips to IsPaid=Y (C_Payment AFTER_COMPLETE interceptor - proforma payments have no allocation lines).
+    And validate created invoices
+      | Identifier     | IsPaid |
+      | advanceInvoice | Y      |
+
+    # Final state: OD advance step Paid; BL step still Pending (open) awaiting the bill-of-lading date.
+    Then the order identified by po7 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueAmt | DueAmt_Actual | DueDate    | Status |
+      | PTB71                  | 10.23  | 10.23         | 2025-10-10 | P      |
+      | PTB72                  | 92.07  | null          | 9999-12-01 | PR     |

--- a/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
+++ b/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
@@ -7,9 +7,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class HttpCallSchedulerTest
 {
@@ -113,10 +115,18 @@ class HttpCallSchedulerTest
 			throw new RuntimeException("test error");
 		}));
 
-		// Should complete exceptionally
-		assertThat(failingFuture).isCompletedExceptionally();
+		// Should complete exceptionally.
+		// The supplier throws on the scheduler's pool thread, so completion happens
+		// asynchronously. Block until the future settles (up to 5s) instead of checking
+		// isCompletedExceptionally() synchronously: that check was racy and failed
+		// intermittently on CPU-contended CI runners where the pool thread had not yet
+		// run the throwing supplier at the instant the assertion was evaluated.
+		assertThatThrownBy(() -> failingFuture.get(5, TimeUnit.SECONDS))
+				.isInstanceOf(ExecutionException.class)
+				.hasCauseInstanceOf(RuntimeException.class);
 
-		// Wait a bit for scheduler to settle
+		// Wait a bit for scheduler to settle (let the pool thread finish run() and
+		// complete executorFuture, so the next schedule() re-submits run() for the queue)
 		Thread.sleep(500);
 
 		// Second request should still succeed


### PR DESCRIPTION
Delivers **F00994 iter-4 — Advance Payment without LC** on the `deep_tundra_release` line.

Net feature delta ported from the `new_dawn_uat` feature branch (equivalent to https://github.com/metasfresh/metasfresh/pull/25271). All 13 touched files were byte-identical on both lines, so the diff matches the trunk change verbatim.

**US01** — proforma allocation marks the single advance line `Paid` for no-LC payment terms; more than one advance break fails loud (`MultipleAdvanceBreaksUnsupported`, migration `5815170`). LC path unchanged.

**US02** — transport-order BL/ETA edits on completed orders recompute the unsettled awaiting-pay pay-schedule due dates (previously stuck at `01.12.9999`).

Carries one new `AD_Message` migration (`5815170`) — DDL review applies before merge.

Tests: 4 payment-schedule/proforma unit classes + cucumber `@Id:S30954_1..4` (identical to the trunk PR https://github.com/metasfresh/metasfresh/pull/25271). On both PRs the substantive checks are green — `test (java)`, all cucumber profiles, frontend, and migrations; the only red is the `mobile test` job, a documented pre-existing flake unrelated to this backend-only diff (https://github.com/metasfresh/me03/issues/31020), whose `barcode_scanner_modes` camera-mode case is hardware-camera dependent. The diff contains zero mobile-webui files. The trunk PR is not yet merged and carries no formal GitHub review approval.