### PR TITLE
merge intensive_care_hotfix -> new_dawn_uat (rolling propagation train)

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
@@ -52,12 +52,14 @@ import de.metas.handlingunits.picking.job.service.external.bpartner.PickingJobBP
 import de.metas.handlingunits.picking.job.service.external.hu.PickingJobHUService;
 import de.metas.handlingunits.picking.job.service.external.product.PickingJobProductService;
 import de.metas.handlingunits.picking.job.service.external.shipmentschedule.PickingJobShipmentScheduleService;
+import de.metas.handlingunits.picking.job.service.external.shipmentschedule.ShipmentScheduleInfo;
 import de.metas.handlingunits.picking.job.service.external.warehouse.PickingJobWarehouseService;
 import de.metas.handlingunits.picking.job.service.shelflife.PickingShelfLifeCheck;
 import de.metas.handlingunits.picking.job.shipment.PickingShipmentService;
 import de.metas.handlingunits.picking.job_schedule.service.PickingJobScheduleService;
 import de.metas.handlingunits.picking.requests.ReleasePickingSlotRequest;
 import de.metas.handlingunits.picking.slot.PickingSlotListener;
+import de.metas.handlingunits.qrcodes.model.IHUQRCode;
 import de.metas.i18n.AdMessageKey;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.order.OrderId;
@@ -66,6 +68,7 @@ import de.metas.picking.api.PickingSlotId;
 import de.metas.picking.job_schedule.model.PickingJobScheduleCollection;
 import de.metas.picking.qrcode.PickingSlotQRCode;
 import de.metas.product.ProductId;
+import de.metas.scannable_code.ScannedCode;
 import de.metas.user.UserId;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -759,5 +762,45 @@ public class PickingJobService implements PickingSlotListener
 				.shipmentSchedules(shipmentScheduleService.newLoadingCache())
 				.request(request)
 				.build().execute();
+	}
+
+	/**
+	 * Resolves the HU which {@code scannedCode} identifies for the given picking job line, using exactly the same
+	 * resolution the pick itself performs (see {@code PickingJobHUService#resolvePickFromHUQRCode}).
+	 * <p>
+	 * Needed because a scanned code is not necessarily an {@code HUQRCode}: a custom weight label, an LMQ label or a
+	 * GS1 barcode identifies its HU only relative to the line's product / customer / warehouse. A caller that merely
+	 * wants to inspect the scanned HU (the mobile UI's over-delivery check) must therefore see the very HU the pick
+	 * would pick, instead of re-implementing a looser lookup.
+	 * <p>
+	 * One deliberate divergence from the pick: {@code PickOnTheFlyQRCode} is not special-cased here, because handling
+	 * it means creating inventory ({@code PickingJobPickCommand#createPickFromHUOnTheFly}), which an inspection-only
+	 * call must not do. Unreachable in practice - the codes that reach this method are whole-TU labels (custom weight,
+	 * LMQ, GS1), none of which can be a pick-on-the-fly code.
+	 */
+	public HUInfo resolvePickFromHU(
+			@NonNull final PickingJobId pickingJobId,
+			@NonNull final PickingJobLineId lineId,
+			@NonNull final ScannedCode scannedCode,
+			@NonNull final UserId callerId)
+	{
+		final PickingJob pickingJob = getById(pickingJobId);
+		pickingJob.assertCanBeEditedBy(callerId);
+
+		final PickingJobLine line = pickingJob.getLineById(lineId);
+		final IHUQRCode huQRCode = huService.parsePickFromScannedCode(scannedCode);
+
+		// Product / customer / warehouse are taken from the very same places PickingJobPickCommand takes them
+		// (see its computePickFromHUIdAndQRCode); resolving from a different source could yield a different HU
+		// than the pick will actually pick, which would make the qty we hand to the caller wrong.
+		final ShipmentScheduleId shipmentScheduleId = line.getScheduleId().getShipmentScheduleId();
+		final ShipmentScheduleInfo shipmentScheduleInfo = shipmentScheduleService.getById(shipmentScheduleId);
+
+		return huService.resolvePickFromHUQRCode(
+						huQRCode,
+						line.getProductId(),
+						shipmentScheduleInfo.getBpartnerId(),
+						shipmentScheduleInfo.getWarehouseId())
+				.orElseThrow();
 	}
 }

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/PickingRestController.java
@@ -22,10 +22,12 @@
 
 package de.metas.picking.rest_api;
 
+import com.google.common.collect.ImmutableSet;
 import de.metas.Profiles;
 import de.metas.common.handlingunits.JsonHU;
 import de.metas.common.handlingunits.JsonHUList;
 import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.picking.job.model.HUInfo;
 import de.metas.handlingunits.picking.job.model.LUPickingTarget;
 import de.metas.handlingunits.picking.job.model.PickingJobLineId;
 import de.metas.handlingunits.picking.job.model.PickingJobQtyAvailable;
@@ -239,12 +241,7 @@ public class PickingRestController
 		assertApplicationAccess();
 
 		final ScannedCode scannedCode = ScannedCode.ofString(request.getScannedCode());
-		final HUQRCode qrCode = toHUQRCode(scannedCode);
-
-		final List<JsonHU> hus = handlingUnitsService.getHUsByQrCode(
-				JsonGetByQRCodeRequest.builder().qrCode(qrCode.toGlobalQRCodeString()).build(),
-				Env.getADLanguageOrBaseLanguage()
-		);
+		final List<JsonHU> hus = getHUsByScannedCode(request, scannedCode);
 
 		if (hus.isEmpty())
 		{
@@ -277,13 +274,46 @@ public class PickingRestController
 						}
 						catch (final NumberFormatException e)
 						{
-							log.warn("Cannot parse HU product qty '{}' for product {}. Overdelivery prompt will not fire.", p.getQty(), productNo, e);
+							log.warn("Cannot parse HU product qty '{}' for product {}. Response omits productQty, so the mobile client rejects the whole-TU scan and nothing is picked.", p.getQty(), productNo, e);
 						}
 						builder.productUom(p.getUom());
 					});
 		}
 
 		return builder.build();
+	}
+
+	/**
+	 * A scanned code is not necessarily an {@code HUQRCode}: a custom weight label parses to a {@code CustomHUQRCode},
+	 * an LMQ label to an {@code LMQRCode}, a GS1 barcode to a {@code GS1HUQRCode} — none of which {@link #toHUQRCode}
+	 * accepts. Those identify their HU only relative to the picking job line, so when the caller supplies the line we
+	 * resolve through the picking job (same resolution as the pick); otherwise we keep the plain-QR-code behaviour.
+	 */
+	private List<JsonHU> getHUsByScannedCode(
+			@NonNull final JsonGetHUInfoByScannedCodeRequest request,
+			@NonNull final ScannedCode scannedCode)
+	{
+		if (request.getWfProcessId() != null && request.getLineId() != null)
+		{
+			final HUInfo huInfo = pickingMobileApplication.resolvePickFromHU(
+					request.getWfProcessId(),
+					request.getLineId(),
+					scannedCode,
+					getLoggedUserId());
+
+			return handlingUnitsService.getByIds(
+					ImmutableSet.of(huInfo.getId()),
+					Env.getADLanguageOrBaseLanguage(),
+					huInfo.getQrCode());
+		}
+		else
+		{
+			final HUQRCode qrCode = toHUQRCode(scannedCode);
+			return handlingUnitsService.getHUsByQrCode(
+					JsonGetByQRCodeRequest.builder().qrCode(qrCode.toGlobalQRCodeString()).build(),
+					Env.getADLanguageOrBaseLanguage()
+			);
+		}
 	}
 
 	private HUQRCode toHUQRCode(final @NotNull ScannedCode scannedCode)

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonGetHUInfoByScannedCodeRequest.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/rest_api/json/JsonGetHUInfoByScannedCodeRequest.java
@@ -1,5 +1,7 @@
 package de.metas.picking.rest_api.json;
 
