### PR TITLE
`Transport Order`: auto-default ETD/ETA/ATD/ATA/B-L date from first assigned Purchase Order (#25332)

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/shipping/PurchaseOrderToShipperTransportationService.java
@@ -67,8 +67,10 @@ import org.springframework.stereotype.Service;
 
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -81,6 +83,15 @@ public class PurchaseOrderToShipperTransportationService
 {
 	@VisibleForTesting
 	static final AdMessageKey MSG_NoLUPackingConfigForOrderLines = AdMessageKey.of("NoLUPackingConfigForOrderLines");
+
+	/**
+	 * Order in which assigned purchase orders are processed, so the "first order" that seeds the transport order's default dates is
+	 * deterministic: earliest {@code DatePromised} first (the promised delivery date), ties broken by {@code C_Order_ID}. A missing
+	 * {@code DatePromised} sorts last.
+	 */
+	private static final Comparator<I_C_Order> SEED_ORDER_COMPARATOR = Comparator
+			.comparing(I_C_Order::getDatePromised, Comparator.nullsLast(Comparator.naturalOrder()))
+			.thenComparingInt(I_C_Order::getC_Order_ID);
 
 	@NonNull private final PurchaseOrderToShipperTransportationRepository repo;
 
@@ -113,7 +124,11 @@ public class PurchaseOrderToShipperTransportationService
 			return tuDistribution;
 		};
 		final IPackageWeightProvider weightProvider = (order, orderLine, tuQtyForPackage) -> null;
-		return new PurchaseOrderToShipperTransportationService(PurchaseOrderToShipperTransportationRepository.newInstanceForUnitTesting(), luQtyProvider, tuProvider, weightProvider);
+		return new PurchaseOrderToShipperTransportationService(
+				PurchaseOrderToShipperTransportationRepository.newInstanceForUnitTesting(),
+				luQtyProvider,
+				tuProvider,
+				weightProvider);
 	}
 
 	private static final String AD_PROCESS_VALUE_C_Order_SSCC_Print_Jasper = "C_Order_SSCC_Print_Jasper";
@@ -142,11 +157,15 @@ public class PurchaseOrderToShipperTransportationService
 			Loggables.addLog("No purchase orders found for shipper transportation with ID: {}", shipperTransportationId);
 		}
 
-		for (final OrderId purchaseOrderId : validPurchaseOrdersIds)
-		{
-			Loggables.addLog("Adding purchase order with ID: {} to shipper transportation with ID: {}", purchaseOrderId, shipperTransportationId);
-			addPurchaseOrderToShipperTransportation(purchaseOrderId, shipperTransportationId);
-		}
+		// Process earliest-promised first (see SEED_ORDER_COMPARATOR) so the "first order" that seeds the transport order's default
+		// dates is deterministic even when several purchase orders are assigned in a single call (the DB/set encounter order is not meaningful).
+		orderDAO.getByIds(validPurchaseOrdersIds)
+				.stream()
+				.sorted(SEED_ORDER_COMPARATOR)
+				.forEach(order -> {
+					Loggables.addLog("Adding purchase order with ID: {} to shipper transportation with ID: {}", order.getC_Order_ID(), shipperTransportationId);
+					addPurchaseOrderToShipperTransportation(order, shipperTransportationId);
+				});
 	}
 
 	public void addOrderLinesToShipperTransportation(@NonNull final ShipperTransportationId shipperTransportationId, @NonNull final Set<OrderLineId> orderLineIds)
@@ -155,6 +174,11 @@ public class PurchaseOrderToShipperTransportationService
 
 		final I_M_ShipperTransportation shipperTransportation = shipperTransportationDAO.getById(shipperTransportationId);
 		orderToLinesMap.keySet()
+				.stream()
+				// Process earliest-promised first (see SEED_ORDER_COMPARATOR) so the "first order" that seeds the transport order's
+				// default dates is deterministic even when a single call carries lines from several purchase orders (the multimap key
+				// order is not meaningful). Mirrors the ordering applied in addPurchaseOrdersToShipperTransportation().
+				.sorted(SEED_ORDER_COMPARATOR)
 				.forEach(order -> addPurchaseOrderLines(shipperTransportation, order, orderToLinesMap.get(order)));
 	}
 
@@ -171,7 +195,7 @@ public class PurchaseOrderToShipperTransportationService
 
 		if (order.getM_Shipper_ID() > 0 && shipperId.getRepoId() != order.getM_Shipper_ID())
 		{
-			Loggables.addLog("Ignoring C_Order.M_Shipper_ID={} of C_Order_ID={}, because M_ShipperTransportation_ID={} takes precedence", order.getM_Shipper_ID(), order.getM_Shipper_ID(), ShipperTransportationId.toRepoId(shipperTransportationId));
+			Loggables.addLog("Ignoring C_Order.M_Shipper_ID={} of C_Order_ID={}, because M_ShipperTransportation_ID={} takes precedence", order.getM_Shipper_ID(), order.getC_Order_ID(), ShipperTransportationId.toRepoId(shipperTransportationId));
 		}
 
 		final List<I_C_OrderLine> orderLines = orderDAO.retrieveOrderLines(order);
