### PR TITLE
MobileUI Picking — show available qty per line (opt-in profile flag)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_MobileUI_UserProfile_Picking.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_MobileUI_UserProfile_Picking.java
@@ -491,7 +491,7 @@ public interface I_MobileUI_UserProfile_Picking
 	String COLUMNNAME_IsConsiderSalesOrderCapacity = "IsConsiderSalesOrderCapacity";
 
 	/**
-	 * Set Show Picking Tray Suggestions.
+	 * Set Show Picking Slot Suggestions.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
@@ -500,7 +500,7 @@ public interface I_MobileUI_UserProfile_Picking
 	void setIsDisplayPickingSlotSuggestions (boolean IsDisplayPickingSlotSuggestions);
 
 	/**
-	 * Get Show Picking Tray Suggestions.
+	 * Get Show Picking Slot Suggestions.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
@@ -556,7 +556,7 @@ public interface I_MobileUI_UserProfile_Picking
 	String COLUMNNAME_IsMassPrinting = "IsMassPrinting";
 
 	/**
-	 * Set Kommissionierfach erforderlich.
+	 * Set Picking Slot required.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
@@ -565,7 +565,7 @@ public interface I_MobileUI_UserProfile_Picking
 	void setIsPickingSlotRequired (boolean IsPickingSlotRequired);
 
 	/**
-	 * Get Kommissionierfach erforderlich.
+	 * Get Picking Slot required.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
@@ -644,6 +644,27 @@ public interface I_MobileUI_UserProfile_Picking
 
 	ModelColumn<I_MobileUI_UserProfile_Picking, Object> COLUMN_IsShowLastPickedBestBeforeDateForLines = new ModelColumn<>(I_MobileUI_UserProfile_Picking.class, "IsShowLastPickedBestBeforeDateForLines", null);
 	String COLUMNNAME_IsShowLastPickedBestBeforeDateForLines = "IsShowLastPickedBestBeforeDateForLines";
+
+	/**
+	 * Set Show available qty per line.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsShowQtyAvailableForLines (boolean IsShowQtyAvailableForLines);
+
+	/**
+	 * Get Show available qty per line.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isShowQtyAvailableForLines();
+
+	ModelColumn<I_MobileUI_UserProfile_Picking, Object> COLUMN_IsShowQtyAvailableForLines = new ModelColumn<>(I_MobileUI_UserProfile_Picking.class, "IsShowQtyAvailableForLines", null);
+	String COLUMNNAME_IsShowQtyAvailableForLines = "IsShowQtyAvailableForLines";
 
 	/**
 	 * Set Lot number.

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_MobileUI_UserProfile_Picking.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_MobileUI_UserProfile_Picking.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class X_MobileUI_UserProfile_Picking extends org.compiere.model.PO implements I_MobileUI_UserProfile_Picking, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = -2103408359L;
+	private static final long serialVersionUID = 899214859L;
 
     /** Standard Constructor */
     public X_MobileUI_UserProfile_Picking (final Properties ctx, final int MobileUI_UserProfile_Picking_ID, @Nullable final String trxName)
