### PR TITLE
mobile: refresh the operator context after a workstation scan, and make a failed context read recoverable

### DIFF
--- a/e2e/mobile-webui/tests/spec/manufacturing/operator_context_read_failure_is_recoverable.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/operator_context_read_failure_is_recoverable.spec.js
@@ -35,7 +35,9 @@ test('A workplace that cannot be read because the connection dropped is recovera
     // === ALLURE METADATA ===
     allure.epic('E0160: Manufacturing Execution');
     allure.feature('F8030: MobileUI Manufacturing');
+    allure.tag('F8030');  // Standalone tag for Tags section;
     allure.tag('F8046: Workstation');
+    allure.tag('F8046');  // Standalone tag for Tags section;
     allure.story('A dropped connection must not silently blank the operator context');
     allure.severity('critical');
 
@@ -73,7 +75,9 @@ test('A workstation that cannot be read because the connection dropped is recove
     // === ALLURE METADATA ===
     allure.epic('E0160: Manufacturing Execution');
     allure.feature('F8030: MobileUI Manufacturing');
+    allure.tag('F8030');  // Standalone tag for Tags section;
     allure.tag('F8046: Workstation');
+    allure.tag('F8046');  // Standalone tag for Tags section;
     allure.story('A dropped connection must not look like a lost workstation assignment');
     allure.severity('critical');
 

--- a/e2e/mobile-webui/tests/spec/manufacturing/operator_context_read_failure_is_recoverable.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/operator_context_read_failure_is_recoverable.spec.js
@@ -1,0 +1,109 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { WorkplaceManagerScreen } from "../../utils/screens/workplaceManager/WorkplaceManagerScreen";
+import { WorkstationManagerScreen } from "../../utils/screens/workstationManager/WorkstationManagerScreen";
+import { ManufacturingJobsListScreen } from "../../utils/screens/manufacturing/ManufacturingJobsListScreen";
+import { ViewHeaderComponent } from "../../utils/components/ViewHeaderComponent";
+import { restoreConnectionFor, simulateConnectionLossFor } from "../../utils/network";
+
+// English captions of the two operator-context header rows (general.workplace / general.workstation).
+const HEADER_WORKPLACE = 'Workplace';
+const HEADER_WORKSTATION = 'Workstation';
+
+// Endpoints the Production jobs list reads the operator's context from.
+const WORKPLACE_ENDPOINT = '**/api/v2/workplace';
+const WORKSTATION_ENDPOINT = '**/api/v2/workstation';
+
+const createMasterdata = async ({ isScanResourceRequired }) => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US" } },
+            mobileConfig: { manufacturing: { isScanResourceRequired } },
+            warehouses: { whA: {} },
+            workplaces: { wpA: { warehouse: 'whA' } },
+            resources: { WS1: { type: 'WS', workplace: 'wpA' } },
+        }
+    });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('A workplace that cannot be read because the connection dropped is recoverable', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0160: Manufacturing Execution');
+    allure.feature('F8030: MobileUI Manufacturing');
+    allure.tag('F8046: Workstation');
+    allure.story('A dropped connection must not silently blank the operator context');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata({ isScanResourceRequired: false });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await test.step('The operator is working on workplace A', async () => {
+        await WorkplaceManagerScreen.scanWorkplace(masterdata.workplaces.wpA.qrCode);
+        await WorkplaceManagerScreen.goBack();
+    });
+
+    await test.step('The connection drops, then the operator opens Production', async () => {
+        await simulateConnectionLossFor(WORKPLACE_ENDPOINT);
+        await ApplicationsListScreen.startApplication('mfg');
+
+        // The operator must be told the workplace could not be read and be offered a retry —
+        // not left looking at a screen that simply shows no workplace at all, with no way back
+        // short of restarting the app.
+        await ManufacturingJobsListScreen.expectConnectionErrorPanel();
+    });
+
+    await test.step('The connection comes back and the operator retries -> workplace A is shown again', async () => {
+        await restoreConnectionFor(WORKPLACE_ENDPOINT);
+        await ManufacturingJobsListScreen.retryLoadingOperatorContext();
+
+        await ManufacturingJobsListScreen.expectNoConnectionErrorPanel();
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKPLACE, value: masterdata.workplaces.wpA.name });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('A workstation that cannot be read because the connection dropped is recoverable', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0160: Manufacturing Execution');
+    allure.feature('F8030: MobileUI Manufacturing');
+    allure.tag('F8046: Workstation');
+    allure.story('A dropped connection must not look like a lost workstation assignment');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata({ isScanResourceRequired: true });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await test.step('The operator is set up on workstation WS1', async () => {
+        await WorkstationManagerScreen.scanWorkstation(masterdata.resources.WS1.qrCode);
+        await WorkstationManagerScreen.expectCurrentWorkstation(masterdata.resources.WS1.name);
+        await WorkstationManagerScreen.goBack();
+    });
+
+    await test.step('The connection drops, then the operator opens Production', async () => {
+        await simulateConnectionLossFor(WORKSTATION_ENDPOINT);
+        await ApplicationsListScreen.startApplication('mfg');
+
+        // The operator IS assigned to WS1 — the read just failed. Asking them to scan a workstation
+        // is misleading (and rescanning fails too while the connection is down); the screen must
+        // report the connection problem and offer a retry.
+        await ManufacturingJobsListScreen.expectConnectionErrorPanel();
+        await ManufacturingJobsListScreen.expectDoesNotAskForWorkstation();
+    });
+
+    await test.step('The connection comes back and the operator retries -> workstation WS1 is shown again', async () => {
+        await restoreConnectionFor(WORKSTATION_ENDPOINT);
+        await ManufacturingJobsListScreen.retryLoadingOperatorContext();
+
+        await ManufacturingJobsListScreen.expectNoConnectionErrorPanel();
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKSTATION, value: masterdata.resources.WS1.name });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/manufacturing/operator_context_reads_are_never_cached.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/operator_context_reads_are_never_cached.spec.js
@@ -1,0 +1,65 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { ManufacturingJobsListScreen } from "../../utils/screens/manufacturing/ManufacturingJobsListScreen";
+import { recordResponsesFor } from "../../utils/network";
+
+// End-to-end guard for the cache directives on the operator-context reads. The servlet filter that
+// sets them has its own unit test; this is the other half — proof that a real handheld request really
+// comes back uncacheable, asserted on the response the device actually receives.
+//
+// REQUIRES the `no-store` filter on /api/v2 to be present in the branch under test. Until it is, this
+// test fails with `Cache-Control ... Received: null` — a true negative, NOT a flake: the endpoint is
+// reached and answers 200 with no cache directive at all, which is precisely the defect.
+
+// Endpoints the Production screen reads the operator's context from.
+const WORKPLACE_ENDPOINT = '/api/v2/workplace';
+const WORKSTATION_ENDPOINT = '/api/v2/workstation';
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US" } },
+            // Required, or the Production screen never reads the workstation at all.
+            mobileConfig: { manufacturing: { isScanResourceRequired: true } },
+            warehouses: { whA: {} },
+            workplaces: { wpA: { warehouse: 'whA' } },
+            resources: { WS1: { type: 'WS', workplace: 'wpA' } },
+        }
+    });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('The operator context is re-read from the server, never served from the device cache', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0160: Manufacturing Execution');
+    allure.feature('F8030: MobileUI Manufacturing');
+    allure.tag('F8046: Workstation');
+    allure.story('A handheld must never answer the operator-context reads from its own cache');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+
+    // Installed before the app is opened, so the reads fired on the way into Production are recorded.
+    const workplaceReads = recordResponsesFor(WORKPLACE_ENDPOINT);
+    const workstationReads = recordResponsesFor(WORKSTATION_ENDPOINT);
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await test.step('Open Production -> the operator context is read from the server', async () => {
+        await ApplicationsListScreen.startApplication('mfg');
+        await ManufacturingJobsListScreen.expectAsksForWorkstation();
+    });
+
+    await test.step('Neither operator-context response may be stored by the device', async () => {
+        workplaceReads.stopRecording();
+        workstationReads.stopRecording();
+
+        await workplaceReads.expectAllForbidStoring();
+        await workstationReads.expectAllForbidStoring();
+    });
+});

--- a/e2e/mobile-webui/tests/spec/manufacturing/operator_context_reads_are_never_cached.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/operator_context_reads_are_never_cached.spec.js
@@ -6,13 +6,14 @@ import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScre
 import { ManufacturingJobsListScreen } from "../../utils/screens/manufacturing/ManufacturingJobsListScreen";
 import { recordResponsesFor } from "../../utils/network";
 
-// End-to-end guard for the cache directives on the operator-context reads. The servlet filter that
-// sets them has its own unit test; this is the other half — proof that a real handheld request really
-// comes back uncacheable, asserted on the response the device actually receives.
+// End-to-end guard for the cache directives on the operator-context reads: proof that a real handheld
+// request comes back uncacheable, asserted on the response the device actually receives.
 //
-// REQUIRES the `no-store` filter on /api/v2 to be present in the branch under test. Until it is, this
-// test fails with `Cache-Control ... Received: null` — a true negative, NOT a flake: the endpoint is
-// reached and answers 200 with no cache directive at all, which is precisely the defect.
+// The servlet filter that sets the directive, and its own unit test, are NOT in this branch - they live
+// in https://github.com/metasfresh/metasfresh/pull/25368, which targets the same base. Until that is
+// merged and this branch picks the base up, this test FAILS with `Cache-Control ... Received: null`.
+// That is a true negative, not a flake: the endpoint is reached and answers 200 with no cache directive
+// at all, which is precisely the defect being guarded against.
 
 // Endpoints the Production screen reads the operator's context from.
 const WORKPLACE_ENDPOINT = '/api/v2/workplace';
