### PR TITLE
PO reactivation guard cleanup: correct a false javadoc invariant, a stale method name, and the reactivate-blocked message text

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5817280_sys_AD_Message_Order_Reactivate_Blocked_Cause.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5817280_sys_AD_Message_Order_Reactivate_Blocked_Cause.sql
@@ -1,0 +1,51 @@
+-- AD_Message 545676 — Order_Reactivate_Blocked_By_PaySchedule_Activity
+-- The text still described the block as "the payment-schedule row is no longer Pending" and told the
+-- buyer to reverse the payments. Both are wrong: the block never looks at Status (an Awaiting_Pay row
+-- with no link does not block, a Pending row carrying M_InOut_ID does), and a payment on its own never
+-- sets M_InOut_ID / C_Invoice_ID, so reversing payments can never lift the block. Name the real cause
+-- instead — a payment-schedule row linked to a goods receipt or a matched vendor invoice — and ask for
+-- those two documents to be reversed.
+
+-- Base row (German base language)
+UPDATE AD_Message
+SET MsgText   = 'Beleg kann nicht reaktiviert werden, da mindestens eine Zeile im Zahlungsplan mit einem Wareneingang oder einer abgeglichenen Eingangsrechnung verknüpft ist. Bitte zuerst die betroffenen Wareneingänge / Rechnungen stornieren.',
+    Updated   = TO_TIMESTAMP('2026-07-31 16:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Message_ID = 545676;
+
+-- de_DE translation
+UPDATE AD_Message_Trl
+SET MsgText      = 'Beleg kann nicht reaktiviert werden, da mindestens eine Zeile im Zahlungsplan mit einem Wareneingang oder einer abgeglichenen Eingangsrechnung verknüpft ist. Bitte zuerst die betroffenen Wareneingänge / Rechnungen stornieren.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-31 16:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Message_ID = 545676
+  AND AD_Language   = 'de_DE';
+
+-- de_CH translation (kept in sync with the German base text, per this message's existing convention)
+UPDATE AD_Message_Trl
+SET MsgText      = 'Beleg kann nicht reaktiviert werden, da mindestens eine Zeile im Zahlungsplan mit einem Wareneingang oder einer abgeglichenen Eingangsrechnung verknüpft ist. Bitte zuerst die betroffenen Wareneingänge / Rechnungen stornieren.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-31 16:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Message_ID = 545676
+  AND AD_Language   = 'de_CH';
+
+-- en_US translation
+UPDATE AD_Message_Trl
+SET MsgText      = 'Cannot reactivate the order because at least one payment-schedule row is linked to a goods receipt or a matched vendor invoice. Please first reverse the goods receipts / invoices concerned.',
+    IsTranslated = 'Y',
+    Updated      = TO_TIMESTAMP('2026-07-31 16:00:03', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy    = 100
+WHERE AD_Message_ID = 545676
+  AND AD_Language   = 'en_US';
+
+-- Re-sync the still-untranslated seed rows (IsTranslated='N', e.g. fr_CH) with the new German base
+-- text. The message loader joins AD_Message_Trl without filtering on IsTranslated, so such a row is
+-- served verbatim to its language and would otherwise keep showing the obsolete wording.
+UPDATE AD_Message_Trl
+SET MsgText   = (SELECT m.MsgText FROM AD_Message m WHERE m.AD_Message_ID = 545676),
+    Updated   = TO_TIMESTAMP('2026-07-31 16:00:04', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Message_ID = 545676
+  AND IsTranslated  = 'N';

--- a/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/interceptor/C_Order.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/paymentschedule/interceptor/C_Order.java
@@ -40,7 +40,10 @@ import org.springframework.stereotype.Component;
  * downstream activity — i.e. at least one pay-schedule line has a goods-receipt link
  * ({@code inoutId != null}) or a matched-invoice link ({@code invoiceId != null}).
  *
- * <p>A {@code Paid} line always implies one of the above, so no separate status guard is needed.
+ * <p>The line's status is irrelevant to the block. A {@code Paid} line does <b>not</b> imply a
+ * downstream link — a proforma prepayment marks its row {@code Paid} with neither ID set — and it cuts
+ * both ways: an {@code Awaiting_Pay} line carrying no link does not block, while a still-{@code Pending}
+ * line carrying an {@code M_InOut_ID} does. The block depends solely on those two IDs.
  *
  * <p>A proforma allocation alone does <b>not</b> block reactivation: the allocation link and its
  * prepayment both survive reactivation (only the derived {@link OrderPaySchedule} rows are dropped),
@@ -61,23 +64,14 @@ public class C_Order
 	@NonNull private final OrderPayScheduleService orderPayScheduleService;
 
 	@DocValidate(timings = ModelValidator.TIMING_BEFORE_REACTIVATE)
-	public void blockReactivateWhenScheduleNotPending(@NonNull final I_C_Order order)
+	public void blockReactivationIfScheduleLinkedToDownstreamDocument(@NonNull final I_C_Order order)
 	{
 		final OrderId orderId = OrderId.ofRepoId(order.getC_Order_ID());
 
 		orderPayScheduleService.getByOrderId(orderId)
-				.filter(this::isBlockedByDownstreamActivity)
+				.filter(OrderPaySchedule::hasLineLinkedToDownstreamDocument)
 				.ifPresent(schedule -> {
 					throw new AdempiereException(MSG_OrderReactivateBlocked).markAsUserValidationError();
 				});
-	}
-
-	/**
-	 * True if the schedule carries committed downstream state that a drop-and-rebuild re-completion would
-	 * orphan: a line linked to a goods receipt or matched invoice.
-	 */
-	private boolean isBlockedByDownstreamActivity(@NonNull final OrderPaySchedule schedule)
-	{
-		return schedule.hasLineLinkedToDownstreamDocument();
 	}
 }

--- a/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/paymentschedule/interceptor/C_Order_Test.java
@@ -73,7 +73,7 @@ class C_Order_Test
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.of(scheduleWithStatuses(OrderPayScheduleStatus.Pending, OrderPayScheduleStatus.Pending)));
 
-		assertThatCode(() -> guard.blockReactivateWhenScheduleNotPending(order))
+		assertThatCode(() -> guard.blockReactivationIfScheduleLinkedToDownstreamDocument(order))
 				.doesNotThrowAnyException();
 	}
 
@@ -89,7 +89,7 @@ class C_Order_Test
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.of(scheduleWithStatuses(OrderPayScheduleStatus.Awaiting_Pay, OrderPayScheduleStatus.Pending)));
 
