### PR TITLE
handlingunits: OLCand barcode re-resolution picks the latest valid packing instruction version

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/import/olCand.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/import/olCand.feature
@@ -478,3 +478,86 @@ Feature: import order candidate to metasfresh
     And validate C_OLCand:
       | C_OLCand_ID.Identifier | OPT.M_HU_PI_Item_Product_ID.Identifier | M_Product_ID.Identifier | QtyEntered | OPT.POReference |
       | olCand_after           | huItemProduct_future                   | product                 | 20         | PORef_after     |
+
+  @from:cucumber
+@allure.label.epic:E0292_EDI
+@allure.label.feature:F00350_EDI
+  Scenario: On and after the switch date the latest-valid M_HU_PI_Item_Product is used even when the barcode view resolves an older, default-flagged row
+  _Given two rows for the same product/UPC/BPartner: a NEW one (Qty 6, ValidFrom 2023-01-01) and an OLD one (Qty 9, ValidFrom 2019-01-01, IsDefaultForProduct) created after it so it has the higher M_HU_PI_Item_Product_ID
+  _And so the date-blind barcode-lookup view resolves the OLD row (highest id)
+  _When importing an OLCand with DatePromised 2024-06-01 (ON/AFTER both rows' ValidFrom, both valid)
+  _Then C_OLCand.M_HU_PI_Item_Product_ID must be the NEW row (latest ValidFrom): the default flag must not override the reference date, and a still-valid old row must not be kept
+
+    Given metasfresh contains C_BPartners:
+      | Identifier      | Name            | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | bpartner_ver    | BPartner_Ver    | N            | Y              | ps_1                          |
+      | orgBPartner_ver | OrgBPartner_Ver | N            | Y              | ps_1                          |
+    # The date-blind barcode-lookup view stamps the OLCand with the highest-id row for the UPC. The old
+    # (superseded, still-valid, product-default) row here carries the HIGHER id, so the view stamps it even
+    # though the delivery date is on/after the new version's switch date. The validator must correct this to
+    # the latest valid version.
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  | OPT.Name        | OPT.C_UOM_ID.X12DE355 | OPT.C_BPartner_ID.Identifier | OPT.UPC       | OPT.IsDefaultForProduct |
+      | huItemProduct_ver_old              | huPiItemTU_1               | product                 | 9   | 2019-01-01 | Packing 9 (old) | PCE                   | bpartner_ver                 | 5555555555558 | Y                       |
+      | huItemProduct_ver_new              | huPiItemTU_2               | product                 | 6   | 2023-01-01 | Packing 6 (new) | PCE                   | bpartner_ver                 | 5555555555558 |                         |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier      | GLN           | C_BPartner_ID.Identifier | OPT.IsShipTo |
+      | bpLoc_ver_main  | 3234567893000 | bpartner_ver             | false        |
+      | bpLoc_ver_store | 3234567893001 | bpartner_ver             | true         |
+      | bpLoc_ver_org   | 4222222222220 | orgBPartner_ver          | false        |
+
+    When send message to RabbitMQ queue defined by:impProcessor
+  """
+<?xml version="1.0" encoding="UTF-8"?><EDI_Imp_C_OLCand AD_Client_Value="SYSTEM" ReplicationEvent="5" ReplicationMode="0" ReplicationType="M" TrxName="" Version="*">
+      <ExternalSystem_ID>540007</ExternalSystem_ID>
+      <AD_DataDestination_ID>
+        <InternalName>DEST.de.metas.ordercandidate</InternalName>
+      </AD_DataDestination_ID>
+      <AD_Org_ID>
+      <GLN>4222222222220</GLN>
+      </AD_Org_ID>
+      <AD_User_EnteredBy_ID>2188223</AD_User_EnteredBy_ID>
+      <C_BPartner_ID>
+        <GLN>3234567893000</GLN>
+        <StoreGLN>3234567893001</StoreGLN>
+      </C_BPartner_ID>
+      <C_BPartner_Location_ID>
+        <C_BPartner_ID>
+          <GLN>3234567893000</GLN>
+          <StoreGLN>3234567893001</StoreGLN>
+        </C_BPartner_ID>
+        <GLN>3234567893000</GLN>
+      </C_BPartner_Location_ID>
+      <C_Currency_ID>
+        <ISO_Code>EUR</ISO_Code>
+      </C_Currency_ID>
+      <C_UOM_ID>
+        <X12DE355>KGM</X12DE355>
+      </C_UOM_ID>
+      <DateCandidate>2024-05-17+03:00</DateCandidate>
+      <DeliveryRule>F</DeliveryRule>
+      <DeliveryViaRule>S</DeliveryViaRule>
+      <IsManualPrice>Y</IsManualPrice>
+      <M_Product_ID>
+        <UPC>5555555555558</UPC>
+        <GLN>3234567893000</GLN>
+      </M_Product_ID>
+      <M_HU_PI_Item_Product_ID>
+        <UPC>5555555555558</UPC>
+        <GLN>3234567893000</GLN>
+        <StoreGLN>3234567893001</StoreGLN>
+      </M_HU_PI_Item_Product_ID>
+      <PriceEntered>5</PriceEntered>
+      <QtyEntered>30</QtyEntered>
+      <POReference>PORef_ver</POReference>
+      <DatePromised>2024-06-01T23:59:59+03:00</DatePromised>
+    </EDI_Imp_C_OLCand>
+"""
+
+    Then after not more than 120s, C_OLCand is found
+      | C_OLCand_ID.Identifier | ExternalSystem.Value | M_Product_ID | OPT.C_BPartner_ID.Identifier | QtyEntered | OPT.POReference | OPT.IMP_Processor_ID.Identifier |
+      | olCand_ver             | Shopware6            | product      | bpartner_ver                 | 30         | PORef_ver       | impProcessor                    |
+
+    And validate C_OLCand:
+      | C_OLCand_ID.Identifier | OPT.M_HU_PI_Item_Product_ID.Identifier | M_Product_ID.Identifier | QtyEntered | OPT.POReference |
+      | olCand_ver             | huItemProduct_ver_new                  | product                 | 30         | PORef_ver       |

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductDAO.java
@@ -171,11 +171,4 @@ public interface IHUPIItemProductDAO extends ISingletonService
 	 */
 	@NonNull
 	Optional<ProductAndHUPIItemProductId> findFirstByGtin(@NonNull GTIN gtin, @Nullable BPartnerId bpartnerId, @Nullable ZonedDateTime date);
-
-	/**
-	 * @return {@code true} if the packing instruction {@code id} is valid on {@code date} — using the same
-	 *         {@code ValidFrom}/{@code ValidTo} rule as {@link #findFirstByGtin(GTIN, ZonedDateTime)}, so a
-	 *         validity gate built on this cannot diverge from that resolution.
-	 */
-	boolean isValidOnDate(@NonNull HUPIItemProductId id, @NonNull ZonedDateTime date);
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductDAO.java
@@ -524,25 +524,27 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 		queryVO.setOnlyActiveProduct(true);             // exclude consolidation-stale rows (inactive product)
 		queryVO.setAllowInfiniteCapacity(true);         // capacity is not a criterion for a barcode lookup
 
-		final IQueryBuilder<I_M_HU_PI_Item_Product> queryBuilder = createHU_PI_Item_Product_QueryBuilder(Env.getCtx(), queryVO, ITrx.TRXNAME_None);
-		// canonical ordering already applied; append a deterministic id tie-break so "first" is stable
-		queryBuilder.orderBy().addColumn(I_M_HU_PI_Item_Product.COLUMNNAME_M_HU_PI_Item_Product_ID, Direction.Ascending, Nulls.Last);
-
-		return Optional.ofNullable(queryBuilder.create().first(I_M_HU_PI_Item_Product.class))
-				.map(record -> ProductAndHUPIItemProductId.of(
-						ProductId.ofRepoId(record.getM_Product_ID()),
-						HUPIItemProductId.ofRepoId(record.getM_HU_PI_Item_Product_ID())));
-	}
-
-	@Override
-	public boolean isValidOnDate(@NonNull final HUPIItemProductId id, @NonNull final ZonedDateTime date)
-	{
-		return queryBL.createQueryBuilder(I_M_HU_PI_Item_Product.class)
-				.addOnlyActiveRecordsFilter()
-				.addEqualsFilter(I_M_HU_PI_Item_Product.COLUMNNAME_M_HU_PI_Item_Product_ID, id)
-				.filter(createValidOnDateFilter(date))
+		// Ordering is intentionally NOT the canonical "default-first" one: a barcode lookup resolves the
+		// packing valid on the date, so among the rows valid on the date the one with the LATEST ValidFrom
+		// (the current version) must win — the product-default flag must not override the reference date.
+		// Partner-specific rows are still preferred over generic (partner-less) ones.
+		final I_M_HU_PI_Item_Product record = queryBL.createQueryBuilder(I_M_HU_PI_Item_Product.class)
+				.filter(createQueryFilter(queryVO))
+				.orderBy()
+				.addColumn(I_M_HU_PI_Item_Product.COLUMNNAME_C_BPartner_ID, Direction.Descending, Nulls.Last)
+				.addColumn(I_M_HU_PI_Item_Product.COLUMNNAME_ValidFrom, Direction.Descending, Nulls.Last)
+				.addColumn(I_M_HU_PI_Item_Product.COLUMNNAME_M_HU_PI_Item_Product_ID, Direction.Ascending, Nulls.Last)
+				.endOrderBy()
 				.create()
-				.anyMatch();
+				.first(I_M_HU_PI_Item_Product.class);
+
+		if (record == null)
+		{
+			return Optional.empty();
+		}
+		return Optional.of(ProductAndHUPIItemProductId.of(
+				ProductId.ofRepoId(record.getM_Product_ID()),
+				HUPIItemProductId.ofRepoId(record.getM_HU_PI_Item_Product_ID())));
 	}
 
 	/**

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductDAO.java
@@ -528,6 +528,9 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 		// packing valid on the date, so among the rows valid on the date the one with the LATEST ValidFrom
 		// (the current version) must win — the product-default flag must not override the reference date.
 		// Partner-specific rows are still preferred over generic (partner-less) ones.
+		// The id tie-break (ASC) only applies when C_BPartner_ID AND ValidFrom are equal — it just makes the
+		// result deterministic (the row established first wins); a genuinely superseding row carries a later
+		// ValidFrom, so it is selected by the ValidFrom order before the tie-break is ever reached.
 		final I_M_HU_PI_Item_Product record = queryBL.createQueryBuilder(I_M_HU_PI_Item_Product.class)
 				.filter(createQueryFilter(queryVO))
 				.orderBy()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/ordercandidate/spi/impl/OLCandProductFromPIIPvalidator.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/ordercandidate/spi/impl/OLCandProductFromPIIPvalidator.java
@@ -131,6 +131,11 @@ public class OLCandProductFromPIIPvalidator implements IOLCandValidator
 		// location), while still switching to a newer version once its ValidFrom is reached: "current is valid"
 		// is not enough — a superseded row stays valid forever without a ValidTo, so we always ask for the
 		// latest valid version and switch only if it differs (the filter below skips the no-op write).
+		//
+		// currentPartner == null means the stamped row is a generic (partner-less) one; findFirstByGtin then
+		// re-resolves across any partner (its pre-existing behaviour). In the EDI flow this path is not
+		// reached: the barcode-lookup view always stamps the partner-specific row derived from the StoreGLN,
+		// so a non-virtual generic incumbent does not occur here (the virtual fallback returned above).
 		final BPartnerId currentPartner = BPartnerId.ofRepoIdOrNull(current.getC_BPartner_ID());
 
 		huPIItemProductDAO.findFirstByGtin(GTIN.ofString(barcode), currentPartner, datePromised)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/ordercandidate/spi/impl/OLCandProductFromPIIPvalidator.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/ordercandidate/spi/impl/OLCandProductFromPIIPvalidator.java
@@ -124,22 +124,16 @@ public class OLCandProductFromPIIPvalidator implements IOLCandValidator
 
 		final ZonedDateTime datePromised = olCandEffectiveValuesBL.getDatePromised_Effective(olCand);
 
-		// The resolved instruction is already valid on DatePromised — keep it. Uses the SAME validity
-		// rule as the resolution below (one source of truth — the gate cannot diverge from it), and
-		// preserves a legitimate selection among several instructions that share one barcode (e.g. the
-		// EDI lookup view's per-BPartner/StoreGLN choice); we only correct one that is NOT valid.
-		if (huPIItemProductDAO.isValidOnDate(currentId, datePromised))
-		{
-			return;
-		}
+		// Re-resolve to the LATEST packing instruction valid on DatePromised, staying within the SAME business
+		// partner the barcode-lookup view already resolved — i.e. the current row's own C_BPartner_ID, which
+		// the view derived from the incoming StoreGLN. This preserves the per-partner selection when a barcode
+		// is shared across partners (re-deriving the order's ship partner can differ when partners share a
+		// location), while still switching to a newer version once its ValidFrom is reached: "current is valid"
+		// is not enough — a superseded row stays valid forever without a ValidTo, so we always ask for the
+		// latest valid version and switch only if it differs (the filter below skips the no-op write).
+		final BPartnerId currentPartner = BPartnerId.ofRepoIdOrNull(current.getC_BPartner_ID());
 
-		// Scope the re-resolution to the order's (ship/consignee) partner — the same partner the EDI lookup
-		// view resolved via StoreGLN — so a barcode shared across partners cannot cross to another partner's PIIP.
-		final BPartnerId shipBPartnerId = olCandEffectiveValuesBL.getDropShipPartnerInfo(olCand)
-				.orElseGet(() -> olCandEffectiveValuesBL.getBuyerPartnerInfo(olCand))
-				.getBpartnerId();
-
-		huPIItemProductDAO.findFirstByGtin(GTIN.ofString(barcode), shipBPartnerId, datePromised)
+		huPIItemProductDAO.findFirstByGtin(GTIN.ofString(barcode), currentPartner, datePromised)
 				.map(ProductAndHUPIItemProductId::getHupiItemProductId)
 				.filter(validId -> !HUPIItemProductId.equals(validId, currentId))
 				.ifPresent(validId -> olCand.setM_HU_PI_Item_Product_ID(validId.getRepoId()));

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUPIItemProductDAOTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUPIItemProductDAOTest.java
@@ -465,6 +465,24 @@ public class HUPIItemProductDAOTest
 		}
 
 		/**
+		 * On and after a version's switch date both the old and the new row are valid; the row with the
+		 * latest ValidFrom (the new version) must win — even when the OLD row is the product default.
+		 */
+		@Test
+		public void selectsLatestValidFrom_onAndAfterSwitch_evenWhenOldRowIsDefaultForProduct()
+		{
+			final I_M_HU_PI_Item_Product oldRow = piipWithGtin("old", bpartner1, "2019-01-01");
+			oldRow.setIsDefaultForProduct(true);
+			saveRecord(oldRow);
+			final I_M_HU_PI_Item_Product newRow = piipWithGtin("new", bpartner1, "2023-01-01");
+
+			// delivery date on/after the new row's ValidFrom -> both valid -> latest ValidFrom (new) wins
+			final Optional<ProductAndHUPIItemProductId> scoped = dao.findFirstByGtin(sharedGtin, bpartner1, date("2024-01-01"));
+			assertThat(scoped).isPresent();
+			assertThat(scoped.get().getHupiItemProductId()).isEqualTo(HUPIItemProductId.ofRepoId(newRow.getM_HU_PI_Item_Product_ID()));
+		}
+
+		/**
 		 * A partner-specific row wins over a generic one even when the generic row has a later ValidFrom.
 		 */
 		@Test

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/ordercandidate/spi/impl/OLCandProductFromPIIPvalidatorTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/ordercandidate/spi/impl/OLCandProductFromPIIPvalidatorTest.java
@@ -83,7 +83,9 @@ public class OLCandProductFromPIIPvalidatorTest
 	void switchesToLatestValidVersion_whenStampedRowIsValidButSuperseded()
 	{
 		// given: one product, one shared barcode, two versions — old (product default, valid from 2019)
-		// and new (valid from 2023)
+		// and new (valid from 2023). The stamped incumbent is set directly below, so the records' relative
+		// id order is irrelevant here (unlike the production EDI view, which picks by MAX id) — this test
+		// isolates the validator's re-resolution, which must key off ValidFrom, not id or the default flag.
 		final I_C_UOM uomRecord = BusinessTestHelper.createUOM("testUOM");
 		final I_M_Product productRecord = BusinessTestHelper.createProduct("testProduct", uomRecord);
 		final GTIN sharedGtin = GTIN.ofString("3333333333336");

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/ordercandidate/spi/impl/OLCandProductFromPIIPvalidatorTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/ordercandidate/spi/impl/OLCandProductFromPIIPvalidatorTest.java
@@ -23,15 +23,20 @@
 package de.metas.handlingunits.ordercandidate.spi.impl;
 
 import de.metas.business.BusinessTestHelper;
+import de.metas.gs1.GTIN;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.ordercandidate.model.I_C_OLCand;
+import lombok.NonNull;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.assertj.core.api.Assertions;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_Product;
+import org.compiere.util.TimeUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
 
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
@@ -66,5 +71,54 @@ public class OLCandProductFromPIIPvalidatorTest
 		// then
 		assertThat(olCandRecord.isError()).isFalse();
 		assertThat(olCandRecord.getM_Product_ID()).isEqualTo(productRecord.getM_Product_ID());
+	}
+
+	/**
+	 * The date-blind barcode-lookup view can stamp an OLCand with an <em>older</em> packing-instruction
+	 * version that is still valid on the delivery date (a superseded row stays valid forever without a
+	 * ValidTo). On/after the newer version's switch date the validator must re-resolve to the latest
+	 * valid version — being "valid on DatePromised" is not enough to keep the stamped one.
+	 */
+	@Test
+	void switchesToLatestValidVersion_whenStampedRowIsValidButSuperseded()
+	{
+		// given: one product, one shared barcode, two versions — old (product default, valid from 2019)
+		// and new (valid from 2023)
+		final I_C_UOM uomRecord = BusinessTestHelper.createUOM("testUOM");
+		final I_M_Product productRecord = BusinessTestHelper.createProduct("testProduct", uomRecord);
+		final GTIN sharedGtin = GTIN.ofString("3333333333336");
+
+		final I_M_HU_PI_Item_Product oldVersion = piip(productRecord, sharedGtin, "2019-01-01", true);
+		final I_M_HU_PI_Item_Product newVersion = piip(productRecord, sharedGtin, "2023-01-01", false);
+
+		// an OLCand the barcode view stamped with the OLD (still-valid, default) version, delivery date
+		// on/after the new version's switch date
+		final I_C_OLCand olCandRecord = newInstance(I_C_OLCand.class);
+		olCandRecord.setM_HU_PI_Item_Product_ID(oldVersion.getM_HU_PI_Item_Product_ID());
+		olCandRecord.setM_Product_ID(productRecord.getM_Product_ID());
+		olCandRecord.setDatePromised(TimeUtil.asTimestamp(LocalDate.parse("2024-06-01")));
+		saveRecord(olCandRecord);
+
+		// when
+		new OLCandProductFromPIIPvalidator().validate(olCandRecord);
+
+		// then: re-resolved to the latest valid version (new), not kept on the still-valid old default
+		assertThat(olCandRecord.getM_HU_PI_Item_Product_ID()).isEqualTo(newVersion.getM_HU_PI_Item_Product_ID());
+	}
+
+	private I_M_HU_PI_Item_Product piip(
+			@NonNull final I_M_Product product,
+			@NonNull final GTIN gtin,
+			@NonNull final String validFrom,
+			final boolean defaultForProduct)
+	{
+		final I_M_HU_PI_Item_Product piip = newInstance(I_M_HU_PI_Item_Product.class);
+		piip.setM_Product_ID(product.getM_Product_ID());
+		piip.setIsInfiniteCapacity(false);
+		piip.setGTIN(gtin.getAsString());
+		piip.setValidFrom(TimeUtil.asTimestamp(LocalDate.parse(validFrom)));
+		piip.setIsDefaultForProduct(defaultForProduct);
+		saveRecord(piip);
+		return piip;
 	}
 }


