### PR TITLE
Purchase order reactivation: a proforma allocation alone must not block it

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5817130_sys_AD_Message_Order_Reactivate_Blocked.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5817130_sys_AD_Message_Order_Reactivate_Blocked.sql
@@ -1,0 +1,38 @@
+-- AD_Message 545676 — Order_Reactivate_Blocked_By_PaySchedule_Activity
+-- A proforma allocation no longer blocks order reactivation, so the message must stop
+-- instructing the buyer to de-allocate the proforma invoice. Only a goods-receipt or
+-- matched-invoice link on a pay-schedule row can still cause the block.
+
+-- Base row (German base language)
+UPDATE AD_Message
+SET MsgText  = 'Beleg kann nicht reaktiviert werden, da mindestens eine Zeile im Zahlungsplan nicht mehr Pending ist. Bitte zuerst die Wareneingänge / Rechnungen / Zahlungen stornieren.',
+    Updated  = TO_TIMESTAMP('2026-07-31 09:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Message_ID = 545676;
+
+-- de_DE translation
+UPDATE AD_Message_Trl
+SET MsgText      = 'Beleg kann nicht reaktiviert werden, da mindestens eine Zeile im Zahlungsplan nicht mehr Pending ist. Bitte zuerst die Wareneingänge / Rechnungen / Zahlungen stornieren.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-31 09:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Message_ID = 545676
+  AND AD_Language   = 'de_DE';
+
+-- de_CH translation (kept in sync with the German base text, per this message's existing convention)
+UPDATE AD_Message_Trl
+SET MsgText      = 'Beleg kann nicht reaktiviert werden, da mindestens eine Zeile im Zahlungsplan nicht mehr Pending ist. Bitte zuerst die Wareneingänge / Rechnungen / Zahlungen stornieren.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-31 09:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Message_ID = 545676
+  AND AD_Language   = 'de_CH';
+
+-- en_US translation
+UPDATE AD_Message_Trl
+SET MsgText      = 'Cannot reactivate the order because at least one payment-schedule row is no longer Pending. Please first reverse the goods receipts / invoices / payments.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-31 09:00:03', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Message_ID = 545676
+  AND AD_Language   = 'en_US';

--- a/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v1/payment/PaymentRestEndpointTest.java
+++ b/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v1/payment/PaymentRestEndpointTest.java
@@ -41,6 +41,7 @@ import lombok.NonNull;
 import org.adempiere.service.ClientId;
 import org.adempiere.service.ISysConfigBL;
 import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.SpringContextHolder;
 import org.compiere.model.I_AD_Org;
 import org.compiere.model.I_C_BP_BankAccount;
 import org.compiere.model.I_C_BPartner;
@@ -74,6 +75,11 @@ class PaymentRestEndpointTest
 	void setUp()
 	{
 		AdempiereTestHelper.get().init();
+
+		// C_Order.newInstanceForUnitTesting() transitively builds OrderPayScheduleLCStepService ->
+		// OrderPayScheduleRegularInvoiceService, whose Services.get(IInvoiceLineBL.class) instantiates
+		// InvoiceLineBL, which pulls ProductTaxCategoryService out of the spring context on construction.
+		SpringContextHolder.registerJUnitBean(new ProductTaxCategoryService(new ProductTaxCategoryRepository()));
 	}
 
 	@Test

--- a/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
@@ -796,7 +796,8 @@ public class C_Order
 		// losing any proforma/prepayment-derived state (Paid/Awaiting_Pay, DueAmt_Actual, ReferenceDate,
 		// DueDate, LC_Date). Re-derive it here from the surviving C_Proforma_Order_Alloc / completed
 		// prepayment so a paid proforma allocation is restored rather than silently dropped.
-		orderPayScheduleLCStepService.recomputeLCStep(OrderId.ofRepoId(order.getC_Order_ID()));
+		// Only orders that carry a proforma allocation are touched — see the method's javadoc.
+		orderPayScheduleLCStepService.recomputeLCStepAfterOrderCompleted(OrderId.ofRepoId(order.getC_Order_ID()));
 	}
 
 	@DocValidate(timings = ModelValidator.TIMING_AFTER_REACTIVATE)

--- a/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
@@ -60,6 +60,7 @@ import de.metas.user.UserGroupRepository;
 import de.metas.user.UserRepository;
 import de.metas.order.location.OrderLocationsUpdater;
 import de.metas.order.paymentschedule.core.service.OrderPayScheduleService;
+import de.metas.order.paymentschedule.steps.letter_of_credit.OrderPayScheduleLCStepService;
 import de.metas.promotioncode.PromotionCodeId;
 import de.metas.organization.IOrgDAO;
 import de.metas.organization.OrgId;
@@ -128,6 +129,7 @@ public class C_Order
 	@NonNull private final IDocumentLocationBL documentLocationBL;
 	@NonNull private final PurchaseOrderToShipperTransportationService purchaseOrderToShipperTransportationService;
 	@NonNull private final OrderPayScheduleService orderPayScheduleService;
+	@NonNull private final OrderPayScheduleLCStepService orderPayScheduleLCStepService;
 
 	@VisibleForTesting
 	public static final String AUTO_ASSIGN_TO_SALES_ORDER_BY_EXTERNAL_ORDER_ID_SYSCONFIG = "de.metas.payment.autoAssignToSalesOrderByExternalOrderId.enabled";
@@ -142,7 +144,8 @@ public class C_Order
 			@NonNull final IDocumentLocationBL documentLocationBL,
 			@NonNull final BPartnerSupplierApprovalService partnerSupplierApprovalService,
 			@NonNull final PurchaseOrderToShipperTransportationService purchaseOrderToShipperTransportationService,
-			@NonNull final OrderPayScheduleService orderPayScheduleService)
+			@NonNull final OrderPayScheduleService orderPayScheduleService,
+			@NonNull final OrderPayScheduleLCStepService orderPayScheduleLCStepService)
 	{
 		this.bpartnerBL = bpartnerBL;
 		this.bpartnerEffectiveBL = bpartnerEffectiveBL;
@@ -152,6 +155,7 @@ public class C_Order
 		this.documentLocationBL = documentLocationBL;
 		this.purchaseOrderToShipperTransportationService = purchaseOrderToShipperTransportationService;
 		this.orderPayScheduleService = orderPayScheduleService;
+		this.orderPayScheduleLCStepService = orderPayScheduleLCStepService;
 
 		final IProgramaticCalloutProvider programmaticCalloutProvider = Services.get(IProgramaticCalloutProvider.class);
 		programmaticCalloutProvider.registerAnnotatedCallout(this);
@@ -170,7 +174,8 @@ public class C_Order
 				DocumentLocationBL.newInstanceForUnitTesting(),
 				new BPartnerSupplierApprovalService(new BPartnerSupplierApprovalRepository(), new UserGroupRepository()),
 				PurchaseOrderToShipperTransportationService.newInstanceForUnitTesting(),
-				OrderPayScheduleService.newInstanceForUnitTesting()));
+				OrderPayScheduleService.newInstanceForUnitTesting(),
+				OrderPayScheduleLCStepService.newInstanceForUnitTesting()));
 	}
 
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE }, ifColumnsChanged = { I_C_Order.COLUMNNAME_M_PriceList_ID })
@@ -785,6 +790,13 @@ public class C_Order
 	public void createOrderPaySchedules(final I_C_Order order)
 	{
 		orderPayScheduleService.createOrderPaySchedules(order);
+
+		// Reactivate deletes every C_OrderPaySchedule row (see deleteOrderPaySchedules below), so a
+		// reactivate -> re-complete round trip rebuilds the schedule from the payment-term breaks alone,
+		// losing any proforma/prepayment-derived state (Paid/Awaiting_Pay, DueAmt_Actual, ReferenceDate,
+		// DueDate, LC_Date). Re-derive it here from the surviving C_Proforma_Order_Alloc / completed
+		// prepayment so a paid proforma allocation is restored rather than silently dropped.
+		orderPayScheduleLCStepService.recomputeLCStep(OrderId.ofRepoId(order.getC_Order_ID()));
 	}
 
 	@DocValidate(timings = ModelValidator.TIMING_AFTER_REACTIVATE)

--- a/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/interceptor/C_Order.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/interceptor/C_Order.java
@@ -26,7 +26,6 @@ import de.metas.i18n.AdMessageKey;
 import de.metas.order.OrderId;
 import de.metas.order.paymentschedule.core.OrderPaySchedule;
 import de.metas.order.paymentschedule.core.service.OrderPayScheduleService;
