### PR TITLE
Return pricing: resolve origin-line Packvorschrift so returns of PI-keyed-priced products invoice correctly

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/inout/IInOutBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/inout/IInOutBL.java
@@ -254,9 +254,16 @@ public interface IInOutBL extends ISingletonService
 
 	boolean isVendorReturn(@NonNull I_M_InOut inOut);
 
-	boolean isVendorReturn(@NonNull InOutId inoutId);
-
 	boolean isEmptiesReturn(I_M_InOut inOut);
+
+	/**
+	 * Resolves the Packvorschrift (M_HU_PI_Item_Product) to feed the pricing context when re-pricing a vendor
+	 * return from its origin receipt line: the line's own PI (base/override) if set, otherwise the linked
+	 * purchase-order line's PI; {@code null} if neither carries one. Specific to vendor-return pricing — not a
+	 * general effective-PI resolver.
+	 */
+	@Nullable
+	HUPIItemProductId resolvePIForVendorReturnPricingCtx(@NonNull I_M_InOutLine returnOriginLine);
 
 	@NonNull
 	BPartnerId getEffectiveDropshipPartnerId(@NonNull I_M_InOut inout);

--- a/backend/de.metas.business/src/main/java/de/metas/inout/IInOutBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/inout/IInOutBL.java
@@ -5,6 +5,7 @@ import de.metas.acct.api.AcctSchemaId;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.currency.CurrencyConversionContext;
+import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.money.Money;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
@@ -129,6 +130,16 @@ public interface IInOutBL extends ISingletonService
 	IPricingContext createPricingCtx(org.compiere.model.I_M_InOutLine inOutLine);
 
 	IPricingResult getProductPrice(org.compiere.model.I_M_InOutLine inOutLine);
+
+	/**
+	 * Same as {@link #getProductPrice(org.compiere.model.I_M_InOutLine)} but overrides the Packvorschrift
+	 * (M_HU_PI_Item_Product) used during HU pricing. When {@code explicitPackingInstruction} is non-null the
+	 * explicit value takes precedence over whatever is stored on the inout line itself.
+	 * <p>
+	 * Used on the return-from-receipt path where the origin receipt line carries no PI
+	 * (it lives on the purchase order line) and must be resolved before pricing is attempted.
+	 */
+	IPricingResult getProductPrice(org.compiere.model.I_M_InOutLine inOutLine, @Nullable HUPIItemProductId explicitPackingInstruction);
 
 	/**
 	 * @return the pricing system fir for the inout,

--- a/backend/de.metas.business/src/main/java/de/metas/inout/IInOutBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/inout/IInOutBL.java
@@ -6,6 +6,7 @@ import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.currency.CurrencyConversionContext;
 import de.metas.handlingunits.HUPIItemProductId;
+import de.metas.inout.InOutId;
 import de.metas.money.Money;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
@@ -252,6 +253,8 @@ public interface IInOutBL extends ISingletonService
 	boolean isCustomerReturn(@NonNull I_M_InOut inOut);
 
 	boolean isVendorReturn(@NonNull I_M_InOut inOut);
+
+	boolean isVendorReturn(@NonNull InOutId inoutId);
 
 	boolean isEmptiesReturn(I_M_InOut inOut);
 

--- a/backend/de.metas.business/src/main/java/de/metas/inout/impl/InOutBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/inout/impl/InOutBL.java
@@ -929,6 +929,12 @@ public class InOutBL implements IInOutBL
 	}
 
 	@Override
+	public boolean isVendorReturn(@NonNull final InOutId inoutId)
+	{
+		return isVendorReturn(getById(inoutId));
+	}
+
+	@Override
 	public boolean isEmptiesReturn(final I_M_InOut inOut)
 	{
 		final DocTypeQuery docTypeQuery = createDocTypeQueryBuilder(inOut)

--- a/backend/de.metas.business/src/main/java/de/metas/inout/impl/InOutBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/inout/impl/InOutBL.java
@@ -63,7 +63,9 @@ import de.metas.request.api.RequestCandidate;
 import de.metas.shipping.ShipperId;
 import de.metas.uom.UomId;
 import de.metas.user.UserId;
+import de.metas.common.util.CoalesceUtil;
 import de.metas.util.Check;
+import de.metas.util.NumberUtils;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.acct.api.IFactAcctBL;
@@ -928,10 +930,23 @@ public class InOutBL implements IInOutBL
 		return docTypeDAO.queryMatchesDocTypeId(docTypeQuery, inOut.getC_DocType_ID());
 	}
 
+	// @see de.metas.handlingunits.model.I_M_InOutLine#COLUMNNAME_M_HU_PI_Item_Product_ID (typed getter not importable from this module)
+	private static final String COLUMNNAME_M_HU_PI_Item_Product_ID = "M_HU_PI_Item_Product_ID";
+
 	@Override
-	public boolean isVendorReturn(@NonNull final InOutId inoutId)
+	@Nullable
+	public HUPIItemProductId resolvePIForVendorReturnPricingCtx(@NonNull final I_M_InOutLine returnOriginLine)
 	{
-		return isVendorReturn(getById(inoutId));
+		// A vendor return is re-priced from its bare origin receipt line, which carries no Packvorschrift of its
+		// own; the PI lives on the linked purchase-order line. Take the line's own PI (base/override) if it ever
+		// has one, else the order line's. This is NOT a general "effective PI" resolver — it exists only to feed
+		// the vendor-return pricing context (own PI read generically: the typed getter lives on the handlingunits I_M_InOutLine).
+		final OrderLineId orderLineId = OrderLineId.ofRepoIdOrNull(returnOriginLine.getC_OrderLine_ID());
+		final de.metas.interfaces.I_C_OrderLine orderLine = orderLineId != null ? orderDAO.getOrderLineById(orderLineId) : null;
+
+		return CoalesceUtil.coalesce(
+				HUPIItemProductId.ofRepoIdOrNull(NumberUtils.asInt(InterfaceWrapperHelper.getValueOverrideOrValue(returnOriginLine, COLUMNNAME_M_HU_PI_Item_Product_ID), 0)),
+				orderLine != null ? HUPIItemProductId.ofRepoIdOrNull(orderLine.getM_HU_PI_Item_Product_ID()) : null);
 	}
 
 	@Override

--- a/backend/de.metas.business/src/main/java/de/metas/inout/impl/InOutBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/inout/impl/InOutBL.java
@@ -234,7 +234,7 @@ public class InOutBL implements IInOutBL
 	}
 
 	@Override
-	public IPricingContext createPricingCtx(@NonNull final org.compiere.model.I_M_InOutLine inOutLine)
+	public IEditablePricingContext createPricingCtx(@NonNull final org.compiere.model.I_M_InOutLine inOutLine)
 	{
 		final I_M_InOut inOut = inOutLine.getM_InOut();
 
@@ -311,7 +311,7 @@ public class InOutBL implements IInOutBL
 			@NonNull final org.compiere.model.I_M_InOutLine inOutLine,
 			@Nullable final HUPIItemProductId explicitPackingInstruction)
 	{
-		final IEditablePricingContext pricingCtx = (IEditablePricingContext) createPricingCtx(inOutLine);
+		final IEditablePricingContext pricingCtx = createPricingCtx(inOutLine);
 		if (explicitPackingInstruction != null)
 		{
 			pricingCtx.setExplicitM_HU_PI_Item_Product_ID(explicitPackingInstruction);

--- a/backend/de.metas.business/src/main/java/de/metas/inout/impl/InOutBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/inout/impl/InOutBL.java
@@ -22,6 +22,7 @@ import de.metas.document.DocSubType;
 import de.metas.document.DocTypeQuery;
 import de.metas.document.IDocTypeDAO;
 import de.metas.document.engine.DocStatus;
+import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.i18n.IModelTranslationMap;
 import de.metas.i18n.ITranslatableString;
 import de.metas.inout.IInOutBL;
@@ -294,9 +295,28 @@ public class InOutBL implements IInOutBL
 	@Override
 	public IPricingResult getProductPrice(final org.compiere.model.I_M_InOutLine inOutLine)
 	{
-		final IPricingContext pricingCtx = createPricingCtx(inOutLine);
-		return pricingBL.calculatePrice(pricingCtx);
+		return getProductPrice(inOutLine, null);
+	}
 
+	@Override
+	public IPricingResult getProductPrice(
+			final org.compiere.model.I_M_InOutLine inOutLine,
+			@Nullable final HUPIItemProductId explicitPackingInstruction)
+	{
+		final IPricingContext pricingCtx = createPricingCtx(inOutLine, explicitPackingInstruction);
+		return pricingBL.calculatePrice(pricingCtx);
+	}
+
+	private IPricingContext createPricingCtx(
+			@NonNull final org.compiere.model.I_M_InOutLine inOutLine,
+			@Nullable final HUPIItemProductId explicitPackingInstruction)
+	{
+		final IEditablePricingContext pricingCtx = (IEditablePricingContext) createPricingCtx(inOutLine);
+		if (explicitPackingInstruction != null)
+		{
+			pricingCtx.setExplicitM_HU_PI_Item_Product_ID(explicitPackingInstruction);
+		}
+		return pricingCtx;
 	}
 
 	@Override

--- a/backend/de.metas.business/src/main/java/de/metas/inout/impl/InOutBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/inout/impl/InOutBL.java
@@ -63,7 +63,6 @@ import de.metas.request.api.RequestCandidate;
 import de.metas.shipping.ShipperId;
 import de.metas.uom.UomId;
 import de.metas.user.UserId;
-import de.metas.common.util.CoalesceUtil;
 import de.metas.util.Check;
 import de.metas.util.NumberUtils;
 import de.metas.util.Services;

--- a/backend/de.metas.business/src/main/java/de/metas/pricing/IEditablePricingContext.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/IEditablePricingContext.java
@@ -23,6 +23,7 @@ package de.metas.pricing;
  */
 
 import de.metas.bpartner.BPartnerId;
+import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.lang.SOTrx;
 import de.metas.location.CountryId;
 import de.metas.money.CurrencyId;
@@ -112,4 +113,6 @@ public interface IEditablePricingContext extends IPricingContext
 	IEditablePricingContext setSkipCheckingPriceListSOTrxFlag(boolean skipCheckingPriceListSOTrxFlag);
 
 	IEditablePricingContext setManualPrice(@Nullable final BigDecimal manualPrice);
+
+	IEditablePricingContext setExplicitM_HU_PI_Item_Product_ID(@Nullable HUPIItemProductId huPiItemProductId);
 }

