### PR TITLE
Flaky test: tolerate dialog detach in GetQuantityDialog disabled-assertion (mobile)

### DIFF
--- a/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
@@ -200,8 +200,16 @@ export const GetQuantityDialog = {
 //
 
 const expectMissingOrDisabled = async (locator) => {
+    // Element should either not exist (dialog already closed) or be disabled (dialog closing).
+    // Race condition: count() > 0 may be true, but by the time toBeDisabled() runs the dialog
+    // may have unmounted. In that case, re-check count — if 0, element is gone (OK).
     if (await locator.count() > 0) {
-        await expect(locator).toBeDisabled();
+        try {
+            await expect(locator).toBeDisabled();
+        } catch (e) {
+            if (await locator.count() === 0) return;
+            throw e;
+        }
     }
 };
 


### PR DESCRIPTION
## What

Make the mobile `GetQuantityDialog` post-OK "components disabled" assertion tolerant of the qty-dialog detaching mid-assertion.

`expectMissingOrDisabled()` had a check-then-act (TOCTOU) race: `count() > 0` observes the element still attached right after OK, but the dialog is closing, so by the time `expect(locator).toBeDisabled()` re-queries it the element has detached → `element(s) not found` → 5s timeout. The helper's intent is "missing **or** disabled", and a detach satisfies "missing".

**Fix (test-only):** on a `toBeDisabled()` failure, re-check `count()` — if the element is now gone, treat it as a pass; otherwise rethrow.

## Why this branch

This is a **down-port of the identical, already-proven helper** that runs green on `new_dawn_uat` (introduced in #23120), `soft_panda_hotfix` and `deep_tundra_release` — the `GetQuantityDialog.js` disabled-assertion seam is quiet on those branches. `intensive_care_hotfix` was the **only** tracked branch still carrying the original buggy helper, which is why the `mobile test` job flaked **6× consecutively** on the intensive_care line (run 29932177750, all attempts at the same seam, shifting spec set = load/timing race).

The applied helper is byte-identical to the version on the three fixed branches.

## Root cause

Test-harness read-before-settle TOCTOU on a transient element — **not** a product bug (no production/UI change).

## Test

Test-only change to a shared E2E helper. The proven-identical helper is already green on 3 branches; CI runs the mobile suite here.
