### PR TITLE
Fix subtab column sort regression (port from new_dawn_uat)

### DIFF
--- a/frontend/src/__tests__/api/window.test.js
+++ b/frontend/src/__tests__/api/window.test.js
@@ -1,0 +1,72 @@
+import { getTabRequest } from '../../api/window';
+
+jest.mock('../../api/view', () => ({
+  getData: jest.fn(),
+}));
+
+const { getData } = require('../../api/view');
+
+// Silence the intentional `console.error` inside getTabRequest's .catch,
+// so a rejection-path test doesn't pollute Jest's output.
+let consoleErrorSpy;
+beforeEach(() => {
+  jest.clearAllMocks();
+  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
+});
+
+describe('getTabRequest', () => {
+  it('returns { rows: [], orderBys: [] } when the underlying getData rejects', async () => {
+    getData.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await getTabRequest(
+      'AD_Tab-999',
+      '541851',
+      '1000001',
+      undefined
+    );
+
+    expect(result).toEqual({ rows: [], orderBys: [] });
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns { rows, orderBys } when getData resolves with a well-formed response', async () => {
+    getData.mockResolvedValueOnce({
+      data: {
+        result: [
+          { rowId: 'r1', fieldsByName: {} },
+          { rowId: 'r2', fieldsByName: {} },
+        ],
+        orderBys: [{ fieldName: 'Amount', ascending: true }],
+      },
+    });
+
+    const result = await getTabRequest(
+      'AD_Tab-999',
+      '541851',
+      '1000001',
+      undefined
+    );
+
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0].rowId).toBe('r1');
+    expect(result.orderBys).toEqual([
+      { fieldName: 'Amount', ascending: true },
+    ]);
+  });
+
+  it('returns empty rows and empty orderBys when the response has no result / orderBys fields', async () => {
+    getData.mockResolvedValueOnce({ data: {} });
+
+    const result = await getTabRequest(
+      'AD_Tab-999',
+      '541851',
+      '1000001',
+      undefined
+    );
+
+    expect(result).toEqual({ rows: [], orderBys: [] });
+  });
+});

--- a/frontend/src/__tests__/reducers/Tables.test.js
+++ b/frontend/src/__tests__/reducers/Tables.test.js
@@ -2,6 +2,7 @@ import { merge } from 'merge-anything';
 
 import { deleteTable, updateTableSelection } from '../../actions/TableActions';
 import * as ACTION_TYPES from '../../constants/ActionTypes';
