### PR TITLE
Product Life Cycle Status: German labels + human-readable block message

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_M_Product.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_M_Product.java
@@ -13,7 +13,7 @@ import javax.annotation.Nullable;
 public class X_M_Product extends org.compiere.model.PO implements I_M_Product, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 1043539037L;
+	private static final long serialVersionUID = -57209193L;
 
     /** Standard Constructor */
     public X_M_Product (final Properties ctx, final int M_Product_ID, @Nullable final String trxName)
@@ -1449,11 +1449,11 @@ public class X_M_Product extends org.compiere.model.PO implements I_M_Product, o
 	public static final int PRODUCTLIFECYCLESTATUS_AD_Reference_ID=542123;
 	/** OK = O */
 	public static final String PRODUCTLIFECYCLESTATUS_OK = "O";
-	/** Phase out = A */
+	/** PhaseOut = A */
 	public static final String PRODUCTLIFECYCLESTATUS_PhaseOut = "A";
 	/** Blocked = G */
 	public static final String PRODUCTLIFECYCLESTATUS_Blocked = "G";
-	/** Delivery stop = N */
+	/** DeliveryStop = N */
 	public static final String PRODUCTLIFECYCLESTATUS_DeliveryStop = "N";
 	@Override
 	public void setProductLifeCycleStatus (final @Nullable java.lang.String ProductLifeCycleStatus)

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5817300_sys_M_Product_ProductLifeCycleStatus_reflist_name_vs_valuename.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5817300_sys_M_Product_ProductLifeCycleStatus_reflist_name_vs_valuename.sql
@@ -1,0 +1,24 @@
+-- Product Life Cycle Status (BBS-Status) ref-list (AD_Reference 542123) — fix de_DE display regression.
+--
+-- The tenant's base language is de_DE, so AD_Ref_List.Name is the GERMAN (base-language) display label
+-- shown in the WebUI dropdown/grid — it must be German, not English. The generated Java constant is NOT
+-- derived from Name; it comes from AD_Ref_List.ValueName (the English identifier). Compare the core
+-- ProductType ref-list: Name='Artikel' (German), ValueName='Item' (English) -> constant PRODUCTTYPE_Item,
+-- while de_DE users see "Artikel".
+--
+-- 5817220 wrongly put the English text into Name (leaving ValueName empty), so de_DE users saw the English
+-- label ("Blocked" instead of "Gesperrt"). This restores the German base Name AND sets the English
+-- ValueName, which keeps the English constants (_PhaseOut / _Blocked / _DeliveryStop) unchanged. de_DE/de_CH
+-- Trl (German) and en_US Trl (English) are already correct and untouched.
+
+UPDATE AD_Ref_List SET Name='Auslauf',     ValueName='PhaseOut',     Updated=TO_TIMESTAMP('2026-08-01 09:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544325 /* A */ AND Name='Phase out';
+
+UPDATE AD_Ref_List SET Name='Gesperrt',    ValueName='Blocked',      Updated=TO_TIMESTAMP('2026-08-01 09:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544326 /* G */ AND Name='Blocked';
+
+UPDATE AD_Ref_List SET Name='Lieferstopp', ValueName='DeliveryStop', Updated=TO_TIMESTAMP('2026-08-01 09:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544327 /* N */ AND Name='Delivery stop';
+
+UPDATE AD_Ref_List SET ValueName='OK',     Updated=TO_TIMESTAMP('2026-08-01 09:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Ref_List_ID=544324 /* O */ AND Name='OK';

--- a/backend/de.metas.business/src/main/java/de/metas/product/impl/ProductBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/impl/ProductBL.java
@@ -101,7 +101,6 @@ public final class ProductBL implements IProductBL
 	private final IUOMConversionDAO uomConversionDAO = Services.get(IUOMConversionDAO.class);
 	private final IBPartnerProductDAO partnerProductDAO = Services.get(IBPartnerProductDAO.class);
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
-	private final ADReferenceService adReferenceService = ADReferenceService.get();
 
 	@Override
 	public I_M_Product getById(@NonNull final ProductId productId)
@@ -479,7 +478,11 @@ public final class ProductBL implements IProductBL
 			// Show the human-readable, locale-resolved status name (e.g. "Gesperrt" / "Blocked"), not the raw
 			// code. retrieveListNameTranslatableString wraps the lookup lazily (forwardingTo), so it resolves
 			// per the reader's language only when the message is actually rendered.
-			final ITranslatableString statusName = adReferenceService
+			// IMPORTANT: resolve ADReferenceService inline here (request time) — do NOT lift it to a class
+			// field. ServerBoot.main constructs ProductBL before the Spring context is configured, so a
+			// field-initializer ADReferenceService.get() throws "SpringApplicationContext not configured yet"
+			// and crashes app/webapi boot (health-check failure on PR #25393).
+			final ITranslatableString statusName = ADReferenceService.get()
 					.retrieveListNameTranslatableString(X_M_Product.PRODUCTLIFECYCLESTATUS_AD_Reference_ID, code);
 			throw new AdempiereException(MSG_M_PRODUCT_BBSSTATUS_ACTION_BLOCKED, product.getValue(), statusName)
 					.setParameter("product", product.getValue())

--- a/backend/de.metas.business/src/main/java/de/metas/product/impl/ProductBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/impl/ProductBL.java
@@ -481,7 +481,7 @@ public final class ProductBL implements IProductBL
 			// IMPORTANT: resolve ADReferenceService inline here (request time) — do NOT lift it to a class
 			// field. ServerBoot.main constructs ProductBL before the Spring context is configured, so a
 			// field-initializer ADReferenceService.get() throws "SpringApplicationContext not configured yet"
-			// and crashes app/webapi boot (health-check failure on PR #25393).
+			// and crashes app/webapi boot.
 			final ITranslatableString statusName = ADReferenceService.get()
 					.retrieveListNameTranslatableString(X_M_Product.PRODUCTLIFECYCLESTATUS_AD_Reference_ID, code);
 			throw new AdempiereException(MSG_M_PRODUCT_BBSSTATUS_ACTION_BLOCKED, product.getValue(), statusName)

--- a/backend/de.metas.business/src/main/java/de/metas/product/impl/ProductBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/impl/ProductBL.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import de.metas.acct.api.AcctSchema;
 import de.metas.acct.api.IAcctSchemaDAO;
+import de.metas.ad_reference.ADReferenceService;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner_product.IBPartnerProductDAO;
 import de.metas.costing.CostingLevel;
@@ -16,7 +17,6 @@ import de.metas.gs1.GS1ProductCodesCollection.GS1ProductCodesCollectionBuilder;
 import de.metas.gs1.GTIN;
 import de.metas.gs1.ean13.EAN13;
 import de.metas.gs1.ean13.EAN13ProductCode;
-import de.metas.ad_reference.ADReferenceService;
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.ITranslatableString;
 import de.metas.i18n.TranslatableStrings;
@@ -62,8 +62,8 @@ import org.compiere.model.I_C_BPartner_Product;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_AttributeSetInstance;
 import org.compiere.model.I_M_Product;
-import org.compiere.model.X_M_Product;
 import org.compiere.model.I_M_Product_Category;
+import org.compiere.model.X_M_Product;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 import org.jetbrains.annotations.NotNull;
@@ -101,6 +101,7 @@ public final class ProductBL implements IProductBL
 	private final IUOMConversionDAO uomConversionDAO = Services.get(IUOMConversionDAO.class);
 	private final IBPartnerProductDAO partnerProductDAO = Services.get(IBPartnerProductDAO.class);
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+	private final ADReferenceService adReferenceService = ADReferenceService.get();
 
 	@Override
 	public I_M_Product getById(@NonNull final ProductId productId)
@@ -478,7 +479,7 @@ public final class ProductBL implements IProductBL
 			// Show the human-readable, locale-resolved status name (e.g. "Gesperrt" / "Blocked"), not the raw
 			// code. retrieveListNameTranslatableString wraps the lookup lazily (forwardingTo), so it resolves
 			// per the reader's language only when the message is actually rendered.
-			final ITranslatableString statusName = ADReferenceService.get()
+			final ITranslatableString statusName = adReferenceService
 					.retrieveListNameTranslatableString(X_M_Product.PRODUCTLIFECYCLESTATUS_AD_Reference_ID, code);
 			throw new AdempiereException(MSG_M_PRODUCT_BBSSTATUS_ACTION_BLOCKED, product.getValue(), statusName)
 					.setParameter("product", product.getValue())

--- a/backend/de.metas.business/src/main/java/de/metas/product/impl/ProductBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/impl/ProductBL.java
@@ -16,6 +16,7 @@ import de.metas.gs1.GS1ProductCodesCollection.GS1ProductCodesCollectionBuilder;
 import de.metas.gs1.GTIN;
 import de.metas.gs1.ean13.EAN13;
 import de.metas.gs1.ean13.EAN13ProductCode;
+import de.metas.ad_reference.ADReferenceService;
 import de.metas.i18n.AdMessageKey;
 import de.metas.i18n.ITranslatableString;
 import de.metas.i18n.TranslatableStrings;
@@ -61,6 +62,7 @@ import org.compiere.model.I_C_BPartner_Product;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_AttributeSetInstance;
 import org.compiere.model.I_M_Product;
+import org.compiere.model.X_M_Product;
 import org.compiere.model.I_M_Product_Category;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
@@ -473,7 +475,12 @@ public final class ProductBL implements IProductBL
 		final String code = product.getProductLifeCycleStatus();
 		if (!isStatusAllowed(code, action))
 		{
-			throw new AdempiereException(MSG_M_PRODUCT_BBSSTATUS_ACTION_BLOCKED, product.getValue(), code)
+			// Show the human-readable, locale-resolved status name (e.g. "Gesperrt" / "Blocked"), not the raw
+			// code. retrieveListNameTranslatableString wraps the lookup lazily (forwardingTo), so it resolves
+			// per the reader's language only when the message is actually rendered.
+			final ITranslatableString statusName = ADReferenceService.get()
+					.retrieveListNameTranslatableString(X_M_Product.PRODUCTLIFECYCLESTATUS_AD_Reference_ID, code);
+			throw new AdempiereException(MSG_M_PRODUCT_BBSSTATUS_ACTION_BLOCKED, product.getValue(), statusName)
 					.setParameter("product", product.getValue())
 					.setParameter("status", code);
 		}

--- a/backend/de.metas.business/src/test/java/de/metas/order/model/interceptor/C_OrderLineTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/model/interceptor/C_OrderLineTest.java
@@ -22,6 +22,8 @@ package de.metas.order.model.interceptor;
  * #L%
  */
 
+import de.metas.ad_reference.ADReferenceService;
+import org.compiere.SpringContextHolder;
 import de.metas.bpartner.BPartnerSupplierApprovalService;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.order.compensationGroup.OrderGroupCompensationChangesHandler;
@@ -54,6 +56,7 @@ public class C_OrderLineTest
 	public void init()
 	{
 		AdempiereTestHelper.get().init();
+		SpringContextHolder.registerJUnitBean(ADReferenceService.newMocked());
 
 		interceptor = new C_OrderLine(
 				mock(OrderGroupCompensationChangesHandler.class),

--- a/backend/de.metas.business/src/test/java/de/metas/order/model/interceptor/C_OrderLineTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/order/model/interceptor/C_OrderLineTest.java
@@ -23,13 +23,13 @@ package de.metas.order.model.interceptor;
  */
 
 import de.metas.ad_reference.ADReferenceService;
-import org.compiere.SpringContextHolder;
 import de.metas.bpartner.BPartnerSupplierApprovalService;
 import de.metas.interfaces.I_C_OrderLine;
 import de.metas.order.compensationGroup.OrderGroupCompensationChangesHandler;
 import de.metas.order.impl.OrderLineDetailRepository;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_M_Product;
 import org.compiere.model.X_M_Product;

--- a/backend/de.metas.business/src/test/java/de/metas/product/ProductBL_assertAllowed_Test.java
+++ b/backend/de.metas.business/src/test/java/de/metas/product/ProductBL_assertAllowed_Test.java
@@ -33,6 +33,7 @@ import org.compiere.SpringContextHolder;
 import org.compiere.model.I_M_Product;
 import org.compiere.model.X_M_Product;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static de.metas.util.Services.get;
@@ -110,20 +111,6 @@ class ProductBL_assertAllowed_Test
 	}
 
 	@Test
-	void blocked_blocksAllActions()
-	{
-		final ProductId productId = createProduct(X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked);
-
-		for (final ProductLifeCycleAction action : ProductLifeCycleAction.values())
-		{
-			assertThat(productBL.isAllowed(productId, action)).as("action=%s", action).isFalse();
-			assertThatThrownBy(() -> productBL.assertAllowed(productId, action))
-					.as("action=%s", action)
-					.isInstanceOfSatisfying(AdempiereException.class, ex -> assertThat(ex.isUserValidationError()).isTrue());
-		}
-	}
-
-	@Test
 	void doNotDeliver_blocksShipOnly()
 	{
 		final ProductId productId = createProduct(X_M_Product.PRODUCTLIFECYCLESTATUS_DeliveryStop);
@@ -140,31 +127,49 @@ class ProductBL_assertAllowed_Test
 		}
 	}
 
-	@Test
-	void blocked_error_resolvesHumanReadableStatusName()
+	@Nested
+	class Blocked
 	{
-		// The action-blocked error must surface the human-readable, locale-resolved status name
-		// ("Gesperrt"), not the raw code "G". Register the ref-list item so the lookup resolves to a
-		// real name instead of falling back to the raw code — the item-found branch the other tests
-		// never exercise (the auto-created mock ref-list has no items).
-		adReferenceService.saveRefList(ADRefListItemCreateRequest.builder()
-				.referenceId(ReferenceId.ofRepoId(X_M_Product.PRODUCTLIFECYCLESTATUS_AD_Reference_ID))
-				.value(X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked)
-				.name(TranslatableStrings.constant("Gesperrt"))
-				.build());
+		@Test
+		void blocksAllActions()
+		{
+			final ProductId productId = createProduct(X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked);
 
-		// The exception hands this ITranslatableString to AdempiereException as a message param, so the
-		// blocked message renders "Gesperrt" once the AD_Message template is loaded (verified end-to-end
-		// against the real stack, not here — the POJO harness has no AD_Message so {0}/{1} don't
-		// interpolate; this asserts the resolution the guard relies on).
-		assertThat(adReferenceService
-				.retrieveListNameTranslatableString(X_M_Product.PRODUCTLIFECYCLESTATUS_AD_Reference_ID, X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked)
-				.translate("de_DE"))
-				.as("resolved status name")
-				.isEqualTo("Gesperrt");
+			for (final ProductLifeCycleAction action : ProductLifeCycleAction.values())
+			{
+				assertThat(productBL.isAllowed(productId, action)).as("action=%s", action).isFalse();
+				assertThatThrownBy(() -> productBL.assertAllowed(productId, action))
+						.as("action=%s", action)
+						.isInstanceOfSatisfying(AdempiereException.class, ex -> assertThat(ex.isUserValidationError()).isTrue());
+			}
+		}
 
-		final ProductId productId = createProduct(X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked);
-		assertThatThrownBy(() -> productBL.assertAllowed(productId, ProductLifeCycleAction.PICK))
-				.isInstanceOfSatisfying(AdempiereException.class, ex -> assertThat(ex.isUserValidationError()).isTrue());
+		@Test
+		void error_resolvesHumanReadableStatusName()
+		{
+			// The action-blocked error must surface the human-readable, locale-resolved status name
+			// ("Gesperrt"), not the raw code "G". Register the ref-list item so the lookup resolves to a
+			// real name instead of falling back to the raw code — the item-found branch the other tests
+			// never exercise (the auto-created mock ref-list has no items).
+			adReferenceService.saveRefList(ADRefListItemCreateRequest.builder()
+					.referenceId(ReferenceId.ofRepoId(X_M_Product.PRODUCTLIFECYCLESTATUS_AD_Reference_ID))
+					.value(X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked)
+					.name(TranslatableStrings.constant("Gesperrt"))
+					.build());
+
+			// The exception hands this ITranslatableString to AdempiereException as a message param, so the
+			// blocked message renders "Gesperrt" once the AD_Message template is loaded (verified end-to-end
+			// against the real stack, not here — the POJO harness has no AD_Message so {0}/{1} don't
+			// interpolate; this asserts the resolution the guard relies on).
+			assertThat(adReferenceService
+					.retrieveListNameTranslatableString(X_M_Product.PRODUCTLIFECYCLESTATUS_AD_Reference_ID, X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked)
+					.translate("de_DE"))
+					.as("resolved status name")
+					.isEqualTo("Gesperrt");
+
+			final ProductId productId = createProduct(X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked);
+			assertThatThrownBy(() -> productBL.assertAllowed(productId, ProductLifeCycleAction.PICK))
+					.isInstanceOfSatisfying(AdempiereException.class, ex -> assertThat(ex.isUserValidationError()).isTrue());
+		}
 	}
 }

--- a/backend/de.metas.business/src/test/java/de/metas/product/ProductBL_assertAllowed_Test.java
+++ b/backend/de.metas.business/src/test/java/de/metas/product/ProductBL_assertAllowed_Test.java
@@ -22,7 +22,10 @@
 
 package de.metas.product;
 
+import de.metas.ad_reference.ADRefListItemCreateRequest;
 import de.metas.ad_reference.ADReferenceService;
+import de.metas.ad_reference.ReferenceId;
+import de.metas.i18n.TranslatableStrings;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
@@ -44,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class ProductBL_assertAllowed_Test
 {
 	private IProductBL productBL;
+	private ADReferenceService adReferenceService;
 
 	@BeforeEach
 	void setUp()
@@ -51,7 +55,8 @@ class ProductBL_assertAllowed_Test
 		AdempiereTestHelper.get().init();
 		// assertAllowed resolves the blocked status' human-readable name via ADReferenceService; register a
 		// mocked one (auto-creates ref-lists on demand) so the guard's error path works in the POJO env.
-		SpringContextHolder.registerJUnitBean(ADReferenceService.newMocked());
+		adReferenceService = ADReferenceService.newMocked();
+		SpringContextHolder.registerJUnitBean(adReferenceService);
 		productBL = get(IProductBL.class);
 	}
 
@@ -133,5 +138,33 @@ class ProductBL_assertAllowed_Test
 			assertThat(productBL.isAllowed(productId, action)).as("action=%s", action).isTrue();
 			assertThatCode(() -> productBL.assertAllowed(productId, action)).as("action=%s", action).doesNotThrowAnyException();
 		}
+	}
+
+	@Test
+	void blocked_error_resolvesHumanReadableStatusName()
+	{
+		// The action-blocked error must surface the human-readable, locale-resolved status name
+		// ("Gesperrt"), not the raw code "G". Register the ref-list item so the lookup resolves to a
+		// real name instead of falling back to the raw code — the item-found branch the other tests
+		// never exercise (the auto-created mock ref-list has no items).
+		adReferenceService.saveRefList(ADRefListItemCreateRequest.builder()
+				.referenceId(ReferenceId.ofRepoId(X_M_Product.PRODUCTLIFECYCLESTATUS_AD_Reference_ID))
+				.value(X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked)
+				.name(TranslatableStrings.constant("Gesperrt"))
+				.build());
+
+		// The exception hands this ITranslatableString to AdempiereException as a message param, so the
+		// blocked message renders "Gesperrt" once the AD_Message template is loaded (verified end-to-end
+		// against the real stack, not here — the POJO harness has no AD_Message so {0}/{1} don't
+		// interpolate; this asserts the resolution the guard relies on).
+		assertThat(adReferenceService
+				.retrieveListNameTranslatableString(X_M_Product.PRODUCTLIFECYCLESTATUS_AD_Reference_ID, X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked)
+				.translate("de_DE"))
+				.as("resolved status name")
+				.isEqualTo("Gesperrt");
+
+		final ProductId productId = createProduct(X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked);
+		assertThatThrownBy(() -> productBL.assertAllowed(productId, ProductLifeCycleAction.PICK))
+				.isInstanceOfSatisfying(AdempiereException.class, ex -> assertThat(ex.isUserValidationError()).isTrue());
 	}
 }

