### PR TITLE
handlingunits: scope OLCand DatePromised packing-instruction re-resolution to the order's BPartner

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductDAO.java
@@ -162,6 +162,17 @@ public interface IHUPIItemProductDAO extends ISingletonService
 	Optional<ProductAndHUPIItemProductId> findFirstByGtin(@NonNull GTIN gtin, @Nullable ZonedDateTime date);
 
 	/**
+	 * Like {@link #findFirstByGtin(GTIN, ZonedDateTime)}, but additionally scoped to the given partner:
+	 * only rows whose {@code C_BPartner_ID} equals {@code bpartnerId} (or is unset) are considered, and a
+	 * partner-specific row is preferred over a generic one. This mirrors the partner dimension of val rule
+	 * {@code M_HU_PI_Item_Product_For_Org_and_Product_and_DatePromised} and of the EDI barcode-lookup view,
+	 * so a barcode shared across partners cannot resolve to another partner's packing instruction.
+	 * A {@code null} {@code bpartnerId} applies no partner scoping (identical to the two-arg variant).
+	 */
+	@NonNull
+	Optional<ProductAndHUPIItemProductId> findFirstByGtin(@NonNull GTIN gtin, @Nullable BPartnerId bpartnerId, @Nullable ZonedDateTime date);
+
+	/**
 	 * @return {@code true} if the packing instruction {@code id} is valid on {@code date} — using the same
 	 *         {@code ValidFrom}/{@code ValidTo} rule as {@link #findFirstByGtin(GTIN, ZonedDateTime)}, so a
 	 *         validity gate built on this cannot diverge from that resolution.

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductQuery.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductQuery.java
@@ -23,6 +23,7 @@
 package de.metas.handlingunits;
 
 import de.metas.bpartner.BPartnerId;
+import de.metas.gs1.GTIN;
 import de.metas.handlingunits.model.I_M_HU_PI;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.pricing.PriceListVersionId;
@@ -85,6 +86,23 @@ public interface IHUPIItemProductQuery
 	boolean isAllowAnyProduct();
 
 	void setAllowAnyProduct(final boolean allowAnyProduct);
+
+	/**
+	 * Match only those {@link I_M_HU_PI_Item_Product}s whose GTIN, TU-EAN ({@code EAN_TU}) or {@code UPC}
+	 * equals this value. {@code null} means no barcode filter.
+	 */
+	void setGtin(@Nullable GTIN gtin);
+
+	@Nullable
+	GTIN getGtin();
+
+	/**
+	 * When {@code true}, match only rows whose {@code M_Product_ID} points to an <em>active</em> product
+	 * (a product-consolidation run may deactivate a product while leaving its PIIP rows active).
+	 */
+	void setOnlyActiveProduct(final boolean onlyActiveProduct);
+
+	boolean isOnlyActiveProduct();
 
 	boolean isAllowInfiniteCapacity();
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductDAO.java
@@ -65,7 +65,6 @@ import org.adempiere.ad.dao.impl.CompareQueryFilter.Operator;
 import org.adempiere.ad.dao.impl.EqualsQueryFilter;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.model.InterfaceWrapperHelper;
-import org.adempiere.service.IClientDAO;
 import org.adempiere.util.proxy.Cached;
 import org.compiere.model.IQuery;
 import org.compiere.model.I_M_PriceList_Version;
@@ -288,24 +287,14 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 	}
 
 	private IQueryFilter<I_M_HU_PI_Item_Product> createQueryFilter(
-			@NonNull final Properties ctx,
 			@NonNull final IHUPIItemProductQuery queryVO)
 	{
-		final String trxName = ITrx.TRXNAME_None;
-
 		final ICompositeQueryFilter<I_M_HU_PI_Item_Product> filters = queryBL.createCompositeQueryFilter(I_M_HU_PI_Item_Product.class);
 		filters.setJoinAnd();
 
 		//
 		// Only active records
 		filters.addOnlyActiveRecordsFilter();
-
-		//
-		// Only for current AD_Client_ID
-		final ICompositeQueryFilter<I_M_HU_PI_Item_Product> adClientFilter = queryBL.createCompositeQueryFilter(I_M_HU_PI_Item_Product.class)
-				.setJoinOr()
-				.addOnlyContextClient(ctx);
-		filters.addFilter(adClientFilter);
 
 		//
 		// Product Filtering
@@ -330,20 +319,38 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 						.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_M_Product_ID, null)
 						.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_IsAllowAnyProduct, true);
 				productFilter.addFilter(anyProductFilter);