-import de.metas.order.paymentschedule.referenced_docs.proforma_invoice.OrderPayScheduleProformaService;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.modelvalidator.annotations.DocValidate;
@@ -60,9 +59,6 @@ public class C_Order
 	private static final AdMessageKey MSG_OrderReactivateBlocked = AdMessageKey.of("Order_Reactivate_Blocked_By_PaySchedule_Activity");
 
 	@NonNull private final OrderPayScheduleService orderPayScheduleService;
-	// Kept only for constructor-compatibility with the covering unit test; the guard predicate no
-	// longer consults the proforma service (see class Javadoc — a proforma allocation does not block).
-	@NonNull private final OrderPayScheduleProformaService orderPayScheduleProformaService;
 
 	@DocValidate(timings = ModelValidator.TIMING_BEFORE_REACTIVATE)
 	public void blockReactivateWhenScheduleNotPending(@NonNull final I_C_Order order)

--- a/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/interceptor/C_Order.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/interceptor/C_Order.java
@@ -38,20 +38,19 @@ import org.springframework.stereotype.Component;
 
 /**
  * Blocks reactivation of a {@code C_Order} whose {@link OrderPaySchedule} reflects committed
- * downstream activity — i.e. at least one of:
- * <ul>
- *   <li>any pay-schedule line has a goods-receipt link ({@code inoutId != null}), or</li>
- *   <li>any pay-schedule line has a matched-invoice link ({@code invoiceId != null}), or</li>
- *   <li>a proforma allocation exists for the order (detected via
- *       {@link OrderPayScheduleProformaService#getByOrderId}; the LC/proforma row carries no
- *       per-line link, so it must be detected through the proforma service).</li>
- * </ul>
+ * downstream activity — i.e. at least one pay-schedule line has a goods-receipt link
+ * ({@code inoutId != null}) or a matched-invoice link ({@code invoiceId != null}).
  *
  * <p>A {@code Paid} line always implies one of the above, so no separate status guard is needed.
  *
- * <p>Reactivation is allowed when no pay-schedule line carries any downstream link AND no proforma
- * allocation exists — meaning nothing has been committed yet and the standard drop-and-rebuild
- * reactivation path is safe. Reactivation is also allowed when the order has no pay-schedule at all.
+ * <p>A proforma allocation alone does <b>not</b> block reactivation: the allocation link and its
+ * prepayment both survive reactivation (only the derived {@link OrderPaySchedule} rows are dropped),
+ * so re-completion can re-derive the proforma-driven schedule state from them. Only a goods receipt
+ * or a matched invoice actually commits state a drop-and-rebuild reactivation would orphan.
+ *
+ * <p>Reactivation is allowed when no pay-schedule line carries any downstream link — meaning nothing
+ * has been committed yet and the standard drop-and-rebuild reactivation path is safe. Reactivation is
+ * also allowed when the order has no pay-schedule at all.
  */
 @Interceptor(I_C_Order.class)
 @Component
@@ -61,6 +60,8 @@ public class C_Order
 	private static final AdMessageKey MSG_OrderReactivateBlocked = AdMessageKey.of("Order_Reactivate_Blocked_By_PaySchedule_Activity");
 
 	@NonNull private final OrderPayScheduleService orderPayScheduleService;
+	// Kept only for constructor-compatibility with the covering unit test; the guard predicate no
+	// longer consults the proforma service (see class Javadoc — a proforma allocation does not block).
 	@NonNull private final OrderPayScheduleProformaService orderPayScheduleProformaService;
 
 	@DocValidate(timings = ModelValidator.TIMING_BEFORE_REACTIVATE)
@@ -68,13 +69,8 @@ public class C_Order
 	{
 		final OrderId orderId = OrderId.ofRepoId(order.getC_Order_ID());
 
-		// The proforma check inside reflectsDownstreamActivity is reached only when a pay-schedule
-		// exists. That is safe because an allocated LC/proforma always creates at least one
-		// pay-schedule line (OrderPayScheduleLCStepService), so "a proforma exists but there is no
-		// pay-schedule" is not a producible state — an order with no pay-schedule at all has nothing
-		// downstream to protect and is always reactivatable.
 		orderPayScheduleService.getByOrderId(orderId)
-				.filter(schedule -> isBlockedByDownstreamActivity(orderId, schedule))
+				.filter(this::isBlockedByDownstreamActivity)
 				.ifPresent(schedule -> {
 					throw new AdempiereException(MSG_OrderReactivateBlocked).markAsUserValidationError();
 				});
@@ -82,11 +78,10 @@ public class C_Order
 
 	/**
 	 * True if the schedule carries committed downstream state that a drop-and-rebuild re-completion would
-	 * orphan: a line linked to a goods receipt or matched invoice, or a proforma allocation on the order.
+	 * orphan: a line linked to a goods receipt or matched invoice.
 	 */
-	private boolean isBlockedByDownstreamActivity(@NonNull final OrderId orderId, @NonNull final OrderPaySchedule schedule)
+	private boolean isBlockedByDownstreamActivity(@NonNull final OrderPaySchedule schedule)
 	{
-		return schedule.hasLineLinkedToDownstreamDocument()
-				|| orderPayScheduleProformaService.getByOrderId(orderId).isPresent();
+		return schedule.hasLineLinkedToDownstreamDocument();
 	}
 }

--- a/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/steps/letter_of_credit/OrderPayScheduleLCStepService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/steps/letter_of_credit/OrderPayScheduleLCStepService.java
@@ -92,6 +92,27 @@ public class OrderPayScheduleLCStepService
 		recomputeLCStep(orderId);
 	}
 
+	/**
+	 * Re-derives the LC/advance step after the order was completed — including a
+	 * reactivate -> re-complete round trip, which drops every {@code C_OrderPaySchedule} row and
+	 * rebuilds it from the payment-term breaks alone, losing the proforma-derived state.
+	 * <p>
+	 * Only an order that actually HAS a proforma allocation has anything to re-derive. Without one
+	 * {@link #recomputeLCStep(OrderId)} would take its {@code proforma == null} branch and reset the
+	 * just-built line to {@code Pending} / {@code 9999-12-01} — which is the wanted behaviour for
+	 * {@code ProformaOrderAllocService.deallocate()}, but would discard the correct schedule on
+	 * every completion of an ordinary order whose payment term has an {@code OD} advance break.
+	 */
+	public void recomputeLCStepAfterOrderCompleted(@NonNull final OrderId orderId)
+	{
+		if (!proformaService.getIdByOrderId(orderId).isPresent())
+		{
+			return;
+		}
+
+		recomputeLCStep(orderId);
+	}
+
 	public void recomputeLCStep(@NonNull OrderId orderId)
 	{
 		recomputeLCStep(orderId, null);

--- a/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
@@ -153,14 +153,50 @@ class C_Order_Test
 				.doesNotThrowAnyException();
 	}
 
-	/** NEW: proforma allocation alone (no per-line link) must block reactivation. */
+	/**
+	 * A proforma allocation carries no committed state that a reactivate would orphan: the allocation
+	 * row and its prepayment both survive the reactivate, and re-completion re-derives the pay-schedule
+	 * state from them. So a proforma alone must NOT block reactivation.
+	 */
 	@Test