--- a/backend/de.metas.business/src/test/java/de/metas/product/ProductBL_assertAllowed_Test.java
+++ b/backend/de.metas.business/src/test/java/de/metas/product/ProductBL_assertAllowed_Test.java
@@ -22,9 +22,11 @@
 
 package de.metas.product;
 
+import de.metas.ad_reference.ADReferenceService;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.SpringContextHolder;
 import org.compiere.model.I_M_Product;
 import org.compiere.model.X_M_Product;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +49,9 @@ class ProductBL_assertAllowed_Test
 	void setUp()
 	{
 		AdempiereTestHelper.get().init();
+		// assertAllowed resolves the blocked status' human-readable name via ADReferenceService; register a
+		// mocked one (auto-creates ref-lists on demand) so the guard's error path works in the POJO env.
+		SpringContextHolder.registerJUnitBean(ADReferenceService.newMocked());
 		productBL = get(IProductBL.class);
 	}
 

--- a/backend/de.metas.business/src/test/java/de/metas/product/model/interceptor/M_InOutTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/product/model/interceptor/M_InOutTest.java
@@ -22,6 +22,8 @@ package de.metas.product.model.interceptor;
  * #L%
  */
 
+import de.metas.ad_reference.ADReferenceService;
+import org.compiere.SpringContextHolder;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.test.AdempiereTestHelper;
 import org.compiere.model.I_M_InOut;
