### PR TITLE
Fix timezone-dependent unit tests that fail outside Europe/Berlin

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/db/Database.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-legacy/org/compiere/db/Database.java
@@ -91,6 +91,12 @@ public class Database
 
 	/**
 	 * Create SQL TO Date String from Timestamp
+	 * <p>
+	 * dev-note: for {@link DisplayType#Date} and {@link DisplayType#Time} the target column is a {@code timestamp without time zone}
+	 * that carries no zone of its own, so the timestamp's wall clock is read in the <b>JVM default zone</b> — deliberately NOT
+	 * {@link SystemTime#zoneId()}. Such a timestamp comes from JDBC decoding a zone-less column in this same JVM, so decoding and
+	 * re-encoding cancel out whichever zone the JVM runs in. {@link DisplayType#DateTime} is the instant-carrying case and is
+	 * rendered in UTC instead. See {@code DatabaseTest} and {@code docs/coding-rules/java-time.md} § "Unit Test Timezone Rules".
 	 *
 	 * @param timestamp Date to be converted; if {@code null}, then the current time is returned.
 	 */

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/process/rpl/exp/ExportHelperTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/process/rpl/exp/ExportHelperTest.java
@@ -27,8 +27,11 @@ import lombok.NonNull;
 import org.adempiere.test.AdempiereTestHelper;
 import org.compiere.model.I_EXP_FormatLine;
 import org.compiere.util.DisplayType;
+import org.compiere.util.Env;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.time.ZoneId;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
@@ -40,7 +43,9 @@ class ExportHelperTest
 	void beforeEach()
 	{
 		AdempiereTestHelper.get().init();
-		AdempiereTestHelper.createOrgWithTimeZone();
+		// dev-note: ExportHelper.encodeDate formats in the time zone of the *context* org, so the org has to be put into the context.
+		// Without this the org below is never consulted and the assertion below silently measures the JVM's default time zone instead.
+		Env.setOrgId(Env.getCtx(), AdempiereTestHelper.createOrgWithTimeZone("org", ZoneId.of("Europe/Berlin")));
 
 		SystemTime.setTimeSource(() -> 1597126895000L/*Tue, 11 Aug 2020 06:21:35 GMT*/);
 	}
@@ -51,7 +56,7 @@ class ExportHelperTest
 		// when
 		final String result = ExportHelper.encodeDate(de.metas.common.util.time.SystemTime.asTimestamp(), DisplayType.DateTime);
 
-		// then
+		// then: Europe/Berlin is UTC+02:00 in August
 		assertThat(result).isEqualTo("2020-08-11T08:21:35+02:00");
 	}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/compiere/db/DatabaseTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/compiere/db/DatabaseTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.sql.Timestamp;