@@ -345,6 +345,18 @@ public class X_MobileUI_UserProfile_Picking extends org.compiere.model.PO implem
 	public boolean isShowLastPickedBestBeforeDateForLines() 
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsShowLastPickedBestBeforeDateForLines);
+	}
+
+	@Override
+	public void setIsShowQtyAvailableForLines (final boolean IsShowQtyAvailableForLines)
+	{
+		set_Value (COLUMNNAME_IsShowQtyAvailableForLines, IsShowQtyAvailableForLines);
+	}
+
+	@Override
+	public boolean isShowQtyAvailableForLines() 
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsShowQtyAvailableForLines);
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5815390_sys_MobileUI_UserProfile_Picking_IsShowQtyAvailableForLines.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5815390_sys_MobileUI_UserProfile_Picking_IsShowQtyAvailableForLines.sql
@@ -1,0 +1,96 @@
+-- Run mode: SWING_CLIENT
+
+-- IDs allocated from idserver.metas.de on 2026-07-22:
+--   AD_Element    585122 (new IsShowQtyAvailableForLines label for MobileUI_UserProfile_Picking)
+--   AD_Column     592976 (MobileUI_UserProfile_Picking.IsShowQtyAvailableForLines, default 'N', NOT NULL)
+--   AD_Field      781765 (picking-profile window 541743 / tab 547258)
+--   AD_UI_Element 652697 (header, group 551252 "flags", SeqNo 190)
+
+-- Element: IsShowQtyAvailableForLines
+-- 2026-07-22T12:12:30.000Z
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,585122 /*From ID Server*/,0,'IsShowQtyAvailableForLines',TO_TIMESTAMP('2026-07-22 12:12:30.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','Verfügbaren Bestand pro Position anzeigen','Verfügbaren Bestand pro Position anzeigen',TO_TIMESTAMP('2026-07-22 12:12:30.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-07-22T12:12:30.100Z
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585122 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- Element: IsShowQtyAvailableForLines (de_CH)
+-- 2026-07-22T12:12:31.000Z
+UPDATE AD_Element_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-07-22 12:12:31.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=585122 AND AD_Language='de_CH'
+;
+
+-- 2026-07-22T12:12:31.010Z
+/* DDL */  select update_ad_element_on_ad_element_trl_update(585122,'de_CH')
+;
+
+-- 2026-07-22T12:12:31.100Z
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(585122,'de_CH')
+;
+
+-- Element: IsShowQtyAvailableForLines (de_DE, base language)
+-- 2026-07-22T12:12:32.000Z
+UPDATE AD_Element_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-07-22 12:12:32.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=585122 AND AD_Language='de_DE'
+;
+
+-- 2026-07-22T12:12:32.100Z
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(585122,'de_DE')
+;
+
+-- Element: IsShowQtyAvailableForLines (en_US)
+-- 2026-07-22T12:12:33.000Z
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Show available qty per line', PrintName='Show available qty per line',Updated=TO_TIMESTAMP('2026-07-22 12:12:33.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=585122 AND AD_Language='en_US'
+;
+
+-- 2026-07-22T12:12:33.010Z
+UPDATE AD_Element base SET Name=trl.Name, PrintName=trl.PrintName, Updated=trl.Updated, UpdatedBy=trl.UpdatedBy FROM AD_Element_Trl trl  WHERE trl.AD_Element_ID=base.AD_Element_ID AND trl.AD_Language='en_US' AND trl.AD_Language=getBaseLanguage()
+;
+
+-- 2026-07-22T12:12:33.100Z
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(585122,'en_US')
+;
+
+-- Column: MobileUI_UserProfile_Picking.IsShowQtyAvailableForLines
+-- 2026-07-22T12:12:34.000Z
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,CloningStrategy,ColumnName,Created,CreatedBy,DDL_NoForeignKey,DefaultValue,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,PersonalDataCategory,Version) VALUES (0,592976 /*From ID Server*/,585122,0,20,542373,'XX','IsShowQtyAvailableForLines',TO_TIMESTAMP('2026-07-22 12:12:34.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N','N','D',0,1,'Y','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','N','Y','N',0,'Verfügbaren Bestand pro Position anzeigen',0,0,TO_TIMESTAMP('2026-07-22 12:12:34.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'NP',0)
+;
+
+-- 2026-07-22T12:12:34.100Z
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=592976 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 2026-07-22T12:12:34.200Z
+/* DDL */  select update_Column_Translation_From_AD_Element(585122)
+;
+
+-- 2026-07-22T12:12:35.000Z
+/* DDL */ SELECT public.db_alter_table('MobileUI_UserProfile_Picking','ALTER TABLE public.MobileUI_UserProfile_Picking ADD COLUMN IsShowQtyAvailableForLines CHAR(1) DEFAULT ''N'' CHECK (IsShowQtyAvailableForLines IN (''Y'',''N'')) NOT NULL')
+;
+
+-- Field: Mobile UI Kommissionierprofil(541743,D) -> Mobile UI Kommissionierprofil(547258,D) -> Verfügbaren Bestand pro Position anzeigen
+-- Column: MobileUI_UserProfile_Picking.IsShowQtyAvailableForLines
+-- 2026-07-22T12:12:36.000Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,DisplayLength,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,Updated,UpdatedBy) VALUES (0,592976,781765 /*From ID Server*/,0,547258,TO_TIMESTAMP('2026-07-22 12:12:36.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,1,'D','Y','N','N','N','N','N','N','N','Verfügbaren Bestand pro Position anzeigen',TO_TIMESTAMP('2026-07-22 12:12:36.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-07-22T12:12:36.100Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=781765 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-07-22T12:12:36.200Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(585122)
+;
+
+-- 2026-07-22T12:12:36.300Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781765
+;
+
+-- 2026-07-22T12:12:36.400Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(781765)
+;
+
+-- UI Element: Mobile UI Kommissionierprofil(541743,D) -> Mobile UI Kommissionierprofil(547258,D) -> main -> 20 -> flags.Verfügbaren Bestand pro Position anzeigen
+-- Column: MobileUI_UserProfile_Picking.IsShowQtyAvailableForLines
+-- 2026-07-22T12:12:37.000Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,781765,0,547258,551252,652697 /*From ID Server*/,'F',TO_TIMESTAMP('2026-07-22 12:12:37.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y','N','Y','N','N','Verfügbaren Bestand pro Position anzeigen',190,0,0,TO_TIMESTAMP('2026-07-22 12:12:37.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/JsonMobileConfigRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/JsonMobileConfigRequest.java
@@ -61,6 +61,7 @@ public class JsonMobileConfigRequest
 		@Nullable Boolean considerOnlyJobScheduledToWorkplace;
 		@Nullable Boolean allowQuickPackAll;
 		@Nullable Boolean massPrinting;
+		@Nullable Boolean showQtyAvailableForLines;
 		@Nullable Boolean showPromptWhenOverPicking;
 
 		@Nullable List<Customer> customers;

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigPickingCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigPickingCommand.java
@@ -50,7 +50,8 @@ class MobileConfigPickingCommand
 					.isActiveWorkplaceRequired(request.getActiveWorkplaceRequired() != null ? request.getActiveWorkplaceRequired() : false)
 					.isConsiderOnlyJobScheduledToWorkplace(request.getConsiderOnlyJobScheduledToWorkplace() != null ? request.getConsiderOnlyJobScheduledToWorkplace() : false)
 					.isAllowQuickPackAll(request.getAllowQuickPackAll() != null ? request.getAllowQuickPackAll() : false)
-					.isMassPrinting(request.getMassPrinting() != null ? request.getMassPrinting() : false);
+					.isMassPrinting(request.getMassPrinting() != null ? request.getMassPrinting() : false)
+					.isShowQtyAvailableForLines(request.getShowQtyAvailableForLines() != null ? request.getShowQtyAvailableForLines() : false);
 
 			if (request.getAllowPickingAnyCustomer() != null)
 			{

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfile.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfile.java
@@ -45,6 +45,7 @@ public class MobileUIPickingUserProfile
 			.name("default")
 			.isAllowPickingAnyCustomer(true)
 			.isMassPrinting(false)
+			.isShowQtyAvailableForLines(false)
 			.defaultPickingJobOptions(PickingJobOptions.builder()
 					.aggregationType(PickingJobAggregationType.DEFAULT)
 					.allowedPickToStructures(AllowedPickToStructures.DEFAULT)
@@ -67,6 +68,7 @@ public class MobileUIPickingUserProfile
 	boolean isConsiderOnlyJobScheduledToWorkplace;
 	boolean isAllowQuickPackAll;
 	boolean isMassPrinting;
+	boolean isShowQtyAvailableForLines;
 	@Getter @NonNull PickingCustomerConfigsCollection customerConfigs;
 	@NonNull PickingJobOptions defaultPickingJobOptions;
 	@Getter(AccessLevel.NONE) @NonNull PickingFiltersList filters;
@@ -84,6 +86,7 @@ public class MobileUIPickingUserProfile
 			final boolean isConsiderOnlyJobScheduledToWorkplace,
 			final boolean isAllowQuickPackAll,
 			final boolean isMassPrinting,
+			final boolean isShowQtyAvailableForLines,
 			final @Nullable PickingCustomerConfigsCollection customerConfigs,
 			final @NonNull PickingJobOptions defaultPickingJobOptions,
 			final @Nullable PickingFiltersList filters,
@@ -96,6 +99,7 @@ public class MobileUIPickingUserProfile
 		this.isConsiderOnlyJobScheduledToWorkplace = isConsiderOnlyJobScheduledToWorkplace;
 		this.isAllowQuickPackAll = isAllowQuickPackAll;
 		this.isMassPrinting = isMassPrinting;
+		this.isShowQtyAvailableForLines = isShowQtyAvailableForLines;
 		this.customerConfigs = customerConfigs != null ? customerConfigs : PickingCustomerConfigsCollection.EMPTY;
 		this.defaultPickingJobOptions = defaultPickingJobOptions;
 		this.filters = filters != null ? filters : PickingFiltersList.EMPTY;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepository.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepository.java
@@ -112,6 +112,7 @@ public class MobileUIPickingUserProfileRepository
 				.isConsiderOnlyJobScheduledToWorkplace(profileRecord.isConsideredOnlyScheduledJobs())
 				.isAllowQuickPackAll(profileRecord.isAllowQuickPackAll())
 				.isMassPrinting(profileRecord.isMassPrinting())
+				.isShowQtyAvailableForLines(profileRecord.isShowQtyAvailableForLines())
 				.customerConfigs(retrievePickingCustomerConfigsCollection(profileId))
 				.defaultPickingJobOptions(extractPickingJobOptions(profileRecord))
 				.filters(retrieveFilters(profileId))
@@ -335,6 +336,7 @@ public class MobileUIPickingUserProfileRepository
 		record.setIsConsideredOnlyScheduledJobs(from.isConsiderOnlyJobScheduledToWorkplace());
 		record.setIsAllowQuickPackAll(from.isAllowQuickPackAll());
 		record.setIsMassPrinting(from.isMassPrinting());
+		record.setIsShowQtyAvailableForLines(from.isShowQtyAvailableForLines());
 		updateRecord(record, from.getDefaultPickingJobOptions());
 	}
 

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepositoryTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepositoryTest.java
@@ -106,6 +106,18 @@ class MobileUIPickingUserProfileRepositoryTest
 	}
 
 	@Test
+	void isShowQtyAvailableForLines_N()
+	{
+		final I_MobileUI_UserProfile_Picking record = newProfileRecord();
+		record.setIsShowQtyAvailableForLines(false);
+		saveRecord(record);
+
+		final MobileUIPickingUserProfile profile = repository.getProfile();
+
+		assertThat(profile.isShowQtyAvailableForLines()).isFalse();
+	}
+
+	@Test
 	void isShowQtyAvailableForLines_default()
 	{
 		// no profile record — should return default (false)

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepositoryTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepositoryTest.java
@@ -29,6 +29,7 @@ import org.adempiere.test.AdempiereTestWatcher;
 import org.compiere.model.I_MobileUI_UserProfile_Picking;
 import org.compiere.model.X_MobileUI_UserProfile_Picking;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -60,69 +61,77 @@ class MobileUIPickingUserProfileRepositoryTest
 		return record;
 	}
 
-	@Test
-	void isMassPrinting_Y()
+	@Nested
+	class IsMassPrinting
 	{
-		final I_MobileUI_UserProfile_Picking record = newProfileRecord();
-		record.setIsMassPrinting(true);
-		saveRecord(record);
+		@Test
+		void set_returnsTrue()
+		{
+			final I_MobileUI_UserProfile_Picking record = newProfileRecord();
+			record.setIsMassPrinting(true);
+			saveRecord(record);
 
-		final MobileUIPickingUserProfile profile = repository.getProfile();
+			final MobileUIPickingUserProfile profile = repository.getProfile();
 
-		assertThat(profile.isMassPrinting()).isTrue();
+			assertThat(profile.isMassPrinting()).isTrue();
+		}
+
+		@Test
+		void unset_returnsFalse()
+		{
+			final I_MobileUI_UserProfile_Picking record = newProfileRecord();
+			record.setIsMassPrinting(false);
+			saveRecord(record);
+
+			final MobileUIPickingUserProfile profile = repository.getProfile();
+
+			assertThat(profile.isMassPrinting()).isFalse();
+		}
+
+		@Test
+		void noProfileRecord_returnsFalse()
+		{
+			// no profile record — should return default (false)
+			final MobileUIPickingUserProfile profile = repository.getProfile();
+
+			assertThat(profile.isMassPrinting()).isFalse();
+		}
 	}
 
-	@Test
-	void isMassPrinting_N()
+	@Nested
+	class IsShowQtyAvailableForLines
 	{
-		final I_MobileUI_UserProfile_Picking record = newProfileRecord();
-		record.setIsMassPrinting(false);
-		saveRecord(record);
+		@Test
+		void set_returnsTrue()
+		{
+			final I_MobileUI_UserProfile_Picking record = newProfileRecord();
+			record.setIsShowQtyAvailableForLines(true);
+			saveRecord(record);
 
-		final MobileUIPickingUserProfile profile = repository.getProfile();
+			final MobileUIPickingUserProfile profile = repository.getProfile();
 
-		assertThat(profile.isMassPrinting()).isFalse();
-	}
+			assertThat(profile.isShowQtyAvailableForLines()).isTrue();
+		}
 
-	@Test
-	void isMassPrinting_default()
-	{
-		// no profile record — should return default (false)
-		final MobileUIPickingUserProfile profile = repository.getProfile();
+		@Test
+		void unset_returnsFalse()
+		{
+			final I_MobileUI_UserProfile_Picking record = newProfileRecord();
+			record.setIsShowQtyAvailableForLines(false);
+			saveRecord(record);
 
-		assertThat(profile.isMassPrinting()).isFalse();
-	}
+			final MobileUIPickingUserProfile profile = repository.getProfile();
 
-	@Test
-	void isShowQtyAvailableForLines_Y()
-	{
-		final I_MobileUI_UserProfile_Picking record = newProfileRecord();
-		record.setIsShowQtyAvailableForLines(true);
-		saveRecord(record);
+			assertThat(profile.isShowQtyAvailableForLines()).isFalse();
+		}
 
-		final MobileUIPickingUserProfile profile = repository.getProfile();
+		@Test
+		void noProfileRecord_returnsFalse()
+		{
+			// no profile record — should return default (false)
+			final MobileUIPickingUserProfile profile = repository.getProfile();
 
-		assertThat(profile.isShowQtyAvailableForLines()).isTrue();
-	}
-
-	@Test
-	void isShowQtyAvailableForLines_N()
-	{
-		final I_MobileUI_UserProfile_Picking record = newProfileRecord();
-		record.setIsShowQtyAvailableForLines(false);
-		saveRecord(record);
-
-		final MobileUIPickingUserProfile profile = repository.getProfile();
-
-		assertThat(profile.isShowQtyAvailableForLines()).isFalse();
-	}
-
-	@Test
-	void isShowQtyAvailableForLines_default()
-	{
-		// no profile record — should return default (false)
-		final MobileUIPickingUserProfile profile = repository.getProfile();
-
-		assertThat(profile.isShowQtyAvailableForLines()).isFalse();
+			assertThat(profile.isShowQtyAvailableForLines()).isFalse();
+		}
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepositoryTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepositoryTest.java
@@ -92,4 +92,25 @@ class MobileUIPickingUserProfileRepositoryTest
 
 		assertThat(profile.isMassPrinting()).isFalse();
 	}
+
+	@Test
+	void isShowQtyAvailableForLines_Y()
+	{
+		final I_MobileUI_UserProfile_Picking record = newProfileRecord();
+		record.setIsShowQtyAvailableForLines(true);
+		saveRecord(record);
+
+		final MobileUIPickingUserProfile profile = repository.getProfile();
+
+		assertThat(profile.isShowQtyAvailableForLines()).isTrue();
+	}
+
+	@Test
+	void isShowQtyAvailableForLines_default()
+	{
+		// no profile record — should return default (false)
+		final MobileUIPickingUserProfile profile = repository.getProfile();
+
+		assertThat(profile.isShowQtyAvailableForLines()).isFalse();
+	}
 }

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/PickingMobileApplication.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/PickingMobileApplication.java
@@ -144,6 +144,7 @@ public class PickingMobileApplication implements WorkflowBasedMobileApplication
 				.showFilterByQtyAvailableAtPickFromLocator(true)
 				.applicationParameter("allowQuickPackAll", profile.isAllowQuickPackAll())
 				.applicationParameter("massPrinting", profile.isMassPrinting())
+				.applicationParameter("isShowQtyAvailableForLines", profile.isShowQtyAvailableForLines())
 				.build();
 	}
 

--- a/e2e/mobile-webui/tests/spec/picking/pickingQtyAvailableForLines.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/pickingQtyAvailableForLines.spec.js
@@ -1,9 +1,9 @@
-import { test } from "../../../playwright.config";
+import { test } from '../../../playwright.config';
 import { allure } from 'allure-playwright';
-import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
-import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
-import { Backend } from "../../utils/screens/Backend";
-import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { PickingJobsListScreen } from '../../utils/screens/picking/PickingJobsListScreen';
+import { Backend } from '../../utils/screens/Backend';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
 import { PickingJobScreen } from '../../utils/screens/picking/PickingJobScreen';
 
 // P1 has stock provisioned in the picking-group locator (workplace1 -> wh); P2 has none.
@@ -11,10 +11,10 @@ const createMasterdata = async ({ showQtyAvailableForLines }) => {
     return await Backend.createMasterdata({
         language: 'de_DE',
         request: {
-            login: { user: { language: 'de_DE', workplace: "workplace1" } },
+            login: { user: { language: 'de_DE', workplace: 'workplace1' } },
             mobileConfig: {
                 picking: {
-                    aggregationType: "sales_order",
+                    aggregationType: 'sales_order',
                     createShipmentPolicy: 'CL',
                     allowPickingAnyHU: true,
                     allowQuickPackAll: false,
@@ -24,27 +24,27 @@ const createMasterdata = async ({ showQtyAvailableForLines }) => {
                     allowCompletingPartialPickingJob: false,
                     allowPickingAnyCustomer: false,
                     customers: [
-                        { customer: "customer1" },
+                        { customer: 'customer1' },
                     ],
                 }
             },
-            bpartners: { "customer1": {} },
-            warehouses: { "wh": {} },
+            bpartners: { 'customer1': {} },
+            warehouses: { 'wh': {} },
             pickingSlots: { slot1: {} },
-            workplaces: { "workplace1": { warehouse: 'wh', pickingSlot: 'slot1' } },
+            workplaces: { 'workplace1': { warehouse: 'wh', pickingSlot: 'slot1' } },
             products: {
-                "P1": { price: 1 }, // WITH stock
-                "P2": { price: 2 }, // WITHOUT stock
+                'P1': { price: 1 }, // WITH stock
+                'P2': { price: 2 }, // WITHOUT stock
             },
             packingInstructions: {
-                "LU_CU": { cu: true, lu: "LU", qtyTUsPerLU: 1 },
+                'LU_CU': { cu: true, lu: 'LU', qtyTUsPerLU: 1 },
             },
             handlingUnits: {
-                "HU1": { product: 'P1', warehouse: 'wh', qty: 1000, packingInstructions: 'LU_CU' },
+                'HU1': { product: 'P1', warehouse: 'wh', qty: 1000, packingInstructions: 'LU_CU' },
                 // no HU for P2 -> zero available stock in the picking-group locator
             },
             salesOrders: {
-                "SO1": {
+                'SO1': {
                     bpartner: 'customer1',
                     warehouse: 'wh',
                     datePromised: '2025-03-01T00:00:00.000+02:00',
@@ -76,9 +76,9 @@ test('Show available qty per line when flag is on', async ({ page }) => {
     await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
     await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
 
-    // AC1: line with stock in the picking-group locator shows the actual available qty.
+    // line with stock in the picking-group locator shows the actual available qty.
     await PickingJobScreen.expectLineQtyAvailable({ index: 1, qtyAvailable: 'Verfügbar: 10 Stk' });
-    // AC2: line without any stock shows zero, not hidden.
+    // line without any stock shows zero, not hidden.
     await PickingJobScreen.expectLineQtyAvailable({ index: 2, qtyAvailable: 'Verfügbar: 0 Stk' });
 });
 
@@ -100,7 +100,7 @@ test('Hide available qty per line when flag is off', async ({ page }) => {
     await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
     await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
 
-    // AC4: gating off -> no Verfügbar element on any line.
+    // flag off -> no Verfügbar element on any line.
     await PickingJobScreen.expectLineQtyAvailableNotVisible({ index: 1 });
     await PickingJobScreen.expectLineQtyAvailableNotVisible({ index: 2 });
 });

--- a/e2e/mobile-webui/tests/spec/picking/pickingQtyAvailableForLines.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/pickingQtyAvailableForLines.spec.js
@@ -1,0 +1,106 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { PickingJobScreen } from '../../utils/screens/picking/PickingJobScreen';
+
+// P1 has stock provisioned in the picking-group locator (workplace1 -> wh); P2 has none.
+const createMasterdata = async ({ showQtyAvailableForLines }) => {
+    return await Backend.createMasterdata({
+        language: 'de_DE',
+        request: {
+            login: { user: { language: 'de_DE', workplace: "workplace1" } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    allowQuickPackAll: false,
+                    showQtyAvailableForLines,
+                    shipOnCloseLU: false,
+                    pickTo: ['CU', 'LU_CU'],
+                    allowCompletingPartialPickingJob: false,
+                    allowPickingAnyCustomer: false,
+                    customers: [
+                        { customer: "customer1" },
+                    ],
+                }
+            },
+            bpartners: { "customer1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            workplaces: { "workplace1": { warehouse: 'wh', pickingSlot: 'slot1' } },
+            products: {
+                "P1": { price: 1 }, // WITH stock
+                "P2": { price: 2 }, // WITHOUT stock
+            },
+            packingInstructions: {
+                "LU_CU": { cu: true, lu: "LU", qtyTUsPerLU: 1 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', qty: 1000, packingInstructions: 'LU_CU' },
+                // no HU for P2 -> zero available stock in the picking-group locator
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'customer1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [
+                        { product: 'P1', qty: 10 },
+                        { product: 'P2', qty: 10 },
+                    ]
+                }
+            },
+        }
+    })
+}
+
+// noinspection JSUnusedLocalSymbols
+test('Show available qty per line when flag is on', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+        allure.tag('F00230');  // Standalone tag for Tags section;
+    allure.story('Show available qty per line');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({ showQtyAvailableForLines: true });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+
+    // AC1: line with stock in the picking-group locator shows the actual available qty.
+    await PickingJobScreen.expectLineQtyAvailable({ index: 1, qtyAvailable: 'Verfügbar: 10 Stk' });
+    // AC2: line without any stock shows zero, not hidden.
+    await PickingJobScreen.expectLineQtyAvailable({ index: 2, qtyAvailable: 'Verfügbar: 0 Stk' });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Hide available qty per line when flag is off', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+        allure.tag('F00230');  // Standalone tag for Tags section;
+    allure.story('Show available qty per line');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({ showQtyAvailableForLines: false });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+
+    // AC4: gating off -> no Verfügbar element on any line.
+    await PickingJobScreen.expectLineQtyAvailableNotVisible({ index: 1 });
+    await PickingJobScreen.expectLineQtyAvailableNotVisible({ index: 2 });
+});

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
@@ -228,6 +228,21 @@ export const PickingJobScreen = {
         }
     }),
 
+    // AC1/AC2: per-line available-qty display, gated by the picking profile's IsShowQtyAvailableForLines flag.
+    // `qtyAvailable` is the full expected text, e.g. 'Verfügbar: 10 Stk' / 'Verfügbar: 0 Stk'.
+    expectLineQtyAvailable: async ({ index, qtyAvailable }) => await step(`${NAME} - Expect line ${index} qty available '${qtyAvailable}'`, async () => {
+        const lineButton = locateLineButton({ index });
+        const qtyAvailableElement = lineButton.getByTestId('picking-line-qty-available');
+        await qtyAvailableElement.waitFor({ state: 'visible', timeout: FAST_ACTION_TIMEOUT });
+        await expect(qtyAvailableElement).toHaveText(qtyAvailable);
+    }),
+
+    // AC4: when the flag is off, no qty-available element must be rendered on the line at all.
+    expectLineQtyAvailableNotVisible: async ({ index }) => await step(`${NAME} - Expect line ${index} qty available not shown`, async () => {
+        const lineButton = locateLineButton({ index });
+        await lineButton.getByTestId('picking-line-qty-available').waitFor({ state: 'detached', timeout: FAST_ACTION_TIMEOUT });
+    }),
+
     clickPickAllButton: async () => await step(`${NAME} - Click Pick All button`, async () => {
         const button = pickAllButton();
         await button.tap();

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
@@ -228,7 +228,7 @@ export const PickingJobScreen = {
         }
     }),
 
-    // AC1/AC2: per-line available-qty display, gated by the picking profile's IsShowQtyAvailableForLines flag.
+    // per-line available-qty display, gated by the picking profile's IsShowQtyAvailableForLines flag.
     // `qtyAvailable` is the full expected text, e.g. 'Verfügbar: 10 Stk' / 'Verfügbar: 0 Stk'.
     expectLineQtyAvailable: async ({ index, qtyAvailable }) => await step(`${NAME} - Expect line ${index} qty available '${qtyAvailable}'`, async () => {
         const lineButton = locateLineButton({ index });
@@ -237,7 +237,7 @@ export const PickingJobScreen = {
         await expect(qtyAvailableElement).toHaveText(qtyAvailable);
     }),
 
-    // AC4: when the flag is off, no qty-available element must be rendered on the line at all.
+    // when the flag is off, no qty-available element must be rendered on the line at all.
     expectLineQtyAvailableNotVisible: async ({ index }) => await step(`${NAME} - Expect line ${index} qty available not shown`, async () => {
         const lineButton = locateLineButton({ index });
         await lineButton.getByTestId('picking-line-qty-available').waitFor({ state: 'detached', timeout: FAST_ACTION_TIMEOUT });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/assets/pick-products.scss
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/assets/pick-products.scss
@@ -30,6 +30,22 @@
   font-size: 1.5em;
 }
 
+.picking-row-available {
+  clear: both;
+  padding-top: 5px;
+  text-align: center;
+}
+
+// The per-line Verfügbar row adds a third text line to the line button, which
+// otherwise has a fixed height (buttons.scss: .button / .full-size-btn = 2.5em).
+// Without extra height the Verfügbar row overflows the fixed box and the next
+// line button overlaps it. Grow the button when the row is present — mirrors the
+// existing .hazard-icons-btn height override in buttons.scss.
+.button:has(.picking-row-available),
+.full-size-btn:has(.picking-row-available) {
+  height: 4.5em !important;
+}
+
 .green-border-button {
   background-color: white;
   color: $base-mf-green;
@@ -49,6 +65,9 @@
   }
   .picking-row-picked {
     font-size: 1em;
+  }
+  .picking-row-available {
+    padding-top: 0;
   }
 }
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/buttons/ButtonQuantityProp.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/buttons/ButtonQuantityProp.jsx
@@ -4,11 +4,24 @@ import PropTypes from 'prop-types';
 import { trl } from '../../utils/translations';
 import { formatQtyToHumanReadableStr } from '../../utils/qtys';
 
-const ButtonQuantityProp = ({ qtyTarget, qtyCurrent, qtyCurrentCatchWeight, uom, applicationId, subtypeId }) => {
+const ButtonQuantityProp = ({
+  qtyTarget,
+  qtyCurrent,
+  qtyCurrentCatchWeight,
+  uom,
+  applicationId,
+  subtypeId,
+  qtyAvailable,
+  qtyAvailableUom,
+}) => {
   const qtyTargetStr = formatQtyToHumanReadableStr({ qty: qtyTarget, uom });
   const qtyCurrentStr = formatQtyToHumanReadableStr({ qty: qtyCurrent, uom });
   const qtyCurrentCatchWeightStr = qtyCurrentCatchWeight ?? '';
   const trlPrefix = `activities.${applicationId}${subtypeId ? `.${subtypeId}` : ''}`;
+  const isShowQtyAvailable = qtyAvailable != null;
+  const qtyAvailableStr = isShowQtyAvailable
+    ? formatQtyToHumanReadableStr({ qty: qtyAvailable, uom: qtyAvailableUom ?? uom })
+    : '';
 
   return (
     <div className="row is-full is-size-7">
@@ -25,6 +38,11 @@ const ButtonQuantityProp = ({ qtyTarget, qtyCurrent, qtyCurrentCatchWeight, uom,
           {qtyCurrentStr}
           {qtyCurrentCatchWeightStr ? ` (${qtyCurrentCatchWeightStr})` : ''}
         </div>
+        {isShowQtyAvailable && (
+          <div className="picking-row-available" data-testid="picking-line-qty-available">
+            {`${trl(`${trlPrefix}.available`)}: ${qtyAvailableStr}`}
+          </div>
+        )}
       </div>
     </div>
   );
@@ -37,6 +55,8 @@ ButtonQuantityProp.propTypes = {
   uom: PropTypes.string.isRequired,
   applicationId: PropTypes.string.isRequired,
   subtypeId: PropTypes.string,
+  qtyAvailable: PropTypes.number,
+  qtyAvailableUom: PropTypes.string,
 };
 
 export default ButtonQuantityProp;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickProductsActivity.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickProductsActivity.jsx
@@ -42,8 +42,11 @@ const PickProductsActivity = ({ applicationId, wfProcessId, activityId, activity
   const history = useMobileNavigation();
   const dispatch = useDispatch();
 
-  const { allowQuickPackAll } = useApplicationInfoParameters({ applicationId });
-  const qtyAvailable = usePickingJobQtyAvailable({ wfProcessId, enabled: allowQuickPackAll });
+  const { allowQuickPackAll, isShowQtyAvailableForLines } = useApplicationInfoParameters({ applicationId });
+  const qtyAvailable = usePickingJobQtyAvailable({
+    wfProcessId,
+    enabled: isShowQtyAvailableForLines || allowQuickPackAll,
+  });
   const isShowQuickPackAllButton = allowQuickPackAll && qtyAvailable?.status === QtyAvailableStatus.FULLY_AVAILABLE;
 
   const { onBarcodeScanned } = usePickProductsScan({ applicationId, wfProcessId, activityId });
@@ -116,6 +119,7 @@ const PickProductsActivity = ({ applicationId, wfProcessId, activityId, activity
               const { uom, qtyToPick, qtyPicked } = line;
               const qtyPickedCatchWeight = computeCatchWeightsArrayForLine({ line });
               const qtyPickedCatchWeightStr = formatCatchWeightToHumanReadableStr(qtyPickedCatchWeight);
+              const lineQtyAvailable = isShowQtyAvailableForLines ? qtyAvailable?.lines?.[lineId] : null;
 
               return (
                 <ButtonWithIndicator
@@ -133,6 +137,8 @@ const PickProductsActivity = ({ applicationId, wfProcessId, activityId, activity
                     qtyCurrent={qtyPicked}
                     qtyCurrentCatchWeight={qtyPickedCatchWeightStr}
                     applicationId={applicationId}
+                    qtyAvailable={lineQtyAvailable?.qtyAvailableToPick}
+                    qtyAvailableUom={lineQtyAvailable?.uom}
                   />
                 </ButtonWithIndicator>
               );

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -133,6 +133,7 @@ const translations = {
       unPickBtn: 'Entpacken',
       target: 'Soll',
       picked: 'Ist',
+      available: 'Verfügbar',
       switchToManualInput: 'Manuell',
       switchToQrCodeInput: 'Scannen',
       scanSerialNo: 'Seriennummer scannen',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -129,6 +129,7 @@ const translations = {
       unPickBtn: 'Unpack',
       target: 'To pack',
       picked: 'Packed',
+      available: 'Available',
       switchToManualInput: 'Manually',
       switchToQrCodeInput: 'Scan',
       scanSerialNo: 'Scan Serial No',


### PR DESCRIPTION
## What

In the mobileUI Picking/Packing workflow, the item-level packing detail previously showed only *Soll* (target) and *Ist* (picked) per line. This adds the **available quantity** per line as text `Verfügbar: <qty> <uom>` (English: `Available`), on **every** line including `Verfügbar: 0 Stk` when nothing is available.

The value is the per-line `qtyAvailableToPick` the backend **already computes and returns** from `GET /picking/job/{id}/qtyAvailable` — same stock source and picking-group locator scope as the jobs-list availability indicator. The item-level frontend previously discarded it; this change renders it.

## Gating — opt-in profile flag

Rendering is behind a new header-level boolean `IsShowQtyAvailableForLines` on `MobileUI_UserProfile_Picking`, defaulting to `'N'`. When off (the default), behaviour and cost are unchanged for every other customer — the per-line availability is not fetched, so no extra stock query is issued. Enabling it for a specific picking profile is a configuration step on the instance.

## How it is built

- **AD migration** — adds `IsShowQtyAvailableForLines` (`CHAR(1) NOT NULL DEFAULT 'N'`) to `MobileUI_UserProfile_Picking`, plus the AD_Field on the picking-profile window's tab and the de_DE/de_CH/en_US translations. Mirrors the existing `IsAllowQuickPackAll` flag's structure.
- **Backend** — the flag round-trips model ↔ profile POJO in `MobileUIPickingUserProfileRepository`, and is exposed to the frontend as an application parameter (`isShowQtyAvailableForLines`), exactly like `allowQuickPackAll`.
- **Frontend** — `PickProductsActivity` reads the parameter and, when on, enables the availability fetch and passes the per-line value + UOM into `ButtonQuantityProp`, which renders the `Verfügbar:` row (distinguishing "no value" from a genuine `0`).
- **No change** to the availability computation, stock source, or locator scope; the "Pick all" quick-pack behaviour is untouched.

## Testing

- Playwright mobile-webui E2E (`pickingQtyAvailableForLines.spec.js`): flag ON shows `Verfügbar: 10 Stk` on a stocked line and `Verfügbar: 0 Stk` on an unstocked line; flag OFF renders no availability element. Both scenarios pass.
- Repository unit test proves the flag round-trips (set/unset/default).
- `pickAllButton.spec.js` regression passes — quick-pack behaviour unaffected.