@@ -54,6 +56,7 @@ public class M_InOutTest
 	public void init()
 	{
 		AdempiereTestHelper.get().init();
+		SpringContextHolder.registerJUnitBean(ADReferenceService.newMocked());
 		interceptor = new M_InOut();
 	}
 

--- a/backend/de.metas.business/src/test/java/de/metas/product/model/interceptor/M_InOutTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/product/model/interceptor/M_InOutTest.java
@@ -23,9 +23,9 @@ package de.metas.product.model.interceptor;
  */
 
 import de.metas.ad_reference.ADReferenceService;
-import org.compiere.SpringContextHolder;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.SpringContextHolder;
 import org.compiere.model.I_M_InOut;
 import org.compiere.model.I_M_InOutLine;
 import org.compiere.model.I_M_Product;

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/candidate/commands/PickHUCommand_LifeCycleStatus_Test.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/candidate/commands/PickHUCommand_LifeCycleStatus_Test.java
@@ -1,7 +1,6 @@
 package de.metas.handlingunits.picking.candidate.commands;
 
 import de.metas.ad_reference.ADReferenceService;
-import org.compiere.SpringContextHolder;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.picking.PackToSpec;
 import de.metas.handlingunits.picking.PickFrom;
@@ -13,6 +12,7 @@ import de.metas.quantity.Quantity;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_Product;
 import org.compiere.model.X_M_Product;

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/candidate/commands/PickHUCommand_LifeCycleStatus_Test.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/candidate/commands/PickHUCommand_LifeCycleStatus_Test.java
@@ -1,5 +1,7 @@
 package de.metas.handlingunits.picking.candidate.commands;
 
