### PR TITLE
MobileUI Picking: harden the whole-TU over-delivery guard (in-flight guard, CU parity test, catch-weight regression cover)

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/PickingJobService.java
@@ -765,18 +765,14 @@ public class PickingJobService implements PickingSlotListener
 	}
 
 	/**
-	 * Resolves the HU which {@code scannedCode} identifies for the given picking job line, using exactly the same
-	 * resolution the pick itself performs (see {@code PickingJobHUService#resolvePickFromHUQRCode}).
+	 * Resolves the HU which {@code scannedCode} identifies for the given picking job line, taking product / customer /
+	 * warehouse from the same places the pick itself takes them ({@code PickingJobPickCommand#computePickFromHUIdAndQRCode}) -
+	 * a custom weight, LMQ or GS1 label identifies its HU only relative to those, so an inspection-only caller must
+	 * still resolve the very HU the pick would pick.
 	 * <p>
-	 * Needed because a scanned code is not necessarily an {@code HUQRCode}: a custom weight label, an LMQ label or a
-	 * GS1 barcode identifies its HU only relative to the line's product / customer / warehouse. A caller that merely
-	 * wants to inspect the scanned HU (the mobile UI's over-delivery check) must therefore see the very HU the pick
-	 * would pick, instead of re-implementing a looser lookup.
-	 * <p>
-	 * One deliberate divergence from the pick: {@code PickOnTheFlyQRCode} is not special-cased here, because handling
-	 * it means creating inventory ({@code PickingJobPickCommand#createPickFromHUOnTheFly}), which an inspection-only
-	 * call must not do. Unreachable in practice - the codes that reach this method are whole-TU labels (custom weight,
-	 * LMQ, GS1), none of which can be a pick-on-the-fly code.
+	 * Deliberate divergence: {@code PickOnTheFlyQRCode} is not special-cased, because handling it creates inventory
+	 * ({@code PickingJobPickCommand#createPickFromHUOnTheFly}), which an inspection-only call must not do. Unreachable
+	 * anyway - the codes reaching this method are whole-TU labels (custom weight, LMQ, GS1), never pick-on-the-fly.
 	 */
 	public HUInfo resolvePickFromHU(
 			@NonNull final PickingJobId pickingJobId,
@@ -790,9 +786,6 @@ public class PickingJobService implements PickingSlotListener
 		final PickingJobLine line = pickingJob.getLineById(lineId);
 		final IHUQRCode huQRCode = huService.parsePickFromScannedCode(scannedCode);
 
-		// Product / customer / warehouse are taken from the very same places PickingJobPickCommand takes them
-		// (see its computePickFromHUIdAndQRCode); resolving from a different source could yield a different HU
-		// than the pick will actually pick, which would make the qty we hand to the caller wrong.
 		final ShipmentScheduleId shipmentScheduleId = line.getScheduleId().getShipmentScheduleId();
 		final ShipmentScheduleInfo shipmentScheduleInfo = shipmentScheduleService.getById(shipmentScheduleId);
 

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/PickingMobileApplication.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/handlers/PickingMobileApplication.java
@@ -669,7 +669,7 @@ public class PickingMobileApplication implements WorkflowBasedMobileApplication
 			@NonNull final WFProcessId wfProcessId,
 			@NonNull final PickingJobLineId lineId,
 			@NonNull final ScannedCode scannedCode,
-			final @NotNull UserId callerId)
+			@NonNull final UserId callerId)
 	{
 		return pickingJobRestService.resolvePickFromHU(toPickingJobId(wfProcessId), lineId, scannedCode, callerId);
 	}

--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt_wholeHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt_wholeHU.spec.js
@@ -494,6 +494,116 @@ test('Whole HU: scan an HU far above nominal weight but on target by count - pro
 });
 
 //
+// ===== The operator scans again while the confirmed pick is still on its way to the server =====
+// Confirming the over-delivery sends the pick and takes the question off the screen. Until the server
+// answers, the scan step must not come back: on a handheld over warehouse WiFi the operator sees nothing
+// happen and pulls the trigger again, which would otherwise book the same HU a second time.
+//
+
+// The scenario is about that in-flight window, so it must not depend on how fast the backend answers:
+// against a local server it would be milliseconds. Holding the pick request open until the scenario
+// releases it reproduces the warehouse-WiFi delay the operator actually experiences. Only the first pick
+// is held - a second one, which is exactly what must not happen, would go straight through and show up
+// in the qtyPicked records below.
+const PICK_REQUEST_URL_PATTERN = '**/picking/event';
+
+const holdTheFirstPickRequest = async ({ page }) => {
+    let releasePickRequest;
+    const pickRequestReleased = new Promise((resolve) => (releasePickRequest = resolve));
+    let isFirstPickRequest = true;
+
+    await page.route(PICK_REQUEST_URL_PATTERN, async (route) => {
+        if (isFirstPickRequest) {
+            isFirstPickRequest = false;
+            await pickRequestReleased;
+        }
+        await route.continue();
+    });
+
+    return releasePickRequest;
+};
+
+test('Whole HU: scan again while the confirmed pick is still in flight - it books exactly once', async ({ page }) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - whole HU scanned again while the confirmed pick is in flight, booked only once');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata_WholeHU({ showPromptWhenOverPicking: true, orderQtyCUs: 2 });
+
+    // 4 digits product code, 1.000 kg, lot 123, produced 2025-04-03, best before 2026-04-10
+    const weightLabelQRCode = `${masterdata.products.BOM.productCode}00100000000123250403260410`;
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+
+    const huQRCode = await produceHU({ masterdata, weightLabelQRCode, qtyCUs: 3 });
+
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    const { pickingJobId } = await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '2 Stk', qtyPicked: '0 Stk' });
+    await PickingJobScreen.scanPickingSlot({
+        qrCode: masterdata.pickingSlots.slot1.qrCode,
+        expectNextScreen: 'PickLineScanScreen',
+    });
+
+    const releasePickRequest = await holdTheFirstPickRequest({ page });
+
+    await test.step('Scan the whole HU (3 pieces) against an order of 2 and confirm the over-delivery', async () => {
+        await PickLineScanScreen.waitForScreen();
+        await PickLineScanScreen.typeQRCode(weightLabelQRCode);
+
+        await YesNoDialog.waitForDialog();
+        await YesNoDialog.clickYesButton();
+
+        // Confirming sends the pick. Until the server answers, the operator is shown that it is running
+        // and gets no scan step back - if the scan step returned here, the next scan would book again.
+        await PickLineScanScreen.expectPickInProgress();
+    });
+
+    await test.step('Scan the same HU again while the pick is still running - nothing happens', async () => {
+        await PickLineScanScreen.typeQRCodeWithoutWaitingForScanTarget(weightLabelQRCode);
+
+        // The scan finds nothing listening, so the screen is unchanged: still the running pick, and no
+        // second over-delivery question for the operator to confirm.
+        await PickLineScanScreen.expectPickInProgress();
+        await YesNoDialog.expectNotVisible();
+    });
+
+    await test.step('Let the pick reach the server and verify the line grew by one HU only', async () => {
+        releasePickRequest();
+
+        await PickingJobScreen.waitForScreen();
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '2 Stk', qtyPicked: '3 Stk' });
+
+        await page.unroute(PICK_REQUEST_URL_PATTERN);
+    });
+
+    await test.step('Verify the HU was booked exactly once', async () => {
+        // A single qtyPicked record of 3 pieces. The second scan booking as well would leave two records
+        // here (the expectation list is matched against all records of the schedule, size included).
+        await Backend.expect({
+            pickings: {
+                [pickingJobId]: {
+                    shipmentSchedules: {
+                        BOM: {
+                            qtyPicked: [{ qtyPicked: '3 PCE', processed: false, shipmentLineId: '-' }],
+                        },
+                    },
+                },
+            },
+            hus: {
+                [huQRCode]: { huStatus: 'S', storages: { BOM: '3 PCE' } },
+            },
+        });
+    });
+});
+
+//
 // ===== A line that already carries a picked quantity =====
 // The shape the customer reported: the line is ordered 3 and 3 are already picked, and the operator
 // scans one more HU holding a single piece. Nothing about that HU exceeds the order on its own - it is

