### PR TITLE
mobile e2e: de-flake the camera-mode assertions by giving the browser a camera

### DIFF
--- a/e2e/mobile-webui/playwright.config.js
+++ b/e2e/mobile-webui/playwright.config.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig, devices, test as testOrig } from '@playwright/test';
 import { setCurrentPage } from "./tests/utils/common";
+import { installFakeCameraIfBrowserExposesNone } from "./tests/utils/fakeCamera";
 import os from 'os';
 
 /**
@@ -77,7 +78,10 @@ export default defineConfig({
                         '--allow-running-insecure-content', // Allows mixed content (HTTP on HTTPS)
                         // '--user-data-dir=/tmp/chrome-test-profile' // Ensures fresh profile each time (prevents stored HSTS rules)
                         '--use-fake-ui-for-media-stream', // Suppress getUserMedia permission dialog in CI (no physical camera)
-                        '--use-fake-device-for-media-stream', // Provide a synthetic camera so getUserMedia() succeeds in CI
+                        // Provide a synthetic camera so getUserMedia() succeeds in CI. NOTE: reachable only
+                        // via navigator.mediaDevices, which plain-HTTP non-localhost origins do not expose —
+                        // see tests/utils/fakeCamera.js, which fills that gap.
+                        '--use-fake-device-for-media-stream',
                     ],
                 },
             },
@@ -91,6 +95,7 @@ export const test = testOrig.extend({
     page: async ({ page }, use) => {
         setCurrentPage(page);
         Object.keys(testContext).forEach(key => delete testContext[key]);
+        await installFakeCameraIfBrowserExposesNone(page);
 
         await use(page);
     },

--- a/e2e/mobile-webui/tests/utils/fakeCamera.js
+++ b/e2e/mobile-webui/tests/utils/fakeCamera.js
@@ -1,0 +1,73 @@
+/**
+ * Makes a camera available to the mobile UI in environments where the browser exposes none.
+ *
+ * `playwright.config.js` launches Chromium with `--use-fake-device-for-media-stream` so that
+ * `getUserMedia()` succeeds without physical hardware. That synthetic device is only reachable
+ * through `navigator.mediaDevices`, which is `[SecureContext]`-gated: it exists on
+ * `http://localhost` but is UNDEFINED on every other plain-HTTP origin. CI serves the mobile UI
+ * from `http://mobile:80/mobile` (see `docker-builds/e2e-tests/compose.yml`) — a non-localhost HTTP
+ * origin — so there `navigator.mediaDevices` is undefined and the browser flag has no effect.
+ *
+ * The visible consequence: switching into camera mode does mount `CameraModePanel`, but ZXing's
+ * `decodeFromVideoDevice()` rejects immediately, `onCancel` reverts to the default mode and
+ * `.camera-mode-panel` unmounts again roughly 30 ms later. Camera-mode assertions were therefore
+ * observing a 30 ms flicker rather than a settled camera mode, and passed or failed depending on
+ * whether their first poll happened to fall inside that window.
+ *
+ * So when — and only when — the browser gives us no `navigator.mediaDevices`, install a minimal
+ * media-device double backed by a repainted canvas stream: `getUserMedia()` resolves, the `<video>`
+ * receives frames so `play()` resolves, ZXing keeps decoding, and camera mode stays active until
+ * the operator leaves it. Whenever the browser does expose `mediaDevices` (any localhost run) the
+ * real Chromium fake device is used unchanged.
+ */
+export const installFakeCameraIfBrowserExposesNone = async (page) =>
+    await page.addInitScript(() => {
+        if (navigator.mediaDevices?.getUserMedia) {
+            return; // secure context: the browser's own fake media device is reachable
+        }
+
+        const newCameraStream = () => {
+            const canvas = document.createElement('canvas');
+            canvas.width = 640;
+            canvas.height = 480;
+            const context2d = canvas.getContext('2d');
+
+            // Repaint continuously: a frame-starved captureStream() never fires `canplay`, which
+            // leaves the <video>.play() promise pending forever inside ZXing.
+            let frameNo = 0;
+            const paintNextFrame = () => {
+                frameNo++;
+                context2d.fillStyle = frameNo % 2 === 0 ? '#202020' : '#303030';
+                context2d.fillRect(0, 0, canvas.width, canvas.height);
+            };
+            paintNextFrame();
+            const painterId = setInterval(paintNextFrame, 100);
+
+            const stream = canvas.captureStream(10);
+            // CameraModePanel stops the tracks when it unmounts — stop repainting with them.
+            stream.getTracks().forEach((track) => {
+                const stopTrack = track.stop.bind(track);
+                track.stop = () => {
+                    clearInterval(painterId);
+                    stopTrack();
+                };
+            });
+            return stream;
+        };
+
+        const fakeCamera = {
+            deviceId: 'fake-camera',
+            groupId: 'fake-camera-group',
+            kind: 'videoinput',
+            label: 'Fake camera',
+        };
+        const fakeMediaDevices = {
+            getUserMedia: async () => newCameraStream(),
+            enumerateDevices: async () => [{ ...fakeCamera, toJSON: () => fakeCamera }],
+            getSupportedConstraints: () => ({ deviceId: true, facingMode: true, width: true, height: true }),
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            dispatchEvent: () => false,
+        };
+        Object.defineProperty(navigator, 'mediaDevices', { value: fakeMediaDevices, configurable: true });
+    });


### PR DESCRIPTION
De-flakes the mobile camera-mode E2E assertions (`barcode_scanner_modes.spec.js` — "camera toggle — clicking hw/camera toggle activates camera mode"). Test-only change; no production code touched.

Tracked as a case in the internal flaky-CI tracker.

## Root cause — a test-environment gap, not a product defect

