### PR TITLE
Transport order: make B/L Date and ETA editable while completed

### DIFF
--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5817120_sys_AdvancePaymentNoLC_TransportOrderDatesAlwaysUpdateable.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5817120_sys_AdvancePaymentNoLC_TransportOrderDatesAlwaysUpdateable.sql
@@ -1,0 +1,34 @@
+-- Make the transport order's B/L Date and ETA editable while the document is completed.
+--
+-- A completed M_ShipperTransportation is Processed='Y', and the WebUI renders every field of a
+-- processed document read-only unless its AD_Column.IsAlwaysUpdateable='Y'. Both dates were left
+-- at 'N', so they could not be entered or corrected once the transport order was completed -- even
+-- though the bill of lading is issued by the carrier only AFTER loading, i.e. normally after the
+-- transport order is done. The user's only recourse was to reactivate and re-complete the
+-- document, which resets M_ShippingPackage.Processed and M_Package.ShipDate on every linked
+-- package.
+--
+-- This also made the completed/closed branch of the transport order's BL/ETA change handler
+-- unreachable from the WebUI: it recomputes the linked purchase orders' pay-schedule due dates
+-- when either date is edited on an already-completed transport order, which the UI never allowed.
+--
+-- Every other logistics field on this window is already always-updateable -- among them
+-- M_ShipperTransportation.ATA, M_ShipperTransportation.ETD and M_ShipperTransportation.IsBLReceived
+-- ("B/L erhalten"), the companion flag of the B/L date -- so these two were the outliers.
+--
+-- Window 540020 "Transport Auftrag", tab 540096 "Speditionslieferung". Both fields already carry
+-- AD_Field.IsReadOnly='N' with no read-only logic, so the column flag is the only thing gating them.
+
+-- Column: M_ShipperTransportation.ETA
+UPDATE AD_Column
+SET IsAlwaysUpdateable='Y',
+    Updated=TO_TIMESTAMP('2026-07-30 16:20:00','YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy=100
+WHERE AD_Column_ID=591246;
+
+-- Column: M_ShipperTransportation.BLDate
+UPDATE AD_Column
+SET IsAlwaysUpdateable='Y',
+    Updated=TO_TIMESTAMP('2026-07-30 16:20:01','YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy=100
+WHERE AD_Column_ID=591254;

--- a/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5817120_sys_AdvancePaymentNoLC_TransportOrderDatesAlwaysUpdateable.sql
+++ b/backend/de.metas.business/src/main/sql/postgresql/system/20-de.metas.business/5817120_sys_AdvancePaymentNoLC_TransportOrderDatesAlwaysUpdateable.sql
@@ -1,4 +1,10 @@
--- Make the transport order's B/L Date and ETA editable while the document is completed.
+-- Make the transport order's B/L Date and ETA editable once the document is processed.
+--
+-- Note this covers every Processed-derived state, not only Completed: the read-only gate keys on
+-- Processed, which Closed keeps set and Void also sets. Editing either date on a VOIDED transport
+-- order therefore saves but propagates nothing, because the BL/ETA change handler only forwards to
+-- the linked orders when the document is completed or closed. That is the same characteristic the
+-- already-always-updateable sibling fields have had since they were introduced.
 --
 -- A completed M_ShipperTransportation is Processed='Y', and the WebUI renders every field of a
 -- processed document read-only unless its AD_Column.IsAlwaysUpdateable='Y'. Both dates were left

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_ShipperTransportation_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_ShipperTransportation_StepDef.java
@@ -305,6 +305,21 @@ public class M_ShipperTransportation_StepDef
 				.ifPresent(packageIdentifier -> packageTable.putOrReplace(packageIdentifier, packageRecord));
 	}
 
+	/**
+	 * Updates the transport order THROUGH THE MODEL LAYER on purpose: {@code saveRecord} fires the real
+	 * {@code @ModelChange} interceptor {@code de.metas.shipping.model.validator.M_ShipperTransportation#syncOrderDatesOnEdit},
+	 * which is what propagates ETA / BLDate onto the linked purchase orders and re-drives their pay schedules.
+	 * Never replace this with a direct SQL/DB write: the propagation would no longer be exercised and the
+	 * scenarios relying on it (S30954_1..S30954_3 in purchaseOrderComplexPaymentTerm.feature) would keep
+	 * passing with the chain broken.
+	 * <p>
+	 * Note this writes straight to the record and therefore bypasses the WebUI Document layer, where a
+	 * completed ({@code Processed='Y'}) transport order is read-only unless the column is always-updateable.
+	 * That gate is covered by the Playwright spec
+	 * {@code e2e/frontend-webui/tests/spec/transport-order-dates-editable-when-completed.spec.js}.
+	 *
+	 * @see de.metas.shipping.model.validator.M_ShipperTransportation
+	 */
 	@And("update transport order")
 	public void update_TransportOrder(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_ShipperTransportation_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_ShipperTransportation_StepDef.java
@@ -310,8 +310,8 @@ public class M_ShipperTransportation_StepDef
 	 * {@code @ModelChange} interceptor {@code de.metas.shipping.model.validator.M_ShipperTransportation#syncOrderDatesOnEdit},
 	 * which is what propagates ETA / BLDate onto the linked purchase orders and re-drives their pay schedules.
 	 * Never replace this with a direct SQL/DB write: the propagation would no longer be exercised and the
-	 * scenarios relying on it (S30954_1..S30954_3 in purchaseOrderComplexPaymentTerm.feature) would keep
-	 * passing with the chain broken.
+	 * scenarios relying on it (S30954_1..S30954_3 and S30954_5 in purchaseOrderComplexPaymentTerm.feature)
+	 * would keep passing with the chain broken.
 	 * <p>
 	 * Note this writes straight to the record and therefore bypasses the WebUI Document layer, where a
 	 * completed ({@code Processed='Y'}) transport order is read-only unless the column is always-updateable.

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_ShipperTransportation_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_ShipperTransportation_StepDef.java
@@ -64,6 +64,22 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+/**
+ * Step definitions for M_ShipperTransportation, the transport order ("Speditionslieferung"). Allows scenarios to:
+ * <ul>
+ *   <li>Create a transport order and add orders / shipments / packages to it;</li>
+ *   <li>Load the transport order belonging to a shipment, and assert its column values;</li>
+ *   <li>Update its dates (notably {@code BLDate} and {@code ETA}) and complete it, which drives
+ *       {@code M_ShipperTransportation.syncOrderDatesOnEdit} and therefore the pay-schedule due
+ *       dates of the linked orders (scenarios {@code @Id:S30954_1..5}).</li>
+ * </ul>
+ * <p>
+ * Note: these steps write through the model layer ({@code InterfaceWrapperHelper}), never through the
+ * WebUI {@code Document} layer. Field editability — {@code AD_Column.IsAlwaysUpdateable} evaluated by
+ * {@code DocumentReadonly} on a {@code Processed} record — is therefore out of reach here by
+ * construction, and is covered instead by the Playwright spec
+ * {@code transport-order-dates-editable-when-completed.spec.js}.
+ */
 @AllArgsConstructor
 public class M_ShipperTransportation_StepDef
 {

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderComplexPaymentTerm.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderComplexPaymentTerm.feature
@@ -247,6 +247,26 @@ Feature: Purchase order with complex payment term
       | PTB32                  | 2025-04-01 | 76.72  | WP     |
 
 
+  # ---------------------------------------------------------------------------------------------
+  # S30954_1..S30954_3 own the BL-date -> pay-schedule propagation. They are the ONLY home for it.
+  #
+  # Why they are meaningful: the "update transport order" step writes through the model layer
+  # (M_ShipperTransportation_StepDef#updateTransportOrder -> record.setBLDate(...) -> saveRecord),
+  # so saving the record fires the real @ModelChange interceptor
+  # de.metas.shipping.model.validator.M_ShipperTransportation#syncOrderDatesOnEdit, which propagates
+  # onto the C_Order and in turn fires C_Order#updateOrderPaySchedules. That is exactly the
+  # production chain — nothing here is stubbed, and no scenario may be rewritten to poke
+  # C_OrderPaySchedule (or any table on the chain) directly: doing so would bypass the very
+  # interceptors these scenarios exist to prove, and they would keep passing after the chain broke.
+  #
+  # What these scenarios deliberately do NOT cover: whether the WebUI even lets a user type the B/L
+  # date once the transport order is completed. The step above goes straight to saveRecord and never
+  # touches the WebUI Document layer, where DocumentReadonly#computeFieldReadonly blanks every field
+  # of a Processed='Y' document unless its AD_Column.IsAlwaysUpdateable='Y'. That read-only gate is
+  # covered — once, in a real browser — by the Playwright spec
+  # e2e/frontend-webui/tests/spec/transport-order-dates-editable-when-completed.spec.js.
+  # Keep the split: model/business chain here, WebUI editability there, no overlap.
+  # ---------------------------------------------------------------------------------------------
   @from:cucumber
 @allure.label.epic:E0140_Purchasing
 @allure.label.feature:F00600_Purchase_Order

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderComplexPaymentTerm.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/purchaseOrder/purchaseOrderComplexPaymentTerm.feature
@@ -248,10 +248,11 @@ Feature: Purchase order with complex payment term
 
 
   # ---------------------------------------------------------------------------------------------
-  # S30954_1..S30954_3 own the BL-date -> pay-schedule propagation. They are the ONLY home for it.
+  # S30954_1..S30954_3 own the BL-date -> pay-schedule propagation, S30954_5 the ETA-date one.
+  # They are the ONLY home for it.
   #
   # Why they are meaningful: the "update transport order" step writes through the model layer
-  # (M_ShipperTransportation_StepDef#updateTransportOrder -> record.setBLDate(...) -> saveRecord),
+  # (M_ShipperTransportation_StepDef#updateTransportOrder -> record.setBLDate(...)/setETA(...) -> saveRecord),
   # so saving the record fires the real @ModelChange interceptor
   # de.metas.shipping.model.validator.M_ShipperTransportation#syncOrderDatesOnEdit, which propagates
   # onto the C_Order and in turn fires C_Order#updateOrderPaySchedules. That is exactly the
@@ -260,7 +261,7 @@ Feature: Purchase order with complex payment term
   # interceptors these scenarios exist to prove, and they would keep passing after the chain broke.
   #
   # What these scenarios deliberately do NOT cover: whether the WebUI even lets a user type the B/L
-  # date once the transport order is completed. The step above goes straight to saveRecord and never
+  # or ETA date once the transport order is completed. The step above goes straight to saveRecord and never
   # touches the WebUI Document layer, where DocumentReadonly#computeFieldReadonly blanks every field
   # of a Processed='Y' document unless its AD_Column.IsAlwaysUpdateable='Y'. That read-only gate is
   # covered — once, in a real browser — by the Playwright spec
@@ -430,6 +431,63 @@ Feature: Purchase order with complex payment term
       | C_PaymentTerm_Break_ID | DueDate    | DueAmt | Status |
       | PTB61                  | 2025-10-10 | 10.23  | WP     |
       | PTB62                  | 2025-10-23 | 92.07  | WP     |
+
+
+  @from:cucumber
+@allure.label.epic:E0140_Purchasing
+@allure.label.feature:F00600_Purchase_Order
+@allure.label.feature:F00994_Multiple_Levels_of_Payment
+@F00600
+@Id:S30954_5
+  Scenario: ETA corrected after transport order completion recomputes the shipping line
+    When metasfresh contains C_PaymentTerm
+      | Identifier |
+      | pt_PO_8    |
+    And metasfresh contains C_PaymentTerm_Break
+      | Identifier | C_PaymentTerm_ID | Percent | OffsetDays | ReferenceDateType | SeqNo |
+      | PTB81      | pt_PO_8          | 10      | 1          | OD                | 10    |
+      | PTB82      | pt_PO_8          | 90      | 5          | ET                | 20    |
+    And validate C_PaymentTerm:
+      | Identifier | IsComplex | IsValid |
+      | pt_PO_8    | Y         | Y       |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po8        | N       | vendor        | 2025-10-09  | POO         | wh             | pt_PO_8          |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | po8_l1     | po8        | product      | 10         |
+    And the order identified by po8 is completed
+    Then the order identified by po8 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueDate    | DueAmt | Status |
+      | PTB81                  | 2025-10-10 | 10.23  | WP     |
+      | PTB82                  | 9999-12-01 | 92.07  | PR     |
+
+    And metasfresh contains Transport Order
+      | Identifier      | M_Shipper_ID | Shipper_BPartner_ID | Shipper_Location_ID |
+      | shipperTransp_5 | shipper_DHL  | shipper             | shipperLocation     |
+    And metasfresh contains M_Package
+      | Identifier | M_Shipper_ID |
+      | Pckg5      | shipper_DHL  |
+    And metasfresh contains M_ShippingPackage
+      | Identifier | C_Order_ID | M_ShipperTransportation_ID | M_Package_ID | C_BPartner_Location_ID |
+      | shPckg5    | po8        | shipperTransp_5            | Pckg5        | shipperLocation        |
+    And update transport order
+      | M_ShipperTransportation_ID | ETA        |
+      | shipperTransp_5            | 2025-10-15 |
+    And the transport order identified by shipperTransp_5 is completed
+    Then the order identified by po8 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueDate    | DueAmt | Status |
+      | PTB81                  | 2025-10-10 | 10.23  | WP     |
+      | PTB82                  | 2025-10-20 | 92.07  | WP     |
+
+    And update transport order
+      | M_ShipperTransportation_ID | ETA        |
+      | shipperTransp_5            | 2025-10-22 |
+    Then the order identified by po8 has following pay schedules
+      | C_PaymentTerm_Break_ID | DueDate    | DueAmt | Status |
+      | PTB81                  | 2025-10-10 | 10.23  | WP     |
+      | PTB82                  | 2025-10-27 | 92.07  | WP     |
 
 
   @from:cucumber

--- a/e2e/frontend-webui/tests/spec/transport-order-dates-editable-when-completed.spec.js
+++ b/e2e/frontend-webui/tests/spec/transport-order-dates-editable-when-completed.spec.js
@@ -39,7 +39,9 @@ test.describe('Transport order — B/L Date and ETA editable while completed', (
     // land under one heading in the Allure report.
     allure.epic('E0140: Purchasing');
     allure.tag('F00600: Purchase Order');
+    allure.tag('F00600');
     allure.tag('F00994: Multiple Levels of Payment');
+    allure.tag('F00994');
     allure.story('B/L Date and ETA remain editable after the transport order is completed');
     allure.severity('critical');
     allure.description(`

--- a/e2e/frontend-webui/tests/spec/transport-order-dates-editable-when-completed.spec.js
+++ b/e2e/frontend-webui/tests/spec/transport-order-dates-editable-when-completed.spec.js
@@ -1,0 +1,372 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { FRONTEND_BASE_URL, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../utils/common';
+import { WEBAPI_BASE_URL } from '../utils/WebAPIValidation';
+import { PURCHASE_ORDER_WINDOW_ID, SHIPPER_WINDOW_ID, TRANSPORT_ORDER_WINDOW_ID } from '../utils/WindowIds';
+
+/** AD_Tab_ID of the "PO Line" tab in the purchase order window. */
+const PURCHASE_ORDER_LINE_TAB_ID = 'AD_Tab-293';
+
+/**
+ * AD_Process_ID 584645 = C_Order_AddTo_M_ShipperTransportation ("Add Purchase Orders to Transportation
+ * Order"), the grid action a procurement worker runs on a completed purchase order to book it onto a
+ * transport order. It is a view action, so it must be invoked with a view + selected row ids.
+ */
+const ADD_PO_TO_TRANSPORT_ORDER_PROCESS_ID = 'ADP_584645';
+
+/**
+ * Transport order (M_ShipperTransportation, window 540020 "Transport Auftrag", tab 540096
+ * "Speditionslieferung"): B/L Date and ETA must stay editable after the document is completed.
+ *
+ * A completed transport order carries Processed='Y', and DocumentReadonly#computeFieldReadonly
+ * renders EVERY field of a processed document read-only unless its AD_Column.IsAlwaysUpdateable='Y'.
+ * The bill of lading is issued by the carrier only after loading, i.e. normally AFTER the transport
+ * order is done, so both dates must remain enterable at that point.
+ *
+ * Scope — this is deliberately the ONLY thing this spec asserts. What the two dates then trigger
+ * (M_ShipperTransportation -> C_Order -> C_OrderPaySchedule due-date recomputation) is owned by the
+ * cucumber scenarios S30954_1..S30954_3 in purchaseOrderComplexPaymentTerm.feature, which drive the
+ * real @ModelChange interceptors on a full stack. Re-asserting that here would duplicate a behaviour
+ * that already has a home. What cucumber cannot reach is this read-only gate: its step writes through
+ * record.setBLDate(...) + saveRecord, bypassing the WebUI Document layer entirely — only a real
+ * browser session exercises it.
+ */
+test.describe('Transport order — B/L Date and ETA editable while completed', () => {
+  test('B/L Date and ETA stay editable on a completed transport order', async ({ page }) => {
+    // Same epic/feature labels the S30954 cucumber scenarios carry, so both halves of the coverage
+    // land under one heading in the Allure report.
+    allure.epic('E0140: Purchasing');
+    allure.tag('F00600: Purchase Order');
+    allure.tag('F00994: Multiple Levels of Payment');
+    allure.story('B/L Date and ETA remain editable after the transport order is completed');
+    allure.severity('critical');
+    allure.description(`
+## Transport order — B/L Date / ETA on a completed document
+
+### Test scenario
+
+1. Creates its own carrier, shipper, vendor, product and purchase order, books the purchase order
+   onto a new transport order and completes it (setup via REST — seed-independent). A transport
+   order cannot be completed without a shipping package, hence the purchase order.
+2. Opens the completed transport order in window ${TRANSPORT_ORDER_WINDOW_ID} in the browser.
+3. Asserts **B/L Date** and **ETA** are rendered editable and that a date typed into them is accepted
+   and survives a page reload.
+4. Asserts, as a control on the very same form, that **Document Date** (DateDoc — not always-updateable)
+   IS read-only. Without that control an "everything is editable" regression would pass unnoticed.
+
+### Assertion mechanism
+
+The frontend renders Date widgets via DatePicker; a read-only field surfaces as the HTML \`disabled\`
+attribute on the underlying \`<input>\`. So "editable" = input not disabled + the typed value round-trips.
+    `);
+
+    test.setTimeout(180000);
+
+    const REST = WEBAPI_BASE_URL;
+
+    // ---------------------------------------------------------------- helpers
+
+    const postJson = async (url, data) => {
+      const response = await page.request.post(url, { data });
+      if (!response.ok()) {
+        throw new Error(`POST ${url} failed: HTTP ${response.status()} ${await response.text()}`);
+      }
+      // /login/loginComplete answers with an empty body, so do not assume JSON
+      const text = await response.text();
+      return text ? JSON.parse(text) : {};
+    };
+
+    // The window endpoints answer either with a bare document array (GET) or with a
+    // { documents: [...] } envelope (PATCH); normalise both to the single root document.
+    const firstDocument = (body) => (Array.isArray(body) ? body : body.documents || [body])[0];
+
+    /** WebUI JSON-patch on a root document. `documentId` may be 'NEW' to allocate a fresh record. */
+    const patchDocument = async (windowId, documentId, changes) => {
+      const response = await page.request.patch(`${REST}/window/${windowId}/${documentId}`, { data: changes });
+      if (!response.ok()) {
+        throw new Error(
+          `PATCH window/${windowId}/${documentId} failed: HTTP ${response.status()} ${await response.text()}`
+        );
+      }
+      return firstDocument(await response.json());
+    };
+
+    const getDocument = async (windowId, documentId) => {
+      return firstDocument(await (await page.request.get(`${REST}/window/${windowId}/${documentId}`)).json());
+    };
+
+    /**
+     * The Date widget parses the SESSION LANGUAGE's format and is strict about zero padding
+     * ("08/10/2026" is accepted in en_US, "8/10/2026" is silently discarded). The session language is
+     * a property of the logged-in user, not of the role we pick, so it is read back from /userSession
+     * rather than assumed — and an unmapped language fails loudly here instead of silently feeding the
+     * widget an unparsable string and failing later as a confusing "field did not persist".
+     */
+    const pad = (n) => String(n).padStart(2, '0');
+    const DATE_FORMATTERS = {
+      en_US: ({ year, month, day }) => `${pad(month)}/${pad(day)}/${year}`,
+      de_DE: ({ year, month, day }) => `${pad(day)}.${pad(month)}.${year}`,
+      de_CH: ({ year, month, day }) => `${pad(day)}.${pad(month)}.${year}`,
+    };
+    let sessionLanguage;
+    const formatForSession = (date) => {
+      const formatter = DATE_FORMATTERS[sessionLanguage];
+      if (!formatter) {
+        throw new Error(
+          `No date format known for session language "${sessionLanguage}" — add it to DATE_FORMATTERS`
+        );
+      }
+      return formatter(date);
+    };
+
+    /**
+     * Locale-independent date assertion: the WebUI renders dates in the session's language
+     * (MM/DD/YYYY, DD.MM.YYYY, ...), so compare the numbers the input shows, not the string.
+     */
+    const expectInputToShowDate = (inputValue, { year, month, day }) => {
+      const numbers = (inputValue.match(/\d+/g) || []).map(Number);
+      expect(numbers, `date input value "${inputValue}"`).toEqual(expect.arrayContaining([year, month, day]));
+    };
+
+    // ------------------------------------------------------------------ setup
+
+    // REST login avoids the AlreadyLoggedInException race on the UI login form; the session cookie
+    // then keeps the SPA logged in for the browser part below.
+    await test.step('Authenticate via REST (WebUI role)', async () => {
+      const sessionBody = await (await page.request.get(`${REST}/userSession`)).json().catch(() => ({}));
+      if (sessionBody.loggedIn) {
+        console.log(`[SETUP] Session already active as ${sessionBody.username}`);
+        return;
+      }
+      const authBody = await postJson(`${REST}/login/authenticate`, {
+        username: 'metasfresh',
+        password: 'metasfresh',
+      });
+      if (authBody.loginComplete === false && authBody.roles && authBody.roles.length > 0) {
+        await postJson(`${REST}/login/loginComplete`, authBody.roles[0]);
+        console.log(`[SETUP] loginComplete sent for role: ${authBody.roles[0].caption}`);
+      }
+    });
+
+    await test.step('Read the session language (drives the date input format)', async () => {
+      const session = await (await page.request.get(`${REST}/userSession`)).json();
+      expect(session.loggedIn, 'REST session is established').toBe(true);
+      sessionLanguage = session.language && session.language.key;
+      expect(sessionLanguage, 'session language').toBeTruthy();
+      console.log(`[SETUP] Session language is ${sessionLanguage}`);
+    });
+
+    let carrierBPartnerId;
+    let carrierLocationId;
+    let vendorBPartnerId;
+    let productId;
+    await test.step('Create the carrier, the goods vendor and a product', async () => {
+      const masterdata = await Backend.createMasterdata({
+        request: {
+          bpartners: {
+            CARRIER: { name: 'Transport order E2E carrier', isVendor: true, isCustomer: false, isSoPriceList: false },
+            VENDOR: { name: 'Transport order E2E vendor', isVendor: true, isCustomer: false, isSoPriceList: false },
+          },
+          products: {
+            PROD1: { name: 'Transport order E2E product', type: 'Item', prices: [{ price: 9.98, currencyCode: 'EUR' }] },
+          },
+        },
+      });
+
+      carrierBPartnerId = masterdata.bpartners.CARRIER.id;
+      carrierLocationId = masterdata.bpartners.CARRIER.bpartnerLocationId;
+      vendorBPartnerId = masterdata.bpartners.VENDOR.id;
+      productId = masterdata.products.PROD1.id;
+      expect(carrierBPartnerId).toBeTruthy();
+      expect(carrierLocationId).toBeTruthy();
+      expect(vendorBPartnerId).toBeTruthy();
+      expect(productId).toBeTruthy();
+    });
+
+    // The transport order's M_Shipper_ID lookup is restricted to shippers of the chosen shipper
+    // partner (AD_Val_Rule "M_Shipper.C_BPartner_ID = @Shipper_BPartner_ID@"), so the spec brings
+    // its own shipper instead of depending on whatever the seed happens to contain.
+    let shipperId;
+    await test.step('Create a shipper for that carrier', async () => {
+      shipperId = (await patchDocument(SHIPPER_WINDOW_ID, 'NEW', [])).id;
+      const shipper = await patchDocument(SHIPPER_WINDOW_ID, shipperId, [
+        { op: 'replace', path: 'Name', value: `Transport order E2E shipper ${Date.now()}` },
+        { op: 'replace', path: 'C_BPartner_ID', value: Number(carrierBPartnerId) },
+      ]);
+      expect(shipper.validStatus && shipper.validStatus.valid, 'shipper is valid').toBe(true);
+    });
+
+    // A transport order cannot be completed empty (MMShipperTransportation#prepareIt -> "No Document
+    // Lines found"), so it gets its shipping package the way a procurement worker does: by booking a
+    // completed purchase order onto it.
+    let purchaseOrderId;
+    await test.step('Create and complete a purchase order', async () => {
+      purchaseOrderId = (await patchDocument(PURCHASE_ORDER_WINDOW_ID, 'NEW', [])).id;
+      await patchDocument(PURCHASE_ORDER_WINDOW_ID, purchaseOrderId, [
+        { op: 'replace', path: 'C_BPartner_ID', value: Number(vendorBPartnerId) },
+      ]);
+
+      const lineResponse = await page.request.patch(
+        `${REST}/window/${PURCHASE_ORDER_WINDOW_ID}/${purchaseOrderId}/${PURCHASE_ORDER_LINE_TAB_ID}/NEW`,
+        { data: [] }
+      );
+      const lineRow = firstDocument(await lineResponse.json());
+      const line = firstDocument(
+        await (
+          await page.request.patch(
+            `${REST}/window/${PURCHASE_ORDER_WINDOW_ID}/${purchaseOrderId}/${PURCHASE_ORDER_LINE_TAB_ID}/${lineRow.rowId}`,
+            {
+              data: [
+                { op: 'replace', path: 'M_Product_ID', value: Number(productId) },
+                { op: 'replace', path: 'QtyEntered', value: 10 },
+              ],
+            }
+          )
+        ).json()
+      );
+      expect(line.validStatus && line.validStatus.valid, 'purchase order line is valid').toBe(true);
+
+      await patchDocument(PURCHASE_ORDER_WINDOW_ID, purchaseOrderId, [
+        { op: 'replace', path: 'DocAction', value: 'CO' },
+      ]);
+      const completedPO = await getDocument(PURCHASE_ORDER_WINDOW_ID, purchaseOrderId);
+      expect(completedPO.fieldsByName.DocStatus.value.key, 'purchase order DocStatus').toBe('CO');
+    });
+
+    let transportOrderId;
+    await test.step('Create a transport order and book the purchase order onto it', async () => {
+      transportOrderId = (await patchDocument(TRANSPORT_ORDER_WINDOW_ID, 'NEW', [])).id;
+
+      const drafted = await patchDocument(TRANSPORT_ORDER_WINDOW_ID, transportOrderId, [
+        { op: 'replace', path: 'Shipper_BPartner_ID', value: Number(carrierBPartnerId) },
+        { op: 'replace', path: 'Shipper_Location_ID', value: Number(carrierLocationId) },
+        { op: 'replace', path: 'M_Shipper_ID', value: Number(shipperId) },
+      ]);
+      expect(drafted.validStatus && drafted.validStatus.valid, 'drafted transport order is valid').toBe(true);
+
+      // The process is a view action, so it needs a view of the purchase order window plus the
+      // selected row id — invoking it from the single document leaves its query filter empty.
+      const view = await postJson(`${REST}/documentView/${PURCHASE_ORDER_WINDOW_ID}`, {
+        windowId: String(PURCHASE_ORDER_WINDOW_ID),
+        viewType: 'grid',
+        filters: [],
+      });
+      const pinstance = await postJson(`${REST}/process/${ADD_PO_TO_TRANSPORT_ORDER_PROCESS_ID}`, {
+        processId: ADD_PO_TO_TRANSPORT_ORDER_PROCESS_ID,
+        viewId: view.viewId,
+        viewDocumentIds: [purchaseOrderId],
+      });
+      await page.request.patch(`${REST}/process/${ADD_PO_TO_TRANSPORT_ORDER_PROCESS_ID}/${pinstance.pinstanceId}`, {
+        data: [{ op: 'replace', path: 'M_ShipperTransportation_ID', value: Number(transportOrderId) }],
+      });
+      const processResult = await (
+        await page.request.get(`${REST}/process/${ADD_PO_TO_TRANSPORT_ORDER_PROCESS_ID}/${pinstance.pinstanceId}/start`)
+      ).json();
+      expect(processResult.error, `booking the PO onto the transport order: ${processResult.summary}`).toBeFalsy();
+    });
+
+    await test.step('Complete the transport order', async () => {
+      await patchDocument(TRANSPORT_ORDER_WINDOW_ID, transportOrderId, [
+        { op: 'replace', path: 'DocAction', value: 'CO' },
+      ]);
+
+      // The whole point of the test is the PROCESSED state, so make sure the setup really reached it
+      // rather than silently leaving a draft that would make every assertion below meaningless.
+      const completed = await getDocument(TRANSPORT_ORDER_WINDOW_ID, transportOrderId);
+      const docStatus = completed.fieldsByName.DocStatus.value;
+      expect(docStatus && docStatus.key, 'transport order DocStatus after Complete').toBe('CO');
+      console.log(`[SETUP] Transport order ${transportOrderId} is completed`);
+    });
+
+    // --------------------------------------------------------------- the test
+
+    await test.step('Open the completed transport order in the browser', async () => {
+      await page.goto(`${FRONTEND_BASE_URL}/window/${TRANSPORT_ORDER_WINDOW_ID}/${transportOrderId}`, {
+        timeout: 120000,
+      });
+
+      // If the REST session cookie did not carry over, the SPA bounces back to /login and the record
+      // never renders — surface that here instead of as a downstream selector timeout.
+      await page.waitForURL((url) => !url.toString().includes('/login'), { timeout: SLOW_ACTION_TIMEOUT });
+
+      await page
+        .locator('.header-wrapper, .window-wrapper')
+        .waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
+      await page
+        .locator('.rotating, .panel-spaced-lg')
+        .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+        .catch(() => {});
+      await page.locator('.form-field-BLDate').waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+    });
+
+    const blDateInput = page.locator('.form-field-BLDate input').first();
+    const etaInput = page.locator('.form-field-ETA input').first();
+    const dateDocInput = page.locator('.form-field-DateDoc input').first();
+
+    await test.step('Control: Document Date IS read-only on the processed document', async () => {
+      await dateDocInput.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await expect(dateDocInput, 'DateDoc is not always-updateable, so it must be disabled').toBeDisabled({
+        timeout: SLOW_ACTION_TIMEOUT,
+      });
+    });
+
+    await test.step('B/L Date is editable', async () => {
+      await blDateInput.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await expect(blDateInput, 'BLDate must be editable on a completed transport order').toBeEnabled({
+        timeout: SLOW_ACTION_TIMEOUT,
+      });
+    });
+
+    await test.step('ETA is editable', async () => {
+      await etaInput.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await expect(etaInput, 'ETA must be editable on a completed transport order').toBeEnabled({
+        timeout: SLOW_ACTION_TIMEOUT,
+      });
+    });
+
+    // "Enabled" alone would still pass if the backend rejected the write, so type real values and
+    // prove they survive a reload: that is the full Document-layer write path the migration unblocks.
+    const blDate = { year: 2026, month: 8, day: 20 };
+    const eta = { year: 2026, month: 8, day: 14 };
+
+    await test.step('Enter a B/L Date and an ETA through the form', async () => {
+      for (const [input, date] of [
+        [blDateInput, blDate],
+        [etaInput, eta],
+      ]) {
+        await input.click();
+        await page.keyboard.press('Control+a');
+        // Type it key by key (rather than input.fill) so the widget sees the same events a user
+        // produces; formatForSession renders it in the session language's format.
+        await page.keyboard.type(formatForSession(date), { delay: 40 });
+        await page.keyboard.press('Enter');
+        await page.waitForTimeout(1500);
+        await page
+          .locator('.indicator-pending, .rotating')
+          .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+          .catch(() => {});
+      }
+
+      const screenshot = await page.screenshot({ fullPage: true });
+      allure.attachment('Completed transport order with B/L Date and ETA entered', screenshot, 'image/png');
+    });
+
+    await test.step('The entered dates are persisted (survive a reload)', async () => {
+      await page.reload({ timeout: 120000 });
+      await page.locator('.form-field-BLDate').waitFor({ state: 'visible', timeout: VERY_SLOW_ACTION_TIMEOUT });
+      await page
+        .locator('.rotating, .panel-spaced-lg')
+        .waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT })
+        .catch(() => {});
+
+      expectInputToShowDate(await blDateInput.inputValue(), blDate);
+      expectInputToShowDate(await etaInput.inputValue(), eta);
+
+      // Still editable after the reload — i.e. the fields did not lock themselves once filled.
+      await expect(blDateInput).toBeEnabled();
+      await expect(etaInput).toBeEnabled();
+    });
+  });
+});

