### PR TITLE
Close ShipmentSchedules: specific (1) vs generic (2+) rejection message

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/process/M_ShipmentSchedule_CloseShipmentSchedules_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/process/M_ShipmentSchedule_CloseShipmentSchedules_StepDef.java
@@ -149,6 +149,33 @@ public class M_ShipmentSchedule_CloseShipmentSchedules_StepDef
 	}
 
 	/**
+	 * Asserts that the last {@code M_ShipmentSchedule_CloseShipmentSchedules} process run was rejected AND that the
+	 * rejection carries the given {@code ErrorCode}. The error code identifies which rejection message was raised:
+	 * {@code ShipmentSchedule_UnfinishedPicking} (exactly one offending schedule → the specific, order-naming message)
+	 * vs {@code ShipmentSchedule_UnfinishedPickings} (two or more offending schedules → the generic message that does
+	 * not enumerate the schedules).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.depends StepDefData: none (reads the exception captured by the previous step)
+	 * @cucumber.example
+	 * <pre>
+	 * Then the M_ShipmentSchedule_CloseShipmentSchedules process is rejected with error code "ShipmentSchedule_UnfinishedPicking"
+	 * </pre>
+	 */
+	@Then("^the M_ShipmentSchedule_CloseShipmentSchedules process is rejected with error code \"([^\"]+)\"$")
+	public void assertCloseShipmentSchedulesProcessRejectedWithErrorCode(@NonNull final String expectedErrorCode)
+	{
+		assertThat(lastCloseProcessException)
+				.as("Closing a shipment schedule with an unfinished (Drafted) picking job must be rejected")
+				.isNotNull()
+				.isInstanceOf(AdempiereException.class);
+
+		assertThat(AdempiereException.extractErrorCodeOrNull(lastCloseProcessException))
+				.as("Close rejection must carry the expected ErrorCode")
+				.isEqualTo(expectedErrorCode);
+	}
+
+	/**
 	 * Asserts that the last {@code M_ShipmentSchedule_CloseShipmentSchedules} process run
 	 * ({@link #runCloseShipmentSchedulesProcess(DataTable)}) completed WITHOUT error (i.e. the close was accepted,
 	 * not refused).

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/process/M_ShipmentSchedule_CloseShipmentSchedules_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/process/M_ShipmentSchedule_CloseShipmentSchedules_StepDef.java
@@ -153,7 +153,8 @@ public class M_ShipmentSchedule_CloseShipmentSchedules_StepDef
 	 * rejection carries the given {@code ErrorCode}. The error code identifies which rejection message was raised:
 	 * {@code ShipmentSchedule_UnfinishedPicking} (exactly one offending schedule → the specific, order-naming message)
 	 * vs {@code ShipmentSchedule_UnfinishedPickings} (two or more offending schedules → the generic message that does
-	 * not enumerate the schedules).
+	 * not enumerate the schedules) vs {@code ShipmentSchedule_NotEligibleToClose} (no unfinished picking, but the whole
+	 * selection is ineligible: every schedule is already processed or still has a picked-but-unshipped qty).
 	 *
 	 * @cucumber.stepdef
 	 * @cucumber.depends StepDefData: none (reads the exception captured by the previous step)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/process/M_ShipmentSchedule_CloseShipmentSchedules_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/process/M_ShipmentSchedule_CloseShipmentSchedules_StepDef.java
@@ -128,27 +128,6 @@ public class M_ShipmentSchedule_CloseShipmentSchedules_StepDef
 	}
 
 	/**
-	 * Asserts that the last {@code M_ShipmentSchedule_CloseShipmentSchedules} process run
-	 * ({@link #runCloseShipmentSchedulesProcess(DataTable)}) was rejected with an {@link AdempiereException}
-	 * (i.e. the close was refused, not silently applied).
-	 *
-	 * @cucumber.stepdef
-	 * @cucumber.depends StepDefData: none (reads the exception captured by the previous step)
-	 * @cucumber.example
-	 * <pre>
-	 * Then the M_ShipmentSchedule_CloseShipmentSchedules process is rejected
-	 * </pre>
-	 */
-	@Then("^the M_ShipmentSchedule_CloseShipmentSchedules process is rejected$")
-	public void assertCloseShipmentSchedulesProcessRejected()
-	{
-		assertThat(lastCloseProcessException)
-				.as("Closing a shipment schedule with an unfinished (Drafted) picking job must be rejected")
-				.isNotNull()
-				.isInstanceOf(AdempiereException.class);
-	}
-
-	/**
 	 * Asserts that the last {@code M_ShipmentSchedule_CloseShipmentSchedules} process run was rejected AND that the
 	 * rejection carries the given {@code ErrorCode}. The error code identifies which rejection message was raised:
 	 * {@code ShipmentSchedule_UnfinishedPicking} (exactly one offending schedule → the specific, order-naming message)

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/closeWithUnfinishedPicking.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/closeWithUnfinishedPicking.feature
@@ -238,3 +238,37 @@ Feature: Closing a shipment schedule with an unfinished picking order
     And after not more than 60s, validate shipment schedules:
       | M_ShipmentSchedule_ID.Identifier | QtyPickList | OPT.IsClosed |
       | shipmentSchedule                 | 12          | false        |
+
+  @Id:S30915_060
+  Scenario: Multi-selection with exactly one offender is rejected (all-or-nothing) with the specific message
+    # a selection of several schedules where only ONE still has an unfinished picking job: the offending-schedules
+    # query must narrow the multi-row selection to that single offender and raise the specific, order-naming message
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | SO1        | true    | customer                 | 2026-07-22  |
+      | SO2        | true    | customer                 | 2026-07-22  |
+    And metasfresh contains C_OrderLines:
+      | C_Order_ID.Identifier | Identifier | M_Product_ID.Identifier | QtyEntered | OPT.M_HU_PI_Item_Product_ID.Identifier |
+      | SO1                   | L1         | product                 | 160        | TUx4                                   |
+      | SO2                   | L2         | product                 | 160        | TUx4                                   |
+    And the order identified by SO1 is completed
+    And the order identified by SO2 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier    | C_OrderLine_ID.Identifier | IsToRecompute |
+      | busySchedule  | L1                        | N             |
+      | cleanSchedule | L2                        | N             |
+
+    # only SO1's schedule is still being picked; SO2's schedule has no picking job at all
+    And start picking job for sales order identified by SO1
+
+    When the M_ShipmentSchedule_CloseShipmentSchedules process is run for selection:
+      | M_ShipmentSchedule_ID |
+      | busySchedule          |
+      | cleanSchedule         |
+
+    # exactly one offending schedule in the selection => the specific, order-naming message
+    Then the M_ShipmentSchedule_CloseShipmentSchedules process is rejected with error code "ShipmentSchedule_UnfinishedPicking"
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID.Identifier | OPT.IsClosed |
+      | busySchedule                     | false        |
+      | cleanSchedule                    | false        |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/closeWithUnfinishedPicking.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/closeWithUnfinishedPicking.feature
@@ -99,7 +99,8 @@ Feature: Closing a shipment schedule with an unfinished picking order
       | M_ShipmentSchedule_ID |
       | shipmentSchedule      |
 
-    Then the M_ShipmentSchedule_CloseShipmentSchedules process is rejected
+    # exactly one offending schedule => the specific, order-naming message
+    Then the M_ShipmentSchedule_CloseShipmentSchedules process is rejected with error code "ShipmentSchedule_UnfinishedPicking"
     And after not more than 60s, validate shipment schedules:
       | M_ShipmentSchedule_ID.Identifier | OPT.IsClosed |
       | shipmentSchedule                 | false        |
@@ -128,7 +129,7 @@ Feature: Closing a shipment schedule with an unfinished picking order
       | shipmentSchedule                 | true         |
 
   @Id:S30915_030
-  Scenario: Multi-selection is all-or-nothing when one of the selected schedules has an unfinished picking job
+  Scenario: Multi-selection with several unfinished pickings is rejected with the generic message (all-or-nothing)
     When metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
       | SO1        | true    | customer                 | 2026-07-22  |
@@ -141,22 +142,24 @@ Feature: Closing a shipment schedule with an unfinished picking order
     And the order identified by SO2 is completed
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier    | C_OrderLine_ID.Identifier | IsToRecompute |
-      | busySchedule  | L1                        | N             |
-      | cleanSchedule | L2                        | N             |
+      | busySchedule1 | L1                        | N             |
+      | busySchedule2 | L2                        | N             |
 
-    # only SO1's schedule is still being picked; SO2's schedule has no picking job at all
+    # both selected schedules are still being picked (their picking jobs are Drafted)
     And start picking job for sales order identified by SO1
+    And start picking job for sales order identified by SO2
 
     When the M_ShipmentSchedule_CloseShipmentSchedules process is run for selection:
       | M_ShipmentSchedule_ID |
-      | busySchedule          |
-      | cleanSchedule         |
+      | busySchedule1         |
+      | busySchedule2         |
 
-    Then the M_ShipmentSchedule_CloseShipmentSchedules process is rejected
+    # two or more offending schedules => the generic message that does not enumerate them (huge-selection optimization)
+    Then the M_ShipmentSchedule_CloseShipmentSchedules process is rejected with error code "ShipmentSchedule_UnfinishedPickings"
     And after not more than 60s, validate shipment schedules:
       | M_ShipmentSchedule_ID.Identifier | OPT.IsClosed |
-      | busySchedule                     | false        |
-      | cleanSchedule                    | false        |
+      | busySchedule1                    | false        |
+      | busySchedule2                    | false        |
 
   @Id:S30915_040
   Scenario: Automatic/system close paths are not affected by the user-Close guard

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/closeWithUnfinishedPicking.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/closeWithUnfinishedPicking.feature
@@ -229,12 +229,13 @@ Feature: Closing a shipment schedule with an unfinished picking order
       | shipmentSchedule                 | 12          | false        |
 
     # no Drafted picking job exists, so the all-or-nothing unfinished-picking guard does not fire; but
-    # QtyPickList > 0 makes the schedule ineligible, so the process closes nothing and ends with @NoSelection@
+    # QtyPickList > 0 makes the schedule ineligible, so the process closes nothing. Since the WHOLE selection
+    # is ineligible, the process is rejected with the friendly not-eligible message (not the misleading @NoSelection@)
     When the M_ShipmentSchedule_CloseShipmentSchedules process is run for selection:
       | M_ShipmentSchedule_ID |
       | shipmentSchedule      |
 
-    Then the M_ShipmentSchedule_CloseShipmentSchedules process is rejected
+    Then the M_ShipmentSchedule_CloseShipmentSchedules process is rejected with error code "ShipmentSchedule_NotEligibleToClose"
     And after not more than 60s, validate shipment schedules:
       | M_ShipmentSchedule_ID.Identifier | QtyPickList | OPT.IsClosed |
       | shipmentSchedule                 | 12          | false        |

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedules.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedules.java
@@ -27,8 +27,6 @@ import java.math.BigDecimal;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.adempiere.ad.dao.IQueryFilter;
 import org.adempiere.exceptions.AdempiereException;
@@ -51,12 +49,10 @@ import de.metas.util.Services;
 
 public class M_ShipmentSchedule_CloseShipmentSchedules extends JavaProcess
 {
+	// exactly-one offender: the specific message that names the offending schedule's order
 	private static final AdMessageKey MSG_CANNOT_CLOSE_UNFINISHED_PICKING = AdMessageKey.of("M_ShipmentSchedule_CannotClose_UnfinishedPicking");
-
-	// The offending-schedules query feeds ONLY the rejection message, so it is capped: listing every schedule of a
-	// pathologically large selection would waste the query and produce an unreadable message. One offender is enough
-	// to reject the all-or-nothing close; the cap just bounds how many get named.
-	private static final int MAX_OFFENDING_SCHEDULES_TO_REPORT = 100;
+	// two-or-more offenders: the generic message that does NOT enumerate the schedules (huge-selection optimization)
+	private static final AdMessageKey MSG_CANNOT_CLOSE_UNFINISHED_PICKINGS = AdMessageKey.of("M_ShipmentSchedule_CannotClose_UnfinishedPickings");
 
 	private final IShipmentSchedulePA shipmentSchedulePA = Services.get(IShipmentSchedulePA.class);
 	private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
@@ -102,43 +98,53 @@ public class M_ShipmentSchedule_CloseShipmentSchedules extends JavaProcess
 	/**
 	 * Rejects the whole close (all-or-nothing) if any selected schedule still has an unfinished (Drafted) picking
 	 * job. The unfinished-picking check is a subquery filter folded into the selection query, so the offending
-	 * schedules come from a single query (no id round-trip / in-memory intersection); the query is capped at
-	 * {@link #MAX_OFFENDING_SCHEDULES_TO_REPORT} because it only feeds the rejection message.
+	 * schedules come from a single query (no id round-trip / in-memory intersection). The query is capped at 2
+	 * because the rejection message only needs to distinguish "exactly one" (named) from "two or more" (generic):
+	 * <ul>
+	 *     <li>none offending → do nothing;</li>
+	 *     <li>exactly one → the specific {@link #MSG_CANNOT_CLOSE_UNFINISHED_PICKING} naming that schedule's order;</li>
+	 *     <li>two or more → the generic {@link #MSG_CANNOT_CLOSE_UNFINISHED_PICKINGS}, which does NOT enumerate the
+	 *         schedules (the huge-selection optimization: no per-schedule order load for a potentially huge set).</li>
+	 * </ul>
 	 */
 	private void assertNoOffendingSchedules(final IQueryFilter<I_M_ShipmentSchedule> userSelectionFilter)
 	{
 		final List<I_M_ShipmentSchedule> offendingSchedules = shipmentSchedulePA.createQueryForShipmentScheduleSelection(getCtx(), userSelectionFilter)
 				.filter(pickingInfoService.newUnfinishedPickingFilter())
-				.setLimit(MAX_OFFENDING_SCHEDULES_TO_REPORT)
+				.setLimit(2)
 				.create()
 				.list();
-		if (!offendingSchedules.isEmpty())
+
+		if (offendingSchedules.isEmpty())
 		{
-			throw new AdempiereException(MSG_CANNOT_CLOSE_UNFINISHED_PICKING, toHumanReadableIdentifiersCsv(offendingSchedules));
+			return;
 		}
+
+		if (offendingSchedules.size() == 1)
+		{
+			final I_M_ShipmentSchedule offendingSchedule = offendingSchedules.get(0);
+			throw new AdempiereException(MSG_CANNOT_CLOSE_UNFINISHED_PICKING, toHumanReadableIdentifier(offendingSchedule, resolveDocumentNoByOrderId(offendingSchedule)));
+		}
+
+		throw new AdempiereException(MSG_CANNOT_CLOSE_UNFINISHED_PICKINGS);
 	}
 
 	/**
-	 * @return a comma-separated, human-readable identifier list for the offending schedules: each schedule's
-	 * 		order {@code DocumentNo} when it references one, else its {@code M_ShipmentSchedule_ID} as a fallback.
-	 * 		Orders are batch-loaded once (never one-by-one per schedule).
+	 * @return a one-entry {@code OrderId -> DocumentNo} map for the single offending schedule's order (never a batch
+	 * 		load): the schedule's order {@code DocumentNo} when it references an existing order, else an empty map so
+	 * 		{@link #toHumanReadableIdentifier(I_M_ShipmentSchedule, Map)} falls back to the {@code M_ShipmentSchedule_ID}.
 	 */
