### PR TITLE
WebUI view auto-invalidation on configured table change

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/java-gen/de/metas/ui/web/base/model/I_WEBUI_ViewInvalidateOnChange.java
+++ b/backend/de.metas.ui.web.base/src/main/java-gen/de/metas/ui/web/base/model/I_WEBUI_ViewInvalidateOnChange.java
@@ -1,0 +1,190 @@
+package de.metas.ui.web.base.model;
+
+import org.adempiere.model.ModelColumn;
+
+/** Generated Interface for WEBUI_ViewInvalidateOnChange
+ *  @author metasfresh (generated) 
+ */
+@SuppressWarnings("unused")
+public interface I_WEBUI_ViewInvalidateOnChange 
+{
+
+	String Table_Name = "WEBUI_ViewInvalidateOnChange";
+
+//	/** AD_Table_ID=542631 */
+//	int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
+
+
+	/**
+	 * Get Client.
+	 * Client/Tenant for this installation.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Client_ID();
+
+	String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+
+	/**
+	 * Set Organisation.
+	 * Organisational entity within client
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setAD_Org_ID (int AD_Org_ID);
+
+	/**
+	 * Get Organisation.
+	 * Organisational entity within client
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Org_ID();
+
+	String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/**
+	 * Set Table.
+	 * Database Table information
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setAD_Table_ID (int AD_Table_ID);
+
+	/**
+	 * Get Table.
+	 * Database Table information
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Table_ID();
+
+	String COLUMNNAME_AD_Table_ID = "AD_Table_ID";
+
+	/**
+	 * Set Window.
+	 * Data entry or display window
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setAD_Window_ID (int AD_Window_ID);
+
+	/**
+	 * Get Window.
+	 * Data entry or display window
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Window_ID();
+
+	ModelColumn<I_WEBUI_ViewInvalidateOnChange, org.compiere.model.I_AD_Window> COLUMN_AD_Window_ID = new ModelColumn<>(I_WEBUI_ViewInvalidateOnChange.class, "AD_Window_ID", org.compiere.model.I_AD_Window.class);
+	String COLUMNNAME_AD_Window_ID = "AD_Window_ID";
+
+	/**
+	 * Get Created.
+	 * Date this record was created
+	 *
+	 * <br>Type: DateTime
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.sql.Timestamp getCreated();
+
+	ModelColumn<I_WEBUI_ViewInvalidateOnChange, Object> COLUMN_Created = new ModelColumn<>(I_WEBUI_ViewInvalidateOnChange.class, "Created", null);
+	String COLUMNNAME_Created = "Created";
+
+	/**
+	 * Get Created By.
+	 * User who created this records
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getCreatedBy();
+
+	String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/**
+	 * Set Active.
+	 * The record is active in the system
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsActive (boolean IsActive);
+
+	/**
+	 * Get Active.
+	 * The record is active in the system
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isActive();
+
+	ModelColumn<I_WEBUI_ViewInvalidateOnChange, Object> COLUMN_IsActive = new ModelColumn<>(I_WEBUI_ViewInvalidateOnChange.class, "IsActive", null);
+	String COLUMNNAME_IsActive = "IsActive";
+
+	/**
+	 * Get Updated.
+	 * Date this record was updated
+	 *
+	 * <br>Type: DateTime
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.sql.Timestamp getUpdated();
+
+	ModelColumn<I_WEBUI_ViewInvalidateOnChange, Object> COLUMN_Updated = new ModelColumn<>(I_WEBUI_ViewInvalidateOnChange.class, "Updated", null);
+	String COLUMNNAME_Updated = "Updated";
+
+	/**
+	 * Get Updated By.
+	 * User who updated this records
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getUpdatedBy();
+
+	String COLUMNNAME_UpdatedBy = "UpdatedBy";
+
+	/**
+	 * Set View invalidate on change.
+	 *
+	 * <br>Type: ID
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setWEBUI_ViewInvalidateOnChange_ID (int WEBUI_ViewInvalidateOnChange_ID);
+
+	/**
+	 * Get View invalidate on change.
+	 *
+	 * <br>Type: ID
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getWEBUI_ViewInvalidateOnChange_ID();
+
+	ModelColumn<I_WEBUI_ViewInvalidateOnChange, Object> COLUMN_WEBUI_ViewInvalidateOnChange_ID = new ModelColumn<>(I_WEBUI_ViewInvalidateOnChange.class, "WEBUI_ViewInvalidateOnChange_ID", null);
+	String COLUMNNAME_WEBUI_ViewInvalidateOnChange_ID = "WEBUI_ViewInvalidateOnChange_ID";
+}

--- a/backend/de.metas.ui.web.base/src/main/java-gen/de/metas/ui/web/base/model/X_WEBUI_ViewInvalidateOnChange.java
+++ b/backend/de.metas.ui.web.base/src/main/java-gen/de/metas/ui/web/base/model/X_WEBUI_ViewInvalidateOnChange.java
@@ -1,0 +1,81 @@
+// Generated Model - DO NOT CHANGE
+package de.metas.ui.web.base.model;
+
+import java.sql.ResultSet;
+import java.util.Properties;
+import javax.annotation.Nullable;
+
+/** Generated Model for WEBUI_ViewInvalidateOnChange
+ *  @author metasfresh (generated) 
+ */
+@SuppressWarnings("unused")
+public class X_WEBUI_ViewInvalidateOnChange extends org.compiere.model.PO implements I_WEBUI_ViewInvalidateOnChange, org.compiere.model.I_Persistent 
+{
+
+	private static final long serialVersionUID = -1872080585L;
+
+    /** Standard Constructor */
+    public X_WEBUI_ViewInvalidateOnChange (final Properties ctx, final int WEBUI_ViewInvalidateOnChange_ID, @Nullable final String trxName)
+    {
+      super (ctx, WEBUI_ViewInvalidateOnChange_ID, trxName);
+    }
+
+    /** Load Constructor */
+    public X_WEBUI_ViewInvalidateOnChange (final Properties ctx, final ResultSet rs, @Nullable final String trxName)
+    {
+      super (ctx, rs, trxName);
+    }
+
+
+	/** Load Meta Data */
+	@Override
+	protected org.compiere.model.POInfo initPO(final Properties ctx)
+	{
+		return org.compiere.model.POInfo.getPOInfo(Table_Name);
+	}
+
+	@Override
+	public void setAD_Table_ID (final int AD_Table_ID)
+	{
+		if (AD_Table_ID < 1) 
+			set_Value (COLUMNNAME_AD_Table_ID, null);
+		else 
+			set_Value (COLUMNNAME_AD_Table_ID, AD_Table_ID);
+	}
+
+	@Override
+	public int getAD_Table_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_AD_Table_ID);
+	}
+
+	@Override
+	public void setAD_Window_ID (final int AD_Window_ID)
+	{
+		if (AD_Window_ID < 1) 
+			set_Value (COLUMNNAME_AD_Window_ID, null);
+		else 
+			set_Value (COLUMNNAME_AD_Window_ID, AD_Window_ID);
+	}
+
+	@Override
+	public int getAD_Window_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_AD_Window_ID);
+	}
+
+	@Override
+	public void setWEBUI_ViewInvalidateOnChange_ID (final int WEBUI_ViewInvalidateOnChange_ID)
+	{
+		if (WEBUI_ViewInvalidateOnChange_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_WEBUI_ViewInvalidateOnChange_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_WEBUI_ViewInvalidateOnChange_ID, WEBUI_ViewInvalidateOnChange_ID);
+	}
+
+	@Override
+	public int getWEBUI_ViewInvalidateOnChange_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_WEBUI_ViewInvalidateOnChange_ID);
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/invalidation/ConfiguredViewInvalidationListener.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/invalidation/ConfiguredViewInvalidationListener.java
@@ -71,8 +71,8 @@ public class ConfiguredViewInvalidationListener implements ICacheResetListener
 	private static final String SYSCONFIG_DelayInMillis = "webui.ConfiguredViewInvalidationListener.debouncer.delayInMillis";
 	private static final int DEFAULT_DelayInMillis = 100;
 
