### PR TITLE
Merge: soft_panda_hotfix → new_dawn_uat (WebUI save-error grid-row fix)

### DIFF
--- a/e2e/frontend-webui/tests/spec/pricelist-version-colliding-date.spec.js
+++ b/e2e/frontend-webui/tests/spec/pricelist-version-colliding-date.spec.js
@@ -369,4 +369,124 @@ with no 404 on that path.
     // (c) the exact old symptom must be absent: no 404 on the PLV document path.
     expect(notFoundUrls, `no 404 on the PLV document path. Captured: ${JSON.stringify(notFoundUrls)}`).toEqual([]);
   });
+
+  test('abandon after a persisted PLV colliding edit: the persisted row STAYS in the parent grid without reload (DB row intact)', async ({ page }) => {
+    allure.epic('E0260: Pricing');
+    allure.tag('F32070: Price List Copy using Price List Schema');
+    allure.tag('F32070');
+    allure.story('Abandoning a failed colliding edit of an already-persisted PLV must NOT drop the persisted row from the parent grid');
+    allure.severity('critical');
+    allure.description(`
+After a NEW Price List Version auto-saves (real DB row), the user edits its ValidFrom to a colliding
+date -> the save fails with a KEPT user-validation error -> the user presses Done and accepts
+"abandon changes". The already-persisted row must REMAIN in the parent included-tab grid WITHOUT a
+browser reload (the DB row is never deleted): abandoning re-queries the persisted row and reverts the
+grid row to its DB value in place, rather than dropping the persisted row client-side. This test
+asserts: (a) the row still exists server-side (DB intact), (b) it stays in the parent grid without a
+reload, showing its reverted DB value.
+    `);
+
+    test.setTimeout(120000);
+
+    const { recordedResponses, notFoundUrls, currentSeq } = recordPlvPathResponses(page);
+
+    await loginAndOpenCleanPriceList(page);
+    await addNewPlvRow(page);
+
+    // (1) Persist a NEW PLV at a unique far-future date (auto-save). This is the row that must survive.
+    const persistedValidFrom = uniqueFarFutureValidFrom();
+    const persistedYear = persistedValidFrom.slice(-4); // locale-independent anchor (year digits)
+    // MM/DD/YYYY (en_US widget input) -> YYYY-MM-DD (the ISO shape the rows GET returns in fieldsByName.ValidFrom.value).
+    const [pMonth, pDay, pYear] = persistedValidFrom.split('/');
+    const persistedValidFromIso = `${pYear}-${pMonth}-${pDay}`;
+    const beforePersistSeq = currentSeq();
+    await setValidFrom(persistedValidFrom);
+    await expect
+      .poll(() => recordedResponses.some((r) => r.seq > beforePersistSeq && r.method === 'PATCH' && r.isSaved === true && r.isError === false), {
+        timeout: SLOW_ACTION_TIMEOUT,
+        message: `the future-dated PLV (${persistedValidFrom}) should save successfully (persisted, no error)`,
+      })
+      .toBeTruthy();
+
+    // The DB row is identified by its unique far-future ValidFrom (this build does NOT expose the child rowId
+    // in the modal URL — the URL stays /window/540321/2008396). We assert the DB row survives by matching this
+    // ValidFrom in the rows GET below; the colliding edit is rejected, so the DB keeps this far-future value.
+    const validFromOf = (row) => String((((row.fieldsByName || {}).ValidFrom) || {}).value || '');
+
+    // (2) Edit that persisted PLV to a COLLIDING date → save fails with a KEPT user-validation error.
+    const beforeEditSeq = currentSeq();
+    await setValidFrom(COLLIDING_DATE);
+    await expect
+      .poll(() => recordedResponses.some((r) => r.seq > beforeEditSeq && r.method === 'PATCH' && r.isError === true), {
+        timeout: SLOW_ACTION_TIMEOUT,
+        message: 'the colliding edit should fail server-side with the duplicate-date error',
+      })
+      .toBeTruthy();
+    const failingEditPatch = recordedResponses.filter((r) => r.seq > beforeEditSeq && r.method === 'PATCH' && r.isError === true).pop();
+    expect(
+      failingEditPatch.isUserValidationError,
+      `the colliding edit must fail with a user-validation (friendly) error. Failing PATCH: ${JSON.stringify(failingEditPatch)}`,
+    ).toBe(true);
+
+    // The new PLV is created/edited in a record MODAL; while it is open the parent included-tab grid row
+    // reflects the in-memory (colliding) edit, and the modal overlays it — so the far-future value is only
+    // observable in the parent grid AFTER the modal closes. Hence all grid assertions are made post-Done.
+    const gridRows = () => page.locator('.table tbody tr, table tbody tr');
+    // Scope the year match to the ValidFrom cell (data-cy="cell-<ColumnName>") rather than the whole
+    // row, so an incidental 4-digit match elsewhere in the row can't satisfy the locator.
+    const seedYear = PLV_SEED_VALIDFROM.slice(0, 4);
+    const plvGridRowsWithYear = () =>
+      page.locator(
+        `.table tbody tr:has([data-cy="cell-ValidFrom"]:has-text("${persistedYear}")), table tbody tr:has([data-cy="cell-ValidFrom"]:has-text("${persistedYear}"))`
+      );
+    const plvGridRowsWithSeed = () =>
+      page.locator(
+        `.table tbody tr:has([data-cy="cell-ValidFrom"]:has-text("${seedYear}")), table tbody tr:has([data-cy="cell-ValidFrom"]:has-text("${seedYear}"))`
+      );
+
+    // (3) Press Done and ACCEPT the abandon-changes confirm (dirty window modal → window.confirm dialog).
+    page.on('dialog', (dialog) => dialog.accept());
+    // Language-invariant Done/close button of the record modal (Modal.js — data-testid, translate('modal.actions.done')).
+    await page.locator('[data-testid="process-modal-cancel-button"]').first().click();
+    // Wait for the modal to close so the parent included-tab grid is the visible/queried DOM.
+    await page.locator('[data-testid="process-modal-cancel-button"]').first().waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT }).catch(() => {});
+    await waitForSpinnersToSettle(page);
+
+    // ============ ASSERT THE FIXED (DESIRED) BEHAVIOR ============
+    // (a) DATA IS INTACT: a direct rows GET on the PLV tab still returns the persisted row (DB row never deleted,
+    //     and it keeps its far-future ValidFrom because the colliding edit was rejected — the abandon reverts the
+    //     document server-side but never deletes the DB row).
+    const rowsResponse = await page.request.get(`${plvTabRowsUrl()}/?orderBy=-ValidFrom`);
+    expect(rowsResponse.ok(), `PLV rows GET should succeed (HTTP ${rowsResponse.status()})`).toBe(true);
+    const rowsBody = await rowsResponse.json();
+    const rows = Array.isArray(rowsBody) ? rowsBody : rowsBody.result || rowsBody.documents || [];
+    expect(
+      rows.some((r) => validFromOf(r).startsWith(persistedValidFromIso)),
+      `the persisted PLV row (ValidFrom ${persistedValidFromIso}) must still exist server-side (data not lost). Row ValidFroms: ${JSON.stringify(rows.map(validFromOf))}`,
+    ).toBe(true);
+
+    // Positive control: the parent grid IS rendered (the untouched 2015 seed row shows). This makes a 0-count on
+    // the far-future row below mean "row removed", not "grid never rendered / locator wrong".
+    await expect
+      .poll(() => plvGridRowsWithSeed().count(), {
+        timeout: SLOW_ACTION_TIMEOUT,
+        message: 'the parent PLV grid must render (seed 2015 row present) after the modal closes',
+      })
+      .toBeGreaterThan(0);
+    console.log(`[plv-abandon-grid] grid rows after Done: ${JSON.stringify(await gridRows().allTextContents())}`);
+    console.log(`[plv-abandon-grid] persisted far-future ValidFrom: ${persistedValidFrom} (ISO ${persistedValidFromIso}), grid rows carrying year ${persistedYear}: ${await plvGridRowsWithYear().count()}`);
+
+    // (b) GRID RETAINS THE ROW: without any reload the parent grid MUST still show the persisted row —
+    //     MasterWindow.closeModalCallback re-queries the row and reverts it in place instead of removing it
+    //     client-side.
+    await expect
+      .poll(() => plvGridRowsWithYear().count(), {
+        timeout: SLOW_ACTION_TIMEOUT,
+        message: `the persisted far-future PLV row (year ${persistedYear}) must STAY in the grid after Done, with no reload (fix under test)`,
+      })
+      .toBeGreaterThan(0);
+
+    // Regression guard for the sibling colliding-date fix: no 404 on the PLV document path throughout.
+    expect(notFoundUrls, `no 404 on the PLV document path. Captured: ${JSON.stringify(notFoundUrls)}`).toEqual([]);
+  });
 });