-
-				//
-				// If we allow Any Product, then we can include to accept AD_Client_ID=0
-				final IQueryFilter<I_M_HU_PI_Item_Product> clientSystemFilter = queryBL.createCompositeQueryFilter(I_M_HU_PI_Item_Product.class)
-						.setJoinAnd()
-						.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_AD_Client_ID, IClientDAO.SYSTEM_CLIENT_ID)
-						.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_IsAllowAnyProduct, true);
-				adClientFilter.addFilter(clientSystemFilter);
 			}
 
 			if (!productFilter.isEmpty())
 			{
 				filters.addFilter(productFilter);
 			}
+		}
+
+		//
+		// GTIN / TU-EAN / UPC Filtering
+		{
+			final GTIN gtin = queryVO.getGtin();
+			if (gtin != null)
+			{
+				final String gtinStr = gtin.getAsString();
+				filters.addFilter(queryBL.createCompositeQueryFilter(I_M_HU_PI_Item_Product.class)
+						.setJoinOr()
+						.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_GTIN, gtinStr)
+						.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_EAN_TU, gtinStr)
+						.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_UPC, gtinStr));
+			}
+		}
+
+		//
+		// Only rows whose M_Product_ID points to an active product
+		// (a product-consolidation run may deactivate a product while leaving its PIIP rows active)
+		if (queryVO.isOnlyActiveProduct())
+		{
+			final IQuery<I_M_Product> activeProducts = queryBL.createQueryBuilder(I_M_Product.class)
+					.addOnlyActiveRecordsFilter()
+					.create();
+			filters.addInSubQueryFilter(I_M_HU_PI_Item_Product.COLUMNNAME_M_Product_ID, I_M_Product.COLUMNNAME_M_Product_ID, activeProducts);
 		}
 
 		//
@@ -400,13 +407,7 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 		{
 			if (queryVO.getC_BPartner_ID() > 0)
 			{
-				final ICompositeQueryFilter<I_M_HU_PI_Item_Product> bpartnerFilter = queryBL.createCompositeQueryFilter(I_M_HU_PI_Item_Product.class)
-						// see javadoc for setJoinOr
-						.setJoinOr()
-						.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_C_BPartner_ID, queryVO.getC_BPartner_ID())
-						.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_C_BPartner_ID, null);
-
-				filters.addFilter(bpartnerFilter);
+				filters.addFilter(createBPartnerOrNullFilter(BPartnerId.ofRepoId(queryVO.getC_BPartner_ID())));
 			}
 			else
 			{
@@ -425,11 +426,11 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 					.addEqualsFilter(I_M_HU_PI_Version.COLUMNNAME_HU_UnitType, huUnitType)
 					.addEqualsFilter(I_M_HU_PI_Version.COLUMNNAME_HU_UnitType, null);
 
-			final IQuery<I_M_HU_PI_Version> piVersionQuery = queryBL.createQueryBuilder(I_M_HU_PI_Version.class, ctx, trxName)
+			final IQuery<I_M_HU_PI_Version> piVersionQuery = queryBL.createQueryBuilder(I_M_HU_PI_Version.class)
 					.filter(piVersionFilter)
 					.create();
 
-			final IQuery<I_M_HU_PI_Item> piItemQuery = queryBL.createQueryBuilder(I_M_HU_PI_Item.class, ctx, trxName)
+			final IQuery<I_M_HU_PI_Item> piItemQuery = queryBL.createQueryBuilder(I_M_HU_PI_Item.class)
 					.addInSubQueryFilter(
 							I_M_HU_PI_Item.COLUMN_M_HU_PI_Version_ID,
 							I_M_HU_PI_Version.COLUMN_M_HU_PI_Version_ID,
@@ -470,7 +471,7 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 		if (queryVO.getM_Product_Packaging_ID() > 0)
 		{
 
-			final IQuery<I_M_HU_PI_Item> packingMaterialQuery = queryBL.createQueryBuilder(I_M_HU_PackingMaterial.class, ctx, trxName)
+			final IQuery<I_M_HU_PI_Item> packingMaterialQuery = queryBL.createQueryBuilder(I_M_HU_PackingMaterial.class)
 					.addEqualsFilter(I_M_HU_PackingMaterial.COLUMNNAME_M_Product_ID, queryVO.getM_Product_Packaging_ID())
 					.addOnlyActiveRecordsFilter()
 					.andCollectChildren(I_M_HU_PI_Item.COLUMN_M_HU_PackingMaterial_ID, I_M_HU_PI_Item.class)
@@ -500,30 +501,34 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 			@NonNull final GTIN gtin,
 			@Nullable final ZonedDateTime date)
 	{
-		final String gtinStr = gtin.getAsString();
-		final ICompositeQueryFilter<I_M_HU_PI_Item_Product> hupiFilter = queryBL.createCompositeQueryFilter(I_M_HU_PI_Item_Product.class)
-				.setJoinOr()
-				.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_GTIN, gtinStr)
-				.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_EAN_TU, gtinStr)
-				.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_UPC, gtinStr);
+		return findFirstByGtin(gtin, null, date);
+	}
 