-		assertThatCode(() -> guard.blockReactivateWhenScheduleNotPending(order))
+		assertThatCode(() -> guard.blockReactivationIfScheduleLinkedToDownstreamDocument(order))
 				.doesNotThrowAnyException();
 	}
 
@@ -106,15 +106,15 @@ class C_Order_Test
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.of(scheduleWithInoutLink(OrderPayScheduleStatus.Awaiting_Pay)));
 
-		assertThatThrownBy(() -> guard.blockReactivateWhenScheduleNotPending(order))
+		assertThatThrownBy(() -> guard.blockReactivationIfScheduleLinkedToDownstreamDocument(order))
 				.isInstanceOf(AdempiereException.class)
 				.hasMessageContaining("Order_Reactivate_Blocked_By_PaySchedule_Activity");
 	}
 
 	/**
-	 * A Paid line always implies a matched-invoice link; bare Paid status alone does not block —
-	 * the block requires the actual downstream link. This test drives the block via an invoiceId on
-	 * a Paid line.
+	 * Bare Paid status alone does not block — a proforma prepayment marks a line Paid with no
+	 * downstream link at all. The block requires the actual link, so this test drives it via an
+	 * invoiceId on a Paid line.
 	 */
 	@Test
 	void rejectReactivate_whenPaidLineHasInvoiceLink()
@@ -123,7 +123,7 @@ class C_Order_Test
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.of(scheduleWithInvoiceLink(OrderPayScheduleStatus.Paid)));
 
-		assertThatThrownBy(() -> guard.blockReactivateWhenScheduleNotPending(order))
+		assertThatThrownBy(() -> guard.blockReactivationIfScheduleLinkedToDownstreamDocument(order))
 				.isInstanceOf(AdempiereException.class)
 				.hasMessageContaining("Order_Reactivate_Blocked_By_PaySchedule_Activity");
 	}
@@ -135,7 +135,7 @@ class C_Order_Test
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.empty());
 
-		assertThatCode(() -> guard.blockReactivateWhenScheduleNotPending(order))
+		assertThatCode(() -> guard.blockReactivationIfScheduleLinkedToDownstreamDocument(order))
 				.doesNotThrowAnyException();
 	}
 
@@ -147,7 +147,7 @@ class C_Order_Test
 		Mockito.when(orderPayScheduleService.getByOrderId(ORDER_ID))
 				.thenReturn(Optional.of(scheduleWithInoutLink(OrderPayScheduleStatus.Pending)));
 