@@ -37,7 +38,9 @@ test('The operator context is re-read from the server, never served from the dev
     // === ALLURE METADATA ===
     allure.epic('E0160: Manufacturing Execution');
     allure.feature('F8030: MobileUI Manufacturing');
+    allure.tag('F8030');  // Standalone tag for Tags section;
     allure.tag('F8046: Workstation');
+    allure.tag('F8046');  // Standalone tag for Tags section;
     allure.story('A handheld must never answer the operator-context reads from its own cache');
     allure.severity('critical');
 

--- a/e2e/mobile-webui/tests/spec/manufacturing/operator_context_reads_are_never_cached.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/operator_context_reads_are_never_cached.spec.js
@@ -9,11 +9,9 @@ import { recordResponsesFor } from "../../utils/network";
 // End-to-end guard for the cache directives on the operator-context reads: proof that a real handheld
 // request comes back uncacheable, asserted on the response the device actually receives.
 //
-// The servlet filter that sets the directive, and its own unit test, are NOT in this branch - they live
-// in https://github.com/metasfresh/metasfresh/pull/25368, which targets the same base. Until that is
-// merged and this branch picks the base up, this test FAILS with `Cache-Control ... Received: null`.
-// That is a true negative, not a flake: the endpoint is reached and answers 200 with no cache directive
-// at all, which is precisely the defect being guarded against.
+// The servlet filter that sets the directive (https://github.com/metasfresh/metasfresh/pull/25368) is
+// merged into this branch's base, so this is now a genuine end-to-end proof of the no-store contract,
+// not a pending true-negative.
 
 // Endpoints the Production screen reads the operator's context from.
 const WORKPLACE_ENDPOINT = '/api/v2/workplace';

--- a/e2e/mobile-webui/tests/spec/manufacturing/operator_context_scan_failure_is_recoverable.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/operator_context_scan_failure_is_recoverable.spec.js
@@ -1,0 +1,74 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { ManufacturingJobsListScreen } from "../../utils/screens/manufacturing/ManufacturingJobsListScreen";
+import { ViewHeaderComponent } from "../../utils/components/ViewHeaderComponent";
+import { restoreConnectionFor, simulateConnectionLossFor } from "../../utils/network";
+
+// English captions of the two operator-context header rows (general.workplace / general.workstation).
+const HEADER_WORKPLACE = 'Workplace';
+const HEADER_WORKSTATION = 'Workstation';
+
+// The endpoint the Production jobs list ASSIGNS the scanned workstation through (as opposed to the
+// plain GET it reads the current one from).
+const WORKSTATION_ASSIGN_ENDPOINT = '**/api/v2/workstation/assign';
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US" } },
+            // The Production app only asks for a workstation when scanning a resource is required.
+            mobileConfig: { manufacturing: { isScanResourceRequired: true } },
+            warehouses: { whA: {} },
+            workplaces: { wpA: { warehouse: 'whA' } },
+            resources: { WS1: { type: 'WS', workplace: 'wpA' } },
+        }
+    });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('A workstation scan that fails because the connection dropped is recoverable', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0160: Manufacturing Execution');
+    allure.feature('F8030: MobileUI Manufacturing');
+    allure.tag('F8030');  // Standalone tag for Tags section;
+    allure.tag('F8046: Workstation');
+    allure.tag('F8046');  // Standalone tag for Tags section;
+    allure.story('A dropped connection during a workstation scan must be retryable, not a vanishing toast');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await test.step('The operator opens Production, which asks for a workstation', async () => {
+        await ApplicationsListScreen.startApplication('mfg');
+        await ManufacturingJobsListScreen.expectAsksForWorkstation();
+    });
+
+    await test.step('The connection drops, then the operator scans WS1', async () => {
+        await simulateConnectionLossFor(WORKSTATION_ASSIGN_ENDPOINT);
+        await ManufacturingJobsListScreen.typeWorkstationQRCode(masterdata.resources.WS1.qrCode);
+
+        // Nothing reached the server, so retrying the very same scan may well succeed. The operator
+        // must be offered that retry on screen — not a toast that fades while they are still holding
+        // the scanner, leaving them staring at the scan prompt with no idea the scan failed.
+        await ManufacturingJobsListScreen.expectConnectionErrorPanel();
+    });
+
+    await test.step('The connection comes back and the operator retries -> WS1 is assigned', async () => {
+        await restoreConnectionFor(WORKSTATION_ASSIGN_ENDPOINT);
+        await ManufacturingJobsListScreen.retryLoadingOperatorContext();
+
+        // Retry re-fires the SCAN, so the operator ends up on the workstation they scanned — being
+        // put back in front of the scan prompt would mean the scan was silently dropped.
+        await ManufacturingJobsListScreen.expectNoConnectionErrorPanel();
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKSTATION, value: masterdata.resources.WS1.name });
+        // Assigning WS1 moves the operator to its workplace, so the header shows that too.
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKPLACE, value: masterdata.workplaces.wpA.name });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/manufacturing/workstation_scan_on_jobs_list_refreshes_context.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/workstation_scan_on_jobs_list_refreshes_context.spec.js
@@ -1,0 +1,92 @@
+import { test } from "../../../playwright.config";
+import { expect } from "@playwright/test";
+import { allure } from 'allure-playwright';
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { WorkplaceManagerScreen } from "../../utils/screens/workplaceManager/WorkplaceManagerScreen";
+import { ManufacturingJobsListScreen } from "../../utils/screens/manufacturing/ManufacturingJobsListScreen";
+import { ViewHeaderComponent } from "../../utils/components/ViewHeaderComponent";
+
+// English captions of the two operator-context header rows (general.workplace / general.workstation).
+const HEADER_WORKPLACE = 'Workplace';
+const HEADER_WORKSTATION = 'Workstation';
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US" } },
+            // The Production app only asks for a workstation — and only filters its job list by it —
+            // when scanning a resource is required.
+            mobileConfig: { manufacturing: { isScanResourceRequired: true } },
+            warehouses: { whA: {}, whB: {} },
+            // Two workplaces linked to DIFFERENT workstations, so an un-refreshed workplace is visible.
+            workplaces: {
+                wpA: { warehouse: 'whA' },
+                wpB: { warehouse: 'whB' },
+            },
+            resources: {
+                WS1: { type: 'WS', workplace: 'wpA' },
+            },
+            products: {
+                COMP1: {},
+                BOM: { bom: { lines: [{ product: 'COMP1', qty: 1 }] } },
+            },
+            // A production order that belongs to NO workstation: it is offered while the operator has
+            // no workstation, and must disappear once they are on WS1.
+            manufacturingOrders: {
+                PP1: { warehouse: 'whA', product: 'BOM', qty: 10, datePromised: '2025-03-01T00:00:00.000+02:00' },
+            },
+        }
+    });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('Scanning the workstation on the Production jobs list updates workplace and job list', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0160: Manufacturing Execution');
+    allure.feature('F8030: MobileUI Manufacturing');
+    allure.tag('F8046: Workstation');
+    allure.story('The jobs list reflects the workstation the operator just scanned');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await test.step('The operator starts out on workplace B', async () => {
+        await WorkplaceManagerScreen.scanWorkplace(masterdata.workplaces.wpB.qrCode);
+        await WorkplaceManagerScreen.goBack();
+    });
+
+    await test.step('Open Production -> it asks for a workstation', async () => {
+        await ApplicationsListScreen.startApplication('mfg');
+        await ManufacturingJobsListScreen.expectAsksForWorkstation();
+    });
+
+    await test.step('Scan workstation WS1', async () => {
+        await ManufacturingJobsListScreen.scanWorkstation(masterdata.resources.WS1.qrCode);
+        await ManufacturingJobsListScreen.expectDoesNotAskForWorkstation();
+    });
+
+    await test.step('The system of record has moved the operator to workplace A', async () => {
+        // Asserted BEFORE the screen assertions below, so that a failure there can only mean the
+        // SCREEN is stale: the server has demonstrably already moved the operator.
+        const { assignedWorkplace } = await Backend.getCurrentWorkplace();
+        expect(assignedWorkplace?.name).toBe(masterdata.workplaces.wpA.name);
+    });
+
+    await test.step('The operator sees workplace A and only WS1 jobs', async () => {
+        // Scanning the workstation moves the operator to the workplace it belongs to (A). The header
+        // must show where the operator now IS — not the workplace they came from (B).
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKSTATION, value: masterdata.resources.WS1.name });
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKPLACE, value: masterdata.workplaces.wpA.name });
+
+        // The offered jobs must be the ones for WS1. PP1 belongs to no workstation, so an operator
+        // standing at WS1 must not be offered it; seeing it means the list was never refreshed
+        // for the workstation that was just scanned.
+        await ManufacturingJobsListScreen.expectJobNotListed({ documentNo: masterdata.manufacturingOrders.PP1.documentNo });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/manufacturing/workstation_scan_on_jobs_list_refreshes_context.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/workstation_scan_on_jobs_list_refreshes_context.spec.js
@@ -47,7 +47,9 @@ test('Scanning the workstation on the Production jobs list updates workplace and
     // === ALLURE METADATA ===
     allure.epic('E0160: Manufacturing Execution');
     allure.feature('F8030: MobileUI Manufacturing');
+    allure.tag('F8030');  // Standalone tag for Tags section;
     allure.tag('F8046: Workstation');
+    allure.tag('F8046');  // Standalone tag for Tags section;
     allure.story('The jobs list reflects the workstation the operator just scanned');
     allure.severity('critical');
 

--- a/e2e/mobile-webui/tests/spec/manufacturing/workstation_switch_is_visible_in_production.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/workstation_switch_is_visible_in_production.spec.js
@@ -8,10 +8,10 @@ import { WorkstationManagerScreen } from "../../utils/screens/workstationManager
 import { ManufacturingJobsListScreen } from "../../utils/screens/manufacturing/ManufacturingJobsListScreen";
 import { ViewHeaderComponent } from "../../utils/components/ViewHeaderComponent";
 
-// REGRESSION GUARD — this spec PASSES BOTH BEFORE AND AFTER the fix, BY DESIGN. It is NOT a broken
-// RED test, and must never be reported as one.
+// REGRESSION GUARD — both tests in this spec PASS BOTH BEFORE AND AFTER the fix, BY DESIGN. They are
+// NOT broken RED tests, and must never be reported as such.
 //
-// It drives the operator path the customer reported: switch workstation in the Arbeitsstation
+// They drive the operator path the customer reported: switch workstation in the Arbeitsstation
 // (workstation) app, then enter the Produktion (manufacturing) app and read its header. The stale
 // header the customer saw is served by the ANDROID WEBVIEW's own HTTP cache on the handheld, which
 // this suite cannot instantiate — Playwright drives Chromium, and Chromium re-fetches these
@@ -21,12 +21,19 @@ import { ViewHeaderComponent } from "../../utils/components/ViewHeaderComponent"
 // What this guard is for: the two-app user path itself — that a switch made in one app is what the
 // other app displays. The RED->GREEN proof of the cache directives is the sibling spec
 // `operator_context_reads_are_never_cached.spec.js`, which asserts the responses forbid storing.
+//
+// The customer hit the stale header twice in one session, once per sub-case, and the contract
+// (REQUIREMENTS.md AC1) names both — so there is one test each:
+//  1. the new workstation is on a DIFFERENT workplace -> both header rows must move;
+//  2. the new workstation is on the SAME workplace   -> the workstation row must move while the
+//     workplace row must stay put. Only the second one catches a header that refreshes by replacing
+//     every row wholesale, or an assertion that merely checks "something changed".
 
 // English captions of the two operator-context header rows (general.workplace / general.workstation).
 const HEADER_WORKPLACE = 'Workplace';
 const HEADER_WORKSTATION = 'Workstation';
 
-const createMasterdata = async () => {
+const createMasterdataOnDifferentWorkplaces = async () => {
     return await Backend.createMasterdata({
         language: "en_US",
         request: {
@@ -40,10 +47,28 @@ const createMasterdata = async () => {
                 wpB: { warehouse: 'whB' },
             },
             // Two workstations on DIFFERENT workplaces, so switching between them must move BOTH
-            // header rows; workstations sharing one workplace would hide a stale workplace row.
+            // header rows. The sub-case where they share one workplace is the second test below.
             resources: {
                 WS1: { type: 'WS', workplace: 'wpA' },
                 WS2: { type: 'WS', workplace: 'wpB' },
+            },
+        }
+    });
+};
+
+const createMasterdataOnOneWorkplace = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US" } },
+            mobileConfig: { manufacturing: { isScanResourceRequired: true } },
+            warehouses: { whA: {} },
+            workplaces: { wpA: { warehouse: 'whA' } },
+            // Two workstations on THE SAME workplace: switching between them must move the
+            // workstation row while leaving the workplace row exactly where it is.
+            resources: {
+                WS1: { type: 'WS', workplace: 'wpA' },
+                WS2: { type: 'WS', workplace: 'wpA' },
             },
         }
     });