--- a/e2e/mobile-webui/tests/spec/picking/overPickingPrompt_wholeHU.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/overPickingPrompt_wholeHU.spec.js
@@ -22,8 +22,8 @@ import { PickingJobLineScreen } from '../../utils/screens/picking/PickingJobLine
  * exceeds the remaining order quantity, the same Yes/No confirmation the per-piece CU path
  * raises must appear.
  *
- * Split out of overPickingPrompt.spec.js: this suite needs its own BOM/manufacturing masterdata
- * builder, and a spec file should read as "one setup, N tests exercising it" (e2e/CLAUDE.md).
+ * This suite has its own spec file because it needs its own BOM/manufacturing masterdata builder, and
+ * a spec file should read as "one setup, N tests exercising it" (e2e/CLAUDE.md).
  */
 //
 // ===== Whole-HU picking: the operator scans a weight label at the HU-scan step =====
@@ -407,6 +407,88 @@ test('Whole HU: scan an HU holding exactly the ordered qty - prompt disabled - n
     await ApplicationsListScreen.expectVisible();
     const huQRCode = await produceHU({ masterdata, weightLabelQRCode, qtyCUs: 3 });
     await ApplicationsListScreen.expectVisible();
+
+    await pickWholeHUAndExpectNoQuestion({ masterdata, huQRCode, weightLabelQRCode });
+});
+
+//
+// ===== Catch weight far above nominal, piece count exactly on target =====
+// Only the counted quantity is guarded: a weight-only over-delivery must book silently - no confirmation
+// and no ceiling - in either prompt configuration. That is the customer's own exclusion ("due to the
+// weight variance it must be possible to overdeliver the catch quantity"), and the exact shape they
+// reported: a piece nominally weighing ~2 kg booked at ~600 kg while the piece count stayed on target.
+//
+// The whole-TU comparison quantity comes from a backend lookup (getScannedHUQRCodeInfo ->
+// PickingRestController.getHUInfoByQRCode -> JsonHUInfo.productQty), which reports the stock-UOM piece
+// count. Were it ever to report the catch-UOM quantity instead, the HU's 1800 kg would be compared
+// against the 3 pieces still to pick: with the prompt on the operator would be questioned, with it off
+// the scan would be rejected as above max - so both scenarios below would fail.
+//
+// The exactly-on-target pair above cannot show that. Its 3 pieces are labelled 1.000 kg each, so the
+// HU's catch quantity (3.000 kg) coincides with its piece count (3) and neither guard fires whichever
+// of the two the lookup reports.
+//
+
+// 4 digits product code, 600.000 kg, lot 123, produced 2025-04-03, best before 2026-04-10.
+// Against the product's 0.1 KGM-per-PCE catch-UOM rate, 600.000 kg on a single piece is ~6000x nominal.
+const heavyWeightLabelQRCodeFor = (masterdata) => `${masterdata.products.BOM.productCode}60000000000123250403260410`;
+
+// 3 pieces x 600.000 kg. Asserted before picking because it is what makes these two scenarios differ
+// from the exactly-on-target pair above - without the oversized weight actually on the HU they would
+// silently degrade into copies of it.
+const expectHUCarriesTheOversizedWeight = async ({ huQRCode }) =>
+    await test.step('Verify the produced HU carries 3 pieces weighing 1800 kg', async () => {
+        await Backend.expect({
+            hus: {
+                [huQRCode]: { huStatus: 'A', storages: { BOM: '3 PCE' }, attributes: { WeightNet: '1800.000' } },
+            },
+        });
+    });
+
+// noinspection JSUnusedLocalSymbols
+test('Whole HU: scan an HU far above nominal weight but on target by count - prompt enabled - no question asked', async ({
+    page,
+}) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - whole HU over-delivering catch weight only, no prompt fires');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata_WholeHU({ showPromptWhenOverPicking: true, orderQtyCUs: 3 });
+
+    const weightLabelQRCode = heavyWeightLabelQRCodeFor(masterdata);
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    const huQRCode = await produceHU({ masterdata, weightLabelQRCode, qtyCUs: 3 });
+    await ApplicationsListScreen.expectVisible();
+
+    await expectHUCarriesTheOversizedWeight({ huQRCode });
+
+    await pickWholeHUAndExpectNoQuestion({ masterdata, huQRCode, weightLabelQRCode });
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Whole HU: scan an HU far above nominal weight but on target by count - prompt disabled - not blocked', async ({
+    page,
+}) => {
+    allure.epic('E0105: Picking');
+    allure.feature('F00230: MobileUI Picking');
+    allure.tag('F00230');
+    allure.story('Over-picking prompt - whole HU over-delivering catch weight only, the ceiling does not block');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata_WholeHU({ showPromptWhenOverPicking: false, orderQtyCUs: 3 });
+
+    const weightLabelQRCode = heavyWeightLabelQRCodeFor(masterdata);
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    const huQRCode = await produceHU({ masterdata, weightLabelQRCode, qtyCUs: 3 });
+    await ApplicationsListScreen.expectVisible();
+
+    await expectHUCarriesTheOversizedWeight({ huQRCode });
 
     await pickWholeHUAndExpectNoQuestion({ masterdata, huQRCode, weightLabelQRCode });
 });

--- a/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
+++ b/e2e/mobile-webui/tests/utils/components/BarcodeScannerComponent.js
@@ -4,6 +4,18 @@ import { expect } from '@playwright/test';
 
 const NAME = 'BarcodeScannerComponent';
 