@@ -180,6 +204,10 @@ public class PurchaseOrderToShipperTransportationService
 
 	private void addPurchaseOrderLines(final @NonNull I_M_ShipperTransportation shipperTransportation, final @NonNull I_C_Order order, @NonNull final List<I_C_OrderLine> orderLines)
 	{
+		final ShipperTransportationId shipperTransportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+		// Detect BEFORE any package is created whether this is the very first purchase order assigned to the transport order.
+		final boolean isFirstOrderOnTransportation = shipperTransportationDAO.retrieveOrderIds(shipperTransportationId).isEmpty();
+
 		final List<I_C_OrderLine> orderLinesWithLUQty = orderLines.stream()
 				.filter(orderBL::isLUQtySet)
 				.collect(Collectors.toList());
@@ -240,6 +268,79 @@ public class PurchaseOrderToShipperTransportationService
 				Loggables.addLog("Skipped {} PO line(s) with no LU packing configuration (lines: {})",
 						skippedLines.size(), skippedLineNos);
 			}
+		}
+
+		// addedCount > 0: a first order whose every line lacks LU packing config already throws above
+		// (MSG_NoLUPackingConfigForOrderLines), so on the normal first-order path this guard is a defensive no-op.
+		// It also keeps date-defaulting from firing should a future change let an all-lines-skipped call return without throwing.
+		if (isFirstOrderOnTransportation && addedCount > 0)
+		{
+			applyDefaultDatesFromFirstOrder(shipperTransportation, order);
+		}
+	}
+
+	/**
+	 * Defaults the transport order's date fields from the first assigned purchase order (each value stays user-overridable afterwards):
+	 * <ul>
+	 *     <li>ETA = the purchase order's {@code DatePromised} (the promised arrival date)</li>
+	 *     <li>ETD = the purchase order's {@code PreparationDate} (its ready/provisioning date), taken as already calculated on the
+	 *         order &mdash; by tour planning, or its {@code DatePromised} minus the vendor transport days fallback. We do NOT re-derive
+	 *         it here, so the transport-days rule stays in exactly one place ({@code OrderDeliveryDayBL}). Left unset when the PO has none.</li>
+	 *     <li>ATD = ETD</li>
+	 *     <li>ATA = ETA</li>
+	 *     <li>B/L date = ATD</li>
+	 * </ul>
+	 * Only applies to purchase (inbound) transport orders; the sales flow is left untouched.
+	 */
+	private void applyDefaultDatesFromFirstOrder(@NonNull final I_M_ShipperTransportation shipperTransportation, @NonNull final I_C_Order order)
+	{
+		if (shipperTransportation.isSOTrx())
+		{
+			return; // sales behaviour on the transport order must keep working unchanged
+		}
+
+		// ETA = the PO's promised (arrival) date; guaranteed non-null here (the caller already dereferences it when building the base
+		// package request, and this runs only for completed/closed purchase orders). ETD = the PO's ready/provisioning date, taken
+		// straight from its PreparationDate exactly as already calculated on the order (may be null); we never recompute it.
+		final Timestamp eta = order.getDatePromised();
+		final Timestamp etd = order.getPreparationDate();
+
+		// Fill each field ONLY if the user has not already set it: these are defaults, so a value entered before the first PO
+		// was assigned must be kept. (After assignment every value stays freely editable as well.)
+		boolean changed = false;
+		if (etd != null && shipperTransportation.getETD() == null)
+		{
+			shipperTransportation.setETD(etd);
+			changed = true;
+		}
+		if (shipperTransportation.getETA() == null)
+		{
+			shipperTransportation.setETA(eta);
+			changed = true;
+		}
+		// ATD/ATA/B-L date derive from the transport order's ETD/ETA FIELDS (read after the fills above), not from the raw PO
+		// dates: if the user pre-set ETD/ETA to something other than the PO default, ATD/ATA/B-L date must follow that value.
+		// Each is filled only when its source field is non-null, so an unset ETD (PO without a PreparationDate) never triggers a
+		// pointless null-to-null write on ATD/B-L date.
+		if (shipperTransportation.getETD() != null && shipperTransportation.getATD() == null)
+		{
+			shipperTransportation.setATD(shipperTransportation.getETD()); // ATD = ETD
+			changed = true;
+		}
+		if (shipperTransportation.getETA() != null && shipperTransportation.getATA() == null)
+		{
+			shipperTransportation.setATA(shipperTransportation.getETA()); // ATA = ETA
+			changed = true;
+		}
+		if (shipperTransportation.getATD() != null && shipperTransportation.getBLDate() == null)
+		{
+			shipperTransportation.setBLDate(shipperTransportation.getATD()); // B/L date = ATD
+			changed = true;
+		}
+
+		if (changed)
+		{
+			shipperTransportationDAO.save(shipperTransportation);
 		}
 	}
 

