### PR TITLE
mobile-webui e2e: de-flake camera-mode toggle (stub navigator.mediaDevices in insecure CI context)

### DIFF
--- a/docker-builds/e2e-tests/compose.yml
+++ b/docker-builds/e2e-tests/compose.yml
@@ -217,7 +217,7 @@ services:
     environment:
       - "FRONTEND_BASE_URL=http://mobile:80/mobile"
       - "WIREMOCK_BASE_URL=http://wiremock:8080"
-      - "CHROMIUM_FLAGS=--unsafely-treat-insecure-origin-as-secure=http://app-test:8282 --disable-web-security --ignore-certificate-errors"
+      - "CHROMIUM_FLAGS=--unsafely-treat-insecure-origin-as-secure=http://app-test:8282,http://mobile:80,http://mobile --disable-web-security --ignore-certificate-errors"
     depends_on:
       mobile:
         condition: service_healthy

--- a/e2e/mobile-webui/playwright.config.js
+++ b/e2e/mobile-webui/playwright.config.js
@@ -68,7 +68,7 @@ export default defineConfig({
                 launchOptions: {
                     args: [
                         '--no-sandbox', // Avoids sandboxing issues inside Docker
-                        '--unsafely-treat-insecure-origin-as-secure=http://app-test:8282', // Treats it as a secure origin
+                        '--unsafely-treat-insecure-origin-as-secure=http://app-test:8282,http://mobile:80,http://mobile', // Treats these as secure origins so navigator.mediaDevices (secure-context-only) is defined at http://mobile — mirrors production HTTPS
                         '--disable-features=StrictOriginPolicy,HttpsOnlyMode,BlockInsecurePrivateNetworkRequests', // Disables HSTS enforcement
                         '--disable-site-isolation-trials', // Helps disable security sandboxing
                         '--disable-web-security', // Disables web security (CORS, mixed content, etc.)

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -299,6 +299,23 @@ export const BarcodeScannerComponent = {
     // document creation, so it is in place when the frontend first requests the camera.
     // Keeps BOTH hardware and camera modes enabled — it makes the real camera path deterministic
     // rather than disabling it, so the hw↔camera toggle under test is still exercised end to end.
+    //
+    // RESIDUAL FLAKE the getUserMedia stub alone does NOT close (case 3, re-flaked on new_dawn_uat
+    // 2026-07-23 WITH this stub present). The only path that unmounts the `.camera-mode-panel`
+    // wrapper after the operator taps the toggle is CameraModePanel.onCancel, which fires only when
+    // ZXing's codeReader.decodeFromVideoDevice() REJECTS. That call awaits playVideoOnLoadAsync() →
+    // video.play() on the synthetic canvas captureStream: under CI-executor load the <video> can be
+    // readyState=HAVE_NOTHING at play() time (the 10fps repaint hasn't delivered a frame yet), so
+    // play() can reject — or stall past ZXing's 5s canplay deadline (which then rejects). Either
+    // rejection → decodeFromVideoDevice throws → startCamera's catch → onCancel → setActiveMode(
+    // hardware) → wrapper unmounts before the first poll → expectCameraModeActive() sees count 0 for
+    // the full 20s. (Local repro caveat: a fully frame-starved stream makes play() HANG rather than
+    // reject — the intermittent CI-load reject was reasoned from the ZXing source, not reproduced
+    // locally; validated instead by mobile-job green-stability across repeated CI runs.)
+    // Fix (below): force HTMLMediaElement.play() to a resolved no-op so ZXing's tryPlayVideo()
+    // returns true immediately — closing BOTH the reject and the stall/hang paths deterministically.
+    // Product code is untouched, the toggle→camera-mode transition is still exercised end-to-end,
+    // and the flat-grey stream still decodes to nothing (no false-positive teardown).
     stubCameraStream: async () => await test.step(`${NAME} - Stub getUserMedia (blank deterministic stream)`, async () => {
         await page.addInitScript(() => {
             const makeBlankStream = () => {
@@ -330,6 +347,19 @@ export const BarcodeScannerComponent = {
                 navigator.mediaDevices.enumerateDevices = () => Promise.resolve(
                     [{ kind: 'videoinput', deviceId: 'fake-cam', label: 'Fake Camera', groupId: 'g', toJSON() { return this; } }]);
             }
+            // Make video.play() a resolved no-op so ZXing's tryPlayVideo() returns true immediately
+            // and never hits the 5s `canplay`-wait reject that tears the camera panel down (see the
+            // RESIDUAL FLAKE note above). Still fire the real play() (fire-and-forget, rejection
+            // swallowed) so the feed renders when the environment allows — we only guarantee the
+            // promise ZXing awaits resolves.
+            const origPlay = window.HTMLMediaElement.prototype.play;
+            window.HTMLMediaElement.prototype.play = function () {
+                try {
+                    const p = origPlay.call(this);
+                    if (p && typeof p.catch === 'function') p.catch(() => {});
+                } catch (e) { /* ignore — deterministic-resolve is the point */ }
+                return Promise.resolve();
+            };
         });
     }),
 

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -325,11 +325,18 @@ export const BarcodeScannerComponent = {
                 });
                 return stream;
             };
-            if (navigator.mediaDevices) {
-                navigator.mediaDevices.getUserMedia = () => Promise.resolve(makeBlankStream());
-                navigator.mediaDevices.enumerateDevices = () => Promise.resolve(
-                    [{ kind: 'videoinput', deviceId: 'fake-cam', label: 'Fake Camera', groupId: 'g', toJSON() { return this; } }]);
+            // navigator.mediaDevices is a secure-context-only API: it is undefined when the page is
+            // served over an insecure origin (e.g. http://mobile in the E2E stack, unless the origin
+            // is whitelisted as secure). Production is always HTTPS, so it is always present there.
+            // Belt-and-suspenders: if it is absent, create it first (it is a read-only accessor on
+            // Navigator, so plain assignment is ignored — use Object.defineProperty), then attach the
+            // stubs unconditionally so the fake camera works even without the secure-context whitelist.
+            if (!navigator.mediaDevices) {
+                Object.defineProperty(navigator, 'mediaDevices', { value: {}, configurable: true, writable: true });
             }
+            navigator.mediaDevices.getUserMedia = () => Promise.resolve(makeBlankStream());
+            navigator.mediaDevices.enumerateDevices = () => Promise.resolve(
+                [{ kind: 'videoinput', deviceId: 'fake-cam', label: 'Fake Camera', groupId: 'g', toJSON() { return this; } }]);
         });
     }),
 

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -299,23 +299,6 @@ export const BarcodeScannerComponent = {
     // document creation, so it is in place when the frontend first requests the camera.
     // Keeps BOTH hardware and camera modes enabled — it makes the real camera path deterministic
     // rather than disabling it, so the hw↔camera toggle under test is still exercised end to end.
-    //
-    // RESIDUAL FLAKE the getUserMedia stub alone does NOT close (case 3, re-flaked on new_dawn_uat
-    // 2026-07-23 WITH this stub present). The only path that unmounts the `.camera-mode-panel`
-    // wrapper after the operator taps the toggle is CameraModePanel.onCancel, which fires only when
-    // ZXing's codeReader.decodeFromVideoDevice() REJECTS. That call awaits playVideoOnLoadAsync() →
-    // video.play() on the synthetic canvas captureStream: under CI-executor load the <video> can be
-    // readyState=HAVE_NOTHING at play() time (the 10fps repaint hasn't delivered a frame yet), so
-    // play() can reject — or stall past ZXing's 5s canplay deadline (which then rejects). Either
-    // rejection → decodeFromVideoDevice throws → startCamera's catch → onCancel → setActiveMode(
-    // hardware) → wrapper unmounts before the first poll → expectCameraModeActive() sees count 0 for
-    // the full 20s. (Local repro caveat: a fully frame-starved stream makes play() HANG rather than
-    // reject — the intermittent CI-load reject was reasoned from the ZXing source, not reproduced
-    // locally; validated instead by mobile-job green-stability across repeated CI runs.)
-    // Fix (below): force HTMLMediaElement.play() to a resolved no-op so ZXing's tryPlayVideo()
-    // returns true immediately — closing BOTH the reject and the stall/hang paths deterministically.
-    // Product code is untouched, the toggle→camera-mode transition is still exercised end-to-end,
-    // and the flat-grey stream still decodes to nothing (no false-positive teardown).
     stubCameraStream: async () => await test.step(`${NAME} - Stub getUserMedia (blank deterministic stream)`, async () => {
         await page.addInitScript(() => {
             const makeBlankStream = () => {
@@ -347,19 +330,6 @@ export const BarcodeScannerComponent = {
                 navigator.mediaDevices.enumerateDevices = () => Promise.resolve(
                     [{ kind: 'videoinput', deviceId: 'fake-cam', label: 'Fake Camera', groupId: 'g', toJSON() { return this; } }]);
             }
-            // Make video.play() a resolved no-op so ZXing's tryPlayVideo() returns true immediately
-            // and never hits the 5s `canplay`-wait reject that tears the camera panel down (see the
-            // RESIDUAL FLAKE note above). Still fire the real play() (fire-and-forget, rejection
-            // swallowed) so the feed renders when the environment allows — we only guarantee the
-            // promise ZXing awaits resolves.
-            const origPlay = window.HTMLMediaElement.prototype.play;
-            window.HTMLMediaElement.prototype.play = function () {
-                try {
-                    const p = origPlay.call(this);
-                    if (p && typeof p.catch === 'function') p.catch(() => {});
-                } catch (e) { /* ignore — deterministic-resolve is the point */ }
-                return Promise.resolve();
-            };
         });
     }),
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/CameraModePanel.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/CameraModePanel.jsx
@@ -26,6 +26,10 @@ const CameraModePanel = ({ isProcessing, onBarcodeScanned, onCancel }) => {
     const startCamera = async () => {
       const codeReader = new BrowserMultiFormatReader(READER_HINTS, READER_OPTIONS);
       try {
+        // TEMP DIAGNOSTIC (flaky case 3 — DO NOT MERGE): the catch below swallows the real
+        // camera-start exception into a generic toast, hiding why the panel unmounts in CI.
+        // eslint-disable-next-line no-console
+        console.log('[case3-diag] startCamera begin; videoRef present =', !!videoRef.current);
         const controls = await codeReader.decodeFromVideoDevice(undefined, videoRef.current, (result, error, ctrl) => {
           if (cancelled) {
             ctrl.stop();
@@ -35,12 +39,18 @@ const CameraModePanel = ({ isProcessing, onBarcodeScanned, onCancel }) => {
             onBarcodeScanned({ scannedBarcode: result.text });
           }
         });
+        // eslint-disable-next-line no-console
+        console.log('[case3-diag] decodeFromVideoDevice RESOLVED; cancelled =', cancelled);
         if (cancelled) {
           controls.stop();
           return;
         }
         cameraControlsRef.current = controls;
       } catch (err) {
+        // TEMP DIAGNOSTIC (flaky case 3 — DO NOT MERGE): surface the real throw before it is swallowed.
+        // eslint-disable-next-line no-console
+        console.error('[case3-diag] decodeFromVideoDevice THREW name=', err && err.name,
+          '| message=', err && err.message, '| stack=', err && err.stack);
         if (cancelled) return;
         toastError({
           plainMessage: trl('components.BarcodeScannerComponent.cameraError'),

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/CameraModePanel.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/CameraModePanel.jsx
@@ -26,10 +26,6 @@ const CameraModePanel = ({ isProcessing, onBarcodeScanned, onCancel }) => {
     const startCamera = async () => {
       const codeReader = new BrowserMultiFormatReader(READER_HINTS, READER_OPTIONS);
       try {
-        // TEMP DIAGNOSTIC (flaky case 3 — DO NOT MERGE): the catch below swallows the real
-        // camera-start exception into a generic toast, hiding why the panel unmounts in CI.
-        // eslint-disable-next-line no-console
-        console.log('[case3-diag] startCamera begin; videoRef present =', !!videoRef.current);
         const controls = await codeReader.decodeFromVideoDevice(undefined, videoRef.current, (result, error, ctrl) => {
           if (cancelled) {
             ctrl.stop();
@@ -39,18 +35,12 @@ const CameraModePanel = ({ isProcessing, onBarcodeScanned, onCancel }) => {
             onBarcodeScanned({ scannedBarcode: result.text });
           }
         });
-        // eslint-disable-next-line no-console
-        console.log('[case3-diag] decodeFromVideoDevice RESOLVED; cancelled =', cancelled);
         if (cancelled) {
           controls.stop();
           return;
         }
         cameraControlsRef.current = controls;
       } catch (err) {
-        // TEMP DIAGNOSTIC (flaky case 3 — DO NOT MERGE): surface the real throw before it is swallowed.
-        // eslint-disable-next-line no-console
-        console.error('[case3-diag] decodeFromVideoDevice THREW name=', err && err.name,
-          '| message=', err && err.message, '| stack=', err && err.stack);
         if (cancelled) return;
         toastError({
           plainMessage: trl('components.BarcodeScannerComponent.cameraError'),

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/CameraModePanel.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/CameraModePanel.jsx
@@ -49,11 +49,8 @@ const CameraModePanel = ({ isProcessing, onBarcodeScanned, onCancel }) => {
       } catch (err) {
         // TEMP DIAGNOSTIC (flaky case 3 — DO NOT MERGE): surface the real throw before it is swallowed.
         // eslint-disable-next-line no-console
-        console.error(
-          `[case3-diag] decodeFromVideoDevice THREW name=${err && err.name} | message=${err && err.message} | stack=${
-            err && err.stack
-          }`
-        );
+        console.error('[case3-diag] decodeFromVideoDevice THREW name=', err && err.name,
+          '| message=', err && err.message, '| stack=', err && err.stack);
         if (cancelled) return;
         toastError({
           plainMessage: trl('components.BarcodeScannerComponent.cameraError'),

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/CameraModePanel.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/BarcodeScanner/CameraModePanel.jsx
@@ -49,8 +49,11 @@ const CameraModePanel = ({ isProcessing, onBarcodeScanned, onCancel }) => {
       } catch (err) {
         // TEMP DIAGNOSTIC (flaky case 3 — DO NOT MERGE): surface the real throw before it is swallowed.
         // eslint-disable-next-line no-console
-        console.error('[case3-diag] decodeFromVideoDevice THREW name=', err && err.name,
-          '| message=', err && err.message, '| stack=', err && err.stack);
+        console.error(
+          `[case3-diag] decodeFromVideoDevice THREW name=${err && err.name} | message=${err && err.message} | stack=${
+            err && err.stack
+          }`
+        );
         if (cancelled) return;
         toastError({
           plainMessage: trl('components.BarcodeScannerComponent.cameraError'),


### PR DESCRIPTION
## What

De-flake the `barcode_scanner_modes.spec.js` "camera toggle — clicking hw/camera toggle activates camera mode" mobile-webui E2E test.

## Root cause (captured in CI, not theorised)

A temporary CI diagnostic captured the real swallowed exception:

```
decodeFromVideoDevice THREW TypeError: Cannot read properties of undefined (reading 'getUserMedia')
```

- CI serves the mobile frontend at the **insecure** origin `http://mobile` (only `http://app-test:8282` is whitelisted as a secure context, in `docker-builds/e2e-tests/compose.yml` + `e2e/mobile-webui/playwright.config.js`).
- `navigator.mediaDevices` is a **secure-context-only** web API, so on `http://mobile` it is **undefined**. ZXing's `decodeFromVideoDevice()` → `navigator.mediaDevices.getUserMedia(...)` therefore throws a `TypeError`.
- The existing `stubCameraStream()` helper patched `getUserMedia` only inside `if (navigator.mediaDevices) { … }` — a no-op on the insecure origin, so nothing actually stubbed the call.
- `CameraModePanel.startCamera()`'s catch then fires `onCancel()` → `setActiveMode(hardware)` → the `.camera-mode-panel` wrapper unmounts. The failure is deterministic; the **flake** is only the race between the brief mount window and `expectCameraModeActive()`'s first `toHaveCount(1)` poll (pass = sampled while mounted, fail = sampled after teardown).

This is a pure **test-harness** artifact: production serves the mobile UI over HTTPS (a secure context), so `navigator.mediaDevices` is always present and this failure cannot reach a deployed operator. No product code is involved (the access lives entirely inside ZXing). No separate bug tracking is warranted.

## Fix (test-harness only)

1. Harden `stubCameraStream()` (`e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js`): when `navigator.mediaDevices` is absent, create it via `Object.defineProperty` (it is a read-only accessor, so plain assignment is ignored), then attach the fake `getUserMedia`/`enumerateDevices` unconditionally. **This is the operative fix** — CI's `chrome-headless-shell` ignores the secure-context flag, so the stub must supply `mediaDevices` itself.
2. Whitelist `http://mobile` as a secure context in `playwright.config.js` + `compose.yml` (defense-in-depth / production-mirror; active only under full-Chrome new-headless).

The assertion `expectCameraModeActive` and the spec are **untouched** — not weakened. The earlier `video.play()`-override commit was **reverted**: the captured exception proved the play/canplay reject-or-stall hypothesis wrong.

## Validation

- Deterministic mechanism proof: standalone Playwright probes (same launch flags) show `navigator.mediaDevices` goes undefined → defined and the patched `getUserMedia` is callable under `chrome-headless-shell`.
- Mobile-job green-stability across repeated CI runs on this branch.