-	@VisibleForTesting
-	String toHumanReadableIdentifiersCsv(final List<I_M_ShipmentSchedule> offendingSchedules)
+	private Map<OrderId, String> resolveDocumentNoByOrderId(final I_M_ShipmentSchedule schedule)
 	{
-		final ImmutableSet<OrderId> orderIds = offendingSchedules.stream()
-				.map(schedule -> OrderId.ofRepoIdOrNull(schedule.getC_Order_ID()))
-				.filter(Objects::nonNull)
-				.collect(ImmutableSet.toImmutableSet());
+		final OrderId orderId = OrderId.ofRepoIdOrNull(schedule.getC_Order_ID());
+		if (orderId == null)
+		{
+			return ImmutableMap.of();
+		}
 
-		final Map<OrderId, String> documentNoByOrderId = orderDAO.getByIds(orderIds)
+		return orderDAO.getByIds(ImmutableSet.of(orderId))
 				.stream()
 				.collect(ImmutableMap.toImmutableMap(order -> OrderId.ofRepoId(order.getC_Order_ID()), I_C_Order::getDocumentNo));
-
-		return offendingSchedules.stream()
-				.map(schedule -> toHumanReadableIdentifier(schedule, documentNoByOrderId))
-				.distinct()
-				.collect(Collectors.joining(", "));
 	}
 
 	@VisibleForTesting

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedules.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedules.java
@@ -134,7 +134,8 @@ public class M_ShipmentSchedule_CloseShipmentSchedules extends JavaProcess
 	 * 		load): the schedule's order {@code DocumentNo} when it references an existing order, else an empty map so
 	 * 		{@link #toHumanReadableIdentifier(I_M_ShipmentSchedule, Map)} falls back to the {@code M_ShipmentSchedule_ID}.
 	 */
-	private Map<OrderId, String> resolveDocumentNoByOrderId(final I_M_ShipmentSchedule schedule)
+	@VisibleForTesting
+	Map<OrderId, String> resolveDocumentNoByOrderId(final I_M_ShipmentSchedule schedule)
 	{
 		final OrderId orderId = OrderId.ofRepoIdOrNull(schedule.getC_Order_ID());
 		if (orderId == null)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedules.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedules.java
@@ -53,6 +53,8 @@ public class M_ShipmentSchedule_CloseShipmentSchedules extends JavaProcess
 	private static final AdMessageKey MSG_CANNOT_CLOSE_UNFINISHED_PICKING = AdMessageKey.of("M_ShipmentSchedule_CannotClose_UnfinishedPicking");
 	/** two-or-more offenders: the generic message that does NOT enumerate the schedules (huge-selection optimization) */
 	private static final AdMessageKey MSG_CANNOT_CLOSE_UNFINISHED_PICKINGS = AdMessageKey.of("M_ShipmentSchedule_CannotClose_UnfinishedPickings");
+	/** no unfinished picking, but the WHOLE selection is ineligible: every selected schedule is already processed or still has a picked-but-unshipped qty (QtyPickList &gt; 0) */
+	private static final AdMessageKey MSG_CANNOT_CLOSE_NOT_ELIGIBLE = AdMessageKey.of("M_ShipmentSchedule_CannotClose_NotEligible");
 
 	private final IShipmentSchedulePA shipmentSchedulePA = Services.get(IShipmentSchedulePA.class);
 	private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
@@ -84,7 +86,11 @@ public class M_ShipmentSchedule_CloseShipmentSchedules extends JavaProcess
 
 		if (!selectionIterator.hasNext())
 		{
-			throw new AdempiereException("@NoSelection@");
+			// The user DID select schedules, but none is eligible to close: every selected schedule is either
+			// already processed (Processed=true, filtered out by the base selection query) or still has a
+			// picked-but-unshipped qty (QtyPickList > 0). "@NoSelection@" ("nothing selected") is misleading here,
+			// so raise a friendly message that explains why nothing was closed.
+			throw new AdempiereException(MSG_CANNOT_CLOSE_NOT_ELIGIBLE);
 		}
 
 		while (selectionIterator.hasNext())

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedules.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedules.java
@@ -56,6 +56,14 @@ public class M_ShipmentSchedule_CloseShipmentSchedules extends JavaProcess
 	/** no unfinished picking, but the WHOLE selection is ineligible: every selected schedule is already processed or still has a picked-but-unshipped qty (QtyPickList &gt; 0) */
 	private static final AdMessageKey MSG_CANNOT_CLOSE_NOT_ELIGIBLE = AdMessageKey.of("M_ShipmentSchedule_CannotClose_NotEligible");
 
+	/**
+	 * Row cap of the offending-schedules query: fetching a third row would add nothing, because the rejection message
+	 * only distinguishes "exactly one" (named) from "two or more" (generic).
+	 *
+	 * @see #assertNoOffendingSchedules(IQueryFilter)
+	 */
+	private static final int MAX_OFFENDING_SCHEDULES_TO_DISTINGUISH = 2;
+
 	private final IShipmentSchedulePA shipmentSchedulePA = Services.get(IShipmentSchedulePA.class);
 	private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
 	private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
@@ -104,8 +112,9 @@ public class M_ShipmentSchedule_CloseShipmentSchedules extends JavaProcess
 	/**
 	 * Rejects the whole close (all-or-nothing) if any selected schedule still has an unfinished (Drafted) picking
 	 * job. The unfinished-picking check is a subquery filter folded into the selection query, so the offending
-	 * schedules come from a single query (no id round-trip / in-memory intersection). The query is capped at 2
-	 * because the rejection message only needs to distinguish "exactly one" (named) from "two or more" (generic):
+	 * schedules come from a single query (no id round-trip / in-memory intersection). The query is capped at
+	 * {@link #MAX_OFFENDING_SCHEDULES_TO_DISTINGUISH} because the rejection message only needs to distinguish
+	 * "exactly one" (named) from "two or more" (generic):
 	 * <ul>
 	 *     <li>none offending → do nothing;</li>
 	 *     <li>exactly one → the specific {@link #MSG_CANNOT_CLOSE_UNFINISHED_PICKING} naming that schedule's order;</li>
@@ -117,7 +126,7 @@ public class M_ShipmentSchedule_CloseShipmentSchedules extends JavaProcess
 	{
 		final List<I_M_ShipmentSchedule> offendingSchedules = shipmentSchedulePA.createQueryForShipmentScheduleSelection(getCtx(), userSelectionFilter)
 				.filter(pickingInfoService.newUnfinishedPickingFilter())
-				.setLimit(2)
+				.setLimit(MAX_OFFENDING_SCHEDULES_TO_DISTINGUISH)
 				.create()
 				.list();
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedules.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedules.java
@@ -49,9 +49,9 @@ import de.metas.util.Services;
 
 public class M_ShipmentSchedule_CloseShipmentSchedules extends JavaProcess
 {
-	// exactly-one offender: the specific message that names the offending schedule's order
+	/** exactly-one offender: the specific message that names the offending schedule's order */
 	private static final AdMessageKey MSG_CANNOT_CLOSE_UNFINISHED_PICKING = AdMessageKey.of("M_ShipmentSchedule_CannotClose_UnfinishedPicking");
-	// two-or-more offenders: the generic message that does NOT enumerate the schedules (huge-selection optimization)
+	/** two-or-more offenders: the generic message that does NOT enumerate the schedules (huge-selection optimization) */
 	private static final AdMessageKey MSG_CANNOT_CLOSE_UNFINISHED_PICKINGS = AdMessageKey.of("M_ShipmentSchedule_CannotClose_UnfinishedPickings");
 
 	private final IShipmentSchedulePA shipmentSchedulePA = Services.get(IShipmentSchedulePA.class);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5816160_sys_AD_Message_M_ShipmentSchedule_CannotClose_UnfinishedPickings.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5816160_sys_AD_Message_M_ShipmentSchedule_CannotClose_UnfinishedPickings.sql
@@ -1,0 +1,55 @@
+-- AD_Message for the shipment-schedule Close guard: the GENERIC rejection raised
+-- when TWO OR MORE selected schedules still have an unfinished (Drafted) picking
+-- job. Unlike M_ShipmentSchedule_CannotClose_UnfinishedPicking (singular, which
+-- names the one offending order via {0}), this message does NOT enumerate the
+-- offending schedules -- optimizing the user-Close over a huge selection.
+
+-- 1. the message (base text = German)
+INSERT INTO AD_Message
+(AD_Client_ID, AD_Message_ID, AD_Org_ID, Created, CreatedBy, EntityType, IsActive, MsgText, MsgType, Updated, UpdatedBy, Value)
+VALUES
+(0, 545788 /*From ID Server*/, 0, TO_TIMESTAMP('2026-07-24 00:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100, 'de.metas.inoutcandidate', 'Y',
+ 'Die Lieferdispositionen können nicht geschlossen werden: es bestehen noch nicht abgeschlossene Kommissionieraufträge.',
+ 'E', TO_TIMESTAMP('2026-07-24 00:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100, 'M_ShipmentSchedule_CannotClose_UnfinishedPickings')
+;
+
+-- 2. short ErrorCode
+UPDATE AD_Message
+SET ErrorCode = 'ShipmentSchedule_UnfinishedPickings',
+    Updated   = TO_TIMESTAMP('2026-07-24 00:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Message_ID = 545788 /*From ID Server*/
+;
+
+-- 3. seed AD_Message_Trl for ALL active system languages with the base (DE) text, IsTranslated='N'
+INSERT INTO AD_Message_Trl
+(AD_Language, AD_Message_ID, MsgText, MsgTip, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Message_ID, t.MsgText, t.MsgTip, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND t.AD_Message_ID = 545788 /*From ID Server*/
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Message_ID = t.AD_Message_ID)
+;
+
+-- 4. en_US override (the real English text) + IsTranslated='Y'
+UPDATE AD_Message_Trl
+SET MsgText      = 'Cannot close the shipment schedules: unfinished picking jobs still exist.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-24 00:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'en_US' AND AD_Message_ID = 545788 /*From ID Server*/
+;
+
+-- 5. flip de_DE + de_CH to IsTranslated='Y' (their text already equals the DE base)
+UPDATE AD_Message_Trl
+SET IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-24 00:00:03', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'de_DE' AND AD_Message_ID = 545788 /*From ID Server*/
+;
+
+UPDATE AD_Message_Trl
+SET IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-24 00:00:04', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'de_CH' AND AD_Message_ID = 545788 /*From ID Server*/
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5816180_sys_AD_Message_M_ShipmentSchedule_CannotClose_NotEligible.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5816180_sys_AD_Message_M_ShipmentSchedule_CannotClose_NotEligible.sql
@@ -1,0 +1,55 @@
+-- AD_Message for the shipment-schedule Close guard: raised when the user runs the
+-- Close-shipment-schedules action on a selection where NO schedule is eligible to
+-- close -- there is no unfinished (Drafted) picking job, but every selected schedule
+-- is either already processed or still has a picked-but-unshipped qty (QtyPickList > 0).
+-- Replaces the misleading generic "@NoSelection@" for this all-ineligible case.
+
+-- 1. the message (base text = German)
+INSERT INTO AD_Message
+(AD_Client_ID, AD_Message_ID, AD_Org_ID, Created, CreatedBy, EntityType, IsActive, MsgText, MsgType, Updated, UpdatedBy, Value)
+VALUES
+(0, 545789 /*From ID Server*/, 0, TO_TIMESTAMP('2026-07-24 00:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100, 'de.metas.inoutcandidate', 'Y',
+ 'Die ausgewählten Lieferdispositionen können nicht geschlossen werden: sie sind bereits verarbeitet oder haben noch eine kommissionierte, noch nicht versandte Menge.',
+ 'E', TO_TIMESTAMP('2026-07-24 00:00:00', 'YYYY-MM-DD HH24:MI:SS'), 100, 'M_ShipmentSchedule_CannotClose_NotEligible')
+;
+
+-- 2. short ErrorCode
+UPDATE AD_Message
+SET ErrorCode = 'ShipmentSchedule_NotEligibleToClose',
+    Updated   = TO_TIMESTAMP('2026-07-24 00:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Message_ID = 545789 /*From ID Server*/
+;
+
+-- 3. seed AD_Message_Trl for ALL active system languages with the base (DE) text, IsTranslated='N'
+INSERT INTO AD_Message_Trl
+(AD_Language, AD_Message_ID, MsgText, MsgTip, IsTranslated, AD_Client_ID, AD_Org_ID, Created, Createdby, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Message_ID, t.MsgText, t.MsgTip, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.Createdby, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive = 'Y' AND l.IsSystemLanguage = 'Y' AND t.AD_Message_ID = 545789 /*From ID Server*/
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language = l.AD_Language AND tt.AD_Message_ID = t.AD_Message_ID)
+;
+
+-- 4. en_US override (the real English text) + IsTranslated='Y'
+UPDATE AD_Message_Trl
+SET MsgText      = 'The selected shipment schedule(s) cannot be closed: they are already processed, or still have a picked quantity awaiting shipment.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-24 00:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'en_US' AND AD_Message_ID = 545789 /*From ID Server*/
+;
+
+-- 5. flip de_DE + de_CH to IsTranslated='Y' (their text already equals the DE base)
+UPDATE AD_Message_Trl
+SET IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-24 00:00:03', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'de_DE' AND AD_Message_ID = 545789 /*From ID Server*/
+;
+
+UPDATE AD_Message_Trl
+SET IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-24 00:00:04', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Language = 'de_CH' AND AD_Message_ID = 545789 /*From ID Server*/
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedulesTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedulesTest.java
@@ -22,7 +22,6 @@ package de.metas.inoutcandidate.process;
  * #L%
  */
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.inoutcandidate.spi.IShipmentSchedulePickingInfoService;
@@ -34,15 +33,14 @@ import org.compiere.model.I_C_Order;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Covers the close-guard's message-formatting helpers ({@link M_ShipmentSchedule_CloseShipmentSchedules#toHumanReadableIdentifiersCsv}
- * / {@link M_ShipmentSchedule_CloseShipmentSchedules#toHumanReadableIdentifier}): order-found → order {@code DocumentNo};
- * fallback (no order) → {@code M_ShipmentSchedule_ID}; and dedup when several offending schedules share the same order.
+ * Covers the close-guard's single-schedule identifier helper
+ * ({@link M_ShipmentSchedule_CloseShipmentSchedules#toHumanReadableIdentifier}): order-found → order
+ * {@code DocumentNo}; fallback (no order, or order not in the resolved map) → {@code M_ShipmentSchedule_ID}.
  */
 class M_ShipmentSchedule_CloseShipmentSchedulesTest
 {
@@ -109,49 +107,5 @@ class M_ShipmentSchedule_CloseShipmentSchedulesTest
 		final String identifier = M_ShipmentSchedule_CloseShipmentSchedules.toHumanReadableIdentifier(schedule, documentNoByOrderId);
 
 		assertThat(identifier).isEqualTo("M_ShipmentSchedule_ID=9003");
-	}
-
-	@Test
-	void toHumanReadableIdentifiersCsv_ordersFound_batchLoadsAndJoinsDocumentNos()
-	{
-		final OrderId order1 = createOrder("SO-2001");
-		final OrderId order2 = createOrder("SO-2002");
-
-		final List<I_M_ShipmentSchedule> offendingSchedules = ImmutableList.of(
-				newSchedule(9101, order1),
-				newSchedule(9102, order2));
-
-		final String csv = new M_ShipmentSchedule_CloseShipmentSchedules().toHumanReadableIdentifiersCsv(offendingSchedules);
-
-		assertThat(csv).isEqualTo("SO-2001, SO-2002");
-	}
-
-	@Test
-	void toHumanReadableIdentifiersCsv_mixedOrderAndFallback_joinsBoth()
-	{
-		final OrderId order1 = createOrder("SO-3001");
-
-		final List<I_M_ShipmentSchedule> offendingSchedules = ImmutableList.of(
-				newSchedule(9201, order1),
-				newSchedule(9202, null));
-
-		final String csv = new M_ShipmentSchedule_CloseShipmentSchedules().toHumanReadableIdentifiersCsv(offendingSchedules);
-
-		assertThat(csv).isEqualTo("SO-3001, M_ShipmentSchedule_ID=9202");
-	}
-
-	@Test
-	void toHumanReadableIdentifiersCsv_sharedOrder_dedupsToOneIdentifier()
-	{
-		// two offending schedules on the SAME sales order -- the order's DocumentNo must appear only once
-		final OrderId sharedOrder = createOrder("SO-4001");
-
-		final List<I_M_ShipmentSchedule> offendingSchedules = ImmutableList.of(
-				newSchedule(9301, sharedOrder),
-				newSchedule(9302, sharedOrder));
-
-		final String csv = new M_ShipmentSchedule_CloseShipmentSchedules().toHumanReadableIdentifiersCsv(offendingSchedules);
-
-		assertThat(csv).isEqualTo("SO-4001");
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedulesTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedulesTest.java
@@ -108,4 +108,28 @@ class M_ShipmentSchedule_CloseShipmentSchedulesTest
 
 		assertThat(identifier).isEqualTo("M_ShipmentSchedule_ID=9003");
 	}
+
+	@Test
+	void resolveDocumentNoByOrderId_orderFound_resolvesToOrderDocumentNo()
+	{
+		// the single-offender path: the order is resolved directly (no batch load) and the rejection message names it
+		final OrderId orderId = createOrder("SO-5001");
+		final I_M_ShipmentSchedule schedule = newSchedule(9401, orderId);
+
+		final Map<OrderId, String> documentNoByOrderId = new M_ShipmentSchedule_CloseShipmentSchedules().resolveDocumentNoByOrderId(schedule);
+
+		assertThat(documentNoByOrderId).hasSize(1).containsEntry(orderId, "SO-5001");
+		assertThat(M_ShipmentSchedule_CloseShipmentSchedules.toHumanReadableIdentifier(schedule, documentNoByOrderId)).isEqualTo("SO-5001");
+	}
+
+	@Test
+	void resolveDocumentNoByOrderId_noOrder_fallsBackToScheduleId()
+	{
+		final I_M_ShipmentSchedule schedule = newSchedule(9402, null);
+
+		final Map<OrderId, String> documentNoByOrderId = new M_ShipmentSchedule_CloseShipmentSchedules().resolveDocumentNoByOrderId(schedule);
+
+		assertThat(documentNoByOrderId).isEmpty();
+		assertThat(M_ShipmentSchedule_CloseShipmentSchedules.toHumanReadableIdentifier(schedule, documentNoByOrderId)).isEqualTo("M_ShipmentSchedule_ID=9402");
+	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedulesTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/process/M_ShipmentSchedule_CloseShipmentSchedulesTest.java
@@ -38,9 +38,14 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Covers the close-guard's single-schedule identifier helper
- * ({@link M_ShipmentSchedule_CloseShipmentSchedules#toHumanReadableIdentifier}): order-found → order
- * {@code DocumentNo}; fallback (no order, or order not in the resolved map) → {@code M_ShipmentSchedule_ID}.
+ * Covers both of the close-guard's single-schedule naming helpers:
+ * <ul>
+ * <li>{@link M_ShipmentSchedule_CloseShipmentSchedules#toHumanReadableIdentifier}: order-found → order
+ * {@code DocumentNo}; fallback (no order, or order not in the resolved map) → {@code M_ShipmentSchedule_ID}.</li>
+ * <li>{@link M_ShipmentSchedule_CloseShipmentSchedules#resolveDocumentNoByOrderId}: schedule referencing an existing
+ * order → one-entry {@code OrderId -> DocumentNo} map; no order → empty map (so the identifier falls back to the
+ * {@code M_ShipmentSchedule_ID}).</li>
+ * </ul>
  */
 class M_ShipmentSchedule_CloseShipmentSchedulesTest
 {


### PR DESCRIPTION
## What

Improve the rejection messages of the user-initiated **Close shipment schedules** action. Two independent improvements:

1. **Unfinished-picking rejection — specific (1) vs generic (2+).** When selected schedules still have an unfinished (Drafted) picking job:
   - **Exactly one** offending schedule → the existing specific message `M_ShipmentSchedule_CannotClose_UnfinishedPicking`, which names that schedule's order (`DocumentNo`, falling back to `M_ShipmentSchedule_ID`).
   - **Two or more** offending schedules → a new generic message `M_ShipmentSchedule_CannotClose_UnfinishedPickings` (no parameter) that does **not** enumerate the offending schedules.

2. **Friendly "nothing eligible" rejection.** The previous `@NoSelection@` throw — raised when, after the unfinished-picking guard, no selected schedule is actually eligible to close — was misleading. It is replaced by a new message `M_ShipmentSchedule_CannotClose_NotEligible` explaining the real reason: the selected schedules are already processed, or still have a picked quantity awaiting shipment.

## Why

The action can run over a very large selection. The previous code always ran the offending-schedules query with `setLimit(100)` and then batch-loaded orders to build a comma-separated identifier list for the message — wasted work whose output is unreadable for a big selection. And `@NoSelection@` gave the user no idea *why* the close was refused. The new behaviour:

- caps the offending-schedules query at **2** (the message only needs to distinguish "exactly one" from "two or more") — the huge-selection optimization;
- for the 2+ case does no per-schedule order load at all;
- keeps a friendly, precise message for the common single-schedule case (naming the order);
- gives a clear, actionable reason when the selection has no eligible schedule, instead of the bare `@NoSelection@`.

## Changes

- `M_ShipmentSchedule_CloseShipmentSchedules`:
  - `assertNoOffendingSchedules`: the offending-schedules query limit dropped from the old `MAX_OFFENDING_SCHEDULES_TO_REPORT=100` to the new named constant `MAX_OFFENDING_SCHEDULES_TO_DISTINGUISH=2`, added the 1-vs-2+ branch and the `MSG_CANNOT_CLOSE_UNFINISHED_PICKINGS` key.
  - replaced the `@NoSelection@` throw with the new `MSG_CANNOT_CLOSE_NOT_ELIGIBLE` message.
  - deleted the now-obsolete `toHumanReadableIdentifiersCsv(...)`; kept `toHumanReadableIdentifier(...)` for the single case (single order resolved directly, no batch load).
- New AD_Message migrations (both `MsgType='E'`, EntityType `de.metas.inoutcandidate`, DE base text + en_US override):
  - `5816160_..._M_ShipmentSchedule_CannotClose_UnfinishedPickings.sql` — generic 2+ message, ErrorCode `ShipmentSchedule_UnfinishedPickings`.
  - `5816180_..._M_ShipmentSchedule_CannotClose_NotEligible.sql` — nothing-eligible message, ErrorCode `ShipmentSchedule_NotEligibleToClose`.
- Tests:
  - removed the three unit tests of the deleted CSV method; kept the `toHumanReadableIdentifier` tests and added direct tests for `resolveDocumentNoByOrderId` (order present → one-entry map; no order → empty map, so the identifier falls back to the `M_ShipmentSchedule_ID`);
  - cucumber `closeWithUnfinishedPicking.feature` now asserts, via the new step `... is rejected with error code "<code>"`: the specific ErrorCode for a single-selection rejection, the new generic ErrorCode for a rejection with two offending schedules, and a new scenario for the not-eligible rejection.

## Follow-up context

Follow-up to the original unfinished-picking Close guard (metasfresh PR https://github.com/metasfresh/metasfresh/pull/25301).

