### PR TITLE
HttpCallSchedulerTest: de-flake exceptionInRequestDoesNotBreakScheduler

### DIFF
--- a/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
+++ b/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
@@ -7,9 +7,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class HttpCallSchedulerTest
 {
@@ -113,10 +115,18 @@ class HttpCallSchedulerTest
 			throw new RuntimeException("test error");
 		}));
 
-		// Should complete exceptionally
-		assertThat(failingFuture).isCompletedExceptionally();
+		// Should complete exceptionally.
+		// The supplier throws on the scheduler's pool thread, so completion happens
+		// asynchronously. Block until the future settles (up to 5s) instead of checking
+		// isCompletedExceptionally() synchronously: that check was racy and failed
+		// intermittently on CPU-contended CI runners where the pool thread had not yet
+		// run the throwing supplier at the instant the assertion was evaluated.
+		assertThatThrownBy(() -> failingFuture.get(5, TimeUnit.SECONDS))
+				.isInstanceOf(ExecutionException.class)
+				.hasCauseInstanceOf(RuntimeException.class);
 
-		// Wait a bit for scheduler to settle
+		// Wait a bit for scheduler to settle (let the pool thread finish run() and
+		// complete executorFuture, so the next schedule() re-submits run() for the queue)
 		Thread.sleep(500);
 
 		// Second request should still succeed


### PR DESCRIPTION
## What

De-flake `HttpCallSchedulerTest.exceptionInRequestDoesNotBreakScheduler`.

The test scheduled a throwing request and then checked
`assertThat(failingFuture).isCompletedExceptionally()` **synchronously**. `schedule()` runs the
supplier asynchronously on the scheduler's pool thread, so on CPU-contended CI runners the pool
thread had not yet run the throwing supplier when the assertion was evaluated → intermittent RED on
the `test (java)` job.

## Fix

Block until the future settles (up to 5s) and assert it completes exceptionally with a
`RuntimeException` cause, instead of the racy synchronous check:

```java
assertThatThrownBy(() -> failingFuture.get(5, TimeUnit.SECONDS))
        .isInstanceOf(ExecutionException.class)
        .hasCauseInstanceOf(RuntimeException.class);
```

The load-bearing `Thread.sleep(500)` after it is kept — it guards a distinct second-half race (the
pool thread must reach `executorFuture.complete(null)` before the next `schedule()` re-submits
`run()`).

Test-only change; no production code touched. Same fix already landed on `deep_tundra_release`
(https://github.com/metasfresh/metasfresh/pull/25299) and `soft_panda_hotfix`
(https://github.com/metasfresh/metasfresh/pull/25306); this ports it to `intensive_care_hotfix`.
Local repro of the racy pattern: 4989/5000 iterations failed before, 0/10000 after.