+import de.metas.handlingunits.picking.job.model.PickingJobLineId;
+import de.metas.workflow.rest_api.model.WFProcessId;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
@@ -14,4 +16,12 @@ public class JsonGetHUInfoByScannedCodeRequest
 {
 	@NonNull String scannedCode;
 	@Nullable String productNo;
+
+	/**
+	 * Picking job + line the code was scanned for. When both are set, the scanned code is resolved to its HU the
+	 * same way the pick resolves it, so non-{@code HUQRCode} labels (custom weight label, LMQ, GS1) are supported.
+	 * When either is missing, only a plain HU QR code can be resolved (legacy behaviour).
+	 */
+	@Nullable WFProcessId wfProcessId;
+	@Nullable PickingJobLineId lineId;
 }

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PickingJobRestService.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/PickingJobRestService.java
@@ -52,6 +52,7 @@ import de.metas.handlingunits.picking.job.service.commands.PickingJobCreateReque
 import de.metas.handlingunits.picking.job.service.commands.get_next_eligible_line.GetNextEligibleLineToPackRequest;
 import de.metas.handlingunits.picking.job.service.commands.get_next_eligible_line.GetNextEligibleLineToPackResponse;
 import de.metas.picking.qrcode.PickingSlotQRCode;
+import de.metas.scannable_code.ScannedCode;
 import de.metas.user.UserId;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -281,5 +282,14 @@ public class PickingJobRestService
 	public GetNextEligibleLineToPackResponse getNextEligibleLineToPack(final @NonNull GetNextEligibleLineToPackRequest request)
 	{
 		return pickingJobService.getNextEligibleLineToPack(request);
+	}
+
+	public HUInfo resolvePickFromHU(
+			@NonNull final PickingJobId pickingJobId,
+			@NonNull final PickingJobLineId lineId,
+			@NonNull final ScannedCode scannedCode,
+			@NonNull final UserId callerId)
+	{
+		return pickingJobService.resolvePickFromHU(pickingJobId, lineId, scannedCode, callerId);
 	}
 }

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/PickingMobileApplication.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/PickingMobileApplication.java
@@ -34,6 +34,7 @@ import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfile
 import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfileService;
 import de.metas.handlingunits.picking.config.mobileui.PickingJobAggregationType;
 import de.metas.handlingunits.picking.config.mobileui.PickingJobOptions;
+import de.metas.handlingunits.picking.job.model.HUInfo;
 import de.metas.handlingunits.picking.job.model.LUPickingTarget;
 import de.metas.handlingunits.picking.job.model.PickingJob;
 import de.metas.handlingunits.picking.job.model.PickingJobId;
@@ -662,5 +663,14 @@ public class PickingMobileApplication implements WorkflowBasedMobileApplication
 				.lineId(response.getLineId())
 				.logs(response.getLogs())
 				.build();
+	}
+
+	public HUInfo resolvePickFromHU(
+			@NonNull final WFProcessId wfProcessId,
+			@NonNull final PickingJobLineId lineId,
+			@NonNull final ScannedCode scannedCode,
+			final @NotNull UserId callerId)
+	{
+		return pickingJobRestService.resolvePickFromHU(toPickingJobId(wfProcessId), lineId, scannedCode, callerId);
 	}
 }

