### PR TITLE
`Credit memo`: mandatory Line_CreditMemoReason to complete

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/service/ISysConfigBL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/service/ISysConfigBL.java
@@ -27,6 +27,7 @@ import de.metas.organization.ClientAndOrgId;
 import de.metas.organization.OrgId;
 import de.metas.util.ISingletonService;
 import de.metas.util.lang.ReferenceListAwareEnum;
+import de.metas.util.lang.RepoIdAware;
 import lombok.NonNull;
 import org.jetbrains.annotations.Contract;
 
@@ -34,6 +35,7 @@ import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.IntFunction;
 
 public interface ISysConfigBL extends ISingletonService
 {
@@ -124,4 +126,13 @@ public interface ISysConfigBL extends ISingletonService
 	Map<String, String> getValuesForPrefix(String prefix, boolean removePrefix, ClientAndOrgId clientAndOrgId);
 
 	<T extends Enum<T>> ImmutableSet<T> getCommaSeparatedEnums(@NonNull String sysconfigName, @NonNull Class<T> enumType);
+
+	/**
+	 * Reads a system-level SysConfig holding a comma-separated list of repo-ids and maps each token to a {@link RepoIdAware}.
+	 * Empty/unset (or the {@code "-"} sentinel) yields an empty set. Consistent with {@link #getCommaSeparatedEnums(String, Class)},
+	 * an unparseable token is logged and skipped rather than aborting the caller.
+	 *
+	 * @param mapper turns a parsed repo-id into the value object, e.g. {@code DocTypeId::ofRepoIdOrNull} (may return {@code null} to skip)
+	 */
+	<T extends RepoIdAware> ImmutableSet<T> getCommaSeparatedRepoIdAwares(@NonNull String sysconfigName, @NonNull IntFunction<T> mapper);
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/service/impl/SysConfigBL.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/service/impl/SysConfigBL.java
@@ -34,6 +34,7 @@ import de.metas.util.Services;
 import de.metas.util.StringUtils;
 import de.metas.util.lang.ReferenceListAwareEnum;
 import de.metas.util.lang.ReferenceListAwareEnums;
+import de.metas.util.lang.RepoIdAware;
 import lombok.NonNull;
 import org.adempiere.service.ClientId;
 import org.adempiere.service.ISysConfigBL;
@@ -46,6 +47,7 @@ import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.IntFunction;
 import java.util.Set;
 
 /**
@@ -369,6 +371,37 @@ public class SysConfigBL implements ISysConfigBL
 					catch (final Exception ex)
 					{
 						logger.warn("Failed converting `{}` to enum {}. Ignoring it.", name, enumType, ex);
+						return null;
+					}
+				})
+				.filter(Objects::nonNull)
+				.collect(ImmutableSet.toImmutableSet());
+	}
+
+	@Override
+	public <T extends RepoIdAware> ImmutableSet<T> getCommaSeparatedRepoIdAwares(
+			@NonNull final String sysconfigName,
+			@NonNull final IntFunction<T> mapper)
+	{
+		final String string = StringUtils.trimBlankToNull(sysConfigDAO.getValue(sysconfigName, ClientAndOrgId.SYSTEM).orElse(null));
+		if (string == null || string.equals("-"))
+		{
+			return ImmutableSet.of();
+		}
+
+		return Splitter.on(",")
+				.trimResults()
+				.omitEmptyStrings()
+				.splitToList(string)
+				.stream()
+				.map(token -> {
+					try
+					{
+						return mapper.apply(Integer.parseInt(token));
+					}
+					catch (final Exception ex)
+					{
+						logger.warn("Failed converting `{}` to a repo-id from SysConfig `{}`. Ignoring it.", token, sysconfigName, ex);
 						return null;
 					}
 				})

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/service/impl/SysConfigBLTests.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/service/impl/SysConfigBLTests.java
@@ -22,6 +22,8 @@ package org.adempiere.service.impl;
  * #L%
  */
 
+import com.google.common.collect.ImmutableSet;
+import de.metas.document.DocTypeId;
 import de.metas.organization.ClientAndOrgId;
 import de.metas.organization.OrgId;
 import de.metas.util.Services;
@@ -77,6 +79,44 @@ public class SysConfigBLTests
 
 			final String value = sysConfigBL.getValue("name", ClientAndOrgId.ofClientAndOrg(ClientId.ofRepoId(1), OrgId.ofRepoId(1)));
 			assertThat(value).isEqualTo("valueStr");
+		}
+	}
+
+	@Nested
+	class getCommaSeparatedRepoIdAwares
+	{
+		private static final String NAME = "some.repoid.list";
+
+		@Test
+		void emptyOrUnset_returnsEmptySet()
+		{
+			// unset
+			assertThat(sysConfigBL.getCommaSeparatedRepoIdAwares(NAME, DocTypeId::ofRepoIdOrNull)).isEmpty();
+
+			sysConfigBL.setValue(NAME, "", ClientId.SYSTEM, OrgId.ANY);
+			assertThat(sysConfigBL.getCommaSeparatedRepoIdAwares(NAME, DocTypeId::ofRepoIdOrNull)).isEmpty();
+
+			// the "-" sentinel also disables the list
+			sysConfigBL.setValue(NAME, "-", ClientId.SYSTEM, OrgId.ANY);
+			assertThat(sysConfigBL.getCommaSeparatedRepoIdAwares(NAME, DocTypeId::ofRepoIdOrNull)).isEmpty();
+		}
+
+		@Test
+		void validCsv_parsesAndTrims()
+		{
+			sysConfigBL.setValue(NAME, " 1000004, 540901 ,540902 ", ClientId.SYSTEM, OrgId.ANY);
+
+			assertThat(sysConfigBL.getCommaSeparatedRepoIdAwares(NAME, DocTypeId::ofRepoIdOrNull))
+					.isEqualTo(ImmutableSet.of(DocTypeId.ofRepoId(1000004), DocTypeId.ofRepoId(540901), DocTypeId.ofRepoId(540902)));
+		}
+
+		@Test
+		void malformedToken_isSkipped_validOnesKept()
+		{
+			sysConfigBL.setValue(NAME, "1000004, not-a-number, 540901", ClientId.SYSTEM, OrgId.ANY);
+
+			assertThat(sysConfigBL.getCommaSeparatedRepoIdAwares(NAME, DocTypeId::ofRepoIdOrNull))
+					.isEqualTo(ImmutableSet.of(DocTypeId.ofRepoId(1000004), DocTypeId.ofRepoId(540901)));
 		}
 	}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/interceptor/C_Invoice.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/interceptor/C_Invoice.java
