### PR TITLE
EDI export cucumber: port the basicGet pull-loop fix for the ack-vs-channel-close race (test-only; unblocks PR 25319)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/MetasfreshToEDIRabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/MetasfreshToEDIRabbitMQ_StepDef.java
@@ -26,8 +26,7 @@ import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
-import com.rabbitmq.client.DefaultConsumer;
-import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.GetResponse;
 import de.metas.CommandLineParser;
 import de.metas.ServerBoot;
 import de.metas.cucumber.stepdefs.DataTableUtil;
@@ -37,6 +36,7 @@ import de.metas.esb.edi.model.I_EDI_cctop_invoic_v;
 import de.metas.logging.LogManager;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
@@ -54,7 +54,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -91,6 +90,74 @@ public class MetasfreshToEDIRabbitMQ_StepDef
 		metasfreshToRabbitMQFactory.setPort(commandLineOptions.getRabbitPort());
 		metasfreshToRabbitMQFactory.setUsername(commandLineOptions.getRabbitUser());
 		metasfreshToRabbitMQFactory.setPassword(commandLineOptions.getRabbitPassword());
+	}
+
+	/**
+	 * Purges the given durable EDI-export RabbitMQ queue so the scenario starts from a known-empty
+	 * state, regardless of what an earlier scenario (or an earlier feature on the same CI executor)
+	 * left behind.
+	 * <p>
+	 * Why this is needed: the EDI export queues (e.g. {@code ediExport}) are <b>durable</b> and
+	 * <b>shared</b> by every scenario in a feature and by every feature that exports through the same
+	 * routing key on one CI executor (all run sequentially against one RabbitMQ broker). The consumer
+	 * in {@link #pollDocumentFromQueue(String)} returns the message at the head of the queue, so a
+	 * single leftover message (a foreign DESADV/INVOIC from a sibling scenario, or a message re-queued
+	 * by the consumer's {@code basicNack(requeue=true)} extra-message path) makes the next scenario
+	 * consume the <i>wrong</i> document. That manifests as the flaky
+	 * {@code [EDI_Exp_Desadv_Pack] Expecting actual not to be null} (a foreign INVOIC has no pack
+	 * element) and the sibling {@code ShutdownSignalException}. Purging in the Background (per the
+	 * setUp-isolation convention) removes the bleed at its source.
+	 * <p>
+	 * The purge is a no-op when the queue does not exist yet (first run on a fresh broker): we
+	 * passively check existence first and skip silently, because "no queue" already means "nothing to
+	 * bleed".
+	 * <p>
+	 * DataTable-free step. Example:
+	 * <pre>
+	 * Given the EDI export RabbitMQ queue 'ediExport' is purged
+	 * </pre>
+	 */
+	@Given("the EDI export RabbitMQ queue {string} is purged")
+	public void edi_export_queue_is_purged(@NonNull final String queueName) throws IOException, TimeoutException
+	{
+		final Connection connection = metasfreshToRabbitMQFactory.newConnection();
+		try
+		{
+			final Channel channel = connection.createChannel();
+			try
+			{
+				try
+				{
+					// queueDeclarePassive throws (and closes the channel) when the queue does not exist yet;
+					// in that case there is nothing to purge, so we treat it as a no-op and return. The dead
+					// channel needs no explicit close (the broker already closed it; the finally below guards
+					// it via isOpen()), and the outer finally closes the connection.
+					channel.queueDeclarePassive(queueName);
+				}
+				catch (final IOException queueAbsent)
+				{
+					logger.info("EDI export queue {} does not exist yet -> nothing to purge", queueName);
+					return;
+				}
+
+				// queuePurge is OUTSIDE the queueAbsent catch on purpose: the queue exists here, so a purge
+				// failure (e.g. ACCESS_REFUSED, or a protocol error) is a real problem and must propagate
+				// rather than be mislogged as "does not exist yet" and silently leave the queue unpurged.
+				final AMQP.Queue.PurgeOk purgeOk = channel.queuePurge(queueName);
+				logger.info("Purged {} message(s) from EDI export queue {}", purgeOk.getMessageCount(), queueName);
+			}
+			finally
+			{
+				if (channel.isOpen())
+				{
+					channel.close();
+				}
+			}
+		}
+		finally
+		{
+			connection.close();
+		}
 	}
 
 	@Then("RabbitMQ receives a EDI_cctop_invoic_v")
