### PR TITLE
nShift: left-pad OrderNo (refNo) to the 8-char minimum

### DIFF
--- a/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftShipmentService.java
+++ b/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftShipmentService.java
@@ -173,7 +173,8 @@ public class NShiftShipmentService
 
 		final JsonShipmentData.JsonShipmentDataBuilder dataBuilder = JsonShipmentData.builder()
 				.actorCSID(Integer.valueOf(actorId))
-				.orderNo(String.valueOf(deliveryRequest.getDeliveryOrderId()))
+				// nShift requires OrderNo (its refNo) to be 8..35 chars long; a delivery-order id is an int (<= 10 digits), so left-pad with zeros to reach the 8-char minimum
+				.orderNo(String.format("%08d", deliveryRequest.getDeliveryOrderId()))
 				.pickupDt(LocalDate.parse(deliveryRequest.getPickupDate()));
 
 		// With shipping rules active (non-manual) nShift re-resolves product / goods type / services from the rules,

--- a/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftShipmentService.java
+++ b/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftShipmentService.java
@@ -173,7 +173,7 @@ public class NShiftShipmentService
 
 		final JsonShipmentData.JsonShipmentDataBuilder dataBuilder = JsonShipmentData.builder()
 				.actorCSID(Integer.valueOf(actorId))
-				// nShift requires OrderNo (its refNo) to be 8..35 chars long; a delivery-order id is an int (<= 10 digits), so left-pad with zeros to reach the 8-char minimum
+				// nShift requires OrderNo (its refNo) to be 8..35 chars long
 				.orderNo(String.format("%08d", deliveryRequest.getDeliveryOrderId()))
 				.pickupDt(LocalDate.parse(deliveryRequest.getPickupDate()));
 

--- a/backend/de.metas.shipper.client.nshift/src/test/resources/de/metas/shipper/client/nshift/NShiftShipmentServiceOrderAdviceTest.snap
+++ b/backend/de.metas.shipper.client.nshift/src/test/resources/de/metas/shipper/client/nshift/NShiftShipmentServiceOrderAdviceTest.snap
@@ -271,7 +271,7 @@ de.metas.shipper.client.nshift.NShiftShipmentServiceOrderAdviceTest.build_order_
           "Width": 200
         }
       ],
-      "OrderNo": "1",
+      "OrderNo": "00000001",
       "PickupDt": "2025-10-02",
       "ProdConceptID": 10305,
       "References": [

--- a/backend/de.metas.shipper.client.nshift/src/test/resources/de/metas/shipper/client/nshift/NShiftShipmentServiceTest.snap
+++ b/backend/de.metas.shipper.client.nshift/src/test/resources/de/metas/shipper/client/nshift/NShiftShipmentServiceTest.snap
@@ -271,7 +271,7 @@ de.metas.shipper.client.nshift.NShiftShipmentServiceTest.build_request_test=[
           "Width": 200
         }
       ],
-      "OrderNo": "1",
+      "OrderNo": "00000001",
       "PickupDt": "2025-10-02",
       "ProdConceptID": 10305,
       "References": [


### PR DESCRIPTION
## What

nShift rejects a shipment booking when `refNo` (the "Shipment reference number", mapped from the request's `OrderNo`) is shorter than 8 characters:

> Parameter refNo (Shipment reference number) must be between 8 and 35 characters long

The delivery-order id was sent verbatim as `OrderNo`, so low ids (e.g. `1000055`) were below the 8-char minimum and the booking failed with no shipment created.

## Change

In `NShiftShipmentService.buildShipmentRequest`, left-pad the order number with leading zeros to the 8-char minimum (`String.format("%08d", …)`). The delivery-order id is an `int` (at most 10 digits), so nShift's 35-char maximum is never exceeded.

## Test

Adjusted the existing `NShiftShipmentServiceTest.build_request_test` snapshot: `OrderNo` `"1"` → `"00000001"`. RED before the fix, green after. Full `NShiftShipmentServiceTest` passes.