--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt_wholeHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt_wholeHU.spec.js
@@ -1,0 +1,509 @@
+import { test } from '../../../playwright.config';
+import { allure } from 'allure-playwright';
+import { expect } from '@playwright/test';
+import { expectErrorToast } from '../../utils/common';
+import { Backend } from '../../utils/screens/Backend';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { PickingJobsListScreen } from '../../utils/screens/picking/PickingJobsListScreen';
+import { PickingJobScreen } from '../../utils/screens/picking/PickingJobScreen';
+import { YesNoDialog } from '../../utils/dialogs/YesNoDialog';
+import { ManufacturingJobsListScreen } from '../../utils/screens/manufacturing/ManufacturingJobsListScreen';
+import { ManufacturingJobScreen } from '../../utils/screens/manufacturing/ManufacturingJobScreen';
+import { MaterialReceiptLineScreen } from '../../utils/screens/manufacturing/receipt/MaterialReceiptLineScreen';
+import { PickLineScanScreen } from '../../utils/screens/picking/PickLineScanScreen';
+import { PickingJobLineScreen } from '../../utils/screens/picking/PickingJobLineScreen';
+
+/**
+ * Whole-HU over-delivery confirmation in mobile UI picking.
+ *
+ * The operator scans a weight label at the HU-scan step rather than typing a quantity, so the
+ * whole scanned HU is picked and its quantity comes from the HU's content. When that content
+ * exceeds the remaining order quantity, the same Yes/No confirmation the per-piece CU path
+ * raises must appear.
+ *
+ * Split out of overPickingPrompt.spec.js: this suite needs its own BOM/manufacturing masterdata
+ * builder, and a spec file should read as "one setup, N tests exercising it" (e2e/CLAUDE.md).
+ */
+//
+// ===== Whole-HU picking: the operator scans a weight label at the HU-scan step =====
+// The label is not a unique HU QR code, so the whole scanned HU is picked and its quantity is
+// decided from the HU's content — the operator never types a quantity.
+// Order: 2 CUs. The scanned HU holds 3 CUs, so picking it whole exceeds the order by 1.
+//
+
+const createMasterdata_WholeHU = async ({ showPromptWhenOverPicking, orderQtyCUs = 2 }) => {
+    return await Backend.createMasterdata({
+        language: 'en_US',
+        request: {
+            login: { user: { language: 'en_US' } },
+            mobileConfig: {
+                picking: {
+                    aggregationType: 'sales_order',
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['TU'],
+                    allowCompletingPartialPickingJob: true,
+                    showLastPickedBestBeforeDateForLines: false,
+                    showPromptWhenOverPicking,
+                },
+            },
+            bpartners: { BP1: {} },
+            warehouses: { wh: {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                COMP1: {},
+                COMP2: {},
+                BOM: {
+                    randomValue: { size: 4, isIncludeDigits: true },
+                    uom: 'PCE',
+                    uomConversions: [{ from: 'PCE', to: 'KGM', multiplyRate: 0.1, isCatchUOMForProduct: true }],
+                    bom: {
+                        lines: [
+                            { product: 'COMP1', qty: 1 },
+                            { product: 'COMP2', qty: 2 },
+                        ],
+                    },
+                    prices: [{ price: 5, uom: 'KGM', invoicableQtyBasedOn: 'CatchWeight' }],
+                },
+            },
+            packingInstructions: {
+                BOM_PI: { tu: 'TU', product: 'BOM', qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                HU_COMP1: { product: 'COMP1', warehouse: 'wh', qty: 1000 },
+                HU_COMP2: { product: 'COMP2', warehouse: 'wh', qty: 1000 },
+            },
+            manufacturingOrders: {
+                PP1: {
+                    warehouse: 'wh',
+                    product: 'BOM',
+                    qty: 100,
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                },
+            },
+            salesOrders: {
+                SO1: {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'BOM', qty: orderQtyCUs, piItemProduct: 'TU' }],
+                },
+            },
+            customQRCodeFormats: [
+                {
+                    name: 'weight label',
+                    parts: [
+                        { startPosition: 1, endPosition: 4, type: 'PRODUCT_CODE' },
+                        { startPosition: 5, endPosition: 10, type: 'WEIGHT_KG' },
+                        { startPosition: 11, endPosition: 18, type: 'LOT' },
+                        { startPosition: 19, endPosition: 24, type: 'PRODUCTION_DATE', dateFormat: 'yyMMdd' },
+                        { startPosition: 25, endPosition: 30, type: 'BEST_BEFORE_DATE', dateFormat: 'yyMMdd' },
+                    ],
+                },
+            ],
+        },
+    });
+};
+
+// Produces one HU carrying `weightLabelQRCode`, filled with `qtyCUs` pieces.
+const produceHU = async ({ masterdata, weightLabelQRCode, qtyCUs }) =>
+    await test.step(`Produce one HU of ${qtyCUs} pieces, labelled ${weightLabelQRCode}`, async () => {
+        await ApplicationsListScreen.startApplication('mfg');
+        await ManufacturingJobsListScreen.waitForScreen();
+        await ManufacturingJobsListScreen.startJob({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+
+        const huQRCode = await ManufacturingJobScreen.generateSingleHUQRCode({
+            piTestId: masterdata.packingInstructions.BOM_PI.tuPITestId,
+            numberOfHUs: 1,
+        });
+
+        await ManufacturingJobScreen.clickReceiveButton({ index: 1 });
+        await MaterialReceiptLineScreen.selectExistingHUTarget({ huQRCode });
+        await MaterialReceiptLineScreen.receiveQty({
+            catchWeightQRCode: Array(qtyCUs).fill(weightLabelQRCode),
+            expectGoBackToJob: false,
+        });
+        await MaterialReceiptLineScreen.goBack();
+
+        await ManufacturingJobScreen.goBack();
+        await ManufacturingJobsListScreen.goBack();
+
+        return huQRCode;
+    });
+
+// noinspection JSUnusedLocalSymbols
+test('Whole HU: scan an HU holding more than ordered - prompt enabled - confirm Yes', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - whole HU scanned at the HU-scan step, over-delivery confirmed');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata_WholeHU({ showPromptWhenOverPicking: true, orderQtyCUs: 2 });
+
+    // 4 digits product code, 1.000 kg, lot 123, produced 2025-04-03, best before 2026-04-10
+    const weightLabelQRCode = `${masterdata.products.BOM.productCode}00100000000123250403260410`;
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    const huQRCode = await produceHU({ masterdata, weightLabelQRCode, qtyCUs: 3 });
+
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '2 Stk', qtyPicked: '0 Stk' });
+    await PickingJobScreen.scanPickingSlot({
+        qrCode: masterdata.pickingSlots.slot1.qrCode,
+        expectNextScreen: 'PickLineScanScreen',
+    });
+
+    await test.step('Scan the whole HU (3 pieces) against an order of 2, confirm the over-delivery', async () => {
+        await PickLineScanScreen.waitForScreen();
+        await PickLineScanScreen.typeQRCode(weightLabelQRCode);
+
+        // The same over-delivery question the operator gets when typing a too-large quantity.
+        // It can only appear if the comparison uses a quantity larger than the 2 pieces
+        // remaining: neither the 0 the client sends today for a whole-HU pick nor the single
+        // handling unit being scanned would exceed it — only the HU's 3 pieces do.
+        await YesNoDialog.waitForDialog();
+        await YesNoDialog.clickYesButton();
+
+        await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '2 Stk', qtyPicked: '3 Stk' });
+    });
+
+    await test.step('Verify the whole HU was picked, i.e. the quantity the operator confirmed', async () => {
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        BOM: {
+                            qtyPicked: [{ qtyPicked: '3 PCE', processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+            hus: {
+                [huQRCode]: { huStatus: 'S', storages: { BOM: '3 PCE' } },
+            },
+        });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Whole HU: scan an HU holding more than ordered - prompt enabled - decline', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - whole HU scanned at the HU-scan step, over-delivery declined');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata_WholeHU({ showPromptWhenOverPicking: true, orderQtyCUs: 2 });
+
+    // 4 digits product code, 1.000 kg, lot 123, produced 2025-04-03, best before 2026-04-10
+    const weightLabelQRCode = `${masterdata.products.BOM.productCode}00100000000123250403260410`;
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    const huQRCode = await produceHU({ masterdata, weightLabelQRCode, qtyCUs: 3 });
+
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '2 Stk', qtyPicked: '0 Stk' });
+    await PickingJobScreen.scanPickingSlot({
+        qrCode: masterdata.pickingSlots.slot1.qrCode,
+        expectNextScreen: 'PickLineScanScreen',
+    });
+
+    await test.step('Scan the whole HU (3 pieces) against an order of 2, decline the over-delivery', async () => {
+        await PickLineScanScreen.waitForScreen();
+        await PickLineScanScreen.typeQRCode(weightLabelQRCode);
+
+        await YesNoDialog.waitForDialog();
+        await YesNoDialog.clickNoButton();
+
+        // Declining returns the operator to the very step the scan came from, ready to scan again.
+        await PickLineScanScreen.waitForScreen();
+        await PickLineScanScreen.goBack();
+        await PickingJobLineScreen.goBack();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '2 Stk', qtyPicked: '0 Stk' });
+    });
+
+    await test.step('Verify nothing was picked and the HU is untouched', async () => {
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        BOM: { qtyPicked: [] },
+                    },
+                },
+            },
+            hus: {
+                [huQRCode]: { huStatus: 'A', storages: { BOM: '3 PCE' } },
+            },
+        });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Whole HU: scan an HU holding more than ordered - prompt disabled - the pick is blocked', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - whole HU scanned at the HU-scan step, prompt disabled, over-delivery blocked');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata_WholeHU({ showPromptWhenOverPicking: false, orderQtyCUs: 2 });
+
+    // 4 digits product code, 1.000 kg, lot 123, produced 2025-04-03, best before 2026-04-10
+    const weightLabelQRCode = `${masterdata.products.BOM.productCode}00100000000123250403260410`;
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    const huQRCode = await produceHU({ masterdata, weightLabelQRCode, qtyCUs: 3 });
+
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '2 Stk', qtyPicked: '0 Stk' });
+    await PickingJobScreen.scanPickingSlot({
+        qrCode: masterdata.pickingSlots.slot1.qrCode,
+        expectNextScreen: 'PickLineScanScreen',
+    });
+
+    await test.step('Scan the whole HU (3 pieces) against an order of 2 - the scan is rejected', async () => {
+        await PickLineScanScreen.waitForScreen();
+
+        // Without the confirmation prompt the operator gets no way to authorise an over-delivery,
+        // so the same qtyAboveMax ceiling the per-piece CU path enforces applies here: the scan
+        // fails and books nothing, rather than silently booking the whole 3-piece HU.
+        await expectErrorToast(
+            'Whole HU exceeds the ordered qty and the prompt is disabled',
+            async () => {
+                await PickLineScanScreen.typeQRCode(weightLabelQRCode);
+                // Reached only if the pick went through - a booked pick leaves the scan screen
+                // for the job screen. Blocked, the operator stays on the scan screen.
+                await PickingJobScreen.waitForScreen();
+            },
+            ({ textContent }) => {
+                expect(textContent).toContain('above max');
+            }
+        );
+    });
+
+    await test.step('Verify nothing was picked and the HU is untouched', async () => {
+        await PickLineScanScreen.goBack();
+        await PickingJobLineScreen.goBack();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '2 Stk', qtyPicked: '0 Stk' });
+
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        BOM: { qtyPicked: [] },
+                    },
+                },
+            },
+            hus: {
+                [huQRCode]: { huStatus: 'A', storages: { BOM: '3 PCE' } },
+            },
+        });
+    });
+});
+
+//
+// ===== Exactly on target: the HU holds exactly the 3 pieces still ordered =====
+// The negative control for both guards above: neither the confirmation nor the ceiling may fire when
+// the scanned HU does not exceed the order. Run in both profile configurations, because with the
+// prompt on and off the whole-TU path takes two different branches.
+//
+
+const pickWholeHUAndExpectNoQuestion = async ({ masterdata, huQRCode, weightLabelQRCode }) =>
+    await test.step('Scan the whole HU (3 pieces) against an order of 3', async () => {
+        await ApplicationsListScreen.startApplication('picking');
+        await PickingJobsListScreen.waitForScreen();
+        await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+        const { pickingJobId } = await PickingJobsListScreen.startJob({
+            documentNo: masterdata.salesOrders.SO1.documentNo,
+        });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 Stk', qtyPicked: '0 Stk' });
+        await PickingJobScreen.scanPickingSlot({
+            qrCode: masterdata.pickingSlots.slot1.qrCode,
+            expectNextScreen: 'PickLineScanScreen',
+        });
+
+        await PickLineScanScreen.waitForScreen();
+        await PickLineScanScreen.typeQRCode(weightLabelQRCode);
+
+        // Landing back on the job screen with the line fully picked is what proves the scan was
+        // neither questioned nor rejected: a confirmation would hold the operator on the scan screen,
+        // and a rejected scan would leave the line at 0.
+        await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 Stk', qtyPicked: '3 Stk' });
+
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        BOM: {
+                            qtyPicked: [{ qtyPicked: '3 PCE', processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+            hus: {
+                [huQRCode]: { huStatus: 'S', storages: { BOM: '3 PCE' } },
+            },
+        });
+    });
+
+// noinspection JSUnusedLocalSymbols
+test('Whole HU: scan an HU holding exactly the ordered qty - prompt enabled - no question asked', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - whole HU scanned at the HU-scan step, exactly on target, no prompt fires');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata_WholeHU({ showPromptWhenOverPicking: true, orderQtyCUs: 3 });
+
+    // 4 digits product code, 1.000 kg, lot 123, produced 2025-04-03, best before 2026-04-10
+    const weightLabelQRCode = `${masterdata.products.BOM.productCode}00100000000123250403260410`;
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    const huQRCode = await produceHU({ masterdata, weightLabelQRCode, qtyCUs: 3 });
+    await ApplicationsListScreen.expectVisible();
+
+    await pickWholeHUAndExpectNoQuestion({ masterdata, huQRCode, weightLabelQRCode });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Whole HU: scan an HU holding exactly the ordered qty - prompt disabled - not blocked', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - whole HU scanned at the HU-scan step, exactly on target, ceiling does not block');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata_WholeHU({ showPromptWhenOverPicking: false, orderQtyCUs: 3 });
+
+    // 4 digits product code, 1.000 kg, lot 123, produced 2025-04-03, best before 2026-04-10
+    const weightLabelQRCode = `${masterdata.products.BOM.productCode}00100000000123250403260410`;
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    const huQRCode = await produceHU({ masterdata, weightLabelQRCode, qtyCUs: 3 });
+    await ApplicationsListScreen.expectVisible();
+
+    await pickWholeHUAndExpectNoQuestion({ masterdata, huQRCode, weightLabelQRCode });
+});
+
+//
+// ===== A line that already carries a picked quantity =====
+// The shape the customer reported: the line is ordered 3 and 3 are already picked, and the operator
+// scans one more HU holding a single piece. Nothing about that HU exceeds the order on its own - it is
+// the quantity already picked that makes it an over-delivery, so this is what proves the whole-HU path
+// compares against the quantity still to pick rather than against the ordered quantity.
+//
+
+// noinspection JSUnusedLocalSymbols
+test('Whole HU: scan an HU on a line that is already fully picked - prompt enabled - confirm Yes', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - whole HU scanned on a line that already carries a picked qty, over-delivery confirmed');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata_WholeHU({ showPromptWhenOverPicking: true, orderQtyCUs: 3 });
+
+    // 4 digits product code, 1.000 kg, lot 123 resp. 124, produced 2025-04-03, best before 2026-04-10.
+    // Each HU gets its own label, differing only in the LOT part (positions 11-18): the label is stored on
+    // the produced HU as its HU_QRCode attribute, and a scanned label is resolved back to its HU by an exact
+    // match on that attribute (PickingJobHUService.getFirstHUIdByQRCodeAttribute), so two HUs sharing one
+    // label would be interchangeable candidates for either scan.
+    const weightLabelQRCodeHU1 = `${masterdata.products.BOM.productCode}00100000000123250403260410`;
+    const weightLabelQRCodeHU2 = `${masterdata.products.BOM.productCode}00100000000124250403260410`;
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    const huQRCode1 = await produceHU({ masterdata, weightLabelQRCode: weightLabelQRCodeHU1, qtyCUs: 3 });
+    await ApplicationsListScreen.expectVisible();
+    const huQRCode2 = await produceHU({ masterdata, weightLabelQRCode: weightLabelQRCodeHU2, qtyCUs: 1 });
+    await ApplicationsListScreen.expectVisible();
+
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 Stk', qtyPicked: '0 Stk' });
+    await PickingJobScreen.scanPickingSlot({
+        qrCode: masterdata.pickingSlots.slot1.qrCode,
+        expectNextScreen: 'PickLineScanScreen',
+    });
+
+    await test.step('Pick the first whole HU (3 pieces), which takes the line to the ordered qty', async () => {
+        await PickLineScanScreen.waitForScreen();
+        await PickLineScanScreen.typeQRCode(weightLabelQRCodeHU1);
+
+        // Neither questioned nor rejected - this HU is exactly on target. It is only the setup: what it
+        // establishes for the second scan is the non-zero picked quantity the scenario is about.
+        await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 Stk', qtyPicked: '3 Stk' });
+    });
+
+    await test.step('Scan a second whole HU (1 piece) onto the fully picked line, confirm the over-delivery', async () => {
+        // Back into the scan step the way the operator gets there once a pick has returned them to the
+        // job screen: open the line, then its Scan button.
+        await PickingJobScreen.clickLineButton({ index: 1 });
+        await PickingJobLineScreen.waitForScreen();
+        await PickingJobLineScreen.clickScanButton();
+        await PickLineScanScreen.waitForScreen();
+        await PickLineScanScreen.typeQRCode(weightLabelQRCodeHU2);
+
+        // The one piece this HU holds stays well inside the 3 the line was ordered, so a comparison
+        // against the ordered quantity raises no question at all. The question can only appear because
+        // the comparison is against what is left to pick, which the first pick took down to 0.
+        await YesNoDialog.waitForDialog();
+        await YesNoDialog.clickYesButton();
+
+        // Confirming books the pick and returns the operator to the line they scanned from.
+        await PickingJobLineScreen.waitForScreen();
+        await PickingJobLineScreen.goBack();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '3 Stk', qtyPicked: '4 Stk' });
+    });
+
+    await test.step('Verify the second HU was picked on top of the first, over-delivering the line by 1', async () => {
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        BOM: {
+                            qtyPicked: [
+                                { qtyPicked: '3 PCE', processed: false, shipmentLineId: '-' },
+                                { qtyPicked: '1 PCE', processed: false, shipmentLineId: '-' },
+                            ],
+                        },
+                    },
+                },
+            },
+            hus: {
+                [huQRCode1]: { huStatus: 'S', storages: { BOM: '3 PCE' } },
+                [huQRCode2]: { huStatus: 'S', storages: { BOM: '1 PCE' } },
+            },
+        });
+    });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/picking/PickLineScanScreen.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/containers/activities/picking/PickLineScanScreen.test.js
@@ -1,6 +1,49 @@
 import { convertScannedBarcodeToResolvedResult } from '../../../../containers/activities/picking/PickLineScanScreen';