@@ -1,6 +1,5 @@
 package de.metas.invoice.interceptor;
 
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import de.metas.adempiere.model.I_C_Invoice;
 import de.metas.adempiere.model.I_C_InvoiceLine;
@@ -62,8 +61,6 @@ import org.compiere.model.ModelValidator;
 import org.compiere.util.TimeUtil;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
-
-import javax.annotation.Nullable;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -565,16 +562,17 @@ public class C_Invoice // 03771
 			return;
 		}
 
-		final ImmutableSet<DocTypeId> mandatoryDocTypeIds = getCreditMemoReasonMandatoryDocTypeIds();
+		final ImmutableSet<DocTypeId> mandatoryDocTypeIds = sysConfigBL.getCommaSeparatedRepoIdAwares(
+				SYSCONFIG_CreditMemoReasonMandatory_DocTypeIDs, DocTypeId::ofRepoIdOrNull);
 		if (mandatoryDocTypeIds.isEmpty())
 		{
 			return; // validation disabled
 		}
 
-		// Match either the effective or the target doc type (the latter covers the pre-complete state).
-		final boolean docTypeMatches = mandatoryDocTypeIds.contains(DocTypeId.ofRepoIdOrNull(invoice.getC_DocType_ID()))
-				|| mandatoryDocTypeIds.contains(DocTypeId.ofRepoIdOrNull(invoice.getC_DocTypeTarget_ID()));
-		if (!docTypeMatches)
+		// The effective doc type resolves C_DocType_ID (post-prepareIt) and falls back to C_DocTypeTarget_ID
+		// (pre-complete state), so we never have to probe the set with a null key.
+		final DocTypeId docTypeId = invoiceBL.getDocTypeIdEffectiveOrNull(invoice);
+		if (!mandatoryDocTypeIds.contains(docTypeId))
 		{
 			return;
 		}
@@ -589,37 +587,7 @@ public class C_Invoice // 03771
 
 		if (!linesWithoutReason.isEmpty())
 		{
-			throw new AdempiereException(MSG_CreditMemoReasonMandatory, linesWithoutReason)
-					.markAsUserValidationError();
-		}
-	}
-
-	private ImmutableSet<DocTypeId> getCreditMemoReasonMandatoryDocTypeIds()
-	{
-		final String value = sysConfigBL.getValue(SYSCONFIG_CreditMemoReasonMandatory_DocTypeIDs, "");
-		return Splitter.on(',')
-				.trimResults()
-				.omitEmptyStrings()
-				.splitToList(value)
-				.stream()
-				.map(this::parseDocTypeIdOrNull)
-				.filter(Objects::nonNull)
-				.collect(ImmutableSet.toImmutableSet());
-	}
-
-	@Nullable
-	private DocTypeId parseDocTypeIdOrNull(@NonNull final String token)
-	{
-		try
-		{
-			return DocTypeId.ofRepoIdOrNull(Integer.parseInt(token));
-		}
-		catch (final NumberFormatException ex)
-		{
-			// A misconfigured SysConfig must not abort every credit-memo completion with a cryptic
-			// stack trace: skip the unparseable token and keep enforcing the valid ones.
-			log.warn("Ignoring non-integer C_DocType_ID token '{}' in SysConfig {}", token, SYSCONFIG_CreditMemoReasonMandatory_DocTypeIDs);
-			return null;
+			throw new AdempiereException(MSG_CreditMemoReasonMandatory, linesWithoutReason);
 		}
 	}
 

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/interceptor/C_Invoice.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/interceptor/C_Invoice.java
@@ -579,9 +579,10 @@ public class C_Invoice // 03771
 			return;
 		}
 
+		// I_C_InvoiceLine (de.metas.adempiere.model) extends org.compiere.model.I_C_InvoiceLine, so
+		// getLine_CreditMemoReason()/getLine() are inherited directly — no re-wrapping needed.
 		final String linesWithoutReason = invoiceBL.getLines(InvoiceId.ofRepoId(invoice.getC_Invoice_ID()))
 				.stream()
-				.map(line -> InterfaceWrapperHelper.create(line, org.compiere.model.I_C_InvoiceLine.class))
 				.filter(line -> Check.isBlank(line.getLine_CreditMemoReason()))
 				.map(line -> Integer.toString(line.getLine()))
 				.collect(Collectors.joining(", "));

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/interceptor/C_Invoice.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/interceptor/C_Invoice.java
@@ -565,15 +565,15 @@ public class C_Invoice // 03771
 			return;
 		}
 
-		final ImmutableSet<Integer> mandatoryDocTypeIds = getCreditMemoReasonMandatoryDocTypeIds();
+		final ImmutableSet<DocTypeId> mandatoryDocTypeIds = getCreditMemoReasonMandatoryDocTypeIds();
 		if (mandatoryDocTypeIds.isEmpty())
 		{
 			return; // validation disabled
 		}
 
 		// Match either the effective or the target doc type (the latter covers the pre-complete state).
