### PR TITLE
Distribution mobile — E2E coverage for the third auto-advance carry-forward branch (allowPickingAnyHU)

### DIFF
--- a/e2e/mobile-webui/tests/spec/distribution/packingTable_navigateToNextOrder.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/packingTable_navigateToNextOrder.spec.js
@@ -188,6 +188,10 @@ test('Packing-table operator: orders sorted by priority then locator priority an
     for (let i = 2; i < N; i++) {
         const next = i + 1;
         await test.step(`Pick DD${i} (scan HU${i} + product P${i}, confirm qty ${i * 10}) → auto-advance to DD${next} pick-from (assert DD${next} header)`, async () => {
+            // Every order here is served from its OWN HU, so the one just picked is never the right
+            // source for the order the app advanced to: the operator must be asked to scan this
+            // order's HU rather than being dropped on the product scan with the previous HU applied.
+            await DistributionLinePickFromScreen.expectHUScanReady();
             await DistributionLinePickFromScreen.scanHUToMove({
                 huQRCode: masterdata.externalBarcodes[i],
                 productScannedCode: masterdata.products[`P${i}`].gtin,

--- a/e2e/mobile-webui/tests/spec/distribution/packingTable_navigateToNextOrder.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/packingTable_navigateToNextOrder.spec.js
@@ -6,6 +6,7 @@ import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScre
 import { DistributionJobsListScreen } from "../../utils/screens/distribution/DistributionJobsListScreen";
 import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
 import { DistributionLinePickFromScreen } from '../../utils/screens/distribution/DistributionLinePickFromScreen';
+import { DistributionUtils } from '../../utils/screens/distribution/DistributionUtils';
 import { generateEAN13 } from '../../utils/ean13';
 
 //
@@ -88,6 +89,14 @@ const createMasterdata = async () => {
                     completeJobAutomatically: true,
                     requireScanningProductCode: true,
                     allowStartNextJobOnly: true,
+                    // Each DD order must be pre-allocated to its OWN source HU — that is the whole
+                    // premise of this scenario (see the auto-advance comment in the pick loop below);
+                    // the backend only builds that move plan when this is false
+                    // (DistributionJobCreateCommand). Set explicitly because allowPickingAnyHU is a
+                    // sticky, global config row the masterdata API leaves untouched when omitted, and
+                    // its seeded value is 'Y' — omitting it would silently run this spec plan-less.
+                    // See e2e/mobile-webui/CLAUDE.md § "Debugging Flaky Tests" rule 3.
+                    allowPickingAnyHU: false,
                     maxLaunchers: 20,
                     maxStartedLaunchers: 3,
                     orderBys: 'Priority, LocatorPriority',
@@ -185,13 +194,27 @@ test('Packing-table operator: orders sorted by priority then locator priority an
         await assertHeaderOnPickFromScreen(2);
     });
 
+    // Assert the order the app just auto-advanced to is the "different source HU" case of
+    // postDistributionPickFromThunk (case 2), then that the operator is asked to scan an HU.
+    //
+    // DD<i> has a pre-allocated move plan drawing from HU<i>, while the operator just picked HU<i-1>:
+    // the just-picked HU is therefore NOT in the next order's plan, so the app must not carry it
+    // forward and must ask for this order's own HU instead of dropping the operator on the product
+    // scan with the previous HU applied. The backend assertion is what makes that literal — without
+    // it the same Scan-HU prompt would also appear for a job with NO move plan at all (case 3, what
+    // this spec silently ran before it set allowPickingAnyHU), which proves nothing about case 2.
+    const assertDifferentSourceHUAndHUScanRequested = async (i) => {
+        await DistributionUtils.expectMovePlanSourceHUs({
+            wfProcessId: `distribution-${masterdata.distributionOrders[`DD${i}`].jobId}`,
+            expectedHUQRCodes: [masterdata.handlingUnits[`HU${i}`].qrCode],
+        });
+        await DistributionLinePickFromScreen.expectHUScanReady();
+    };
+
     for (let i = 2; i < N; i++) {
         const next = i + 1;
         await test.step(`Pick DD${i} (scan HU${i} + product P${i}, confirm qty ${i * 10}) → auto-advance to DD${next} pick-from (assert DD${next} header)`, async () => {
-            // Every order here is served from its OWN HU, so the one just picked is never the right
-            // source for the order the app advanced to: the operator must be asked to scan this
-            // order's HU rather than being dropped on the product scan with the previous HU applied.
-            await DistributionLinePickFromScreen.expectHUScanReady();
+            await assertDifferentSourceHUAndHUScanRequested(i);
             await DistributionLinePickFromScreen.scanHUToMove({
                 huQRCode: masterdata.externalBarcodes[i],
                 productScannedCode: masterdata.products[`P${i}`].gtin,
@@ -204,6 +227,9 @@ test('Packing-table operator: orders sorted by priority then locator priority an
     }
 
     await test.step(`Pick DD${N} (scan HU${N} + product P${N}, confirm qty ${N * 10}) → no more orders, return to jobs list`, async () => {
+        // Same screen in the same state as every loop iteration above — the last order is not special
+        // in how it was reached, so it gets the same case-2 assertions.
+        await assertDifferentSourceHUAndHUScanRequested(N);
         await DistributionLinePickFromScreen.scanHUToMove({
             huQRCode: masterdata.externalBarcodes[N],
             productScannedCode: masterdata.products[`P${N}`].gtin,

--- a/e2e/mobile-webui/tests/spec/distribution/scan_HU_barcodes.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/scan_HU_barcodes.spec.js
@@ -22,6 +22,13 @@ const createMasterdata = async ({ externalBarcode } = {}) => {
             mobileConfig: {
                 distribution: {
                     // mobileConfig->distribution entry is important to make sure we get the default distribution config
+                    //
+                    // ...except for allowPickingAnyHU, which the masterdata API does NOT reset when omitted
+                    // (MobileConfigDistributionCommand writes it only when non-null) — it is a sticky, global
+                    // config row that keeps whatever an earlier spec left. This scenario needs it TRUE: the
+                    // line screen's "Scan QR Code" button, which every case below taps, renders only then
+                    // (DistributionLineScreen.jsx). See e2e/mobile-webui/CLAUDE.md § "Debugging Flaky Tests" rule 3.
+                    allowPickingAnyHU: true,
                 }
             },
             resources: {

--- a/e2e/mobile-webui/tests/spec/distribution/sweep_scan_HU_after_autoAdvance_anyHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/sweep_scan_HU_after_autoAdvance_anyHU.spec.js
@@ -1,0 +1,165 @@
+import { test } from "../../../playwright.config";
+import { Backend } from "../../utils/screens/Backend";
+import { allure } from 'allure-playwright';
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { DistributionJobsListScreen } from "../../utils/screens/distribution/DistributionJobsListScreen";
+import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
+import { DistributionLinePickFromScreen } from '../../utils/screens/distribution/DistributionLinePickFromScreen';
+import { DistributionUtils } from '../../utils/screens/distribution/DistributionUtils';
+import { generateEAN13 } from '../../utils/ean13';
+
+//
+// Auto-advance carry-forward, the "pick any HU" case.
+//
+// When a distribution job is fully picked, the app auto-starts the next offered order and jumps
+// straight to its Pick-From screen. Whether the just-scanned source HU is carried forward to that
+// screen (skipping the HU scan) is decided by HU identity — see postDistributionPickFromThunk.js.
+// Three cases:
+//   1. The next order's pre-allocated move plan draws from the SAME physical HU -> carry forward,
+//      the operator only scans the product (covered by sweep_scan_product_after_autoAdvance.spec.js).
+//   2. The next order's plan draws from a DIFFERENT HU -> omit it, the operator re-scans the HU
+//      (covered by packingTable_navigateToNextOrder.spec.js).
+//   3. THIS SPEC: allowPickingAnyHU=true, so the next order has NO pre-allocated move plan at all
+//      (the backend skips createPlan, see DistributionJobCreateCommand) -> the set of the next
+//      order's source HUs is EMPTY, nothing can match, so no HU is carried forward and the operator
+//      lands on the "Scan HU" prompt. Safe default: never assume it is the same HU.
+//
+// The fixture is deliberately IDENTICAL to sweep_scan_product_after_autoAdvance.spec.js — ONE staging
+// LU at a ground locator that every DD order draws from — so the ONLY difference between the two
+// specs is allowPickingAnyHU. That is what makes this test discriminating: with the flag false the
+// very same data lands the operator on the PRODUCT scan (case 1); it is the flag, not the data, that
+// produces the HU scan here. A fixture with a distinct HU per order would land on "Scan HU" too, but
+// via case 2 — i.e. it would prove nothing about case 3.
+//
+// Mobile distribution profile:
+//   navigateToJobsListAfterPickFromComplete: true — auto-advance to the next order after pick-from
+//   requireScanningProductCode: true              — operator must scan the product GTIN
+//   completeJobAutomatically: true                — auto-complete a job once fully moved
+//   allowStartNextJobOnly: true                   — start jobs strictly in offered order
+//   allowPickingAnyHU: true                       — THE case under test: no move plan is built
+//   orderBys: 'Priority, LocatorPriority'         — offer orders sorted by priority, then source-locator priority
+//
+
+const ORDER_COUNT = 3;
+
+// Plenty of qty on the staging LU so every DD order below is a small, partial pick off it.
+const LU_QTY = 1000;
+
+const createMasterdata = async () => {
+    const luExternalBarcode = `EXT-SWEEP-ANYHU-${Date.now()}`;
+
+    // Single-line DD orders: auto-advance only fires once an order is FULLY picked, which a
+    // single-line order reaches in one pick.
+    const distributionOrders = {};
+    for (let i = 1; i <= ORDER_COUNT; i++) {
+        distributionOrders[`DD${i}`] = {
+            seqNo: i * 10,
+            warehouseFrom: "wh",
+            warehouseTo: "wh",
+            warehouseInTransit: "whInTransit",
+            plant: "plantId",
+            lines: [{ product: "P", qtyEntered: i * 10, locatorFrom: "LZ", locatorTo: "packingTable" }],
+        };
+    }
+
+    const masterdata = await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US", workplace: "sweepAnyHUWorkplace" } },
+            mobileConfig: {
+                distribution: {
+                    navigateToJobsListAfterPickFromComplete: true,
+                    completeJobAutomatically: true,
+                    requireScanningProductCode: true,
+                    allowStartNextJobOnly: true,
+                    // THE flag under test. With it true the backend builds no pre-allocated move plan
+                    // for a started order, so the auto-advanced order has no source HU to compare
+                    // against and nothing can be carried forward. It must be set here explicitly for a
+                    // second reason too: it is a sticky, global, unscoped config row
+                    // (MobileConfigDistributionCommand keeps the previous value when omitted, unlike
+                    // its siblings which reset to false), so relying on whatever an earlier spec left
+                    // behind would make this scenario order-dependent.
+                    allowPickingAnyHU: true,
+                    orderBys: 'Priority, LocatorPriority',
+                    // Job-level caption (asserted nowhere here, but kept consistent with the mirror
+                    // spec's convention so the launcher/job header renders a meaningful caption).
+                    captionFormat: 'LocatorFrom,LocatorTo,ProductValueAndName,Qty',
+                },
+            },
+            // The workplace is the packing table: a single warehouse, pick-from = packingTable.
+            workplaces: { sweepAnyHUWorkplace: { warehouse: 'wh', pickFromLocator: 'packingTable' } },
+            resources: { "plantId": { type: "PT" } },
+            products: { "P": { gtin: generateEAN13().ean13 } },
+            warehouses: {
+                "wh": {
+                    locators: {
+                        // The ground locator where the ONE staging LU sits.
+                        LZ: { isGroundLocator: true, priorityNo: 10 },
+                        // The non-ground target every DD order drops to.
+                        packingTable: { isGroundLocator: false, priorityNo: 999 },
+                    },
+                },
+                "whInTransit": { inTransit: true },
+            },
+            handlingUnits: {
+                // The single staging LU, scannable via its external barcode, holding plenty of P.
+                LU: { product: "P", warehouse: "wh", locator: "LZ", qty: LU_QTY, externalBarcode: luExternalBarcode },
+            },
+            distributionOrders,
+        },
+    });
+
+    masterdata.luExternalBarcode = luExternalBarcode;
+    return masterdata;
+};
+
+// noinspection JSUnusedLocalSymbols
+test('Pick-any-HU: after auto-advance, the operator is asked to scan the HU (nothing is carried forward)', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114: MobileUI Distribution');
+    allure.tag('F5114');
+    allure.story('With allowPickingAnyHU, the auto-advanced order has no move plan, so the operator scans the source HU again');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+
+    await test.step('Open the Distribution app, start DD1', async () => {
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('distribution');
+        await DistributionJobsListScreen.waitForScreen();
+        await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+        await DistributionJobScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD1.jobId });
+    });
+
+    await test.step('Pick DD1 off the staging LU (scan the LU + product P, confirm qty 10) → auto-advance to DD2 pick-from', async () => {
+        await DistributionJobScreen.scanHUToMove({
+            huQRCode: masterdata.luExternalBarcode,
+            productScannedCode: masterdata.products.P.gtin,
+            expectedQtyToMove: 10,
+            expectNextScreen: 'DistributionLinePickFromScreen',
+        });
+        await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD2.jobId });
+    });
+
+    // *** THE ASSERTION THIS SPEC EXISTS FOR ***
+    // DD2 has no pre-allocated move plan, so the app cannot know which HU will serve it — not even
+    // though the staging LU the operator just scanned holds plenty of stock for DD2 as well. The
+    // operator is therefore asked to scan the source HU, instead of being dropped on the product scan
+    // with an assumed-but-unverified HU already applied.
+    await test.step('On the auto-advanced DD2: the screen asks for the HU scan (no HU carried forward)', async () => {
+        await DistributionLinePickFromScreen.expectHUScanReady();
+        await DistributionLinePickFromScreen.expectProductScanNotReady();
+    });
+
+    // Anti-false-positive: "Scan HU" is also what the operator gets when the carry-forward's HU
+    // re-resolution merely fails (the thunk's getResolvedHUQR swallows the error and returns null).
+    // Assert DD2 genuinely has no steps, so we know the empty-move-plan branch is the one that ran.
+    await test.step('Backend: DD2 was started WITHOUT a pre-allocated move plan (no steps)', async () => {
+        await DistributionUtils.expectNoPreAllocatedMovePlan({
+            wfProcessId: `distribution-${masterdata.distributionOrders.DD2.jobId}`,
+        });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/distribution/sweep_scan_HU_after_autoAdvance_anyHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/sweep_scan_HU_after_autoAdvance_anyHU.spec.js
@@ -7,7 +7,7 @@ import { DistributionJobsListScreen } from "../../utils/screens/distribution/Dis
 import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
 import { DistributionLinePickFromScreen } from '../../utils/screens/distribution/DistributionLinePickFromScreen';
 import { DistributionUtils } from '../../utils/screens/distribution/DistributionUtils';
-import { generateEAN13 } from '../../utils/ean13';
+import { createSweepMasterdata } from '../../utils/sweepDistributionMasterdata';
 
 //
 // The "sweep" distribution flow when the operator may serve an order from ANY handling unit: small
@@ -16,80 +16,19 @@ import { generateEAN13 } from '../../utils/ean13';
 // the next order will be served from the LU just scanned — so on every auto-advanced order the operator
 // scans the staging LU again, then the product code.
 //
-// The fixture is deliberately field-identical to sweep_scan_product_after_autoAdvance.spec.js apart
-// from the barcode prefix, the workplace key and allowPickingAnyHU: with that flag off, the very same
-// data lands the operator on the PRODUCT scan instead. That contrast is what makes this spec
-// discriminating, so keep the two fixtures in sync. The carry-forward rule itself is owned by
+// The fixture comes from the factory shared with sweep_scan_product_after_autoAdvance.spec.js: with
+// allowPickingAnyHU off, the very same data lands the operator on the PRODUCT scan instead, and that
+// contrast is what makes this spec discriminating. The carry-forward rule itself is owned by
 // postDistributionPickFromThunk.js.
 //
 
-const ORDER_COUNT = 3;
-
-// Plenty of qty on the staging LU so every DD order below is a small, partial pick off it.
-const LU_QTY = 1000;
-
-const createMasterdata = async () => {
-    const luExternalBarcode = `EXT-SWEEP-ANYHU-${Date.now()}`;
-
-    // Single-line DD orders: auto-advance only fires once an order is FULLY picked, which a
-    // single-line order reaches in one pick.
-    const distributionOrders = {};
-    for (let i = 1; i <= ORDER_COUNT; i++) {
-        distributionOrders[`DD${i}`] = {
-            seqNo: i * 10,
-            warehouseFrom: "wh",
-            warehouseTo: "wh",
-            warehouseInTransit: "whInTransit",
-            plant: "plantId",
-            lines: [{ product: "P", qtyEntered: i * 10, locatorFrom: "LZ", locatorTo: "packingTable" }],
-        };
-    }
-
-    const masterdata = await Backend.createMasterdata({
-        language: "en_US",
-        request: {
-            login: { user: { language: "en_US", workplace: "sweepAnyHUWorkplace" } },
-            mobileConfig: {
-                distribution: {
-                    navigateToJobsListAfterPickFromComplete: true,
-                    completeJobAutomatically: true,
-                    requireScanningProductCode: true,
-                    allowStartNextJobOnly: true,
-                    // THE flag under test, and sticky — see e2e/mobile-webui/CLAUDE.md § "Debugging
-                    // Flaky Tests" rule 3: always set, never inherited.
-                    allowPickingAnyHU: true,
-                    orderBys: 'Priority, LocatorPriority',
-                    // Job-level caption (asserted nowhere here, but kept consistent with the mirror
-                    // spec's convention so the launcher/job header renders a meaningful caption).
-                    captionFormat: 'LocatorFrom,LocatorTo,ProductValueAndName,Qty',
-                },
-            },
-            // The workplace is the packing table: a single warehouse, pick-from = packingTable.
-            workplaces: { sweepAnyHUWorkplace: { warehouse: 'wh', pickFromLocator: 'packingTable' } },
-            resources: { "plantId": { type: "PT" } },
-            products: { "P": { gtin: generateEAN13().ean13 } },
-            warehouses: {
-                "wh": {
-                    locators: {
-                        // The ground locator where the ONE staging LU sits.
-                        LZ: { isGroundLocator: true, priorityNo: 10 },
-                        // The non-ground target every DD order drops to.
-                        packingTable: { isGroundLocator: false, priorityNo: 999 },
-                    },
-                },
-                "whInTransit": { inTransit: true },
-            },
-            handlingUnits: {
-                // The single staging LU, scannable via its external barcode, holding plenty of P.
-                LU: { product: "P", warehouse: "wh", locator: "LZ", qty: LU_QTY, externalBarcode: luExternalBarcode },
-            },
-            distributionOrders,
-        },
+const createMasterdata = async () =>
+    await createSweepMasterdata({
+        // THE flag under test.
+        allowPickingAnyHU: true,
+        barcodePrefix: 'EXT-SWEEP-ANYHU',
+        workplaceKey: 'sweepAnyHUWorkplace',
     });
-
-    masterdata.luExternalBarcode = luExternalBarcode;
-    return masterdata;
-};
 
 // noinspection JSUnusedLocalSymbols
 test('Sweep: after auto-advance, the operator scans the staging LU again (it does not carry forward)', async ({ page }) => {

--- a/e2e/mobile-webui/tests/spec/distribution/sweep_scan_HU_after_autoAdvance_anyHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/sweep_scan_HU_after_autoAdvance_anyHU.spec.js
@@ -10,35 +10,17 @@ import { DistributionUtils } from '../../utils/screens/distribution/Distribution
 import { generateEAN13 } from '../../utils/ean13';
 
 //
-// Auto-advance carry-forward, the "pick any HU" case.
+// The "sweep" distribution flow when the operator may serve an order from ANY handling unit: small
+// quantities are picked off ONE staging LU at a ground locator, order after order, as the app
+// auto-advances. Because such an order has no source HU assigned to it up front, the app never assumes
+// the next order will be served from the LU just scanned — so on every auto-advanced order the operator
+// scans the staging LU again, then the product code.
 //
-// When a distribution job is fully picked, the app auto-starts the next offered order and jumps
-// straight to its Pick-From screen. Whether the just-scanned source HU is carried forward to that
-// screen (skipping the HU scan) is decided by HU identity — see postDistributionPickFromThunk.js.
-// Three cases:
-//   1. The next order's pre-allocated move plan draws from the SAME physical HU -> carry forward,
-//      the operator only scans the product (covered by sweep_scan_product_after_autoAdvance.spec.js).
-//   2. The next order's plan draws from a DIFFERENT HU -> omit it, the operator re-scans the HU
-//      (covered by packingTable_navigateToNextOrder.spec.js).
-//   3. THIS SPEC: allowPickingAnyHU=true, so the next order has NO pre-allocated move plan at all
-//      (the backend skips createPlan, see DistributionJobCreateCommand) -> the set of the next
-//      order's source HUs is EMPTY, nothing can match, so no HU is carried forward and the operator
-//      lands on the "Scan HU" prompt. Safe default: never assume it is the same HU.
-//
-// The fixture is deliberately IDENTICAL to sweep_scan_product_after_autoAdvance.spec.js — ONE staging
-// LU at a ground locator that every DD order draws from — so the ONLY difference between the two
-// specs is allowPickingAnyHU. That is what makes this test discriminating: with the flag false the
-// very same data lands the operator on the PRODUCT scan (case 1); it is the flag, not the data, that
-// produces the HU scan here. A fixture with a distinct HU per order would land on "Scan HU" too, but
-// via case 2 — i.e. it would prove nothing about case 3.
-//
-// Mobile distribution profile:
-//   navigateToJobsListAfterPickFromComplete: true — auto-advance to the next order after pick-from
-//   requireScanningProductCode: true              — operator must scan the product GTIN
-//   completeJobAutomatically: true                — auto-complete a job once fully moved
-//   allowStartNextJobOnly: true                   — start jobs strictly in offered order
-//   allowPickingAnyHU: true                       — THE case under test: no move plan is built
-//   orderBys: 'Priority, LocatorPriority'         — offer orders sorted by priority, then source-locator priority
+// The fixture is deliberately field-identical to sweep_scan_product_after_autoAdvance.spec.js apart
+// from the barcode prefix, the workplace key and allowPickingAnyHU: with that flag off, the very same
+// data lands the operator on the PRODUCT scan instead. That contrast is what makes this spec
+// discriminating, so keep the two fixtures in sync. The carry-forward rule itself is owned by
+// postDistributionPickFromThunk.js.
 //
 
 const ORDER_COUNT = 3;
@@ -73,13 +55,8 @@ const createMasterdata = async () => {
                     completeJobAutomatically: true,
                     requireScanningProductCode: true,
                     allowStartNextJobOnly: true,
-                    // THE flag under test. With it true the backend builds no pre-allocated move plan
-                    // for a started order, so the auto-advanced order has no source HU to compare
-                    // against and nothing can be carried forward. It must be set here explicitly for a
-                    // second reason too: it is a sticky, global, unscoped config row
-                    // (MobileConfigDistributionCommand keeps the previous value when omitted, unlike
-                    // its siblings which reset to false), so relying on whatever an earlier spec left
-                    // behind would make this scenario order-dependent.
+                    // THE flag under test, and sticky — see e2e/mobile-webui/CLAUDE.md § "Debugging
+                    // Flaky Tests" rule 3: always set, never inherited.
                     allowPickingAnyHU: true,
                     orderBys: 'Priority, LocatorPriority',
                     // Job-level caption (asserted nowhere here, but kept consistent with the mirror
@@ -115,12 +92,12 @@ const createMasterdata = async () => {
 };
 
 // noinspection JSUnusedLocalSymbols
-test('Pick-any-HU: after auto-advance, the operator is asked to scan the HU (nothing is carried forward)', async ({ page }) => {
+test('Sweep: after auto-advance, the operator scans the staging LU again (it does not carry forward)', async ({ page }) => {
     // === ALLURE METADATA ===
     allure.epic('E0370: Intralogistic (HUs)');
     allure.tag('F5114: MobileUI Distribution');
     allure.tag('F5114');
-    allure.story('With allowPickingAnyHU, the auto-advanced order has no move plan, so the operator scans the source HU again');
+    allure.story('Sweep: when an order may be served from any HU, the operator scans the staging LU again on each auto-advanced order, then the product code');
     allure.severity('critical');
 
     const masterdata = await createMasterdata();
@@ -145,21 +122,47 @@ test('Pick-any-HU: after auto-advance, the operator is asked to scan the HU (not
     });
 
     // *** THE ASSERTION THIS SPEC EXISTS FOR ***
-    // DD2 has no pre-allocated move plan, so the app cannot know which HU will serve it — not even
-    // though the staging LU the operator just scanned holds plenty of stock for DD2 as well. The
-    // operator is therefore asked to scan the source HU, instead of being dropped on the product scan
-    // with an assumed-but-unverified HU already applied.
-    await test.step('On the auto-advanced DD2: the screen asks for the HU scan (no HU carried forward)', async () => {
+    // No HU is assigned to DD2, so the app cannot know which one will serve it — not even though the
+    // staging LU the operator just scanned holds plenty of stock for DD2 as well. The operator is
+    // therefore asked to scan the source HU, instead of being dropped on the product scan with an
+    // assumed-but-unverified HU already applied.
+    await test.step('On the auto-advanced DD2: the screen asks for the HU scan', async () => {
         await DistributionLinePickFromScreen.expectHUScanReady();
-        await DistributionLinePickFromScreen.expectProductScanNotReady();
     });
 
-    // Anti-false-positive: "Scan HU" is also what the operator gets when the carry-forward's HU
-    // re-resolution merely fails (the thunk's getResolvedHUQR swallows the error and returns null).
-    // Assert DD2 genuinely has no steps, so we know the empty-move-plan branch is the one that ran.
-    await test.step('Backend: DD2 was started WITHOUT a pre-allocated move plan (no steps)', async () => {
-        await DistributionUtils.expectNoPreAllocatedMovePlan({
+    // The screen alone cannot show WHY it asks: an app that had simply failed to recognise the LU just
+    // picked from would land the operator on exactly the same prompt. The two checks below rule that
+    // look-alike out — one on the app's own diagnostics, one on the job the backend actually built.
+    await test.step('Diagnostic: the HU scan is not the fallback of a failed HU lookup', async () => {
+        await DistributionLinePickFromScreen.expectHUScanNotCausedByFailedHULookup();
+    });
+
+    await test.step('Backend: DD2 was started in pick-any-HU mode, without a pre-allocated move plan', async () => {
+        await DistributionUtils.expectPickAnyHUJobWithoutMovePlan({
             wfProcessId: `distribution-${masterdata.distributionOrders.DD2.jobId}`,
+        });
+    });
+
+    await test.step('Scan the staging LU + product P for DD2 (confirm qty 20) → auto-advance to DD3, asking for the HU again', async () => {
+        await DistributionLinePickFromScreen.scanHUToMove({
+            huQRCode: masterdata.luExternalBarcode,
+            productScannedCode: masterdata.products.P.gtin,
+            expectedQtyToMove: 20,
+            expectNextScreen: 'DistributionLinePickFromScreen',
+        });
+        await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD3.jobId });
+        await DistributionLinePickFromScreen.expectHUScanReady();
+    });
+
+    await test.step('Backend: the DD2 pick landed (the moved qty of P is on the split-off HU)', async () => {
+        const pickedHUQRCode = await DistributionUtils.getPickedHUQRCode({
+            wfProcessId: `distribution-${masterdata.distributionOrders.DD2.jobId}`,
+        });
+        await Backend.expect({
+            title: 'DD2 pick landed',
+            hus: {
+                [pickedHUQRCode]: { huStatus: 'A', warehouse: 'whInTransit', storages: { P: '20 PCE' } },
+            },
         });
     });
 });

--- a/e2e/mobile-webui/tests/spec/distribution/sweep_scan_HU_after_autoAdvance_anyHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/sweep_scan_HU_after_autoAdvance_anyHU.spec.js
@@ -70,8 +70,11 @@ test('Sweep: after auto-advance, the operator scans the staging LU again (it doe
     });
 
     // The screen alone cannot show WHY it asks: an app that had simply failed to recognise the LU just
-    // picked from would land the operator on exactly the same prompt. The two checks below rule that
-    // look-alike out — one on the app's own diagnostics, one on the job the backend actually built.
+    // picked from would land the operator on exactly the same prompt. Only the FIRST of the two checks
+    // below rules that look-alike out — the app's own diagnostics, the one observable that actually
+    // differs between the two paths. The second is a PRECONDITION check: DD2's configuration is fixed at
+    // job-creation time and identical either way, so it cannot say which path ran; what it does buy is
+    // that the scenario cannot silently degrade into covering a differently-configured job.
     await test.step('Diagnostic: the HU scan is not the fallback of a failed HU lookup', async () => {
         await DistributionLinePickFromScreen.expectHUScanNotCausedByFailedHULookup();
     });

--- a/e2e/mobile-webui/tests/spec/distribution/sweep_scan_product_after_autoAdvance.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/sweep_scan_product_after_autoAdvance.spec.js
@@ -7,7 +7,7 @@ import { DistributionJobsListScreen } from "../../utils/screens/distribution/Dis
 import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
 import { DistributionLinePickFromScreen } from '../../utils/screens/distribution/DistributionLinePickFromScreen';
 import { DistributionUtils } from '../../utils/screens/distribution/DistributionUtils';
-import { generateEAN13 } from '../../utils/ean13';
+import { createSweepMasterdata } from '../../utils/sweepDistributionMasterdata';
 
 //
 // The "sweep" distribution flow: an operator scans ONE staging LU (a large HU sitting at a ground
@@ -17,84 +17,19 @@ import { generateEAN13 } from '../../utils/ean13';
 // single staging LU/product shared by all orders (instead of one dedicated HU per order), because
 // that is what exercises the auto-advance carrying the scanned HU forward to the next order.
 //
-// Mobile distribution profile (same as the mirror spec):
-//   navigateToJobsListAfterPickFromComplete: true — auto-advance to the next order after pick-from
-//   requireScanningProductCode: true              — operator must scan the product GTIN
-//   completeJobAutomatically: true                — auto-complete a job once fully moved
-//   allowStartNextJobOnly: true                   — start jobs strictly in offered order
-//   orderBys: 'Priority, LocatorPriority'         — offer orders sorted by priority, then source-locator priority
+// The fixture is built by the factory shared with sweep_scan_HU_after_autoAdvance_anyHU.spec.js, so
+// the two scenarios provably differ in allowPickingAnyHU alone — see sweepDistributionMasterdata.js
+// for the profile and why that identity matters.
 //
 
-const ORDER_COUNT = 3;
-
-// Plenty of qty on the staging LU so every DD order below is a small, partial pick off it.
-const LU_QTY = 1000;
-
-const createMasterdata = async () => {
-    const luExternalBarcode = `EXT-SWEEP-${Date.now()}`;
-
-    const distributionOrders = {};
-    for (let i = 1; i <= ORDER_COUNT; i++) {
-        distributionOrders[`DD${i}`] = {
-            seqNo: i * 10,
-            warehouseFrom: "wh",
-            warehouseTo: "wh",
-            warehouseInTransit: "whInTransit",
-            plant: "plantId",
-            lines: [{ product: "P", qtyEntered: i * 10, locatorFrom: "LZ", locatorTo: "packingTable" }],
-        };
-    }
-
-    const masterdata = await Backend.createMasterdata({
-        language: "en_US",
-        request: {
-            login: { user: { language: "en_US", workplace: "sweepWorkplace" } },
-            mobileConfig: {
-                distribution: {
-                    navigateToJobsListAfterPickFromComplete: true,
-                    completeJobAutomatically: true,
-                    requireScanningProductCode: true,
-                    allowStartNextJobOnly: true,
-                    // Explicit (not the request-level default): this scenario's whole premise is a
-                    // pre-allocated move plan carrying a FIXED source HU per step (see
-                    // DistributionJobCreateCommand), which the backend only builds when this is
-                    // false. Unlike the other flags above, allowPickingAnyHU is NOT reset to a
-                    // request-level default when omitted (MobileConfigDistributionCommand keeps the
-                    // previous value) — a global, unscoped config row — so this must be set here to
-                    // keep the scenario deterministic regardless of what an earlier test left behind.
-                    allowPickingAnyHU: false,
-                    orderBys: 'Priority, LocatorPriority',
-                    // Job-level caption (asserted nowhere here, but kept consistent with the mirror
-                    // spec's convention so the launcher/job header renders a meaningful caption).
-                    captionFormat: 'LocatorFrom,LocatorTo,ProductValueAndName,Qty',
-                },
-            },
-            // The workplace is the packing table: a single warehouse, pick-from = packingTable.
-            workplaces: { sweepWorkplace: { warehouse: 'wh', pickFromLocator: 'packingTable' } },
-            resources: { "plantId": { type: "PT" } },
-            products: { "P": { gtin: generateEAN13().ean13 } },
-            warehouses: {
-                "wh": {
-                    locators: {
-                        // The ground locator where the ONE staging LU sits.
-                        LZ: { isGroundLocator: true, priorityNo: 10 },
-                        // The non-ground target every DD order drops to.
-                        packingTable: { isGroundLocator: false, priorityNo: 999 },
-                    },
-                },
-                "whInTransit": { inTransit: true },
-            },
-            handlingUnits: {
-                // The single staging LU, scannable via its external barcode, holding plenty of P.
-                LU: { product: "P", warehouse: "wh", locator: "LZ", qty: LU_QTY, externalBarcode: luExternalBarcode },
-            },
-            distributionOrders,
-        },
+const createMasterdata = async () =>
+    await createSweepMasterdata({
+        // This scenario's whole premise is a pre-allocated move plan carrying a FIXED source HU per
+        // step (see DistributionJobCreateCommand), which the backend only builds when this is false.
+        allowPickingAnyHU: false,
+        barcodePrefix: 'EXT-SWEEP',
+        workplaceKey: 'sweepWorkplace',
     });
-
-    masterdata.luExternalBarcode = luExternalBarcode;
-    return masterdata;
-};
 
 // noinspection JSUnusedLocalSymbols
 test('Sweep: after auto-advance, the operator scans only the product code (the staging LU carries forward)', async ({ page }) => {

--- a/e2e/mobile-webui/tests/utils/common.js
+++ b/e2e/mobile-webui/tests/utils/common.js
@@ -16,22 +16,46 @@ export const ID_BACK_BUTTON = '#Back-button';
 
 export let page = null;
 
-// Every browser console message of the CURRENT test, in order.
-// Some app code paths are invisible on screen but log a diagnostic before falling back to a state that
-// looks exactly like the normal one; the logged line is then the only observable that tells the two
-// apart (see DistributionLinePickFromScreen.expectHUScanNotCausedByFailedHULookup). Recording is armed
-// with the page fixture, so no spec has to set anything up and a normal run pays no timing cost.
-let consoleMessages = [];
+// Browser-console recording. Some app code paths are invisible on screen but log a diagnostic before
+// falling back to a state that looks exactly like the normal one; the logged line is then the only
+// observable that tells the two apart (see
+// DistributionLinePickFromScreen.expectHUScanNotCausedByFailedHULookup). Recording is armed with the
+// page fixture, so no spec has to set anything up and a normal run pays no timing cost.
+//
+// Cap on the messages one test keeps, so a chatty page cannot grow the buffer without bound. Anything
+// past the cap is counted, not kept — see expectNoConsoleMessageMatching for why the count matters.
 const MAX_RECORDED_CONSOLE_MESSAGES = 5000;
 
-export const setCurrentPage = (currentPage) => {
-    page = currentPage;
-    consoleMessages = [];
-    currentPage.on('console', (message) => {
-        if (consoleMessages.length < MAX_RECORDED_CONSOLE_MESSAGES) {
-            consoleMessages.push(`${message.type()}: ${message.text()}`);
+// The recorder of the CURRENT test, or null before the page fixture armed one.
+let consoleRecorder = null;
+
+// Each recorder owns its OWN buffer and counters, closed over by its handler — never a module-level
+// binding. A handler that closed over the *binding* would keep writing into whatever buffer is current,
+// so a page still emitting after the next test started would pollute that test's buffer and produce a
+// RED attributed to the wrong test.
+const startConsoleRecorder = (currentPage) => {
+    const messages = [];
+    let droppedMessageCount = 0;
+    const handler = (message) => {
+        if (messages.length < MAX_RECORDED_CONSOLE_MESSAGES) {
+            messages.push(`${message.type()}: ${message.text()}`);
+        } else {
+            droppedMessageCount++;
         }
-    });
+    };
+    currentPage.on('console', handler);
+    return {
+        messages,
+        getDroppedMessageCount: () => droppedMessageCount,
+        stop: () => currentPage.off('console', handler),
+    };
+};
+
+export const setCurrentPage = (currentPage) => {
+    // Stop the previous test's recorder so its page cannot go on feeding a listener we no longer read.
+    consoleRecorder?.stop();
+    page = currentPage;
+    consoleRecorder = startConsoleRecorder(currentPage);
 }
 
 /**
@@ -40,7 +64,17 @@ export const setCurrentPage = (currentPage) => {
  * have already awaited (otherwise it can pass simply because the log has not happened yet).
  */
 export const expectNoConsoleMessageMatching = ({ pattern, because }) => {
-    expect(consoleMessages.filter((message) => pattern.test(message)), because).toEqual([]);
+    // A NEGATIVE assertion must never pass by omission. Two ways this one could:
+    //  - no recorder armed at all (the page fixture did not run) -> the buffer is trivially empty;
+    //  - the recorder hit its cap -> a matching message may have been dropped rather than never logged.
+    expect(consoleRecorder, 'no console recorder is armed, so the absence of a message proves nothing').not.toBeNull();
+    expect(
+        consoleRecorder.getDroppedMessageCount(),
+        `the console recorder hit its ${MAX_RECORDED_CONSOLE_MESSAGES}-message cap, so a matching message may have been`
+        + ` dropped rather than never logged - the absence assertion below would be vacuous`
+    ).toEqual(0);
+
+    expect(consoleRecorder.messages.filter((message) => pattern.test(message)), because).toEqual([]);
 };
 
 export const step = async (title, func) => await test.step(title, async () => await runAndWatchForErrors(func));

--- a/e2e/mobile-webui/tests/utils/common.js
+++ b/e2e/mobile-webui/tests/utils/common.js
@@ -1,4 +1,5 @@
 import { test } from '../../playwright.config';
+import { expect } from '@playwright/test';
 import { ErrorScreen } from './screens/ErrorScreen';
 import { ErrorToast } from './dialogs/ErrorToast';
 
@@ -15,9 +16,32 @@ export const ID_BACK_BUTTON = '#Back-button';
 
 export let page = null;
 
+// Every browser console message of the CURRENT test, in order.
+// Some app code paths are invisible on screen but log a diagnostic before falling back to a state that
+// looks exactly like the normal one; the logged line is then the only observable that tells the two
+// apart (see DistributionLinePickFromScreen.expectHUScanNotCausedByFailedHULookup). Recording is armed
+// with the page fixture, so no spec has to set anything up and a normal run pays no timing cost.
+let consoleMessages = [];
+const MAX_RECORDED_CONSOLE_MESSAGES = 5000;
+
 export const setCurrentPage = (currentPage) => {
     page = currentPage;
+    consoleMessages = [];
+    currentPage.on('console', (message) => {
+        if (consoleMessages.length < MAX_RECORDED_CONSOLE_MESSAGES) {
+            consoleMessages.push(`${message.type()}: ${message.text()}`);
+        }
+    });
 }
+
+/**
+ * Assert the app did NOT log a console message matching `pattern` so far in this test.
+ * Not a polling assertion: use it only for a message the app would have logged *before* a state you
+ * have already awaited (otherwise it can pass simply because the log has not happened yet).
+ */
+export const expectNoConsoleMessageMatching = ({ pattern, because }) => {
+    expect(consoleMessages.filter((message) => pattern.test(message)), because).toEqual([]);
+};
 
 export const step = async (title, func) => await test.step(title, async () => await runAndWatchForErrors(func));
 

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLinePickFromScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLinePickFromScreen.js
@@ -1,6 +1,12 @@
 import { test } from '../../../../playwright.config';
 import { expect } from '@playwright/test';
-import { FAST_ACTION_TIMEOUT, ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from '../../common';
+import {
+    expectNoConsoleMessageMatching,
+    FAST_ACTION_TIMEOUT,
+    ID_BACK_BUTTON,
+    page,
+    SLOW_ACTION_TIMEOUT,
+} from '../../common';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
 import { GetQuantityDialog } from '../picking/GetQuantityDialog';
 import { DistributionUtils } from './DistributionUtils';
@@ -43,27 +49,29 @@ export const DistributionLinePickFromScreen = {
             await expect(page.getByTestId('scanProductCode-input')).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
         }),
 
-        // Mirror image of expectProductScanReady: the screen renders EXACTLY ONE of "Scan HU" /
-        // "Scan product", so asserting the HU-scan input is `visible` also proves the product-scan
-        // input is NOT the one showing. Used to guard the auto-advance case where the next order has
-        // NO pre-allocated move plan (allowPickingAnyHU=true): the operator must be asked to scan the
-        // source HU, because the app cannot know which HU the next order will be served from.
-        expectHUScanReady: async () => await test.step(`${NAME} - Expect ready for HU scan (nothing carried forward, operator must scan the source HU)`, async () => {
+        // Mirror image of expectProductScanReady: the operator is asked to (re-)scan the source HU
+        // because the app has no HU to work from yet. The product-scan input must be gone; that is
+        // asserted here rather than in a separate method because the check is only meaningful AFTER
+        // the HU input is visible — while the component is still uninitialised it renders neither
+        // input, so an isolated toHaveCount(0) would pass vacuously. FAST timeout: at that point the
+        // product input can only be absent, so a slow one would just burn budget on a real failure.
+        expectHUScanReady: async () => await test.step(`${NAME} - Expect ready for HU scan (operator must scan the source HU)`, async () => {
             await DistributionLinePickFromScreen.waitForScreen();
             await expect(page.getByTestId('scanHUBarcode-input')).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+            await expect(page.getByTestId('scanProductCode-input')).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
         }),
 
-        // Explicit negative companion to expectHUScanReady. The mutual exclusion is implied by the
-        // component's progressStatus switch, but stating it costs one fast assertion and makes the
-        // failure mode obvious if that switch is ever turned into overlapping panels. FAST timeout:
-        // by the time this runs the HU-scan input is already visible, so the product input can only
-        // be absent — a slow timeout here would just burn budget on a genuine failure.
-        expectProductScanNotReady: async () => await test.step(`${NAME} - Expect NOT ready for product scan`, async () => {
-            // waitForScreen first, like every other assertion in this file: without it a caller that
-            // does NOT pair this with expectHUScanReady would happily "pass" against a screen that
-            // never rendered at all (absent input == count 0).
+        // Of the two causes for landing on "Scan HU" after an auto-advance, only the failed-HU-lookup
+        // fallback logs this warning; on screen the two are identical. Sound to assert without polling:
+        // the app awaits that lookup before it navigates, so once this screen is up the warning has
+        // either been logged already or never will be.
+        expectHUScanNotCausedByFailedHULookup: async () => await test.step(`${NAME} - Expect the HU scan is not the fallback of a failed HU lookup`, async () => {
             await DistributionLinePickFromScreen.waitForScreen();
-            await expect(page.getByTestId('scanProductCode-input')).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
+            expectNoConsoleMessageMatching({
+                pattern: /Failed to resolve scanned HU QR for auto-advance carry-forward/,
+                because: 'the auto-advance asked for the HU again because it could NOT re-resolve the just-picked HU'
+                    + ' — not because the next order has no source HU of its own',
+            });
         }),
 
         scanHUToMove: async ({ huQRCode, productScannedCode, expectQuantityDialog = true, expectedQtyToMove, expectNextScreen }) => await test.step(`${NAME} - Scan HU to move`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLinePickFromScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLinePickFromScreen.js
@@ -1,6 +1,6 @@
 import { test } from '../../../../playwright.config';
 import { expect } from '@playwright/test';
-import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from '../../common';
+import { FAST_ACTION_TIMEOUT, ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from '../../common';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
 import { GetQuantityDialog } from '../picking/GetQuantityDialog';
 import { DistributionUtils } from './DistributionUtils';
@@ -41,6 +41,29 @@ export const DistributionLinePickFromScreen = {
         expectProductScanReady: async () => await test.step(`${NAME} - Expect ready for PRODUCT scan (HU carried forward, no re-scan needed)`, async () => {
             await DistributionLinePickFromScreen.waitForScreen();
             await expect(page.getByTestId('scanProductCode-input')).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+        }),
+
+        // Mirror image of expectProductScanReady: the screen renders EXACTLY ONE of "Scan HU" /
+        // "Scan product", so asserting the HU-scan input is `visible` also proves the product-scan
+        // input is NOT the one showing. Used to guard the auto-advance case where the next order has
+        // NO pre-allocated move plan (allowPickingAnyHU=true): the operator must be asked to scan the
+        // source HU, because the app cannot know which HU the next order will be served from.
+        expectHUScanReady: async () => await test.step(`${NAME} - Expect ready for HU scan (nothing carried forward, operator must scan the source HU)`, async () => {
+            await DistributionLinePickFromScreen.waitForScreen();
+            await expect(page.getByTestId('scanHUBarcode-input')).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+        }),
+
+        // Explicit negative companion to expectHUScanReady. The mutual exclusion is implied by the
+        // component's progressStatus switch, but stating it costs one fast assertion and makes the
+        // failure mode obvious if that switch is ever turned into overlapping panels. FAST timeout:
+        // by the time this runs the HU-scan input is already visible, so the product input can only
+        // be absent — a slow timeout here would just burn budget on a genuine failure.
+        expectProductScanNotReady: async () => await test.step(`${NAME} - Expect NOT ready for product scan`, async () => {
+            // waitForScreen first, like every other assertion in this file: without it a caller that
+            // does NOT pair this with expectHUScanReady would happily "pass" against a screen that
+            // never rendered at all (absent input == count 0).
+            await DistributionLinePickFromScreen.waitForScreen();
+            await expect(page.getByTestId('scanProductCode-input')).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
         }),
 
         scanHUToMove: async ({ huQRCode, productScannedCode, expectQuantityDialog = true, expectedQtyToMove, expectNextScreen }) => await test.step(`${NAME} - Scan HU to move`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionUtils.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionUtils.js
@@ -44,8 +44,7 @@ export const DistributionUtils = {
      */
     getPickedHUQRCode: async ({ wfProcessId, lineId }) => await test.step(`Backend: get distribution picked HU QR code for wfProcess "${wfProcessId}"${lineId != null ? ` line "${lineId}"` : ''}`, async () => {
         const wfProcess = await Backend.getWFProcess({ wfProcessId });
-        const moveActivity = wfProcess.activities?.find((activity) => activity.componentProps?.job?.lines != null);
-        const lines = moveActivity?.componentProps?.job?.lines ?? [];
+        const lines = getJobLines({ wfProcess });
 
         let line;
         if (lineId != null) {
@@ -73,4 +72,35 @@ export const DistributionUtils = {
         }
         return qrCode;
     }),
+
+    /**
+     * Assert the given distribution job carries NO pre-allocated move plan: it has lines, but not a
+     * single step. That is exactly what the backend builds when allowPickingAnyHU=true
+     * (DistributionJobCreateCommand skips createPlan), so there is no fixed source HU per step and the
+     * operator is free to serve the order from any HU.
+     *
+     * Why an E2E asserts this and not just the screen: after an auto-advance, landing on the "Scan HU"
+     * prompt is ALSO what happens when the carry-forward's HU re-resolution merely FAILS
+     * (postDistributionPickFromThunk's getResolvedHUQR swallows the error and returns null, whose safe
+     * default is likewise "Scan HU"). Proving the next job genuinely has no steps is what distinguishes
+     * "the empty-move-plan branch was taken" from that look-alike failure path.
+     */
+    expectNoPreAllocatedMovePlan: async ({ wfProcessId }) => await test.step(`Backend: expect NO pre-allocated move plan (no steps) for wfProcess "${wfProcessId}"`, async () => {
+        const wfProcess = await Backend.getWFProcess({ wfProcessId });
+        const lines = getJobLines({ wfProcess });
+
+        // Guard against a vacuous pass: if the response shape ever changes and the traversal finds no
+        // lines at all, "no steps" would be trivially true and the assertion below would prove nothing.
+        expect(lines.length, `wfProcess "${wfProcessId}" has no distribution lines:\n` + JSON.stringify(wfProcess, null, 2)).toBeGreaterThan(0);
+
+        const steps = lines.flatMap((line) => line.steps ?? []);
+        expect(steps, `wfProcess "${wfProcessId}" was expected to have NO pre-allocated steps`).toEqual([]);
+    }),
+};
+
+// The distribution job's lines, read off the wfProcess JSON's move activity (the one activity that
+// carries `componentProps.job.lines`).
+const getJobLines = ({ wfProcess }) => {
+    const moveActivity = wfProcess.activities?.find((activity) => activity.componentProps?.job?.lines != null);
+    return moveActivity?.componentProps?.job?.lines ?? [];
 };

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionUtils.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionUtils.js
@@ -74,6 +74,28 @@ export const DistributionUtils = {
     }),
 
     /**
+     * Assert the source HUs of the given distribution job's pre-allocated move plan are EXACTLY
+     * `expectedHUQRCodes` (order-insensitive, one entry per step across all lines).
+     *
+     * The complement of expectPickAnyHUJobWithoutMovePlan below, and the check that makes the
+     * auto-advance "different source HU" case (postDistributionPickFromThunk case 2) literal: it pins
+     * BOTH that a plan exists at all — a job started with allowPickingAnyHU on has none, which is the
+     * look-alike that lands the operator on the same Scan-HU prompt for a different reason — and that
+     * the plan draws from this order's OWN HU, not from the one the operator just picked.
+     */
+    expectMovePlanSourceHUs: async ({ wfProcessId, expectedHUQRCodes }) => await test.step(`Backend: expect the move plan of wfProcess "${wfProcessId}" to draw from exactly ${JSON.stringify(expectedHUQRCodes)}`, async () => {
+        const wfProcess = await Backend.getWFProcess({ wfProcessId });
+        const lines = getJobLines({ wfProcess });
+        const steps = lines.flatMap((line) => line.steps ?? []);
+
+        expect(
+            steps.map((step) => step.pickFromHU?.qrCode?.code).sort(),
+            `the pre-allocated move plan of wfProcess "${wfProcessId}" was expected to draw from exactly the listed HUs:\n`
+            + JSON.stringify(lines, null, 2)
+        ).toEqual([...expectedHUQRCodes].sort());
+    }),
+
+    /**
      * Assert the given distribution job is in "pick any HU" mode AND carries no pre-allocated move
      * plan: every line reports allowPickingAnyHU, and there is not a single step.
      *

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionUtils.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionUtils.js
@@ -74,24 +74,25 @@ export const DistributionUtils = {
     }),
 
     /**
-     * Assert the given distribution job carries NO pre-allocated move plan: it has lines, but not a
-     * single step. That is exactly what the backend builds when allowPickingAnyHU=true
-     * (DistributionJobCreateCommand skips createPlan), so there is no fixed source HU per step and the
-     * operator is free to serve the order from any HU.
+     * Assert the given distribution job is in "pick any HU" mode AND carries no pre-allocated move
+     * plan: every line reports allowPickingAnyHU, and there is not a single step.
      *
-     * Why an E2E asserts this and not just the screen: after an auto-advance, landing on the "Scan HU"
-     * prompt is ALSO what happens when the carry-forward's HU re-resolution merely FAILS
-     * (postDistributionPickFromThunk's getResolvedHUQR swallows the error and returns null, whose safe
-     * default is likewise "Scan HU"). Proving the next job genuinely has no steps is what distinguishes
-     * "the empty-move-plan branch was taken" from that look-alike failure path.
+     * A PRECONDITION check — it pins the state a scenario needs before it can mean anything, so the
+     * scenario cannot silently degrade into covering a differently-configured job and still pass. It
+     * says nothing about which path the app then took.
      */
-    expectNoPreAllocatedMovePlan: async ({ wfProcessId }) => await test.step(`Backend: expect NO pre-allocated move plan (no steps) for wfProcess "${wfProcessId}"`, async () => {
+    expectPickAnyHUJobWithoutMovePlan: async ({ wfProcessId }) => await test.step(`Backend: expect a pick-any-HU job with NO pre-allocated move plan (no steps) for wfProcess "${wfProcessId}"`, async () => {
         const wfProcess = await Backend.getWFProcess({ wfProcessId });
         const lines = getJobLines({ wfProcess });
 
         // Guard against a vacuous pass: if the response shape ever changes and the traversal finds no
-        // lines at all, "no steps" would be trivially true and the assertion below would prove nothing.
+        // lines at all, both assertions below would be trivially true and would prove nothing.
         expect(lines.length, `wfProcess "${wfProcessId}" has no distribution lines:\n` + JSON.stringify(wfProcess, null, 2)).toBeGreaterThan(0);
+
+        expect(
+            lines.map((line) => line.allowPickingAnyHU),
+            `every line of wfProcess "${wfProcessId}" was expected to report allowPickingAnyHU=true:\n` + JSON.stringify(lines, null, 2)
+        ).toEqual(lines.map(() => true));
 
         const steps = lines.flatMap((line) => line.steps ?? []);
         expect(steps, `wfProcess "${wfProcessId}" was expected to have NO pre-allocated steps`).toEqual([]);

--- a/e2e/mobile-webui/tests/utils/sweepDistributionMasterdata.js
+++ b/e2e/mobile-webui/tests/utils/sweepDistributionMasterdata.js
@@ -1,0 +1,91 @@
+import { Backend } from './screens/Backend';
+import { generateEAN13 } from './ean13';
+
+//
+// The fixture shared by the two "sweep" distribution specs:
+//   - sweep_scan_product_after_autoAdvance.spec.js       (allowPickingAnyHU: false)
+//   - sweep_scan_HU_after_autoAdvance_anyHU.spec.js      (allowPickingAnyHU: true)
+//
+// ONE staging LU at a ground locator, feeding every DD order. The two specs must differ in NOTHING
+// but allowPickingAnyHU (plus the per-spec barcode prefix and workplace key, which only keep their
+// data apart): that is exactly what makes each of them discriminating — with the same data, the flag
+// alone decides whether the operator lands on the PRODUCT scan or back on the HU scan after an
+// auto-advance. Both therefore build their masterdata HERE, so the identity is structural instead of
+// two ~60-line copies asked by a comment to stay in sync.
+//
+// The auto-advance carry-forward rule itself is owned by postDistributionPickFromThunk.js.
+//
+
+// Single-line DD orders: auto-advance only fires once an order is FULLY picked, which a single-line
+// order reaches in one pick. Both specs reference DD1..DD3 by name, so this is not a free knob.
+const SWEEP_ORDER_COUNT = 3;
+
+// Plenty of qty on the staging LU so every DD order is a small, partial pick off it.
+const LU_QTY = 1000;
+
+/**
+ * @param allowPickingAnyHU THE variable under test — the ONLY behavioural difference between the two
+ *        sweep specs. Always passed explicitly: it is a sticky, global config row that the masterdata
+ *        API leaves untouched when omitted (see e2e/mobile-webui/CLAUDE.md § "Debugging Flaky Tests"
+ *        rule 3).
+ * @param barcodePrefix per-spec prefix of the staging LU's external barcode.
+ * @param workplaceKey per-spec workplace name.
+ */
+export const createSweepMasterdata = async ({ allowPickingAnyHU, barcodePrefix, workplaceKey }) => {
+    const luExternalBarcode = `${barcodePrefix}-${Date.now()}`;
+
+    const distributionOrders = {};
+    for (let i = 1; i <= SWEEP_ORDER_COUNT; i++) {
+        distributionOrders[`DD${i}`] = {
+            seqNo: i * 10,
+            warehouseFrom: "wh",
+            warehouseTo: "wh",
+            warehouseInTransit: "whInTransit",
+            plant: "plantId",
+            lines: [{ product: "P", qtyEntered: i * 10, locatorFrom: "LZ", locatorTo: "packingTable" }],
+        };
+    }
+
+    const masterdata = await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US", workplace: workplaceKey } },
+            mobileConfig: {
+                distribution: {
+                    navigateToJobsListAfterPickFromComplete: true,
+                    completeJobAutomatically: true,
+                    requireScanningProductCode: true,
+                    allowStartNextJobOnly: true,
+                    allowPickingAnyHU,
+                    orderBys: 'Priority, LocatorPriority',
+                    // Job-level caption: asserted by neither sweep spec, but it makes the launcher/job
+                    // header render a meaningful caption on the recordings.
+                    captionFormat: 'LocatorFrom,LocatorTo,ProductValueAndName,Qty',
+                },
+            },
+            // The workplace is the packing table: a single warehouse, pick-from = packingTable.
+            workplaces: { [workplaceKey]: { warehouse: 'wh', pickFromLocator: 'packingTable' } },
+            resources: { "plantId": { type: "PT" } },
+            products: { "P": { gtin: generateEAN13().ean13 } },
+            warehouses: {
+                "wh": {
+                    locators: {
+                        // The ground locator where the ONE staging LU sits.
+                        LZ: { isGroundLocator: true, priorityNo: 10 },
+                        // The non-ground target every DD order drops to.
+                        packingTable: { isGroundLocator: false, priorityNo: 999 },
+                    },
+                },
+                "whInTransit": { inTransit: true },
+            },
+            handlingUnits: {
+                // The single staging LU, scannable via its external barcode, holding plenty of P.
+                LU: { product: "P", warehouse: "wh", locator: "LZ", qty: LU_QTY, externalBarcode: luExternalBarcode },
+            },
+            distributionOrders,
+        },
+    });
+
+    masterdata.luExternalBarcode = luExternalBarcode;
+    return masterdata;
+};

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/distribution/redux/postDistributionPickFromThunk.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/distribution/redux/postDistributionPickFromThunk.js
@@ -41,9 +41,9 @@ export const postDistributionPickFromThunk =
           // Carry the just-picked source HU's QR code forward to the next order's Pick-From screen
           // ONLY when the next order's pre-allocated move plan draws from that SAME physical HU —
           // never unconditionally (an earlier fix carried it forward unconditionally and regressed
-          // packingTable_navigateToNextOrder + navigateToJobsListAfterPickFromComplete, where the
-          // next order's source HU is a DIFFERENT one even when it shares the source locator). Three
-          // cases, decided by HU identity (not locator):
+          // packingTable_navigateToNextOrder + navigateToJobsListAfterPickFromComplete, where the HU
+          // the operator must scan next is a DIFFERENT physical one even when it shares the source
+          // locator). Three cases, decided by HU identity (not locator):
           //  1. Same source HU (the "sweep" flow: one staging LU feeding several orders) -> carry
           //     forward, landing the operator directly on the product-scan step.
           //  2. A different source HU (distinct HU per order, even sharing a locator) -> omit
@@ -94,6 +94,12 @@ const getResolvedHUQR = async ({ scannedCode }) => {
     const { qrCode } = await getDistributionScannedHUQRCodeInfo({ qrCode: toQRCodeString(scannedCode) });
     return toQRCodeString(qrCode);
   } catch (e) {
+    // NOTE to dev: keep this message in sync with
+    // e2e/mobile-webui/tests/utils/screens/distribution/DistributionLinePickFromScreen.js
+    // -> expectHUScanNotCausedByFailedHULookup, which greps for it. On screen this fallback is
+    // indistinguishable from the no-move-plan case, so that grep is the ONLY thing telling the two
+    // apart in sweep_scan_HU_after_autoAdvance_anyHU.spec.js. Reword it and the assertion goes
+    // vacuously green.
     console.warn('Failed to resolve scanned HU QR for auto-advance carry-forward; defaulting to Scan-HU', e);
     return null; // unresolvable -> no match below -> safe default (Scan-HU)
   }


### PR DESCRIPTION
Follow-up coverage split out of the bugfix PR https://github.com/metasfresh/metasfresh/pull/25328, as agreed (same underlying report, separate PR).

## What

`postDistributionPickFromThunk` documents three branches for carrying the just-picked source HU forward to the auto-advanced next order. This PR covers the third — and makes the second one real.

| Case | Condition | Operator lands on | Covered by |
|---|---|---|---|
| 1 | Next order's move plan draws from the **same** HU | product scan | `sweep_scan_product_after_autoAdvance.spec.js` |
| 2 | Next order's move plan draws from a **different** HU | Scan-HU | `packingTable_navigateToNextOrder.spec.js` (fixed here — see below) |
| 3 | `allowPickingAnyHU=true` → next order has **no move plan at all** | Scan-HU | `sweep_scan_HU_after_autoAdvance_anyHU.spec.js` (new) |

With `allowPickingAnyHU=true` the backend skips `createPlan` (`DistributionJobCreateCommand`), so the auto-advanced order has no source HU to compare against, nothing can be carried forward, and the operator is asked to scan the source HU.

## Case 2 was not actually covered until this PR

`MobileUI_UserProfile_DD.IsAllowPickingAnyHU` is seeded `'Y'`, and `MobileConfigDistributionCommand` writes the field only when the request value is non-null — so a spec that omits it runs with the flag **true**, `DistributionJobCreateCommand` skips `createPlan`, and the auto-advanced job has no move plan at all. `packingTable_navigateToNextOrder.spec.js` omitted it, so on a fresh CI database it was exercising **case 3**, not case 2; the case-2 row of the table above was aspirational.

It now sets `allowPickingAnyHU: false` itself, so the backend really pre-allocates a per-order plan, and asserts that plan through the new `DistributionUtils.expectMovePlanSourceHUs`: DD*i*'s plan must draw from exactly HU*i* while the operator just picked HU*i-1*. Non-empty plan + different source HU — case 2, literally.

## Why the case-3 test is discriminating

The fixture is shared with the case-1 spec through `tests/utils/sweepDistributionMasterdata.js`, so the two provably differ in `allowPickingAnyHU` alone — with the flag `false` the very same data lands the operator on the *product* scan.

Landing on Scan-HU is also what happens when the carry-forward's HU re-resolution merely *fails* (`getResolvedHUQR` swallows the error and returns `null`); on screen and in the job's step list the two are identical, so the only thing that excludes the look-alike is the warning the failure path logs — asserted by `DistributionLinePickFromScreen.expectHUScanNotCausedByFailedHULookup`. The companion backend assertion (`expectPickAnyHUJobWithoutMovePlan`) is a **precondition** check, not an exclusion: it stops the scenario silently degrading into a differently-configured job.

Each discriminating assertion was mutation-proven: forcing the carry-forward unconditional, and forcing the HU lookup to throw, each turns the relevant assertion RED.

## Changes

- `sweep_scan_HU_after_autoAdvance_anyHU.spec.js` (new) — case 3.
- `packingTable_navigateToNextOrder.spec.js` — sets `allowPickingAnyHU: false` in its own masterdata and asserts each order's plan source HU, so it genuinely covers case 2.
- `scan_HU_barcodes.spec.js` — sets `allowPickingAnyHU: true` explicitly; it had been silently inheriting the seeded default for the line screen's `scanQRCode-button`.
- `tests/utils/sweepDistributionMasterdata.js` (new) — the shared sweep fixture, so the case-1/case-3 identity is structural rather than a comment asking two files to be kept in sync.
- `DistributionLinePickFromScreen`: `expectHUScanReady()`, `expectHUScanNotCausedByFailedHULookup()`.
- `DistributionUtils`: `expectPickAnyHUJobWithoutMovePlan()`, `expectMovePlanSourceHUs()`.
- `tests/utils/common.js` — per-test console recorder used by the failed-lookup assertion.

Test-only. The one production file in the diff (`postDistributionPickFromThunk.js`) changes comments only — a note keeping the `console.warn` string in sync with the E2E that greps it.