@@ -60,7 +85,7 @@ test('A workstation switched in the Workstation app is the one the Production ap
     allure.story('Switching workstation in one app is what every other app displays');
     allure.severity('critical');
 
-    const masterdata = await createMasterdata();
+    const masterdata = await createMasterdataOnDifferentWorkplaces();
 
     await LoginScreen.login(masterdata.login.user);
     await ApplicationsListScreen.expectVisible();
@@ -101,5 +126,62 @@ test('A workstation switched in the Workstation app is the one the Production ap
         await ApplicationsListScreen.startApplication('mfg');
         await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKSTATION, value: masterdata.resources.WS2.name });
         await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKPLACE, value: masterdata.workplaces.wpB.name });
+    });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Switching to a workstation of the same workplace moves only the workstation the Production app shows', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0160: Manufacturing Execution');
+    allure.feature('F8030: MobileUI Manufacturing');
+    allure.tag('F8030');  // Standalone tag for Tags section;
+    allure.tag('F8046: Workstation');
+    allure.tag('F8046');  // Standalone tag for Tags section;
+    allure.story('Switching workstation in one app is what every other app displays');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdataOnOneWorkplace();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await test.step('The operator starts the shift on workstation WS1 of workplace A', async () => {
+        await WorkstationManagerScreen.scanWorkstation(masterdata.resources.WS1.qrCode);
+        await WorkstationManagerScreen.expectCurrentWorkstation(masterdata.resources.WS1.name);
+        await WorkstationManagerScreen.expectCurrentWorkplace(masterdata.workplaces.wpA.name);
+        await WorkstationManagerScreen.goBack();
+    });
+
+    await test.step('The operator works in Production, seeing WS1 / workplace A', async () => {
+        // As in the sibling test above, the first visit is part of the scenario: the customer hit the
+        // stale header on a RE-entry, after Production had already shown them the old workstation.
+        await ApplicationsListScreen.startApplication('mfg');
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKSTATION, value: masterdata.resources.WS1.name });
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKPLACE, value: masterdata.workplaces.wpA.name });
+        await ManufacturingJobsListScreen.goBack();
+    });
+
+    await test.step('The operator moves to workstation WS2, one bench over on the same workplace', async () => {
+        await WorkstationManagerScreen.scanWorkstation(masterdata.resources.WS2.qrCode);
+        await WorkstationManagerScreen.expectCurrentWorkstation(masterdata.resources.WS2.name);
+        await WorkstationManagerScreen.expectCurrentWorkplace(masterdata.workplaces.wpA.name);
+        await WorkstationManagerScreen.goBack();
+    });
+
+    await test.step('The operator has NOT left workplace A', async () => {
+        // Asserted against the system of record, so the workplace-row assertion below is a real
+        // invariant — the operator genuinely still belongs to workplace A — and not merely the
+        // observation that nothing happened to that row.
+        const { assignedWorkplace } = await Backend.getCurrentWorkplace();
+        expect(assignedWorkplace?.name).toBe(masterdata.workplaces.wpA.name);
+    });
+
+    await test.step('Re-entering Production shows WS2, with workplace A still standing', async () => {
+        await ApplicationsListScreen.startApplication('mfg');
+        // The row that MUST have moved. A header still naming WS1 is exactly what the customer
+        // reported on this sub-case (`Portionen2` scanned, `Portionen1` displayed).
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKSTATION, value: masterdata.resources.WS2.name });
+        // The row that MUST NOT have moved — the half a "did anything change?" check would miss.
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKPLACE, value: masterdata.workplaces.wpA.name });
     });
 });

--- a/e2e/mobile-webui/tests/spec/manufacturing/workstation_switch_is_visible_in_production.spec.js
+++ b/e2e/mobile-webui/tests/spec/manufacturing/workstation_switch_is_visible_in_production.spec.js
@@ -1,0 +1,105 @@
+import { test } from "../../../playwright.config";
+import { expect } from "@playwright/test";
+import { allure } from 'allure-playwright';
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { WorkstationManagerScreen } from "../../utils/screens/workstationManager/WorkstationManagerScreen";
+import { ManufacturingJobsListScreen } from "../../utils/screens/manufacturing/ManufacturingJobsListScreen";
+import { ViewHeaderComponent } from "../../utils/components/ViewHeaderComponent";
+
+// REGRESSION GUARD — this spec PASSES BOTH BEFORE AND AFTER the fix, BY DESIGN. It is NOT a broken
+// RED test, and must never be reported as one.
+//
+// It drives the operator path the customer reported: switch workstation in the Arbeitsstation
+// (workstation) app, then enter the Produktion (manufacturing) app and read its header. The stale
+// header the customer saw is served by the ANDROID WEBVIEW's own HTTP cache on the handheld, which
+// this suite cannot instantiate — Playwright drives Chromium, and Chromium re-fetches these
+// operator-context responses (measured: 13 mounts / 3 profiles / 0 reuses, plus a 4/4 desktop
+// control). So on Chromium the header is correct with or without the cache directives.
+//
+// What this guard is for: the two-app user path itself — that a switch made in one app is what the
+// other app displays. The RED->GREEN proof of the cache directives is the sibling spec
+// `operator_context_reads_are_never_cached.spec.js`, which asserts the responses forbid storing.
+
+// English captions of the two operator-context header rows (general.workplace / general.workstation).
+const HEADER_WORKPLACE = 'Workplace';
+const HEADER_WORKSTATION = 'Workstation';
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: { user: { language: "en_US" } },
+            // The Production app shows the workstation header row — and filters its job list by the
+            // workstation — only when scanning a resource is required.
+            mobileConfig: { manufacturing: { isScanResourceRequired: true } },
+            warehouses: { whA: {}, whB: {} },
+            workplaces: {
+                wpA: { warehouse: 'whA' },
+                wpB: { warehouse: 'whB' },
+            },
+            // Two workstations on DIFFERENT workplaces, so switching between them must move BOTH
+            // header rows; workstations sharing one workplace would hide a stale workplace row.
+            resources: {
+                WS1: { type: 'WS', workplace: 'wpA' },
+                WS2: { type: 'WS', workplace: 'wpB' },
+            },
+        }
+    });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('A workstation switched in the Workstation app is the one the Production app shows', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0160: Manufacturing Execution');
+    allure.feature('F8030: MobileUI Manufacturing');
+    allure.tag('F8030');  // Standalone tag for Tags section;
+    allure.tag('F8046: Workstation');
+    allure.tag('F8046');  // Standalone tag for Tags section;
+    allure.story('Switching workstation in one app is what every other app displays');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await test.step('The operator starts the shift on workstation WS1 (workplace A)', async () => {
+        await WorkstationManagerScreen.scanWorkstation(masterdata.resources.WS1.qrCode);
+        await WorkstationManagerScreen.expectCurrentWorkstation(masterdata.resources.WS1.name);
+        await WorkstationManagerScreen.expectCurrentWorkplace(masterdata.workplaces.wpA.name);
+        await WorkstationManagerScreen.goBack();
+    });
+
+    await test.step('The operator works in Production, seeing WS1 / workplace A', async () => {
+        // The first visit is part of the scenario, not scaffolding: the customer hit the stale header
+        // on a RE-entry, after the app had already shown them the old workstation once.
+        await ApplicationsListScreen.startApplication('mfg');
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKSTATION, value: masterdata.resources.WS1.name });
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKPLACE, value: masterdata.workplaces.wpA.name });
+        await ManufacturingJobsListScreen.goBack();
+    });
+
+    await test.step('The operator moves to workstation WS2 (workplace B) in the Workstation app', async () => {
+        await WorkstationManagerScreen.scanWorkstation(masterdata.resources.WS2.qrCode);
+        // The scan screen confirms the switch — exactly what the customer saw before it failed to
+        // show up in Production.
+        await WorkstationManagerScreen.expectCurrentWorkstation(masterdata.resources.WS2.name);
+        await WorkstationManagerScreen.expectCurrentWorkplace(masterdata.workplaces.wpB.name);
+        await WorkstationManagerScreen.goBack();
+    });
+
+    await test.step('The system of record has moved the operator to workplace B', async () => {
+        // Asserted BEFORE the screen assertions below, so that a failure there can only mean the
+        // SCREEN is stale: the server has demonstrably already moved the operator.
+        const { assignedWorkplace } = await Backend.getCurrentWorkplace();
+        expect(assignedWorkplace?.name).toBe(masterdata.workplaces.wpB.name);
+    });
+
+    await test.step('Re-entering Production shows WS2 / workplace B, not the workstation left behind', async () => {
+        await ApplicationsListScreen.startApplication('mfg');
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKSTATION, value: masterdata.resources.WS2.name });
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKPLACE, value: masterdata.workplaces.wpB.name });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/picking/operator_context_scan_failure_is_recoverable.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/operator_context_scan_failure_is_recoverable.spec.js
@@ -1,0 +1,75 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { Backend } from '../../utils/screens/Backend';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { PickingJobsListScreen } from '../../utils/screens/picking/PickingJobsListScreen';
+import { ViewHeaderComponent } from '../../utils/components/ViewHeaderComponent';
+import { restoreConnectionFor, simulateConnectionLossFor } from '../../utils/network';
+
+// English caption of the operator-context header row (general.workplace).
+const HEADER_WORKPLACE = 'Workplace';
+
+// The endpoint the Packing jobs list ASSIGNS the scanned workplace through (as opposed to the plain
+// GET it reads the current one from).
+const WORKPLACE_ASSIGN_ENDPOINT = '**/api/v2/workplace/*/assign';
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            // Deliberately NO workplace on the user: the jobs list is what has to ask for it.
+            login: { user: { language: "en_US" } },
+            mobileConfig: {
+                picking: {
+                    // The Packing app only asks for a workplace when an active one is required.
+                    activeWorkplaceRequired: true,
+                    // A picking profile is rejected without at least one pick-to structure; the
+                    // scenario never reaches a job, so the simplest one will do.
+                    pickTo: ['CU'],
+                }
+            },
+            warehouses: { wh: {} },
+            workplaces: { wpA: {} },
+        }
+    });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('A workplace scan that fails because the connection dropped is recoverable', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230.3');
+    allure.story('A dropped connection during a workplace scan must be retryable, not a vanishing toast');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await test.step('The operator opens Packing, which asks for a workplace', async () => {
+        await ApplicationsListScreen.startPickingApplication();
+        await PickingJobsListScreen.expectAsksForWorkplace();
+    });
+
+    await test.step('The connection drops, then the operator scans workplace A', async () => {
+        await simulateConnectionLossFor(WORKPLACE_ASSIGN_ENDPOINT);
+        await PickingJobsListScreen.typeWorkplaceQRCode(masterdata.workplaces.wpA.qrCode);
+
+        // Nothing reached the server, so retrying the very same scan may well succeed. The operator
+        // must be offered that retry on screen — not a toast that fades while they are still holding
+        // the scanner, leaving them staring at the scan prompt with no idea the scan failed.
+        await PickingJobsListScreen.expectConnectionErrorPanel();
+    });
+
+    await test.step('The connection comes back and the operator retries -> workplace A is assigned', async () => {
+        await restoreConnectionFor(WORKPLACE_ASSIGN_ENDPOINT);
+        await PickingJobsListScreen.retryLoadingOperatorContext();
+
+        // Retry re-fires the SCAN, so the operator ends up on the workplace they scanned — being put
+        // back in front of the scan prompt would mean the scan was silently dropped.
+        await PickingJobsListScreen.expectNoConnectionErrorPanel();
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKPLACE, value: masterdata.workplaces.wpA.name });
+    });
+});