-		assertThatThrownBy(() -> guard.blockReactivateWhenScheduleNotPending(order))
+		assertThatThrownBy(() -> guard.blockReactivationIfScheduleLinkedToDownstreamDocument(order))
 				.isInstanceOf(AdempiereException.class)
 				.hasMessageContaining("Order_Reactivate_Blocked_By_PaySchedule_Activity");
 	}


### PR DESCRIPTION
Follow-up cleanup on the purchase-order reactivation guard (`de.metas.order.paymentschedule.interceptor.C_Order`). A post-merge audit of the code that PR https://github.com/metasfresh/metasfresh/pull/25372 touched found three text-level defects. **No behaviour change** — comments, one method name, and one user-facing message.

## 1. A javadoc invariant that now states the opposite of the truth

The class javadoc still read:

> A `Paid` line always implies one of the above, so no separate status guard is needed.

That sentence was the stated *justification* for the guard having no status check, and it is false. A proforma prepayment marks its pay-schedule row `Paid` while leaving both `M_InOut_ID` and `C_Invoice_ID` unset — and allowing exactly that case is the point of the guard's current shape.

Replaced with the real invariant: status is irrelevant **in both directions** (an `Awaiting_Pay` line with no link does not block; a still-`Pending` line carrying an `M_InOut_ID` does), and the block depends solely on those two IDs. The same false claim was repeated in the unit test's javadoc and is corrected there too.

## 2. Stale method name + a pointless wrapper

`blockReactivateWhenScheduleNotPending` → `blockReactivationIfScheduleLinkedToDownstreamDocument`. The block has not depended on `Pending` status for two iterations, so the old name described something the method no longer does. The new name follows the sibling guard `blockReactivationIfProcessedTransportationOrder` — same table, same `TIMING_BEFORE_REACTIVATE`.

The one-line `isBlockedByDownstreamActivity` pass-through is inlined into the `.filter(...)` as a method reference on `OrderPaySchedule`; the wrapper added nothing over `OrderPaySchedule.hasLineLinkedToDownstreamDocument`, which carries its own javadoc.

## 3. The reactivate-blocked message misdescribed what triggers the block

`AD_Message` `Order_Reactivate_Blocked_By_PaySchedule_Activity` read *"… because at least one payment-schedule row is no longer Pending. Please first reverse the goods receipts / invoices / payments."* Both halves were wrong:

- **`Status` is not consulted.** An `Awaiting_Pay` row with no link does not block, while a `Pending` row carrying an `M_InOut_ID` does — so "no longer Pending" is neither necessary nor sufficient.
- **Payments never block.** A payment alone never sets `M_InOut_ID` / `C_Invoice_ID`, so reversing payments cannot lift the block; listing them sends the buyer down a dead end.

New migration `5817280_sys_AD_Message_Order_Reactivate_Blocked_Cause.sql` rewrites all four language rows to name the actual cause — a payment-schedule row linked to a goods receipt or a matched vendor invoice — and to ask for those two documents to be reversed:

| Row | After |
|---|---|
| base / `de_DE` / `de_CH` | Beleg kann nicht reaktiviert werden, da mindestens eine Zeile im Zahlungsplan mit einem Wareneingang oder einer abgeglichenen Eingangsrechnung verknüpft ist. Bitte zuerst die betroffenen Wareneingänge / Rechnungen stornieren. |
| `en_US` | Cannot reactivate the order because at least one payment-schedule row is linked to a goods receipt or a matched vendor invoice. Please first reverse the goods receipts / invoices concerned. |

It also re-syncs the rows still at `IsTranslated='N'` (currently `fr_CH`) with the German base text: `MessagesMapRepository` joins `AD_Message_Trl` **without** filtering on `IsTranslated`, so such a row is served verbatim to its language and would otherwise keep showing the obsolete wording.

Shipped as a **new** script rather than an edit of the already-applied `5817130`.

## Verification

Local, 2026-07-31, against a local Docker infrastructure stack:

| What | Result |
|---|---|
| `mvn_build.sh --skip-tests` | `✓ backend build succeeded` |
| Migration `5817280` applied + text verified by query | 4 language rows + base as tabled above |
| `C_Order_Test` | 6 run, 0 failures |
| `OrderPayScheduleLCServiceTest` | 13 run, 0 failures |
| `OrderTest` (`de.metas.swat.base`) | 10 run, 0 failures |
| cucumber `order/orderReactivatePayScheduleGuard.feature` | 8 scenarios |

The existing tests assert the message **key**, not its text, so none needed changing and no assertion was touched.
