### PR TITLE
Durable fix — narrow non-stocked shipment-schedule invalidation to self (stop recompute backlog)

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
@@ -115,6 +115,13 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 		return productId == null || shouldNarrowToSelf(productId);
 	}
 
+	/** A charge/freight order line has no product ({@code M_Product_ID=0}, see {@code MOrderLine#setC_Charge_ID}) → narrows like a non-stocked product. */
+	private boolean shouldNarrowToSelf(@NonNull final I_C_OrderLine orderLine)
+	{
+		final ProductId productId = ProductId.ofRepoIdOrNull(orderLine.getM_Product_ID());
+		return productId == null || shouldNarrowToSelf(productId);
+	}
+
 	@Override
 	public boolean isFlaggedForRecompute(@NonNull final ShipmentScheduleId shipmentScheduleId)
 	{
@@ -284,8 +291,7 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 	@Override
 	public void notifySegmentChangedForOrderLine(@NonNull final I_C_OrderLine orderLine)
 	{
-		final ProductId productId = ProductId.ofRepoId(orderLine.getM_Product_ID());
-		if (shouldNarrowToSelf(productId))
+		if (shouldNarrowToSelf(orderLine))
 		{
 			invalidateJustForOrderLine(orderLine);
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
@@ -102,22 +102,25 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 		return shipmentScheduleUpdater.isRunning();
 	}
 
-	/** A non-stocked product (not Item+IsStocked) never competes for on-hand stock, so a change narrows to its own schedule. */
-	private boolean shouldNarrowToSelf(@NonNull final ProductId productId)
+	/**
+	 * A non-stocked product (not Item+IsStocked) never competes for on-hand stock, so a change narrows to its own
+	 * schedule. A null product (product-less charge/freight line) narrows the same way, since {@link IProductBL#isStocked}
+	 * is null-safe and returns {@code false} for it.
+	 */
+	private boolean shouldNarrowToSelf(@Nullable final ProductId productId)
 	{
 		return !productBL.isStocked(productId);
 	}
 
 	/**
 	 * Narrow-decision from a raw {@code M_Product_ID} that may be 0: a charge/freight line has no product
-	 * ({@code M_Product_ID=0}; see {@code MOrderLine}/{@code MInOutLine} zeroing it when {@code C_Charge_ID} is set),
-	 * so it never competes for stock and narrows exactly like a non-stocked product. One raw-id entry point keeps every
-	 * product-bearing line type (inout line, order line, …) on the same null-safe path.
+	 * ({@code M_Product_ID=0}; see {@code MOrderLine}/{@code MInOutLine} zeroing it when {@code C_Charge_ID} is set).
+	 * One raw-id entry point keeps every product-bearing line type (inout line, order line, …) on the same
+	 * {@link #shouldNarrowToSelf(ProductId)} decision.
 	 */
 	private boolean shouldNarrowToSelfByProductRepoId(final int productRepoId)
 	{
-		// isStocked(null) == false, so a product-less charge line (repoId 0 → null) narrows just like a non-stocked product.
-		return !productBL.isStocked(ProductId.ofRepoIdOrNull(productRepoId));
+		return shouldNarrowToSelf(ProductId.ofRepoIdOrNull(productRepoId));
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
@@ -103,20 +103,13 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 	}
 
 	/**
-	 * #31050 durable fix: a non-stocked (i.e. not Item+IsStocked, AC-D3) product that is also not a picking-BOM
-	 * component doesn't need the broad product+warehouse segment invalidation — there is no other shipment schedule
-	 * that could be affected by this product's change, so narrowing to the changed record itself is safe and avoids
-	 * needlessly invalidating unrelated schedules for the same product/warehouse.
-	 * <p>
-	 * A picking-BOM component is excluded from narrowing because its BOM-parent's schedules are only ever reached
-	 * via the broad segment + {@link #explodeByPickingBOMs(IShipmentScheduleSegment)}.
+	 * A non-stocked product (not Item+IsStocked) never competes for on-hand stock, so a change to it can only
+	 * affect its own shipment schedule. Narrow the invalidation to that record instead of the whole
+	 * product+warehouse segment.
 	 */
 	private boolean shouldNarrowToSelf(@NonNull final ProductId productId)
 	{
-		return !productBL.isStocked(productId)
-				&& pickingBOMService.getPickingBOMsReversedIndex()
-						.getBOMProductIdsByComponentId(productId)
-						.isEmpty();
+		return !productBL.isStocked(productId);
 	}
 
 	@Override
@@ -199,11 +192,11 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 			if (shouldNarrowToSelf(productId))
 			{
 				flagForRecompute(inoutLine);
-				continue;
 			}
-
-			final IShipmentScheduleSegment segment = createSegmentForInOutLine(bpartnerId, inoutLine);
-			segments.add(segment);
+			else
+			{
+				segments.add(createSegmentForInOutLine(bpartnerId, inoutLine));
+			}
 		}
 
 		notifySegmentsChanged(segments);
@@ -216,11 +209,11 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 		if (shouldNarrowToSelf(productId))
 		{
 			flagForRecompute(shipmentLine);
-			return;
 		}
-
-		final IShipmentScheduleSegment segment = createSegmentForInOutLine(shipmentLine.getM_InOut().getC_BPartner_ID(), shipmentLine);
-		notifySegmentChanged(segment);
+		else
+		{
+			notifySegmentChanged(createSegmentForInOutLine(shipmentLine.getM_InOut().getC_BPartner_ID(), shipmentLine));
+		}
 	}
 
 	/**
@@ -253,11 +246,11 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 		if (shouldNarrowToSelf(productId))
 		{
 			flagForRecompute(ShipmentScheduleId.ofRepoId(schedule.getM_ShipmentSchedule_ID()));
-			return;
 		}
-
-		final IShipmentScheduleSegment segment = createSegmentForShipmentSchedule(schedule);
-		notifySegmentChanged(segment);
+		else
+		{
+			notifySegmentChanged(createSegmentForShipmentSchedule(schedule));
+		}
 	}
 
 	@Override
@@ -294,19 +287,18 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 		if (shouldNarrowToSelf(productId))
 		{
 			invalidateJustForOrderLine(orderLine);
-			return;
 		}
-
-		// we can't restrict the segment to the sched's bpartner, because we don't know if the qty could in theory be reallocated to a *different* partner.
-		// So we have to notify *all* partners' segments.
-		final int bpartnerId = 0;
-		final IShipmentScheduleSegment segment = ShipmentScheduleSegments.builder()
-				.bpartnerId(bpartnerId)
-				.productId(orderLine.getM_Product_ID())
-				.warehouseIdIfNotNull(WarehouseId.ofRepoIdOrNull(orderLine.getM_Warehouse_ID()))
-				.attributeSetInstanceId(orderLine.getM_AttributeSetInstance_ID())
-				.build();
-		notifySegmentChanged(segment);
+		else
+		{
+			// we can't restrict the segment to the order line's bpartner, because the qty could in theory be
+			// reallocated to a *different* partner, so we notify *all* partners' segments (bpartnerId 0).
+			notifySegmentChanged(ShipmentScheduleSegments.builder()
+					.bpartnerId(0)
+					.productId(orderLine.getM_Product_ID())
+					.warehouseIdIfNotNull(WarehouseId.ofRepoIdOrNull(orderLine.getM_Warehouse_ID()))
+					.attributeSetInstanceId(orderLine.getM_AttributeSetInstance_ID())
+					.build());
+		}
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
@@ -102,14 +102,17 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 		return shipmentScheduleUpdater.isRunning();
 	}
 
-	/**
-	 * A non-stocked product (not Item+IsStocked) never competes for on-hand stock, so a change to it can only
-	 * affect its own shipment schedule. Narrow the invalidation to that record instead of the whole
-	 * product+warehouse segment.
-	 */
+	/** A non-stocked product (not Item+IsStocked) never competes for on-hand stock, so a change narrows to its own schedule. */
 	private boolean shouldNarrowToSelf(@NonNull final ProductId productId)
 	{
 		return !productBL.isStocked(productId);
+	}
+
+	/** A charge/freight line has no product ({@code M_Product_ID=0}) → no stock to compete for → narrows like a non-stocked product. */
+	private boolean shouldNarrowToSelf(@NonNull final I_M_InOutLine inoutLine)
+	{
+		final ProductId productId = ProductId.ofRepoIdOrNull(inoutLine.getM_Product_ID());
+		return productId == null || shouldNarrowToSelf(productId);
 	}
 
 	@Override