+import { SORT_TAB } from '../../constants/ActionTypes';
 import reducer, {
   initialState,
   initialTableState,
@@ -237,6 +238,113 @@ describe('Tables reducer', () => {
 
       const state = reducer(initialStateData, action);
       expect(state[id].activeSort).toBe(true);
+    });
+  });
+
+  describe('Tab column sort — SORT_TAB + UPDATE_TAB_ROWS_DATA with orderBys', () => {
+    const windowId = '541851';
+    const docId = '1000001';
+    const tabId = 'AD_Tab-999';
+    const tableId = `${windowId}_${docId}_${tabId}`;
+
+    const numericRow = (rowId, amount) => ({
+      rowId,
+      fieldsByName: {
+        Amount: { value: amount, widgetType: 'Amount' },
+      },
+    });
+
+    const stringRow = (rowId, name) => ({
+      rowId,
+      fieldsByName: {
+        Name: { value: name, widgetType: 'Text' },
+      },
+    });
+
+    it('SORT_TAB is ignored when the table does not exist (no throw, state unchanged)', () => {
+      const action = { type: SORT_TAB, scope: 'master', windowId, docId, tabId, field: 'Amount', asc: true };
+      expect(() => reducer(initialState, action)).not.toThrow();
+      expect(reducer(initialState, action)).toEqual(initialState);
+    });
+
+    it('SORT_TAB is ignored when scope is not "master"', () => {
+      const action = { type: SORT_TAB, scope: 'included', windowId, docId, tabId, field: 'Amount', asc: false };
+      expect(reducer(initialState, action)).toEqual(initialState);
+    });
+
+    it('SORT_TAB writes orderBys onto the target tab when the table exists', () => {
+      const state = createState({
+        [tableId]: { ...initialTableState, windowId, docId, tabId },
+        length: 1,
+      });
+      const action = { type: SORT_TAB, scope: 'master', windowId, docId, tabId, field: 'Amount', asc: true };
+      expect(reducer(state, action)[tableId].orderBys).toEqual([
+        { fieldName: 'Amount', ascending: true },
+      ]);
+    });
+
+    it('UPDATE_TAB_ROWS_DATA merges a new numeric row respecting the current ASC orderBys', () => {
+      const state = createState({
+        [tableId]: {
+          ...initialTableState,
+          windowId, docId, tabId,
+          rows: [numericRow('r1', 5), numericRow('r3', 20)],
+          orderBys: [{ fieldName: 'Amount', ascending: true }],
+        },
+        length: 1,
+      });
+      const action = {
+        type: ACTION_TYPES.UPDATE_TAB_ROWS_DATA,
+        payload: {
+          id: tableId,
+          rows: { changed: { r2: numericRow('r2', 10) }, removed: undefined },
+        },
+      };
+      const rowsAfter = reducer(state, action)[tableId].rows.map((r) => r.rowId);
+      expect(rowsAfter).toEqual(['r1', 'r2', 'r3']);
+    });
+
+    it('UPDATE_TAB_ROWS_DATA merges a new string row respecting DESC orderBys', () => {
+      const state = createState({
+        [tableId]: {
+          ...initialTableState,
+          windowId, docId, tabId,
+          rows: [stringRow('r1', 'Zeta'), stringRow('r3', 'Alpha')],
+          orderBys: [{ fieldName: 'Name', ascending: false }],
+        },
+        length: 1,
+      });
+      const action = {
+        type: ACTION_TYPES.UPDATE_TAB_ROWS_DATA,
+        payload: {
+          id: tableId,
+          rows: { changed: { r2: stringRow('r2', 'Mu') }, removed: undefined },
+        },
+      };
+      const rowsAfter = reducer(state, action)[tableId].rows.map((r) => r.rowId);
+      expect(rowsAfter).toEqual(['r1', 'r2', 'r3']);
+    });
+
+    it('UPDATE_TAB_ROWS_DATA in-place replacement preserves the numeric sort order for a value change', () => {
+      const state = createState({
+        [tableId]: {
+          ...initialTableState,
+          windowId, docId, tabId,
+          rows: [numericRow('r1', 5), numericRow('r2', 10), numericRow('r3', 20)],
+          orderBys: [{ fieldName: 'Amount', ascending: true }],
+        },
+        length: 1,
+      });
+      // r1's Amount changes from 5 to 15 → new order should be r2 (10), r1 (15), r3 (20)
+      const action = {
+        type: ACTION_TYPES.UPDATE_TAB_ROWS_DATA,
+        payload: {
+          id: tableId,
+          rows: { changed: { r1: numericRow('r1', 15) }, removed: undefined },
+        },
+      };
+      const rowsAfter = reducer(state, action)[tableId].rows.map((r) => r.rowId);
+      expect(rowsAfter).toEqual(['r2', 'r1', 'r3']);
     });
   });
 });

--- a/frontend/src/__tests__/reducers/Tables.test.js
+++ b/frontend/src/__tests__/reducers/Tables.test.js
@@ -2,7 +2,6 @@ import { merge } from 'merge-anything';
 
 import { deleteTable, updateTableSelection } from '../../actions/TableActions';
 import * as ACTION_TYPES from '../../constants/ActionTypes';
