### PR TITLE
Cost Revaluation CopyFromCostElement: cover organization costing level and negative on-hand stock (tests only)

### DIFF
--- a/backend/de.metas.business/src/test/java/de/metas/costrevaluation/CostRevaluationServiceTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/costrevaluation/CostRevaluationServiceTest.java
@@ -147,7 +147,7 @@ public class CostRevaluationServiceTest
 		euroCurrencyId = PlainCurrencyDAO.createCurrency(CurrencyCode.EUR).getId();
 		eachUOM = BusinessTestHelper.createUomEach();
 
-		acctSchemaId = createAcctSchema();
+		acctSchemaId = createAcctSchema(CostingLevel.Client);
 
 		sourceCostElementId = createCostElement("SourceElement", CostingMethod.AveragePO);
 		targetCostElementId = createCostElement("TargetElement", CostingMethod.MovingAverageInvoice);
@@ -166,13 +166,17 @@ public class CostRevaluationServiceTest
 		return CostElementId.ofRepoId(record.getM_CostElement_ID());
 	}
 
-	private AcctSchemaId createAcctSchema()
+	/**
+	 * @param costingLevel the schema's {@code CostingLevel} — {@link CostingLevel#Client} for the default fixture,
+	 * {@link CostingLevel#Organization} for the org-level one (see {@link CopyFromCostElement_OrganizationCostingLevel}).
+	 */
+	private AcctSchemaId createAcctSchema(@NonNull final CostingLevel costingLevel)
 	{
 		final I_C_AcctSchema acctSchemaRecord = newInstance(I_C_AcctSchema.class);
-		acctSchemaRecord.setName("Test AcctSchema");
+		acctSchemaRecord.setName("Test AcctSchema " + costingLevel);
 		acctSchemaRecord.setC_Currency_ID(euroCurrencyId.getRepoId());
 		acctSchemaRecord.setM_CostType_ID(costTypeId.getRepoId());
-		acctSchemaRecord.setCostingLevel(CostingLevel.Client.getCode());
+		acctSchemaRecord.setCostingLevel(costingLevel.getCode());
 		acctSchemaRecord.setCostingMethod(CostingMethod.MovingAverageInvoice.getCode());
 		acctSchemaRecord.setSeparator("-");
 		acctSchemaRecord.setTaxCorrectionType(TaxCorrectionType.NONE.getCode());
@@ -201,6 +205,16 @@ public class CostRevaluationServiceTest
 
 	private ProductId createProduct(@NonNull final String value)
 	{
+		return createProduct(value, acctSchemaId);
+	}
+
+	/**
+	 * @param acctSchemaId the accounting schema the product's category gets its {@code M_Product_Category_Acct} for. The
+	 * product's effective costing level is resolved from that schema (the category record carries no override), so passing
+	 * the org-level schema is what puts the product on {@link CostingLevel#Organization}.
+	 */
+	private ProductId createProduct(@NonNull final String value, @NonNull final AcctSchemaId acctSchemaId)
+	{
 		final I_M_Product_Category productCategory = newInstanceOutOfTrx(I_M_Product_Category.class);
 		saveRecord(productCategory);
 
@@ -221,6 +235,29 @@ public class CostRevaluationServiceTest
 		return ProductId.ofRepoId(product.getM_Product_ID());
 	}
 
+	/**
+	 * Builds the cost segment the fixtures assert against: the default (client-level) one when {@code costingLevel} is
+	 * {@link CostingLevel#Client} / {@code orgId} is {@link OrgId#ANY}, the per-org one otherwise.
+	 */
+	private CostSegmentAndElement costSegmentAndElement(
+			@NonNull final ProductId productId,
+			@NonNull final CostElementId costElementId,
+			@NonNull final AcctSchemaId acctSchemaId,
+			@NonNull final CostingLevel costingLevel,
+			@NonNull final OrgId orgId)
+	{
+		return CostSegmentAndElement.builder()
+				.costingLevel(costingLevel)
+				.acctSchemaId(acctSchemaId)
+				.costTypeId(costTypeId)
+				.clientId(ClientId.METASFRESH)
+				.orgId(orgId)
+				.productId(productId)
+				.attributeSetInstanceId(AttributeSetInstanceId.NONE)
+				.costElementId(costElementId)
+				.build();
+	}
+
 	/** Seeds a {@code M_Cost} row for {@code sourceCostElementId} directly (bypassing the costing engine). */
 	private void seedSourceCurrentCost(
 			@NonNull final ProductId productId,
@@ -228,16 +265,20 @@ public class CostRevaluationServiceTest
 			@NonNull final String componentsCostPrice,
 			@NonNull final String qty)
 	{
-		final CostSegmentAndElement costSegmentAndElement = CostSegmentAndElement.builder()
-				.costingLevel(CostingLevel.Client)
-				.acctSchemaId(acctSchemaId)
-				.costTypeId(costTypeId)
-				.clientId(ClientId.METASFRESH)
-				.orgId(OrgId.ANY)
-				.productId(productId)
-				.attributeSetInstanceId(AttributeSetInstanceId.NONE)
-				.costElementId(sourceCostElementId)
-				.build();
+		seedSourceCurrentCost(productId, acctSchemaId, CostingLevel.Client, OrgId.ANY, ownCostPrice, componentsCostPrice, qty);
+	}
+
+	/** Org-aware sibling of {@link #seedSourceCurrentCost(ProductId, String, String, String)}. */
+	private void seedSourceCurrentCost(
+			@NonNull final ProductId productId,
+			@NonNull final AcctSchemaId acctSchemaId,
+			@NonNull final CostingLevel costingLevel,
+			@NonNull final OrgId orgId,
+			@NonNull final String ownCostPrice,
+			@NonNull final String componentsCostPrice,
+			@NonNull final String qty)
+	{
+		final CostSegmentAndElement costSegmentAndElement = costSegmentAndElement(productId, sourceCostElementId, acctSchemaId, costingLevel, orgId);
 
 		final CostElement sourceCostElement = costElementRepo.getById(sourceCostElementId);
 
@@ -262,16 +303,7 @@ public class CostRevaluationServiceTest
 			@NonNull final String componentsCostPrice,
 			@NonNull final String qty)
 	{
-		final CostSegmentAndElement seg = CostSegmentAndElement.builder()
-				.costingLevel(CostingLevel.Client)
-				.acctSchemaId(acctSchemaId)
-				.costTypeId(costTypeId)
-				.clientId(ClientId.METASFRESH)
-				.orgId(OrgId.ANY)
-				.productId(productId)
-				.attributeSetInstanceId(AttributeSetInstanceId.NONE)
-				.costElementId(sourceCostElementId)
-				.build();
+		final CostSegmentAndElement seg = costSegmentAndElement(productId, sourceCostElementId, acctSchemaId, CostingLevel.Client, OrgId.ANY);
 
 		final CurrentCost currentCost = currentCostsRepo.getOrCreate(seg);
 		currentCost.setFrom(CostDetailPreviousAmounts.builder()
@@ -289,8 +321,16 @@ public class CostRevaluationServiceTest
 
 	private CostRevaluationId createCopyFromCostElementHeader()
 	{
+		return createCopyFromCostElementHeader(acctSchemaId, OrgId.ANY);
+	}
+
+	/** Org-aware sibling of {@link #createCopyFromCostElementHeader()}: the document is booked on {@code orgId}. */
+	private CostRevaluationId createCopyFromCostElementHeader(
+			@NonNull final AcctSchemaId acctSchemaId,
+			@NonNull final OrgId orgId)
+	{
 		final I_M_CostRevaluation record = newInstance(I_M_CostRevaluation.class);
-		record.setAD_Org_ID(OrgId.ANY.getRepoId());
+		record.setAD_Org_ID(orgId.getRepoId());
 		record.setC_AcctSchema_ID(acctSchemaId.getRepoId());
 		record.setM_CostElement_ID(targetCostElementId.getRepoId());
 		record.setCopyFrom_M_CostElement_ID(sourceCostElementId.getRepoId());
@@ -754,6 +794,208 @@ public class CostRevaluationServiceTest
 			assertThat(after.getQty().toBigDecimal()).isEqualByComparingTo("5");
 			assertThat(after.getDateAcct()).isEqualTo(Instant.parse("2025-06-15T00:00:00Z"));
 		}
+	}
+
+	/**
+	 * FR9 — <b>organization costing level</b>. Every other fixture in this class runs at {@link CostingLevel#Client}
+	 * ({@link OrgId#ANY}), where {@code CostingLevel.effectiveValue(orgId)} collapses to {@code ANY} and the org filter in
+	 * {@code CostRevaluationService#queryCurrentCosts} can never discriminate. This nested class is the only place that
+	 * exercises it: an accounting schema at {@link CostingLevel#Organization} and <b>two</b> organizations, each carrying
+	 * its own source {@code M_Cost} row for the same product — the customer's real configuration.
+	 * <p>
+	 * <b>Load-bearing</b>: the filter is a plain Java stream predicate ({@code CostSegment#isMatching(OrgId)} — the SQL
+	 * query deliberately does NOT filter by org, "because we don't know the costing level yet"). Were it dropped, a switch
+	 * booked on one org would revalue BOTH orgs' costs; were it inverted, it would revalue the wrong org's. Both fixtures
+	 * below give the two orgs deliberately different numbers, so either mistake fails an assertion.
+	 */
+	@Nested
+	class CopyFromCostElement_OrganizationCostingLevel
+	{
+		private AcctSchemaId orgLevelAcctSchemaId;
+		private OrgId org1;
+		private OrgId org2;
+
+		@BeforeEach
+		public void setUpOrgLevelCostingWithTwoOrgs()
+		{
+			orgLevelAcctSchemaId = createAcctSchema(CostingLevel.Organization);
+			org1 = AdempiereTestHelper.createOrgWithTimeZone("org1", ZONE_ID);
+			org2 = AdempiereTestHelper.createOrgWithTimeZone("org2", ZONE_ID);
+		}
+
+		/** One product, one source M_Cost row per org — 12.50/100 in org1 and 99.00/500 in org2. */
+		private ProductId createProductStockedInBothOrgs()
+		{
+			final ProductId productId = createProduct("productAtOrgCostingLevel", orgLevelAcctSchemaId);
+			seedSourceCurrentCost(productId, orgLevelAcctSchemaId, CostingLevel.Organization, org1, "12.50", "3.75", "100");
+			seedSourceCurrentCost(productId, orgLevelAcctSchemaId, CostingLevel.Organization, org2, "99.00", "9.90", "500");
+			return productId;
+		}
+
+		@Test
+		public void createLines_seedsOnlyTheDocumentOrgsCost()
+		{
+			final ProductId productId = createProductStockedInBothOrgs();
+
+			final CostRevaluationId costRevaluationId = createCopyFromCostElementHeader(orgLevelAcctSchemaId, org1);
+
+			costRevaluationService.createLines(costRevaluationId);
+
+			final List<I_M_CostRevaluationLine> lines = getLineRecords(costRevaluationId);
+			// org2's source cost is NOT picked up, even though it exists for the same product/element/schema.
+			assertThat(lines).hasSize(1);
+
+			final I_M_CostRevaluationLine line = getLineForProduct(lines, productId);
+			assertThat(line.getAD_Org_ID()).as("line booked on the document's org").isEqualTo(org1.getRepoId());
+			assertThat(line.getCostingLevel()).isEqualTo(CostingLevel.Organization.getCode());
+			assertThat(line.getM_CostElement_ID()).isEqualTo(targetCostElementId.getRepoId());
+			assertThat(line.getNewCostPrice()).isEqualByComparingTo("12.50");
+			assertThat(line.getCurrentQty()).isEqualByComparingTo("100");
+		}
+
+		/**
+		 * The mirror of {@link #createLines_seedsOnlyTheDocumentOrgsCost()}: booking the same switch on the OTHER org picks
+		 * that org's numbers. Together the two rule out a filter that is org-blind (2 lines) or picks a fixed org (wrong
+		 * numbers in one of the two directions).
+		 */
+		@Test
+		public void createLines_seedsTheOtherOrgWhenTheDocumentIsBookedThere()
+		{
+			final ProductId productId = createProductStockedInBothOrgs();
+
+			final CostRevaluationId costRevaluationId = createCopyFromCostElementHeader(orgLevelAcctSchemaId, org2);
+
+			costRevaluationService.createLines(costRevaluationId);
+
+			final List<I_M_CostRevaluationLine> lines = getLineRecords(costRevaluationId);
+			assertThat(lines).hasSize(1);
+
+			final I_M_CostRevaluationLine line = getLineForProduct(lines, productId);
+			assertThat(line.getAD_Org_ID()).as("line booked on the document's org").isEqualTo(org2.getRepoId());
+			assertThat(line.getNewCostPrice()).isEqualByComparingTo("99.00");
+			assertThat(line.getCurrentQty()).isEqualByComparingTo("500");
+		}
+
+		/**
+		 * Completing the switch seeds the target element's {@code M_Cost} for the document's org ONLY, and writes exactly
+		 * one opening anchor — on that org. The other org keeps no MAI cost at all: its own switch is a separate document.
+		 */
+		@Test
+		public void createDetails_seedsTheTargetCostOfTheDocumentOrgOnly()
+		{
+			final ProductId productId = createProductStockedInBothOrgs();
+
+			final CostRevaluationId costRevaluationId = createCopyFromCostElementHeader(orgLevelAcctSchemaId, org1);
+			costRevaluationService.createLines(costRevaluationId);
+
+			costRevaluationService.createDetails(costRevaluationId);
+
+			final CurrentCost org1TargetCost = currentCostsRepo.getOrNull(
+					costSegmentAndElement(productId, targetCostElementId, orgLevelAcctSchemaId, CostingLevel.Organization, org1));
+			assertThat(org1TargetCost).isNotNull();
+			assertThat(org1TargetCost.getCostPrice().getOwnCostPrice().toBigDecimal()).isEqualByComparingTo("12.50");
+			assertThat(org1TargetCost.getCostPrice().getComponentsCostPrice().toBigDecimal()).isEqualByComparingTo("3.75");
+			assertThat(org1TargetCost.getCurrentQty().toBigDecimal()).isEqualByComparingTo("100");
+			assertThat(org1TargetCost.getCumulatedAmt().toBigDecimal()).isEqualByComparingTo("1250.00");
+
+			assertThat(currentCostsRepo.getOrNull(
+					costSegmentAndElement(productId, targetCostElementId, orgLevelAcctSchemaId, CostingLevel.Organization, org2)))
+					.as("org2's MAI cost is untouched by a switch booked on org1")
+					.isNull();
+
+			final List<CostDetail> anchorDetails = getCostDetails(orgLevelAcctSchemaId, targetCostElementId, productId);
+			assertThat(anchorDetails).hasSize(1);
+			assertThat(anchorDetails.get(0).getOrgId()).isEqualTo(org1);
+		}
+	}
+
+	/**
+	 * FR9 — <b>negative-stock</b> sibling of the zero-stock coverage in
+	 * {@link CreateLines_CopyFromCostElement#seedsOneLinePerSourceCurrentCost()}. A negative {@code M_Cost.CurrentQty} is a
+	 * reachable production state on the SOURCE element: the average-costing handlers move on-hand through
+	 * {@code CurrentCost#addWeightedAverage}, which — unlike {@code addToCurrentQtyAndCumulate} — does NOT clamp the result
+	 * to zero, so an outbound movement exceeding on-hand leaves the row negative.
+	 * <p>
+	 * <b>Current behaviour, pinned here as correct</b>: the switch carries the negative on-hand through unchanged rather
+	 * than clamping or refusing. That is the value-neutral outcome FR2 demands — a negative on-hand at a positive cost
+	 * price IS a negative inventory asset value, and it is already on the books; clamping the qty to zero would silently
+	 * create {@code price × |qty|} of value with no GL posting to back it.
+	 * <p>
+	 * <b>The concrete regression this prevents</b>: someone "fixing" the negative-stock anomaly by adding a
+	 * {@code toZeroIfNegative()} (or a positive-qty guard) into the seed path — {@code createDetailsForCopyFromCostElement}
+	 * or {@code CurrentCost#setFrom} — which would break value-neutrality for exactly these products and leave the
+	 * discrepancy invisible, since the switch posts nothing to compare against.
+	 */
+	@Nested
+	class CopyFromCostElement_NegativeOnHandStock
+	{
+		@Test
+		public void carriesTheNegativeOnHandIntoTheOpeningBalance()
+		{
+			final ProductId productId = createProduct("productWithNegativeStock");
+			seedSourceCurrentCost(productId, "12.50", "3.75", "-40");
+
+			final CostRevaluationId costRevaluationId = createCopyFromCostElementHeader();
+			costRevaluationService.createLines(costRevaluationId);
+
+			// Not skipped: a negative-on-hand product gets a drafted line previewing the negative qty.
+			final List<I_M_CostRevaluationLine> lines = getLineRecords(costRevaluationId);
+			assertThat(lines).hasSize(1);
+			final I_M_CostRevaluationLine line = getLineForProduct(lines, productId);
+			assertThat(line.getNewCostPrice()).isEqualByComparingTo("12.50");
+			assertThat(line.getCurrentQty()).isEqualByComparingTo("-40");
+
+			costRevaluationService.createDetails(costRevaluationId);
+
+			final CurrentCost targetCurrentCost = currentCostsRepo.getOrNull(
+					costSegmentAndElement(productId, targetCostElementId, acctSchemaId, CostingLevel.Client, OrgId.ANY));
+			assertThat(targetCurrentCost).isNotNull();
+			assertThat(targetCurrentCost.getCostPrice().getOwnCostPrice().toBigDecimal()).isEqualByComparingTo("12.50");
+			assertThat(targetCurrentCost.getCostPrice().getComponentsCostPrice().toBigDecimal()).isEqualByComparingTo("3.75");
+			// NOT clamped to 0 — the negative on-hand is carried through.
+			assertThat(targetCurrentCost.getCurrentQty().toBigDecimal()).isEqualByComparingTo("-40");
+			// ... and so is the negative asset value it implies (12.50 * -40), keeping the switch value-neutral.
+			assertThat(targetCurrentCost.getCumulatedAmt().toBigDecimal()).isEqualByComparingTo("-500.00");
+			assertThat(targetCurrentCost.getCumulatedQty().toBigDecimal()).isEqualByComparingTo("-40");
+
+			final List<CostDetail> anchorDetails = getCostDetails(acctSchemaId, targetCostElementId, productId);
+			assertThat(anchorDetails).hasSize(1);
+
+			final CostDetail anchor = anchorDetails.get(0);
+			// The anchor itself stays a zero-delta row (its job is to CARRY the opening in Prev_*, not to move value).
+			assertThat(anchor.isChangingCosts()).isTrue();
+			assertThat(anchor.getQty().toBigDecimal()).isEqualByComparingTo("0");
+			assertThat(anchor.getAmt().toBigDecimal()).isEqualByComparingTo("0");
+
+			final CostDetailPreviousAmounts previousAmounts = anchor.getPreviousAmounts();
+			assertThat(previousAmounts).isNotNull();
+			assertThat(previousAmounts.getCostPrice().getOwnCostPrice().toBigDecimal()).isEqualByComparingTo("12.50");
+			assertThat(previousAmounts.getCostPrice().getComponentsCostPrice().toBigDecimal()).isEqualByComparingTo("3.75");
+			assertThat(previousAmounts.getQty().toBigDecimal()).isEqualByComparingTo("-40");
+			assertThat(previousAmounts.getCumulatedAmt().toBigDecimal()).isEqualByComparingTo("-500.00");
+			assertThat(previousAmounts.getCumulatedQty().toBigDecimal()).isEqualByComparingTo("-40");
+		}
+	}
+
+	private List<I_M_CostRevaluationLine> getLineRecords(@NonNull final CostRevaluationId costRevaluationId)
+	{
+		return costRevaluationRepository
+				.streamAllLineRecordsByCostRevaluationId(costRevaluationId)
+				.collect(ImmutableList.toImmutableList());
+	}
+
+	private List<CostDetail> getCostDetails(
+			@NonNull final AcctSchemaId acctSchemaId,
+			@NonNull final CostElementId costElementId,
+			@NonNull final ProductId productId)
+	{
+		return new CostDetailRepository()
+				.stream(CostDetailQuery.builder()
+						.acctSchemaId(acctSchemaId)
+						.costElementId(costElementId)
+						.productId(productId)
+						.build())
+				.collect(ImmutableList.toImmutableList());
 	}
 
 	/**


### PR DESCRIPTION
**Tests only** — no production code is touched (the diff is a single test file).

Closes the last two automated-coverage gaps of the Moving-Average-Invoice switch (`M_CostRevaluation` with `RevaluationSource=CopyFromCostElement`): **organization costing level** and **negative on-hand stock**. The service under test shipped in earlier, already-merged PRs; this PR adds only the missing coverage.

## 1. Organization costing level — was uncovered entirely

Every pre-existing fixture in `CostRevaluationServiceTest` runs at `CostingLevel.Client` / `OrgId.ANY`, where `CostingLevel.effectiveValue(orgId)` collapses to `ANY`. So the org filter in `CostRevaluationService.queryCurrentCosts` (`backend/de.metas.business/src/main/java/de/metas/costrevaluation/CostRevaluationService.java` — the `.filter(currentCost -> isMatching(currentCost, orgId))` on the `CurrentCostQuery` stream) could never discriminate and had **zero** coverage. That matters wherever a client books at costing level `Organization` with more than one organization: a wrong org filter would revalue the wrong org's costs.

New nested class `CopyFromCostElement_OrganizationCostingLevel` (3 tests) builds exactly that shape — an accounting schema at `CostingLevel.Organization` plus two organizations, each carrying its own source `M_Cost` row for the **same** product with deliberately different numbers (`12.50 / 100` vs `99.00 / 500`):

| Test | Asserts |
|---|---|
| `createLines_seedsOnlyTheDocumentOrgsCost` | exactly **one** line, `AD_Org_ID` = the document's org, `CostingLevel='O'`, that org's price/qty |
| `createLines_seedsTheOtherOrgWhenTheDocumentIsBookedThere` | the mirror case — booking on the other org picks the **other** org's numbers |
| `createDetails_seedsTheTargetCostOfTheDocumentOrgOnly` | the target element's `M_Cost` **and** the single opening anchor exist for the document's org only; the other org's MAI cost stays absent |

The distinct per-org numbers are what make this bind in both directions: an org-blind filter yields 2 lines, a fixed-org filter yields the wrong numbers in one of the two cases.

## 2. Negative on-hand stock — was untested

Sibling of the existing zero-stock coverage (`seedsOneLinePerSourceCurrentCost`: a qty-0 line, not skipped). A negative `M_Cost.CurrentQty` is a **reachable** production state on the source element: the average-costing handlers move on-hand through `CurrentCost.addWeightedAverage`, which — unlike `addToCurrentQtyAndCumulate` — does **not** clamp the result to zero.

**No defect found.** The current behaviour is correct and is pinned by `CopyFromCostElement_NegativeOnHandStock.carriesTheNegativeOnHandIntoTheOpeningBalance`: the switch carries the negative on-hand through unchanged (qty `-40`, cumulated amt `-500.00`, lower-level cost intact), and the opening anchor stays a zero-delta row carrying that negative opening in its `Prev_*` columns.

That is what value-neutrality requires. A negative on-hand at a positive cost price *is* a negative inventory asset value, and it is already on the books; clamping the qty to zero would silently create `price × |qty|` of value with **no GL posting behind it** — and, because the switch posts nothing, nothing to reconcile it against. The test's stated purpose is to fail if anyone later "fixes" the anomaly with a clamp or a positive-qty guard in the seed path.

## Layer choice — why JUnit, not cucumber

The `CopyFromCostElement` **document flow** is already covered end-to-end by the cucumber scenarios in `switchToMovingAverageInvoice.feature`. What was uncovered is not the flow but (a) a plain Java stream predicate over `M_Cost` rows and (b) the seed's arithmetic — no SQL (the query deliberately does *not* filter by org: *"don't filter by OrgId here because we don't know the costing level yet"*), no document engine, no UI. The JUnit layer reaches that mechanism completely, exercising the real `CurrentCostsRepository`, `ProductCostingBL` and `CostSegment`.

Cucumber also cannot express the org-level configuration today: no step definition sets `C_AcctSchema.CostingLevel` or `M_Product_Category_Acct.CostingLevel`, and the cucumber instance has a single **shared** accounting schema — flipping its costing level would change the cost segment of every other scenario in the run. Duplicating the flow in a new cucumber scenario would also violate the no-overlap rule.

## Verification

Module `backend/de.metas.business`, `TZ=Europe/Berlin`, JDK 8 (`jdk8u492-b09`), workspace-local `.m2-local` — plain in-memory JUnit, no Docker stack and no database involved.

**GREEN** — `mvn test -Dtest=CostRevaluationServiceTest`, 2026-07-31 13:54:08 +02:00: `Tests run: 14, Failures: 0, Errors: 0, Skipped: 0` (10 before this PR; +4).

**Full-module regression** — `mvn test` over all of `backend/de.metas.business`, 2026-07-31 13:55:34 +02:00: `Tests run: 552, Failures: 0, Errors: 0, Skipped: 0` (aggregated independently from the surefire XML reports; the 3 org tests and the negative-stock test are among them). Confirms the fixture refactor broke nothing.

**Proof the new tests bind** — production code temporarily perturbed, then reverted (`CostRevaluationService.java` is byte-identical to `intensive_care_hotfix` in this PR):

| Perturbation | Result |
|---|---|
| removed `.filter(currentCost -> isMatching(currentCost, orgId))` in `queryCurrentCosts` | 13:52:22 — `Tests run: 14, Failures: 3` — **all 3** org tests RED (the failure dump shows lines created for *both* `AD_Org_ID`s), and **no other test in the class failed** — which independently confirms the gap was real |
| added `.toZeroIfNegative()` to the seeded source qty | 13:53:11 — `Tests run: 14, Failures: 1` — only the negative-stock test RED: `expected: -40 but was: 0` |

## Fixture changes (behaviour-preserving for existing tests)

`createAcctSchema` / `createProduct` / `seedSourceCurrentCost` / `createCopyFromCostElementHeader` gained schema- and org-aware overloads; the original signatures delegate with the previous values (`CostingLevel.Client`, `OrgId.ANY`, the default schema). The `CostSegmentAndElement` builder that was repeated inline is extracted into a `costSegmentAndElement(...)` helper. **No existing test, assertion or scenario was removed, disabled, weakened or re-tagged.**
