### PR TITLE
HttpCallSchedulerTest: de-flake exceptionInRequestDoesNotBreakScheduler

### DIFF
--- a/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
+++ b/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
@@ -7,9 +7,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class HttpCallSchedulerTest
 {
@@ -113,10 +115,18 @@ class HttpCallSchedulerTest
 			throw new RuntimeException("test error");
 		}));
 
-		// Should complete exceptionally
-		assertThat(failingFuture).isCompletedExceptionally();
+		// Should complete exceptionally.
+		// The supplier throws on the scheduler's pool thread, so completion happens
+		// asynchronously. Block until the future settles (up to 5s) instead of checking
+		// isCompletedExceptionally() synchronously: that check was racy and failed
+		// intermittently on CPU-contended CI runners where the pool thread had not yet
+		// run the throwing supplier at the instant the assertion was evaluated.
+		assertThatThrownBy(() -> failingFuture.get(5, TimeUnit.SECONDS))
+				.isInstanceOf(ExecutionException.class)
+				.hasCauseInstanceOf(RuntimeException.class);
 
-		// Wait a bit for scheduler to settle
+		// Wait a bit for scheduler to settle (let the pool thread finish run() and
+		// complete executorFuture, so the next schedule() re-submits run() for the queue)
 		Thread.sleep(500);
 
 		// Second request should still succeed


### PR DESCRIPTION
De-flakes `HttpCallSchedulerTest.exceptionInRequestDoesNotBreakScheduler` (module `de.metas.util.web`), which intermittently reds the `test (java)` CI job on CPU-contended runners.

**Root cause:** the test scheduled a throwing request then asserted `assertThat(failingFuture).isCompletedExceptionally()` synchronously. `HttpCallScheduler.schedule()` runs the supplier asynchronously on its pool thread, so the future is not necessarily completed at the instant the assertion evaluates — race.

**Fix (test-only, deterministic, strengthens the assertion):** block on `failingFuture.get(5, TimeUnit.SECONDS)` and assert the `ExecutionException` cause, instead of the synchronous check. No production code changed.

Cherry-pick of the verified fix authored on `deep_tundra_release` (https://github.com/metasfresh/metasfresh/commit/49e6569c419 , PR https://github.com/metasfresh/metasfresh/pull/25299) — propagated here because sibling customer branches need their own origin fix. Flaky-case tracking: me03 https://github.com/metasfresh/me03/issues/31020 (case 25).
