### PR TITLE
`Manufactuirng Order`: default `Plant / Work Station` from `Product Category`

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_M_Product_Category.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_M_Product_Category.java
@@ -1,5 +1,8 @@
 package org.compiere.model;
 
+import org.adempiere.model.ModelColumn;
+
+import javax.annotation.Nullable;
 
 /** Generated Interface for M_Product_Category
  *  @author Adempiere (generated) 
@@ -645,4 +648,59 @@ public interface I_M_Product_Category
     public static final org.adempiere.model.ModelColumn<I_M_Product_Category, Object> COLUMN_Value = new org.adempiere.model.ModelColumn<I_M_Product_Category, Object>(I_M_Product_Category.class, "Value", null);
     /** Column name Value */
     public static final String COLUMNNAME_Value = "Value";
+
+	/**
+	 * Set Resource.
+	 * Resource
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setS_Resource_ID (int S_Resource_ID);
+
+	/**
+	 * Get Resource.
+	 * Resource
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getS_Resource_ID();
+
+	@Nullable org.compiere.model.I_S_Resource getS_Resource();
+
+	void setS_Resource(@Nullable org.compiere.model.I_S_Resource S_Resource);
+
+	ModelColumn<I_M_Product_Category, org.compiere.model.I_S_Resource> COLUMN_S_Resource_ID = new ModelColumn<>(I_M_Product_Category.class, "S_Resource_ID", org.compiere.model.I_S_Resource.class);
+	String COLUMNNAME_S_Resource_ID = "S_Resource_ID";
+
+	/**
+	 * Set Work Station.
+	 * The Workstation at which this manufacturing order is to be processed. In MobileUI Manufacturing, only orders whose Workstation matches the one scanned by the operator are shown.
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setWorkStation_ID (int WorkStation_ID);
+
+	/**
+	 * Get Work Station.
+	 * The Workstation at which this manufacturing order is to be processed. In MobileUI Manufacturing, only orders whose Workstation matches the one scanned by the operator are shown.
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	int getWorkStation_ID();
+
+	@Nullable
+	org.compiere.model.I_S_Resource getWorkStation();
+
+	void setWorkStation(@Nullable org.compiere.model.I_S_Resource WorkStation);
+
+	ModelColumn<I_M_Product_Category, I_S_Resource> COLUMN_WorkStation_ID = new ModelColumn<>(I_M_Product_Category.class, "WorkStation_ID", org.compiere.model.I_S_Resource.class);
+	String COLUMNNAME_WorkStation_ID = "WorkStation_ID";
 }

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_M_Product_Category.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_M_Product_Category.java
@@ -580,4 +580,58 @@ public class X_M_Product_Category extends org.compiere.model.PO implements I_M_P
 	{
 		return (java.lang.String)get_Value(COLUMNNAME_Value);
 	}
+
+	@Override
+	public org.compiere.model.I_S_Resource getS_Resource()
+	{
+		return get_ValueAsPO(COLUMNNAME_S_Resource_ID, org.compiere.model.I_S_Resource.class);
+	}
+
+	@Override
+	public void setS_Resource(final org.compiere.model.I_S_Resource S_Resource)
+	{
+		set_ValueFromPO(COLUMNNAME_S_Resource_ID, org.compiere.model.I_S_Resource.class, S_Resource);
+	}
+
+	@Override
+	public void setS_Resource_ID (final int S_Resource_ID)
+	{
+		if (S_Resource_ID < 1)
+			set_Value (COLUMNNAME_S_Resource_ID, null);
+		else
+			set_Value (COLUMNNAME_S_Resource_ID, S_Resource_ID);
+	}
+
+	@Override
+	public int getS_Resource_ID()
+	{
+		return get_ValueAsInt(COLUMNNAME_S_Resource_ID);
+	}
+
+	@Override
+	public org.compiere.model.I_S_Resource getWorkStation()
+	{
+		return get_ValueAsPO(COLUMNNAME_WorkStation_ID, org.compiere.model.I_S_Resource.class);
+	}
+
+	@Override
+	public void setWorkStation(final org.compiere.model.I_S_Resource WorkStation)
+	{
+		set_ValueFromPO(COLUMNNAME_WorkStation_ID, org.compiere.model.I_S_Resource.class, WorkStation);
+	}
+
+	@Override
+	public void setWorkStation_ID (final int WorkStation_ID)
+	{
+		if (WorkStation_ID < 1)
+			set_Value (COLUMNNAME_WorkStation_ID, null);
+		else
+			set_Value (COLUMNNAME_WorkStation_ID, WorkStation_ID);
+	}
+
+	@Override
+	public int getWorkStation_ID()
+	{
+		return get_ValueAsInt(COLUMNNAME_WorkStation_ID);
+	}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/product/IProductBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/IProductBL.java
@@ -43,6 +43,7 @@ import org.adempiere.service.ClientId;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_AttributeSetInstance;
 import org.compiere.model.I_M_Product;
+import org.compiere.model.I_M_Product_Category;
 
 import javax.annotation.Nullable;
 import java.time.LocalDate;
@@ -188,6 +189,9 @@ public interface IProductBL extends ISingletonService
 	boolean isASIMandatory(ProductId productId, boolean isSOTrx);
 
 	boolean isProductInCategory(ProductId productId, ProductCategoryId expectedProductCategoryId);
+
+	@Nullable
+	I_M_Product_Category getProductCategoryByProductId(@NonNull ProductId productId);
 
 	String getProductValueAndName(@Nullable ProductId productId);
 

--- a/backend/de.metas.business/src/main/java/de/metas/product/impl/ProductBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/impl/ProductBL.java
@@ -476,6 +476,16 @@ public final class ProductBL implements IProductBL
 	}
 
 	@Override
+	@Nullable
+	public I_M_Product_Category getProductCategoryByProductId(@NonNull final ProductId productId)
+	{
+		final ProductCategoryId productCategoryId = productsRepo.retrieveProductCategoryByProductId(productId);
+		return productCategoryId != null
+				? productsRepo.getProductCategoryById(productCategoryId)
+				: null;
+	}
+
+	@Override
 	public String getProductValueAndName(@Nullable final ProductId productId)
 	{
 		if (productId == null)

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5817090_sys_gh31188_Product_Category_Resource_Fields.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5817090_sys_gh31188_Product_Category_Resource_Fields.sql
@@ -1,0 +1,106 @@
+-- Run mode: SWING_CLIENT
+
+-- Column: M_Product_Category.S_Resource_ID
+-- 2026-07-30T11:05:39.640Z
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,AD_Val_Rule_ID,CloningStrategy,ColumnName,Created,CreatedBy,DDL_NoForeignKey,Description,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterInactiveValues,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593051,1777,0,18,53320,209,52002,'XX','S_Resource_ID',TO_TIMESTAMP('2026-07-30 11:05:38.880000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N','Produktionressource','D',0,10,'Y','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','Y','N',0,'Produktionressource',0,0,TO_TIMESTAMP('2026-07-30 11:05:38.880000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,0)
+;
+
+-- 2026-07-30T11:05:39.766Z
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=593051 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 2026-07-30T11:05:39.921Z
+/* DDL */  select update_Column_Translation_From_AD_Element(1777)
+;
+
+-- 2026-07-30T11:06:19.840Z
+/* DDL */ SELECT public.db_alter_table('M_Product_Category','ALTER TABLE public.M_Product_Category ADD COLUMN S_Resource_ID NUMERIC(10)')
+;
+
+-- 2026-07-30T11:06:20.355Z
+ALTER TABLE M_Product_Category ADD CONSTRAINT SResource_MProductCategory FOREIGN KEY (S_Resource_ID) REFERENCES public.S_Resource DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Column: M_Product_Category.WorkStation_ID
+-- 2026-07-30T11:08:37.632Z
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,AD_Val_Rule_ID,CloningStrategy,ColumnName,Created,CreatedBy,DDL_NoForeignKey,Description,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterInactiveValues,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593052,583018,0,30,541855,209,540669,'XX','WorkStation_ID',TO_TIMESTAMP('2026-07-30 11:08:29.576000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N','Die Arbeitsstation, an der dieser Produktionsauftrag bearbeitet werden soll. In der MobileUI-Produktion erscheinen nur Aufträge, deren Arbeitsstation der vom Bediener gescannten entspricht.','D',0,10,'Y','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','Y','N',0,'Arbeitsstation',0,0,TO_TIMESTAMP('2026-07-30 11:08:29.576000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,0)
+;
+
+-- 2026-07-30T11:08:37.757Z
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=593052 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 2026-07-30T11:08:37.898Z
+/* DDL */  select update_Column_Translation_From_AD_Element(583018)
+;
+
+-- 2026-07-30T11:09:52.720Z
+/* DDL */ SELECT public.db_alter_table('M_Product_Category','ALTER TABLE public.M_Product_Category ADD COLUMN WorkStation_ID NUMERIC(10)')
+;
+
+-- 2026-07-30T11:09:53.110Z
+ALTER TABLE M_Product_Category ADD CONSTRAINT WorkStation_MProductCategory FOREIGN KEY (WorkStation_ID) REFERENCES public.S_Resource DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Field: Produkt Kategorie(144,D) -> Produkt-Kategorie(189,D) -> Arbeitsstation
+-- Column: M_Product_Category.WorkStation_ID
+-- 2026-07-30T11:16:39.615Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,FacetFilterSeqNo,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,593052,781860,0,189,0,TO_TIMESTAMP('2026-07-30 11:16:38.584000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Die Arbeitsstation, an der dieser Produktionsauftrag bearbeitet werden soll. In der MobileUI-Produktion erscheinen nur Aufträge, deren Arbeitsstation der vom Bediener gescannten entspricht.',0,'D',0,0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Arbeitsstation',0,0,160,0,1,1,TO_TIMESTAMP('2026-07-30 11:16:38.584000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-07-30T11:16:39.756Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=781860 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-07-30T11:16:39.820Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(583018)
+;
+
+-- 2026-07-30T11:16:39.888Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781860
+;
+
+-- 2026-07-30T11:16:39.956Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(781860)
+;
+
+-- Field: Produkt Kategorie(144,D) -> Produkt-Kategorie(189,D) -> Produktionsstätte
+-- Column: M_Product_Category.S_Resource_ID
+-- 2026-07-30T11:17:58.762Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Name_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,DisplayLength,EntityType,FacetFilterSeqNo,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,593051,781861,542433,0,189,0,TO_TIMESTAMP('2026-07-30 11:17:58.045000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,0,'D',0,0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Produktionsstätte',0,0,170,0,1,1,TO_TIMESTAMP('2026-07-30 11:17:58.045000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-07-30T11:17:58.886Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=781861 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-07-30T11:17:59.006Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(542433)
+;
+
+-- 2026-07-30T11:17:59.075Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781861
+;
+
+-- 2026-07-30T11:17:59.132Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(781861)
+;
+
+-- UI Column: Produkt Kategorie(144,D) -> Produkt-Kategorie(189,D) -> main -> 20
+-- UI Element Group: resource
+-- 2026-07-30T11:19:15.259Z
+INSERT INTO AD_UI_ElementGroup (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_ElementGroup_ID,Created,CreatedBy,IsActive,Name,SeqNo,Updated,UpdatedBy) VALUES (0,0,540192,555532,TO_TIMESTAMP('2026-07-30 11:19:14.790000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y','resource',17,TO_TIMESTAMP('2026-07-30 11:19:14.790000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- UI Element: Produkt Kategorie(144,D) -> Produkt-Kategorie(189,D) -> main -> 20 -> resource.Produktionsstätte
+-- Column: M_Product_Category.S_Resource_ID
+-- 2026-07-30T11:20:06.602Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,781861,0,189,555532,652786,'F',TO_TIMESTAMP('2026-07-30 11:20:06.105000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y','N','N','Y','N','N','N',0,'Produktionsstätte',10,0,0,TO_TIMESTAMP('2026-07-30 11:20:06.105000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- UI Element: Produkt Kategorie(144,D) -> Produkt-Kategorie(189,D) -> main -> 20 -> resource.Arbeitsstation
+-- Column: M_Product_Category.WorkStation_ID
+-- 2026-07-30T11:21:10.042Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,781860,0,189,555532,652787,'F',TO_TIMESTAMP('2026-07-30 11:21:09.530000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Die Arbeitsstation, an der dieser Produktionsauftrag bearbeitet werden soll. In der MobileUI-Produktion erscheinen nur Aufträge, deren Arbeitsstation der vom Bediener gescannten entspricht.','Y','N','N','Y','N','N','N',0,'Arbeitsstation',20,0,0,TO_TIMESTAMP('2026-07-30 11:21:09.530000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5817170_sys_gh31188_PP_Order_Warehouse_Filter.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5817170_sys_gh31188_PP_Order_Warehouse_Filter.sql
@@ -1,0 +1,12 @@
+-- Run mode: SWING_CLIENT
+
+-- Column: PP_Order.M_Warehouse_ID
+-- 2026-07-31T07:07:29.513Z
+UPDATE AD_Column SET FilterOperator='E', IsSelectionColumn='Y',Updated=TO_TIMESTAMP('2026-07-31 07:07:29.513000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=53624
+;
+
+-- Column: PP_Order.M_Warehouse_ID
+-- 2026-07-31T07:08:42.974Z
+UPDATE AD_Column SET AD_Reference_ID=30,Updated=TO_TIMESTAMP('2026-07-31 07:08:42.974000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Column_ID=53624
+;
+

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/callout/PP_Order.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/callout/PP_Order.java
@@ -13,6 +13,8 @@ import de.metas.material.planning.pporder.IPPRoutingRepository;
 import de.metas.material.planning.pporder.PPRoutingId;
 import de.metas.organization.OrgId;
 import de.metas.product.IProductBL;
+import de.metas.product.IProductDAO;
+import de.metas.product.ProductCategoryId;
 import de.metas.product.ProductId;
 import de.metas.product.ResourceId;
 import de.metas.quantity.Quantity;
@@ -29,6 +31,7 @@ import org.adempiere.warehouse.api.IWarehouseBL;
 import org.compiere.model.CalloutEngine;
 import org.compiere.model.I_C_DocType;
 import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_M_Product_Category;
 import org.eevolution.api.IPPOrderBL;
 import org.eevolution.api.IProductBOMDAO;
 import org.eevolution.api.ProductBOMId;
@@ -53,6 +56,7 @@ public class PP_Order extends CalloutEngine
 	private final IWarehouseBL warehouseBL = Services.get(IWarehouseBL.class);
 	private final IDocTypeBL docTypeBL = Services.get(IDocTypeBL.class);
 	private final IProductBL productBL = Services.get(IProductBL.class);
+	private final IProductDAO productsRepo = Services.get(IProductDAO.class);
 	private final IProductBOMDAO bomsRepo = Services.get(IProductBOMDAO.class);
 	private final ProductBOMVersionsDAO bomVersionsRepo;
 	private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
@@ -104,6 +108,16 @@ public class PP_Order extends CalloutEngine
 		if (productId == null)
 		{
 			return;
+		}
+
+		//
+		// Plant (Produktionsstätte) and WorkStation (Arbeitsstation) follow the product's category (gh31188)
+		final ProductCategoryId productCategoryId = productsRepo.retrieveProductCategoryByProductId(productId);
+		if (productCategoryId != null)
+		{
+			final I_M_Product_Category productCategory = productsRepo.getProductCategoryById(productCategoryId);
+			ppOrder.setS_Resource_ID(productCategory.getS_Resource_ID());
+			ppOrder.setWorkStation_ID(productCategory.getWorkStation_ID());
 		}
 
 		final UomId uomId = productBL.getStockUOMId(productId);

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/callout/PP_Order.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/callout/PP_Order.java
@@ -13,8 +13,6 @@ import de.metas.material.planning.pporder.IPPRoutingRepository;
 import de.metas.material.planning.pporder.PPRoutingId;
 import de.metas.organization.OrgId;
 import de.metas.product.IProductBL;
-import de.metas.product.IProductDAO;
-import de.metas.product.ProductCategoryId;
 import de.metas.product.ProductId;
 import de.metas.product.ResourceId;
 import de.metas.quantity.Quantity;
@@ -56,7 +54,6 @@ public class PP_Order extends CalloutEngine
 	private final IWarehouseBL warehouseBL = Services.get(IWarehouseBL.class);
 	private final IDocTypeBL docTypeBL = Services.get(IDocTypeBL.class);
 	private final IProductBL productBL = Services.get(IProductBL.class);
-	private final IProductDAO productsRepo = Services.get(IProductDAO.class);
 	private final IProductBOMDAO bomsRepo = Services.get(IProductBOMDAO.class);
 	private final ProductBOMVersionsDAO bomVersionsRepo;
 	private final IUOMDAO uomDAO = Services.get(IUOMDAO.class);
@@ -112,10 +109,9 @@ public class PP_Order extends CalloutEngine
 
 		//
 		// Plant (Produktionsstätte) and WorkStation (Arbeitsstation) follow the product's category (gh31188)
-		final ProductCategoryId productCategoryId = productsRepo.retrieveProductCategoryByProductId(productId);
-		if (productCategoryId != null)
+		final I_M_Product_Category productCategory = productBL.getProductCategoryByProductId(productId);
+		if (productCategory != null)
 		{
-			final I_M_Product_Category productCategory = productsRepo.getProductCategoryById(productCategoryId);
 			ppOrder.setS_Resource_ID(productCategory.getS_Resource_ID());
 			ppOrder.setWorkStation_ID(productCategory.getWorkStation_ID());
 		}

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/model/validator/PP_Order.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/model/validator/PP_Order.java
@@ -13,6 +13,8 @@ import de.metas.material.planning.pporder.PPOrderPojoConverter;
 import de.metas.order.IOrderBL;
 import de.metas.order.OrderLineId;
 import de.metas.product.IProductBL;
+import de.metas.product.IProductDAO;
+import de.metas.product.ProductCategoryId;
 import de.metas.product.ProductId;
 import de.metas.project.ProjectId;
 import de.metas.uom.UomId;
@@ -33,6 +35,7 @@ import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.IWarehouseBL;
 import org.compiere.model.I_C_DocType;
+import org.compiere.model.I_M_Product_Category;
 import org.compiere.model.ModelValidator;
 import org.eevolution.api.IPPOrderBL;
 import org.eevolution.api.IPPOrderCostBL;
@@ -51,6 +54,7 @@ import java.sql.Timestamp;
 public class PP_Order
 {
 	private final IProductBL productBL = Services.get(IProductBL.class);
+	private final IProductDAO productsRepo = Services.get(IProductDAO.class);
 	private final IWarehouseBL warehouseBL = Services.get(IWarehouseBL.class);
 	private final IAttributeSetInstanceBL asiBL = Services.get(IAttributeSetInstanceBL.class);
 	private final IOrderBL orderBL = Services.get(IOrderBL.class);
@@ -151,6 +155,27 @@ public class PP_Order
 			final AttributeSetInstanceId asiId = AttributeSetInstanceId.ofRepoIdOrNone(ppOrder.getC_OrderLine().getM_AttributeSetInstance_ID());
 			final AttributeSetInstanceId asiIdCopy = asiBL.copy(asiId);
 			ppOrder.setM_AttributeSetInstance_ID(asiIdCopy.getRepoId());
+		}
+
+		//
+		// Default production Plant (S_Resource) and WorkStation from the product's category, if not set yet (gh31188)
+		if (ppOrder.getS_Resource_ID() <= 0 || ppOrder.getWorkStation_ID() <= 0)
+		{
+			final ProductId productId = ProductId.ofRepoId(ppOrder.getM_Product_ID());
+			final ProductCategoryId productCategoryId = productsRepo.retrieveProductCategoryByProductId(productId);
+			if (productCategoryId != null)
+			{
+				final I_M_Product_Category productCategory = productsRepo.getProductCategoryById(productCategoryId);
+
+				if (ppOrder.getS_Resource_ID() <= 0 && productCategory.getS_Resource_ID() > 0)
+				{
+					ppOrder.setS_Resource_ID(productCategory.getS_Resource_ID());
+				}
+				if (ppOrder.getWorkStation_ID() <= 0 && productCategory.getWorkStation_ID() > 0)
+				{
+					ppOrder.setWorkStation_ID(productCategory.getWorkStation_ID());
+				}
+			}
 		}
 
 		//

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/model/validator/PP_Order.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/model/validator/PP_Order.java
@@ -13,8 +13,6 @@ import de.metas.material.planning.pporder.PPOrderPojoConverter;
 import de.metas.order.IOrderBL;
 import de.metas.order.OrderLineId;
 import de.metas.product.IProductBL;
-import de.metas.product.IProductDAO;
-import de.metas.product.ProductCategoryId;
 import de.metas.product.ProductId;
 import de.metas.project.ProjectId;
 import de.metas.uom.UomId;
@@ -35,7 +33,6 @@ import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.api.IWarehouseBL;
 import org.compiere.model.I_C_DocType;
-import org.compiere.model.I_M_Product_Category;
 import org.compiere.model.ModelValidator;
 import org.eevolution.api.IPPOrderBL;
 import org.eevolution.api.IPPOrderCostBL;
@@ -54,7 +51,6 @@ import java.sql.Timestamp;
 public class PP_Order
 {
 	private final IProductBL productBL = Services.get(IProductBL.class);
-	private final IProductDAO productsRepo = Services.get(IProductDAO.class);
 	private final IWarehouseBL warehouseBL = Services.get(IWarehouseBL.class);
 	private final IAttributeSetInstanceBL asiBL = Services.get(IAttributeSetInstanceBL.class);
 	private final IOrderBL orderBL = Services.get(IOrderBL.class);
@@ -155,27 +151,6 @@ public class PP_Order
 			final AttributeSetInstanceId asiId = AttributeSetInstanceId.ofRepoIdOrNone(ppOrder.getC_OrderLine().getM_AttributeSetInstance_ID());
 			final AttributeSetInstanceId asiIdCopy = asiBL.copy(asiId);
 			ppOrder.setM_AttributeSetInstance_ID(asiIdCopy.getRepoId());
-		}
-
-		//
-		// Default production Plant (S_Resource) and WorkStation from the product's category, if not set yet (gh31188)
-		if (ppOrder.getS_Resource_ID() <= 0 || ppOrder.getWorkStation_ID() <= 0)
-		{
-			final ProductId productId = ProductId.ofRepoId(ppOrder.getM_Product_ID());
-			final ProductCategoryId productCategoryId = productsRepo.retrieveProductCategoryByProductId(productId);
-			if (productCategoryId != null)
-			{
-				final I_M_Product_Category productCategory = productsRepo.getProductCategoryById(productCategoryId);
-
-				if (ppOrder.getS_Resource_ID() <= 0 && productCategory.getS_Resource_ID() > 0)
-				{
-					ppOrder.setS_Resource_ID(productCategory.getS_Resource_ID());
-				}
-				if (ppOrder.getWorkStation_ID() <= 0 && productCategory.getWorkStation_ID() > 0)
-				{
-					ppOrder.setWorkStation_ID(productCategory.getWorkStation_ID());
-				}
-			}
 		}
 
 		//


### PR DESCRIPTION
Add S_Resource_ID (Plant) and WorkStation_ID fields to M_Product_Category and derive PP_Order.S_Resource_ID / PP_Order.WorkStation_ID from the selected product's category when not already set.                                                                                                  
       
  - migration 5817090: add M_Product_Category.S_Resource_ID + WorkStation_ID                                                                         
    (FK to S_Resource)                                                                                                                               
  - regenerate I_/X_M_Product_Category model                                                                                                         
  - PP_Order interceptor (beforeSave): fill plant/workstation from the  product's category as a fallback, without overriding values already set (e.g. from Produktionsdispo/PP_Product_Planning)    