### PR TITLE
Distribution mobile — carry the source HU across auto-advance in pick-any-HU mode

### DIFF
--- a/e2e/mobile-webui/tests/spec/distribution/carried_hu_cannot_serve_next_order.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/carried_hu_cannot_serve_next_order.spec.js
@@ -40,10 +40,10 @@ import { expectErrorToast } from '../../utils/common';
 // the case the frontend can rule out up front — the next order asks for an article the handling unit
 // does not hold, so nothing is carried and the prompt is there from the start.
 //
-// RESIDUAL GAP, stated rather than implied: the refusal covered here is the one the operator meets at
-// the article-code prompt, where the pick is posted directly because a single unit is left to pick. A
-// multi-unit order opens the quantity dialog first; the same refusal then arrives while that dialog is
-// on screen, and no spec covers it.
+// RESIDUAL GAP, stated rather than implied: the refusal is met here at the article-code prompt,
+// because a single unit left to pick posts the pick directly. A multi-unit order opens the quantity
+// dialog first, so the operator meets the same refusal with that dialog on screen. It travels the same
+// path (DistributionPickFromScreen.onResult), and this spec does NOT cover it.
 //
 
 // One unit per order — the customer's orders ask for 1-2 Stk. At one unit remaining the pick is

--- a/e2e/mobile-webui/tests/spec/distribution/carried_hu_cannot_serve_next_order.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/carried_hu_cannot_serve_next_order.spec.js
@@ -1,0 +1,230 @@
+import { test } from "../../../playwright.config";
+import { Backend } from "../../utils/screens/Backend";
+import { allure } from 'allure-playwright';
+import { expect } from '@playwright/test';
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { DistributionJobsListScreen } from "../../utils/screens/distribution/DistributionJobsListScreen";
+import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
+import { DistributionLinePickFromScreen } from '../../utils/screens/distribution/DistributionLinePickFromScreen';
+import { DistributionUtils } from '../../utils/screens/distribution/DistributionUtils';
+import { generateEAN13 } from '../../utils/ean13';
+import { expectErrorToast } from '../../utils/common';
+
+//
+// Several handling units of ONE article stand at one source locator and the operator picks a series of
+// single-unit orders off them — the recorded customer situation, under the setting every customer runs
+// (MobileUI_UserProfile_DD.IsAllowPickingAnyHU = 'Y', so the backend pre-allocates no move plan and
+// the operator chooses the handling unit themselves). Once an order takes a handling unit's whole
+// content, that handling unit leaves the source locator, and the NEXT order cannot be served from it.
+//
+// The auto-advance carries the operator's handling unit into the next order whenever it holds that
+// order's article (postDistributionPickFromThunk) — and it does still hold it, in transit. Only the
+// backend can say that it may no longer be picked from, and it says so when the pick is posted. With a
+// handling unit applied, the pick-from screen renders NO handling-unit input at all: it goes straight
+// to the article-code scan (ScanHUAndGetQtyComponent). So the refusal has to hand the operator the
+// handling-unit prompt back, on the same screen, or every article-code scan they make is refused for
+// the same reason and the order can only be left.
+//
+// The scenario therefore drives three single-unit orders off two handling units:
+//   DD1  picked whole off HU_A, which leaves the source locator -> auto-advance to DD2 with HU_A
+//        carried, so DD2 asks only for the article code.
+//   DD2  the article-code scan is refused because HU_A can no longer be picked from. The operator
+//        must be told why AND get the handling-unit prompt back, identify HU_B, and finish DD2.
+//   DD3  auto-advanced with HU_B carried — HU_B still stands at the source locator with stock left,
+//        so the sweep continues on the article code alone. This is what pins that recovering from the
+//        refusal does not cost the operator the carry-forward for the orders that follow.
+//
+// Sibling coverage: sweep_scan_HU_after_autoAdvance_anyHU.spec.js covers the plain carry-forward (the
+// handling unit keeps serving order after order), and navigateToJobsListAfterPickFromComplete.spec.js
+// the case the frontend can rule out up front — the next order asks for an article the handling unit
+// does not hold, so nothing is carried and the prompt is there from the start.
+//
+// RESIDUAL GAP, stated rather than implied: the refusal covered here is the one the operator meets at
+// the article-code prompt, where the pick is posted directly because a single unit is left to pick. A
+// multi-unit order opens the quantity dialog first; the same refusal then arrives while that dialog is
+// on screen, and no spec covers it.
+//
+
+// One unit per order — the customer's orders ask for 1-2 Stk. At one unit remaining the pick is
+// posted straight from the article-code scan, with no quantity dialog in between.
+const QTY_PER_ORDER = 1;
+
+// HU_A holds exactly one order's worth, so DD1 takes it whole and it leaves the source locator.
+const HU_A_QTY = QTY_PER_ORDER;
+// HU_B holds two orders' worth, so it survives DD2 and is still available for DD3.
+const HU_B_QTY = QTY_PER_ORDER * 2;
+
+// The run language is en_US (set by createMasterdata), so this is the en text of
+// activities.distribution.cannotPickFromSelectedHU, up to the backend's reason it interpolates.
+const EXPECTED_MESSAGE = 'Cannot pick from the selected HU:';
+
+const createMasterdata = async ({ huABarcode, huBBarcode }) =>
+    await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US", workplace: "carriedHUWorkplace" } },
+            mobileConfig: {
+                distribution: {
+                    // Auto-advance to the next order's pick-from screen once an order is fully picked
+                    // — the moment the handling unit is carried across.
+                    navigateToJobsListAfterPickFromComplete: true,
+                    completeJobAutomatically: true,
+                    requireScanningProductCode: true,
+                    allowStartNextJobOnly: true,
+                    // allowPickingAnyHU is a sticky, global config row the masterdata API leaves
+                    // untouched when omitted (e2e/mobile-webui/CLAUDE.md § "Debugging Flaky Tests"
+                    // rule 3), so it is always set explicitly. It is the setting every customer runs,
+                    // and the one under which the operator picks the handling unit themselves.
+                    allowPickingAnyHU: true,
+                },
+            },
+            workplaces: { carriedHUWorkplace: { warehouse: 'wh', pickFromLocator: 'packingTable' } },
+            resources: { "plantId": { type: "PT" } },
+            products: { "P": { gtin: generateEAN13().ean13 } },
+            warehouses: {
+                "wh": {
+                    locators: {
+                        // The ground locator both handling units stand at.
+                        LZ: { isGroundLocator: true, priorityNo: 10 },
+                        // The non-ground target every order drops to.
+                        packingTable: { isGroundLocator: false, priorityNo: 999 },
+                    },
+                },
+                "whInTransit": { inTransit: true },
+            },
+            handlingUnits: {
+                // Both identified by an external barcode, the way the customer's handling units are
+                // labelled.
+                HU_A: { product: "P", warehouse: "wh", locator: "LZ", qty: HU_A_QTY, externalBarcode: huABarcode },
+                HU_B: { product: "P", warehouse: "wh", locator: "LZ", qty: HU_B_QTY, externalBarcode: huBBarcode },
+            },
+            distributionOrders: {
+                DD1: buildOrder({ seqNo: 10 }),
+                DD2: buildOrder({ seqNo: 20 }),
+                DD3: buildOrder({ seqNo: 30 }),
+            },
+        },
+    });
+
+// Single-line orders: the auto-advance fires only once an order is FULLY picked, which a single-line
+// order reaches in one pick.
+const buildOrder = ({ seqNo }) => ({
+    seqNo,
+    warehouseFrom: "wh",
+    warehouseTo: "wh",
+    warehouseInTransit: "whInTransit",
+    plant: "plantId",
+    lines: [{ product: "P", qtyEntered: QTY_PER_ORDER, locatorFrom: "LZ", locatorTo: "packingTable" }],
+});
+
+// noinspection JSUnusedLocalSymbols
+test('A carried handling unit that can no longer be picked from hands the handling-unit prompt back', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114.3');
+    allure.tag('F5114');
+    allure.story('When the handling unit carried across the auto-advance cannot serve the next order, the operator is told why and identifies another one without leaving the screen');
+    allure.severity('critical');
+
+    const huABarcode = `EXT-CARRIED-A-${Date.now()}`;
+    const huBBarcode = `EXT-CARRIED-B-${Date.now()}`;
+    const masterdata = await createMasterdata({ huABarcode, huBBarcode });
+    const articleCode = masterdata.products.P.gtin;
+
+    await test.step('Open the Distribution app and start DD1', async () => {
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('distribution');
+        await DistributionJobsListScreen.waitForScreen();
+        await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+        await DistributionJobScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD1.jobId });
+    });
+
+    await test.step('Pick DD1 off HU_A (identify HU_A, scan the article code) → auto-advance to DD2 pick-from', async () => {
+        await DistributionJobScreen.scanHUToMove({
+            huQRCode: huABarcode,
+            productScannedCode: articleCode,
+            // One unit to pick: the pick is posted straight from the article-code scan.
+            expectQuantityDialog: false,
+            expectNextScreen: 'DistributionLinePickFromScreen',
+        });
+        await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD2.jobId });
+    });
+
+    // PRECONDITIONS, all asserted before the target assertions so a fixture/config drift fails HERE
+    // and is never mistaken for the behaviour under test.
+    await test.step('Backend: DD2 was started in pick-any-HU mode, without a pre-allocated move plan', async () => {
+        await DistributionUtils.expectPickAnyHUJobWithoutMovePlan({
+            wfProcessId: `distribution-${masterdata.distributionOrders.DD2.jobId}`,
+        });
+    });
+
+    await test.step('Backend: DD1 took HU_A whole, so HU_A is in transit and no longer at the source locator', async () => {
+        await Backend.expect({
+            title: 'DD1 picked HU_A whole',
+            hus: {
+                HU_A: { warehouse: 'whInTransit', huStatus: 'A', storages: { P: `${HU_A_QTY} PCE` } },
+            },
+        });
+    });
+
+    await test.step('On the auto-advanced DD2 the screen asks only for the article code (HU_A was carried across)', async () => {
+        await DistributionLinePickFromScreen.expectProductScanReady();
+    });
+
+    // *** THE ASSERTION THIS SPEC EXISTS FOR ***
+    // HU_A still holds the article DD2 asks for, so the app had no way to rule it out up front — the
+    // backend refuses the pick because HU_A has left the source locator. The operator must be told, in
+    // words they can act on, both that the handling unit they are on cannot be picked from and why.
+    await expectErrorToast(
+        'Scan the article code while the carried HU_A can no longer be picked from',
+        async () => await DistributionLinePickFromScreen.typeProductCode(articleCode),
+        ({ textContent }) => {
+            expect(textContent).toContain(EXPECTED_MESSAGE);
+            // The message carries the backend's reason, which is the "why" half of it. Asserted as
+            // "the placeholder was filled" rather than against the backend's wording, so this stays a
+            // check on the app and not on an AD_Message text.
+            expect(textContent).not.toContain('%(reason)s');
+        }
+    );
+
+    // *** THE ASSERTION THIS SPEC EXISTS FOR ***
+    // ... and the message alone would leave them stranded: with a handling unit applied this screen
+    // renders no handling-unit input, so every further article-code scan is refused for the same
+    // reason. The prompt must be the handling-unit one again, on this same screen.
+    await test.step('The screen asks for the handling unit again', async () => {
+        await DistributionLinePickFromScreen.expectHUScanReady();
+    });
+
+    await test.step('Identify HU_B instead and scan the article code → DD2 is picked and auto-advances to DD3', async () => {
+        await DistributionLinePickFromScreen.typeHUQRCode(huBBarcode);
+        await DistributionLinePickFromScreen.typeProductCode(articleCode);
+        await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD3.jobId });
+    });
+
+    await test.step('On the auto-advanced DD3 the screen asks only for the article code (HU_B was carried across)', async () => {
+        await DistributionLinePickFromScreen.expectProductScanReady();
+    });
+
+    await test.step('Scan the article code for DD3 → the last order is picked and the jobs list is shown', async () => {
+        await DistributionLinePickFromScreen.typeProductCode(articleCode);
+        await DistributionJobsListScreen.waitForScreen();
+    });
+
+    await test.step('Backend: all three orders are picked — one unit in transit per order', async () => {
+        // DD2 was served by a unit split off HU_B, which exists only from the pick on, so it can only
+        // be named through the QR code DD2's job step reports.
+        const dd2PickedHUQRCode = await DistributionUtils.getPickedHUQRCode({
+            wfProcessId: `distribution-${masterdata.distributionOrders.DD2.jobId}`,
+        });
+        await Backend.expect({
+            title: 'DD1, DD2 and DD3 each moved one unit of P into transit',
+            hus: {
+                HU_A: { warehouse: 'whInTransit', huStatus: 'A', storages: { P: `${QTY_PER_ORDER} PCE` } },
+                [dd2PickedHUQRCode]: { warehouse: 'whInTransit', huStatus: 'A', storages: { P: `${QTY_PER_ORDER} PCE` } },
+                HU_B: { warehouse: 'whInTransit', huStatus: 'A', storages: { P: `${QTY_PER_ORDER} PCE` } },
+            },
+        });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/distribution/carried_hu_cannot_serve_next_order.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/carried_hu_cannot_serve_next_order.spec.js
@@ -228,3 +228,136 @@ test('A carried handling unit that can no longer be picked from hands the handli
         });
     });
 });