--- a/e2e/mobile-webui/tests/spec/picking/workplace_switch_is_visible_in_picking.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/workplace_switch_is_visible_in_picking.spec.js
@@ -1,0 +1,108 @@
+import { test } from "../../../playwright.config";
+import { expect } from "@playwright/test";
+import { allure } from 'allure-playwright';
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { WorkplaceManagerScreen } from "../../utils/screens/workplaceManager/WorkplaceManagerScreen";
+import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
+import { ViewHeaderComponent } from "../../utils/components/ViewHeaderComponent";
+
+// REGRESSION GUARD — this spec PASSES BOTH BEFORE AND AFTER the fix, BY DESIGN. It is NOT a broken
+// RED test, and must never be reported as one.
+//
+// It is the workplace direction of the same guarantee the sibling
+// `manufacturing/workstation_switch_is_visible_in_production.spec.js` covers for the workstation: a
+// switch made in one app is what the next app displays. The stale header the customer reported is
+// served by the ANDROID WEBVIEW's own HTTP cache on the handheld, which this suite cannot
+// instantiate — Playwright drives Chromium, and Chromium re-fetches these operator-context
+// responses. So on Chromium the header is correct with or without the cache directives.
+//
+// The RED->GREEN proof of the cache directives is
+// `manufacturing/operator_context_reads_are_never_cached.spec.js`, which asserts the responses
+// forbid storing. What THIS guard is for is the two-app user path itself.
+//
+// Picking is the app the contract names for this direction (REQUIREMENTS.md AC3): it requires an
+// active workplace and filters its job list by it, so an operator reading a stale workplace here is
+// told they are somewhere they are not, above a list already filtered for where they actually are.
+
+// English caption of the operator-context header row (general.workplace).
+const HEADER_WORKPLACE = 'Workplace';
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            // Deliberately NO workplace on the user: every workplace this operator has comes from a
+            // scan in the Workplace app, which is the action under test.
+            login: { user: { language: "en_US" } },
+            mobileConfig: {
+                picking: {
+                    // The Packing app shows the workplace header row — and filters its job list by
+                    // the workplace — only when an active workplace is required.
+                    activeWorkplaceRequired: true,
+                    // A picking profile is rejected without at least one pick-to structure; the
+                    // scenario never reaches a job, so the simplest one will do.
+                    pickTo: ['CU'],
+                }
+            },
+            warehouses: { wh: {} },
+            workplaces: { wpA: {}, wpB: {} },
+        }
+    });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('A workplace switched in the Workplace app is the one the Packing app shows', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');  // Standalone tag for Tags section;
+    allure.tag('F8046: Workstation');
+    allure.tag('F8046');  // Standalone tag for Tags section;
+    allure.story('Switching workplace in one app is what every other app displays');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    await test.step('The operator starts the shift on workplace A', async () => {
+        await WorkplaceManagerScreen.scanWorkplace(masterdata.workplaces.wpA.qrCode);
+        await WorkplaceManagerScreen.expectHeaderProperty({ caption: 'Name', value: masterdata.workplaces.wpA.name });
+        await WorkplaceManagerScreen.expectHeaderProperty({ caption: 'Assigned', value: 'Yes' });
+        await WorkplaceManagerScreen.goBack();
+    });
+
+    await test.step('The operator works in Packing, seeing workplace A', async () => {
+        // The first visit is part of the scenario, not scaffolding: the stale header is only
+        // reachable on a RE-entry, after the app has already displayed the old workplace once.
+        await ApplicationsListScreen.startPickingApplication();
+        await PickingJobsListScreen.waitForScreen();
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKPLACE, value: masterdata.workplaces.wpA.name });
+        await PickingJobsListScreen.goBack();
+    });
+
+    await test.step('The operator moves to workplace B in the Workplace app', async () => {
+        await WorkplaceManagerScreen.scanWorkplace(masterdata.workplaces.wpB.qrCode);
+        // The scan screen confirms the switch — the same confirmation the customer got before the
+        // other app went on showing the workplace they had left.
+        await WorkplaceManagerScreen.expectHeaderProperty({ caption: 'Name', value: masterdata.workplaces.wpB.name });
+        await WorkplaceManagerScreen.expectHeaderProperty({ caption: 'Assigned', value: 'Yes' });
+        await WorkplaceManagerScreen.goBack();
+    });
+
+    await test.step('The system of record has moved the operator to workplace B', async () => {
+        // Asserted BEFORE the screen assertion below, so that a failure there can only mean the
+        // SCREEN is stale: the server has demonstrably already moved the operator.
+        const { assignedWorkplace } = await Backend.getCurrentWorkplace();
+        expect(assignedWorkplace?.name).toBe(masterdata.workplaces.wpB.name);
+    });
+
+    await test.step('Re-entering Packing shows workplace B, not the workplace left behind', async () => {
+        await ApplicationsListScreen.startPickingApplication();
+        await PickingJobsListScreen.waitForScreen();
+        await ViewHeaderComponent.expectProperty({ caption: HEADER_WORKPLACE, value: masterdata.workplaces.wpB.name });
+    });
+});

--- a/e2e/mobile-webui/tests/utils/components/OperatorContextErrorPanel.js
+++ b/e2e/mobile-webui/tests/utils/components/OperatorContextErrorPanel.js
@@ -1,0 +1,29 @@
+import { FAST_ACTION_TIMEOUT, page, SLOW_ACTION_TIMEOUT } from '../common';
+import { test } from '../../../playwright.config';
+import { expect } from '@playwright/test';
+
+const NAME = 'OperatorContextErrorPanel';
+
+// The panel WFLaunchersScreen (misc/services/mobile-webui/mobile-webui-frontend/src/containers/
+// wfLaunchersScreen/WFLaunchersScreen.jsx) renders instead of the job list when the operator's
+// workplace/workstation could not be READ or ASSIGNED because the connection dropped. Every
+// launchers-based app (manufacturing, picking, distribution, ...) renders that same screen, so this
+// belongs to a component shared by their screen objects rather than to any one of them.
+/** @returns {import('@playwright/test').Locator} */
+const panelElement = () => page.getByTestId('operator-context-error-panel');
+/** @returns {import('@playwright/test').Locator} */
+const retryButtonElement = () => page.getByTestId('operator-context-error-retry');
+
+export const OperatorContextErrorPanel = {
+    expectVisible: async () => await test.step(`${NAME} - Expect the panel to be displayed`, async () => {
+        await expect(panelElement()).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+    }),
+
+    expectNotVisible: async () => await test.step(`${NAME} - Expect no panel`, async () => {
+        await expect(panelElement()).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
+    }),
+
+    tapRetry: async () => await test.step(`${NAME} - Tap retry`, async () => {
+        await retryButtonElement().tap();
+    }),
+};

--- a/e2e/mobile-webui/tests/utils/components/ViewHeaderComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/ViewHeaderComponent.js
@@ -1,0 +1,21 @@
+import { page, SLOW_ACTION_TIMEOUT } from '../common';
+import { test } from '../../../playwright.config';
+import { expect } from '@playwright/test';
+
+const NAME = 'ViewHeaderComponent';
+
+// The app-wide header table rendered by containers/ViewHeader.jsx — one <tr> per entry:
+// <th>caption</th><td>value</td>. It carries the operator's session-global context
+// (Workplace / Workstation) on every screen that publishes header entries.
+/** @returns {import('@playwright/test').Locator} */
+const valueElement = (caption) => page.locator(`table.view-header tr:has(th:text-is("${caption}")) td`);
+
+export const ViewHeaderComponent = {
+    // Asserts the header row for `caption` is painted and reads exactly `value`.
+    // toHaveText (not a :has-text substring match) so a STALE value fails instead of
+    // silently passing, and `visible` so the operator really sees it on screen.
+    expectProperty: async ({ caption, value, timeout = SLOW_ACTION_TIMEOUT }) => await test.step(`${NAME} - Expect header '${caption}' = '${value}'`, async () => {
+        await valueElement(caption).waitFor({ state: 'visible', timeout });
+        await expect(valueElement(caption)).toHaveText(value, { timeout });
+    }),
+};

--- a/e2e/mobile-webui/tests/utils/network.js
+++ b/e2e/mobile-webui/tests/utils/network.js
@@ -1,5 +1,6 @@
 import { page } from './common';
 import { test } from '../../playwright.config';
+import { expect } from '@playwright/test';
 
 // Warehouse WiFi drops out routinely, and the handheld then gets NO http response at all —
 // as opposed to the server answering 4xx/5xx. These helpers reproduce exactly that