@@ -145,70 +212,99 @@ public class MetasfreshToEDIRabbitMQ_StepDef
 		ediExpDesadvTable.put(ediExpDesadvIdentifier, export);
 	}
 
+	/**
+	 * Polls one EDI-export message off the given queue and parses it into an XML {@link Document}.
+	 * <p>
+	 * Implemented with a <b>synchronous {@code basicGet} pull-loop</b> rather than an asynchronous push
+	 * consumer ({@code basicConsume} + a {@code DefaultConsumer.handleDelivery} callback). The
+	 * push-consumer approach is racy here: with no prefetch limit the broker dispatches <i>every</i>
+	 * queued message at once to the consumer; after we ack the first one and let the poll method's
+	 * {@code finally} close the channel, the broker's still-pending extra deliveries re-enter the
+	 * callback and call {@code basicAck}/{@code basicNack} on the now-closed channel — which throws
+	 * inside the callback and makes the RabbitMQ client tear the channel down with
+	 * {@code ShutdownSignalException: ... Closed due to exception from Consumer ... handleDelivery}
+	 * (the observed CI flake). A pull-loop fetches exactly one message per {@code basicGet}, on the
+	 * test thread, so there is no consumer callback to throw and no extra-delivery/close race.
+	 * <p>
+	 * The loop is also tolerant of a foreign or unparseable message left on the (shared, durable) queue:
+	 * any message that does not parse as XML is acked-and-skipped (removed) and polling continues, so a
+	 * cross-scenario/cross-feature leftover can neither be returned as the wrong document nor crash the
+	 * poll. See also the Background queue-purge step {@link #edi_export_queue_is_purged(String)}.
+	 */
 	@NonNull
 	private Document pollDocumentFromQueue(@NonNull final String queueName) throws IOException, TimeoutException, InterruptedException, ParserConfigurationException, SAXException
 	{
 		final Connection connection = metasfreshToRabbitMQFactory.newConnection();
-		final Channel channel = connection.createChannel();
-
-		final CountDownLatch countDownLatch = new CountDownLatch(1);
-
-		final String[] messages = new String[1];
-
-		final DefaultConsumer consumer = new DefaultConsumer(channel)
-		{
-			@Override
-			public void handleDelivery(final String consumerTag, final Envelope envelope, final AMQP.BasicProperties properties, final byte[] body) throws IOException
-			{
-				// Only accept the first delivery and ack it; cancel the consumer immediately so the
-				// broker requeues / leaves any remaining messages (e.g. a second DESADV pre-queued
-				// before this poll) for the next pollDocumentFromQueue call.
-				if (countDownLatch.getCount() == 0)
-				{
-					// Reject without requeue is wrong (would lose the message); nack with requeue=true
-					// keeps it in the queue for the next caller. With basicCancel below, this path is
-					// only hit if the broker dispatched extra messages before cancellation took effect.
-					channel.basicNack(envelope.getDeliveryTag(), false, true);
-					return;
-				}
-
-				messages[0] = new String(body, StandardCharsets.UTF_8);
-
-				logger.info("*** Queue: {}, received message: {}", queueName, messages[0]);
-
-				countDownLatch.countDown();
-
-				channel.basicAck(envelope.getDeliveryTag(), false);
-
-				try
-				{
-					channel.basicCancel(consumerTag);
-				}
-				catch (final Exception e)
-				{
-					// best-effort cancel; channel may already be in the process of closing
-					logger.warn("basicCancel failed (ignored): {}", e.getMessage());
-				}
-			}
-		};
-
 		try
 		{
-			// autoAck=false: we manually ack the first message and nack-with-requeue any extras the
-			// broker dispatched before basicCancel took effect, so a follow-up pollDocumentFromQueue
-			// call still finds those messages in the queue.
-			channel.basicConsume(queueName, false, consumer);
+			// createChannel() is inside the outer try so the connection is still closed if it throws.
+			final Channel channel = connection.createChannel();
+			try
+			{
+				final long deadlineMillis = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(60);
 
-			final boolean messageReceivedWithinTimeout = countDownLatch.await(60, TimeUnit.SECONDS);
+				while (System.currentTimeMillis() < deadlineMillis)
+				{
+					// autoAck=false: pull exactly one message at a time on the test thread, then ack it
+					// explicitly once we have read its body. No prefetch storm, no consumer-callback thread.
+					final GetResponse getResponse = channel.basicGet(queueName, false);
+					if (getResponse == null)
+					{
+						// Queue currently empty (the export workpackage may not have published yet) -> wait
+						// briefly and retry until the deadline.
+						try
+						{
+							Thread.sleep(250);
+						}
+						catch (final InterruptedException interrupted)
+						{
+							Thread.currentThread().interrupt();
+							throw interrupted;
+						}
+						continue;
+					}
 
-			assertThat(messageReceivedWithinTimeout).isTrue();
+					final String message = new String(getResponse.getBody(), StandardCharsets.UTF_8);
+					channel.basicAck(getResponse.getEnvelope().getDeliveryTag(), false);
+
+					try
+					{
+						final Document document = parseXmlStringToDocument(message);
+						logger.info("*** Queue: {}, received message: {}", queueName, message);
+						return document;
+					}
+					catch (final SAXException | IOException foreignMessage)
+					{
+						// A leftover / foreign message that is not the expected EDI XML: it is already acked
+						// (removed) above, so just skip it and keep polling for the message we expect.
+						// ParserConfigurationException is intentionally NOT caught here: it signals a broken
+						// JAXP/JVM configuration (the DocumentBuilderFactory is created once at construction),
+						// not a per-message condition, so it must propagate and fail the run loudly rather
+						// than be swallowed as a "foreign message" and masked by the 60s-timeout AssertionError.
+						// The full body is logged on purpose: after the Background queue-purge, a non-parseable
+						// message most likely means the system under test published malformed XML, and the only
+						// other symptom is the generic 60s-timeout AssertionError below — the body is what makes
+						// that root cause diagnosable from the CI log.
+						logger.warn("*** Queue: {}, skipping non-XML/foreign message (body={}): {}", queueName, message, foreignMessage.getMessage());
+					}
+				}
+
+				throw new AssertionError("No EDI-export message received on queue '" + queueName + "' within 60s");
+			}
+			finally
+			{
+				// guard with isOpen(): if the broker already force-closed the channel, an unconditional
+				// close() would throw AlreadyClosedException in finally and suppress the real failure.
+				if (channel.isOpen())
+				{
+					channel.close();
+				}
+			}
 		}
 		finally
 		{
-			channel.close();
+			connection.close();
 		}
-
-		return parseXmlStringToDocument(messages[0]);
 	}
 
 	@NonNull

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/MetasfreshToExternalSystemRabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/MetasfreshToExternalSystemRabbitMQ_StepDef.java
@@ -29,8 +29,7 @@ import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
-import com.rabbitmq.client.DefaultConsumer;
-import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.GetResponse;
 import de.metas.CommandLineParser;
 import de.metas.JsonObjectMapperHolder;
 import de.metas.ServerBoot;