-		final boolean docTypeMatches = mandatoryDocTypeIds.contains(invoice.getC_DocType_ID())
-				|| mandatoryDocTypeIds.contains(invoice.getC_DocTypeTarget_ID());
+		final boolean docTypeMatches = mandatoryDocTypeIds.contains(DocTypeId.ofRepoIdOrNull(invoice.getC_DocType_ID()))
+				|| mandatoryDocTypeIds.contains(DocTypeId.ofRepoIdOrNull(invoice.getC_DocTypeTarget_ID()));
 		if (!docTypeMatches)
 		{
 			return;
@@ -594,7 +594,7 @@ public class C_Invoice // 03771
 		}
 	}
 
-	private ImmutableSet<Integer> getCreditMemoReasonMandatoryDocTypeIds()
+	private ImmutableSet<DocTypeId> getCreditMemoReasonMandatoryDocTypeIds()
 	{
 		final String value = sysConfigBL.getValue(SYSCONFIG_CreditMemoReasonMandatory_DocTypeIDs, "");
 		return Splitter.on(',')
@@ -608,11 +608,11 @@ public class C_Invoice // 03771
 	}
 
 	@Nullable
-	private Integer parseDocTypeIdOrNull(@NonNull final String token)
+	private DocTypeId parseDocTypeIdOrNull(@NonNull final String token)
 	{
 		try
 		{
-			return Integer.valueOf(token);
+			return DocTypeId.ofRepoIdOrNull(Integer.parseInt(token));
 		}
 		catch (final NumberFormatException ex)
 		{

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/interceptor/C_Invoice.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/interceptor/C_Invoice.java
@@ -1,5 +1,7 @@
 package de.metas.invoice.interceptor;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
 import de.metas.adempiere.model.I_C_Invoice;
 import de.metas.adempiere.model.I_C_InvoiceLine;
 import de.metas.allocation.api.IAllocationBL;
@@ -41,6 +43,7 @@ import de.metas.pricing.PriceListId;
 import de.metas.pricing.service.IPriceListDAO;
 import de.metas.pricing.service.ProductPrices;
 import de.metas.product.ProductId;
+import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +52,7 @@ import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ISysConfigBL;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_DocType;
 import org.compiere.model.I_C_Order;
@@ -66,6 +70,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Interceptor(I_C_Invoice.class)
 @Component
@@ -78,6 +83,18 @@ public class C_Invoice // 03771
 	 * Error key for the readonly-after-Complete guard on IsPartialInvoice.
 	 */
 	static final AdMessageKey MSG_IsPartialInvoiceReadOnlyAfterComplete = AdMessageKey.of("de.metas.invoice.IsPartialInvoiceReadOnlyAfterComplete");
+
+	/**
+	 * Error shown when a credit memo is completed while at least one line is missing its {@code Line_CreditMemoReason}.
+	 * The single parameter is the comma-separated list of offending line numbers.
+	 */
+	static final AdMessageKey MSG_CreditMemoReasonMandatory = AdMessageKey.of("de.metas.invoice.CreditMemoReasonMandatory");
+
+	/**
+	 * CSV of {@code C_DocType_ID}s for which the {@code Line_CreditMemoReason} is mandatory before a credit memo can be
+	 * completed. Empty/unset (the core default) disables the validation entirely.
+	 */
+	static final String SYSCONFIG_CreditMemoReasonMandatory_DocTypeIDs = "C_Invoice.CreditMemoReasonMandatory_DocTypeIDs";
 
 	@NonNull private final PaymentReservationService paymentReservationService;
 	@NonNull private final IDocumentLocationBL documentLocationBL;
@@ -95,6 +112,7 @@ public class C_Invoice // 03771
 	@NonNull private final IAllocationDAO allocationDAO = Services.get(IAllocationDAO.class);
 	@NonNull private final IOrderBL orderBL = Services.get(IOrderBL.class);
 	@NonNull private final IDocTypeDAO docTypeDAO = Services.get(IDocTypeDAO.class);
+	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 
 	// ==========================================================================
 	// Default IsPartialInvoice from C_DocType on BEFORE_NEW
@@ -528,6 +546,61 @@ public class C_Invoice // 03771
 	public void onDocTypeChange(@NonNull final I_C_Invoice invoice)
 	{
 		invoice.setIsFinancial(invoiceBL.getInvoiceDocBaseType(invoice).isFinancial());
+	}
+
+	/**
+	 * Blocks completing a credit memo while any of its lines is missing the {@code Line_CreditMemoReason}.
+	 * <p>
+	 * Only applies to credit memos ({@code DocBaseType} ARC/APC) whose document type is listed in the
+	 * {@link #SYSCONFIG_CreditMemoReasonMandatory_DocTypeIDs} SysConfig. The SysConfig is empty by default, so the
+	 * validation is disabled unless an instance explicitly opts in (see dt204/me03#31242).
+	 */
+	@DocValidate(timings = { ModelValidator.TIMING_BEFORE_COMPLETE })
+	public void validateCreditMemoReason(@NonNull final I_C_Invoice invoice)
+	{
+		if (!invoiceBL.isCreditMemo(invoice))
+		{
+			return;
+		}
+
+		final ImmutableSet<Integer> mandatoryDocTypeIds = getCreditMemoReasonMandatoryDocTypeIds();
+		if (mandatoryDocTypeIds.isEmpty())
+		{
+			return; // validation disabled
+		}
+
+		// Match either the effective or the target doc type (the latter covers the pre-complete state).
+		final boolean docTypeMatches = mandatoryDocTypeIds.contains(invoice.getC_DocType_ID())
+				|| mandatoryDocTypeIds.contains(invoice.getC_DocTypeTarget_ID());
+		if (!docTypeMatches)
+		{
+			return;
+		}
+
+		final String linesWithoutReason = invoiceBL.getLines(InvoiceId.ofRepoId(invoice.getC_Invoice_ID()))
+				.stream()
+				.map(line -> InterfaceWrapperHelper.create(line, org.compiere.model.I_C_InvoiceLine.class))
+				.filter(line -> Check.isBlank(line.getLine_CreditMemoReason()))
+				.map(line -> Integer.toString(line.getLine()))
+				.collect(Collectors.joining(", "));
+
+		if (!linesWithoutReason.isEmpty())
+		{
+			throw new AdempiereException(MSG_CreditMemoReasonMandatory, linesWithoutReason)
+					.markAsUserValidationError();
+		}
+	}
+
+	private ImmutableSet<Integer> getCreditMemoReasonMandatoryDocTypeIds()
+	{
+		final String value = sysConfigBL.getValue(SYSCONFIG_CreditMemoReasonMandatory_DocTypeIDs, "");
+		return Splitter.on(',')
+				.trimResults()
+				.omitEmptyStrings()
+				.splitToList(value)
+				.stream()
+				.map(Integer::parseInt)
+				.collect(ImmutableSet.toImmutableSet());
 	}
 
 	@DocValidate(timings = { ModelValidator.TIMING_BEFORE_COMPLETE })

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/interceptor/C_Invoice.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/interceptor/C_Invoice.java
@@ -63,6 +63,8 @@ import org.compiere.util.TimeUtil;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Nullable;
+
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.LocalDate;
@@ -599,8 +601,25 @@ public class C_Invoice // 03771
 				.omitEmptyStrings()
 				.splitToList(value)
 				.stream()
-				.map(Integer::parseInt)
+				.map(this::parseDocTypeIdOrNull)
+				.filter(Objects::nonNull)
 				.collect(ImmutableSet.toImmutableSet());
+	}
+
+	@Nullable
+	private Integer parseDocTypeIdOrNull(@NonNull final String token)
+	{
+		try
+		{
+			return Integer.valueOf(token);
+		}
+		catch (final NumberFormatException ex)
+		{
+			// A misconfigured SysConfig must not abort every credit-memo completion with a cryptic
+			// stack trace: skip the unparseable token and keep enforcing the valid ones.
+			log.warn("Ignoring non-integer C_DocType_ID token '{}' in SysConfig {}", token, SYSCONFIG_CreditMemoReasonMandatory_DocTypeIDs);
+			return null;
+		}
 	}
 
 	@DocValidate(timings = { ModelValidator.TIMING_BEFORE_COMPLETE })

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/service/IInvoiceBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/service/IInvoiceBL.java
@@ -146,6 +146,12 @@ public interface IInvoiceBL extends ISingletonService
 	 */
 	boolean isCreditMemo(String docBaseType);
 
+	/**
+	 * @return the effective document type: {@code C_DocType_ID} if set, otherwise {@code C_DocTypeTarget_ID}; {@code null} if neither is set.
+	 */
+	@Nullable
+	DocTypeId getDocTypeIdEffectiveOrNull(I_C_Invoice invoice);
+
     boolean isReversal(InvoiceId invoiceId);
 
 	/**

--- a/backend/de.metas.business/src/main/java/de/metas/invoice/service/impl/AbstractInvoiceBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/invoice/service/impl/AbstractInvoiceBL.java
@@ -1652,6 +1652,16 @@ public abstract class AbstractInvoiceBL implements IInvoiceBL
 	}
 
 	@Override
+	@Nullable
+	public final DocTypeId getDocTypeIdEffectiveOrNull(@NonNull final org.compiere.model.I_C_Invoice invoice)
+	{
+		final DocTypeId docTypeId = DocTypeId.ofRepoIdOrNull(invoice.getC_DocType_ID());
+		return docTypeId != null
+				? docTypeId
+				: DocTypeId.ofRepoIdOrNull(invoice.getC_DocTypeTarget_ID());
+	}
+
+	@Override
 	public final boolean isPurchaseProforma(@NonNull final org.compiere.model.I_C_Invoice invoice)
 	{
 		return getInvoiceDocBaseType(invoice).isPurchaseProformaInvoice();

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5816290_sys_gh31242_C_Invoice_CreditMemoReasonMandatory_ADMessage.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5816290_sys_gh31242_C_Invoice_CreditMemoReasonMandatory_ADMessage.sql
@@ -1,0 +1,28 @@
+-- Run mode: SWING_CLIENT
+
+-- User-facing, localized error shown when a credit memo is completed while at least one line is
+-- missing its Line_CreditMemoReason (de.metas.invoice.interceptor.C_Invoice). {0} = the affected line numbers.
+
+-- Value: de.metas.invoice.CreditMemoReasonMandatory
+-- 1. the message (base text = German)
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value,ErrorCode)
+VALUES (0,545792 /*From ID Server*/,0,TO_TIMESTAMP('2026-07-27 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Die Gutschrift kann nicht abgeschlossen werden: Bitte erfassen Sie auf allen Positionen einen Gutschriftsgrund. Betroffene Zeilen: {0}','E',TO_TIMESTAMP('2026-07-27 12:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.invoice.CreditMemoReasonMandatory','CreditMemoReasonMandatory')
+;
+
+-- 2. seed AD_Message_Trl for ALL active system languages with the base (DE) text, IsTranslated='N'
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Message_ID=545792
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- 3. en_US override (the real English text) + IsTranslated='Y'
+UPDATE AD_Message_Trl SET MsgText='The credit memo cannot be completed: please enter a credit-memo reason on all lines. Affected lines: {0}',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-07-27 12:00:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545792
+;
+
+-- 4. flip de_DE + de_CH to IsTranslated='Y' (their text already equals the DE base)
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-07-27 12:00:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545792
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-07-27 12:00:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545792
+;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5816300_sys_gh31242_C_Invoice_CreditMemoReasonMandatory_DocTypeIDs_SysConfig.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5816300_sys_gh31242_C_Invoice_CreditMemoReasonMandatory_DocTypeIDs_SysConfig.sql
@@ -1,0 +1,19 @@
+-- SysConfig gate for the "credit-memo reason is mandatory to complete" validation
+-- (de.metas.invoice.interceptor.C_Invoice). Holds a comma-separated list of C_DocType IDs; when a
+-- credit memo whose (target) document type is in this list is completed, every C_InvoiceLine must
+-- carry a Line_CreditMemoReason, otherwise completion is blocked.
+-- This seeds the row with the safe default '' (empty = validation disabled, no behaviour change for
+-- existing tenants); the per-instance value (the credit-memo doc-type IDs) is set in the customer repo
+-- via set_sysconfig_value once this row exists.
+
+INSERT INTO AD_SysConfig (AD_Client_ID, AD_Org_ID, AD_SysConfig_ID, ConfigurationLevel,
+                          Created, CreatedBy, Updated, UpdatedBy,
+                          EntityType, IsActive, Name, Value, Description)
+VALUES (0, 0, 541839 /*From ID Server*/, 'O',
+        TO_TIMESTAMP('2026-07-27 12:05:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        TO_TIMESTAMP('2026-07-27 12:05:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+        'D', 'Y',
+        'C_Invoice.CreditMemoReasonMandatory_DocTypeIDs',
+        '',
+        'Komma-getrennte Liste von C_DocType-IDs. Wird eine Gutschrift mit einem dieser (Ziel-)Belegtypen abgeschlossen, muss auf jeder Position ein Gutschriftsgrund (Line_CreditMemoReason) erfasst sein, sonst wird der Abschluss verhindert. Leer (Standard) = Prüfung deaktiviert.')
+;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5816300_sys_gh31242_C_Invoice_CreditMemoReasonMandatory_DocTypeIDs_SysConfig.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5816300_sys_gh31242_C_Invoice_CreditMemoReasonMandatory_DocTypeIDs_SysConfig.sql
@@ -9,7 +9,7 @@
 INSERT INTO AD_SysConfig (AD_Client_ID, AD_Org_ID, AD_SysConfig_ID, ConfigurationLevel,
                           Created, CreatedBy, Updated, UpdatedBy,
                           EntityType, IsActive, Name, Value, Description)
-VALUES (0, 0, 541839 /*From ID Server*/, 'O',
+VALUES (0, 0, 541839 /*From ID Server*/, 'S',
         TO_TIMESTAMP('2026-07-27 12:05:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
         TO_TIMESTAMP('2026-07-27 12:05:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
         'D', 'Y',

--- a/backend/de.metas.business/src/test/java/de/metas/invoice/interceptor/C_Invoice_CreditMemoReasonTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/invoice/interceptor/C_Invoice_CreditMemoReasonTest.java
@@ -107,7 +107,8 @@ class C_Invoice_CreditMemoReasonTest
 		final I_C_Invoice invoice = creditMemoInvoice(DOCTYPE_IN_LIST);
 
 		assertThatThrownBy(() -> interceptor.validateCreditMemoReason(invoice))
-				.isInstanceOf(AdempiereException.class);
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("20"); // the offending line number
 	}
 
 	@Test

--- a/backend/de.metas.business/src/test/java/de/metas/invoice/interceptor/C_Invoice_CreditMemoReasonTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/invoice/interceptor/C_Invoice_CreditMemoReasonTest.java
@@ -22,11 +22,15 @@
 
 package de.metas.invoice.interceptor;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import de.metas.adempiere.model.I_C_Invoice;
+import de.metas.adempiere.model.I_C_InvoiceLine;
 import de.metas.allocation.api.IAllocationBL;
 import de.metas.allocation.api.IAllocationDAO;
 import de.metas.bpartner.service.IBPartnerDAO;
+import de.metas.document.DocTypeId;
 import de.metas.document.location.IDocumentLocationBL;
 import de.metas.invoice.InvoiceId;
 import de.metas.invoice.due_date.InvoiceDueDateProviderService;
@@ -51,6 +55,8 @@ import javax.annotation.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.compiere.model.X_C_InvoiceLine.LINE_CREDITMEMOREASON_Doppellieferung;
+import static org.compiere.model.X_C_InvoiceLine.LINE_CREDITMEMOREASON_Falschlieferung;
 import static org.mockito.ArgumentMatchers.any;
 
 /**
@@ -91,6 +97,14 @@ class C_Invoice_CreditMemoReasonTest
 		Services.registerService(IInvoiceBL.class, invoiceBL);
 		Services.registerService(org.adempiere.service.ISysConfigBL.class, sysConfigBL);
 
+		// Mirror the real effective-doc-type resolution: C_DocType_ID if set, else C_DocTypeTarget_ID.
+		Mockito.when(invoiceBL.getDocTypeIdEffectiveOrNull(any(org.compiere.model.I_C_Invoice.class)))
+				.thenAnswer(inv -> {
+					final org.compiere.model.I_C_Invoice invoice = inv.getArgument(0);
+					final DocTypeId docTypeId = DocTypeId.ofRepoIdOrNull(invoice.getC_DocType_ID());
+					return docTypeId != null ? docTypeId : DocTypeId.ofRepoIdOrNull(invoice.getC_DocTypeTarget_ID());
+				});
+
 		interceptor = new C_Invoice(
 				Mockito.mock(PaymentReservationService.class),
 				Mockito.mock(IDocumentLocationBL.class),
@@ -102,7 +116,7 @@ class C_Invoice_CreditMemoReasonTest
 	{
 		stubSysConfig(CONFIGURED_DOCTYPE_IDS);
 		stubCreditMemo(true);
-		stubLines(line(10, "CMF"), line(20, null)); // line 20 has no reason
+		stubLines(line(10, LINE_CREDITMEMOREASON_Falschlieferung), line(20, null)); // line 20 has no reason
 
 		final I_C_Invoice invoice = creditMemoInvoice(DOCTYPE_IN_LIST);
 
@@ -130,7 +144,7 @@ class C_Invoice_CreditMemoReasonTest
 	{
 		stubSysConfig(CONFIGURED_DOCTYPE_IDS);
 		stubCreditMemo(true);
-		stubLines(line(10, "CMF"), line(20, "CMD"));
+		stubLines(line(10, LINE_CREDITMEMOREASON_Falschlieferung), line(20, LINE_CREDITMEMOREASON_Doppellieferung));
 
 		final I_C_Invoice invoice = creditMemoInvoice(DOCTYPE_IN_LIST);
 
@@ -207,29 +221,21 @@ class C_Invoice_CreditMemoReasonTest
 		assertThatCode(() -> interceptor.validateCreditMemoReason(invoice)).doesNotThrowAnyException();
 	}
 
-	/**
-	 * A malformed SysConfig token must not abort completion: the bad token is skipped and the valid
-	 * doc-type IDs still enforce the rule.
-	 */
-	@Test
-	void malformedSysConfigToken_ignored_validIdsStillEnforce()
-	{
-		stubSysConfig("1000004, not-a-number");
-		stubCreditMemo(true);
-		stubLines(line(10, null));
-
-		final I_C_Invoice invoice = creditMemoInvoice(DOCTYPE_IN_LIST);
-
-		assertThatThrownBy(() -> interceptor.validateCreditMemoReason(invoice))
-				.isInstanceOf(AdempiereException.class);
-	}
-
 	// -------------------------------------------------------------------------
 
+	// Parsing of the SysConfig CSV (incl. skipping malformed tokens) lives in
+	// ISysConfigBL#getCommaSeparatedRepoIdAwares and is covered by SysConfigBLTests. Here we stub it to
+	// return the already-parsed set of gated doc-type IDs.
 	private void stubSysConfig(final String docTypeIdsCsv)
 	{
-		Mockito.when(sysConfigBL.getValue(C_Invoice.SYSCONFIG_CreditMemoReasonMandatory_DocTypeIDs, ""))
-				.thenReturn(docTypeIdsCsv);
+		final ImmutableSet.Builder<DocTypeId> docTypeIds = ImmutableSet.builder();
+		for (final String token : Splitter.on(',').trimResults().omitEmptyStrings().split(docTypeIdsCsv))
+		{
+			docTypeIds.add(DocTypeId.ofRepoId(Integer.parseInt(token)));
+		}
+		Mockito.doReturn(docTypeIds.build())
+				.when(sysConfigBL)
+				.getCommaSeparatedRepoIdAwares(Mockito.eq(C_Invoice.SYSCONFIG_CreditMemoReasonMandatory_DocTypeIDs), any());
 	}
 
 	private void stubCreditMemo(final boolean isCreditMemo)
@@ -237,7 +243,7 @@ class C_Invoice_CreditMemoReasonTest
 		Mockito.when(invoiceBL.isCreditMemo(any(I_C_Invoice.class))).thenReturn(isCreditMemo);
 	}
 
-	private void stubLines(final de.metas.adempiere.model.I_C_InvoiceLine... lines)
+	private void stubLines(final I_C_InvoiceLine... lines)
 	{
 		Mockito.when(invoiceBL.getLines(any(InvoiceId.class))).thenReturn(ImmutableList.copyOf(lines));
 	}
@@ -250,15 +256,11 @@ class C_Invoice_CreditMemoReasonTest
 		return invoice;
 	}
 
-	private de.metas.adempiere.model.I_C_InvoiceLine line(final int lineNo, @Nullable final String reason)
+	private I_C_InvoiceLine line(final int lineNo, @Nullable final String reason)
 	{
-		final de.metas.adempiere.model.I_C_InvoiceLine invoiceLine =
-				InterfaceWrapperHelper.newInstance(de.metas.adempiere.model.I_C_InvoiceLine.class);
-		InterfaceWrapperHelper.setValue(invoiceLine, org.compiere.model.I_C_InvoiceLine.COLUMNNAME_Line, lineNo);
-		if (reason != null)
-		{
-			InterfaceWrapperHelper.setValue(invoiceLine, org.compiere.model.I_C_InvoiceLine.COLUMNNAME_Line_CreditMemoReason, reason);
-		}
+		final I_C_InvoiceLine invoiceLine = InterfaceWrapperHelper.newInstance(I_C_InvoiceLine.class);
+		invoiceLine.setLine(lineNo);
+		invoiceLine.setLine_CreditMemoReason(reason);
 		InterfaceWrapperHelper.saveRecord(invoiceLine);
 		return invoiceLine;
 	}

--- a/backend/de.metas.business/src/test/java/de/metas/invoice/interceptor/C_Invoice_CreditMemoReasonTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/invoice/interceptor/C_Invoice_CreditMemoReasonTest.java
@@ -1,0 +1,199 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.invoice.interceptor;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.adempiere.model.I_C_Invoice;
+import de.metas.allocation.api.IAllocationBL;
+import de.metas.allocation.api.IAllocationDAO;
+import de.metas.bpartner.service.IBPartnerDAO;
+import de.metas.document.location.IDocumentLocationBL;
+import de.metas.invoice.InvoiceId;
+import de.metas.invoice.due_date.InvoiceDueDateProviderService;
+import de.metas.invoice.service.IInvoiceBL;
+import de.metas.invoice.service.IInvoiceDAO;
+import de.metas.order.IOrderBL;
+import de.metas.organization.IOrgDAO;
+import de.metas.payment.api.IPaymentBL;
+import de.metas.payment.api.IPaymentDAO;
+import de.metas.payment.paymentterm.repository.IPaymentTermRepository;
+import de.metas.payment.reservation.PaymentReservationService;
+import de.metas.pricing.service.IPriceListDAO;
+import de.metas.util.Services;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.annotation.Nullable;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+
+/**
+ * Unit tests for the {@link C_Invoice#validateCreditMemoReason} BEFORE_COMPLETE guard (me03#31242):
+ * completing a credit memo whose (target) doc type is configured must be blocked while any line is
+ * missing its {@code Line_CreditMemoReason}.
+ */
+class C_Invoice_CreditMemoReasonTest
+{
+	private static final int DOCTYPE_IN_LIST = 1000004;
+	private static final int DOCTYPE_NOT_IN_LIST = 999999;
+	private static final String CONFIGURED_DOCTYPE_IDS = "1000004,540901,540902,540943";
+
+	private IInvoiceBL invoiceBL;
+	private org.adempiere.service.ISysConfigBL sysConfigBL;
+	private C_Invoice interceptor;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		// Register lightweight mocks for the ~10 service fields C_Invoice resolves via Services.get(...),
+		// mirroring C_Invoice_IsPartialInvoiceTest. Only IInvoiceBL and ISysConfigBL are stubbed per test.
+		Services.registerService(IOrgDAO.class, Mockito.mock(IOrgDAO.class));
+		Services.registerService(IPriceListDAO.class, Mockito.mock(IPriceListDAO.class));
+		Services.registerService(IPaymentDAO.class, Mockito.mock(IPaymentDAO.class));
+		Services.registerService(IPaymentBL.class, Mockito.mock(IPaymentBL.class));
+		Services.registerService(IAllocationBL.class, Mockito.mock(IAllocationBL.class));
+		Services.registerService(IInvoiceDAO.class, Mockito.mock(IInvoiceDAO.class));
+		Services.registerService(IBPartnerDAO.class, Mockito.mock(IBPartnerDAO.class));
+		Services.registerService(IAllocationDAO.class, Mockito.mock(IAllocationDAO.class));
+		Services.registerService(IOrderBL.class, Mockito.mock(IOrderBL.class));
+		Services.registerService(IPaymentTermRepository.class, Mockito.mock(IPaymentTermRepository.class));
+
+		invoiceBL = Mockito.mock(IInvoiceBL.class);
+		sysConfigBL = Mockito.mock(org.adempiere.service.ISysConfigBL.class);
+		Services.registerService(IInvoiceBL.class, invoiceBL);
+		Services.registerService(org.adempiere.service.ISysConfigBL.class, sysConfigBL);
+
+		interceptor = new C_Invoice(
+				Mockito.mock(PaymentReservationService.class),
+				Mockito.mock(IDocumentLocationBL.class),
+				Mockito.mock(InvoiceDueDateProviderService.class));
+	}
+
+	@Test
+	void creditMemo_docTypeConfigured_lineWithoutReason_blocks()
+	{
+		stubSysConfig(CONFIGURED_DOCTYPE_IDS);
+		stubCreditMemo(true);
+		stubLines(line(10, "CMF"), line(20, null)); // line 20 has no reason
+
+		final I_C_Invoice invoice = creditMemoInvoice(DOCTYPE_IN_LIST);
+
+		assertThatThrownBy(() -> interceptor.validateCreditMemoReason(invoice))
+				.isInstanceOf(AdempiereException.class);
+	}
+
+	@Test
+	void creditMemo_docTypeConfigured_allLinesWithReason_passes()
+	{
+		stubSysConfig(CONFIGURED_DOCTYPE_IDS);
+		stubCreditMemo(true);
+		stubLines(line(10, "CMF"), line(20, "CMD"));
+
+		final I_C_Invoice invoice = creditMemoInvoice(DOCTYPE_IN_LIST);
+
+		assertThatCode(() -> interceptor.validateCreditMemoReason(invoice)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void sysConfigEmpty_validationDisabled_passes()
+	{
+		stubSysConfig(""); // feature off
+		stubCreditMemo(true);
+		stubLines(line(10, null)); // blank reason but feature disabled
+
+		final I_C_Invoice invoice = creditMemoInvoice(DOCTYPE_IN_LIST);
+
+		assertThatCode(() -> interceptor.validateCreditMemoReason(invoice)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void creditMemo_docTypeNotConfigured_passes()
+	{
+		stubSysConfig(CONFIGURED_DOCTYPE_IDS);
+		stubCreditMemo(true);
+		stubLines(line(10, null)); // blank reason but this doc type is not gated
+
+		final I_C_Invoice invoice = creditMemoInvoice(DOCTYPE_NOT_IN_LIST);
+
+		assertThatCode(() -> interceptor.validateCreditMemoReason(invoice)).doesNotThrowAnyException();
+	}
+
+	@Test
+	void notACreditMemo_passes()
+	{
+		stubSysConfig(CONFIGURED_DOCTYPE_IDS);
+		stubCreditMemo(false); // regular invoice
+		// getLines is never reached; no stub needed
+
+		final I_C_Invoice invoice = creditMemoInvoice(DOCTYPE_IN_LIST);
+
+		assertThatCode(() -> interceptor.validateCreditMemoReason(invoice)).doesNotThrowAnyException();
+	}
+
+	// -------------------------------------------------------------------------
+
+	private void stubSysConfig(final String docTypeIdsCsv)
+	{
+		Mockito.when(sysConfigBL.getValue(C_Invoice.SYSCONFIG_CreditMemoReasonMandatory_DocTypeIDs, ""))
+				.thenReturn(docTypeIdsCsv);
+	}
+
+	private void stubCreditMemo(final boolean isCreditMemo)
+	{
+		Mockito.when(invoiceBL.isCreditMemo(any(I_C_Invoice.class))).thenReturn(isCreditMemo);
+	}
+
+	private void stubLines(final de.metas.adempiere.model.I_C_InvoiceLine... lines)
+	{
+		Mockito.when(invoiceBL.getLines(any(InvoiceId.class))).thenReturn(ImmutableList.copyOf(lines));
+	}
+
+	private I_C_Invoice creditMemoInvoice(final int docTypeTargetId)
+	{
+		final I_C_Invoice invoice = InterfaceWrapperHelper.newInstance(I_C_Invoice.class);
+		invoice.setC_DocTypeTarget_ID(docTypeTargetId);
+		InterfaceWrapperHelper.saveRecord(invoice); // assigns a positive C_Invoice_ID for InvoiceId.ofRepoId
+		return invoice;
+	}
+
+	private de.metas.adempiere.model.I_C_InvoiceLine line(final int lineNo, @Nullable final String reason)
+	{
+		final de.metas.adempiere.model.I_C_InvoiceLine invoiceLine =
+				InterfaceWrapperHelper.newInstance(de.metas.adempiere.model.I_C_InvoiceLine.class);
+		InterfaceWrapperHelper.setValue(invoiceLine, org.compiere.model.I_C_InvoiceLine.COLUMNNAME_Line, lineNo);
+		if (reason != null)
+		{
+			InterfaceWrapperHelper.setValue(invoiceLine, org.compiere.model.I_C_InvoiceLine.COLUMNNAME_Line_CreditMemoReason, reason);
+		}
+		InterfaceWrapperHelper.saveRecord(invoiceLine);
+		return invoiceLine;
+	}
+}

--- a/backend/de.metas.business/src/test/java/de/metas/invoice/interceptor/C_Invoice_CreditMemoReasonTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/invoice/interceptor/C_Invoice_CreditMemoReasonTest.java
@@ -112,6 +112,20 @@ class C_Invoice_CreditMemoReasonTest
 	}
 
 	@Test
+	void creditMemo_docTypeConfigured_lineWithWhitespaceReason_blocks()
+	{
+		stubSysConfig(CONFIGURED_DOCTYPE_IDS);
+		stubCreditMemo(true);
+		stubLines(line(10, "   ")); // whitespace-only is still blank per Check.isBlank
+
+		final I_C_Invoice invoice = creditMemoInvoice(DOCTYPE_IN_LIST);
+
+		assertThatThrownBy(() -> interceptor.validateCreditMemoReason(invoice))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("10");
+	}
+
+	@Test
 	void creditMemo_docTypeConfigured_allLinesWithReason_passes()
 	{
 		stubSysConfig(CONFIGURED_DOCTYPE_IDS);

--- a/backend/de.metas.business/src/test/java/de/metas/invoice/interceptor/C_Invoice_CreditMemoReasonTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/invoice/interceptor/C_Invoice_CreditMemoReasonTest.java
@@ -158,6 +158,57 @@ class C_Invoice_CreditMemoReasonTest
 		assertThatCode(() -> interceptor.validateCreditMemoReason(invoice)).doesNotThrowAnyException();
 	}
 
+	/**
+	 * Post-prepareIt state: the effective {@code C_DocType_ID} (not the target) is set. Covers the
+	 * first branch of the dual doc-type check.
+	 */
+	@Test
+	void creditMemo_effectiveDocTypeConfigured_lineWithoutReason_blocks()
+	{
+		stubSysConfig(CONFIGURED_DOCTYPE_IDS);
+		stubCreditMemo(true);
+		stubLines(line(10, null));
+
+		final I_C_Invoice invoice = InterfaceWrapperHelper.newInstance(I_C_Invoice.class);
+		invoice.setC_DocType_ID(DOCTYPE_IN_LIST); // effective doc type, target left unset
+		InterfaceWrapperHelper.saveRecord(invoice);
+
+		assertThatThrownBy(() -> interceptor.validateCreditMemoReason(invoice))
+				.isInstanceOf(AdempiereException.class);
+	}
+
+	/**
+	 * A credit memo with no lines has nothing to validate — completion must not be blocked.
+	 */
+	@Test
+	void creditMemo_noLines_passes()
+	{
+		stubSysConfig(CONFIGURED_DOCTYPE_IDS);
+		stubCreditMemo(true);
+		stubLines(); // no lines
+
+		final I_C_Invoice invoice = creditMemoInvoice(DOCTYPE_IN_LIST);
+
+		assertThatCode(() -> interceptor.validateCreditMemoReason(invoice)).doesNotThrowAnyException();
+	}
+
+	/**
+	 * A malformed SysConfig token must not abort completion: the bad token is skipped and the valid
+	 * doc-type IDs still enforce the rule.
+	 */
+	@Test
+	void malformedSysConfigToken_ignored_validIdsStillEnforce()
+	{
+		stubSysConfig("1000004, not-a-number");
+		stubCreditMemo(true);
+		stubLines(line(10, null));
+
+		final I_C_Invoice invoice = creditMemoInvoice(DOCTYPE_IN_LIST);
+
+		assertThatThrownBy(() -> interceptor.validateCreditMemoReason(invoice))
+				.isInstanceOf(AdempiereException.class);
+	}
+
 	// -------------------------------------------------------------------------
 
 	private void stubSysConfig(final String docTypeIdsCsv)


### PR DESCRIPTION
- Block completing a credit memo while any invoice line is missing its Line_CreditMemoReason. 
- A BEFORE_COMPLETE guard in the C_Invoice interceptor applies only to credit memos (DocBaseType ARC/APC) whose (target) document type is listed in the new SysConfig C_Invoice.CreditMemoReasonMandatory_DocTypeIDs (CSV of C_DocType IDs). 
- The SysConfig ships empty, so the validation is off by default and only activates for instances that configure it.                                                                                
                                                                                                   
  - C_Invoice interceptor: validateCreditMemoReason @DocValidate(BEFORE_COMPLETE)                                                                    
  - AD_Message de.metas.invoice.CreditMemoReasonMandatory (DE base + en_US)                                                                          
  - AD_SysConfig C_Invoice.CreditMemoReasonMandatory_DocTypeIDs seeded empty (off)                                                                   
  - Unit test C_Invoice_CreditMemoReasonTest (5 cases)  