### PR TITLE
Costing - plain repost driver: accounting_docs_repost_all_from_date

### DIFF
--- a/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/accounting_docs_repost_all_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/accounting_docs_repost_all_from_date.sql
@@ -1,0 +1,223 @@
+DROP FUNCTION IF EXISTS "de_metas_acct".accounting_docs_repost_all_from_date(
+    p_C_AcctSchema_ID numeric,
+    p_StartDateAcct   timestamp WITH TIME ZONE
+)
+;
+
+
+-- Reposts EVERY accountable, product-bearing, non-invoice document of an accounting schema from a given
+-- accounting date onwards, WITHOUT recomputing anything. Returns the number of documents enqueued.
+--
+-- This is the counterpart of "de_metas_acct".product_costs_recreate_all_from_date, and the difference is the
+-- whole point: the recompute driver DELETES the cost details in range so that reposting rebuilds them, while
+-- this function deletes nothing at all. It exists for the situation where the cost details are already
+-- correct and only the general ledger is not - the canonical case being a change of the accounting schema's
+-- costing method. The amount a document posts is filtered to the cost element that is accountable under the
+-- schema's current costing configuration (de.metas.costing.CostDetailCreateResultsList#getAmtAndQtyToPost),
+-- so after such a change the existing Fact_Acct rows are valued by the OLD method and every document has to
+-- be reposted to be valued by the new one. The cost details themselves must survive that untouched:
+-- de.metas.costing.methods.CostingMethodHandlerTemplate#createOrUpdateCost returns the EXISTING cost details
+-- when they exist (it only refreshes their DateAcct) and computes nothing, so reposting re-values the GL from
+-- exactly the costs that are already there.
+--
+-- Consequently, and unlike the recompute driver:
+--   * ordering is NOT a correctness contract here - nothing is computed, so nothing depends on the sequence.
+--     Documents are still enqueued in accounting-date order because it costs nothing and keeps the GL rows
+--     produced in a sensible order;
+--   * there is no staging table, no progress table and no resume. There is nothing to hold documents back
+--     for: the enqueue is a single INSERT in a single transaction, so the run either happened or it did not;
+--   * it does not delete Fact_Acct rows either - the queue-driven repost does that itself. Verified:
+--     de.metas.acct.api.impl.PostingService#postNow calls doc.post(force, /*repost*/ true) with that second
+--     argument hardcoded, and org.compiere.acct.Doc#post does `if (repost) { deleteAcct(); }` before saving
+--     the new facts.
+--
+-- REJECTED ALTERNATIVE: looping "de_metas_acct".fact_acct_unpost() over the documents. It is the sanctioned
+-- way to enqueue a repost (see the rule deviation below), but it cannot do this job:
+--   * it sets Processing='Y' on every document it touches and, at its default p_Force:='N', RAISEs when a
+--     document is already Processing='Y' - so a single such document anywhere in the range aborts the loop,
+--     and on a real installation that range holds hundreds of thousands of documents. Passing p_Force:='Y'
+--     does not fix it: it only trades the abort for overwriting whatever process owns that lock;
+--   * it DELETEs every Fact_Acct row of every document up front - work the repost redoes anyway (see above),
+--     and it leaves the ledger empty for as long as the queue takes to drain;
+--   * it enqueues one document per call as it goes, with the SeqNo left to the queue sequence, so there is no
+--     way to reserve a contiguous, deliberately ordered block.
+--
+-- KNOWN, DELIBERATE RULE DEVIATION - documented here rather than hidden:
+--   `docs/coding-rules/production-database-support.md` and `backend/de.metas.acct.base/CLAUDE.md` both state:
+--   never INSERT directly into Accounting_Docs_To_Repost - always use the "de_metas_acct".fact_acct_unpost*
+--   functions. The INSERT below breaks that rule knowingly, on exactly the same grounds as the recompute
+--   driver's release step. The rule exists because fact_acct_unpost bundles three effects with the enqueue,
+--   and here two of them are provably redundant and the third is done differently:
+--     * deleting the stale Fact_Acct rows - redundant, the repost does it itself (PostingService#postNow ->
+--       Doc#post -> deleteAcct(), see above);
+--     * resetting Posted='N' so the document can be locked again - redundant, because
+--       de.metas.acct.doc.SqlAcctDocLockService#lock only adds the `AND Posted='N'` condition when repost is
+--       FALSE, so a document left at Posted='Y' still locks and reposts;
+--     * checking that the period is open - NOT redundant, and therefore replaced by the explicit
+--       assert_period_open sweep in (c) below, which is strictly stronger: it covers the whole range up front
+--       instead of one document at a time.
+--   The rule itself is deliberately NOT amended - that is not this function's call to make.
+CREATE OR REPLACE FUNCTION "de_metas_acct".accounting_docs_repost_all_from_date(
+    p_C_AcctSchema_ID numeric,
+    p_StartDateAcct   timestamp WITH TIME ZONE
+)
+    RETURNS integer
+    LANGUAGE plpgsql
+AS
+$BODY$
+DECLARE
+    -- Same advisory-lock class id as "de_metas_acct".product_costs_recreate_all_from_date, on purpose - see (a).
+    c_AdvisoryLock_ClassId constant integer := 26253;
+    --
+    v_AD_Client_ID         numeric;
+    v_documentCount        integer;
+    v_seqNoLast            numeric;
+    v_seqNoBase            numeric;
+    v_period               record;
+BEGIN
+    IF (p_StartDateAcct IS NULL) THEN
+        RAISE EXCEPTION 'p_StartDateAcct shall be set';
+    END IF;
+
+    SELECT cas.ad_client_id
+    INTO v_AD_Client_ID
+    FROM c_acctschema cas
+    WHERE cas.c_acctschema_id = p_C_AcctSchema_ID;
+    IF (v_AD_Client_ID IS NULL) THEN
+        RAISE EXCEPTION 'C_AcctSchema_ID % not found', p_C_AcctSchema_ID;
+    END IF;
+
+    --
+    --
+    -- (a) NEVER WHILE A COST RECOMPUTE IS RUNNING
+    --
+    --
+    -- Deliberately the SAME lock class and key as "de_metas_acct".product_costs_recreate_all_from_date, so the
+    -- two exclude each other rather than merely each other's own kind. Overlapping them is precisely the
+    -- damaging case: while a recompute run is in flight its documents are parked in the staging table exactly
+    -- so that nothing reaches the poller until every product has been rewound. Documents this function pushes
+    -- straight onto the queue in the meantime would be reposted against half-rewound costs, and the recompute
+    -- would then reuse the wrong cost details it finds - silently, and for good.
+    -- The lock is taken at SESSION level (like the driver's), not transaction level, because the two must be
+    -- comparable: the driver commits per batch and therefore cannot hold a transaction-level lock at all.
+    IF NOT pg_try_advisory_lock(c_AdvisoryLock_ClassId, p_C_AcctSchema_ID::integer) THEN
+        RAISE EXCEPTION 'Another cost recompute or repost run is already in progress for C_AcctSchema_ID=%', p_C_AcctSchema_ID;
+    END IF;
+
+    -- Everything after the lock is wrapped, so that a failure releases it. Without this, the very failure this
+    -- function is most likely to hit - assert_period_open refusing a closed period in (c) - would leave the
+    -- session holding lock (26253, C_AcctSchema_ID) for as long as it lives, and the operator's next attempt
+    -- FROM ANOTHER SESSION, or a cost recompute run started to investigate, would be refused with a message
+    -- about a run that is not actually in progress. A plain function may do this; the recompute driver may not,
+    -- because PL/pgSQL forbids transaction control inside a block that has an EXCEPTION handler.
+    BEGIN
+        --
+        --
+        -- (b) THE DOCUMENTS TO REPOST
+        --
+        --
+        -- Same predicate as "de_metas_acct".product_costs_recreate_all_from_date's document set, so that this
+        -- function reposts exactly what a recompute over the same range would have reposted - no more, no less.
+        -- Invoices are excluded, so reposting never touches VAT.
+        -- Materialised rather than read twice: (c) sweeps the periods and (d) enqueues the documents, and they
+        -- must see the SAME set. Reading the view again in (d) would enqueue a document that posted in between
+        -- without its period ever having been checked.
+        --
+        DROP TABLE IF EXISTS tmp_adr_docs;
+        CREATE TEMPORARY TABLE tmp_adr_docs AS
+        SELECT DISTINCT doc.tablename,
+                        doc.record_id,
+                        doc.tablename_prio,
+                        doc.dateacct,
+                        doc.docbasetype,
+                        doc.ad_client_id,
+                        doc.ad_org_id
+        FROM "de_metas_acct".accountable_docs_and_lines_v doc
+        WHERE doc.m_product_id IS NOT NULL
+          AND doc.tablename <> 'C_Invoice'
+          AND doc.dateacct >= p_StartDateAcct
+          AND doc.ad_client_id = v_AD_Client_ID;
+
+        --
+        --
+        -- (c) ALL PERIODS IN RANGE MUST BE OPEN - CHECKED BEFORE ANYTHING IS ENQUEUED
+        --
+        --
+        -- Not a courtesy, and not optional for a repost: org.compiere.acct.Doc#post rejects an ALREADY-POSTED
+        -- document whose period is closed with @PeriodClosed@ even when reposting, and every document this
+        -- function enqueues is already posted. Without this sweep the run would look like a success - the rows
+        -- are on the queue - and then fail document by document in the accounting server, one AD_Issue at a
+        -- time, with the ledger left half re-valued.
+        --
+        FOR v_period IN (SELECT DISTINCT t.dateacct, t.docbasetype, t.ad_client_id, t.ad_org_id
+                         FROM tmp_adr_docs t
+                         ORDER BY t.dateacct, t.docbasetype, t.ad_client_id, t.ad_org_id)
+            LOOP
+                PERFORM "de_metas_acct".assert_period_open(
+                        p_DateAcct := v_period.dateacct,
+                        p_DocBaseType := v_period.docbasetype,
+                        p_AD_Client_ID := v_period.ad_client_id,
+                        p_AD_Org_ID := v_period.ad_org_id);
+            END LOOP;
+
+        --
+        --
+        -- (d) ENQUEUE, ONE ROW PER DOCUMENT, IN ACCOUNTING-DATE ORDER
+        --
+        --
+        -- One row per DOCUMENT, not per line: accountable_docs_and_lines_v yields a row per product line, and a
+        -- document enqueued twice is reposted twice.
+        --
+        DROP TABLE IF EXISTS tmp_adr_repost_docs;
+        CREATE TEMPORARY TABLE tmp_adr_repost_docs AS
+        SELECT d.tablename,
+               d.record_id,
+               MIN(d.tablename_prio) AS tablename_prio,
+               MIN(d.dateacct)       AS dateacct,
+               MIN(d.ad_client_id)   AS ad_client_id
+        FROM tmp_adr_docs d
+        GROUP BY d.tablename, d.record_id;
+
+        SELECT COUNT(1) INTO v_documentCount FROM tmp_adr_repost_docs;
+
+        --
+        -- SeqNo is assigned EXPLICITLY via row_number() over the enqueue order, out of a block reserved by
+        -- advancing the queue's own sequence in a single statement. It is never left to the column's nextval
+        -- default: the order in which INSERT ... SELECT evaluates rows - and therefore the order in which it
+        -- consumes a sequence - is not guaranteed by an ORDER BY in the SELECT. Reserving the block first is
+        -- what keeps these rows from colliding with whatever another producer enqueues in the meantime.
+        --
+        IF (v_documentCount > 0) THEN
+            SELECT setval('"de_metas_acct".accounting_docs_to_repost_seqno',
+                          nextval('"de_metas_acct".accounting_docs_to_repost_seqno') + v_documentCount - 1)
+            INTO v_seqNoLast;
+            v_seqNoBase := v_seqNoLast - v_documentCount;
+
+            INSERT INTO "de_metas_acct".accounting_docs_to_repost
+            (seqno, tablename, record_id, ad_client_id, description)
+            SELECT v_seqNoBase + ROW_NUMBER() OVER (ORDER BY d.dateacct, d.tablename_prio, d.record_id),
+                   d.tablename,
+                   d.record_id,
+                   d.ad_client_id,
+                   'accounting_docs_repost_all_from_date'
+            FROM tmp_adr_repost_docs d;
+        END IF;
+    EXCEPTION
+        WHEN OTHERS THEN
+            PERFORM pg_advisory_unlock(c_AdvisoryLock_ClassId, p_C_AcctSchema_ID::integer);
+            RAISE;
+    END;
+
+    PERFORM pg_advisory_unlock(c_AdvisoryLock_ClassId, p_C_AcctSchema_ID::integer);
+
+    RAISE NOTICE 'accounting_docs_repost_all_from_date: C_AcctSchema_ID=%, StartDateAcct=% => % document(s) enqueued for reposting',
+        p_C_AcctSchema_ID, p_StartDateAcct, v_documentCount;
+
+    RETURN v_documentCount;
+END;
+$BODY$
+;
+
+COMMENT ON FUNCTION "de_metas_acct".accounting_docs_repost_all_from_date(numeric, timestamp WITH TIME ZONE) IS
+    'Enqueues every accountable non-invoice document of an accounting schema from a date onwards for reposting, in accounting-date order, without recomputing or deleting any cost detail'
+;

--- a/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5817140_sys_gh26253_accounting_docs_repost_all_from_date.sql
+++ b/backend/de.metas.acct.base/src/main/sql/postgresql/system/43-de.metas.acct/5817140_sys_gh26253_accounting_docs_repost_all_from_date.sql
@@ -1,0 +1,224 @@
+-- Source DDL: backend/de.metas.acct.base/src/main/sql/postgresql/ddl/functions/accounting_docs_repost_all_from_date.sql
+DROP FUNCTION IF EXISTS "de_metas_acct".accounting_docs_repost_all_from_date(
+    p_C_AcctSchema_ID numeric,
+    p_StartDateAcct   timestamp WITH TIME ZONE
+)
+;
+
+
+-- Reposts EVERY accountable, product-bearing, non-invoice document of an accounting schema from a given
+-- accounting date onwards, WITHOUT recomputing anything. Returns the number of documents enqueued.
+--
+-- This is the counterpart of "de_metas_acct".product_costs_recreate_all_from_date, and the difference is the
+-- whole point: the recompute driver DELETES the cost details in range so that reposting rebuilds them, while
+-- this function deletes nothing at all. It exists for the situation where the cost details are already
+-- correct and only the general ledger is not - the canonical case being a change of the accounting schema's
+-- costing method. The amount a document posts is filtered to the cost element that is accountable under the
+-- schema's current costing configuration (de.metas.costing.CostDetailCreateResultsList#getAmtAndQtyToPost),
+-- so after such a change the existing Fact_Acct rows are valued by the OLD method and every document has to
+-- be reposted to be valued by the new one. The cost details themselves must survive that untouched:
+-- de.metas.costing.methods.CostingMethodHandlerTemplate#createOrUpdateCost returns the EXISTING cost details
+-- when they exist (it only refreshes their DateAcct) and computes nothing, so reposting re-values the GL from
+-- exactly the costs that are already there.
+--
+-- Consequently, and unlike the recompute driver:
+--   * ordering is NOT a correctness contract here - nothing is computed, so nothing depends on the sequence.
+--     Documents are still enqueued in accounting-date order because it costs nothing and keeps the GL rows
+--     produced in a sensible order;
+--   * there is no staging table, no progress table and no resume. There is nothing to hold documents back
+--     for: the enqueue is a single INSERT in a single transaction, so the run either happened or it did not;
+--   * it does not delete Fact_Acct rows either - the queue-driven repost does that itself. Verified:
+--     de.metas.acct.api.impl.PostingService#postNow calls doc.post(force, /*repost*/ true) with that second
+--     argument hardcoded, and org.compiere.acct.Doc#post does `if (repost) { deleteAcct(); }` before saving
+--     the new facts.
+--
+-- REJECTED ALTERNATIVE: looping "de_metas_acct".fact_acct_unpost() over the documents. It is the sanctioned
+-- way to enqueue a repost (see the rule deviation below), but it cannot do this job:
+--   * it sets Processing='Y' on every document it touches and, at its default p_Force:='N', RAISEs when a
+--     document is already Processing='Y' - so a single such document anywhere in the range aborts the loop,
+--     and on a real installation that range holds hundreds of thousands of documents. Passing p_Force:='Y'
+--     does not fix it: it only trades the abort for overwriting whatever process owns that lock;
+--   * it DELETEs every Fact_Acct row of every document up front - work the repost redoes anyway (see above),
+--     and it leaves the ledger empty for as long as the queue takes to drain;
+--   * it enqueues one document per call as it goes, with the SeqNo left to the queue sequence, so there is no
+--     way to reserve a contiguous, deliberately ordered block.
+--
+-- KNOWN, DELIBERATE RULE DEVIATION - documented here rather than hidden:
+--   `docs/coding-rules/production-database-support.md` and `backend/de.metas.acct.base/CLAUDE.md` both state:
+--   never INSERT directly into Accounting_Docs_To_Repost - always use the "de_metas_acct".fact_acct_unpost*
+--   functions. The INSERT below breaks that rule knowingly, on exactly the same grounds as the recompute
+--   driver's release step. The rule exists because fact_acct_unpost bundles three effects with the enqueue,
+--   and here two of them are provably redundant and the third is done differently:
+--     * deleting the stale Fact_Acct rows - redundant, the repost does it itself (PostingService#postNow ->
+--       Doc#post -> deleteAcct(), see above);
+--     * resetting Posted='N' so the document can be locked again - redundant, because
+--       de.metas.acct.doc.SqlAcctDocLockService#lock only adds the `AND Posted='N'` condition when repost is
+--       FALSE, so a document left at Posted='Y' still locks and reposts;
+--     * checking that the period is open - NOT redundant, and therefore replaced by the explicit
+--       assert_period_open sweep in (c) below, which is strictly stronger: it covers the whole range up front
+--       instead of one document at a time.
+--   The rule itself is deliberately NOT amended - that is not this function's call to make.
+CREATE OR REPLACE FUNCTION "de_metas_acct".accounting_docs_repost_all_from_date(
+    p_C_AcctSchema_ID numeric,
+    p_StartDateAcct   timestamp WITH TIME ZONE
+)
+    RETURNS integer
+    LANGUAGE plpgsql
+AS
+$BODY$
+DECLARE
+    -- Same advisory-lock class id as "de_metas_acct".product_costs_recreate_all_from_date, on purpose - see (a).
+    c_AdvisoryLock_ClassId constant integer := 26253;
+    --
+    v_AD_Client_ID         numeric;
+    v_documentCount        integer;
+    v_seqNoLast            numeric;
+    v_seqNoBase            numeric;
+    v_period               record;
+BEGIN
+    IF (p_StartDateAcct IS NULL) THEN
+        RAISE EXCEPTION 'p_StartDateAcct shall be set';
+    END IF;
+
+    SELECT cas.ad_client_id
+    INTO v_AD_Client_ID
+    FROM c_acctschema cas
+    WHERE cas.c_acctschema_id = p_C_AcctSchema_ID;
+    IF (v_AD_Client_ID IS NULL) THEN
+        RAISE EXCEPTION 'C_AcctSchema_ID % not found', p_C_AcctSchema_ID;
+    END IF;
+
+    --
+    --
+    -- (a) NEVER WHILE A COST RECOMPUTE IS RUNNING
+    --
+    --
+    -- Deliberately the SAME lock class and key as "de_metas_acct".product_costs_recreate_all_from_date, so the
+    -- two exclude each other rather than merely each other's own kind. Overlapping them is precisely the
+    -- damaging case: while a recompute run is in flight its documents are parked in the staging table exactly
+    -- so that nothing reaches the poller until every product has been rewound. Documents this function pushes
+    -- straight onto the queue in the meantime would be reposted against half-rewound costs, and the recompute
+    -- would then reuse the wrong cost details it finds - silently, and for good.
+    -- The lock is taken at SESSION level (like the driver's), not transaction level, because the two must be
+    -- comparable: the driver commits per batch and therefore cannot hold a transaction-level lock at all.
+    IF NOT pg_try_advisory_lock(c_AdvisoryLock_ClassId, p_C_AcctSchema_ID::integer) THEN
+        RAISE EXCEPTION 'Another cost recompute or repost run is already in progress for C_AcctSchema_ID=%', p_C_AcctSchema_ID;
+    END IF;
+
+    -- Everything after the lock is wrapped, so that a failure releases it. Without this, the very failure this
+    -- function is most likely to hit - assert_period_open refusing a closed period in (c) - would leave the
+    -- session holding lock (26253, C_AcctSchema_ID) for as long as it lives, and the operator's next attempt
+    -- FROM ANOTHER SESSION, or a cost recompute run started to investigate, would be refused with a message
+    -- about a run that is not actually in progress. A plain function may do this; the recompute driver may not,
+    -- because PL/pgSQL forbids transaction control inside a block that has an EXCEPTION handler.
+    BEGIN
+        --
+        --
+        -- (b) THE DOCUMENTS TO REPOST
+        --
+        --
+        -- Same predicate as "de_metas_acct".product_costs_recreate_all_from_date's document set, so that this
+        -- function reposts exactly what a recompute over the same range would have reposted - no more, no less.
+        -- Invoices are excluded, so reposting never touches VAT.
+        -- Materialised rather than read twice: (c) sweeps the periods and (d) enqueues the documents, and they
+        -- must see the SAME set. Reading the view again in (d) would enqueue a document that posted in between
+        -- without its period ever having been checked.
+        --
+        DROP TABLE IF EXISTS tmp_adr_docs;
+        CREATE TEMPORARY TABLE tmp_adr_docs AS
+        SELECT DISTINCT doc.tablename,
+                        doc.record_id,
+                        doc.tablename_prio,
+                        doc.dateacct,
+                        doc.docbasetype,
+                        doc.ad_client_id,
+                        doc.ad_org_id
+        FROM "de_metas_acct".accountable_docs_and_lines_v doc
+        WHERE doc.m_product_id IS NOT NULL
+          AND doc.tablename <> 'C_Invoice'
+          AND doc.dateacct >= p_StartDateAcct
+          AND doc.ad_client_id = v_AD_Client_ID;
+
+        --
+        --
+        -- (c) ALL PERIODS IN RANGE MUST BE OPEN - CHECKED BEFORE ANYTHING IS ENQUEUED
+        --
+        --
+        -- Not a courtesy, and not optional for a repost: org.compiere.acct.Doc#post rejects an ALREADY-POSTED
+        -- document whose period is closed with @PeriodClosed@ even when reposting, and every document this
+        -- function enqueues is already posted. Without this sweep the run would look like a success - the rows
+        -- are on the queue - and then fail document by document in the accounting server, one AD_Issue at a
+        -- time, with the ledger left half re-valued.
+        --
+        FOR v_period IN (SELECT DISTINCT t.dateacct, t.docbasetype, t.ad_client_id, t.ad_org_id
+                         FROM tmp_adr_docs t
+                         ORDER BY t.dateacct, t.docbasetype, t.ad_client_id, t.ad_org_id)
+            LOOP
+                PERFORM "de_metas_acct".assert_period_open(
+                        p_DateAcct := v_period.dateacct,
+                        p_DocBaseType := v_period.docbasetype,
+                        p_AD_Client_ID := v_period.ad_client_id,
+                        p_AD_Org_ID := v_period.ad_org_id);
+            END LOOP;
+
+        --
+        --
+        -- (d) ENQUEUE, ONE ROW PER DOCUMENT, IN ACCOUNTING-DATE ORDER
+        --
+        --
+        -- One row per DOCUMENT, not per line: accountable_docs_and_lines_v yields a row per product line, and a
+        -- document enqueued twice is reposted twice.
+        --
+        DROP TABLE IF EXISTS tmp_adr_repost_docs;
+        CREATE TEMPORARY TABLE tmp_adr_repost_docs AS
+        SELECT d.tablename,
+               d.record_id,
+               MIN(d.tablename_prio) AS tablename_prio,
+               MIN(d.dateacct)       AS dateacct,
+               MIN(d.ad_client_id)   AS ad_client_id
+        FROM tmp_adr_docs d
+        GROUP BY d.tablename, d.record_id;
+
+        SELECT COUNT(1) INTO v_documentCount FROM tmp_adr_repost_docs;
+
+        --
+        -- SeqNo is assigned EXPLICITLY via row_number() over the enqueue order, out of a block reserved by
+        -- advancing the queue's own sequence in a single statement. It is never left to the column's nextval
+        -- default: the order in which INSERT ... SELECT evaluates rows - and therefore the order in which it
+        -- consumes a sequence - is not guaranteed by an ORDER BY in the SELECT. Reserving the block first is
+        -- what keeps these rows from colliding with whatever another producer enqueues in the meantime.
+        --
+        IF (v_documentCount > 0) THEN
+            SELECT setval('"de_metas_acct".accounting_docs_to_repost_seqno',
+                          nextval('"de_metas_acct".accounting_docs_to_repost_seqno') + v_documentCount - 1)
+            INTO v_seqNoLast;
+            v_seqNoBase := v_seqNoLast - v_documentCount;
+
+            INSERT INTO "de_metas_acct".accounting_docs_to_repost
+            (seqno, tablename, record_id, ad_client_id, description)
+            SELECT v_seqNoBase + ROW_NUMBER() OVER (ORDER BY d.dateacct, d.tablename_prio, d.record_id),
+                   d.tablename,
+                   d.record_id,
+                   d.ad_client_id,
+                   'accounting_docs_repost_all_from_date'
+            FROM tmp_adr_repost_docs d;
+        END IF;
+    EXCEPTION
+        WHEN OTHERS THEN
+            PERFORM pg_advisory_unlock(c_AdvisoryLock_ClassId, p_C_AcctSchema_ID::integer);
+            RAISE;
+    END;
+
+    PERFORM pg_advisory_unlock(c_AdvisoryLock_ClassId, p_C_AcctSchema_ID::integer);
+
+    RAISE NOTICE 'accounting_docs_repost_all_from_date: C_AcctSchema_ID=%, StartDateAcct=% => % document(s) enqueued for reposting',
+        p_C_AcctSchema_ID, p_StartDateAcct, v_documentCount;
+
+    RETURN v_documentCount;
+END;
+$BODY$
+;
+
+COMMENT ON FUNCTION "de_metas_acct".accounting_docs_repost_all_from_date(numeric, timestamp WITH TIME ZONE) IS
+    'Enqueues every accountable non-invoice document of an accounting schema from a date onwards for reposting, in accounting-date order, without recomputing or deleting any cost detail'
+;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/ProductCostsRecreateAll_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/ProductCostsRecreateAll_StepDef.java
@@ -313,6 +313,11 @@ public class ProductCostsRecreateAll_StepDef
 	 * computed in. Each of them must appear exactly ONCE, and no document may be staged twice: a resume that
 	 * restarted from the first batch instead of continuing would stage and release an already-done batch's
 	 * document a second time. For the same reason the recorded batch numbers must be free of duplicates.
+	 * <p>
+	 * Shared by both drivers, and the expected <code>IsStaged</code> differs between them: the cost RECOMPUTE driver
+	 * stages a document until every product has been rewound, so it can legitimately be <code>Y</code>; the plain
+	 * REPOST driver rewinds nothing and therefore stages nothing, so a repost row is always <code>N</code> — asserting
+	 * it per document is what proves the repost went to the queue directly.
 	 *
 	 * @cucumber.stepdef
 	 * @cucumber.columns

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/ProductCostsRecreateAll_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/ProductCostsRecreateAll_StepDef.java
@@ -153,9 +153,7 @@ public class ProductCostsRecreateAll_StepDef
 	public void repostRuns(@NonNull final DataTable dataTable)
 	{
 		final DataTableRow row = DataTableRows.of(dataTable).singleRow();
-		final int acctSchemaId = row.getAsIdentifier(I_C_AcctSchema.COLUMNNAME_C_AcctSchema_ID)
-				.lookupNotNullIn(acctSchemaTable)
-				.getC_AcctSchema_ID();
+		final int acctSchemaId = getAcctSchemaId(row);
 		final LocalDate startDateAcct = row.getAsLocalDate("StartDateAcct");
 
 		final String callSql = "SELECT \"de_metas_acct\".accounting_docs_repost_all_from_date("
@@ -587,11 +585,17 @@ public class ProductCostsRecreateAll_StepDef
 		return outcome;
 	}
 
-	private String buildCallSql(@NonNull final DataTableRow row)
+	/** Resolves the {@code C_AcctSchema_ID} column both drivers take as their first parameter. */
+	private int getAcctSchemaId(@NonNull final DataTableRow row)
 	{
-		final int acctSchemaId = row.getAsIdentifier(I_C_AcctSchema.COLUMNNAME_C_AcctSchema_ID)
+		return row.getAsIdentifier(I_C_AcctSchema.COLUMNNAME_C_AcctSchema_ID)
 				.lookupNotNullIn(acctSchemaTable)
 				.getC_AcctSchema_ID();
+	}
+
+	private String buildCallSql(@NonNull final DataTableRow row)
+	{
+		final int acctSchemaId = getAcctSchemaId(row);
 		final CostElementId costElementId = costElementTable.getSingleId(row.getAsString("M_CostElement_ID"));
 		final LocalDate startDateAcct = row.getAsLocalDate("StartDateAcct");
 		final int productsPerCommit = row.getAsInt("ProductsPerCommit");

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/ProductCostsRecreateAll_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/costing/ProductCostsRecreateAll_StepDef.java
@@ -56,9 +56,16 @@ import java.util.ArrayList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Drives {@code de_metas_acct.product_costs_recreate_all_from_date} — the batched, resumable cost-recompute
- * driver that parks every document it wants reposted in a staging table and releases the whole table into
- * {@code de_metas_acct.accounting_docs_to_repost} in document-date order — and asserts what a run left behind.
+ * Drives the two SQL entry points that feed {@code de_metas_acct.accounting_docs_to_repost}, and asserts what a
+ * run left behind:
+ * <ul>
+ * <li>{@code de_metas_acct.product_costs_recreate_all_from_date} — the batched, resumable cost-recompute driver
+ * that parks every document it wants reposted in a staging table and releases the whole table into the queue in
+ * document-date order;</li>
+ * <li>{@code de_metas_acct.accounting_docs_repost_all_from_date} — the plain repost of the same document set,
+ * which recomputes nothing and enqueues in one step.</li>
+ * </ul>
+ * Both are asserted through the same outcome snapshot, which is why they share this class.
  * <p>
  * Three things about this step def are deliberate and load-bearing:
  * <ul>
@@ -122,6 +129,40 @@ public class ProductCostsRecreateAll_StepDef
 	public void run(@NonNull final DataTable dataTable)
 	{
 		rememberOutcome(invokeDriver(DataTableRows.of(dataTable).singleRow(), null, false /*runMustFail*/));
+	}
+
+	/**
+	 * Runs the plain repost driver {@code de_metas_acct.accounting_docs_repost_all_from_date}, which enqueues the
+	 * same documents the cost-recompute driver would cover, but recomputes nothing: no cost detail is deleted, no
+	 * {@code M_Cost} is rewound, nothing is staged. Its only effect is that the enqueued documents are reposted,
+	 * so their GL entries are rewritten from the cost details that already exist.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>C_AcctSchema_ID</b> — (required, identifier-ref) accounting schema whose documents are reposted<br>
+	 *   <b>StartDateAcct</b> — (required) first accounting date the repost covers (inclusive)<br>
+	 * @cucumber.depends StepDefData: C_AcctSchema_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * When the accounting repost driver runs:
+	 *   | C_AcctSchema_ID | StartDateAcct |
+	 *   | acctSchema      | 2027-12-10    |
+	 * </pre>
+	 */
+	@When("^the accounting repost driver runs:$")
+	public void repostRuns(@NonNull final DataTable dataTable)
+	{
+		final DataTableRow row = DataTableRows.of(dataTable).singleRow();
+		final int acctSchemaId = row.getAsIdentifier(I_C_AcctSchema.COLUMNNAME_C_AcctSchema_ID)
+				.lookupNotNullIn(acctSchemaTable)
+				.getC_AcctSchema_ID();
+		final LocalDate startDateAcct = row.getAsLocalDate("StartDateAcct");
+
+		final String callSql = "SELECT \"de_metas_acct\".accounting_docs_repost_all_from_date("
+				+ "p_C_AcctSchema_ID:=" + acctSchemaId
+				+ ", p_StartDateAcct:='" + startDateAcct + "'::date)";
+
+		rememberOutcome(invoke(callSql, null /*dieOnDocument*/, false /*runMustFail*/));
 	}
 
 	/**
@@ -291,6 +332,7 @@ public class ProductCostsRecreateAll_StepDef
 	 * </pre>
 	 */
 	@Then("^the cost recompute run left these documents:$")
+	@Then("^the accounting repost run left these documents:$")
 	public void runLeftTheseDocuments(@NonNull final DataTable dataTable)
 	{
 		final RunOutcome outcome = getLastRunOutcome();
@@ -353,6 +395,54 @@ public class ProductCostsRecreateAll_StepDef
 	public void stagingTableIsEmpty()
 	{
 		assertThat(getLastRunOutcome().getStagedDocuments()).as("staged documents").isEmpty();
+	}
+
+	/**
+	 * Asserts every document the run put on the repost queue carries its own SeqNo. Together with the release
+	 * order asserted by <code>… run left these documents:</code> — which reads the queue ordered by SeqNo — this
+	 * is the statement that SeqNo increases monotonically along the release order.
+	 * <p>
+	 * Not a formality: the poller consumes the queue with <code>ORDER BY SeqNo</code>, and the queue table has no
+	 * uniqueness constraint on it. Two documents sharing a SeqNo are reposted in an order PostgreSQL picks, which
+	 * is exactly the out-of-order reposting these drivers exist to prevent. It is what would happen if the SeqNo
+	 * were left to the column's <code>nextval</code> default inside an <code>INSERT … SELECT … ORDER BY</code>,
+	 * whose row evaluation order — and therefore sequence consumption order — PostgreSQL does not guarantee.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * And every document on the repost queue has its own SeqNo
+	 * </pre>
+	 */
+	@Then("^every document on the repost queue has its own SeqNo$")
+	public void queueSeqNosAreDistinct()
+	{
+		assertThat(getLastRunOutcome().getQueuedSeqNos()).as("SeqNos on the repost queue").doesNotHaveDuplicates();
+	}
+
+	/**
+	 * Asserts the number of {@code M_CostDetail} rows is still what it was immediately before the most recent run
+	 * was invoked — the defining property of a PLAIN repost, as opposed to a recompute.
+	 * <p>
+	 * Belongs BOTH right after the repost run (proving the enqueue itself deleted nothing) AND after the queue has
+	 * drained (proving the reposting that follows neither deleted nor created anything, because
+	 * {@code CostingMethodHandlerTemplate#createOrUpdateCost} returns the existing cost details and only refreshes
+	 * their DateAcct). Counting the whole table rather than one product's rows is deliberate: the driver has no
+	 * product parameter, so "nothing anywhere was rebuilt" is the property under test, and a scenario-scoped count
+	 * could not see a foreign product's details being destroyed.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * And the M_CostDetail row count is unchanged since the run was invoked
+	 * </pre>
+	 */
+	@Then("^the M_CostDetail row count is unchanged since the run was invoked$")
+	public void costDetailRowCountIsUnchanged()
+	{
+		assertThat(countCostDetailRows())
+				.as("M_CostDetail row count — a plain repost must neither delete nor create cost details")
+				.isEqualTo(getLastRunOutcome().getCostDetailCountBefore());
 	}
 
 	/**
@@ -422,8 +512,19 @@ public class ProductCostsRecreateAll_StepDef
 			@Nullable final TableRecordReference dieOnDocument,
 			final boolean runMustFail)
 	{
-		final String callSql = buildCallSql(row);
-		logger.info("Invoking cost-recompute driver: {}", callSql);
+		return invoke(buildCallSql(row), dieOnDocument, runMustFail);
+	}
+
+	/**
+	 * @param dieOnDocument see {@link #invokeDriver(DataTableRow, TableRecordReference, boolean)}
+	 * @param runMustFail   see {@link #invokeDriver(DataTableRow, TableRecordReference, boolean)}
+	 */
+	private RunOutcome invoke(
+			@NonNull final String callSql,
+			@Nullable final TableRecordReference dieOnDocument,
+			final boolean runMustFail)
+	{
+		logger.info("Invoking: {}", callSql);
 
 		Exception failure = null;
 		final RunOutcome outcome;
@@ -431,6 +532,10 @@ public class ProductCostsRecreateAll_StepDef
 		final Connection connection = DB.createConnection(true /*autoCommit*/, Connection.TRANSACTION_READ_COMMITTED);
 		try
 		{
+			// taken BEFORE the run and on the run's own connection, so a step asserting "the plain repost changed
+			// no cost details" has a baseline the run itself cannot have moved
+			final int costDetailCountBefore = countCostDetailRows(connection);
+
 			if (dieOnDocument != null)
 			{
 				installStagingAbortTrigger(connection, dieOnDocument);
@@ -444,7 +549,7 @@ public class ProductCostsRecreateAll_StepDef
 				// logged, not only remembered: when the run was expected to succeed the exception is rethrown
 				// below, but when the failure IS the expected outcome (an injected abort, or a refusal) its
 				// message is the only clue whether the run died for that reason or for an unrelated one.
-				logger.warn("Cost-recompute driver run failed", ex);
+				logger.warn("Run failed: {}", callSql, ex);
 				failure = ex;
 			}
 			finally
@@ -457,7 +562,7 @@ public class ProductCostsRecreateAll_StepDef
 				execute(connection, "SELECT pg_advisory_unlock_all()");
 			}
 
-			outcome = takeSnapshot(connection, failure);
+			outcome = takeSnapshot(connection, costDetailCountBefore, failure);
 		}
 		finally
 		{
@@ -529,11 +634,15 @@ public class ProductCostsRecreateAll_StepDef
 		execute(connection, "DROP FUNCTION IF EXISTS " + ABORT_TRIGGER_FUNCTION + "()");
 	}
 
-	private RunOutcome takeSnapshot(@NonNull final Connection connection, @Nullable final Exception failure)
+	private RunOutcome takeSnapshot(
+			@NonNull final Connection connection,
+			final int costDetailCountBefore,
+			@Nullable final Exception failure)
 	{
 		final ImmutableList.Builder<Integer> doneBatchNos = ImmutableList.builder();
 		final ArrayList<TableRecordReference> stagedDocuments = new ArrayList<>();
 		final ArrayList<TableRecordReference> queuedDocuments = new ArrayList<>();
+		final ArrayList<Integer> queuedSeqNos = new ArrayList<>();
 
 		try (final Statement statement = connection.createStatement())
 		{
@@ -554,29 +663,51 @@ public class ProductCostsRecreateAll_StepDef
 				}
 			}
 			try (final ResultSet rs = statement.executeQuery(
-					"SELECT tablename, record_id FROM " + TABLE_Queue + " ORDER BY seqno"))
+					"SELECT seqno, tablename, record_id FROM " + TABLE_Queue + " ORDER BY seqno"))
 			{
 				while (rs.next())
 				{
 					queuedDocuments.add(TableRecordReference.of(rs.getString("tablename"), rs.getInt("record_id")));
+					queuedSeqNos.add(rs.getInt("seqno"));
 				}
 			}
 		}
 		catch (final SQLException ex)
 		{
-			throw new AdempiereException("Failed snapshotting the cost-recompute run outcome", ex);
+			throw new AdempiereException("Failed snapshotting the run outcome", ex);
 		}
 
 		return new RunOutcome(
 				doneBatchNos.build(),
 				ImmutableList.copyOf(stagedDocuments),
 				ImmutableList.copyOf(queuedDocuments),
+				ImmutableList.copyOf(queuedSeqNos),
+				costDetailCountBefore,
 				failure);
 	}
 
 	private static int countQueueRows()
 	{
 		return DB.getSQLValueEx(null, "SELECT COUNT(1) FROM " + TABLE_Queue);
+	}
+
+	private static int countCostDetailRows()
+	{
+		return DB.getSQLValueEx(null, "SELECT COUNT(1) FROM M_CostDetail");
+	}
+
+	private static int countCostDetailRows(@NonNull final Connection connection)
+	{
+		try (final Statement statement = connection.createStatement();
+			 final ResultSet rs = statement.executeQuery("SELECT COUNT(1) FROM M_CostDetail"))
+		{
+			rs.next();
+			return rs.getInt(1);
+		}
+		catch (final SQLException ex)
+		{
+			throw new AdempiereException("Failed counting M_CostDetail rows", ex);
+		}
 	}
 
 	private static void execute(@NonNull final Connection connection, @NonNull final String sql)
@@ -599,6 +730,10 @@ public class ProductCostsRecreateAll_StepDef
 		@NonNull ImmutableList<TableRecordReference> stagedDocuments;
 		/** Documents in the repost queue, ordered by SeqNo, i.e. in the order they will be reposted. */
 		@NonNull ImmutableList<TableRecordReference> queuedDocuments;
+		/** The SeqNos of {@link #queuedDocuments}, in the same order. */
+		@NonNull ImmutableList<Integer> queuedSeqNos;
+		/** {@code M_CostDetail} row count immediately BEFORE the run was invoked. */
+		int costDetailCountBefore;
 		/** What the run failed with, or {@code null} when it succeeded. */
 		@Nullable Exception failure;
 	}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
@@ -821,3 +821,18 @@ Feature: Switch to Moving Average Invoice
       | repostFirst  | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
       | repostSecond | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
       | repostThird  | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+    #
+    # And finally what the whole driver exists for: the general ledger. Each reposted stock count carries its
+    # two facts again - the stock going up against the warehouse differences account, valued from the cost
+    # details above. The match is exhaustive per document, so a repost that wiped the ledger, or one that
+    # posted a second time on top of the first, fails here.
+    #
+    And Wait until documents invRepost1, invRepost2, invRepost3 are posted
+    And Fact_Acct records are matching
+      | Record_ID  | AccountConceptualName | M_Product_ID | AmtAcctDr | AmtAcctCr | Qty     |
+      | invRepost1 | P_Asset_Acct          | repostFirst  | 100       | 0         | 10 PCE  |
+      | invRepost1 | W_Differences_Acct    | repostFirst  | 0         | 100       | -10 PCE |
+      | invRepost2 | P_Asset_Acct          | repostSecond | 100       | 0         | 10 PCE  |
+      | invRepost2 | W_Differences_Acct    | repostSecond | 0         | 100       | -10 PCE |
+      | invRepost3 | P_Asset_Acct          | repostThird  | 100       | 0         | 10 PCE  |
+      | invRepost3 | W_Differences_Acct    | repostThird  | 0         | 100       | -10 PCE |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
@@ -814,7 +814,11 @@ Feature: Switch to Moving Average Invoice
       | M_InventoryLine | invPreCutRepost3_l1 | 100 CHF | 10 PCE |
       | M_InventoryLine | invRepost3_l1       | 100 CHF | 10 PCE |
     #
-    # Including the opening anchors the switch created: a repost must never reach back over the cut-off.
+    # Including the opening anchors the switch created: a repost must never reach back over the cut-off. Each one
+    # is still there exactly once and still dated AT the cut-off - surviving the repost is what this asserts.
+    # Their own Qty and Amt are zero BY DESIGN, as in every scenario above: an anchor is value-neutral and books
+    # no GL, so the copied opening lives in M_Cost and in the anchor's Prev_* columns, never in its own delta
+    # (seedCurrentCostFromOpening writes qty/amt as .toZero() and passes the opening as the Prev_* amounts).
     #
     And the cost revaluation identified by switchRepost seeded opening cost details:
       | M_Product_ID | M_CostElement_ID     | DateAcct   | Qty   | Amt   |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/switchToMovingAverageInvoice.feature
@@ -698,3 +698,126 @@ Feature: Switch to Moving Average Invoice
       | lateJoiner        | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
       | doneBatchProduct  | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
       | crashBatchProduct | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+
+  @Id:S26253_TC13
+  Scenario: A plain repost enqueues the documents in accounting-date order and rebuilds no cost at all
+    #
+    # Once the accounting schema's costing method has been switched, the already-computed cost details have to
+    # reach the general ledger - and only that. Reposting regenerates Fact_Acct from the cost details that
+    # already exist; recomputing them again would be wrong, because they are what the switch just established.
+    #
+    # Same isolation technique as the batched-recompute scenarios above: this driver also has no product
+    # parameter, so the scenario is separated from the shared test database by ACCOUNTING DATE - it books its
+    # stock counts into the LAST THREE WEEKS of 2027 and reposts from 10.12.2027 onwards, later than every
+    # range the scenarios above reach into. It stays inside 2027, whose end is also the end of the test
+    # database's fiscal calendar.
+    #
+    Given after not more than 60s, the repost queue is drained
+    And metasfresh contains M_Products:
+      | Identifier   |
+      | repostFirst  |
+      | repostSecond |
+      | repostThird  |
+    #
+    # Pre-cut-off history on the prior method (AveragePO), so the switch has a non-trivial opening to copy.
+    #
+    And update current costs
+      | M_Product_ID | M_CostElement_ID | CurrentCostPrice |
+      | repostFirst  | AveragePO        | 10 CHF           |
+      | repostSecond | AveragePO        | 10 CHF           |
+      | repostThird  | AveragePO        | 10 CHF           |
+    And metasfresh contains single line completed inventories
+      | M_Inventory_ID   | M_InventoryLine_ID  | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | invPreCutRepost1 | invPreCutRepost1_l1 | 2025-12-15   | warehouseStd   | repostFirst  | 0       | 10       | PCE          |
+      | invPreCutRepost2 | invPreCutRepost2_l1 | 2025-12-15   | warehouseStd   | repostSecond | 0       | 10       | PCE          |
+      | invPreCutRepost3 | invPreCutRepost3_l1 | 2025-12-15   | warehouseStd   | repostThird  | 0       | 10       | PCE          |
+    #
+    # Switch to MovingAverageInvoice, back-dated to the 31.12.2025 cut-off: one opening anchor per product.
+    #
+    And metasfresh contains M_CostRevaluation:
+      | Identifier   | C_AcctSchema_ID | M_CostElement_ID     | RevaluationSource   | CopyFrom_M_CostElement_ID | EvaluationStartDate | DateAcct   |
+      | switchRepost | acctSchema      | MovingAverageInvoice | CopyFromCostElement | AveragePO                 | 2025-12-31          | 2025-12-31 |
+    And create lines for cost revaluation switchRepost
+    And the cost revaluation identified by switchRepost is completed
+    #
+    # One stock count per product inside the repost's range, dated OPPOSITE to the product order: the driver
+    # must release by accounting date, so the two orders have to disagree to prove anything.
+    #
+    When metasfresh contains single line completed inventories
+      | M_Inventory_ID | M_InventoryLine_ID | MovementDate | M_Warehouse_ID | M_Product_ID | QtyBook | QtyCount | UOM.X12DE355 |
+      | invRepost1     | invRepost1_l1      | 2027-12-28   | warehouseStd   | repostFirst  | 10      | 20       | PCE          |
+      | invRepost2     | invRepost2_l1      | 2027-12-20   | warehouseStd   | repostSecond | 10      | 20       | PCE          |
+      | invRepost3     | invRepost3_l1      | 2027-12-12   | warehouseStd   | repostThird  | 10      | 20       | PCE          |
+    #
+    # Wait until they are posted. Their cost details are what the repost has to REUSE - so they must exist
+    # before it runs, and the very same rows must still be there afterwards.
+    #
+    And after not more than 60s, M_CostDetails are found for product repostFirst and cost element AveragePO
+      | TableName       | Record_ID           | Amt     | Qty    |
+      | M_InventoryLine | invPreCutRepost1_l1 | 100 CHF | 10 PCE |
+      | M_InventoryLine | invRepost1_l1       | 100 CHF | 10 PCE |
+    And after not more than 60s, M_CostDetails are found for product repostSecond and cost element AveragePO
+      | TableName       | Record_ID           | Amt     | Qty    |
+      | M_InventoryLine | invPreCutRepost2_l1 | 100 CHF | 10 PCE |
+      | M_InventoryLine | invRepost2_l1       | 100 CHF | 10 PCE |
+    And after not more than 60s, M_CostDetails are found for product repostThird and cost element AveragePO
+      | TableName       | Record_ID           | Amt     | Qty    |
+      | M_InventoryLine | invPreCutRepost3_l1 | 100 CHF | 10 PCE |
+      | M_InventoryLine | invRepost3_l1       | 100 CHF | 10 PCE |
+    And after not more than 60s, the repost queue is drained
+    #
+    # The repost itself. It enqueues the three in-range stock counts - and only them, the pre-cut-off ones lie
+    # before its start date - ordered by accounting date: 12.12. first, 28.12. last. Each gets its own SeqNo,
+    # because the poller consumes the queue by SeqNo and a shared one would repost in an order nobody chose.
+    #
+    When the accounting repost driver runs:
+      | C_AcctSchema_ID | StartDateAcct |
+      | acctSchema      | 2027-12-10    |
+    Then the accounting repost run left these documents:
+      | Record_ID           | IsStaged | IsReleased |
+      | invRepost3          | N        | Y          |
+      | invRepost2          | N        | Y          |
+      | invRepost1          | N        | Y          |
+      | invPreCutRepost1    | N        | N          |
+      | invPreCutRepost2    | N        | N          |
+      | invPreCutRepost3    | N        | N          |
+    And every document on the repost queue has its own SeqNo
+    #
+    # Note the IsStaged column above: every one of them went to the queue DIRECTLY. Staging belongs to the
+    # recompute driver, which has to hold documents back until every product has been rewound; a plain repost
+    # rewinds nothing, so it has nothing to hold. (Asserted per document rather than by emptying the staging
+    # table, which the scenarios above deliberately leave a crashed run's document parked in.)
+    #
+    # It also deleted no cost detail on its way there - that is what makes it a PLAIN repost.
+    #
+    And the M_CostDetail row count is unchanged since the run was invoked
+    #
+    # Now the accounting server drains the queue and reposts. Reposting is where a recompute WOULD rebuild the
+    # costs, so this is the moment the "no recompute" contract is actually tested: cost details are returned
+    # as they are when they already exist, so not a single row may be created or deleted.
+    #
+    And after not more than 120s, the repost queue is drained
+    And the M_CostDetail row count is unchanged since the run was invoked
+    #
+    # Same cost details, same values, for every product - reused, not rebuilt.
+    #
+    And after not more than 60s, M_CostDetails are found for product repostFirst and cost element AveragePO
+      | TableName       | Record_ID           | Amt     | Qty    |
+      | M_InventoryLine | invPreCutRepost1_l1 | 100 CHF | 10 PCE |
+      | M_InventoryLine | invRepost1_l1       | 100 CHF | 10 PCE |
+    And after not more than 60s, M_CostDetails are found for product repostSecond and cost element AveragePO
+      | TableName       | Record_ID           | Amt     | Qty    |
+      | M_InventoryLine | invPreCutRepost2_l1 | 100 CHF | 10 PCE |
+      | M_InventoryLine | invRepost2_l1       | 100 CHF | 10 PCE |
+    And after not more than 60s, M_CostDetails are found for product repostThird and cost element AveragePO
+      | TableName       | Record_ID           | Amt     | Qty    |
+      | M_InventoryLine | invPreCutRepost3_l1 | 100 CHF | 10 PCE |
+      | M_InventoryLine | invRepost3_l1       | 100 CHF | 10 PCE |
+    #
+    # Including the opening anchors the switch created: a repost must never reach back over the cut-off.
+    #
+    And the cost revaluation identified by switchRepost seeded opening cost details:
+      | M_Product_ID | M_CostElement_ID     | DateAcct   | Qty   | Amt   |
+      | repostFirst  | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+      | repostSecond | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |
+      | repostThird  | MovingAverageInvoice | 2025-12-31 | 0 PCE | 0 CHF |


### PR DESCRIPTION
## What

Adds `de_metas_acct.accounting_docs_repost_all_from_date(p_C_AcctSchema_ID, p_StartDateAcct)` — a **plain repost** driver — plus its recorded migration `5817140` and cucumber coverage.

## Why

When an accounting schema's **costing method is switched**, the cost details are already correct but every `Fact_Acct` row is still valued by the OLD method: the amount a document posts is filtered to the cost element accountable under the schema's *current* costing configuration (`CostDetailCreateResultsList#getAmtAndQtyToPost`). So every affected document has to be reposted — and nothing else. Recomputing would delete and rebuild exactly the cost details the switch just established.

There was no way to ask for that. `product_costs_recreate_all_from_date` always deletes the cost details in range so that reposting rebuilds them, and `fact_acct_unpost` cannot do it at scale (see below).

## How

The new function is the counterpart of `product_costs_recreate_all_from_date` and deliberately mirrors it where it matters:

- **same document set** — same `accountable_docs_and_lines_v` predicate (`m_product_id IS NOT NULL`, `tablename <> 'C_Invoice'`, `dateacct >= p_StartDateAcct`, client-scoped), collapsed to one row per document;
- **same release order and SeqNo discipline** — the block of SeqNos is reserved by advancing the queue's own sequence in a single statement, and each SeqNo is assigned *explicitly* via `row_number() OVER (ORDER BY dateacct, tablename_prio, record_id)`. Never left to the column's `nextval` default: the order in which `INSERT … SELECT` evaluates rows, and therefore consumes a sequence, is not guaranteed by an `ORDER BY` in the `SELECT`;
- **same session advisory lock** — the same lock class and key as the recompute driver, so the two exclude *each other*, not merely their own kind. Enqueuing documents while a recompute has them parked in its staging table would repost them against half-rewound costs.

And differs where it must: it deletes nothing (no cost detail, no `M_Cost` rewind, no `Fact_Acct` purge), stages nothing, records no progress, and has no resume — the enqueue is a single `INSERT` in a single transaction, so the run either happened or it did not.

One thing it must do that the recompute driver gets for free: it **sweeps `assert_period_open` over the whole range before enqueuing anything**. `Doc#post` rejects an already-posted document whose period is closed even when reposting, and every document this function enqueues is already posted. Without the sweep the run would look like a success — the rows are on the queue — and then fail document by document in the accounting server, one `AD_Issue` at a time, with the ledger left half re-valued.

### Known, deliberate rule deviation

`docs/coding-rules/production-database-support.md` and `backend/de.metas.acct.base/CLAUDE.md` both say: never `INSERT` directly into `Accounting_Docs_To_Repost`, always use `de_metas_acct.fact_acct_unpost*`. This function breaks that knowingly, on the same grounds as the recompute driver's release step, and **says so in its own body** rather than hiding it. Of the three effects `fact_acct_unpost` bundles with the enqueue, two are provably redundant here (the `Fact_Acct` delete — the repost does it itself via `PostingService#postNow` → `Doc#post` → `deleteAcct()`; and the `Posted='N'` reset — `SqlAcctDocLockService#lock` only adds `AND Posted='N'` when `repost` is false) and the third, the period check, is replaced by the explicit sweep, which is strictly stronger: it covers the whole range up front instead of one document at a time.

The `fact_acct_unpost` loop was considered and **rejected**, also recorded in the body: at its default `p_Force:='N'` it aborts on the first document already `Processing='Y'` (over a range holding hundreds of thousands of documents), it deletes every `Fact_Acct` row up front — work the repost redoes anyway, leaving the ledger empty until the queue drains — and it enqueues one document at a time with the SeqNo left to the sequence, so no contiguous ordered block can be reserved.

The coding rule itself is deliberately **not** amended — that is not this function's call to make.

## Test

A new scenario in `switchToMovingAverageInvoice.feature`. It books stock counts whose accounting-date order is deliberately the *opposite* of the product order, switches the schema to `MovingAverageInvoice` back-dated to a cut-off, and then asserts that the repost:

- enqueues exactly the in-range documents, in accounting-date order, none of them staged;
- gives every queued document its own SeqNo (the poller consumes by SeqNo and the queue has no uniqueness constraint on it);
- leaves the `M_CostDetail` row count **unchanged** — both immediately after the call *and* again after the queue has drained, which is where a recompute would have rebuilt the costs;
- leaves the pre-cut-off opening anchors intact.

Verified locally against a local docker stack: RED first (the scenario fails at the driver step with `function … does not exist`), then GREEN after applying migration `5817140`.