+import { getScannedHUQRCodeInfo } from '../../../../api/picking';
+import { trl } from '../../../../utils/translations';
+
+jest.mock('../../../../api/picking', () => ({
+  ...jest.requireActual('../../../../api/picking'),
+  getScannedHUQRCodeInfo: jest.fn(),
+}));
+
+//
+// Tier: Jest rather than Playwright. The state under test - the HU lookup answering with an HU that
+// carries no qty of the line's product - cannot be provoked through the E2E masterdata: the backend
+// resolves such a label by external lot number, an attribute no test fixture (nor JsonCreateHURequest)
+// can set. Mocking the one API call is the only honest way to reach the branch.
+//
+// A whole-TU label: the custom weight-label format from the whole-HU over-picking picking E2E spec.
+// parseCustomQRCode flags every match as isTUToBePickedAsWhole, so a barcode matching this format
+// takes the whole-TU branch.
+const WEIGHT_LABEL_FORMAT = {
+  name: 'weight label',
+  parts: [
+    { startPosition: 1, endPosition: 4, type: 'PRODUCT_CODE' },
+    { startPosition: 5, endPosition: 10, type: 'WEIGHT_KG' },
+    { startPosition: 11, endPosition: 18, type: 'LOT' },
+    { startPosition: 19, endPosition: 24, type: 'PRODUCTION_DATE', dateFormat: 'yyMMdd' },
+    { startPosition: 25, endPosition: 30, type: 'BEST_BEFORE_DATE', dateFormat: 'yyMMdd' },
+  ],
+};
+// product 1234, 1.000 kg, lot 123, produced 2025-04-03, best before 2026-04-10
+const WEIGHT_LABEL_BARCODE = '123400100000000123250403260410';
+
+const resolveWeightLabelForLine = () =>
+  convertScannedBarcodeToResolvedResult({
+    scannedBarcode: WEIGHT_LABEL_BARCODE,
+    expectedProductNo: '1234',
+    customQRCodeFormats: [WEIGHT_LABEL_FORMAT],
+    // the picking job + line the operator is picking - what gates the whole-TU HU lookup
+    wfProcessId: 'wfProcess-1',
+    lineId: 'line-1',
+  });
 
 describe('PickingLineScanScreen', () => {
+  beforeEach(() => {
+    getScannedHUQRCodeInfo.mockReset();
+  });
+
   it('convertScannedBarcodeToResolvedResult', async () => {
     const scannedBarcode =
       'HU#1#{"id":"59c0e3b5845d9fca58ccd9f2a906-30926","packingInfo":{"huUnitType":"V","packingInstructionsId":101,"caption":"No Packing Item"},"product":{"id":2009297,"code":"MyCode","name":"MyProduct"},"attributes":[{"code":"HU_BestBeforeDate","displayName":"Mindesthaltbarkeit","value":"2024-04-10"},{"code":"Lot-Nummer","displayName":"Lot-Nummer","value":"010124"},{"code":"WeightNet","displayName":"Gewicht Netto","value":"180.000"}]}';
@@ -29,5 +72,42 @@ describe('PickingLineScanScreen', () => {
       lotNo: '010124',
       scannedHU: { huUnitType: 'V' },
     });
+  });
+
+  // The lookup resolves an HU - it just carries no pickable qty of the product this line picks. Both
+  // shapes reach the UI: the backend omits productQty when the HU holds none of the product, and reports
+  // 0 for a storage row that has been emptied. Without a positive qty there is nothing to bound the pick
+  // by, so the whole TU would book unasked and unbounded: the scan has to fail instead.
+  it.each([
+    ['reports no qty at all', {}],
+    ['reports a zero qty', { productQty: 0 }],
+  ])('fails the scan when the whole-TU HU lookup %s of the line product', async (_caption, productQtyPart) => {
+    getScannedHUQRCodeInfo.mockResolvedValue({
+      huQRCode: { code: 'HU#1#{"id":"other-hu"}' },
+      qtyTUs: 1,
+      ...productQtyPart,
+    });
+
+    await expect(resolveWeightLabelForLine()).rejects.toEqual(trl('activities.picking.notEligibleHUBarcode'));
+
+    expect(getScannedHUQRCodeInfo).toHaveBeenCalledWith({
+      qrCode: WEIGHT_LABEL_BARCODE,
+      productNo: '1234',
+      wfProcessId: 'wfProcess-1',
+      lineId: 'line-1',
+    });
+  });
+
+  it('resolves qtyInitial from the whole-TU HU lookup when it reports a qty of the line product', async () => {
+    getScannedHUQRCodeInfo.mockResolvedValue({
+      huQRCode: { code: 'HU#1#{"id":"the-hu"}' },
+      qtyTUs: 1,
+      productQty: 3, // JsonHUInfo.productQty is a BigDecimal, so it arrives as a JSON number
+    });
+
+    const result = await resolveWeightLabelForLine();
+
+    expect(result.isTUToBePickedAsWhole).toBe(true);
+    expect(result.qtyInitial).toBe(3);
   });
 });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/picking.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/picking.js