-	void rejectReactivate_whenProformaAllocationExists()
+	void allowReactivate_whenProformaAllocatedAndNoLineLink()
 	{
 		final I_C_Order order = newOrder();
-		// schedule lines carry NO per-line downstream link — the block must come from the proforma alone
+		// schedule lines carry NO per-line downstream link — only the proforma allocation exists
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.of(scheduleWithStatuses(OrderPayScheduleStatus.Pending, OrderPayScheduleStatus.Pending)));
+				.thenReturn(Optional.of(scheduleWithStatuses(OrderPayScheduleStatus.Awaiting_Pay, OrderPayScheduleStatus.Pending)));
+		Mockito.when(proformaService.getByOrderId(ORDER_ID))
+				.thenReturn(Optional.of(stubProformaInvoice()));
+
+		assertThatCode(() -> guard.blockReactivateWhenScheduleNotPending(order))
+				.doesNotThrowAnyException();
+	}
+
+	/**
+	 * The proforma no longer blocks, but a goods-receipt link still does — even on the same order.
+	 * Guards against over-correcting the guard into permissiveness.
+	 */
+	@Test
+	void rejectReactivate_whenProformaAllocatedAndLineHasInoutLink()
+	{
+		final I_C_Order order = newOrder();
+		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
+				.thenReturn(Optional.of(scheduleWithInoutLink(OrderPayScheduleStatus.Awaiting_Pay)));
+		Mockito.when(proformaService.getByOrderId(ORDER_ID))
+				.thenReturn(Optional.of(stubProformaInvoice()));
+
+		assertThatThrownBy(() -> guard.blockReactivateWhenScheduleNotPending(order))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("Order_Reactivate_Blocked_By_PaySchedule_Activity");
+	}
+
+	/** Sibling of the inout case: a matched-invoice link also still blocks, proforma or not. */
+	@Test
+	void rejectReactivate_whenProformaAllocatedAndLineHasInvoiceLink()
+	{
+		final I_C_Order order = newOrder();
+		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
+				.thenReturn(Optional.of(scheduleWithInvoiceLink(OrderPayScheduleStatus.Paid)));
 		Mockito.when(proformaService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.of(stubProformaInvoice()));
 

--- a/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
@@ -33,8 +33,6 @@ import de.metas.order.paymentschedule.core.OrderPayScheduleId;
 import de.metas.order.paymentschedule.core.OrderPayScheduleLine;
 import de.metas.order.paymentschedule.core.OrderPayScheduleStatus;
 import de.metas.order.paymentschedule.core.service.OrderPayScheduleService;
-import de.metas.order.paymentschedule.referenced_docs.proforma_invoice.OrderPayScheduleProformaService;
-import de.metas.order.paymentschedule.referenced_docs.proforma_invoice.ProformaInvoice;
 import de.metas.payment.paymentterm.PaymentTermBreakId;
 import de.metas.payment.paymentterm.ReferenceDateType;
 import de.metas.util.lang.Percent;
@@ -57,7 +55,6 @@ class C_Order_Test
 	private static final OrderId ORDER_ID = OrderId.ofRepoId(9001);
 
 	private OrderPayScheduleService orderPayScheduleService;
-	private OrderPayScheduleProformaService proformaService;
 	private C_Order guard;
 
 	@BeforeEach
@@ -66,8 +63,7 @@ class C_Order_Test
 		AdempiereTestHelper.get().init();
 
 		this.orderPayScheduleService = Mockito.mock(OrderPayScheduleService.class);
-		this.proformaService = Mockito.mock(OrderPayScheduleProformaService.class);
-		this.guard = new C_Order(orderPayScheduleService, proformaService);
+		this.guard = new C_Order(orderPayScheduleService);
 	}
 
 	@Test
@@ -76,8 +72,6 @@ class C_Order_Test
 		final I_C_Order order = newOrder();
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.of(scheduleWithStatuses(OrderPayScheduleStatus.Pending, OrderPayScheduleStatus.Pending)));
-		Mockito.when(proformaService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.empty());
 
 		assertThatCode(() -> guard.blockReactivateWhenScheduleNotPending(order))
 				.doesNotThrowAnyException();
@@ -94,8 +88,6 @@ class C_Order_Test
 		// schedule has one Awaiting_Pay and one Pending line — but NO downstream links
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.of(scheduleWithStatuses(OrderPayScheduleStatus.Awaiting_Pay, OrderPayScheduleStatus.Pending)));
-		Mockito.when(proformaService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.empty());
 
 		assertThatCode(() -> guard.blockReactivateWhenScheduleNotPending(order))
 				.doesNotThrowAnyException();
@@ -113,8 +105,6 @@ class C_Order_Test
 		final I_C_Order order = newOrder();
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.of(scheduleWithInoutLink(OrderPayScheduleStatus.Awaiting_Pay)));
-		Mockito.when(proformaService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.empty());
 
 		assertThatThrownBy(() -> guard.blockReactivateWhenScheduleNotPending(order))
 				.isInstanceOf(AdempiereException.class)
@@ -132,8 +122,6 @@ class C_Order_Test
 		final I_C_Order order = newOrder();
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.of(scheduleWithInvoiceLink(OrderPayScheduleStatus.Paid)));
-		Mockito.when(proformaService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.empty());
 
 		assertThatThrownBy(() -> guard.blockReactivateWhenScheduleNotPending(order))
 				.isInstanceOf(AdempiereException.class)
@@ -146,63 +134,9 @@ class C_Order_Test
 		final I_C_Order order = newOrder();
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.empty());
-		Mockito.when(proformaService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.empty());
 
 		assertThatCode(() -> guard.blockReactivateWhenScheduleNotPending(order))
 				.doesNotThrowAnyException();
-	}
-
-	/**
-	 * A proforma allocation carries no committed state that a reactivate would orphan: the allocation
-	 * row and its prepayment both survive the reactivate, and re-completion re-derives the pay-schedule
-	 * state from them. So a proforma alone must NOT block reactivation.
-	 */
-	@Test
-	void allowReactivate_whenProformaAllocatedAndNoLineLink()
-	{
-		final I_C_Order order = newOrder();
-		// schedule lines carry NO per-line downstream link — only the proforma allocation exists
-		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.of(scheduleWithStatuses(OrderPayScheduleStatus.Awaiting_Pay, OrderPayScheduleStatus.Pending)));
-		Mockito.when(proformaService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.of(stubProformaInvoice()));
-
-		assertThatCode(() -> guard.blockReactivateWhenScheduleNotPending(order))
-				.doesNotThrowAnyException();
-	}
-
-	/**
-	 * The proforma no longer blocks, but a goods-receipt link still does — even on the same order.
-	 * Guards against over-correcting the guard into permissiveness.
-	 */
-	@Test
-	void rejectReactivate_whenProformaAllocatedAndLineHasInoutLink()
-	{
-		final I_C_Order order = newOrder();
-		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.of(scheduleWithInoutLink(OrderPayScheduleStatus.Awaiting_Pay)));
-		Mockito.when(proformaService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.of(stubProformaInvoice()));
-
-		assertThatThrownBy(() -> guard.blockReactivateWhenScheduleNotPending(order))
-				.isInstanceOf(AdempiereException.class)
-				.hasMessageContaining("Order_Reactivate_Blocked_By_PaySchedule_Activity");
-	}
-
-	/** Sibling of the inout case: a matched-invoice link also still blocks, proforma or not. */
-	@Test
-	void rejectReactivate_whenProformaAllocatedAndLineHasInvoiceLink()
-	{
-		final I_C_Order order = newOrder();
-		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.of(scheduleWithInvoiceLink(OrderPayScheduleStatus.Paid)));
-		Mockito.when(proformaService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.of(stubProformaInvoice()));
-
-		assertThatThrownBy(() -> guard.blockReactivateWhenScheduleNotPending(order))
-				.isInstanceOf(AdempiereException.class)
-				.hasMessageContaining("Order_Reactivate_Blocked_By_PaySchedule_Activity");
 	}
 
 	/** NEW: even a Pending line carrying an inoutId (goods-receipt link) must block reactivation. */
@@ -212,8 +146,6 @@ class C_Order_Test
 		final I_C_Order order = newOrder();
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.of(scheduleWithInoutLink(OrderPayScheduleStatus.Pending)));
-		Mockito.when(proformaService.getByOrderId(ORDER_ID))
-				.thenReturn(Optional.empty());
 
 		assertThatThrownBy(() -> guard.blockReactivateWhenScheduleNotPending(order))
 				.isInstanceOf(AdempiereException.class)
@@ -258,17 +190,6 @@ class C_Order_Test
 				.invoiceId(InvoiceId.ofRepoId(600))
 				.build();
 		return OrderPaySchedule.ofList(ORDER_ID, ImmutableList.of(line));
-	}
-
-	/** Minimal real ProformaInvoice instance (ProformaInvoice is @Value/final — cannot be mocked). */
-	private ProformaInvoice stubProformaInvoice()
-	{
-		return ProformaInvoice.builder()
-				.id(InvoiceId.ofRepoId(700))
-				.grandTotal(Money.of(1000, CurrencyId.EUR))
-				.dateInvoiced(LocalDate.of(2026, 1, 1))
-				.dueDate(LocalDate.of(2026, 2, 1))
-				.build();
 	}
 
 	private OrderPayScheduleLine scheduleLine(final int seq, final OrderPayScheduleStatus status)

--- a/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
@@ -78,7 +78,7 @@ class C_Order_Test
 	}
 
 	/**
-	 * A line with status Awaiting_Pay but no downstream link (no inoutId, no invoiceId, no proforma)
+	 * A line with status Awaiting_Pay but no downstream link (no inoutId, no invoiceId)
 	 * must NOT block reactivation under the new semantics.
 	 */
 	@Test