--- a/e2e/frontend-webui/tests/utils/WindowIds.js
+++ b/e2e/frontend-webui/tests/utils/WindowIds.js
@@ -6,7 +6,7 @@
  * 2. For tables with both sales/purchase contexts, use po_window_id column
  * 3. Otherwise, find AD_Tab with seqno=0 for the table and get its ad_window_id
  *
- * Last updated: 2025-11-28 via metasfresh-application-dictionary skill
+ * Last updated: 2026-07-30 via metasfresh-application-dictionary skill
  */
 
 // ============================================================================
@@ -36,9 +36,26 @@ export const VENDOR_INVOICE_WINDOW_ID = 183;
  */
 export const INVOICE_CANDIDATE_WINDOW_ID = 540983;
 
+/**
+ * Transport Order window (Transport Auftrag)
+ * Table: M_ShipperTransportation
+ * Window ID: 540020
+ * Description: Transport orders (freight bookings); tab 540096 "Speditionslieferung" carries the
+ * logistics dates ETD/ETA/ATD/ATA/B-L date.
+ */
+export const TRANSPORT_ORDER_WINDOW_ID = 540020;
+
 // ============================================================================
 // MASTER DATA WINDOWS
 // ============================================================================
+
+/**
+ * Shipper window (Lieferweg)
+ * Table: M_Shipper
+ * Window ID: 142
+ * Description: Carriers/shipping methods; M_Shipper.C_BPartner_ID links the carrier partner.
+ */
+export const SHIPPER_WINDOW_ID = 142;
 
 /**
  * Business Partner window


### PR DESCRIPTION
## Problem

A completed `M_ShipperTransportation` is `Processed='Y'`, and the WebUI renders every field of a processed document read-only unless the column carries `AD_Column.IsAlwaysUpdateable='Y'` (`DocumentReadonly.computeFieldReadonly`). `M_ShipperTransportation.BLDate` and `M_ShipperTransportation.ETA` were both left at `'N'`, so neither date could be entered or corrected once the transport order was completed — although the bill of lading is issued by the carrier only **after** loading, i.e. normally after the transport order is done.

This also left the completed/closed branch of `M_ShipperTransportation.syncOrderDatesOnEdit` unreachable from the WebUI. That handler recomputes the linked purchase orders' pay-schedule due dates when `BLDate` or `ETA` is edited on an already-completed transport order — an edit the UI never permitted. The only workaround was to reactivate and re-complete the document, which resets `M_ShippingPackage.Processed` and nulls/re-derives `M_Package.ShipDate` on every linked package.

## Fix

Set `AD_Column.IsAlwaysUpdateable='Y'` on the two columns.

This is an alignment, not a new behaviour: every other logistics field on the same tab is already always-updateable — among them `M_ShipperTransportation.ATA`, `M_ShipperTransportation.ETD` and `M_ShipperTransportation.IsBLReceived` ("B/L erhalten"), the companion flag of the B/L date. `BLDate` and `ETA` were the only two outliers.

## Scope / blast radius

- `M_ShipperTransportation.BLDate` and `.ETA` are read in exactly one place — the transport-order validator → `OrderBL.syncDatesFromTransportOrder` → `C_Order.BLDate`/`C_Order.ETA` → the order's pay schedule. No posting, accounting or material-planning consumer.
- `M_ReceiptSchedule.BLDate` is a virtual `ColumnSQL` reading `max(st.BLDate)` live, so it follows automatically.
- `AD_Column.IsAlwaysUpdateable` makes the fields editable in every document state, not only Completed. That is harmless here: `syncOrderDatesOnEdit` is guarded on `docStatus.isCompletedOrClosed()`, so an edit in any other state does not propagate. A draft transport order's tentative dates still do **not** reach the pay schedule.

## Verification

Application dictionary probed on a customer-faithful DB (all core + customer migrations applied), window 540020 "Transport Auftrag", tab 540096 "Speditionslieferung":

| Column | `IsUpdateable` | `IsAlwaysUpdateable` before |
|---|---|---|
| `M_ShipperTransportation.ATA` | Y | Y |
| `M_ShipperTransportation.ETD` | Y | Y |
| `M_ShipperTransportation.IsBLReceived` | Y | Y |
| `M_ShipperTransportation.BLDate` | Y | **N** |
| `M_ShipperTransportation.ETA` | Y | **N** |

Both fields already carry `AD_Field.IsReadOnly='N'` with no read-only logic, so the column flag was the only thing gating them. `AD_Window.Overrides_Window_ID = 540020` returns no row — there is no override window, so the column-level change reaches the window that is actually opened.