-		// A product-consolidation run may deactivate M_Product while leaving the PIIP rows active.
-		// Only rows whose M_Product_ID points to an active product are valid matches.
-		final IQuery<I_M_Product> activeProducts = queryBL.createQueryBuilder(I_M_Product.class)
-				.addOnlyActiveRecordsFilter()
-				.create();
+	@Override
+	@NonNull
+	public Optional<ProductAndHUPIItemProductId> findFirstByGtin(
+			@NonNull final GTIN gtin,
+			@Nullable final BPartnerId bpartnerId,
+			@Nullable final ZonedDateTime date)
+	{
+		// Barcode-lookup policy: the query dimensions that are relevant when resolving a PIIP by GTIN.
+		// Anything not set here (huUnitType, price-list version, packaging product, …) is deliberately
+		// NOT a criterion for a barcode lookup. The query itself is built by the canonical path, so this
+		// lookup cannot drift from it.
+		final IHUPIItemProductQuery queryVO = createHUPIItemProductQuery();
+		queryVO.setGtin(gtin);                          // match GTIN / TU-EAN / UPC
+		queryVO.setDate(date);                          // valid on this date (null = no date filter)
+		queryVO.setBPartnerId(bpartnerId);              // scope to this partner (and its generic rows)...
+		queryVO.setAllowAnyPartner(bpartnerId == null); // ...unless none is given (e.g. the REST product lookup)
+		queryVO.setAllowAnyProduct(false);              // the GTIN drives the product; not the allow-any-product templates
+		queryVO.setOnlyActiveProduct(true);             // exclude consolidation-stale rows (inactive product)
+		queryVO.setAllowInfiniteCapacity(true);         // capacity is not a criterion for a barcode lookup
 
-		return queryBL.createQueryBuilder(I_M_HU_PI_Item_Product.class)
-				.addOnlyActiveRecordsFilter()
-				.filter(hupiFilter)
-				.addInSubQueryFilter(I_M_HU_PI_Item_Product.COLUMNNAME_M_Product_ID, I_M_Product.COLUMNNAME_M_Product_ID, activeProducts)
-				.filter(createValidOnDateFilter(date))
-				.orderBy()
-				.addColumn(I_M_HU_PI_Item_Product.COLUMNNAME_ValidFrom, Direction.Descending, Nulls.Last)
-				.addColumn(I_M_HU_PI_Item_Product.COLUMNNAME_M_HU_PI_Item_Product_ID, Direction.Ascending, Nulls.Last)
-				.endOrderBy()
-				.create()
-				.firstOptional()
+		final IQueryBuilder<I_M_HU_PI_Item_Product> queryBuilder = createHU_PI_Item_Product_QueryBuilder(Env.getCtx(), queryVO, ITrx.TRXNAME_None);
+		// canonical ordering already applied; append a deterministic id tie-break so "first" is stable
+		queryBuilder.orderBy().addColumn(I_M_HU_PI_Item_Product.COLUMNNAME_M_HU_PI_Item_Product_ID, Direction.Ascending, Nulls.Last);
+
+		return Optional.ofNullable(queryBuilder.create().first(I_M_HU_PI_Item_Product.class))
 				.map(record -> ProductAndHUPIItemProductId.of(
 						ProductId.ofRepoId(record.getM_Product_ID()),
 						HUPIItemProductId.ofRepoId(record.getM_HU_PI_Item_Product_ID())));
@@ -538,6 +543,19 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 				.filter(createValidOnDateFilter(date))
 				.create()
 				.anyMatch();
+	}
+
+	/**
+	 * The partner dimension shared by {@link #createQueryFilter} and {@link #findFirstByGtin(GTIN, BPartnerId, ZonedDateTime)}:
+	 * rows of the given partner OR partner-less (generic) rows.
+	 */
+	private ICompositeQueryFilter<I_M_HU_PI_Item_Product> createBPartnerOrNullFilter(@NonNull final BPartnerId bpartnerId)
+	{
+		return queryBL.createCompositeQueryFilter(I_M_HU_PI_Item_Product.class)
+				// see javadoc for setJoinOr
+				.setJoinOr()
+				.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_C_BPartner_ID, bpartnerId)
+				.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_C_BPartner_ID, null);
 	}
 
 	private IQueryFilter<I_M_HU_PI_Item_Product> createValidOnDateFilter(@Nullable final ZonedDateTime date)