@@ -95,7 +95,7 @@ class C_Order_Test
 
 	/**
 	 * Status Awaiting_Pay without a downstream link must NOT block reactivation — the block requires
-	 * an actual inoutId/invoiceId/proforma. This test drives the block via an inoutId on an
+	 * an actual inoutId/invoiceId link. This test drives the block via an inoutId on an
 	 * Awaiting_Pay line, demonstrating the guard is status-agnostic (blocks on the link, regardless
 	 * of status).
 	 */
@@ -139,7 +139,7 @@ class C_Order_Test
 				.doesNotThrowAnyException();
 	}
 
-	/** NEW: even a Pending line carrying an inoutId (goods-receipt link) must block reactivation. */
+	/** Even a Pending line carrying an inoutId (goods-receipt link) must block reactivation. */
 	@Test
 	void rejectReactivate_whenAnyLineHasInoutLink()
 	{

--- a/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/service/OrderPayScheduleLCServiceTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/service/OrderPayScheduleLCServiceTest.java
@@ -400,6 +400,59 @@ class OrderPayScheduleLCServiceTest
 				.isNotEqualTo(X_C_OrderPaySchedule.STATUS_Paid);
 	}
 
+	/**
+	 * Order completion on a no-LC payment term whose first break is an {@code OD} advance, with NO
+	 * proforma allocation at all: {@code recomputeLCStepAfterOrderCompleted} must leave the schedule
+	 * that {@code OrderPayScheduleService.createOrderPaySchedules} just built completely alone.
+	 * <p>
+	 * Guards the regression where the unconditional {@code recomputeLCStep} took its
+	 * {@code proforma == null} branch on every ordinary completion and reset the advance line to
+	 * {@code Pending} / {@code 9999-12-01} with a null {@code ReferenceDate}.
+	 */
+	@Test
+	void afterOrderCompleted_noProformaAllocation_leavesAdvanceLineUntouched()
+	{
+		final OrderId orderId = createOrder();
+		createAdvancePayScheduleLine(orderId, X_C_OrderPaySchedule.STATUS_Awaiting_Pay);
+		createMaterialReceiptPayScheduleLine(orderId, X_C_OrderPaySchedule.STATUS_Pending_Ref);
+
+		service.recomputeLCStepAfterOrderCompleted(orderId);
+
+		final I_C_OrderPaySchedule odLine = findLineByReferenceDateType(orderId, ReferenceDateType.OrderDate);
+		assertThat(odLine.getStatus())
+				.as("no proforma allocation — the freshly built advance (OD) line must keep its status")
+				.isEqualTo(X_C_OrderPaySchedule.STATUS_Awaiting_Pay);
+		assertThat(TimeUtil.asLocalDate(odLine.getDueDate()))
+				.as("no proforma allocation — the advance line's DueDate must not be reset")
+				.isEqualTo(LocalDate.of(2026, 6, 1));
+
+		final I_C_OrderPaySchedule blLine = findLineByReferenceDateType(orderId, ReferenceDateType.BillOfLadingDate);
+		assertThat(blLine.getStatus()).isEqualTo(X_C_OrderPaySchedule.STATUS_Pending_Ref);
+	}
+
+	/**
+	 * The same order completion, but WITH an allocated (unpaid) proforma: then there IS something to
+	 * re-derive, so the advance line must pick the proforma up and reach {@code Awaiting_Pay} with
+	 * {@code DueAmt_Actual == proforma GrandTotal}. Proves the guard above narrows the call to the
+	 * no-proforma case only, rather than disabling the re-derivation altogether.
+	 */
+	@Test
+	void afterOrderCompleted_proformaAllocated_rederivesAdvanceLine()
+	{
+		final OrderId orderId = createOrder();
+		createAdvancePayScheduleLine(orderId, X_C_OrderPaySchedule.STATUS_Awaiting_Pay);
+
+		final int proformaInvoiceId = createProformaInvoice(TimeUtil.asTimestamp(LocalDate.of(2026, 7, 3)));
+		createAlloc(orderId, proformaInvoiceId);
+
+		service.recomputeLCStepAfterOrderCompleted(orderId);
+
+		final I_C_OrderPaySchedule odLine = findLineByReferenceDateType(orderId, ReferenceDateType.OrderDate);
+		assertThat(odLine.getStatus()).isEqualTo(X_C_OrderPaySchedule.STATUS_Awaiting_Pay);
+		assertThat(odLine.getDueAmt_Actual()).isEqualByComparingTo(PROFORMA_GRAND_TOTAL);
+		assertThat(TimeUtil.asLocalDate(odLine.getDueDate())).isEqualTo(LocalDate.of(2026, 7, 3));
+	}
+
 	// -----------------------------------------------------------------------
 	// Fixture helpers
 	// -----------------------------------------------------------------------

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
@@ -88,10 +88,10 @@ Feature: PO reactivation guard — downstream-activity check
 
   @from:cucumber
   @Id:S30621_TC2
-  Scenario: Reactivate blocked — proforma allocation exists
+  Scenario: Reactivate allowed — proforma allocation exists, nothing committed downstream
     # A buyer allocates a purchase proforma invoice to the order (LC step → Awaiting_Pay).
-    # The guard detects the proforma allocation and blocks reactivation. The buyer must
-    # de-allocate the proforma before they can reactivate.
+    # The allocation link and its prepayment both survive reactivation, so nothing downstream
+    # would be lost — the guard must allow reactivation without requiring a de-allocation first.
 
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
@@ -115,8 +115,8 @@ Feature: PO reactivation guard — downstream-activity check
       | ReferenceDateType | DueAmt   | DueAmt_Actual | Status |
       | LC                | 21000.00 | 21000.00      | WP     |
 
-    # Guard blocks — proforma allocation exists; user must de-allocate first
-    And the order identified by po cannot be reactivated
+    # Guard allows reactivation — proforma allocation with no goods-receipt/invoice link does not block
+    And the order identified by po is reactivated
 
 
   @from:cucumber

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
@@ -40,11 +40,14 @@ Feature: PO reactivation guard — downstream-activity check
 
     # pt_od: LC 30% + OD 70% — OrderDate break resolves at completion, OD row immediately WP
     # pt_bl: LC 30% + BL 70% — BillOfLadingDate break resolves only on goods receipt
+    # pt_net5: TC4's proforma term — a real 5-day offset so the proforma's DueDate diverges
+    # from its DateInvoiced, making DueDate diagnostic of whether the LC recompute fired.
     And metasfresh contains C_PaymentTerm
-      | Identifier   |
-      | pt_od        |
-      | pt_bl        |
-      | pt_immediate |
+      | Identifier   | OPT.NetDays |
+      | pt_od        |             |
+      | pt_bl        |             |
+      | pt_immediate |             |
+      | pt_net5      | 5           |
     And metasfresh contains C_PaymentTerm_Break
       | Identifier  | C_PaymentTerm_ID | Percent | OffsetDays | ReferenceDateType | SeqNo |
       | ptb_od_lc   | pt_od            | 30      | 0          | LC                | 10    |
@@ -194,10 +197,11 @@ Feature: PO reactivation guard — downstream-activity check
       | poL1       | po         | product      | 700        |
     And the order identified by po is completed
 
-    # Allocate a proforma invoice to the order (LC row -> Awaiting_Pay)
+    # Allocate a proforma invoice to the order (LC row -> Awaiting_Pay). pt_net5 gives the
+    # proforma a real 5-day offset (DueDate = DateInvoiced + 5), unlike pt_immediate.
     And metasfresh contains C_Invoice:
       | Identifier | C_BPartner_ID | C_DocTypeTarget_ID.Name       | DateInvoiced | IsSOTrx | C_Currency_ID | C_PaymentTerm_ID |
-      | proforma   | vendor        | Proforma-Rechnung (Lieferant) | 2026-04-24   | false   | EUR           | pt_immediate     |
+      | proforma   | vendor        | Proforma-Rechnung (Lieferant) | 2026-04-24   | false   | EUR           | pt_net5          |
     And metasfresh contains C_InvoiceLines
       | Identifier | C_Invoice_ID | M_Product_ID | QtyInvoiced | Price    |
       | proformaL1 | proforma     | product      | 1 PCE       | 21000.00 |
@@ -212,16 +216,20 @@ Feature: PO reactivation guard — downstream-activity check
 
     Then the order identified by po has following pay schedule lines by ReferenceDateType
       | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
-      | LC                | 21000.00 | 21000.00      | 2026-04-24    | 2026-04-24 | P      |
+      | LC                | 21000.00 | 21000.00      | 2026-04-24    | 2026-04-29 | P      |
 
     # Reactivate (allowed - proforma allocation no longer blocks) and re-complete the order
     And the order identified by po is reactivated
     And the order identified by po is completed
 
