### PR TITLE
Workstation MobileUI — re-read operator workstation and workplace on screen re-entry

### DIFF
--- a/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
@@ -7,6 +7,7 @@ import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScre
 import { WorkstationManagerScreen } from "../../utils/screens/workstationManager/WorkstationManagerScreen";
 import { WorkplaceManagerScreen } from "../../utils/screens/workplaceManager/WorkplaceManagerScreen";
 import { ManufacturingJobsListScreen } from "../../utils/screens/manufacturing/ManufacturingJobsListScreen";
+import { AppLifecycleComponent } from "../../utils/components/AppLifecycleComponent";
 
 const createMasterdata = async () => {
     return await Backend.createMasterdata({
@@ -16,9 +17,11 @@ const createMasterdata = async () => {
             // established purely by scanning, which is exactly what this scenario drives.
             login: { user: { language: "en_US" } },
             // The manufacturing app only reads (and only displays) the operator's workstation when its
-            // config says a resource scan is required — MobileUI_UserProfile_MFG.IsScanResourceRequired,
-            // which the customer runs on, but whose built-in default is off. Set here rather than
-            // inherited, so the Produktion launchers screen really shows a Workstation header row.
+            // config says a resource scan is required — MobileUI_UserProfile_MFG.IsScanResourceRequired
+            // (ManufacturingMobileApplication.java) — whose built-in default is off. It must be on here
+            // to reproduce the reported screen at all: the customer's Produktion screenshots show an
+            // Arbeitsstation header row, which only renders when the workstation is read. Set in this
+            // spec's own masterdata rather than inherited, per the fresh-fixture rule.
             mobileConfig: { manufacturing: { isScanResourceRequired: true } },
             warehouses: {
                 whA: {},
@@ -119,12 +122,7 @@ test('A workstation switch made while the Produktion screen stays open must show
     });
 
     await test.step('Returning to the screen must re-read the operator context — it must not stay on WS1 / A', async () => {
-        // Coming back to an app that stayed open fires exactly these two events; the screen must treat
-        // them as "re-read the operator's context", not keep whatever it loaded when it first mounted.
-        await page.evaluate(() => {
-            document.dispatchEvent(new Event('visibilitychange'));
-            window.dispatchEvent(new Event('focus'));
-        });
+        await AppLifecycleComponent.returnToForeground();
 
         // RED before the fix: both of these still show WS1 / wpA, because the screen read the
         // operator's workstation and workplace once at mount and has no refresh trigger at all.

--- a/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
@@ -6,6 +6,7 @@ import { LoginScreen } from "../../utils/screens/LoginScreen";
 import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
 import { WorkstationManagerScreen } from "../../utils/screens/workstationManager/WorkstationManagerScreen";
 import { WorkplaceManagerScreen } from "../../utils/screens/workplaceManager/WorkplaceManagerScreen";
+import { ManufacturingJobsListScreen } from "../../utils/screens/manufacturing/ManufacturingJobsListScreen";
 
 const createMasterdata = async () => {
     return await Backend.createMasterdata({
@@ -25,6 +26,9 @@ const createMasterdata = async () => {
             resources: {
                 // WS1 is a workstation statically linked to workplace A.
                 WS1: { type: 'WS', workplace: 'wpA' },
+                // WS2 belongs to a DIFFERENT workplace (B), so switching to it must move both the
+                // displayed workstation and the displayed active workplace.
+                WS2: { type: 'WS', workplace: 'wpB' },
             },
         }
     });
@@ -74,5 +78,52 @@ test('Re-scanning an already-assigned workstation must re-switch a drifted activ
         // The re-scan must re-assign the workstation and switch the active workplace back to A; a
         // read-only scan leaves it on the drifted workplace B and this assertion fails.
         expect(assignedWorkplace?.name).toBe(masterdata.workplaces.wpA.name);
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('A workstation switch made while the Produktion screen stays open must show on re-entry', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0160: Manufacturing Execution');
+    allure.tag('F8046: Workstation');
+    allure.tag('F8046');  // Standalone tag for Tags section;
+    allure.story('A screen showing the operator\'s workstation re-reads it when the operator returns to it');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await test.step('Scan workstation WS1 (linked to workplace A), then open the manufacturing job list', async () => {
+        await WorkstationManagerScreen.scanWorkstation(masterdata.resources.WS1.qrCode);
+        await WorkstationManagerScreen.goBack();
+        await ApplicationsListScreen.startApplication('mfg');
+        await ManufacturingJobsListScreen.waitForScreen();
+        await ManufacturingJobsListScreen.expectCurrentWorkstation(masterdata.resources.WS1.name);
+        await ManufacturingJobsListScreen.expectCurrentWorkplace(masterdata.workplaces.wpA.name);
+    });
+
+    await test.step('While this screen stays open, the operator\'s workstation switches to WS2 (workplace B)', async () => {
+        // Not a fabricated state: this posts to the very endpoint the workstation app posts to on a
+        // scan. It stands in for the real-world trigger — the operator scanning in a second app
+        // instance (installed PWA plus a browser tab) while this screen remains mounted.
+        await Backend.assignWorkstationByQRCode({ qrCode: masterdata.resources.WS2.qrCode });
+        const { assignedWorkplace } = await Backend.getCurrentWorkplace();
+        expect(assignedWorkplace?.name).toBe(masterdata.workplaces.wpB.name);
+    });
+
+    await test.step('Returning to the screen must re-read the operator context — it must not stay on WS1 / A', async () => {
+        // Coming back to an app that stayed open fires exactly these two events; the screen must treat
+        // them as "re-read the operator's context", not keep whatever it loaded when it first mounted.
+        await page.evaluate(() => {
+            document.dispatchEvent(new Event('visibilitychange'));
+            window.dispatchEvent(new Event('focus'));
+        });
+
+        // RED before the fix: both of these still show WS1 / wpA, because the screen read the
+        // operator's workstation and workplace once at mount and has no refresh trigger at all.
+        await ManufacturingJobsListScreen.expectCurrentWorkstation(masterdata.resources.WS2.name);
+        await ManufacturingJobsListScreen.expectCurrentWorkplace(masterdata.workplaces.wpB.name);
     });
 });

--- a/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/workstation_switches_workplace.spec.js
@@ -15,6 +15,11 @@ const createMasterdata = async () => {
             // No workplace preassigned to the login user — the operator's active workplace is
             // established purely by scanning, which is exactly what this scenario drives.
             login: { user: { language: "en_US" } },
+            // The manufacturing app only reads (and only displays) the operator's workstation when its
+            // config says a resource scan is required — MobileUI_UserProfile_MFG.IsScanResourceRequired,
+            // which the customer runs on, but whose built-in default is off. Set here rather than
+            // inherited, so the Produktion launchers screen really shows a Workstation header row.
+            mobileConfig: { manufacturing: { isScanResourceRequired: true } },
             warehouses: {
                 whA: {},
                 whB: {},

--- a/e2e/mobile-webui/tests/utils/components/AppLifecycleComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/AppLifecycleComponent.js
@@ -1,0 +1,18 @@
+import { test } from '../../../playwright.config';
+import { page } from '../common';
+
+const NAME = 'AppLifecycleComponent';
+
+export const AppLifecycleComponent = {
+    // Simulates the operator returning to an app that stayed open — switching back to the installed
+    // PWA, unlocking the device, or re-selecting the browser tab. The browser fires exactly these two
+    // events on that transition, and there is no Playwright API that produces them, so they are
+    // dispatched directly (same reason BarcodeScannerComponent dispatches raw keyboard events to
+    // stand in for a hardware scanner).
+    returnToForeground: async () => await test.step(`${NAME} - Operator returns to the app`, async () => {
+        await page.evaluate(() => {
+            document.dispatchEvent(new Event('visibilitychange'));
+            window.dispatchEvent(new Event('focus'));
+        });
+    }),
+};

--- a/e2e/mobile-webui/tests/utils/screens/Backend.js
+++ b/e2e/mobile-webui/tests/utils/screens/Backend.js
@@ -90,6 +90,20 @@ export const Backend = {
         return responseBody;
     }),
 
+    // Assigns the operator to a workstation through the SAME endpoint the app itself posts to when a
+    // workstation QR is scanned. Used to change the assignment while a screen under test stays open —
+    // the deterministic stand-in for the real-world trigger (a second app instance doing the scan).
+    assignWorkstationByQRCode: async ({ qrCode }) => await test.step(`Backend: assign workstation by QR code`, async () => {
+        const backendBaseUrl = await getBackendBaseUrl();
+        const response = await page.request.post(`${backendBaseUrl}/workstation/assign`, {
+            headers: { 'Content-Type': 'application/json', 'Authorization': getAuthToken() },
+            data: { workstationQRCode: qrCode },
+        });
+        const responseBody = await response.json();
+        assertNoErrors({ responseBody });
+        return responseBody;
+    }),
+
     getWFProcess: async ({ wfProcessId }) => {
         const backendBaseUrl = await getBackendBaseUrl();
         const response = await page.request.get(`${backendBaseUrl}/userWorkflows/wfProcess/${wfProcessId}`, {

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/ManufacturingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/ManufacturingJobsListScreen.js
@@ -40,4 +40,21 @@ export const ManufacturingJobsListScreen = {
         return match ? match[1] : null;
     },
 
+    expectHeaderProperty: async ({ caption, value }) => await test.step(`${NAME} - Check header property '${caption}'='${value}'`, async () => {
+        const row = await page.locator(
+            `tr:has(th:has-text("${caption}")):has(td:has-text("${value}"))`
+        );
+        await expect(row).toHaveCount(1)
+    }),
+
+    // The operator's current workstation as THIS screen displays it (GET /api/v2/workstation).
+    expectCurrentWorkstation: async (name) => await test.step(`${NAME} - Expect header workstation = '${name}'`, async () => {
+        await ManufacturingJobsListScreen.expectHeaderProperty({ caption: 'Workstation', value: name });
+    }),
+
+    // The operator's current ACTIVE workplace as THIS screen displays it (GET /api/v2/workplace).
+    expectCurrentWorkplace: async (name) => await test.step(`${NAME} - Expect header workplace = '${name}'`, async () => {
+        await ManufacturingJobsListScreen.expectHeaderProperty({ caption: 'Workplace', value: name });
+    }),
+
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/hooks/useReentryKey.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/hooks/useReentryKey.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { useReentryKey } from '../../hooks/useReentryKey';
+
+const Probe = () => <span data-testid="key">{useReentryKey()}</span>;
+const currentKey = () => Number(screen.getByTestId('key').textContent);
+
+describe('useReentryKey', () => {
+  it('starts at 0', () => {
+    render(<Probe />);
+    expect(currentKey()).toBe(0);
+  });
+
+  it('increases when the window regains focus', () => {
+    render(<Probe />);
+    const before = currentKey();
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+    expect(currentKey()).toBe(before + 1);
+  });
+
+  it('increases when the document becomes visible again', () => {
+    render(<Probe />);
+    const before = currentKey();
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(currentKey()).toBe(before + 1);
+  });
+
+  it('does not increase while the document is hidden', () => {
+    render(<Probe />);
+    const before = currentKey();
+    const spy = jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+    expect(currentKey()).toBe(before);
+    spy.mockRestore();
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/workplace.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/workplace.js
@@ -27,6 +27,7 @@ import { toastError } from '../utils/toast';
 import { useEffect, useState } from 'react';
 import { parseWorkplaceQRCodeString } from '../utils/qrCode/workplace';
 import { useApplicationInfo } from '../reducers/applications';
+import { useReentryKey } from '../hooks/useReentryKey';
 
 const workplaceAPIBase = `${apiBasePath}/workplace`;
 
@@ -36,6 +37,7 @@ export const getCurrentWorkplaceInfo = () => {
 
 export const useCurrentWorkplace = ({ applicationId }) => {
   const { requiresWorkplace: requiresWorkplaceIfAvailable } = useApplicationInfo({ applicationId });
+  const reentryKey = useReentryKey();
   const [isLoading, setIsLoading] = useState(true);
   const [isWorkplaceRequired, setIsWorkplaceRequired] = useState(false);
   const [workplace, setWorkplace] = useState(null);
@@ -49,7 +51,11 @@ export const useCurrentWorkplace = ({ applicationId }) => {
       })
       .catch((axiosError) => toastError({ axiosError }))
       .finally(() => setIsLoading(false));
-  }, []);
+    // reentryKey: re-read when the operator returns to this screen — the active workplace may have
+    // been changed elsewhere (another app instance, or a workstation scan) while the screen stayed
+    // mounted. It also makes a read that failed (offline blip) retry on the next re-entry instead of
+    // leaving the header blank.
+  }, [reentryKey]);
 
   const setWorkplaceByQRCode = (qrCode) => {
     const { workplaceId } = parseWorkplaceQRCodeString(qrCode);

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/workstation.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/workstation.js
@@ -4,6 +4,7 @@ import { unboxAxiosResponse } from '../utils';
 import { useApplicationInfo } from '../reducers/applications';
 import { useEffect, useState } from 'react';
 import { toastError } from '../utils/toast';
+import { useReentryKey } from '../hooks/useReentryKey';
 
 const workstationAPIBase = `${apiBasePath}/workstation`;
 
@@ -13,6 +14,7 @@ export const getCurrentWorkstationInfo = () => {
 
 export const useCurrentWorkstation = ({ applicationId }) => {
   const { requiresWorkstation: requiresWorkstationIfAvailable } = useApplicationInfo({ applicationId });
+  const reentryKey = useReentryKey();
   const [isLoading, setIsLoading] = useState(requiresWorkstationIfAvailable);
   const [workstation, setWorkstation] = useState(null);
 
@@ -28,7 +30,12 @@ export const useCurrentWorkstation = ({ applicationId }) => {
     } else {
       setIsLoading(false);
     }
-  }, []);
+    // reentryKey: re-read when the operator returns to this screen — the assignment may have been
+    // changed elsewhere (another app instance) while the screen stayed mounted. It also makes a read
+    // that failed (offline blip) retry on the next re-entry instead of leaving the header blank.
+    // requiresWorkstationIfAvailable: it arrives from the applications store, so an effect that ran
+    // once while it was still falsy would never fetch at all.
+  }, [reentryKey, requiresWorkstationIfAvailable]);
 
   const setWorkstationByQRCode = (qrCode) => {
     assignWorkstationByQRCode(qrCode)

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useReentryKey.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/hooks/useReentryKey.js
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * A key that increases each time the operator RE-ENTERS the app — the window regains focus, or the
+ * document becomes visible again after being hidden (app switch, tab switch, screen unlock).
+ *
+ * Feed it into the dependency array of an effect that loads session-global operator context (active
+ * workplace, assigned workstation) so that context is re-read on re-entry instead of only on mount.
+ * A screen that stays mounted across an app switch otherwise displays the value it loaded when it
+ * first mounted, forever — see the module CLAUDE.md, "Shared operator state must not be read once
+ * per mount".
+ *
+ * Listeners are registered here rather than via `useEventListener` because that helper is
+ * window-only, while `visibilitychange` is dispatched at the document.
+ */
+export const useReentryKey = () => {
+  const [key, setKey] = useState(0);
+
+  useEffect(() => {
+    const bump = () => setKey((previous) => previous + 1);
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== 'hidden') {
+        bump();
+      }
+    };
+
+    window.addEventListener('focus', bump);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      window.removeEventListener('focus', bump);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, []);
+
+  return key;
+};


### PR DESCRIPTION
## Problem

On the Mobile-UI, a screen that displays the operator's current workstation / active workplace read
those values **once per mount**. `useCurrentWorkstation` (`src/api/workstation.js`) and
`useCurrentWorkplace` (`src/api/workplace.js`) both fetched inside `useEffect(…, [])`, with nothing
listening for focus or visibility changes.

Navigating in and out happened to work, because the launchers screen unmounts. A screen that **stays
open** — a second app instance, or an OS-level app switch — showed the value it had at mount, forever.
Operators scanned a new workstation, switched back to the Produktion screen, and saw the previous
station indefinitely, while the server and the server-filtered job list were already on the new one.
Every re-scan therefore looked like it had failed.

Reproduced live on the target instance across a 21-variant sweep: the navigation route was uniformly
correct; only the screen-stays-mounted scenarios were stale.

## Fix

A small `useReentryKey()` hook returns a counter that increments whenever the app is re-entered
(window `focus`, or `visibilitychange` back to visible). Both effects take that key as a dependency.

Deliberately minimal and behaviour-preserving: no change to loading/error/spinner semantics, no state
moved into redux, no polling. `useCurrentWorkstation` additionally gains
`requiresWorkstationIfAvailable` as a dependency — it arrives from the applications store, so an effect
that ran once while it was still falsy would never fetch at all.

`useCurrentTrolley` has the same one-shot shape but is not named by any acceptance criterion; it is
left alone deliberately.

Migrating the two hooks to `useQuery` (the newer pattern the trolley hook uses) was considered and
rejected for this bugfix: `useQuery` has no error branch and starts `isPending: false`, so it would
change both hooks' spinner/toast behaviour for no gain on this defect.

## Verification

Local mobile-webui Playwright, driven against a dev server serving this branch's frontend:

- `workstation_switches_workplace.spec.js` — new test **RED before** the hook change (header stayed on
  `WS1` / `wpA` after the switch to `WS2` / `wpB`), **GREEN after**; the pre-existing test in the file
  passes throughout. The same RED was reproduced against the prebuilt base-branch frontend first, to
  confirm it is the production defect and not a harness artifact.
- Regression: `distribution/filter_by_workplace.spec.js` (3) and `manufacturing/manufacturing.spec.js`
  (4) — all pass.
- Jest: 4 test methods on `useReentryKey` (starts at 0; increments on `focus`; increments on
  `visibilitychange` when visible; does **not** increment while hidden). Observed failing before the
  hook existed.
- `yarn lint` clean.

## Note for the reviewer

The change also makes a **failed** read retry on the next re-entry, instead of leaving the header blank
until the screen is remounted. That is a second defect found during the reproduction, and it is not
named by any acceptance criterion — it comes with the same one dependency-array entry rather than being
separable. Say the word if it should be excluded.