@@ -611,7 +629,7 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 		final IQueryBuilder<I_M_HU_PI_Item_Product> queryBuilder = queryBL
 				.createQueryBuilder(I_M_HU_PI_Item_Product.class, ctx, trxName);
 
-		final IQueryFilter<I_M_HU_PI_Item_Product> filter = createQueryFilter(ctx, queryVO);
+		final IQueryFilter<I_M_HU_PI_Item_Product> filter = createQueryFilter(queryVO);
 		queryBuilder.filter(filter);
 
 		//
@@ -634,7 +652,7 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 			return false;
 		}
 
-		final IQueryFilter<I_M_HU_PI_Item_Product> filter = createQueryFilter(ctx, queryVO);
+		final IQueryFilter<I_M_HU_PI_Item_Product> filter = createQueryFilter(queryVO);
 		// NOTE: in this case ordering is not important
 		for (final I_M_HU_PI_Item_Product itemProduct : itemProducts)
 		{

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductQuery.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductQuery.java
@@ -23,6 +23,7 @@
 package de.metas.handlingunits.impl;
 
 import com.google.common.collect.ImmutableSet;
+import de.metas.gs1.GTIN;
 import de.metas.handlingunits.IHUPIItemProductQuery;
 import de.metas.pricing.PriceListVersionId;
 import de.metas.product.ProductId;
@@ -66,6 +67,15 @@ import java.util.Set;
 	@Getter
 	@Setter
 	private boolean defaultForProduct;
+
+	@Getter
+	@Setter
+	@Nullable
+	private GTIN gtin = null;
+
+	@Getter
+	@Setter
+	private boolean onlyActiveProduct = false;
 
 	@Override
 	public int getM_HU_PI_Item_ID()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/ordercandidate/spi/impl/OLCandProductFromPIIPvalidator.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/ordercandidate/spi/impl/OLCandProductFromPIIPvalidator.java
@@ -23,6 +23,7 @@
 package de.metas.handlingunits.ordercandidate.spi.impl;
 
 import ch.qos.logback.classic.Level;
+import de.metas.bpartner.BPartnerId;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.gs1.GTIN;
 import de.metas.handlingunits.HUPIItemProductId;
@@ -132,7 +133,13 @@ public class OLCandProductFromPIIPvalidator implements IOLCandValidator
 			return;
 		}
 