--- a/backend/de.metas.business/src/main/java/de/metas/pricing/IEditablePricingContext.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/IEditablePricingContext.java
@@ -114,5 +114,8 @@ public interface IEditablePricingContext extends IPricingContext
 
 	IEditablePricingContext setManualPrice(@Nullable final BigDecimal manualPrice);
 
+	/**
+	 * @see IPricingContext#getExplicitM_HU_PI_Item_Product_ID()
+	 */
 	IEditablePricingContext setExplicitM_HU_PI_Item_Product_ID(@Nullable HUPIItemProductId huPiItemProductId);
 }

--- a/backend/de.metas.business/src/main/java/de/metas/pricing/IPricingContext.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/IPricingContext.java
@@ -23,6 +23,7 @@ package de.metas.pricing;
  */
 
 import de.metas.bpartner.BPartnerId;
+import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.lang.SOTrx;
 import de.metas.location.CountryId;
 import de.metas.money.CurrencyId;
@@ -36,6 +37,7 @@ import org.adempiere.mm.attributes.asi_aware.IAttributeSetInstanceAware;
 import org.adempiere.util.lang.IContextAware;
 import org.compiere.model.I_M_PriceList_Version;
 
+import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Optional;
@@ -127,4 +129,14 @@ public interface IPricingContext extends IContextAware
 	Quantity getQuantity();
 
 	BigDecimal getManualPrice();
+
+	/**
+	 * Returns the explicit packing instruction (Packvorschrift) to use during pricing,
+	 * instead of deriving it from the referenced object. Used when the origin line's
+	 * {@code M_HU_PI_Item_Product_ID} column is null (e.g. return lines).
+	 *
+	 * @return the explicit HU packing instruction ID, or {@code null} if not set
+	 */
+	@Nullable
+	HUPIItemProductId getExplicitM_HU_PI_Item_Product_ID();
 }

--- a/backend/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingContext.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingContext.java
@@ -1,8 +1,8 @@
 package de.metas.pricing.service.impl;
 
 import de.metas.bpartner.BPartnerId;
-import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.common.util.time.SystemTime;
+import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.lang.SOTrx;
 import de.metas.location.CountryId;
 import de.metas.money.CurrencyId;

--- a/backend/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingContext.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingContext.java
@@ -428,6 +428,7 @@ class PricingContext implements IEditablePricingContext
 		return this;
 	}
 
+	@Override
 	@Nullable
 	public BigDecimal getManualPrice()
 	{

--- a/backend/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingContext.java
+++ b/backend/de.metas.business/src/main/java/de/metas/pricing/service/impl/PricingContext.java
@@ -1,6 +1,7 @@
 package de.metas.pricing.service.impl;
 
 import de.metas.bpartner.BPartnerId;
+import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.common.util.time.SystemTime;
 import de.metas.lang.SOTrx;
 import de.metas.location.CountryId;
@@ -82,6 +83,9 @@ class PricingContext implements IEditablePricingContext
 	@Nullable
 	private BigDecimal manualPrice;
 
+	@Nullable
+	private HUPIItemProductId explicitM_HU_PI_Item_Product_ID;
+
 	@Getter
 	private PricingConditionsBreak forcePricingConditionsBreak;
 
@@ -115,6 +119,7 @@ class PricingContext implements IEditablePricingContext
 		pricingCtxNew.skipCheckingPriceListSOTrxFlag = skipCheckingPriceListSOTrxFlag;
 		pricingCtxNew.properties.putAll(properties);
 		pricingCtxNew.manualPrice = manualPrice;
+		pricingCtxNew.explicitM_HU_PI_Item_Product_ID = explicitM_HU_PI_Item_Product_ID;
 
 		return pricingCtxNew;
 	}
@@ -433,6 +438,20 @@ class PricingContext implements IEditablePricingContext
 	public IEditablePricingContext setManualPrice(@Nullable final BigDecimal manualPrice)
 	{
 		this.manualPrice = manualPrice;
+		return this;
+	}
+
+	@Override
+	@Nullable
+	public HUPIItemProductId getExplicitM_HU_PI_Item_Product_ID()
+	{
+		return explicitM_HU_PI_Item_Product_ID;
+	}
+
+	@Override
+	public IEditablePricingContext setExplicitM_HU_PI_Item_Product_ID(@Nullable final HUPIItemProductId huPiItemProductId)
+	{
+		this.explicitM_HU_PI_Item_Product_ID = huPiItemProductId;
 		return this;
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -624,6 +624,15 @@ public class C_Invoice_Candidate_StepDef
 									softly.assertThat(finalInvoiceCandidate.getC_Project_ID()).as("C_Project_ID").isEqualTo(project.getC_Project_ID());
 								});
 
+						row.getAsOptionalBoolean(I_C_Invoice_Candidate.COLUMNNAME_IsError)
+								.ifPresent(expected -> softly.assertThat(finalInvoiceCandidate.isError()).as("IsError").isEqualTo(expected));
+
+						row.getAsOptionalString(I_C_Invoice_Candidate.COLUMNNAME_ErrorMsg)
+								.ifPresent(expected -> softly.assertThat(finalInvoiceCandidate.getErrorMsg()).as("ErrorMsg").contains(expected));
+
+						row.getAsOptionalBigDecimal(I_C_Invoice_Candidate.COLUMNNAME_PriceActual)
+								.ifPresent(expected -> softly.assertThat(finalInvoiceCandidate.getPriceActual()).as("PriceActual").isEqualByComparingTo(expected));
+
 						softly.assertAll();
 					}
 					catch (final Throwable e)
@@ -718,13 +727,40 @@ public class C_Invoice_Candidate_StepDef
 
 	}
 
+	/**
+	 * Loads the invoice candidate for the given return inout, optionally filtered by product.
+	 *
+	 * <p>Required columns:
+	 * <ul>
+	 *   <li>{@code M_InOut_ID.Identifier} – identifier of the vendor/customer return inout</li>
+	 *   <li>{@code C_Invoice_Candidate_ID.Identifier} – identifier under which to store the found IC</li>
+	 * </ul>
+	 *
+	 * <p>Optional columns:
+	 * <ul>
+	 *   <li>{@code OPT.M_Product_ID.Identifier} – when present, filters ICs by this product; required when
+	 *       the return generates multiple ICs (e.g. packing-material lines alongside the product line)</li>
+	 * </ul>
+	 *
+	 * @return {@code true} if exactly one matching IC was found and stored; {@code false} if none found yet
+	 */
 	private boolean loadCreditMemoCandidate(@NonNull final Map<String, String> row)
 	{
 		final String customerReturnIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_M_InOut_ID + "." + TABLECOLUMN_IDENTIFIER);
 		final int customerReturnId = shipmentTable.get(customerReturnIdentifier).getM_InOut_ID();
 
-		final Optional<I_C_Invoice_Candidate> invoiceCandidate = queryBL.createQueryBuilder(I_C_Invoice_Candidate.class)
-				.addEqualsFilter(I_C_Invoice_Candidate.COLUMNNAME_M_InOut_ID, customerReturnId)
+		final IQueryBuilder<I_C_Invoice_Candidate> queryBuilder = queryBL.createQueryBuilder(I_C_Invoice_Candidate.class)
+				.addEqualsFilter(I_C_Invoice_Candidate.COLUMNNAME_M_InOut_ID, customerReturnId);
+
+		// Optional product filter — required when the return generates multiple ICs (packing-material lines alongside the product IC)
+		final String productIdentifierRaw = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + COLUMNNAME_M_Product_ID + "." + TABLECOLUMN_IDENTIFIER);
+		if (!EmptyUtil.isBlank(productIdentifierRaw))
+		{
+			final I_M_Product product = productTable.get(productIdentifierRaw);
+			queryBuilder.addEqualsFilter(COLUMNNAME_M_Product_ID, product.getM_Product_ID());
+		}
+
+		final Optional<I_C_Invoice_Candidate> invoiceCandidate = queryBuilder
 				.create()
 				.firstOnlyOptional(I_C_Invoice_Candidate.class);
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -268,6 +268,21 @@ public class C_Invoice_Candidate_StepDef
 		return invoiceCandidateHolder.getValueNotNull();
 	}
 