+import de.metas.ad_reference.ADReferenceService;
+import org.compiere.SpringContextHolder;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.picking.PackToSpec;
 import de.metas.handlingunits.picking.PickFrom;
@@ -40,6 +42,7 @@ public class PickHUCommand_LifeCycleStatus_Test
 	public void beforeEach()
 	{
 		this.helper = new ProcessPickingCandidatesCommandTestHelper();
+		SpringContextHolder.registerJUnitBean(ADReferenceService.newMocked());
 		this.pickingCandidateRepository = helper.pickingCandidateRepository;
 		this.uomEach = helper.uomEach;
 	}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/external/product/PickingJobProductServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/external/product/PickingJobProductServiceTest.java
@@ -1,5 +1,7 @@
 package de.metas.handlingunits.picking.job.service.external.product;
 
+import de.metas.ad_reference.ADReferenceService;
+import org.compiere.SpringContextHolder;
 import de.metas.product.ProductId;
 import de.metas.product.ProductType;
 import org.adempiere.exceptions.AdempiereException;
@@ -37,6 +39,7 @@ class PickingJobProductServiceTest
 	void beforeEach()
 	{
 		AdempiereTestHelper.get().init();
+		SpringContextHolder.registerJUnitBean(ADReferenceService.newMocked());
 		attributesTestHelper = new AttributesTestHelper();
 		pickingJobProductService = PickingJobProductService.newInstanceForUnitTesting();
 	}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/external/product/PickingJobProductServiceTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/external/product/PickingJobProductServiceTest.java
