### PR TITLE
Costing — back-dated MovingAverageInvoice switch: as-of-cut-off opening, opening-anchor guard, batched recompute driver

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/m_costdetail_delete_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/m_costdetail_delete_from_date.sql
@@ -159,14 +159,22 @@ BEGIN
                 --        LastInvoiceCostingMethodHandler.createCostForMatchInvoice_MaterialCosts), so averaging
                 --        would silently write a WRONG CurrentCostPrice. Example: prevPrice=20, prevQty=10,
                 --        inbound qty=10 amt=400 -> replace gives 40, averaging gives 600/20 = 30.
-                --        CAVEAT for 'p': ManufacturingLastPOCostingMethodHandler.createMainProductOrCoProductReceipt
-                --        DOES call addWeightedAverage for a PP_Cost_Collector main/co-product receipt - but there
-                --        amt = currentCostPrice*qty, so that average is a no-op (same shape as 'S'). So 'p' behaves
-                --        two ways depending on the DOCUMENT, and a costingmethod-only gate cannot separate them;
-                --        'p' is therefore excluded wholesale, which is safe for BOTH sub-cases. Known residual
-                --        gap: a 'p' element whose last pre-range detail is a PP_Cost_Collector receipt still
-                --        RAISEs instead of being reconstructed. Widening the gate to a (method, document) key
-                --        would close it - deliberately out of scope here.
+                --        CAVEAT - 'p' is NOT uniform: it has at least three reachable shapes, because the
+                --        manufacturing handler (ManufacturingLastPOCostingMethodHandler) overrides the base one.
+                --          (1) M_MatchPO                       -> REPLACE with amt/qty (base handler, above).
+                --          (2) PP_Cost_Collector main/co-product receipt (createMainProductOrCoProductReceipt)
+                --              -> addWeightedAverage, but with amt = currentCostPrice*qty, so a no-op.
+                --          (3) PP_Cost_Collector component-issue REVERSAL (createComponentIssue, isReversal)
+                --              -> addWeightedAverage on the reversal's own amt/qty. An issue is outbound, so its
+                --                 reversal is qty>0 with ischangingcosts='Y' and no inventory line - it reaches
+                --                 this branch shape - and amt/qty is the price at the ORIGINAL issue, which need
+                --                 NOT equal the current price. That one is a GENUINE average, not a no-op.
+                --        So do NOT read the (2) no-op as licence to add 'p' to the gate. Excluding 'p' wholesale
+                --        is safe for a different and stronger reason: the ONLY fallback is the loud RAISE below,
+                --        never a silently wrong CurrentCostPrice - which holds for every shape, including (3).
+                --        Known residual gap: a 'p' element whose last pre-range detail is any PP_Cost_Collector
+                --        row therefore still RAISEs instead of being reconstructed. Closing it needs a
+                --        (method, document) key, not a method-only one - deliberately out of scope here.
                 --   'L' Lifo / 'F' Fifo / 'U' UserDefined / 'x' ExternalProcessing are likewise excluded.
                 -- Everything excluded falls through to the RAISE below - i.e. exactly the behaviour those
                 -- methods already have today - so this change can never turn a loud abort into a silent

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/m_costdetail_delete_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/m_costdetail_delete_from_date.sql
@@ -153,15 +153,26 @@ BEGIN
                 --        -> a changing-costs inbound records amt = prevPrice*qty
                 --           (StandardCostingMethodHandler.createCostForMaterialReceipt), so the weighted
                 --           average provably reproduces prevPrice: it is a no-op, not an approximation.