`navigator.mediaDevices` is `[SecureContext]`-gated: it exists on `http://localhost`, and is **undefined** on every other plain-HTTP origin. CI serves the mobile UI from `http://mobile:80/mobile` (`docker-builds/e2e-tests/compose.yml`), a non-localhost HTTP origin — so `navigator.mediaDevices` is undefined there and Chromium's `--use-fake-device-for-media-stream` (`e2e/mobile-webui/playwright.config.js`) is unreachable, silently.

Consequence in the camera-mode flow:

1. the operator taps the footer toggle → `BarcodeScannerFooter` `onModeSelected(CAMERA)` → `activeMode = CAMERA` → `.camera-mode-panel` mounts (`BarcodeScannerComponent.jsx:145-151`);
2. `CameraModePanel`'s effect calls `codeReader.decodeFromVideoDevice(...)` (`CameraModePanel.jsx:29`), which reaches for `navigator.mediaDevices` and rejects;
3. the `catch` toasts "Camera could not be started" and calls `onCancel()` (`CameraModePanel.jsx:43-49`) → `setActiveMode(defaultMode)` → `.camera-mode-panel` **unmounts ~30 ms after it appeared**.

So `expectCameraModeActive()` (`tests/utils/components/BarcodeScannerComponent.js:241`, `toHaveCount(1)`) was polling a ~30 ms flicker: it passed when its first poll landed inside the window and failed (`Expected 1 / Received 0 / Timeout 20000ms`, `24 × locator resolved to 0 elements`) whenever it did not. That is exactly the intermittent CI signature, and it explains why it never reproduced on a localhost dev box — there the origin *is* a secure context, the browser's fake device works, and camera mode stays up.

Instrumented local timeline on a CI-faithful (non-localhost) origin, before the fix:

```
+0ms    ENV origin=http://172.17.0.1:26301 isSecureContext=false mediaDevices=undefined
+1108ms click -> barcode-scanner-toggle-hw-camera
+1113ms ADDED .camera-mode-panel
+1140ms REMOVED .camera-mode-panel
+1148ms TOAST: Camera could not be started. Please check camera permissions.
```

## Fix

`e2e/mobile-webui/tests/utils/fakeCamera.js` (new) installs a minimal canvas-backed media-device double **when, and only when, the browser exposes no `navigator.mediaDevices`** — wired into the shared `page` fixture in `playwright.config.js`. `getUserMedia()` then resolves, the `<video>` receives frames (so `play()` resolves rather than waiting forever for `canplay`), ZXing keeps decoding, and camera mode stays active until the operator leaves it.

Nothing is skipped, relaxed or timed out longer: the assertion now observes a **settled** camera mode instead of a race, so it is strictly stronger than before. On any localhost run the double is not installed and Chromium's own fake device is used unchanged. Same timeline after the fix:

```
+0ms   ENV origin=http://172.17.0.1:26301 isSecureContext=false mediaDevices=object
+476ms click -> barcode-scanner-toggle-hw-camera
+478ms ADDED .camera-mode-panel
+492ms getUserMedia called
+495ms getUserMedia RESOLVED tracks=1
+495ms video.play() called
+498ms video.play() resolved      (panel still mounted after a 2s settle + re-assert)
```

## Evidence

Local mobile-E2E stack from the CI images (`metas-app` / `metas-mobile` / `metas-db` `5.175-deep-tundra-release.40797`), own compose project on isolated ports, mobile UI reached over a **non-localhost** origin so the run matches CI's secure-context conditions. Every run below was executed on 2026-07-27 against [this branch's head commit](https://github.com/metasfresh/metasfresh/commit/dc2d2cb1ac4):

| Run | Command | Result |
|---|---|---|
| Reproduction (before fix) | `npx playwright test tests/spec/barcode_scanner_modes.spec.js -g "camera toggle" --repeat-each=10` | **8 passed / 2 failed** — pass↔fail flip on one commit, failures verbatim the CI signature |
| Proof (after fix) | same command with `--repeat-each=20` | **20 passed / 0 failed** |
| Proof, secure-context path (after fix) | same, over `http://localhost:…` | **10 passed / 0 failed** |
| Whole spec (after fix) | `tests/spec/barcode_scanner_modes.spec.js` | **11 passed / 0 failed** |
| Whole mobile suite (after fix) | `npx playwright test tests` | **275 passed / 2 failed in 24.0m** — neither failure is related to this change (details below) |

CI history for the same test independently confirms nondeterminism: a same-commit pass↔fail flip on [one and the same commit](https://github.com/metasfresh/metasfresh/commit/9092c8dc02b678917f9c36814217b34479c68841) (2026-07-23) and a green→red flip across a comment-only commit with zero production change (2026-07-17); both are recorded in the internal flaky-CI tracker.

### The two unrelated reds in the full-suite run

Both are artefacts of the *local reproduction stack*, not of this change:

* `barcode_scanner_modes.spec.js:76` (`#input-text … readOnly absent`) — `barcodeScanner.mode.hardware.input.readOnly` is a **global** `AD_SysConfig` value that the CT60 test at `:117` sets to `Y` and nothing resets, so a **reused** local DB serves the leaked `Y` to a later run of `:76`. After clearing that row (and restarting the app server so its SysConfig cache reloads) `:76` passes, and the whole spec is 11/11 — see the table above. CI is unaffected: it runs against a fresh preloaded DB in which `:76` executes before `:117`. The same test also fails **3/3 in a control run with this fix reverted**, i.e. it is independent of this change.
* `picking/pickingQtyAvailableForLines.spec.js:62` — the feature under test landed on 2026-07-23, while the pinned CI images used by the reproduction stack were built on 2026-07-18/22, so the running backend simply does not have it yet.