@@ -1,7 +1,6 @@
 package de.metas.handlingunits.picking.job.service.external.product;
 
 import de.metas.ad_reference.ADReferenceService;
-import org.compiere.SpringContextHolder;
 import de.metas.product.ProductId;
 import de.metas.product.ProductType;
 import org.adempiere.exceptions.AdempiereException;
@@ -10,6 +9,7 @@ import org.adempiere.mm.attributes.api.AttributeConstants;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.SpringContextHolder;
 import org.compiere.model.I_M_Product;
 import org.compiere.model.X_M_Attribute;
 import org.compiere.model.X_M_Product;

--- a/backend/de.metas.manufacturing/src/test/java/org/eevolution/model/validator/PP_OrderTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/org/eevolution/model/validator/PP_OrderTest.java
@@ -1,5 +1,7 @@
 package org.eevolution.model.validator;
 
+import de.metas.ad_reference.ADReferenceService;
+import org.compiere.SpringContextHolder;
 import de.metas.document.sequence.IDocumentNoBuilderFactory;
 import de.metas.material.event.PostMaterialEventService;
 import de.metas.material.planning.pporder.IPPOrderBOMBL;
@@ -61,6 +63,7 @@ public class PP_OrderTest
 	public void init()
 	{
 		AdempiereTestHelper.get().init();
+		SpringContextHolder.registerJUnitBean(ADReferenceService.newMocked());
 
 		// validateBOMAndProduct uses only the Services.get(...) fields (productBL, productBOMDAO);
 		// the constructor collaborators are irrelevant to it, so mocks suffice.

--- a/backend/de.metas.manufacturing/src/test/java/org/eevolution/model/validator/PP_OrderTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/org/eevolution/model/validator/PP_OrderTest.java
@@ -1,13 +1,13 @@
 package org.eevolution.model.validator;
 
 import de.metas.ad_reference.ADReferenceService;
-import org.compiere.SpringContextHolder;
 import de.metas.document.sequence.IDocumentNoBuilderFactory;
 import de.metas.material.event.PostMaterialEventService;
 import de.metas.material.planning.pporder.IPPOrderBOMBL;
 import de.metas.material.planning.pporder.PPOrderPojoConverter;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.SpringContextHolder;
 import org.compiere.model.I_M_Product;
 import org.compiere.model.X_M_Product;
 import org.eevolution.api.impl.ProductBOMVersionsDAO;

--- a/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/interceptor/C_PurchaseCandidateTest.java
+++ b/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/interceptor/C_PurchaseCandidateTest.java
@@ -23,12 +23,12 @@
 package de.metas.purchasecandidate.interceptor;
 
 import de.metas.ad_reference.ADReferenceService;
-import org.compiere.SpringContextHolder;
 import de.metas.purchasecandidate.PurchaseCandidateRepository;
 import de.metas.purchasecandidate.model.I_C_PurchaseCandidate;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.SpringContextHolder;
 import org.compiere.model.I_M_Product;
 import org.compiere.model.ModelValidator;
 import org.compiere.model.X_M_Product;

--- a/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/interceptor/C_PurchaseCandidateTest.java
+++ b/backend/de.metas.purchasecandidate.base/src/test/java/de/metas/purchasecandidate/interceptor/C_PurchaseCandidateTest.java
@@ -22,6 +22,8 @@
 
 package de.metas.purchasecandidate.interceptor;
 
+import de.metas.ad_reference.ADReferenceService;
+import org.compiere.SpringContextHolder;
 import de.metas.purchasecandidate.PurchaseCandidateRepository;
 import de.metas.purchasecandidate.model.I_C_PurchaseCandidate;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
@@ -65,6 +67,7 @@ class C_PurchaseCandidateTest
 	void beforeEach()
 	{
 		AdempiereTestHelper.get().init();
+		SpringContextHolder.registerJUnitBean(ADReferenceService.newMocked());
 		interceptor = new C_PurchaseCandidate(Mockito.mock(PurchaseCandidateRepository.class));
 	}
 


### PR DESCRIPTION
## What

Two defects reported on the merged Product Life Cycle Status ("BBS-Status") feature.

**1. German dropdown/grid showed English labels.**
The tenant base language is de_DE, so `AD_Ref_List.Name` is the base-language (German) display label. The original migration put the English text into `Name` with an empty `ValueName`, so de_DE users saw "Blocked" instead of "Gesperrt". Migration `5817300` restores the German base `Name` **and** sets the English `ValueName` — mirroring core `ProductType` (`Name='Artikel'`, `ValueName='Item'`). The generated Java constants derive from `ValueName`, so they stay unchanged (`_PhaseOut` / `_Blocked` / `_DeliveryStop`); only `X_M_Product` doc-comments refresh.

**2. Action-blocked error message showed the raw status letter** (e.g. `G`) instead of the human-readable status.
`ProductBL.assertAllowed` now resolves the locale-aware status name via `ADReferenceService.retrieveListNameTranslatableString` (lazy `forwardingTo` — resolves per the reader's language at render time).

## Tests

- 7 guard tests register a mocked `ADReferenceService` so the error path resolves the ref-list name in the POJO test environment.
- Migration is idempotent-guarded (fires only while `Name` is still English) so it correctly follows the already-merged base migration in a fresh CI build.