--- a/backend/de.metas.business/src/main/java/de/metas/shipping/api/IShipperTransportationDAO.java
+++ b/backend/de.metas.business/src/main/java/de/metas/shipping/api/IShipperTransportationDAO.java
@@ -63,6 +63,9 @@ public interface IShipperTransportationDAO extends ISingletonService
 	@NonNull
 	ShipperTransportationId getOrCreate(@NonNull CreateShipperTransportationRequest request);
 
+	/** Persists changes made to an already-loaded transport-order header record. */
+	void save(@NonNull I_M_ShipperTransportation shipperTransportation);
+
 	ImmutableList<OrderId> retrieveOrderIds(@NonNull ShipperTransportationId shipperTransportationId);
 
 	Collection<I_M_ShipperTransportation> getByQuery(@NonNull ShipperTransportationQuery query);

--- a/backend/de.metas.business/src/main/java/de/metas/shipping/api/impl/ShipperTransportationDAO.java
+++ b/backend/de.metas.business/src/main/java/de/metas/shipping/api/impl/ShipperTransportationDAO.java
@@ -144,6 +144,12 @@ public class ShipperTransportationDAO implements IShipperTransportationDAO
 		return ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
 	}
 
+	@Override
+	public void save(@NonNull final I_M_ShipperTransportation shipperTransportation)
+	{
+		saveRecord(shipperTransportation);
+	}
+
 	@NonNull
 	public Optional<ShipperTransportationId> getSingleByQuery(@NonNull final ShipperTransportationQuery shipperTransportationQuery)
 	{

--- a/backend/de.metas.business/src/test/java/de/metas/shipping/PurchaseOrderToShipperTransportationServiceTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/shipping/PurchaseOrderToShipperTransportationServiceTest.java
@@ -11,6 +11,7 @@ import de.metas.interfaces.I_C_OrderLine;
 import de.metas.money.CurrencyId;
 import de.metas.money.Money;
 import de.metas.order.OrderId;
+import de.metas.order.OrderLineId;
 import de.metas.organization.IOrgDAO;
 import de.metas.organization.OrgId;
 import de.metas.product.ProductId;
@@ -27,6 +28,7 @@ import de.metas.uom.UomId;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_BP_Group;
 import org.compiere.model.I_C_BPartner_Location;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_PaymentTerm;
@@ -39,6 +41,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
@@ -542,6 +545,367 @@ public class PurchaseOrderToShipperTransportationServiceTest
 				.isEqualTo(line2.getC_OrderLine_ID());
 	}
 
