### PR TITLE
mobile e2e: de-flake the camera-mode assertions by giving the browser a camera

### DIFF
--- a/e2e/mobile-webui/playwright.config.js
+++ b/e2e/mobile-webui/playwright.config.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig, devices, test as testOrig } from '@playwright/test';
 import { setCurrentPage } from "./tests/utils/common";
+import { installFakeCameraIfBrowserExposesNone } from "./tests/utils/fakeCamera";
 import os from 'os';
 
 /**
@@ -77,7 +78,10 @@ export default defineConfig({
                         '--allow-running-insecure-content', // Allows mixed content (HTTP on HTTPS)
                         // '--user-data-dir=/tmp/chrome-test-profile' // Ensures fresh profile each time (prevents stored HSTS rules)
                         '--use-fake-ui-for-media-stream', // Suppress getUserMedia permission dialog in CI (no physical camera)
-                        '--use-fake-device-for-media-stream', // Provide a synthetic camera so getUserMedia() succeeds in CI
+                        // Provide a synthetic camera so getUserMedia() succeeds in CI. NOTE: reachable only
+                        // via navigator.mediaDevices, which plain-HTTP non-localhost origins do not expose —
+                        // see tests/utils/fakeCamera.js, which fills that gap.
+                        '--use-fake-device-for-media-stream',
                     ],
                 },
             },
@@ -91,6 +95,7 @@ export const test = testOrig.extend({
     page: async ({ page }, use) => {
         setCurrentPage(page);
         Object.keys(testContext).forEach(key => delete testContext[key]);
+        await installFakeCameraIfBrowserExposesNone(page);
 
         await use(page);
     },

--- a/e2e/mobile-webui/tests/utils/fakeCamera.js
+++ b/e2e/mobile-webui/tests/utils/fakeCamera.js
@@ -1,0 +1,73 @@
+/**
+ * Makes a camera available to the mobile UI in environments where the browser exposes none.
+ *
+ * `playwright.config.js` launches Chromium with `--use-fake-device-for-media-stream` so that
+ * `getUserMedia()` succeeds without physical hardware. That synthetic device is only reachable
+ * through `navigator.mediaDevices`, which is `[SecureContext]`-gated: it exists on
+ * `http://localhost` but is UNDEFINED on every other plain-HTTP origin. CI serves the mobile UI
+ * from `http://mobile:80/mobile` (see `docker-builds/e2e-tests/compose.yml`) — a non-localhost HTTP
+ * origin — so there `navigator.mediaDevices` is undefined and the browser flag has no effect.
+ *
+ * The visible consequence: switching into camera mode does mount `CameraModePanel`, but ZXing's
+ * `decodeFromVideoDevice()` rejects immediately, `onCancel` reverts to the default mode and
+ * `.camera-mode-panel` unmounts again roughly 30 ms later. Camera-mode assertions were therefore
+ * observing a 30 ms flicker rather than a settled camera mode, and passed or failed depending on
+ * whether their first poll happened to fall inside that window.
+ *
+ * So when — and only when — the browser gives us no `navigator.mediaDevices`, install a minimal
+ * media-device double backed by a repainted canvas stream: `getUserMedia()` resolves, the `<video>`
+ * receives frames so `play()` resolves, ZXing keeps decoding, and camera mode stays active until
+ * the operator leaves it. Whenever the browser does expose `mediaDevices` (any localhost run) the
+ * real Chromium fake device is used unchanged.
+ */
+export const installFakeCameraIfBrowserExposesNone = async (page) =>
+    await page.addInitScript(() => {
+        if (navigator.mediaDevices?.getUserMedia) {
+            return; // secure context: the browser's own fake media device is reachable
+        }
+
+        const newCameraStream = () => {
+            const canvas = document.createElement('canvas');
+            canvas.width = 640;
+            canvas.height = 480;
+            const context2d = canvas.getContext('2d');
+
+            // Repaint continuously: a frame-starved captureStream() never fires `canplay`, which
+            // leaves the <video>.play() promise pending forever inside ZXing.
+            let frameNo = 0;
+            const paintNextFrame = () => {
+                frameNo++;
+                context2d.fillStyle = frameNo % 2 === 0 ? '#202020' : '#303030';
+                context2d.fillRect(0, 0, canvas.width, canvas.height);
+            };
+            paintNextFrame();
+            const painterId = setInterval(paintNextFrame, 100);
+
+            const stream = canvas.captureStream(10);
+            // CameraModePanel stops the tracks when it unmounts — stop repainting with them.
+            stream.getTracks().forEach((track) => {
+                const stopTrack = track.stop.bind(track);
+                track.stop = () => {
+                    clearInterval(painterId);
+                    stopTrack();
+                };
+            });
+            return stream;
+        };
+
+        const fakeCamera = {
+            deviceId: 'fake-camera',
+            groupId: 'fake-camera-group',
+            kind: 'videoinput',
+            label: 'Fake camera',
+        };
+        const fakeMediaDevices = {
+            getUserMedia: async () => newCameraStream(),
+            enumerateDevices: async () => [{ ...fakeCamera, toJSON: () => fakeCamera }],
+            getSupportedConstraints: () => ({ deviceId: true, facingMode: true, width: true, height: true }),
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            dispatchEvent: () => false,
+        };
+        Object.defineProperty(navigator, 'mediaDevices', { value: fakeMediaDevices, configurable: true });
+    });


### PR DESCRIPTION
Ports the test-only mobile-e2e camera-mode de-flake to `soft_panda_hotfix`.

Cherry-pick of squash commit https://github.com/metasfresh/metasfresh/commit/d2089d3fa281ddfb963ea20ef745e460dc3e54d1 from `deep_tundra_release` (https://github.com/metasfresh/metasfresh/pull/25336) — self-contained, applies cleanly (`playwright.config.js` on this branch was identical to the fix's parent).

`navigator.mediaDevices` is `[SecureContext]`-gated: present on `http://localhost` but undefined on every other plain-HTTP origin. CI serves the mobile UI from `http://mobile:80/mobile`, so Chromium's `--use-fake-device-for-media-stream` was unreachable and the hw/camera toggle mounted `.camera-mode-panel` only to have `decodeFromVideoDevice()` reject, `onCancel` revert to hardware mode, and the panel unmount ~30ms later. `expectCameraModeActive` was thus racing a ~30ms flicker.

Fix installs a minimal canvas-backed `navigator.mediaDevices` double when, and only when, the browser exposes none (localhost runs keep Chromium's own fake device). No production code, no skipped/relaxed assertion, no longer timeout — the assertion now observes a settled camera mode.

Test-only: touches only `e2e/mobile-webui/`.