-    # Re-complete must restore the same proforma-derived Paid state
+    # Load-bearing columns: Status, DueAmt_Actual and DueDate actually prove the LC recompute
+    # fired on re-complete (DueDate = proforma.DueDate, 5 days past DateInvoiced — the naive
+    # create-path that only reads LC_Date + pt_od's zero OffsetDays cannot reproduce it).
+    # ReferenceDate and LC_Date coincide with DateInvoiced either way, so they document the
+    # intended state rather than prove the recompute ran.
     Then the order identified by po has following pay schedule lines by ReferenceDateType
       | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
-      | LC                | 21000.00 | 21000.00      | 2026-04-24    | 2026-04-24 | P      |
+      | LC                | 21000.00 | 21000.00      | 2026-04-24    | 2026-04-29 | P      |
     And validate the created orders
       | Identifier | LC_Date    |
       | po         | 2026-04-24 |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
@@ -171,3 +171,57 @@ Feature: PO reactivation guard — downstream-activity check
 
     # Guard blocks — pay-schedule line carries a downstream goods-receipt link
     And the order identified by po cannot be reactivated
+
+
+  @from:cucumber
+  @Id:S30621_TC4
+  Scenario: Reactivate then re-complete preserves the paid-proforma pay-schedule state
+    # A buyer completes a PO, allocates a proforma invoice, and pays it in full (payment
+    # carries Proforma_Invoice_ID) — the LC row is Paid with the proforma's actual amount
+    # and dates. Reactivating the order and re-completing it must restore that same Paid
+    # state: the proforma allocation and its completed prepayment both survive reactivation,
+    # so re-complete must re-derive the LC row from them, not just from the payment-term breaks.
+
+    And metasfresh contains organization bank accounts
+      | Identifier      | C_Currency_ID |
+      | org_EUR_account | EUR           |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po         | N       | vendor        | 2026-04-24  | POO         | wh             | pt_od            |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | poL1       | po         | product      | 700        |
+    And the order identified by po is completed
+
+    # Allocate a proforma invoice to the order (LC row -> Awaiting_Pay)
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID | C_DocTypeTarget_ID.Name       | DateInvoiced | IsSOTrx | C_Currency_ID | C_PaymentTerm_ID |
+      | proforma   | vendor        | Proforma-Rechnung (Lieferant) | 2026-04-24   | false   | EUR           | pt_immediate     |
+    And metasfresh contains C_InvoiceLines
+      | Identifier | C_Invoice_ID | M_Product_ID | QtyInvoiced | Price    |
+      | proformaL1 | proforma     | product      | 1 PCE       | 21000.00 |
+    And the invoice identified by proforma is completed
+    And I allocate proforma 'proforma' to order 'po'
+
+    # Pay the proforma in full (Proforma_Invoice_ID -> IsPrepayment=Y) — marks the LC row Paid
+    And metasfresh contains C_Payment
+      | Identifier | C_BPartner_ID | PayAmt       | IsReceipt | C_BP_BankAccount_ID | Proforma_Invoice_ID |
+      | payment    | vendor        | 21000.00 EUR | false     | org_EUR_account      | proforma            |
+    And the payment identified by payment is completed
+
+    Then the order identified by po has following pay schedule lines by ReferenceDateType
+      | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
+      | LC                | 21000.00 | 21000.00      | 2026-04-24    | 2026-04-24 | P      |
+
+    # Reactivate (allowed - proforma allocation no longer blocks) and re-complete the order
+    And the order identified by po is reactivated
+    And the order identified by po is completed
+
+    # Re-complete must restore the same proforma-derived Paid state
+    Then the order identified by po has following pay schedule lines by ReferenceDateType
+      | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
+      | LC                | 21000.00 | 21000.00      | 2026-04-24    | 2026-04-24 | P      |
+    And validate the created orders
+      | Identifier | LC_Date    |
+      | po         | 2026-04-24 |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
@@ -233,3 +233,148 @@ Feature: PO reactivation guard — downstream-activity check
     And validate the created orders
       | Identifier | LC_Date    |
       | po         | 2026-04-24 |
+
+
+  @from:cucumber
+  @Id:S30621_TC5
+  Scenario: Reactivate then re-complete preserves the paid-proforma pay-schedule state on a B/L term
+    # Same reactivate -> re-complete round trip as TC4, but on pt_bl (LC 30% + BL 70%) instead of
+    # pt_od. The BL break resolves only on goods receipt, so — with no receipt in this scenario —
+    # its row stays Pending at the infinite-future sentinel throughout. Proves the LC recompute
+    # restores the paid-proforma state on a B/L term too, and that the untouched BL row survives
+    # the round trip unchanged.
+
+    And metasfresh contains organization bank accounts
+      | Identifier      | C_Currency_ID |
+      | org_EUR_account | EUR           |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po         | N       | vendor        | 2026-04-24  | POO         | wh             | pt_bl            |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | poL1       | po         | product      | 700        |
+    And the order identified by po is completed
+
+    # Allocate a proforma invoice to the order (LC row -> Awaiting_Pay). pt_net5 gives the
+    # proforma a real 5-day offset (DueDate = DateInvoiced + 5), unlike pt_immediate.
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID | C_DocTypeTarget_ID.Name       | DateInvoiced | IsSOTrx | C_Currency_ID | C_PaymentTerm_ID |
+      | proforma   | vendor        | Proforma-Rechnung (Lieferant) | 2026-04-24   | false   | EUR           | pt_net5          |
+    And metasfresh contains C_InvoiceLines
+      | Identifier | C_Invoice_ID | M_Product_ID | QtyInvoiced | Price    |
+      | proformaL1 | proforma     | product      | 1 PCE       | 21000.00 |
+    And the invoice identified by proforma is completed
+    And I allocate proforma 'proforma' to order 'po'
+
+    # Pay the proforma in full (Proforma_Invoice_ID -> IsPrepayment=Y) — marks the LC row Paid
+    And metasfresh contains C_Payment
+      | Identifier | C_BPartner_ID | PayAmt       | IsReceipt | C_BP_BankAccount_ID | Proforma_Invoice_ID |
+      | payment    | vendor        | 21000.00 EUR | false     | org_EUR_account      | proforma            |
+    And the payment identified by payment is completed
+
+    # LC: Paid from the proforma. BL: still Pending — no goods receipt exists in this scenario.
+    Then the order identified by po has following pay schedule lines by ReferenceDateType
+      | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
+      | LC                | 21000.00 | 21000.00      | 2026-04-24    | 2026-04-29 | P      |
+      | BL                | 49000.00 | null          | null          | 9999-12-01 | PR     |
+
+    # Reactivate (allowed - proforma allocation no longer blocks) and re-complete the order
+    And the order identified by po is reactivated
+    And the order identified by po is completed
+
+    # Load-bearing columns: Status, DueAmt_Actual and DueDate on the LC row actually prove the LC
+    # recompute fired on re-complete (DueDate = proforma.DueDate, 5 days past DateInvoiced — the
+    # naive create-path that only reads LC_Date + pt_bl's zero OffsetDays cannot reproduce it). The
+    # BL row is untouched by the recompute (it targets only the LC/prepaid line) and must come back
+    # exactly as it went in — still Pending at the infinite-future sentinel.
+    Then the order identified by po has following pay schedule lines by ReferenceDateType
+      | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
+      | LC                | 21000.00 | 21000.00      | 2026-04-24    | 2026-04-29 | P      |
+      | BL                | 49000.00 | null          | null          | 9999-12-01 | PR     |
+    And validate the created orders
+      | Identifier | LC_Date    |
+      | po         | 2026-04-24 |
+
+
+  @from:cucumber
+  @Id:S30621_TC6
+  Scenario: Reactivate then re-complete preserves the awaiting-pay proforma pay-schedule state
+    # A buyer completes a PO and allocates a proforma invoice but does not pay it — the LC row is
+    # Awaiting_Pay (not Paid), carrying the proforma's own dates and amount but no completed
+    # prepayment. Reactivating and re-completing must restore that same Awaiting_Pay state,
+    # exercising the recompute's awaitingPayment() branch (proforma present, no completed
+    # prepayment) rather than paid().
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po         | N       | vendor        | 2026-04-24  | POO         | wh             | pt_od            |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | poL1       | po         | product      | 700        |
+    And the order identified by po is completed
+
+    # Allocate a proforma invoice to the order (LC row -> Awaiting_Pay). pt_net5 gives the
+    # proforma a real 5-day offset (DueDate = DateInvoiced + 5), unlike pt_immediate.
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID | C_DocTypeTarget_ID.Name       | DateInvoiced | IsSOTrx | C_Currency_ID | C_PaymentTerm_ID |
+      | proforma   | vendor        | Proforma-Rechnung (Lieferant) | 2026-04-24   | false   | EUR           | pt_net5          |
+    And metasfresh contains C_InvoiceLines
+      | Identifier | C_Invoice_ID | M_Product_ID | QtyInvoiced | Price    |
+      | proformaL1 | proforma     | product      | 1 PCE       | 21000.00 |
+    And the invoice identified by proforma is completed
+    And I allocate proforma 'proforma' to order 'po'
+
+    # No payment is made — LC row stays Awaiting_Pay, projecting the proforma's own dates/amount.
+    Then the order identified by po has following pay schedule lines by ReferenceDateType
+      | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
+      | LC                | 21000.00 | 21000.00      | 2026-04-24    | 2026-04-29 | WP     |
+
+    # Reactivate (allowed - proforma allocation with no downstream link does not block) and
+    # re-complete the order
+    And the order identified by po is reactivated
+    And the order identified by po is completed
+
+    # Load-bearing columns: Status, DueAmt_Actual and DueDate actually prove the LC recompute
+    # fired on re-complete via the awaitingPayment() branch (DueDate = proforma.DueDate, 5 days
+    # past DateInvoiced — the naive create-path that only reads LC_Date + pt_od's zero OffsetDays
+    # cannot reproduce it).
+    Then the order identified by po has following pay schedule lines by ReferenceDateType
+      | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
+      | LC                | 21000.00 | 21000.00      | 2026-04-24    | 2026-04-29 | WP     |
+    And validate the created orders
+      | Identifier | LC_Date    |
+      | po         | 2026-04-24 |
+
+
+  @from:cucumber
+  @Id:S30621_TC7
+  Scenario: Reactivate then re-complete leaves an ordinary order's pay schedule untouched
+    # Regression guard: an order with no proforma at all must come back through reactivate ->
+    # re-complete exactly as it went in. Proves the now-unconditional recomputeLCStep call does
+    # not disturb an ordinary order that never had a proforma allocation.
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po         | N       | vendor        | 2026-04-24  | POO         | wh             | pt_od            |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | poL1       | po         | product      | 700        |
+    And the order identified by po is completed
+
+    # OD row: Awaiting_Pay (DateOrdered known at completion); LC row: Pending (no proforma at all)
+    Then the order identified by po has following pay schedule lines by ReferenceDateType
+      | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
+      | LC                | 21000.00 | null          | null          | 9999-12-01 | PR     |
+      | OD                | 49000.00 | null          | 2026-04-24    | 2026-04-24 | WP     |
+
+    # Reactivate and re-complete — no proforma exists, so recomputeLCStep is a no-op
+    And the order identified by po is reactivated
+    And the order identified by po is completed
+
+    # Unchanged: the re-created schedule matches the payment-term breaks exactly as before
+    # reactivation — proving the unconditional recompute call does not disturb an ordinary order.
+    Then the order identified by po has following pay schedule lines by ReferenceDateType
+      | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
+      | LC                | 21000.00 | null          | null          | 9999-12-01 | PR     |
+      | OD                | 49000.00 | null          | 2026-04-24    | 2026-04-24 | WP     |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
@@ -6,7 +6,8 @@ Feature: PO reactivation guard — downstream-activity check
   # Guard blocks reactivation only when the pay schedule carries committed downstream
   # state: a goods-receipt link (M_InOut_ID) or a matched-invoice link (C_Invoice_ID).
   # An Awaiting_Pay line with no downstream must NOT block.