-import { SORT_TAB } from '../../constants/ActionTypes';
 import reducer, {
   initialState,
   initialTableState,
@@ -262,13 +261,13 @@ describe('Tables reducer', () => {
     });
 
     it('SORT_TAB is ignored when the table does not exist (no throw, state unchanged)', () => {
-      const action = { type: SORT_TAB, scope: 'master', windowId, docId, tabId, field: 'Amount', asc: true };
+      const action = { type: ACTION_TYPES.SORT_TAB, scope: 'master', windowId, docId, tabId, field: 'Amount', asc: true };
       expect(() => reducer(initialState, action)).not.toThrow();
       expect(reducer(initialState, action)).toEqual(initialState);
     });
 
     it('SORT_TAB is ignored when scope is not "master"', () => {
-      const action = { type: SORT_TAB, scope: 'included', windowId, docId, tabId, field: 'Amount', asc: false };
+      const action = { type: ACTION_TYPES.SORT_TAB, scope: 'included', windowId, docId, tabId, field: 'Amount', asc: false };
       expect(reducer(initialState, action)).toEqual(initialState);
     });
 
@@ -277,7 +276,7 @@ describe('Tables reducer', () => {
         [tableId]: { ...initialTableState, windowId, docId, tabId },
         length: 1,
       });
-      const action = { type: SORT_TAB, scope: 'master', windowId, docId, tabId, field: 'Amount', asc: true };
+      const action = { type: ACTION_TYPES.SORT_TAB, scope: 'master', windowId, docId, tabId, field: 'Amount', asc: true };
       expect(reducer(state, action)[tableId].orderBys).toEqual([
         { fieldName: 'Amount', ascending: true },
       ]);

--- a/frontend/src/__tests__/reducers/Tables.test.js
+++ b/frontend/src/__tests__/reducers/Tables.test.js
@@ -3,6 +3,7 @@ import { merge } from 'merge-anything';
 import { deleteTable, updateTableSelection } from '../../actions/TableActions';
 import * as ACTION_TYPES from '../../constants/ActionTypes';
 import reducer, {
+  getTableId,
   initialState,
   initialTableState,
 } from '../../reducers/tables';
@@ -244,7 +245,7 @@ describe('Tables reducer', () => {
     const windowId = '541851';
     const docId = '1000001';
     const tabId = 'AD_Tab-999';
-    const tableId = `${windowId}_${docId}_${tabId}`;
+    const tableId = getTableId({ windowId, docId, tabId });
 
     const numericRow = (rowId, amount) => ({
       rowId,

--- a/frontend/src/actions/TableActions.js
+++ b/frontend/src/actions/TableActions.js
@@ -181,6 +181,7 @@ export function createTableData(rawData) {
     defaultOrderBys: rawData.defaultOrderBys
       ? rawData.defaultOrderBys
       : undefined,
+    orderBys: rawData.orderBys?.length ? rawData.orderBys : undefined,
     expandedDepth: rawData.expandedDepth,
     collapsible: rawData.collapsible,
     indentSupported: rawData.supportTree,

--- a/frontend/src/actions/WindowActions.js
+++ b/frontend/src/actions/WindowActions.js
@@ -278,10 +278,12 @@ export function clearMasterData() {
   };
 }
 
-export function sortTab(scope, tabId, field, asc) {
+export function sortTab({ scope, windowId, docId, tabId, field, asc }) {
   return {
     type: SORT_TAB,
     scope,
+    windowId,
+    docId,
     tabId,
     field,
     asc,

--- a/frontend/src/actions/WindowActions.js
+++ b/frontend/src/actions/WindowActions.js
@@ -416,14 +416,16 @@ export function fetchTab({ tabId, windowId, docId, orderBy }) {
     const tableId = getTableId({ windowId, tabId, docId });
     dispatch(updateTabTable({ tableId, pending: true }));
     return getTabRequest(tabId, windowId, docId, orderBy)
-      .then((response) => {
-        const tableData = { result: response };
-
+      .then(({ rows, orderBys }) => {
         dispatch(
-          updateTabTable({ tableId, tableResponse: tableData, pending: false })
+          updateTabTable({
+            tableId,
+            tableResponse: { result: rows, orderBys },
+            pending: false,
+          })
         );
 
-        return Promise.resolve(response);
+        return Promise.resolve(rows);
       })
       .catch((error) => {
         //show error message ?

--- a/frontend/src/api/window.js
+++ b/frontend/src/api/window.js
@@ -72,15 +72,17 @@ export function getTabRequest(tabId, windowType, docId, orderBy) {
     rowId: null, // all rows
     orderBy: formatSortingQuery(orderBy),
   })
-    .then(
-      (res) =>
-        res.data &&
-        res.data.result &&
-        res.data.result.map((row) => ({
+    .then((res) => {
+      const rows =
+        res?.data?.result?.map((row) => ({
           ...row,
           fieldsByName: parseToDisplay(row.fieldsByName),
-        }))
-    )
+        })) ?? [];
+
+      const orderBys = res?.data?.orderBys ?? [];
+
+      return { rows, orderBys };
+    })
     .catch((error) => {
       // eslint-disable-next-line no-console
       console.error('getTabRequest error: ', error);

--- a/frontend/src/api/window.js
+++ b/frontend/src/api/window.js
@@ -86,6 +86,10 @@ export function getTabRequest(tabId, windowType, docId, orderBy) {
     .catch((error) => {
       // eslint-disable-next-line no-console
       console.error('getTabRequest error: ', error);
+      // Callers destructure { rows, orderBys } — return a shape-consistent
+      // empty result so a request failure degrades gracefully rather than
+      // crashing the destructure downstream.
+      return { rows: [], orderBys: [] };
     });
 }
 

--- a/frontend/src/components/window/Tab.js
+++ b/frontend/src/components/window/Tab.js
@@ -3,7 +3,6 @@ import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 
 import { fetchTab } from '../../actions/WindowActions';
-import { toOrderBysCommaSeparatedString } from '../../utils/windowHelpers';
 
 const Tab = ({
   children,
@@ -18,16 +17,14 @@ const Tab = ({
 }) => {
   useEffect(() => {
     if (docId && queryOnActivate) {
-      const query = toOrderBysCommaSeparatedString(orderBy);
-
       if (singleRowView) {
-        fetchTab({ tabId, windowId, docId, query }).then((res) => {
-          if (res.length) {
+        fetchTab({ tabId, windowId, docId, orderBy }).then((rows) => {
+          if (rows.length) {
             onChange && onChange();
           }
         });
       } else {
-        fetchTab({ tabId, windowId, docId, query }).then(() => {
+        fetchTab({ tabId, windowId, docId, orderBy }).then(() => {
           onChange && onChange();
         });
       }

--- a/frontend/src/constants/Constants.js
+++ b/frontend/src/constants/Constants.js
@@ -65,6 +65,8 @@ export const ARROW_UP_KEY = 'ArrowUp';
  */
 export const AMOUNT_FIELD_TYPES = ['Amount', 'CostPrice', 'Quantity'];
 
+export const NUMERIC_FIELD_TYPES = [...AMOUNT_FIELD_TYPES, 'Integer', 'Number'];
+
 /**
  * @constant
  * @type {array} ToDo: Description for the constant.

--- a/frontend/src/containers/MasterWindow.js
+++ b/frontend/src/containers/MasterWindow.js
@@ -253,7 +253,7 @@ class MasterWindowContainer extends PureComponent {
 
     updateTabLayout(windowId, activeTabId)
       .then(() => {
-        getTabRequest(activeTabId, windowId, docId, orderBy).then((rows) =>
+        getTabRequest(activeTabId, windowId, docId, orderBy).then(({ rows }) =>
           updateTabTableData(tableId, rows)
         );
       })
@@ -305,7 +305,7 @@ class MasterWindowContainer extends PureComponent {
     });
 
     sortTab({ scope: 'master', windowId, docId, tabId, field, asc });
-    getTabRequest(tabId, windowId, dataId, orderBy).then((rows) => {
+    getTabRequest(tabId, windowId, dataId, orderBy).then(({ rows }) => {
       updateTabTableData(tableId, rows);
     });
   };

--- a/frontend/src/containers/MasterWindow.js
+++ b/frontend/src/containers/MasterWindow.js
@@ -304,7 +304,7 @@ class MasterWindowContainer extends PureComponent {
       tabId: activeTabId,
     });
 
-    sortTab('master', tabId, field, asc);
+    sortTab({ scope: 'master', windowId, docId, tabId, field, asc });
     getTabRequest(tabId, windowId, dataId, orderBy).then((rows) => {
       updateTabTableData(tableId, rows);
     });

--- a/frontend/src/reducers/tables.js
+++ b/frontend/src/reducers/tables.js
@@ -1,9 +1,11 @@
 import { original, produce } from 'immer';
-import { difference, forEach, get } from 'lodash';
+import { difference, get } from 'lodash';
 import { createSelector } from 'reselect';
 import { merge } from 'merge-anything';
 
 import * as types from '../constants/ActionTypes';
+import { SORT_TAB } from '../constants/ActionTypes';
+import { NUMERIC_FIELD_TYPES } from '../constants/Constants';
 import { doesSelectionExist } from '../utils/documentListHelper';
 
 export const initialTableState = {
@@ -44,6 +46,66 @@ export const initialState = { length: 0 };
  */
 export const getTableId = ({ windowId, viewId, docId, tabId }) => {
   return `${windowId}_${viewId ? viewId : `${docId}_${tabId}`}`;
+};
+
+const addRowToArray = ({ orderedRows, rowToAdd, orderBys }) => {
+  if (!orderedRows.length) {
+    orderedRows.push(rowToAdd);
+    return;
+  }
+  for (let i = 0; i < orderedRows.length; i++) {
+    const currentRow = orderedRows[i];
+    const cmp = compareRows({ row1: currentRow, row2: rowToAdd, orderBys });
+    if (cmp > 0) {
+      orderedRows.splice(i, 0, rowToAdd);
+      return;
+    }
+  }
+  orderedRows.push(rowToAdd);
+};
+
+const compareRows = ({ row1, row2, orderBys }) => {
+  for (const orderBy of orderBys) {
+    const { fieldName, ascending } = orderBy;
+    const value1 = extractValueToCompare(row1, fieldName);
+    const value2 = extractValueToCompare(row2, fieldName);
+    const cmp = compareValues({ value1, value2, ascending });
+    if (cmp !== 0) {
+      return cmp;
+    }
+  }
+};
+
+const extractValueToCompare = (row, fieldName) => {
+  const field = row?.fieldsByName?.[fieldName];
+  if (!field) {
+    return undefined;
+  }
+  let value = field.value;
+  const widgetType = field.widgetType;
+  if (NUMERIC_FIELD_TYPES.includes(widgetType)) {
+    if (value == null) {
+      return null;
+    }
+    return Number(value);
+  } else {
+    if (value?.caption) {
+      value = value.caption;
+    }
+    return value;
+  }
+};
+
+const compareValues = ({ value1, value2, ascending }) => {
+  if (value1 == null && value2 == null) {
+    return 0;
+  } else if (value1 == value2) {
+    return 0;
+  } else if (value1 < value2) {
+    return ascending ? -1 : +1;
+  } else {
+    return ascending ? +1 : -1;
+  }
 };
 
 /**
@@ -236,15 +298,13 @@ const reducer = produce((draftState, action) => {
           rows = rows.filter((row) => !removed[row.rowId]);
         }
 
-        // find&replace updated rows (unfortunately it's a table so we'll have to traverse it)
+        // find & replace updated rows in place (they may be reordered below if their sort key changed)
         if (changed && Object.values(changed).length) {
           rows = rows.map((row) => {
             if (changed[row.rowId]) {
-              row = { ...changed[row.rowId] };
-
+              const replaced = { ...changed[row.rowId] };
               delete changed[row.rowId];
-
-              return row;
+              return replaced;
             }
             return row;
           });
@@ -252,8 +312,33 @@ const reducer = produce((draftState, action) => {
       } else {
         rows = [];
       }
-      // added rows
-      forEach(changed, (value) => rows.push(value));
+
+      // add remaining (new) rows, respecting the currently active orderBys (falls back to defaultOrderBys, then unordered append)
+      if (changed) {
+        const rowsToAdd = Object.values(changed);
+        if (rowsToAdd.length) {
+          const orderBys = original(
+            draftState[id].orderBys ?? draftState[id].defaultOrderBys
+          );
+          if (orderBys && orderBys.length) {
+            rowsToAdd.forEach((rowToAdd) =>
+              addRowToArray({ orderedRows: rows, rowToAdd, orderBys })
+            );
+          } else {
+            rowsToAdd.forEach((rowToAdd) => rows.push(rowToAdd));
+          }
+        }
+      }
+
+      // if any row's sort key changed in the in-place replace above, re-order the whole array
+      const orderBys = original(
+        draftState[id].orderBys ?? draftState[id].defaultOrderBys
+      );
+      if (orderBys && orderBys.length) {
+        rows = [...rows].sort((row1, row2) =>
+          compareRows({ row1, row2, orderBys })
+        );
+      }
 
       draftState[id].rows = rows;
 
@@ -339,6 +424,28 @@ const reducer = produce((draftState, action) => {
         draftState[id].activeSort = active;
       }
 
+      return;
+    }
+
+    case SORT_TAB: {
+      const {
+        scope,
+        windowId,
+        docId,
+        tabId,
+        field: fieldName,
+        asc: ascending,
+      } = action;
+
+      if (scope !== 'master') {
+        return;
+      }
+
+      const tableId = getTableId({ windowId, docId, tabId });
+      // Guard against race condition where sort action fires before table creation.
+      if (draftState[tableId]) {
+        draftState[tableId].orderBys = [{ fieldName, ascending }];
+      }
       return;
     }
 

--- a/frontend/src/reducers/tables.js
+++ b/frontend/src/reducers/tables.js
@@ -4,7 +4,6 @@ import { createSelector } from 'reselect';
 import { merge } from 'merge-anything';
 
 import * as types from '../constants/ActionTypes';
-import { SORT_TAB } from '../constants/ActionTypes';
 import { NUMERIC_FIELD_TYPES } from '../constants/Constants';
 import { doesSelectionExist } from '../utils/documentListHelper';
 
@@ -74,6 +73,7 @@ const compareRows = ({ row1, row2, orderBys }) => {
       return cmp;
     }
   }
+  return 0;
 };
 
 const extractValueToCompare = (row, fieldName) => {
@@ -427,7 +427,7 @@ const reducer = produce((draftState, action) => {
       return;
     }
 
-    case SORT_TAB: {
+    case types.SORT_TAB: {
       const {
         scope,
         windowId,


### PR DESCRIPTION
Fix a subtab column-sort regression on the `inner_silence_hotfix` chain: after a sort click, subsequent websocket-driven tab-row refreshes and tab-activation refetches append newly-observed rows to the end of the array without respecting the currently-active sort direction, so the visible order degrades a little more with every refresh cycle.

## Root cause

Commit https://github.com/metasfresh/metasfresh/commit/f41fd98cfb2fcd47c2413bc1669268ac507ffa96 (June 2024 — *"included tabs: rows notified via websockets shall be added respecting order bys"*) landed on `new_dawn_uat` but never propagated to the affected branch. `git branch -r --contains <that-sha>` confirms.

Consequence on the affected branch:

- No `SORT_TAB` reducer case → the store's `orderBys` never records the user's chosen sort direction.
- `frontend/src/reducers/tables.js`'s `UPDATE_TAB_ROWS_DATA` case ends with `forEach(changed, (value) => rows.push(value))` — any row not already present is appended to the end of the array, ignoring the currently-active sort.
- `frontend/src/components/window/Tab.js`'s tab-activation `useEffect` calls `fetchTab({ tabId, windowId, docId, query })` — but the `fetchTab` action creator destructures `{ orderBy }`. The intermediate `query` string never reached the request, so every tab activation went out with no sort direction and the backend responded in default order.

The sort-click path itself is fine: it dispatches `UPDATE_TABLE_DATA` which replaces `rows` wholesale with the backend-sorted payload.

**Verified live 2026-07-28:** `GET /rest/api/window/.../?orderBy=-QtyEntered` returned `[{QtyEntered:98263}, {QtyEntered:125}, {QtyEntered:19}, ...]` — numerically DESC. `?orderBy=+QtyEntered` returned rows starting at `QtyEntered:3` ASC. Backend sorting is correct; the visible order degrades in the frontend.

## What this PR does

Targeted frontend port of the six frontend pieces of the reference commit (linked above), adapted to this branch's file layout (backend changes deliberately excluded — no Java conflicts on a hotfix branch; the frontend `orderBys ?? []` fallback handles a backend that doesn't populate the extra field):

1. Add `NUMERIC_FIELD_TYPES` constant to `frontend/src/constants/Constants.js`.
2. Add `SORT_TAB` reducer case + client-side sort helpers (`addRowToArray`, `compareRows`, `extractValueToCompare`, `compareValues`) to `frontend/src/reducers/tables.js`; use them from `UPDATE_TAB_ROWS_DATA` so websocket-driven row updates respect the currently-active `orderBys`.
3. Extend `sortTab` action-creator signature to `{ scope, windowId, docId, tabId, field, asc }` and update the caller in `frontend/src/containers/MasterWindow.js`.
4. Fix `frontend/src/components/window/Tab.js`: pass `orderBy` directly to `fetchTab` instead of the intermediate `query` string.
5. Change `getTabRequest` in `frontend/src/api/window.js` to return `{ rows, orderBys }`; update all three callers (`fetchTab` in `WindowActions.js`, `sort` and `refreshActiveTab` in `containers/MasterWindow.js`).
6. Map the API response's `orderBys` into `state.tables[tableId].orderBys` via `createTableData` in `frontend/src/actions/TableActions.js`.

## Tests

6 new reducer tests in `frontend/src/__tests__/reducers/Tables.test.js`:
- 4 substantive tests covering `SORT_TAB` writes `orderBys` when the table exists, `UPDATE_TAB_ROWS_DATA` merges numeric ASC / string DESC rows respecting `orderBys`, and in-place row replacement preserves sort key changes.
- 2 guard-invariant tests covering `SORT_TAB` is a no-op when the table doesn't exist and when `scope !== 'master'`.

## Reviews

Two rounds of `/review` on the whole-state diff. Round 1: H:1, M:3, L:2. Round 2 (this HEAD): C:0, H:0, M:0, L:2 — both LOWs are non-correctness (editorial PR body + a missing rejection-path test for the new `.catch` fallback shape).