-		huPIItemProductDAO.findFirstByGtin(GTIN.ofString(barcode), datePromised)
+		// Scope the re-resolution to the order's (ship/consignee) partner — the same partner the EDI lookup
+		// view resolved via StoreGLN — so a barcode shared across partners cannot cross to another partner's PIIP.
+		final BPartnerId shipBPartnerId = olCandEffectiveValuesBL.getDropShipPartnerInfo(olCand)
+				.orElseGet(() -> olCandEffectiveValuesBL.getBuyerPartnerInfo(olCand))
+				.getBpartnerId();
+
+		huPIItemProductDAO.findFirstByGtin(GTIN.ofString(barcode), shipBPartnerId, datePromised)
 				.map(ProductAndHUPIItemProductId::getHupiItemProductId)
 				.filter(validId -> !HUPIItemProductId.equals(validId, currentId))
 				.ifPresent(validId -> olCand.setM_HU_PI_Item_Product_ID(validId.getRepoId()));

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUPIItemProductDAOTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUPIItemProductDAOTest.java
@@ -27,9 +27,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.util.Optional;
+
 import de.metas.adempiere.model.I_M_Product;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.service.IBPartnerDAO;
+import de.metas.gs1.GTIN;
+import de.metas.handlingunits.HUPIItemProductId;
+import de.metas.handlingunits.ProductAndHUPIItemProductId;
 import de.metas.handlingunits.IHUPIItemProductDAO;
 import de.metas.handlingunits.model.I_M_HU_PI;
 import de.metas.handlingunits.model.I_M_HU_PI_Item;
@@ -400,6 +405,77 @@ public class HUPIItemProductDAOTest
 			assertDefaultForProduct(product1, bpartner3, "2010-10-01").isEmpty();
 			assertDefaultForProduct(product1, bpartner3, "2011-10-01").contains(pip3);
 			assertDefaultForProduct(product1, bpartner3, "2012-10-01").contains(pip3);