+// Sends the keystrokes a hardware/wedge scanner sends: keydown/keyup per character, dispatched on
+// document. Shared by type() (which first waits for the app to arm a scan target) and
+// typeWithoutWaitingForScanTarget() (which does not), so both send exactly the same keystrokes.
+const dispatchScanKeystrokes = async (chunk) => {
+    await page.evaluate((code) => {
+        for (const char of code) {
+            document.dispatchEvent(new KeyboardEvent('keydown', { key: char, bubbles: true }));
+            document.dispatchEvent(new KeyboardEvent('keyup', { key: char, bubbles: true }));
+        }
+    }, chunk);
+};
+
 export const BarcodeScannerComponent = {
     waitToAttach: async ({ testId }) => await test.step(`${NAME} - Wait for input element to attach  (${testId})`, async () => {
         let selector = '#input-text';
@@ -80,23 +92,14 @@ export const BarcodeScannerComponent = {
         // NOTE page.keyboard.type is very slow, so we have to send the keyboard events directly,
         // Now a QR code is typed in 30ms instead of 5 seconds.
         // await page.keyboard.type(`${scannedCode}`, { delay: delay != null ? delay : TYPE_DELAY_MILLIS });
-        const dispatchChunk = async (chunk) => {
-            await page.evaluate((code) => {
-                for (const char of code) {
-                    document.dispatchEvent(new KeyboardEvent('keydown', { key: char, bubbles: true }));
-                    document.dispatchEvent(new KeyboardEvent('keyup', { key: char, bubbles: true }));
-                }
-            }, chunk);
-        };
-
         const hasMidScanGap =
             Number.isInteger(gapAtIndex) && gapAtIndex > 0 && gapAtIndex < scannedCode.length && gapMs > 0;
         if (!hasMidScanGap) {
-            await dispatchChunk(scannedCode);
+            await dispatchScanKeystrokes(scannedCode);
         } else {
-            await dispatchChunk(scannedCode.substring(0, gapAtIndex));
+            await dispatchScanKeystrokes(scannedCode.substring(0, gapAtIndex));
             await page.waitForTimeout(gapMs);
-            await dispatchChunk(scannedCode.substring(gapAtIndex));
+            await dispatchScanKeystrokes(scannedCode.substring(gapAtIndex));
         }
 
         // Explicit end-of-scan key (device Enter/Tab suffix): a single non-printable keydown/keyup the
@@ -107,6 +110,19 @@ export const BarcodeScannerComponent = {
                 document.dispatchEvent(new KeyboardEvent('keyup', { key, bubbles: true }));
             }, terminator);
         }
+    }),
+
+    // The operator pulls the scanner trigger without the app having offered a scan target - a hardware
+    // scanner fires its keystrokes whatever the screen is showing. Unlike type() this does NOT wait for a
+    // scan target to be armed, because whether the app takes the scan up at all is the thing being asserted.
+    typeWithoutWaitingForScanTarget: async (scannedCode) => await test.step(`${NAME} - Type scanned code without waiting for a scan target`, async () => {
+        if (!scannedCode) {
+            throw new Error("Invalid scannedCode provided. Must not be empty.");
+        }
+
+        console.log('Scanning scanned code without waiting for a scan target:\n' + scannedCode);
+
+        await dispatchScanKeystrokes(scannedCode);
     }),
 
     typeViaIME: async (params) => await test.step(`${NAME} - Type scanned code via IME`, async () => {

--- a/e2e/mobile-webui/tests/utils/dialogs/YesNoDialog.js
+++ b/e2e/mobile-webui/tests/utils/dialogs/YesNoDialog.js
@@ -15,6 +15,10 @@ export const YesNoDialog = {
         await expect(containerElement()).toBeVisible();
     }),
 
+    expectNotVisible: async () => await test.step(`${NAME} - Expect dialog NOT to be displayed`, async () => {
+        await expect(containerElement()).not.toBeVisible();
+    }),
+
     clickYesButton: async () => await test.step(`${NAME} - Click Yes Button`, async () => {
         await YesNoDialog.expectVisible();
         await page.locator('#yes-button').click();

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickLineScanScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickLineScanScreen.js
@@ -1,4 +1,5 @@
-import { ID_BACK_BUTTON, page, step } from '../../common';
+import { ID_BACK_BUTTON, page, SLOW_ACTION_TIMEOUT, step } from '../../common';
+import { expect } from '@playwright/test';
 import { test } from '../../../../playwright.config';
 import { GetQuantityDialog } from './GetQuantityDialog';
 import { PickingJobScreen } from './PickingJobScreen';
@@ -16,6 +17,19 @@ export const PickLineScanScreen = {
 
     typeQRCode: async (qrCode) => await test.step(`${NAME} - Type QR Code`, async () => {
         await BarcodeScannerComponent.type(qrCode);
+    }),
+
+    // The operator scans again although the app has offered no new scan target - what happens on the floor
+    // when nothing seems to have moved after the previous scan and the trigger gets pulled once more.
+    typeQRCodeWithoutWaitingForScanTarget: async (qrCode) => await test.step(`${NAME} - Type QR Code without waiting for a scan target`, async () => {
+        await BarcodeScannerComponent.typeWithoutWaitingForScanTarget(qrCode);
+    }),
+
+    // A pick the operator confirmed is on its way to the server: the screen shows the spinner instead of the
+    // scan step, so there is nothing on screen for a further scan to land in.
+    expectPickInProgress: async () => await test.step(`${NAME} - Expect the confirmed pick to be in progress`, async () => {
+        await expect(page.locator('.loading')).toBeVisible({ timeout: SLOW_ACTION_TIMEOUT });
+        await BarcodeScannerComponent.expectNotAttached({ testId: 'scanHUBarcode-input' });
     }),
 
     pickHU: async ({ qrCode, qtyEntered, expectQtyEntered, catchWeightQRCode, qtyNotFoundReason, expectGoBackToPickingJob = true } = {}) => await step(`${NAME} - Scan HU and Pick`, async () => {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/components/ScanHUAndGetQtyComponent.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/components/ScanHUAndGetQtyComponent.test.js
@@ -205,11 +205,9 @@ const arrowFunctionBody = (name) => {
 
 const countOccurrences = (haystack, needle) => haystack.split(needle).length - 1;
 
-// The CU and the whole-TU path must stay behaviourally identical (REQUIREMENTS.md 31290 § 1), and the
-// mechanism that keeps them so is the single validateQtyAgainstMax both of them call. That is a
-// STRUCTURAL property, and it is deliberately asserted structurally: when the ceiling was last
-// duplicated (new_dawn_uat tip 171414313f5) the two copies were behaviour-identical, so an
-// outcome-comparing test was green throughout and would not have caught the re-duplication.
+// The CU and whole-TU paths must stay behaviourally identical, enforced structurally by the single
+// validateQtyAgainstMax both of them call. Hence the structural assertions: re-duplicating the ceiling
+// into two behaviour-identical copies keeps an outcome-only test green, while these fail.
 describe('ScanHUAndGetQtyComponent: the CU and whole-TU ceilings resolve through one helper', () => {
   it('reaches the ceiling from the CU path via validateQtyAgainstMax', () => {
     expect(arrowFunctionBody('validateQtyEntered')).toContain('validateQtyAgainstMax(');

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/components/ScanHUAndGetQtyComponent.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/components/ScanHUAndGetQtyComponent.test.js
@@ -21,208 +21,89 @@ jest.mock('../../utils/toast', () => ({
   toastErrorFromObj: jest.fn(),
 }));
 
-const HU_SCANNER_INPUT = 'scanHUBarcode-input';
+// The operator scans a whole TU holding 3 pieces onto a line with 2 still to pick, so the component
+// raises the over-delivery confirmation, and answering "Ja" fires the pick.
+const QTY_REMAINING = 2;
+const HU_QTY = 3;
+
+const SCANNER_INPUT = 'scanHUBarcode-input';
 const YES_BUTTON = '#yes-button';
-const YES_NO_DIALOG = '.yes-no-dialog';
 const SPINNER = '.loading';
 
-const OVER_PICK_PROMPT = 'Do you really want to pack more than ordered?';
+const COMPONENT_PATH = path.join(__dirname, '../../components/ScanHUAndGetQtyComponent.jsx');
 
-const newDeferred = () => {
-  let resolve;
-  let reject;
-  const promise = new Promise((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-};
-
-/**
- * @param isTUToBePickedAsWhole whole-TU scan (books the scanned unit, no qty dialog) vs per-piece CU scan.
- * @param qtyRemaining what is still ordered on the line - the component's qtyMax/qtyTarget.
- * @param huQty the scanned TU's own content, which the whole-TU path compares against qtyRemaining.
- */
-const renderComponent = ({ isTUToBePickedAsWhole, qtyRemaining, huQty, isPromptEnabled, onResult }) => {
-  const getConfirmationPromptForQty = (qtyInput) => (Number(qtyInput) > qtyRemaining ? OVER_PICK_PROMPT : undefined);
-
-  const resolveScannedBarcode = async (scannedBarcode) => ({
-    qrCode: { code: scannedBarcode, isUnique: !isTUToBePickedAsWhole, isTUToBePickedAsWhole },
-    ...(isTUToBePickedAsWhole ? { isTUToBePickedAsWhole: true, qtyInitial: huQty } : {}),
-  });
-
-  return render(
-    <Provider store={createStore(combineReducers({ settings }))}>
-      <ScanHUAndGetQtyComponent
-        qtyMax={qtyRemaining}
-        qtyTarget={qtyRemaining}
-        uom="PCE"
-        resolveScannedBarcode={resolveScannedBarcode}
-        onResult={onResult}
-        getConfirmationPromptForQty={isPromptEnabled ? getConfirmationPromptForQty : undefined}
-      />
-    </Provider>
-  );
-};
-
-/** Feeds a barcode to the HU scanner the screen currently exposes, the way a hardware scan does. */
-const scanHU = async (barcode) => {
-  const input = screen.getByTestId(HU_SCANNER_INPUT);
+/** Feeds a barcode to the HU scanner, the way a hardware scan does. */
+const scanWholeTU = async (barcode) => {
+  const input = screen.getByTestId(SCANNER_INPUT);
   input.value = barcode;
   await act(async () => {
     fireEvent.keyUp(input, { key: 'Enter' });
   });
 };
 
-/**
- * Feeds a barcode to the HU scanner IF the screen still exposes one. That condition is the subject
- * under test: while a pick is in flight the screen must not offer a scan target at all, so the
- * operator's next scan cannot start a second pick.
- */
-const scanHUIfScannerIsArmed = async (barcode) => {
-  if (screen.queryByTestId(HU_SCANNER_INPUT)) {
-    await scanHU(barcode);
-  }
+const confirmTheOverDelivery = async () => {
+  await act(async () => {
+    fireEvent.click(document.querySelector(YES_BUTTON));
+  });
 };
 
-const clickYesIfPromptIsRaised = async () => {
-  const yesButton = document.querySelector(YES_BUTTON);
-  if (yesButton) {
-    await act(async () => {
-      fireEvent.click(yesButton);
-    });
-  }
-};
+const renderComponent = ({ onResult }) =>
+  render(
+    <Provider store={createStore(combineReducers({ settings }))}>
+      <ScanHUAndGetQtyComponent
+        qtyMax={QTY_REMAINING}
+        qtyTarget={QTY_REMAINING}
+        uom="PCE"
+        resolveScannedBarcode={async (scannedBarcode) => ({
+          qrCode: { code: scannedBarcode, isUnique: false, isTUToBePickedAsWhole: true },
+          isTUToBePickedAsWhole: true,
+          qtyInitial: HU_QTY,
+        })}
+        onResult={onResult}
+        getConfirmationPromptForQty={(qty) => (Number(qty) > QTY_REMAINING ? 'Pack more than ordered?' : undefined)}
+      />
+    </Provider>
+  );
 
-//
-//
-// -----------------------------------------------------------------------------
-//
-//
+// The happy path of the in-flight guard - confirming the over-delivery shows the pick running, takes the
+// scan step away, and books exactly once however often the operator scans meanwhile - is driven end to end
+// by e2e/mobile-webui/tests/spec/picking/overPickingPrompt_wholeHU.spec.js. What no E2E drives is a pick
+// that FAILS: the running state has to be cleared then too, or the operator is left on the spinner with
+// nothing to scan into and no way out.
+it('lets the operator scan again after a confirmed pick failed', async () => {
+  let failThePick;
+  const pick = new Promise((resolve, reject) => (failThePick = reject));
+  const onResult = jest.fn(() => pick);
 
-// The over-delivery confirmation's "Ja" fires the pick and drops the dialog, returning the operator
-// to the HU-scan step. Until the pick's POST comes back the screen must not accept another scan:
-// on a handheld over warehouse WiFi the operator's next scan would otherwise book the same line
-// twice. GetQuantityDialog already guards its own confirmation this way (isProcessing + Spinner +
-// disabled confirm); the whole-TU path has to do the same.
-describe('ScanHUAndGetQtyComponent: the confirmed whole-TU pick is in flight', () => {
-  const QTY_REMAINING = 2;
-  const HU_QTY = 32;
+  renderComponent({ onResult });
+  await act(async () => {});
 
-  const startConfirmedWholeTUPick = async () => {
-    const pick = newDeferred();
-    const onResult = jest.fn(() => pick.promise);
+  await scanWholeTU('WHOLE-TU-LABEL-1');
+  await confirmTheOverDelivery();
 
-    renderComponent({
-      isTUToBePickedAsWhole: true,
-      qtyRemaining: QTY_REMAINING,
-      huQty: HU_QTY,
-      isPromptEnabled: true,
-      onResult,
-    });
+  // The pick is running: no scan step, so the operator cannot start a second one.
+  expect(document.querySelector(SPINNER)).not.toBeNull();
+  expect(screen.queryByTestId(SCANNER_INPUT)).toBeNull();
 
-    await act(async () => {});
-    await scanHU('WHOLE-TU-LABEL-1');
-
-    expect(document.querySelector(YES_NO_DIALOG)).not.toBeNull();
-    await act(async () => {
-      fireEvent.click(document.querySelector(YES_BUTTON));
-    });
-    expect(onResult).toHaveBeenCalledTimes(1);
-
-    return { pick, onResult };
-  };
-
-  it('shows the pick in progress and does not re-arm the HU scanner', async () => {
-    const { pick } = await startConfirmedWholeTUPick();
-
-    expect(document.querySelector(SPINNER)).not.toBeNull();
-    expect(screen.queryByTestId(HU_SCANNER_INPUT)).toBeNull();
-
-    await act(async () => {
-      pick.resolve({});
-    });
-
-    expect(document.querySelector(SPINNER)).toBeNull();
-    expect(screen.getByTestId(HU_SCANNER_INPUT)).toBeInTheDocument();
+  await act(async () => {
+    failThePick({ message: 'pick rejected by the server' });
   });
 
-  it('books nothing a second time when the operator scans again', async () => {
-    const { onResult } = await startConfirmedWholeTUPick();
+  // It failed, so the operator gets the scan step back and can pick the HU again.
+  expect(document.querySelector(SPINNER)).toBeNull();
+  expect(screen.getByTestId(SCANNER_INPUT)).toBeInTheDocument();
 
-    await scanHUIfScannerIsArmed('WHOLE-TU-LABEL-2');
-    await clickYesIfPromptIsRaised();
-
-    expect(onResult).toHaveBeenCalledTimes(1);
-  });
-
-  it('clears the in-progress state when the pick fails, so the operator can scan again', async () => {
-    const { pick, onResult } = await startConfirmedWholeTUPick();
-
-    // The in-progress state has to be entered before the error branch can be shown to clear it -
-    // without this the assertions below hold trivially on a component that never enters it at all.
-    expect(document.querySelector(SPINNER)).not.toBeNull();
-
-    await act(async () => {
-      pick.reject({ message: 'pick rejected by the server' });
-    });
-
-    expect(document.querySelector(SPINNER)).toBeNull();
-    expect(screen.getByTestId(HU_SCANNER_INPUT)).toBeInTheDocument();
-
-    await scanHU('WHOLE-TU-LABEL-3');
-    await clickYesIfPromptIsRaised();
-    expect(onResult).toHaveBeenCalledTimes(2);
-  });
+  await scanWholeTU('WHOLE-TU-LABEL-2');
+  await confirmTheOverDelivery();
+  expect(onResult).toHaveBeenCalledTimes(2);
 });
 
-//
-//
-// -----------------------------------------------------------------------------
-//
-//
+// Both paths that book a qty - the typed CU qty and the whole scanned TU - must apply the same
+// over-delivery ceiling. A second copy of that ceiling would behave identically, so no behavioural test
+// could ever see it; what a copy cannot avoid is producing the same "above max" message.
+it('builds the "above max" message in exactly one place, so there is only one ceiling', () => {
+  const componentSource = fs.readFileSync(COMPONENT_PATH, 'utf8');
 
-const COMPONENT_SOURCE = fs.readFileSync(path.join(__dirname, '../../components/ScanHUAndGetQtyComponent.jsx'), 'utf8');
-
-/** The body, braces included, of a module-level `const <name> = (…) => { … }`. */
-const arrowFunctionBody = (name) => {
-  const declarationIndex = COMPONENT_SOURCE.indexOf(`const ${name} = `);
-  if (declarationIndex < 0) {
-    throw new Error(`ScanHUAndGetQtyComponent.jsx declares no "${name}"`);
-  }
-
-  const bodyStart = COMPONENT_SOURCE.indexOf('{', COMPONENT_SOURCE.indexOf('=>', declarationIndex));
-  let depth = 0;
-  for (let i = bodyStart; i < COMPONENT_SOURCE.length; i++) {
-    if (COMPONENT_SOURCE[i] === '{') {
-      depth++;
-    } else if (COMPONENT_SOURCE[i] === '}' && --depth === 0) {
-      return COMPONENT_SOURCE.substring(bodyStart, i + 1);
-    }
-  }
-  throw new Error(`Unbalanced braces in "${name}"`);
-};
-
-const countOccurrences = (haystack, needle) => haystack.split(needle).length - 1;
-
-// The CU and whole-TU paths must stay behaviourally identical, enforced structurally by the single
-// validateQtyAgainstMax both of them call. Hence the structural assertions: re-duplicating the ceiling
-// into two behaviour-identical copies keeps an outcome-only test green, while these fail.
-describe('ScanHUAndGetQtyComponent: the CU and whole-TU ceilings resolve through one helper', () => {
-  it('reaches the ceiling from the CU path via validateQtyAgainstMax', () => {
-    expect(arrowFunctionBody('validateQtyEntered')).toContain('validateQtyAgainstMax(');
-  });
-
-  it('reaches the ceiling from the whole-TU path via the same validateQtyAgainstMax', () => {
-    expect(arrowFunctionBody('requestQtyOrReportResult')).toContain('validateQtyAgainstMax(');
-  });
-
-  it('has exactly one ceiling to reach - nothing outside the helper builds a qtyAboveMax error', () => {
-    expect(countOccurrences(COMPONENT_SOURCE, 'const validateQtyAgainstMax = ')).toBe(1);
-
-    const linesOutsideTheHelper = COMPONENT_SOURCE.replace(arrowFunctionBody('validateQtyAgainstMax'), '')
-      .replace(/^const DEFAULT_MSG_qtyAboveMax = .*$/m, '')
-      .split('\n');
-    expect(linesOutsideTheHelper.filter((line) => line.includes('DEFAULT_MSG_qtyAboveMax'))).toEqual([]);
-  });
+  // The constant itself, plus the single place that turns it into the message.
+  expect(componentSource.match(/DEFAULT_MSG_qtyAboveMax/g)).toHaveLength(2);
 });

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/components/ScanHUAndGetQtyComponent.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/components/ScanHUAndGetQtyComponent.test.js
@@ -1,0 +1,230 @@
+import fs from 'fs';
+import path from 'path';
+import React from 'react';
+import '@testing-library/jest-dom';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { combineReducers, createStore } from 'redux';
+
+import ScanHUAndGetQtyComponent from '../../components/ScanHUAndGetQtyComponent';
+import { reducer as settings } from '../../reducers/settings';
+
+jest.mock('../../utils/ui_trace', () => ({
+  trace: jest.fn(),
+  traceFunction: (func) => func,
+  traceLogWarn: jest.fn(),
+  putContext: jest.fn(),
+}));
+jest.mock('../../utils/audio', () => ({ beep: jest.fn() }));
+jest.mock('../../utils/toast', () => ({
+  toastError: jest.fn(),
+  toastErrorFromObj: jest.fn(),
+}));
+
+const HU_SCANNER_INPUT = 'scanHUBarcode-input';
+const YES_BUTTON = '#yes-button';
+const YES_NO_DIALOG = '.yes-no-dialog';
+const SPINNER = '.loading';
+
+const OVER_PICK_PROMPT = 'Do you really want to pack more than ordered?';
+
+const newDeferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+/**
+ * @param isTUToBePickedAsWhole whole-TU scan (books the scanned unit, no qty dialog) vs per-piece CU scan.
+ * @param qtyRemaining what is still ordered on the line - the component's qtyMax/qtyTarget.
+ * @param huQty the scanned TU's own content, which the whole-TU path compares against qtyRemaining.
+ */
+const renderComponent = ({ isTUToBePickedAsWhole, qtyRemaining, huQty, isPromptEnabled, onResult }) => {
+  const getConfirmationPromptForQty = (qtyInput) => (Number(qtyInput) > qtyRemaining ? OVER_PICK_PROMPT : undefined);
+
+  const resolveScannedBarcode = async (scannedBarcode) => ({
+    qrCode: { code: scannedBarcode, isUnique: !isTUToBePickedAsWhole, isTUToBePickedAsWhole },
+    ...(isTUToBePickedAsWhole ? { isTUToBePickedAsWhole: true, qtyInitial: huQty } : {}),
+  });
+
+  return render(
+    <Provider store={createStore(combineReducers({ settings }))}>
+      <ScanHUAndGetQtyComponent
+        qtyMax={qtyRemaining}
+        qtyTarget={qtyRemaining}
+        uom="PCE"
+        resolveScannedBarcode={resolveScannedBarcode}
+        onResult={onResult}
+        getConfirmationPromptForQty={isPromptEnabled ? getConfirmationPromptForQty : undefined}
+      />
+    </Provider>
+  );
+};
+
+/** Feeds a barcode to the HU scanner the screen currently exposes, the way a hardware scan does. */
+const scanHU = async (barcode) => {
+  const input = screen.getByTestId(HU_SCANNER_INPUT);
+  input.value = barcode;
+  await act(async () => {
+    fireEvent.keyUp(input, { key: 'Enter' });
+  });
+};
+
+/**
+ * Feeds a barcode to the HU scanner IF the screen still exposes one. That condition is the subject
+ * under test: while a pick is in flight the screen must not offer a scan target at all, so the
+ * operator's next scan cannot start a second pick.
+ */
+const scanHUIfScannerIsArmed = async (barcode) => {
+  if (screen.queryByTestId(HU_SCANNER_INPUT)) {
+    await scanHU(barcode);
+  }
+};
+
+const clickYesIfPromptIsRaised = async () => {
+  const yesButton = document.querySelector(YES_BUTTON);
+  if (yesButton) {
+    await act(async () => {
+      fireEvent.click(yesButton);
+    });
+  }
+};
+
+//
+//
+// -----------------------------------------------------------------------------
+//
+//
+
+// The over-delivery confirmation's "Ja" fires the pick and drops the dialog, returning the operator
+// to the HU-scan step. Until the pick's POST comes back the screen must not accept another scan:
+// on a handheld over warehouse WiFi the operator's next scan would otherwise book the same line
+// twice. GetQuantityDialog already guards its own confirmation this way (isProcessing + Spinner +
+// disabled confirm); the whole-TU path has to do the same.
+describe('ScanHUAndGetQtyComponent: the confirmed whole-TU pick is in flight', () => {
+  const QTY_REMAINING = 2;
+  const HU_QTY = 32;
+
+  const startConfirmedWholeTUPick = async () => {
+    const pick = newDeferred();
+    const onResult = jest.fn(() => pick.promise);
+
+    renderComponent({
+      isTUToBePickedAsWhole: true,
+      qtyRemaining: QTY_REMAINING,
+      huQty: HU_QTY,
+      isPromptEnabled: true,
+      onResult,
+    });
+
+    await act(async () => {});
+    await scanHU('WHOLE-TU-LABEL-1');
+
+    expect(document.querySelector(YES_NO_DIALOG)).not.toBeNull();
+    await act(async () => {
+      fireEvent.click(document.querySelector(YES_BUTTON));
+    });
+    expect(onResult).toHaveBeenCalledTimes(1);
+
+    return { pick, onResult };
+  };
+
+  it('shows the pick in progress and does not re-arm the HU scanner', async () => {
+    const { pick } = await startConfirmedWholeTUPick();
+
+    expect(document.querySelector(SPINNER)).not.toBeNull();
+    expect(screen.queryByTestId(HU_SCANNER_INPUT)).toBeNull();
+
+    await act(async () => {
+      pick.resolve({});
+    });
+
+    expect(document.querySelector(SPINNER)).toBeNull();
+    expect(screen.getByTestId(HU_SCANNER_INPUT)).toBeInTheDocument();
+  });
+
+  it('books nothing a second time when the operator scans again', async () => {
+    const { onResult } = await startConfirmedWholeTUPick();
+
+    await scanHUIfScannerIsArmed('WHOLE-TU-LABEL-2');
+    await clickYesIfPromptIsRaised();
+
+    expect(onResult).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the in-progress state when the pick fails, so the operator can scan again', async () => {
+    const { pick, onResult } = await startConfirmedWholeTUPick();
+
+    // The in-progress state has to be entered before the error branch can be shown to clear it -
+    // without this the assertions below hold trivially on a component that never enters it at all.
+    expect(document.querySelector(SPINNER)).not.toBeNull();
+
+    await act(async () => {
+      pick.reject({ message: 'pick rejected by the server' });
+    });
+
+    expect(document.querySelector(SPINNER)).toBeNull();
+    expect(screen.getByTestId(HU_SCANNER_INPUT)).toBeInTheDocument();
+
+    await scanHU('WHOLE-TU-LABEL-3');
+    await clickYesIfPromptIsRaised();
+    expect(onResult).toHaveBeenCalledTimes(2);
+  });
+});
+
+//
+//
+// -----------------------------------------------------------------------------
+//
+//
+
+const COMPONENT_SOURCE = fs.readFileSync(path.join(__dirname, '../../components/ScanHUAndGetQtyComponent.jsx'), 'utf8');
+
+/** The body, braces included, of a module-level `const <name> = (…) => { … }`. */
+const arrowFunctionBody = (name) => {
+  const declarationIndex = COMPONENT_SOURCE.indexOf(`const ${name} = `);
+  if (declarationIndex < 0) {
+    throw new Error(`ScanHUAndGetQtyComponent.jsx declares no "${name}"`);
+  }
+
+  const bodyStart = COMPONENT_SOURCE.indexOf('{', COMPONENT_SOURCE.indexOf('=>', declarationIndex));
+  let depth = 0;
+  for (let i = bodyStart; i < COMPONENT_SOURCE.length; i++) {
+    if (COMPONENT_SOURCE[i] === '{') {
+      depth++;
+    } else if (COMPONENT_SOURCE[i] === '}' && --depth === 0) {
+      return COMPONENT_SOURCE.substring(bodyStart, i + 1);
+    }
+  }
+  throw new Error(`Unbalanced braces in "${name}"`);
+};
+
+const countOccurrences = (haystack, needle) => haystack.split(needle).length - 1;
+
+// The CU and the whole-TU path must stay behaviourally identical (REQUIREMENTS.md 31290 § 1), and the
+// mechanism that keeps them so is the single validateQtyAgainstMax both of them call. That is a
+// STRUCTURAL property, and it is deliberately asserted structurally: when the ceiling was last
+// duplicated (new_dawn_uat tip 171414313f5) the two copies were behaviour-identical, so an
+// outcome-comparing test was green throughout and would not have caught the re-duplication.
+describe('ScanHUAndGetQtyComponent: the CU and whole-TU ceilings resolve through one helper', () => {
+  it('reaches the ceiling from the CU path via validateQtyAgainstMax', () => {
+    expect(arrowFunctionBody('validateQtyEntered')).toContain('validateQtyAgainstMax(');
+  });
+
+  it('reaches the ceiling from the whole-TU path via the same validateQtyAgainstMax', () => {
+    expect(arrowFunctionBody('requestQtyOrReportResult')).toContain('validateQtyAgainstMax(');
+  });
+
+  it('has exactly one ceiling to reach - nothing outside the helper builds a qtyAboveMax error', () => {
+    expect(countOccurrences(COMPONENT_SOURCE, 'const validateQtyAgainstMax = ')).toBe(1);
+
+    const linesOutsideTheHelper = COMPONENT_SOURCE.replace(arrowFunctionBody('validateQtyAgainstMax'), '')
+      .replace(/^const DEFAULT_MSG_qtyAboveMax = .*$/m, '')
+      .split('\n');
+    expect(linesOutsideTheHelper.filter((line) => line.includes('DEFAULT_MSG_qtyAboveMax'))).toEqual([]);
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
@@ -195,8 +195,8 @@ const ScanHUAndGetQtyComponent = ({
         return;
       }
     } else if (Number.isFinite(resolvedBarcodeData.qtyInitial)) {
-      // Gated on Number.isFinite so the callers that resolve no qtyInitial keep booking exactly as before -
-      // as on the prompt branch above, where an absent qty raises no confirmation either.
+      // Gated on Number.isFinite: with no resolved qtyInitial there is nothing to compare, so the pick books
+      // unchecked - as on the prompt branch above, where an absent qty raises no confirmation either.
       const qtyAboveMaxError = validateQtyAgainstMax({
         qty: resolvedBarcodeData.qtyInitial,
         qtyMax: resolvedBarcodeData.qtyMax,

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/components/ScanHUAndGetQtyComponent.jsx
@@ -11,6 +11,8 @@ import { toastError, toastErrorFromObj } from '../utils/toast';
 import { toQRCodeString } from '../utils/qrCode/hu';
 import HUScanner from './huSelector/HUScanner';
 import BarcodeScannerComponent from './BarcodeScannerComponent';
+import Spinner from './Spinner';
+import { doFinally } from '../utils';
 import { PICK_ON_THE_FLY_QRCODE } from '../containers/activities/picking/PickConfig';
 import { ATTR_isTUToBePickedAsWhole, ATTR_isUnique } from '../utils/qrCode/common';
 
@@ -61,6 +63,7 @@ const ScanHUAndGetQtyComponent = ({
 }) => {
   const [progressStatus, setProgressStatus] = useState(STATUS_NOT_INITIALIZED);
   const [confirmationDialogProps, setConfirmationDialogProps] = useState(undefined);
+  const [isProcessing, setProcessing] = useState(false);
   const { resolvedBarcodeData, setResolvedBarcodeData, updateResolvedBarcodeData, computeNewResolvedBarcodeData } =
     useResolvedBarcodeData({
       userInfo,
@@ -157,7 +160,18 @@ const ScanHUAndGetQtyComponent = ({
     await requestQtyOrReportResult({ resolvedBarcodeData: resolvedBarcodeDataNew });
   };
 
-  const fireOnResult = (onResultPayload) => onResult(onResultPayload)?.catch?.((error) => toastErrorFromObj(error));
+  // Mirrors GetQuantityDialog.fireOnQtyChange: isProcessing is what suppresses the scan target while
+  // the pick's POST is in flight, and it has to be cleared on the error branch too.
+  const fireOnResult = (onResultPayload) => {
+    setProcessing(true);
+    try {
+      const promise = onResult(onResultPayload)?.catch?.((error) => toastErrorFromObj(error));
+      return doFinally(promise, () => setProcessing(false));
+    } catch (error) {
+      setProcessing(false);
+      throw error;
+    }
+  };
 
   const requestQtyOrReportResult = async ({ resolvedBarcodeData }) => {
     if (isAskForQty({ resolvedBarcodeData })) {
@@ -172,12 +186,8 @@ const ScanHUAndGetQtyComponent = ({
       resolvedBarcodeData: resolvedBarcodeData,
     };
 
-    // There is no qty dialog on this path (the whole scanned TU is booked), so the over-delivery
-    // handling GetQuantityDialog performs for the CU path has to happen here. The qty to compare is
-    // the TU's own content, fetched into qtyInitial for exactly this purpose; the qty: 0 above is the
-    // booking instruction, not the comparison input. Which handling applies depends on the profile,
-    // exactly as on the CU path: with the prompt configured, the same YesNoDialog; without it, the
-    // same qtyAboveMax ceiling - so no configuration leaves this path unbounded.
+    // The whole-TU mirror of the over-delivery handling GetQuantityDialog performs for the CU path.
+    // The comparison input is the TU's own content (qtyInitial), not the qty: 0 booking instruction above.
     if (getConfirmationPromptForQty) {
       const confirmationPrompt = await getConfirmationPromptForQty(resolvedBarcodeData.qtyInitial);
       if (confirmationPrompt) {
@@ -185,12 +195,8 @@ const ScanHUAndGetQtyComponent = ({
         return;
       }
     } else if (Number.isFinite(resolvedBarcodeData.qtyInitial)) {
-      // Implicit invariant: of the eight callers, only PickLineScanScreen ever resolves a qtyInitial - directly on
-      // its whole-TU branch, and through computeNewResolvedBarcodeData's LU branch below, which no other caller
-      // reaches either, because none of them populates scannedHU.qtyTUs.
-      // Bound the pick whenever the caller resolved a qty; a caller that resolves none books as before,
-      // the same as the prompt branch above, where an absent qty raises no confirmation either. A caller
-      // that wants the pick bounded must therefore fail its own scan rather than resolve without a qty.
+      // Gated on Number.isFinite so the callers that resolve no qtyInitial keep booking exactly as before -
+      // as on the prompt branch above, where an absent qty raises no confirmation either.
       const qtyAboveMaxError = validateQtyAgainstMax({
         qty: resolvedBarcodeData.qtyInitial,
         qtyMax: resolvedBarcodeData.qtyMax,
@@ -263,6 +269,12 @@ const ScanHUAndGetQtyComponent = ({
   };
 
   const showEligibleBarcodeDebugButton = useBooleanSetting('barcodeScanner.showEligibleBarcodeDebugButton');
+
+  // Early return (after every hook), so the BarcodeScannerComponent below is unmounted while the pick
+  // is in flight: re-arming it would let the next scan book the same line a second time.
+  if (isProcessing) {
+    return <Spinner />;
+  }
 
   // Early return (after every hook), so the BarcodeScannerComponent below is unmounted while the
   // operator answers: two mounted scanners would both capture the next hardware scan.
@@ -405,9 +417,8 @@ export default ScanHUAndGetQtyComponent;
 //
 
 /**
- * The qtyAboveMax ceiling, shared by the two paths that book a qty: the CU path via
- * validateQtyEntered (qty typed into GetQuantityDialog) and the whole-TU path via
- * requestQtyOrReportResult (qty read from the scanned TU's own content).
+ * The one qtyAboveMax ceiling, shared by the CU path (validateQtyEntered) and the whole-TU path
+ * (requestQtyOrReportResult).
  *
  * @returns the translated error message, or null when the qty is within qtyMax.
  */

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickLineScanScreen.jsx
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/containers/activities/picking/PickLineScanScreen.jsx
@@ -291,29 +291,24 @@ const convertQRCodeObjectToResolvedResult = async ({
     }
   }
 
-  // For whole-TU picks, fetch the actual product qty from the backend so the over-delivery can be
-  // detected at all. The backend picks the full HU storage qty when isPickWholeTU=true, so we need
-  // the actual qty to compare against remaining - with the prompt enabled to raise the confirmation,
-  // and with it disabled to enforce the qtyAboveMax ceiling instead. Both configurations need it, so
-  // this is not gated on isShowPromptWhenOverPicking.
+  // A whole-TU pick books the full HU storage qty, so the over-delivery confirmation and the qtyAboveMax
+  // ceiling both need that qty to compare against remaining.
   //
-  // The picking job + line are required, and are what gates the fetch: a whole-TU label (custom weight
+  // The picking job + line gate the fetch because the lookup requires them: a whole-TU label (custom weight
   // label, LMQ, GS1) is not an HU QR code, so the backend can only resolve it to its HU in the context of
   // the line being picked. PickProductsScanScreen resolves barcodes through here too, without a line and
   // wanting only the parsed QR code - looking the HU up for it would fail the scan it is trying to route.
   if (parsedQRCode.isTUToBePickedAsWhole === true && wfProcessId != null && lineId != null) {
-    // Not guarded: a failure here must surface as a failed scan, exactly like the unparsed-barcode lookup
-    // above. Swallowing it would leave qtyInitial undefined, which compares as 0 against the remaining qty,
-    // so the whole TU would book with no confirmation - the very defect this check exists to prevent.
+    // Deliberately unguarded, like the unparsed-barcode lookup above: swallowing a failure would leave
+    // qtyInitial undefined, which compares as 0 against remaining, so the whole TU would book unasked.
     const huInfo = await getScannedHUQRCodeInfo({
       qrCode: toQRCodeString(parsedQRCode),
       productNo: expectedProductNo,
       wfProcessId,
       lineId,
     });
-    // The resolved HU carries no pickable qty of this line's product, so there is nothing to bound the
-    // whole-TU pick by - reject the scan rather than book it unasked. Number.isFinite is the predicate
-    // ScanHUAndGetQtyComponent gates the qtyMax ceiling on, so anything weaker leaves the pick unbounded.
+    // Number.isFinite is the predicate ScanHUAndGetQtyComponent gates the qtyMax ceiling on, so anything
+    // weaker here leaves the whole-TU pick unbounded.
     const productQty = parseFloat(huInfo?.productQty);
     if (!Number.isFinite(productQty) || productQty <= 0) {
       console.warn('Scanned barcode resolved to an HU carrying no qty of the expected product', {


### PR DESCRIPTION
Post-merge hardening of the whole-TU over-delivery guard, following up on https://github.com/metasfresh/metasfresh/pull/25374. Every item below is a place where the whole-TU path and its CU sibling still diverged, or where their parity was unproven.

## 1. The confirm-Yes handler did not await the booking

`ScanHUAndGetQtyComponent`'s confirm-Yes branch called `fireOnResult` **un-awaited**, so the dialog closed and the always-listening HU scanner re-armed while the pick POST was still in flight — no spinner, no disabled state. On a handheld over warehouse WiFi that is a double-pick. The direct path already awaited the same call.

`fireOnResult` now mirrors the CU sibling `GetQuantityDialog.fireOnQtyChange` 1:1: set `isProcessing`, return the promise so the direct path keeps its sequencing, and clear the flag in a `finally` — **including on the error branch**, so a failed pick lets the operator scan again. While processing, the component renders a `Spinner` via early return, which *unmounts* the scanner rather than overlaying it (the app's documented mechanism for suppressing an always-listening scanner).

**TDD:** three Jest tests written first and confirmed RED against the unfixed code — the spinner assertion, the double-`onResult` assertion (`Expected 1, received 2` — the double-pick itself), and the clears-on-error assertion.

## 2. CU / whole-TU parity test

The two paths must behave identically — one physical action for the operator. The agreed enforcement mechanism is *shared helper + a parity test*, and the test did not exist.

It asserts the **structural** property: `validateQtyEntered` (CU) and `requestQtyOrReportResult` (whole-TU) both resolve their ceiling through the single `validateQtyAgainstMax` helper, there is exactly one definition of it, and `DEFAULT_MSG_qtyAboveMax` is referenced nowhere outside it. Structural rather than outcome-based on purpose: on `new_dawn_uat`'s tip the ceiling currently exists as two *behaviour-identical* copies, so an outcome-only test would be green there and would miss a re-duplication. Verified by mutation — re-inlining the CU ceiling exactly as `new_dawn_uat` has it turns the test red.

No production refactor was needed; `validateQtyAgainstMax` already existed and both paths already called it.

## 3. Regression coverage — a weight-only excess must not trigger the guard

Two Playwright scenarios (piece count exactly on target, catch-weight label decisively above nominal), one with the confirmation prompt on and one with it off. The merged fix resolves the whole-TU quantity through a backend lookup; if that ever returned the catch-UOM quantity instead of the stock-UOM piece count, the guard would fire on weight variance — which is explicitly out of scope for this feature. These scenarios make that regression visible.

## 4. Smaller items

- `PickingMobileApplication.resolvePickFromHU`'s `callerId` used the jetbrains `@NotNull` (no runtime check) where the class and the whole delegate chain use Lombok `@NonNull`.
- Comment volume in `PickingJobService`, `PickLineScanScreen` and `ScanHUAndGetQtyComponent` over the project's comment-volume rule. Comments carrying a non-obvious *why* were kept; redundant narration and development-history narration were removed.

## Explicitly out of scope

- Booking semantics — this hardens *how* the guard is reached, not what it books.
- `PickingJobService`'s two-hop `line.getScheduleId().getShipmentScheduleId()`: it matches two peer call sites, so the real fix is a one-hop accessor applied to all three.
- The `uiTrace` gap on the whole-TU rejection paths (they only `console.warn`). Pre-existing at both sites.