@@ -67,7 +66,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
@@ -123,9 +121,29 @@ public class MetasfreshToExternalSystemRabbitMQ_StepDef
 	public void rabbitMQs_MF_TO_ExternalSystem_queue_is_empty() throws IOException, TimeoutException
 	{
 		final Connection connection = metasfreshToRabbitMQFactory.newConnection();
-		final Channel channel = connection.createChannel();
-		final AMQP.Queue.PurgeOk purgeOk = channel.queuePurge(QUEUE_NAME_MF_TO_ES);
-		logger.info("Purged {} messages from queue {}", purgeOk.getMessageCount(), QUEUE_NAME_MF_TO_ES);
+		try
+		{
+			// createChannel() is inside the outer try so the connection is still closed if it throws.
+			final Channel channel = connection.createChannel();
+			try
+			{
+				final AMQP.Queue.PurgeOk purgeOk = channel.queuePurge(QUEUE_NAME_MF_TO_ES);
+				logger.info("Purged {} messages from queue {}", purgeOk.getMessageCount(), QUEUE_NAME_MF_TO_ES);
+			}
+			finally
+			{
+				// guard with isOpen(): if the broker already force-closed the channel, an unconditional
+				// close() would throw AlreadyClosedException in finally and suppress the real failure.
+				if (channel.isOpen())
+				{
+					channel.close();
+				}
+			}
+		}
+		finally
+		{
+			connection.close();
+		}
 	}
 
 	@Then("RabbitMQ receives a JsonExternalSystemRequest with the following external system config and bpartnerId as parameters:")
