### PR TITLE
Hide country name on Order Board UI

### DIFF
--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5816840_sys_OrderBoard_DoNotDisplayCountryName.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5816840_sys_OrderBoard_DoNotDisplayCountryName.sql
@@ -1,0 +1,62 @@
+-- Run mode: SWING_CLIENT
+
+-- UI Element: Auftrags-Board(542168,D) -> Übersicht(549338,D) -> main -> 10 -> default.Landname
+-- Column: M_Picking_OrderBoard_Overview_v.CountryName
+-- 2026-07-29T12:31:32.270Z
+UPDATE AD_UI_Element SET IsDisplayed='N',Updated=TO_TIMESTAMP('2026-07-29 12:31:32.269000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=652527
+;
+
+-- UI Element: Auftrags-Board(542168,D) -> Wartend(549335,D) -> main -> 10 -> default.Landname
+-- Column: M_Picking_OrderBoard_v.CountryName
+-- 2026-07-29T12:32:31.871Z
+UPDATE AD_UI_Element SET IsDisplayed='N',Updated=TO_TIMESTAMP('2026-07-29 12:32:31.871000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=652502
+;
+
+-- UI Element: Auftrags-Board(542168,D) -> Wartend(549335,D) -> main -> 10 -> default.Landname
+-- Column: M_Picking_OrderBoard_v.CountryName
+-- 2026-07-29T12:32:56.131Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='N', SeqNoGrid=0,Updated=TO_TIMESTAMP('2026-07-29 12:32:56.131000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=652502
+;
+
+-- UI Element: Auftrags-Board(542168,D) -> Wartend(549335,D) -> main -> 10 -> default.Land
+-- Column: M_Picking_OrderBoard_v.C_Country_ID
+-- 2026-07-29T12:32:56.551Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=50,Updated=TO_TIMESTAMP('2026-07-29 12:32:56.551000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=652503
+;
+
+-- UI Element: Auftrags-Board(542168,D) -> In Kommissionierung(549336,D) -> main -> 10 -> default.Landname
+-- Column: M_Picking_OrderBoard_v.CountryName
+-- 2026-07-29T12:33:22.337Z
+UPDATE AD_UI_Element SET IsDisplayed='N',Updated=TO_TIMESTAMP('2026-07-29 12:33:22.337000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=652510
+;
+
+-- UI Element: Auftrags-Board(542168,D) -> In Kommissionierung(549336,D) -> main -> 10 -> default.Landname
+-- Column: M_Picking_OrderBoard_v.CountryName
+-- 2026-07-29T12:33:42.299Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='N', SeqNoGrid=0,Updated=TO_TIMESTAMP('2026-07-29 12:33:42.299000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=652510
+;
+
+-- UI Element: Auftrags-Board(542168,D) -> In Kommissionierung(549336,D) -> main -> 10 -> default.Land
+-- Column: M_Picking_OrderBoard_v.C_Country_ID
+-- 2026-07-29T12:33:42.719Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=50,Updated=TO_TIMESTAMP('2026-07-29 12:33:42.718000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=652511
+;
+
+-- UI Element: Auftrags-Board(542168,D) -> Packen(549337,D) -> main -> 10 -> default.Landname
+-- Column: M_Picking_OrderBoard_v.CountryName
+-- 2026-07-29T12:34:10.755Z
+UPDATE AD_UI_Element SET IsDisplayed='N',Updated=TO_TIMESTAMP('2026-07-29 12:34:10.755000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=652518
+;
+
+-- UI Element: Auftrags-Board(542168,D) -> Packen(549337,D) -> main -> 10 -> default.Landname
+-- Column: M_Picking_OrderBoard_v.CountryName
+-- 2026-07-29T12:34:27.539Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='N', SeqNoGrid=0,Updated=TO_TIMESTAMP('2026-07-29 12:34:27.539000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=652518
+;
+
+-- UI Element: Auftrags-Board(542168,D) -> Packen(549337,D) -> main -> 10 -> default.Land
+-- Column: M_Picking_OrderBoard_v.C_Country_ID
+-- 2026-07-29T12:34:27.962Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=50,Updated=TO_TIMESTAMP('2026-07-29 12:34:27.961000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=652519
+;
+


### PR DESCRIPTION
Add SQL system migration to hide the CountryName column on the Order Board and enable the C_Country_ID (country) column in grid view.