+	/**
+	 * Polls (up to {@code timeoutSec}) for the invoice candidate(s) of a vendor/customer return inout and
+	 * stores each under its identifier. Each DataTable row is delegated to {@link #loadCreditMemoCandidate(Map)}.
+	 *
+	 * <p>Required columns per row:
+	 * <ul>
+	 *   <li>{@code M_InOut_ID.Identifier} – the return inout</li>
+	 *   <li>{@code C_Invoice_Candidate_ID.Identifier} – identifier under which to store the found IC</li>
+	 * </ul>
+	 * <p>Optional columns per row:
+	 * <ul>
+	 *   <li>{@code OPT.M_Product_ID.Identifier} – filters the lookup to this product; required when the return
+	 *       generates several ICs (e.g. HU packing-material lines alongside the product line)</li>
+	 * </ul>
+	 */
 	@And("^after not more than (.*)s, credit memo candidates are found:$")
 	public void find_credit_memo_candidates(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -771,6 +771,8 @@ public class C_Invoice_Candidate_StepDef
 				.map(productIdentifier -> productIdentifier.lookupNotNullIn(productTable))
 				.ifPresent(product -> queryBuilder.addEqualsFilter(COLUMNNAME_M_Product_ID, product.getM_Product_ID()));
 
+		// firstOnlyOptional throws when >1 IC matches: pass OPT.M_Product_ID.Identifier to narrow the lookup
+		// whenever the return generates several ICs (e.g. HU packing-material lines alongside the product line).
 		final Optional<I_C_Invoice_Candidate> invoiceCandidate = queryBuilder
 				.create()
 				.firstOnlyOptional(I_C_Invoice_Candidate.class);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -270,7 +270,7 @@ public class C_Invoice_Candidate_StepDef
 
 	/**
 	 * Polls (up to {@code timeoutSec}) for the invoice candidate(s) of a vendor/customer return inout and
-	 * stores each under its identifier. Each DataTable row is delegated to {@link #loadCreditMemoCandidate(Map)}.
+	 * stores each under its identifier. Each DataTable row is delegated to {@link #loadCreditMemoCandidate(DataTableRow)}.
 	 *
 	 * <p>Required columns per row:
 	 * <ul>
@@ -286,7 +286,7 @@ public class C_Invoice_Candidate_StepDef
 	@And("^after not more than (.*)s, credit memo candidates are found:$")
 	public void find_credit_memo_candidates(final int timeoutSec, @NonNull final DataTable dataTable) throws InterruptedException
 	{
-		for (final Map<String, String> row : dataTable.asMaps())
+		for (final DataTableRow row : DataTableRows.of(dataTable).toList())
 		{
 			StepDefUtil.tryAndWait(timeoutSec, 500, () -> loadCreditMemoCandidate(row));
 		}
@@ -759,21 +759,17 @@ public class C_Invoice_Candidate_StepDef
 	 *
 	 * @return {@code true} if exactly one matching IC was found and stored; {@code false} if none found yet
 	 */
-	private boolean loadCreditMemoCandidate(@NonNull final Map<String, String> row)
+	private boolean loadCreditMemoCandidate(@NonNull final DataTableRow row)
 	{
-		final String customerReturnIdentifier = DataTableUtil.extractStringForColumnName(row, I_M_InOut.COLUMNNAME_M_InOut_ID + "." + TABLECOLUMN_IDENTIFIER);
-		final int customerReturnId = shipmentTable.get(customerReturnIdentifier).getM_InOut_ID();
+		final int returnInOutId = row.getAsIdentifier(I_M_InOut.COLUMNNAME_M_InOut_ID).lookupNotNullIn(shipmentTable).getM_InOut_ID();
 
 		final IQueryBuilder<I_C_Invoice_Candidate> queryBuilder = queryBL.createQueryBuilder(I_C_Invoice_Candidate.class)
-				.addEqualsFilter(I_C_Invoice_Candidate.COLUMNNAME_M_InOut_ID, customerReturnId);
+				.addEqualsFilter(I_C_Invoice_Candidate.COLUMNNAME_M_InOut_ID, returnInOutId);
 
 		// Optional product filter — required when the return generates multiple ICs (packing-material lines alongside the product IC)
-		final String productIdentifierRaw = DataTableUtil.extractStringOrNullForColumnName(row, "OPT." + COLUMNNAME_M_Product_ID + "." + TABLECOLUMN_IDENTIFIER);
-		if (!EmptyUtil.isBlank(productIdentifierRaw))
-		{
-			final I_M_Product product = productTable.get(productIdentifierRaw);
-			queryBuilder.addEqualsFilter(COLUMNNAME_M_Product_ID, product.getM_Product_ID());
-		}
+		row.getAsOptionalIdentifier(COLUMNNAME_M_Product_ID)
+				.map(productIdentifier -> productIdentifier.lookupNotNullIn(productTable))
+				.ifPresent(product -> queryBuilder.addEqualsFilter(COLUMNNAME_M_Product_ID, product.getM_Product_ID()));
 
 		final Optional<I_C_Invoice_Candidate> invoiceCandidate = queryBuilder
 				.create()
@@ -784,8 +780,7 @@ public class C_Invoice_Candidate_StepDef
 			return false;
 		}
 
-		final String invoiceCandIdentifier = DataTableUtil.extractStringForColumnName(row, COLUMNNAME_C_Invoice_Candidate_ID + "." + TABLECOLUMN_IDENTIFIER);
-		invoiceCandTable.putOrReplace(invoiceCandIdentifier, invoiceCandidate.get());
+		invoiceCandTable.putOrReplace(row.getAsIdentifier(COLUMNNAME_C_Invoice_Candidate_ID), invoiceCandidate.get());
 
 		return true;
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
@@ -66,6 +66,7 @@ import de.metas.externalsystem.model.I_ExternalSystem;
 import de.metas.handlingunits.IHUWarehouseDAO;
 import de.metas.handlingunits.inout.IHUInOutBL;
 import de.metas.handlingunits.inout.IHUShipmentAssignmentBL;
+import de.metas.handlingunits.inout.returns.ReturnsServiceFacade;
 import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.shipmentschedule.api.M_ShipmentSchedule_QuantityTypeToUse;
 import de.metas.handlingunits.shipmentschedule.api.QtyToDeliverMap;
@@ -1175,6 +1176,52 @@ public class M_InOut_StepDef
 				InterfaceWrapperHelper.save(returnLine);
 			}
 