+
+//
+// The second case on the same fixture: the pick fails for a reason that is NOT about the handling
+// unit. The operator has HU_B applied — here by scanning it on the job screen, the other way this
+// screen is opened with a handling unit already selected — and the server answers the pick with a
+// workflow-state conflict. The handling unit is not what went wrong, so the operator must be told what
+// did, and must keep it: repeating the same scan can succeed, and taking it away costs them a scan of
+// a handling unit that was never the problem.
+//
+// The refusal above and this failure arrive on the same endpoint (/distribution/event) and both carry
+// an HTTP response, so only the backend's error code tells them apart — the HU-specific rejections
+// carry one (DISTRIBUTION_HU_NOT_AT_TARGET and its siblings, MobileQRCodeMessages), while every other
+// rejection on this path is a plain-message AdempiereException with none at all.
+//
+// RESIDUAL GAP, stated rather than implied: this covers a rejection with NO error code, which is what
+// every non-HU rejection reachable here produces today (DDOrderPickFromCommand's "Already picked",
+// DistributionJob.assertCanEdit, movement generation, an infra 5xx). It therefore does NOT distinguish
+// the named-code list the app matches on from a plainer "any error code at all" test — no reachable
+// rejection on this path separates the two.
+//
+
+// What the app really receives when the pick fails for a reason that is not about the handling unit:
+// RestResponseEntityExceptionHandler answers an AdempiereException with 422 and a JsonError body, and
+// a plain-message one — DDOrderPickFromCommand.executeInTrx's "Already picked" workflow-state conflict,
+// raised when the schedule was already picked from — carries no errorCode and is not user-friendly, so
+// the app shows its own error.InternalError text.
+const WORKFLOW_CONFLICT_RESPONSE = {
+    status: 422,
+    contentType: 'application/json',
+    body: JSON.stringify({
+        errors: [
+            {
+                message: 'Already picked',
+                userFriendlyError: false,
+                parameters: {},
+                stackTrace: 'de.metas.distribution.ddorder.movement.schedule.commands.pick_from.DDOrderPickFromCommand.executeInTrx',
+            },
+        ],
+    }),
+};
+
+// The en text of error.InternalError, which is what a rejection flagged not-user-friendly surfaces as.
+const EXPECTED_INTERNAL_ERROR_MESSAGE = 'If the problem persists, contact support';
+
+// Answer the NEXT pick with the workflow-state conflict above and let every later one reach the
+// backend, so the operator's retry is a real pick against real stock.
+const answerNextPickWithWorkflowConflict = async (page) => {
+    let alreadyAnswered = false;
+    await page.route('**/distribution/event', async (route) => {
+        if (alreadyAnswered) {
+            await route.continue();
+            return;
+        }
+        alreadyAnswered = true;
+        await route.fulfill(WORKFLOW_CONFLICT_RESPONSE);
+    });
+};
+
+test('A pick refused for a reason that is not about the handling unit keeps it selected', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114.3');
+    allure.tag('F5114');
+    allure.story('A pick rejected for a reason that is not about the handling unit reports that reason and leaves the selected handling unit in place, so repeating the scan books the pick');
+    allure.severity('critical');
+
+    const huABarcode = `EXT-CONFLICT-A-${Date.now()}`;
+    const huBBarcode = `EXT-CONFLICT-B-${Date.now()}`;
+    const masterdata = await createMasterdata({ huABarcode, huBBarcode });
+    const articleCode = masterdata.products.P.gtin;
+
+    await test.step('Open the Distribution app and start DD1', async () => {
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('distribution');
+        await DistributionJobsListScreen.waitForScreen();
+        await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+        await DistributionJobScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD1.jobId });
+    });
+
+    await test.step('Identify HU_B on the job screen — it holds two orders\' worth and stands at the source locator', async () => {
+        await DistributionJobScreen.scanHU({ huQRCode: huBBarcode });
+        await DistributionLinePickFromScreen.expectProductScanReady();
+    });
+
+    await answerNextPickWithWorkflowConflict(page);
+
+    let refusalToastText;
+    await expectErrorToast(
+        'Scan the article code while the server answers the pick with a workflow-state conflict',
+        async () => await DistributionLinePickFromScreen.typeProductCode(articleCode),
+        ({ textContent }) => {
+            refusalToastText = textContent;
+        }
+    );
+
+    // *** THE ASSERTION THIS SPEC EXISTS FOR ***
+    // Asserted before the message, because this is the half that strands the operator: HU_B is not
+    // what the server rejected, so it stays applied and the screen keeps asking for the article code.
+    // Dropping it would send them to re-scan a handling unit that was never the problem.
+    await test.step('HU_B is still the selected handling unit, so the screen still asks for the article code', async () => {
+        await DistributionLinePickFromScreen.expectProductScanReady();
+    });
+
+    // *** THE ASSERTION THIS SPEC EXISTS FOR ***
+    // ... and the operator is told what actually went wrong. Naming HU_B as unusable would send them
+    // looking for another handling unit for a failure that had nothing to do with this one.
+    await test.step('The operator is shown the failure itself, not that the handling unit cannot be picked from', async () => {
+        expect(refusalToastText).toContain(EXPECTED_INTERNAL_ERROR_MESSAGE);
+        expect(refusalToastText).not.toContain(EXPECTED_MESSAGE);
+    });
+
+    await test.step('Scan the article code again → the pick books off HU_B and DD1 auto-advances to DD2', async () => {
+        await DistributionLinePickFromScreen.typeProductCode(articleCode);
+        await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD2.jobId });
+        await DistributionLinePickFromScreen.expectProductScanReady();
+    });
+
+    await test.step('Backend: DD1 moved one unit into transit and HU_B kept the rest', async () => {
+        // DD1 was served by a unit split off HU_B, which exists only from the pick on, so it can only
+        // be named through the QR code DD1's job step reports.
+        const dd1PickedHUQRCode = await DistributionUtils.getPickedHUQRCode({
+            wfProcessId: `distribution-${masterdata.distributionOrders.DD1.jobId}`,
+        });
+        await Backend.expect({
+            title: 'DD1 picked one unit off HU_B after the retry',
+            hus: {
+                [dd1PickedHUQRCode]: { warehouse: 'whInTransit', huStatus: 'A', storages: { P: `${QTY_PER_ORDER} PCE` } },
+                HU_B: { warehouse: 'wh', locator: 'LZ', huStatus: 'A', storages: { P: `${HU_B_QTY - QTY_PER_ORDER} PCE` } },
+            },
+        });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/distribution/refused_hu_serves_a_later_order.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/refused_hu_serves_a_later_order.spec.js
@@ -1,0 +1,243 @@
+import { test } from "../../../playwright.config";
+import { Backend } from "../../utils/screens/Backend";
+import { allure } from 'allure-playwright';
+import { expect } from '@playwright/test';
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { DistributionJobsListScreen } from "../../utils/screens/distribution/DistributionJobsListScreen";
+import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
+import { DistributionLinePickFromScreen } from '../../utils/screens/distribution/DistributionLinePickFromScreen';
+import { DistributionUtils } from '../../utils/screens/distribution/DistributionUtils';
+import { generateEAN13 } from '../../utils/ean13';
+import { expectErrorToast } from '../../utils/common';
+
+//
+// A refusal to pick from a handling unit says something about the ORDER it was refused on, not about
+// the handling unit for the rest of the shift. The same unit can serve a later order of the same
+// sweep, and when the auto-advance carries it there the screen must ask only for the article code —
+// AC1 holds "at the first auto-advance and at every subsequent one".
+//
+// Two source ground locators of the same article, which is why a refusal here is recoverable at all:
+// an order draws from one locator (DD_OrderLine.M_Locator_ID), and a handling unit standing at the
+// other is refused with DISTRIBUTION_HU_NOT_AT_TARGET (DistributionHUService.assertHUCanBePickedFrom)
+// while staying exactly where it was, still full, still pickable for an order that draws from ITS
+// locator. Set under IsAllowPickingAnyHU='Y', the setting every customer runs, so the backend
+// pre-allocates no move plan and the operator chooses the handling unit themselves.
+//
+// The sweep, four single-unit orders:
+//   DD1 (from LZ1)  the operator scans HU_P_LZ2 on the job screen — it stands at the other locator,
+//                   so the pick is refused and the handling-unit prompt comes back. They identify
+//                   HU_P_LZ1 and finish DD1.
+//   DD2 (from LZ1, article Q)  nothing is carried across: HU_P_LZ1 holds P, not Q
+//                   (postDistributionPickFromThunk gates the carry on isHUServingWholeOrder). The
+//                   operator identifies HU_Q_LZ1 and finishes DD2.
+//   DD3 (from LZ2)  again nothing is carried: HU_Q_LZ1 holds Q, not P. The operator identifies
+//                   HU_P_LZ2 — the unit refused back on DD1 — and it picks, because DD3 draws from
+//                   the locator it stands at.
+//   DD4 (from LZ2)  auto-advanced with HU_P_LZ2 carried across, and it can serve DD4. The screen must
+//                   ask only for the article code.
+//
+// Sibling coverage: carried_hu_cannot_serve_next_order.spec.js covers the refusal itself (the message
+// and the handling-unit prompt coming back), sweep_scan_HU_after_autoAdvance_anyHU.spec.js the plain
+// carry-forward, navigateToJobsListAfterPickFromComplete.spec.js the case the app rules out up front.
+//
+
+// One unit per order — the customer's orders ask for 1-2 Stk. At one unit remaining the pick is
+// posted straight from the article-code scan, with no quantity dialog in between.
+const QTY_PER_ORDER = 1;
+
+// HU_P_LZ2 serves DD3 and DD4 and still has stock left afterwards, so nothing about the end state
+// depends on it being emptied.
+const HU_P_LZ2_QTY = QTY_PER_ORDER * 3;
+
+// The run language is en_US (set by createMasterdata), so this is the en text of
+// activities.distribution.cannotPickFromSelectedHU, up to the backend's reason it interpolates.
+const EXPECTED_REFUSAL_MESSAGE = 'Cannot pick from the selected HU:';
+
+const createMasterdata = async ({ huPLZ1Barcode, huPLZ2Barcode, huQLZ1Barcode }) =>
+    await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US", workplace: "refusedHUWorkplace" } },
+            mobileConfig: {
+                distribution: {
+                    // Auto-advance to the next order's pick-from screen once an order is fully picked
+                    // — the moment the handling unit is carried across.
+                    navigateToJobsListAfterPickFromComplete: true,
+                    completeJobAutomatically: true,
+                    requireScanningProductCode: true,
+                    allowStartNextJobOnly: true,
+                    // allowPickingAnyHU is a sticky, global config row the masterdata API leaves
+                    // untouched when omitted (e2e/mobile-webui/CLAUDE.md § "Debugging Flaky Tests"
+                    // rule 3), so it is always set explicitly. It is the setting every customer runs,
+                    // and the one under which the operator picks the handling unit themselves.
+                    allowPickingAnyHU: true,
+                },
+            },
+            workplaces: { refusedHUWorkplace: { warehouse: 'wh', pickFromLocator: 'packingTable' } },
+            resources: { "plantId": { type: "PT" } },
+            products: { "P": { gtin: generateEAN13().ean13 }, "Q": { gtin: generateEAN13().ean13 } },
+            warehouses: {
+                "wh": {
+                    locators: {
+                        // Two source ground locators of the same article. An order names one of them,
+                        // and a handling unit at the other cannot be picked from for that order.
+                        LZ1: { isGroundLocator: true, priorityNo: 10 },
+                        LZ2: { isGroundLocator: true, priorityNo: 20 },
+                        // The non-ground target every order drops to.
+                        packingTable: { isGroundLocator: false, priorityNo: 999 },
+                    },
+                },
+                "whInTransit": { inTransit: true },
+            },
+            handlingUnits: {
+                // All identified by an external barcode, the way the customer's handling units are
+                // labelled.
+                HU_P_LZ1: { product: "P", warehouse: "wh", locator: "LZ1", qty: QTY_PER_ORDER, externalBarcode: huPLZ1Barcode },
+                HU_P_LZ2: { product: "P", warehouse: "wh", locator: "LZ2", qty: HU_P_LZ2_QTY, externalBarcode: huPLZ2Barcode },
+                HU_Q_LZ1: { product: "Q", warehouse: "wh", locator: "LZ1", qty: QTY_PER_ORDER, externalBarcode: huQLZ1Barcode },
+            },
+            distributionOrders: {
+                DD1: buildOrder({ seqNo: 10, product: "P", locatorFrom: "LZ1" }),
+                DD2: buildOrder({ seqNo: 20, product: "Q", locatorFrom: "LZ1" }),
+                DD3: buildOrder({ seqNo: 30, product: "P", locatorFrom: "LZ2" }),
+                DD4: buildOrder({ seqNo: 40, product: "P", locatorFrom: "LZ2" }),
+            },
+        },
+    });
+
+// Single-line orders: the auto-advance fires only once an order is FULLY picked, which a single-line
+// order reaches in one pick.
+const buildOrder = ({ seqNo, product, locatorFrom }) => ({
+    seqNo,
+    warehouseFrom: "wh",
+    warehouseTo: "wh",
+    warehouseInTransit: "whInTransit",
+    plant: "plantId",
+    lines: [{ product, qtyEntered: QTY_PER_ORDER, locatorFrom, locatorTo: "packingTable" }],
+});
+
+// noinspection JSUnusedLocalSymbols
+test('A handling unit refused on one order is carried across the auto-advance into a later one it can serve', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114.3');
+    allure.tag('F5114');
+    allure.story('A refusal to pick from a handling unit is scoped to the order it happened on, so a later order of the sweep still gets it carried across the auto-advance');
+    allure.severity('critical');
+
+    const huPLZ1Barcode = `EXT-REFUSED-P-LZ1-${Date.now()}`;
+    const huPLZ2Barcode = `EXT-REFUSED-P-LZ2-${Date.now()}`;
+    const huQLZ1Barcode = `EXT-REFUSED-Q-LZ1-${Date.now()}`;
+    const masterdata = await createMasterdata({ huPLZ1Barcode, huPLZ2Barcode, huQLZ1Barcode });
+    const articleCodeP = masterdata.products.P.gtin;
+    const articleCodeQ = masterdata.products.Q.gtin;
+
+    await test.step('Open the Distribution app and start DD1', async () => {
+        await LoginScreen.login(masterdata.login.user);
+        await ApplicationsListScreen.expectVisible();
+        await ApplicationsListScreen.startApplication('distribution');
+        await DistributionJobsListScreen.waitForScreen();
+        await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+        await DistributionJobScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD1.jobId });
+    });
+
+    await test.step('On DD1 the operator picks HU_P_LZ2, which stands at the other source locator', async () => {
+        await DistributionJobScreen.scanHU({ huQRCode: huPLZ2Barcode });
+        await DistributionLinePickFromScreen.expectProductScanReady();
+    });
+
+    await expectErrorToast(
+        'Scan the article code while HU_P_LZ2 is not at the locator DD1 draws from',
+        async () => await DistributionLinePickFromScreen.typeProductCode(articleCodeP),
+        ({ textContent }) => expect(textContent).toContain(EXPECTED_REFUSAL_MESSAGE)
+    );
+
+    await test.step('The screen asks for the handling unit again', async () => {
+        await DistributionLinePickFromScreen.expectHUScanReady();
+    });
+
+    await test.step('Identify HU_P_LZ1 and finish DD1 → auto-advance to DD2, which asks for article Q', async () => {
+        await DistributionLinePickFromScreen.typeHUQRCode(huPLZ1Barcode);
+        await DistributionLinePickFromScreen.typeProductCode(articleCodeP);
+        await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD2.jobId });
+        // HU_P_LZ1 holds P, DD2 asks for Q, so nothing is carried across and the prompt is the
+        // handling-unit one from the start.
+        await DistributionLinePickFromScreen.expectHUScanReady();
+    });
+
+    await test.step('Pick DD2 off HU_Q_LZ1 → auto-advance to DD3, which asks for article P again', async () => {
+        await DistributionLinePickFromScreen.typeHUQRCode(huQLZ1Barcode);
+        await DistributionLinePickFromScreen.typeProductCode(articleCodeQ);
+        await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD3.jobId });
+        // HU_Q_LZ1 holds Q, DD3 asks for P, so again nothing is carried across.
+        await DistributionLinePickFromScreen.expectHUScanReady();
+    });
+
+    await test.step('Pick DD3 off HU_P_LZ2 — the handling unit DD1 refused — and auto-advance to DD4', async () => {
+        await DistributionLinePickFromScreen.typeHUQRCode(huPLZ2Barcode);
+        await DistributionLinePickFromScreen.typeProductCode(articleCodeP);
+        await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD4.jobId });
+    });
+
+    // PRECONDITIONS, asserted before the target assertion so a fixture/config drift fails HERE and is
+    // never mistaken for the behaviour under test.
+    await test.step('Backend: DD4 was started in pick-any-HU mode, without a pre-allocated move plan', async () => {
+        await DistributionUtils.expectPickAnyHUJobWithoutMovePlan({
+            wfProcessId: `distribution-${masterdata.distributionOrders.DD4.jobId}`,
+        });
+    });
+
+    await test.step('Backend: HU_P_LZ2 still stands at LZ2 with stock, so carrying it into DD4 is legitimate', async () => {
+        await Backend.expect({
+            title: 'HU_P_LZ2 survived the DD3 pick at its own locator',
+            hus: {
+                HU_P_LZ2: {
+                    warehouse: 'wh',
+                    locator: 'LZ2',
+                    huStatus: 'A',
+                    storages: { P: `${HU_P_LZ2_QTY - QTY_PER_ORDER} PCE` },
+                },
+            },
+        });
+    });
+
+    // *** THE ASSERTION THIS SPEC EXISTS FOR ***
+    // DD4 draws from LZ2, HU_P_LZ2 stands there with stock left, and DD3 just picked off it — so the
+    // auto-advance carries it across and the operator needs only the article code. The refusal DD1
+    // met is spent: it belonged to DD1, an order that drew from the other locator.
+    await test.step('On the auto-advanced DD4 the screen asks only for the article code (HU_P_LZ2 was carried across)', async () => {
+        await DistributionLinePickFromScreen.expectProductScanReady();
+    });
+
+    await test.step('Scan the article code for DD4 → the last order is picked and the jobs list is shown', async () => {
+        await DistributionLinePickFromScreen.typeProductCode(articleCodeP);
+        await DistributionJobsListScreen.waitForScreen();
+    });
+
+    await test.step('Backend: all four orders are picked — one unit in transit per order', async () => {
+        // DD3 and DD4 were each served by a unit split off HU_P_LZ2, which exists only from the pick
+        // on, so it can only be named through the QR code that order's job step reports.
+        const dd3PickedHUQRCode = await DistributionUtils.getPickedHUQRCode({
+            wfProcessId: `distribution-${masterdata.distributionOrders.DD3.jobId}`,
+        });
+        const dd4PickedHUQRCode = await DistributionUtils.getPickedHUQRCode({
+            wfProcessId: `distribution-${masterdata.distributionOrders.DD4.jobId}`,
+        });
+        await Backend.expect({
+            title: 'DD1..DD4 each moved one unit into transit, and HU_P_LZ2 kept the rest',
+            hus: {
+                HU_P_LZ1: { warehouse: 'whInTransit', huStatus: 'A', storages: { P: `${QTY_PER_ORDER} PCE` } },
+                HU_Q_LZ1: { warehouse: 'whInTransit', huStatus: 'A', storages: { Q: `${QTY_PER_ORDER} PCE` } },
+                [dd3PickedHUQRCode]: { warehouse: 'whInTransit', huStatus: 'A', storages: { P: `${QTY_PER_ORDER} PCE` } },
+                [dd4PickedHUQRCode]: { warehouse: 'whInTransit', huStatus: 'A', storages: { P: `${QTY_PER_ORDER} PCE` } },
+                HU_P_LZ2: {
+                    warehouse: 'wh',
+                    locator: 'LZ2',
+                    huStatus: 'A',
+                    storages: { P: `${HU_P_LZ2_QTY - 2 * QTY_PER_ORDER} PCE` },
+                },
+            },
+        });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/distribution/scan_product_code_while_awaiting_hu.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/scan_product_code_while_awaiting_hu.spec.js
@@ -22,21 +22,14 @@ import { expectErrorToast } from '../../utils/common';
 // with an untranslated wrong-QR-code-type rejection ("Falscher QR-Code-Typ: EAN13HUQRCode") that
 // tells the operator nothing they can act on.
 //
-// TWO tests, differing ONLY in whether product-code scanning is required, because that setting sends
-// the article code down a DIFFERENT code path to the same defect, and both settings ship:
-//
-//   required     the screen asked for the handling unit and took the article code as the chosen one
-//                locally, without asking the backend, silently moving the operator on to the
-//                article-code prompt — so the operator got no message at all, and the article code
-//                only travelled in the huQRCode slot one step later, on their next scan.
-//   not required the screen resolved the handling unit against the backend on the spot, so the
-//                article code went out in the huQRCode slot immediately and came back 422
-//                wrong-QR-code-type — the symptom the customer reported.
-//
-// Both tests make both assertions — the on-screen message and that nothing ever put the article code
-// in the huQRCode slot — and on the old app both fail in both tests. What the split buys is that each
-// setting is covered on its own path, and that the huQRCode assertion is the FIRST thing to notice the
-// defect in the "not required" test, where the message never differed from the server's.
+// TWO tests, differing ONLY in whether product-code scanning is required. Both settings ship to
+// customers, and the refusal itself is deliberately independent of them — it is decided before
+// requireScanningProductCode is read — so NEITHER test discriminates on that setting, and neither is
+// claimed to. What differs is the legitimate route each one then finishes the pick through: with the
+// setting on, the article code is scanned again at the article-code prompt; with it off, identifying
+// the handling unit goes straight to the quantity dialog. Each test asserts BOTH halves of the
+// behaviour — the on-screen message, and that no request ever carried the article code in the
+// huQRCode slot — so each setting is covered end to end.
 //
 // Everything else is held constant, and allowPickingAnyHU is on in both — the setting every customer
 // runs, and the one that puts the "Scan QR Code" button on the line screen these scenarios enter
@@ -45,6 +38,11 @@ import { expectErrorToast } from '../../utils/common';
 // Sibling coverage: scan_HU_barcodes.spec.js covers the other two things an operator can scan at this
 // prompt — a locator QR code and an unrecognised barcode — both of which the backend already answers
 // with a readable message and which this behaviour leaves alone.
+//
+// RESIDUAL GAP, stated rather than implied: only an EAN13 article code is refused on the screen,
+// because that is the one article-code format the pick-from screen recognises without asking the
+// backend. A GS1-encoded article code still reaches the backend and still surfaces its wrong-QR-type
+// message, so it is NOT covered here or by any sibling spec.
 //
 
 // Moved in ONE pick, so the whole handling unit travels and keeps its identity — that is what lets
@@ -160,9 +158,10 @@ test('Article code scanned where the handling unit is expected: the operator is 
 
     // ... and the message must not cost them their place: the prompt is still the handling-unit one,
     // so their next scan is read as a handling unit. The pick-from screen renders exactly ONE of the
-    // two scan inputs (ScanHUAndGetQtyComponent's progressStatus), and the article-code prompt is what
-    // the old app showed here — having accepted the article code as the chosen handling unit — so this
-    // is the assertion that tells the two apart under this configuration.
+    // two scan inputs (ScanHUAndGetQtyComponent's progressStatus), so asserting the handling-unit
+    // input is the one showing distinguishes "the scan was refused and the operator kept their place"
+    // from "the article code was taken as the chosen handling unit and the screen moved on to the
+    // article-code prompt" — the two outcomes differ in exactly this value.
     await test.step('The screen still asks for the handling unit', async () => {
         await DistributionLinePickFromScreen.expectHUScanReady();
     });
@@ -225,10 +224,11 @@ test('Article code scanned where the handling unit is expected: it is never sent
     await expectPickLanded();
 
     // *** THE ASSERTION THIS TEST EXISTS FOR ***
-    // With no product code required, the app resolves the scan against the backend immediately — so
-    // this is where the article code used to travel in the huQRCode slot and come back rejected as
-    // the wrong QR-code type. Nothing in the whole session may put it there: the only handling-unit
-    // code the backend is ever offered is the real one, scanned above.
+    // With no product code required, identifying the handling unit resolves it against the backend
+    // straight away — so in this configuration the huQRCode slot is filled from the very first scan
+    // the operator makes. Across the whole session it may only ever hold the real handling-unit code
+    // scanned above, never the article code, whose rejection is what the backend answers with the
+    // wrong-QR-code-type message the operator must never see.
     await DistributionUtils.expectNoPickFromLineRequestCarriedHUQRCode({
         recorder: pickFromLineRequests,
         huQRCode: articleCode,

--- a/e2e/mobile-webui/tests/spec/distribution/scan_product_code_while_awaiting_hu.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/scan_product_code_while_awaiting_hu.spec.js
@@ -1,0 +1,236 @@
+import { test } from "../../../playwright.config";
+import { Backend } from "../../utils/screens/Backend";
+import { allure } from 'allure-playwright';
+import { expect } from '@playwright/test';
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { DistributionJobsListScreen } from "../../utils/screens/distribution/DistributionJobsListScreen";
+import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
+import { DistributionLineScreen } from '../../utils/screens/distribution/DistributionLineScreen';
+import { DistributionLinePickFromScreen } from '../../utils/screens/distribution/DistributionLinePickFromScreen';
+import { DistributionUtils } from '../../utils/screens/distribution/DistributionUtils';
+import { generateEAN13 } from '../../utils/ean13';
+import { expectErrorToast } from '../../utils/common';
+
+//
+// The distribution pick-from screen is asking for a handling unit and the operator scans the ARTICLE
+// code (the product's GTIN) instead. In distribution that can never identify a handling unit — a
+// source locator holds many handling units of one article, so a bare article code cannot say which
+// one to pick from, and the backend accordingly resolves that slot to a real handling-unit QR code
+// only (DistributionHUService.resolveHUQRCode). So the app must say so on the screen, and must keep
+// the article code out of the handling-unit slot rather than pass it on and let the server answer
+// with an untranslated wrong-QR-code-type rejection ("Falscher QR-Code-Typ: EAN13HUQRCode") that
+// tells the operator nothing they can act on.
+//
+// TWO tests, differing ONLY in whether product-code scanning is required, because that setting sends
+// the article code down a DIFFERENT code path to the same defect, and both settings ship:
+//
+//   required     the screen asked for the handling unit and took the article code as the chosen one
+//                locally, without asking the backend, silently moving the operator on to the
+//                article-code prompt — so the operator got no message at all, and the article code
+//                only travelled in the huQRCode slot one step later, on their next scan.
+//   not required the screen resolved the handling unit against the backend on the spot, so the
+//                article code went out in the huQRCode slot immediately and came back 422
+//                wrong-QR-code-type — the symptom the customer reported.
+//
+// Both tests make both assertions — the on-screen message and that nothing ever put the article code
+// in the huQRCode slot — and on the old app both fail in both tests. What the split buys is that each
+// setting is covered on its own path, and that the huQRCode assertion is the FIRST thing to notice the
+// defect in the "not required" test, where the message never differed from the server's.
+//
+// Everything else is held constant, and allowPickingAnyHU is on in both — the setting every customer
+// runs, and the one that puts the "Scan QR Code" button on the line screen these scenarios enter
+// through.
+//
+// Sibling coverage: scan_HU_barcodes.spec.js covers the other two things an operator can scan at this
+// prompt — a locator QR code and an unrecognised barcode — both of which the backend already answers
+// with a readable message and which this behaviour leaves alone.
+//
+
+// Moved in ONE pick, so the whole handling unit travels and keeps its identity — that is what lets
+// the closing assertions name HU1 directly instead of chasing a split-off HU's QR code.
+const QTY_TO_MOVE = 100;
+
+// The run language is en_US (set by createMasterdata), so this is the en text of
+// activities.distribution.qrcode.productCodeWhereHUExpected.
+const EXPECTED_MESSAGE = 'This is an article barcode (GTIN), not an HU barcode. Please scan the HU first.';
+
+/**
+ * @param requireScanningProductCode the ONE configuration difference between the two tests — see the
+ *        file header. Passed explicitly by both, never inherited.
+ */
+const createMasterdata = async ({ huExternalBarcode, requireScanningProductCode }) =>
+    await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US", workplace: "articleCodeWorkplace" } },
+            mobileConfig: {
+                distribution: {
+                    // allowPickingAnyHU is a sticky, global config row the masterdata API leaves
+                    // untouched when omitted (e2e/mobile-webui/CLAUDE.md § "Debugging Flaky Tests"
+                    // rule 3), so it is always set explicitly here. It is the setting every customer
+                    // runs, and it renders the line screen's "Scan QR Code" button
+                    // (DistributionLineScreen.jsx) — the operator's way onto the pick-from screen with
+                    // no handling unit chosen yet, which is the situation under test.
+                    allowPickingAnyHU: true,
+                    requireScanningProductCode,
+                },
+            },
+            resources: { "plantId": { type: "PT" } },
+            products: { "P1": { gtin: generateEAN13().ean13 } },
+            warehouses: {
+                "wh1": {},
+                "wh2": { locators: { wh2_l1: {} } },
+                "whInTransit": { inTransit: true },
+            },
+            workplaces: { articleCodeWorkplace: { warehouse: 'wh2', pickFromLocator: 'wh2_l1' } },
+            handlingUnits: {
+                // Identified by an external barcode, the way the handling units in the reported
+                // scenario are labelled.
+                "HU1": { product: "P1", warehouse: "wh1", qty: QTY_TO_MOVE, externalBarcode: huExternalBarcode },
+            },
+            distributionOrders: {
+                "DD1": {
+                    warehouseFrom: "wh1",
+                    warehouseTo: "wh2",
+                    warehouseInTransit: "whInTransit",
+                    plant: "plantId",
+                    lines: [{ product: "P1", qtyEntered: QTY_TO_MOVE }],
+                },
+            },
+        },
+    });
+
+const startJobAndOpenPickFrom = async ({ masterdata }) => await test.step('Open the Distribution app, start DD1 and open its line to pick from', async () => {
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('distribution');
+    await DistributionJobsListScreen.waitForScreen();
+    await DistributionJobsListScreen.startJob({ launcherTestId: masterdata.distributionOrders.DD1.launcherTestId });
+    await DistributionJobScreen.clickLineButton({ index: 1 });
+    await DistributionLineScreen.openPickFromScreen();
+});
+
+const expectPickLanded = async () => await test.step('Backend: the pick landed — the handling unit is in transit with its full qty', async () => {
+    await Backend.expect({
+        title: 'DD1 picked from HU1',
+        hus: {
+            HU1: { warehouse: 'whInTransit', huStatus: 'A', storages: { P1: `${QTY_TO_MOVE} PCE` } },
+        },
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Article code scanned where the handling unit is expected: the operator is told, and the screen keeps asking for the handling unit', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114.3');
+    allure.tag('F5114');
+    allure.story('Scanning the article code while the pick-from screen asks for the handling unit is answered on the screen, and the prompt stays on the handling unit');
+    allure.severity('critical');
+
+    const huExternalBarcode = `EXT-ARTICLE-CODE-REQ-${Date.now()}`;
+    const masterdata = await createMasterdata({ huExternalBarcode, requireScanningProductCode: true });
+    const articleCode = masterdata.products.P1.gtin;
+
+    // Recording starts before the operator does anything, so the closing assertion covers EVERY
+    // request of the session — including the legitimate pick at the end, which does send this article
+    // code, as productScannedCode alongside the real handling unit's QR code, and must still never
+    // send it as huQRCode.
+    const pickFromLineRequests = DistributionUtils.recordNextEligiblePickFromLineRequests();
+
+    await startJobAndOpenPickFrom({ masterdata });
+
+    // PRECONDITION, asserted before the target assertion so a fixture/config drift fails HERE and is
+    // never mistaken for the behaviour under test: the screen really is asking for the handling unit.
+    await test.step('The screen asks the operator to scan the handling unit', async () => {
+        await DistributionLinePickFromScreen.expectHUScanReady();
+    });
+
+    // *** THE ASSERTION THIS TEST EXISTS FOR ***
+    // The operator scans the article's GTIN at the handling-unit prompt and must be told, in words
+    // they can act on, that this is an article code and a handling unit is what is wanted.
+    await expectErrorToast(
+        'Scan the article code where the handling unit is expected',
+        async () => await DistributionLinePickFromScreen.typeHUQRCode(articleCode),
+        ({ textContent }) => {
+            expect(textContent).toContain(EXPECTED_MESSAGE);
+        }
+    );
+
+    // ... and the message must not cost them their place: the prompt is still the handling-unit one,
+    // so their next scan is read as a handling unit. The pick-from screen renders exactly ONE of the
+    // two scan inputs (ScanHUAndGetQtyComponent's progressStatus), and the article-code prompt is what
+    // the old app showed here — having accepted the article code as the chosen handling unit — so this
+    // is the assertion that tells the two apart under this configuration.
+    await test.step('The screen still asks for the handling unit', async () => {
+        await DistributionLinePickFromScreen.expectHUScanReady();
+    });
+
+    await test.step('Identify the handling unit by its external barcode, then scan the article code and confirm the qty', async () => {
+        await DistributionLinePickFromScreen.typeHUQRCode(huExternalBarcode);
+        await DistributionLinePickFromScreen.typeProductCode(articleCode);
+        await DistributionLinePickFromScreen.fillQuantityDialog({ expectedQtyToMove: QTY_TO_MOVE });
+        await DistributionLineScreen.waitForScreen();
+    });
+
+    await expectPickLanded();
+
+    await DistributionUtils.expectNoPickFromLineRequestCarriedHUQRCode({
+        recorder: pickFromLineRequests,
+        huQRCode: articleCode,
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Article code scanned where the handling unit is expected: it is never sent to the backend as a handling-unit code', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0370: Intralogistic (HUs)');
+    allure.tag('F5114.3');
+    allure.tag('F5114');
+    allure.story('Scanning the article code while the pick-from screen asks for the handling unit never puts it in the huQRCode slot, so no wrong-QR-code-type rejection reaches the operator');
+    allure.severity('critical');
+
+    const huExternalBarcode = `EXT-ARTICLE-CODE-NOREQ-${Date.now()}`;
+    const masterdata = await createMasterdata({ huExternalBarcode, requireScanningProductCode: false });
+    const articleCode = masterdata.products.P1.gtin;
+
+    const pickFromLineRequests = DistributionUtils.recordNextEligiblePickFromLineRequests();
+
+    await startJobAndOpenPickFrom({ masterdata });
+
+    // PRECONDITION — see the sibling test.
+    await test.step('The screen asks the operator to scan the handling unit', async () => {
+        await DistributionLinePickFromScreen.expectHUScanReady();
+    });
+
+    await expectErrorToast(
+        'Scan the article code where the handling unit is expected',
+        async () => await DistributionLinePickFromScreen.typeHUQRCode(articleCode),
+        ({ textContent }) => {
+            expect(textContent).toContain(EXPECTED_MESSAGE);
+        }
+    );
+
+    await test.step('The screen still asks for the handling unit', async () => {
+        await DistributionLinePickFromScreen.expectHUScanReady();
+    });
+
+    await test.step('Identify the handling unit by its external barcode and confirm the qty', async () => {
+        await DistributionLinePickFromScreen.typeHUQRCode(huExternalBarcode);
+        await DistributionLinePickFromScreen.fillQuantityDialog({ expectedQtyToMove: QTY_TO_MOVE });
+        await DistributionLineScreen.waitForScreen();
+    });
+
+    await expectPickLanded();
+
+    // *** THE ASSERTION THIS TEST EXISTS FOR ***
+    // With no product code required, the app resolves the scan against the backend immediately — so
+    // this is where the article code used to travel in the huQRCode slot and come back rejected as
+    // the wrong QR-code type. Nothing in the whole session may put it there: the only handling-unit
+    // code the backend is ever offered is the real one, scanned above.
+    await DistributionUtils.expectNoPickFromLineRequestCarriedHUQRCode({
+        recorder: pickFromLineRequests,
+        huQRCode: articleCode,
+    });
+});

--- a/e2e/mobile-webui/tests/spec/distribution/sweep_scan_HU_after_autoAdvance_anyHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/sweep_scan_HU_after_autoAdvance_anyHU.spec.js
@@ -7,48 +7,65 @@ import { DistributionJobsListScreen } from "../../utils/screens/distribution/Dis
 import { DistributionJobScreen } from '../../utils/screens/distribution/DistributionJobScreen';
 import { DistributionLinePickFromScreen } from '../../utils/screens/distribution/DistributionLinePickFromScreen';
 import { DistributionUtils } from '../../utils/screens/distribution/DistributionUtils';
-import { createSweepMasterdata } from '../../utils/sweepDistributionMasterdata';
+import { createSweepMasterdata, SWEEP_HU_QTY } from '../../utils/sweepDistributionMasterdata';
 
 //
 // The "sweep" distribution flow when the operator may serve an order from ANY handling unit — the
-// setting every customer runs (MobileUI_UserProfile_DD.IsAllowPickingAnyHU = 'Y'): small quantities
-// are picked off ONE staging LU at a ground locator, order after order, as the app auto-advances.
-// With that setting the backend builds NO pre-allocated move plan (see DistributionJobCreateCommand),
-// so no source HU is fixed at job-creation time and the app has no plan to compare the operator's
-// scan against.
+// setting every customer runs (MobileUI_UserProfile_DD.IsAllowPickingAnyHU = 'Y'): several handling
+// units of the same article stand at one ground locator, and small quantities are picked off the one
+// the operator identifies, order after order, as the app auto-advances. With that setting the backend
+// builds NO pre-allocated move plan (see DistributionJobCreateCommand), so no source handling unit is
+// fixed at job-creation time and the app has no plan to compare the operator's scan against — their
+// own choice among the handling units standing there is the only source information that exists.
 //
-// That must NOT cost the operator a handling-unit re-scan. They physically used the SAME staging LU
-// for the order just picked, and nothing contradicts that choice, so the app carries that HU forward:
-// the auto-advanced screen goes straight to the product-code scan — exactly as it does when a move
-// plan pins the HU (sweep_scan_product_after_autoAdvance.spec.js) — and scanning the product code
-// ALONE books the pick onto the HU split off for that order. Asking for the handling unit again
-// instead is the defect this spec guards: the operator's next scan is the product GTIN, which then
-// lands in the HU slot and the backend rejects it as the wrong QR-code type.
+// That must NOT cost the operator a handling-unit re-scan. They physically used one of those handling
+// units for the order just picked, and it holds the article the next order asks for, so the app
+// carries it forward: the auto-advanced screen goes straight to the article-code scan — exactly as it
+// does when a move plan pins the handling unit (sweep_scan_product_after_autoAdvance.spec.js) — and
+// scanning the article code ALONE books the pick. Asking for the handling unit again instead is the
+// defect this spec guards: the operator's next scan is the article GTIN, which then lands in the
+// handling-unit slot and the backend rejects it as the wrong QR-code type.
 //
-// The fixture comes from the factory shared with sweep_scan_product_after_autoAdvance.spec.js, so the
-// two specs cover the two sides of allowPickingAnyHU with everything else held constant — see
-// sweepDistributionMasterdata.js. The carry-forward rule itself is owned by
-// postDistributionPickFromThunk.js.
+// The fixture comes from the factory shared with sweep_scan_product_after_autoAdvance.spec.js — see
+// sweepDistributionMasterdata.js for what the two specs hold constant and why this one needs several
+// handling units where the plan-driven sibling needs exactly one. The carry-forward rule itself is
+// owned by postDistributionPickFromThunk.js.
 //
+
+// Several handling units of the same article at one source locator — the recorded situation, where a
+// dozen of one article stand at a single locator. Three is what the assertions need: enough for the
+// handling unit the operator identifies to be neither end of the candidates standing there.
+const HU_COUNT = 3;
+
+// The handling unit the operator identifies, out of the three. Weighing all three in the end-result
+// assertion is what pins which one the picks came off; taking the MIDDLE one is what makes an
+// implementation reaching for the first or the last candidate fail instead of passing by coincidence.
+const IDENTIFIED_HU = 'HU2';
+
+// DD1 (10) and DD2 (20) are both served from IDENTIFIED_HU: DD1 because the operator identified it,
+// DD2 because it is carried across the auto-advance. That is what the closing assertion weighs.
+const QTY_PICKED_OFF_IDENTIFIED_HU = 10 + 20;
 
 const createMasterdata = async () =>
     await createSweepMasterdata({
         // THE flag under test.
         allowPickingAnyHU: true,
+        handlingUnitCount: HU_COUNT,
         barcodePrefix: 'EXT-SWEEP-ANYHU',
         workplaceKey: 'sweepAnyHUWorkplace',
     });
 
 // noinspection JSUnusedLocalSymbols
-test('Sweep (pick-any-HU): after auto-advance, the operator scans only the product code (the staging LU carries forward)', async ({ page }) => {
+test('Sweep (pick-any-HU): after auto-advance, the operator scans only the article code (the handling unit they identified carries forward)', async ({ page }) => {
     // === ALLURE METADATA ===
     allure.epic('E0370: Intralogistic (HUs)');
     allure.tag('F5114: MobileUI Distribution');
     allure.tag('F5114');
-    allure.story('Sweep (pick-any-HU): with no pre-allocated move plan, the operator still scans only the product code on every auto-advanced order');
+    allure.story('Sweep (pick-any-HU): with no pre-allocated move plan, the operator still scans only the article code on every auto-advanced order');
     allure.severity('critical');
 
     const masterdata = await createMasterdata();
+    const identifiedHUBarcode = masterdata.huExternalBarcodes[IDENTIFIED_HU];
 
     await test.step('Open the Distribution app, start DD1', async () => {
         await LoginScreen.login(masterdata.login.user);
@@ -59,9 +76,9 @@ test('Sweep (pick-any-HU): after auto-advance, the operator scans only the produ
         await DistributionJobScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD1.jobId });
     });
 
-    await test.step('Pick DD1 off the staging LU (scan the LU + product P, confirm qty 10) → auto-advance to DD2 pick-from', async () => {
+    await test.step(`Pick DD1 off ${IDENTIFIED_HU} (identify it by its external barcode, scan article P, confirm qty 10) → auto-advance to DD2 pick-from`, async () => {
         await DistributionJobScreen.scanHUToMove({
-            huQRCode: masterdata.luExternalBarcode,
+            huQRCode: identifiedHUBarcode,
             productScannedCode: masterdata.products.P.gtin,
             expectedQtyToMove: 10,
             expectNextScreen: 'DistributionLinePickFromScreen',
@@ -79,31 +96,47 @@ test('Sweep (pick-any-HU): after auto-advance, the operator scans only the produ
     });
 
     // *** THE ASSERTION THIS SPEC EXISTS FOR ***
-    // No move plan pins a source HU for DD2 — but the operator just scanned the staging LU for DD1,
-    // and that same LU holds plenty of stock for DD2 too. The app must carry it forward: the operator
-    // is NOT asked to re-scan the handling unit, only the product code.
-    await test.step('On the auto-advanced DD2: the screen is ready for the PRODUCT scan (no HU re-scan requested)', async () => {
+    // No move plan pins a source handling unit for DD2 — but the operator just identified one for DD1,
+    // and it holds plenty of stock for DD2 too. The app must carry it forward: the operator is NOT
+    // asked to identify a handling unit again, only to scan the article code.
+    await test.step('On the auto-advanced DD2: the screen is ready for the ARTICLE scan (no handling-unit re-scan requested)', async () => {
         await DistributionLinePickFromScreen.expectProductScanReady();
     });
 
-    // Scanning ONLY the product code must book the pick — no wrong-QR-type error, no HU barcode.
-    // The trailing product-scan assertion covers the SECOND order boundary: the carry-forward has to
-    // hold at every auto-advance, not just the first one.
-    await test.step('Scan product P for DD2 (confirm qty 20) → no error, auto-advance to DD3 which is again ready for the PRODUCT scan', async () => {
+    // Scanning ONLY the article code must book the pick — no wrong-QR-type error, no handling-unit
+    // barcode. The trailing article-scan assertion covers the SECOND order boundary: the carry-forward
+    // has to hold at every auto-advance, not just the first one.
+    await test.step('Scan article P for DD2 (confirm qty 20) → no error, auto-advance to DD3 which is again ready for the ARTICLE scan', async () => {
         await DistributionLinePickFromScreen.typeProductCode(masterdata.products.P.gtin);
         await DistributionLinePickFromScreen.fillQuantityDialog({ expectedQtyToMove: 20 });
         await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD3.jobId });
         await DistributionLinePickFromScreen.expectProductScanReady();
     });
 
-    await test.step('Backend: the DD2 pick landed (the moved qty of P is on the split-off HU)', async () => {
+    await test.step(`Backend: DD2's pick landed, and it came off ${IDENTIFIED_HU} — the other handling units at the locator are untouched`, async () => {
+        // What DD2 moved is a handling unit split off at pick time, so it exists only from the pick on
+        // and can only be named through the QR code DD2's job step reports.
         const pickedHUQRCode = await DistributionUtils.getPickedHUQRCode({
             wfProcessId: `distribution-${masterdata.distributionOrders.DD2.jobId}`,
         });
+
+        // Every handling unit at the source locator, with the qty that must be left on it: the one the
+        // operator identified is short exactly what DD1 and DD2 took off it, and every other one still
+        // stands there full. This is what pins both picks onto the handling unit the operator chose —
+        // with a single handling unit at the locator there would be nothing else they could have come
+        // off, and the carry-forward's identity would go unchecked.
+        const expectedSourceHUs = {};
+        for (let i = 1; i <= HU_COUNT; i++) {
+            const huIdentifier = `HU${i}`;
+            const qtyLeft = huIdentifier === IDENTIFIED_HU ? SWEEP_HU_QTY - QTY_PICKED_OFF_IDENTIFIED_HU : SWEEP_HU_QTY;
+            expectedSourceHUs[huIdentifier] = { huStatus: 'A', locator: 'LZ', storages: { P: `${qtyLeft} PCE` } };
+        }
+
         await Backend.expect({
-            title: 'DD2 pick landed',
+            title: `DD2 pick landed off ${IDENTIFIED_HU}`,
             hus: {
                 [pickedHUQRCode]: { huStatus: 'A', warehouse: 'whInTransit', storages: { P: '20 PCE' } },
+                ...expectedSourceHUs,
             },
         });
     });

--- a/e2e/mobile-webui/tests/spec/distribution/sweep_scan_HU_after_autoAdvance_anyHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/sweep_scan_HU_after_autoAdvance_anyHU.spec.js
@@ -10,15 +10,24 @@ import { DistributionUtils } from '../../utils/screens/distribution/Distribution
 import { createSweepMasterdata } from '../../utils/sweepDistributionMasterdata';
 
 //
-// The "sweep" distribution flow when the operator may serve an order from ANY handling unit: small
-// quantities are picked off ONE staging LU at a ground locator, order after order, as the app
-// auto-advances. Because such an order has no source HU assigned to it up front, the app never assumes
-// the next order will be served from the LU just scanned — so on every auto-advanced order the operator
-// scans the staging LU again, then the product code.
+// The "sweep" distribution flow when the operator may serve an order from ANY handling unit — the
+// setting every customer runs (MobileUI_UserProfile_DD.IsAllowPickingAnyHU = 'Y'): small quantities
+// are picked off ONE staging LU at a ground locator, order after order, as the app auto-advances.
+// With that setting the backend builds NO pre-allocated move plan (see DistributionJobCreateCommand),
+// so no source HU is fixed at job-creation time and the app has no plan to compare the operator's
+// scan against.
 //
-// The fixture comes from the factory shared with sweep_scan_product_after_autoAdvance.spec.js: with
-// allowPickingAnyHU off, the very same data lands the operator on the PRODUCT scan instead, and that
-// contrast is what makes this spec discriminating. The carry-forward rule itself is owned by
+// That must NOT cost the operator a handling-unit re-scan. They physically used the SAME staging LU
+// for the order just picked, and nothing contradicts that choice, so the app carries that HU forward:
+// the auto-advanced screen goes straight to the product-code scan — exactly as it does when a move
+// plan pins the HU (sweep_scan_product_after_autoAdvance.spec.js) — and scanning the product code
+// ALONE books the pick onto the HU split off for that order. Asking for the handling unit again
+// instead is the defect this spec guards: the operator's next scan is the product GTIN, which then
+// lands in the HU slot and the backend rejects it as the wrong QR-code type.
+//
+// The fixture comes from the factory shared with sweep_scan_product_after_autoAdvance.spec.js, so the
+// two specs cover the two sides of allowPickingAnyHU with everything else held constant — see
+// sweepDistributionMasterdata.js. The carry-forward rule itself is owned by
 // postDistributionPickFromThunk.js.
 //
 
@@ -31,12 +40,12 @@ const createMasterdata = async () =>
     });
 
 // noinspection JSUnusedLocalSymbols
-test('Sweep: after auto-advance, the operator scans the staging LU again (it does not carry forward)', async ({ page }) => {
+test('Sweep (pick-any-HU): after auto-advance, the operator scans only the product code (the staging LU carries forward)', async ({ page }) => {
     // === ALLURE METADATA ===
     allure.epic('E0370: Intralogistic (HUs)');
     allure.tag('F5114: MobileUI Distribution');
     allure.tag('F5114');
-    allure.story('Sweep: when an order may be served from any HU, the operator scans the staging LU again on each auto-advanced order, then the product code');
+    allure.story('Sweep (pick-any-HU): with no pre-allocated move plan, the operator still scans only the product code on every auto-advanced order');
     allure.severity('critical');
 
     const masterdata = await createMasterdata();
@@ -60,40 +69,31 @@ test('Sweep: after auto-advance, the operator scans the staging LU again (it doe
         await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD2.jobId });
     });
 
-    // *** THE ASSERTION THIS SPEC EXISTS FOR ***
-    // No HU is assigned to DD2, so the app cannot know which one will serve it — not even though the
-    // staging LU the operator just scanned holds plenty of stock for DD2 as well. The operator is
-    // therefore asked to scan the source HU, instead of being dropped on the product scan with an
-    // assumed-but-unverified HU already applied.
-    await test.step('On the auto-advanced DD2: the screen asks for the HU scan', async () => {
-        await DistributionLinePickFromScreen.expectHUScanReady();
-    });
-
-    // The screen alone cannot show WHY it asks: an app that had simply failed to recognise the LU just
-    // picked from would land the operator on exactly the same prompt. Only the FIRST of the two checks
-    // below rules that look-alike out — the app's own diagnostics, the one observable that actually
-    // differs between the two paths. The second is a PRECONDITION check: DD2's configuration is fixed at
-    // job-creation time and identical either way, so it cannot say which path ran; what it does buy is
-    // that the scenario cannot silently degrade into covering a differently-configured job.
-    await test.step('Diagnostic: the HU scan is not the fallback of a failed HU lookup', async () => {
-        await DistributionLinePickFromScreen.expectHUScanNotCausedByFailedHULookup();
-    });
-
+    // PRECONDITION, asserted before the target assertion so a fixture/config drift fails HERE and is
+    // never mistaken for the behaviour under test: DD2 really is a pick-any-HU job with no
+    // pre-allocated move plan. It says nothing about which path the app then took.
     await test.step('Backend: DD2 was started in pick-any-HU mode, without a pre-allocated move plan', async () => {
         await DistributionUtils.expectPickAnyHUJobWithoutMovePlan({
             wfProcessId: `distribution-${masterdata.distributionOrders.DD2.jobId}`,
         });
     });
 
-    await test.step('Scan the staging LU + product P for DD2 (confirm qty 20) → auto-advance to DD3, asking for the HU again', async () => {
-        await DistributionLinePickFromScreen.scanHUToMove({
-            huQRCode: masterdata.luExternalBarcode,
-            productScannedCode: masterdata.products.P.gtin,
-            expectedQtyToMove: 20,
-            expectNextScreen: 'DistributionLinePickFromScreen',
-        });
+    // *** THE ASSERTION THIS SPEC EXISTS FOR ***
+    // No move plan pins a source HU for DD2 — but the operator just scanned the staging LU for DD1,
+    // and that same LU holds plenty of stock for DD2 too. The app must carry it forward: the operator
+    // is NOT asked to re-scan the handling unit, only the product code.
+    await test.step('On the auto-advanced DD2: the screen is ready for the PRODUCT scan (no HU re-scan requested)', async () => {
+        await DistributionLinePickFromScreen.expectProductScanReady();
+    });
+
+    // Scanning ONLY the product code must book the pick — no wrong-QR-type error, no HU barcode.
+    // The trailing product-scan assertion covers the SECOND order boundary: the carry-forward has to
+    // hold at every auto-advance, not just the first one.
+    await test.step('Scan product P for DD2 (confirm qty 20) → no error, auto-advance to DD3 which is again ready for the PRODUCT scan', async () => {
+        await DistributionLinePickFromScreen.typeProductCode(masterdata.products.P.gtin);
+        await DistributionLinePickFromScreen.fillQuantityDialog({ expectedQtyToMove: 20 });
         await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD3.jobId });
-        await DistributionLinePickFromScreen.expectHUScanReady();
+        await DistributionLinePickFromScreen.expectProductScanReady();
     });
 
     await test.step('Backend: the DD2 pick landed (the moved qty of P is on the split-off HU)', async () => {

--- a/e2e/mobile-webui/tests/spec/distribution/sweep_scan_product_after_autoAdvance.spec.js
+++ b/e2e/mobile-webui/tests/spec/distribution/sweep_scan_product_after_autoAdvance.spec.js
@@ -18,8 +18,9 @@ import { createSweepMasterdata } from '../../utils/sweepDistributionMasterdata';
 // that is what exercises the auto-advance carrying the scanned HU forward to the next order.
 //
 // The fixture is built by the factory shared with sweep_scan_HU_after_autoAdvance_anyHU.spec.js, so
-// the two scenarios provably differ in allowPickingAnyHU alone — see sweepDistributionMasterdata.js
-// for the profile and why that identity matters.
+// the two scenarios hold the whole distribution profile and layout constant — see
+// sweepDistributionMasterdata.js for that profile, and for why this scenario stands ONE handling unit
+// at the source locator while the pick-any-HU one stands several.
 //
 
 const createMasterdata = async () =>
@@ -53,7 +54,7 @@ test('Sweep: after auto-advance, the operator scans only the product code (the s
 
     await test.step('Pick DD1 off the staging LU (scan the LU + product P, confirm qty 10) → auto-advance to DD2 pick-from', async () => {
         await DistributionJobScreen.scanHUToMove({
-            huQRCode: masterdata.luExternalBarcode,
+            huQRCode: masterdata.huExternalBarcodes.HU1,
             productScannedCode: masterdata.products.P.gtin,
             expectedQtyToMove: 10,
             expectNextScreen: 'DistributionLinePickFromScreen',
@@ -61,7 +62,7 @@ test('Sweep: after auto-advance, the operator scans only the product code (the s
         await DistributionLinePickFromScreen.expectJobId({ distributionJobId: masterdata.distributionOrders.DD2.jobId });
     });
 
-    // *** REGRESSION GUARD (was THE RED ASSERTION) ***
+    // *** REGRESSION GUARD ***
     // The staging LU was already scanned for DD1 and holds plenty of stock for DD2 too, so the
     // operator does not need to re-scan it — the auto-advanced screen goes straight to the
     // product-code scan. The thunk carries the just-picked HU's QR code forward only when the next

--- a/e2e/mobile-webui/tests/utils/common.js
+++ b/e2e/mobile-webui/tests/utils/common.js
@@ -1,5 +1,4 @@
 import { test } from '../../playwright.config';
-import { expect } from '@playwright/test';
 import { ErrorScreen } from './screens/ErrorScreen';
 import { ErrorToast } from './dialogs/ErrorToast';
 
@@ -16,66 +15,9 @@ export const ID_BACK_BUTTON = '#Back-button';
 
 export let page = null;
 
-// Browser-console recording. Some app code paths are invisible on screen but log a diagnostic before
-// falling back to a state that looks exactly like the normal one; the logged line is then the only
-// observable that tells the two apart (see
-// DistributionLinePickFromScreen.expectHUScanNotCausedByFailedHULookup). Recording is armed with the
-// page fixture, so no spec has to set anything up and a normal run pays no timing cost.
-//
-// Cap on the messages one test keeps, so a chatty page cannot grow the buffer without bound. Anything
-// past the cap is counted, not kept — see expectNoConsoleMessageMatching for why the count matters.
-const MAX_RECORDED_CONSOLE_MESSAGES = 5000;
-
-// The recorder of the CURRENT test, or null before the page fixture armed one.
-let consoleRecorder = null;
-
-// Each recorder owns its OWN buffer and counters, closed over by its handler — never a module-level
-// binding. A handler that closed over the *binding* would keep writing into whatever buffer is current,
-// so a page still emitting after the next test started would pollute that test's buffer and produce a
-// RED attributed to the wrong test.
-const startConsoleRecorder = (currentPage) => {
-    const messages = [];
-    let droppedMessageCount = 0;
-    const handler = (message) => {
-        if (messages.length < MAX_RECORDED_CONSOLE_MESSAGES) {
-            messages.push(`${message.type()}: ${message.text()}`);
-        } else {
-            droppedMessageCount++;
-        }
-    };
-    currentPage.on('console', handler);
-    return {
-        messages,
-        getDroppedMessageCount: () => droppedMessageCount,
-        stop: () => currentPage.off('console', handler),
-    };
-};
-
 export const setCurrentPage = (currentPage) => {
-    // Stop the previous test's recorder so its page cannot go on feeding a listener we no longer read.
-    consoleRecorder?.stop();
     page = currentPage;
-    consoleRecorder = startConsoleRecorder(currentPage);
 }
-
-/**
- * Assert the app did NOT log a console message matching `pattern` so far in this test.
- * Not a polling assertion: use it only for a message the app would have logged *before* a state you
- * have already awaited (otherwise it can pass simply because the log has not happened yet).
- */
-export const expectNoConsoleMessageMatching = ({ pattern, because }) => {
-    // A NEGATIVE assertion must never pass by omission. Two ways this one could:
-    //  - no recorder armed at all (the page fixture did not run) -> the buffer is trivially empty;
-    //  - the recorder hit its cap -> a matching message may have been dropped rather than never logged.
-    expect(consoleRecorder, 'no console recorder is armed, so the absence of a message proves nothing').not.toBeNull();
-    expect(
-        consoleRecorder.getDroppedMessageCount(),
-        `the console recorder hit its ${MAX_RECORDED_CONSOLE_MESSAGES}-message cap, so a matching message may have been`
-        + ` dropped rather than never logged - the absence assertion below would be vacuous`
-    ).toEqual(0);
-
-    expect(consoleRecorder.messages.filter((message) => pattern.test(message)), because).toEqual([]);
-};
 
 export const step = async (title, func) => await test.step(title, async () => await runAndWatchForErrors(func));
 

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLinePickFromScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionLinePickFromScreen.js
@@ -1,12 +1,6 @@
 import { test } from '../../../../playwright.config';
 import { expect } from '@playwright/test';
-import {
-    expectNoConsoleMessageMatching,
-    FAST_ACTION_TIMEOUT,
-    ID_BACK_BUTTON,
-    page,
-    SLOW_ACTION_TIMEOUT,
-} from '../../common';
+import { FAST_ACTION_TIMEOUT, ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from '../../common';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
 import { GetQuantityDialog } from '../picking/GetQuantityDialog';
 import { DistributionUtils } from './DistributionUtils';
@@ -59,19 +53,6 @@ export const DistributionLinePickFromScreen = {
             await DistributionLinePickFromScreen.waitForScreen();
             await expect(page.getByTestId('scanHUBarcode-input')).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
             await expect(page.getByTestId('scanProductCode-input')).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
-        }),
-
-        // Of the two causes for landing on "Scan HU" after an auto-advance, only the failed-HU-lookup
-        // fallback logs this warning; on screen the two are identical. Sound to assert without polling:
-        // the app awaits that lookup before it navigates, so once this screen is up the warning has
-        // either been logged already or never will be.
-        expectHUScanNotCausedByFailedHULookup: async () => await test.step(`${NAME} - Expect the HU scan is not the fallback of a failed HU lookup`, async () => {
-            await DistributionLinePickFromScreen.waitForScreen();
-            expectNoConsoleMessageMatching({
-                pattern: /Failed to resolve scanned HU QR for auto-advance carry-forward/,
-                because: 'the auto-advance asked for the HU again because it could NOT re-resolve the just-picked HU'
-                    + ' — not because the next order has no source HU of its own',
-            });
         }),
 
         scanHUToMove: async ({ huQRCode, productScannedCode, expectQuantityDialog = true, expectedQtyToMove, expectNextScreen }) => await test.step(`${NAME} - Scan HU to move`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionUtils.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionUtils.js
@@ -96,6 +96,60 @@ export const DistributionUtils = {
     }),
 
     /**
+     * Start recording every `nextEligiblePickFromLine` request the app fires from now on, and return
+     * the recorder to read back later. The pick-from screen resolves an operator's scan through that
+     * one endpoint, so its request bodies are where "what did the app send, and in which slot" is
+     * answered — a scanned value can be legitimate as `productScannedCode` and wrong as `huQRCode`,
+     * which no on-screen assertion can tell apart.
+     *
+     * Recording (rather than `page.waitForResponse` around one action) is what suits a NEGATIVE
+     * assertion: there is no request to wait for, and the claim is about every request in a span.
+     * Start it before the first operator action, so nothing can slip in ahead of the listener.
+     *
+     * The listener lives on the per-test `page` and dies with it, so it needs no teardown.
+     */
+    recordNextEligiblePickFromLineRequests: () => {
+        const requestBodies = [];
+        page.on('request', (request) => {
+            if (request.method() !== 'POST' || !request.url().includes('/distribution/nextEligiblePickFromLine')) {
+                return;
+            }
+            let body;
+            try {
+                body = request.postDataJSON();
+            } catch {
+                // Keep the raw payload rather than dropping the request: a body we cannot parse must
+                // still show up in the assertion's failure output instead of silently reducing the
+                // recording — and with it the assertion — to nothing.
+                body = { unparsablePostData: request.postData() };
+            }
+            requestBodies.push(body);
+        });
+        return { requestBodies };
+    },
+
+    /**
+     * Assert that none of the recorded `nextEligiblePickFromLine` requests sent `huQRCode` — i.e. the
+     * app never offered that value to the backend as a handling-unit code. Pair it with a recorder
+     * started before the actions it must cover (recordNextEligiblePickFromLineRequests above).
+     */
+    expectNoPickFromLineRequestCarriedHUQRCode: async ({ recorder, huQRCode }) => await test.step(`Expect no nextEligiblePickFromLine request carried "${huQRCode}" as huQRCode`, async () => {
+        // Guard against a vacuous pass: this is a negative assertion over a recording, so a recorder
+        // that captured nothing at all — a moved endpoint path, a listener started too late, a
+        // scenario that never got as far as resolving a line — would satisfy it while proving
+        // nothing. The scenarios this serves all book a pick, and a pick cannot be booked without at
+        // least one nextEligiblePickFromLine round trip.
+        expect(recorder.requestBodies.length, 'no nextEligiblePickFromLine request was recorded at all, so this assertion would prove nothing').toBeGreaterThan(0);
+
+        const offending = recorder.requestBodies.filter((body) => body?.huQRCode === huQRCode);
+        expect(
+            offending,
+            `"${huQRCode}" was sent to nextEligiblePickFromLine in the huQRCode slot. All recorded requests:\n`
+            + JSON.stringify(recorder.requestBodies, null, 2)
+        ).toEqual([]);
+    }),
+
+    /**
      * Assert the given distribution job is in "pick any HU" mode AND carries no pre-allocated move
      * plan: every line reports allowPickingAnyHU, and there is not a single step.
      *

--- a/e2e/mobile-webui/tests/utils/screens/distribution/DistributionUtils.js
+++ b/e2e/mobile-webui/tests/utils/screens/distribution/DistributionUtils.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page } from '../../common';
+import { page, SLOW_ACTION_TIMEOUT } from '../../common';
 import { expect } from '@playwright/test';
 import { Backend } from '../Backend';
 
@@ -12,8 +12,19 @@ export const DistributionUtils = {
         return match ? match[1] : null;
     },
 
+    /**
+     * Assert the screen is showing the given distribution job, reading the job from the URL.
+     *
+     * Polled, because the app reaches the next order WITHOUT a screen transition: the auto-advance
+     * replaces the job in the URL while the same pick-from screen container stays mounted, so there
+     * is nothing else for a caller to wait on — and when the order just picked needed no quantity
+     * dialog, nothing in the flow blocks until the pick has even been posted. Reading the URL once
+     * would then compare against the order the operator is still leaving.
+     */
     expectJobId: async ({ distributionJobId }) => {
-        await expect(await DistributionUtils.getJobIdFromPageUrl()).toEqual(distributionJobId);
+        await expect
+            .poll(async () => await DistributionUtils.getJobIdFromPageUrl(), { timeout: SLOW_ACTION_TIMEOUT })
+            .toEqual(distributionJobId);
     },
 
     // Assert a row of the shared `.view-header` table (the job/line header rendered on the

--- a/e2e/mobile-webui/tests/utils/sweepDistributionMasterdata.js
+++ b/e2e/mobile-webui/tests/utils/sweepDistributionMasterdata.js
@@ -6,15 +6,23 @@ import { generateEAN13 } from './ean13';
 //   - sweep_scan_product_after_autoAdvance.spec.js       (allowPickingAnyHU: false)
 //   - sweep_scan_HU_after_autoAdvance_anyHU.spec.js      (allowPickingAnyHU: true)
 //
-// ONE staging LU at a ground locator, feeding every DD order. The two specs must differ in NOTHING
-// but allowPickingAnyHU (plus the per-spec barcode prefix and workplace key, which only keep their
-// data apart), so each covers one side of that flag with everything else held constant: with it off
-// the backend pre-allocates a move plan pinning a source HU per step, with it on it builds no plan at
-// all (the anyHU spec pins that as a precondition —
-// DistributionUtils.expectPickAnyHUJobWithoutMovePlan). The operator's experience must be the SAME
-// either way: after an auto-advance the screen is ready for the PRODUCT scan, never a repeat HU scan.
-// Both specs therefore build their masterdata HERE, so the identity is structural instead of two
-// ~60-line copies asked by a comment to stay in sync.
+// Handling units of ONE product stand at a ground locator and feed a series of single-line DD orders
+// that drop onto a packing table. Both specs build their masterdata HERE, so what they share is
+// structural instead of two ~60-line copies asked by a comment to stay in sync, and each covers one
+// side of allowPickingAnyHU: with it off the backend pre-allocates a move plan pinning a source
+// handling unit per step, with it on it builds no plan at all (the anyHU spec pins that as a
+// precondition — DistributionUtils.expectPickAnyHUJobWithoutMovePlan). The operator's experience must
+// be the SAME either way: after an auto-advance the screen is ready for the PRODUCT scan, never a
+// repeat handling-unit scan.
+//
+// The two specs differ in that flag, in `handlingUnitCount`, and in the per-spec barcode prefix and
+// workplace key (which only keep their data apart). The count follows the flag:
+//   - true — the recorded customer situation, several handling units of one article at one source
+//     locator with the operator identifying one of them; only then can an assertion pin a pick onto
+//     THEIR choice rather than onto the only thing standing there.
+//   - false — the move plan allocates from whichever eligible handling units the supplier offers first
+//     (DDOrderMovePlanCreateCommand.createPlanStep), so several equivalent candidates leave that spec
+//     no fixture-determined handling unit to scan; it takes the default of one.
 //
 // The auto-advance carry-forward rule itself is owned by postDistributionPickFromThunk.js.
 //
@@ -23,19 +31,35 @@ import { generateEAN13 } from './ean13';
 // order reaches in one pick. Both specs reference DD1..DD3 by name, so this is not a free knob.
 const SWEEP_ORDER_COUNT = 3;
 
-// Plenty of qty on the staging LU so every DD order is a small, partial pick off it.
-const LU_QTY = 1000;
+// Plenty of qty on each handling unit, so every DD order is a small PARTIAL pick and the handling unit
+// stays at the source locator to serve the orders that follow. A handling unit an order takes WHOLE is
+// moved into transit instead, which is the case carried_hu_cannot_serve_next_order.spec.js owns.
+// Exported because a spec pinning WHICH handling unit a pick came off states the qty left on each.
+export const SWEEP_HU_QTY = 1000;
 
 /**
- * @param allowPickingAnyHU THE variable under test — the ONLY configuration difference between the
+ * @param allowPickingAnyHU THE variable under test — the configuration difference between the
  *        two sweep specs. Always passed explicitly: it is a sticky, global config row that the masterdata
  *        API leaves untouched when omitted (see e2e/mobile-webui/CLAUDE.md § "Debugging Flaky Tests"
  *        rule 3).
- * @param barcodePrefix per-spec prefix of the staging LU's external barcode.
+ * @param barcodePrefix per-spec prefix of the handling units' external barcodes.
  * @param workplaceKey per-spec workplace name.
+ * @param handlingUnitCount how many handling units of the product stand at the source locator. They
+ *        are created as HU1..HU<n> and their external barcodes returned in
+ *        `masterdata.huExternalBarcodes`, keyed by the same identifiers. One by default — what each
+ *        spec passes, and why, is in the comment above.
  */
-export const createSweepMasterdata = async ({ allowPickingAnyHU, barcodePrefix, workplaceKey }) => {
-    const luExternalBarcode = `${barcodePrefix}-${Date.now()}`;
+export const createSweepMasterdata = async ({ allowPickingAnyHU, barcodePrefix, workplaceKey, handlingUnitCount = 1 }) => {
+    const huExternalBarcodes = {};
+    const handlingUnits = {};
+    for (let i = 1; i <= handlingUnitCount; i++) {
+        const huIdentifier = `HU${i}`;
+        const externalBarcode = `${barcodePrefix}-${i}-${Date.now()}`;
+        huExternalBarcodes[huIdentifier] = externalBarcode;
+        // Each identified by its own external barcode, the way the customer's handling units are
+        // labelled — they carry no other label an operator could scan.
+        handlingUnits[huIdentifier] = { product: "P", warehouse: "wh", locator: "LZ", qty: SWEEP_HU_QTY, externalBarcode };
+    }
 
     const distributionOrders = {};
     for (let i = 1; i <= SWEEP_ORDER_COUNT; i++) {
@@ -73,7 +97,7 @@ export const createSweepMasterdata = async ({ allowPickingAnyHU, barcodePrefix, 
             warehouses: {
                 "wh": {
                     locators: {
-                        // The ground locator where the ONE staging LU sits.
+                        // The ground locator the handling units stand at.
                         LZ: { isGroundLocator: true, priorityNo: 10 },
                         // The non-ground target every DD order drops to.
                         packingTable: { isGroundLocator: false, priorityNo: 999 },
@@ -81,14 +105,11 @@ export const createSweepMasterdata = async ({ allowPickingAnyHU, barcodePrefix, 
                 },
                 "whInTransit": { inTransit: true },
             },
-            handlingUnits: {
-                // The single staging LU, scannable via its external barcode, holding plenty of P.
-                LU: { product: "P", warehouse: "wh", locator: "LZ", qty: LU_QTY, externalBarcode: luExternalBarcode },
-            },
+            handlingUnits,
             distributionOrders,
         },
     });
 
-    masterdata.luExternalBarcode = luExternalBarcode;
+    masterdata.huExternalBarcodes = huExternalBarcodes;
     return masterdata;
 };

--- a/e2e/mobile-webui/tests/utils/sweepDistributionMasterdata.js
+++ b/e2e/mobile-webui/tests/utils/sweepDistributionMasterdata.js
@@ -8,10 +8,13 @@ import { generateEAN13 } from './ean13';
 //
 // ONE staging LU at a ground locator, feeding every DD order. The two specs must differ in NOTHING
 // but allowPickingAnyHU (plus the per-spec barcode prefix and workplace key, which only keep their
-// data apart): that is exactly what makes each of them discriminating — with the same data, the flag
-// alone decides whether the operator lands on the PRODUCT scan or back on the HU scan after an
-// auto-advance. Both therefore build their masterdata HERE, so the identity is structural instead of
-// two ~60-line copies asked by a comment to stay in sync.
+// data apart), so each covers one side of that flag with everything else held constant: with it off
+// the backend pre-allocates a move plan pinning a source HU per step, with it on it builds no plan at
+// all (the anyHU spec pins that as a precondition —
+// DistributionUtils.expectPickAnyHUJobWithoutMovePlan). The operator's experience must be the SAME
+// either way: after an auto-advance the screen is ready for the PRODUCT scan, never a repeat HU scan.
+// Both specs therefore build their masterdata HERE, so the identity is structural instead of two
+// ~60-line copies asked by a comment to stay in sync.
 //
 // The auto-advance carry-forward rule itself is owned by postDistributionPickFromThunk.js.
 //
@@ -24,8 +27,8 @@ const SWEEP_ORDER_COUNT = 3;
 const LU_QTY = 1000;
 
 /**
- * @param allowPickingAnyHU THE variable under test — the ONLY behavioural difference between the two
- *        sweep specs. Always passed explicitly: it is a sticky, global config row that the masterdata
+ * @param allowPickingAnyHU THE variable under test — the ONLY configuration difference between the
+ *        two sweep specs. Always passed explicitly: it is a sticky, global config row that the masterdata
  *        API leaves untouched when omitted (see e2e/mobile-webui/CLAUDE.md § "Debugging Flaky Tests"
  *        rule 3).
  * @param barcodePrefix per-spec prefix of the staging LU's external barcode.

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/distribution/redux/postDistributionPickFromThunk.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/distribution/redux/postDistributionPickFromThunk.js
@@ -38,22 +38,32 @@ export const postDistributionPickFromThunk =
           const nextWfProcess = await startWorkflowRequest({ wfParameters: nextLauncher.wfParameters });
           dispatch(updateWFProcess({ wfProcess: nextWfProcess }));
 
-          // Carry the just-picked source HU's QR code forward to the next order's Pick-From screen
-          // ONLY when the next order's pre-allocated move plan draws from that SAME physical HU —
-          // never unconditionally (an earlier fix carried it forward unconditionally and regressed
+          // Carry the just-picked source HU's QR code forward to the next order's Pick-From screen —
+          // but never unconditionally (an earlier fix did, and regressed
           // packingTable_navigateToNextOrder + navigateToJobsListAfterPickFromComplete, where the HU
           // the operator must scan next is a DIFFERENT physical one even when it shares the source
-          // locator). Three cases, decided by HU identity (not locator):
-          //  1. Same source HU (the "sweep" flow: one staging LU feeding several orders) -> carry
-          //     forward, landing the operator directly on the product-scan step.
-          //  2. A different source HU (distinct HU per order, even sharing a locator) -> omit
-          //     huQRCode, landing on Scan-HU so the operator (re-)scans the correct source HU.
-          //  3. allowPickingAnyHU=true, so the next order has no pre-allocated move plan
-          //     (nextOrderHUQRs empty) -> omit huQRCode. Safe default: never assume it's the same HU.
-          const justPickedHUQR = await getResolvedHUQR({ scannedCode: huScannedCode });
-          const nextOrderHUQRs = getNextOrderHUQRs({ state: getState(), wfProcessId: nextWfProcess.id });
-          const carryForwardHUQRCode =
-            justPickedHUQR != null && nextOrderHUQRs.has(justPickedHUQR) ? huScannedCode : undefined;
+          // locator). Three cases; the case NUMBERS are referenced from the specs, so they keep the
+          // established order even though isSourceHUCarriedForward decides case 3 first:
+          //  1. The next order's pre-allocated move plan draws from that SAME physical HU (the
+          //     "sweep" flow: one staging LU feeding several orders) -> carry forward, landing the
+          //     operator directly on the product-scan step.
+          //     Proven by sweep_scan_product_after_autoAdvance.spec.js.
+          //  2. Its plan names a DIFFERENT source HU (a distinct HU per order, even when they share
+          //     the source locator) -> omit huQRCode, landing on Scan-HU so the operator scans the
+          //     HU the plan actually points at. Proven by packingTable_navigateToNextOrder.spec.js.
+          //  3. allowPickingAnyHU=true, so the next order has no pre-allocated move plan at all
+          //     -> carry forward. No source HU is designated for it, so the operator's own choice is
+          //     the only source information that exists and nothing contradicts it; same landing as
+          //     case 1. Proven by sweep_scan_HU_after_autoAdvance_anyHU.spec.js.
+          //     This is the case that used to omit the HU, stranding the operator at every order
+          //     boundary on the setting every customer runs.
+          const carryForwardHUQRCode = (await isSourceHUCarriedForward({
+            getState,
+            wfProcessId: nextWfProcess.id,
+            huScannedCode,
+          }))
+            ? huScannedCode
+            : undefined;
 
           history.goTo(
             distributionPickFromScreenLocation({
@@ -81,6 +91,38 @@ export const postDistributionPickFromThunk =
 //
 //
 
+// Whether the source HU the operator just scanned stays selected on the next order's Pick-From
+// screen. The three cases are spelled out at the call site.
+const isSourceHUCarriedForward = async ({ getState, wfProcessId, huScannedCode }) => {
+  // Case 3. Nothing to compare the operator's choice against, so their choice stands. Checked FIRST
+  // so the HU re-resolution round trip below is skipped entirely: it exists only to compare against
+  // a move plan, and here there is none.
+  if (isPickAnyHUOrder({ state: getState(), wfProcessId })) {
+    return true;
+  }
+
+  // Cases 1 and 2: a move plan exists, so carry forward only when it draws from that same physical HU.
+  const justPickedHUQR = await getResolvedHUQR({ scannedCode: huScannedCode });
+  const nextOrderHUQRs = getNextOrderHUQRs({ state: getState(), wfProcessId });
+  return justPickedHUQR != null && nextOrderHUQRs.has(justPickedHUQR);
+};
+
+// Whether the next order lets the operator serve it from ANY handling unit
+// (MobileUI_UserProfile_DD.IsAllowPickingAnyHU='Y' — the setting every customer runs). The backend
+// then builds NO pre-allocated move plan at all (DistributionJobCreateCommand.executeInTrx creates
+// one only inside `if (!config.isAllowPickingAnyHU())`), so the job has no steps and no designated
+// source HU, and getNextOrderHUQRs is necessarily empty. That emptiness is why the flag has to be
+// read directly instead of inferred from it: an empty set cannot tell "no plan was ever built" from
+// "the plan's steps are all picked already", and the old condition — which required a NON-empty set
+// to match — therefore never fired at any customer.
+// Read per line, as JsonDistributionJobLine reports it; `some` mirrors picking's
+// isAllowPickingAnyHUOnHeaderLevel, and for distribution every line carries the same job-level
+// config value (DistributionJobLoader).
+const isPickAnyHUOrder = ({ state, wfProcessId }) => {
+  const activity = getActivityById(state, wfProcessId, ACTIVITY_ID_MoveLines);
+  return getLinesArrayFromActivity(activity).some((line) => !!line?.allowPickingAnyHU);
+};
+
 // Re-resolve the operator's scan to its CURRENT backend-normalized HU identity — a fresh lookup, not
 // a cached/plan-snapshot value. This matters because on a PARTIAL pick the just-completed step's own
 // pickFromHU is overwritten to report the ephemeral split HU that the picked/moved portion is packed
@@ -94,19 +136,19 @@ const getResolvedHUQR = async ({ scannedCode }) => {
     const { qrCode } = await getDistributionScannedHUQRCodeInfo({ qrCode: toQRCodeString(scannedCode) });
     return toQRCodeString(qrCode);
   } catch (e) {
-    // NOTE to dev: keep this message in sync with
-    // e2e/mobile-webui/tests/utils/screens/distribution/DistributionLinePickFromScreen.js
-    // -> expectHUScanNotCausedByFailedHULookup, which greps for it. On screen this fallback is
-    // indistinguishable from the no-move-plan case, so that grep is the ONLY thing telling the two
-    // apart in sweep_scan_HU_after_autoAdvance_anyHU.spec.js. Reword it and the assertion goes
-    // vacuously green.
+    // Only reachable when the next order HAS a move plan (case 3 returns before this runs), so the
+    // fallback is well-defined: with the scanned HU's identity unknown we cannot show it matches the
+    // plan, and carrying it forward anyway would drop the operator on the product scan of an HU the
+    // plan may not point at. Land them on Scan-HU instead. Logged because on screen this is
+    // indistinguishable from case 2, the plan naming a different HU.
     console.warn('Failed to resolve scanned HU QR for auto-advance carry-forward; defaulting to Scan-HU', e);
-    return null; // unresolvable -> no match below -> safe default (Scan-HU)
+    return null; // unresolvable -> no match in the caller -> safe default (Scan-HU)
   }
 };
 
 // The set of source HUs the next order's pre-allocated move plan draws from (across all its lines
-// and steps). Empty when allowPickingAnyHU=true, i.e. no move plan was built.
+// and steps). Only ever called once a plan is known to exist — isPickAnyHUOrder short-circuits the
+// no-plan case, where this would be empty and could decide nothing.
 const getNextOrderHUQRs = ({ state, wfProcessId }) => {
   const activity = getActivityById(state, wfProcessId, ACTIVITY_ID_MoveLines);
   const huQRCodes = getLinesArrayFromActivity(activity).flatMap((line) =>

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/apps/distribution/redux/postDistributionPickFromThunk.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/apps/distribution/redux/postDistributionPickFromThunk.js
@@ -1,5 +1,5 @@
 import { getDistributionScannedHUQRCodeInfo, postDistributionPickFrom } from '../../../api/distribution';
-import { toQRCodeString } from '../../../utils/qrCode/hu';
+import { parseQRCodeString, toQRCodeString } from '../../../utils/qrCode/hu';
 import { updateWFProcess } from '../../../actions/WorkflowActions';
 import { getDistributionJobPickedStatus } from '../../../reducers/wfProcesses/distribution/getDistributionJobPickedStatus';
 import { distributionJobsListScreenLocation, distributionPickFromScreenLocation } from '../../../routes/distribution';
@@ -39,11 +39,10 @@ export const postDistributionPickFromThunk =
           dispatch(updateWFProcess({ wfProcess: nextWfProcess }));
 
           // Carry the just-picked source HU's QR code forward to the next order's Pick-From screen —
-          // but never unconditionally (an earlier fix did, and regressed
-          // packingTable_navigateToNextOrder + navigateToJobsListAfterPickFromComplete, where the HU
-          // the operator must scan next is a DIFFERENT physical one even when it shares the source
-          // locator). Three cases; the case NUMBERS are referenced from the specs, so they keep the
-          // established order even though isSourceHUCarriedForward decides case 3 first:
+          // never unconditionally: the HU the next order must be served from can be a different
+          // physical one, or one that cannot serve that order at all, even when it stands at the same
+          // source locator. Three cases; the case NUMBERS are referenced from the specs, so they keep
+          // the established order:
           //  1. The next order's pre-allocated move plan draws from that SAME physical HU (the
           //     "sweep" flow: one staging LU feeding several orders) -> carry forward, landing the
           //     operator directly on the product-scan step.
@@ -52,11 +51,16 @@ export const postDistributionPickFromThunk =
           //     the source locator) -> omit huQRCode, landing on Scan-HU so the operator scans the
           //     HU the plan actually points at. Proven by packingTable_navigateToNextOrder.spec.js.
           //  3. allowPickingAnyHU=true, so the next order has no pre-allocated move plan at all
-          //     -> carry forward. No source HU is designated for it, so the operator's own choice is
-          //     the only source information that exists and nothing contradicts it; same landing as
-          //     case 1. Proven by sweep_scan_HU_after_autoAdvance_anyHU.spec.js.
-          //     This is the case that used to omit the HU, stranding the operator at every order
-          //     boundary on the setting every customer runs.
+          //     -> carry forward, but ONLY while the scanned HU can actually serve that order (see
+          //     isHUServingWholeOrder). Nothing designates a source HU, so the operator's own choice
+          //     is the only source information that exists — yet it stands only as long as it still
+          //     works for what they are about to pick: with an HU applied the Pick-From screen
+          //     renders no HU input at all (ScanHUAndGetQtyComponent goes straight to the product
+          //     scan), so an HU that cannot serve the order leaves the operator unable to identify
+          //     one that can.
+          //     Proven by sweep_scan_HU_after_autoAdvance_anyHU.spec.js (the carry-forward) and
+          //     navigateToJobsListAfterPickFromComplete.spec.js (the gate on it — that spec's next
+          //     order asks for a product the just-picked HU does not hold).
           const carryForwardHUQRCode = (await isSourceHUCarriedForward({
             getState,
             wfProcessId: nextWfProcess.id,
@@ -94,17 +98,49 @@ export const postDistributionPickFromThunk =
 // Whether the source HU the operator just scanned stays selected on the next order's Pick-From
 // screen. The three cases are spelled out at the call site.
 const isSourceHUCarriedForward = async ({ getState, wfProcessId, huScannedCode }) => {
-  // Case 3. Nothing to compare the operator's choice against, so their choice stands. Checked FIRST
-  // so the HU re-resolution round trip below is skipped entirely: it exists only to compare against
-  // a move plan, and here there is none.
+  const justPickedHU = await resolveScannedHU({ scannedCode: huScannedCode });
+  if (justPickedHU == null) {
+    return false;
+  }
+
+  // Case 3: no move plan designates a source HU, so the operator's own choice stands — as long as
+  // that HU can serve the order they were just advanced to.
   if (isPickAnyHUOrder({ state: getState(), wfProcessId })) {
-    return true;
+    return isHUServingWholeOrder({ state: getState(), wfProcessId, huProductId: justPickedHU.productId });
   }
 
   // Cases 1 and 2: a move plan exists, so carry forward only when it draws from that same physical HU.
-  const justPickedHUQR = await getResolvedHUQR({ scannedCode: huScannedCode });
-  const nextOrderHUQRs = getNextOrderHUQRs({ state: getState(), wfProcessId });
-  return justPickedHUQR != null && nextOrderHUQRs.has(justPickedHUQR);
+  return getNextOrderHUQRs({ state: getState(), wfProcessId }).has(justPickedHU.qrCodeString);
+};
+
+// Whether the just-picked HU can serve EVERY line of the next order. This is the proviso the
+// carry-forward carries in case 3, where no move plan can vouch for the operator's choice: the
+// handling unit stays selected only while it still holds the product that order asks for.
+//
+// EVERY line, not merely one of them, because the auto-advanced Pick-From screen carries no lineId:
+// the app cannot know which line the operator will pick next — they choose it by scanning a product
+// GTIN and the backend resolves the matching line (nextEligiblePickFromLine). So the HU must hold the
+// product of whatever they may scan; one that serves only part of the order would trap them the
+// moment they scan the rest. The next order was just started (getNextJobLauncher passes
+// excludeAlreadyStarted), so none of it is picked yet and every line is still to pick.
+//
+// The HU's product comes from its own QR code, the same source — and the same strict string compare
+// against the line's productId — that DistributionPickFromScreen.resolveHUScannedCode already uses to
+// reject a scan of the wrong product. A mixed-product HU has no product in its QR code
+// (HUQRCodeGenerateForExistingHUsCommand fills it from getSingleProductIdOrNull), so it can never
+// prove the proviso and is not carried forward.
+const isHUServingWholeOrder = ({ state, wfProcessId, huProductId }) => {
+  if (huProductId == null) {
+    return false;
+  }
+
+  const activity = getActivityById(state, wfProcessId, ACTIVITY_ID_MoveLines);
+  const lines = getLinesArrayFromActivity(activity);
+
+  // The emptiness check is load-bearing, not a formality: getLinesArrayFromActivity returns [] for an
+  // activity that is not in the store, and `every` over [] is true — so an order whose lines could
+  // not be read would otherwise pass as "the HU serves all of it" and be carried forward blindly.
+  return lines.length > 0 && lines.every((line) => line.productId === huProductId);
 };
 
 // Whether the next order lets the operator serve it from ANY handling unit
@@ -113,8 +149,8 @@ const isSourceHUCarriedForward = async ({ getState, wfProcessId, huScannedCode }
 // one only inside `if (!config.isAllowPickingAnyHU())`), so the job has no steps and no designated
 // source HU, and getNextOrderHUQRs is necessarily empty. That emptiness is why the flag has to be
 // read directly instead of inferred from it: an empty set cannot tell "no plan was ever built" from
-// "the plan's steps are all picked already", and the old condition — which required a NON-empty set
-// to match — therefore never fired at any customer.
+// "the plan's steps are all picked already", so a condition keyed on that set alone could never
+// decide this case.
 // Read per line, as JsonDistributionJobLine reports it; `some` mirrors picking's
 // isAllowPickingAnyHUOnHeaderLevel, and for distribution every line carries the same job-level
 // config value (DistributionJobLoader).
@@ -131,18 +167,23 @@ const isPickAnyHUOrder = ({ state, wfProcessId }) => {
 // and never match nextOrderHUQRs — even for the genuinely-same source LU. Re-resolving the scanned
 // barcode (an external label in the sweep case) reflects what was actually scanned, the same way the
 // backend's resolveHuIdToPick does, so it compares ground truth against the next order's freshly-built plan.
-const getResolvedHUQR = async ({ scannedCode }) => {
+//
+// Returns the HU's normalized QR code string plus the product it holds (null for a mixed-product HU),
+// which are what cases 1/2 and case 3 respectively decide on. Both come out of the one round trip:
+// the backend renders the HU's own QR code, whose payload carries the product.
+const resolveScannedHU = async ({ scannedCode }) => {
   try {
     const { qrCode } = await getDistributionScannedHUQRCodeInfo({ qrCode: toQRCodeString(scannedCode) });
-    return toQRCodeString(qrCode);
+    const qrCodeString = toQRCodeString(qrCode);
+    const parsedQRCode = parseQRCodeString({ string: qrCodeString, returnFalseOnError: true });
+    return { qrCodeString, productId: parsedQRCode?.productId ?? null };
   } catch (e) {
-    // Only reachable when the next order HAS a move plan (case 3 returns before this runs), so the
-    // fallback is well-defined: with the scanned HU's identity unknown we cannot show it matches the
-    // plan, and carrying it forward anyway would drop the operator on the product scan of an HU the
-    // plan may not point at. Land them on Scan-HU instead. Logged because on screen this is
+    // With the scanned HU's identity unknown, no case can be decided in favour of keeping it: we can
+    // neither show it matches the next order's move plan (cases 1/2) nor that it holds what that
+    // order asks for (case 3). Land the operator on Scan-HU instead. Logged because on screen this is
     // indistinguishable from case 2, the plan naming a different HU.
     console.warn('Failed to resolve scanned HU QR for auto-advance carry-forward; defaulting to Scan-HU', e);
-    return null; // unresolvable -> no match in the caller -> safe default (Scan-HU)
+    return null; // unresolvable -> no carry-forward in the caller -> safe default (Scan-HU)
   }
 };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { getNextEligiblePickFromLine } from '../../../api/distribution';
 import { toQRCodeString } from '../../../utils/qrCode/hu';
+import { ATTR_barcodeType, BARCODE_TYPE_EAN13 } from '../../../utils/qrCode/common';
 import { trl } from '../../../utils/translations';
 import { distributionJobScreenLocation, distributionLineScreenLocation } from '../../../routes/distribution';
 import ScanHUAndGetQtyComponent from '../../../components/ScanHUAndGetQtyComponent';
@@ -30,6 +31,24 @@ const DistributionPickFromScreen = () => {
 
   const resolveHUScannedCode = async (scannedBarcode) => {
     const parsedQRCode = await resolveDistributionScannedBarcodeToParsedQRCode(scannedBarcode);
+
+    // An article code is not a handling unit. A source locator holds many handling units of one
+    // article, so a bare article code cannot say which one to pick from — which is why
+    // DistributionHUService.resolveHUQRCode identifies a handling unit only from a real handling-unit
+    // code (a full HUQRCode, a bare M_HU.Value, or an HU's ExternalBarcode attribute) and answers an
+    // EAN13 with 422 QR_WRONG_TYPE. So the operator gains nothing from that round trip: tell them here
+    // instead, in words they can act on. Throwing leaves ScanHUAndGetQtyComponent in its
+    // STATUS_READ_HU_BARCODE step, so the article code is never remembered as the chosen handling unit,
+    // never reaches getNextEligiblePickFromLine in the huQRCode slot, and the operator keeps their
+    // place — their next scan is still read as a handling unit.
+    //
+    // EAN13 is the only article code this parse can recognise on its own:
+    // resolveDistributionScannedBarcodeToParsedQRCode asks for precise formats only, which rules GS1
+    // out. Anything else is left to the backend and keeps the message it answers with — a locator QR
+    // code and an unrecognised barcode are covered by scan_HU_barcodes.spec.js.
+    if (parsedQRCode?.[ATTR_barcodeType] === BARCODE_TYPE_EAN13) {
+      throw trl('activities.distribution.qrcode.productCodeWhereHUExpected');
+    }
 
     const { productId, qtyToPickRemaining, uom } = getLineInfo({ activity, lineId: lineIdParam });
     if (productId != null && parsedQRCode?.productId != null && parsedQRCode.productId !== productId) {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
@@ -32,20 +32,19 @@ const DistributionPickFromScreen = () => {
   const resolveHUScannedCode = async (scannedBarcode) => {
     const parsedQRCode = await resolveDistributionScannedBarcodeToParsedQRCode(scannedBarcode);
 
-    // An article code is not a handling unit. A source locator holds many handling units of one
-    // article, so a bare article code cannot say which one to pick from — which is why
-    // DistributionHUService.resolveHUQRCode identifies a handling unit only from a real handling-unit
-    // code (a full HUQRCode, a bare M_HU.Value, or an HU's ExternalBarcode attribute) and answers an
-    // EAN13 with 422 QR_WRONG_TYPE. So the operator gains nothing from that round trip: tell them here
-    // instead, in words they can act on. Throwing leaves ScanHUAndGetQtyComponent in its
-    // STATUS_READ_HU_BARCODE step, so the article code is never remembered as the chosen handling unit,
-    // never reaches getNextEligiblePickFromLine in the huQRCode slot, and the operator keeps their
-    // place — their next scan is still read as a handling unit.
+    // An article code names an article, not one specific handling unit — and a source locator holds
+    // many handling units of the same article, so it cannot say which one to pick from. The huQRCode
+    // slot only ever accepts a code identifying a single unit (DistributionHUService.resolveHUQRCode)
+    // and answers an EAN13 with 422 QR_WRONG_TYPE, so say it here instead: throwing leaves
+    // ScanHUAndGetQtyComponent in STATUS_READ_HU_BARCODE, so the article code is never remembered as
+    // the chosen handling unit, never reaches getNextEligiblePickFromLine in the huQRCode slot, and
+    // the operator keeps their place for the next scan.
     //
-    // EAN13 is the only article code this parse can recognise on its own:
-    // resolveDistributionScannedBarcodeToParsedQRCode asks for precise formats only, which rules GS1
-    // out. Anything else is left to the backend and keeps the message it answers with — a locator QR
-    // code and an unrecognised barcode are covered by scan_HU_barcodes.spec.js.
+    // Two deliberate limits. Only EAN13 is refused here — the one article-code format this parse
+    // recognises without a round trip, since it asks for precise formats and GS1 is not one; a GS1
+    // article code therefore still gets the backend's wrong-QR-type message. And a 13-digit numeric
+    // M_HU.Value / ExternalBarcode carrying a valid EAN13 check digit would be read as an article
+    // code here; no handling-unit barcode of that shape is in use.
     if (parsedQRCode?.[ATTR_barcodeType] === BARCODE_TYPE_EAN13) {
       throw trl('activities.distribution.qrcode.productCodeWhereHUExpected');
     }

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
@@ -30,17 +30,9 @@ const DistributionPickFromScreen = () => {
   const dispatch = useDispatch();
   const [lineId, setLineId] = useState(lineIdParam);
 
-  // The handling unit this screen was OPENED with — scanned on the job screen
-  // (DistributionMoveActivity) or carried across an auto-advance (postDistributionPickFromThunk) —
-  // minus the one the backend has refused to pick from. While one is applied,
-  // ScanHUAndGetQtyComponent renders no handling-unit input at all and goes straight to the
-  // article-code scan, so a refused handling unit would leave the operator with no way to name
-  // another one; forgetting it puts the handling-unit prompt back on the same screen.
-  //
-  // What is remembered is WHICH code was refused, rather than a copy of the current one, because
-  // this component stays mounted across the auto-advance: a copy would not pick up the handling unit
-  // the next order carries in, and the operator would be asked to identify one again on every order
-  // after the refusal.
+  // The handling unit the screen was opened with — a job-screen scan, or one carried across an
+  // auto-advance — until the server refuses to pick from it. The refused code is what is remembered,
+  // so a handling unit a LATER order carries into this still-mounted screen is applied again.
   const [refusedHUQRCode, setRefusedHUQRCode] = useState(null);
   const appliedHUQRCode = huQRCodeParam === refusedHUQRCode ? undefined : huQRCodeParam;
 
@@ -138,15 +130,9 @@ const DistributionPickFromScreen = () => {
         qty,
       })
     ).catch((axiosError) => {
-      // A handling unit the operator did not choose on this screen and the server refuses to pick
-      // from is a dead end: they cannot name another one while it stays applied. Forget it, so the
-      // handling-unit prompt returns here instead of the order having to be left, and carry the
-      // server's reason into the message so the operator knows what to reach for.
-      //
-      // Only a refusal — a response — is answered this way. A network-layer failure carries no
-      // verdict on the handling unit and retrying the same scan can succeed, so it must not cost the
-      // operator the handling unit they are picking from (the response/no-response discriminator is
-      // this app's convention for that distinction).
+      // A refused handling unit the operator did not choose here is a dead end: this screen renders no
+      // handling-unit input while one is applied. Forget it so the prompt returns, with the reason.
+      // A network failure is no verdict on it and retrying can succeed, so it travels on untouched.
       const isServerRefusal = axiosError?.response != null;
       if (appliedHUQRCode == null || !isServerRefusal) {
         throw axiosError;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
@@ -4,7 +4,7 @@ import { getNextEligiblePickFromLine } from '../../../api/distribution';
 import { toQRCodeString } from '../../../utils/qrCode/hu';
 import { ATTR_barcodeType, BARCODE_TYPE_EAN13 } from '../../../utils/qrCode/common';
 import { trl } from '../../../utils/translations';
-import { extractUserFriendlyErrorMessageFromAxiosError } from '../../../utils/toast';
+import { extractErrorCodeFromAxiosError, extractUserFriendlyErrorMessageFromAxiosError } from '../../../utils/toast';
 import { distributionJobScreenLocation, distributionLineScreenLocation } from '../../../routes/distribution';
 import ScanHUAndGetQtyComponent from '../../../components/ScanHUAndGetQtyComponent';
 import { resolveDistributionScannedBarcodeToParsedQRCode } from '../../../apps/distribution/services/barcodeResolverService';
@@ -16,6 +16,20 @@ import { useScreenDefinition } from '../../../hooks/useScreenDefinition';
 import { isRequireScanningProductCode } from '../../../reducers/wfProcesses/distribution/getDistributionJobCompleteStatus';
 import { postDistributionPickFromThunk } from '../../../apps/distribution/redux/postDistributionPickFromThunk';
 import { useDistributionLineHeaders } from './DistributionLineScreen';
+
+// The rejections that say the applied handling unit itself cannot serve the pick, so the operator has
+// to name another one. Any other failure leaves it the best information the screen has about where to
+// pick from, and reads as itself: relabelling it sends the operator after a handling unit for nothing.
+const HU_REFUSAL_ERROR_CODES = new Set([
+  // DistributionHUService.assertHUCanBePickedFrom
+  'DISTRIBUTION_HU_RESERVED',
+  'DISTRIBUTION_HU_ALREADY_AT_TARGET',
+  'DISTRIBUTION_HU_NOT_AT_TARGET',
+  // DistributionJobPickFromCommand.resolveHuIdToPick, keyed by AD_Message because neither message
+  // carries an AD_Message.ErrorCode and AdempiereException then reports the key.
+  'de.metas.distribution.workflows_api.ProductDoesNotMatch',
+  'de.metas.distribution.workflows_api.NotEnoughQty',
+]);
 
 const DistributionPickFromScreen = () => {
   const {
@@ -31,10 +45,11 @@ const DistributionPickFromScreen = () => {
   const [lineId, setLineId] = useState(lineIdParam);
 
   // The handling unit the screen was opened with — a job-screen scan, or one carried across an
-  // auto-advance — until the server refuses to pick from it. The refused code is what is remembered,
-  // so a handling unit a LATER order carries into this still-mounted screen is applied again.
-  const [refusedHUQRCode, setRefusedHUQRCode] = useState(null);
-  const appliedHUQRCode = huQRCodeParam === refusedHUQRCode ? undefined : huQRCodeParam;
+  // auto-advance — until the server refuses to pick from it. The refusal belongs to the order it was
+  // met on: this screen stays mounted across auto-advances, and a later order may carry the same
+  // handling unit in legitimately.
+  const [refusedOnWFProcessId, setRefusedOnWFProcessId] = useState(null);
+  const appliedHUQRCode = refusedOnWFProcessId === wfProcessId ? undefined : huQRCodeParam;
 
   const resolveHUScannedCode = async (scannedBarcode) => {
     const parsedQRCode = await resolveDistributionScannedBarcodeToParsedQRCode(scannedBarcode);
@@ -131,14 +146,15 @@ const DistributionPickFromScreen = () => {
       })
     ).catch((axiosError) => {
       // A refused handling unit the operator did not choose here is a dead end: this screen renders no
-      // handling-unit input while one is applied. Forget it so the prompt returns, with the reason.
-      // A network failure is no verdict on it and retrying can succeed, so it travels on untouched.
-      const isServerRefusal = axiosError?.response != null;
-      if (appliedHUQRCode == null || !isServerRefusal) {
+      // handling-unit input while one is applied. Forget it for this order so the prompt returns, with
+      // the reason. A failure that says nothing about it — a conflict elsewhere, a server fault, a lost
+      // connection, which carries no response at all — travels on untouched, and it stays applied.
+      const isHURefusal = HU_REFUSAL_ERROR_CODES.has(extractErrorCodeFromAxiosError(axiosError));
+      if (appliedHUQRCode == null || !isHURefusal) {
         throw axiosError;
       }
 
-      setRefusedHUQRCode(appliedHUQRCode);
+      setRefusedOnWFProcessId(wfProcessId);
       throw trl('activities.distribution.cannotPickFromSelectedHU', {
         reason: extractUserFriendlyErrorMessageFromAxiosError({ axiosError }),
       });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/distribution/DistributionPickFromScreen.jsx
@@ -4,6 +4,7 @@ import { getNextEligiblePickFromLine } from '../../../api/distribution';
 import { toQRCodeString } from '../../../utils/qrCode/hu';
 import { ATTR_barcodeType, BARCODE_TYPE_EAN13 } from '../../../utils/qrCode/common';
 import { trl } from '../../../utils/translations';
+import { extractUserFriendlyErrorMessageFromAxiosError } from '../../../utils/toast';
 import { distributionJobScreenLocation, distributionLineScreenLocation } from '../../../routes/distribution';
 import ScanHUAndGetQtyComponent from '../../../components/ScanHUAndGetQtyComponent';
 import { resolveDistributionScannedBarcodeToParsedQRCode } from '../../../apps/distribution/services/barcodeResolverService';
@@ -28,6 +29,20 @@ const DistributionPickFromScreen = () => {
   } = useDistributionScreenDefinition();
   const dispatch = useDispatch();
   const [lineId, setLineId] = useState(lineIdParam);
+
+  // The handling unit this screen was OPENED with — scanned on the job screen
+  // (DistributionMoveActivity) or carried across an auto-advance (postDistributionPickFromThunk) —
+  // minus the one the backend has refused to pick from. While one is applied,
+  // ScanHUAndGetQtyComponent renders no handling-unit input at all and goes straight to the
+  // article-code scan, so a refused handling unit would leave the operator with no way to name
+  // another one; forgetting it puts the handling-unit prompt back on the same screen.
+  //
+  // What is remembered is WHICH code was refused, rather than a copy of the current one, because
+  // this component stays mounted across the auto-advance: a copy would not pick up the handling unit
+  // the next order carries in, and the operator would be asked to identify one again on every order
+  // after the refusal.
+  const [refusedHUQRCode, setRefusedHUQRCode] = useState(null);
+  const appliedHUQRCode = huQRCodeParam === refusedHUQRCode ? undefined : huQRCodeParam;
 
   const resolveHUScannedCode = async (scannedBarcode) => {
     const parsedQRCode = await resolveDistributionScannedBarcodeToParsedQRCode(scannedBarcode);
@@ -122,7 +137,26 @@ const DistributionPickFromScreen = () => {
         huScannedCode,
         qty,
       })
-    );
+    ).catch((axiosError) => {
+      // A handling unit the operator did not choose on this screen and the server refuses to pick
+      // from is a dead end: they cannot name another one while it stays applied. Forget it, so the
+      // handling-unit prompt returns here instead of the order having to be left, and carry the
+      // server's reason into the message so the operator knows what to reach for.
+      //
+      // Only a refusal — a response — is answered this way. A network-layer failure carries no
+      // verdict on the handling unit and retrying the same scan can succeed, so it must not cost the
+      // operator the handling unit they are picking from (the response/no-response discriminator is
+      // this app's convention for that distinction).
+      const isServerRefusal = axiosError?.response != null;
+      if (appliedHUQRCode == null || !isServerRefusal) {
+        throw axiosError;
+      }
+
+      setRefusedHUQRCode(appliedHUQRCode);
+      throw trl('activities.distribution.cannotPickFromSelectedHU', {
+        reason: extractUserFriendlyErrorMessageFromAxiosError({ axiosError }),
+      });
+    });
   };
 
   return (
@@ -130,7 +164,7 @@ const DistributionPickFromScreen = () => {
       key={`${applicationId}_${wfProcessId}_${activityId}_${lineIdParam ?? '-'}_scan`}
       scanHUPlaceholderText={trl('activities.distribution.scanHUBarcodePlaceholder')}
       scanProductPlaceholderText={trl('activities.distribution.scanProductGtinPlaceholder')}
-      scannedBarcode={huQRCodeParam}
+      scannedBarcode={appliedHUQRCode}
       resolveScannedBarcode={resolveHUScannedCode}
       resolveProductScannedCode={resolveProductScannedCode}
       qtyTargetCaption={trl('general.QtyToPick')}

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -201,6 +201,8 @@ const translations = {
       switchPickFromLocator: 'Lagerort leer',
       invalidLocatorQRCode: 'Lagerplatz QR ungültig',
       invalidQtyToMove: 'Bewegungsmenge ungültig',
+      cannotPickFromSelectedHU:
+        'Aus der gewählten HU kann nicht entnommen werden: %(reason)s. Bitte die HU zum Entnehmen scannen.',
       qrcode: {
         differentProduct: 'Das gescannte QR Produkt stimmt nicht mit dem im Pickauftrag überein',
         productCodeWhereHUExpected: 'Das ist ein Artikel-Barcode (GTIN), kein HU-Barcode. Bitte zuerst die HU scannen.',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -203,6 +203,7 @@ const translations = {
       invalidQtyToMove: 'Bewegungsmenge ungültig',
       qrcode: {
         differentProduct: 'Das gescannte QR Produkt stimmt nicht mit dem im Pickauftrag überein',
+        productCodeWhereHUExpected: 'Das ist ein Artikel-Barcode (GTIN), kein HU-Barcode. Bitte zuerst die HU scannen.',
       },
       printMaterialInTransitReport: 'Materialbegleitschein',
     },

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -198,6 +198,7 @@ const translations = {
       invalidQtyToMove: 'Invalid qty to move',
       qrcode: {
         differentProduct: 'The scanned QR Product does not match',
+        productCodeWhereHUExpected: 'This is an article barcode (GTIN), not an HU barcode. Please scan the HU first.',
       },
       printMaterialInTransitReport: 'In Transit Report',
     },

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -196,6 +196,7 @@ const translations = {
       switchPickFromLocator: 'Locator empty',
       invalidLocatorQRCode: 'Invalid locator QR code',
       invalidQtyToMove: 'Invalid qty to move',
+      cannotPickFromSelectedHU: 'Cannot pick from the selected HU: %(reason)s. Please scan the HU to pick from.',
       qrcode: {
         differentProduct: 'The scanned QR Product does not match',
         productCodeWhereHUExpected: 'This is an article barcode (GTIN), not an HU barcode. Please scan the HU first.',


### PR DESCRIPTION
## Problem

In mobile-UI distribution, an operator sweeping small quantities off handling units standing at one
source locator, order after order, hit `Falscher QR-Code-Typ: EAN13HUQRCode` when scanning a product
GTIN on an auto-advanced order. Two earlier PRs — https://github.com/metasfresh/metasfresh/pull/25328
and https://github.com/metasfresh/metasfresh/pull/25338 — carried the scanned source handling unit
across the auto-advance, but gated that carry on a **pre-allocated move plan** existing. With
`IsAllowPickingAnyHU = 'Y'` no move plan is created at job-creation time, so the condition never became
true and the fix could not execute at any customer. The covering test happened to run with
`allowPickingAnyHU: false`, the minority setting, so green CI proved nothing.

## What this changes

**1 — Carry the handling unit forward in pick-any-HU mode, while it can serve the next order**
(`apps/distribution/redux/postDistributionPickFromThunk.js`)

The carry is keyed on the **next order's own `allowPickingAnyHU` flag** instead of on a non-empty
pre-allocated handling-unit set, so it fires under the configuration customers actually run. The screen
then goes straight to the product-code scan, exactly as it does when a move plan pins the handling unit.

- The scanned handling unit is now resolved in the pick-any-HU case too (previously skipped), returning
  both its QR code and its product from the one round trip.
- It is carried forward only when its product matches every line of the freshly started next order. A
  mixed-product handling unit (no product in its QR code) and an unresolvable scan never carry. Without
  that gate, a carried handling unit that cannot serve the next order leaves the screen with no
  handling-unit input at all, trapping the operator.
- Cases where a move plan exists are behaviourally unchanged, so designated-source-handling-unit
  behaviour is untouched.

**2 — An article code scanned where a handling unit is expected is answered on the screen**
(`containers/activities/distribution/DistributionPickFromScreen.jsx`, `utils/translations_{de,en}.js`)

A value that parses as an EAN13 article barcode is refused locally, before any request, with a message
naming what went wrong; it is never forwarded in the `huQRCode` slot. In distribution a bare GTIN is
never a valid handling-unit identifier — `DistributionHUService.resolveHUQRCode` accepts only a full
`HUQRCode` — so previously this reached the server and came back as a `QR_WRONG_TYPE` rejection,
surfaced to the operator as the raw wrong-QR-type message. New translation key
`activities.distribution.qrcode.productCodeWhereHUExpected`.

*Stated limit:* the refusal covers **EAN13**. A GS1-encoded article code is not recognisable client-side
without a backend round trip and still surfaces the backend's wrong-QR-type message. This matches the
reported field evidence, and the limit is documented in the production comment and in the spec rather
than left implied.

**3 — The carried handling unit cannot trap the operator, and only a rejection about the unit itself
hands the prompt back** (`containers/activities/distribution/DistributionPickFromScreen.jsx`,
`translations_{de,en}.js`)

If the auto-advanced order's product is not on the carried handling unit, the operator is returned to
the handling-unit prompt with a message saying why, and can identify a different handling unit without
leaving the screen or restarting the order. Two refinements make that state behave for the whole sweep:

- The refusal is **scoped to the `wfProcessId` it was met on**. The pick-from screen stays mounted for
  the whole sweep (`wfProcessId` is a route param, so an auto-advance replaces the order under the same
  component), so a refusal remembered screen-wide would drop a handling unit on every later
  auto-advance that legitimately carried it in — forcing a re-scan of a unit a manual scan picks from
  without complaint. It now keeps the prompt up only for the order that cannot be served from that unit.
- Only rejections that **name the unit** drop it (reserved by another document, already at the drop-to
  locator, no longer at the pick-from locator, holds none of the line's product, holds less than is
  being picked). Any other failure — a workflow-state conflict, a stock conflict, a server fault, a lost
  connection — now surfaces as itself and **leaves the handling unit applied**, so repeating the scan
  can book the pick, instead of taking the operator's unit away for a failure it had no part in.

**4 — Tests** (`e2e/mobile-webui`)

- `sweep_scan_HU_after_autoAdvance_anyHU.spec.js` previously asserted the broken behaviour (the operator
  re-scans the staging handling unit) as correct. Inverted to assert the target behaviour; its fixture
  now stands **several** handling units of one product at one source locator — matching the recorded
  flow — with the operator identifying one, and the closing assertion weighs all of them so the pick is
  pinned onto the chosen unit rather than the only thing present.
- New `scan_product_code_while_awaiting_hu.spec.js` — asserts both halves: the on-screen message, and
  that no `nextEligiblePickFromLine` request carries the GTIN in the `huQRCode` slot (read from recorded
  network requests, with a guard against a vacuous pass).
- New `carried_hu_cannot_serve_next_order.spec.js` — the carried unit cannot serve the next order:
  asserts the return to the handling-unit prompt and that identifying a different unit completes the
  pick; a second case sends a plain-message 422 (no error code) and asserts the unit stays applied.
- New `refused_hu_serves_a_later_order.spec.js` — a unit refused for one order (drawn from another
  locator) is still carried into, and picks off of, a later order that draws from its own locator.
- Removed an orphaned assertion helper and the console-recorder chain it was the sole consumer of.

## Verification

Local runs, one spec per invocation — the `allowPickingAnyHU` profile row is sticky and global, so
batching specs in one invocation silently tests the wrong configuration. Re-verified on the pushed HEAD
`4663551`, 2026-07-28:

| Spec | Result |
|---|---|
| `sweep_scan_HU_after_autoAdvance_anyHU.spec.js` | 1 passed |
| `carried_hu_cannot_serve_next_order.spec.js` | 2 passed |
| `scan_product_code_while_awaiting_hu.spec.js` | 2 passed |
| `packingTable_navigateToNextOrder.spec.js` | 1 passed |
| `switchPickFromLocator.spec.js` | 6 passed |
| `sweep_scan_product_after_autoAdvance.spec.js` | 1 passed |
| `scan_HU_barcodes.spec.js` | 5 passed |
| `navigateToJobsListAfterPickFromComplete.spec.js` | 1 passed |

19 tests, all green. Each behavioural change was driven from a failing test proven to fail on its
target assertion — not on a fixture error or an unexplained timeout — before the production change
landed.