-  # pt_od = LC 30% + OD 70% (OD resolves at completion); pt_bl = LC 30% + BL 70%.
+  # pt_od = LC 30% + OD 70% (OD resolves at completion); pt_bl = LC 30% + BL 70%;
+  # pt_od_nolc = OD 25% + BL 75% — no LC break at all, so the OD row is itself the recompute target.
   # PO: 700 PCE × 100 EUR = 70,000 EUR (IsTaxIncluded=Y → GrandTotal = 70,000).
 
   Background:
@@ -40,24 +41,31 @@ Feature: PO reactivation guard — downstream-activity check
 
     # pt_od: LC 30% + OD 70% — OrderDate break resolves at completion, OD row immediately WP
     # pt_bl: LC 30% + BL 70% — BillOfLadingDate break resolves only on goods receipt
-    # pt_net5: TC4's proforma term — a real 5-day offset so the proforma's DueDate diverges
-    # from its DateInvoiced, making DueDate diagnostic of whether the LC recompute fired.
+    # pt_od_nolc: OD 25% (+1 day) + BL 75% — TC8's term. NO LetterOfCredit break, so the OD row is
+    # the recompute target itself (getSingleLCLine finds nothing and the prepaid fallback picks OD).
+    # Exactly one prepaid (OD/LC) break, otherwise the multiple-advance-breaks guard trips.
+    # pt_net5: the proforma term of TC4, TC5, TC6 and TC8 — a real 5-day offset so the proforma's
+    # DueDate diverges from its DateInvoiced, making DueDate diagnostic of whether the recompute fired.
     And metasfresh contains C_PaymentTerm
       | Identifier   | OPT.NetDays |
       | pt_od        |             |
       | pt_bl        |             |
+      | pt_od_nolc   |             |
       | pt_immediate |             |
       | pt_net5      | 5           |
     And metasfresh contains C_PaymentTerm_Break
-      | Identifier  | C_PaymentTerm_ID | Percent | OffsetDays | ReferenceDateType | SeqNo |
-      | ptb_od_lc   | pt_od            | 30      | 0          | LC                | 10    |
-      | ptb_od_od   | pt_od            | 70      | 0          | OD                | 20    |
-      | ptb_bl_lc   | pt_bl            | 30      | 0          | LC                | 10    |
-      | ptb_bl_bl   | pt_bl            | 70      | 0          | BL                | 20    |
+      | Identifier    | C_PaymentTerm_ID | Percent | OffsetDays | ReferenceDateType | SeqNo |
+      | ptb_od_lc     | pt_od            | 30      | 0          | LC                | 10    |
+      | ptb_od_od     | pt_od            | 70      | 0          | OD                | 20    |
+      | ptb_bl_lc     | pt_bl            | 30      | 0          | LC                | 10    |
+      | ptb_bl_bl     | pt_bl            | 70      | 0          | BL                | 20    |
+      | ptb_odnolc_od | pt_od_nolc       | 25      | 1          | OD                | 10    |
+      | ptb_odnolc_bl | pt_od_nolc       | 75      | 0          | BL                | 20    |
     And validate C_PaymentTerm:
       | Identifier | IsComplex | IsValid |
       | pt_od      | Y         | Y       |
       | pt_bl      | Y         | Y       |
+      | pt_od_nolc | Y         | Y       |
 
     And metasfresh contains M_Warehouse:
       | M_Warehouse_ID |
@@ -211,7 +219,7 @@ Feature: PO reactivation guard — downstream-activity check
     # Pay the proforma in full (Proforma_Invoice_ID -> IsPrepayment=Y) — marks the LC row Paid
     And metasfresh contains C_Payment
       | Identifier | C_BPartner_ID | PayAmt       | IsReceipt | C_BP_BankAccount_ID | Proforma_Invoice_ID |
-      | payment    | vendor        | 21000.00 EUR | false     | org_EUR_account      | proforma            |
+      | payment    | vendor        | 21000.00 EUR | false     | org_EUR_account     | proforma            |
     And the payment identified by payment is completed
 
     Then the order identified by po has following pay schedule lines by ReferenceDateType
@@ -270,7 +278,7 @@ Feature: PO reactivation guard — downstream-activity check
     # Pay the proforma in full (Proforma_Invoice_ID -> IsPrepayment=Y) — marks the LC row Paid
     And metasfresh contains C_Payment
       | Identifier | C_BPartner_ID | PayAmt       | IsReceipt | C_BP_BankAccount_ID | Proforma_Invoice_ID |
-      | payment    | vendor        | 21000.00 EUR | false     | org_EUR_account      | proforma            |
+      | payment    | vendor        | 21000.00 EUR | false     | org_EUR_account     | proforma            |
     And the payment identified by payment is completed
 
     # LC: Paid from the proforma. BL: still Pending — no goods receipt exists in this scenario.