@@ -206,55 +224,115 @@ public class MetasfreshToExternalSystemRabbitMQ_StepDef
 		}
 	}
 
+	/**
+	 * Polls {@code numberOfMessages} qualifying {@link JsonExternalSystemRequest}s off the
+	 * {@code MF_TO_ExternalSystem} queue.
+	 * <p>
+	 * Implemented with a <b>synchronous {@code basicGet} pull-loop</b> rather than an asynchronous push
+	 * consumer ({@code basicConsume} + a {@code DefaultConsumer.handleDelivery} callback). The
+	 * push-consumer approach is racy here: with no prefetch limit the broker dispatches <i>every</i>
+	 * queued message at once to the consumer; after the poll method's {@code finally} closes the channel,
+	 * still-pending deliveries re-enter the callback and act on the now-closed channel — which throws
+	 * inside the callback and makes the RabbitMQ client tear the channel down with
+	 * {@code ShutdownSignalException: ... Closed due to exception from Consumer ... handleDelivery}.
+	 * A pull-loop fetches exactly one message per {@code basicGet}, on the test thread, so there is no
+	 * consumer callback to throw and no extra-delivery/close race.
+	 * <p>
+	 * The loop is also tolerant of a foreign or unparseable message left on the (shared, durable) queue:
+	 * any message that does not parse as a {@link JsonExternalSystemRequest} is acked-and-skipped (removed)
+	 * and polling continues, so a cross-scenario/cross-feature leftover can neither be collected nor crash
+	 * the poll. Messages that parse but do not satisfy {@code messageQualifier} are likewise acked-and-skipped.
+	 * Closes both channel (guarded by {@code isOpen()}) and connection in {@code finally}.
+	 */
 	@NonNull
 	private List<JsonExternalSystemRequest> pollRequestFromQueue(
 			final int numberOfMessages,
 			final Function<JsonExternalSystemRequest, Boolean> messageQualifier) throws IOException, TimeoutException, InterruptedException
 	{
-		Channel channel = null;
-
+		final Connection connection = metasfreshToRabbitMQFactory.newConnection();
 		try
 		{
-			final ImmutableList.Builder<JsonExternalSystemRequest> collector = ImmutableList.builder();
-
-			final Connection connection = metasfreshToRabbitMQFactory.newConnection();
-			channel = connection.createChannel();
-
-			final CountDownLatch countDownLatch = new CountDownLatch(numberOfMessages);
-
-			final DefaultConsumer consumer = new DefaultConsumer(channel)
+			// createChannel() is inside the outer try so the connection is still closed if it throws.
+			final Channel channel = connection.createChannel();
+			try
 			{
-				@Override
-				public void handleDelivery(final String consumerTag, final Envelope envelope, final AMQP.BasicProperties properties, final byte[] body) throws JsonProcessingException
+				final ImmutableList.Builder<JsonExternalSystemRequest> collector = ImmutableList.builder();
+				int collected = 0;
+
+				final long deadlineMillis = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(60);
+
+				while (collected < numberOfMessages && System.currentTimeMillis() < deadlineMillis)
 				{
-					final String externalSystemRequest = new String(body, StandardCharsets.UTF_8);
+					// autoAck=false: pull exactly one message at a time on the test thread, then ack it
+					// explicitly once we have read its body. No prefetch storm, no consumer-callback thread.
+					final GetResponse getResponse = channel.basicGet(QUEUE_NAME_MF_TO_ES, false);
+					if (getResponse == null)
+					{
+						// Queue currently empty (the export workpackage may not have published yet) -> wait
+						// briefly and retry until the deadline.
+						try
+						{
+							Thread.sleep(250);
+						}
+						catch (final InterruptedException interrupted)
+						{
+							Thread.currentThread().interrupt();
+							throw interrupted;
+						}
+						continue;
+					}
+
+					final String externalSystemRequest = new String(getResponse.getBody(), StandardCharsets.UTF_8);
+					channel.basicAck(getResponse.getEnvelope().getDeliveryTag(), false);
+
+					final JsonExternalSystemRequest jsonExternalSystemRequest;
+					try
+					{
+						jsonExternalSystemRequest = objectMapper.readValue(externalSystemRequest, JsonExternalSystemRequest.class);
+					}
+					catch (final JsonProcessingException foreignMessage)
+					{
+						// A leftover / foreign message that is not a JsonExternalSystemRequest: it is already acked
+						// (removed) above, so just skip it and keep polling for the messages we expect.
+						// The full body is logged on purpose: after the queue-empty isolation step, a non-parseable
+						// message most likely means the system under test published a malformed request, and the only
+						// other symptom is the generic 60s-timeout assertion below — the body is what makes that root
+						// cause diagnosable from the CI log.
+						logger.warn("*** {}: skipping non-JsonExternalSystemRequest/foreign message (body={}): {}", QUEUE_NAME_MF_TO_ES, externalSystemRequest, foreignMessage.getMessage());
+						continue;
+					}
 
 					logger.info("*** {}: received message: {}", QUEUE_NAME_MF_TO_ES, externalSystemRequest);
-
-					final JsonExternalSystemRequest jsonExternalSystemRequest = objectMapper.readValue(externalSystemRequest, JsonExternalSystemRequest.class);
 
 					if (messageQualifier.apply(jsonExternalSystemRequest))
 					{
 						collector.add(jsonExternalSystemRequest);
-						countDownLatch.countDown();
+						collected++;
 					}
 				}
-			};
 
-			channel.basicConsume(QUEUE_NAME_MF_TO_ES, true, consumer);
+				// the while-loop exits at collected == numberOfMessages (success) or on the deadline
+				// (collected < numberOfMessages); collected can never exceed numberOfMessages, so assert
+				// exact equality rather than >= which would disguise the loop's invariant.
+				assertThat(collected)
+						.as("Expected %s qualifying message(s) on queue '%s' within 60s, but got %s", numberOfMessages, QUEUE_NAME_MF_TO_ES, collected)
+						.isEqualTo(numberOfMessages);
 
-			final boolean messageReceivedWithinTimeout = countDownLatch.await(60, TimeUnit.SECONDS);
-
-			assertThat(messageReceivedWithinTimeout).isTrue();
-
-			return collector.build();
+				return collector.build();
+			}
+			finally
+			{
+				// guard with isOpen(): if the broker already force-closed the channel, an unconditional
+				// close() would throw AlreadyClosedException in finally and suppress the real failure.
+				if (channel.isOpen())
+				{
+					channel.close();
+				}
+			}
 		}
 		finally
 		{
-			if (channel != null)
-			{
-				channel.close();
-			}
+			connection.close();
 		}
 	}
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediExport.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediExport.feature
@@ -8,6 +8,10 @@ Feature: EDI_cctop_invoic_v export format
 
   Background:
     Given infrastructure and metasfresh are running