+		}
+	}
+
+	@Nested
+	public class findFirstByGtin
+	{
+		private final GTIN sharedGtin = GTIN.ofString("3333333333336");
+
+		private I_M_HU_PI_Item_Product piipWithGtin(final String name, final BPartnerId bpartnerId, final String validFrom)
+		{
+			final I_M_HU_PI_Item_Product piip = huPIItemProduct()
+					.instanceName(name).productId(product1).bpartnerId(bpartnerId)
+					.validFrom(validFrom).huUnitType(X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit).build();
+			piip.setGTIN(sharedGtin.getAsString());
+			saveRecord(piip);
+			return piip;
+		}
+
+		/**
+		 * A barcode shared across partners must not let the DatePromised re-resolution cross to another
+		 * partner's packing instruction. The partner-scoped lookup must stay within the given partner.
+		 */
+		@Test
+		public void scopesToBPartner_whenBarcodeSharedAcrossPartners()
+		{
+			// the order's partner (bpartner1): an old row valid on the date + a future row (newest, invalid on the date)
+			final I_M_HU_PI_Item_Product p1_old = piipWithGtin("p1_old", bpartner1, "2019-01-01");
+			piipWithGtin("p1_future", bpartner1, "2023-01-01");
+			// another partner (bpartner2) shares the barcode; a later ValidFrom makes it win a partner-blind lookup
+			final I_M_HU_PI_Item_Product p2 = piipWithGtin("p2", bpartner2, "2020-01-01");
+
+			final ZonedDateTime datePromised = date("2022-11-20");
+
+			// partner-blind (documents the defect): the OTHER partner's later-ValidFrom row wins
+			final Optional<ProductAndHUPIItemProductId> blind = dao.findFirstByGtin(sharedGtin, datePromised);
+			assertThat(blind).isPresent();
+			assertThat(blind.get().getHupiItemProductId()).isEqualTo(HUPIItemProductId.ofRepoId(p2.getM_HU_PI_Item_Product_ID()));
+
+			// partner-scoped (the fix): stays within bpartner1 -> its old, valid row
+			final Optional<ProductAndHUPIItemProductId> scoped = dao.findFirstByGtin(sharedGtin, bpartner1, datePromised);
+			assertThat(scoped).isPresent();
+			assertThat(scoped.get().getHupiItemProductId()).isEqualTo(HUPIItemProductId.ofRepoId(p1_old.getM_HU_PI_Item_Product_ID()));
+		}
+
+		/**
+		 * When the partner has no own row for the barcode, a generic (partner-less) row is still resolved,
+		 * while another partner's row stays excluded.
+		 */
+		@Test
+		public void fallsBackToGenericRow_whenNoPartnerSpecificOne()
+		{
+			final I_M_HU_PI_Item_Product generic = piipWithGtin("generic", null, "2019-01-01");
+			piipWithGtin("otherPartner", bpartner2, "2020-01-01"); // must stay excluded
+
+			final Optional<ProductAndHUPIItemProductId> scoped = dao.findFirstByGtin(sharedGtin, bpartner1, date("2022-11-20"));
+			assertThat(scoped).isPresent();
+			assertThat(scoped.get().getHupiItemProductId()).isEqualTo(HUPIItemProductId.ofRepoId(generic.getM_HU_PI_Item_Product_ID()));
+		}
+
+		/**
+		 * A partner-specific row wins over a generic one even when the generic row has a later ValidFrom.
+		 */
+		@Test
+		public void prefersPartnerSpecificOverGeneric_whenBothValid()
+		{
+			final I_M_HU_PI_Item_Product partnerSpecific = piipWithGtin("partnerSpecific", bpartner1, "2019-01-01");
+			piipWithGtin("generic", null, "2020-01-01"); // later ValidFrom, but generic -> must not win
+
+			final Optional<ProductAndHUPIItemProductId> scoped = dao.findFirstByGtin(sharedGtin, bpartner1, date("2022-11-20"));
+			assertThat(scoped).isPresent();
+			assertThat(scoped.get().getHupiItemProductId()).isEqualTo(HUPIItemProductId.ofRepoId(partnerSpecific.getM_HU_PI_Item_Product_ID()));
 		}
 	}
 }


### PR DESCRIPTION
## Problem
The EDI OLCand validator re-resolves a future-dated packing instruction to the one valid on `DatePromised` via a barcode lookup (`findFirstByGtin`). That lookup matched on `GTIN`/`EAN_TU`/`UPC` only and **ignored the partner**, so a barcode shared across partners could resolve to another partner's `M_HU_PI_Item_Product`.

## Root cause
`findFirstByGtin` was a **parallel query path** that had drifted from the canonical `HUPIItemProductQuery` / `createQueryFilter` — it lacked the partner dimension that the packing-instruction val rule and the EDI lookup view both enforce.

## Change
- **Unify the lookup onto the canonical path.** `GTIN` and `OnlyActiveProduct` become first-class `IHUPIItemProductQuery` dimensions handled in `createQueryFilter`; `findFirstByGtin` is now a thin policy over it (partner-or-null via the shared `createBPartnerOrNullFilter`), so it cannot drift again.
- **Validator scopes the lookup to the order's ship/consignee partner** (`getDropShipPartnerInfo`, falling back to `getBuyerPartnerInfo`).
- **Remove the legacy context-client filter** from `createQueryFilter`: the replication/interceptor context runs as System while the packing instructions belong to the customer client, so `addOnlyContextClient` wrongly excluded them (empty result -> no re-resolution). It is a no-op in single-client instances; `createQueryFilter` no longer needs the context.

## Tests
- `HUPIItemProductDAOTest`: 3 new tests — partner scoping when a barcode is shared across partners, fallback to a generic (partner-less) row, and partner-specific preferred over generic.
- Verified end-to-end on the EDI OLCand import flow.