@@ -154,9 +154,9 @@ export const getClosedLUs = ({ wfProcessId, lineId }) => {
     .then((response) => unboxAxiosResponse(response));
 };
 
-export const getScannedHUQRCodeInfo = ({ qrCode, productNo }) => {
+export const getScannedHUQRCodeInfo = ({ qrCode, productNo, wfProcessId, lineId }) => {
   return axios
-    .post(`${apiBasePath}/picking/hu/byScannedCode`, { scannedCode: qrCode, productNo })
+    .post(`${apiBasePath}/picking/hu/byScannedCode`, { scannedCode: qrCode, productNo, wfProcessId, lineId })
     .then((response) => unboxAxiosResponse(response));
 };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { trl } from '../utils/translations';
 import GetQuantityDialog from './dialogs/GetQuantityDialog';
+import YesNoDialog from './dialogs/YesNoDialog';
 import Button from './buttons/Button';
 import { formatQtyToHumanReadable, formatQtyToHumanReadableStr } from '../utils/qtys';
 import { useBooleanSetting } from '../reducers/settings';
@@ -59,6 +60,7 @@ const ScanHUAndGetQtyComponent = ({
   onClose: onCloseCallback,
 }) => {
   const [progressStatus, setProgressStatus] = useState(STATUS_NOT_INITIALIZED);
+  const [confirmationDialogProps, setConfirmationDialogProps] = useState(undefined);
   const { resolvedBarcodeData, setResolvedBarcodeData, updateResolvedBarcodeData, computeNewResolvedBarcodeData } =
     useResolvedBarcodeData({
       userInfo,
@@ -155,17 +157,54 @@ const ScanHUAndGetQtyComponent = ({
     await requestQtyOrReportResult({ resolvedBarcodeData: resolvedBarcodeDataNew });
   };
 
+  const fireOnResult = (onResultPayload) => onResult(onResultPayload)?.catch?.((error) => toastErrorFromObj(error));
+
   const requestQtyOrReportResult = async ({ resolvedBarcodeData }) => {
     if (isAskForQty({ resolvedBarcodeData })) {
       setProgressStatus(STATUS_READ_QTY);
-    } else {
-      await onResult({
-        qty: 0,
-        reason: null,
-        scannedBarcode: resolvedBarcodeData.scannedBarcode,
-        resolvedBarcodeData: resolvedBarcodeData,
-      })?.catch?.((error) => toastErrorFromObj(error));
+      return;
     }
+
+    const onResultPayload = {
+      qty: 0,
+      reason: null,
+      scannedBarcode: resolvedBarcodeData.scannedBarcode,
+      resolvedBarcodeData: resolvedBarcodeData,
+    };
+
+    // There is no qty dialog on this path (the whole scanned TU is booked), so the over-delivery
+    // handling GetQuantityDialog performs for the CU path has to happen here. The qty to compare is
+    // the TU's own content, fetched into qtyInitial for exactly this purpose; the qty: 0 above is the
+    // booking instruction, not the comparison input. Which handling applies depends on the profile,
+    // exactly as on the CU path: with the prompt configured, the same YesNoDialog; without it, the
+    // same qtyAboveMax ceiling - so no configuration leaves this path unbounded.
+    if (getConfirmationPromptForQty) {
+      const confirmationPrompt = await getConfirmationPromptForQty(resolvedBarcodeData.qtyInitial);
+      if (confirmationPrompt) {
+        setConfirmationDialogProps({ promptQuestion: confirmationPrompt, onResultPayload });
+        return;
+      }
+    } else if (Number.isFinite(resolvedBarcodeData.qtyInitial)) {
+      // Implicit invariant: of the eight callers, only PickLineScanScreen ever resolves a qtyInitial - directly on
+      // its whole-TU branch, and through computeNewResolvedBarcodeData's LU branch below, which no other caller
+      // reaches either, because none of them populates scannedHU.qtyTUs.
+      // Bound the pick whenever the caller resolved a qty; a caller that resolves none books as before,
+      // the same as the prompt branch above, where an absent qty raises no confirmation either. A caller
+      // that wants the pick bounded must therefore fail its own scan rather than resolve without a qty.
+      const qtyAboveMaxError = validateQtyAgainstMax({
+        qty: resolvedBarcodeData.qtyInitial,
+        qtyMax: resolvedBarcodeData.qtyMax,
+        uom: resolvedBarcodeData.uom,
+        invalidQtyMessageKey,
+      });
+      if (qtyAboveMaxError) {
+        // Thrown, not toasted: the caller (BarcodeScannerComponent / HUScanner) turns this into the
+        // error beep + toast every other rejected scan produces, and leaves the scanner armed.
+        throw qtyAboveMaxError;
+      }
+    }
+
+    await fireOnResult(onResultPayload);
   };
 
   const validateQtyEntered = (qtyEntered, uom) => {
@@ -177,16 +216,8 @@ const ScanHUAndGetQtyComponent = ({
     // Qty shall be less than or equal to qtyMax
     // NOTE: skip qtyMax validation when over-pick confirmation prompt is enabled,
     // because the prompt handles the over-delivery scenario instead
-    if (!getConfirmationPromptForQty && resolvedBarcodeData.qtyMax && resolvedBarcodeData.qtyMax > 0) {
-      const { qtyEffective: diff, uomEffective: diffUom } = formatQtyToHumanReadable({
-        qty: qtyEntered - resolvedBarcodeData.qtyMax,
-        uom,
-      });
-
-      if (diff > 0) {
-        const qtyDiff = formatQtyToHumanReadableStr({ qty: diff, uom: diffUom });
-        return trl(invalidQtyMessageKey || DEFAULT_MSG_qtyAboveMax, { qtyDiff });
-      }
+    if (!getConfirmationPromptForQty) {
+      return validateQtyAgainstMax({ qty: qtyEntered, qtyMax: resolvedBarcodeData.qtyMax, uom, invalidQtyMessageKey });
     }
 
     // OK
@@ -232,6 +263,22 @@ const ScanHUAndGetQtyComponent = ({
   };
 
   const showEligibleBarcodeDebugButton = useBooleanSetting('barcodeScanner.showEligibleBarcodeDebugButton');
+
+  // Early return (after every hook), so the BarcodeScannerComponent below is unmounted while the
+  // operator answers: two mounted scanners would both capture the next hardware scan.
+  // progressStatus is deliberately left untouched, so declining returns to the very step we came from.
+  if (confirmationDialogProps) {
+    return (
+      <YesNoDialog
+        promptQuestion={confirmationDialogProps.promptQuestion}
+        onYes={() => {
+          fireOnResult(confirmationDialogProps.onResultPayload);
+          setConfirmationDialogProps(undefined);
+        }}
+        onNo={() => setConfirmationDialogProps(undefined)}
+      />
+    );
+  }
 
   switch (progressStatus) {
     case STATUS_READ_HU_BARCODE: {
@@ -356,6 +403,27 @@ export default ScanHUAndGetQtyComponent;
 // -----------------------------------------------------------------------------
 //
 //
+
+/**
+ * The qtyAboveMax ceiling, shared by the two paths that book a qty: the CU path via
+ * validateQtyEntered (qty typed into GetQuantityDialog) and the whole-TU path via
+ * requestQtyOrReportResult (qty read from the scanned TU's own content).
+ *
+ * @returns the translated error message, or null when the qty is within qtyMax.
+ */
+const validateQtyAgainstMax = ({ qty, qtyMax, uom, invalidQtyMessageKey }) => {
+  if (!qtyMax || qtyMax <= 0) {
+    return null;
+  }
+
+  const { qtyEffective: diff, uomEffective: diffUom } = formatQtyToHumanReadable({ qty: qty - qtyMax, uom });
+  if (diff <= 0) {
+    return null;
+  }
+
+  const qtyDiff = formatQtyToHumanReadableStr({ qty: diff, uom: diffUom });
+  return trl(invalidQtyMessageKey || DEFAULT_MSG_qtyAboveMax, { qtyDiff });
+};
 
 const isAskForQty = ({ resolvedBarcodeData }) => {
   const qrCode = resolvedBarcodeData?.qrCode;

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickLineScanScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickLineScanScreen.jsx
@@ -94,11 +94,12 @@ const PickLineScanScreen = () => {
         scannedBarcode,
         expectedProductId: productId,
         expectedProductNo: productNo,
-        isShowPromptWhenOverPicking,
         customQRCodeFormats,
         pickingUnit,
+        wfProcessId,
+        lineId,
       }),
-    [productId, productNo, isShowPromptWhenOverPicking, customQRCodeFormats, pickingUnit]
+    [productId, productNo, customQRCodeFormats, pickingUnit, wfProcessId, lineId]
   );
 
   const onClose = useOnClose({ applicationId, wfProcessId, activity, lineId, next });
@@ -192,9 +193,10 @@ export const convertScannedBarcodeToResolvedResult = async ({
   scannedBarcode,
   expectedProductId,
   expectedProductNo,
-  isShowPromptWhenOverPicking,
   customQRCodeFormats,
   pickingUnit,
+  wfProcessId,
+  lineId,
 }) => {
   let parsedQRCode = parseQRCodeString({
     string: scannedBarcode,
@@ -234,7 +236,8 @@ export const convertScannedBarcodeToResolvedResult = async ({
     pickingUnit,
     huInfoFromBackend,
     expectedProductNo,
-    isShowPromptWhenOverPicking,
+    wfProcessId,
+    lineId,
   });
 };
 
@@ -249,7 +252,8 @@ const convertQRCodeObjectToResolvedResult = async ({
   pickingUnit,
   huInfoFromBackend,
   expectedProductNo,
-  isShowPromptWhenOverPicking,
+  wfProcessId,
+  lineId,
 }) => {
   const result = {
     qrCode: parsedQRCode,
@@ -287,21 +291,39 @@ const convertQRCodeObjectToResolvedResult = async ({
     }
   }
 
-  // For whole-TU picks with overdelivery prompt enabled,
-  // fetch actual product qty from backend so the prompt can detect overdelivery.
-  // The backend picks the full HU storage qty when isPickWholeTU=true,
-  // so we need the actual qty to compare against remaining.
-  if (parsedQRCode.isTUToBePickedAsWhole === true && isShowPromptWhenOverPicking) {
-    try {
-      const huInfo =
-        huInfoFromBackend ??
-        (await getScannedHUQRCodeInfo({ qrCode: toQRCodeString(parsedQRCode), productNo: expectedProductNo }));
-      if (huInfo?.productQty != null) {
-        result.qtyInitial = parseFloat(huInfo.productQty);
-      }
-    } catch (error) {
-      console.warn('Failed to get HU product qty for overdelivery check. Ignored', error);
+  // For whole-TU picks, fetch the actual product qty from the backend so the over-delivery can be
+  // detected at all. The backend picks the full HU storage qty when isPickWholeTU=true, so we need
+  // the actual qty to compare against remaining - with the prompt enabled to raise the confirmation,
+  // and with it disabled to enforce the qtyAboveMax ceiling instead. Both configurations need it, so
+  // this is not gated on isShowPromptWhenOverPicking.
+  //
+  // The picking job + line are required, and are what gates the fetch: a whole-TU label (custom weight
+  // label, LMQ, GS1) is not an HU QR code, so the backend can only resolve it to its HU in the context of
+  // the line being picked. PickProductsScanScreen resolves barcodes through here too, without a line and
+  // wanting only the parsed QR code - looking the HU up for it would fail the scan it is trying to route.
+  if (parsedQRCode.isTUToBePickedAsWhole === true && wfProcessId != null && lineId != null) {
+    // Not guarded: a failure here must surface as a failed scan, exactly like the unparsed-barcode lookup
+    // above. Swallowing it would leave qtyInitial undefined, which compares as 0 against the remaining qty,
+    // so the whole TU would book with no confirmation - the very defect this check exists to prevent.
+    const huInfo = await getScannedHUQRCodeInfo({
+      qrCode: toQRCodeString(parsedQRCode),
+      productNo: expectedProductNo,
+      wfProcessId,
+      lineId,
+    });
+    // The resolved HU carries no pickable qty of this line's product, so there is nothing to bound the
+    // whole-TU pick by - reject the scan rather than book it unasked. Number.isFinite is the predicate
+    // ScanHUAndGetQtyComponent gates the qtyMax ceiling on, so anything weaker leaves the pick unbounded.
+    const productQty = parseFloat(huInfo?.productQty);
+    if (!Number.isFinite(productQty) || productQty <= 0) {
+      console.warn('Scanned barcode resolved to an HU carrying no qty of the expected product', {
+        expectedProductNo,
+        huInfo,
+        parsedQRCode,
+      });
+      throw trl('activities.picking.notEligibleHUBarcode');
     }
+    result.qtyInitial = productQty;
   }
 
   // console.log('convertQRCodeObjectToResolvedResult', { result, qrCodeObj: parsedQRCode, pickingUnit });


### PR DESCRIPTION
## What

Forward merge-through of the **whole** `intensive_care_hotfix` branch into `new_dawn_uat` — the up-propagation of the work developed on the hotfix line.

This is a **merge commit**, not a cherry-pick and not a squash. It must be merged with `--merge` (merge commit) so the branch relationship survives; squashing it would make every future `intensive_care_hotfix -> new_dawn_uat` merge re-conflict on the same changes.

---

## ⚠️ Update 2026-07-31 — head refreshed, and the DDL gate below is now MOOT

The head was a stale pre-merge snapshot. It has been refreshed in place (no force-push, no rebase) by merging `origin/intensive_care_hotfix` onto the existing PR head, so the PR now carries:

- https://github.com/metasfresh/metasfresh/commit/15b3232a066f316d36429411321575dde3bcff8d — "MobileUI Picking: raise the over-delivery confirmation on the whole-TU scan path", squash of https://github.com/metasfresh/metasfresh/pull/25374

**Two things changed materially since the review below was written:**

**1. The original payload has already reached `new_dawn_uat` by another route.** Both commits listed under "Commits carried up" are now ancestors of `new_dawn_uat`:

```
git merge-base --is-ancestor 59cd28bc9334d60ef67aec69839ae5f6d99dfc77 origin/new_dawn_uat   # exit 0
git merge-base --is-ancestor 3cfed254831d8a4c387492309bf5981631d93a23 origin/new_dawn_uat   # exit 0
```

**2. Consequently this PR's effective diff no longer contains ANY SQL.** `git diff origin/new_dawn_uat HEAD` is exactly the 10 files of the picking commit above — 5 backend Java, 4 mobile frontend, 1 new Playwright spec, **zero** migration scripts and **zero** DDL reference files. The costing DDL reviewed in the "DDL / migration review" section below is already on the target, so that whole-object regression question is settled and no longer applies to the current head. That section is kept for the record, not as an open gate.

### Conflicts resolved by hand (5 files)

The refresh merge did **not** apply cleanly — which is why `auto-port` could not advance this train on its own (its refresh merge errors out on conflict and the head stays frozen). Every conflict was an **add/add at the same location where each side introduced a DIFFERENT new member**, and all were resolved as a **union** — nothing from either side was dropped:

| File | Conflict | Resolution |
|---|---|---|
| `PickingJobService.java` | target's `resolveUnpick(...)` and incoming `resolvePickFromHU(...)` were appended at the same spot; their shared tail (`scannedCode`/`callerId` params, `getById` + `assertCanBeEditedBy`) interleaved | both methods kept, each with its own complete signature and body |
| `PickingRestController.java` | import block — target added the `massprinting` imports, incoming added `job.model.HUInfo` | both kept, sorted |
| `PickingJobRestService.java` | same `resolveUnpick` vs `resolvePickFromHU` add/add, plus the `JsonUnpickResolveResponse`/`Quantity` imports | both kept |
| `PickingMobileApplication.java` | same add/add pair | both kept |
| `ScanHUAndGetQtyComponent.jsx` | both sides added a state hook right after `progressStatus` — incoming's `confirmationDialogProps`, target's GRAI Flow-Through block | both kept, state declarations grouped first |

**Verification that the union is faithful:** for every one of the 10 files, the PR's net diff against the target is line-for-line identical to the fix commit's own diff:

```
git diff origin/new_dawn_uat HEAD -- <file>
git show 15b3232a066f316d36429411321575dde3bcff8d -- <file>
```

with two benign exceptions in `PickingJobService.java` — one blank line, and an `import de.metas.scannable_code.ScannedCode;` the fix commit adds but the target already had (its `resolveUnpick` uses the same type). Nothing the target had is missing, and nothing the incoming commit added is missing.

**Semantic composition check.** Both sides added an interception before `onResult` fires, so they were checked for collision: the incoming over-pick confirmation guards the **whole-TU** path (`requestQtyOrReportResult`, the branch with no qty dialog), while the target's GRAI capture guards the **CU** path (`onQtyEntered`, after `GetQuantityDialog`). They are on disjoint paths and cannot both fire for one scan; `GetQuantityDialog` still receives `getConfirmationPromptForQty` for the CU path's own over-pick handling, unchanged.

### Updated definition of done

Propagation is complete only once the picking commit is an ancestor of the target:

```
git fetch origin new_dawn_uat
git merge-base --is-ancestor 15b3232a066f316d36429411321575dde3bcff8d origin/new_dawn_uat && echo propagated
```

---

## Commits carried up (original payload, 2)

Both are already merged on `intensive_care_hotfix`:

- https://github.com/metasfresh/metasfresh/commit/59cd28bc9334d60ef67aec69839ae5f6d99dfc77 — "Costing — back-dated MovingAverageInvoice switch: as-of-cut-off opening, opening-anchor guard, batched recompute driver", squash of https://github.com/metasfresh/metasfresh/pull/25314
- https://github.com/metasfresh/metasfresh/commit/3cfed254831d8a4c387492309bf5981631d93a23 — "mobile e2e: de-flake the camera-mode assertions by giving the browser a camera", via https://github.com/metasfresh/metasfresh/pull/25362 (port of https://github.com/metasfresh/metasfresh/pull/25336)

Carrying everything on the branch is by design — every commit on `intensive_care_hotfix` is itself destined for `new_dawn_uat`.

Predecessor of this merge line: https://github.com/metasfresh/metasfresh/pull/25326 (merged 2026-07-27).

## Merge result (original snapshot)

Clean 3-way merge — **no conflicts**. Four files had genuinely diverged on both sides; each resolution was verified by hand:

| File | Divergence | Resolution taken |
|---|---|---|
| `e2e/mobile-webui/playwright.config.js` | both sides changed | keeps `new_dawn_uat`'s **wider** `--unsafely-treat-insecure-origin-as-secure` list (`app-test:8282,mobile:80,mobile`) — the target side is the newer one |
| `e2e/mobile-webui/tests/utils/fakeCamera.js` | add/add | contents identical on both sides |
| `backend/de.metas.business/.../costing/impl/CostingService.java` | target renamed `ICurrentCostsRepository#getOrCreate` to `getOrCreateForUpdate` | merged tree uses `getOrCreateForUpdate` at both call sites; no `getOrCreate` call on that repository survives anywhere in the tree |
| `backend/de.metas.business/.../costrevaluation/CostRevaluationServiceTest.java` | same rename | merged tree uses `getOrCreateForUpdate` |

## DDL / migration review (historical — settled, see Update above)

At the time this was written the diff contained migration scripts and DDL reference files. Per-object regression verdict:

**Redefined shared object — 1:**

- `backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/m_costdetail_delete_from_date.sql` — the target's version of this file is byte-identical to the merge base, i.e. `new_dawn_uat` has **no independent content** in this function. The incoming definition is a strict **superset**: it adds the `case 2.5` weighted-average inbound reconstruction and the cost-revaluation opening-anchor guard, and enriches one `RAISE` message. **No regression.**

**Brand-new objects (no clobber risk) — 3:**

- `ddl/functions/product_costs_recreate_all_from_date.sql`
- `ddl/table/accounting_docs_to_repost_staging.sql`
- `ddl/table/product_costs_recreate_progress.sql`

**Migration scripts — 8, all new, all under `43-de.metas.acct`, prefixes `5816000`–`5817060`.** `new_dawn_uat` already carries this feature's earlier scripts up to prefix `5815940`, so the new prefixes are strictly higher — ordering is correct and no filename collides.

No other feature's DDL rides along in this merge.

**All of the above is now on `new_dawn_uat` already** (see Update), so none of it is in this PR's current diff.