+    # Isolate the shared, durable EDI export queues so a leftover message from an earlier scenario
+    # (or an earlier feature on the same CI executor) cannot be consumed by the wrong scenario.
+    And the EDI export RabbitMQ queue 'ediExport' is purged
+    And the EDI export RabbitMQ queue 'ediExport_150' is purged
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
     And metasfresh has date and time 2021-04-16T13:30:13+01:00[Europe/Berlin]


### PR DESCRIPTION
## What

Ports the **already-merged `new_dawn_uat` test-harness fix** https://github.com/metasfresh/metasfresh/commit/4991c8e7a5966b4c4a0bfb4eb29dfa92490f48c5 ("EDI export cucumber: drop racy push-consumer for a synchronous basicGet pull-loop", https://github.com/metasfresh/metasfresh/pull/24612) to `deep_tundra_release`, which never received it.

Straight `git cherry-pick -x` — **no rewrite, no local variant**. Both Java files are now byte-identical to `origin/new_dawn_uat`, so the eventual `deep_tundra_release → new_dawn_uat` propagation merge is a no-op on them.

**Test-only.** Zero production classes touched. Diff is 3 files, all under `src/test`:

- `backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/MetasfreshToEDIRabbitMQ_StepDef.java`
- `backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/MetasfreshToExternalSystemRabbitMQ_StepDef.java`
- `backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/ediExport.feature`