@@ -12,3 +13,39 @@ export const simulateConnectionLossFor = async (urlPattern) => await test.step(`
 export const restoreConnectionFor = async (urlPattern) => await test.step(`Restore connection for '${urlPattern}'`, async () => {
     await page.unroute(urlPattern);
 });
+
+// The handheld's Android WebView caches a GET whose response carries no cache directives, and then
+// answers the operator-context reads from its own disk — the screen freezes on whatever workplace /
+// workstation was true when the app was first opened, and no amount of re-entering the app fixes it.
+// The only durable guard is that the responses themselves forbid storing, so assert exactly that on
+// the real end-to-end responses (the servlet filter that sets it also has its own unit test).
+//
+// Records every response whose URL contains `urlSubstring`, from install time on. Install BEFORE the
+// navigation that triggers the reads; responses that arrive later are still recorded.
+export const recordResponsesFor = (urlSubstring) => {
+    const responses = [];
+    const handler = (response) => {
+        if (response.url().includes(urlSubstring)) {
+            responses.push({
+                url: response.url(),
+                status: response.status(),
+                cacheControl: response.headers()['cache-control'] ?? null,
+            });
+        }
+    };
+    page.on('response', handler);
+
+    return {
+        stopRecording: () => page.removeListener('response', handler),
+
+        // Asserts the endpoint was actually reached (a silent zero-response recording would make this
+        // guard vacuous) and that every response it produced forbids storing.
+        expectAllForbidStoring: async () => await test.step(`Expect every '${urlSubstring}' response to forbid storing`, async () => {
+            expect(responses.length, `no response recorded for '${urlSubstring}' — the endpoint was never reached`).toBeGreaterThan(0);
+            for (const { url, status, cacheControl } of responses) {
+                expect(cacheControl, `Cache-Control of ${status} ${url}`).not.toBeNull();
+                expect(cacheControl.toLowerCase(), `Cache-Control of ${status} ${url}`).toContain('no-store');
+            }
+        }),
+    };
+};

--- a/e2e/mobile-webui/tests/utils/network.js
+++ b/e2e/mobile-webui/tests/utils/network.js
@@ -20,12 +20,20 @@ export const restoreConnectionFor = async (urlPattern) => await test.step(`Resto
 // The only durable guard is that the responses themselves forbid storing, so assert exactly that on
 // the real end-to-end responses (the servlet filter that sets it also has its own unit test).
 //
-// Records every response whose URL contains `urlSubstring`, from install time on. Install BEFORE the
+// Records every response for exactly the endpoint at `path`, from install time on. Install BEFORE the
 // navigation that triggers the reads; responses that arrive later are still recorded.
-export const recordResponsesFor = (urlSubstring) => {
+// Matched on the exact URL pathname, not a substring, so a future sibling endpoint that merely shares
+// the prefix (`/api/v2/workplaceManager`) cannot be swept silently into the same assertion set.
+export const recordResponsesFor = (path) => {
     const responses = [];
     const handler = (response) => {
-        if (response.url().includes(urlSubstring)) {
+        let pathname;
+        try {
+            pathname = new URL(response.url()).pathname;
+        } catch {
+            return; // not an absolute URL — cannot be the endpoint under test
+        }
+        if (pathname === path) {
             responses.push({
                 url: response.url(),
                 status: response.status(),
@@ -40,8 +48,8 @@ export const recordResponsesFor = (urlSubstring) => {
 
         // Asserts the endpoint was actually reached (a silent zero-response recording would make this
         // guard vacuous) and that every response it produced forbids storing.
-        expectAllForbidStoring: async () => await test.step(`Expect every '${urlSubstring}' response to forbid storing`, async () => {
-            expect(responses.length, `no response recorded for '${urlSubstring}' — the endpoint was never reached`).toBeGreaterThan(0);
+        expectAllForbidStoring: async () => await test.step(`Expect every '${path}' response to forbid storing`, async () => {
+            expect(responses.length, `no response recorded for '${path}' — the endpoint was never reached`).toBeGreaterThan(0);
             for (const { url, status, cacheControl } of responses) {
                 expect(cacheControl, `Cache-Control of ${status} ${url}`).not.toBeNull();
                 expect(cacheControl.toLowerCase(), `Cache-Control of ${status} ${url}`).toContain('no-store');

--- a/e2e/mobile-webui/tests/utils/network.js
+++ b/e2e/mobile-webui/tests/utils/network.js
@@ -1,0 +1,14 @@
+import { page } from './common';
+import { test } from '../../playwright.config';
+
+// Warehouse WiFi drops out routinely, and the handheld then gets NO http response at all —
+// as opposed to the server answering 4xx/5xx. These helpers reproduce exactly that
+// network-layer failure for a given endpoint, so a screen's offline behaviour can be driven.
+
+export const simulateConnectionLossFor = async (urlPattern) => await test.step(`Simulate connection loss for '${urlPattern}'`, async () => {
+    await page.route(urlPattern, (route) => route.abort('failed'));
+});
+
+export const restoreConnectionFor = async (urlPattern) => await test.step(`Restore connection for '${urlPattern}'`, async () => {
+    await page.unroute(urlPattern);
+});

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/ManufacturingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/ManufacturingJobsListScreen.js
@@ -4,6 +4,7 @@ import { ManufacturingJobScreen } from './ManufacturingJobScreen';
 import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
+import { OperatorContextErrorPanel } from '../../components/OperatorContextErrorPanel';
 
 const NAME = 'ManufacturingJobsListScreen';
 /** @returns {import('@playwright/test').Locator} */
@@ -32,8 +33,14 @@ export const ManufacturingJobsListScreen = {
         await BarcodeScannerComponent.expectNotAttached({});
     }),
 
-    scanWorkstation: async (qrCode) => await test.step(`${NAME} - Scan workstation QR '${qrCode}'`, async () => {
+    // Scan without asserting the job list takes over — for scenarios where the assign is expected to
+    // fail (e.g. the connection dropped), so the scanner does NOT give way to the job list.
+    typeWorkstationQRCode: async (qrCode) => await test.step(`${NAME} - Scan workstation QR '${qrCode}'`, async () => {
         await BarcodeScannerComponent.type(qrCode);
+    }),
+
+    scanWorkstation: async (qrCode) => await test.step(`${NAME} - Scan workstation QR '${qrCode}' and wait for the job list`, async () => {
+        await ManufacturingJobsListScreen.typeWorkstationQRCode(qrCode);
         // The scanner disappears once the workstation is assigned and the job list takes over.
         await BarcodeScannerComponent.expectNotAttached({ timeout: SLOW_ACTION_TIMEOUT });
         await ManufacturingJobsListScreen.waitForScreen();
@@ -44,18 +51,19 @@ export const ManufacturingJobsListScreen = {
             .toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
     }),
 
-    // When the operator's workplace/workstation cannot be read because the connection dropped,
-    // the screen must say so and offer a retry — instead of silently showing no workplace at all.
+    // When the operator's workplace/workstation cannot be read — or assigned from a scan — because
+    // the connection dropped, the screen must say so and offer a retry, instead of silently showing
+    // no workplace at all.
     expectConnectionErrorPanel: async () => await test.step(`${NAME} - Expect operator-context connection error panel`, async () => {
-        await expect(page.getByTestId('operator-context-error-panel')).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+        await OperatorContextErrorPanel.expectVisible();
     }),
 
     expectNoConnectionErrorPanel: async () => await test.step(`${NAME} - Expect no operator-context connection error panel`, async () => {
-        await expect(page.getByTestId('operator-context-error-panel')).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
+        await OperatorContextErrorPanel.expectNotVisible();
     }),
 
     retryLoadingOperatorContext: async () => await test.step(`${NAME} - Retry loading workplace/workstation`, async () => {
-        await page.getByTestId('operator-context-error-retry').tap();
+        await OperatorContextErrorPanel.tapRetry();
         await ManufacturingJobsListScreen.waitForScreen();
     }),
 

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/ManufacturingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/ManufacturingJobsListScreen.js
@@ -1,8 +1,9 @@
-import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from '../../common';
+import { FAST_ACTION_TIMEOUT, ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT } from '../../common';
 import { test } from '../../../../playwright.config';
 import { ManufacturingJobScreen } from './ManufacturingJobScreen';
 import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
+import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
 
 const NAME = 'ManufacturingJobsListScreen';
 /** @returns {import('@playwright/test').Locator} */
@@ -16,6 +17,51 @@ export const ManufacturingJobsListScreen = {
 
     expectVisible: async () => await test.step(`${NAME} - Expect screen to be displayed`, async () => {
         await expect(containerElement()).toBeVisible();
+    }),
+
+    // The jobs list itself asks for a workstation when the Production app is configured to require
+    // one and the operator has none assigned yet: the screen renders its own scanner instead of the
+    // job buttons.
+    expectAsksForWorkstation: async () => await test.step(`${NAME} - Expect the screen to ask for a workstation`, async () => {
+        await ManufacturingJobsListScreen.expectVisible();
+        await BarcodeScannerComponent.expectAttached({});
+    }),
+
+    expectDoesNotAskForWorkstation: async () => await test.step(`${NAME} - Expect the screen NOT to ask for a workstation`, async () => {
+        await ManufacturingJobsListScreen.expectVisible();
+        await BarcodeScannerComponent.expectNotAttached({});
+    }),
+
+    scanWorkstation: async (qrCode) => await test.step(`${NAME} - Scan workstation QR '${qrCode}'`, async () => {
+        await BarcodeScannerComponent.type(qrCode);
+        // The scanner disappears once the workstation is assigned and the job list takes over.
+        await BarcodeScannerComponent.expectNotAttached({ timeout: SLOW_ACTION_TIMEOUT });
+        await ManufacturingJobsListScreen.waitForScreen();
+    }),
+
+    expectJobListed: async ({ documentNo }) => await test.step(`${NAME} - Expect job '${documentNo}' listed`, async () => {
+        await expect(page.locator('.wflauncher-button').filter({ hasText: documentNo }))
+            .toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+    }),
+
+    expectJobNotListed: async ({ documentNo }) => await test.step(`${NAME} - Expect job '${documentNo}' NOT listed`, async () => {
+        await expect(page.locator('.wflauncher-button').filter({ hasText: documentNo }))
+            .toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
+    }),
+
+    // When the operator's workplace/workstation cannot be read because the connection dropped,
+    // the screen must say so and offer a retry — instead of silently showing no workplace at all.
+    expectConnectionErrorPanel: async () => await test.step(`${NAME} - Expect operator-context connection error panel`, async () => {
+        await expect(page.getByTestId('operator-context-error-panel')).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+    }),
+
+    expectNoConnectionErrorPanel: async () => await test.step(`${NAME} - Expect no operator-context connection error panel`, async () => {
+        await expect(page.getByTestId('operator-context-error-panel')).toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });
+    }),
+
+    retryLoadingOperatorContext: async () => await test.step(`${NAME} - Retry loading workplace/workstation`, async () => {
+        await page.getByTestId('operator-context-error-retry').tap();
+        await ManufacturingJobsListScreen.waitForScreen();
     }),
 
     goBack: async () => await test.step(`${NAME} - Go back`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/manufacturing/ManufacturingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/manufacturing/ManufacturingJobsListScreen.js
@@ -39,11 +39,6 @@ export const ManufacturingJobsListScreen = {
         await ManufacturingJobsListScreen.waitForScreen();
     }),
 
-    expectJobListed: async ({ documentNo }) => await test.step(`${NAME} - Expect job '${documentNo}' listed`, async () => {
-        await expect(page.locator('.wflauncher-button').filter({ hasText: documentNo }))
-            .toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
-    }),
-
     expectJobNotListed: async ({ documentNo }) => await test.step(`${NAME} - Expect job '${documentNo}' NOT listed`, async () => {
         await expect(page.locator('.wflauncher-button').filter({ hasText: documentNo }))
             .toHaveCount(0, { timeout: FAST_ACTION_TIMEOUT });

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
@@ -6,6 +6,8 @@ import { PickingJobsListScanScreen } from './PickingJobsListScanScreen';
 import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
 import { expectClasses } from '../../expectations';
+import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
+import { OperatorContextErrorPanel } from '../../components/OperatorContextErrorPanel';
 
 const NAME = 'PickingJobsListScreen';
 /** @returns {import('@playwright/test').Locator} */
@@ -104,6 +106,34 @@ export const PickingJobsListScreen = {
         // Make sure we have the expected number of buttons
         // NOTE: we do this at the end because expect does not wait for the elements to stabilize
         await expect(locateJobButtons()).toHaveCount(expectationsArray.length);
+    }),
+
+    // The jobs list itself asks for a workplace when the picking profile requires an active one and
+    // the operator has none assigned yet: the screen renders its own scanner instead of the job list.
+    expectAsksForWorkplace: async () => await test.step(`${NAME} - Expect the screen to ask for a workplace`, async () => {
+        await PickingJobsListScreen.expectVisible();
+        await BarcodeScannerComponent.expectAttached({});
+    }),
+
+    // Scan without asserting the job list takes over — for scenarios where the assign is expected to
+    // fail (e.g. the connection dropped), so the scanner does NOT give way to the job list.
+    typeWorkplaceQRCode: async (qrCode) => await test.step(`${NAME} - Scan workplace QR '${qrCode}'`, async () => {
+        await BarcodeScannerComponent.type(qrCode);
+    }),
+
+    // When the operator's workplace cannot be read — or assigned from a scan — because the connection
+    // dropped, the screen must say so and offer a retry, instead of silently showing no workplace.
+    expectConnectionErrorPanel: async () => await test.step(`${NAME} - Expect operator-context connection error panel`, async () => {
+        await OperatorContextErrorPanel.expectVisible();
+    }),
+
+    expectNoConnectionErrorPanel: async () => await test.step(`${NAME} - Expect no operator-context connection error panel`, async () => {
+        await OperatorContextErrorPanel.expectNotVisible();
+    }),
+
+    retryLoadingOperatorContext: async () => await test.step(`${NAME} - Retry loading workplace/workstation`, async () => {
+        await OperatorContextErrorPanel.tapRetry();
+        await PickingJobsListScreen.waitForScreen();
     }),
 
     goBack: async () => await test.step(`${NAME} - Go back`, async () => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/workplace.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/workplace.js
@@ -24,7 +24,7 @@ import axios from 'axios';
 import { unboxAxiosResponse } from '../utils';
 import { apiBasePath } from '../constants';
 import { extractUserFriendlyErrorMessageFromAxiosError, toastError } from '../utils/toast';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { parseWorkplaceQRCodeString } from '../utils/qrCode/workplace';
 import { useApplicationInfo } from '../reducers/applications';
 import * as uiTrace from '../utils/ui_trace';
@@ -40,36 +40,46 @@ export const useCurrentWorkplace = ({ applicationId }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [isWorkplaceRequired, setIsWorkplaceRequired] = useState(false);
   const [workplace, setWorkplace] = useState(null);
-  const [loadErrorMessage, setLoadErrorMessage] = useState(null);
+  const [errorMessage, setErrorMessage] = useState(null);
+  // What "Retry" has to re-run. Re-READING after a failed SCAN would drop the scan instead of
+  // retrying it, putting the operator back in front of the scan prompt with no clue why, so the
+  // operation that actually failed is remembered here.
+  const retryFailedOperationRef = useRef(null);
+
+  // A server response means the backend answered and retrying the same request won't help, so keep the
+  // toast (existing automation asserts on it). No response at all is the routine warehouse-WiFi blip —
+  // retrying may well succeed — so surface it inline with a retry instead.
+  // Shape per module CLAUDE.md § "API Error Surfacing"; reference impl ConfirmActivity.jsx.
+  const onRequestFailed = ({ axiosError, eventName, retry }) => {
+    const isNetworkFailure = !axiosError?.response;
+    const message = extractUserFriendlyErrorMessageFromAxiosError({ axiosError });
+    uiTrace.trace({
+      eventName,
+      httpStatus: axiosError?.response?.status ?? null,
+      axiosCode: axiosError?.code ?? null,
+      isNetworkFailure,
+      message,
+    });
+    if (isNetworkFailure) {
+      retryFailedOperationRef.current = retry;
+      setErrorMessage(message);
+    } else {
+      toastError({ axiosError });
+    }
+  };
 
   const reloadWorkplace = useCallback(() => {
     setIsLoading(true);
-    setLoadErrorMessage(null);
+    setErrorMessage(null);
     getCurrentWorkplaceInfo()
       .then(({ workplaceRequired, assignedWorkplace }) => {
         setIsWorkplaceRequired(workplaceRequired);
         setWorkplace(assignedWorkplace);
       })
-      .catch((axiosError) => {
-        // A server response means the backend answered and retrying the same read won't help, so keep the
-        // toast (existing automation asserts on it). No response at all is the routine warehouse-WiFi blip:
-        // leaving the workplace unset blanks the header row for good — the screen never re-reads it — so
-        // surface it for retry instead.
-        const isNetworkFailure = !axiosError?.response;
-        const message = extractUserFriendlyErrorMessageFromAxiosError({ axiosError });
-        uiTrace.trace({
-          eventName: 'currentWorkplaceLoadFailed',
-          httpStatus: axiosError?.response?.status ?? null,
-          axiosCode: axiosError?.code ?? null,
-          isNetworkFailure,
-          message,
-        });
-        if (isNetworkFailure) {
-          setLoadErrorMessage(message);
-        } else {
-          toastError({ axiosError });
-        }
-      })
+      .catch((axiosError) =>
+        // Leaving the workplace unset blanks the header row for good — the screen never re-reads it.
+        onRequestFailed({ axiosError, eventName: 'currentWorkplaceLoadFailed', retry: reloadWorkplace })
+      )
       .finally(() => setIsLoading(false));
   }, []);
 
@@ -79,16 +89,32 @@ export const useCurrentWorkplace = ({ applicationId }) => {
 
   const setWorkplaceByQRCode = (qrCode) => {
     const { workplaceId } = parseWorkplaceQRCodeString(qrCode);
+    setErrorMessage(null);
     assignWorkplace(workplaceId)
       .then((workplace) => setWorkplace(workplace))
-      .catch((axiosError) => toastError({ axiosError }));
+      .catch((axiosError) =>
+        onRequestFailed({
+          axiosError,
+          eventName: 'assignWorkplaceFailed',
+          retry: () => setWorkplaceByQRCode(qrCode),
+        })
+      );
+  };
+
+  // Re-runs whatever failed last, then forgets it so a gloved double-tap on Retry cannot fire the same
+  // assign twice; that second tap falls back to a plain re-read rather than crashing on a null op.
+  const retryWorkplace = () => {
+    const retry = retryFailedOperationRef.current ?? reloadWorkplace;
+    retryFailedOperationRef.current = null;
+    retry();
   };
 
   return {
     isWorkplaceLoading: isLoading,
     isWorkplaceRequired: requiresWorkplaceIfAvailable && isWorkplaceRequired,
     workplace,
-    workplaceLoadErrorMessage: loadErrorMessage,
+    workplaceErrorMessage: errorMessage,
+    retryWorkplace,
     reloadWorkplace,
     setWorkplaceByQRCode,
   };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/workplace.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/workplace.js
@@ -23,10 +23,11 @@
 import axios from 'axios';
 import { unboxAxiosResponse } from '../utils';
 import { apiBasePath } from '../constants';
-import { toastError } from '../utils/toast';
-import { useEffect, useState } from 'react';
+import { extractUserFriendlyErrorMessageFromAxiosError, toastError } from '../utils/toast';
+import { useCallback, useEffect, useState } from 'react';
 import { parseWorkplaceQRCodeString } from '../utils/qrCode/workplace';
 import { useApplicationInfo } from '../reducers/applications';
+import * as uiTrace from '../utils/ui_trace';
 
 const workplaceAPIBase = `${apiBasePath}/workplace`;
 
@@ -39,17 +40,42 @@ export const useCurrentWorkplace = ({ applicationId }) => {
   const [isLoading, setIsLoading] = useState(true);
   const [isWorkplaceRequired, setIsWorkplaceRequired] = useState(false);
   const [workplace, setWorkplace] = useState(null);
+  const [loadErrorMessage, setLoadErrorMessage] = useState(null);
 
-  useEffect(() => {
+  const reloadWorkplace = useCallback(() => {
     setIsLoading(true);
+    setLoadErrorMessage(null);
     getCurrentWorkplaceInfo()
       .then(({ workplaceRequired, assignedWorkplace }) => {
         setIsWorkplaceRequired(workplaceRequired);
         setWorkplace(assignedWorkplace);
       })
-      .catch((axiosError) => toastError({ axiosError }))
+      .catch((axiosError) => {
+        // A server response means the backend answered and retrying the same read won't help, so keep the
+        // toast (existing automation asserts on it). No response at all is the routine warehouse-WiFi blip:
+        // leaving the workplace unset blanks the header row for good — the screen never re-reads it — so
+        // surface it for retry instead.
+        const isNetworkFailure = !axiosError?.response;
+        const message = extractUserFriendlyErrorMessageFromAxiosError({ axiosError });
+        uiTrace.trace({
+          eventName: 'currentWorkplaceLoadFailed',
+          httpStatus: axiosError?.response?.status ?? null,
+          axiosCode: axiosError?.code ?? null,
+          isNetworkFailure,
+          message,
+        });
+        if (isNetworkFailure) {
+          setLoadErrorMessage(message);
+        } else {
+          toastError({ axiosError });
+        }
+      })
       .finally(() => setIsLoading(false));
   }, []);
+
+  useEffect(() => {
+    reloadWorkplace();
+  }, [reloadWorkplace]);
 
   const setWorkplaceByQRCode = (qrCode) => {
     const { workplaceId } = parseWorkplaceQRCodeString(qrCode);
@@ -62,6 +88,8 @@ export const useCurrentWorkplace = ({ applicationId }) => {
     isWorkplaceLoading: isLoading,
     isWorkplaceRequired: requiresWorkplaceIfAvailable && isWorkplaceRequired,
     workplace,
+    workplaceLoadErrorMessage: loadErrorMessage,
+    reloadWorkplace,
     setWorkplaceByQRCode,
   };
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/workstation.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/workstation.js
@@ -2,8 +2,9 @@ import { apiBasePath } from '../constants';
 import axios from 'axios';
 import { unboxAxiosResponse } from '../utils';
 import { useApplicationInfo } from '../reducers/applications';
-import { useEffect, useState } from 'react';
-import { toastError } from '../utils/toast';
+import { useCallback, useEffect, useState } from 'react';
+import { extractUserFriendlyErrorMessageFromAxiosError, toastError } from '../utils/toast';
+import * as uiTrace from '../utils/ui_trace';
 
 const workstationAPIBase = `${apiBasePath}/workstation`;
 
@@ -11,28 +12,64 @@ export const getCurrentWorkstationInfo = () => {
   return axios.get(`${workstationAPIBase}`).then(unboxAxiosResponse);
 };
 
-export const useCurrentWorkstation = ({ applicationId }) => {
+/**
+ * @param applicationId the mobile application whose config decides whether a workstation is needed at all
+ * @param onWorkstationAssigned called after a scan successfully assigned a workstation. Assigning a
+ *        workstation ALSO re-assigns the operator's workplace server-side (to the workstation's linked
+ *        workplace, see WorkstationRestController#assign) — state this hook does not own, so its owner
+ *        has to be told to re-read it.
+ */
+export const useCurrentWorkstation = ({ applicationId, onWorkstationAssigned }) => {
   const { requiresWorkstation: requiresWorkstationIfAvailable } = useApplicationInfo({ applicationId });
   const [isLoading, setIsLoading] = useState(requiresWorkstationIfAvailable);
   const [workstation, setWorkstation] = useState(null);
+  const [loadErrorMessage, setLoadErrorMessage] = useState(null);
+
+  const reloadWorkstation = useCallback(() => {
+    if (!requiresWorkstationIfAvailable) {
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setLoadErrorMessage(null);
+    getCurrentWorkstationInfo()
+      .then(({ assignedWorkstation }) => {
+        setWorkstation(assignedWorkstation);
+      })
+      .catch((axiosError) => {
+        // A server response means the backend answered and retrying the same read won't help, so keep the
+        // toast (existing automation asserts on it). No response at all is the routine warehouse-WiFi blip:
+        // leaving the workstation unset would ask the operator to re-scan a workstation they are still
+        // assigned to, so surface it for retry instead.
+        const isNetworkFailure = !axiosError?.response;
+        const message = extractUserFriendlyErrorMessageFromAxiosError({ axiosError });
+        uiTrace.trace({
+          eventName: 'currentWorkstationLoadFailed',
+          httpStatus: axiosError?.response?.status ?? null,
+          axiosCode: axiosError?.code ?? null,
+          isNetworkFailure,
+          message,
+        });
+        if (isNetworkFailure) {
+          setLoadErrorMessage(message);
+        } else {
+          toastError({ axiosError });
+        }
+      })
+      .finally(() => setIsLoading(false));
+  }, [requiresWorkstationIfAvailable]);
 
   useEffect(() => {
-    if (requiresWorkstationIfAvailable) {
-      setIsLoading(true);
-      getCurrentWorkstationInfo()
-        .then(({ assignedWorkstation }) => {
-          setWorkstation(assignedWorkstation);
-        })
-        .catch((axiosError) => toastError({ axiosError }))
-        .finally(() => setIsLoading(false));
-    } else {
-      setIsLoading(false);
-    }
-  }, []);
+    reloadWorkstation();
+  }, [reloadWorkstation]);
 
   const setWorkstationByQRCode = (qrCode) => {
     assignWorkstationByQRCode(qrCode)
-      .then((workstation) => setWorkstation(workstation))
+      .then((workstation) => {
+        setWorkstation(workstation);
+        onWorkstationAssigned?.(workstation);
+      })
       .catch((axiosError) => toastError({ axiosError }));
   };
 
@@ -40,6 +77,8 @@ export const useCurrentWorkstation = ({ applicationId }) => {
     isWorkstationRequired: requiresWorkstationIfAvailable,
     isWorkstationLoading: isLoading,
     workstation,
+    workstationLoadErrorMessage: loadErrorMessage,
+    reloadWorkstation,
     setWorkstationByQRCode,
   };
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/api/workstation.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/api/workstation.js
@@ -2,7 +2,7 @@ import { apiBasePath } from '../constants';
 import axios from 'axios';
 import { unboxAxiosResponse } from '../utils';
 import { useApplicationInfo } from '../reducers/applications';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { extractUserFriendlyErrorMessageFromAxiosError, toastError } from '../utils/toast';
 import * as uiTrace from '../utils/ui_trace';
 
@@ -23,7 +23,33 @@ export const useCurrentWorkstation = ({ applicationId, onWorkstationAssigned }) 
   const { requiresWorkstation: requiresWorkstationIfAvailable } = useApplicationInfo({ applicationId });
   const [isLoading, setIsLoading] = useState(requiresWorkstationIfAvailable);
   const [workstation, setWorkstation] = useState(null);
-  const [loadErrorMessage, setLoadErrorMessage] = useState(null);
+  const [errorMessage, setErrorMessage] = useState(null);
+  // What "Retry" has to re-run. Re-READING after a failed SCAN would drop the scan instead of
+  // retrying it, putting the operator back in front of the scan prompt with no clue why, so the
+  // operation that actually failed is remembered here.
+  const retryFailedOperationRef = useRef(null);
+
+  // A server response means the backend answered and retrying the same request won't help, so keep the
+  // toast (existing automation asserts on it). No response at all is the routine warehouse-WiFi blip —
+  // retrying may well succeed — so surface it inline with a retry instead.
+  // Shape per module CLAUDE.md § "API Error Surfacing"; reference impl ConfirmActivity.jsx.
+  const onRequestFailed = ({ axiosError, eventName, retry }) => {
+    const isNetworkFailure = !axiosError?.response;
+    const message = extractUserFriendlyErrorMessageFromAxiosError({ axiosError });
+    uiTrace.trace({
+      eventName,
+      httpStatus: axiosError?.response?.status ?? null,
+      axiosCode: axiosError?.code ?? null,
+      isNetworkFailure,
+      message,
+    });
+    if (isNetworkFailure) {
+      retryFailedOperationRef.current = retry;
+      setErrorMessage(message);
+    } else {
+      toastError({ axiosError });
+    }
+  };
 
   const reloadWorkstation = useCallback(() => {
     if (!requiresWorkstationIfAvailable) {
@@ -32,31 +58,16 @@ export const useCurrentWorkstation = ({ applicationId, onWorkstationAssigned }) 
     }
 
     setIsLoading(true);
-    setLoadErrorMessage(null);
+    setErrorMessage(null);
     getCurrentWorkstationInfo()
       .then(({ assignedWorkstation }) => {
         setWorkstation(assignedWorkstation);
       })
-      .catch((axiosError) => {
-        // A server response means the backend answered and retrying the same read won't help, so keep the
-        // toast (existing automation asserts on it). No response at all is the routine warehouse-WiFi blip:
-        // leaving the workstation unset would ask the operator to re-scan a workstation they are still
-        // assigned to, so surface it for retry instead.
-        const isNetworkFailure = !axiosError?.response;
-        const message = extractUserFriendlyErrorMessageFromAxiosError({ axiosError });
-        uiTrace.trace({
-          eventName: 'currentWorkstationLoadFailed',
-          httpStatus: axiosError?.response?.status ?? null,
-          axiosCode: axiosError?.code ?? null,
-          isNetworkFailure,
-          message,
-        });
-        if (isNetworkFailure) {
-          setLoadErrorMessage(message);
-        } else {
-          toastError({ axiosError });
-        }
-      })
+      .catch((axiosError) =>
+        // Leaving the workstation unset would ask the operator to re-scan a workstation they are
+        // still assigned to.
+        onRequestFailed({ axiosError, eventName: 'currentWorkstationLoadFailed', retry: reloadWorkstation })
+      )
       .finally(() => setIsLoading(false));
   }, [requiresWorkstationIfAvailable]);
 
@@ -65,20 +76,35 @@ export const useCurrentWorkstation = ({ applicationId, onWorkstationAssigned }) 
   }, [reloadWorkstation]);
 
   const setWorkstationByQRCode = (qrCode) => {
+    setErrorMessage(null);
     assignWorkstationByQRCode(qrCode)
       .then((workstation) => {
         setWorkstation(workstation);
         onWorkstationAssigned?.(workstation);
       })
-      .catch((axiosError) => toastError({ axiosError }));
+      .catch((axiosError) =>
+        onRequestFailed({
+          axiosError,
+          eventName: 'assignWorkstationFailed',
+          retry: () => setWorkstationByQRCode(qrCode),
+        })
+      );
+  };
+
+  // Re-runs whatever failed last, then forgets it so a gloved double-tap on Retry cannot fire the same
+  // assign twice; that second tap falls back to a plain re-read rather than crashing on a null op.
+  const retryWorkstation = () => {
+    const retry = retryFailedOperationRef.current ?? reloadWorkstation;
+    retryFailedOperationRef.current = null;
+    retry();
   };
 
   return {
     isWorkstationRequired: requiresWorkstationIfAvailable,
     isWorkstationLoading: isLoading,
     workstation,
-    workstationLoadErrorMessage: loadErrorMessage,
-    reloadWorkstation,
+    workstationErrorMessage: errorMessage,
+    retryWorkstation,
     setWorkstationByQRCode,
   };
 };

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/WFLaunchersScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/WFLaunchersScreen.jsx
@@ -26,15 +26,49 @@ const WFLaunchersScreen = () => {
   const { url, applicationId } = useMobileLocation();
 
   const { showFilterByQRCode, showFilters } = useApplicationInfo({ applicationId });
-  const { isWorkstationLoading, isWorkstationRequired, workstation, setWorkstationByQRCode } = useCurrentWorkstation({
+  const {
+    isWorkplaceLoading,
+    isWorkplaceRequired,
+    workplace,
+    workplaceLoadErrorMessage,
+    reloadWorkplace,
+    setWorkplaceByQRCode,
+  } = useCurrentWorkplace({ applicationId });
+  const {
+    isWorkstationLoading,
+    isWorkstationRequired,
+    workstation,
+    workstationLoadErrorMessage,
+    reloadWorkstation,
+    setWorkstationByQRCode,
+  } = useCurrentWorkstation({
     applicationId,
-  });
-  const { isWorkplaceLoading, isWorkplaceRequired, workplace, setWorkplaceByQRCode } = useCurrentWorkplace({
-    applicationId,
+    // Assigning a workstation re-assigns the operator's workplace server-side too, so the workplace this
+    // screen shows (and filters its jobs by) has to be re-read — nothing remounts this screen.
+    onWorkstationAssigned: reloadWorkplace,
   });
   const { isTrolleyRequired, isTrolleyLoading, trolley, setTrolleyByScannedCode, clearTrolley } = useCurrentTrolley({
     applicationId,
   });
+
+  const operatorContextLoadErrorMessage = workstationLoadErrorMessage ?? workplaceLoadErrorMessage;
+  const isAskingForWorkstation = isWorkstationRequired && !workstation;
+  const isAskingForWorkplace = isWorkplaceRequired && !workplace;
+  const isAskingForTrolley = isTrolleyRequired && !trolley;
+  // The launchers are filtered server-side by the operator's context (e.g. manufacturing jobs by the
+  // assigned workstation), so fetching them before that context is established returns a list for the
+  // wrong context — and nothing would refetch it once the operator scans. Gate the fetch on the very
+  // conditions that gate rendering the list below; `isEnabled` is a fetch dependency, so the list is
+  // fetched exactly once the context is complete.
+  const isOperatorContextReady =
+    !operatorContextLoadErrorMessage &&
+    !isWorkstationLoading &&
+    !isWorkplaceLoading &&
+    !isTrolleyLoading &&
+    !isAskingForWorkstation &&
+    !isAskingForWorkplace &&
+    !isAskingForTrolley;
+
   const filters = useFilters({ applicationId });
   const facets = useFacets({ applicationId });
   const { isLaunchersLoading, launchers, filterByQRCode, actions } = useLaunchers({
@@ -42,7 +76,7 @@ const WFLaunchersScreen = () => {
     showFilterByQRCode,
     filters,
     facets,
-    isEnabled: !isWorkplaceLoading && !isTrolleyLoading,
+    isEnabled: isOperatorContextReady,
   });
 
   const workplaceName = workplace?.name;
@@ -68,6 +102,31 @@ const WFLaunchersScreen = () => {
   }, [url, workplaceName, workstationName]);
 
   //
+  // Operator context (workplace / workstation) could not be read
+  // Takes over the screen: without it we would either hide the header row for good or ask the operator
+  // to re-scan a workstation/workplace they are in fact still assigned to.
+  if (operatorContextLoadErrorMessage) {
+    return (
+      <div className="container launchers-container">
+        <div className="notification is-danger mt-3" data-testid="operator-context-error-panel">
+          <p className="mb-3">
+            <strong>{trl('launchers.operatorContext.error.title')}</strong>
+          </p>
+          <p className="mb-3">{operatorContextLoadErrorMessage}</p>
+          <ButtonWithIndicator
+            testId="operator-context-error-retry"
+            captionKey="launchers.operatorContext.error.retry"
+            onClick={() => {
+              reloadWorkstation();
+              reloadWorkplace();
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  //
   // Get Workstation
   if (isWorkstationLoading) {
     return (
@@ -75,7 +134,7 @@ const WFLaunchersScreen = () => {
         <Spinner />
       </div>
     );
-  } else if (isWorkstationRequired && !workstation) {
+  } else if (isAskingForWorkstation) {
     return (
       <div className="container launchers-container">
         <BarcodeScannerComponent
@@ -94,7 +153,7 @@ const WFLaunchersScreen = () => {
         <Spinner />
       </div>
     );
-  } else if (isWorkplaceRequired && !workplace) {
+  } else if (isAskingForWorkplace) {
     return (
       <div className="container launchers-container">
         <BarcodeScannerComponent
@@ -113,7 +172,7 @@ const WFLaunchersScreen = () => {
         <Spinner />
       </div>
     );
-  } else if (isTrolleyRequired && !trolley) {
+  } else if (isAskingForTrolley) {
     return (
       <div className="container launchers-container">
         <BarcodeScannerComponent

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/WFLaunchersScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/wfLaunchersScreen/WFLaunchersScreen.jsx
@@ -30,7 +30,8 @@ const WFLaunchersScreen = () => {
     isWorkplaceLoading,
     isWorkplaceRequired,
     workplace,
-    workplaceLoadErrorMessage,
+    workplaceErrorMessage,
+    retryWorkplace,
     reloadWorkplace,
     setWorkplaceByQRCode,
   } = useCurrentWorkplace({ applicationId });
@@ -38,8 +39,8 @@ const WFLaunchersScreen = () => {
     isWorkstationLoading,
     isWorkstationRequired,
     workstation,
-    workstationLoadErrorMessage,
-    reloadWorkstation,
+    workstationErrorMessage,
+    retryWorkstation,
     setWorkstationByQRCode,
   } = useCurrentWorkstation({
     applicationId,
@@ -51,7 +52,7 @@ const WFLaunchersScreen = () => {
     applicationId,
   });
 
-  const operatorContextLoadErrorMessage = workstationLoadErrorMessage ?? workplaceLoadErrorMessage;
+  const operatorContextErrorMessage = workstationErrorMessage ?? workplaceErrorMessage;
   const isAskingForWorkstation = isWorkstationRequired && !workstation;
   const isAskingForWorkplace = isWorkplaceRequired && !workplace;
   const isAskingForTrolley = isTrolleyRequired && !trolley;
@@ -61,7 +62,7 @@ const WFLaunchersScreen = () => {
   // conditions that gate rendering the list below; `isEnabled` is a fetch dependency, so the list is
   // fetched exactly once the context is complete.
   const isOperatorContextReady =
-    !operatorContextLoadErrorMessage &&
+    !operatorContextErrorMessage &&
     !isWorkstationLoading &&
     !isWorkplaceLoading &&
     !isTrolleyLoading &&
@@ -102,24 +103,23 @@ const WFLaunchersScreen = () => {
   }, [url, workplaceName, workstationName]);
 
   //
-  // Operator context (workplace / workstation) could not be read
-  // Takes over the screen: without it we would either hide the header row for good or ask the operator
-  // to re-scan a workstation/workplace they are in fact still assigned to.
-  if (operatorContextLoadErrorMessage) {
+  // Operator context (workplace / workstation) could not be read, or could not be assigned from a scan
+  // Takes over the screen: without it we would either hide the header row for good, ask the operator to
+  // re-scan a workstation/workplace they are in fact still assigned to, or silently swallow their scan.
+  if (operatorContextErrorMessage) {
     return (
       <div className="container launchers-container">
         <div className="notification is-danger mt-3" data-testid="operator-context-error-panel">
           <p className="mb-3">
             <strong>{trl('launchers.operatorContext.error.title')}</strong>
           </p>
-          <p className="mb-3">{operatorContextLoadErrorMessage}</p>
+          <p className="mb-3">{operatorContextErrorMessage}</p>
           <ButtonWithIndicator
             testId="operator-context-error-retry"
             captionKey="launchers.operatorContext.error.retry"
-            onClick={() => {
-              reloadWorkstation();
-              reloadWorkplace();
-            }}
+            // Re-fire only what actually failed — the message above is the workstation's whenever it
+            // has one, so retrying the workplace too would be a wasted request the operator waits on.
+            onClick={workstationErrorMessage ? retryWorkstation : retryWorkplace}
           />
         </div>
       </div>

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -81,7 +81,7 @@ const translations = {
   launchers: {
     operatorContext: {
       error: {
-        title: 'Arbeitsplatz/Arbeitsstation konnte nicht geladen werden',
+        title: 'Arbeitsplatz/Arbeitsstation derzeit nicht verfügbar',
         retry: 'Erneut versuchen',
       },
     },

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_de.js
@@ -78,6 +78,14 @@ const translations = {
       appName: 'Picken',
     },
   },
+  launchers: {
+    operatorContext: {
+      error: {
+        title: 'Arbeitsplatz/Arbeitsstation konnte nicht geladen werden',
+        retry: 'Erneut versuchen',
+      },
+    },
+  },
   components: {
     BarcodeScannerComponent: {
       scanTextPlaceholder: 'scan...',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -74,6 +74,14 @@ const translations = {
       appName: 'Picking',
     },
   },
+  launchers: {
+    operatorContext: {
+      error: {
+        title: 'Workplace/workstation could not be loaded',
+        retry: 'Retry',
+      },
+    },
+  },
   components: {
     BarcodeScannerComponent: {
       scanTextPlaceholder: 'scan...',

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/utils/translations_en.js
@@ -77,7 +77,7 @@ const translations = {
   launchers: {
     operatorContext: {
       error: {
-        title: 'Workplace/workstation could not be loaded',
+        title: 'Workplace/workstation is currently unavailable',
         retry: 'Retry',
       },
     },


### PR DESCRIPTION
Two mobile-UI defects around the operator context (workplace / workstation) on the launchers screen. Companion to https://github.com/metasfresh/metasfresh/pull/25368, which stops the handheld caching the same reads.

## Defect 1 — a workstation scan on the launchers screen left the workplace stale

`POST /workstation/assign` also re-assigns the operator's **workplace** server-side (to the workstation's linked workplace), but only the workstation hook's own state was updated. Nothing told `useCurrentWorkplace`, and nothing remounts the screen — so after scanning a workstation the `Workplace` header row kept showing the *previous* workplace indefinitely, and the job list (filtered by the workstation server-side) was never re-fetched.

- `useCurrentWorkstation` now reports a successful assignment via `onWorkstationAssigned`, and the launchers screen re-reads the workplace.
- The launchers fetch is gated on the operator context being settled, so the list is requested once workplace/workstation/trolley are known — instead of being fetched for a context that is about to change and then never refreshed.

## Defect 2 — a failed operator-context read hid the header row until a remount

A failed read of workplace/workstation only raised a toast and left the value `null`, which hides the header row for good — the screen never re-reads it. On warehouse WiFi that is routine.

Following the module's API-error-surfacing rule: a **network-layer** failure (no response at all) now renders an inline retry panel modelled on `ConfirmActivity`, while a **server rejection** (4xx/5xx) keeps the existing toast.

## Tests

Three new mobile-webui Playwright specs under `e2e/mobile-webui/tests/spec/manufacturing/`.

Both defect specs were confirmed **RED against unmodified production code** before the fix, on a local stack:

- `workstation_scan_on_jobs_list_refreshes_context.spec.js` — after scanning `WS1` (linked to workplace A) while the operator was on workplace B, the header still read `wpB_...` where `wpA_...` was expected. The spec asserts the **server** has already moved the operator to workplace A *before* it asserts the screen, so a red there can only mean the screen is stale. It also asserts the job list itself refreshed, not only the header.
- `operator_context_read_failure_is_recoverable.spec.js` — `operator-context-error-panel` did not exist (element not found); pre-fix only a toast appeared. Covers both the workplace and the workstation read, and asserts the value is shown again after Retry.

Both are green with the fix applied.

## Known red — `operator_context_reads_are_never_cached.spec.js`

This is the end-to-end half of the cache-control guard requested in review on https://github.com/metasfresh/metasfresh/pull/25368#discussion_r3685530455 ("why a unit test and not a playwright test that checks the api response header?" — the answer was *both*). It drives the real Production screen and asserts `Cache-Control: no-store` on the responses the device actually receives.

**It fails on this base**, reporting `Cache-Control of 200 .../api/v2/workplace — Received: null`. That is a true negative, not a flake: the `no-store` servlet filter lives on https://github.com/metasfresh/metasfresh/pull/25368 and is not in `intensive_care_hotfix` yet. It goes green once that PR is merged and this branch picks the base up. Deliberately **not** skipped or weakened.