-                --   'p' LastPOPrice / 'i' LastInvoice are DELIBERATELY EXCLUDED: their handlers REPLACE the
-                --        price with amt/qty (LastPOCostingMethodHandler.createCostForMatchPO,
+                --   'p' LastPOPrice / 'i' LastInvoice are DELIBERATELY EXCLUDED: on the M_MatchPO /
+                --        M_MatchInv path their handlers REPLACE the price with amt/qty
+                --        (LastPOCostingMethodHandler.createCostForMatchPO,
                 --        LastInvoiceCostingMethodHandler.createCostForMatchInvoice_MaterialCosts), so averaging
                 --        would silently write a WRONG CurrentCostPrice. Example: prevPrice=20, prevQty=10,
                 --        inbound qty=10 amt=400 -> replace gives 40, averaging gives 600/20 = 30.
+                --        CAVEAT for 'p': ManufacturingLastPOCostingMethodHandler.createMainProductOrCoProductReceipt
+                --        DOES call addWeightedAverage for a PP_Cost_Collector main/co-product receipt - but there
+                --        amt = currentCostPrice*qty, so that average is a no-op (same shape as 'S'). So 'p' behaves
+                --        two ways depending on the DOCUMENT, and a costingmethod-only gate cannot separate them;
+                --        'p' is therefore excluded wholesale, which is safe for BOTH sub-cases. Known residual
+                --        gap: a 'p' element whose last pre-range detail is a PP_Cost_Collector receipt still
+                --        RAISEs instead of being reconstructed. Widening the gate to a (method, document) key
+                --        would close it - deliberately out of scope here.
                 --   'L' Lifo / 'F' Fifo / 'U' UserDefined / 'x' ExternalProcessing are likewise excluded.
                 -- Everything excluded falls through to the RAISE below - i.e. exactly the behaviour those
                 -- methods already have today - so this change can never turn a loud abort into a silent
                 -- mis-valuation.
+                -- A NULL costingmethod (unresolvable cost element) makes the IN test NULL, not TRUE, so it
+                -- also falls through to the RAISE rather than averaging blindly.
                 v_next_costs_found := TRUE;
                 v_next_costs_debugInfo := 'case 2.5: based on prev costs of last cost details (inbound trx, weighted average), with changing costs';
                 v_next_currentqty   := v_firstCostDetail.prev_currentqty   + v_firstCostDetail.qty;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/m_costdetail_delete_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/m_costdetail_delete_from_date.sql
@@ -150,9 +150,17 @@ BEGIN
                 --   'A' AveragePO / 'I' AverageInvoice / 'M' MovingAverageInvoice
                 --        -> their handlers call CurrentCost.addWeightedAverage, so the formula matches.
                 --   'S' StandardCosting
-                --        -> a changing-costs inbound records amt = prevPrice*qty
-                --           (StandardCostingMethodHandler.createCostForMaterialReceipt), so the weighted
-                --           average provably reproduces prevPrice: it is a no-op, not an approximation.
+                --        -> INVARIANT: every Standard-costing handler posts amt = currentCostPrice*qty by
+                --           construction - it multiplies the CURRENT cost price of the very same cost
+                --           segment+element by the quantity and never derives a price from the document:
+                --             StandardCostingMethodHandler.createCostForMaterialReceipt /
+                --                 .createOutboundCostDefaultImpl / .createCostForMatchInvoice_MaterialCosts
+                --             ManufacturingStandardCostingMethodHandler.createIssueOrReceipt /
+                --                 .createActivityControl / .createUsageVariance
+                --           Substituting amt = prevPrice*qty into the weighted average gives
+                --           (prevPrice*prevQty + prevPrice*qty) / (prevQty + qty) = prevPrice, so the
+                --           reconstruction provably reproduces prevPrice for EVERY such inbound: it is a
+                --           no-op, not an approximation.
                 --   'p' LastPOPrice / 'i' LastInvoice are DELIBERATELY EXCLUDED: on the M_MatchPO /
                 --        M_MatchInv path their handlers REPLACE the price with amt/qty
                 --        (LastPOCostingMethodHandler.createCostForMatchPO,

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/m_costdetail_delete_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/m_costdetail_delete_from_date.sql
@@ -159,21 +159,23 @@ BEGIN
                 --        LastInvoiceCostingMethodHandler.createCostForMatchInvoice_MaterialCosts), so averaging
                 --        would silently write a WRONG CurrentCostPrice. Example: prevPrice=20, prevQty=10,
                 --        inbound qty=10 amt=400 -> replace gives 40, averaging gives 600/20 = 30.
-                --        CAVEAT - 'p' is NOT uniform: it has at least three reachable shapes, because the
-                --        manufacturing handler (ManufacturingLastPOCostingMethodHandler) overrides the base one.
-                --          (1) M_MatchPO                       -> REPLACE with amt/qty (base handler, above).
-                --          (2) PP_Cost_Collector main/co-product receipt (createMainProductOrCoProductReceipt)
-                --              -> addWeightedAverage, but with amt = currentCostPrice*qty, so a no-op.
-                --          (3) PP_Cost_Collector component-issue REVERSAL (createComponentIssue, isReversal)
-                --              -> addWeightedAverage on the reversal's own amt/qty. An issue is outbound, so its
-                --                 reversal is qty>0 with ischangingcosts='Y' and no inventory line - it reaches
-                --                 this branch shape - and amt/qty is the price at the ORIGINAL issue, which need
-                --                 NOT equal the current price. That one is a GENUINE average, not a no-op.
-                --        So do NOT read the (2) no-op as licence to add 'p' to the gate. Excluding 'p' wholesale
-                --        is safe for a different and stronger reason: the ONLY fallback is the loud RAISE below,
-                --        never a silently wrong CurrentCostPrice - which holds for every shape, including (3).
-                --        Known residual gap: a 'p' element whose last pre-range detail is any PP_Cost_Collector
-                --        row therefore still RAISEs instead of being reconstructed. Closing it needs a
+                --        CAVEAT - for 'p' and 'i' the price movement depends on the DOCUMENT, not on the method
+                --        alone, so a method-only rule cannot model them. Observed variants, all reachable with
+                --        qty>0 + ischangingcosts='Y' + no inventory line (i.e. all matching this branch's shape):
+                --          - REPLACE with amt/qty                     (base handler, M_MatchPO / M_MatchInv)
+                --          - weighted average that IS a no-op         (ManufacturingLastPOCostingMethodHandler
+                --                                                      .createMainProductOrCoProductReceipt:
+                --                                                      amt = currentCostPrice*qty)
+                --          - weighted average that is NOT a no-op     (same class, .createComponentIssue reversal:
+                --                                                      amt/qty is the price at the ORIGINAL issue)
+                --          - price left UNTOUCHED, qty only           (createOutboundCostDefaultImpl reversal ->
+                --                                                      CurrentCost.addToCurrentQtyAndCumulate)
+                --        Treat that list as EXAMPLES, never as exhaustive - it has already been wrong twice.
+                --        So do NOT read any single no-op variant as licence to add 'p' or 'i' to the gate.
+                --        Excluding them is safe for a reason that does NOT depend on enumerating the variants:
+                --        the ONLY fallback is the loud RAISE below, never a silently wrong CurrentCostPrice.
+                --        Known residual gap: a 'p' / 'i' element whose last pre-range detail has this shape
+                --        therefore still RAISEs instead of being reconstructed. Closing it needs a
                 --        (method, document) key, not a method-only one - deliberately out of scope here.
                 --   'L' Lifo / 'F' Fifo / 'U' UserDefined / 'x' ExternalProcessing are likewise excluded.
                 -- Everything excluded falls through to the RAISE below - i.e. exactly the behaviour those

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/m_costdetail_delete_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/m_costdetail_delete_from_date.sql
@@ -34,9 +34,17 @@ DECLARE
     v_next_cumulatedamt       numeric;
     v_next_cumulatedqty       numeric;
     v_m_cost_id               numeric;
+    v_costingmethod           char(1);
 BEGIN
     RAISE DEBUG 'm_costdetail_delete_from_date: p_C_AcctSchema_ID=%, p_M_CostElement_ID=%, p_M_Product_ID=%, p_AD_Org_ID=%, p_StartDateAcct=%, p_DryRun=%',
         p_C_AcctSchema_ID, p_M_CostElement_ID, p_M_Product_ID, p_AD_Org_ID, p_StartDateAcct, p_DryRun;
+
+    -- The cost element's costing method decides HOW a changing-costs inbound moves the current cost
+    -- price, so case 2.5 below can only reconstruct that price for the methods that average (see there).
+    SELECT ce.costingmethod
+    INTO v_costingmethod
+    FROM m_costelement ce
+    WHERE ce.m_costelement_id = p_M_CostElement_ID;
 
     --
     -- Compute current cost prices at target date
@@ -125,7 +133,8 @@ BEGIN
                 v_next_currentqty := v_firstCostDetail.prev_currentqty + v_firstCostDetail.qty;
                 v_next_cumulatedamt := v_firstCostDetail.prev_cumulatedamt + v_firstCostDetail.amt;
                 v_next_cumulatedqty := v_firstCostDetail.prev_cumulatedqty + v_firstCostDetail.qty;
-            ELSIF (v_firstCostDetail.qty > 0 AND v_firstCostDetail.ischangingcosts = 'Y') THEN
+            ELSIF (v_firstCostDetail.qty > 0 AND v_firstCostDetail.ischangingcosts = 'Y'
+                AND v_costingmethod IN ('A', 'I', 'M', 'S')) THEN
                 -- case 2.5: inbound trx (qty > 0) that changed the cost price but is NOT an inventory line
                 -- (M_MatchPO, M_InOutLine non-material costs, PP_Cost_Collector receipts, ...).
                 -- Unlike case 2.4 (inventory lines post at the unchanged current price), these inbounds
@@ -135,8 +144,24 @@ BEGIN
                 -- M_CostDetail stores no resulting price, so it must be recomputed here; copying case 2.4
                 -- verbatim would leave M_Cost.CurrentCostPrice stale and mis-value the repost.
                 -- NOTE: this reconstructs the price from the stored prev_* / amt / qty of the cost detail, exactly
-                -- like the surrounding cases; it stays correct for Standard costing too, because a Standard-cost
-                -- changing-costs inbound records amt = prevPrice*qty, so the weighted average reproduces prevPrice.
+                -- like the surrounding cases.
+                --
+                -- The costing-method gate is REQUIRED: only the averaging methods move the price this way.
+                --   'A' AveragePO / 'I' AverageInvoice / 'M' MovingAverageInvoice
+                --        -> their handlers call CurrentCost.addWeightedAverage, so the formula matches.
+                --   'S' StandardCosting
+                --        -> a changing-costs inbound records amt = prevPrice*qty
+                --           (StandardCostingMethodHandler.createCostForMaterialReceipt), so the weighted
+                --           average provably reproduces prevPrice: it is a no-op, not an approximation.
+                --   'p' LastPOPrice / 'i' LastInvoice are DELIBERATELY EXCLUDED: their handlers REPLACE the
+                --        price with amt/qty (LastPOCostingMethodHandler.createCostForMatchPO,
+                --        LastInvoiceCostingMethodHandler.createCostForMatchInvoice_MaterialCosts), so averaging
+                --        would silently write a WRONG CurrentCostPrice. Example: prevPrice=20, prevQty=10,
+                --        inbound qty=10 amt=400 -> replace gives 40, averaging gives 600/20 = 30.
+                --   'L' Lifo / 'F' Fifo / 'U' UserDefined / 'x' ExternalProcessing are likewise excluded.
+                -- Everything excluded falls through to the RAISE below - i.e. exactly the behaviour those
+                -- methods already have today - so this change can never turn a loud abort into a silent
+                -- mis-valuation.
                 v_next_costs_found := TRUE;
                 v_next_costs_debugInfo := 'case 2.5: based on prev costs of last cost details (inbound trx, weighted average), with changing costs';
                 v_next_currentqty   := v_firstCostDetail.prev_currentqty   + v_firstCostDetail.qty;
@@ -153,8 +178,8 @@ BEGIN
                     v_next_currentcostprice := v_firstCostDetail.prev_currentcostprice;
                 END IF;
                 v_next_currentcostpricell := v_firstCostDetail.prev_currentcostpricell; -- LL untouched by addWeightedAverage
-            ELSE -- (v_firstCostDetail.qty > 0) THEN
-                RAISE EXCEPTION 'Extracting current costs from an inbound transaction is not implemented (%)', v_firstCostDetail;
+            ELSE -- (v_firstCostDetail.qty > 0), or a costing method case 2.5 must not average for
+                RAISE EXCEPTION 'Extracting current costs from an inbound transaction is not implemented (costing method %) (%)', v_costingmethod, v_firstCostDetail;
             END IF;
         ELSE
             v_next_costs_found := FALSE;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/product_costs_recreate_all_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/product_costs_recreate_all_from_date.sql
@@ -1,0 +1,449 @@
+DROP PROCEDURE IF EXISTS "de_metas_acct".product_costs_recreate_all_from_date(
+    p_C_AcctSchema_ID   numeric,
+    p_M_CostElement_ID  numeric,
+    p_StartDateAcct     timestamp WITH TIME ZONE,
+    p_ProductsPerCommit numeric,
+    p_Resume            char(1)
+)
+;
+
+
+-- Recreates the costs of EVERY product of an accounting schema from a given accounting date onwards.
+--
+-- It is a PROCEDURE, not a function, because it MUST commit as it goes: a full run over a real
+-- installation is ~5 000 products / ~376 000 documents and cannot be one transaction. A single-transaction
+-- attempt ran 2h13m and then died with a backend I/O error, rolling back everything. So the work is cut
+-- into commit-batches of p_ProductsPerCommit products, each batch recorded in
+-- "de_metas_acct".product_costs_recreate_progress, and p_Resume='Y' picks up where an aborted run stopped
+-- instead of starting over.
+--
+-- The documents to repost are NOT enqueued as they are found. They are parked in
+-- "de_metas_acct".accounting_docs_to_repost_staging and released into the real queue in ONE atomic step at
+-- the very end (see "RELEASE" below). That is the whole point: costs are computed WHILE reposting, so the
+-- documents must reach the accounting server strictly in document-date order. The server's poller drains
+-- the real queue continuously, so anything inserted there early would be reposted early - out of order -
+-- and would freeze wrong costs. Holding the rows outside the queue is also what keeps this run from
+-- needing any change to the queue table, to its poller, or to fact_acct_unpost.
+CREATE OR REPLACE PROCEDURE "de_metas_acct".product_costs_recreate_all_from_date(
+    p_C_AcctSchema_ID   numeric,
+    p_M_CostElement_ID  numeric,
+    p_StartDateAcct     timestamp WITH TIME ZONE,
+    p_ProductsPerCommit numeric = 100,
+    p_Resume            char(1) = 'N'
+)
+    LANGUAGE plpgsql
+AS
+$BODY$
+DECLARE
+    -- Advisory-lock class id. Arbitrary but stable: it only has to be a value no other advisory lock in
+    -- this database uses, so that two runs of THIS procedure (and only those) collide.
+    c_AdvisoryLock_ClassId constant integer := 26253;
+    --
+    v_AD_Client_ID         numeric;
+    v_costingLevel         char(1);
+    v_orgIds               numeric[];
+    v_targetCostElementId  numeric;
+    --
+    v_doneBatchCount       integer;
+    v_productCount         integer;
+    v_documentCount        integer;
+    v_releasedCount        integer;
+    v_seqNoLast            numeric;
+    v_seqNoBase            numeric;
+    rowcount               integer;
+    --
+    v_batch                record;
+    v_period               record;
+    v_purge                record;
+    v_productId            numeric;
+    v_orgId                numeric;
+BEGIN
+    IF (p_StartDateAcct IS NULL) THEN
+        RAISE EXCEPTION 'p_StartDateAcct shall be set';
+    END IF;
+    IF (p_ProductsPerCommit IS NULL OR p_ProductsPerCommit < 1) THEN
+        RAISE EXCEPTION 'p_ProductsPerCommit shall be >= 1 but it was %', p_ProductsPerCommit;
+    END IF;
+
+    --
+    --
+    -- (a) SINGLE RUN AT A TIME
+    --
+    --
+    -- The lock is SESSION level, not transaction level: this procedure commits after every batch, and a
+    -- transaction-level lock would be released by the very first of those commits, leaving the rest of a
+    -- multi-hour run unprotected. Two overlapping runs would delete each other's cost details and stage
+    -- each other's documents, and the ordering guarantee of the release step would be lost.
+    -- A session-level lock is re-entrant within its own session, so resuming from the same session works.
+    IF NOT pg_try_advisory_lock(c_AdvisoryLock_ClassId, p_C_AcctSchema_ID::integer) THEN
+        RAISE EXCEPTION 'Another product_costs_recreate_all_from_date run is already in progress for C_AcctSchema_ID=%', p_C_AcctSchema_ID;
+    END IF;
+
+    --
+    -- Validate parameter: Accounting Schema => extract client and eligible Orgs
+    -- (same rules as "de_metas_acct".product_costs_recreate_from_date)
+    --
+    SELECT cas.ad_client_id, cas.costinglevel
+    INTO v_AD_Client_ID, v_costingLevel
+    FROM c_acctschema cas
+    WHERE cas.c_acctschema_id = p_C_AcctSchema_ID;
+    IF (v_AD_Client_ID IS NULL) THEN
+        RAISE EXCEPTION 'C_AcctSchema_ID % not found', p_C_AcctSchema_ID;
+    END IF;
+    --
+    IF (v_costingLevel = 'C') THEN
+        v_orgIds := ARRAY [ 0 ];
+    ELSIF (v_costingLevel = 'O') THEN
+        SELECT ARRAY_AGG(org.ad_org_id ORDER BY org.ad_org_id)
+        INTO v_orgIds
+        FROM ad_org org
+        WHERE org.ad_client_id = v_AD_Client_ID
+          AND org.ad_org_id != 0;
+    ELSE
+        RAISE EXCEPTION 'Costing level `%` not supported for C_AcctSchema_ID=%', v_costingLevel, p_C_AcctSchema_ID;
+    END IF;
+
+    --
+    -- Resolve the target Moving-Average-Invoice cost element.
+    -- Same lookup as public.C_AcctSchema_InitMovingAvgInvoice: the active Material cost element whose
+    -- costing method is 'M'. It is derived rather than passed in because it is not a free choice - it is
+    -- the element the switch seeds, and the purge below must cover exactly that one.
+    --
+    SELECT ce.m_costelement_id
+    INTO v_targetCostElementId
+    FROM m_costelement ce
+    WHERE ce.ad_client_id = v_AD_Client_ID
+      AND ce.costelementtype = 'M'
+      AND ce.costingmethod = 'M'
+      AND ce.isactive = 'Y'
+    ORDER BY ce.m_costelement_id
+    LIMIT 1;
+    IF (v_targetCostElementId IS NULL) THEN
+        RAISE EXCEPTION 'No active MovingAverageInvoice cost element (costingmethod=M) found for AD_Client_ID=%', v_AD_Client_ID;
+    END IF;
+
+    RAISE NOTICE 'product_costs_recreate_all_from_date: C_AcctSchema_ID=%, M_CostElement_ID=%, target(MAI) M_CostElement_ID=%, StartDateAcct=%, ProductsPerCommit=%, Resume=%',
+        p_C_AcctSchema_ID, p_M_CostElement_ID, v_targetCostElementId, p_StartDateAcct, p_ProductsPerCommit, p_Resume;
+
+    --
+    -- Fresh start vs. resume.
+    -- A fresh run must not inherit anything: leftover staged documents would be released together with
+    -- this run's, and leftover DONE markers would make it skip batches it never did.
+    --
+    IF (p_Resume = 'Y') THEN
+        SELECT COUNT(1) INTO v_doneBatchCount FROM "de_metas_acct".product_costs_recreate_progress WHERE status = 'DONE';
+        RAISE NOTICE 'Resuming: % batch(es) already DONE will be skipped', v_doneBatchCount;
+    ELSE
+        DELETE FROM "de_metas_acct".accounting_docs_to_repost_staging;
+        DELETE FROM "de_metas_acct".product_costs_recreate_progress;
+    END IF;
+
+    --
+    -- The (product, document) pairs this run covers.
+    -- Same predicate as "de_metas_acct".product_costs_recreate_from_date, minus the product restriction:
+    -- invoices are excluded, so reposting never touches VAT.
+    --
+    DROP TABLE IF EXISTS tmp_pcra_docs;
+    CREATE TEMPORARY TABLE tmp_pcra_docs AS
+    SELECT DISTINCT doc.m_product_id,
+                    doc.tablename,
+                    doc.record_id,
+                    doc.tablename_prio,
+                    doc.dateacct,
+                    doc.docbasetype,
+                    doc.ad_client_id,
+                    doc.ad_org_id
+    FROM "de_metas_acct".accountable_docs_and_lines_v doc
+    WHERE doc.m_product_id IS NOT NULL
+      AND doc.tablename <> 'C_Invoice'
+      AND doc.dateacct >= p_StartDateAcct
+      AND doc.ad_client_id = v_AD_Client_ID;
+
+    --
+    -- Cut the products into commit-batches, ordered by M_Product_ID so a resume reproduces exactly the
+    -- same batch numbers as the run it continues.
+    --
+    DROP TABLE IF EXISTS tmp_pcra_products;
+    CREATE TEMPORARY TABLE tmp_pcra_products AS
+    SELECT p.m_product_id,
+           (((ROW_NUMBER() OVER (ORDER BY p.m_product_id)) - 1) / p_ProductsPerCommit::bigint)::integer + 1 AS batch_no
+    FROM (SELECT DISTINCT d.m_product_id FROM tmp_pcra_docs d) p;
+
+    --
+    -- One row per DOCUMENT, assigned to the batch of its lowest-numbered product.
+    -- A document with lines for products in several batches must be staged exactly ONCE, otherwise it
+    -- would be reposted several times. Which of its batches stages it does not matter: nothing is
+    -- released until every batch is done, so by release time all of its products have been rewound.
+    --
+    DROP TABLE IF EXISTS tmp_pcra_staged_docs;
+    CREATE TEMPORARY TABLE tmp_pcra_staged_docs AS
+    SELECT d.tablename,
+           d.record_id,
+           MIN(p.batch_no)        AS batch_no,
+           MIN(d.tablename_prio)  AS tablename_prio,
+           MIN(d.dateacct)        AS dateacct,
+           MIN(d.ad_client_id)    AS ad_client_id
+    FROM tmp_pcra_docs d
+             INNER JOIN tmp_pcra_products p ON p.m_product_id = d.m_product_id
+    GROUP BY d.tablename, d.record_id;
+
+    SELECT COUNT(1) INTO v_productCount FROM tmp_pcra_products;
+    SELECT COUNT(1) INTO v_documentCount FROM tmp_pcra_staged_docs;
+    RAISE NOTICE 'Selected % product(s) and % document(s) to be reposted', v_productCount, v_documentCount;
+
+    --
+    --
+    -- (b) ALL PERIODS IN RANGE MUST BE OPEN - CHECKED BEFORE THE FIRST MUTATION
+    --
+    --
+    -- Not merely a courtesy: the reposting that follows throws @PeriodClosed@ for an already-posted
+    -- document whose period is closed (org.compiere.acct.Doc#post rejects that combination even when
+    -- reposting). Finding that out batch 40 into a multi-hour run, with the cost details of batches 1..39
+    -- already deleted and committed, would leave the installation mid-rewind. So the whole range is
+    -- checked up front, while nothing has been changed yet and aborting costs nothing.
+    --
+    FOR v_period IN (SELECT DISTINCT t.dateacct, t.docbasetype, t.ad_client_id, t.ad_org_id
+                     FROM tmp_pcra_docs t
+                     ORDER BY t.dateacct, t.docbasetype, t.ad_client_id, t.ad_org_id)
+        LOOP
+            PERFORM "de_metas_acct".assert_period_open(
+                    p_DateAcct := v_period.dateacct,
+                    p_DocBaseType := v_period.docbasetype,
+                    p_AD_Client_ID := v_period.ad_client_id,
+                    p_AD_Org_ID := v_period.ad_org_id);
+        END LOOP;
+
+    --
+    --
+    -- (c) PURGE THE TARGET (MAI) ELEMENT'S IN-RANGE COST DETAILS FIRST
+    --
+    --
+    -- Posting explodes a document into EVERY active Material cost element, not just the one the
+    -- accounting schema currently values with. So the MAI element may already carry cost details in this
+    -- range, built before it had an opening balance - i.e. based on zero. Two ways those wreck the run,
+    -- both silent:
+    --   1. cost details are REUSED as-is when they already exist (de.metas.costing.methods
+    --      .CostingMethodHandlerTemplate#createOrUpdateCost only refreshes their DateAcct), so the repost
+    --      would keep them and MAI would stay zero-based;
+    --   2. worse, m_costdetail_delete_from_date's case 1 restores M_Cost from the Prev_* of the FIRST
+    --      changing-costs detail at/after the start date. A stale zero-based in-range detail would
+    --      therefore win over the opening anchor and write a zero opening into M_Cost.
+    -- Hence the order below: raw DELETE first, and only THEN m_costdetail_delete_from_date for the same
+    -- product - which now finds no in-range detail, falls back to the last detail BEFORE the range (the
+    -- cost-revaluation opening anchor, created last and therefore the tie-break winner) and restores
+    -- M_Cost from the anchor's Prev_*, i.e. from the opening balance. Calling it without the raw DELETE
+    -- first would reproduce exactly the failure this purge exists to prevent.
+    -- A PARTIAL purge is the dangerous case: whatever in-range MAI detail survives becomes case 1's
+    -- answer, so the run silently ends up zero-based for that product.
+    --
+    -- Only products that actually HAVE in-range MAI details are touched. That is deliberate: for a
+    -- product with no in-range detail, m_costdetail_delete_from_date finds nothing to restore from and
+    -- DELETES the M_Cost row outright - which for a seeded-but-not-moved product would destroy the
+    -- opening balance the switch just created.
+    --
+    IF (v_targetCostElementId <> p_M_CostElement_ID) THEN
+        DROP TABLE IF EXISTS tmp_pcra_mai_purge;
+        CREATE TEMPORARY TABLE tmp_pcra_mai_purge AS
+        SELECT DISTINCT cd.m_product_id, cd.ad_org_id
+        FROM m_costdetail_v cd
+        WHERE cd.c_acctschema_id = p_C_AcctSchema_ID
+          AND cd.m_costelement_id = v_targetCostElementId
+          AND cd.ad_client_id = v_AD_Client_ID
+          AND cd.dateacct >= p_StartDateAcct;
+
+        DELETE
+        FROM m_costdetail
+        WHERE m_costdetail_id IN (SELECT cd.m_costdetail_id
+                                  FROM m_costdetail_v cd
+                                  WHERE cd.c_acctschema_id = p_C_AcctSchema_ID
+                                    AND cd.m_costelement_id = v_targetCostElementId
+                                    AND cd.ad_client_id = v_AD_Client_ID
+                                    AND cd.dateacct >= p_StartDateAcct);
+        GET DIAGNOSTICS rowcount = ROW_COUNT;
+        RAISE NOTICE 'Purged % pre-existing M_CostDetail(s) of the target cost element %', rowcount, v_targetCostElementId;
+
+        FOR v_purge IN (SELECT t.m_product_id, t.ad_org_id FROM tmp_pcra_mai_purge t ORDER BY t.m_product_id, t.ad_org_id)
+            LOOP
+                PERFORM "de_metas_acct".m_costdetail_delete_from_date(
+                        p_C_AcctSchema_ID := p_C_AcctSchema_ID,
+                        p_M_CostElement_ID := v_targetCostElementId,
+                        p_M_Product_ID := v_purge.m_product_id,
+                        p_AD_Org_ID := v_purge.ad_org_id,
+                        p_StartDateAcct := p_StartDateAcct,
+                        p_DryRun := 'N');
+            END LOOP;
+
+        COMMIT;
+    END IF;
+
+    --
+    --
+    -- (d) ONE COMMIT-BATCH OF PRODUCTS AT A TIME
+    --
+    --
+    -- Everything a batch does - rewinding its products' cost details, staging its documents and recording
+    -- itself DONE - happens in ONE transaction. That is what makes the run resumable: a batch is either
+    -- fully done AND marked done, or it is as if it never ran. There is deliberately no intermediate
+    -- 'RUNNING' marker: it could only be written in the same transaction, so no other session could ever
+    -- see it, and an abort would roll it back anyway.
+    --
+    -- There is deliberately no EXCEPTION handler around this loop: PL/pgSQL forbids transaction control
+    -- inside a block that has one, so an exception handler here would make the per-batch COMMIT illegal.
+    -- An error therefore propagates, this batch rolls back, and the batches before it stay committed -
+    -- exactly the state p_Resume='Y' expects.
+    --
+    FOR v_batch IN (
+        WITH numbered AS (SELECT p.m_product_id, p.batch_no FROM tmp_pcra_products p)
+        SELECT n.batch_no,
+               ARRAY_AGG(n.m_product_id ORDER BY n.m_product_id) AS products
+        FROM numbered n
+        GROUP BY n.batch_no
+        ORDER BY n.batch_no)
+        LOOP
+            IF (p_Resume = 'Y'
+                AND EXISTS(SELECT 1
+                           FROM "de_metas_acct".product_costs_recreate_progress pr
+                           WHERE pr.batch_no = v_batch.batch_no
+                             AND pr.status = 'DONE')) THEN
+                RAISE NOTICE 'Batch % is already DONE, skipping it', v_batch.batch_no;
+                CONTINUE;
+            END IF;
+
+            --
+            -- Rewind the cost details of this batch's products for the cost element being recomputed.
+            -- m_costdetail_delete_from_date is the single choke point that also fixes M_Cost and that
+            -- refuses to delete a cost-revaluation opening anchor - which is why the start date of a run
+            -- must lie strictly after the switch's cut-off.
+            --
+            FOREACH v_productId IN ARRAY v_batch.products
+                LOOP
+                    FOREACH v_orgId IN ARRAY v_orgIds
+                        LOOP
+                            PERFORM "de_metas_acct".m_costdetail_delete_from_date(
+                                    p_C_AcctSchema_ID := p_C_AcctSchema_ID,
+                                    p_M_CostElement_ID := p_M_CostElement_ID,
+                                    p_M_Product_ID := v_productId,
+                                    p_AD_Org_ID := v_orgId,
+                                    p_StartDateAcct := p_StartDateAcct,
+                                    p_DryRun := 'N');
+                        END LOOP;
+                END LOOP;
+
+            --
+            -- Manufacturing order costs are a cached copy of the cost details just deleted, so they have
+            -- to go with them (same step as in "de_metas_acct".product_costs_recreate_from_date).
+            --
+            DELETE
+            FROM pp_order_cost poc
+            WHERE EXISTS(SELECT 1
+                         FROM pp_order o
+                         WHERE o.pp_order_id = poc.pp_order_id
+                           AND o.m_product_id = ANY (v_batch.products)
+                           AND o.dateordered >= p_StartDateAcct);
+
+            --
+            -- Park this batch's documents. NOT in "de_metas_acct".accounting_docs_to_repost - see the
+            -- release step below for why.
+            --
+            INSERT INTO "de_metas_acct".accounting_docs_to_repost_staging
+            (tablename, record_id, ad_client_id, description, dateacct, tablename_prio, batch_no)
+            SELECT d.tablename,
+                   d.record_id,
+                   d.ad_client_id,
+                   'product_costs_recreate_all_from_date',
+                   d.dateacct,
+                   d.tablename_prio,
+                   d.batch_no
+            FROM tmp_pcra_staged_docs d
+            WHERE d.batch_no = v_batch.batch_no;
+            GET DIAGNOSTICS rowcount = ROW_COUNT;
+
+            INSERT INTO "de_metas_acct".product_costs_recreate_progress
+                (batch_no, status, products, started_at, finished_at)
+            VALUES (v_batch.batch_no, 'DONE', v_batch.products, NOW(), NOW());
+
+            RAISE NOTICE 'Batch % DONE: % product(s), % document(s) staged',
+                v_batch.batch_no, ARRAY_LENGTH(v_batch.products, 1), rowcount;
+
+            COMMIT;
+        END LOOP;
+
+    --
+    --
+    -- (e) NO Fact_Acct DELETE, NO fact_acct_unpost
+    --
+    --
+    -- Verified, not assumed - the two effects fact_acct_unpost would contribute are both redundant here:
+    --   * deleting the stale Fact_Acct rows: the queue-driven repost does it itself. The queue's poller
+    --     posts through de.metas.acct.api.impl.PostingService#postNow, which calls
+    --     doc.post(force, /*repost*/ true) with that second argument hardcoded, and
+    --     org.compiere.acct.Doc#post does `if (repost) { deleteAcct(); }` before saving the new facts.
+    --   * resetting Posted='N' so the document can be locked again: de.metas.acct.doc
+    --     .SqlAcctDocLockService#lock only adds the `AND Posted='N'` condition when repost is FALSE, so a
+    --     document left at Posted='Y' still locks and reposts.
+    -- Skipping it is not just an optimisation: fact_acct_unpost INSERTs straight into
+    -- "de_metas_acct".accounting_docs_to_repost, which would hand the documents to the poller one by one
+    -- as they are found - the out-of-order reposting this whole procedure exists to prevent.
+    --
+
+    --
+    --
+    -- (f) RELEASE: STAGING -> REAL QUEUE, IN DOCUMENT-DATE ORDER, IN ONE STEP
+    --
+    --
+    -- KNOWN, DELIBERATE RULE DEVIATION - documented here rather than hidden:
+    --   `docs/coding-rules/production-database-support.md` and
+    --   `backend/de.metas.acct.base/CLAUDE.md` both state: never INSERT directly into
+    --   Accounting_Docs_To_Repost - always use the "de_metas_acct".fact_acct_unpost* functions.
+    -- This statement breaks that rule knowingly. The rule exists because fact_acct_unpost bundles two
+    -- safety-relevant side effects with the enqueue (delete the stale Fact_Acct rows, reset Posted='N'),
+    -- and both are redundant for a queue-driven repost - see (e) above for the exact code that makes them
+    -- redundant. What fact_acct_unpost cannot do is enqueue a whole set of documents with a chosen
+    -- SeqNo ordering in one statement, and that ordering is the entire correctness contract of a cost
+    -- recompute. Using it here would therefore trade a provable ordering guarantee for two no-ops.
+    -- The one effect that is NOT redundant is the period check, and that is why (b) asserts every period
+    -- in range is open before anything is mutated.
+    --
+    -- SeqNo is assigned EXPLICITLY via row_number() over the release order. It is never left to the
+    -- column's nextval default: the order in which INSERT ... SELECT evaluates rows - and therefore the
+    -- order in which it consumes a sequence - is not guaranteed by an ORDER BY in the SELECT. The poller
+    -- consumes the queue with `ORDER BY SeqNo`, so getting this wrong reposts documents out of order and
+    -- freezes wrong costs, silently.
+    -- The block of SeqNos is reserved by advancing the queue's own sequence in a single statement, so the
+    -- released rows cannot collide with rows another producer enqueues afterwards.
+    --
+    SELECT COUNT(1) INTO v_releasedCount FROM "de_metas_acct".accounting_docs_to_repost_staging;
+    IF (v_releasedCount > 0) THEN
+        SELECT setval('"de_metas_acct".accounting_docs_to_repost_seqno',
+                      nextval('"de_metas_acct".accounting_docs_to_repost_seqno') + v_releasedCount - 1)
+        INTO v_seqNoLast;
+        v_seqNoBase := v_seqNoLast - v_releasedCount;
+
+        INSERT INTO "de_metas_acct".accounting_docs_to_repost
+        (seqno, tablename, record_id, ad_client_id, force, on_error_notify_user_id, selection_id, description)
+        SELECT v_seqNoBase + ROW_NUMBER() OVER (ORDER BY s.dateacct, s.tablename_prio, s.record_id),
+               s.tablename,
+               s.record_id,
+               s.ad_client_id,
+               s.force,
+               s.on_error_notify_user_id,
+               s.selection_id,
+               s.description
+        FROM "de_metas_acct".accounting_docs_to_repost_staging s;
+
+        DELETE FROM "de_metas_acct".accounting_docs_to_repost_staging;
+    END IF;
+    RAISE NOTICE 'Released % staged document(s) to the reposting queue', v_releasedCount;
+
+    COMMIT;
+
+    PERFORM pg_advisory_unlock(c_AdvisoryLock_ClassId, p_C_AcctSchema_ID::integer);
+
+    RAISE NOTICE 'DONE: % product(s), % document(s) released', v_productCount, v_releasedCount;
+END;
+$BODY$
+;
+
+COMMENT ON PROCEDURE "de_metas_acct".product_costs_recreate_all_from_date(numeric, numeric, timestamp WITH TIME ZONE, numeric, char) IS
+    'Recreates all products'' cost details from a date onwards in resumable commit-batches, staging the documents to repost and releasing them to the queue in document-date order'
+;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/table/accounting_docs_to_repost_staging.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/table/accounting_docs_to_repost_staging.sql
@@ -1,0 +1,42 @@
+DROP TABLE IF EXISTS "de_metas_acct".accounting_docs_to_repost_staging
+;
+
+-- Holding area for the documents a cost-recompute run will hand to the accounting server.
+-- Same payload columns as "de_metas_acct".accounting_docs_to_repost (identical types, so the
+-- final release is a plain INSERT ... SELECT into the real queue), plus the ordering and
+-- batching columns the run needs while it is still collecting:
+--   dateacct, tablename_prio -> the release order (together with record_id, which the payload
+--                               already carries), taken from accountable_docs_and_lines_v
+--   batch_no                 -> which commit-batch of the run staged the row
+-- seqno carries no DEFAULT here on purpose: the real queue's seqno is assigned explicitly at
+-- release time (row_number() over the release order), never by consuming the queue's sequence
+-- for rows that are still staged.
+CREATE TABLE "de_metas_acct".accounting_docs_to_repost_staging
+(
+    seqno                   numeric(10),
+    --
+    tablename               varchar(255)                       NOT NULL,
+    record_id               numeric(10)                        NOT NULL,
+    ad_client_id            numeric(10)              DEFAULT 1000000 NOT NULL,
+    force                   char(1)                  DEFAULT 'N'     NOT NULL,
+    on_error_notify_user_id numeric(10),
+    --
+    selection_id            varchar(60),
+    created                 time WITH TIME ZONE      DEFAULT NOW()   NOT NULL,
+    description             varchar(2000),
+    --
+    dateacct                timestamp WITH TIME ZONE           NOT NULL,
+    tablename_prio          numeric(10)                        NOT NULL,
+    batch_no                numeric(10)                        NOT NULL
+)
+;
+
+COMMENT ON TABLE "de_metas_acct".accounting_docs_to_repost_staging IS
+    'Documents staged by a cost-recompute run; released into accounting_docs_to_repost in document-date order when the run is done'
+;
+
+CREATE INDEX accounting_docs_to_repost_staging_batch_no ON "de_metas_acct".accounting_docs_to_repost_staging (batch_no)
+;
+
+CREATE INDEX accounting_docs_to_repost_staging_dateacct_prio_record ON "de_metas_acct".accounting_docs_to_repost_staging (dateacct, tablename_prio, record_id)
+;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/table/product_costs_recreate_progress.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/table/product_costs_recreate_progress.sql
@@ -1,0 +1,25 @@
+DROP TABLE IF EXISTS "de_metas_acct".product_costs_recreate_progress
+;
+
+-- One row per commit-batch of a cost-recompute run, so an aborted run can be resumed without
+-- redoing the batches that already finished.
+--   products    -> the batch's M_Product_IDs; numeric[] is the type the recompute functions in
+--                  this module already pass product id sets around as (product_costs_recreate,
+--                  product_costs_recreate_from_date)
+--   finished_at -> NULL while the batch is still running
+--   error       -> text, not varchar(n): it holds SQLERRM plus context, and a length limit would
+--                  make the very INSERT that records a failure fail on an over-long message
+CREATE TABLE "de_metas_acct".product_costs_recreate_progress
+(
+    batch_no    numeric(10)                            NOT NULL,
+    status      varchar(20)                            NOT NULL,
+    products    numeric[]                              NOT NULL,
+    started_at  timestamp WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    finished_at timestamp WITH TIME ZONE,
+    error       text
+)
+;
+
+COMMENT ON TABLE "de_metas_acct".product_costs_recreate_progress IS
+    'Per-batch progress of a cost-recompute run, so an aborted run can resume instead of restarting'
+;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/table/product_costs_recreate_progress.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/table/product_costs_recreate_progress.sql
@@ -9,14 +9,29 @@ DROP TABLE IF EXISTS "de_metas_acct".product_costs_recreate_progress
 --   finished_at -> NULL while the batch is still running
 --   error       -> text, not varchar(n): it holds SQLERRM plus context, and a length limit would
 --                  make the very INSERT that records a failure fail on an over-long message
+--
+-- The four run-identity columns record the parameters the batch was produced under, because
+-- batch_no alone is NOT a stable name for a set of products: product_costs_recreate_all_from_date
+-- recomputes it on every call purely from the caller's own p_ProductsPerCommit. Without them a
+-- p_Resume='Y' call that passes a different products-per-commit - or one that runs for a different
+-- accounting schema / cost element / start date and meets the DONE rows a previously COMPLETED run
+-- left behind - would read "batch 3 is DONE" and skip a DIFFERENT set of products. Those products
+-- would never be rewound, never staged, and the run would report success. The resume compares these
+-- columns against the current call's parameters and refuses on any difference.
+--   Nullable on purpose: rows written before these columns existed carry no identity at all, and a
+--   resume has to refuse those too rather than trust them.
 CREATE TABLE "de_metas_acct".product_costs_recreate_progress
 (
-    batch_no    numeric(10)                            NOT NULL,
-    status      varchar(20)                            NOT NULL,
-    products    numeric[]                              NOT NULL,
-    started_at  timestamp WITH TIME ZONE DEFAULT NOW() NOT NULL,
-    finished_at timestamp WITH TIME ZONE,
-    error       text
+    batch_no            numeric(10)                            NOT NULL,
+    status              varchar(20)                            NOT NULL,
+    products            numeric[]                              NOT NULL,
+    started_at          timestamp WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    finished_at         timestamp WITH TIME ZONE,
+    error               text,
+    c_acctschema_id     numeric(10),
+    m_costelement_id    numeric(10),
+    startdateacct       timestamp WITH TIME ZONE,
+    products_per_commit numeric(10)
 )
 ;
 

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816000_sys_gh26253_m_costdetail_delete_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816000_sys_gh26253_m_costdetail_delete_from_date.sql
@@ -160,21 +160,23 @@ BEGIN
                 --        LastInvoiceCostingMethodHandler.createCostForMatchInvoice_MaterialCosts), so averaging
                 --        would silently write a WRONG CurrentCostPrice. Example: prevPrice=20, prevQty=10,
                 --        inbound qty=10 amt=400 -> replace gives 40, averaging gives 600/20 = 30.
-                --        CAVEAT - 'p' is NOT uniform: it has at least three reachable shapes, because the
-                --        manufacturing handler (ManufacturingLastPOCostingMethodHandler) overrides the base one.
-                --          (1) M_MatchPO                       -> REPLACE with amt/qty (base handler, above).
-                --          (2) PP_Cost_Collector main/co-product receipt (createMainProductOrCoProductReceipt)
-                --              -> addWeightedAverage, but with amt = currentCostPrice*qty, so a no-op.
-                --          (3) PP_Cost_Collector component-issue REVERSAL (createComponentIssue, isReversal)
-                --              -> addWeightedAverage on the reversal's own amt/qty. An issue is outbound, so its
-                --                 reversal is qty>0 with ischangingcosts='Y' and no inventory line - it reaches
-                --                 this branch shape - and amt/qty is the price at the ORIGINAL issue, which need
-                --                 NOT equal the current price. That one is a GENUINE average, not a no-op.
-                --        So do NOT read the (2) no-op as licence to add 'p' to the gate. Excluding 'p' wholesale
-                --        is safe for a different and stronger reason: the ONLY fallback is the loud RAISE below,
-                --        never a silently wrong CurrentCostPrice - which holds for every shape, including (3).
-                --        Known residual gap: a 'p' element whose last pre-range detail is any PP_Cost_Collector
-                --        row therefore still RAISEs instead of being reconstructed. Closing it needs a
+                --        CAVEAT - for 'p' and 'i' the price movement depends on the DOCUMENT, not on the method
+                --        alone, so a method-only rule cannot model them. Observed variants, all reachable with
+                --        qty>0 + ischangingcosts='Y' + no inventory line (i.e. all matching this branch's shape):
+                --          - REPLACE with amt/qty                     (base handler, M_MatchPO / M_MatchInv)
+                --          - weighted average that IS a no-op         (ManufacturingLastPOCostingMethodHandler
+                --                                                      .createMainProductOrCoProductReceipt:
+                --                                                      amt = currentCostPrice*qty)
+                --          - weighted average that is NOT a no-op     (same class, .createComponentIssue reversal:
+                --                                                      amt/qty is the price at the ORIGINAL issue)
+                --          - price left UNTOUCHED, qty only           (createOutboundCostDefaultImpl reversal ->
+                --                                                      CurrentCost.addToCurrentQtyAndCumulate)
+                --        Treat that list as EXAMPLES, never as exhaustive - it has already been wrong twice.
+                --        So do NOT read any single no-op variant as licence to add 'p' or 'i' to the gate.
+                --        Excluding them is safe for a reason that does NOT depend on enumerating the variants:
+                --        the ONLY fallback is the loud RAISE below, never a silently wrong CurrentCostPrice.
+                --        Known residual gap: a 'p' / 'i' element whose last pre-range detail has this shape
+                --        therefore still RAISEs instead of being reconstructed. Closing it needs a
                 --        (method, document) key, not a method-only one - deliberately out of scope here.
                 --   'L' Lifo / 'F' Fifo / 'U' UserDefined / 'x' ExternalProcessing are likewise excluded.
                 -- Everything excluded falls through to the RAISE below - i.e. exactly the behaviour those

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816000_sys_gh26253_m_costdetail_delete_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816000_sys_gh26253_m_costdetail_delete_from_date.sql
@@ -160,14 +160,22 @@ BEGIN
                 --        LastInvoiceCostingMethodHandler.createCostForMatchInvoice_MaterialCosts), so averaging
                 --        would silently write a WRONG CurrentCostPrice. Example: prevPrice=20, prevQty=10,
                 --        inbound qty=10 amt=400 -> replace gives 40, averaging gives 600/20 = 30.
-                --        CAVEAT for 'p': ManufacturingLastPOCostingMethodHandler.createMainProductOrCoProductReceipt
-                --        DOES call addWeightedAverage for a PP_Cost_Collector main/co-product receipt - but there
-                --        amt = currentCostPrice*qty, so that average is a no-op (same shape as 'S'). So 'p' behaves
-                --        two ways depending on the DOCUMENT, and a costingmethod-only gate cannot separate them;
-                --        'p' is therefore excluded wholesale, which is safe for BOTH sub-cases. Known residual
-                --        gap: a 'p' element whose last pre-range detail is a PP_Cost_Collector receipt still
-                --        RAISEs instead of being reconstructed. Widening the gate to a (method, document) key
-                --        would close it - deliberately out of scope here.
+                --        CAVEAT - 'p' is NOT uniform: it has at least three reachable shapes, because the
+                --        manufacturing handler (ManufacturingLastPOCostingMethodHandler) overrides the base one.
+                --          (1) M_MatchPO                       -> REPLACE with amt/qty (base handler, above).
+                --          (2) PP_Cost_Collector main/co-product receipt (createMainProductOrCoProductReceipt)
+                --              -> addWeightedAverage, but with amt = currentCostPrice*qty, so a no-op.
+                --          (3) PP_Cost_Collector component-issue REVERSAL (createComponentIssue, isReversal)
+                --              -> addWeightedAverage on the reversal's own amt/qty. An issue is outbound, so its
+                --                 reversal is qty>0 with ischangingcosts='Y' and no inventory line - it reaches
+                --                 this branch shape - and amt/qty is the price at the ORIGINAL issue, which need
+                --                 NOT equal the current price. That one is a GENUINE average, not a no-op.
+                --        So do NOT read the (2) no-op as licence to add 'p' to the gate. Excluding 'p' wholesale
+                --        is safe for a different and stronger reason: the ONLY fallback is the loud RAISE below,
+                --        never a silently wrong CurrentCostPrice - which holds for every shape, including (3).
+                --        Known residual gap: a 'p' element whose last pre-range detail is any PP_Cost_Collector
+                --        row therefore still RAISEs instead of being reconstructed. Closing it needs a
+                --        (method, document) key, not a method-only one - deliberately out of scope here.
                 --   'L' Lifo / 'F' Fifo / 'U' UserDefined / 'x' ExternalProcessing are likewise excluded.
                 -- Everything excluded falls through to the RAISE below - i.e. exactly the behaviour those
                 -- methods already have today - so this change can never turn a loud abort into a silent

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816000_sys_gh26253_m_costdetail_delete_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816000_sys_gh26253_m_costdetail_delete_from_date.sql
@@ -151,9 +151,17 @@ BEGIN
                 --   'A' AveragePO / 'I' AverageInvoice / 'M' MovingAverageInvoice
                 --        -> their handlers call CurrentCost.addWeightedAverage, so the formula matches.
                 --   'S' StandardCosting
-                --        -> a changing-costs inbound records amt = prevPrice*qty
-                --           (StandardCostingMethodHandler.createCostForMaterialReceipt), so the weighted
-                --           average provably reproduces prevPrice: it is a no-op, not an approximation.
+                --        -> INVARIANT: every Standard-costing handler posts amt = currentCostPrice*qty by
+                --           construction - it multiplies the CURRENT cost price of the very same cost
+                --           segment+element by the quantity and never derives a price from the document:
+                --             StandardCostingMethodHandler.createCostForMaterialReceipt /
+                --                 .createOutboundCostDefaultImpl / .createCostForMatchInvoice_MaterialCosts
+                --             ManufacturingStandardCostingMethodHandler.createIssueOrReceipt /
+                --                 .createActivityControl / .createUsageVariance
+                --           Substituting amt = prevPrice*qty into the weighted average gives
+                --           (prevPrice*prevQty + prevPrice*qty) / (prevQty + qty) = prevPrice, so the
+                --           reconstruction provably reproduces prevPrice for EVERY such inbound: it is a
+                --           no-op, not an approximation.
                 --   'p' LastPOPrice / 'i' LastInvoice are DELIBERATELY EXCLUDED: on the M_MatchPO /
                 --        M_MatchInv path their handlers REPLACE the price with amt/qty
                 --        (LastPOCostingMethodHandler.createCostForMatchPO,

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816000_sys_gh26253_m_costdetail_delete_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816000_sys_gh26253_m_costdetail_delete_from_date.sql
@@ -154,15 +154,26 @@ BEGIN
                 --        -> a changing-costs inbound records amt = prevPrice*qty
                 --           (StandardCostingMethodHandler.createCostForMaterialReceipt), so the weighted
                 --           average provably reproduces prevPrice: it is a no-op, not an approximation.
-                --   'p' LastPOPrice / 'i' LastInvoice are DELIBERATELY EXCLUDED: their handlers REPLACE the
-                --        price with amt/qty (LastPOCostingMethodHandler.createCostForMatchPO,
+                --   'p' LastPOPrice / 'i' LastInvoice are DELIBERATELY EXCLUDED: on the M_MatchPO /
+                --        M_MatchInv path their handlers REPLACE the price with amt/qty
+                --        (LastPOCostingMethodHandler.createCostForMatchPO,
                 --        LastInvoiceCostingMethodHandler.createCostForMatchInvoice_MaterialCosts), so averaging
                 --        would silently write a WRONG CurrentCostPrice. Example: prevPrice=20, prevQty=10,
                 --        inbound qty=10 amt=400 -> replace gives 40, averaging gives 600/20 = 30.
+                --        CAVEAT for 'p': ManufacturingLastPOCostingMethodHandler.createMainProductOrCoProductReceipt
+                --        DOES call addWeightedAverage for a PP_Cost_Collector main/co-product receipt - but there
+                --        amt = currentCostPrice*qty, so that average is a no-op (same shape as 'S'). So 'p' behaves
+                --        two ways depending on the DOCUMENT, and a costingmethod-only gate cannot separate them;
+                --        'p' is therefore excluded wholesale, which is safe for BOTH sub-cases. Known residual
+                --        gap: a 'p' element whose last pre-range detail is a PP_Cost_Collector receipt still
+                --        RAISEs instead of being reconstructed. Widening the gate to a (method, document) key
+                --        would close it - deliberately out of scope here.
                 --   'L' Lifo / 'F' Fifo / 'U' UserDefined / 'x' ExternalProcessing are likewise excluded.
                 -- Everything excluded falls through to the RAISE below - i.e. exactly the behaviour those
                 -- methods already have today - so this change can never turn a loud abort into a silent
                 -- mis-valuation.
+                -- A NULL costingmethod (unresolvable cost element) makes the IN test NULL, not TRUE, so it
+                -- also falls through to the RAISE rather than averaging blindly.
                 v_next_costs_found := TRUE;
                 v_next_costs_debugInfo := 'case 2.5: based on prev costs of last cost details (inbound trx, weighted average), with changing costs';
                 v_next_currentqty   := v_firstCostDetail.prev_currentqty   + v_firstCostDetail.qty;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816000_sys_gh26253_m_costdetail_delete_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816000_sys_gh26253_m_costdetail_delete_from_date.sql
@@ -1,3 +1,4 @@
+-- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/m_costdetail_delete_from_date.sql
 DROP FUNCTION IF EXISTS "de_metas_acct".m_costdetail_delete_from_date(
     p_C_AcctSchema_ID  numeric,
     p_M_CostElement_ID numeric,
@@ -248,4 +249,4 @@ BEGIN
     RETURN 'OK';
 END;
 $BODY$
-
+;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816000_sys_gh26253_m_costdetail_delete_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816000_sys_gh26253_m_costdetail_delete_from_date.sql
@@ -35,9 +35,17 @@ DECLARE
     v_next_cumulatedamt       numeric;
     v_next_cumulatedqty       numeric;
     v_m_cost_id               numeric;
+    v_costingmethod           char(1);
 BEGIN
     RAISE DEBUG 'm_costdetail_delete_from_date: p_C_AcctSchema_ID=%, p_M_CostElement_ID=%, p_M_Product_ID=%, p_AD_Org_ID=%, p_StartDateAcct=%, p_DryRun=%',
         p_C_AcctSchema_ID, p_M_CostElement_ID, p_M_Product_ID, p_AD_Org_ID, p_StartDateAcct, p_DryRun;
+
+    -- The cost element's costing method decides HOW a changing-costs inbound moves the current cost
+    -- price, so case 2.5 below can only reconstruct that price for the methods that average (see there).
+    SELECT ce.costingmethod
+    INTO v_costingmethod
+    FROM m_costelement ce
+    WHERE ce.m_costelement_id = p_M_CostElement_ID;
 
     --
     -- Compute current cost prices at target date
@@ -126,7 +134,8 @@ BEGIN
                 v_next_currentqty := v_firstCostDetail.prev_currentqty + v_firstCostDetail.qty;
                 v_next_cumulatedamt := v_firstCostDetail.prev_cumulatedamt + v_firstCostDetail.amt;
                 v_next_cumulatedqty := v_firstCostDetail.prev_cumulatedqty + v_firstCostDetail.qty;
-            ELSIF (v_firstCostDetail.qty > 0 AND v_firstCostDetail.ischangingcosts = 'Y') THEN
+            ELSIF (v_firstCostDetail.qty > 0 AND v_firstCostDetail.ischangingcosts = 'Y'
+                AND v_costingmethod IN ('A', 'I', 'M', 'S')) THEN
                 -- case 2.5: inbound trx (qty > 0) that changed the cost price but is NOT an inventory line
                 -- (M_MatchPO, M_InOutLine non-material costs, PP_Cost_Collector receipts, ...).
                 -- Unlike case 2.4 (inventory lines post at the unchanged current price), these inbounds
@@ -136,8 +145,24 @@ BEGIN
                 -- M_CostDetail stores no resulting price, so it must be recomputed here; copying case 2.4
                 -- verbatim would leave M_Cost.CurrentCostPrice stale and mis-value the repost.
                 -- NOTE: this reconstructs the price from the stored prev_* / amt / qty of the cost detail, exactly
-                -- like the surrounding cases; it stays correct for Standard costing too, because a Standard-cost
-                -- changing-costs inbound records amt = prevPrice*qty, so the weighted average reproduces prevPrice.
+                -- like the surrounding cases.
+                --
+                -- The costing-method gate is REQUIRED: only the averaging methods move the price this way.
+                --   'A' AveragePO / 'I' AverageInvoice / 'M' MovingAverageInvoice
+                --        -> their handlers call CurrentCost.addWeightedAverage, so the formula matches.
+                --   'S' StandardCosting
+                --        -> a changing-costs inbound records amt = prevPrice*qty
+                --           (StandardCostingMethodHandler.createCostForMaterialReceipt), so the weighted
+                --           average provably reproduces prevPrice: it is a no-op, not an approximation.
+                --   'p' LastPOPrice / 'i' LastInvoice are DELIBERATELY EXCLUDED: their handlers REPLACE the
+                --        price with amt/qty (LastPOCostingMethodHandler.createCostForMatchPO,
+                --        LastInvoiceCostingMethodHandler.createCostForMatchInvoice_MaterialCosts), so averaging
+                --        would silently write a WRONG CurrentCostPrice. Example: prevPrice=20, prevQty=10,
+                --        inbound qty=10 amt=400 -> replace gives 40, averaging gives 600/20 = 30.
+                --   'L' Lifo / 'F' Fifo / 'U' UserDefined / 'x' ExternalProcessing are likewise excluded.
+                -- Everything excluded falls through to the RAISE below - i.e. exactly the behaviour those
+                -- methods already have today - so this change can never turn a loud abort into a silent
+                -- mis-valuation.
                 v_next_costs_found := TRUE;
                 v_next_costs_debugInfo := 'case 2.5: based on prev costs of last cost details (inbound trx, weighted average), with changing costs';
                 v_next_currentqty   := v_firstCostDetail.prev_currentqty   + v_firstCostDetail.qty;
@@ -154,8 +179,8 @@ BEGIN
                     v_next_currentcostprice := v_firstCostDetail.prev_currentcostprice;
                 END IF;
                 v_next_currentcostpricell := v_firstCostDetail.prev_currentcostpricell; -- LL untouched by addWeightedAverage
-            ELSE -- (v_firstCostDetail.qty > 0) THEN
-                RAISE EXCEPTION 'Extracting current costs from an inbound transaction is not implemented (%)', v_firstCostDetail;
+            ELSE -- (v_firstCostDetail.qty > 0), or a costing method case 2.5 must not average for
+                RAISE EXCEPTION 'Extracting current costs from an inbound transaction is not implemented (costing method %) (%)', v_costingmethod, v_firstCostDetail;
             END IF;
         ELSE
             v_next_costs_found := FALSE;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816900_sys_gh26253_m_costdetail_delete_from_date_anchor_guard.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816900_sys_gh26253_m_costdetail_delete_from_date_anchor_guard.sql
@@ -1,3 +1,4 @@
+-- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/m_costdetail_delete_from_date.sql
 DROP FUNCTION IF EXISTS "de_metas_acct".m_costdetail_delete_from_date(
     p_C_AcctSchema_ID  numeric,
     p_M_CostElement_ID numeric,

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816910_sys_gh26253_accounting_docs_to_repost_staging.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816910_sys_gh26253_accounting_docs_to_repost_staging.sql
@@ -1,8 +1,6 @@
 -- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/table/accounting_docs_to_repost_staging.sql
--- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/table/product_costs_recreate_progress.sql
--- Scaffolding only: two brand-new tables in the de_metas_acct schema. The real queue table
--- "de_metas_acct".accounting_docs_to_repost is deliberately NOT touched -- it keeps its exact
--- current shape so the accounting-server poller is unaffected.
+-- New table only. The real queue table "de_metas_acct".accounting_docs_to_repost is deliberately
+-- NOT touched -- it keeps its exact current shape, so the accounting-server poller is unaffected.
 
 DROP TABLE IF EXISTS "de_metas_acct".accounting_docs_to_repost_staging
 ;
@@ -45,30 +43,4 @@ CREATE INDEX accounting_docs_to_repost_staging_batch_no ON "de_metas_acct".accou
 ;
 
 CREATE INDEX accounting_docs_to_repost_staging_dateacct_prio_record ON "de_metas_acct".accounting_docs_to_repost_staging (dateacct, tablename_prio, record_id)
-;
-
-DROP TABLE IF EXISTS "de_metas_acct".product_costs_recreate_progress
-;
-
--- One row per commit-batch of a cost-recompute run, so an aborted run can be resumed without
--- redoing the batches that already finished.
---   products    -> the batch's M_Product_IDs; numeric[] is the type the recompute functions in
---                  this module already pass product id sets around as (product_costs_recreate,
---                  product_costs_recreate_from_date)
---   finished_at -> NULL while the batch is still running
---   error       -> text, not varchar(n): it holds SQLERRM plus context, and a length limit would
---                  make the very INSERT that records a failure fail on an over-long message
-CREATE TABLE "de_metas_acct".product_costs_recreate_progress
-(
-    batch_no    numeric(10)                            NOT NULL,
-    status      varchar(20)                            NOT NULL,
-    products    numeric[]                              NOT NULL,
-    started_at  timestamp WITH TIME ZONE DEFAULT NOW() NOT NULL,
-    finished_at timestamp WITH TIME ZONE,
-    error       text
-)
-;
-
-COMMENT ON TABLE "de_metas_acct".product_costs_recreate_progress IS
-    'Per-batch progress of a cost-recompute run, so an aborted run can resume instead of restarting'
 ;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816910_sys_gh26253_accounting_docs_to_repost_staging.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816910_sys_gh26253_accounting_docs_to_repost_staging.sql
@@ -1,0 +1,74 @@
+-- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/table/accounting_docs_to_repost_staging.sql
+-- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/table/product_costs_recreate_progress.sql
+-- Scaffolding only: two brand-new tables in the de_metas_acct schema. The real queue table
+-- "de_metas_acct".accounting_docs_to_repost is deliberately NOT touched -- it keeps its exact
+-- current shape so the accounting-server poller is unaffected.
+
+DROP TABLE IF EXISTS "de_metas_acct".accounting_docs_to_repost_staging
+;
+
+-- Holding area for the documents a cost-recompute run will hand to the accounting server.
+-- Same payload columns as "de_metas_acct".accounting_docs_to_repost (identical types, so the
+-- final release is a plain INSERT ... SELECT into the real queue), plus the ordering and
+-- batching columns the run needs while it is still collecting:
+--   dateacct, tablename_prio -> the release order (together with record_id, which the payload
+--                               already carries), taken from accountable_docs_and_lines_v
+--   batch_no                 -> which commit-batch of the run staged the row
+-- seqno carries no DEFAULT here on purpose: the real queue's seqno is assigned explicitly at
+-- release time (row_number() over the release order), never by consuming the queue's sequence
+-- for rows that are still staged.
+CREATE TABLE "de_metas_acct".accounting_docs_to_repost_staging
+(
+    seqno                   numeric(10),
+    --
+    tablename               varchar(255)                       NOT NULL,
+    record_id               numeric(10)                        NOT NULL,
+    ad_client_id            numeric(10)              DEFAULT 1000000 NOT NULL,
+    force                   char(1)                  DEFAULT 'N'     NOT NULL,
+    on_error_notify_user_id numeric(10),
+    --
+    selection_id            varchar(60),
+    created                 time WITH TIME ZONE      DEFAULT NOW()   NOT NULL,
+    description             varchar(2000),
+    --
+    dateacct                timestamp WITH TIME ZONE           NOT NULL,
+    tablename_prio          numeric(10)                        NOT NULL,
+    batch_no                numeric(10)                        NOT NULL
+)
+;
+
+COMMENT ON TABLE "de_metas_acct".accounting_docs_to_repost_staging IS
+    'Documents staged by a cost-recompute run; released into accounting_docs_to_repost in document-date order when the run is done'
+;
+
+CREATE INDEX accounting_docs_to_repost_staging_batch_no ON "de_metas_acct".accounting_docs_to_repost_staging (batch_no)
+;
+
+CREATE INDEX accounting_docs_to_repost_staging_dateacct_prio_record ON "de_metas_acct".accounting_docs_to_repost_staging (dateacct, tablename_prio, record_id)
+;
+
+DROP TABLE IF EXISTS "de_metas_acct".product_costs_recreate_progress
+;
+
+-- One row per commit-batch of a cost-recompute run, so an aborted run can be resumed without
+-- redoing the batches that already finished.
+--   products    -> the batch's M_Product_IDs; numeric[] is the type the recompute functions in
+--                  this module already pass product id sets around as (product_costs_recreate,
+--                  product_costs_recreate_from_date)
+--   finished_at -> NULL while the batch is still running
+--   error       -> text, not varchar(n): it holds SQLERRM plus context, and a length limit would
+--                  make the very INSERT that records a failure fail on an over-long message
+CREATE TABLE "de_metas_acct".product_costs_recreate_progress
+(
+    batch_no    numeric(10)                            NOT NULL,
+    status      varchar(20)                            NOT NULL,
+    products    numeric[]                              NOT NULL,
+    started_at  timestamp WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    finished_at timestamp WITH TIME ZONE,
+    error       text
+)
+;
+
+COMMENT ON TABLE "de_metas_acct".product_costs_recreate_progress IS
+    'Per-batch progress of a cost-recompute run, so an aborted run can resume instead of restarting'
+;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816920_sys_gh26253_product_costs_recreate_progress.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816920_sys_gh26253_product_costs_recreate_progress.sql
@@ -1,0 +1,27 @@
+-- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/table/product_costs_recreate_progress.sql
+
+DROP TABLE IF EXISTS "de_metas_acct".product_costs_recreate_progress
+;
+
+-- One row per commit-batch of a cost-recompute run, so an aborted run can be resumed without
+-- redoing the batches that already finished.
+--   products    -> the batch's M_Product_IDs; numeric[] is the type the recompute functions in
+--                  this module already pass product id sets around as (product_costs_recreate,
+--                  product_costs_recreate_from_date)
+--   finished_at -> NULL while the batch is still running
+--   error       -> text, not varchar(n): it holds SQLERRM plus context, and a length limit would
+--                  make the very INSERT that records a failure fail on an over-long message
+CREATE TABLE "de_metas_acct".product_costs_recreate_progress
+(
+    batch_no    numeric(10)                            NOT NULL,
+    status      varchar(20)                            NOT NULL,
+    products    numeric[]                              NOT NULL,
+    started_at  timestamp WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    finished_at timestamp WITH TIME ZONE,
+    error       text
+)
+;
+
+COMMENT ON TABLE "de_metas_acct".product_costs_recreate_progress IS
+    'Per-batch progress of a cost-recompute run, so an aborted run can resume instead of restarting'
+;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816930_sys_gh26253_product_costs_recreate_all_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816930_sys_gh26253_product_costs_recreate_all_from_date.sql
@@ -1,0 +1,450 @@
+-- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/product_costs_recreate_all_from_date.sql
+DROP PROCEDURE IF EXISTS "de_metas_acct".product_costs_recreate_all_from_date(
+    p_C_AcctSchema_ID   numeric,
+    p_M_CostElement_ID  numeric,
+    p_StartDateAcct     timestamp WITH TIME ZONE,
+    p_ProductsPerCommit numeric,
+    p_Resume            char(1)
+)
+;
+
+
+-- Recreates the costs of EVERY product of an accounting schema from a given accounting date onwards.
+--
+-- It is a PROCEDURE, not a function, because it MUST commit as it goes: a full run over a real
+-- installation is ~5 000 products / ~376 000 documents and cannot be one transaction. A single-transaction
+-- attempt ran 2h13m and then died with a backend I/O error, rolling back everything. So the work is cut
+-- into commit-batches of p_ProductsPerCommit products, each batch recorded in
+-- "de_metas_acct".product_costs_recreate_progress, and p_Resume='Y' picks up where an aborted run stopped
+-- instead of starting over.
+--
+-- The documents to repost are NOT enqueued as they are found. They are parked in
+-- "de_metas_acct".accounting_docs_to_repost_staging and released into the real queue in ONE atomic step at
+-- the very end (see "RELEASE" below). That is the whole point: costs are computed WHILE reposting, so the
+-- documents must reach the accounting server strictly in document-date order. The server's poller drains
+-- the real queue continuously, so anything inserted there early would be reposted early - out of order -
+-- and would freeze wrong costs. Holding the rows outside the queue is also what keeps this run from
+-- needing any change to the queue table, to its poller, or to fact_acct_unpost.
+CREATE OR REPLACE PROCEDURE "de_metas_acct".product_costs_recreate_all_from_date(
+    p_C_AcctSchema_ID   numeric,
+    p_M_CostElement_ID  numeric,
+    p_StartDateAcct     timestamp WITH TIME ZONE,
+    p_ProductsPerCommit numeric = 100,
+    p_Resume            char(1) = 'N'
+)
+    LANGUAGE plpgsql
+AS
+$BODY$
+DECLARE
+    -- Advisory-lock class id. Arbitrary but stable: it only has to be a value no other advisory lock in
+    -- this database uses, so that two runs of THIS procedure (and only those) collide.
+    c_AdvisoryLock_ClassId constant integer := 26253;
+    --
+    v_AD_Client_ID         numeric;
+    v_costingLevel         char(1);
+    v_orgIds               numeric[];
+    v_targetCostElementId  numeric;
+    --
+    v_doneBatchCount       integer;
+    v_productCount         integer;
+    v_documentCount        integer;
+    v_releasedCount        integer;
+    v_seqNoLast            numeric;
+    v_seqNoBase            numeric;
+    rowcount               integer;
+    --
+    v_batch                record;
+    v_period               record;
+    v_purge                record;
+    v_productId            numeric;
+    v_orgId                numeric;
+BEGIN
+    IF (p_StartDateAcct IS NULL) THEN
+        RAISE EXCEPTION 'p_StartDateAcct shall be set';
+    END IF;
+    IF (p_ProductsPerCommit IS NULL OR p_ProductsPerCommit < 1) THEN
+        RAISE EXCEPTION 'p_ProductsPerCommit shall be >= 1 but it was %', p_ProductsPerCommit;
+    END IF;
+
+    --
+    --
+    -- (a) SINGLE RUN AT A TIME
+    --
+    --
+    -- The lock is SESSION level, not transaction level: this procedure commits after every batch, and a
+    -- transaction-level lock would be released by the very first of those commits, leaving the rest of a
+    -- multi-hour run unprotected. Two overlapping runs would delete each other's cost details and stage
+    -- each other's documents, and the ordering guarantee of the release step would be lost.
+    -- A session-level lock is re-entrant within its own session, so resuming from the same session works.
+    IF NOT pg_try_advisory_lock(c_AdvisoryLock_ClassId, p_C_AcctSchema_ID::integer) THEN
+        RAISE EXCEPTION 'Another product_costs_recreate_all_from_date run is already in progress for C_AcctSchema_ID=%', p_C_AcctSchema_ID;
+    END IF;
+
+    --
+    -- Validate parameter: Accounting Schema => extract client and eligible Orgs
+    -- (same rules as "de_metas_acct".product_costs_recreate_from_date)
+    --
+    SELECT cas.ad_client_id, cas.costinglevel
+    INTO v_AD_Client_ID, v_costingLevel
+    FROM c_acctschema cas
+    WHERE cas.c_acctschema_id = p_C_AcctSchema_ID;
+    IF (v_AD_Client_ID IS NULL) THEN
+        RAISE EXCEPTION 'C_AcctSchema_ID % not found', p_C_AcctSchema_ID;
+    END IF;
+    --
+    IF (v_costingLevel = 'C') THEN
+        v_orgIds := ARRAY [ 0 ];
+    ELSIF (v_costingLevel = 'O') THEN
+        SELECT ARRAY_AGG(org.ad_org_id ORDER BY org.ad_org_id)
+        INTO v_orgIds
+        FROM ad_org org
+        WHERE org.ad_client_id = v_AD_Client_ID
+          AND org.ad_org_id != 0;
+    ELSE
+        RAISE EXCEPTION 'Costing level `%` not supported for C_AcctSchema_ID=%', v_costingLevel, p_C_AcctSchema_ID;
+    END IF;
+
+    --
+    -- Resolve the target Moving-Average-Invoice cost element.
+    -- Same lookup as public.C_AcctSchema_InitMovingAvgInvoice: the active Material cost element whose
+    -- costing method is 'M'. It is derived rather than passed in because it is not a free choice - it is
+    -- the element the switch seeds, and the purge below must cover exactly that one.
+    --
+    SELECT ce.m_costelement_id
+    INTO v_targetCostElementId
+    FROM m_costelement ce
+    WHERE ce.ad_client_id = v_AD_Client_ID
+      AND ce.costelementtype = 'M'
+      AND ce.costingmethod = 'M'
+      AND ce.isactive = 'Y'
+    ORDER BY ce.m_costelement_id
+    LIMIT 1;
+    IF (v_targetCostElementId IS NULL) THEN
+        RAISE EXCEPTION 'No active MovingAverageInvoice cost element (costingmethod=M) found for AD_Client_ID=%', v_AD_Client_ID;
+    END IF;
+
+    RAISE NOTICE 'product_costs_recreate_all_from_date: C_AcctSchema_ID=%, M_CostElement_ID=%, target(MAI) M_CostElement_ID=%, StartDateAcct=%, ProductsPerCommit=%, Resume=%',
+        p_C_AcctSchema_ID, p_M_CostElement_ID, v_targetCostElementId, p_StartDateAcct, p_ProductsPerCommit, p_Resume;
+
+    --
+    -- Fresh start vs. resume.
+    -- A fresh run must not inherit anything: leftover staged documents would be released together with
+    -- this run's, and leftover DONE markers would make it skip batches it never did.
+    --
+    IF (p_Resume = 'Y') THEN
+        SELECT COUNT(1) INTO v_doneBatchCount FROM "de_metas_acct".product_costs_recreate_progress WHERE status = 'DONE';
+        RAISE NOTICE 'Resuming: % batch(es) already DONE will be skipped', v_doneBatchCount;
+    ELSE
+        DELETE FROM "de_metas_acct".accounting_docs_to_repost_staging;
+        DELETE FROM "de_metas_acct".product_costs_recreate_progress;
+    END IF;
+
+    --
+    -- The (product, document) pairs this run covers.
+    -- Same predicate as "de_metas_acct".product_costs_recreate_from_date, minus the product restriction:
+    -- invoices are excluded, so reposting never touches VAT.
+    --
+    DROP TABLE IF EXISTS tmp_pcra_docs;
+    CREATE TEMPORARY TABLE tmp_pcra_docs AS
+    SELECT DISTINCT doc.m_product_id,
+                    doc.tablename,
+                    doc.record_id,
+                    doc.tablename_prio,
+                    doc.dateacct,
+                    doc.docbasetype,
+                    doc.ad_client_id,
+                    doc.ad_org_id
+    FROM "de_metas_acct".accountable_docs_and_lines_v doc
+    WHERE doc.m_product_id IS NOT NULL
+      AND doc.tablename <> 'C_Invoice'
+      AND doc.dateacct >= p_StartDateAcct
+      AND doc.ad_client_id = v_AD_Client_ID;
+
+    --
+    -- Cut the products into commit-batches, ordered by M_Product_ID so a resume reproduces exactly the
+    -- same batch numbers as the run it continues.
+    --
+    DROP TABLE IF EXISTS tmp_pcra_products;
+    CREATE TEMPORARY TABLE tmp_pcra_products AS
+    SELECT p.m_product_id,
+           (((ROW_NUMBER() OVER (ORDER BY p.m_product_id)) - 1) / p_ProductsPerCommit::bigint)::integer + 1 AS batch_no
+    FROM (SELECT DISTINCT d.m_product_id FROM tmp_pcra_docs d) p;
+
+    --
+    -- One row per DOCUMENT, assigned to the batch of its lowest-numbered product.
+    -- A document with lines for products in several batches must be staged exactly ONCE, otherwise it
+    -- would be reposted several times. Which of its batches stages it does not matter: nothing is
+    -- released until every batch is done, so by release time all of its products have been rewound.
+    --
+    DROP TABLE IF EXISTS tmp_pcra_staged_docs;
+    CREATE TEMPORARY TABLE tmp_pcra_staged_docs AS
+    SELECT d.tablename,
+           d.record_id,
+           MIN(p.batch_no)        AS batch_no,
+           MIN(d.tablename_prio)  AS tablename_prio,
+           MIN(d.dateacct)        AS dateacct,
+           MIN(d.ad_client_id)    AS ad_client_id
+    FROM tmp_pcra_docs d
+             INNER JOIN tmp_pcra_products p ON p.m_product_id = d.m_product_id
+    GROUP BY d.tablename, d.record_id;
+
+    SELECT COUNT(1) INTO v_productCount FROM tmp_pcra_products;
+    SELECT COUNT(1) INTO v_documentCount FROM tmp_pcra_staged_docs;
+    RAISE NOTICE 'Selected % product(s) and % document(s) to be reposted', v_productCount, v_documentCount;
+
+    --
+    --
+    -- (b) ALL PERIODS IN RANGE MUST BE OPEN - CHECKED BEFORE THE FIRST MUTATION
+    --
+    --
+    -- Not merely a courtesy: the reposting that follows throws @PeriodClosed@ for an already-posted
+    -- document whose period is closed (org.compiere.acct.Doc#post rejects that combination even when
+    -- reposting). Finding that out batch 40 into a multi-hour run, with the cost details of batches 1..39
+    -- already deleted and committed, would leave the installation mid-rewind. So the whole range is
+    -- checked up front, while nothing has been changed yet and aborting costs nothing.
+    --
+    FOR v_period IN (SELECT DISTINCT t.dateacct, t.docbasetype, t.ad_client_id, t.ad_org_id
+                     FROM tmp_pcra_docs t
+                     ORDER BY t.dateacct, t.docbasetype, t.ad_client_id, t.ad_org_id)
+        LOOP
+            PERFORM "de_metas_acct".assert_period_open(
+                    p_DateAcct := v_period.dateacct,
+                    p_DocBaseType := v_period.docbasetype,
+                    p_AD_Client_ID := v_period.ad_client_id,
+                    p_AD_Org_ID := v_period.ad_org_id);
+        END LOOP;
+
+    --
+    --
+    -- (c) PURGE THE TARGET (MAI) ELEMENT'S IN-RANGE COST DETAILS FIRST
+    --
+    --
+    -- Posting explodes a document into EVERY active Material cost element, not just the one the
+    -- accounting schema currently values with. So the MAI element may already carry cost details in this
+    -- range, built before it had an opening balance - i.e. based on zero. Two ways those wreck the run,
+    -- both silent:
+    --   1. cost details are REUSED as-is when they already exist (de.metas.costing.methods
+    --      .CostingMethodHandlerTemplate#createOrUpdateCost only refreshes their DateAcct), so the repost
+    --      would keep them and MAI would stay zero-based;
+    --   2. worse, m_costdetail_delete_from_date's case 1 restores M_Cost from the Prev_* of the FIRST
+    --      changing-costs detail at/after the start date. A stale zero-based in-range detail would
+    --      therefore win over the opening anchor and write a zero opening into M_Cost.
+    -- Hence the order below: raw DELETE first, and only THEN m_costdetail_delete_from_date for the same
+    -- product - which now finds no in-range detail, falls back to the last detail BEFORE the range (the
+    -- cost-revaluation opening anchor, created last and therefore the tie-break winner) and restores
+    -- M_Cost from the anchor's Prev_*, i.e. from the opening balance. Calling it without the raw DELETE
+    -- first would reproduce exactly the failure this purge exists to prevent.
+    -- A PARTIAL purge is the dangerous case: whatever in-range MAI detail survives becomes case 1's
+    -- answer, so the run silently ends up zero-based for that product.
+    --
+    -- Only products that actually HAVE in-range MAI details are touched. That is deliberate: for a
+    -- product with no in-range detail, m_costdetail_delete_from_date finds nothing to restore from and
+    -- DELETES the M_Cost row outright - which for a seeded-but-not-moved product would destroy the
+    -- opening balance the switch just created.
+    --
+    IF (v_targetCostElementId <> p_M_CostElement_ID) THEN
+        DROP TABLE IF EXISTS tmp_pcra_mai_purge;
+        CREATE TEMPORARY TABLE tmp_pcra_mai_purge AS
+        SELECT DISTINCT cd.m_product_id, cd.ad_org_id
+        FROM m_costdetail_v cd
+        WHERE cd.c_acctschema_id = p_C_AcctSchema_ID
+          AND cd.m_costelement_id = v_targetCostElementId
+          AND cd.ad_client_id = v_AD_Client_ID
+          AND cd.dateacct >= p_StartDateAcct;
+
+        DELETE
+        FROM m_costdetail
+        WHERE m_costdetail_id IN (SELECT cd.m_costdetail_id
+                                  FROM m_costdetail_v cd
+                                  WHERE cd.c_acctschema_id = p_C_AcctSchema_ID
+                                    AND cd.m_costelement_id = v_targetCostElementId
+                                    AND cd.ad_client_id = v_AD_Client_ID
+                                    AND cd.dateacct >= p_StartDateAcct);
+        GET DIAGNOSTICS rowcount = ROW_COUNT;
+        RAISE NOTICE 'Purged % pre-existing M_CostDetail(s) of the target cost element %', rowcount, v_targetCostElementId;
+
+        FOR v_purge IN (SELECT t.m_product_id, t.ad_org_id FROM tmp_pcra_mai_purge t ORDER BY t.m_product_id, t.ad_org_id)
+            LOOP
+                PERFORM "de_metas_acct".m_costdetail_delete_from_date(
+                        p_C_AcctSchema_ID := p_C_AcctSchema_ID,
+                        p_M_CostElement_ID := v_targetCostElementId,
+                        p_M_Product_ID := v_purge.m_product_id,
+                        p_AD_Org_ID := v_purge.ad_org_id,
+                        p_StartDateAcct := p_StartDateAcct,
+                        p_DryRun := 'N');
+            END LOOP;
+
+        COMMIT;
+    END IF;
+
+    --
+    --
+    -- (d) ONE COMMIT-BATCH OF PRODUCTS AT A TIME
+    --
+    --
+    -- Everything a batch does - rewinding its products' cost details, staging its documents and recording
+    -- itself DONE - happens in ONE transaction. That is what makes the run resumable: a batch is either
+    -- fully done AND marked done, or it is as if it never ran. There is deliberately no intermediate
+    -- 'RUNNING' marker: it could only be written in the same transaction, so no other session could ever
+    -- see it, and an abort would roll it back anyway.
+    --
+    -- There is deliberately no EXCEPTION handler around this loop: PL/pgSQL forbids transaction control
+    -- inside a block that has one, so an exception handler here would make the per-batch COMMIT illegal.
+    -- An error therefore propagates, this batch rolls back, and the batches before it stay committed -
+    -- exactly the state p_Resume='Y' expects.
+    --
+    FOR v_batch IN (
+        WITH numbered AS (SELECT p.m_product_id, p.batch_no FROM tmp_pcra_products p)
+        SELECT n.batch_no,
+               ARRAY_AGG(n.m_product_id ORDER BY n.m_product_id) AS products
+        FROM numbered n
+        GROUP BY n.batch_no
+        ORDER BY n.batch_no)
+        LOOP
+            IF (p_Resume = 'Y'
+                AND EXISTS(SELECT 1
+                           FROM "de_metas_acct".product_costs_recreate_progress pr
+                           WHERE pr.batch_no = v_batch.batch_no
+                             AND pr.status = 'DONE')) THEN
+                RAISE NOTICE 'Batch % is already DONE, skipping it', v_batch.batch_no;
+                CONTINUE;
+            END IF;
+
+            --
+            -- Rewind the cost details of this batch's products for the cost element being recomputed.
+            -- m_costdetail_delete_from_date is the single choke point that also fixes M_Cost and that
+            -- refuses to delete a cost-revaluation opening anchor - which is why the start date of a run
+            -- must lie strictly after the switch's cut-off.
+            --
+            FOREACH v_productId IN ARRAY v_batch.products
+                LOOP
+                    FOREACH v_orgId IN ARRAY v_orgIds
+                        LOOP
+                            PERFORM "de_metas_acct".m_costdetail_delete_from_date(
+                                    p_C_AcctSchema_ID := p_C_AcctSchema_ID,
+                                    p_M_CostElement_ID := p_M_CostElement_ID,
+                                    p_M_Product_ID := v_productId,
+                                    p_AD_Org_ID := v_orgId,
+                                    p_StartDateAcct := p_StartDateAcct,
+                                    p_DryRun := 'N');
+                        END LOOP;
+                END LOOP;
+
+            --
+            -- Manufacturing order costs are a cached copy of the cost details just deleted, so they have
+            -- to go with them (same step as in "de_metas_acct".product_costs_recreate_from_date).
+            --
+            DELETE
+            FROM pp_order_cost poc
+            WHERE EXISTS(SELECT 1
+                         FROM pp_order o
+                         WHERE o.pp_order_id = poc.pp_order_id
+                           AND o.m_product_id = ANY (v_batch.products)
+                           AND o.dateordered >= p_StartDateAcct);
+
+            --
+            -- Park this batch's documents. NOT in "de_metas_acct".accounting_docs_to_repost - see the
+            -- release step below for why.
+            --
+            INSERT INTO "de_metas_acct".accounting_docs_to_repost_staging
+            (tablename, record_id, ad_client_id, description, dateacct, tablename_prio, batch_no)
+            SELECT d.tablename,
+                   d.record_id,
+                   d.ad_client_id,
+                   'product_costs_recreate_all_from_date',
+                   d.dateacct,
+                   d.tablename_prio,
+                   d.batch_no
+            FROM tmp_pcra_staged_docs d
+            WHERE d.batch_no = v_batch.batch_no;
+            GET DIAGNOSTICS rowcount = ROW_COUNT;
+
+            INSERT INTO "de_metas_acct".product_costs_recreate_progress
+                (batch_no, status, products, started_at, finished_at)
+            VALUES (v_batch.batch_no, 'DONE', v_batch.products, NOW(), NOW());
+
+            RAISE NOTICE 'Batch % DONE: % product(s), % document(s) staged',
+                v_batch.batch_no, ARRAY_LENGTH(v_batch.products, 1), rowcount;
+
+            COMMIT;
+        END LOOP;
+
+    --
+    --
+    -- (e) NO Fact_Acct DELETE, NO fact_acct_unpost
+    --
+    --
+    -- Verified, not assumed - the two effects fact_acct_unpost would contribute are both redundant here:
+    --   * deleting the stale Fact_Acct rows: the queue-driven repost does it itself. The queue's poller
+    --     posts through de.metas.acct.api.impl.PostingService#postNow, which calls
+    --     doc.post(force, /*repost*/ true) with that second argument hardcoded, and
+    --     org.compiere.acct.Doc#post does `if (repost) { deleteAcct(); }` before saving the new facts.
+    --   * resetting Posted='N' so the document can be locked again: de.metas.acct.doc
+    --     .SqlAcctDocLockService#lock only adds the `AND Posted='N'` condition when repost is FALSE, so a
+    --     document left at Posted='Y' still locks and reposts.
+    -- Skipping it is not just an optimisation: fact_acct_unpost INSERTs straight into
+    -- "de_metas_acct".accounting_docs_to_repost, which would hand the documents to the poller one by one
+    -- as they are found - the out-of-order reposting this whole procedure exists to prevent.
+    --
+
+    --
+    --
+    -- (f) RELEASE: STAGING -> REAL QUEUE, IN DOCUMENT-DATE ORDER, IN ONE STEP
+    --
+    --
+    -- KNOWN, DELIBERATE RULE DEVIATION - documented here rather than hidden:
+    --   `docs/coding-rules/production-database-support.md` and
+    --   `backend/de.metas.acct.base/CLAUDE.md` both state: never INSERT directly into
+    --   Accounting_Docs_To_Repost - always use the "de_metas_acct".fact_acct_unpost* functions.
+    -- This statement breaks that rule knowingly. The rule exists because fact_acct_unpost bundles two
+    -- safety-relevant side effects with the enqueue (delete the stale Fact_Acct rows, reset Posted='N'),
+    -- and both are redundant for a queue-driven repost - see (e) above for the exact code that makes them
+    -- redundant. What fact_acct_unpost cannot do is enqueue a whole set of documents with a chosen
+    -- SeqNo ordering in one statement, and that ordering is the entire correctness contract of a cost
+    -- recompute. Using it here would therefore trade a provable ordering guarantee for two no-ops.
+    -- The one effect that is NOT redundant is the period check, and that is why (b) asserts every period
+    -- in range is open before anything is mutated.
+    --
+    -- SeqNo is assigned EXPLICITLY via row_number() over the release order. It is never left to the
+    -- column's nextval default: the order in which INSERT ... SELECT evaluates rows - and therefore the
+    -- order in which it consumes a sequence - is not guaranteed by an ORDER BY in the SELECT. The poller
+    -- consumes the queue with `ORDER BY SeqNo`, so getting this wrong reposts documents out of order and
+    -- freezes wrong costs, silently.
+    -- The block of SeqNos is reserved by advancing the queue's own sequence in a single statement, so the
+    -- released rows cannot collide with rows another producer enqueues afterwards.
+    --
+    SELECT COUNT(1) INTO v_releasedCount FROM "de_metas_acct".accounting_docs_to_repost_staging;
+    IF (v_releasedCount > 0) THEN
+        SELECT setval('"de_metas_acct".accounting_docs_to_repost_seqno',
+                      nextval('"de_metas_acct".accounting_docs_to_repost_seqno') + v_releasedCount - 1)
+        INTO v_seqNoLast;
+        v_seqNoBase := v_seqNoLast - v_releasedCount;
+
+        INSERT INTO "de_metas_acct".accounting_docs_to_repost
+        (seqno, tablename, record_id, ad_client_id, force, on_error_notify_user_id, selection_id, description)
+        SELECT v_seqNoBase + ROW_NUMBER() OVER (ORDER BY s.dateacct, s.tablename_prio, s.record_id),
+               s.tablename,
+               s.record_id,
+               s.ad_client_id,
+               s.force,
+               s.on_error_notify_user_id,
+               s.selection_id,
+               s.description
+        FROM "de_metas_acct".accounting_docs_to_repost_staging s;
+
+        DELETE FROM "de_metas_acct".accounting_docs_to_repost_staging;
+    END IF;
+    RAISE NOTICE 'Released % staged document(s) to the reposting queue', v_releasedCount;
+
+    COMMIT;
+
+    PERFORM pg_advisory_unlock(c_AdvisoryLock_ClassId, p_C_AcctSchema_ID::integer);
+
+    RAISE NOTICE 'DONE: % product(s), % document(s) released', v_productCount, v_releasedCount;
+END;
+$BODY$
+;
+
+COMMENT ON PROCEDURE "de_metas_acct".product_costs_recreate_all_from_date(numeric, numeric, timestamp WITH TIME ZONE, numeric, char) IS
+    'Recreates all products'' cost details from a date onwards in resumable commit-batches, staging the documents to repost and releasing them to the queue in document-date order'
+;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816940_sys_gh26253_product_costs_recreate_progress_run_identity.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816940_sys_gh26253_product_costs_recreate_progress_run_identity.sql
@@ -1,0 +1,14 @@
+-- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/table/product_costs_recreate_progress.sql
+
+-- Records, per commit-batch, the run parameters the batch was produced under, so that a resume can
+-- refuse a call that does not continue the recorded run instead of skipping batches it never did.
+-- Full rationale in the Source DDL above.
+-- Nullable on purpose: rows a run started before this change left behind carry no identity, and the
+-- resume has to refuse those too rather than trust them.
+SELECT public.db_alter_table('product_costs_recreate_progress',
+                             'ALTER TABLE "de_metas_acct".product_costs_recreate_progress
+                                  ADD COLUMN c_acctschema_id numeric(10),
+                                  ADD COLUMN m_costelement_id numeric(10),
+                                  ADD COLUMN startdateacct timestamp WITH TIME ZONE,
+                                  ADD COLUMN products_per_commit numeric(10)')
+;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816950_sys_gh26253_product_costs_recreate_all_from_date_run_identity.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5816950_sys_gh26253_product_costs_recreate_all_from_date_run_identity.sql
@@ -1,3 +1,4 @@
+-- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/product_costs_recreate_all_from_date.sql
 DROP PROCEDURE IF EXISTS "de_metas_acct".product_costs_recreate_all_from_date(
     p_C_AcctSchema_ID   numeric,
     p_M_CostElement_ID  numeric,

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5817060_sys_gh26253_product_costs_recreate_all_from_date_population_precheck.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5817060_sys_gh26253_product_costs_recreate_all_from_date_population_precheck.sql
@@ -1,3 +1,4 @@
+-- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/product_costs_recreate_all_from_date.sql
 DROP PROCEDURE IF EXISTS "de_metas_acct".product_costs_recreate_all_from_date(
     p_C_AcctSchema_ID   numeric,
     p_M_CostElement_ID  numeric,

--- a/backend/de.metas.business/src/main/java/de/metas/costing/CostDetailQuery.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/CostDetailQuery.java
@@ -58,6 +58,9 @@ public class CostDetailQuery
 
 	@Nullable CostDetailId afterCostDetailId;
 
+	/** {@code TRUE}/{@code FALSE} match {@code IsChangingCosts}; {@code null} means "don't care". */
+	@Nullable Boolean changingCosts;
+
 	@Nullable Range<Instant> dateAcctRage;
 
 	@NonNull @Singular ImmutableList<OrderBy> orderBys;

--- a/backend/de.metas.business/src/main/java/de/metas/costing/ICostDetailRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/ICostDetailRepository.java
@@ -72,6 +72,19 @@ public interface ICostDetailRepository
 	boolean hasCostDetailsByProductId(ProductId productId);
 
 	/**
+	 * @return the earliest changing-costs {@code M_CostDetail} of the given segment+element dated strictly AFTER
+	 * {@code asOfDate}, ordered by {@code DateAcct, M_CostDetail_ID}. Its {@code Prev_*} columns hold the state the cost
+	 * element was in immediately before that movement — i.e. the state as of {@code asOfDate}.
+	 * <p>
+	 * Deliberately the same algorithm as the SQL function {@code getCurrentCostInfo}
+	 * ({@code de.metas.acct.base/.../ddl/functions/getCurrentCost.sql}), so a point-in-time valuation read done in SQL and
+	 * one done here agree by construction.
+	 */
+	Optional<CostDetail> getFirstChangingCostsDetailAfter(
+			@NonNull CostSegmentAndElement costSegmentAndElement,
+			@NonNull Instant asOfDate);
+
+	/**
 	 * @return the subset of {@code productIds} for which a completed {@code M_CostRevaluation} line has already written a
 	 * cost detail on this {@code (acctSchemaId, costElementId)} — i.e. carries an {@code M_CostDetail} with
 	 * {@code M_CostRevaluationLine_ID} set. This is a broad, source-agnostic signal: it fires for ANY completed

--- a/backend/de.metas.business/src/main/java/de/metas/costing/ICostDetailService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/ICostDetailService.java
@@ -84,4 +84,9 @@ public interface ICostDetailService
 	boolean hasCostDetails(@NonNull CostDetailQuery query);
 
 	Optional<CostDetail> firstOnly(@NonNull CostDetailQuery query);
+
+	/** @see ICostDetailRepository#getFirstChangingCostsDetailAfter(CostSegmentAndElement, Instant) */
+	Optional<CostDetail> getFirstChangingCostsDetailAfter(
+			@NonNull CostSegmentAndElement costSegmentAndElement,
+			@NonNull Instant asOfDate);
 }

--- a/backend/de.metas.business/src/main/java/de/metas/costing/ICostingService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/ICostingService.java
@@ -57,6 +57,26 @@ public interface ICostingService
 
 	Optional<CurrentCost> getCurrentCost(@NonNull CostSegmentAndElement costSegmentAndElement);
 
+	/**
+	 * Point-in-time read of a cost element's cost: the state it was in as of {@code asOfDate}.
+	 * <p>
+	 * The live {@code M_Cost} row only ever carries the LATEST state, so for a cut-off that lies in the past it yields the
+	 * cost AFTER every movement booked since — not the cost AT the cut-off. Therefore the state is reconstructed from the
+	 * {@code Prev_*} columns of the first changing-costs {@code M_CostDetail} dated after {@code asOfDate}: those columns
+	 * hold exactly the state the element was in immediately before that movement. With no such detail, nothing moved after
+	 * the cut-off and the live row IS the state as of {@code asOfDate}.
+	 * <p>
+	 * The boundary is strictly {@code >}, never {@code >=}: a {@code CopyFromCostElement} switch writes its own opening
+	 * anchor dated exactly AT the cut-off, and that anchor must never count as a forward event — otherwise the switch would
+	 * seed itself from its own anchor's {@code Prev_*} instead of from the source element's cost at the cut-off.
+	 *
+	 * @return the cost as of {@code asOfDate}, or empty if the cost element has neither a post-cut-off changing-costs
+	 * detail nor a live {@code M_Cost} row for the segment.
+	 */
+	Optional<CostDetailPreviousAmounts> getCostAsOf(
+			@NonNull CostSegmentAndElement costSegmentAndElement,
+			@NonNull Instant asOfDate);
+
 	void seedCurrentCostFromOpening(
 			@NonNull CostSegmentAndElement targetSegmentAndElement,
 			@NonNull CostDetailPreviousAmounts opening,

--- a/backend/de.metas.business/src/main/java/de/metas/costing/ICostingService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/ICostingService.java
@@ -77,6 +77,10 @@ public interface ICostingService
 			@NonNull CostSegmentAndElement costSegmentAndElement,
 			@NonNull Instant asOfDate);
 
+	/**
+	 * Writes the {@code CopyFromCostElement} switch's opening anchor. For what the "anchor" IS and what it is for, see the
+	 * canonical definition on {@code de.metas.costrevaluation.CostRevaluationService#createDetailsForCopyFromCostElement}.
+	 */
 	void seedCurrentCostFromOpening(
 			@NonNull CostSegmentAndElement targetSegmentAndElement,
 			@NonNull CostDetailPreviousAmounts opening,

--- a/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostDetailRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostDetailRepository.java
@@ -3,6 +3,7 @@ package de.metas.costing.impl;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
 import de.metas.acct.api.AcctSchemaId;
 import de.metas.costing.CostAmount;
 import de.metas.costing.CostDetail;
@@ -11,6 +12,7 @@ import de.metas.costing.CostDetailPreviousAmounts;
 import de.metas.costing.CostDetailQuery;
 import de.metas.costing.CostElementId;
 import de.metas.costing.CostPrice;
+import de.metas.costing.CostSegmentAndElement;
 import de.metas.costing.CostingDocumentRef;
 import de.metas.costing.ICostDetailRepository;
 import de.metas.costing.methods.CostAmountType;
@@ -448,6 +450,25 @@ public class CostDetailRepository implements ICostDetailRepository
 				.addNotNull(I_M_CostDetail.COLUMNNAME_M_CostRevaluationLine_ID)
 				.create()
 				.listDistinctAsImmutableSet(I_M_CostDetail.COLUMNNAME_M_Product_ID, ProductId.class);
+	}
+
+	@Override
+	public Optional<CostDetail> getFirstChangingCostsDetailAfter(
+			@NonNull final CostSegmentAndElement costSegmentAndElement,
+			@NonNull final Instant asOfDate)
+	{
+		// Range.greaterThan => DateAcct > asOfDate, STRICTLY after. A detail dated exactly ON asOfDate is a pre-cut-off
+		// event; see ICostingService#getCostAsOf for why that boundary must not be relaxed to >=.
+		return toSqlQuery(CostDetailQuery.builderFrom(costSegmentAndElement)
+				.dateAcctRage(Range.greaterThan(asOfDate))
+				.orderBy(CostDetailQuery.OrderBy.DATE_ACCT_ASC)
+				.orderBy(CostDetailQuery.OrderBy.ID_ASC)
+				.build())
+				// Only changing-costs details carry a meaningful Prev_* state; recording-only ones repeat the current one.
+				.addEqualsFilter(I_M_CostDetail.COLUMNNAME_IsChangingCosts, true)
+				.create()
+				.firstOptional()
+				.map(this::toCostDetail);
 	}
 
 	@Override

--- a/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostDetailRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostDetailRepository.java
@@ -256,6 +256,13 @@ public class CostDetailRepository implements ICostDetailRepository
 			queryBuilder.addEqualsFilter(I_M_CostDetail.COLUMNNAME_M_CostDetail_Type, amtType.getCode());
 		}
 
+		// IsChangingCosts
+		// Not a "someFiltersApplied" filter on its own: it would still match half the table.
+		if (query.getChangingCosts() != null)
+		{
+			queryBuilder.addEqualsFilter(I_M_CostDetail.COLUMNNAME_IsChangingCosts, query.getChangingCosts());
+		}
+
 		// Product
 		if (query.getProductId() != null)
 		{
@@ -460,12 +467,12 @@ public class CostDetailRepository implements ICostDetailRepository
 		// Range.greaterThan => DateAcct > asOfDate, STRICTLY after. A detail dated exactly ON asOfDate is a pre-cut-off
 		// event; see ICostingService#getCostAsOf for why that boundary must not be relaxed to >=.
 		return toSqlQuery(CostDetailQuery.builderFrom(costSegmentAndElement)
+				// Only changing-costs details carry a meaningful Prev_* state; recording-only ones repeat the current one.
+				.changingCosts(true)
 				.dateAcctRage(Range.greaterThan(asOfDate))
 				.orderBy(CostDetailQuery.OrderBy.DATE_ACCT_ASC)
 				.orderBy(CostDetailQuery.OrderBy.ID_ASC)
 				.build())
-				// Only changing-costs details carry a meaningful Prev_* state; recording-only ones repeat the current one.
-				.addEqualsFilter(I_M_CostDetail.COLUMNNAME_IsChangingCosts, true)
 				.create()
 				.firstOptional()
 				.map(this::toCostDetail);

--- a/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostDetailService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostDetailService.java
@@ -291,4 +291,12 @@ public class CostDetailService implements ICostDetailService
 		return costDetailsRepo.firstOnly(query);
 	}
 
+	@Override
+	public Optional<CostDetail> getFirstChangingCostsDetailAfter(
+			@NonNull final CostSegmentAndElement costSegmentAndElement,
+			@NonNull final Instant asOfDate)
+	{
+		return costDetailsRepo.getFirstChangingCostsDetailAfter(costSegmentAndElement, asOfDate);
+	}
+
 }

--- a/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostingService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostingService.java
@@ -141,6 +141,22 @@ public class CostingService implements ICostingService
 	}
 
 	@Override
+	public Optional<CostDetailPreviousAmounts> getCostAsOf(
+			@NonNull final CostSegmentAndElement costSegmentAndElement,
+			@NonNull final Instant asOfDate)
+	{
+		final Optional<CostDetail> firstDetailAfter = costDetailsService.getFirstChangingCostsDetailAfter(costSegmentAndElement, asOfDate);
+		if (firstDetailAfter.isPresent())
+		{
+			// That detail's Prev_* IS the state as of asOfDate: the state right before the first movement booked after it.
+			return firstDetailAfter.map(CostDetail::getPreviousAmounts);
+		}
+
+		// Nothing moved after asOfDate, so the live M_Cost row still carries the state as of asOfDate.
+		return getCurrentCost(costSegmentAndElement).map(CostDetailPreviousAmounts::of);
+	}
+
+	@Override
 	public CostDetailCreateResultsList createCostDetail(@NonNull final CostDetailCreateRequest request)
 	{
 		return createCostDetailOrEmpty(request).orElseThrow();

--- a/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostingService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostingService.java
@@ -582,6 +582,9 @@ public class CostingService implements ICostingService
 	/**
 	 * {@code CopyFromCostElement} complete-time seed: sets the target element's {@code M_Cost} to {@code opening} and
 	 * writes one zero-delta anchor {@code M_CostDetail} carrying the same {@code opening} as its {@code Prev_*}.
+	 * <p>
+	 * Canonical definition of the "anchor" term:
+	 * {@code de.metas.costrevaluation.CostRevaluationService#createDetailsForCopyFromCostElement}.
 	 */
 	@Override
 	public void seedCurrentCostFromOpening(

--- a/backend/de.metas.business/src/main/java/de/metas/costrevaluation/CostRevaluationRepository.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costrevaluation/CostRevaluationRepository.java
@@ -155,8 +155,8 @@ public class CostRevaluationRepository
 
 		final CostPrice costPrice = sourceCurrentCost.getCostPrice();
 		// Only the own price is copied here; the lower-level (components) cost is deliberately NOT persisted at line
-		// level (M_CostRevaluationLine has no LL column, as in the Calculated path) — it is re-read fresh from the
-		// source at complete time (see CostRevaluationService.createDetailsForCopyFromCostElement).
+		// level (M_CostRevaluationLine has no LL column, as in the Calculated path) — it is re-read at complete time
+		// (see CostRevaluationService.createDetailsForCopyFromCostElement).
 		record.setCurrentCostPrice(costPrice.getOwnCostPrice().toBigDecimal());
 		// Always mirror the source's own price (value-neutral copy, not a user-adjustable revaluation).
 		record.setNewCostPrice(costPrice.getOwnCostPrice().toBigDecimal());

--- a/backend/de.metas.business/src/main/java/de/metas/costrevaluation/CostRevaluationService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costrevaluation/CostRevaluationService.java
@@ -143,15 +143,13 @@ public class CostRevaluationService
 	{
 		final CostSegmentAndElement segmentAndElement = CostSegmentAndElement.of(currentCost.getCostSegment(), currentCost.getCostElementId());
 
-		// getCostAsOf falls back to the very live M_Cost row this CurrentCost was just read from, so an empty result
-		// means "the as-of value IS this live cost" — return it unchanged rather than restating it.
-		return costingService.getCostAsOf(segmentAndElement, asOfDate)
-				.map(costAsOf -> {
-					final CurrentCost restated = currentCost.copy();
-					restated.setFrom(costAsOf);
-					return restated;
-				})
-				.orElse(currentCost);
+		// Fails loudly rather than silently falling back to the live cost — the very bug the as-of read exists to fix.
+		final CostDetailPreviousAmounts costAsOf = costingService.getCostAsOf(segmentAndElement, asOfDate)
+				.orElseThrow(() -> new AdempiereException("No current cost found for source cost element " + segmentAndElement));
+
+		final CurrentCost restated = currentCost.copy();
+		restated.setFrom(costAsOf);
+		return restated;
 	}
 
 	/**

--- a/backend/de.metas.business/src/main/java/de/metas/costrevaluation/CostRevaluationService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costrevaluation/CostRevaluationService.java
@@ -428,6 +428,41 @@ public class CostRevaluationService
 	 * The opening is the source's cost <b>as of the cut-off</b> ({@code EvaluationStartDate}) — not its live cost at
 	 * complete time. For a back-dated switch those differ: the live {@code M_Cost} row already reflects every movement
 	 * booked since the cut-off, so copying it would open the target with a value the source never had at the cut-off.
+	 * <p>
+	 * <b>THE "OPENING ANCHOR" — CANONICAL DEFINITION.</b> This is the one place the <i>anchor</i> is created, so this is
+	 * where the term is defined; the Java, SQL and tests of this feature all mean exactly the row described here.
+	 * <p>
+	 * <b>ELI5:</b> a product is moved to a new costing method as of a date in the PAST. Somebody has to write down
+	 * "on that date the product was worth X" — otherwise the new method has nothing to start counting from. The anchor
+	 * is that written-down number.
+	 * <p>
+	 * <b>What it is:</b> the single {@code M_CostDetail} row written here (via
+	 * {@link ICostingService#seedCurrentCostFromOpening}). It is dated AT the cut-off and its {@code Prev_*} fields carry
+	 * the PREVIOUS method's cost <b>as of that date</b> — not that method's later value. It is the new method's
+	 * <b>opening balance</b>.
+	 * <p>
+	 * <b>Why "anchor":</b> it is the fixed point the product's cost history under the new method hangs from — every later
+	 * cost detail is computed forward from it.
+	 * <p>
+	 * <b>How to recognise it:</b> {@code M_CostRevaluationLine_ID IS NOT NULL} (that nullable FK is set only on a cost
+	 * detail written by a completed {@code M_CostRevaluation} line), {@code IsChangingCosts='Y'}, own {@code Qty} and
+	 * {@code Amt} zero, and {@code Prev_*} equal to the seeded opening.
+	 * <p>
+	 * <b>Its three jobs:</b>
+	 * <ol>
+	 *     <li>it is the only record of the opening balance — no other row carries it;</li>
+	 *     <li>it is the row {@link ICostingService#reverseSeededCurrentCost} deletes to undo the switch;</li>
+	 *     <li>it is the marker the double-seed guard keys on — {@link #retrieveAlreadySeededProductIds} →
+	 *         {@code CostDetailRepository#retrieveProductIdsWithCostRevaluationSeed}, i.e. the same
+	 *         {@code M_CostRevaluationLine_ID IS NOT NULL} — so an already-switched product is never re-seeded.</li>
+	 * </ol>
+	 * <p>
+	 * <b>Hence the guard in {@code de_metas_acct.m_costdetail_delete_from_date}:</b> a cost recompute whose start date
+	 * reaches back over the cut-off would delete the anchor, so that function refuses the range instead. Note what is NOT
+	 * the problem: deleting the anchor does not zero-base the new method — the anchor is {@code IsChangingCosts='Y'} and
+	 * its {@code Prev_*} ARE the seeded opening, so the function's "Approach 1" restores {@code M_Cost} to identical
+	 * numbers. The damage is losing the ROW: no opening-balance record, no basis for reversal, and a blind double-seed
+	 * guard that would let a re-switch re-seed an already-in-use cost.
 	 */
 	private void createDetailsForCopyFromCostElement(
 			@NonNull final CostRevaluation costRevaluation,

--- a/backend/de.metas.business/src/main/java/de/metas/costrevaluation/CostRevaluationService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costrevaluation/CostRevaluationService.java
@@ -27,6 +27,8 @@ import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.service.ClientId;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
+
 @Service
 public class CostRevaluationService
 {
@@ -92,8 +94,9 @@ public class CostRevaluationService
 	}
 
 	/**
-	 * {@code CopyFromCostElement}: seeds lines from the SOURCE element's current cost ({@code CopyFrom_M_CostElement_ID}),
-	 * one per source {@code M_Cost} row including zero-on-hand.
+	 * {@code CopyFromCostElement}: seeds lines from the SOURCE element's cost as of the cut-off
+	 * ({@code CopyFrom_M_CostElement_ID}), one per source {@code M_Cost} row including zero-on-hand — so the drafted
+	 * lines preview exactly the numbers {@link #createDetailsForCopyFromCostElement} will write at complete time.
 	 */
 	private void createLinesFromCopyFromCostElement(
 			@NonNull final CostRevaluationId costRevaluationId,
@@ -118,7 +121,37 @@ public class CostRevaluationService
 			throw new AdempiereException("No current costs found for source cost element " + sourceCostElementId);
 		}
 
-		costRevaluationRepository.createLinesForCopyFromCostElement(costRevaluationId, costRevaluation.getCostElementId(), sourceCurrentCosts);
+		final ImmutableList<CurrentCost> sourceCostsAsOfCutoff = toCostsAsOf(sourceCurrentCosts, costRevaluation.getEvaluationStartDate());
+
+		costRevaluationRepository.createLinesForCopyFromCostElement(costRevaluationId, costRevaluation.getCostElementId(), sourceCostsAsOfCutoff);
+	}
+
+	/**
+	 * Restates each given live {@link CurrentCost} as the cost its element carried as of {@code asOfDate}. Only the
+	 * {@code CopyFromCostElement} preview uses this; the {@code Calculated} source keeps revaluating the live cost.
+	 */
+	private ImmutableList<CurrentCost> toCostsAsOf(
+			@NonNull final ImmutableList<CurrentCost> currentCosts,
+			@NonNull final Instant asOfDate)
+	{
+		return currentCosts.stream()
+				.map(currentCost -> toCostAsOf(currentCost, asOfDate))
+				.collect(ImmutableList.toImmutableList());
+	}
+
+	private CurrentCost toCostAsOf(@NonNull final CurrentCost currentCost, @NonNull final Instant asOfDate)
+	{
+		final CostSegmentAndElement segmentAndElement = CostSegmentAndElement.of(currentCost.getCostSegment(), currentCost.getCostElementId());
+
+		// getCostAsOf falls back to the very live M_Cost row this CurrentCost was just read from, so an empty result
+		// means "the as-of value IS this live cost" — return it unchanged rather than restating it.
+		return costingService.getCostAsOf(segmentAndElement, asOfDate)
+				.map(costAsOf -> {
+					final CurrentCost restated = currentCost.copy();
+					restated.setFrom(costAsOf);
+					return restated;
+				})
+				.orElse(currentCost);
 	}
 
 	/**
@@ -393,6 +426,10 @@ public class CostRevaluationService
 	/**
 	 * {@code CopyFromCostElement} complete-time path: directly sets the target element's {@code M_Cost} from the source's
 	 * opening amounts and writes one opening-anchor {@code M_CostDetail}, instead of the {@code Calculated} history-replay.
+	 * <p>
+	 * The opening is the source's cost <b>as of the cut-off</b> ({@code EvaluationStartDate}) — not its live cost at
+	 * complete time. For a back-dated switch those differ: the live {@code M_Cost} row already reflects every movement
+	 * booked since the cut-off, so copying it would open the target with a value the source never had at the cut-off.
 	 */
 	private void createDetailsForCopyFromCostElement(
 			@NonNull final CostRevaluation costRevaluation,
@@ -408,15 +445,15 @@ public class CostRevaluationService
 		final CostSegment targetSegment = targetSegmentAndElement.toCostSegment();
 		final CostSegmentAndElement sourceSegmentAndElement = CostSegmentAndElement.of(targetSegment, sourceCostElementId);
 
-		final CurrentCost sourceCurrentCost = costingService.getCurrentCost(sourceSegmentAndElement)
+		final CostDetailPreviousAmounts sourceCostAsOfCutoff = costingService.getCostAsOf(sourceSegmentAndElement, costRevaluation.getEvaluationStartDate())
 				.orElseThrow(() -> new AdempiereException("No current cost found for source cost element " + sourceSegmentAndElement));
 
-		// Value-neutral seed: snapshot own price + LL + qty together from a SINGLE fresh read of the source's M_Cost
-		// at complete time — never a stale-own/qty + fresh-LL mix. The line's own/qty are only the drafted preview
-		// frozen at create-lines time; a gap during which the still-active source keeps moving would make them
-		// inconsistent with a fresh LL and silently corrupt the target's forward-costing base.
-		final CostPrice sourceCostPrice = sourceCurrentCost.getCostPrice();
-		final Quantity sourceQty = sourceCurrentCost.getCurrentQty();
+		// Value-neutral seed: snapshot own price + LL + qty together from that SINGLE as-of-the-cut-off read of the
+		// source — never a stale-own/qty + fresh-LL mix. The line's own/qty are only the drafted preview frozen at
+		// create-lines time; a gap during which the still-active source keeps moving would make them inconsistent with
+		// a fresh LL and silently corrupt the target's forward-costing base.
+		final CostPrice sourceCostPrice = sourceCostAsOfCutoff.getCostPrice();
+		final Quantity sourceQty = sourceCostAsOfCutoff.getQty();
 		final CostAmount cumulatedAmt = sourceCostPrice.getOwnCostPrice().multiply(sourceQty);
 
 		// ONE opening object, reused for both the M_Cost seed and the anchor's Prev_*.

--- a/backend/de.metas.business/src/test/java/de/metas/costing/impl/CostingServiceAsOfTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/costing/impl/CostingServiceAsOfTest.java
@@ -1,0 +1,356 @@
+package de.metas.costing.impl;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.acct.api.AcctSchemaId;
+import de.metas.acct.api.TaxCorrectionType;
+import de.metas.ad_reference.ADReferenceService;
+import de.metas.business.BusinessTestHelper;
+import de.metas.costing.CostAmount;
+import de.metas.costing.CostDetail;
+import de.metas.costing.CostDetailPreviousAmounts;
+import de.metas.costing.CostElement;
+import de.metas.costing.CostElementId;
+import de.metas.costing.CostElementType;
+import de.metas.costing.CostPrice;
+import de.metas.costing.CostSegmentAndElement;
+import de.metas.costing.CostTypeId;
+import de.metas.costing.CostingDocumentRef;
+import de.metas.costing.CostingLevel;
+import de.metas.costing.CostingMethod;
+import de.metas.costing.CurrentCost;
+import de.metas.costing.methods.CostAmountType;
+import de.metas.costing.methods.CostingMethodHandlerUtils;
+import de.metas.currency.CurrencyCode;
+import de.metas.currency.CurrencyPrecision;
+import de.metas.currency.CurrencyRepository;
+import de.metas.currency.impl.PlainCurrencyDAO;
+import de.metas.money.CurrencyId;
+import de.metas.order.model.I_M_Product_Category;
+import de.metas.organization.OrgId;
+import de.metas.product.ProductId;
+import de.metas.product.ProductType;
+import de.metas.quantity.Quantity;
+import de.metas.uom.UomId;
+import lombok.NonNull;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.model.I_C_AcctSchema;
+import org.compiere.model.I_C_AcctSchema_Default;
+import org.compiere.model.I_C_AcctSchema_GL;
+import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_M_CostElement;
+import org.compiere.model.I_M_Product;
+import org.compiere.model.I_M_Product_Category_Acct;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.newInstanceOutOfTrx;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * Covers {@code CostingService#getCostAsOf(CostSegmentAndElement, Instant)} — a point-in-time read of a cost element's
+ * cost, reconstructed from the {@code Prev_*} chain of {@code M_CostDetail} rather than from the live {@code M_Cost} row.
+ * <p>
+ * The live {@code M_Cost} row only ever carries the LATEST state. For a cut-off that lies in the past (a cost-method
+ * switch back-dated to a closed year-end), reading it yields the cost AFTER every movement booked since — not the cost
+ * AT the cut-off. The first changing-costs detail dated strictly after the cut-off carries, in its {@code Prev_*}
+ * columns, exactly the state the cost element was in immediately before that movement — i.e. the state at the cut-off.
+ * <p>
+ * The boundary is deliberately strict ({@code >}, not {@code >=}): a detail dated exactly ON the cut-off is a
+ * pre-cut-off event and must not be read as a forward one.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class CostingServiceAsOfTest
+{
+	private static final ZoneId ZONE_ID = ZoneId.of("Europe/Berlin");
+	private static final CostTypeId costTypeId = CostTypeId.ofRepoId(1);
+
+	private static final Instant CUTOFF = Instant.parse("2025-12-31T00:00:00Z");
+	private static final Instant BEFORE_CUTOFF = Instant.parse("2025-06-01T00:00:00Z");
+	private static final Instant AFTER_CUTOFF = Instant.parse("2026-03-01T00:00:00Z");
+
+	private CostElementRepository costElementRepo;
+	private CurrentCostsRepository currentCostsRepo;
+	private CostDetailRepository costDetailsRepo;
+	private CostingService costingService;
+
+	private CurrencyId euroCurrencyId;
+	private I_C_UOM eachUOM;
+	private AcctSchemaId acctSchemaId;
+	private CostElementId costElementId;
+	private ProductId productId;
+
+	@BeforeEach
+	public void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		AdempiereTestHelper.createOrgWithTimeZone(ZONE_ID);
+
+		final Properties ctx = Env.getCtx();
+		Env.setClientId(ctx, ClientId.METASFRESH);
+
+		costElementRepo = new CostElementRepository(ADReferenceService.newMocked());
+		currentCostsRepo = new CurrentCostsRepository(costElementRepo);
+		costDetailsRepo = new CostDetailRepository();
+
+		final CostDetailService costDetailsService = new CostDetailService(costDetailsRepo, costElementRepo);
+		final CostingMethodHandlerUtils handlerUtils = new CostingMethodHandlerUtils(
+				new CurrencyRepository(),
+				currentCostsRepo,
+				costDetailsService);
+		costingService = new CostingService(
+				handlerUtils,
+				costDetailsService,
+				costElementRepo,
+				currentCostsRepo,
+				ImmutableList.of());
+
+		euroCurrencyId = PlainCurrencyDAO.createCurrency(CurrencyCode.EUR).getId();
+		eachUOM = BusinessTestHelper.createUomEach();
+
+		acctSchemaId = createAcctSchema();
+		costElementId = createCostElement("SourceElement", CostingMethod.AveragePO);
+		productId = createProduct("product");
+	}
+
+	private CostElementId createCostElement(@NonNull final String name, @NonNull final CostingMethod costingMethod)
+	{
+		final I_M_CostElement record = InterfaceWrapperHelper.newInstanceOutOfTrx(I_M_CostElement.class);
+		record.setAD_Org_ID(OrgId.ANY.getRepoId());
+		record.setName(name);
+		record.setCostElementType(CostElementType.Material.getCode());
+		record.setCostingMethod(costingMethod.getCode());
+		record.setIsCalculated(false);
+		InterfaceWrapperHelper.saveRecord(record);
+
+		return CostElementId.ofRepoId(record.getM_CostElement_ID());
+	}
+
+	private AcctSchemaId createAcctSchema()
+	{
+		final I_C_AcctSchema acctSchemaRecord = newInstance(I_C_AcctSchema.class);
+		acctSchemaRecord.setName("Test AcctSchema");
+		acctSchemaRecord.setC_Currency_ID(euroCurrencyId.getRepoId());
+		acctSchemaRecord.setM_CostType_ID(costTypeId.getRepoId());
+		acctSchemaRecord.setCostingLevel(CostingLevel.Client.getCode());
+		acctSchemaRecord.setCostingMethod(CostingMethod.AveragePO.getCode());
+		acctSchemaRecord.setSeparator("-");
+		acctSchemaRecord.setTaxCorrectionType(TaxCorrectionType.NONE.getCode());
+		saveRecord(acctSchemaRecord);
+
+		final I_C_AcctSchema_GL acctSchemaGL = newInstance(I_C_AcctSchema_GL.class);
+		acctSchemaGL.setC_AcctSchema_ID(acctSchemaRecord.getC_AcctSchema_ID());
+		acctSchemaGL.setIntercompanyDueFrom_Acct(1);
+		acctSchemaGL.setIntercompanyDueTo_Acct(1);
+		acctSchemaGL.setIncomeSummary_Acct(1);
+		acctSchemaGL.setRetainedEarning_Acct(1);
+		acctSchemaGL.setPPVOffset_Acct(1);
+		acctSchemaGL.setCashRounding_Acct(1);
+		saveRecord(acctSchemaGL);
+
+		final I_C_AcctSchema_Default acctSchemaDefault = newInstance(I_C_AcctSchema_Default.class);
+		acctSchemaDefault.setC_AcctSchema_ID(acctSchemaRecord.getC_AcctSchema_ID());
+		acctSchemaDefault.setRealizedGain_Acct(1);
+		acctSchemaDefault.setRealizedLoss_Acct(1);
+		acctSchemaDefault.setUnrealizedGain_Acct(1);
+		acctSchemaDefault.setUnrealizedLoss_Acct(1);
+		saveRecord(acctSchemaDefault);
+
+		return AcctSchemaId.ofRepoId(acctSchemaRecord.getC_AcctSchema_ID());
+	}
+
+	private ProductId createProduct(@NonNull final String value)
+	{
+		final I_M_Product_Category productCategory = newInstanceOutOfTrx(I_M_Product_Category.class);
+		saveRecord(productCategory);
+
+		final I_M_Product_Category_Acct productCategoryAcct = newInstanceOutOfTrx(I_M_Product_Category_Acct.class);
+		productCategoryAcct.setM_Product_Category_ID(productCategory.getM_Product_Category_ID());
+		productCategoryAcct.setC_AcctSchema_ID(acctSchemaId.getRepoId());
+		saveRecord(productCategoryAcct);
+
+		final I_M_Product product = newInstanceOutOfTrx(I_M_Product.class);
+		product.setValue(value);
+		product.setName(value);
+		product.setC_UOM_ID(eachUOM.getC_UOM_ID());
+		product.setProductType(ProductType.Item.getCode());
+		product.setIsStocked(true);
+		product.setM_Product_Category_ID(productCategory.getM_Product_Category_ID());
+		saveRecord(product);
+
+		return ProductId.ofRepoId(product.getM_Product_ID());
+	}
+
+	private CostSegmentAndElement costSegmentAndElement()
+	{
+		return CostSegmentAndElement.builder()
+				.costingLevel(CostingLevel.Client)
+				.acctSchemaId(acctSchemaId)
+				.costTypeId(costTypeId)
+				.clientId(ClientId.METASFRESH)
+				.orgId(OrgId.ANY)
+				.productId(productId)
+				.attributeSetInstanceId(AttributeSetInstanceId.NONE)
+				.costElementId(costElementId)
+				.build();
+	}
+
+	/** Writes the LIVE {@code M_Cost} row — the latest state, which a naive read would return for any date. */
+	private void seedLiveCurrentCost(
+			@NonNull final String ownCostPrice,
+			@NonNull final String qty)
+	{
+		final CostElement costElement = costElementRepo.getById(costElementId);
+
+		final CurrentCost currentCost = CurrentCost.builder()
+				.costSegment(costSegmentAndElement().toCostSegment())
+				.costElement(costElement)
+				.currencyId(euroCurrencyId)
+				.precision(CurrencyPrecision.ofInt(2))
+				.uom(eachUOM)
+				.ownCostPrice(new BigDecimal(ownCostPrice))
+				.componentsCostPrice(BigDecimal.ZERO)
+				.currentQty(new BigDecimal(qty))
+				.cumulatedAmt(new BigDecimal(ownCostPrice).multiply(new BigDecimal(qty)))
+				.cumulatedQty(new BigDecimal(qty))
+				.build();
+
+		currentCostsRepo.save(currentCost);
+	}
+
+	/**
+	 * Writes a changing-costs {@code M_CostDetail} whose {@code Prev_*} columns hold the given state — i.e. the state
+	 * the cost element was in immediately BEFORE the movement this detail represents.
+	 */
+	private void createChangingCostsDetail(
+			@NonNull final Instant dateAcct,
+			@NonNull final String prevPrice,
+			@NonNull final String prevQty,
+			@NonNull final String prevCumulatedAmt,
+			@NonNull final String prevCumulatedQty)
+	{
+		costDetailsRepo.create(CostDetail.builder()
+				.clientId(ClientId.METASFRESH)
+				.orgId(OrgId.ANY)
+				.acctSchemaId(acctSchemaId)
+				.costElementId(costElementId)
+				.productId(productId)
+				.attributeSetInstanceId(AttributeSetInstanceId.NONE)
+				.amtType(CostAmountType.MAIN)
+				.amt(CostAmount.of("60.00", euroCurrencyId))
+				.qty(Quantity.of("5", eachUOM))
+				.changingCosts(true)
+				.previousAmounts(CostDetailPreviousAmounts.builder()
+						.costPrice(CostPrice.builder()
+								.ownCostPrice(CostAmount.of(prevPrice, euroCurrencyId))
+								.componentsCostPrice(CostAmount.zero(euroCurrencyId))
+								.uomId(UomId.ofRepoId(eachUOM.getC_UOM_ID()))
+								.build())
+						.qty(Quantity.of(prevQty, eachUOM))
+						.cumulatedAmt(CostAmount.of(prevCumulatedAmt, euroCurrencyId))
+						.cumulatedQty(Quantity.of(prevCumulatedQty, eachUOM))
+						.build())
+				.documentRef(CostingDocumentRef.ofInventoryLineId(1))
+				.dateAcct(dateAcct));
+	}
+
+	/**
+	 * The whole point of the as-of read: the reconstruction from the first post-cut-off detail's {@code Prev_*} wins over
+	 * the live {@code M_Cost} row, which by then already reflects the 2026 movement.
+	 */
+	@Test
+	public void returnsPrevAmountsOfFirstDetailStrictlyAfterTheDate()
+	{
+		// The live row carries the LATER (post-cut-off) state.
+		seedLiveCurrentCost("12", "80");
+
+		// The 2026 movement, whose Prev_* preserve the state as of the cut-off.
+		createChangingCostsDetail(AFTER_CUTOFF, "10", "100", "1000", "100");
+
+		final Optional<CostDetailPreviousAmounts> costAsOf = costingService.getCostAsOf(costSegmentAndElement(), CUTOFF);
+
+		assertThat(costAsOf).isPresent();
+		final CostDetailPreviousAmounts amounts = costAsOf.get();
+		assertThat(amounts.getCostPrice().getOwnCostPrice().toBigDecimal()).isEqualByComparingTo("10");
+		assertThat(amounts.getQty().toBigDecimal()).isEqualByComparingTo("100");
+		assertThat(amounts.getCumulatedAmt().toBigDecimal()).isEqualByComparingTo("1000");
+		assertThat(amounts.getCumulatedQty().toBigDecimal()).isEqualByComparingTo("100");
+	}
+
+	/**
+	 * No movement after the cut-off means the live {@code M_Cost} row IS the state at the cut-off. Pins today's
+	 * behaviour, which stays correct for a switch performed at the cut-off rather than back-dated.
+	 */
+	@Test
+	public void fallsBackToLiveCurrentCostWhenNoDetailAfterTheDate()
+	{
+		seedLiveCurrentCost("12", "80");
+
+		// The only detail is dated BEFORE the cut-off, so there is nothing to reconstruct from.
+		createChangingCostsDetail(BEFORE_CUTOFF, "10", "100", "1000", "100");
+
+		final Optional<CostDetailPreviousAmounts> costAsOf = costingService.getCostAsOf(costSegmentAndElement(), CUTOFF);
+
+		assertThat(costAsOf).isPresent();
+		final CostDetailPreviousAmounts amounts = costAsOf.get();
+		assertThat(amounts.getCostPrice().getOwnCostPrice().toBigDecimal()).isEqualByComparingTo("12");
+		assertThat(amounts.getQty().toBigDecimal()).isEqualByComparingTo("80");
+	}
+
+	/**
+	 * The strict {@code >} boundary. A detail dated exactly ON the cut-off — which is where the switch writes its own
+	 * opening anchor — must not be read as a forward event; otherwise the switch would seed itself from its own
+	 * anchor's {@code Prev_*} instead of from the source's cost at the cut-off.
+	 */
+	@Test
+	public void treatsADetailOnTheDateItselfAsBeforeTheDate()
+	{
+		seedLiveCurrentCost("12", "80");
+
+		// Dated exactly AT the cut-off: pre-cut-off, not post-cut-off.
+		createChangingCostsDetail(CUTOFF, "10", "100", "1000", "100");
+
+		final Optional<CostDetailPreviousAmounts> costAsOf = costingService.getCostAsOf(costSegmentAndElement(), CUTOFF);
+
+		assertThat(costAsOf).isPresent();
+		final CostDetailPreviousAmounts amounts = costAsOf.get();
+		assertThat(amounts.getCostPrice().getOwnCostPrice().toBigDecimal()).isEqualByComparingTo("12");
+		assertThat(amounts.getQty().toBigDecimal()).isEqualByComparingTo("80");
+	}
+}

--- a/backend/de.metas.business/src/test/java/de/metas/costrevaluation/CostRevaluationServiceTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/costrevaluation/CostRevaluationServiceTest.java
@@ -556,6 +556,78 @@ public class CostRevaluationServiceTest
 			assertThat(previousAmounts.getCumulatedAmt().toBigDecimal()).isEqualByComparingTo("4000.00");
 			assertThat(previousAmounts.getCumulatedQty().toBigDecimal()).isEqualByComparingTo("200");
 		}
+
+		/**
+		 * The opening is the source's cost AS OF the cut-off ({@code EvaluationStartDate}), not its live (today) cost. A
+		 * switch back-dated to a closed year-end must open the target element with the value the source carried AT that
+		 * year-end; the live {@code M_Cost} row by then already reflects every movement booked since.
+		 * <p>
+		 * Here the source moved after the cut-off: the 2026-03-01 movement's {@code Prev_*} preserve the cut-off state
+		 * (own 10 / LL 2 / qty 100) while the live row already shows own 12 / LL 3 / qty 80. Own price, LL price and qty
+		 * must ALL come from that single as-of snapshot — a fresh LL mixed with a stale own/qty would silently corrupt the
+		 * target's forward-costing base.
+		 */
+		@Test
+		public void seedsTheSourceCostAsOfTheEvaluationStartDate()
+		{
+			final ProductId productWithStock = createProduct("productWithStock");
+
+			// The live source M_Cost carries the POST-cut-off state (what a naive read would copy).
+			seedSourceCurrentCost(productWithStock, "12", "3", "80");
+
+			// The 2026 movement on the source, whose Prev_* preserve the state as of the 2025-12-31 cut-off.
+			createPostCutoffCostEventOnSourceWithPreviousAmounts(productWithStock, "10", "2", "100");
+
+			final CostRevaluationId costRevaluationId = createCopyFromCostElementHeader(); // EvaluationStartDate = 2025-12-31
+			costRevaluationService.createLines(costRevaluationId);
+
+			// The drafted line PREVIEWS the same as-of numbers the complete will write (10 / 100), not the live ones.
+			final List<I_M_CostRevaluationLine> draftedLines = costRevaluationRepository
+					.streamAllLineRecordsByCostRevaluationId(costRevaluationId)
+					.collect(ImmutableList.toImmutableList());
+			final I_M_CostRevaluationLine draftedLine = getLineForProduct(draftedLines, productWithStock);
+			assertThat(draftedLine.getNewCostPrice()).isEqualByComparingTo("10");
+			assertThat(draftedLine.getCurrentQty()).isEqualByComparingTo("100");
+
+			costRevaluationService.createDetails(costRevaluationId);
+
+			final CostSegmentAndElement targetSeg = CostSegmentAndElement.builder()
+					.costingLevel(CostingLevel.Client)
+					.acctSchemaId(acctSchemaId)
+					.costTypeId(costTypeId)
+					.clientId(ClientId.METASFRESH)
+					.orgId(OrgId.ANY)
+					.productId(productWithStock)
+					.attributeSetInstanceId(AttributeSetInstanceId.NONE)
+					.costElementId(targetCostElementId)
+					.build();
+
+			final CurrentCost targetCurrentCost = currentCostsRepo.getOrNull(targetSeg);
+			assertThat(targetCurrentCost).isNotNull();
+			// The CUT-OFF state (10 / 2 / 100), not the live one (12 / 3 / 80).
+			assertThat(targetCurrentCost.getCostPrice().getOwnCostPrice().toBigDecimal()).isEqualByComparingTo("10");
+			assertThat(targetCurrentCost.getCostPrice().getComponentsCostPrice().toBigDecimal()).isEqualByComparingTo("2");
+			assertThat(targetCurrentCost.getCurrentQty().toBigDecimal()).isEqualByComparingTo("100");
+			assertThat(targetCurrentCost.getCumulatedAmt().toBigDecimal()).isEqualByComparingTo("1000");
+			assertThat(targetCurrentCost.getCumulatedQty().toBigDecimal()).isEqualByComparingTo("100");
+
+			final List<CostDetail> anchorDetails = new CostDetailRepository()
+					.stream(CostDetailQuery.builder()
+							.acctSchemaId(acctSchemaId)
+							.costElementId(targetCostElementId)
+							.productId(productWithStock)
+							.build())
+					.collect(ImmutableList.toImmutableList());
+			assertThat(anchorDetails).hasSize(1);
+
+			final CostDetailPreviousAmounts previousAmounts = anchorDetails.get(0).getPreviousAmounts();
+			assertThat(previousAmounts).isNotNull();
+			assertThat(previousAmounts.getCostPrice().getOwnCostPrice().toBigDecimal()).isEqualByComparingTo("10");
+			assertThat(previousAmounts.getCostPrice().getComponentsCostPrice().toBigDecimal()).isEqualByComparingTo("2");
+			assertThat(previousAmounts.getQty().toBigDecimal()).isEqualByComparingTo("100");
+			assertThat(previousAmounts.getCumulatedAmt().toBigDecimal()).isEqualByComparingTo("1000");
+			assertThat(previousAmounts.getCumulatedQty().toBigDecimal()).isEqualByComparingTo("100");
+		}
 	}
 
 	@Nested
@@ -724,6 +796,45 @@ public class CostRevaluationServiceTest
 				.documentRef(CostingDocumentRef.ofInventoryLineId(2))
 				.dateAcct(Instant.parse("2025-06-15T00:00:00Z"))
 				.description("pre-cut-off 2025 history (test stand-in)"));
+	}
+
+	/**
+	 * Directly writes a changing-costs {@code M_CostDetail} on the SOURCE (AveragePO) element, dated AFTER the cut-off and
+	 * carrying in its {@code Prev_*} columns the state the source element was in immediately before that movement — i.e.
+	 * its state AS OF the cut-off.
+	 */
+	private void createPostCutoffCostEventOnSourceWithPreviousAmounts(
+			@NonNull final ProductId productId,
+			@NonNull final String prevOwnCostPrice,
+			@NonNull final String prevComponentsCostPrice,
+			@NonNull final String prevQty)
+	{
+		final BigDecimal prevCumulatedAmt = new BigDecimal(prevOwnCostPrice).multiply(new BigDecimal(prevQty));
+
+		new CostDetailRepository().create(CostDetail.builder()
+				.clientId(ClientId.METASFRESH)
+				.orgId(OrgId.ANY)
+				.acctSchemaId(acctSchemaId)
+				.costElementId(sourceCostElementId)
+				.productId(productId)
+				.attributeSetInstanceId(AttributeSetInstanceId.NONE)
+				.amtType(CostAmountType.MAIN)
+				.amt(CostAmount.of("24.00", euroCurrencyId))
+				.qty(Quantity.of("2", eachUOM))
+				.changingCosts(true)
+				.previousAmounts(CostDetailPreviousAmounts.builder()
+						.costPrice(CostPrice.builder()
+								.ownCostPrice(CostAmount.of(prevOwnCostPrice, euroCurrencyId))
+								.componentsCostPrice(CostAmount.of(prevComponentsCostPrice, euroCurrencyId))
+								.uomId(UomId.ofRepoId(eachUOM.getC_UOM_ID()))
+								.build())
+						.qty(Quantity.of(prevQty, eachUOM))
+						.cumulatedAmt(CostAmount.of(prevCumulatedAmt, euroCurrencyId))
+						.cumulatedQty(Quantity.of(prevQty, eachUOM))
+						.build())
+				.documentRef(CostingDocumentRef.ofInventoryLineId(3))
+				.dateAcct(Instant.parse("2026-03-01T00:00:00Z"))
+				.description("post-cut-off 2026 source movement (test stand-in)"));
 	}
 
 	/** Directly writes a changing-costs {@code M_CostDetail} on the TARGET (MAI) element, dated after the cut-off. */

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/M_CostRevaluation_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/M_CostRevaluation_StepDef.java
@@ -45,7 +45,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Creates, seeds and completes {@link I_M_CostRevaluation} cost-revaluation documents.
+ * Creates, seeds and completes {@link I_M_CostRevaluation} cost-revaluation documents, and validates the cost details
+ * they wrote.
  */
 @RequiredArgsConstructor
 public class M_CostRevaluation_StepDef
@@ -211,6 +212,11 @@ public class M_CostRevaluation_StepDef
 	 * a product's target cost element — the anchor at which the target's moving average starts.
 	 * <p>
 	 * Scoped to the given document's own line, so an anchor left by another scenario or another switch cannot satisfy it.
+	 * <p>
+	 * Deliberately does NOT reuse {@code M_CostDetail_StepDef}'s matcher machinery: {@link CostDetailMatcher} never
+	 * asserts {@code DateAcct} (the whole point here — the anchor must sit AT the cut-off), and
+	 * {@link CostingDocumentRefResolver} cannot resolve a {@code M_CostRevaluationLine}-scoped document ref because
+	 * revaluation lines are created by the document itself and so are held in no {@code StepDefData} registry.
 	 *
 	 * @cucumber.stepdef
 	 * @cucumber.columns

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/M_CostRevaluation_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/M_CostRevaluation_StepDef.java
@@ -1,8 +1,15 @@
 package de.metas.cucumber.stepdefs.costing;
 
+import com.google.common.collect.ImmutableList;
 import de.metas.acct.api.AcctSchemaId;
+import de.metas.costing.CostDetail;
+import de.metas.costing.CostDetailQuery;
 import de.metas.costing.CostElementId;
+import de.metas.costing.CostingDocumentRef;
+import de.metas.costing.impl.CostDetailRepository;
 import de.metas.costrevaluation.CostRevaluationId;
+import de.metas.costrevaluation.CostRevaluationLine;
+import de.metas.costrevaluation.CostRevaluationRepository;
 import de.metas.costrevaluation.CostRevaluationService;
 import de.metas.document.DocBaseType;
 import de.metas.document.DocTypeId;
@@ -10,20 +17,31 @@ import de.metas.document.DocTypeQuery;
 import de.metas.document.IDocTypeDAO;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.acctschema.C_AcctSchema_StepDefData;
 import de.metas.document.engine.IDocument;
 import de.metas.document.engine.IDocumentBL;
+import de.metas.money.MoneyService;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.uom.IUOMDAO;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.assertj.core.api.SoftAssertions;
 import org.compiere.SpringContextHolder;
+import org.compiere.model.I_M_CostDetail;
 import org.compiere.model.I_M_CostRevaluation;
 import org.compiere.util.Env;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
@@ -33,12 +51,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class M_CostRevaluation_StepDef
 {
 	@NonNull private final CostRevaluationService costRevaluationService = SpringContextHolder.instance.getBean(CostRevaluationService.class);
+	@NonNull private final CostRevaluationRepository costRevaluationRepository = SpringContextHolder.instance.getBean(CostRevaluationRepository.class);
+	@NonNull private final CostDetailRepository costDetailRepository = SpringContextHolder.instance.getBean(CostDetailRepository.class);
+	@NonNull private final MoneyService moneyService = SpringContextHolder.instance.getBean(MoneyService.class);
 	@NonNull private final IDocumentBL documentBL = Services.get(IDocumentBL.class);
 	@NonNull private final IDocTypeDAO docTypeDAO = Services.get(IDocTypeDAO.class);
+	@NonNull private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
 
 	@NonNull private final M_CostRevaluation_StepDefData costRevaluationTable;
 	@NonNull private final C_AcctSchema_StepDefData acctSchemaTable;
 	@NonNull private final M_CostElement_StepDefData costElementTable;
+	@NonNull private final M_Product_StepDefData productTable;
 
 	/**
 	 * Creates a drafted cost-revaluation header.
@@ -181,5 +204,74 @@ public class M_CostRevaluation_StepDef
 		final I_M_CostRevaluation record = costRevaluationTable.get(identifier);
 		assertThatThrownBy(() -> costRevaluationService.createLines(CostRevaluationId.ofRepoId(record.getM_CostRevaluation_ID())))
 				.hasMessageContaining("onto itself");
+	}
+
+	/**
+	 * Asserts the opening-anchor {@code M_CostDetail} that a completed {@code CopyFromCostElement} revaluation wrote for
+	 * a product's target cost element — the anchor at which the target's moving average starts.
+	 * <p>
+	 * Scoped to the given document's own line, so an anchor left by another scenario or another switch cannot satisfy it.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_Product_ID</b> — (required, identifier-ref) the product whose line seeded the anchor<br>
+	 *   <b>M_CostElement_ID</b> — (required) target cost element (costing-method name, e.g. MovingAverageInvoice)<br>
+	 *   <b>DateAcct</b> — (required) expected accounting date of the anchor<br>
+	 *   <b>Qty</b> — (required) expected anchor quantity with UOM (e.g. "0 PCE")<br>
+	 *   <b>Amt</b> — (required) expected anchor amount with currency (e.g. "0 CHF")<br>
+	 * @cucumber.depends StepDefData: M_CostRevaluation_StepDefData, M_Product_StepDefData, M_CostElement_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * Then the cost revaluation identified by costRevalMAI seeded opening cost details:
+	 *   | M_Product_ID | M_CostElement_ID     | DateAcct   | Qty   | Amt   |
+	 *   | product      | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+	 * </pre>
+	 */
+	@Then("^the cost revaluation identified by (.*) seeded opening cost details:$")
+	public void costRevaluation_seededOpeningCostDetails(@NonNull final String identifier, @NonNull final DataTable dataTable)
+	{
+		final I_M_CostRevaluation record = costRevaluationTable.get(identifier);
+		final List<CostRevaluationLine> lines = costRevaluationRepository.getLinesByCostRevaluationId(
+				CostRevaluationId.ofRepoId(record.getM_CostRevaluation_ID()));
+
+		DataTableRows.of(dataTable).forEach(row -> {
+			final ProductId productId = row.getAsIdentifier(I_M_CostDetail.COLUMNNAME_M_Product_ID).lookupIdIn(productTable);
+			final CostElementId costElementId = costElementTable.getSingleId(row.getAsString(I_M_CostDetail.COLUMNNAME_M_CostElement_ID));
+
+			final CostDetail anchor = getSingleAnchor(lines, productId, costElementId);
+
+			final Quantity expectedQty = row.getAsQuantity(I_M_CostDetail.COLUMNNAME_Qty, null, uomDAO::getByX12DE355);
+
+			final SoftAssertions softly = new SoftAssertions();
+			softly.assertThat(anchor.getDateAcct()).as("DateAcct")
+					.isEqualTo(row.getAsLocalDateTimestamp(I_M_CostDetail.COLUMNNAME_DateAcct).toInstant());
+			softly.assertThat(anchor.getQty().getUomId()).as("Qty UOM").isEqualTo(expectedQty.getUomId());
+			softly.assertThat(anchor.getQty().toBigDecimal()).as("Qty").isEqualByComparingTo(expectedQty.toBigDecimal());
+			softly.assertThat(anchor.getAmt().toMoney()).as("Amt")
+					.isEqualTo(row.getAsMoney(I_M_CostDetail.COLUMNNAME_Amt, moneyService::getCurrencyIdByCurrencyCode));
+			softly.assertAll();
+		});
+	}
+
+	private CostDetail getSingleAnchor(
+			@NonNull final List<CostRevaluationLine> lines,
+			@NonNull final ProductId productId,
+			@NonNull final CostElementId costElementId)
+	{
+		final ImmutableList<CostRevaluationLine> matchingLines = lines.stream()
+				.filter(line -> productId.equals(line.getCostSegmentAndElement().getProductId()))
+				.filter(line -> costElementId.equals(line.getCostSegmentAndElement().getCostElementId()))
+				.collect(ImmutableList.toImmutableList());
+		assertThat(matchingLines).as("active cost revaluation lines for %s / %s", productId, costElementId).hasSize(1);
+
+		final ImmutableList<CostDetail> anchors = costDetailRepository.stream(CostDetailQuery.builder()
+						.productId(productId)
+						.costElementId(costElementId)
+						.documentRef(CostingDocumentRef.ofCostRevaluationLineId(matchingLines.get(0).getId()))
+						.build())
+				.collect(ImmutableList.toImmutableList());
+		assertThat(anchors).as("opening anchor cost details of %s", matchingLines.get(0).getId()).hasSize(1);
+
+		return anchors.get(0);
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/ProductCostsRecreateAll_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/ProductCostsRecreateAll_StepDef.java
@@ -118,7 +118,53 @@ public class ProductCostsRecreateAll_StepDef
 	@When("^the cost recompute driver runs:$")
 	public void run(@NonNull final DataTable dataTable)
 	{
-		rememberOutcome(invokeDriver(DataTableRows.of(dataTable).singleRow(), null));
+		rememberOutcome(invokeDriver(DataTableRows.of(dataTable).singleRow(), null, false /*runMustFail*/));
+	}
+
+	/**
+	 * Runs the cost-recompute driver as a resume and asserts it is REFUSED because the recorded batches were
+	 * not produced by this call's run — here because that run used a different products-per-commit.
+	 * <p>
+	 * A batch number is not a stable name for a set of products: the driver recomputes it on every call from
+	 * the caller's own {@code p_ProductsPerCommit}. So a resume with a different products-per-commit reads a
+	 * batch number recorded DONE under the old grouping as "already done" for a DIFFERENT set of products —
+	 * which are then never rewound, never staged, and the run reports success. Refusing is the only safe
+	 * answer, and the refusal must name BOTH products-per-commit values: that is what tells the operator
+	 * which parameter to correct in order to actually continue the crashed run.
+	 * <p>
+	 * The run's outcome is still snapshotted and remembered, so the steps after this one can assert that the
+	 * refused run changed nothing.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns same as <code>the cost recompute driver runs:</code>, plus<br>
+	 *   <b>RecordedProductsPerCommit</b> — (required) products-per-commit of the run that recorded the DONE batches; the refusal must name it<br>
+	 * @cucumber.depends StepDefData: C_AcctSchema_StepDefData, M_CostElement_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * When the cost recompute driver run is refused because the recorded run used a different products-per-commit:
+	 *   | C_AcctSchema_ID | M_CostElement_ID | StartDateAcct | ProductsPerCommit | Resume | RecordedProductsPerCommit |
+	 *   | acctSchema      | AveragePO        | 2027-06-01    | 2                 | Y      | 1                         |
+	 * </pre>
+	 */
+	@When("^the cost recompute driver run is refused because the recorded run used a different products-per-commit:$")
+	public void runIsRefused_recordedRunUsedADifferentProductsPerCommit(@NonNull final DataTable dataTable)
+	{
+		final DataTableRow row = DataTableRows.of(dataTable).singleRow();
+		final int requestedProductsPerCommit = row.getAsInt("ProductsPerCommit");
+		final int recordedProductsPerCommit = row.getAsInt("RecordedProductsPerCommit");
+
+		rememberOutcome(invokeDriver(row, null, true /*runMustFail*/));
+
+		assertThat(getLastRunOutcome().getFailure())
+				.as("resuming with ProductsPerCommit=%s must be refused, because the recorded batches were produced with ProductsPerCommit=%s",
+						requestedProductsPerCommit, recordedProductsPerCommit)
+				.isNotNull()
+				// hasStackTraceContaining, not hasMessageContaining: the driver is CALLed through a plain JDBC
+				// statement, so the refusal raised by the procedure is the CAUSE of the exception this step
+				// sees, and the top-level message is only "Failed executing: CALL ...".
+				.hasStackTraceContaining("Cannot resume")
+				.hasStackTraceContaining("ProductsPerCommit=" + recordedProductsPerCommit)
+				.hasStackTraceContaining("ProductsPerCommit=" + requestedProductsPerCommit);
 	}
 
 	/**
@@ -135,6 +181,12 @@ public class ProductCostsRecreateAll_StepDef
 	 * pool: a real operator runs the driver in its own {@code psql} session, so a crashed run's advisory lock
 	 * dies with that session — a pooled JDBC connection outlives the failure, so the lock has to be released
 	 * explicitly or the resume run could not acquire it.
+	 * <p>
+	 * The failure's message is asserted to be the INJECTED one, not merely "the run failed": the driver
+	 * recomputes every product of the accounting schema, so it can also die for a reason that has nothing to
+	 * do with this scenario (a foreign document in the recompute's date range whose period has no calendar,
+	 * say). Accepting any failure would let such a run pass this step and then fail several steps later on an
+	 * assertion that looks unrelated, hiding the real cause.
 	 *
 	 * @cucumber.stepdef
 	 * @cucumber.columns same as <code>the cost recompute driver runs:</code>
@@ -152,7 +204,7 @@ public class ProductCostsRecreateAll_StepDef
 	{
 		final TableRecordReference dieOnDocument = identifiersResolver.getTableRecordReference(
 				StepDefDataIdentifier.ofString(documentIdentifier));
-		rememberOutcome(invokeDriver(DataTableRows.of(dataTable).singleRow(), dieOnDocument));
+		rememberOutcome(invokeDriver(DataTableRows.of(dataTable).singleRow(), dieOnDocument, true /*runMustFail*/));
 	}
 
 	/**
@@ -301,7 +353,17 @@ public class ProductCostsRecreateAll_StepDef
 		return lastRunOutcome;
 	}
 
-	private RunOutcome invokeDriver(@NonNull final DataTableRow row, @Nullable final TableRecordReference dieOnDocument)
+	/**
+	 * @param dieOnDocument when set, an abort is injected while this document is staged
+	 * @param runMustFail   {@code true} when the failure IS the expected outcome (an injected abort, or a
+	 *                      refusal the calling step asserts on). Only a run that is expected to SUCCEED
+	 *                      rethrows its failure here — otherwise the assertion the caller wants to make
+	 *                      about the failure could never be reached.
+	 */
+	private RunOutcome invokeDriver(
+			@NonNull final DataTableRow row,
+			@Nullable final TableRecordReference dieOnDocument,
+			final boolean runMustFail)
 	{
 		final String callSql = buildCallSql(row);
 		logger.info("Invoking cost-recompute driver: {}", callSql);
@@ -323,8 +385,8 @@ public class ProductCostsRecreateAll_StepDef
 			catch (final Exception ex)
 			{
 				// logged, not only remembered: when the run was expected to succeed the exception is rethrown
-				// below, but when an abort was injected the exception is the expected outcome and its message is
-				// the only clue whether the run died for the injected reason or for an unrelated one.
+				// below, but when the failure IS the expected outcome (an injected abort, or a refusal) its
+				// message is the only clue whether the run died for that reason or for an unrelated one.
 				logger.warn("Cost-recompute driver run failed", ex);
 				failure = ex;
 			}
@@ -338,7 +400,7 @@ public class ProductCostsRecreateAll_StepDef
 				execute(connection, "SELECT pg_advisory_unlock_all()");
 			}
 
-			outcome = takeSnapshot(connection);
+			outcome = takeSnapshot(connection, failure);
 		}
 		finally
 		{
@@ -349,9 +411,13 @@ public class ProductCostsRecreateAll_StepDef
 		{
 			assertThat(failure)
 					.as("cost-recompute driver run must die while staging %s", dieOnDocument)
-					.isNotNull();
+					.isNotNull()
+					// hasStackTraceContaining, not hasMessageContaining: the driver is CALLed through a plain
+					// JDBC statement, so the PostgreSQL error is the CAUSE of the exception this step sees and
+					// the top-level message is only "Failed executing: CALL ...".
+					.hasStackTraceContaining(stagingAbortMessage(dieOnDocument));
 		}
-		else if (failure != null)
+		else if (!runMustFail && failure != null)
 		{
 			throw AdempiereException.wrapIfNeeded(failure);
 		}
@@ -377,6 +443,13 @@ public class ProductCostsRecreateAll_StepDef
 				+ ", p_Resume:='" + resume + "')";
 	}
 
+	/** The message the injected abort raises with — the proof a failed run failed for the injected reason. */
+	private static String stagingAbortMessage(@NonNull final TableRecordReference dieOnDocument)
+	{
+		return "cucumber: cost-recompute run died while staging "
+				+ dieOnDocument.getTableName() + "/" + dieOnDocument.getRecord_ID();
+	}
+
 	private void installStagingAbortTrigger(@NonNull final Connection connection, @NonNull final TableRecordReference dieOnDocument)
 	{
 		execute(connection, "CREATE OR REPLACE FUNCTION " + ABORT_TRIGGER_FUNCTION + "() RETURNS trigger LANGUAGE plpgsql AS $fn$"
@@ -399,7 +472,7 @@ public class ProductCostsRecreateAll_StepDef
 		execute(connection, "DROP FUNCTION IF EXISTS " + ABORT_TRIGGER_FUNCTION + "()");
 	}
 
-	private RunOutcome takeSnapshot(@NonNull final Connection connection)
+	private RunOutcome takeSnapshot(@NonNull final Connection connection, @Nullable final Exception failure)
 	{
 		final ImmutableList.Builder<Integer> doneBatchNos = ImmutableList.builder();
 		final ArrayList<TableRecordReference> stagedDocuments = new ArrayList<>();
@@ -440,7 +513,8 @@ public class ProductCostsRecreateAll_StepDef
 		return new RunOutcome(
 				doneBatchNos.build(),
 				ImmutableList.copyOf(stagedDocuments),
-				ImmutableList.copyOf(queuedDocuments));
+				ImmutableList.copyOf(queuedDocuments),
+				failure);
 	}
 
 	private static int countQueueRows()
@@ -468,5 +542,7 @@ public class ProductCostsRecreateAll_StepDef
 		@NonNull ImmutableList<TableRecordReference> stagedDocuments;
 		/** Documents in the repost queue, ordered by SeqNo, i.e. in the order they will be reposted. */
 		@NonNull ImmutableList<TableRecordReference> queuedDocuments;
+		/** What the run failed with, or {@code null} when it succeeded. */
+		@Nullable Exception failure;
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/ProductCostsRecreateAll_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/ProductCostsRecreateAll_StepDef.java
@@ -1,0 +1,472 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.costing;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.costing.CostElementId;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
+import de.metas.cucumber.stepdefs.StepDefUtil;
+import de.metas.cucumber.stepdefs.acctschema.C_AcctSchema_StepDefData;
+import de.metas.cucumber.stepdefs.util.IdentifiersResolver;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_C_AcctSchema;
+import org.compiere.util.DB;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.LocalDate;
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Drives {@code de_metas_acct.product_costs_recreate_all_from_date} — the batched, resumable cost-recompute
+ * driver that parks every document it wants reposted in a staging table and releases the whole table into
+ * {@code de_metas_acct.accounting_docs_to_repost} in document-date order — and asserts what a run left behind.
+ * <p>
+ * Three things about this step def are deliberate and load-bearing:
+ * <ul>
+ * <li><b>The driver is CALLed on a dedicated auto-commit connection.</b> It is a PROCEDURE that COMMITs after
+ * every batch, and PostgreSQL rejects transaction control inside an explicit transaction block. metasfresh's
+ * {@code DB.executeUpdate*} always runs its statement inside a JDBC transaction (it commits afterwards
+ * itself), so it cannot be used here.</li>
+ * <li><b>Everything a run leaves behind is snapshotted immediately after the CALL returns</b>, in the same
+ * step, and every later assertion reads that snapshot. The accounting server's poller drains
+ * {@code accounting_docs_to_repost} on its own schedule, so reading the queue in a later step would race the
+ * drain.</li>
+ * <li><b>Assertions name the documents they expect, never a total row count.</b> The driver deliberately has
+ * no product parameter — it recomputes EVERY product of the accounting schema — so any other document in the
+ * recompute's date range takes part in the run. Counting rows would make the assertions depend on what the
+ * rest of the test database happens to contain.</li>
+ * </ul>
+ */
+@RequiredArgsConstructor
+public class ProductCostsRecreateAll_StepDef
+{
+	private static final Logger logger = LoggerFactory.getLogger(ProductCostsRecreateAll_StepDef.class);
+
+	private static final String TABLE_Queue = "\"de_metas_acct\".accounting_docs_to_repost";
+	private static final String TABLE_Staging = "\"de_metas_acct\".accounting_docs_to_repost_staging";
+	private static final String TABLE_Progress = "\"de_metas_acct\".product_costs_recreate_progress";
+
+	/** Trigger + trigger function this step def installs to make a run die mid-flight. Test-only. */
+	private static final String ABORT_TRIGGER_FUNCTION = "public.cucumber_abort_cost_recompute_staging";
+	private static final String ABORT_TRIGGER_NAME = "cucumber_abort_cost_recompute_staging_tg";
+
+	@NonNull private final C_AcctSchema_StepDefData acctSchemaTable;
+	@NonNull private final M_CostElement_StepDefData costElementTable;
+	@NonNull private final IdentifiersResolver identifiersResolver;
+
+	/** What the most recent driver run left behind. */
+	@Nullable private RunOutcome lastRunOutcome;
+	/** What the run before that left behind; lets a resume be compared against the run it continues. */
+	@Nullable private RunOutcome previousRunOutcome;
+
+	/**
+	 * Runs the cost-recompute driver {@code de_metas_acct.product_costs_recreate_all_from_date} and expects it
+	 * to succeed, i.e. to work through every batch and release the staging table into the repost queue.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>C_AcctSchema_ID</b> — (required, identifier-ref) accounting schema to recompute<br>
+	 *   <b>M_CostElement_ID</b> — (required, identifier-ref or costing-method code/name, e.g. <code>AveragePO</code>) the cost element the run recomputes<br>
+	 *   <b>StartDateAcct</b> — (required) first accounting date the recompute covers (inclusive)<br>
+	 *   <b>ProductsPerCommit</b> — (required) products per commit-batch<br>
+	 *   <b>Resume</b> — (optional, default <code>N</code>) <code>Y</code> to skip the batches an earlier run already finished<br>
+	 * @cucumber.depends StepDefData: C_AcctSchema_StepDefData, M_CostElement_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * When the cost recompute driver runs:
+	 *   | C_AcctSchema_ID | M_CostElement_ID | StartDateAcct | ProductsPerCommit | Resume |
+	 *   | acctSchema      | AveragePO        | 2027-01-01    | 1                 | Y      |
+	 * </pre>
+	 */
+	@When("^the cost recompute driver runs:$")
+	public void run(@NonNull final DataTable dataTable)
+	{
+		rememberOutcome(invokeDriver(DataTableRows.of(dataTable).singleRow(), null));
+	}
+
+	/**
+	 * Runs the cost-recompute driver and asserts it dies while staging the given document, leaving the batches
+	 * before it committed — the local, deterministic stand-in for the production abort this driver exists for
+	 * (a multi-hour run losing its backend connection after several batches had already committed).
+	 * <p>
+	 * The abort is injected by a test-only {@code BEFORE INSERT} trigger on the staging table that raises for
+	 * exactly that one document; the trigger is dropped again before the step returns, whatever happens. The
+	 * document is named rather than a batch number, so the injection does not depend on how many other
+	 * products the run happens to cover.
+	 * <p>
+	 * The step also releases every session-level advisory lock on its connection before handing it back to the
+	 * pool: a real operator runs the driver in its own {@code psql} session, so a crashed run's advisory lock
+	 * dies with that session — a pooled JDBC connection outlives the failure, so the lock has to be released
+	 * explicitly or the resume run could not acquire it.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns same as <code>the cost recompute driver runs:</code>
+	 * @cucumber.depends StepDefData: C_AcctSchema_StepDefData, M_CostElement_StepDefData; the document
+	 *   identifier must be resolvable by <code>IdentifiersResolver</code>
+	 * @cucumber.example
+	 * <pre>
+	 * When the cost recompute driver run dies while staging document invProduct3:
+	 *   | C_AcctSchema_ID | M_CostElement_ID | StartDateAcct | ProductsPerCommit | Resume |
+	 *   | acctSchema      | AveragePO        | 2027-01-01    | 1                 | N      |
+	 * </pre>
+	 */
+	@When("^the cost recompute driver run dies while staging document ([^ :]+):$")
+	public void runDiesWhileStagingDocument(@NonNull final String documentIdentifier, @NonNull final DataTable dataTable)
+	{
+		final TableRecordReference dieOnDocument = identifiersResolver.getTableRecordReference(
+				StepDefDataIdentifier.ofString(documentIdentifier));
+		rememberOutcome(invokeDriver(DataTableRows.of(dataTable).singleRow(), dieOnDocument));
+	}
+
+	/**
+	 * Asserts, per named document, whether the most recent driver run left it parked in the staging table and
+	 * whether it released it to the repost queue. Both come from the snapshot taken right after the run, so the
+	 * accounting server's poller cannot race this assertion.
+	 * <p>
+	 * The rows marked <code>IsReleased=Y</code> must appear in the repost queue in the order they are listed
+	 * here — that is the order the documents will be reposted in, and therefore the order their costs are
+	 * computed in. Each of them must appear exactly ONCE, and no document may be staged twice: a resume that
+	 * restarted from the first batch instead of continuing would stage and release an already-done batch's
+	 * document a second time. For the same reason the recorded batch numbers must be free of duplicates.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>Record_ID</b> — (required, identifier-ref) the document<br>
+	 *   <b>IsStaged</b> — (required) whether it must be parked in the staging table<br>
+	 *   <b>IsReleased</b> — (required) whether it must be in the repost queue; the <code>Y</code> rows are checked in the listed order<br>
+	 * @cucumber.depends the identifier must be resolvable by <code>IdentifiersResolver</code>
+	 * @cucumber.example
+	 * <pre>
+	 * Then the cost recompute run left these documents:
+	 *   | Record_ID   | IsStaged | IsReleased |
+	 *   | invProduct1 | Y        | N          |
+	 *   | invProduct2 | Y        | N          |
+	 *   | invProduct3 | N        | N          |
+	 * </pre>
+	 */
+	@Then("^the cost recompute run left these documents:$")
+	public void runLeftTheseDocuments(@NonNull final DataTable dataTable)
+	{
+		final RunOutcome outcome = getLastRunOutcome();
+		final ImmutableList.Builder<TableRecordReference> expectedReleasedInOrder = ImmutableList.builder();
+
+		for (final DataTableRow row : DataTableRows.of(dataTable).toList())
+		{
+			final TableRecordReference documentRef = identifiersResolver.getTableRecordReference(row.getAsIdentifier("Record_ID"));
+
+			if (row.getAsBoolean("IsStaged"))
+			{
+				assertThat(outcome.getStagedDocuments()).as("staged documents").contains(documentRef);
+			}
+			else
+			{
+				assertThat(outcome.getStagedDocuments()).as("staged documents").doesNotContain(documentRef);
+			}
+
+			if (row.getAsBoolean("IsReleased"))
+			{
+				assertThat(outcome.getQueuedDocuments())
+						.as("documents released to the repost queue")
+						.containsOnlyOnce(documentRef);
+				expectedReleasedInOrder.add(documentRef);
+			}
+			else
+			{
+				assertThat(outcome.getQueuedDocuments())
+						.as("documents released to the repost queue")
+						.doesNotContain(documentRef);
+			}
+		}
+
+		// guarded: AssertJ's containsSubsequence rejects an empty expectation against a non-empty actual, and
+		// "this run released none of these documents" is a legitimate expectation - it is what the per-document
+		// doesNotContain assertions above already covered.
+		final ImmutableList<TableRecordReference> releasedInOrder = expectedReleasedInOrder.build();
+		if (!releasedInOrder.isEmpty())
+		{
+			assertThat(outcome.getQueuedDocuments())
+					.as("documents released to the repost queue, ordered by SeqNo")
+					.containsSubsequence(releasedInOrder.toArray(new TableRecordReference[0]));
+		}
+
+		assertThat(outcome.getStagedDocuments()).as("staged documents").doesNotHaveDuplicates();
+		assertThat(outcome.getDoneBatchNos()).as("commit-batches recorded DONE").doesNotHaveDuplicates();
+	}
+
+	/**
+	 * Asserts the staging table is empty, i.e. the run released everything it had parked. Safe to state
+	 * absolutely: the release step empties the whole staging table in the same transaction that fills the queue.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * And the cost recompute staging table is empty
+	 * </pre>
+	 */
+	@Then("^the cost recompute staging table is empty$")
+	public void stagingTableIsEmpty()
+	{
+		assertThat(getLastRunOutcome().getStagedDocuments()).as("staged documents").isEmpty();
+	}
+
+	/**
+	 * Asserts the most recent run finished exactly the given number of commit-batches MORE than the run before
+	 * it — the direct statement of "it resumed" as opposed to "it started over": a run that restarted from the
+	 * first batch would re-do, and re-record, every batch the crashed run had already finished.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * And the cost recompute run finished 1 more batch than the run before it
+	 * </pre>
+	 */
+	@Then("^the cost recompute run finished (\\d+) more batch(?:es)? than the run before it$")
+	public void runFinishedNMoreBatches(final int expectedAdditionalBatches)
+	{
+		final int previousDoneBatches = previousRunOutcome != null ? previousRunOutcome.getDoneBatchNos().size() : 0;
+		assertThat(getLastRunOutcome().getDoneBatchNos().size() - previousDoneBatches)
+				.as("commit-batches finished on top of the %s the previous run had finished", previousDoneBatches)
+				.isEqualTo(expectedAdditionalBatches);
+	}
+
+	/**
+	 * Waits until the accounting server's repost poller has taken every released document off the queue.
+	 * A drained queue is the signal that the released documents are on their way to being reposted.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * And after not more than 120s, the repost queue is drained
+	 * </pre>
+	 */
+	@Then("^after not more than (\\d+)s, the repost queue is drained$")
+	public void repostQueueIsDrained(final int maxWaitSeconds) throws InterruptedException
+	{
+		StepDefUtil.tryAndWait(
+				maxWaitSeconds,
+				1000,
+				() -> countQueueRows() == 0,
+				() -> logger.info("Repost queue still holds {} row(s)", countQueueRows()));
+	}
+
+	private void rememberOutcome(@NonNull final RunOutcome outcome)
+	{
+		previousRunOutcome = lastRunOutcome;
+		lastRunOutcome = outcome;
+	}
+
+	private RunOutcome getLastRunOutcome()
+	{
+		if (lastRunOutcome == null)
+		{
+			throw new AdempiereException("No cost-recompute driver run was performed yet in this scenario");
+		}
+		return lastRunOutcome;
+	}
+
+	private RunOutcome invokeDriver(@NonNull final DataTableRow row, @Nullable final TableRecordReference dieOnDocument)
+	{
+		final String callSql = buildCallSql(row);
+		logger.info("Invoking cost-recompute driver: {}", callSql);
+
+		Exception failure = null;
+		final RunOutcome outcome;
+
+		final Connection connection = DB.createConnection(true /*autoCommit*/, Connection.TRANSACTION_READ_COMMITTED);
+		try
+		{
+			if (dieOnDocument != null)
+			{
+				installStagingAbortTrigger(connection, dieOnDocument);
+			}
+			try
+			{
+				execute(connection, callSql);
+			}
+			catch (final Exception ex)
+			{
+				// logged, not only remembered: when the run was expected to succeed the exception is rethrown
+				// below, but when an abort was injected the exception is the expected outcome and its message is
+				// the only clue whether the run died for the injected reason or for an unrelated one.
+				logger.warn("Cost-recompute driver run failed", ex);
+				failure = ex;
+			}
+			finally
+			{
+				if (dieOnDocument != null)
+				{
+					removeStagingAbortTrigger(connection);
+				}
+				// see the step-def Javadoc: emulate the session teardown a real operator's psql session performs
+				execute(connection, "SELECT pg_advisory_unlock_all()");
+			}
+
+			outcome = takeSnapshot(connection);
+		}
+		finally
+		{
+			DB.close(connection);
+		}
+
+		if (dieOnDocument != null)
+		{
+			assertThat(failure)
+					.as("cost-recompute driver run must die while staging %s", dieOnDocument)
+					.isNotNull();
+		}
+		else if (failure != null)
+		{
+			throw AdempiereException.wrapIfNeeded(failure);
+		}
+
+		return outcome;
+	}
+
+	private String buildCallSql(@NonNull final DataTableRow row)
+	{
+		final int acctSchemaId = row.getAsIdentifier(I_C_AcctSchema.COLUMNNAME_C_AcctSchema_ID)
+				.lookupNotNullIn(acctSchemaTable)
+				.getC_AcctSchema_ID();
+		final CostElementId costElementId = costElementTable.getSingleId(row.getAsString("M_CostElement_ID"));
+		final LocalDate startDateAcct = row.getAsLocalDate("StartDateAcct");
+		final int productsPerCommit = row.getAsInt("ProductsPerCommit");
+		final String resume = row.getAsOptionalString("Resume").orElse("N");
+
+		return "CALL \"de_metas_acct\".product_costs_recreate_all_from_date("
+				+ "p_C_AcctSchema_ID:=" + acctSchemaId
+				+ ", p_M_CostElement_ID:=" + costElementId.getRepoId()
+				+ ", p_StartDateAcct:='" + startDateAcct + "'::date"
+				+ ", p_ProductsPerCommit:=" + productsPerCommit
+				+ ", p_Resume:='" + resume + "')";
+	}
+
+	private void installStagingAbortTrigger(@NonNull final Connection connection, @NonNull final TableRecordReference dieOnDocument)
+	{
+		execute(connection, "CREATE OR REPLACE FUNCTION " + ABORT_TRIGGER_FUNCTION + "() RETURNS trigger LANGUAGE plpgsql AS $fn$"
+				+ " BEGIN"
+				+ "   IF NEW.tablename = " + DB.TO_STRING(dieOnDocument.getTableName())
+				+ "      AND NEW.record_id = " + dieOnDocument.getRecord_ID() + " THEN"
+				+ "     RAISE EXCEPTION 'cucumber: cost-recompute run died while staging %/%', NEW.tablename, NEW.record_id;"
+				+ "   END IF;"
+				+ "   RETURN NEW;"
+				+ " END $fn$");
+		execute(connection, "DROP TRIGGER IF EXISTS " + ABORT_TRIGGER_NAME + " ON " + TABLE_Staging);
+		execute(connection, "CREATE TRIGGER " + ABORT_TRIGGER_NAME
+				+ " BEFORE INSERT ON " + TABLE_Staging
+				+ " FOR EACH ROW EXECUTE PROCEDURE " + ABORT_TRIGGER_FUNCTION + "()");
+	}
+
+	private void removeStagingAbortTrigger(@NonNull final Connection connection)
+	{
+		execute(connection, "DROP TRIGGER IF EXISTS " + ABORT_TRIGGER_NAME + " ON " + TABLE_Staging);
+		execute(connection, "DROP FUNCTION IF EXISTS " + ABORT_TRIGGER_FUNCTION + "()");
+	}
+
+	private RunOutcome takeSnapshot(@NonNull final Connection connection)
+	{
+		final ImmutableList.Builder<Integer> doneBatchNos = ImmutableList.builder();
+		final ArrayList<TableRecordReference> stagedDocuments = new ArrayList<>();
+		final ArrayList<TableRecordReference> queuedDocuments = new ArrayList<>();
+
+		try (final Statement statement = connection.createStatement())
+		{
+			try (final ResultSet rs = statement.executeQuery(
+					"SELECT batch_no FROM " + TABLE_Progress + " WHERE status='DONE' ORDER BY batch_no"))
+			{
+				while (rs.next())
+				{
+					doneBatchNos.add(rs.getInt("batch_no"));
+				}
+			}
+			try (final ResultSet rs = statement.executeQuery(
+					"SELECT tablename, record_id FROM " + TABLE_Staging + " ORDER BY dateacct, tablename_prio, record_id"))
+			{
+				while (rs.next())
+				{
+					stagedDocuments.add(TableRecordReference.of(rs.getString("tablename"), rs.getInt("record_id")));
+				}
+			}
+			try (final ResultSet rs = statement.executeQuery(
+					"SELECT tablename, record_id FROM " + TABLE_Queue + " ORDER BY seqno"))
+			{
+				while (rs.next())
+				{
+					queuedDocuments.add(TableRecordReference.of(rs.getString("tablename"), rs.getInt("record_id")));
+				}
+			}
+		}
+		catch (final SQLException ex)
+		{
+			throw new AdempiereException("Failed snapshotting the cost-recompute run outcome", ex);
+		}
+
+		return new RunOutcome(
+				doneBatchNos.build(),
+				ImmutableList.copyOf(stagedDocuments),
+				ImmutableList.copyOf(queuedDocuments));
+	}
+
+	private static int countQueueRows()
+	{
+		return DB.getSQLValueEx(null, "SELECT COUNT(1) FROM " + TABLE_Queue);
+	}
+
+	private static void execute(@NonNull final Connection connection, @NonNull final String sql)
+	{
+		try (final Statement statement = connection.createStatement())
+		{
+			statement.execute(sql);
+		}
+		catch (final SQLException ex)
+		{
+			throw new AdempiereException("Failed executing: " + sql, ex);
+		}
+	}
+
+	@Value
+	private static class RunOutcome
+	{
+		@NonNull ImmutableList<Integer> doneBatchNos;
+		/** Documents still parked in the staging table, in release order. */
+		@NonNull ImmutableList<TableRecordReference> stagedDocuments;
+		/** Documents in the repost queue, ordered by SeqNo, i.e. in the order they will be reposted. */
+		@NonNull ImmutableList<TableRecordReference> queuedDocuments;
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/ProductCostsRecreateAll_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/ProductCostsRecreateAll_StepDef.java
@@ -26,10 +26,12 @@ import com.google.common.collect.ImmutableList;
 import de.metas.costing.CostElementId;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.StepDefUtil;
 import de.metas.cucumber.stepdefs.acctschema.C_AcctSchema_StepDefData;
 import de.metas.cucumber.stepdefs.util.IdentifiersResolver;
+import de.metas.product.ProductId;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -89,6 +91,7 @@ public class ProductCostsRecreateAll_StepDef
 
 	@NonNull private final C_AcctSchema_StepDefData acctSchemaTable;
 	@NonNull private final M_CostElement_StepDefData costElementTable;
+	@NonNull private final M_Product_StepDefData productTable;
 	@NonNull private final IdentifiersResolver identifiersResolver;
 
 	/** What the most recent driver run left behind. */
@@ -165,6 +168,60 @@ public class ProductCostsRecreateAll_StepDef
 				.hasStackTraceContaining("Cannot resume")
 				.hasStackTraceContaining("ProductsPerCommit=" + recordedProductsPerCommit)
 				.hasStackTraceContaining("ProductsPerCommit=" + requestedProductsPerCommit);
+	}
+
+	/**
+	 * Runs the cost-recompute driver as a resume and asserts it is REFUSED because the PRODUCT POPULATION has
+	 * changed since the run that recorded the DONE batches — every one of this call's parameters matches that
+	 * run, so the run-identity check has nothing to complain about.
+	 * <p>
+	 * The driver has no product parameter: it derives its product set from the documents in the recompute's
+	 * date range on every call. So a document that posts into that range between the crash and the resume
+	 * brings a new product in, and because the batches are cut by {@code M_Product_ID}, a newcomer with a
+	 * lower id shifts every batch boundary after it. A batch number recorded DONE then names a DIFFERENT set
+	 * of products, which would be skipped: never rewound, never staged, and the run still reports success.
+	 * <p>
+	 * The refusal must arrive BEFORE the driver purges the target element's in-range cost details, because
+	 * that purge is committed and cannot be rolled back — which is what the steps following this one assert.
+	 * The message must name both product sets, so the operator can see which product joined.
+	 * <p>
+	 * The expectation names the two PRODUCTS and deliberately not the batch number: the driver recomputes
+	 * every product of the accounting schema, so how many foreign products sort ahead of these two — and
+	 * therefore which batch number the shift lands on — depends on what the rest of the test database
+	 * contains. The pair of product sets identifies the shifted batch exactly and is stable.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns same as <code>the cost recompute driver runs:</code>, plus<br>
+	 *   <b>RecordedProduct</b> — (required, identifier-ref) the product the shifted batch was recorded for<br>
+	 *   <b>CurrentProduct</b> — (required, identifier-ref) the product that batch covers now<br>
+	 * @cucumber.depends StepDefData: C_AcctSchema_StepDefData, M_CostElement_StepDefData, M_Product_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * When the cost recompute driver run is refused because the product population changed:
+	 *   | C_AcctSchema_ID | M_CostElement_ID | StartDateAcct | ProductsPerCommit | Resume | RecordedProduct  | CurrentProduct |
+	 *   | acctSchema      | AveragePO        | 2027-09-01    | 1                 | Y      | doneBatchProduct | lateJoiner     |
+	 * </pre>
+	 */
+	@When("^the cost recompute driver run is refused because the product population changed:$")
+	public void runIsRefused_productPopulationChanged(@NonNull final DataTable dataTable)
+	{
+		final DataTableRow row = DataTableRows.of(dataTable).singleRow();
+		final ProductId recordedProductId = productTable.getId(row.getAsIdentifier("RecordedProduct"));
+		final ProductId currentProductId = productTable.getId(row.getAsIdentifier("CurrentProduct"));
+
+		rememberOutcome(invokeDriver(row, null, true /*runMustFail*/));
+
+		assertThat(getLastRunOutcome().getFailure())
+				.as("resuming must be refused: the batch recorded for product %s now covers product %s",
+						recordedProductId, currentProductId)
+				.isNotNull()
+				// hasStackTraceContaining, not hasMessageContaining: the driver is CALLed through a plain JDBC
+				// statement, so the refusal raised by the procedure is the CAUSE of the exception this step
+				// sees, and the top-level message is only "Failed executing: CALL ...".
+				.hasStackTraceContaining("Cannot resume")
+				.hasStackTraceContaining("the product population changed")
+				.hasStackTraceContaining("was recorded for product(s) {" + recordedProductId.getRepoId()
+						+ "} but now covers product(s) {" + currentProductId.getRepoId() + "}");
 	}
 
 	/**

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/inventory/M_Inventory_RecomputeCosts_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/inventory/M_Inventory_RecomputeCosts_StepDef.java
@@ -29,6 +29,7 @@ import de.metas.costing.CostingMethod;
 import de.metas.costing.ICostElementRepository;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.acctschema.C_AcctSchema_StepDefData;
 import de.metas.inventory.IInventoryDAO;
 import de.metas.inventory.InventoryId;
@@ -44,12 +45,17 @@ import org.adempiere.exceptions.AdempiereException;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_AcctSchema;
 import org.compiere.model.I_M_Inventory;
+import org.compiere.model.I_M_Product;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 @RequiredArgsConstructor
 public class M_Inventory_RecomputeCosts_StepDef
@@ -60,6 +66,7 @@ public class M_Inventory_RecomputeCosts_StepDef
 
 	@NonNull private final M_Inventory_StepDefData inventoryTable;
 	@NonNull private final C_AcctSchema_StepDefData acctSchemaTable;
+	@NonNull private final M_Product_StepDefData productTable;
 
 	/**
 	 * Mirrors {@code de.metas.inventory.process.M_Inventory_RecomputeCosts.doIt()} —
@@ -86,6 +93,48 @@ public class M_Inventory_RecomputeCosts_StepDef
 	public void invoke(@NonNull final DataTable dataTable)
 	{
 		DataTableRows.of(dataTable).forEach(this::invokeOne);
+	}
+
+	/**
+	 * Runs the same recompute as {@link #invoke(DataTable)} — i.e. the {@code M_Inventory_RecomputeCosts}
+	 * process the user starts from an inventory document — and asserts it is REFUSED because the recompute
+	 * range reaches back over a cost-revaluation opening anchor.
+	 * <p>
+	 * The refusal must name the product and the anchor's accounting date: those two facts are what tells the
+	 * operator which product blocks the run and after which date the recompute has to be restarted.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_Inventory_ID</b> — (required, identifier-ref) inventory whose products + MovementDate drive the recompute<br>
+	 *   <b>C_AcctSchema_ID</b> — (required, identifier-ref) accounting schema to recompute<br>
+	 *   <b>CostingMethod</b> — (optional) costing method code; empty = all active material elements<br>
+	 *   <b>M_Product_ID</b> — (required, identifier-ref) product whose ID the refusal must name<br>
+	 *   <b>AnchorDateAcct</b> — (required) accounting date of the opening anchor the refusal must name<br>
+	 * @cucumber.depends StepDefData: M_Inventory_StepDefData, C_AcctSchema_StepDefData, M_Product_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * Then invoke M_Inventory_RecomputeCosts expecting the cost-revaluation opening anchor to block it:
+	 *   | M_Inventory_ID | C_AcctSchema_ID | CostingMethod | M_Product_ID | AnchorDateAcct |
+	 *   | invDec2025     | acctSchema      | M             | product      | 2025-12-31     |
+	 * </pre>
+	 */
+	@When("invoke M_Inventory_RecomputeCosts expecting the cost-revaluation opening anchor to block it:")
+	public void invoke_expectingOpeningAnchorToBlockIt(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row -> {
+			final ProductId productId = row.getAsIdentifier(I_M_Product.COLUMNNAME_M_Product_ID).lookupIdIn(productTable);
+			final LocalDate anchorDateAcct = row.getAsLocalDate("AnchorDateAcct");
+
+			// catchThrowable + assertThat, not assertThatThrownBy: the latter fails INSIDE itself when nothing
+			// is thrown, before its .as(...) description is attached — so the "nothing was refused" failure
+			// would print no hint of what the step expected.
+			final Throwable refusal = catchThrowable(() -> invokeOne(row));
+			assertThat(refusal)
+					.as("recompute must be refused because its range covers the opening anchor of %s dated %s", productId, anchorDateAcct)
+					.isNotNull()
+					.hasMessageContaining(String.valueOf(productId.getRepoId()))
+					.hasMessageContaining(anchorDateAcct.toString());
+		});
 	}
 
 	private void invokeOne(@NonNull final DataTableRow row)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/inventory/M_Inventory_RecomputeCosts_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/inventory/M_Inventory_RecomputeCosts_StepDef.java
@@ -57,6 +57,10 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+/**
+ * Runs the {@code M_Inventory_RecomputeCosts} process — recreating a product's cost details and current cost
+ * from an inventory document's date onwards — and validates its outcome.
+ */
 @RequiredArgsConstructor
 public class M_Inventory_RecomputeCosts_StepDef
 {

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/util/IdentifiersResolver.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/util/IdentifiersResolver.java
@@ -28,6 +28,7 @@ import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
 import de.metas.cucumber.stepdefs.allocation.C_AllocationHdr_StepDefData;
 import de.metas.cucumber.stepdefs.costing.M_CostRevaluation_StepDefData;
 import de.metas.cucumber.stepdefs.dunning.C_DunningDoc_StepDefData;
+import de.metas.cucumber.stepdefs.inventory.M_Inventory_StepDefData;
 import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.match_inv.M_MatchInv_StepDefData;
 import de.metas.cucumber.stepdefs.order.C_Order_StepDefData;
@@ -36,6 +37,7 @@ import de.metas.cucumber.stepdefs.pporder.PP_Cost_Collector_StepDefData;
 import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
 import de.metas.dunning.DunningDocId;
 import de.metas.inout.InOutId;
+import de.metas.inventory.InventoryId;
 import de.metas.invoice.InvoiceId;
 import de.metas.invoice.matchinv.MatchInvId;
 import de.metas.order.OrderId;
@@ -51,6 +53,7 @@ import org.compiere.model.I_C_Invoice;
 import org.compiere.model.I_C_Payment;
 import org.compiere.model.I_M_CostRevaluation;
 import org.compiere.model.I_M_InOut;
+import org.compiere.model.I_M_Inventory;
 import org.compiere.model.I_M_MatchInv;
 import org.eevolution.model.I_PP_Cost_Collector;
 
@@ -68,6 +71,7 @@ public class IdentifiersResolver
 	@NonNull private final C_AllocationHdr_StepDefData allocationTable;
 	@NonNull private final M_MatchInv_StepDefData matchInvTable;
 	@NonNull private final M_InOut_StepDefData inOutTable;
+	@NonNull private final M_Inventory_StepDefData inventoryTable;
 	@NonNull private final C_Order_StepDefData orderTable;
 	@NonNull private final C_DunningDoc_StepDefData dunningDocTable;
 	@NonNull private final PP_Cost_Collector_StepDefData ppCostCollectorTable;
@@ -111,6 +115,9 @@ public class IdentifiersResolver
 				.ifPresent(result::add);
 		inOutTable.getIdOptional(identifier)
 				.map(InOutId::toRecordRef)
+				.ifPresent(result::add);
+		inventoryTable.getIdOptional(identifier)
+				.map(id -> TableRecordReference.of(I_M_Inventory.Table_Name, id))
 				.ifPresent(result::add);
 		orderTable.getIdOptional(identifier)
 				.map(OrderId::toRecordRef)
@@ -156,6 +163,8 @@ public class IdentifiersResolver
 				return matchInvTable.getFirstIdentifierById(MatchInvId.ofRepoId(recordId));
 			case I_M_InOut.Table_Name:
 				return inOutTable.getFirstIdentifierById(InOutId.ofRepoId(recordId));
+			case I_M_Inventory.Table_Name:
+				return inventoryTable.getFirstIdentifierById(InventoryId.ofRepoId(recordId));
 			default:
 				return Optional.empty();
 		}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/average_po/recomputeCosts_matchPOInboundBeforeStartDate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/average_po/recomputeCosts_matchPOInboundBeforeStartDate.feature
@@ -115,10 +115,15 @@ Feature: Recompute Costs - last pre-range cost detail is a weighted-average Matc
       | Identifier | C_OrderLine_ID |
       | mpo2       | po2_l1         |
     And Wait until M_MatchPO mpo2 is posted
+    # Each purchase receipt books TWO AveragePO cost details: the cost-changing M_MatchPO (which drives
+    # the average) and a non-cost-changing M_InOutLine for the same amount and qty. Both are listed
+    # because this step asserts the COMPLETE set of cost details for the product and cost element.
     And after not more than 10s, M_CostDetails are found for product product and cost element AveragePO
-      | TableName | Record_ID | IsSOTrx | Amt     | Qty    | IsChangingCosts |
-      | M_MatchPO | mpo1      | N       | 200 CHF | 10 PCE | Y               |
-      | M_MatchPO | mpo2      | N       | 400 CHF | 10 PCE | Y               |
+      | TableName   | Record_ID      | IsSOTrx | Amt     | Qty    | IsChangingCosts |
+      | M_MatchPO   | mpo1           | N       | 200 CHF | 10 PCE | Y               |
+      | M_InOutLine | receipt1_line1 | N       | 200 CHF | 10 PCE | N               |
+      | M_MatchPO   | mpo2           | N       | 400 CHF | 10 PCE | Y               |
+      | M_InOutLine | receipt2_line1 | N       | 400 CHF | 10 PCE | N               |
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
       | acctSchema      | product      | AveragePO        | 30 CHF           | 20 PCE     |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/average_po/recomputeCosts_matchPOInboundBeforeStartDate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/average_po/recomputeCosts_matchPOInboundBeforeStartDate.feature
@@ -1,0 +1,148 @@
+@from:cucumber
+@allure.label.epic:E0226_Costing
+@allure.label.feature:F1530_Recreate_product_costs
+@Id:S26253_TC1
+@ghActions:run_on_executor7
+Feature: Recompute Costs - last pre-range cost detail is a weighted-average MatchPO inbound
+  ## F1530: Recreate product costs
+
+  Regression guard: when the recompute range (>= start date) contains no cost-changing detail,
+  m_costdetail_delete_from_date rolls the LAST cost detail before the start date forward to
+  reconstruct the current cost as-of the start date. If that last detail is a NON-inventory,
+  cost-changing inbound (an M_MatchPO here), the function used to abort with
+  `RAISE EXCEPTION 'Extracting current costs from an inbound transaction is not implemented'`
+  (only inventory-line inbounds were handled). It must instead reconstruct the current cost price
+  via weighted average (mirroring CurrentCost.addWeightedAverage), NOT leave it at the pre-inbound
+  price.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
+    And metasfresh has date and time 2024-02-10T09:00:00+01:00[Europe/Berlin]
+    And load and update C_AcctSchema:
+      | C_AcctSchema_ID | Name                  |
+      | acctSchema      | metas fresh UN/34 CHF |
+    And cost elements for material costing methods AveragePO are active
+    And load M_Warehouse:
+      | M_Warehouse_ID | Value        |
+      | warehouseStd   | StdWarehouse |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_1       |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl_1       | ps_1               | CH           | CHF           | false |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_1      | pl_1           |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | pp_1       | plv_1                  | product      | 10.0     | PCE      |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID |
+      | vendor     | Y        | N          | ps_1               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier     | C_BPartner_ID | C_Country_ID | IsShipToDefault | IsBillToDefault |
+      | vendorLocation | vendor        | CH           | Y               | Y               |
+
+  Scenario: Recompute reconstructs current cost from a weighted-average MatchPO inbound dated before the start date
+    #
+    # First purchase: 10 PCE @ 20 CHF (dated 2024-02-10).
+    # The M_MatchPO cost detail is cost-changing and drives the average to 20 CHF / 10 PCE.
+    #
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | C_PaymentTerm_ID | DocBaseType | M_PricingSystem_ID | DatePromised        | M_Warehouse_ID |
+      | po1        | N       | vendor        | 2024-02-10  | 1000012          | POO         | ps_1               | 2024-02-10T15:00:00 | warehouseStd   |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | Price | Description   |
+      | po1_l1     | po1        | product      | 10         | 20    | first receipt |
+    And the order identified by po1 is completed
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier |
+      | rs1                             | po1                   | po1_l1                    | vendor                   | vendorLocation                    | product                 | 10         | warehouseStd              |
+    And create M_HU_LUTU_Configuration for M_ReceiptSchedule and generate M_HUs
+      | M_HU_LUTU_Configuration_ID.Identifier | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier | OPT.M_LU_HU_PI_ID.Identifier |
+      | huLuTuConfig1                         | hu1                | rs1                             | N               | 1     | N               | 1     | N               | 10          | 101                                | 1000006                      |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And create material receipt
+      | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | hu1                | rs1                             | receipt1              |
+    And validate the created material receipt lines
+      | M_InOutLine_ID | M_InOut_ID | M_Product_ID | C_OrderLine_ID |
+      | receipt1_line1 | receipt1   | product      | po1_l1         |
+    And Wait until receipt receipt1 is posted
+    And M_MatchPO are found
+      | Identifier | C_OrderLine_ID |
+      | mpo1       | po1_l1         |
+    And Wait until M_MatchPO mpo1 is posted
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
+      | acctSchema      | product      | AveragePO        | 20 CHF           | 10 PCE     |
+
+    #
+    # Second purchase: 10 PCE @ 40 CHF (dated 2024-02-20).
+    # Weighted average: (20*10 + 40*10) / 20 = 30 CHF / 20 PCE.
+    # This M_MatchPO is the LAST cost-changing detail; it is dated BEFORE the recompute start date.
+    #
+    And metasfresh has date and time 2024-02-20T09:00:00+01:00[Europe/Berlin]
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | C_PaymentTerm_ID | DocBaseType | M_PricingSystem_ID | DatePromised        | M_Warehouse_ID |
+      | po2        | N       | vendor        | 2024-02-20  | 1000012          | POO         | ps_1               | 2024-02-20T15:00:00 | warehouseStd   |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | Price | Description    |
+      | po2_l1     | po2        | product      | 10         | 40    | second receipt |
+    And the order identified by po2 is completed
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier |
+      | rs2                             | po2                   | po2_l1                    | vendor                   | vendorLocation                    | product                 | 10         | warehouseStd              |
+    And create M_HU_LUTU_Configuration for M_ReceiptSchedule and generate M_HUs
+      | M_HU_LUTU_Configuration_ID.Identifier | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier | OPT.M_LU_HU_PI_ID.Identifier |
+      | huLuTuConfig2                         | hu2                | rs2                             | N               | 1     | N               | 1     | N               | 10          | 101                                | 1000006                      |
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+    And create material receipt
+      | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | hu2                | rs2                             | receipt2              |
+    And validate the created material receipt lines
+      | M_InOutLine_ID | M_InOut_ID | M_Product_ID | C_OrderLine_ID |
+      | receipt2_line1 | receipt2   | product      | po2_l1         |
+    And Wait until receipt receipt2 is posted
+    And M_MatchPO are found
+      | Identifier | C_OrderLine_ID |
+      | mpo2       | po2_l1         |
+    And Wait until M_MatchPO mpo2 is posted
+    And after not more than 10s, M_CostDetails are found for product product and cost element AveragePO
+      | TableName | Record_ID | IsSOTrx | Amt     | Qty    | IsChangingCosts |
+      | M_MatchPO | mpo1      | N       | 200 CHF | 10 PCE | Y               |
+      | M_MatchPO | mpo2      | N       | 400 CHF | 10 PCE | Y               |
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
+      | acctSchema      | product      | AveragePO        | 30 CHF           | 20 PCE     |
+
+    #
+    # A cost-recount inventory dated 2024-03-01 with zero difference (QtyBook = QtyCount, no explicit
+    # cost price) — it creates NO cost detail, so the recompute range (>= 2024-03-01) holds no
+    # cost-changing detail. This forces m_costdetail_delete_from_date down the Approach-2 branch that
+    # rolls the last pre-range detail (mpo2, a weighted-average MatchPO inbound) forward.
+    #
+    And metasfresh has date and time 2024-03-01T09:00:00+01:00[Europe/Berlin]
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | inv_trigger    | inv_trigger_l1     | 2024-03-01   | warehouseStd   | product      | 0       | 0        | PCE          |
+
+    #
+    # Run the recompute from 2024-03-01. Before the fix this aborts with
+    # "Extracting current costs from an inbound transaction is not implemented".
+    # After the fix, the current cost is reconstructed by weighted average = 30 CHF / 20 PCE
+    # (NOT the pre-inbound 20 CHF that a naive copy of the inventory-line branch would leave).
+    #
+    When invoke M_Inventory_RecomputeCosts:
+      | M_Inventory_ID | C_AcctSchema_ID | CostingMethod |
+      | inv_trigger    | acctSchema      | A             |
+    Then validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty |
+      | acctSchema      | product      | AveragePO        | 30 CHF           | 20 PCE     |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/average_po/recomputeCosts_matchPOInboundBeforeStartDate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/average_po/recomputeCosts_matchPOInboundBeforeStartDate.feature
@@ -1,6 +1,7 @@
 @from:cucumber
 @allure.label.epic:E0226_Costing
 @allure.label.feature:F1530_Recreate_product_costs
+@allure.label.feature:F1514_Cost_Type_Moving_Average_Invoice
 @Id:S26253_TC1
 @ghActions:run_on_executor7
 Feature: Recompute Costs - last pre-range cost detail is a weighted-average MatchPO inbound

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/average_po/recomputeCosts_matchPOInboundBeforeStartDate.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/average_po/recomputeCosts_matchPOInboundBeforeStartDate.feature
@@ -2,7 +2,7 @@
 @allure.label.epic:E0226_Costing
 @allure.label.feature:F1530_Recreate_product_costs
 @allure.label.feature:F1514_Cost_Type_Moving_Average_Invoice
-@Id:S26253_TC1
+@Id:S26253_TC9
 @ghActions:run_on_executor7
 Feature: Recompute Costs - last pre-range cost detail is a weighted-average MatchPO inbound
   ## F1530: Recreate product costs

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
@@ -486,3 +486,82 @@ Feature: Switch to Moving Average Invoice
       | product1     | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
       | product2     | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
       | product3     | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+
+  @Id:S26253_TC11
+  Scenario: A resume that regroups the products into different commit-batches is refused
+    #
+    # Same isolation technique as the batched-recompute scenario above: the driver recomputes EVERY product
+    # of the accounting schema, so this scenario is separated from the shared test database by ACCOUNTING
+    # DATE - it books its post-switch stock counts into the SECOND HALF of 2027 and recomputes from
+    # 01.06.2027 onwards, which is disjoint from the 01.2027-03.2027 slice the scenario above uses - and
+    # names the documents it expects instead of counting rows.
+    # The range stays inside 2027 on purpose: the test database's fiscal calendar ends with 2027, so a
+    # later year has no C_Period at all and completing a document there fails with @PeriodClosed@.
+    #
+    Given after not more than 60s, the repost queue is drained
+    And metasfresh contains M_Products:
+      | Identifier   |
+      | resumeFirst  |
+      | resumeSecond |
+    #
+    # Pre-cut-off history on the prior method (AveragePO), so the switch has a non-trivial opening to copy.
+    #
+    And update current costs
+      | M_Product_ID | M_CostElement_ID | CurrentCostPrice |
+      | resumeFirst  | AveragePO        | 10 CHF           |
+      | resumeSecond | AveragePO        | 10 CHF           |
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID  | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | invPreCutFirst  | invPreCutFirst_l1  | 2025-12-15   | warehouseStd   | resumeFirst  | 0       | 10       | PCE          |
+      | invPreCutSecond | invPreCutSecond_l1 | 2025-12-15   | warehouseStd   | resumeSecond | 0       | 10       | PCE          |
+    #
+    # One post-cut-off stock count per product, both inside the recompute's second-half-of-2027 range:
+    # exactly the two commit-batches the crashed run below is cut into.
+    #
+    When metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | invFirst       | invFirst_l1        | 2027-08-01   | warehouseStd   | resumeFirst  | 10      | 20       | PCE          |
+      | invSecond      | invSecond_l1       | 2027-07-01   | warehouseStd   | resumeSecond | 10      | 20       | PCE          |
+    #
+    # Switch to MovingAverageInvoice, back-dated to the 31.12.2025 cut-off - far outside the recompute range.
+    #
+    And metasfresh contains M_CostRevaluation:
+      | Identifier   | C_AcctSchema_ID | M_CostElement_ID     | RevaluationSource   | CopyFrom_M_CostElement_ID | EvaluationStartDate | DateAcct   |
+      | switchResume | acctSchema      | MovingAverageInvoice | CopyFromCostElement | AveragePO                 | 2025-12-31          | 2025-12-31 |
+    And create lines for cost revaluation switchResume
+    And the cost revaluation identified by switchResume is completed
+    Then the cost revaluation identified by switchResume seeded opening cost details:
+      | M_Product_ID | M_CostElement_ID     | DateAcct   | Qty   | Amt   |
+      | resumeFirst  | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+      | resumeSecond | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+    #
+    # First run, ONE product per commit-batch, dies while staging the second product's stock count. The
+    # batch before it stays committed, and its document stays parked in the staging table.
+    #
+    When the cost recompute driver run dies while staging document invSecond:
+      | C_AcctSchema_ID | M_CostElement_ID | StartDateAcct | ProductsPerCommit | Resume |
+      | acctSchema      | AveragePO        | 2027-06-01    | 1                 | N      |
+    Then the cost recompute run left these documents:
+      | Record_ID | IsStaged | IsReleased |
+      | invFirst  | Y        | N          |
+      | invSecond | N        | N          |
+    #
+    # Now the operator does the natural thing after a crash and resumes with a SMALLER batch count - TWO
+    # products per commit instead of one. That regroups both products into a single batch numbered 1, and
+    # batch 1 is already recorded DONE - for the FIRST product alone. Skipping it would leave the second
+    # product's costs un-rewound and its stock count unstaged, and the run would still report success and
+    # release the first product's document. That silent half-recompute is what the refusal prevents; the
+    # message names both products-per-commit values so the operator can resume with the right one.
+    #
+    When the cost recompute driver run is refused because the recorded run used a different products-per-commit:
+      | C_AcctSchema_ID | M_CostElement_ID | StartDateAcct | ProductsPerCommit | Resume | RecordedProductsPerCommit |
+      | acctSchema      | AveragePO        | 2027-06-01    | 2                 | Y      | 1                         |
+    #
+    # A refused resume changes nothing: it finished no further batch, released nothing to the repost queue,
+    # and left the crashed run's parked document exactly where it was - so resuming correctly is still possible.
+    #
+    Then the cost recompute run finished 0 more batches than the run before it
+    And the cost recompute run left these documents:
+      | Record_ID | IsStaged | IsReleased |
+      | invFirst  | Y        | N          |
+      | invSecond | N        | N          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
@@ -565,3 +565,136 @@ Feature: Switch to Moving Average Invoice
       | Record_ID | IsStaged | IsReleased |
       | invFirst  | Y        | N          |
       | invSecond | N        | N          |
+
+  @Id:S26253_TC12
+  Scenario: A resume refused because a product joined the population purges nothing on its way to the refusal
+    #
+    # Same isolation technique as the two batched-recompute scenarios above: the driver recomputes EVERY
+    # product of the accounting schema, so this scenario is separated from the shared test database by
+    # ACCOUNTING DATE - it books its post-switch stock counts into the LAST QUARTER of 2027 and recomputes
+    # from 01.09.2027 onwards, disjoint from the 01.2027-03.2027 slice of the resume-after-a-crash scenario
+    # and from the 07.2027-08.2027 slice of the regrouping-resume scenario.
+    # Its slice is the LATEST of the three on purpose: a run's range is open-ended - every document at or
+    # after the start date takes part - so a scenario may only book into dates no EARLIER scenario's range
+    # already reaches into. The range still stays inside 2027, because the test database's fiscal calendar
+    # ends with it.
+    #
+    Given after not more than 60s, the repost queue is drained
+    #
+    # All three products are created in ONE step and therefore in ascending M_Product_ID order, and that
+    # order is what this scenario turns on: the driver cuts its commit-batches by M_Product_ID, so
+    # lateJoiner - created first, hence the LOWEST id of the three - takes over the FIRST batch the moment
+    # it enters the population, pushing every other product one batch up.
+    #
+    And metasfresh contains M_Products:
+      | Identifier        |
+      | lateJoiner        |
+      | doneBatchProduct  |
+      | crashBatchProduct |
+    #
+    # Pre-cut-off history on the prior method (AveragePO) for all three, so the switch has a non-trivial
+    # opening to copy for each of them.
+    #
+    And update current costs
+      | M_Product_ID      | M_CostElement_ID | CurrentCostPrice |
+      | lateJoiner        | AveragePO        | 10 CHF           |
+      | doneBatchProduct  | AveragePO        | 10 CHF           |
+      | crashBatchProduct | AveragePO        | 10 CHF           |
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID      | QtyBook | QtyCount | UOM.X12DE355 |
+      | invPreCutLate  | invPreCutLate_l1   | 2025-12-15   | warehouseStd   | lateJoiner        | 0       | 10       | PCE          |
+      | invPreCutDone  | invPreCutDone_l1   | 2025-12-15   | warehouseStd   | doneBatchProduct  | 0       | 10       | PCE          |
+      | invPreCutCrash | invPreCutCrash_l1  | 2025-12-15   | warehouseStd   | crashBatchProduct | 0       | 10       | PCE          |
+    #
+    # Only TWO of the three products get a document inside the recompute's range for now. lateJoiner enters
+    # the population later - between the crash and the resume - and that is the whole situation under test.
+    #
+    When metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID      | QtyBook | QtyCount | UOM.X12DE355 |
+      | invDone        | invDone_l1         | 2027-10-01   | warehouseStd   | doneBatchProduct  | 10      | 20       | PCE          |
+      | invCrash       | invCrash_l1        | 2027-11-01   | warehouseStd   | crashBatchProduct | 10      | 20       | PCE          |
+    #
+    # Switch to MovingAverageInvoice, back-dated to the 31.12.2025 cut-off - far outside the recompute range.
+    #
+    And metasfresh contains M_CostRevaluation:
+      | Identifier | C_AcctSchema_ID | M_CostElement_ID     | RevaluationSource   | CopyFrom_M_CostElement_ID | EvaluationStartDate | DateAcct   |
+      | switchLate | acctSchema      | MovingAverageInvoice | CopyFromCostElement | AveragePO                 | 2025-12-31          | 2025-12-31 |
+    And create lines for cost revaluation switchLate
+    And the cost revaluation identified by switchLate is completed
+    Then the cost revaluation identified by switchLate seeded opening cost details:
+      | M_Product_ID      | M_CostElement_ID     | DateAcct   | Qty   | Amt   |
+      | lateJoiner        | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+      | doneBatchProduct  | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+      | crashBatchProduct | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+    #
+    # First run, ONE product per commit-batch, dies while staging the second product's stock count: batch 1
+    # (doneBatchProduct) stays committed with its document parked in the staging table.
+    #
+    When the cost recompute driver run dies while staging document invCrash:
+      | C_AcctSchema_ID | M_CostElement_ID | StartDateAcct | ProductsPerCommit | Resume |
+      | acctSchema      | AveragePO        | 2027-09-01    | 1                 | N      |
+    Then the cost recompute run left these documents:
+      | Record_ID | IsStaged | IsReleased |
+      | invDone   | Y        | N          |
+      | invCrash  | N        | N          |
+    #
+    # While the operator investigates the crash, an ordinary new document posts into the recompute's range -
+    # for lateJoiner, the product that had none there yet. Posting explodes into EVERY active material cost
+    # element, so this also gives the MovingAverageInvoice element an in-range cost detail: exactly the kind
+    # of row the driver's purge deletes and commits.
+    #
+    When metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | invLate        | invLate_l1         | 2027-12-01   | warehouseStd   | lateJoiner   | 10      | 20       | PCE          |
+    #
+    # Wait for it to be posted: what the refusal below must leave alone only exists once it is.
+    #
+    And after not more than 60s, M_CostDetails are found for product lateJoiner and cost element AveragePO
+      | TableName       | Record_ID        | Amt     | Qty    |
+      | M_InventoryLine | invPreCutLate_l1 | 100 CHF | 10 PCE |
+      | M_InventoryLine | invLate_l1       | 100 CHF | 10 PCE |
+    #
+    # MovingAverageInvoice now carries the seeded opening (10 CHF / 10 PCE / 100 CHF) plus the new document's
+    # movement: 10 CHF / 20 PCE / 200 CHF. This is the state the refused resume must not touch.
+    #
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
+      | acctSchema      | lateJoiner   | MovingAverageInvoice | 10 CHF           | 20 PCE     | 200 CHF      |
+    #
+    # Now the operator resumes with EXACTLY the parameters of the crashed run, so the run-identity check has
+    # nothing to complain about. What changed is the POPULATION: lateJoiner sorts ahead of doneBatchProduct,
+    # so the batch recorded DONE for doneBatchProduct alone now covers lateJoiner instead. Skipping it would
+    # leave lateJoiner un-rewound and its document unstaged while the run reports success, so the resume is
+    # refused, naming both product sets.
+    #
+    When the cost recompute driver run is refused because the product population changed:
+      | C_AcctSchema_ID | M_CostElement_ID | StartDateAcct | ProductsPerCommit | Resume | RecordedProduct  | CurrentProduct |
+      | acctSchema      | AveragePO        | 2027-09-01    | 1                 | Y      | doneBatchProduct | lateJoiner     |
+    #
+    # A refused resume changes NOTHING: it finished no further batch, released nothing to the repost queue,
+    # and left the crashed run's parked document exactly where it was.
+    #
+    Then the cost recompute run finished 0 more batches than the run before it
+    And the cost recompute run left these documents:
+      | Record_ID | IsStaged | IsReleased |
+      | invDone   | Y        | N          |
+      | invCrash  | N        | N          |
+      | invLate   | N        | N          |
+    #
+    # And "nothing" includes the MovingAverageInvoice purge, which is the point: the purge deletes the target
+    # element's in-range cost details and COMMITs, so a refusal that arrives after it has already destroyed
+    # the very rows a later, correct resume needs. lateJoiner's MovingAverageInvoice current cost still
+    # carries its new document's movement on top of the seeded opening - it was not rewound to the opening,
+    # which is what deleting that in-range cost detail would have done.
+    #
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
+      | acctSchema      | lateJoiner   | MovingAverageInvoice | 10 CHF           | 20 PCE     | 200 CHF      |
+    #
+    # The opening anchors are all still there too, for every one of the three products.
+    #
+    And the cost revaluation identified by switchLate seeded opening cost details:
+      | M_Product_ID      | M_CostElement_ID     | DateAcct   | Qty   | Amt   |
+      | lateJoiner        | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+      | doneBatchProduct  | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+      | crashBatchProduct | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
@@ -339,9 +339,12 @@ Feature: Switch to Moving Average Invoice
       | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
       | invDec2025     | invDec2025_l1      | 2025-12-01   | warehouseStd   | product      | 5       | 5        | PCE          |
     #
-    # The recompute must refuse. Deleting the anchor would leave MovingAverageInvoice with no opening
-    # at all, silently zero-basing every cost after the cut-off. The refusal names the product and the
-    # anchor's date, so the operator knows to restart the recompute strictly after the cut-off.
+    # The recompute must refuse. Deleting the anchor does NOT corrupt M_Cost — the anchor is
+    # cost-changing and its Prev_* equal the opening, so the recompute restores M_Cost to identical
+    # numbers. What is lost is the anchor row itself: the only record of the opening balance, the row
+    # reverseSeededCurrentCost deletes to undo the switch, and the marker the double-seed guard keys
+    # on — so once it is gone, a re-switch re-seeds a cost that is already in use. The refusal names
+    # the product and the anchor's date, so the operator knows to restart strictly after the cut-off.
     #
     Then invoke M_Inventory_RecomputeCosts expecting the cost-revaluation opening anchor to block it:
       | M_Inventory_ID | C_AcctSchema_ID | CostingMethod | M_Product_ID | AnchorDateAcct |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
@@ -217,3 +217,97 @@ Feature: Switch to Moving Average Invoice
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
       | acctSchema      | product1     | MovingAverageInvoice | 10 CHF           | 0 PCE      | 0 CHF        |
       | acctSchema      | product2     | MovingAverageInvoice | 20 CHF           | 0 PCE      | 0 CHF        |
+
+  @Id:S26253_TC7
+  Scenario: A back-dated switch opens MovingAverageInvoice with the source cost as of the cut-off, not its later value
+    #
+    # Purchasing masterdata for the two purchases below.
+    #
+    Given metasfresh contains M_PricingSystems
+      | Identifier |
+      | purchasePS |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | purchasePL | purchasePS         | CH           | CHF           | false |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier  | M_PriceList_ID |
+      | purchasePLV | purchasePL     |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | purchasePLV            | product      | 10.0     | PCE      |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID |
+      | vendor     | Y        | N          | purchasePS         |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier     | C_BPartner_ID | C_Country_ID | IsShipToDefault | IsBillToDefault |
+      | vendorLocation | vendor        | CH           | Y               | Y               |
+    #
+    # Pre-cut-off purchase, received 2025-12-15: 10 PCE @ 10 CHF.
+    # The prior method (AveragePO) therefore carries 10 CHF / 10 PCE at the 31.12.2025 cut-off.
+    #
+    And metasfresh has date and time 2025-12-15T09:00:00+01:00[Europe/Berlin]
+    And for costing, create completed order with one line
+      | C_OrderLine_ID | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | M_Product_ID | QtyEntered | Price |
+      | po2025_l1      | vendor        | 2025-12-15  | POO         | warehouseStd   | product      | 10         | 10    |
+    And for costing, create completed material receipt with one line
+      | C_OrderLine_ID | M_InOutLine_ID    | M_MatchPO_ID |
+      | po2025_l1      | receipt2025_line1 | mpo2025      |
+    # Only the M_MatchPO detail changes the AveragePO cost; the receipt line records the same amount without
+    # changing it. Waiting for both to be posted is what this step does before comparing.
+    And after not more than 30s, M_CostDetails are found for product product and cost element AveragePO
+      | TableName   | Record_ID         | IsSOTrx | Amt     | Qty    | IsChangingCosts |
+      | M_MatchPO   | mpo2025           | N       | 100 CHF | 10 PCE | Y               |
+      | M_InOutLine | receipt2025_line1 | N       | 100 CHF | 10 PCE | N               |
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty | CumulatedAmt |
+      | acctSchema      | product      | AveragePO        | 10 CHF           | 10 PCE     | 100 CHF      |
+    #
+    # Post-cut-off purchase, received and invoiced 2026-01-15: 10 PCE @ 30 CHF.
+    # It moves the still-active AveragePO cost on to the weighted average (100 + 300) / 20 = 20 CHF / 20 PCE
+    # — a value the prior method never had at the cut-off.
+    #
+    When metasfresh has date and time 2026-01-15T09:00:00+01:00[Europe/Berlin]
+    And for costing, create completed order with one line
+      | C_OrderLine_ID | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | M_Product_ID | QtyEntered | Price |
+      | po2026_l1      | vendor        | 2026-01-15  | POO         | warehouseStd   | product      | 10         | 30    |
+    And for costing, create completed material receipt with one line
+      | C_OrderLine_ID | M_InOutLine_ID    | M_MatchPO_ID |
+      | po2026_l1      | receipt2026_line1 | mpo2026      |
+    And for costing, create completed invoice with one line
+      | C_OrderLine_ID | M_MatchInv_ID |
+      | po2026_l1      | matchInv2026  |
+    And after not more than 30s, M_CostDetails are found for product product and cost element AveragePO
+      | TableName   | Record_ID         | IsSOTrx | Amt     | Qty    | IsChangingCosts |
+      | M_MatchPO   | mpo2025           | N       | 100 CHF | 10 PCE | Y               |
+      | M_InOutLine | receipt2025_line1 | N       | 100 CHF | 10 PCE | N               |
+      | M_MatchPO   | mpo2026           | N       | 300 CHF | 10 PCE | Y               |
+      | M_InOutLine | receipt2026_line1 | N       | 300 CHF | 10 PCE | N               |
+      | M_MatchInv  | matchInv2026      | N       | 300 CHF | 10 PCE | N               |
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID | CurrentCostPrice | CurrentQty | CumulatedAmt |
+      | acctSchema      | product      | AveragePO        | 20 CHF           | 20 PCE     | 400 CHF      |
+    #
+    # Switch to MovingAverageInvoice, back-dated to the 31.12.2025 cut-off.
+    #
+    When metasfresh contains M_CostRevaluation:
+      | Identifier   | C_AcctSchema_ID | M_CostElement_ID     | RevaluationSource   | CopyFrom_M_CostElement_ID | EvaluationStartDate | DateAcct   |
+      | costRevalMAI | acctSchema      | MovingAverageInvoice | CopyFromCostElement | AveragePO                 | 2025-12-31          | 2025-12-31 |
+    And create lines for cost revaluation costRevalMAI
+    And the cost revaluation identified by costRevalMAI is completed
+    #
+    # The MovingAverageInvoice opening is the source's price AND quantity as of the cut-off (10 CHF / 10 PCE),
+    # not the live post-cut-off value (20 CHF / 20 PCE) the source has moved on to.
+    #
+    Then validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
+      | acctSchema      | product      | MovingAverageInvoice | 10 CHF           | 10 PCE     | 100 CHF      |
+    #
+    # The opening is anchored AT the cut-off and is value-neutral: the anchor itself moves no quantity and no value.
+    #
+    And the cost revaluation identified by costRevalMAI seeded opening cost details:
+      | M_Product_ID | M_CostElement_ID     | DateAcct   | Qty   | Amt   |
+      | product      | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+    #
+    # A value-neutral seed posts no GL. This step also waits for the document to finish posting.
+    #
+    And no Fact_Acct records are found for documents costRevalMAI

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
@@ -311,3 +311,48 @@ Feature: Switch to Moving Average Invoice
     # A value-neutral seed posts no GL. This step also waits for the document to finish posting.
     #
     And no Fact_Acct records are found for documents costRevalMAI
+
+  @Id:S26253_TC8
+  Scenario: A cost recompute reaching back over the opening anchor is refused instead of deleting it
+    #
+    # Perform the switch: seed the prior method (AveragePO) at the cut-off and copy it onto
+    # MovingAverageInvoice. The opening anchor cost detail sits AT the 31.12.2025 cut-off.
+    #
+    Given update current costs
+      | M_Product_ID | M_CostElement_ID | CurrentCostPrice |
+      | product      | AveragePO        | 10 CHF           |
+    When metasfresh contains M_CostRevaluation:
+      | Identifier   | C_AcctSchema_ID | M_CostElement_ID     | RevaluationSource   | CopyFrom_M_CostElement_ID | EvaluationStartDate | DateAcct   |
+      | costRevalMAI | acctSchema      | MovingAverageInvoice | CopyFromCostElement | AveragePO                 | 2025-12-31          | 2025-12-31 |
+    And create lines for cost revaluation costRevalMAI
+    And the cost revaluation identified by costRevalMAI is completed
+    Then the cost revaluation identified by costRevalMAI seeded opening cost details:
+      | M_Product_ID | M_CostElement_ID     | DateAcct   | Qty   | Amt   |
+      | product      | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+    #
+    # December is re-opened for a back-dated year-end adjustment: a zero-difference stock count dated
+    # 01.12.2025 (QtyCount = QtyBook, so no stock movement and no value change).
+    # Recomputing from that document starts the MovingAverageInvoice recompute at 01.12.2025 —
+    # i.e. BEFORE the 31.12.2025 anchor, so the anchor lies inside the recompute's delete range.
+    #
+    When metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | invDec2025     | invDec2025_l1      | 2025-12-01   | warehouseStd   | product      | 5       | 5        | PCE          |
+    #
+    # The recompute must refuse. Deleting the anchor would leave MovingAverageInvoice with no opening
+    # at all, silently zero-basing every cost after the cut-off. The refusal names the product and the
+    # anchor's date, so the operator knows to restart the recompute strictly after the cut-off.
+    #
+    Then invoke M_Inventory_RecomputeCosts expecting the cost-revaluation opening anchor to block it:
+      | M_Inventory_ID | C_AcctSchema_ID | CostingMethod | M_Product_ID | AnchorDateAcct |
+      | invDec2025     | acctSchema      | M             | product      | 2025-12-31     |
+    #
+    # A refused recompute destroys nothing: the opening anchor cost detail is still there, and the
+    # seeded MovingAverageInvoice current-cost row still carries the opening it was seeded with.
+    #
+    And the cost revaluation identified by costRevalMAI seeded opening cost details:
+      | M_Product_ID | M_CostElement_ID     | DateAcct   | Qty   | Amt   |
+      | product      | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
+      | acctSchema      | product      | MovingAverageInvoice | 10 CHF           | 0 PCE      | 0 CHF        |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
@@ -359,3 +359,130 @@ Feature: Switch to Moving Average Invoice
     And validate current costs
       | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
       | acctSchema      | product      | MovingAverageInvoice | 10 CHF           | 0 PCE      | 0 CHF        |
+
+  @Id:S26253_TC10
+  Scenario: A batched cost recompute stages its documents, releases them in document-date order, and resumes after a crash
+    #
+    # The recompute driver deliberately has no product parameter: it recomputes EVERY product of the
+    # accounting schema. So this scenario is separated from what other scenarios leave behind in the shared
+    # test database by ACCOUNTING DATE - it books its post-switch stock counts into 2027 and recomputes from
+    # 2027 onwards - and every assertion below names the documents it expects rather than counting rows.
+    #
+    # Whatever an earlier scenario left in the repost queue is let through first, so this run starts from a
+    # queue the accounting server has caught up with.
+    #
+    Given after not more than 60s, the repost queue is drained
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product1   |
+      | product2   |
+      | product3   |
+    #
+    # The prior method (AveragePO) carries 10 CHF for each of the three products, and a pre-cut-off stock
+    # count gives each of them 10 PCE of history before the cut-off. That history is what the opening balance
+    # is made of, so the switch has something non-trivial to copy.
+    #
+    And update current costs
+      | M_Product_ID | M_CostElement_ID | CurrentCostPrice |
+      | product1     | AveragePO        | 10 CHF           |
+      | product2     | AveragePO        | 10 CHF           |
+      | product3     | AveragePO        | 10 CHF           |
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID    | M_InventoryLine_ID   | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | invPreCutProduct1 | invPreCutProduct1_l1 | 2025-12-15   | warehouseStd   | product1     | 0       | 10       | PCE          |
+      | invPreCutProduct2 | invPreCutProduct2_l1 | 2025-12-15   | warehouseStd   | product2     | 0       | 10       | PCE          |
+      | invPreCutProduct3 | invPreCutProduct3_l1 | 2025-12-15   | warehouseStd   | product3     | 0       | 10       | PCE          |
+    #
+    # One post-cut-off stock count per product, each on its own accounting date. Posting explodes into EVERY
+    # active material cost element, so MovingAverageInvoice already carries 2027 cost details before the
+    # switch - built without an opening balance, i.e. from zero. Purging exactly those is the driver's first job.
+    # The dates deliberately run opposite to the product order: the driver batches products by M_Product_ID
+    # but must release documents by accounting date, so the two orders have to disagree to prove anything.
+    #
+    When metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | invProduct1    | invProduct1_l1     | 2027-03-01   | warehouseStd   | product1     | 10      | 20       | PCE          |
+      | invProduct2    | invProduct2_l1     | 2027-02-01   | warehouseStd   | product2     | 10      | 20       | PCE          |
+      | invProduct3    | invProduct3_l1     | 2027-01-15   | warehouseStd   | product3     | 10      | 20       | PCE          |
+    #
+    # Switch to MovingAverageInvoice, back-dated to the 31.12.2025 cut-off: one opening anchor per product,
+    # dated at the cut-off and therefore far outside the recompute's range.
+    #
+    And metasfresh contains M_CostRevaluation:
+      | Identifier | C_AcctSchema_ID | M_CostElement_ID     | RevaluationSource   | CopyFrom_M_CostElement_ID | EvaluationStartDate | DateAcct   |
+      | switch     | acctSchema      | MovingAverageInvoice | CopyFromCostElement | AveragePO                 | 2025-12-31          | 2025-12-31 |
+    And create lines for cost revaluation switch
+    And the cost revaluation identified by switch is completed
+    Then the cost revaluation identified by switch seeded opening cost details:
+      | M_Product_ID | M_CostElement_ID     | DateAcct   | Qty   | Amt   |
+      | product1     | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+      | product2     | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+      | product3     | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+    #
+    # First run, one product per commit-batch, dies while staging product3's stock count - the shape of the
+    # abort this driver exists for. The batches before it stay committed and their documents stay parked in
+    # the staging table: nothing reaches the repost queue, because releasing is the run's very last step.
+    #
+    When the cost recompute driver run dies while staging document invProduct3:
+      | C_AcctSchema_ID | M_CostElement_ID | StartDateAcct | ProductsPerCommit | Resume |
+      | acctSchema      | AveragePO        | 2027-01-01    | 1                 | N      |
+    Then the cost recompute run left these documents:
+      | Record_ID   | IsStaged | IsReleased |
+      | invProduct1 | Y        | N          |
+      | invProduct2 | Y        | N          |
+      | invProduct3 | N        | N          |
+    #
+    # The resume run picks up where the crash left off - it must finish only the one batch that was missing,
+    # never redo the batches before it - and then releases everything staged across both runs, in
+    # accounting-date order: product3's count (15.01.) first, product1's (01.03.) last.
+    #
+    When the cost recompute driver runs:
+      | C_AcctSchema_ID | M_CostElement_ID | StartDateAcct | ProductsPerCommit | Resume |
+      | acctSchema      | AveragePO        | 2027-01-01    | 1                 | Y      |
+    Then the cost recompute run finished 1 more batch than the run before it
+    And the cost recompute run left these documents:
+      | Record_ID   | IsStaged | IsReleased |
+      | invProduct3 | N        | Y          |
+      | invProduct2 | N        | Y          |
+      | invProduct1 | N        | Y          |
+    And the cost recompute staging table is empty
+    #
+    # From here the accounting server takes over: it drains the queue and reposts, and reposting is what
+    # recreates the cost details.
+    #
+    And after not more than 120s, the repost queue is drained
+    #
+    # Every product's cost details are rebuilt for the recomputed element (AveragePO): the pre-cut-off count
+    # was never touched, and the post-cut-off one - which the run deleted - is back, at the same value.
+    #
+    And after not more than 60s, M_CostDetails are found for product product1 and cost element AveragePO
+      | TableName       | Record_ID            | Amt     | Qty    |
+      | M_InventoryLine | invPreCutProduct1_l1 | 100 CHF | 10 PCE |
+      | M_InventoryLine | invProduct1_l1       | 100 CHF | 10 PCE |
+    And after not more than 60s, M_CostDetails are found for product product2 and cost element AveragePO
+      | TableName       | Record_ID            | Amt     | Qty    |
+      | M_InventoryLine | invPreCutProduct2_l1 | 100 CHF | 10 PCE |
+      | M_InventoryLine | invProduct2_l1       | 100 CHF | 10 PCE |
+    And after not more than 60s, M_CostDetails are found for product product3 and cost element AveragePO
+      | TableName       | Record_ID            | Amt     | Qty    |
+      | M_InventoryLine | invPreCutProduct3_l1 | 100 CHF | 10 PCE |
+      | M_InventoryLine | invProduct3_l1       | 100 CHF | 10 PCE |
+    #
+    # MovingAverageInvoice was rebuilt from the SEEDED OPENING (10 CHF / 10 PCE / 100 CHF), not from zero -
+    # which is exactly what the purge step guarantees. The current cost is the proof: the run had rewound the
+    # element to its opening and deleted its post-cut-off detail, so reaching 20 PCE / 200 CHF is only
+    # possible if the repost recreated that detail on top of the opening.
+    #
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
+      | acctSchema      | product1     | MovingAverageInvoice | 10 CHF           | 20 PCE     | 200 CHF      |
+      | acctSchema      | product2     | MovingAverageInvoice | 10 CHF           | 20 PCE     | 200 CHF      |
+      | acctSchema      | product3     | MovingAverageInvoice | 10 CHF           | 20 PCE     | 200 CHF      |
+    #
+    # And the opening anchors are all still there: the recompute never reached back over the cut-off.
+    #
+    And the cost revaluation identified by switch seeded opening cost details:
+      | M_Product_ID | M_CostElement_ID     | DateAcct   | Qty   | Amt   |
+      | product1     | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+      | product2     | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+      | product3     | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |


### PR DESCRIPTION
Makes a **back-dated switch to MovingAverageInvoice costing** survivable: the switch opens the target cost element with the source's cost **as of the cut-off**, the recompute that follows **refuses** to destroy that opening, and a full-installation recompute runs as a **batched, resumable procedure** that releases its documents to the reposting queue in document-date order.

Four independent streams, each with its own tests. They share one branch because they are only correct together — the opening is worthless if the recompute deletes it, and the recompute cannot run at all while a pre-range inbound aborts it.

---

## 1. Recompute no longer aborts on a weighted-average inbound before the range

`de_metas_acct.product_costs_recreate_from_date` → `m_costdetail_delete_from_date` aborted with `Extracting current costs from an inbound transaction is not implemented` when a product's last cost detail before the recompute start date was a **non-inventory, changing-costs inbound** (`M_MatchPO`, `M_InOutLine` non-material costs, `PP_Cost_Collector` receipt). The qty-classification only handled such an inbound when it was an inventory line (case 2.4); every other one fell to an unimplemented `ELSE … RAISE`.

New **case 2.5** in `m_costdetail_delete_from_date` reconstructs the current cost price by **weighted average** `round((prevPrice·prevQty + amt)/(prevQty + qty), costingPrecision)`, mirroring `de.metas.costing.CurrentCost.addWeightedAverage`. Case 2.4 is unchanged; the original `ELSE … RAISE` stays as the fallback.

### Gated on the cost element's costing method

Case 2.5 fires only for `costingmethod IN ('A','I','M','S')`, because only those move the price by averaging:

| Method | Behaviour on a changing-costs inbound | In gate |
|---|---|---|
| `A` AveragePO, `I` AverageInvoice, `M` MovingAverageInvoice | handlers call `CurrentCost.addWeightedAverage` | yes |
| `S` StandardCosting | records `amt = prevPrice·qty`, so the average provably reproduces `prevPrice` — a no-op, not an approximation | yes |
| `p` LastPOPrice, `i` LastInvoice | on `M_MatchPO` / `M_MatchInv` the handlers **replace** the price with `amt/qty` | no |
| `L` Lifo, `F` Fifo, `U` UserDefined, `x` ExternalProcessing | not established | no |

Without the gate, a LastPOPrice/LastInvoice-costed product would get a silently **wrong** `M_Cost.CurrentCostPrice`: with `prevPrice=20, prevQty=10` and an inbound `qty=10, amt=400`, replace yields `40` but averaging yields `600/20 = 30`.

Excluded methods fall through to the pre-existing `RAISE`, i.e. exactly the behaviour they have today — so this change can never convert a loud abort into a silent mis-valuation. A `NULL` costingmethod (unresolvable cost element) likewise falls through rather than averaging blindly. The `RAISE` message now reports the costing method so a future abort is diagnosable.

**Known residual gap (deliberate, out of scope):** for `p` and `i` the price movement depends on the **document**, not on the method alone, so a method-only rule cannot model them. Variants reachable with `qty>0` + `IsChangingCosts='Y'` + no inventory line — i.e. all matching case 2.5's shape — include: replace with `amt/qty` (base handler, `M_MatchPO`/`M_MatchInv`); a weighted average that *is* a no-op (`ManufacturingLastPOCostingMethodHandler.createMainProductOrCoProductReceipt`, where `amt = currentCostPrice·qty`); a weighted average that is *not* a no-op (same class, `createComponentIssue` reversal, where `amt/qty` is the price at the original issue); and price left **untouched** with only qty moving (`createOutboundCostDefaultImpl` reversal → `CurrentCost.addToCurrentQtyAndCumulate`). That list is examples, not exhaustive — it was incomplete twice.

So no single no-op variant is licence to add `p`/`i` to the gate. Excluding them is safe for a reason that does **not** depend on enumerating variants: the only fallback is the loud `RAISE`, never a silently wrong `CurrentCostPrice`. Consequence: a `p`/`i` element whose last pre-range detail has this shape still aborts instead of being reconstructed. Closing that needs a `(method, document)` key.

---

## 2. A point-in-time cost read, and the switch uses it

`ICostingService.getCurrentCost` only ever answers with the **live** `M_Cost` row. For a back-dated cut-off that is the cost *after* every movement booked since, so a `CopyFromCostElement` cost revaluation dated `EvaluationStartDate = <cut-off>` opened the target element with a value the source never had at the cut-off — and stamped it as of the cut-off.

New read:

- `ICostingService#getCostAsOf(costSegmentAndElement, asOfDate)` → `Optional<CostDetailPreviousAmounts>`. It reconstructs the state from the `Prev_*` columns of the **first changing-costs `M_CostDetail` dated after `asOfDate`** — those columns hold exactly the state the element was in immediately before that movement. With no such detail nothing moved after the cut-off, so the live `M_Cost` row *is* the state as of the date.
- `ICostDetailRepository#getFirstChangingCostsDetailAfter(...)`, expressed as a `CostDetailQuery` filter (`changingCosts`, `dateAcctRage`, `DATE_ACCT_ASC` + `ID_ASC`). Deliberately the same algorithm as the SQL function `getCurrentCostInfo`, so a point-in-time valuation read done in SQL and one done in Java agree by construction.
- The boundary is strictly `>`, never `>=`: the switch writes its own opening anchor dated exactly **at** the cut-off, and that anchor must never count as a forward event — otherwise the switch would seed itself from its own anchor's `Prev_*`.

`CostRevaluationService` now uses it on **both** sides, so the drafted lines preview exactly the numbers complete-time will write:

- `createLinesFromCopyFromCostElement` restates each source `M_Cost` as of `EvaluationStartDate` before creating the lines;
- `createDetailsForCopyFromCostElement` seeds `M_Cost` + the opening anchor from that same as-of read (own price, lower-level price and qty from **one** read — never a stale-own/qty + fresh-LL mix).

Both fail loudly (`AdempiereException`) when the source has no cost as of the cut-off, instead of silently falling back to the live cost — that fallback is the very bug this read exists to remove.

---

## 3. The recompute refuses to delete a cost-revaluation opening anchor

`m_costdetail_delete_from_date` now refuses, before its `DELETE`, when the delete range contains an `M_CostDetail` with `M_CostRevaluationLine_ID IS NOT NULL` — the single zero-delta opening anchor a completed `CopyFromCostElement` revaluation writes at the cut-off. Same range predicate as the `DELETE`, so the guard fires exactly when the `DELETE` would hit an anchor, and it sits at the choke point, so it protects direct callers too, not only `product_costs_recreate_from_date`.

Concrete failure it prevents: December is re-opened for year-end adjustments and someone recomputes a product from a December document, i.e. from a date at or before the cut-off. What makes it dangerous is that **nothing visibly breaks** — the anchor is `IsChangingCosts='Y'` and its `Prev_*` *are* the seeded opening, so case 1 picks the anchor, `M_Cost` is updated back to the very same numbers and survives at the correct price. The damage is the silent loss of the anchor **row**: the `M_CostRevaluationLine` survives with no corresponding `M_CostDetail`, which destroys (a) the reversal basis (`reverseSeededCurrentCost` undoes the switch by deleting that anchor), (b) the only record of what the opening balance was, and (c) the double-seed guard (`retrieveProductIdsWithCostRevaluationSeed` keys on exactly that column), so a re-run of the switch re-seeds an already-in-use cost.

Refusing costs nothing: the recompute is re-runnable with a start date strictly after the cut-off, which is the only correct range anyway — the opening is a given, not something a recompute may replay. Until now the *only* thing preventing this was that the previous year's periods happen to be closed.

---

## 4. `product_costs_recreate_all_from_date` — batched, resumable, order-preserving

New procedure `de_metas_acct.product_costs_recreate_all_from_date(p_C_AcctSchema_ID, p_M_CostElement_ID, p_StartDateAcct, p_ProductsPerCommit = 100, p_Resume = 'N')`, plus two new tables, `de_metas_acct.accounting_docs_to_repost_staging` and `de_metas_acct.product_costs_recreate_progress`.

Why a procedure and not a function: a full run over a real installation is thousands of products and hundreds of thousands of documents and cannot be one transaction — a single-transaction attempt ran 2h13m and then died with a backend I/O error, rolling everything back. So the work is cut into commit-batches of `p_ProductsPerCommit` products; each batch rewinds its products, stages its documents and records itself `DONE` in **one** transaction, and `p_Resume='Y'` skips the batches already done.

Ordering is the whole point of the staging table. Costs are computed *while* reposting, so documents must reach the accounting server strictly in document-date order — but the server's poller drains `accounting_docs_to_repost` continuously, so anything inserted there as it is found would be reposted early, out of order, and would freeze wrong costs. The rows are therefore parked in the staging table and released in **one** step at the end, with `SeqNo` assigned explicitly by `row_number() OVER (ORDER BY dateacct, tablename_prio, record_id)` over a block of sequence values reserved in a single `setval(nextval(…) + n - 1)` statement. `SeqNo` is never left to the column's `nextval` default: the order in which `INSERT … SELECT` consumes a sequence is not guaranteed by an `ORDER BY` in the `SELECT`. Nothing in the real queue, its poller, or `fact_acct_unpost` changes.

Guards, all of them before the first mutation:

- **one run at a time** — a *session*-level advisory lock (a transaction-level one would be released by the first per-batch commit, leaving the rest of a multi-hour run unprotected);
- **every period in range open** — `assert_period_open` per distinct `(dateacct, docbasetype, org)`, because the repost throws `@PeriodClosed@` for an already-posted document in a closed period, and finding that out 40 batches in would leave the installation mid-rewind;
- **a resume must prove it continues the run it resumes** — `product_costs_recreate_progress` carries the four run-identity columns (`c_acctschema_id`, `m_costelement_id`, `startdateacct`, `products_per_commit`), written in the same transaction that marks a batch `DONE`. `batch_no` is *not* a stable name for a set of products — it is recomputed on every call from the caller's own `p_ProductsPerCommit`, and the product population is re-derived from the documents in range. So a resume with a different products-per-commit, a resume that meets the `DONE` rows of a *completed* earlier run, or a resume after a new document brought a new product into range, would each read "batch 3 is DONE" for a **different** set of products: never rewound, never staged, and the run reports success. Both halves of the check (parameters, then population) therefore run **up front** — the population half sits at the last mutation-free moment, because the target-element purge below commits, and a refusal raised after it would already have destroyed the rows a later correct resume needs.

The run also purges the target MovingAverageInvoice element's in-range cost details first (raw `DELETE`, then `m_costdetail_delete_from_date` for the same products): posting explodes a document into *every* active Material cost element, so the target may already carry in-range details built before it had an opening balance, and those are reused as-is by `CostingMethodHandlerTemplate#createOrUpdateCost` and win over the anchor in case 1. Only products that actually have such details are passed to `m_costdetail_delete_from_date` — for a seeded-but-not-moved product it would find nothing to restore from and delete the `M_Cost` row outright.

### Deliberate, evidenced deviation from a coding rule

`backend/de.metas.acct.base/CLAUDE.md:81` and `docs/coding-rules/production-database-support.md:65` both state: *never insert directly into `Accounting_Docs_To_Repost` — always use the `de_metas_acct.fact_acct_unpost*` functions.* **The release step inserts directly, knowingly.** Not an oversight, and not a rule amendment either — the rule stands; this run documents why it does not apply. `fact_acct_unpost` bundles two safety-relevant side effects with the enqueue, and both are redundant for a queue-driven repost:

- **deleting the stale `Fact_Acct` rows** — the repost does it itself: `PostingService.postNow` calls `doc.post(request.isForce(), true)` with `repost` **hardcoded** `true` (`backend/de.metas.acct.base/src/main/java/de/metas/acct/api/impl/PostingService.java:97`), and `Doc.post` does `if (repost) { deleteAcct(); }` before saving the new facts (`backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc.java:360-363`). So no bulk `fact_acct` `DELETE` is needed;
- **resetting `Posted='N'` so the document can be locked again** — `SqlAcctDocLockService.lock()` adds the `AND Posted='N'` condition only when `repost` is false (`SqlAcctDocLockService.java:29-32`), so a document left at `Posted='Y'` locks and reposts fine.

What `fact_acct_unpost` cannot do is enqueue a whole set of documents with a chosen `SeqNo` ordering in one statement — and that ordering is the entire correctness contract of a cost recompute. Worse, it inserts straight into `accounting_docs_to_repost`, handing documents to the poller one by one as they are found: exactly the out-of-order reposting this procedure exists to prevent. Using it here would trade a provable ordering guarantee for two no-ops.

The driver therefore only deletes `M_CostDetail`, fixes `M_Cost` and enqueues in chronological order — it never touches `Fact_Acct` and never enters the real repost queue except through the ordered release.

**Retained caveat:** the one `fact_acct_unpost` effect that is *not* redundant is the period check. `Doc.java:333-339` still throws `@PeriodClosed@` for an already-posted document in a closed period, so every period in the run's range must be open — which is why the driver asserts that up front (see the guards above).

---

## Migration scripts

| Script | Content |
|---|---|
| `5816000` | `m_costdetail_delete_from_date` — case 2.5 |
| `5816900` | `m_costdetail_delete_from_date` — the opening-anchor guard |
| `5816910` | `accounting_docs_to_repost_staging` table |
| `5816920` | `product_costs_recreate_progress` table |
| `5816930` | `product_costs_recreate_all_from_date` procedure |
| `5816940` / `5816950` | run-identity columns + the resume check that uses them |
| `5817060` | the population pre-check hoisted before the purge |

Each function/table also has its source-of-truth `ddl/functions/` resp. `ddl/table/` mirror in `backend/de.metas.acct.base/src/main/sql/postgresql/`.

## Tests added

| Test | Covers |
|---|---|
| `CostingServiceAsOfTest` (3 tests) | `getCostAsOf`: reconstruction from the first detail strictly after the date, fallback to the live `M_Cost`, and a detail *on* the date counted as before it |
| `CostRevaluationServiceTest#seedsTheSourceCostAsOfTheEvaluationStartDate` | the seed reads the source as of the cut-off, not its live value |
| `@Id:S26253_TC7` | back-dated switch opens with the source cost as of the cut-off, end to end (incl. an `M_CostRevaluation` step-def asserting the anchor's `DateAcct`) |
| `@Id:S26253_TC8` | a recompute reaching back over the opening anchor is refused instead of deleting it |
| `@Id:S26253_TC9` | recompute reconstructs the current cost from a weighted-average `M_MatchPO` inbound dated before the start date (case 2.5) |
| `@Id:S26253_TC10` | the batched driver stages its documents, releases them in document-date order, and resumes after a crash |
| `@Id:S26253_TC11` | a resume that regroups the products into different commit-batches is refused |
| `@Id:S26253_TC12` | a resume refused because a product joined the population purges nothing on its way to the refusal |

`TC9` is the case-2.5 regression scenario, in its own feature file; `TC7`, `TC8`, `TC10`–`TC12` extend the existing `switchToMovingAverageInvoice.feature` (which already carried `TC1`–`TC6` on the base branch). `TC10`–`TC12` are driven by a new `ProductCostsRecreateAll_StepDef`.

`TC9` distinguishes three outcomes: RED (the old function aborts), a naive "copy case 2.4" fix (would leave 20 CHF) and the correct weighted-average fix (30 CHF). Its `M_CostDetails are found` step asserts an **exact** set, so it lists all four details the two receipts book — the two cost-changing `M_MatchPO` rows and the two non-cost-changing `M_InOutLine` rows.

Coverage note: case 2.5 is exercised for method `A` only; the `I` / `M` / `S` claims above are established from the handler sources, not from a scenario in this PR.

The originally failing case was additionally reproduced and confirmed fixed by an isolated single-product dry-run on a customer's hotfix instance.

## Status

Draft. Each of `@Id:S26253_TC7`, `TC8`, `TC9`, `TC10`, `TC11`, `TC12` was run locally (`scenarios=1 failures=0` each) against a stack carrying this branch's migrations, and the module's JUnit suites are green.

CI on the current head is still running. On the previous head https://github.com/metasfresh/metasfresh/commit/00bc4289933 (run https://github.com/metasfresh/metasfresh/actions/runs/30526098979) everything was green — cucumber 724/724, JUnit backend 8299 passed / 0 failed, frontend-webui 19/19, camel 192, jest 338, `db-apply-migrations`, `migration-cli`, `db-images`, `compatibility-images`, CodeQL — **except `mobile test`**, which is red for reasons unrelated to this diff:

- `git diff origin/intensive_care_hotfix...HEAD -- e2e/ misc/services/mobile-webui/ frontend/` is **empty** — this PR changes no frontend, mobile or E2E code at all;
- the suite is red on **67 %** of recent runs of the base branch `intensive_care_hotfix` itself (4 of the last 6), with none of this PR's code, and on 52 % of runs on this branch (11 of 21);
- the failures are 1–2 of ~201 specs and land on three distinct client-side seams: `barcode_scanner_modes.spec.js:396` (camera-toggle case 3 — fixed on `new_dawn_uat` by https://github.com/metasfresh/metasfresh/pull/25307, not ported to this base branch), `distribution/distribution.spec.js:161` (`#WFProcessScreen` job-start seam) and `picking/picking.spec.js:703` (`expectErrorToast` grace-window race).