## Root cause (harness, not product)

`pollDocumentFromQueue` used an asynchronous push consumer (`basicConsume` + `DefaultConsumer.handleDelivery`) with **no prefetch limit**, and inside `handleDelivery` called `countDownLatch.countDown()` **before** `channel.basicAck(...)` / `channel.basicCancel(...)`. The countdown releases the main thread parked on `countDownLatch.await(60s)`, whose `finally` runs `channel.close()` — so the ack can be lost, the broker **requeues** the delivery, and the next `pollDocumentFromQueue` re-reads the **same** document. The step binds whatever it polled to the identifier named in the data-table row (arrival-order binding), so the wrong document lands under the wrong identifier.

### Log evidence

Failing job: https://github.com/metasfresh/metasfresh/actions/runs/30362621686/job/90294199165 — `test (cucumber) (profile5)`, scenario `S29231_150 — Two orders, one consolidated shipment → both DESADVs exported via the Replication Interface (RPL) path` (`ediExport.feature:264`), failing at `:437`:

```
org.opentest4j.AssertionFailedError: [QtyCUsPerTU]
expected: "20"
 but was: "10"
	at de.metas.cucumber.stepdefs.edi.EDI_Desadv_StepDef.validateEDIExpDesadvPack(EDI_Desadv_StepDef.java:262)
```

From that run's raw profile5 log, inside the `S29231_150` window:

- exactly **two** `*** Queue: ediExport_150, received message:` dumps, **10.7 ms apart** (`13:55:28.9765`, `13:55:28.9872`);
- `POReference>PO_A_S29231_150` appears **4×**, `POReference>PO_B_S29231_150` appears **0×** (each DESADV XML carries its POReference twice ⇒ 2 dumps × 2 = 4, all of them **A**) ⇒ both polls received **DESADV A**; B's message was never received;
- immediately after the second dump: `[WARN] MetasfreshToEDIRabbitMQ_StepDef - basicCancel failed (ignored): channel is already closed due to clean channel shutdown; protocol method: #method<channel.close>(reply-code=200, reply-text=OK, …)` — the channel was already closed before the consumer finished its ack/cancel sequence, i.e. the lost ack.

So `e_dA_150` = A (passes, `QtyCUsPerTU=10`) and `e_dB_150` = **A again** → `expected: "20" but was: "10"`, exactly as observed. The feature deliberately gives A `QtyCUsPerTU=10` and B `QtyCUsPerTU=20` to prove per-source-DESADV projection, which is why the mis-bind surfaces with those precise numbers.

**Production exported both DESADVs correctly** — the harness lost one and double-counted the other. The sibling surface recorded on three branches (`com.rabbitmq.client.ShutdownSignalException: clean channel shutdown … Closed due to exception from Consumer … handleDelivery`) is the identical close-vs-callback collision seen from the AMQP client side.

## The fix (as authored upstream)

- `pollDocumentFromQueue` / `pollRequestFromQueue` rewritten as a **synchronous `basicGet` pull-loop on the test thread**: one message per `basicGet`, `basicAck` issued **before** the method returns and before the channel is closed. No consumer-callback thread ⇒ no prefetch storm, no ack-vs-close race, no requeue, so the redelivery that mis-binds the documents cannot occur. This is a strictly stronger harness, not a relaxed one — no assertion was weakened, none skipped, none disabled.
- Foreign/unparseable leftovers on the shared durable queue are acked-and-skipped (with the body logged) instead of crashing the consumer or being returned as the wrong document.
- New Background isolation step `the EDI export RabbitMQ queue '<name>' is purged`, applied to `ediExport` and `ediExport_150`, so each scenario starts from a known-empty queue regardless of what an earlier scenario/feature on the same executor left behind. No-op when the queue does not exist yet.
- Channel/connection lifecycle tightened: connection closed in `finally` (the old code leaked it), `channel.close()` guarded by `isOpen()` so a broker force-close cannot suppress the real failure, `Thread.sleep` restores the interrupt flag.

