### PR TITLE
gh26253 seed AD_SysConfig accounting_docs_to_repost.pollIntervalInSeconds (System, 10)

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5815940_sys_gh26253_accounting_docs_to_repost_pollInterval.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5815940_sys_gh26253_accounting_docs_to_repost_pollInterval.sql
@@ -1,0 +1,17 @@
+-- gh26253: Seed System-level SysConfig for the accounting-docs-to-repost poller poll interval.
+-- Sets the background reposting poller's sleep interval to 10 seconds (matches the code default
+-- Duration.ofSeconds(10)); making it an explicit AD_SysConfig row lets ops tune it without a rebuild.
+-- Creation only (INSERT guarded by NOT EXISTS) -> idempotent, safe to re-run.
+
+INSERT INTO AD_SysConfig (AD_SysConfig_ID, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive, Name, Value, Description, ConfigurationLevel, EntityType)
+SELECT 541838 /*From ID Server*/,
+       0, 0,
+       TO_TIMESTAMP('2026-07-23 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       TO_TIMESTAMP('2026-07-23 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+       'Y',
+       'de.metas.acct.accounting_docs_to_repost.pollIntervalInSeconds',
+       '10',
+       'Poll interval (in seconds) the accounting-docs-to-repost background poller waits between scans for documents to repost. Default 10.',
+       'S',
+       'D'
+WHERE NOT EXISTS (SELECT 1 FROM AD_SysConfig WHERE Name='de.metas.acct.accounting_docs_to_repost.pollIntervalInSeconds');


### PR DESCRIPTION
Adds a migration script seeding one System-level `AD_SysConfig` row:
`de.metas.acct.accounting_docs_to_repost.pollIntervalInSeconds` = `10`.

This makes the accounting-docs-to-repost background poller's scan interval (code default 10s) tunable via config without a rebuild. INSERT is `NOT EXISTS`-guarded (idempotent); `AD_SysConfig_ID=541838` comes from the central ID server.

Targets the `intensive_care_hotfix` base branch.