+	/**
+	 * The five transport-order date fields (ETD, ETA, ATD, ATA, B/L date) must auto-populate from the first assigned purchase order:
+	 * ETA = PO.DatePromised, ETD = PO.PreparationDate (taken as already calculated on the order), ATD = ETD, ATA = ETA, B/L date = ATD.
+	 * <p>
+	 * me03 https://github.com/metasfresh/me03/issues/30956
+	 */
+	@Test
+	public void defaultDates_appliedFromFirstPurchaseOrder()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+		final ShipperTransportationId transportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("VendorDefaults", "addressDefaults");
+		final OrderId orderId = createOrder(bpartnerAndLocation);
+
+		createOrderLine(orderId, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+
+		// the PO already carries its provisioning date (PreparationDate) as computed elsewhere; ETD is taken straight from it
+		final I_C_Order order = load(orderId, I_C_Order.class);
+		final Timestamp preparationDate = TimeUtil.asTimestamp(LocalDate.of(2019, 6, 1), orgDAO.getTimeZone(OrgId.ofRepoId(order.getAD_Org_ID())));
+		order.setPreparationDate(preparationDate);
+		save(order);
+
+		service.addPurchaseOrdersToShipperTransportation(transportationId, Collections.singletonList(orderId));
+
+		final Timestamp expectedEta = order.getDatePromised(); // ETA = promised arrival date
+		final Timestamp expectedEtd = preparationDate;         // ETD = PO's PreparationDate (taken as-is)
+
+		final I_M_ShipperTransportation reloaded = load(transportationId, I_M_ShipperTransportation.class);
+		assertThat(reloaded.getETD()).as("ETD = PO.PreparationDate (taken as already calculated on the order)").isEqualTo(expectedEtd);
+		assertThat(reloaded.getETA()).as("ETA = PO.DatePromised (promised arrival)").isEqualTo(expectedEta);
+		assertThat(reloaded.getATD()).as("ATD = ETD").isEqualTo(expectedEtd);
+		assertThat(reloaded.getATA()).as("ATA = ETA").isEqualTo(expectedEta);
+		assertThat(reloaded.getBLDate()).as("B/L date = ATD").isEqualTo(expectedEtd);
+	}
+
+	/**
+	 * ETD is taken from the purchase order's {@code PreparationDate} (its provisioning date, as already calculated on the order),
+	 * independently of the {@code DatePromised} used for ETA.
+	 */
+	@Test
+	public void defaultDates_etdUsesOrderPreparationDate()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+		final ShipperTransportationId transportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("VendorPrep", "addressPrep");
+		final OrderId orderId = createOrder(bpartnerAndLocation);
+		createOrderLine(orderId, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+
+		final I_C_Order order = load(orderId, I_C_Order.class);
+		final Timestamp datePromised = TimeUtil.asTimestamp(LocalDate.of(2025, 3, 10), orgDAO.getTimeZone(OrgId.ofRepoId(order.getAD_Org_ID())));
+		final Timestamp preparationDate = TimeUtil.asTimestamp(LocalDate.of(2025, 3, 1), orgDAO.getTimeZone(OrgId.ofRepoId(order.getAD_Org_ID())));
+		order.setDatePromised(datePromised);
+		order.setPreparationDate(preparationDate);
+		save(order);
+
+		service.addPurchaseOrdersToShipperTransportation(transportationId, Collections.singletonList(orderId));
+
+		final I_M_ShipperTransportation reloaded = load(transportationId, I_M_ShipperTransportation.class);
+		assertThat(reloaded.getETD()).as("ETD = the PO's PreparationDate").isEqualTo(preparationDate);
+		assertThat(reloaded.getETA()).as("ETA = PO.DatePromised").isEqualTo(datePromised);
+	}
+
+	/**
+	 * When the purchase order carries no {@code PreparationDate}, ETD (and the ATD/B-L date that cascade from it) are left unset;
+	 * ETA is still defaulted from the PO's {@code DatePromised}.
+	 */
+	@Test
+	public void defaultDates_noPreparationDate_etdLeftUnset()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+		final ShipperTransportationId transportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("VendorNoPrep", "addressNoPrep");
+		final OrderId orderId = createOrder(bpartnerAndLocation);
+		createOrderLine(orderId, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+
+		service.addPurchaseOrdersToShipperTransportation(transportationId, Collections.singletonList(orderId));
+
+		final Timestamp expectedEta = load(orderId, I_C_Order.class).getDatePromised();
+		final I_M_ShipperTransportation reloaded = load(transportationId, I_M_ShipperTransportation.class);
+		assertThat(reloaded.getETD()).as("ETD left unset when the PO carries no PreparationDate").isNull();
+		assertThat(reloaded.getATD()).as("ATD cascades from ETD, so also unset").isNull();
+		assertThat(reloaded.getBLDate()).as("B/L date cascades from ATD, so also unset").isNull();
+		assertThat(reloaded.getETA()).as("ETA still defaulted from PO.DatePromised").isEqualTo(expectedEta);
+		assertThat(reloaded.getATA()).as("ATA = ETA").isEqualTo(expectedEta);
+	}
+
+	/**
+	 * Only the FIRST assigned purchase order drives the defaults; assigning further orders (or re-editing) must not overwrite the values.
+	 */
+	@Test
+	public void defaultDates_onlyFirstOrderWins()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+		final ShipperTransportationId transportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("VendorFirstWins", "addressFirstWins");
+
+		final OrderId order1 = createOrder(bpartnerAndLocation);
+		createOrderLine(order1, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+		final I_C_Order order1Record = load(order1, I_C_Order.class);
+		final Timestamp firstOrderPreparationDate = TimeUtil.asTimestamp(LocalDate.of(2019, 5, 5), orgDAO.getTimeZone(OrgId.ofRepoId(order1Record.getAD_Org_ID())));
+		order1Record.setPreparationDate(firstOrderPreparationDate);
+		save(order1Record);
+
+		// second order with a DIFFERENT PreparationDate
+		final OrderId order2 = createOrder(bpartnerAndLocation);
+		createOrderLine(order2, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+		final I_C_Order order2Record = load(order2, I_C_Order.class);
+		order2Record.setPreparationDate(TimeUtil.asTimestamp(LocalDate.of(2020, 1, 1), orgDAO.getTimeZone(OrgId.ofRepoId(order2Record.getAD_Org_ID()))));
+		save(order2Record);
+
+		// assign order1 first, then order2
+		service.addPurchaseOrdersToShipperTransportation(transportationId, Collections.singletonList(order1));
+		service.addPurchaseOrdersToShipperTransportation(transportationId, Collections.singletonList(order2));
+
+		final I_M_ShipperTransportation reloaded = load(transportationId, I_M_ShipperTransportation.class);
+		assertThat(reloaded.getETD())
+				.as("ETD stays derived from the FIRST assigned order, not the second")
+				.isEqualTo(firstOrderPreparationDate);
+	}
+
+	/**
+	 * Regression-safety: the auto-defaulting must NOT run for a sales (SOTrx=Y) transport order, so the existing sales flow is untouched.
+	 */
+	@Test
+	public void defaultDates_notAppliedForSalesTransportOrder()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+		shipperTransportation.setIsSOTrx(true);
+		save(shipperTransportation);
+		final ShipperTransportationId transportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("VendorSales", "addressSales");
+		final OrderId orderId = createOrder(bpartnerAndLocation);
+		createOrderLine(orderId, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+
+		// give the PO a PreparationDate so a PURCHASE transport order would get a non-null ETD — proving the sales guard is what suppresses it
+		final I_C_Order order = load(orderId, I_C_Order.class);
+		order.setPreparationDate(TimeUtil.asTimestamp(LocalDate.of(2019, 6, 1), orgDAO.getTimeZone(OrgId.ofRepoId(order.getAD_Org_ID()))));
+		save(order);
+
+		service.addPurchaseOrdersToShipperTransportation(transportationId, Collections.singletonList(orderId));
+
+		final I_M_ShipperTransportation reloaded = load(transportationId, I_M_ShipperTransportation.class);
+		assertThat(reloaded.getETD()).as("ETD must not be defaulted on a sales transport order").isNull();
+		assertThat(reloaded.getETA()).isNull();
+		assertThat(reloaded.getATD()).isNull();
+		assertThat(reloaded.getATA()).isNull();
+		assertThat(reloaded.getBLDate()).isNull();
+	}
+
+	/**
+	 * Assigning via {@code addOrderLinesToShipperTransportation} (which passes only a SELECTED subset of the PO's lines): ETD is
+	 * still taken from the whole purchase order's {@code PreparationDate}, independent of which line subset is assigned.
+	 */
+	@Test
+	public void defaultDates_viaAddOrderLines_usesPurchaseOrderPreparationDate()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+		final ShipperTransportationId transportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("VendorSubset", "addressSubset");
+		final OrderId orderId = createOrder(bpartnerAndLocation);
+
+		final I_C_OrderLine line1 = createOrderLine(orderId, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+		line1.setLine(10);
+		save(line1);
+		final I_C_OrderLine line2 = createOrderLine(orderId, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product2, uom1), Money.of(10, chf));
+		line2.setLine(20);
+		save(line2);
+
+		final I_C_Order order = load(orderId, I_C_Order.class);
+		final Timestamp preparationDate = TimeUtil.asTimestamp(LocalDate.of(2019, 6, 1), orgDAO.getTimeZone(OrgId.ofRepoId(order.getAD_Org_ID())));
+		order.setPreparationDate(preparationDate);
+		save(order);
+
+		// assign ONLY the second line — ETD must still come from the whole PO's PreparationDate
+		service.addOrderLinesToShipperTransportation(transportationId, ImmutableSet.of(OrderLineId.ofRepoId(line2.getC_OrderLine_ID())));
+
+		final Timestamp expectedEta = order.getDatePromised();
+
+		final I_M_ShipperTransportation reloaded = load(transportationId, I_M_ShipperTransportation.class);
+		assertThat(reloaded.getETA()).isEqualTo(expectedEta);
+		assertThat(reloaded.getETD())
+				.as("ETD taken from the PO's PreparationDate, independent of the assigned line subset")
+				.isEqualTo(preparationDate);
+	}
+
+	/**
+	 * Defaults are fill-only-if-unset: a date the user entered BEFORE the first PO was assigned is kept, while the remaining
+	 * unset fields are still populated from the PO.
+	 */
+	@Test
+	public void defaultDates_keepUserPresetField_fillOnlyUnset()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+		final ShipperTransportationId transportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+
+		final Timestamp presetEtd = TimeUtil.asTimestamp(LocalDate.of(2021, 5, 5), orgDAO.getTimeZone(OrgId.ofRepoId(shipperTransportation.getAD_Org_ID())));
+		shipperTransportation.setETD(presetEtd);
+		save(shipperTransportation);
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("VendorPreset", "addressPreset");
+		final OrderId orderId = createOrder(bpartnerAndLocation);
+		createOrderLine(orderId, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+
+		final I_C_Order order = load(orderId, I_C_Order.class);
+
+		service.addPurchaseOrdersToShipperTransportation(transportationId, Collections.singletonList(orderId));
+
+		final Timestamp expectedEta = order.getDatePromised(); // ETA = promised arrival date
+
+		final I_M_ShipperTransportation reloaded = load(transportationId, I_M_ShipperTransportation.class);
+		assertThat(reloaded.getETD()).as("pre-set ETD is kept, not overwritten").isEqualTo(presetEtd);
+		assertThat(reloaded.getETA()).as("unset ETA still filled from the PO default (= DatePromised)").isEqualTo(expectedEta);
+		assertThat(reloaded.getATD()).as("ATD = ETD, so it follows the user-preset ETD, not the PO's DatePromised").isEqualTo(presetEtd);
+		assertThat(reloaded.getATA()).as("ATA = ETA").isEqualTo(expectedEta);
+		assertThat(reloaded.getBLDate()).as("B/L date = ATD, which here equals the user-preset ETD").isEqualTo(presetEtd);
+	}
+
+	/**
+	 * B/L date follows ATD (not ETD): when the user pre-sets ATD to a value different from ETD and leaves ETD/BLDate unset,
+	 * the B/L date default must be the (kept) ATD, not the PO-derived ETD.
+	 */
+	@Test
+	public void defaultDates_blDateFollowsPresetAtd_notEtd()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+		final ShipperTransportationId transportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+
+		// user pre-sets ATD only; ETD, ETA, ATA and B/L date are left unset
+		final Timestamp presetAtd = TimeUtil.asTimestamp(LocalDate.of(2025, 1, 15), orgDAO.getTimeZone(OrgId.ofRepoId(shipperTransportation.getAD_Org_ID())));
+		shipperTransportation.setATD(presetAtd);
+		save(shipperTransportation);
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("VendorBlAtd", "addressBlAtd");
+		final OrderId orderId = createOrder(bpartnerAndLocation);
+		createOrderLine(orderId, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+
+		// the PO's PreparationDate is deliberately DIFFERENT from the preset ATD, so ETD (= PO's PreparationDate) and ATD (= preset) diverge
+		final I_C_Order order = load(orderId, I_C_Order.class);
+		final Timestamp poPreparationDate = TimeUtil.asTimestamp(LocalDate.of(2025, 2, 1), orgDAO.getTimeZone(OrgId.ofRepoId(order.getAD_Org_ID())));
+		order.setPreparationDate(poPreparationDate);
+		save(order);
+
+		service.addPurchaseOrdersToShipperTransportation(transportationId, Collections.singletonList(orderId));
+
+		final I_M_ShipperTransportation reloaded = load(transportationId, I_M_ShipperTransportation.class);
+		assertThat(reloaded.getETD()).as("unset ETD is filled from the PO's PreparationDate").isEqualTo(poPreparationDate);
+		assertThat(reloaded.getATD()).as("pre-set ATD is kept, not overwritten").isEqualTo(presetAtd);
+		assertThat(reloaded.getBLDate())
+				.as("B/L date = ATD (the kept preset), NOT the PO-derived ETD")
+				.isEqualTo(presetAtd)
+				.isNotEqualTo(poPreparationDate);
+	}
+
+	/**
+	 * When several purchase orders are assigned in a SINGLE call, the "first order" that seeds the default dates must be the one
+	 * with the EARLIEST {@code DatePromised} (ties broken by {@code C_Order_ID}), regardless of the encounter order of the passed
+	 * collection or of the C_Order_IDs. Here the earliest-promised order is deliberately NOT the lowest-id one.
+	 */
+	@Test
+	public void defaultDates_batchAssignment_firstIsEarliestDatePromised()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+		final ShipperTransportationId transportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("VendorBatch", "addressBatch");
+
+		// order1: LOWEST C_Order_ID but the LATEST DatePromised => must NOT seed the dates
+		final OrderId order1 = createOrder(bpartnerAndLocation);
+		createOrderLine(order1, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+		final I_C_Order order1Record = load(order1, I_C_Order.class);
+		order1Record.setDatePromised(TimeUtil.asTimestamp(LocalDate.of(2021, 3, 3), orgDAO.getTimeZone(OrgId.ofRepoId(order1Record.getAD_Org_ID()))));
+		order1Record.setPreparationDate(TimeUtil.asTimestamp(LocalDate.of(2019, 1, 1), orgDAO.getTimeZone(OrgId.ofRepoId(order1Record.getAD_Org_ID()))));
+		save(order1Record);
+
+		final OrderId order2 = createOrder(bpartnerAndLocation);
+		createOrderLine(order2, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+		final I_C_Order order2Record = load(order2, I_C_Order.class);
+		order2Record.setDatePromised(TimeUtil.asTimestamp(LocalDate.of(2020, 2, 2), orgDAO.getTimeZone(OrgId.ofRepoId(order2Record.getAD_Org_ID()))));
+		order2Record.setPreparationDate(TimeUtil.asTimestamp(LocalDate.of(2019, 2, 2), orgDAO.getTimeZone(OrgId.ofRepoId(order2Record.getAD_Org_ID()))));
+		save(order2Record);
+
+		// order3: HIGHEST C_Order_ID but the EARLIEST DatePromised => it must seed the dates
+		final OrderId order3 = createOrder(bpartnerAndLocation);
+		createOrderLine(order3, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+		final I_C_Order order3Record = load(order3, I_C_Order.class);
+		order3Record.setDatePromised(TimeUtil.asTimestamp(LocalDate.of(2019, 1, 1), orgDAO.getTimeZone(OrgId.ofRepoId(order3Record.getAD_Org_ID()))));
+		final Timestamp order3PreparationDate = TimeUtil.asTimestamp(LocalDate.of(2018, 12, 1), orgDAO.getTimeZone(OrgId.ofRepoId(order3Record.getAD_Org_ID())));
+		order3Record.setPreparationDate(order3PreparationDate);
+		save(order3Record);
+
+		// sanity: order3 has the HIGHEST C_Order_ID yet the earliest DatePromised
+		assertThat(order1.getRepoId()).isLessThan(order2.getRepoId()).isLessThan(order3.getRepoId());
+
+		// assign all three at once, in a collection order that does NOT start with order3
+		service.addPurchaseOrdersToShipperTransportation(transportationId, ImmutableSet.of(order3, order2, order1));
+
+		final I_M_ShipperTransportation reloaded = load(transportationId, I_M_ShipperTransportation.class);
+		assertThat(reloaded.getETD())
+				.as("ETD is seeded by the earliest-DatePromised order (order3), not the lowest C_Order_ID or the collection order")
+				.isEqualTo(order3PreparationDate);
+	}
+
+	/**
+	 * Same determinism contract as {@link #defaultDates_batchAssignment_firstIsEarliestDatePromised()} but driven through
+	 * {@code addOrderLinesToShipperTransportation} (the line-level entry point): when a single call carries lines from several
+	 * purchase orders, the "first order" that seeds the default dates must be the one with the EARLIEST {@code DatePromised}
+	 * (ties broken by {@code C_Order_ID}), regardless of the encounter order of the passed line-id set.
+	 */
+	@Test
+	public void defaultDates_viaAddOrderLines_batchAssignment_firstIsEarliestDatePromised()
+	{
+		final I_M_ShipperTransportation shipperTransportation = createShipperTransportation();
+		final ShipperTransportationId transportationId = ShipperTransportationId.ofRepoId(shipperTransportation.getM_ShipperTransportation_ID());
+
+		final BPartnerLocationId bpartnerAndLocation = createBPartnerAndLocation("VendorBatchLines", "addressBatchLines");
+
+		// order1: LOWEST C_Order_ID but the LATEST DatePromised => must NOT seed the dates
+		final OrderId order1 = createOrder(bpartnerAndLocation);
+		final I_C_OrderLine line1 = createOrderLine(order1, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+		final I_C_Order order1Record = load(order1, I_C_Order.class);
+		order1Record.setDatePromised(TimeUtil.asTimestamp(LocalDate.of(2021, 3, 3), orgDAO.getTimeZone(OrgId.ofRepoId(order1Record.getAD_Org_ID()))));
+		order1Record.setPreparationDate(TimeUtil.asTimestamp(LocalDate.of(2019, 1, 1), orgDAO.getTimeZone(OrgId.ofRepoId(order1Record.getAD_Org_ID()))));
+		save(order1Record);
+
+		final OrderId order2 = createOrder(bpartnerAndLocation);
+		final I_C_OrderLine line2 = createOrderLine(order2, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+		final I_C_Order order2Record = load(order2, I_C_Order.class);
+		order2Record.setDatePromised(TimeUtil.asTimestamp(LocalDate.of(2020, 2, 2), orgDAO.getTimeZone(OrgId.ofRepoId(order2Record.getAD_Org_ID()))));
+		order2Record.setPreparationDate(TimeUtil.asTimestamp(LocalDate.of(2019, 2, 2), orgDAO.getTimeZone(OrgId.ofRepoId(order2Record.getAD_Org_ID()))));
+		save(order2Record);
+
+		// order3: HIGHEST C_Order_ID but the EARLIEST DatePromised => it must seed the dates
+		final OrderId order3 = createOrder(bpartnerAndLocation);
+		final I_C_OrderLine line3 = createOrderLine(order3, StockQtyAndUOMQtys.createConvert(BigDecimal.valueOf(2), product1, uom1), Money.of(10, chf));
+		final I_C_Order order3Record = load(order3, I_C_Order.class);
+		order3Record.setDatePromised(TimeUtil.asTimestamp(LocalDate.of(2019, 1, 1), orgDAO.getTimeZone(OrgId.ofRepoId(order3Record.getAD_Org_ID()))));
+		final Timestamp order3PreparationDate = TimeUtil.asTimestamp(LocalDate.of(2018, 12, 1), orgDAO.getTimeZone(OrgId.ofRepoId(order3Record.getAD_Org_ID())));
+		order3Record.setPreparationDate(order3PreparationDate);
+		save(order3Record);
+
+		// sanity: order3 has the HIGHEST C_Order_ID yet the earliest DatePromised
+		assertThat(order1.getRepoId()).isLessThan(order2.getRepoId()).isLessThan(order3.getRepoId());
+
+		// assign one line from each order at once, in a set order that does NOT start with order3's line
+		service.addOrderLinesToShipperTransportation(transportationId, ImmutableSet.of(
+				OrderLineId.ofRepoId(line3.getC_OrderLine_ID()),
+				OrderLineId.ofRepoId(line2.getC_OrderLine_ID()),
+				OrderLineId.ofRepoId(line1.getC_OrderLine_ID())));
+
+		final I_M_ShipperTransportation reloaded = load(transportationId, I_M_ShipperTransportation.class);
+		assertThat(reloaded.getETD())
+				.as("ETD is seeded by the earliest-DatePromised order (order3), not the lowest C_Order_ID or the line-id set order")
+				.isEqualTo(order3PreparationDate);
+	}
+
 	private I_M_ShipperTransportation createShipperTransportation()
 	{
 		final I_M_Shipper shipper = createShipper();
@@ -550,6 +914,7 @@ public class PurchaseOrderToShipperTransportationServiceTest
 		shipperTransportation.setM_Shipper_ID(shipper.getM_Shipper_ID());
 
 		shipperTransportation.setDateDoc(TimeUtil.asTimestamp(LocalDate.of(2019, 6, 6), orgDAO.getTimeZone(OrgId.ofRepoId(shipper.getAD_Org_ID()))));
+		shipperTransportation.setIsSOTrx(false); // purchase (inbound) transport order
 
 		save(shipperTransportation);
 
@@ -569,8 +934,12 @@ public class PurchaseOrderToShipperTransportationServiceTest
 
 	private BPartnerLocationId createBPartnerAndLocation(final String partnerName, final String address)
 	{
+		final I_C_BP_Group bpGroup = newInstance(I_C_BP_Group.class);
+		save(bpGroup);
+
 		final I_C_BPartner bpartnerRecord = newInstance(I_C_BPartner.class);
 		bpartnerRecord.setName(partnerName);
+		bpartnerRecord.setC_BP_Group_ID(bpGroup.getC_BP_Group_ID());
 		save(bpartnerRecord);
 
 		final int bpartnerId = bpartnerRecord.getC_BPartner_ID();


### PR DESCRIPTION
* `Transport Order`: auto-default ETD/ETA/ATD/ATA/B-L date from first assigned Purchase Order

* `Transport Order`: default ETA — use BPartnerProductEffectiveBL.getPurchaseTransportDays for vendor delivery time

* `Transport Order`: default dates — use BPartnerProductEffectiveBL + address review

* `Transport Order`: default dates — fill-only-if-unset + guaranteed first-line ordering

* `Transport Order`: default dates — deterministic first order + review tidy-ups

Address bot code review on PR #25332:
- Sort the assignable purchase orders by C_Order_ID before the loop so the "first order" that seeds the default dates is deterministic when several POs are assigned in a single call (real-DB row order is unspecified).
- Remove the unreachable etd==null guard in applyDefaultDatesFromFirstOrder (DatePromised is already dereferenced when building the base package request, so a null PO would fail earlier) and document the invariant.
- Expand the compact single-line if-statements to the file's normal style.
- Add defaultDates_batchAssignment_firstIsLowestOrderId as a contract guard.



* `Transport Order`: default dates — deterministic first order in addOrderLines path

Sort the order key-set in addOrderLinesToShipperTransportation() by C_Order_ID so the first order that seeds the transport order's default dates is deterministic when a single call carries lines from several purchase orders, matching the ordering already applied in addPurchaseOrdersToShipperTransportation(). Adds a mirror determinism test and a clarifying comment on the addedCount>0 guard.

Addresses PR #25332 review feedback.



* `Transport Order`: default dates — derive ATD/ATA/B-L date from ETD/ETA fields

Default ATD/ATA/B-L date from the transport order's ETD/ETA fields (read after the fill-if-unset block) rather than from the raw PO dates, so a user-preset ETD/ETA flows through to ATD/ATA/B-L date. Updates the fill-only-if-unset test to assert the preset ETD is what ATD/B-L date follow.

Addresses PR #25332 review point #1 (ATD = ETD semantics).



* `Transport Order`: default dates — B/L date follows ATD, not ETD

Fix the B/L date default to derive from the ATD field (per spec: B/L date = ATD) instead of ETD. When the user pre-sets ATD to a value different from ETD and leaves ETD/BLDate unset, the B/L date must follow the kept ATD, not the PO-derived ETD. ATD is guaranteed non-null at this point (its fill block runs first). Adds a regression test for the pre-set-ATD scenario.

Addresses PR #25332 review (B/L date bug).



* `Transport Order`: default dates — derive ETD from PO provisioning date, ETA from DatePromised

Rework the first-order date defaulting so it matches the metasfresh date model: DatePromised is the promised ARRIVAL date and PreparationDate = DatePromised minus the vendor transport days. Previously ETD was set to DatePromised (arrival treated as departure) and ETA re-added the vendor delivery time, double-counting a lead time already embedded in the PO's own dates.

Now:
- ETA = PO.DatePromised (promised arrival)
- ETD = PO.PreparationDate when set (already computed by tour planning), else DatePromised - IOrderBL.getMaxPurchaseTransportDays(order) (max across ALL lines)

This removes the first-line/skipped-line delivery-time lookup entirely and takes the lead time from the PO's own dates. Also route the header save through IShipperTransportationDAO.save(...) instead of calling InterfaceWrapperHelper directly from the service.

Addresses PR #25332 review from mrie04.



* `Transport Order`: default ETD from PO PreparationDate as-is, drop transport-days recompute

Take the dates already calculated on the purchase order instead of re-deriving them: ETD now comes straight from C_Order.PreparationDate (computed by tour planning / OrderDeliveryDayBL), removing the duplicated DatePromised - getMaxPurchaseTransportDays fallback so the transport-days rule lives in one place. When the PO has no PreparationDate, ETD (and the ATD/B-L date that cascade from it) is left unset; ETA still defaults from DatePromised. Guarded the ATD/ATA/B-L date fills on their source field being non-null to avoid null-to-null writes.

Tests updated to seed PreparationDate accordingly.



* `Transport Order`: seed default dates from earliest-DatePromised order; import Timestamp in test

Review follow-up (mrie04):
- Seed the transport order's default dates from the purchase order with the earliest DatePromised (ties broken by C_Order_ID) instead of simply the lowest C_Order_ID. Shared SEED_ORDER_COMPARATOR applied at both entry points (addPurchaseOrdersToShipperTransportation and addOrderLinesToShipperTransportation). DatePromised is used as the ordering key because it is always set; a missing value sorts last.
- Test: import java.sql.Timestamp instead of fully-qualifying it; batch determinism tests now prove earliest-DatePromised wins over lowest id.



---------