@@ -326,9 +334,12 @@ Feature: PO reactivation guard — downstream-activity check
     And I allocate proforma 'proforma' to order 'po'
 
     # No payment is made — LC row stays Awaiting_Pay, projecting the proforma's own dates/amount.
+    # The OD sibling row is not the recompute target on this LC-carrying term, so it keeps the
+    # plain payment-term-break state it got at completion.
     Then the order identified by po has following pay schedule lines by ReferenceDateType
       | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
       | LC                | 21000.00 | 21000.00      | 2026-04-24    | 2026-04-29 | WP     |
+      | OD                | 49000.00 | null          | 2026-04-24    | 2026-04-24 | WP     |
 
     # Reactivate (allowed - proforma allocation with no downstream link does not block) and
     # re-complete the order
@@ -338,10 +349,11 @@ Feature: PO reactivation guard — downstream-activity check
     # Load-bearing columns: Status, DueAmt_Actual and DueDate actually prove the LC recompute
     # fired on re-complete via the awaitingPayment() branch (DueDate = proforma.DueDate, 5 days
     # past DateInvoiced — the naive create-path that only reads LC_Date + pt_od's zero OffsetDays
-    # cannot reproduce it).
+    # cannot reproduce it). The OD sibling row must come back exactly as it went in.
     Then the order identified by po has following pay schedule lines by ReferenceDateType
       | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
       | LC                | 21000.00 | 21000.00      | 2026-04-24    | 2026-04-29 | WP     |
+      | OD                | 49000.00 | null          | 2026-04-24    | 2026-04-24 | WP     |
     And validate the created orders
       | Identifier | LC_Date    |
       | po         | 2026-04-24 |
@@ -351,8 +363,13 @@ Feature: PO reactivation guard — downstream-activity check
   @Id:S30621_TC7
   Scenario: Reactivate then re-complete leaves an ordinary order's pay schedule untouched
     # Regression guard: an order with no proforma at all must come back through reactivate ->
-    # re-complete exactly as it went in. Proves the now-unconditional recomputeLCStep call does
-    # not disturb an ordinary order that never had a proforma allocation.
+    # re-complete exactly as it went in. Proves the AFTER_COMPLETE recompute call does not disturb
+    # an ordinary order that never had a proforma allocation.
+    #
+    # NOTE this term (pt_od) carries an LC break, which makes it BLIND to a recompute that resets
+    # the wrong row: the LC row is the recompute target here, and it is already Pending with a null
+    # LC_Date, so even a reset would be invisible. TC8 covers the no-LC term where the OD row IS
+    # the target and a reset is observable — keep both.
 
     And metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
@@ -368,13 +385,87 @@ Feature: PO reactivation guard — downstream-activity check
       | LC                | 21000.00 | null          | null          | 9999-12-01 | PR     |
       | OD                | 49000.00 | null          | 2026-04-24    | 2026-04-24 | WP     |
 
-    # Reactivate and re-complete — no proforma exists, so recomputeLCStep is a no-op
+    # Reactivate and re-complete. No proforma allocation exists, so the AFTER_COMPLETE recompute
+    # returns without touching the schedule at all.
     And the order identified by po is reactivated
     And the order identified by po is completed
 
     # Unchanged: the re-created schedule matches the payment-term breaks exactly as before
-    # reactivation — proving the unconditional recompute call does not disturb an ordinary order.
+    # reactivation — proving the AFTER_COMPLETE recompute call does not disturb an ordinary order.
     Then the order identified by po has following pay schedule lines by ReferenceDateType
       | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
       | LC                | 21000.00 | null          | null          | 9999-12-01 | PR     |
       | OD                | 49000.00 | null          | 2026-04-24    | 2026-04-24 | WP     |
+
+
+  @from:cucumber
+  @Id:S30621_TC8
+  Scenario: Reactivate then re-complete preserves the paid-proforma state on the order-date step of a no-LC term
+    # The customer's real configuration: a purchase term with NO Letter-of-Credit break at all
+    # (pt_od_nolc = OD 25% advance + BL 75% on goods receipt). The procurement worker pays the 25%
+    # advance up front through a purchase proforma invoice, so the ORDER-DATE step — not an LC step —
+    # is what the proforma drives, and it is what the recompute must target and restore.
+    #
+    # This is the only scenario in this file where the OD row is the recompute target: every other
+    # term here carries an LC break, so getSingleLCLine() always wins and the OD row is never
+    # touched. Without this scenario a recompute that wrongly resets the OD row stays invisible.
+
+    And metasfresh contains organization bank accounts
+      | Identifier      | C_Currency_ID |
+      | org_EUR_account | EUR           |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | C_PaymentTerm_ID |
+      | po         | N       | vendor        | 2026-04-24  | POO         | wh             | pt_od_nolc       |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | poL1       | po         | product      | 700        |
+    And the order identified by po is completed
+
+    # Completion alone: the OD row resolves off DateOrdered (+1 day offset) and is immediately
+    # Awaiting_Pay; the BL row stays Pending at the infinite-future sentinel (no goods receipt).
+    # No proforma is allocated yet, so nothing may overwrite this state.
+    Then the order identified by po has following pay schedule lines by ReferenceDateType
+      | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
+      | OD                | 17500.00 | null          | 2026-04-24    | 2026-04-25 | WP     |
+      | BL                | 52500.00 | null          | null          | 9999-12-01 | PR     |
+
+    # Vendor sends the proforma for the 25% advance. pt_net5 gives it a real 5-day offset
+    # (DueDate = DateInvoiced + 5), so DueDate is diagnostic of whether the recompute fired.
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID | C_DocTypeTarget_ID.Name       | DateInvoiced | IsSOTrx | C_Currency_ID | C_PaymentTerm_ID |
+      | proforma   | vendor        | Proforma-Rechnung (Lieferant) | 2026-04-24   | false   | EUR           | pt_net5          |
+    And metasfresh contains C_InvoiceLines
+      | Identifier | C_Invoice_ID | M_Product_ID | QtyInvoiced | Price    |
+      | proformaL1 | proforma     | product      | 1 PCE       | 17500.00 |
+    And the invoice identified by proforma is completed
+    And I allocate proforma 'proforma' to order 'po'
+
+    # Pay the proforma in full (Proforma_Invoice_ID -> IsPrepayment=Y) — marks the OD row Paid
+    And metasfresh contains C_Payment
+      | Identifier | C_BPartner_ID | PayAmt       | IsReceipt | C_BP_BankAccount_ID | Proforma_Invoice_ID |
+      | payment    | vendor        | 17500.00 EUR | false     | org_EUR_account     | proforma            |
+    And the payment identified by payment is completed
+
+    # OD: Paid, now carrying the proforma's own amount and dates instead of the break-derived ones.
+    Then the order identified by po has following pay schedule lines by ReferenceDateType
+      | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
+      | OD                | 17500.00 | 17500.00      | 2026-04-24    | 2026-04-29 | P      |
+      | BL                | 52500.00 | null          | null          | 9999-12-01 | PR     |
+
+    # Reactivate (allowed - the paid proforma carries no goods-receipt/invoice link) and re-complete
+    And the order identified by po is reactivated
+    And the order identified by po is completed
+
+    # Load-bearing columns on the OD row: Status, DueAmt_Actual and DueDate prove the recompute
+    # re-derived the order-date step from the surviving allocation + prepayment (DueDate =
+    # proforma.DueDate, 2026-04-29 — the create-path would put back the break-derived 2026-04-25).
+    # The BL row is not the recompute target and must come back exactly as it went in.
+    Then the order identified by po has following pay schedule lines by ReferenceDateType
+      | ReferenceDateType | DueAmt   | DueAmt_Actual | ReferenceDate | DueDate    | Status |
+      | OD                | 17500.00 | 17500.00      | 2026-04-24    | 2026-04-29 | P      |
+      | BL                | 52500.00 | null          | null          | 9999-12-01 | PR     |
+    # No LetterOfCredit break on this term, so nothing may stamp C_Order.LC_Date.
+    And validate the created orders
+      | Identifier | LC_Date |
+      | po         | null    |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/order/orderReactivatePayScheduleGuard.feature
@@ -4,8 +4,8 @@
 @ghActions:run_on_executor1
 Feature: PO reactivation guard — downstream-activity check
   # Guard blocks reactivation only when the pay schedule carries committed downstream