-	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
-	private final ITrxManager trxManager = Services.get(ITrxManager.class);
+	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+	@NonNull private final ITrxManager trxManager = Services.get(ITrxManager.class);
 
 	private final IViewsRepository viewsRepository;
 	private final WebuiViewInvalidateOnChangeRepository configRepository;

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/invalidation/ConfiguredViewInvalidationListener.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/invalidation/ConfiguredViewInvalidationListener.java
@@ -1,0 +1,172 @@
+/*
+ * #%L
+ * de.metas.ui.web.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ui.web.view.invalidation;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import de.metas.cache.CacheMgt;
+import de.metas.cache.ICacheResetListener;
+import de.metas.cache.model.CacheInvalidateMultiRequest;
+import de.metas.logging.LogManager;
+import de.metas.ui.web.view.IView;
+import de.metas.ui.web.view.IViewsRepository;
+import de.metas.ui.web.window.datatypes.WindowId;
+import de.metas.util.Services;
+import de.metas.util.async.Debouncer;
+import lombok.NonNull;
+import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.ad.trx.api.ITrxManager;
+import org.adempiere.ad.trx.api.OnTrxMissingPolicy;
+import org.adempiere.service.ISysConfigBL;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Config-driven, standalone cache-reset listener that full-invalidates all WebUI views of a
+ * configured window whenever a record of a configured trigger table is (after-commit) cache-reset.
+ * <p>
+ * Mechanism (see {@code DocumentCacheInvalidationDispatcher} for the reference after-commit + debounce
+ * pattern): {@link #reset(CacheInvalidateMultiRequest)} first does a cheap pre-filter against the
+ * configured trigger tables (so it is a no-op on any instance that has no config rows), then defers the
+ * work to <b>after the current transaction commits</b> (so the push reflects committed data) and
+ * <b>debounces</b> it (so a bulk change coalesces into a single refresh). On flush it resolves the
+ * changed trigger table names to window ids via {@link WebuiViewInvalidateOnChangeRepository} and
+ * full-invalidates every frontend-watched view of those windows via {@link IViewsRepository}.
+ * <p>
+ * The mapping table ships empty; this component only does work once a row is configured.
+ */
+@Component
+public class ConfiguredViewInvalidationListener implements ICacheResetListener
+{
+	private static final Logger logger = LogManager.getLogger(ConfiguredViewInvalidationListener.class);
+
+	private static final String SYSCONFIG_BufferMaxSize = "webui.ConfiguredViewInvalidationListener.debouncer.bufferMaxSize";
+	private static final String SYSCONFIG_DelayInMillis = "webui.ConfiguredViewInvalidationListener.debouncer.delayInMillis";
+
+	private final IViewsRepository viewsRepository;
+	private final WebuiViewInvalidateOnChangeRepository configRepository;
+	private final Debouncer<String> debouncer;
+
+	public ConfiguredViewInvalidationListener(
+			@NonNull final IViewsRepository viewsRepository,
+			@NonNull final WebuiViewInvalidateOnChangeRepository configRepository)
+	{
+		this.viewsRepository = viewsRepository;
+		this.configRepository = configRepository;
+
+		final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+		this.debouncer = Debouncer.<String>builder()
+				.name(ConfiguredViewInvalidationListener.class.getSimpleName() + "-debouncer")
+				.bufferMaxSize(sysConfigBL.getIntValue(SYSCONFIG_BufferMaxSize, 500))
+				.delayInMillis(sysConfigBL.getIntValue(SYSCONFIG_DelayInMillis, 100))
+				.distinct(true)
+				.consumer(this::invalidateViewsForTableNamesNow)
+				.build();
+		logger.info("debouncer: {}", debouncer);
+	}
+
+	@PostConstruct
+	private void postConstruct()
+	{
+		CacheMgt.get().addCacheResetListener(this);
+	}
+
+	@Override
+	public long reset(@NonNull final CacheInvalidateMultiRequest request)
+	{
+		//
+		// Cheap pre-filter: on a vanilla instance (no config rows) this returns immediately.
+		final Set<String> triggerTableNames = configRepository.getAllTriggerTableNames();
+		if (triggerTableNames.isEmpty())
+		{
+			return 0;
+		}
+
+		final ImmutableSet<String> changedTriggerTableNames = request.getTableNamesEffective()
+				.stream()
+				.filter(triggerTableNames::contains)
+				.collect(ImmutableSet.toImmutableSet());
+		if (changedTriggerTableNames.isEmpty())
+		{
+			return 0;
+		}
+
+		//
+		// Defer after commit (committed data) + debounce (coalesce bulk changes).
+		final ITrxManager trxManager = Services.get(ITrxManager.class);
+		final ITrx currentTrx = trxManager.getThreadInheritedTrx(OnTrxMissingPolicy.ReturnTrxNone);
+		if (trxManager.isActive(currentTrx))
+		{
+			currentTrx.accumulateAndProcessAfterCommit(
+					ConfiguredViewInvalidationListener.class.getName(),
+					changedTriggerTableNames,
+					this::enqueue);
+		}
+		else
+		{
+			// no active transaction: the reset already refers to committed data
+			enqueue(changedTriggerTableNames);
+		}
+
+		return changedTriggerTableNames.size();
+	}
+
+	private void enqueue(@NonNull final Collection<String> tableNames)
+	{
+		debouncer.addAll(ImmutableList.copyOf(tableNames));
+	}
+
+	/**
+	 * Flush: resolve the changed trigger table names to window ids and full-invalidate every
+	 * frontend-watched view of those windows. Package-visible so it can be unit-tested directly
+	 * (bypassing the after-commit + debounce deferral).
+	 */
+	@VisibleForTesting
+	void invalidateViewsForTableNamesNow(@NonNull final Collection<String> tableNames)
+	{
+		final ImmutableSet<WindowId> windowIds = tableNames.stream()
+				.flatMap(tableName -> configRepository.getWindowIdsToInvalidateForTable(tableName).stream())
+				.collect(ImmutableSet.toImmutableSet());
+		if (windowIds.isEmpty())
+		{
+			return;
+		}
+
+		final List<IView> viewsToInvalidate = viewsRepository.getViews()
+				.stream()
+				.filter(view -> windowIds.contains(view.getViewId().getWindowId()))
+				.filter(view -> viewsRepository.isWatchedByFrontend(view.getViewId()))
+				.collect(ImmutableList.toImmutableList());
+
+		for (final IView view : viewsToInvalidate)
+		{
+			viewsRepository.invalidateView(view);
+		}
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/invalidation/ConfiguredViewInvalidationListener.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/invalidation/ConfiguredViewInvalidationListener.java
@@ -67,7 +67,12 @@ public class ConfiguredViewInvalidationListener implements ICacheResetListener
 	private static final Logger logger = LogManager.getLogger(ConfiguredViewInvalidationListener.class);
 
 	private static final String SYSCONFIG_BufferMaxSize = "webui.ConfiguredViewInvalidationListener.debouncer.bufferMaxSize";
+	private static final int DEFAULT_BufferMaxSize = 500;
 	private static final String SYSCONFIG_DelayInMillis = "webui.ConfiguredViewInvalidationListener.debouncer.delayInMillis";
+	private static final int DEFAULT_DelayInMillis = 100;
+
+	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+	private final ITrxManager trxManager = Services.get(ITrxManager.class);
 
 	private final IViewsRepository viewsRepository;
 	private final WebuiViewInvalidateOnChangeRepository configRepository;
@@ -80,11 +85,10 @@ public class ConfiguredViewInvalidationListener implements ICacheResetListener
 		this.viewsRepository = viewsRepository;
 		this.configRepository = configRepository;
 
-		final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 		this.debouncer = Debouncer.<String>builder()
 				.name(ConfiguredViewInvalidationListener.class.getSimpleName() + "-debouncer")
-				.bufferMaxSize(sysConfigBL.getIntValue(SYSCONFIG_BufferMaxSize, 500))
-				.delayInMillis(sysConfigBL.getIntValue(SYSCONFIG_DelayInMillis, 100))
+				.bufferMaxSize(sysConfigBL.getIntValue(SYSCONFIG_BufferMaxSize, DEFAULT_BufferMaxSize))
+				.delayInMillis(sysConfigBL.getIntValue(SYSCONFIG_DelayInMillis, DEFAULT_DelayInMillis))
 				.distinct(true)
 				.consumer(this::invalidateViewsForTableNamesNow)
 				.build();
@@ -119,7 +123,6 @@ public class ConfiguredViewInvalidationListener implements ICacheResetListener
 
 		//
 		// Defer after commit (committed data) + debounce (coalesce bulk changes).
-		final ITrxManager trxManager = Services.get(ITrxManager.class);
 		final ITrx currentTrx = trxManager.getThreadInheritedTrx(OnTrxMissingPolicy.ReturnTrxNone);
 		if (trxManager.isActive(currentTrx))
 		{

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/invalidation/WebuiViewInvalidateOnChangeRepository.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/invalidation/WebuiViewInvalidateOnChangeRepository.java
@@ -45,6 +45,9 @@ import java.util.Set;
  * {@link ConfiguredViewInvalidationListener} is a total no-op.
  * <p>
  * Pattern mirrors {@code de.metas.incoterms.IncotermsRepository}.
+ *
+ * Repository Tables: WEBUI_ViewInvalidateOnChange
+ * Repository Cluster: WebuiViewInvalidateOnChangeRepository
  */
 @Repository
 public class WebuiViewInvalidateOnChangeRepository

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/invalidation/WebuiViewInvalidateOnChangeRepository.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/view/invalidation/WebuiViewInvalidateOnChangeRepository.java
@@ -1,0 +1,118 @@
+/*
+ * #%L
+ * de.metas.ui.web.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ui.web.view.invalidation;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import de.metas.cache.CCache;
+import de.metas.ui.web.base.model.I_WEBUI_ViewInvalidateOnChange;
+import de.metas.ui.web.window.datatypes.WindowId;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.table.api.AdTableId;
+import org.adempiere.ad.table.api.IADTableDAO;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+
+/**
+ * Reads the {@link I_WEBUI_ViewInvalidateOnChange} config table into an in-memory
+ * trigger-table-name &rarr; {@link WindowId} map, cached in a table-scoped {@link CCache} that
+ * auto-invalidates whenever a config row changes.
+ * <p>
+ * On a vanilla instance the table is empty, so both accessors return empty sets and
+ * {@link ConfiguredViewInvalidationListener} is a total no-op.
+ * <p>
+ * Pattern mirrors {@code de.metas.incoterms.IncotermsRepository}.
+ */
+@Repository
+public class WebuiViewInvalidateOnChangeRepository
+{
+	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	private final IADTableDAO adTableDAO = Services.get(IADTableDAO.class);
+
+	private final CCache<Integer, TriggerTableToWindows> cache = CCache.<Integer, TriggerTableToWindows>builder()
+			.tableName(I_WEBUI_ViewInvalidateOnChange.Table_Name)
+			.maximumSize(1)
+			.build();
+
+	/**
+	 * @return the window ids whose views must be full-invalidated when a record of the given
+	 * trigger table changes; empty if the table is not configured as a trigger.
+	 */
+	public Set<WindowId> getWindowIdsToInvalidateForTable(@NonNull final String tableName)
+	{
+		return getMapping().getWindowIds(tableName);
+	}
+
+	/**
+	 * @return all configured trigger table names (for the listener's cheap pre-filter).
+	 */
+	public Set<String> getAllTriggerTableNames()
+	{
+		return getMapping().getAllTableNames();
+	}
+
+	private TriggerTableToWindows getMapping()
+	{
+		return cache.getOrLoadNonNull(0, this::retrieve);
+	}
+
+	private TriggerTableToWindows retrieve()
+	{
+		final ImmutableSetMultimap.Builder<String, WindowId> builder = ImmutableSetMultimap.builder();
+
+		queryBL.createQueryBuilder(I_WEBUI_ViewInvalidateOnChange.class)
+				.addOnlyActiveRecordsFilter()
+				.create()
+				.stream()
+				.forEach(record -> {
+					final String tableName = adTableDAO.retrieveTableName(AdTableId.ofRepoId(record.getAD_Table_ID()));
+					final WindowId windowId = WindowId.of(record.getAD_Window_ID());
+					builder.put(tableName, windowId);
+				});
+
+		return new TriggerTableToWindows(builder.build());
+	}
+
+	private static final class TriggerTableToWindows
+	{
+		private final ImmutableSetMultimap<String, WindowId> windowIdsByTableName;
+
+		private TriggerTableToWindows(@NonNull final ImmutableSetMultimap<String, WindowId> windowIdsByTableName)
+		{
+			this.windowIdsByTableName = windowIdsByTableName;
+		}
+
+		public Set<WindowId> getWindowIds(@NonNull final String tableName)
+		{
+			return windowIdsByTableName.get(tableName);
+		}
+
+		public Set<String> getAllTableNames()
+		{
+			return ImmutableSet.copyOf(windowIdsByTableName.keySet());
+		}
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5816550_sys_WEBUI_ViewInvalidateOnChange_table.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5816550_sys_WEBUI_ViewInvalidateOnChange_table.sql
@@ -1,0 +1,122 @@
+-- Generic WebUI view-invalidation config table.
+-- One row = "when a record of AD_Table_ID has an after-commit cache reset, full-invalidate all
+-- WebUI views of AD_Window_ID". Ships the mechanism only — NO rows: on a vanilla instance the
+-- table is empty and the configured-view-invalidation listener is a total no-op.
+--
+-- IDs allocated from idserver.metas.de on 2026-07-27:
+--   AD_MigrationScript prefix 5816550
+--   AD_Table   542631 (WEBUI_ViewInvalidateOnChange)
+--   AD_Sequence 556614
+--   AD_Element 585139 (WEBUI_ViewInvalidateOnChange_ID)
+--   AD_Column  593041..593050
+
+-- AD_Table
+INSERT INTO AD_Table (AccessLevel,ACTriggerLength,AD_Client_ID,AD_Org_ID,AD_Table_ID,CopyColumnsFromTable,Created,CreatedBy,EntityType,ImportTable,IsActive,IsAutocomplete,IsChangeLog,IsDeleteable,IsDLM,IsEnableRemoteCacheInvalidation,IsHighVolume,IsSecurityEnabled,IsView,LoadSeq,Name,PersonalDataCategory,ReplicationType,TableName,Updated,UpdatedBy) VALUES ('7',0,0,0,542631/*From ID Server*/,'N',TO_TIMESTAMP('2026-07-27 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.ui.web','N','Y','N','N','Y','N','Y','N','N','N',0,'View-Invalidierung bei Änderung','NP','L','WEBUI_ViewInvalidateOnChange',TO_TIMESTAMP('2026-07-27 10:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Table_Trl (AD_Language,AD_Table_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Table_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Table t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Table_ID=542631 AND NOT EXISTS (SELECT * FROM AD_Table_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Table_ID=t.AD_Table_ID)
+;
+
+-- AD_Sequence (native PK sequence is also auto-created by dba_seq_check_native(); this row mirrors the WEBUI_* sibling convention)
+INSERT INTO AD_Sequence (AD_Client_ID,AD_Org_ID,AD_Sequence_ID,Created,CreatedBy,CurrentNext,CurrentNextSys,Description,IncrementNo,IsActive,IsAudited,IsAutoSequence,IsTableID,Name,StartNo,Updated,UpdatedBy) VALUES (0,0,556614/*From ID Server*/,TO_TIMESTAMP('2026-07-27 10:00:01','YYYY-MM-DD HH24:MI:SS'),100,1000000,50000,'Table WEBUI_ViewInvalidateOnChange',1,'Y','N','Y','Y','WEBUI_ViewInvalidateOnChange',1000000,TO_TIMESTAMP('2026-07-27 10:00:01','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- AD_Element for the primary key column
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,585139/*From ID Server*/,0,'WEBUI_ViewInvalidateOnChange_ID',TO_TIMESTAMP('2026-07-27 10:00:02','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.ui.web','Y','View-Invalidierung bei Änderung','View-Invalidierung bei Änderung',TO_TIMESTAMP('2026-07-27 10:00:02','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Element_ID, t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Element t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Element_ID=585139 AND NOT EXISTS (SELECT * FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- en_US override for the new element
+UPDATE AD_Element_Trl SET Name='View invalidate on change', PrintName='View invalidate on change', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-27 10:00:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=585139 AND AD_Language='en_US'
+;
+
+-- ============================ AD_Column ============================
+-- AD_Client_ID
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593041/*From ID Server*/,102,0,19,542631,'AD_Client_ID',TO_TIMESTAMP('2026-07-27 10:01:00','YYYY-MM-DD HH24:MI:SS'),100,'Mandant für diese Installation.','de.metas.ui.web',10,'Ein Mandant ist eine Firma oder eine juristische Person. Sie können keine Daten über Mandanten hinweg verwenden.','Y','N','N','N','N','Y','N','N','Y','N','N','Mandant','NP',0,TO_TIMESTAMP('2026-07-27 10:01:00','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Column_ID=593041 AND NOT EXISTS (SELECT * FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- AD_Org_ID
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593042/*From ID Server*/,113,0,19,542631,'AD_Org_ID',TO_TIMESTAMP('2026-07-27 10:01:01','YYYY-MM-DD HH24:MI:SS'),100,'Organisatorische Einheit des Mandanten','de.metas.ui.web',10,'Eine Organisation ist ein Bereich ihres Mandanten - z.B. Laden oder Abteilung. Sie können Daten über Organisationen hinweg gemeinsam verwenden.','Y','N','N','N','N','Y','N','N','Y','N','N','Sektion','NP',0,TO_TIMESTAMP('2026-07-27 10:01:01','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Column_ID=593042 AND NOT EXISTS (SELECT * FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- WEBUI_ViewInvalidateOnChange_ID (primary key)
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,EntityType,FieldLength,IsActive,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593043/*From ID Server*/,585139,0,13,542631,'WEBUI_ViewInvalidateOnChange_ID',TO_TIMESTAMP('2026-07-27 10:01:02','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.ui.web',10,'Y','N','N','N','Y','Y','N','N','Y','N','N','View-Invalidierung bei Änderung','NP',0,TO_TIMESTAMP('2026-07-27 10:01:02','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Column_ID=593043 AND NOT EXISTS (SELECT * FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- IsActive
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DefaultValue,Description,EntityType,FieldLength,Help,IsActive,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593044/*From ID Server*/,348,0,20,542631,'IsActive',TO_TIMESTAMP('2026-07-27 10:01:03','YYYY-MM-DD HH24:MI:SS'),100,'Y','Der Eintrag ist im System aktiv','de.metas.ui.web',1,'Es gibt zwei Möglichkeiten, einen Datensatz nicht mehr verfügbar zu machen: einer ist, ihn zu löschen; der andere, ihn zu deaktivieren.','Y','N','N','N','N','Y','N','N','Y','N','Y','Aktiv','NP',0,TO_TIMESTAMP('2026-07-27 10:01:03','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Column_ID=593044 AND NOT EXISTS (SELECT * FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Created
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593045/*From ID Server*/,245,0,16,542631,'Created',TO_TIMESTAMP('2026-07-27 10:01:04','YYYY-MM-DD HH24:MI:SS'),100,'Datum, an dem dieser Eintrag erstellt wurde','de.metas.ui.web',29,'Das Feld Erstellt zeigt an, zu welchem Datum dieser Eintrag erstellt wurde.','Y','N','N','N','N','Y','N','N','Y','N','N','Erstellt','NP',0,TO_TIMESTAMP('2026-07-27 10:01:04','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Column_ID=593045 AND NOT EXISTS (SELECT * FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- CreatedBy
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593046/*From ID Server*/,246,0,18,110,542631,'CreatedBy',TO_TIMESTAMP('2026-07-27 10:01:05','YYYY-MM-DD HH24:MI:SS'),100,'Nutzer, der diesen Eintrag erstellt hat','de.metas.ui.web',10,'Das Feld Erstellt durch zeigt an, welcher Nutzer diesen Eintrag erstellt hat.','Y','N','N','N','N','Y','N','N','Y','N','N','Erstellt durch','NP',0,TO_TIMESTAMP('2026-07-27 10:01:05','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Column_ID=593046 AND NOT EXISTS (SELECT * FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Updated
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593047/*From ID Server*/,607,0,16,542631,'Updated',TO_TIMESTAMP('2026-07-27 10:01:06','YYYY-MM-DD HH24:MI:SS'),100,'Datum, an dem dieser Eintrag aktualisiert wurde','de.metas.ui.web',29,'Aktualisiert zeigt an, wann dieser Eintrag aktualisiert wurde.','Y','N','N','N','N','Y','N','N','Y','N','N','Aktualisiert','NP',0,TO_TIMESTAMP('2026-07-27 10:01:06','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Column_ID=593047 AND NOT EXISTS (SELECT * FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- UpdatedBy
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593048/*From ID Server*/,608,0,18,110,542631,'UpdatedBy',TO_TIMESTAMP('2026-07-27 10:01:07','YYYY-MM-DD HH24:MI:SS'),100,'Nutzer, der diesen Eintrag aktualisiert hat','de.metas.ui.web',10,'Aktualisiert durch zeigt an, welcher Nutzer diesen Eintrag aktualisiert hat.','Y','N','N','N','N','Y','N','N','Y','N','N','Aktualisiert durch','NP',0,TO_TIMESTAMP('2026-07-27 10:01:07','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Column_ID=593048 AND NOT EXISTS (SELECT * FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- AD_Window_ID (FK → AD_Window, mandatory)
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,Description,EntityType,FieldLength,Help,IsActive,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593049/*From ID Server*/,143,0,19,542631,'AD_Window_ID',TO_TIMESTAMP('2026-07-27 10:01:08','YYYY-MM-DD HH24:MI:SS'),100,'N','Fenster, dessen Views bei einer Änderung vollständig invalidiert werden','de.metas.ui.web',10,'Alle offenen WebUI-Views dieses Fensters werden nach Commit einer Änderung an der Auslöser-Tabelle vollständig neu geladen.','Y','N','N','N','N','Y','N','N','Y','N','Y','Fenster','NP',0,TO_TIMESTAMP('2026-07-27 10:01:08','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Column_ID=593049 AND NOT EXISTS (SELECT * FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- AD_Table_ID (FK → AD_Table, trigger table, mandatory)
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,DDL_NoForeignKey,Description,EntityType,FieldLength,Help,IsActive,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593050/*From ID Server*/,126,0,19,542631,'AD_Table_ID',TO_TIMESTAMP('2026-07-27 10:01:09','YYYY-MM-DD HH24:MI:SS'),100,'N','Auslöser-Tabelle: eine After-Commit-Cache-Invalidierung eines Datensatzes dieser Tabelle löst die View-Invalidierung aus','de.metas.ui.web',10,'Wenn ein Datensatz dieser Tabelle nach Commit invalidiert wird, werden alle Views des zugeordneten Fensters neu geladen.','Y','N','N','N','N','Y','N','N','Y','N','Y','DB-Tabelle','NP',0,TO_TIMESTAMP('2026-07-27 10:01:09','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language,t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Column_ID=593050 AND NOT EXISTS (SELECT * FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- ============================ Physical DDL ============================
+/* DDL */ CREATE TABLE public.WEBUI_ViewInvalidateOnChange (
+	AD_Client_ID NUMERIC(10) NOT NULL,
+	AD_Org_ID NUMERIC(10) NOT NULL,
+	WEBUI_ViewInvalidateOnChange_ID NUMERIC(10) NOT NULL,
+	IsActive CHAR(1) DEFAULT 'Y' CHECK (IsActive IN ('Y','N')) NOT NULL,
+	Created TIMESTAMP WITH TIME ZONE NOT NULL,
+	CreatedBy NUMERIC(10) NOT NULL,
+	Updated TIMESTAMP WITH TIME ZONE NOT NULL,
+	UpdatedBy NUMERIC(10) NOT NULL,
+	AD_Window_ID NUMERIC(10) NOT NULL,
+	AD_Table_ID NUMERIC(10) NOT NULL,
+	CONSTRAINT WEBUIViewInvalidateOnChange_Key PRIMARY KEY (WEBUI_ViewInvalidateOnChange_ID),
+	CONSTRAINT ADWindow_WEBUIViewInvalidateOnChg FOREIGN KEY (AD_Window_ID) REFERENCES public.AD_Window DEFERRABLE INITIALLY DEFERRED,
+	CONSTRAINT ADTable_WEBUIViewInvalidateOnChg FOREIGN KEY (AD_Table_ID) REFERENCES public.AD_Table DEFERRABLE INITIALLY DEFERRED)
+;
+
+-- One active mapping per (window, trigger-table). Partial-on-IsActive so a row can be soft-deactivated
+-- and re-created without violating the constraint (metasfresh soft-delete convention).
+/* DDL */ CREATE UNIQUE INDEX WEBUI_ViewInvalidateOnChange_uq ON public.WEBUI_ViewInvalidateOnChange (AD_Window_ID, AD_Table_ID) WHERE IsActive='Y'
+;
+
+-- Propagate the new element's translations to its column, then backfill any missing _Trl rows.
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585139)
+;
+SELECT add_missing_translations()
+;

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5816570_sys_WEBUI_ViewInvalidateOnChange_window.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5816570_sys_WEBUI_ViewInvalidateOnChange_window.sql
@@ -1,0 +1,329 @@
+-- Minimal System-Administration admin window for the generic WEBUI_ViewInvalidateOnChange config
+-- table (created by 5816550). One single header tab over WEBUI_ViewInvalidateOnChange with the two
+-- config fields (AD_Window_ID = window whose views get invalidated, AD_Table_ID = trigger table)
+-- plus the standard IsActive / Org / Client fields. Reachable under the System-Administration menu.
+--
+-- Also corrects the en_US label of the shared element 585139 to "View Invalidation on Change"
+-- (5816550 seeded the grammatically-off "View invalidate on change"). German (de_DE/de_CH) is kept
+-- as-is. This re-runs on every DB — including one that already applied 5816550 with the old text —
+-- so 5816550 stays immutable and the corrected label converges everywhere via this script.
+--
+-- EntityType matches the table's: de.metas.ui.web (NOT 'D').
+--
+-- IDs allocated from idserver.metas.de on 2026-07-27:
+--   AD_MigrationScript prefix 5816570
+--   AD_Window        542178
+--   AD_Tab           549358 (header, WEBUI_ViewInvalidateOnChange)
+--   AD_Menu          542350
+--   AD_UI_Section    547863 ; AD_UI_Column 549610 (left), 549611 (right)
+--   AD_UI_ElementGroup 555529 (primary/left), 555530 (flags/right), 555531 (org/right)
+--   AD_Field         781850 AD_Window_ID, 781851 AD_Table_ID, 781852 IsActive, 781853 AD_Org_ID, 781854 AD_Client_ID
+--   AD_UI_Element    652774..652778
+--
+-- Reused: AD_Table 542631 WEBUI_ViewInvalidateOnChange
+--   cols  AD_Window_ID=593049 AD_Table_ID=593050 IsActive=593044 AD_Org_ID=593042 AD_Client_ID=593041
+--   Elements: window/tab/menu caption=585139 ; field labels AD_Window_ID=143 AD_Table_ID=126
+--             IsActive=348 AD_Org_ID=113 AD_Client_ID=102
+--   Menu: AD_Tree_ID=10, parent 218 (System-Administration)
+
+-- ============================================================
+-- 0. Correct en_US wording of the reused caption element (finding: "View Invalidation on Change")
+-- ============================================================
+UPDATE AD_Element_Trl SET Name='View Invalidation on Change', PrintName='View Invalidation on Change', IsTranslated='Y',
+     Updated=TO_TIMESTAMP('2026-07-27 12:00:00', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Element_ID=585139 AND AD_Language='en_US';
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585139 /*propagate corrected en_US to column trl*/);
+
+-- ============================================================
+-- 1. AD_Window
+-- ============================================================
+INSERT INTO AD_Window (AD_Window_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     Name, WindowType, IsSOTrx, IsDefault, IsBetaFunctionality, EntityType, AD_Element_ID, InternalName)
+VALUES (542178 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:01:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'View-Invalidierung bei Änderung', 'M', 'Y', 'N', 'N', 'de.metas.ui.web', 585139, 'WEBUI_ViewInvalidateOnChange');
+
+INSERT INTO AD_Window_Trl (AD_Language, AD_Window_ID, IsTranslated, Name, Description, Help,
+     AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, 542178 /*From ID Server*/, 'N', w.Name, w.Description, w.Help,
+     0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:01:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:01:01', 'YYYY-MM-DD HH24:MI:SS'), 100
+FROM AD_Language l, AD_Window w
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND w.AD_Window_ID=542178
+  AND NOT EXISTS (SELECT 1 FROM AD_Window_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Window_ID=542178);
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585139 /*window element*/);
+
+UPDATE AD_Table SET AD_Window_ID=542178 /*From ID Server*/,
+     Updated=TO_TIMESTAMP('2026-07-27 12:01:10', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Table_ID=542631;
+
+-- ============================================================
+-- 2. AD_Tab (header, level 0)
+-- ============================================================
+INSERT INTO AD_Tab (AD_Tab_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     Name, AD_Window_ID, AD_Table_ID, TabLevel, SeqNo,
+     IsSingleRow, IsInfoTab, IsTranslationTab, IsReadOnly, IsInsertRecord, IsAdvancedTab, IsSortTab, HasTree,
+     EntityType, AD_Element_ID)
+VALUES (549358 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:02:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'View-Invalidierung bei Änderung', 542178 /*From ID Server*/, 542631 /*WEBUI_ViewInvalidateOnChange*/, 0, 10,
+     'Y', 'N', 'N', 'N', 'Y', 'N', 'N', 'N',
+     'de.metas.ui.web', 585139);
+
+INSERT INTO AD_Tab_Trl (AD_Language, AD_Tab_ID, IsTranslated, Name, Description, Help, CommitWarning,
+     AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, 549358 /*From ID Server*/, 'N', t.Name, t.Description, t.Help, NULL,
+     0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:02:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:02:01', 'YYYY-MM-DD HH24:MI:SS'), 100
+FROM AD_Language l, AD_Tab t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Tab_ID=549358
+  AND NOT EXISTS (SELECT 1 FROM AD_Tab_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Tab_ID=549358);
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585139 /*header tab element*/);
+
+-- ============================================================
+-- 3. Header tab fields (AD_Tab_ID=549358)
+-- ============================================================
+-- 3a. AD_Window_ID
+INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     Name, AD_Tab_ID, AD_Column_ID, IsDisplayed, SeqNo, IsDisplayedGrid, SeqNoGrid,
+     IsSameLine, IsHeading, IsFieldOnly, IsEncrypted, EntityType)
+VALUES (781850 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:03:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:03:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'Fenster', 549358 /*From ID Server*/, 593049 /*AD_Window_ID*/, 'Y', 10, 'Y', 10,
+     'N', 'N', 'N', 'N', 'de.metas.ui.web');
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, IsTranslated, Name, Description, Help,
+     AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, 781850 /*From ID Server*/, 'N', f.Name, f.Description, f.Help,
+     0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:03:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:03:01', 'YYYY-MM-DD HH24:MI:SS'), 100
+FROM AD_Language l, AD_Field f
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND f.AD_Field_ID=781850
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=781850);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(143 /*AD_Window_ID element*/);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781850;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781850);
+
+-- 3b. AD_Table_ID
+INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     Name, AD_Tab_ID, AD_Column_ID, IsDisplayed, SeqNo, IsDisplayedGrid, SeqNoGrid,
+     IsSameLine, IsHeading, IsFieldOnly, IsEncrypted, EntityType)
+VALUES (781851 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:03:10', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:03:10', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'DB-Tabelle', 549358 /*From ID Server*/, 593050 /*AD_Table_ID*/, 'Y', 20, 'Y', 20,
+     'N', 'N', 'N', 'N', 'de.metas.ui.web');
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, IsTranslated, Name, Description, Help,
+     AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, 781851 /*From ID Server*/, 'N', f.Name, f.Description, f.Help,
+     0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:03:11', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:03:11', 'YYYY-MM-DD HH24:MI:SS'), 100
+FROM AD_Language l, AD_Field f
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND f.AD_Field_ID=781851
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=781851);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(126 /*AD_Table_ID element*/);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781851;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781851);
+
+-- 3c. IsActive (flags group)
+INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     Name, AD_Tab_ID, AD_Column_ID, IsDisplayed, SeqNo, IsDisplayedGrid, SeqNoGrid,
+     IsSameLine, IsHeading, IsFieldOnly, IsEncrypted, EntityType)
+VALUES (781852 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:03:20', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:03:20', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'Aktiv', 549358 /*From ID Server*/, 593044 /*IsActive*/, 'Y', 30, 'N', 0,
+     'N', 'N', 'N', 'N', 'de.metas.ui.web');
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, IsTranslated, Name, Description, Help,
+     AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, 781852 /*From ID Server*/, 'N', f.Name, f.Description, f.Help,
+     0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:03:21', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:03:21', 'YYYY-MM-DD HH24:MI:SS'), 100
+FROM AD_Language l, AD_Field f
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND f.AD_Field_ID=781852
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=781852);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(348 /*IsActive element*/);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781852;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781852);
+
+-- 3d. AD_Org_ID (org group)
+INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     Name, AD_Tab_ID, AD_Column_ID, IsDisplayed, SeqNo, IsDisplayedGrid, SeqNoGrid,
+     IsSameLine, IsHeading, IsFieldOnly, IsEncrypted, EntityType)
+VALUES (781853 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:03:30', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:03:30', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'Sektion', 549358 /*From ID Server*/, 593042 /*AD_Org_ID*/, 'Y', 40, 'Y', 30,
+     'N', 'N', 'N', 'N', 'de.metas.ui.web');
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, IsTranslated, Name, Description, Help,
+     AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, 781853 /*From ID Server*/, 'N', f.Name, f.Description, f.Help,
+     0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:03:31', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:03:31', 'YYYY-MM-DD HH24:MI:SS'), 100
+FROM AD_Language l, AD_Field f
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND f.AD_Field_ID=781853
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=781853);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(113 /*AD_Org_ID element*/);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781853;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781853);
+
+-- 3e. AD_Client_ID (org group, last)
+INSERT INTO AD_Field (AD_Field_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     Name, AD_Tab_ID, AD_Column_ID, IsDisplayed, SeqNo, IsDisplayedGrid, SeqNoGrid,
+     IsSameLine, IsHeading, IsFieldOnly, IsEncrypted, EntityType)
+VALUES (781854 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:03:40', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:03:40', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'Mandant', 549358 /*From ID Server*/, 593041 /*AD_Client_ID*/, 'Y', 50, 'N', 0,
+     'N', 'N', 'N', 'N', 'de.metas.ui.web');
+
+INSERT INTO AD_Field_Trl (AD_Language, AD_Field_ID, IsTranslated, Name, Description, Help,
+     AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, 781854 /*From ID Server*/, 'N', f.Name, f.Description, f.Help,
+     0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:03:41', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:03:41', 'YYYY-MM-DD HH24:MI:SS'), 100
+FROM AD_Language l, AD_Field f
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND f.AD_Field_ID=781854
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=781854);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(102 /*AD_Client_ID element*/);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781854;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(781854);
+
+-- ============================================================
+-- 4. UI structure — 2-column header layout
+-- ============================================================
+INSERT INTO AD_UI_Section (AD_UI_Section_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     AD_Tab_ID, SeqNo, Name, Value)
+VALUES (547863 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:05:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:05:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     549358, 10, 'main', 'main');
+
+INSERT INTO AD_UI_Column (AD_UI_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     AD_UI_Section_ID, SeqNo)
+VALUES (549610 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:05:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:05:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     547863, 10);
+
+INSERT INTO AD_UI_Column (AD_UI_Column_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     AD_UI_Section_ID, SeqNo)
+VALUES (549611 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:05:02', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:05:02', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     547863, 20);
+
+INSERT INTO AD_UI_ElementGroup (AD_UI_ElementGroup_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     AD_UI_Column_ID, SeqNo, UIStyle, Name)
+VALUES (555529 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:05:03', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:05:03', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     549610 /*left*/, 10, 'primary', 'default');
+
+INSERT INTO AD_UI_ElementGroup (AD_UI_ElementGroup_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     AD_UI_Column_ID, SeqNo, UIStyle, Name)
+VALUES (555530 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:05:04', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:05:04', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     549611 /*right*/, 10, NULL, 'flags');
+
+INSERT INTO AD_UI_ElementGroup (AD_UI_ElementGroup_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     AD_UI_Column_ID, SeqNo, UIStyle, Name)
+VALUES (555531 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:05:05', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:05:05', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     549611 /*right*/, 20, NULL, 'default');
+
+-- ============================================================
+-- 5. AD_UI_Elements
+-- ============================================================
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+     Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+     Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 781850, 0, 549358, 555529, 652774 /*From ID Server*/, 'F',
+     TO_TIMESTAMP('2026-07-27 12:06:00', 'YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N',
+     'Fenster', 10, 10, 0, TO_TIMESTAMP('2026-07-27 12:06:00', 'YYYY-MM-DD HH24:MI:SS'), 100);
+
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+     Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+     Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 781851, 0, 549358, 555529, 652775 /*From ID Server*/, 'F',
+     TO_TIMESTAMP('2026-07-27 12:06:01', 'YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N',
+     'DB-Tabelle', 20, 20, 0, TO_TIMESTAMP('2026-07-27 12:06:01', 'YYYY-MM-DD HH24:MI:SS'), 100);
+
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+     Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+     Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 781852, 0, 549358, 555530, 652776 /*From ID Server*/, 'F',
+     TO_TIMESTAMP('2026-07-27 12:06:02', 'YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'N', 'N',
+     'Aktiv', 10, 0, 0, TO_TIMESTAMP('2026-07-27 12:06:02', 'YYYY-MM-DD HH24:MI:SS'), 100);
+
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+     Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+     Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 781853, 0, 549358, 555531, 652777 /*From ID Server*/, 'F',
+     TO_TIMESTAMP('2026-07-27 12:06:03', 'YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'Y', 'N',
+     'Sektion', 10, 30, 0, TO_TIMESTAMP('2026-07-27 12:06:03', 'YYYY-MM-DD HH24:MI:SS'), 100);
+
+INSERT INTO AD_UI_Element (AD_Client_ID, AD_Field_ID, AD_Org_ID, AD_Tab_ID, AD_UI_ElementGroup_ID, AD_UI_Element_ID, AD_UI_ElementType,
+     Created, CreatedBy, IsActive, IsAdvancedField, IsDisplayed, IsDisplayedGrid, IsDisplayed_SideList,
+     Name, SeqNo, SeqNoGrid, SeqNo_SideList, Updated, UpdatedBy)
+VALUES (0, 781854, 0, 549358, 555531, 652778 /*From ID Server*/, 'F',
+     TO_TIMESTAMP('2026-07-27 12:06:04', 'YYYY-MM-DD HH24:MI:SS'), 100, 'Y', 'N', 'Y', 'N', 'N',
+     'Mandant', 20, 0, 0, TO_TIMESTAMP('2026-07-27 12:06:04', 'YYYY-MM-DD HH24:MI:SS'), 100);
+
+-- ============================================================
+-- 6. Filter config — AD_Window_ID + AD_Table_ID default filters
+-- ============================================================
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=10,
+     Updated=TO_TIMESTAMP('2026-07-27 12:07:00', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Column_ID=593049 /*WEBUI_ViewInvalidateOnChange.AD_Window_ID*/;
+
+UPDATE AD_Column SET IsSelectionColumn='Y', SelectionColumnSeqNo=20,
+     Updated=TO_TIMESTAMP('2026-07-27 12:07:01', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Column_ID=593050 /*WEBUI_ViewInvalidateOnChange.AD_Table_ID*/;
+
+-- ============================================================
+-- 7. AD_Menu + tree placement (under System-Administration, node 218)
+-- ============================================================
+INSERT INTO AD_Menu (AD_Menu_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     Name, Action, AD_Window_ID, IsSummary, EntityType, AD_Element_ID, InternalName)
+VALUES (542350 /*From ID Server*/, 0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:08:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:08:00', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     'View-Invalidierung bei Änderung', 'W', 542178 /*From ID Server*/, 'N', 'de.metas.ui.web', 585139, 'WEBUI_ViewInvalidateOnChange');
+
+INSERT INTO AD_Menu_Trl (AD_Language, AD_Menu_ID, IsTranslated, Name, Description,
+     AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy)
+SELECT l.AD_Language, 542350 /*From ID Server*/, 'N', m.Name, m.Description,
+     0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:08:01', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:08:01', 'YYYY-MM-DD HH24:MI:SS'), 100
+FROM AD_Language l, AD_Menu m
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND m.AD_Menu_ID=542350
+  AND NOT EXISTS (SELECT 1 FROM AD_Menu_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Menu_ID=542350);
+
+SELECT update_menu_translation_from_ad_element(585139 /*element id*/, NULL /*all languages*/);
+
+INSERT INTO AD_TreeNodeMM (AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+     AD_Tree_ID, Node_ID, Parent_ID, SeqNo)
+VALUES (0, 0, 'Y',
+     TO_TIMESTAMP('2026-07-27 12:08:10', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     TO_TIMESTAMP('2026-07-27 12:08:10', 'YYYY-MM-DD HH24:MI:SS'), 100,
+     10 /*menu tree*/, 542350 /*new menu*/, 218 /*System-Administration*/, 13);

--- a/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5816590_sys_WEBUI_ConfiguredViewInvalidationListener_debouncer_sysconfig.sql
+++ b/backend/de.metas.ui.web.base/src/main/sql/postgresql/system/41-de.metas.ui.web.base/5816590_sys_WEBUI_ConfiguredViewInvalidationListener_debouncer_sysconfig.sql
@@ -1,0 +1,16 @@
+-- Seed the two AD_SysConfig rows read by the ConfiguredViewInvalidationListener debouncer.
+-- The listener coalesces config-driven WebUI view invalidations; these tune its debouncer.
+-- Both are read with a code-side default equal to the value seeded here.
+-- IDs allocated from idserver.metas.de on 2026-07-28:
+--   AD_SysConfig 541840 (webui.ConfiguredViewInvalidationListener.debouncer.bufferMaxSize)
+--   AD_SysConfig 541841 (webui.ConfiguredViewInvalidationListener.debouncer.delayInMillis)
+
+-- Max. number of collected events the debouncer buffers before flushing.
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID /*From ID Server*/,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value)
+VALUES (0,0,541840,'S',TO_TIMESTAMP('2026-07-28 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Max. number of collected events the ConfiguredViewInvalidationListener debouncer buffers before flushing a WebUI view invalidation.','de.metas.ui.web','Y','webui.ConfiguredViewInvalidationListener.debouncer.bufferMaxSize',TO_TIMESTAMP('2026-07-28 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'500')
+;
+
+-- Max. number of milliseconds the debouncer waits for more events before flushing.
+INSERT INTO AD_SysConfig (AD_Client_ID,AD_Org_ID,AD_SysConfig_ID /*From ID Server*/,ConfigurationLevel,Created,CreatedBy,Description,EntityType,IsActive,Name,Updated,UpdatedBy,Value)
+VALUES (0,0,541841,'S',TO_TIMESTAMP('2026-07-28 10:00:01','YYYY-MM-DD HH24:MI:SS'),100,'Max. number of milliseconds the ConfiguredViewInvalidationListener debouncer waits for more events before flushing a WebUI view invalidation.','de.metas.ui.web','Y','webui.ConfiguredViewInvalidationListener.debouncer.delayInMillis',TO_TIMESTAMP('2026-07-28 10:00:01','YYYY-MM-DD HH24:MI:SS'),100,'100')
+;

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/view/invalidation/ConfiguredViewInvalidationListenerTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/view/invalidation/ConfiguredViewInvalidationListenerTest.java
@@ -1,0 +1,140 @@
+/*
+ * #%L
+ * de.metas.ui.web.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ui.web.view.invalidation;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import de.metas.cache.model.CacheInvalidateMultiRequest;
+import de.metas.ui.web.view.IView;
+import de.metas.ui.web.view.IViewsRepository;
+import de.metas.ui.web.view.ViewId;
+import de.metas.ui.web.window.datatypes.WindowId;
+import org.adempiere.service.ISysConfigBL;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ConfiguredViewInvalidationListenerTest
+{
+	private static final String TRIGGER_TABLE = "M_ReceiptSchedule";
+	private static final String UNRELATED_TABLE = "C_Order";
+
+	private final WindowId windowCockpit = WindowId.of(1000001);
+	private final WindowId windowOther = WindowId.of(1000002);
+
+	private IViewsRepository viewsRepository;
+	private WebuiViewInvalidateOnChangeRepository configRepository;
+	private ConfiguredViewInvalidationListener listener;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+
+		// The debouncer built in the constructor reads two sysconfig ints; return their defaults.
+		final ISysConfigBL sysConfigBL = mock(ISysConfigBL.class);
+		when(sysConfigBL.getIntValue(anyString(), anyInt())).thenAnswer(inv -> inv.getArgument(1));
+		de.metas.util.Services.registerService(ISysConfigBL.class, sysConfigBL);
+
+		viewsRepository = mock(IViewsRepository.class);
+		configRepository = mock(WebuiViewInvalidateOnChangeRepository.class);
+
+		listener = new ConfiguredViewInvalidationListener(viewsRepository, configRepository);
+	}
+
+	private IView viewForWindow(final WindowId windowId, final boolean watched)
+	{
+		final IView view = mock(IView.class);
+		final ViewId viewId = ViewId.random(windowId);
+		when(view.getViewId()).thenReturn(viewId);
+		when(viewsRepository.isWatchedByFrontend(viewId)).thenReturn(watched);
+		return view;
+	}
+
+	@Test
+	void flush_invalidatesOnlyWatchedViewsOfConfiguredWindow()
+	{
+		when(configRepository.getWindowIdsToInvalidateForTable(TRIGGER_TABLE))
+				.thenReturn(ImmutableSet.of(windowCockpit));
+
+		final IView watchedCockpitView1 = viewForWindow(windowCockpit, true);
+		final IView watchedCockpitView2 = viewForWindow(windowCockpit, true);
+		final IView idleCockpitView = viewForWindow(windowCockpit, false);   // right window, not watched
+		final IView otherWindowView = viewForWindow(windowOther, true);      // watched, wrong window
+		when(viewsRepository.getViews())
+				.thenReturn(ImmutableList.of(watchedCockpitView1, watchedCockpitView2, idleCockpitView, otherWindowView));
+
+		listener.invalidateViewsForTableNamesNow(ImmutableList.of(TRIGGER_TABLE));
+
+		verify(viewsRepository).invalidateView(watchedCockpitView1);
+		verify(viewsRepository).invalidateView(watchedCockpitView2);
+		verify(viewsRepository, never()).invalidateView(idleCockpitView);
+		verify(viewsRepository, never()).invalidateView(otherWindowView);
+	}
+
+	@Test
+	void flush_unrelatedTable_isNoop()
+	{
+		when(configRepository.getWindowIdsToInvalidateForTable(UNRELATED_TABLE))
+				.thenReturn(ImmutableSet.of());
+
+		listener.invalidateViewsForTableNamesNow(ImmutableList.of(UNRELATED_TABLE));
+
+		// no configured window -> never even enumerate the views, never invalidate
+		verify(viewsRepository, never()).getViews();
+		verify(viewsRepository, never()).invalidateView(any(IView.class));
+	}
+
+	@Test
+	void reset_whenNoTriggerTablesConfigured_isNoop()
+	{
+		when(configRepository.getAllTriggerTableNames()).thenReturn(ImmutableSet.of());
+
+		final long affected = listener.reset(CacheInvalidateMultiRequest.rootRecord(TRIGGER_TABLE, 1));
+
+		org.assertj.core.api.Assertions.assertThat(affected).isZero();
+		verify(viewsRepository, never()).getViews();
+		verify(viewsRepository, never()).invalidateView(any(IView.class));
+		verify(viewsRepository, never()).isWatchedByFrontend(any());
+	}
+
+	@Test
+	void reset_whenRequestTablesDoNotMatchTriggers_isNoop()
+	{
+		when(configRepository.getAllTriggerTableNames()).thenReturn(ImmutableSet.of(TRIGGER_TABLE));
+
+		final long affected = listener.reset(CacheInvalidateMultiRequest.rootRecord(UNRELATED_TABLE, 1));
+
+		org.assertj.core.api.Assertions.assertThat(affected).isZero();
+		verify(viewsRepository, never()).invalidateView(any(IView.class));
+		verify(viewsRepository, never()).getViews();
+	}
+}

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/view/invalidation/WebuiViewInvalidateOnChangeRepositoryTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/view/invalidation/WebuiViewInvalidateOnChangeRepositoryTest.java
@@ -1,0 +1,116 @@
+/*
+ * #%L
+ * de.metas.ui.web.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ui.web.view.invalidation;
+
+import de.metas.ui.web.base.model.I_WEBUI_ViewInvalidateOnChange;
+import de.metas.ui.web.window.datatypes.WindowId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_AD_Table;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the {@link WebuiViewInvalidateOnChangeRepository#retrieve()} mapping logic:
+ * AD_Table_ID &rarr; TableName resolution, the active-only filter, and multimap construction.
+ * A fresh repository + reset persistence per test (see {@link #setUp()}) keeps the table-scoped
+ * cache from leaking rows between scenarios.
+ */
+class WebuiViewInvalidateOnChangeRepositoryTest
+{
+	private static final int WINDOW_A = 1000001;
+	private static final int WINDOW_B = 1000002;
+
+	private WebuiViewInvalidateOnChangeRepository repository;
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		repository = new WebuiViewInvalidateOnChangeRepository();
+	}
+
+	private int createTable(final String tableName)
+	{
+		final I_AD_Table table = InterfaceWrapperHelper.newInstance(I_AD_Table.class);
+		table.setName(tableName);
+		table.setTableName(tableName);
+		InterfaceWrapperHelper.saveRecord(table);
+		return table.getAD_Table_ID();
+	}
+
+	private void createConfig(final int adTableId, final int adWindowId, final boolean active)
+	{
+		final I_WEBUI_ViewInvalidateOnChange record = InterfaceWrapperHelper.newInstance(I_WEBUI_ViewInvalidateOnChange.class);
+		record.setAD_Table_ID(adTableId);
+		record.setAD_Window_ID(adWindowId);
+		record.setIsActive(active);
+		InterfaceWrapperHelper.saveRecord(record);
+	}
+
+	@Test
+	void resolvesTableNameAndMapsToWindow()
+	{
+		final int receiptScheduleTableId = createTable("M_ReceiptSchedule");
+		createConfig(receiptScheduleTableId, WINDOW_A, true);
+
+		assertThat(repository.getWindowIdsToInvalidateForTable("M_ReceiptSchedule"))
+				.containsExactly(WindowId.of(WINDOW_A));
+		assertThat(repository.getAllTriggerTableNames())
+				.containsExactly("M_ReceiptSchedule");
+	}
+
+	@Test
+	void inactiveConfigRowsAreExcluded()
+	{
+		final int receiptScheduleTableId = createTable("M_ReceiptSchedule");
+		final int orderTableId = createTable("C_Order");
+		createConfig(receiptScheduleTableId, WINDOW_A, true);
+		createConfig(orderTableId, WINDOW_B, false /*inactive*/);
+
+		assertThat(repository.getWindowIdsToInvalidateForTable("C_Order")).isEmpty();
+		assertThat(repository.getAllTriggerTableNames()).containsExactly("M_ReceiptSchedule");
+	}
+
+	@Test
+	void multipleWindowsForSameTriggerTable()
+	{
+		final int receiptScheduleTableId = createTable("M_ReceiptSchedule");
+		createConfig(receiptScheduleTableId, WINDOW_A, true);
+		createConfig(receiptScheduleTableId, WINDOW_B, true);
+
+		assertThat(repository.getWindowIdsToInvalidateForTable("M_ReceiptSchedule"))
+				.containsExactlyInAnyOrder(WindowId.of(WINDOW_A), WindowId.of(WINDOW_B));
+	}
+
+	@Test
+	void unconfiguredTableReturnsEmpty()
+	{
+		final int receiptScheduleTableId = createTable("M_ReceiptSchedule");
+		createConfig(receiptScheduleTableId, WINDOW_A, true);
+
+		assertThat(repository.getWindowIdsToInvalidateForTable("C_Invoice")).isEmpty();
+	}
+}

--- a/e2e/frontend-webui/tests/spec/view-invalidate-config-window.spec.js
+++ b/e2e/frontend-webui/tests/spec/view-invalidate-config-window.spec.js
@@ -1,0 +1,284 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { LoginPage } from '../utils/pages/LoginPage';
+import { DashboardPage } from '../utils/pages/DashboardPage';
+import { FRONTEND_BASE_URL, SLOW_ACTION_TIMEOUT } from '../utils/common';
+import { VIEW_INVALIDATE_ON_CHANGE_WINDOW_ID } from '../utils/WindowIds';
+
+/**
+ * View Invalidation on Change admin window E2E test.
+ *
+ * Verifies the new minimal System-Administration admin window over the
+ * WEBUI_ViewInvalidateOnChange config table (AD_Window_ID=542178,
+ * "View Invalidation on Change" / element 585139).
+ *
+ * This spec satisfies the metasfresh-window-design-rules § Verification mandate:
+ * every new AD_Window ships with a Playwright test in the SAME PR proving it
+ * renders and persists.
+ *
+ * Scenario:
+ * 1. Log in and open window 542178 in NEW mode.
+ * 2. Assert the two mandatory lookup fields (AD_Window_ID, AD_Table_ID) render.
+ * 3. Set both via the WebAPI PATCH endpoint to valid ids.
+ * 4. Wait until the record becomes valid (validStatus.valid=true, i.e. saved).
+ * 5. Reload the page and assert both values persisted via the WebAPI record
+ *    (fieldsByName.<Column>.value.key), language-independent.
+ *
+ * Assertions use only language-invariant identifiers (.form-field-<Column>,
+ * WebAPI fieldsByName.<Column>.value) — no getByText / localized text.
+ */
+
+const testCases = [
+  { language: 'en_US', label: 'English' },
+  { language: 'de_DE', label: 'German' },
+];
+
+// Valid ids to set on the two mandatory TableDir lookups.
+// AD_Table_ID: M_ReceiptSchedule (queried from AD_Table on localhost:21432).
+// AD_Window_ID: Forecast window (Prognose, 328) — any existing window is valid.
+const RECEIPT_SCHEDULE_TABLE_ID = 540524; // AD_Table.TableName='M_ReceiptSchedule'
+const FORECAST_WINDOW_ID_VALUE = 328; // AD_Window Prognose
+
+/**
+ * Poll the WebAPI until the record becomes valid (all mandatory fields filled and saved).
+ * Returns the validStatus object.
+ */
+async function waitForRecordValid(page, windowId, recordId, { timeout = 30000 } = {}) {
+  const start = Date.now();
+  let lastStatus = null;
+  while (Date.now() - start < timeout) {
+    lastStatus = await page.evaluate(
+      async ({ windowId, recordId }) => {
+        const resp = await fetch(`/rest/api/window/${windowId}/${recordId}`, {
+          credentials: 'include',
+          headers: { Accept: 'application/json' },
+        });
+        if (!resp.ok) return { valid: false, reason: `HTTP ${resp.status}` };
+        const data = await resp.json();
+        return data[0]?.validStatus || { valid: false, reason: 'no validStatus' };
+      },
+      { windowId, recordId }
+    );
+    if (lastStatus?.valid) return lastStatus;
+    await page.waitForTimeout(500);
+  }
+  return lastStatus;
+}
+
+/**
+ * Set a field value via the WebAPI PATCH endpoint (language-independent, reliable
+ * for lookups). Lookup values are passed as { key, caption } objects.
+ */
+async function patchField(page, windowId, recordId, fieldName, value) {
+  return page.evaluate(
+    async ({ windowId, recordId, fieldName, value }) => {
+      const resp = await fetch(`/rest/api/window/${windowId}/${recordId}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify([{ op: 'replace', path: fieldName, value }]),
+      });
+      if (!resp.ok) {
+        const text = await resp.text();
+        throw new Error(`PATCH ${fieldName} failed: ${resp.status} ${text}`);
+      }
+      return resp.json();
+    },
+    { windowId, recordId, fieldName, value }
+  );
+}
+
+/**
+ * Delete a record via the WebUI REST DELETE endpoint. Best-effort cleanup so
+ * the partial-unique index (ad_window_id, ad_table_id) WHERE isactive='Y' does
+ * not block re-runs. Swallows errors (e.g. NEW draft never persisted).
+ */
+async function deleteRecord(page, windowId, recordId) {
+  if (!recordId || recordId === 'NEW') return;
+  return page.evaluate(
+    async ({ windowId, recordId }) => {
+      try {
+        await fetch(`/rest/api/window/${windowId}/${recordId}`, {
+          method: 'DELETE',
+          credentials: 'include',
+          headers: { Accept: 'application/json' },
+        });
+      } catch (e) {
+        // ignore — best-effort cleanup
+      }
+    },
+    { windowId, recordId }
+  );
+}
+
+/**
+ * Read the raw WebAPI record document (element [0]) for assertions on
+ * fieldsByName.<Column>.value.
+ */
+async function readRecord(page, windowId, recordId) {
+  return page.evaluate(
+    async ({ windowId, recordId }) => {
+      const resp = await fetch(`/rest/api/window/${windowId}/${recordId}`, {
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+      });
+      if (!resp.ok) throw new Error(`GET record failed: HTTP ${resp.status}`);
+      const data = await resp.json();
+      return data[0];
+    },
+    { windowId, recordId }
+  );
+}
+
+testCases.forEach(({ language, label }) => {
+  test.describe(`View Invalidation on Change window (${label})`, () => {
+    test(`Admin window renders both lookup fields and persists them (${label} UI)`, async ({
+      page,
+    }) => {
+      // === ALLURE METADATA ===
+      allure.epic('E0200: WebUI Table Features');
+      allure.tag('F00655: Einkaufs-Cockpit');
+      allure.tag('F00655');
+      allure.story('View Invalidation on Change: admin window renders and persists');
+      allure.severity('normal');
+      allure.parameter('Language', language);
+      allure.parameter('UI Label', label);
+      allure.tag(language);
+
+      allure.description(`
+## E0200: WebUI Table Features
+
+## View Invalidation on Change (AD_Window_ID=542178)
+
+### Test Scenario
+Verifies the new minimal System-Administration admin window over the
+WEBUI_ViewInvalidateOnChange config table:
+
+1. **Login** — Login user via Backend API
+2. **Open window NEW** — Navigate to /window/542178/NEW
+3. **Assert fields render** — .form-field-AD_Window_ID and .form-field-AD_Table_ID present
+4. **Set lookups via PATCH** — AD_Table_ID=M_ReceiptSchedule, AD_Window_ID=Prognose(328)
+5. **Wait valid** — Poll WebAPI until validStatus.valid=true (saved)
+6. **Reload + assert persisted** — fieldsByName.<Column>.value.key matches the set ids
+
+### Business Value
+Satisfies the window-design § Verification mandate: the new AD_Window is proven
+to render and persist in the same PR that introduces it.
+      `);
+
+      test.setTimeout(120000);
+
+      // Step 1: Login-only setup
+      const masterdata = await Backend.createMasterdata({
+        request: {
+          login: {
+            user: {
+              language,
+              firstname: 'viewinvalidate',
+              lastname: 'tester',
+            },
+          },
+        },
+      });
+      allure.attachment('Test Data', JSON.stringify(masterdata, null, 2), 'application/json');
+      console.log(`[${language}] Master data created (login user)`);
+
+      // Step 2: Login
+      await LoginPage.goto();
+      await LoginPage.login(masterdata.login.user);
+      await DashboardPage.expectVisible();
+      console.log(`[${language}] Logged in successfully`);
+
+      // Step 3: Open window 542178 in NEW mode
+      let recordId;
+      try {
+      await test.step('Open View Invalidation window in NEW mode', async () => {
+        await page.goto(`${FRONTEND_BASE_URL}/window/${VIEW_INVALIDATE_ON_CHANGE_WINDOW_ID}/NEW`);
+        await page.waitForURL(/\/window\/\d+\/\d+/, { timeout: SLOW_ACTION_TIMEOUT });
+        await page.waitForLoadState('networkidle', { timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+        await page
+          .locator('.rotating, .indicator-pending')
+          .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+          .catch(() => {});
+        await page.waitForTimeout(1000);
+
+        recordId = page.url().split('/').pop();
+        console.log(`[${language}] New record created in WebUI: ${recordId}`);
+      });
+
+      // Step 4: Assert both mandatory lookup fields are rendered in the form
+      await test.step('Assert AD_Window_ID and AD_Table_ID fields render', async () => {
+        const windowField = page.locator('.form-field-AD_Window_ID');
+        const tableField = page.locator('.form-field-AD_Table_ID');
+
+        await windowField.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+        await tableField.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+
+        expect(await windowField.count()).toBeGreaterThan(0);
+        expect(await tableField.count()).toBeGreaterThan(0);
+
+        const screenshot = await page.screenshot();
+        allure.attachment('Admin window NEW form', screenshot, 'image/png');
+        console.log(`[${language}] Both lookup fields render in the form`);
+      });
+
+      // Step 5: Set both mandatory lookups via PATCH and wait until the record is valid
+      await test.step('Set both lookups via PATCH and wait for valid', async () => {
+        await patchField(page, VIEW_INVALIDATE_ON_CHANGE_WINDOW_ID, recordId, 'AD_Table_ID', {
+          key: RECEIPT_SCHEDULE_TABLE_ID,
+          caption: 'M_ReceiptSchedule',
+        });
+        console.log(`[${language}] AD_Table_ID set: ${RECEIPT_SCHEDULE_TABLE_ID}`);
+
+        await patchField(page, VIEW_INVALIDATE_ON_CHANGE_WINDOW_ID, recordId, 'AD_Window_ID', {
+          key: FORECAST_WINDOW_ID_VALUE,
+          caption: 'Prognose',
+        });
+        console.log(`[${language}] AD_Window_ID set: ${FORECAST_WINDOW_ID_VALUE}`);
+
+        const validStatus = await waitForRecordValid(
+          page,
+          VIEW_INVALIDATE_ON_CHANGE_WINDOW_ID,
+          recordId
+        );
+        if (!validStatus?.valid) {
+          console.log(`[${language}] validStatus not valid: ${JSON.stringify(validStatus)}`);
+        }
+        expect(validStatus?.valid).toBe(true);
+        console.log(`[${language}] Record is valid and saved`);
+      });
+
+      // Step 6: Reload and assert both values persisted via the WebAPI record
+      await test.step('Reload and assert both lookups persisted', async () => {
+        await page
+          .reload({ waitUntil: 'networkidle', timeout: SLOW_ACTION_TIMEOUT })
+          .catch(() => {});
+        await page.waitForTimeout(1000);
+
+        const record = await readRecord(page, VIEW_INVALIDATE_ON_CHANGE_WINDOW_ID, recordId);
+        allure.attachment('Reloaded record', JSON.stringify(record, null, 2), 'application/json');
+
+        const windowValue = record?.fieldsByName?.AD_Window_ID?.value;
+        const tableValue = record?.fieldsByName?.AD_Table_ID?.value;
+
+        // Lookup values are { key, caption } objects; key holds the id (as string).
+        expect(Number(windowValue?.key)).toBe(FORECAST_WINDOW_ID_VALUE);
+        expect(Number(tableValue?.key)).toBe(RECEIPT_SCHEDULE_TABLE_ID);
+
+        console.log(
+          `[${language}] Persisted: AD_Window_ID=${windowValue?.key}, AD_Table_ID=${tableValue?.key}`
+        );
+      });
+      } finally {
+        // Clean up the created config record so the partial-unique index does
+        // not block re-runs (independent of pass/fail).
+        await deleteRecord(page, VIEW_INVALIDATE_ON_CHANGE_WINDOW_ID, recordId);
+        console.log(`[${language}] Cleanup: deleted record ${recordId}`);
+      }
+
+      console.log(`[${language}] View Invalidation window test completed successfully`);
+    });
+  });
+});

--- a/e2e/frontend-webui/tests/utils/WindowIds.js
+++ b/e2e/frontend-webui/tests/utils/WindowIds.js
@@ -195,6 +195,22 @@ export const PICKING_TERMINAL_V2_WINDOW_ID = 540485;
 export const PICKING_TERMINAL_V1_WINDOW_ID = 540350;
 
 // ============================================================================
+// SYSTEM ADMINISTRATION WINDOWS
+// ============================================================================
+
+/**
+ * View Invalidation on Change window (View-Invalidierung bei Änderung)
+ * Table: WEBUI_ViewInvalidateOnChange (AD_Table_ID=542631)
+ * Window ID: 542178
+ * Element: 585139
+ * Description: Minimal System-Administration admin window over the
+ * WEBUI_ViewInvalidateOnChange config table. Single tab with fields
+ * AD_Window_ID (TableDir, mandatory), AD_Table_ID (TableDir, mandatory),
+ * IsActive, AD_Org_ID, AD_Client_ID.
+ */
+export const VIEW_INVALIDATE_ON_CHANGE_WINDOW_ID = 542178;
+
+// ============================================================================
 // SYSTEM/TEST WINDOWS
 // ============================================================================
 


### PR DESCRIPTION
## WebUI view auto-invalidation on configured table change

Generic, config-driven mechanism to auto-refresh (websocket push) an aggregate SQL-backed WebUI view when a record of a configured trigger table has an after-commit cache reset.

### Why
An aggregate SQL view (synthetic/hash PK) cannot be mapped by the default per-table view-invalidation advisor: the changed records' ids never match the view's synthetic row ids, so the view never refreshes when its underlying data changes. This adds a config-driven full-invalidate for such views.

### What
- New config table `WEBUI_ViewInvalidateOnChange` — one row = "when a record of `AD_Table_ID` has an after-commit cache reset, full-invalidate all views of `AD_Window_ID`". Empty by default (no-op on a vanilla instance; no customer identifier in core).
- `WebuiViewInvalidateOnChangeRepository` — table-scoped `CCache` reader (IncotermsRepository pattern), self-invalidating when the config table changes.
- `ConfiguredViewInvalidationListener` — an `ICacheResetListener` that, after commit (debounced), full-invalidates the configured window's frontend-watched views via `IViewsRepository.invalidateView`. Piggy-backs the existing after-commit dispatcher, so it reflects committed data even when the triggering work is asynchronous.

### Tests
`ConfiguredViewInvalidationListenerTest` (4 cases): trigger-table match invalidates the configured window's watched views; unrelated table is a no-op.

### Consumers
Config rows are seeded per customer in the consuming customer repo (no customer identifier in core). The first consumer maps a purchasing-overview view (`RV_PurchaseCockpit`) to `M_ReceiptSchedule`, so it auto-refreshes `QtyOrdered` after purchase orders are created — via a separate seed migration in that customer repo.