## Why this must merge before https://github.com/metasfresh/metasfresh/pull/25319 can go green

This flake is **the only thing keeping https://github.com/metasfresh/metasfresh/pull/25319 red.** That PR is *not* test-only, so it cannot use the flaky-red carve-out — the harness fix has to land on its base branch `deep_tundra_release` first.

Evidence the flake is not caused by that PR: the same scenario fails on the **diff-free base** `deep_tundra_release` (runs https://github.com/metasfresh/metasfresh/actions/runs/30009980484 and https://github.com/metasfresh/metasfresh/actions/runs/30343940854), the PR touches zero EDI/DESADV files, and its own immediately-preceding commit `39ec8ea0aef` was cucumber-green with the full production diff already in place (https://github.com/metasfresh/metasfresh/actions/runs/30360221405).

**⇒ Please merge this PR, then re-run CI on https://github.com/metasfresh/metasfresh/pull/25319.**

## Tracking

Internal flaky-test registry, case 34 (verified mechanism + fix recipe; 7 scenario-failures across 6 runs on 3 branches, intermittency proven by same-SHA green re-runs). The registry also records a still-unverified second surface (`[EDI_Exp_Desadv_Pack] Expecting actual not to be null` on `ediExport.feature:175` / `:424`, an async pack-materialization hypothesis); the Background queue-purge plus the skip-foreign-message tolerance in this port address the cross-scenario-bleed half of that surface, and the case will be updated with this PR's CI outcome.

## Validation

- Ported by `git cherry-pick -x` and verified byte-identical to `origin/new_dawn_uat` for both step-def classes; the only feature-file delta vs `new_dawn_uat` is `new_dawn_uat`-only extra GLN assertions this branch does not carry (the purge lines are identical).
- Checked on this branch: no duplicate cucumber step expression for the new purge step; queue names `ediExport` / `ediExport_150` match the feature's `routingKey` parameters; `amqp-client 5.10.0` (`misc/parent-pom/pom.xml`) provides `Channel#basicGet` / `GetResponse`; the removed `DefaultConsumer` / `Envelope` / `CountDownLatch` imports have no remaining references; every checked exception thrown in the new code is declared by its method.
- `pollRequestFromQueue` behaviour is preserved: the pre-port version consumed with `autoAck=true`, so non-qualifying messages were already removed — the new ack-and-skip is equivalent, and the count assertion was tightened (`isEqualTo` instead of `>=`), not loosened.
- **Local execution was not possible** for this change: no Maven build and no local stack were available in this worktree (the workspace's `.m2-local` is exclusively owned by a concurrent build in the sibling checkout, and running a second build would have raced it). Verification was therefore static, plus the strongest available runtime evidence: this exact code has been running on `new_dawn_uat` since 2026-06-18 and **every** recorded occurrence of this flake since then is on a branch that lacks it (`deep_tundra_release`, `soft_panda_hotfix`, `intensive_care_hotfix`) — none on `new_dawn_uat`. CI on this PR is the runtime gate.

## Residual, reported honestly

The pull-loop removes the *redelivery* that caused the observed mis-bind, but the step still binds the polled document to the data-table identifier **by arrival order**, not by content. If the two independent RPL export workpackages ever published B before A, `S29231_150` would fail as `expected: "10" but was: "20"` on the first pack row. That shape has **never** been observed (all recorded failures are the duplicate-A shape). Content-matching the polled document against its expected identifier is deliberately **not** added here: it would fork this file away from `new_dawn_uat` and conflict on the propagation train. If that shape ever appears, the content-match belongs upstream on `new_dawn_uat` first and then ports down.
