### PR TITLE
Enable `from/to (Between) amount` filtering

### DIFF
--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5816690_sys_gh31052_C_Invoice_enableAmountBetweenFilter.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5816690_sys_gh31052_C_Invoice_enableAmountBetweenFilter.sql
@@ -1,0 +1,164 @@
+-- Run mode: SWING_CLIENT
+
+-- me03#31052 Nach Beträgen suchen können: enable amount from/to (Between) filter
+
+-- Column: C_Invoice.GrandTotal
+-- 2026-07-28T10:00:00.000Z
+UPDATE AD_Column SET FilterOperator='B', IsSelectionColumn='Y',Updated=TO_TIMESTAMP('2026-07-28 10:00:00.000','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_Column_ID=3507
+;
+
+-- Column: C_Invoice.OpenAmt
+-- 2026-07-28T10:00:00.000Z
+UPDATE AD_Column SET FilterOperator='B', IsSelectionColumn='Y',Updated=TO_TIMESTAMP('2026-07-28 10:00:00.000','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_Column_ID=589596
+;
+
+-- Column: C_Invoice.netsum (Netto Summe)
+-- 2026-07-28T10:00:00.000Z
+UPDATE AD_Column SET FilterOperator='B', IsSelectionColumn='Y',Updated=TO_TIMESTAMP('2026-07-28 10:00:00.000','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_Column_ID=544451
+;
+
+-- UI Element: Rechnung_OLD(167,D) -> Rechnung(263,D) -> main -> 10 -> rest.Summe Gesamt
+-- Column: C_Invoice.GrandTotal
+-- 2026-07-28T13:47:50.687Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,2780,0,263,540029,652780,'F',TO_TIMESTAMP('2026-07-28 14:47:49.892','YYYY-MM-DD HH24:MI:SS.US'),100,'Summe über Alles zu diesem Beleg','Die Summe Gesamt zeigt die Summe über Alles inklusive Steuern und Fracht in Belegwährung an.','Y','N','N','N','N','N','N',0,'Summe Gesamt',60,0,0,TO_TIMESTAMP('2026-07-28 14:47:49.892','YYYY-MM-DD HH24:MI:SS.US'),100)
+;
+
+-- Field: Rechnung_OLD(167,D) -> Rechnung(263,D) -> Offener Betrag
+-- Column: C_Invoice.OpenAmt
+-- 2026-07-28T13:49:38.557Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,DisplayLength,EntityType,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsForbidNewRecordCreation,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,589596,781856,0,263,0,TO_TIMESTAMP('2026-07-28 14:49:37.404','YYYY-MM-DD HH24:MI:SS.US'),100,0,'D',0,'Y','Y','Y','N','N','N','N','N','N','Offener Betrag',0,560,0,1,1,TO_TIMESTAMP('2026-07-28 14:49:37.404','YYYY-MM-DD HH24:MI:SS.US'),100)
+;
+
+-- 2026-07-28T13:49:38.669Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=781856 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-07-28T13:49:38.768Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(1526)
+;
+
+-- 2026-07-28T13:49:38.837Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781856
+;
+
+-- 2026-07-28T13:49:38.896Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(781856)
+;
+
+-- UI Element: Rechnung_OLD(167,D) -> Rechnung(263,D) -> main -> 10 -> rest.Offener Betrag
+-- Column: C_Invoice.OpenAmt
+-- 2026-07-28T13:50:10.922Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,781856,0,263,540029,652781,'F',TO_TIMESTAMP('2026-07-28 14:50:10.033','YYYY-MM-DD HH24:MI:SS.US'),100,'Y','N','N','N','N','N','N',0,'Offener Betrag',70,0,0,TO_TIMESTAMP('2026-07-28 14:50:10.033','YYYY-MM-DD HH24:MI:SS.US'),100)
+;
+
+-- UI Element: Rechnung_OLD(167,D) -> Rechnung(263,D) -> main -> 10 -> rest.Summe Gesamt
+-- Column: C_Invoice.GrandTotal
+-- 2026-07-28T13:50:40.115Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=110,Updated=TO_TIMESTAMP('2026-07-28 14:50:40.115','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=652780
+;
+
+-- UI Element: Rechnung_OLD(167,D) -> Rechnung(263,D) -> main -> 10 -> rest.Offener Betrag
+-- Column: C_Invoice.OpenAmt
+-- 2026-07-28T13:50:40.509Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=120,Updated=TO_TIMESTAMP('2026-07-28 14:50:40.509','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=652781
+;
+
+-- UI Element: Rechnung_OLD(167,D) -> Rechnung(263,D) -> main -> 20 -> dates.Belegstatus
+-- Column: C_Invoice.DocStatus
+-- 2026-07-28T13:50:40.884Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=130,Updated=TO_TIMESTAMP('2026-07-28 14:50:40.883','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=547013
+;
+
+-- UI Element: Rechnung_OLD(167,D) -> Rechnung(263,D) -> main -> 20 -> org.Section Code
+-- Column: C_Invoice.M_SectionCode_ID
+-- 2026-07-28T13:50:41.252Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=140,Updated=TO_TIMESTAMP('2026-07-28 14:50:41.252','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=611343
+;
+
+-- UI Element: Rechnung_OLD(167,D) -> Rechnung(263,D) -> main -> 20 -> posted.Posted
+-- Column: C_Invoice.Posted
+-- 2026-07-28T13:50:41.615Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=150,Updated=TO_TIMESTAMP('2026-07-28 14:50:41.615','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=564735
+;
+
+-- UI Element: Rechnung_OLD(167,D) -> Rechnung(263,D) -> main -> 20 -> posted.Projekt
+-- Column: C_Invoice.C_Project_ID
+-- 2026-07-28T13:50:41.989Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=160,Updated=TO_TIMESTAMP('2026-07-28 14:50:41.989','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=611329
+;
+
+-- UI Element: Rechnung_OLD(167,D) -> Rechnung(263,D) -> main -> 20 -> org.Sektion
+-- Column: C_Invoice.AD_Org_ID
+-- 2026-07-28T13:50:42.347Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=170,Updated=TO_TIMESTAMP('2026-07-28 14:50:42.345','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=540791
+;
+
+-- UI Element: Eingangsrechnung_OLD(183,D) -> Eingangsrechnung(290,D) -> main -> 10 -> preise.Summe Gesamt
+-- Column: C_Invoice.GrandTotal
+-- 2026-07-28T13:55:36.345Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,3337,0,290,540225,652782,'F',TO_TIMESTAMP('2026-07-28 14:55:35.457','YYYY-MM-DD HH24:MI:SS.US'),100,'Summe über Alles zu diesem Beleg','Die Summe Gesamt zeigt die Summe über Alles inklusive Steuern und Fracht in Belegwährung an.','Y','N','N','N','N','N','N',0,'Summe Gesamt',40,0,0,TO_TIMESTAMP('2026-07-28 14:55:35.457','YYYY-MM-DD HH24:MI:SS.US'),100)
+;
+
+-- Field: Eingangsrechnung_OLD(183,D) -> Eingangsrechnung(290,D) -> Offener Betrag
+-- Column: C_Invoice.OpenAmt
+-- 2026-07-28T13:57:36.680Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,DisplayLength,EntityType,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsForbidNewRecordCreation,IsHeading,IsReadOnly,IsSameLine,Name,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,589596,781857,0,290,0,TO_TIMESTAMP('2026-07-28 14:57:35.684','YYYY-MM-DD HH24:MI:SS.US'),100,0,'D',0,'Y','Y','Y','N','N','N','N','N','N','Offener Betrag',0,350,0,1,1,TO_TIMESTAMP('2026-07-28 14:57:35.684','YYYY-MM-DD HH24:MI:SS.US'),100)
+;
+
+-- 2026-07-28T13:57:36.740Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=781857 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-07-28T13:57:36.800Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(1526)
+;
+
+-- 2026-07-28T13:57:36.864Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781857
+;
+
+-- 2026-07-28T13:57:36.923Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(781857)
+;
+
+-- UI Element: Eingangsrechnung_OLD(183,D) -> Eingangsrechnung(290,D) -> main -> 10 -> preise.Offener Betrag
+-- Column: C_Invoice.OpenAmt
+-- 2026-07-28T13:58:12.463Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,781857,0,290,540225,652783,'F',TO_TIMESTAMP('2026-07-28 14:58:11.678','YYYY-MM-DD HH24:MI:SS.US'),100,'Y','N','N','N','N','N','N',0,'Offener Betrag',50,0,0,TO_TIMESTAMP('2026-07-28 14:58:11.678','YYYY-MM-DD HH24:MI:SS.US'),100)
+;
+
+-- UI Element: Eingangsrechnung_OLD(183,D) -> Eingangsrechnung(290,D) -> main -> 10 -> preise.Offener Betrag
+-- Column: C_Invoice.OpenAmt
+-- 2026-07-28T13:58:48.698Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=130,Updated=TO_TIMESTAMP('2026-07-28 14:58:48.698','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=652783
+;
+
+-- UI Element: Eingangsrechnung_OLD(183,D) -> Eingangsrechnung(290,D) -> main -> 20 -> rest.Status
+-- Column: C_Invoice.DocStatus
+-- 2026-07-28T13:58:49.078Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=140,Updated=TO_TIMESTAMP('2026-07-28 14:58:49.078','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=542729
+;
+
+-- UI Element: Eingangsrechnung_OLD(183,D) -> Eingangsrechnung(290,D) -> main -> 20 -> posted.Verbucht
+-- Column: C_Invoice.Posted
+-- 2026-07-28T13:58:49.457Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=150,Updated=TO_TIMESTAMP('2026-07-28 14:58:49.457','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=542660
+;
+
+-- UI Element: Eingangsrechnung_OLD(183,D) -> Eingangsrechnung(290,D) -> advanced edit -> 10 -> advanced edit.Sales invoice count
+-- Column: C_Invoice.Sales_Invoice_Count
+-- 2026-07-28T13:58:49.845Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=160,Updated=TO_TIMESTAMP('2026-07-28 14:58:49.845','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=594686
+;
+
+-- UI Element: Eingangsrechnung_OLD(183,D) -> Eingangsrechnung(290,D) -> main -> 20 -> org.Section Code
+-- Column: C_Invoice.M_SectionCode_ID
+-- 2026-07-28T13:58:50.249Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=170,Updated=TO_TIMESTAMP('2026-07-28 14:58:50.249','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=611346
+;
+
+-- UI Element: Eingangsrechnung_OLD(183,D) -> Eingangsrechnung(290,D) -> main -> 20 -> org.Sektion
+-- Column: C_Invoice.AD_Org_ID
+-- 2026-07-28T13:58:50.615Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=180,Updated=TO_TIMESTAMP('2026-07-28 14:58:50.615','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=542725
+;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5816700_sys_gh31052_C_Payment_enableAmountBetweenFilter.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5816700_sys_gh31052_C_Payment_enableAmountBetweenFilter.sql
@@ -1,0 +1,8 @@
+-- Run mode: SWING_CLIENT
+
+-- me03#31052 Nach Beträgen suchen können: enable amount from/to (Between) filter
+
+-- Column: C_Payment.PayAmt
+-- 2026-07-28T10:00:00.000Z
+UPDATE AD_Column SET FilterOperator='B', IsSelectionColumn='Y',Updated=TO_TIMESTAMP('2026-07-28 10:00:00.000','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_Column_ID=5303
+;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5816710_sys_gh31052_C_Invoice_Candidate_enableAmountBetweenFilter.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5816710_sys_gh31052_C_Invoice_Candidate_enableAmountBetweenFilter.sql
@@ -1,0 +1,161 @@
+-- Run mode: SWING_CLIENT
+
+-- me03#31052 Nach Beträgen suchen können: enable amount from/to (Between) filter
+
+-- Column: C_Invoice_Candidate.NetAmtToInvoice
+-- 2026-07-28T10:00:00.000Z
+UPDATE AD_Column SET FilterOperator='B', IsSelectionColumn='Y',Updated=TO_TIMESTAMP('2026-07-28 10:00:00.000','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_Column_ID=545315
+;
+
+-- Column: C_Invoice_Candidate.NetAmtInvoiced
+-- 2026-07-28T10:00:00.000Z
+UPDATE AD_Column SET FilterOperator='B', IsSelectionColumn='Y',Updated=TO_TIMESTAMP('2026-07-28 10:00:00.000','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_Column_ID=545854
+;
+
+-- UI Element: Rechnungsdisposition_OLD(540092,de.metas.invoicecandidate) -> Rechnungskandidaten(540279,de.metas.invoicecandidate) -> advanced edit -> 10 -> advanced edit.Freigabe zur Fakturierung
+-- Column: C_Invoice_Candidate.ApprovalForInvoicing
+-- 2026-07-28T14:49:49.966Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=80,Updated=TO_TIMESTAMP('2026-07-28 15:49:49.966','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=541058
+;
+
+-- UI Element: Rechnungsdisposition_OLD(540092,de.metas.invoicecandidate) -> Rechnungskandidaten(540279,de.metas.invoicecandidate) -> main -> 10 -> qtyInStockingUOM.QtyOrdered
+-- Column: C_Invoice_Candidate.QtyOrdered
+-- 2026-07-28T14:49:50.346Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=90,Updated=TO_TIMESTAMP('2026-07-28 15:49:50.346','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=548108
+;
+
+-- UI Element: Rechnungsdisposition_OLD(540092,de.metas.invoicecandidate) -> Rechnungskandidaten(540279,de.metas.invoicecandidate) -> main -> 10 -> qtyInStockingUOM.Gelieferte Menge
+-- Column: C_Invoice_Candidate.QtyDelivered
+-- 2026-07-28T14:49:50.727Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=100,Updated=TO_TIMESTAMP('2026-07-28 15:49:50.726','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=548109
+;
+
+-- UI Element: Rechnungsdisposition_OLD(540092,de.metas.invoicecandidate) -> Rechnungskandidaten(540279,de.metas.invoicecandidate) -> main -> 10 -> qtyInStockingUOM.Lieferung geschlossen
+-- Column: C_Invoice_Candidate.IsDeliveryClosed
+-- 2026-07-28T14:49:51.109Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=110,Updated=TO_TIMESTAMP('2026-07-28 15:49:51.109','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=609542
+;
+
+-- UI Element: Rechnungsdisposition_OLD(540092,de.metas.invoicecandidate) -> Rechnungskandidaten(540279,de.metas.invoicecandidate) -> main -> 10 -> qtyInStockingUOM.Berechnete Menge
+-- Column: C_Invoice_Candidate.QtyInvoiced
+-- 2026-07-28T14:49:51.497Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=120,Updated=TO_TIMESTAMP('2026-07-28 15:49:51.497','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=548110
+;
+
+-- UI Element: Rechnungsdisposition_OLD(540092,de.metas.invoicecandidate) -> Rechnungskandidaten(540279,de.metas.invoicecandidate) -> main -> 10 -> qtyInStockingUOM.QtyToInvoice
+-- Column: C_Invoice_Candidate.QtyToInvoice
+-- 2026-07-28T14:49:51.857Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=130,Updated=TO_TIMESTAMP('2026-07-28 15:49:51.857','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=548111
+;
+
+-- UI Element: Rechnungsdisposition_OLD(540092,de.metas.invoicecandidate) -> Rechnungskandidaten(540279,de.metas.invoicecandidate) -> main -> 20 -> dates & flags.Abrechnung ab eff.
+-- Column: C_Invoice_Candidate.DateToInvoice_Effective
+-- 2026-07-28T14:49:52.219Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=140,Updated=TO_TIMESTAMP('2026-07-28 15:49:52.219','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=541084
+;
+
+-- UI Element: Rechnungsdisposition_OLD(540092,de.metas.invoicecandidate) -> Rechnungskandidaten(540279,de.metas.invoicecandidate) -> main -> 20 -> totals.NetAmtInvoiced
+-- Column: C_Invoice_Candidate.NetAmtInvoiced
+-- 2026-07-28T14:49:52.591Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=150,Updated=TO_TIMESTAMP('2026-07-28 15:49:52.591','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=560339
+;
+
+-- UI Element: Rechnungsdisposition_OLD(540092,de.metas.invoicecandidate) -> Rechnungskandidaten(540279,de.metas.invoicecandidate) -> main -> 20 -> totals.NetAmtToInvoice
+-- Column: C_Invoice_Candidate.NetAmtToInvoice
+-- 2026-07-28T14:49:53.232Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=160,Updated=TO_TIMESTAMP('2026-07-28 15:49:53.232','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=560340
+;
+
+-- UI Element: Rechnungsdisposition_OLD(540092,de.metas.invoicecandidate) -> Rechnungskandidaten(540279,de.metas.invoicecandidate) -> main -> 20 -> dates & flags.Lieferdatum
+-- Column: C_Invoice_Candidate.DeliveryDate
+-- 2026-07-28T14:49:53.860Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=170,Updated=TO_TIMESTAMP('2026-07-28 15:49:53.86','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=541085
+;
+
+-- UI Element: Rechnungsdisposition_OLD(540092,de.metas.invoicecandidate) -> Rechnungskandidaten(540279,de.metas.invoicecandidate) -> main -> 20 -> financial.Projekt
+-- Column: C_Invoice_Candidate.C_Project_ID
+-- 2026-07-28T14:49:54.240Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=180,Updated=TO_TIMESTAMP('2026-07-28 15:49:54.24','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=611336
+;
+
+-- UI Element: Rechnungsdisposition_OLD(540092,de.metas.invoicecandidate) -> Rechnungskandidaten(540279,de.metas.invoicecandidate) -> main -> 20 -> org.Sektion
+-- Column: C_Invoice_Candidate.AD_Org_ID
+-- 2026-07-28T14:49:54.678Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=190,Updated=TO_TIMESTAMP('2026-07-28 15:49:54.678','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=541953
+;
+
+-- UI Element: Rechnungsdisposition_OLD(540092,de.metas.invoicecandidate) -> Rechnungskandidaten(540279,de.metas.invoicecandidate) -> main -> 10 -> override.Total des Auftrags
+-- Column: C_Invoice_Candidate.TotalOfOrder
+-- 2026-07-28T14:49:55.065Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=200,Updated=TO_TIMESTAMP('2026-07-28 15:49:55.064','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=548120
+;
+
+-- Run mode: SWING_CLIENT
+
+-- UI Element: Rechnungsdisposition Einkauf_OLD(540983,de.metas.invoicecandidate) -> Rechnungskandidaten(543052,de.metas.invoicecandidate) -> main -> 10 -> qtyInStockingUOM.QtyOrdered
+-- Column: C_Invoice_Candidate.QtyOrdered
+-- 2026-07-28T14:56:42.192Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=110,Updated=TO_TIMESTAMP('2026-07-28 15:56:42.192','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=573388
+;
+
+-- UI Element: Rechnungsdisposition Einkauf_OLD(540983,de.metas.invoicecandidate) -> Rechnungskandidaten(543052,de.metas.invoicecandidate) -> main -> 10 -> qtyInStockingUOM.Gelieferte Menge
+-- Column: C_Invoice_Candidate.QtyDelivered
+-- 2026-07-28T14:56:42.552Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=120,Updated=TO_TIMESTAMP('2026-07-28 15:56:42.552','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=573389
+;
+
+-- UI Element: Rechnungsdisposition Einkauf_OLD(540983,de.metas.invoicecandidate) -> Rechnungskandidaten(543052,de.metas.invoicecandidate) -> main -> 10 -> qtyInStockingUOM.Berechnete Menge
+-- Column: C_Invoice_Candidate.QtyInvoiced
+-- 2026-07-28T14:56:42.906Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=130,Updated=TO_TIMESTAMP('2026-07-28 15:56:42.905','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=573390
+;
+
+-- UI Element: Rechnungsdisposition Einkauf_OLD(540983,de.metas.invoicecandidate) -> Rechnungskandidaten(543052,de.metas.invoicecandidate) -> main -> 10 -> qtyInStockingUOM.QtyToInvoice
+-- Column: C_Invoice_Candidate.QtyToInvoice
+-- 2026-07-28T14:56:43.326Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=140,Updated=TO_TIMESTAMP('2026-07-28 15:56:43.326','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=573392
+;
+
+-- UI Element: Rechnungsdisposition Einkauf_OLD(540983,de.metas.invoicecandidate) -> Rechnungskandidaten(543052,de.metas.invoicecandidate) -> main -> 20 -> dates & flags.Abrechnung ab eff.
+-- Column: C_Invoice_Candidate.DateToInvoice_Effective
+-- 2026-07-28T14:56:43.695Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=150,Updated=TO_TIMESTAMP('2026-07-28 15:56:43.695','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=573406
+;
+
+-- UI Element: Rechnungsdisposition Einkauf_OLD(540983,de.metas.invoicecandidate) -> Rechnungskandidaten(543052,de.metas.invoicecandidate) -> main -> 20 -> totals.NetAmtInvoiced
+-- Column: C_Invoice_Candidate.NetAmtInvoiced
+-- 2026-07-28T14:56:44.076Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=160,Updated=TO_TIMESTAMP('2026-07-28 15:56:44.076','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=573418
+;
+
+-- UI Element: Rechnungsdisposition Einkauf_OLD(540983,de.metas.invoicecandidate) -> Rechnungskandidaten(543052,de.metas.invoicecandidate) -> main -> 20 -> totals.NetAmtToInvoice
+-- Column: C_Invoice_Candidate.NetAmtToInvoice
+-- 2026-07-28T14:56:44.458Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=170,Updated=TO_TIMESTAMP('2026-07-28 15:56:44.458','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=573419
+;
+
+-- UI Element: Rechnungsdisposition Einkauf_OLD(540983,de.metas.invoicecandidate) -> Rechnungskandidaten(543052,de.metas.invoicecandidate) -> main -> 20 -> dates & flags.Lieferdatum
+-- Column: C_Invoice_Candidate.DeliveryDate
+-- 2026-07-28T14:56:44.823Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=180,Updated=TO_TIMESTAMP('2026-07-28 15:56:44.823','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=573407
+;
+
+-- UI Element: Rechnungsdisposition Einkauf_OLD(540983,de.metas.invoicecandidate) -> Rechnungskandidaten(543052,de.metas.invoicecandidate) -> advanced edit -> 10 -> advanced edit.Rechnungs-Belegart
+-- Column: C_Invoice_Candidate.C_DocTypeInvoice_ID
+-- 2026-07-28T14:56:45.186Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=190,Updated=TO_TIMESTAMP('2026-07-28 15:56:45.186','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=573430
+;
+
+-- UI Element: Rechnungsdisposition Einkauf_OLD(540983,de.metas.invoicecandidate) -> Rechnungskandidaten(543052,de.metas.invoicecandidate) -> main -> 10 -> override.Total des Auftrags
+-- Column: C_Invoice_Candidate.TotalOfOrder
+-- 2026-07-28T14:56:45.546Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=200,Updated=TO_TIMESTAMP('2026-07-28 15:56:45.546','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=573397
+;
+
+-- UI Element: Rechnungsdisposition Einkauf_OLD(540983,de.metas.invoicecandidate) -> Rechnungskandidaten(543052,de.metas.invoicecandidate) -> main -> 20 -> org.Sektion
+-- Column: C_Invoice_Candidate.AD_Org_ID
+-- 2026-07-28T14:56:45.901Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=210,Updated=TO_TIMESTAMP('2026-07-28 15:56:45.901','YYYY-MM-DD HH24:MI:SS.US'),UpdatedBy=100 WHERE AD_UI_Element_ID=573420
+;
+
+


### PR DESCRIPTION
Enable from/to (Between) amount filtering and show the amounts as grid columns in the Debitoren, Kreditoren, Zahlung and Rechnungsdisposition windows:                                                                                                                                           
                                                                                                                           
  - C_Invoice: GrandTotal, OpenAmt, netsum (Netto Summe)                                                                                             
  - C_Payment: PayAmt                                                                                                                                
  - C_Invoice_Candidate: NetAmtToInvoice, NetAmtInvoiced 