--- a/frontend/src/__tests__/components/app/MasterWindow.test.js
+++ b/frontend/src/__tests__/components/app/MasterWindow.test.js
@@ -1,0 +1,318 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { getTableId } from '../../../reducers/tables';
+
+import MasterWindow from '../../../components/app/MasterWindow';
+import { discardNewRequest, getRowsData } from '../../../api';
+
+// closeModalCallback calls discardNewRequest (from ../../../api) and awaits its
+// promise, then — for an already-persisted (numeric-id) abandoned row — re-fetches
+// that row via getRowsData and applies its reverted DB value to the parent grid.
+jest.mock('../../../api', () => ({
+  __esModule: true,
+  discardNewRequest: jest.fn(() => Promise.resolve()),
+  getRowsData: jest.fn(() => Promise.resolve({ data: { result: [] } })),
+}));
+
+describe('MasterWindow.closeModalCallback - abandon must not drop a persisted new-record row', () => {
+  const WINDOW_TYPE = '540321';
+  const DOCUMENT_ID = 'd1';
+  const TAB_ID = 't1';
+
+  // Minimal props so shallow() can construct the instance without render throwing.
+  const buildProps = (overrides = {}) => ({
+    modal: { visible: false },
+    master: {
+      docId: DOCUMENT_ID,
+      data: { DocumentNo: undefined },
+      layout: {},
+      includedTabsInfo: {},
+      hasComments: false,
+    },
+    breadcrumb: [],
+    rawModal: {},
+    pluginModal: {},
+    me: {},
+    overlay: { data: {}, visible: false },
+    params: { windowId: WINDOW_TYPE, docId: DOCUMENT_ID },
+    updateTabRowsData: jest.fn(),
+    onRefreshTab: jest.fn(),
+    ...overrides,
+  });
+
+  const getInstance = (props) =>
+    shallow(<MasterWindow {...props} />).instance();
+
+  // A realistic ?ids= re-fetch response: the persisted row, reverted server-side
+  // to its DB ValidFrom (a far-future year) after discardChanges — the abandoned
+  // in-memory colliding value (01/01/2015) is gone.
+  const PERSISTED_ROW_ID = '1234567';
+  const revertedRowsResponse = {
+    data: {
+      result: [
+        {
+          rowId: PERSISTED_ROW_ID,
+          fieldsByName: {
+            ValidFrom: {
+              field: 'ValidFrom',
+              value: '2053-11-30',
+              widgetType: 'Date',
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  beforeEach(() => {
+    discardNewRequest.mockClear();
+    discardNewRequest.mockResolvedValue();
+    getRowsData.mockClear();
+    getRowsData.mockResolvedValue(revertedRowsResponse);
+  });
+
+  // Case A - the bug: a modal auto-saved (rowId became a real numeric id) but
+  // saveStatus stayed falsy. Abandon must NOT remove the now-persisted row.
+  it('does not remove a persisted (numeric rowId) row when saveStatus is falsy', async () => {
+    const props = buildProps();
+    const instance = getInstance(props);
+
+    await instance.closeModalCallback({
+      isNew: true,
+      windowType: WINDOW_TYPE,
+      documentId: DOCUMENT_ID,
+      tabId: TAB_ID,
+      rowId: PERSISTED_ROW_ID,
+      saveStatus: false,
+    });
+
+    const removedPersistedRow = props.updateTabRowsData.mock.calls.some(
+      ([, payload]) =>
+        payload && payload.removed && payload.removed[PERSISTED_ROW_ID]
+    );
+    expect(removedPersistedRow).toBe(false);
+  });
+
+  // Case B - regression guard: a genuinely unsaved new row (rowId === 'NEW')
+  // must still be discarded from the parent grid.
+  it('removes an unsaved new row (rowId === NEW) when saveStatus is falsy', async () => {
+    const props = buildProps();
+    const instance = getInstance(props);
+
+    await instance.closeModalCallback({
+      isNew: true,
+      windowType: WINDOW_TYPE,
+      documentId: DOCUMENT_ID,
+      tabId: TAB_ID,
+      rowId: 'NEW',
+      saveStatus: false,
+    });
+
+    const expectedTableId = getTableId({
+      windowId: WINDOW_TYPE,
+      docId: DOCUMENT_ID,
+      tabId: TAB_ID,
+    });
+    expect(props.updateTabRowsData).toHaveBeenCalledWith(expectedTableId, {
+      removed: { NEW: true },
+    });
+  });
+
+  // Case C - the fix: abandoning an already-persisted (numeric rowId) row with a
+  // falsy saveStatus must re-fetch the row and UPDATE (not remove) it in the grid,
+  // so the retained row shows its reverted DB value without a browser reload.
+  it('re-fetches and UPDATES a persisted row with its reverted DB value on abandon', async () => {
+    const props = buildProps();
+    const instance = getInstance(props);
+
+    await instance.closeModalCallback({
+      isNew: true,
+      windowType: WINDOW_TYPE,
+      documentId: DOCUMENT_ID,
+      tabId: TAB_ID,
+      rowId: PERSISTED_ROW_ID,
+      saveStatus: false,
+    });
+
+    const expectedTableId = getTableId({
+      windowId: WINDOW_TYPE,
+      docId: DOCUMENT_ID,
+      tabId: TAB_ID,
+    });
+
+    // the reverted DB row was re-fetched for exactly this persisted row
+    expect(getRowsData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity: 'window',
+        docType: WINDOW_TYPE,
+        docId: DOCUMENT_ID,
+        tabId: TAB_ID,
+        rows: [PERSISTED_ROW_ID],
+      })
+    );
+
+    // it was applied as an UPDATE (changed), never a removal
+    const updateCall = props.updateTabRowsData.mock.calls.find(
+      ([, payload]) =>
+        payload && payload.changed && payload.changed[PERSISTED_ROW_ID]
+    );
+    expect(updateCall).toBeDefined();
+    expect(updateCall[0]).toBe(expectedTableId);
+    expect(
+      updateCall[1].changed[PERSISTED_ROW_ID].fieldsByName.ValidFrom.value
+    ).toBe('2053-11-30');
+
+    const removedAny = props.updateTabRowsData.mock.calls.some(
+      ([, payload]) => payload && payload.removed
+    );
+    expect(removedAny).toBe(false);
+  });
+
+  // Case D - reconcile the deleted-row edge: if the persisted row was removed
+  // server-side between the abandon and the re-fetch, the ?ids= GET reports it in
+  // missingIds → the grid row must be removed (not left stranded).
+  it('removes a persisted row from the grid when the re-fetch reports it missing', async () => {
+    getRowsData.mockResolvedValue({
+      data: { result: [], missingIds: [PERSISTED_ROW_ID] },
+    });
+
+    const props = buildProps();
+    const instance = getInstance(props);
+
+    await instance.closeModalCallback({
+      isNew: true,
+      windowType: WINDOW_TYPE,
+      documentId: DOCUMENT_ID,
+      tabId: TAB_ID,
+      rowId: PERSISTED_ROW_ID,
+      saveStatus: false,
+    });
+
+    const expectedTableId = getTableId({
+      windowId: WINDOW_TYPE,
+      docId: DOCUMENT_ID,
+      tabId: TAB_ID,
+    });
+    expect(props.updateTabRowsData).toHaveBeenCalledWith(expectedTableId, {
+      removed: { [PERSISTED_ROW_ID]: true },
+    });
+  });
+
+  // Case E - the .catch() fallback: if the revert re-fetch itself fails, the grid
+  // row would otherwise strand showing the stale abandoned value. The fallback must
+  // fire a full tab refresh (onRefreshTab) and must NOT apply any re-fetched row
+  // update to the grid.
+  it('falls back to a tab refresh (and does not update the grid) when the revert re-fetch fails', async () => {
+    getRowsData.mockRejectedValue(new Error('re-fetch failed'));
+    // the fallback intentionally logs the failure — silence it to keep the suite output clean
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const props = buildProps();
+    const instance = getInstance(props);
+
+    await instance.closeModalCallback({
+      isNew: true,
+      windowType: WINDOW_TYPE,
+      documentId: DOCUMENT_ID,
+      tabId: TAB_ID,
+      rowId: PERSISTED_ROW_ID,
+      saveStatus: false,
+    });
+
+    // the re-fetch was attempted for the persisted row
+    expect(getRowsData).toHaveBeenCalledWith(
+      expect.objectContaining({ rows: [PERSISTED_ROW_ID] })
+    );
+    // the fallback fired
+    expect(props.onRefreshTab).toHaveBeenCalledTimes(1);
+    // no re-fetch-derived grid update was applied (the fetch rejected)
+    expect(props.updateTabRowsData).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  // Case F - the discard call itself fails. discardNewRequest is the FIRST async
+  // step of the chain; if it rejects (network error, 500 from /discardChanges) the
+  // whole reconcile branch never runs, so without a fallback the grid strands on
+  // the abandoned in-memory value exactly as in Case E. Modal.closeModal() does not
+  // await this callback, so an unhandled rejection would also surface no error at
+  // all. The same tab-refresh fallback must fire, and the returned promise must
+  // settle rather than reject.
+  it('falls back to a tab refresh when the discard request itself fails', async () => {
+    discardNewRequest.mockRejectedValue(new Error('discard failed'));
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const props = buildProps();
+    const instance = getInstance(props);
+
+    await expect(
+      instance.closeModalCallback({
+        isNew: true,
+        windowType: WINDOW_TYPE,
+        documentId: DOCUMENT_ID,
+        tabId: TAB_ID,
+        rowId: PERSISTED_ROW_ID,
+        saveStatus: false,
+      })
+    ).resolves.toBeUndefined();
+
+    // the discard rejected, so no re-fetch was attempted ...
+    expect(getRowsData).not.toHaveBeenCalled();
+    // ... and no grid update was applied ...
+    expect(props.updateTabRowsData).not.toHaveBeenCalled();
+    // ... but the grid was still reconciled with the DB via a full tab refresh
+    expect(props.onRefreshTab).toHaveBeenCalledTimes(1);
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  // Case G - guard branch: a modal that is not a new-record modal is none of this
+  // callback's business. It must short-circuit before any server call, so an
+  // ordinary edit-modal close cannot discard the document or disturb the grid.
+  it('does nothing at all when the modal is not a new-record modal', async () => {
+    const props = buildProps();
+    const instance = getInstance(props);
+
+    const result = instance.closeModalCallback({
+      isNew: false,
+      windowType: WINDOW_TYPE,
+      documentId: DOCUMENT_ID,
+      tabId: TAB_ID,
+      rowId: PERSISTED_ROW_ID,
+      saveStatus: false,
+    });
+
+    expect(result).toBeUndefined();
+    expect(discardNewRequest).not.toHaveBeenCalled();
+    expect(getRowsData).not.toHaveBeenCalled();
+    expect(props.updateTabRowsData).not.toHaveBeenCalled();
+    expect(props.onRefreshTab).not.toHaveBeenCalled();
+  });
+
+  // Case H - a saved modal owns no abandoned in-memory change, so there is nothing
+  // to reconcile: the discard still runs, but the grid must be left untouched (no
+  // re-fetch, no row update, no removal).
+  it('leaves the grid untouched when the modal was saved (saveStatus truthy)', async () => {
+    const props = buildProps();
+    const instance = getInstance(props);
+
+    await instance.closeModalCallback({
+      isNew: true,
+      windowType: WINDOW_TYPE,
+      documentId: DOCUMENT_ID,
+      tabId: TAB_ID,
+      rowId: PERSISTED_ROW_ID,
+      saveStatus: true,
+    });
+
+    expect(discardNewRequest).toHaveBeenCalledTimes(1);
+    expect(getRowsData).not.toHaveBeenCalled();
+    expect(props.updateTabRowsData).not.toHaveBeenCalled();
+    expect(props.onRefreshTab).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/containers/MasterWindow.test.js
+++ b/frontend/src/__tests__/containers/MasterWindow.test.js
@@ -460,8 +460,8 @@ describe.skip('MasterWindowContainer', () => {
       await waitFor(async() => {
         wrapper.update();
         expect(wrapper.html()).toContain('2,888.60');
-      }, { timeout: 8000, interval: 500 });  
-    });     
+      }, { timeout: 8000, interval: 500 });
+    });
 
   }, 20000);
 });

--- a/frontend/src/__tests__/utils/tableHelper.test.js
+++ b/frontend/src/__tests__/utils/tableHelper.test.js
@@ -1,4 +1,5 @@
 import {
+  buildTabRowsDataUpdate,
   createAmount,
   createSpecialField,
   fieldValueToString,
@@ -325,5 +326,36 @@ describe('Table helpers', () => {
       isGerman,
     });
     expect(fieldToCheck.props.style.backgroundColor).toBe('DDDDDD');
+  });
+
+  describe('buildTabRowsDataUpdate', () => {
+    it('maps result rows into `changed` (rowId -> row) and missingIds into `removed` (rowId -> true)', () => {
+      const result = [
+        { rowId: '10', fieldsByName: { Name: { value: 'A' } } },
+        { rowId: '11', fieldsByName: { Name: { value: 'B' } } },
+      ];
+      const missingIds = ['99'];
+
+      const payload = buildTabRowsDataUpdate({ result, missingIds });
+
+      expect(payload).toEqual({
+        changed: {
+          10: { rowId: '10', fieldsByName: { Name: { value: 'A' } } },
+          11: { rowId: '11', fieldsByName: { Name: { value: 'B' } } },
+        },
+        removed: { 99: true },
+      });
+    });
+
+    it('omits the `changed`/`removed` keys when the corresponding input is empty or absent', () => {
+      expect(buildTabRowsDataUpdate({ result: [], missingIds: [] })).toEqual(
+        {}
+      );
+      expect(buildTabRowsDataUpdate({})).toEqual({});
+      expect(buildTabRowsDataUpdate()).toEqual({});
+      expect(buildTabRowsDataUpdate({ missingIds: ['5'] })).toEqual({
+        removed: { 5: true },
+      });
+    });
   });
 });

--- a/frontend/src/components/app/MasterWindow.js
+++ b/frontend/src/components/app/MasterWindow.js
@@ -2,8 +2,9 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 
-import { discardNewRequest } from '../../api';
+import { discardNewRequest, getRowsData } from '../../api';
 import { getTableId } from '../../reducers/tables';
+import { buildTabRowsDataUpdate } from '../../utils/tableHelpers';
 
 import { BlankPage } from '../BlankPage';
 import Container from '../Container';
@@ -87,28 +88,77 @@ export default class MasterWindow extends PureComponent {
     rowId,
     saveStatus,
   } = {}) => {
-    if (isNew) {
-      const { updateTabRowsData } = this.props;
-      const tableId = getTableId({
-        windowId: windowType,
-        docId: documentId,
-        tabId,
-      });
+    if (!isNew) {
+      return undefined;
+    }
 
-      return discardNewRequest({
-        windowId: windowType,
-        documentId,
-        tabId,
-        rowId,
-      }).then(() => {
-        // if modal was not saved, discard the new row
-        if (!saveStatus) {
+    const { updateTabRowsData, onRefreshTab } = this.props;
+    const tableId = getTableId({
+      windowId: windowType,
+      docId: documentId,
+      tabId,
+    });
+
+    // Any failure along the discard/re-fetch chain would leave the grid row
+    // stranded on the abandoned in-memory value. Modal.closeModal() does not await
+    // this callback, so an unhandled rejection would surface nothing to the user —
+    // fall back to a full tab refresh so the grid still reconciles with the DB.
+    const refreshTabAfter = (message) => (error) => {
+      console.error(`closeModalCallback: ${message}`, error);
+      if (onRefreshTab) {
+        onRefreshTab();
+      }
+    };
+
+    return discardNewRequest({
+      windowId: windowType,
+      documentId,
+      tabId,
+      rowId,
+    })
+      .then(() => {
+        if (saveStatus) {
+          // A saved modal owns no abandoned in-memory change — nothing to reconcile.
+          return undefined;
+        } else if (rowId === 'NEW') {
+          // A genuinely-unsaved new row (never persisted) is a phantom — discard it.
           updateTabRowsData(tableId, {
             removed: { [`${rowId}`]: true },
           });
+          return undefined;
+        } else {
+          // The row was auto-saved to the DB before the abandon (rowId is a real
+          // id), so it must stay in the grid. discardChanges reverted the document
+          // to its DB state server-side, but its response carries no body —
+          // re-fetch the row and revert the grid row to its DB value in-place (no
+          // browser reload), using the same shape the container's
+          // mergeDataIntoIncludedTab applies.
+          return getRowsData({
+            entity: 'window',
+            docType: windowType,
+            docId: documentId,
+            tabId,
+            rows: [rowId],
+          })
+            .then((response) => {
+              const rowsChanged = buildTabRowsDataUpdate(response.data);
+
+              if (rowsChanged.changed || rowsChanged.removed) {
+                updateTabRowsData(tableId, rowsChanged);
+              }
+            })
+            .catch(
+              refreshTabAfter(
+                're-fetch of the reverted row failed, falling back to a tab refresh'
+              )
+            );
         }
-      });
-    }
+      })
+      .catch(
+        refreshTabAfter(
+          'the discard request failed, falling back to a tab refresh'
+        )
+      );
   };
 
   /**

--- a/frontend/src/containers/MasterWindowContainer.js
+++ b/frontend/src/containers/MasterWindowContainer.js
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { forEach, get } from 'lodash';
 
 import { getRowsData, getTabRequest } from '../api';
 import { getTab } from '../utils';
+import { buildTabRowsDataUpdate } from '../utils/tableHelpers';
 
 import { getTableId } from '../reducers/tables';
 import { addNotification, updateLastBackPage } from '../actions/AppActions';
@@ -177,45 +177,12 @@ class MasterWindowContainer extends PureComponent {
       updateTabRowsData,
       params: { windowId, docId },
     } = this.props;
-    const {
-      data: { result, missingIds },
-    } = response;
-    const changedTabs = {};
-    let rowsById = null;
-    let removedRows = null;
 
-    if (missingIds && missingIds.length) {
-      removedRows = removedRows || {};
-      missingIds.forEach((rowId) => {
-        removedRows[rowId] = true;
-      });
-    }
-    if (result && result.length) {
-      rowsById = rowsById || {};
-      result.forEach((row) => {
-        rowsById[row.rowId] = { ...row };
-      });
-    }
-
-    changedTabs[tabId] = get(changedTabs, `${tabId}`, {});
-
-    if (rowsById) {
-      changedTabs[tabId].changed = {
-        ...get(changedTabs, `${tabId}.changed`, {}),
-        ...rowsById,
-      };
-    }
-    if (removedRows) {
-      changedTabs[tabId].removed = {
-        ...get(changedTabs, `${tabId}.removed`, {}),
-        ...removedRows,
-      };
-    }
-
-    forEach(changedTabs, (rowsChanged, tabId) => {
-      const tableId = getTableId({ windowId: windowId, docId, tabId });
-      updateTabRowsData(tableId, rowsChanged);
-    });
+    // Build the { changed, removed } payload the tables reducer expects from the
+    // rows GET response (shared with MasterWindow.closeModalCallback).
+    const rowsChanged = buildTabRowsDataUpdate(response.data);
+    const tableId = getTableId({ windowId, docId, tabId });
+    updateTabRowsData(tableId, rowsChanged);
   }
 
   refreshActiveTab = () => {

--- a/frontend/src/utils/tableHelpers.js
+++ b/frontend/src/utils/tableHelpers.js
@@ -572,6 +572,38 @@ export function getTooltipWidget(item, widgetData) {
   return { tooltipData, tooltipWidget };
 }
 
+/**
+ * @method buildTabRowsDataUpdate
+ * @summary Build the `{ changed, removed }` payload that the `updateTabRowsData`
+ *   action / `UPDATE_TAB_ROWS_DATA` reducer (reducers/tables.js) expects, from a
+ *   `getRowsData` response's `result` array and `missingIds`.
+ *   `changed` maps rowId -> row (add/replace); `removed` maps rowId -> true.
+ *   Each key is present only when it has data (so callers can guard on it).
+ *
+ * @param {object} params
+ * @param {array} [params.result] - rows from the getRowsData response
+ * @param {array} [params.missingIds] - ids no longer present server-side (to remove)
+ * @return {object} { changed?: {[rowId]: row}, removed?: {[rowId]: true} }
+ */
+export function buildTabRowsDataUpdate({ result, missingIds } = {}) {
+  const rowsChanged = {};
+
+  if (missingIds && missingIds.length) {
+    rowsChanged.removed = {};
+    missingIds.forEach((id) => {
+      rowsChanged.removed[id] = true;
+    });
+  }
+  if (result && result.length) {
+    rowsChanged.changed = {};
+    result.forEach((row) => {
+      rowsChanged.changed[row.rowId] = { ...row };
+    });
+  }
+
+  return rowsChanged;
+}
+
 export const computeNumberOfPages = (size, pageLength) => {
   if (pageLength > 0) {
     return size ? Math.ceil(size / pageLength) : 0;


### PR DESCRIPTION
Propagation merge (forward merge-through, **merge commit — do not squash**) of `soft_panda_hotfix` into `new_dawn_uat`.

## What it carries

Only the WebUI save-error fix from https://github.com/metasfresh/metasfresh/pull/25317 — every other `soft_panda_hotfix` commit is already an ancestor of `new_dawn_uat`.

- Commit: https://github.com/metasfresh/metasfresh/commit/51f4702d5ad1f3ac6c25a699bc073599de9a1c6c — "WebUI save-error — keep an abandoned but already-persisted new-record row visible in the grid"

## Diff scope

Frontend only, 7 files, no SQL / no migration script / no DDL:

- `frontend/src/components/app/MasterWindow.js`
- `frontend/src/containers/MasterWindowContainer.js`
- `frontend/src/utils/tableHelpers.js`
- `frontend/src/__tests__/components/app/MasterWindow.test.js` (new)
- `frontend/src/__tests__/containers/MasterWindow.test.js`
- `frontend/src/__tests__/utils/tableHelper.test.js`
- `e2e/frontend-webui/tests/spec/pricelist-version-colliding-date.spec.js`

## Merge details

- No conflicts — merged with the `ort` strategy, no manual resolution.
- Base: `new_dawn_uat` @ https://github.com/metasfresh/metasfresh/commit/4afb012a5f09125353efa9a524d5ee796c2603ab
- Second parent: https://github.com/metasfresh/metasfresh/commit/51f4702d5ad1f3ac6c25a699bc073599de9a1c6c