-  # state: a goods-receipt link (M_InOut_ID), a matched-invoice link (C_Invoice_ID),
-  # or a proforma allocation. An Awaiting_Pay line with no downstream must NOT block.
+  # state: a goods-receipt link (M_InOut_ID) or a matched-invoice link (C_Invoice_ID).
+  # An Awaiting_Pay line with no downstream must NOT block.
   # pt_od = LC 30% + OD 70% (OD resolves at completion); pt_bl = LC 30% + BL 70%.
   # PO: 700 PCE × 100 EUR = 70,000 EUR (IsTaxIncluded=Y → GrandTotal = 70,000).
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/interceptor/OrderTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/interceptor/OrderTest.java
@@ -34,6 +34,8 @@ import de.metas.greeting.GreetingRepository;
 import de.metas.money.CurrencyId;
 import de.metas.order.BPartnerOrderParamsRepository;
 import de.metas.order.model.interceptor.C_Order;
+import de.metas.pricing.tax.ProductTaxCategoryRepository;
+import de.metas.pricing.tax.ProductTaxCategoryService;
 import de.metas.util.Services;
 import org.adempiere.ad.modelvalidator.IModelInterceptorRegistry;
 import org.adempiere.exceptions.AdempiereException;
@@ -67,6 +69,10 @@ public class OrderTest
 
 		SpringContextHolder.registerJUnitBean(new GreetingRepository());
 		SpringContextHolder.registerJUnitBean(BPartnerOrderParamsRepository.newInstanceForUnitTesting());
+		// C_Order.newInstanceForUnitTesting() transitively builds OrderPayScheduleLCStepService ->
+		// OrderPayScheduleRegularInvoiceService, whose Services.get(IInvoiceLineBL.class) instantiates
+		// InvoiceLineBL, which pulls ProductTaxCategoryService out of the spring context on construction.
+		SpringContextHolder.registerJUnitBean(new ProductTaxCategoryService(new ProductTaxCategoryRepository()));
 
 		Services.get(IModelInterceptorRegistry.class).addModelInterceptor(C_Order.newInstanceForUnitTesting());
 


### PR DESCRIPTION
## What changed

A proforma invoice allocated to a purchase order no longer prevents that order from being reactivated.

Reactivation is now blocked **only** by committed downstream activity — a goods receipt (`M_InOut_ID`) or a matched invoice (`C_Invoice_ID`) linked to a pay-schedule line. `OrderPayScheduleProformaService` is no longer consulted by the reactivate guard at all, so the dependency was removed rather than left injected-but-unused.

## Why the guard removal alone was not enough

Reactivate deletes every `C_OrderPaySchedule` row. Before this change a proforma allocation always blocked reactivation, so the reactivate → re-complete round trip on a proforma-linked order was unreachable. Relaxing the guard makes it reachable — and re-complete rebuilt the schedule from the payment-term breaks alone, silently dropping the proforma-derived state (Paid status, `DueAmt_Actual`, `ReferenceDate`, `DueDate`, and the order's `LC_Date`).

So the second half of this PR re-derives that state: `de.metas.order.model.interceptor.C_Order#createOrderPaySchedules` now calls `OrderPayScheduleLCStepService#recomputeLCStepAfterOrderCompleted` immediately after `orderPayScheduleService.createOrderPaySchedules(order)`, where it observes the freshly rebuilt schedule. The allocation and its prepayment survive reactivation untouched, so the round trip is lossless.

The call could not go inside `OrderPayScheduleService.createOrderPaySchedules` — `OrderPayScheduleLCStepService` already depends on `OrderPayScheduleService`, which would close a dependency cycle. The interceptor is a leaf, so injecting there is safe.

## Regression introduced by this PR, and fixed inside it

The recompute call started out **unconditional**, and that reset a just-built **order-date** pay-schedule line on completion.

The recompute resolves its target as *the single LC line, else the single prepaid line* — and `isPrepaidLine()` admits order-date lines. So on a payment term with an order-date break and **no** LC break, and an order with no proforma allocation at all, `getSingleLCLine()` found nothing, the prepaid fallback picked the order-date line that `createOrderPaySchedules` had just built correctly, and the no-proforma branch reset it to `Pending` / `9999-12-01` with a null `ReferenceDate`.

That reset is load-bearing for de-allocation, so it stayed as it is. Instead the completion call site was routed through the guarded `OrderPayScheduleLCStepService#recomputeLCStepAfterOrderCompleted`, which early-returns when the order has no proforma allocation — i.e. it re-derives only when there is something to restore. It reuses `OrderPayScheduleProformaService#getIdByOrderId`, the same query the branch it guards uses, so the two cannot diverge.

Symptom and fix: https://github.com/metasfresh/metasfresh/commit/1fbb6157f3dbe47b296afd9c5ade82344148decd. The unconditional call broke 6 of the 9 scenarios in `purchaseOrder/purchaseOrderComplexPaymentTerm.feature` — precisely the 6 whose payment term has an order-date break and no LC break (`[DueDate] expected 2025-10-10 but was 9999-12-01`, `[Status] expected Awaiting_Pay but was Pending`); all 9 are green with the guard in place. `S30621_TC8` is the covering scenario in this PR's own feature file, and it is the first one there in which the order-date line is actually the recompute target — every earlier term carries an LC break, so `getSingleLCLine()` always wins and a wrongly reset order-date row stays invisible.

## Message text

`Order_Reactivate_Blocked_By_PaySchedule_Activity` no longer tells the user to de-allocate the proforma invoice, since that is no longer a remedy. Reworded in DE and EN (and `de_CH`, kept in sync with the German base as the two prior migrations for this message did).

## Testing

**Unit** — `C_Order_Test`, 6 tests covering the guard predicate: `Tests run: 6, Failures: 0`. `OrderPayScheduleLCServiceTest`: `Tests run: 13, Failures: 0, Errors: 0, Skipped: 0` (includes the two cases pinning both sides of the new completion guard: no allocation leaves the advance line untouched, allocation present still re-derives it). `OrderTest`: `Tests run: 10, Failures: 0, Errors: 0, Skipped: 0`.

**Cucumber** — `orderReactivatePayScheduleGuard.feature`, all **8** scenarios green (`@Id:S30621_TC1` … `TC8`):

- `TC1` Reactivate allowed — Awaiting_Pay OD row with no downstream (regression guard)
- `TC2` Reactivate allowed — proforma allocation exists, nothing committed downstream *(this scenario previously asserted the opposite; inverting it is the behaviour change under test)*
- `TC3` Reactivate blocked — goods receipt links a pay-schedule line
- `TC4` Reactivate then re-complete preserves the paid-proforma pay-schedule state
- `TC5` Reactivate then re-complete preserves the paid-proforma pay-schedule state on a B/L term
- `TC6` Reactivate then re-complete preserves the awaiting-pay proforma pay-schedule state
- `TC7` Reactivate then re-complete leaves an ordinary order's pay schedule untouched
- `TC8` Reactivate then re-complete preserves the paid-proforma state on the order-date step of a no-LC term

`purchaseOrder/purchaseOrderComplexPaymentTerm.feature`, all 9 scenarios green — the feature the regression above broke, and the reason the completion call is guarded.

`S30621_TC4` was verified to actually be diagnostic rather than incidentally green: with the recompute call temporarily commented out, it fails on `Status` (`Paid` → `Awaiting_Pay`), `DueAmt_Actual` (null) **and** `DueDate` (`2026-04-29` → `2026-04-24`). The proforma deliberately uses a payment term with a 5-day offset so its due date diverges from what the naive rebuild path would produce; without that, three of the five asserted columns would have passed with the fix absent.

**CI** — https://github.com/metasfresh/metasfresh/actions/runs/30618383055: every job green, Merge Gate pass.

## Accepted risk — retired, no longer applies

This section previously disclosed an accepted risk: because the completion interceptor called `recomputeLCStep` on **every** order completion, a payment term carrying more than one letter-of-credit break, or more than one advance/order-date break, would make `OrderPaySchedule#getSingleLCLine` / `#getSinglePrepaidLine` throw and abort **every** completion of every order on that term (`PaymentTerm.assertValid()` only checks that break percentages sum to 100%, so it does not reject such a term).

That is no longer the case. https://github.com/metasfresh/metasfresh/commit/1fbb6157f3dbe47b296afd9c5ade82344148decd routes the completion call through the guarded `recomputeLCStepAfterOrderCompleted`, which early-returns when the order has no proforma allocation. The fail-fast is therefore reachable again only for orders that carry a proforma allocation — exactly the blast radius it had before this PR. Nothing about the risk was left open; it was closed by the guard, not waived.

For orders that never had a proforma the call is inert by construction: it returns after the single allocation lookup, without reading or writing the pay schedule at all.