@@ -38,21 +39,26 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.TimeZone;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DatabaseTest
 {
+	private TimeZone jvmTimezoneBackup;
+
 	@BeforeEach
 	void beforeEach()
 	{
 		SystemTime.resetTimeSource();
+		jvmTimezoneBackup = TimeZone.getDefault();
 	}
 
 	@AfterEach
 	void afterEach()
 	{
 		SystemTime.resetTimeSource();
+		TimeZone.setDefault(jvmTimezoneBackup);
 	}
 
 	@Test
@@ -89,18 +95,27 @@ public class DatabaseTest
 		@Test
 		void null_Time() {assert_TO_DATE(null, DisplayType.Time).isEqualTo("current_date()");}
 
-		@Test
-		void ZonedDateTime_asTimestamp_Date()
+		/**
+		 * dev-note: a column without time information is a {@code timestamp without time zone} and carries no zone of its own,
+		 * so the value is rendered as the timestamp's wall clock in the JVM's default time zone.
+		 * The instant under test, {@code 2023-12-04T23:59:59Z}, therefore falls on a different day east and west of UTC.
+		 */
+		@ParameterizedTest(name = "JVM.zoneId={0}")
+		@CsvSource({
+				"America/Jamaica, 2023-12-04", // -05:00
+				"UTC, 2023-12-04",
+				"Europe/Berlin, 2023-12-05", // +01:00
+				"Asia/Tokyo, 2023-12-05", // +09:00
+		})
+		void ZonedDateTime_asTimestamp_Date(final String jvmTimezone, final String expectedLocalDate)
 		{
+			TimeZone.setDefault(TimeZone.getTimeZone(jvmTimezone));
+
 			final ZonedDateTime zonedDateTime = ZonedDateTime.parse("2023-12-04T23:59:59.000+00:00")
 					.withZoneSameInstant(ZoneId.of("Etc/UTC"));
 			final Timestamp time = TimeUtil.asTimestamp(zonedDateTime);
 
-			// setting zoneId to Europe/Berlin
-			SystemTime.setFixedTimeSource(ZonedDateTime.now(ZoneId.of("Europe/Berlin")));
-
-			// dev-note: we expect 2023-12-05 as for column without time information, the values should always be in local time
-			assert_TO_DATE(time, DisplayType.Date).isEqualTo("'2023-12-05'::timestamp without time zone");
+			assert_TO_DATE(time, DisplayType.Date).isEqualTo("'" + expectedLocalDate + "'::timestamp without time zone");
 		}
 
 		@Test


### PR DESCRIPTION
## What

Two unit tests in `de.metas.adempiere.adempiere.base` failed on any machine whose timezone is not `Europe/Berlin`. Both are **test** defects — the production code they cover is intentional and already specified by other tests — so there is no production behaviour change here.

Every metasfresh CI image pins `ENV TZ=Europe/Berlin` (13 `docker-builds/Dockerfile.*`, incl. `Dockerfile.junit`), so CI never saw it. A developer outside that timezone had to export `TZ=Europe/Berlin` or build with `-DskipTests`.

## Why each one failed

**`DatabaseTest$TO_DATE.ZonedDateTime_asTimestamp_Date`** — `Database.TO_DATE(Timestamp, DisplayType.Date)` renders the timestamp's wall clock in the **JVM default zone** (`Timestamp#toLocalDateTime()`). That is deliberate: a date-only column is `timestamp without time zone` and carries no zone, so JDBC decode and re-encode happen in the same JVM and cancel out. Two sibling tests in the same class — `parseLocalDateAsTimestamp_TO_DATE_Date` and `TO_DATE_Time`, each parameterized over 8 `SystemTime.zoneId()` values — already pin that contract.

The failing test predates it. Commit https://github.com/metasfresh/metasfresh/commit/7dc152d7503cfa046cc6f4c89ef983aeb6913f89 (2025-01-31) switched the implementation from `TimeUtil.asLocalDate(time, SystemTime.zoneId())` to `toLocalDateTime()` and added those two parameterized tests, but carried this one over verbatim — including its now-inert `SystemTime.setFixedTimeSource(Europe/Berlin)` line and a dev-note describing behaviour the code no longer had. The test silently became a test of the machine's timezone. The instant `2023-12-04T23:59:59Z` is `2023-12-05` in Berlin but `2023-12-04` in UTC.

**`ExportHelperTest.encodeDate`** — `ExportHelper.encodeDate` formats using `IOrgDAO.getTimeZone(Env.getOrgId())`. The test created a `Europe/Berlin` org but never made it the context org, so `Env.getOrgId()` was not a regular `OrgId`, `OrgDAO.getTimeZone` took its fallback to `SystemTime.zoneId()`, and the test's bare `millis` lambda time source (whose `TimeSource.zoneId()` defaults to `ZoneId.systemDefault()`) handed back the machine's zone. The org in setup was dead weight and the `+02:00` assertion measured the machine.

## How they are fixed

- **`DatabaseTest`** — parameterize over the **JVM default zone** with `TimeZone.setDefault`, backed up in `@BeforeEach` and restored in `@AfterEach`, mirroring the pattern `org.compiere.util.TimeUtilTest` already uses in this same module. The existing `Europe/Berlin -> 2023-12-05` expectation is kept as one of four rows; `America/Jamaica`, `UTC` and `Asia/Tokyo` are added, so the test now covers both sides of UTC and states which zone each expected value belongs to. All four are DST-free at that date. The inert `SystemTime.setFixedTimeSource` line and the stale dev-note are removed.
- **`ExportHelperTest`** — `Env.setOrgId(Env.getCtx(), createOrgWithTimeZone(...))`, the idiom already used with `createOrgWithTimeZone()` in `ProductDAOTest`, `SubProducerAttributeDAOTest` and `DocTypeDAOTest`. The assertion is unchanged and now actually exercises the org-timezone path it claims to cover.
- **`Database.TO_DATE(Timestamp, int)`** — a Javadoc note documenting the JVM-default-zone contract at the source. Its absence is what let the stale test survive the 2025-01-31 port.

No test was weakened: no assertion dropped, no case removed, nothing disabled. Coverage of `TO_DATE(Timestamp, Date)` goes from one zone to four.

## Not done, deliberately

Pinning `TZ` / `-Duser.timezone` for the surefire fork was the simplest option on the table. It would make CI and local agree while **hiding** the timezone-dependence, and would let the next such test in unnoticed. The tests now pin the zone they actually mean instead.

## Verification

| Run | Result |
|---|---|
| `DatabaseTest,ExportHelperTest` @ `TZ=UTC` — before the fix | 2 failures (exactly the reported ones) |
| `DatabaseTest,ExportHelperTest` @ `TZ=UTC` — after | 28 tests, 0 failures |
| `DatabaseTest,ExportHelperTest` @ `TZ=Europe/Berlin` — after | 28 tests, 0 failures |
| whole `de.metas.adempiere.adempiere.base` suite @ `TZ=UTC` | 1420 tests, 0 failures, 0 errors, 6 skipped |

The full-module run confirms no other test in that module depends on the machine's timezone.