+			final StepDefDataIdentifier returnIdentifier = row.getAsIdentifier("VendorReturn_ID");
+			inoutTable.putOrReplace(returnIdentifier, vendorReturn);
+		});
+	}
+
+	/**
+	 * Create a vendor return via the real HU-producer path ({@link ReturnsServiceFacade#createVendorReturnInOutForHUs}).
+	 * The producer auto-completes the return (DocStatus=CO) and stamps M_HU_PI_Item_Product_ID on each return line.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns <b>M_InOut_ID</b> — (required, identifier-ref) the completed vendor receipt whose HUs to return<br>
+	 * <b>VendorReturn_ID</b> — (required, identifier) alias to store the created vendor-return M_InOut<br>
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData (populated)
+	 * @cucumber.example <pre>
+	 * And generate vendor return from receipt HUs
+	 *   | M_InOut_ID    | VendorReturn_ID    |
+	 *   | receipt_VR_PI | vendorReturn_VR_PI |
+	 * </pre>
+	 */
+	@And("generate vendor return from receipt HUs")
+	public void generateVendorReturnFromReceiptHUs(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(row ->
+		{
+			final I_M_InOut receipt = row.getAsIdentifier(I_M_InOut.COLUMNNAME_M_InOut_ID).lookupNotNullIn(inoutTable);
+			final List<I_M_HU> hus = huInOutBL.retrieveHandlingUnits(receipt);
+			assertThat(hus)
+					.as("Receipt %s must have assigned HUs before creating a vendor return via the HU path", receipt.getM_InOut_ID())
+					.isNotEmpty();
+			final List<Integer> receiptLineIds = inOutBL.getLines(receipt).stream()
+					.map(org.compiere.model.I_M_InOutLine::getM_InOutLine_ID)
+					.collect(Collectors.toList());
+			assertThat(receiptLineIds).as("Receipt %s must have lines", receipt.getM_InOut_ID()).isNotEmpty();
+			final ReturnsServiceFacade returnsServiceFacade = SpringContextHolder.instance.getBean(ReturnsServiceFacade.class);
+			returnsServiceFacade.createVendorReturnInOutForHUs(hus, SystemTime.asTimestamp());
+			final Integer vendorReturnId = queryBL.createQueryBuilder(de.metas.inout.model.I_M_InOutLine.class)
+					.addInArrayFilter(de.metas.inout.model.I_M_InOutLine.COLUMNNAME_Return_Origin_InOutLine_ID, receiptLineIds)
+					.orderByDescending(de.metas.inout.model.I_M_InOutLine.COLUMNNAME_M_InOut_ID)
+					.create()
+					.stream()
+					.map(de.metas.inout.model.I_M_InOutLine::getM_InOut_ID)
+					.distinct()
+					.findFirst()
+					.orElseThrow(() -> new AdempiereException("No vendor return found whose lines reference receipt lines: " + receiptLineIds));
+			final I_M_InOut vendorReturn = inOutDAO.getById(InOutId.ofRepoId(vendorReturnId));
+			assertThat(vendorReturn).as("Vendor return %d must exist", vendorReturnId).isNotNull();
 			final StepDefDataIdentifier returnIdentifier = row.getAsIdentifier("VendorReturn_ID");
 			inoutTable.putOrReplace(returnIdentifier, vendorReturn);
 		});

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
@@ -168,6 +168,7 @@ public class M_InOut_StepDef
 	private final IShipmentScheduleAllocDAO shipmentScheduleAllocDAO = Services.get(IShipmentScheduleAllocDAO.class);
 	private final ShipmentService shipmentService = SpringContextHolder.instance.getBean(ShipmentService.class);
 	private final ExternalSystemRepository externalSystemRepository = SpringContextHolder.instance.getBean(ExternalSystemRepository.class);
+	private final ReturnsServiceFacade returnsServiceFacade = SpringContextHolder.instance.getBean(ReturnsServiceFacade.class);
 
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	private final IADPInstanceDAO pinstanceDAO = Services.get(IADPInstanceDAO.class);
@@ -1186,13 +1187,14 @@ public class M_InOut_StepDef
 	 * The producer auto-completes the return (DocStatus=CO) and stamps M_HU_PI_Item_Product_ID on each return line.
 	 *
 	 * @cucumber.stepdef
-	 * @cucumber.columns <b>M_InOut_ID</b> — (required, identifier-ref) the completed vendor receipt whose HUs to return<br>
+	 * @cucumber.columns <b>M_InOut_ID</b> — (required, identifier-ref) the completed vendor receipt the return is located from<br>
+	 * <b>M_HU_ID</b> — (required, identifier-ref) the HU(s) to return, by identifier (comma-separated for several) — the same HU the receipt step created<br>
 	 * <b>VendorReturn_ID</b> — (required, identifier) alias to store the created vendor-return M_InOut<br>
-	 * @cucumber.depends StepDefData: M_InOut_StepDefData (populated)
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData, M_HU_StepDefData (populated)
 	 * @cucumber.example <pre>
 	 * And generate vendor return from receipt HUs
-	 *   | M_InOut_ID    | VendorReturn_ID    |
-	 *   | receipt_VR_PI | vendorReturn_VR_PI |
+	 *   | M_InOut_ID    | M_HU_ID  | VendorReturn_ID    |
+	 *   | receipt_VR_PI | hu_VR_PI | vendorReturn_VR_PI |
 	 * </pre>
 	 */
 	@And("generate vendor return from receipt HUs")
@@ -1201,15 +1203,18 @@ public class M_InOut_StepDef
 		DataTableRows.of(dataTable).forEach(row ->
 		{
 			final I_M_InOut receipt = row.getAsIdentifier(I_M_InOut.COLUMNNAME_M_InOut_ID).lookupNotNullIn(inoutTable);
-			final List<I_M_HU> hus = huInOutBL.retrieveHandlingUnits(receipt);
+			// Return the HU(s) the receipt step already created (by identifier), mirroring the real flow where the
+			// user selects specific HUs to return — rather than re-retrieving them from the receipt.
+			final List<I_M_HU> hus = row.getAsIdentifierList(I_M_HU.COLUMNNAME_M_HU_ID).stream()
+					.map(huIdentifier -> huIdentifier.lookupNotNullIn(huTable))
+					.collect(Collectors.toList());
 			assertThat(hus)
-					.as("Receipt %s must have assigned HUs before creating a vendor return via the HU path", receipt.getM_InOut_ID())
+					.as("At least one M_HU_ID identifier must be given to return via the HU path")
 					.isNotEmpty();
 			final List<Integer> receiptLineIds = inOutBL.getLines(receipt).stream()
 					.map(org.compiere.model.I_M_InOutLine::getM_InOutLine_ID)
 					.collect(Collectors.toList());
 			assertThat(receiptLineIds).as("Receipt %s must have lines", receipt.getM_InOut_ID()).isNotEmpty();
-			final ReturnsServiceFacade returnsServiceFacade = SpringContextHolder.instance.getBean(ReturnsServiceFacade.class);
 			returnsServiceFacade.createVendorReturnInOutForHUs(hus, SystemTime.asTimestamp());
 			final Integer vendorReturnId = queryBL.createQueryBuilder(de.metas.inout.model.I_M_InOutLine.class)
 					.addInArrayFilter(de.metas.inout.model.I_M_InOutLine.COLUMNNAME_Return_Origin_InOutLine_ID, receiptLineIds)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
@@ -1217,6 +1217,7 @@ public class M_InOut_StepDef
 			assertThat(receiptLineIds).as("Receipt %s must have lines", receipt.getM_InOut_ID()).isNotEmpty();
 			returnsServiceFacade.createVendorReturnInOutForHUs(hus, SystemTime.asTimestamp());
 			final Integer vendorReturnId = queryBL.createQueryBuilder(de.metas.inout.model.I_M_InOutLine.class)
+					.addOnlyActiveRecordsFilter()
 					.addInArrayFilter(de.metas.inout.model.I_M_InOutLine.COLUMNNAME_Return_Origin_InOutLine_ID, receiptLineIds)
 					.orderByDescending(de.metas.inout.model.I_M_InOutLine.COLUMNNAME_M_InOut_ID)
 					.create()

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/vendorReturn.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/vendorReturn.feature
@@ -341,8 +341,8 @@ Feature: Vendor Return from Material Receipt
 
     # Step 5: Create vendor return via the real HU-producer path (auto-completes; no separate complete step needed)
     And generate vendor return from receipt HUs
-      | M_InOut_ID    | VendorReturn_ID    |
-      | receipt_VR_PI | vendorReturn_VR_PI |
+      | M_InOut_ID    | M_HU_ID  | VendorReturn_ID    |
+      | receipt_VR_PI | hu_VR_PI | vendorReturn_VR_PI |
 
     # Step 6: Wait for the product IC (filter by product to exclude packing-material ICs) and assert the price.
     # The return invoice candidate is priced from the origin receipt line (PI null); resolving the PI from the

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/vendorReturn.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/vendorReturn.feature
@@ -339,12 +339,10 @@ Feature: Vendor Return from Material Receipt
       | M_HU_ID  | M_ReceiptSchedule_ID  | M_InOut_ID    |
       | hu_VR_PI | receiptSchedule_VR_PI | receipt_VR_PI |
 
-    # Step 5: Create vendor return referencing the receipt
-    And generate vendor return from receipt
+    # Step 5: Create vendor return via the real HU-producer path (auto-completes; no separate complete step needed)
+    And generate vendor return from receipt HUs
       | M_InOut_ID    | VendorReturn_ID    |
       | receipt_VR_PI | vendorReturn_VR_PI |
-
-    And the return inOut identified by vendorReturn_VR_PI is completed
 
     # Step 6: Wait for the product IC (filter by product to exclude packing-material ICs) and assert the price.
     # The return invoice candidate is priced from the origin receipt line (PI null); resolving the PI from the

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/vendorReturn.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/vendorReturn.feature
@@ -253,12 +253,12 @@ Feature: Vendor Return from Material Receipt
   @Id:S30583_TC1
   @allure.label.epic:E0140_Purchasing
   @allure.label.feature:F00600_Purchase_Order
-  Scenario: Vendor return invoice candidate prices correctly when product price is keyed on Packvorschrift (RED until Task 3 fix)
-    # The product has TWO PI-keyed prices (one for the order-line PI, one decoy for a different PI).
-    # Having ≥2 prices defeats UniqueProductPriceFallbackRule (which would otherwise silently mask the bug).
-    # With the bug present: origin receipt line has null PI → strict rules find no PI-keyed match → IsError=Y.
-    # After Task 3 fix: the order-line PI is resolved and passed to pricing → correct price found → IsError=N.
-    # RED assertion (IsError=false, PriceActual=15) fails now because the bug makes IsError=Y; it turns GREEN after the fix.
+  Scenario: Vendor return invoice candidate prices correctly when product price is keyed on Packvorschrift
+    # The product has TWO PI-keyed prices (the order-line PI + a decoy for a different PI). Having ≥2 prices
+    # defeats UniqueProductPriceFallbackRule, which would otherwise return the single price and mask the defect.
+    # The origin receipt line carries no Packvorschrift (vendor receipt lines are not PI-stamped); pricing must
+    # resolve it from the linked purchase-order line. The invoice candidate is then priced correctly:
+    # IsError=N and PriceActual=15 (the original PO price).
 
     # Step 0: Define the return product first — it is referenced by the PI chains and prices below.
     Given metasfresh contains M_Products:
@@ -346,9 +346,9 @@ Feature: Vendor Return from Material Receipt
 
     And the return inOut identified by vendorReturn_VR_PI is completed
 
-    # Step 6: Wait for the product IC (filter by product to exclude packing-material ICs) and assert desired post-fix state.
-    # RED now (bug present: IsError=Y because origin receipt line PI=null → ≥2 PI-keyed prices → strict rules → no match).
-    # GREEN after Task 3 fix (order-line PI resolved → pp_VR_PI matched → IsError=N, PriceActual=15).
+    # Step 6: Wait for the product IC (filter by product to exclude packing-material ICs) and assert the price.
+    # The return invoice candidate is priced from the origin receipt line (PI null); resolving the PI from the
+    # order line finds the PI-keyed price: IsError=N, PriceActual=15 (the original PO price).
     And after not more than 60s, credit memo candidates are found:
       | M_InOut_ID.Identifier | C_Invoice_Candidate_ID.Identifier | OPT.M_Product_ID.Identifier |
       | vendorReturn_VR_PI    | ic_VR_PI                          | product_VR_PI               |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/vendorReturn.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/vendorReturn.feature
@@ -247,3 +247,112 @@ Feature: Vendor Return from Material Receipt
     And M_HU are validated:
       | M_HU_ID    | HUStatus | IsActive |
       | return_hu3 | A        | Y        |
+
+
+  @from:cucumber
+  @Id:S30583_TC1
+  @allure.label.epic:E0140_Purchasing
+  @allure.label.feature:F00600_Purchase_Order
+  Scenario: Vendor return invoice candidate prices correctly when product price is keyed on Packvorschrift (RED until Task 3 fix)
+    # The product has TWO PI-keyed prices (one for the order-line PI, one decoy for a different PI).
+    # Having ≥2 prices defeats UniqueProductPriceFallbackRule (which would otherwise silently mask the bug).
+    # With the bug present: origin receipt line has null PI → strict rules find no PI-keyed match → IsError=Y.
+    # After Task 3 fix: the order-line PI is resolved and passed to pricing → correct price found → IsError=N.
+    # RED assertion (IsError=false, PriceActual=15) fails now because the bug makes IsError=Y; it turns GREEN after the fix.
+
+    # Step 0: Define the return product first — it is referenced by the PI chains and prices below.
+    Given metasfresh contains M_Products:
+      | Identifier    |
+      | product_VR_PI |
+
+    # Step 1a: Main Packvorschrift for product_VR_PI — used by the order line, HU config, and the main (15) price.
+    # It MUST belong to product_VR_PI (a Packvorschrift is product-scoped; reusing the Background's
+    # huPiItemProduct_VR — which belongs to product_VR — would make the order line get restamped to a
+    # valid PI for product_VR_PI, silently defeating the test). We hang it off the Background's IFCO TU
+    # item (huPiItem_IFCO_VR), which is structurally loadable onto the Tauschpalette LU used below;
+    # a fresh bare TU is NOT loadable onto that LU.
+    Given metasfresh contains M_HU_PI_Item_Product:
+      | Identifier              | M_HU_PI_Item_ID  | M_Product_ID  | Qty | ValidFrom  |
+      | huPiItemProd_VR_PI_main | huPiItem_IFCO_VR | product_VR_PI | 10  | 2022-03-01 |
+
+    # Step 1b: Build the decoy PI chain (a second PI for product_VR_PI, to force ≥2 PI-keyed price candidates).
+    # Having ≥2 candidates defeats UniqueProductPriceFallbackRule — without the decoy, a single
+    # PI-keyed price might be returned as a fallback regardless of which PI the order line carries.
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID           |
+      | huPackTU_VR_PI_decoy |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID     | M_HU_PI_ID           | HU_UnitType | IsCurrent |
+      | packingVer_VR_PI_decoy | huPackTU_VR_PI_decoy | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID      | M_HU_PI_Version_ID     | ItemType |
+      | huPiItem_VR_PI_decoy | packingVer_VR_PI_decoy | MI       |
+
+    # Step 1c: Set up the pricing system / price list (product defined in Step 0; two PI-keyed prices defeat UniqueProductPriceFallbackRule)
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_VR_PI   |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | OPT.C_Country.CountryCode | C_Currency.ISO_Code | SOTrx |
+      | pl_VR_PI   | ps_VR_PI           | DE                        | EUR                 | false |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID | ValidFrom  |
+      | plv_VR_PI  | pl_VR_PI       | 2022-03-01 |
+    # Decoy PI item product (must exist before it can be referenced by a M_ProductPrice)
+    And metasfresh contains M_HU_PI_Item_Product:
+      | Identifier               | M_HU_PI_Item_ID      | M_Product_ID  | Qty | ValidFrom  |
+      | huPiItemProd_VR_PI_decoy | huPiItem_VR_PI_decoy | product_VR_PI | 10  | 2022-03-01 |
+    # Two PI-keyed prices, BOTH for product_VR_PI Packvorschriften:
+    #   pp_VR_PI      → huPiItemProd_VR_PI_main (PriceStd=15): the price matched by the order-line PI.
+    #   pp_VR_PI_decoy→ huPiItemProd_VR_PI_decoy (PriceStd=99): unreferenced by order/HU; exists only
+    #                    to give product_VR_PI ≥2 PI-keyed candidates, defeating UniqueProductPriceFallbackRule.
+    And metasfresh contains M_ProductPrices
+      | Identifier         | M_PriceList_Version_ID | M_Product_ID  | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName | M_HU_PI_Item_Product_ID  |
+      | pp_VR_PI           | plv_VR_PI              | product_VR_PI   | 15.0     | PCE               | Normal                        | huPiItemProd_VR_PI_main  |
+      | pp_VR_PI_decoy     | plv_VR_PI              | product_VR_PI   | 99.0     | PCE               | Normal                        | huPiItemProd_VR_PI_decoy |
+      | pm_VR_PI           | plv_VR_PI              | packingMaterial | 0.2      | PCE               | Normal                        |                          |
+    And metasfresh contains C_BPartners:
+      | Identifier     | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID |
+      | supplier_VR_PI | Y            | N              | ps_VR_PI           |
+
+    # Step 2: Create Purchase Order — order line carries the main Packvorschrift (huPiItemProd_VR_PI_main)
+    Given metasfresh contains C_Orders:
+      | Identifier  | IsSOTrx | C_BPartner_ID  | DateOrdered | OPT.POReference | OPT.DocBaseType | OPT.M_PricingSystem_ID | OPT.C_BPartner_Location_ID | OPT.DeliveryRule | OPT.DeliveryViaRule |
+      | order_VR_PI | N       | supplier_VR_PI | 2022-06-10  | po_ref_VR_PI    | POO             | ps_VR_PI               | supplier_VR_PI              | F                | S                   |
+    And metasfresh contains C_OrderLines:
+      | Identifier      | C_Order_ID  | M_Product_ID  | QtyEntered | M_HU_PI_Item_Product_ID |
+      | orderLine_VR_PI | order_VR_PI | product_VR_PI | 10         | huPiItemProd_VR_PI_main |
+
+    When the order identified by order_VR_PI is completed
+
+    # Step 3: Wait for receipt schedule and create HUs with the main Packvorschrift (huPiItemProd_VR_PI_main)
+    And after not more than 30s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID  | C_Order_ID  | C_OrderLine_ID  | C_BPartner_ID  | C_BPartner_Location_ID | M_Product_ID  | QtyOrdered | M_Warehouse_ID |
+      | receiptSchedule_VR_PI | order_VR_PI | orderLine_VR_PI | supplier_VR_PI | supplier_VR_PI         | product_VR_PI | 10         | warehouseStd   |
+
+    And create M_HU_LUTU_Configuration for M_ReceiptSchedule and generate M_HUs
+      | Identifier         | M_HU_ID  | M_ReceiptSchedule_ID  | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID | M_LU_HU_PI_ID          |
+      | huLuTuConfig_VR_PI | hu_VR_PI | receiptSchedule_VR_PI | N               | 1     | N               | 1     | N               | 10          | huPiItemProd_VR_PI_main | huPackingTauschpalette |
+
+    # Step 4: Create material receipt — origin receipt line has null PI columns (design: receipt lines are not PI-stamped)
+    When create material receipt
+      | M_HU_ID  | M_ReceiptSchedule_ID  | M_InOut_ID    |
+      | hu_VR_PI | receiptSchedule_VR_PI | receipt_VR_PI |
+
+    # Step 5: Create vendor return referencing the receipt
+    And generate vendor return from receipt
+      | M_InOut_ID    | VendorReturn_ID    |
+      | receipt_VR_PI | vendorReturn_VR_PI |
+
+    And the return inOut identified by vendorReturn_VR_PI is completed
+
+    # Step 6: Wait for the product IC (filter by product to exclude packing-material ICs) and assert desired post-fix state.
+    # RED now (bug present: IsError=Y because origin receipt line PI=null → ≥2 PI-keyed prices → strict rules → no match).
+    # GREEN after Task 3 fix (order-line PI resolved → pp_VR_PI matched → IsError=N, PriceActual=15).
+    And after not more than 60s, credit memo candidates are found:
+      | M_InOut_ID.Identifier | C_Invoice_Candidate_ID.Identifier | OPT.M_Product_ID.Identifier |
+      | vendorReturn_VR_PI    | ic_VR_PI                          | product_VR_PI               |
+
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID | IsError | PriceActual |
+      | ic_VR_PI               | false   | 15          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/customerReturn.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/customerReturn.feature
@@ -190,3 +190,108 @@ Feature: Customer Return from Shipment
     And M_HU are validated:
       | M_HU_ID    | HUStatus | IsActive |
       | return_hu3 | D        | N        |
+
+
+  @from:cucumber
+  @Id:S30583_TC2
+  @allure.label.epic:E0110_Sales
+  @allure.label.feature:F00200_Sales_Order
+  Scenario: Customer return invoice candidate prices correctly when product price is keyed on Packvorschrift (RED until Task 3 fix)
+    # The product has TWO PI-keyed prices (one for the order-line PI, one decoy for a different PI).
+    # Having ≥2 prices defeats UniqueProductPriceFallbackRule (which would otherwise silently mask the bug).
+    # With the bug present: origin shipment line has null PI → strict rules find no PI-keyed match → IsError=Y.
+    # After Task 3 fix: the order-line PI is resolved and passed to pricing → correct price found → IsError=N.
+    # RED assertion (IsError=false, PriceActual=20) fails now because the bug makes IsError=Y; it turns GREEN after the fix.
+
+    # Step 1a: Build the primary PI chain for the SO order line
+    Given metasfresh contains M_Products:
+      | Identifier    |
+      | product_CR_PI |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID     |
+      | huPackTU_CR_PI |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID     | HU_UnitType | IsCurrent |
+      | packingVer_CR_PI   | huPackTU_CR_PI | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID | M_HU_PI_Version_ID | ItemType |
+      | huPiItem_CR_PI  | packingVer_CR_PI   | MI       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | Identifier         | M_HU_PI_Item_ID | M_Product_ID  | Qty | ValidFrom  |
+      | huPiItemProd_CR_PI | huPiItem_CR_PI  | product_CR_PI | 10  | 2022-03-01 |
+
+    # Step 1b: Build the decoy PI chain (different PI, to force ≥2 PI-keyed price candidates)
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID            |
+      | huPackTU_CR_PI_decoy  |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID       | M_HU_PI_ID           | HU_UnitType | IsCurrent |
+      | packingVer_CR_PI_decoy   | huPackTU_CR_PI_decoy | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID          | M_HU_PI_Version_ID     | ItemType |
+      | huPiItem_CR_PI_decoy     | packingVer_CR_PI_decoy | MI       |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | Identifier               | M_HU_PI_Item_ID      | M_Product_ID  | Qty | ValidFrom  |
+      | huPiItemProd_CR_PI_decoy | huPiItem_CR_PI_decoy | product_CR_PI | 10  | 2022-03-01 |
+
+    # Step 1c: Price list — two PI-keyed prices (no non-PI fallback)
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_CR_PI   |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | OPT.C_Country.CountryCode | C_Currency.ISO_Code | SOTrx |
+      | pl_CR_PI   | ps_CR_PI           | DE                        | EUR                 | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID | ValidFrom  |
+      | plv_CR_PI  | pl_CR_PI       | 2022-03-01 |
+    # pp_CR_PI is keyed on the SO order-line PI (PriceStd=20, the expected post-fix price).
+    # pp_CR_PI_decoy is keyed on the decoy PI. Having ≥2 PI-keyed rows defeats UniqueProductPriceFallbackRule.
+    And metasfresh contains M_ProductPrices
+      | Identifier           | M_PriceList_Version_ID | M_Product_ID  | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName | M_HU_PI_Item_Product_ID  |
+      | pp_CR_PI             | plv_CR_PI              | product_CR_PI | 20.0     | PCE               | Normal                        | huPiItemProd_CR_PI       |
+      | pp_CR_PI_decoy       | plv_CR_PI              | product_CR_PI | 99.0     | PCE               | Normal                        | huPiItemProd_CR_PI_decoy |
+    And metasfresh contains C_BPartners:
+      | Identifier     | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID |
+      | customer_CR_PI | N            | Y              | ps_CR_PI           |
+
+    # Step 2: Create Sales Order — SO line carries the Packvorschrift (huPiItemProd_CR_PI)
+    Given metasfresh contains C_Orders:
+      | Identifier  | IsSOTrx | C_BPartner_ID  | DateOrdered | OPT.POReference | OPT.M_PricingSystem_ID | OPT.C_BPartner_Location_ID | OPT.DeliveryRule | OPT.DeliveryViaRule |
+      | order_CR_PI | Y       | customer_CR_PI | 2022-06-10  | so_ref_CR_PI    | ps_CR_PI               | customer_CR_PI             | F                | S                   |
+    And metasfresh contains C_OrderLines:
+      | Identifier      | C_Order_ID  | M_Product_ID  | QtyEntered | M_HU_PI_Item_Product_ID |
+      | orderLine_CR_PI | order_CR_PI | product_CR_PI | 10         | huPiItemProd_CR_PI      |
+
+    When the order identified by order_CR_PI is completed
+
+    # Step 3: Wait for shipment schedule, generate and complete shipment
+    # Shipment line PI columns are null by design (ShipmentLineBuilder only stamps PI when HU storage supplies it)
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier     | C_OrderLine_ID  | IsToRecompute |
+      | schedule_CR_PI | orderLine_CR_PI | N             |
+
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | schedule_CR_PI        | D            | true                | false       |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID     |
+      | schedule_CR_PI        | shipment_CR_PI |
+
+    # Step 4: Create customer return referencing the shipment
+    And generate customer return from shipment
+      | M_InOut_ID     | CustomerReturn_ID    |
+      | shipment_CR_PI | customerReturn_CR_PI |
+
+    And the return inOut identified by customerReturn_CR_PI is completed
+
+    # Step 5: Wait for the product IC (filter by product to exclude packing-material ICs) and assert desired post-fix state.
+    # RED now (bug present: IsError=Y because origin shipment line PI=null → ≥2 PI-keyed prices → strict rules → no match).
+    # GREEN after Task 3 fix (order-line PI resolved → pp_CR_PI matched → IsError=N, PriceActual=20).
+    And after not more than 60s, credit memo candidates are found:
+      | M_InOut_ID.Identifier | C_Invoice_Candidate_ID.Identifier | OPT.M_Product_ID.Identifier |
+      | customerReturn_CR_PI  | ic_CR_PI                          | product_CR_PI               |
+
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID | IsError | PriceActual |
+      | ic_CR_PI               | false   | 20          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/customerReturn.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipment/customerReturn.feature
@@ -196,12 +196,13 @@ Feature: Customer Return from Shipment
   @Id:S30583_TC2
   @allure.label.epic:E0110_Sales
   @allure.label.feature:F00200_Sales_Order
-  Scenario: Customer return invoice candidate prices correctly when product price is keyed on Packvorschrift (RED until Task 3 fix)
-    # The product has TWO PI-keyed prices (one for the order-line PI, one decoy for a different PI).
-    # Having ≥2 prices defeats UniqueProductPriceFallbackRule (which would otherwise silently mask the bug).
-    # With the bug present: origin shipment line has null PI → strict rules find no PI-keyed match → IsError=Y.
-    # After Task 3 fix: the order-line PI is resolved and passed to pricing → correct price found → IsError=N.
-    # RED assertion (IsError=false, PriceActual=20) fails now because the bug makes IsError=Y; it turns GREEN after the fix.
+  Scenario: Customer return invoice candidate prices correctly when product price is keyed on Packvorschrift
+    # Regression guard for the customer-return path. Unlike vendor receipt lines, HU shipment lines ARE
+    # PI-stamped (ShipmentLineBuilder writes the Override/Calculated columns from the order line), so a
+    # customer return pricing from its origin shipment line already finds the PI-keyed price — customer
+    # returns are NOT affected by the vendor-return defect. This scenario therefore prices correctly both
+    # before and after the fix (IsError=N, PriceActual=20), guarding that the return-scoped fix does not
+    # regress customer-return pricing. The product carries two PI-keyed prices (a realistic setup).
 
     # Step 1a: Build the primary PI chain for the SO order line
     Given metasfresh contains M_Products:
@@ -244,8 +245,8 @@ Feature: Customer Return from Shipment
     And metasfresh contains M_PriceList_Versions
       | Identifier | M_PriceList_ID | ValidFrom  |
       | plv_CR_PI  | pl_CR_PI       | 2022-03-01 |
-    # pp_CR_PI is keyed on the SO order-line PI (PriceStd=20, the expected post-fix price).
-    # pp_CR_PI_decoy is keyed on the decoy PI. Having ≥2 PI-keyed rows defeats UniqueProductPriceFallbackRule.
+    # pp_CR_PI is keyed on the SO order-line PI (PriceStd=20, the price the return resolves to).
+    # pp_CR_PI_decoy is keyed on a different PI — a realistic second PI-keyed row for the same product.
     And metasfresh contains M_ProductPrices
       | Identifier           | M_PriceList_Version_ID | M_Product_ID  | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName | M_HU_PI_Item_Product_ID  |
       | pp_CR_PI             | plv_CR_PI              | product_CR_PI | 20.0     | PCE               | Normal                        | huPiItemProd_CR_PI       |
@@ -265,7 +266,8 @@ Feature: Customer Return from Shipment
     When the order identified by order_CR_PI is completed
 
     # Step 3: Wait for shipment schedule, generate and complete shipment
-    # Shipment line PI columns are null by design (ShipmentLineBuilder only stamps PI when HU storage supplies it)
+    # The shipment line IS PI-stamped (ShipmentLineBuilder writes the Override/Calculated columns from the
+    # order line) — this is why the customer return, pricing from this origin line, is not affected by the bug.
     And after not more than 60s, M_ShipmentSchedules are found:
       | Identifier     | C_OrderLine_ID  | IsToRecompute |
       | schedule_CR_PI | orderLine_CR_PI | N             |
@@ -285,9 +287,9 @@ Feature: Customer Return from Shipment
 
     And the return inOut identified by customerReturn_CR_PI is completed
 
-    # Step 5: Wait for the product IC (filter by product to exclude packing-material ICs) and assert desired post-fix state.
-    # RED now (bug present: IsError=Y because origin shipment line PI=null → ≥2 PI-keyed prices → strict rules → no match).
-    # GREEN after Task 3 fix (order-line PI resolved → pp_CR_PI matched → IsError=N, PriceActual=20).
+    # Step 5: Wait for the product IC (filter by product to exclude packing-material ICs) and assert the price.
+    # The customer return prices correctly regardless of the fix (origin shipment line carries the PI):
+    # IsError=N, PriceActual=20 (the original sales price).
     And after not more than 60s, credit memo candidates are found:
       | M_InOut_ID.Identifier | C_Invoice_Candidate_ID.Identifier | OPT.M_Product_ID.Identifier |
       | customerReturn_CR_PI  | ic_CR_PI                          | product_CR_PI               |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pricing/spi/impl/HUPricing.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pricing/spi/impl/HUPricing.java
@@ -241,6 +241,9 @@ public class HUPricing extends AttributePricing
 	{
 		// If an explicit Packvorschrift was set on the pricing context (e.g. for return lines
 		// whose origin M_HU_PI_Item_Product_ID is null), prefer it over the referenced-object extraction.
+		// Only regular IDs are honored here — VIRTUAL_HU (101) and TEMPLATE_HU (100) are sentinels
+		// meaning "no packing instruction"; in that case we fall through to the referenced-object path
+		// so callers that set a non-regular explicit ID get the same behavior as if they had not set one.
 		final HUPIItemProductId explicitId = pricingCtx.getExplicitM_HU_PI_Item_Product_ID();
 		if (explicitId != null && explicitId.isRegular())
 		{

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pricing/spi/impl/HUPricing.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pricing/spi/impl/HUPricing.java
@@ -241,11 +241,11 @@ public class HUPricing extends AttributePricing
 	{
 		// If an explicit Packvorschrift was set on the pricing context (e.g. for return lines
 		// whose origin M_HU_PI_Item_Product_ID is null), prefer it over the referenced-object extraction.
-		// Only regular IDs are honored here — VIRTUAL_HU (101) and TEMPLATE_HU (100) are sentinels
-		// meaning "no packing instruction"; in that case we fall through to the referenced-object path
-		// so callers that set a non-regular explicit ID get the same behavior as if they had not set one.
+		// Only regular IDs are honored here — VIRTUAL_HU and TEMPLATE_HU sentinels mean "no packing
+		// instruction"; in that case we fall through to the referenced-object path so callers that set
+		// a non-regular explicit ID get the same behavior as if they had not set one.
 		final HUPIItemProductId explicitId = pricingCtx.getExplicitM_HU_PI_Item_Product_ID();
-		if (explicitId != null && explicitId.isRegular())
+		if (HUPIItemProductId.isRegular(explicitId))
 		{
 			return explicitId;
 		}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pricing/spi/impl/HUPricing.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pricing/spi/impl/HUPricing.java
@@ -239,6 +239,14 @@ public class HUPricing extends AttributePricing
 	@Nullable
 	private HUPIItemProductId getPackingMaterialId(final IPricingContext pricingCtx)
 	{
+		// If an explicit Packvorschrift was set on the pricing context (e.g. for return lines
+		// whose origin M_HU_PI_Item_Product_ID is null), prefer it over the referenced-object extraction.
+		final HUPIItemProductId explicitId = pricingCtx.getExplicitM_HU_PI_Item_Product_ID();
+		if (explicitId != null && explicitId.isRegular())
+		{
+			return explicitId;
+		}
+
 		final Object referencedObj = pricingCtx.getReferencedObject();
 		if (referencedObj == null)
 		{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
@@ -21,6 +21,7 @@ import de.metas.document.dimension.Dimension;
 import de.metas.document.dimension.DimensionService;
 import de.metas.document.engine.DocStatus;
 import de.metas.document.location.DocumentLocation;
+import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.inout.IInOutBL;
 import de.metas.inout.IInOutDAO;
 import de.metas.inout.InOutId;
@@ -353,8 +354,10 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 
 		//
 		// Pricing Informations
-		final org.compiere.model.I_M_InOutLine inOutLineRecordToUse = inOutLineRecord.getReturn_Origin_InOutLine_ID() > 0 ? inOutLineRecord.getReturn_Origin_InOutLine() : inOutLineRecord;
-		calculatePriceAndTaxAndUpdate(icRecord, inOutLineRecordToUse);
+		final boolean isReturnFromOrigin = inOutLineRecord.getReturn_Origin_InOutLine_ID() > 0;
+		final org.compiere.model.I_M_InOutLine inOutLineRecordToUse = isReturnFromOrigin ? inOutLineRecord.getReturn_Origin_InOutLine() : inOutLineRecord;
+		final HUPIItemProductId explicitPackingInstruction = isReturnFromOrigin ? resolveReturnOriginPackingInstruction(inOutLineRecordToUse) : null;
+		calculatePriceAndTaxAndUpdate(icRecord, inOutLineRecordToUse, explicitPackingInstruction);
 
 		//
 		// Description
@@ -919,16 +922,26 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 	public PriceAndTax calculatePriceAndTax(@NonNull final I_C_Invoice_Candidate icRecord)
 	{
 		final I_M_InOutLine inoutLine = getM_InOutLine(icRecord);
-		final org.compiere.model.I_M_InOutLine inOutLineRecordToUse = inoutLine.getReturn_Origin_InOutLine_ID() > 0 ? inoutLine.getReturn_Origin_InOutLine() : inoutLine;
+		final boolean isReturnFromOrigin = inoutLine.getReturn_Origin_InOutLine_ID() > 0;
+		final org.compiere.model.I_M_InOutLine inOutLineRecordToUse = isReturnFromOrigin ? inoutLine.getReturn_Origin_InOutLine() : inoutLine;
+		final HUPIItemProductId explicitPackingInstruction = isReturnFromOrigin ? resolveReturnOriginPackingInstruction(inOutLineRecordToUse) : null;
 
-		return calculatePriceAndTax(icRecord, inOutLineRecordToUse);
+		return calculatePriceAndTax(icRecord, inOutLineRecordToUse, explicitPackingInstruction);
 	}
 
 	public static PriceAndTax calculatePriceAndTax(
 			final I_C_Invoice_Candidate icRecord,
 			final org.compiere.model.I_M_InOutLine inoutLineRecord)
 	{
-		final IPricingResult pricingResult = calculatePricingResult(inoutLineRecord);
+		return calculatePriceAndTax(icRecord, inoutLineRecord, null);
+	}
+
+	private static PriceAndTax calculatePriceAndTax(
+			final I_C_Invoice_Candidate icRecord,
+			final org.compiere.model.I_M_InOutLine inoutLineRecord,
+			@Nullable final HUPIItemProductId explicitPackingInstruction)
+	{
+		final IPricingResult pricingResult = calculatePricingResult(inoutLineRecord, explicitPackingInstruction);
 
 		final boolean taxIncluded;
 		if (icRecord.getC_Order_ID() > 0)
@@ -986,8 +999,34 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 
 	private static IPricingResult calculatePricingResult(@NonNull final org.compiere.model.I_M_InOutLine fromInOutLine)
 	{
+		return calculatePricingResult(fromInOutLine, null);
+	}
+
+	private static IPricingResult calculatePricingResult(
+			@NonNull final org.compiere.model.I_M_InOutLine fromInOutLine,
+			@Nullable final HUPIItemProductId explicitPackingInstruction)
+	{
 		final IInOutBL inOutBL = Services.get(IInOutBL.class);
-		return inOutBL.getProductPrice(fromInOutLine);
+		return inOutBL.getProductPrice(fromInOutLine, explicitPackingInstruction);
+	}
+
+	/**
+	 * Resolves the effective Packvorschrift (M_HU_PI_Item_Product) for a return's origin line via its linked
+	 * order line. This mirrors the order-line fallback of {@code InOutLineHUPackingAware} (which lives in
+	 * de.metas.handlingunits.base and is not visible from this module): a vendor-receipt origin line carries
+	 * no PI in its own columns — it lives on the purchase order line — so pricing must recover it there.
+	 * Returns {@code null} when there is no order line or it carries no PI, leaving pricing behaviour
+	 * identical to before (e.g. standalone returns / empties without an order line stay unchanged).
+	 */
+	@Nullable
+	private static HUPIItemProductId resolveReturnOriginPackingInstruction(@NonNull final org.compiere.model.I_M_InOutLine originLine)
+	{
+		if (originLine.getC_OrderLine_ID() <= 0)
+		{
+			return null;
+		}
+		final de.metas.interfaces.I_C_OrderLine orderLine = create(originLine.getC_OrderLine(), de.metas.interfaces.I_C_OrderLine.class);
+		return HUPIItemProductId.ofRepoIdOrNull(orderLine.getM_HU_PI_Item_Product_ID());
 	}
 
 	@Nullable
@@ -995,9 +1034,18 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 			@NonNull final I_C_Invoice_Candidate icRecord,
 			final org.compiere.model.I_M_InOutLine fromInOutLine)
 	{
+		return calculatePriceAndTaxAndUpdate(icRecord, fromInOutLine, null);
+	}
+
+	@Nullable
+	private static PriceAndTax calculatePriceAndTaxAndUpdate(
+			@NonNull final I_C_Invoice_Candidate icRecord,
+			final org.compiere.model.I_M_InOutLine fromInOutLine,
+			@Nullable final HUPIItemProductId explicitPackingInstruction)
+	{
 		try
 		{
-			final PriceAndTax priceAndTax = calculatePriceAndTax(icRecord, fromInOutLine);
+			final PriceAndTax priceAndTax = calculatePriceAndTax(icRecord, fromInOutLine, explicitPackingInstruction);
 			IInvoiceCandInvalidUpdater.updatePriceAndTax(icRecord, priceAndTax);
 			return priceAndTax;
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
@@ -25,6 +25,9 @@ import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.inout.IInOutBL;
 import de.metas.inout.IInOutDAO;
 import de.metas.inout.InOutId;
+import de.metas.inout.InOutLineId;
+import de.metas.order.IOrderDAO;
+import de.metas.order.OrderLineId;
 import de.metas.inout.location.adapter.InOutDocumentLocationAdapterFactory;
 import de.metas.inout.model.I_M_InOut;
 import de.metas.invoicecandidate.InvoiceCandidateId;
@@ -93,6 +96,7 @@ import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
 import static org.adempiere.model.InterfaceWrapperHelper.create;
 import static org.adempiere.model.InterfaceWrapperHelper.getCtx;
+import static org.adempiere.model.InterfaceWrapperHelper.getValueOverrideOrValue;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 
@@ -354,9 +358,16 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 
 		//
 		// Pricing Informations
-		final boolean isReturnFromOrigin = inOutLineRecord.getReturn_Origin_InOutLine_ID() > 0;
-		final org.compiere.model.I_M_InOutLine inOutLineRecordToUse = isReturnFromOrigin ? inOutLineRecord.getReturn_Origin_InOutLine() : inOutLineRecord;
-		final HUPIItemProductId explicitPackingInstruction = isReturnFromOrigin ? resolveReturnOriginPackingInstruction(inOutLineRecordToUse) : null;
+		final InOutLineId returnOriginLineId = InOutLineId.ofRepoIdOrNull(inOutLineRecord.getReturn_Origin_InOutLine_ID());
+		final org.compiere.model.I_M_InOutLine inOutLineRecordToUse = returnOriginLineId != null
+				? inOutBL.getLineByIdInTrx(returnOriginLineId)
+				: inOutLineRecord;
+		// A vendor return is invoiced via this inout IC (it has no PO IC) and re-priced from the bare origin
+		// receipt line, whose Packvorschrift lives on the linked purchase-order line. Resolve+inject it explicitly
+		// so the PI-keyed price is found; scoped to vendor returns so shipment / customer-return pricing is untouched.
+		final HUPIItemProductId explicitPackingInstruction = inOutBL.isVendorReturn(InOutId.ofRepoId(inOut.getM_InOut_ID()))
+				? resolvePackingInstruction(inOutLineRecordToUse)
+				: null;
 		calculatePriceAndTaxAndUpdate(icRecord, inOutLineRecordToUse, explicitPackingInstruction);
 
 		//
@@ -922,9 +933,13 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 	public PriceAndTax calculatePriceAndTax(@NonNull final I_C_Invoice_Candidate icRecord)
 	{
 		final I_M_InOutLine inoutLine = getM_InOutLine(icRecord);
-		final boolean isReturnFromOrigin = inoutLine.getReturn_Origin_InOutLine_ID() > 0;
-		final org.compiere.model.I_M_InOutLine inOutLineRecordToUse = isReturnFromOrigin ? inoutLine.getReturn_Origin_InOutLine() : inoutLine;
-		final HUPIItemProductId explicitPackingInstruction = isReturnFromOrigin ? resolveReturnOriginPackingInstruction(inOutLineRecordToUse) : null;
+		final InOutLineId returnOriginLineId = InOutLineId.ofRepoIdOrNull(inoutLine.getReturn_Origin_InOutLine_ID());
+		final org.compiere.model.I_M_InOutLine inOutLineRecordToUse = returnOriginLineId != null
+				? inOutBL.getLineByIdInTrx(returnOriginLineId)
+				: inoutLine;
+		final HUPIItemProductId explicitPackingInstruction = inOutBL.isVendorReturn(InOutId.ofRepoId(inoutLine.getM_InOut_ID()))
+				? resolvePackingInstruction(inOutLineRecordToUse)
+				: null;
 
 		return calculatePriceAndTax(icRecord, inOutLineRecordToUse, explicitPackingInstruction);
 	}
@@ -1011,21 +1026,35 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 	}
 
 	/**
-	 * Resolves the effective Packvorschrift (M_HU_PI_Item_Product) for a return's origin line via its linked
-	 * order line. This mirrors the order-line fallback of {@code InOutLineHUPackingAware} (which lives in
-	 * de.metas.handlingunits.base and is not visible from this module): a vendor-receipt origin line carries
-	 * no PI in its own columns — it lives on the purchase order line — so pricing must recover it there.
-	 * Returns {@code null} when there is no order line or it carries no PI, leaving pricing behaviour
-	 * identical to before (e.g. standalone returns / empties without an order line stay unchanged).
+	 * Resolves the effective Packvorschrift (M_HU_PI_Item_Product) to price a vendor return from, mirroring the
+	 * resolution order of {@code InOutLineHUPackingAware} (which lives in de.metas.handlingunits.base and is not
+	 * visible from this module): prefer the line's <b>own</b> Packvorschrift when it carries one (e.g. a standalone
+	 * vendor-return line the HU return producer stamps), otherwise fall back to the linked purchase-order line,
+	 * where a vendor-receipt origin line keeps the PI (the receipt line itself carries none). Returns {@code null}
+	 * when neither carries a PI (e.g. empties / returns without an order line), leaving pricing unchanged.
+	 * <p>
+	 * The line's own PI is read generically because its typed getter lives on the handlingunits {@code I_M_InOutLine},
+	 * which this module cannot import; the order-line PI is read through {@link IOrderDAO} rather than a model getter.
 	 */
 	@Nullable
-	private static HUPIItemProductId resolveReturnOriginPackingInstruction(@NonNull final org.compiere.model.I_M_InOutLine originLine)
+	private static HUPIItemProductId resolvePackingInstruction(@NonNull final org.compiere.model.I_M_InOutLine inOutLine)
 	{
-		if (originLine.getC_OrderLine_ID() <= 0)
+		final Integer ownPackingInstructionRepoId = getValueOverrideOrValue(inOutLine, "M_HU_PI_Item_Product_ID");
+		final HUPIItemProductId ownPackingInstruction = ownPackingInstructionRepoId != null
+				? HUPIItemProductId.ofRepoIdOrNull(ownPackingInstructionRepoId)
+				: null;
+		if (ownPackingInstruction != null)
+		{
+			return ownPackingInstruction;
+		}
+
+		final OrderLineId orderLineId = OrderLineId.ofRepoIdOrNull(inOutLine.getC_OrderLine_ID());
+		if (orderLineId == null)
 		{
 			return null;
 		}
-		final de.metas.interfaces.I_C_OrderLine orderLine = create(originLine.getC_OrderLine(), de.metas.interfaces.I_C_OrderLine.class);
+
+		final de.metas.interfaces.I_C_OrderLine orderLine = Services.get(IOrderDAO.class).getOrderLineById(orderLineId);
 		return HUPIItemProductId.ofRepoIdOrNull(orderLine.getM_HU_PI_Item_Product_ID());
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
@@ -1025,6 +1025,9 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 		return inOutBL.getProductPrice(fromInOutLine, explicitPackingInstruction);
 	}
 
+	// @see de.metas.handlingunits.model.I_M_InOutLine#COLUMNNAME_M_HU_PI_Item_Product_ID (typed getter not importable from this module)
+	private static final String COLUMNNAME_M_HU_PI_Item_Product_ID = "M_HU_PI_Item_Product_ID";
+
 	/**
 	 * Resolves the effective Packvorschrift (M_HU_PI_Item_Product) to price a vendor return from, mirroring the
 	 * resolution order of {@code InOutLineHUPackingAware} (which lives in de.metas.handlingunits.base and is not
@@ -1036,11 +1039,6 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 	 * The line's own PI is read generically because its typed getter lives on the handlingunits {@code I_M_InOutLine},
 	 * which this module cannot import; the order-line PI is read through {@link IOrderDAO} rather than a model getter.
 	 */
-	// The typed getter for this column lives on de.metas.handlingunits.model.I_M_InOutLine, which this module
-	// cannot import; read it generically by column name instead.
-	// @see de.metas.handlingunits.model.I_M_InOutLine#COLUMNNAME_M_HU_PI_Item_Product_ID
-	private static final String COLUMNNAME_M_HU_PI_Item_Product_ID = "M_HU_PI_Item_Product_ID";
-
 	@Nullable
 	private static HUPIItemProductId resolvePackingInstruction(@NonNull final org.compiere.model.I_M_InOutLine inOutLine)
 	{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
@@ -1036,10 +1036,15 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 	 * The line's own PI is read generically because its typed getter lives on the handlingunits {@code I_M_InOutLine},
 	 * which this module cannot import; the order-line PI is read through {@link IOrderDAO} rather than a model getter.
 	 */
+	// The typed getter for this column lives on de.metas.handlingunits.model.I_M_InOutLine, which this module
+	// cannot import; read it generically by column name instead.
+	// @see de.metas.handlingunits.model.I_M_InOutLine#COLUMNNAME_M_HU_PI_Item_Product_ID
+	private static final String COLUMNNAME_M_HU_PI_Item_Product_ID = "M_HU_PI_Item_Product_ID";
+
 	@Nullable
 	private static HUPIItemProductId resolvePackingInstruction(@NonNull final org.compiere.model.I_M_InOutLine inOutLine)
 	{
-		final Integer ownPackingInstructionRepoId = getValueOverrideOrValue(inOutLine, "M_HU_PI_Item_Product_ID");
+		final Integer ownPackingInstructionRepoId = getValueOverrideOrValue(inOutLine, COLUMNNAME_M_HU_PI_Item_Product_ID);
 		final HUPIItemProductId ownPackingInstruction = ownPackingInstructionRepoId != null
 				? HUPIItemProductId.ofRepoIdOrNull(ownPackingInstructionRepoId)
 				: null;
@@ -1055,6 +1060,10 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 		}
 
 		final de.metas.interfaces.I_C_OrderLine orderLine = Services.get(IOrderDAO.class).getOrderLineById(orderLineId);
+		if (orderLine == null)
+		{
+			return null;
+		}
 		return HUPIItemProductId.ofRepoIdOrNull(orderLine.getM_HU_PI_Item_Product_ID());
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inout/invoicecandidate/M_InOutLine_Handler.java
@@ -26,8 +26,6 @@ import de.metas.inout.IInOutBL;
 import de.metas.inout.IInOutDAO;
 import de.metas.inout.InOutId;
 import de.metas.inout.InOutLineId;
-import de.metas.order.IOrderDAO;
-import de.metas.order.OrderLineId;
 import de.metas.inout.location.adapter.InOutDocumentLocationAdapterFactory;
 import de.metas.inout.model.I_M_InOut;
 import de.metas.invoicecandidate.InvoiceCandidateId;
@@ -96,7 +94,6 @@ import static java.math.BigDecimal.ONE;
 import static java.math.BigDecimal.ZERO;
 import static org.adempiere.model.InterfaceWrapperHelper.create;
 import static org.adempiere.model.InterfaceWrapperHelper.getCtx;
-import static org.adempiere.model.InterfaceWrapperHelper.getValueOverrideOrValue;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 
@@ -365,8 +362,8 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 		// A vendor return is invoiced via this inout IC (it has no PO IC) and re-priced from the bare origin
 		// receipt line, whose Packvorschrift lives on the linked purchase-order line. Resolve+inject it explicitly
 		// so the PI-keyed price is found; scoped to vendor returns so shipment / customer-return pricing is untouched.
-		final HUPIItemProductId explicitPackingInstruction = inOutBL.isVendorReturn(InOutId.ofRepoId(inOut.getM_InOut_ID()))
-				? resolvePackingInstruction(inOutLineRecordToUse)
+		final HUPIItemProductId explicitPackingInstruction = inOutBL.isVendorReturn(inOut)
+				? inOutBL.resolvePIForVendorReturnPricingCtx(inOutLineRecordToUse)
 				: null;
 		calculatePriceAndTaxAndUpdate(icRecord, inOutLineRecordToUse, explicitPackingInstruction);
 
@@ -933,12 +930,13 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 	public PriceAndTax calculatePriceAndTax(@NonNull final I_C_Invoice_Candidate icRecord)
 	{
 		final I_M_InOutLine inoutLine = getM_InOutLine(icRecord);
+		final org.compiere.model.I_M_InOut inOut = inOutBL.getById(InOutId.ofRepoId(inoutLine.getM_InOut_ID()));
 		final InOutLineId returnOriginLineId = InOutLineId.ofRepoIdOrNull(inoutLine.getReturn_Origin_InOutLine_ID());
 		final org.compiere.model.I_M_InOutLine inOutLineRecordToUse = returnOriginLineId != null
 				? inOutBL.getLineByIdInTrx(returnOriginLineId)
 				: inoutLine;
-		final HUPIItemProductId explicitPackingInstruction = inOutBL.isVendorReturn(InOutId.ofRepoId(inoutLine.getM_InOut_ID()))
-				? resolvePackingInstruction(inOutLineRecordToUse)
+		final HUPIItemProductId explicitPackingInstruction = inOutBL.isVendorReturn(inOut)
+				? inOutBL.resolvePIForVendorReturnPricingCtx(inOutLineRecordToUse)
 				: null;
 
 		return calculatePriceAndTax(icRecord, inOutLineRecordToUse, explicitPackingInstruction);
@@ -1023,46 +1021,6 @@ public class M_InOutLine_Handler extends AbstractInvoiceCandidateHandler
 	{
 		final IInOutBL inOutBL = Services.get(IInOutBL.class);
 		return inOutBL.getProductPrice(fromInOutLine, explicitPackingInstruction);
-	}
-
-	// @see de.metas.handlingunits.model.I_M_InOutLine#COLUMNNAME_M_HU_PI_Item_Product_ID (typed getter not importable from this module)
-	private static final String COLUMNNAME_M_HU_PI_Item_Product_ID = "M_HU_PI_Item_Product_ID";
-
-	/**
-	 * Resolves the effective Packvorschrift (M_HU_PI_Item_Product) to price a vendor return from, mirroring the
-	 * resolution order of {@code InOutLineHUPackingAware} (which lives in de.metas.handlingunits.base and is not
-	 * visible from this module): prefer the line's <b>own</b> Packvorschrift when it carries one (e.g. a standalone
-	 * vendor-return line the HU return producer stamps), otherwise fall back to the linked purchase-order line,
-	 * where a vendor-receipt origin line keeps the PI (the receipt line itself carries none). Returns {@code null}
-	 * when neither carries a PI (e.g. empties / returns without an order line), leaving pricing unchanged.
-	 * <p>
-	 * The line's own PI is read generically because its typed getter lives on the handlingunits {@code I_M_InOutLine},
-	 * which this module cannot import; the order-line PI is read through {@link IOrderDAO} rather than a model getter.
-	 */
-	@Nullable
-	private static HUPIItemProductId resolvePackingInstruction(@NonNull final org.compiere.model.I_M_InOutLine inOutLine)
-	{
-		final Integer ownPackingInstructionRepoId = getValueOverrideOrValue(inOutLine, COLUMNNAME_M_HU_PI_Item_Product_ID);
-		final HUPIItemProductId ownPackingInstruction = ownPackingInstructionRepoId != null
-				? HUPIItemProductId.ofRepoIdOrNull(ownPackingInstructionRepoId)
-				: null;
-		if (ownPackingInstruction != null)
-		{
-			return ownPackingInstruction;
-		}
-
-		final OrderLineId orderLineId = OrderLineId.ofRepoIdOrNull(inOutLine.getC_OrderLine_ID());
-		if (orderLineId == null)
-		{
-			return null;
-		}
-
-		final de.metas.interfaces.I_C_OrderLine orderLine = Services.get(IOrderDAO.class).getOrderLineById(orderLineId);
-		if (orderLine == null)
-		{
-			return null;
-		}
-		return HUPIItemProductId.ofRepoIdOrNull(orderLine.getM_HU_PI_Item_Product_ID());
 	}
 
 	@Nullable


### PR DESCRIPTION
## Problem

A product **return** that references its original document fails to invoice — the invoice candidate errors **"Produkt nicht auf der Preisliste"** — when the product's active price is keyed on a **Packvorschrift** (`M_HU_PI_Item_Product_ID`). The only workaround was a manual 0.00 price-list entry.

## Root cause

For a return, `M_InOutLine_Handler` prices from the **origin document line** (`getReturn_Origin_InOutLine()`), to reproduce the original price at the original date. A vendor **receipt** line carries no Packvorschrift in any of its columns — the PI lives on the linked **purchase-order line** (receipt lines are not PI-stamped, unlike HU shipment lines). `HUPricing.getPackingMaterialId()` reads only the line's own columns → null → the PI-keyed price is never matched → "Produkt nicht auf der Preisliste".

(The single-price case is masked by `UniqueProductPriceFallbackRule`; the defect surfaces when the product has more than one active price.)

**Verified (local cucumber + DB):** the new `vendorReturn.feature` scenario reproduces it — before the fix the return's `C_Invoice_Candidate` is `IsError=Y` and its origin receipt line has `M_HU_PI_Item_Product_ID` (base/override/calculated) all `NULL` while the linked order line carries the PI (confirmed by `psql` on the local stack). After the fix the same scenario is GREEN (`IsError=N`, `PriceActual` = the original PO price). The receipt/order candidate priced correctly throughout, isolating the defect to the return→origin pricing path.

## Fix (return-scoped)

- `IPricingContext` / `IEditablePricingContext` / `PricingContext`: an optional explicit Packvorschrift carrier (default none; carried across `copy()`).
- `HUPricing.getPackingMaterialId`: honor the explicit Packvorschrift when set (and regular), otherwise the existing referenced-object extraction — unchanged when not set.
- `InOutBL` / `IInOutBL`: a `getProductPrice(inOutLine, explicitPackingInstruction)` overload; the existing single-arg method delegates with `null`.
- `M_InOutLine_Handler`: at both origin-line pricing sites (candidate creation + recompute), when the line is a return (`Return_Origin_InOutLine_ID > 0`), resolve the origin line's order-line Packvorschrift and pass it explicitly. Non-return pricing passes `null` and is byte-for-byte unchanged; returns without an order line stay unchanged.

**Direct shipment/receipt invoicing (incl. shipment-IC and mixed-PI shipment lines) is untouched** — the explicit value is set only on the return→origin path.

## Scope

The defect is **vendor-return-specific**: customer returns price from an origin **shipment** line, which *is* PI-stamped by `ShipmentLineBuilder`, so they already price correctly (confirmed: the customer-return scenario passes before and after the fix).

## Tests (cucumber, `de.metas.cucumber`)

- **Vendor return** scenario in `purchaseOrder/vendorReturn.feature` — RED before the fix, GREEN after. Reproduction + regression test.
- **Customer return** scenario in `shipment/customerReturn.feature` — passes before and after (regression guard).
- `C_Invoice_Candidate_StepDef`: optional `IsError` / `ErrorMsg` / `PriceActual` assertions + an optional `M_Product_ID` filter on the credit-memo-candidate lookup.

No AD migration, no data backfill.