### PR DESCRIPTION
## Problem

On and after a packing-instruction version's switch date, a still-valid **older** `M_HU_PI_Item_Product` row could be applied instead of the newer version — especially when the old row is flagged `IsDefaultForProduct`.

The date-blind barcode-lookup view stamps the OLCand by ordering `M_HU_PI_Item_Product_ID DESC`. When record reuse gives a superseded row the higher id, the view stamps that stale row, and two things then keep it:

1. **Barcode lookup ordering.** `findFirstByGtin` used the canonical order (`createQueryOrderByBuilder`), which ranks `IsDefaultForProduct` **before** `ValidFrom` — so a default old row outranked a newer valid one.
2. **Validator gate.** The OLCand validator kept the current instruction whenever it was merely *valid* on `DatePromised`. A superseded row stays valid forever when it has no `ValidTo`, so "current is valid" is not "current is the latest version" — the newer version was never picked up.

## Change

- `findFirstByGtin` now orders `C_BPartner_ID DESC → ValidFrom DESC → id ASC`: among rows valid on the date the **latest `ValidFrom`** wins; the product-default flag no longer overrides the reference date.
- The validator always re-resolves to the latest valid version, scoped to the **current row's own business partner** (the one the barcode-lookup view derived from the incoming StoreGLN) — preserving per-partner selection when a barcode is shared across partners — and switches only when the latest differs from the current.
- Removes the now-unused `isValidOnDate` DAO method.

## Tests

- `HUPIItemProductDAOTest.selectsLatestValidFrom_onAndAfterSwitch_evenWhenOldRowIsDefaultForProduct` — latest `ValidFrom` wins even when the old row is the product default.
- `OLCandProductFromPIIPvalidatorTest.switchesToLatestValidVersion_whenStampedRowIsValidButSuperseded` — an OLCand stamped with a superseded-but-valid row is re-resolved to the latest version (verified RED with the old gate simulated back in).
- `olCand.feature` — end-to-end EDI import scenario across the version switch date.