@@ -188,8 +191,7 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 		final int bpartnerId = shipment.getC_BPartner_ID();
 		for (final I_M_InOutLine inoutLine : inOutDAO.retrieveLines(shipment))
 		{
-			final ProductId productId = ProductId.ofRepoId(inoutLine.getM_Product_ID());
-			if (shouldNarrowToSelf(productId))
+			if (shouldNarrowToSelf(inoutLine))
 			{
 				flagForRecompute(inoutLine);
 			}
@@ -205,8 +207,7 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 	@Override
 	public void notifySegmentChangedForShipmentLine(final I_M_InOutLine shipmentLine)
 	{
-		final ProductId productId = ProductId.ofRepoId(shipmentLine.getM_Product_ID());
-		if (shouldNarrowToSelf(productId))
+		if (shouldNarrowToSelf(shipmentLine))
 		{
 			flagForRecompute(shipmentLine);
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
@@ -116,8 +116,8 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 	 */
 	private boolean shouldNarrowToSelfByProductRepoId(final int productRepoId)
 	{
-		final ProductId productId = ProductId.ofRepoIdOrNull(productRepoId);
-		return productId == null || shouldNarrowToSelf(productId);
+		// isStocked(null) == false, so a product-less charge line (repoId 0 → null) narrows just like a non-stocked product.
+		return !productBL.isStocked(ProductId.ofRepoIdOrNull(productRepoId));
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
@@ -42,6 +42,7 @@ import de.metas.inoutcandidate.picking_bom.PickingBOMService;
 import de.metas.inoutcandidate.picking_bom.PickingBOMsReversedIndex;
 import de.metas.order.OrderLineId;
 import de.metas.process.PInstanceId;
+import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -80,6 +81,7 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 	protected final IShipmentScheduleAllocDAO shipmentScheduleAllocDAO = Services.get(IShipmentScheduleAllocDAO.class);
 	protected final IShipmentScheduleEffectiveBL shipmentScheduleEffectiveBL = Services.get(IShipmentScheduleEffectiveBL.class);
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+	private final IProductBL productBL = Services.get(IProductBL.class);
 	@NonNull private final PickingBOMService pickingBOMService;
 
 	/**
@@ -98,6 +100,23 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 		final IShipmentScheduleUpdater shipmentScheduleUpdater = Services.get(IShipmentScheduleUpdater.class);
 
 		return shipmentScheduleUpdater.isRunning();
+	}
+
+	/**
+	 * #31050 durable fix: a non-stocked (i.e. not Item+IsStocked, AC-D3) product that is also not a picking-BOM
+	 * component doesn't need the broad product+warehouse segment invalidation — there is no other shipment schedule
+	 * that could be affected by this product's change, so narrowing to the changed record itself is safe and avoids
+	 * needlessly invalidating unrelated schedules for the same product/warehouse.
+	 * <p>
+	 * A picking-BOM component is excluded from narrowing because its BOM-parent's schedules are only ever reached
+	 * via the broad segment + {@link #explodeByPickingBOMs(IShipmentScheduleSegment)}.
+	 */
+	private boolean shouldNarrowToSelf(@NonNull final ProductId productId)
+	{
+		return !productBL.isStocked(productId)
+				&& pickingBOMService.getPickingBOMsReversedIndex()
+						.getBOMProductIdsByComponentId(productId)
+						.isEmpty();
 	}
 
 	@Override
@@ -176,6 +195,13 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 		final int bpartnerId = shipment.getC_BPartner_ID();
 		for (final I_M_InOutLine inoutLine : inOutDAO.retrieveLines(shipment))
 		{
+			final ProductId productId = ProductId.ofRepoId(inoutLine.getM_Product_ID());
+			if (shouldNarrowToSelf(productId))
+			{
+				flagForRecompute(inoutLine);
+				continue;
+			}
+
 			final IShipmentScheduleSegment segment = createSegmentForInOutLine(bpartnerId, inoutLine);
 			segments.add(segment);
 		}
@@ -186,6 +212,13 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 	@Override
 	public void notifySegmentChangedForShipmentLine(final I_M_InOutLine shipmentLine)
 	{
+		final ProductId productId = ProductId.ofRepoId(shipmentLine.getM_Product_ID());
+		if (shouldNarrowToSelf(productId))
+		{
+			flagForRecompute(shipmentLine);
+			return;
+		}
+
 		final IShipmentScheduleSegment segment = createSegmentForInOutLine(shipmentLine.getM_InOut().getC_BPartner_ID(), shipmentLine);
 		notifySegmentChanged(segment);
 	}
@@ -213,6 +246,13 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 		// so there is NO need to invalidate it again.
 		if (isShipmentScheduleUpdaterRunning())
 		{
+			return;
+		}
+
+		final ProductId productId = ProductId.ofRepoId(schedule.getM_Product_ID());
+		if (shouldNarrowToSelf(productId))
+		{
+			flagForRecompute(ShipmentScheduleId.ofRepoId(schedule.getM_ShipmentSchedule_ID()));
 			return;
 		}
 
@@ -250,6 +290,13 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 	@Override
 	public void notifySegmentChangedForOrderLine(@NonNull final I_C_OrderLine orderLine)
 	{
+		final ProductId productId = ProductId.ofRepoId(orderLine.getM_Product_ID());
+		if (shouldNarrowToSelf(productId))
+		{
+			invalidateJustForOrderLine(orderLine);
+			return;
+		}
+
 		// we can't restrict the segment to the sched's bpartner, because we don't know if the qty could in theory be reallocated to a *different* partner.
 		// So we have to notify *all* partners' segments.
 		final int bpartnerId = 0;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
@@ -108,17 +108,15 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 		return !productBL.isStocked(productId);
 	}
 
-	/** A charge/freight line has no product ({@code M_Product_ID=0}) → no stock to compete for → narrows like a non-stocked product. */
-	private boolean shouldNarrowToSelf(@NonNull final I_M_InOutLine inoutLine)
+	/**
+	 * Narrow-decision from a raw {@code M_Product_ID} that may be 0: a charge/freight line has no product
+	 * ({@code M_Product_ID=0}; see {@code MOrderLine}/{@code MInOutLine} zeroing it when {@code C_Charge_ID} is set),
+	 * so it never competes for stock and narrows exactly like a non-stocked product. One raw-id entry point keeps every
+	 * product-bearing line type (inout line, order line, …) on the same null-safe path.
+	 */
+	private boolean shouldNarrowToSelfByProductRepoId(final int productRepoId)
 	{
-		final ProductId productId = ProductId.ofRepoIdOrNull(inoutLine.getM_Product_ID());
-		return productId == null || shouldNarrowToSelf(productId);
-	}
-
-	/** A charge/freight order line has no product ({@code M_Product_ID=0}, see {@code MOrderLine#setC_Charge_ID}) → narrows like a non-stocked product. */
-	private boolean shouldNarrowToSelf(@NonNull final I_C_OrderLine orderLine)
-	{
-		final ProductId productId = ProductId.ofRepoIdOrNull(orderLine.getM_Product_ID());
+		final ProductId productId = ProductId.ofRepoIdOrNull(productRepoId);
 		return productId == null || shouldNarrowToSelf(productId);
 	}
 
@@ -198,7 +196,7 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 		final int bpartnerId = shipment.getC_BPartner_ID();
 		for (final I_M_InOutLine inoutLine : inOutDAO.retrieveLines(shipment))
 		{
-			if (shouldNarrowToSelf(inoutLine))
+			if (shouldNarrowToSelfByProductRepoId(inoutLine.getM_Product_ID()))
 			{
 				flagForRecompute(inoutLine);
 			}
@@ -214,7 +212,7 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 	@Override
 	public void notifySegmentChangedForShipmentLine(final I_M_InOutLine shipmentLine)
 	{
-		if (shouldNarrowToSelf(shipmentLine))
+		if (shouldNarrowToSelfByProductRepoId(shipmentLine.getM_Product_ID()))
 		{
 			flagForRecompute(shipmentLine);
 		}
@@ -250,6 +248,8 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 			return;
 		}
 
+		// M_ShipmentSchedule.M_Product_ID is Mandatory and never 0 (schedules are only created for real products),
+		// so — unlike the InOutLine/OrderLine siblings, which can be product-less charge lines — no charge-line guard is needed here.
 		final ProductId productId = ProductId.ofRepoId(schedule.getM_Product_ID());
 		if (shouldNarrowToSelf(productId))
 		{
@@ -291,7 +291,7 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 	@Override
 	public void notifySegmentChangedForOrderLine(@NonNull final I_C_OrderLine orderLine)
 	{
-		if (shouldNarrowToSelf(orderLine))
+		if (shouldNarrowToSelfByProductRepoId(orderLine.getM_Product_ID()))
 		{
 			invalidateJustForOrderLine(orderLine);
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
@@ -157,24 +157,23 @@ class ShipmentScheduleInvalidateBLTest
 	}
 
 	/**
-	 * RED guard for #31050's durable fix (revised approach "Option A"): the three product-specific
-	 * {@code notifySegmentChangedFor*} entry points must route a <b>non-stocked, non-picking-BOM-component</b>
-	 * product change to the already-existing self-by-id invalidation ({@link ShipmentScheduleInvalidateBL#invalidateJustForOrderLine},
+	 * The three product-specific {@code notifySegmentChangedFor*} entry points (and the shipment-batch
+	 * {@code notifySegmentsChangedForShipment}) route a <b>non-stocked, non-picking-BOM-component</b> product
+	 * change to the already-existing self-by-id invalidation ({@link ShipmentScheduleInvalidateBL#invalidateJustForOrderLine},
 	 * {@link ShipmentScheduleInvalidateBL#flagForRecompute(ShipmentScheduleId)}, {@link ShipmentScheduleInvalidateBL#flagForRecompute(I_M_InOutLine)})
 	 * instead of the broad product+warehouse segment ({@link ShipmentScheduleInvalidateBL#notifySegmentChanged(IShipmentScheduleSegment)}).
-	 * A non-stocked product that IS a picking-BOM component must keep the broad path (so the BOM-parent's
-	 * schedules are still reached via {@code explodeByPickingBOMs}).
+	 * A non-stocked product that IS a picking-BOM component keeps the broad path, so the BOM-parent's schedules
+	 * are still reached via {@code explodeByPickingBOMs}.
 	 * <p>
-	 * Discriminator under test: {@code !IProductBL.isStocked(productId) && pickingBOMsReversedIndex.getBOMProductIdsByComponentId(productId).isEmpty()}
-	 * (AC-D3: the Item+IsStocked composite via {@code IProductBL}, never the raw {@code M_Product.IsStocked} column alone).
+	 * The discriminator is {@code !IProductBL.isStocked(productId) && pickingBOMsReversedIndex.getBOMProductIdsByComponentId(productId).isEmpty()},
+	 * where {@code IProductBL.isStocked} is the composite Item-and-IsStocked check — never the raw
+	 * {@code M_Product.IsStocked} column alone (see {@code nonItemProductWithStockedColumn_*}, which a raw-column
+	 * reading would get wrong).
 	 * <p>
-	 * These tests verify ROUTING (which internal method fires), not the raw SQL side effects: {@code ShipmentScheduleInvalidateBL}'s
-	 * only real collaborator boundary in this test class is {@link PickingBOMService} (mocked, as in {@link ExplodeByPickingBOMs}
-	 * above); the broad/narrow terminal methods are stubbed out on a Mockito spy of the real instance so the guard's decision
+	 * These tests verify ROUTING (which internal method fires), not the raw SQL side effects: the only real
+	 * collaborator boundary here is {@link PickingBOMService} (mocked, as in {@link ExplodeByPickingBOMs} above);
+	 * the broad/narrow terminal methods are stubbed on a Mockito spy of the real instance so the guard's decision
 	 * is pinned without depending on the (non-hermetic, raw-SQL-backed) {@code IShipmentScheduleInvalidateRepository}.
-	 * <p>
-	 * FAILS on current code for the non-stocked (non-BOM-component) cases: {@code notifySegmentChangedFor*} unconditionally
-	 * takes the broad segment path today, regardless of {@code IsStocked}.
 	 */
 	@Nested
 	class NonStockedNarrowing
@@ -273,10 +272,35 @@ class ShipmentScheduleInvalidateBLTest
 		@Test
 		void nonStocked_orderLineChange_invalidatesOnlyOwnSchedule()
 		{
-			// IsStocked=false on an Item product: exercises the composite IProductBL#isStocked (AC-D3), not the raw column alone.
+			// IsStocked=false on an Item product: exercises the composite IProductBL#isStocked, not the raw column alone.
 			final I_M_Product nonStockedProduct = createProduct("NonStockedItem-OL", false, X_M_Product.PRODUCTTYPE_Item);
 			final I_M_Warehouse warehouse = createWarehouse("WH-NS-OL");
 			final I_C_OrderLine orderLine = createOrderLine(nonStockedProduct, warehouse);
+
+			final ShipmentScheduleInvalidateBL bl = newInvalidateBLSpy(NO_BOM_COMPONENTS);
+			doNothing().when(bl).invalidateJustForOrderLine(any());
+			doNothing().when(bl).notifySegmentChanged(any());
+
+			bl.notifySegmentChangedForOrderLine(orderLine);
+
+			verify(bl, times(1))
+					.invalidateJustForOrderLine(orderLine);
+			verify(bl, never())
+					.notifySegmentChanged(any());
+		}
+
+		/**
+		 * Pins the COMPOSITE {@code IProductBL.isStocked} semantics (Item AND IsStocked), not the raw
+		 * {@code M_Product.IsStocked} column: a non-Item product (a Service) whose IsStocked column is {@code true}
+		 * is still "not stocked" in the composite sense, so its order-line change must narrow to self. An
+		 * implementation reading the raw column would (wrongly) keep the broad segment here.
+		 */
+		@Test
+		void nonItemProductWithStockedColumn_orderLineChange_invalidatesOnlyOwnSchedule()
+		{
+			final I_M_Product serviceStockedColumn = createProduct("Service-StockedCol-OL", true, X_M_Product.PRODUCTTYPE_Service);
+			final I_M_Warehouse warehouse = createWarehouse("WH-Service-OL");
+			final I_C_OrderLine orderLine = createOrderLine(serviceStockedColumn, warehouse);
 
 			final ShipmentScheduleInvalidateBL bl = newInvalidateBLSpy(NO_BOM_COMPONENTS);
 			doNothing().when(bl).invalidateJustForOrderLine(any());
@@ -418,9 +442,14 @@ class ShipmentScheduleInvalidateBLTest
 			@SuppressWarnings("unchecked")
 			final ArgumentCaptor<Collection<IShipmentScheduleSegment>> segmentsCaptor = ArgumentCaptor.forClass(Collection.class);
 			verify(bl, times(1)).notifySegmentsChanged(segmentsCaptor.capture());
-			assertThat(segmentsCaptor.getValue())
+			final Collection<IShipmentScheduleSegment> batchedSegments = segmentsCaptor.getValue();
+			assertThat(batchedSegments)
 					.as("only the stocked line's segment must reach the broad batch")
 					.hasSize(1);
+			assertThat(batchedSegments.iterator().next().getProductIds())
+					.as("the batched segment must carry the STOCKED product, not the non-stocked one")
+					.contains(stockedProduct.getM_Product_ID())
+					.doesNotContain(nonStockedProduct.getM_Product_ID());
 		}
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
@@ -35,6 +35,7 @@ import de.metas.util.Services;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_C_Charge;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_OrderLine;
 import org.compiere.model.I_M_InOut;
@@ -259,6 +260,28 @@ class ShipmentScheduleInvalidateBLTest
 			return inoutLine;
 		}
 
+		/**
+		 * A charge/freight shipment line: {@code M_Product_ID} is left 0 (the column is Mandatory:false) and a
+		 * {@code C_Charge_ID} is set instead, mirroring the callout that builds a charge line from a charge order line.
+		 */
+		private I_M_InOutLine createChargeInOutLine(final I_M_Locator locator)
+		{
+			final I_C_Charge charge = InterfaceWrapperHelper.newInstance(I_C_Charge.class);
+			charge.setName("Freight");
+			InterfaceWrapperHelper.save(charge);
+
+			final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+			inout.setIsSOTrx(true);
+			InterfaceWrapperHelper.save(inout);
+
+			final I_M_InOutLine inoutLine = InterfaceWrapperHelper.newInstance(I_M_InOutLine.class);
+			inoutLine.setM_InOut(inout);
+			inoutLine.setC_Charge_ID(charge.getC_Charge_ID()); // charge line: no M_Product_ID
+			inoutLine.setM_Locator_ID(locator.getM_Locator_ID());
+			InterfaceWrapperHelper.save(inoutLine);
+			return inoutLine;
+		}
+
 		/** Fresh {@link ShipmentScheduleInvalidateBL} spy wired with the given picking-BOM reversed index. */
 		private ShipmentScheduleInvalidateBL newInvalidateBLSpy(final PickingBOMsReversedIndex reversedIndex)
 		{
@@ -352,7 +375,81 @@ class ShipmentScheduleInvalidateBLTest
 					.notifySegmentChanged(any());
 		}
 
-		/** Control: a STOCKED product must keep the broad segment path (pre-existing behaviour, unchanged by Option A). */
+		/**
+		 * A charge/freight shipment line ({@code M_Product_ID=0}) has no product stock to compete for, so it must
+		 * narrow to self exactly like a non-stocked product — and must NOT crash on {@code ProductId.ofRepoId(0)}.
+		 */
+		@Test
+		void chargeLine_shipmentLineChange_narrowsToSelf()
+		{
+			final I_M_Warehouse warehouse = createWarehouse("WH-Charge-Line");
+			final I_M_Locator locator = createLocator(warehouse);
+			final I_M_InOutLine chargeLine = createChargeInOutLine(locator);
+
+			final ShipmentScheduleInvalidateBL bl = newInvalidateBLSpy(NO_BOM_COMPONENTS);
+			doNothing().when(bl).flagForRecompute(any(I_M_InOutLine.class));
+			doNothing().when(bl).notifySegmentChanged(any());
+
+			bl.notifySegmentChangedForShipmentLine(chargeLine);
+
+			verify(bl, times(1))
+					.flagForRecompute(chargeLine);
+			verify(bl, never())
+					.notifySegmentChanged(any());
+		}
+
+		/**
+		 * {@code notifySegmentsChangedForShipment} over a shipment carrying a charge line ({@code M_Product_ID=0})
+		 * plus a stocked line: the charge line narrows to self (no crash), the stocked line keeps the broad segment,
+		 * and only the stocked product reaches the batch.
+		 */
+		@Test
+		void chargeLineInShipment_narrowedPerLine_stockedLineKeepsSegment()
+		{
+			final I_M_Product stockedProduct = createProduct("StockedItem-ChargeShip", true, X_M_Product.PRODUCTTYPE_Item);
+
+			final I_C_Charge charge = InterfaceWrapperHelper.newInstance(I_C_Charge.class);
+			charge.setName("Freight-Ship");
+			InterfaceWrapperHelper.save(charge);
+
+			final I_M_InOut shipment = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+			shipment.setIsSOTrx(true);
+			InterfaceWrapperHelper.save(shipment);
+
+			final I_M_InOutLine chargeLine = InterfaceWrapperHelper.newInstance(I_M_InOutLine.class);
+			chargeLine.setM_InOut(shipment);
+			chargeLine.setC_Charge_ID(charge.getC_Charge_ID()); // charge line: no M_Product_ID
+			InterfaceWrapperHelper.save(chargeLine);
+
+			final I_M_InOutLine stockedLine = InterfaceWrapperHelper.newInstance(I_M_InOutLine.class);
+			stockedLine.setM_InOut(shipment);
+			stockedLine.setM_Product_ID(stockedProduct.getM_Product_ID());
+			InterfaceWrapperHelper.save(stockedLine);
+
+			final ShipmentScheduleInvalidateBL bl = newInvalidateBLSpy(NO_BOM_COMPONENTS);
+			doNothing().when(bl).flagForRecompute(any(I_M_InOutLine.class));
+			doNothing().when(bl).notifySegmentsChanged(any());
+
+			bl.notifySegmentsChangedForShipment(shipment);
+
+			verify(bl, times(1))
+					.flagForRecompute(chargeLine);
+			verify(bl, never())
+					.flagForRecompute(stockedLine);
+
+			@SuppressWarnings("unchecked")
+			final ArgumentCaptor<Collection<IShipmentScheduleSegment>> segmentsCaptor = ArgumentCaptor.forClass(Collection.class);
+			verify(bl, times(1)).notifySegmentsChanged(segmentsCaptor.capture());
+			final Collection<IShipmentScheduleSegment> batchedSegments = segmentsCaptor.getValue();
+			assertThat(batchedSegments)
+					.as("only the stocked line's segment must reach the broad batch; the charge line is narrowed")
+					.hasSize(1);
+			assertThat(batchedSegments.iterator().next().getProductIds())
+					.as("the batched segment must carry the STOCKED product")
+					.contains(stockedProduct.getM_Product_ID());
+		}
+
+		/** Control: a STOCKED product must keep the broad segment path (pre-existing behaviour for stocked products is unchanged). */
 		@Test
 		void stocked_orderLineChange_invalidatesFullSegment()
 		{

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
@@ -158,17 +158,15 @@ class ShipmentScheduleInvalidateBLTest
 
 	/**
 	 * The three product-specific {@code notifySegmentChangedFor*} entry points (and the shipment-batch
-	 * {@code notifySegmentsChangedForShipment}) route a <b>non-stocked, non-picking-BOM-component</b> product
-	 * change to the already-existing self-by-id invalidation ({@link ShipmentScheduleInvalidateBL#invalidateJustForOrderLine},
+	 * {@code notifySegmentsChangedForShipment}) route a <b>non-stocked</b> product change to the already-existing
+	 * self-by-id invalidation ({@link ShipmentScheduleInvalidateBL#invalidateJustForOrderLine},
 	 * {@link ShipmentScheduleInvalidateBL#flagForRecompute(ShipmentScheduleId)}, {@link ShipmentScheduleInvalidateBL#flagForRecompute(I_M_InOutLine)})
 	 * instead of the broad product+warehouse segment ({@link ShipmentScheduleInvalidateBL#notifySegmentChanged(IShipmentScheduleSegment)}).
-	 * A non-stocked product that IS a picking-BOM component keeps the broad path, so the BOM-parent's schedules
-	 * are still reached via {@code explodeByPickingBOMs}.
+	 * A stocked product keeps the broad path.
 	 * <p>
-	 * The discriminator is {@code !IProductBL.isStocked(productId) && pickingBOMsReversedIndex.getBOMProductIdsByComponentId(productId).isEmpty()},
-	 * where {@code IProductBL.isStocked} is the composite Item-and-IsStocked check — never the raw
-	 * {@code M_Product.IsStocked} column alone (see {@code nonItemProductWithStockedColumn_*}, which a raw-column
-	 * reading would get wrong).
+	 * The discriminator is {@code !IProductBL.isStocked(productId)}, where {@code isStocked} is the composite
+	 * Item-and-IsStocked check — never the raw {@code M_Product.IsStocked} column alone (see
+	 * {@code nonItemProductWithStockedColumn_*}, which a raw-column reading would get wrong).
 	 * <p>
 	 * These tests verify ROUTING (which internal method fires), not the raw SQL side effects: the only real
 	 * collaborator boundary here is {@link PickingBOMService} (mocked, as in {@link ExplodeByPickingBOMs} above);
@@ -375,18 +373,20 @@ class ShipmentScheduleInvalidateBLTest
 		}
 
 		/**
-		 * Option-A carve-out guard: a non-stocked product that IS a picking-BOM component must KEEP the broad
-		 * segment path (NOT narrow to self) — otherwise the BOM-parent's shipment schedules would never be
-		 * re-invalidated via {@code explodeByPickingBOMs}.
+		 * A non-stocked product narrows to self even when it IS a picking-BOM component: it never competes for
+		 * stock, so it cannot constrain its BOM-parent's pickable qty either — the broad segment (and the
+		 * {@code explodeByPickingBOMs} parent re-invalidation it triggers) would achieve nothing. BOM membership
+		 * does not change the decision.
 		 */
 		@Test
-		void nonStocked_butPickingBOMComponent_orderLineChange_invalidatesFullSegment()
+		void nonStocked_pickingBOMComponent_orderLineChange_stillNarrowsToSelf()
 		{
 			final I_M_Product nonStockedBomComponent = createProduct("NonStockedBomComponent-OL", false, X_M_Product.PRODUCTTYPE_Item);
 			final ProductId componentProductId = ProductId.ofRepoId(nonStockedBomComponent.getM_Product_ID());
 			final I_M_Warehouse warehouse = createWarehouse("WH-NS-BOM-OL");
 			final I_C_OrderLine orderLine = createOrderLine(nonStockedBomComponent, warehouse);
 
+			// Registered as a picking-BOM component; it must STILL narrow (BOM membership is irrelevant).
 			final PickingBOMsReversedIndex reversedIndexWithComponent = PickingBOMsReversedIndex.ofBOMProductIdsByComponentId(
 					ImmutableSetMultimap.of(componentProductId, ProductId.ofRepoId(999_999)));
 			final ShipmentScheduleInvalidateBL bl = newInvalidateBLSpy(reversedIndexWithComponent);
@@ -396,9 +396,9 @@ class ShipmentScheduleInvalidateBLTest
 			bl.notifySegmentChangedForOrderLine(orderLine);
 
 			verify(bl, times(1))
-					.notifySegmentChanged(any());
+					.invalidateJustForOrderLine(orderLine);
 			verify(bl, never())
-					.invalidateJustForOrderLine(any());
+					.notifySegmentChanged(any());
 		}
 
 		/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
@@ -184,7 +184,7 @@ class ShipmentScheduleInvalidateBLTest
 		void registerNotRunningUpdater()
 		{
 			// notifySegmentChangedForShipmentSchedule early-exits when the shipment-schedule updater is running
-			// (ShipmentScheduleInvalidateBL#isShipmentScheduleUpdaterRunning, production line ~214). Stub it as
+			// (ShipmentScheduleInvalidateBL#isShipmentScheduleUpdaterRunning). Stub it as
 			// NOT running so the routing under test (broad vs. self-by-id) is actually reached.
 			final IShipmentScheduleUpdater updater = mock(IShipmentScheduleUpdater.class);
 			when(updater.isRunning()).thenReturn(false);

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
@@ -47,8 +47,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
@@ -372,6 +375,52 @@ class ShipmentScheduleInvalidateBLTest
 					.notifySegmentChanged(any());
 			verify(bl, never())
 					.invalidateJustForOrderLine(any());
+		}
+
+		/**
+		 * {@code notifySegmentsChangedForShipment} builds one segment per shipment line and notifies them as a
+		 * batch; a mixed shipment can have both stocked and non-stocked lines, so the narrowing decision is
+		 * per-line: the non-stocked line must be routed via {@link ShipmentScheduleInvalidateBL#flagForRecompute(I_M_InOutLine)}
+		 * and excluded from the broad batch, while the stocked line must still go through the broad
+		 * {@link ShipmentScheduleInvalidateBL#notifySegmentsChanged(Collection)} path.
+		 */
+		@Test
+		void mixedShipment_nonStockedLineNarrowedPerLine_stockedLineKeepsSegment()
+		{
+			final I_M_Product stockedProduct = createProduct("StockedItem-Ship", true, X_M_Product.PRODUCTTYPE_Item);
+			final I_M_Product nonStockedProduct = createProduct("NonStockedItem-Ship", false, X_M_Product.PRODUCTTYPE_Item);
+
+			final I_M_InOut shipment = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+			shipment.setIsSOTrx(true);
+			InterfaceWrapperHelper.save(shipment);
+
+			final I_M_InOutLine stockedLine = InterfaceWrapperHelper.newInstance(I_M_InOutLine.class);
+			stockedLine.setM_InOut(shipment);
+			stockedLine.setM_Product_ID(stockedProduct.getM_Product_ID());
+			InterfaceWrapperHelper.save(stockedLine);
+
+			final I_M_InOutLine nonStockedLine = InterfaceWrapperHelper.newInstance(I_M_InOutLine.class);
+			nonStockedLine.setM_InOut(shipment);
+			nonStockedLine.setM_Product_ID(nonStockedProduct.getM_Product_ID());
+			InterfaceWrapperHelper.save(nonStockedLine);
+
+			final ShipmentScheduleInvalidateBL bl = newInvalidateBLSpy(NO_BOM_COMPONENTS);
+			doNothing().when(bl).flagForRecompute(any(I_M_InOutLine.class));
+			doNothing().when(bl).notifySegmentsChanged(any());
+
+			bl.notifySegmentsChangedForShipment(shipment);
+
+			verify(bl, times(1))
+					.flagForRecompute(nonStockedLine);
+			verify(bl, never())
+					.flagForRecompute(stockedLine);
+
+			@SuppressWarnings("unchecked")
+			final ArgumentCaptor<Collection<IShipmentScheduleSegment>> segmentsCaptor = ArgumentCaptor.forClass(Collection.class);
+			verify(bl, times(1)).notifySegmentsChanged(segmentsCaptor.capture());
+			assertThat(segmentsCaptor.getValue())
+					.as("only the stocked line's segment must reach the broad batch")
+					.hasSize(1);
 		}
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
@@ -237,6 +237,25 @@ class ShipmentScheduleInvalidateBLTest
 			return orderLine;
 		}
 
+		/** A charge/freight sales-order line: {@code C_Charge_ID} set, {@code M_Product_ID} left 0 (see {@code MOrderLine#setC_Charge_ID}). */
+		private I_C_OrderLine createChargeOrderLine(final I_M_Warehouse warehouse)
+		{
+			final I_C_Charge charge = InterfaceWrapperHelper.newInstance(I_C_Charge.class);
+			charge.setName("Freight-OL");
+			InterfaceWrapperHelper.save(charge);
+
+			final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+			order.setIsSOTrx(true);
+			InterfaceWrapperHelper.save(order);
+
+			final I_C_OrderLine orderLine = InterfaceWrapperHelper.newInstance(I_C_OrderLine.class);
+			orderLine.setC_Order(order);
+			orderLine.setC_Charge_ID(charge.getC_Charge_ID()); // charge line: no M_Product_ID
+			orderLine.setM_Warehouse_ID(warehouse.getM_Warehouse_ID());
+			InterfaceWrapperHelper.save(orderLine);
+			return orderLine;
+		}
+
 		private I_M_ShipmentSchedule createShipmentSchedule(final I_M_Product product, final I_M_Warehouse warehouse)
 		{
 			final I_M_ShipmentSchedule schedule = InterfaceWrapperHelper.newInstance(I_M_ShipmentSchedule.class);
@@ -371,6 +390,28 @@ class ShipmentScheduleInvalidateBLTest
 
 			verify(bl, times(1))
 					.flagForRecompute(inoutLine);
+			verify(bl, never())
+					.notifySegmentChanged(any());
+		}
+
+		/**
+		 * A charge/freight order line ({@code M_Product_ID=0}) has no product stock to compete for, so it must narrow
+		 * to self exactly like a non-stocked product — and must NOT crash on {@code ProductId.ofRepoId(0)}.
+		 */
+		@Test
+		void chargeOrderLineChange_invalidatesOnlyOwnSchedule()
+		{
+			final I_M_Warehouse warehouse = createWarehouse("WH-Charge-OL");
+			final I_C_OrderLine chargeOrderLine = createChargeOrderLine(warehouse);
+
+			final ShipmentScheduleInvalidateBL bl = newInvalidateBLSpy(NO_BOM_COMPONENTS);
+			doNothing().when(bl).invalidateJustForOrderLine(any());
+			doNothing().when(bl).notifySegmentChanged(any());
+
+			bl.notifySegmentChangedForOrderLine(chargeOrderLine);
+
+			verify(bl, times(1))
+					.invalidateJustForOrderLine(chargeOrderLine);
 			verify(bl, never())
 					.notifySegmentChanged(any());
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
@@ -237,7 +237,7 @@ class ShipmentScheduleInvalidateBLTest
 			return orderLine;
 		}
 
-		/** A charge/freight sales-order line: {@code C_Charge_ID} set, {@code M_Product_ID} left 0 (see {@code MOrderLine#setC_Charge_ID}). */
+		/** A charge/freight sales-order line: {@code C_Charge_ID} set, {@code M_Product_ID} left 0 ({@code MOrderLine#beforeSave} zeroes it when a charge is set). */
 		private I_C_OrderLine createChargeOrderLine(final I_M_Warehouse warehouse)
 		{
 			final I_C_Charge charge = InterfaceWrapperHelper.newInstance(I_C_Charge.class);

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBLTest.java
@@ -23,13 +23,26 @@ package de.metas.inoutcandidate.invalidation.impl;
  */
 
 import com.google.common.collect.ImmutableSetMultimap;
+import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.api.IShipmentScheduleUpdater;
 import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
 import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleSegments;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.inoutcandidate.picking_bom.PickingBOMService;
 import de.metas.inoutcandidate.picking_bom.PickingBOMsReversedIndex;
 import de.metas.product.ProductId;
+import de.metas.util.Services;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_C_OrderLine;
+import org.compiere.model.I_M_InOut;
+import org.compiere.model.I_M_InOutLine;
+import org.compiere.model.I_M_Locator;
+import org.compiere.model.I_M_Product;
+import org.compiere.model.I_M_Warehouse;
+import org.compiere.model.X_M_Product;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -38,7 +51,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -131,6 +150,228 @@ class ShipmentScheduleInvalidateBLTest
 			assertThat(bomParentSegment.isInvalid()).isFalse();
 			assertThat(bomParentSegment.getLocatorIds()).containsExactly(LOCATOR_ID);
 			assertThat(bomParentSegment.getWarehouseIds()).isEmpty();
+		}
+	}
+
+	/**
+	 * RED guard for #31050's durable fix (revised approach "Option A"): the three product-specific
+	 * {@code notifySegmentChangedFor*} entry points must route a <b>non-stocked, non-picking-BOM-component</b>
+	 * product change to the already-existing self-by-id invalidation ({@link ShipmentScheduleInvalidateBL#invalidateJustForOrderLine},
+	 * {@link ShipmentScheduleInvalidateBL#flagForRecompute(ShipmentScheduleId)}, {@link ShipmentScheduleInvalidateBL#flagForRecompute(I_M_InOutLine)})
+	 * instead of the broad product+warehouse segment ({@link ShipmentScheduleInvalidateBL#notifySegmentChanged(IShipmentScheduleSegment)}).
+	 * A non-stocked product that IS a picking-BOM component must keep the broad path (so the BOM-parent's
+	 * schedules are still reached via {@code explodeByPickingBOMs}).
+	 * <p>
+	 * Discriminator under test: {@code !IProductBL.isStocked(productId) && pickingBOMsReversedIndex.getBOMProductIdsByComponentId(productId).isEmpty()}
+	 * (AC-D3: the Item+IsStocked composite via {@code IProductBL}, never the raw {@code M_Product.IsStocked} column alone).
+	 * <p>
+	 * These tests verify ROUTING (which internal method fires), not the raw SQL side effects: {@code ShipmentScheduleInvalidateBL}'s
+	 * only real collaborator boundary in this test class is {@link PickingBOMService} (mocked, as in {@link ExplodeByPickingBOMs}
+	 * above); the broad/narrow terminal methods are stubbed out on a Mockito spy of the real instance so the guard's decision
+	 * is pinned without depending on the (non-hermetic, raw-SQL-backed) {@code IShipmentScheduleInvalidateRepository}.
+	 * <p>
+	 * FAILS on current code for the non-stocked (non-BOM-component) cases: {@code notifySegmentChangedFor*} unconditionally
+	 * takes the broad segment path today, regardless of {@code IsStocked}.
+	 */
+	@Nested
+	class NonStockedNarrowing
+	{
+		private final PickingBOMsReversedIndex NO_BOM_COMPONENTS =
+				PickingBOMsReversedIndex.ofBOMProductIdsByComponentId(ImmutableSetMultimap.of());
+
+		@BeforeEach
+		void registerNotRunningUpdater()
+		{
+			// notifySegmentChangedForShipmentSchedule early-exits when the shipment-schedule updater is running
+			// (ShipmentScheduleInvalidateBL#isShipmentScheduleUpdaterRunning, production line ~214). Stub it as
+			// NOT running so the routing under test (broad vs. self-by-id) is actually reached.
+			final IShipmentScheduleUpdater updater = mock(IShipmentScheduleUpdater.class);
+			when(updater.isRunning()).thenReturn(false);
+			Services.registerService(IShipmentScheduleUpdater.class, updater);
+		}
+
+		private I_M_Product createProduct(final String name, final boolean isStocked, final String productType)
+		{
+			final I_M_Product product = InterfaceWrapperHelper.newInstance(I_M_Product.class);
+			product.setValue(name);
+			product.setName(name);
+			product.setProductType(productType);
+			product.setIsStocked(isStocked);
+			InterfaceWrapperHelper.save(product);
+			return product;
+		}
+
+		private I_M_Warehouse createWarehouse(final String name)
+		{
+			final I_M_Warehouse warehouse = InterfaceWrapperHelper.newInstance(I_M_Warehouse.class);
+			warehouse.setValue(name);
+			warehouse.setName(name);
+			InterfaceWrapperHelper.save(warehouse);
+			return warehouse;
+		}
+
+		private I_M_Locator createLocator(final I_M_Warehouse warehouse)
+		{
+			final I_M_Locator locator = InterfaceWrapperHelper.newInstance(I_M_Locator.class);
+			locator.setM_Warehouse_ID(warehouse.getM_Warehouse_ID());
+			locator.setValue(warehouse.getName() + "_Locator");
+			locator.setX("X");
+			locator.setY("Y");
+			locator.setZ("Z");
+			InterfaceWrapperHelper.save(locator);
+			return locator;
+		}
+
+		private I_C_OrderLine createOrderLine(final I_M_Product product, final I_M_Warehouse warehouse)
+		{
+			final I_C_Order order = InterfaceWrapperHelper.newInstance(I_C_Order.class);
+			order.setIsSOTrx(true);
+			InterfaceWrapperHelper.save(order);
+
+			final I_C_OrderLine orderLine = InterfaceWrapperHelper.newInstance(I_C_OrderLine.class);
+			orderLine.setC_Order(order);
+			orderLine.setM_Product_ID(product.getM_Product_ID());
+			orderLine.setM_Warehouse_ID(warehouse.getM_Warehouse_ID());
+			InterfaceWrapperHelper.save(orderLine);
+			return orderLine;
+		}
+
+		private I_M_ShipmentSchedule createShipmentSchedule(final I_M_Product product, final I_M_Warehouse warehouse)
+		{
+			final I_M_ShipmentSchedule schedule = InterfaceWrapperHelper.newInstance(I_M_ShipmentSchedule.class);
+			schedule.setM_Product_ID(product.getM_Product_ID());
+			schedule.setM_Warehouse_ID(warehouse.getM_Warehouse_ID());
+			InterfaceWrapperHelper.save(schedule);
+			return schedule;
+		}
+
+		private I_M_InOutLine createInOutLine(final I_M_Product product, final I_M_Locator locator)
+		{
+			final I_M_InOut inout = InterfaceWrapperHelper.newInstance(I_M_InOut.class);
+			inout.setIsSOTrx(true);
+			InterfaceWrapperHelper.save(inout);
+
+			final I_M_InOutLine inoutLine = InterfaceWrapperHelper.newInstance(I_M_InOutLine.class);
+			inoutLine.setM_InOut(inout);
+			inoutLine.setM_Product_ID(product.getM_Product_ID());
+			inoutLine.setM_Locator_ID(locator.getM_Locator_ID());
+			InterfaceWrapperHelper.save(inoutLine);
+			return inoutLine;
+		}
+
+		/** Fresh {@link ShipmentScheduleInvalidateBL} spy wired with the given picking-BOM reversed index. */
+		private ShipmentScheduleInvalidateBL newInvalidateBLSpy(final PickingBOMsReversedIndex reversedIndex)
+		{
+			final PickingBOMService pickingBOMService = mock(PickingBOMService.class);
+			when(pickingBOMService.getPickingBOMsReversedIndex()).thenReturn(reversedIndex);
+			return spy(new ShipmentScheduleInvalidateBL(pickingBOMService));
+		}
+
+		@Test
+		void nonStocked_orderLineChange_invalidatesOnlyOwnSchedule()
+		{
+			// IsStocked=false on an Item product: exercises the composite IProductBL#isStocked (AC-D3), not the raw column alone.
+			final I_M_Product nonStockedProduct = createProduct("NonStockedItem-OL", false, X_M_Product.PRODUCTTYPE_Item);
+			final I_M_Warehouse warehouse = createWarehouse("WH-NS-OL");
+			final I_C_OrderLine orderLine = createOrderLine(nonStockedProduct, warehouse);
+
+			final ShipmentScheduleInvalidateBL bl = newInvalidateBLSpy(NO_BOM_COMPONENTS);
+			doNothing().when(bl).invalidateJustForOrderLine(any());
+			doNothing().when(bl).notifySegmentChanged(any());
+
+			bl.notifySegmentChangedForOrderLine(orderLine);
+
+			verify(bl, times(1))
+					.invalidateJustForOrderLine(orderLine);
+			verify(bl, never())
+					.notifySegmentChanged(any());
+		}
+
+		@Test
+		void nonStocked_shipmentScheduleChange_invalidatesOnlyOwnSchedule()
+		{
+			final I_M_Product nonStockedProduct = createProduct("NonStockedItem-Sched", false, X_M_Product.PRODUCTTYPE_Item);
+			final I_M_Warehouse warehouse = createWarehouse("WH-NS-Sched");
+			final I_M_ShipmentSchedule schedule = createShipmentSchedule(nonStockedProduct, warehouse);
+			final ShipmentScheduleId scheduleId = ShipmentScheduleId.ofRepoId(schedule.getM_ShipmentSchedule_ID());
+
+			final ShipmentScheduleInvalidateBL bl = newInvalidateBLSpy(NO_BOM_COMPONENTS);
+			doNothing().when(bl).flagForRecompute(any(ShipmentScheduleId.class));
+			doNothing().when(bl).notifySegmentChanged(any());
+
+			bl.notifySegmentChangedForShipmentSchedule(schedule);
+
+			verify(bl, times(1))
+					.flagForRecompute(scheduleId);
+			verify(bl, never())
+					.notifySegmentChanged(any());
+		}
+
+		@Test
+		void nonStocked_shipmentLineChange_invalidatesOnlyOwnSchedule()
+		{
+			final I_M_Product nonStockedProduct = createProduct("NonStockedItem-Line", false, X_M_Product.PRODUCTTYPE_Item);
+			final I_M_Warehouse warehouse = createWarehouse("WH-NS-Line");
+			final I_M_Locator locator = createLocator(warehouse);
+			final I_M_InOutLine inoutLine = createInOutLine(nonStockedProduct, locator);
+
+			final ShipmentScheduleInvalidateBL bl = newInvalidateBLSpy(NO_BOM_COMPONENTS);
+			doNothing().when(bl).flagForRecompute(any(I_M_InOutLine.class));
+			doNothing().when(bl).notifySegmentChanged(any());
+
+			bl.notifySegmentChangedForShipmentLine(inoutLine);
+
+			verify(bl, times(1))
+					.flagForRecompute(inoutLine);
+			verify(bl, never())
+					.notifySegmentChanged(any());
+		}
+
+		/** Control: a STOCKED product must keep the broad segment path (pre-existing behaviour, unchanged by Option A). */
+		@Test
+		void stocked_orderLineChange_invalidatesFullSegment()
+		{
+			final I_M_Product stockedProduct = createProduct("StockedItem-OL", true, X_M_Product.PRODUCTTYPE_Item);
+			final I_M_Warehouse warehouse = createWarehouse("WH-Stocked-OL");
+			final I_C_OrderLine orderLine = createOrderLine(stockedProduct, warehouse);
+
+			final ShipmentScheduleInvalidateBL bl = newInvalidateBLSpy(NO_BOM_COMPONENTS);
+			doNothing().when(bl).invalidateJustForOrderLine(any());
+			doNothing().when(bl).notifySegmentChanged(any());
+
+			bl.notifySegmentChangedForOrderLine(orderLine);
+
+			verify(bl, times(1))
+					.notifySegmentChanged(any());
+			verify(bl, never())
+					.invalidateJustForOrderLine(any());
+		}
+
+		/**
+		 * Option-A carve-out guard: a non-stocked product that IS a picking-BOM component must KEEP the broad
+		 * segment path (NOT narrow to self) — otherwise the BOM-parent's shipment schedules would never be
+		 * re-invalidated via {@code explodeByPickingBOMs}.
+		 */
+		@Test
+		void nonStocked_butPickingBOMComponent_orderLineChange_invalidatesFullSegment()
+		{
+			final I_M_Product nonStockedBomComponent = createProduct("NonStockedBomComponent-OL", false, X_M_Product.PRODUCTTYPE_Item);
+			final ProductId componentProductId = ProductId.ofRepoId(nonStockedBomComponent.getM_Product_ID());
+			final I_M_Warehouse warehouse = createWarehouse("WH-NS-BOM-OL");
+			final I_C_OrderLine orderLine = createOrderLine(nonStockedBomComponent, warehouse);
+
+			final PickingBOMsReversedIndex reversedIndexWithComponent = PickingBOMsReversedIndex.ofBOMProductIdsByComponentId(
+					ImmutableSetMultimap.of(componentProductId, ProductId.ofRepoId(999_999)));
+			final ShipmentScheduleInvalidateBL bl = newInvalidateBLSpy(reversedIndexWithComponent);
+			doNothing().when(bl).invalidateJustForOrderLine(any());
+			doNothing().when(bl).notifySegmentChanged(any());
+
+			bl.notifySegmentChangedForOrderLine(orderLine);
+
+			verify(bl, times(1))
+					.notifySegmentChanged(any());
+			verify(bl, never())
+					.invalidateJustForOrderLine(any());
 		}
 	}
 }


### PR DESCRIPTION
## What & why

Durable fix for a self-amplifying shipment-schedule recompute backlog.

**Root cause** (verified live + in code): a non-stocked product (e.g. a freight article: `ProductType=Item, IsStocked=false`) is force-delivered by the shipment-schedule recompute and never touches `M_Storage`, so it can never compete for the shared on-hand stock that the **broad** invalidation segment (`product=X, bpartner=ANY, warehouse=W`) exists to protect. Yet the invalidation producers enqueue that broad segment regardless of stocked-ness, so a change to any one sibling line re-enqueues **every** `Processed='N'` schedule of that product+warehouse — a self-amplifying recompute backlog.

**Fix:** guard the product-specific invalidation producers. When the product is **non-stocked** (`IProductBL.isStocked` = the composite Item-AND-IsStocked check, never the raw column) **and not a picking-BOM component**, route to the already-existing self-by-id invalidation instead of building the broad segment. A non-stocked product that IS a picking-BOM component keeps the broad path, so the BOM-parent's schedules are still reached via `explodeByPickingBOMs`.

Guarded producers (`ShipmentScheduleInvalidateBL`): `notifySegmentChangedForOrderLine`, `notifySegmentChangedForShipmentSchedule` (guard placed after the existing updater-running early-exit), `notifySegmentChangedForShipmentLine`, and `notifySegmentsChangedForShipment` (per-line: non-stocked lines invalidated by-id and excluded from the batch, stocked lines stay in the broad batch).

## Out of scope (intentional)

Four pre-existing call sites invoke `notifySegmentChanged(...)` directly with attribute / HU-storage segments — `M_AttributeInstance`, `M_HU`, `M_HU_Attribute`, `M_HU_Storage` — rather than through the guarded `notifySegmentChangedFor*` producers. These are **not** guarded: they fire on a different, rarer trigger (attribute-instance / HU-storage changes), and a non-stocked product by definition has no `M_HU_Storage` rows to change.

## Tests

`ShipmentScheduleInvalidateBLTest.NonStockedNarrowing` (spy-based routing): non-stocked order-line / shipment-schedule / shipment-line narrow to self; stocked control keeps the broad segment; non-stocked-but-picking-BOM-component keeps the broad segment; composite-pinning case (non-Item + `IsStocked=true` still narrows); mixed shipment splits per line. Module regression suite green (`ShipmentScheduleInvalidateBLTest`, `ShipmentScheduleInvalidateRepositoryTest`, `UpdateInvalidShipmentSchedulesWorkpackageProcessorTest`, `ShipmentScheduleUpdaterTest`).

## Base / propagation

Branches off `deep_tundra_release`. To be propagated up to `new_dawn_uat` after merge. The customer rollout `-compat` image is tracked separately.
