### PR TITLE
Product Life Cycle Status: block finished-good receipt for a manufacture-blocked product

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
@@ -245,6 +245,8 @@ public class PP_Order_StepDef
 	 *   | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | ErrorCode                         |
 	 *   | ppOrder_blocked        | MOP         | blocked                 | 10         | testResource             | 2022-01-05T23:59:00.00Z | 2022-01-05T23:59:00.00Z | 2022-01-05T23:59:00.00Z | M_Product_BBSStatus_ActionBlocked |
 	 * </pre>
+	 *
+	 * @see #compute_PPOrderCreateRequest_to_create_pp_order(io.cucumber.datatable.DataTable) the create step whose full column contract this reuses
 	 */
 	@And("create PP_Order expecting error:")
 	public void create_pp_order_expecting_error(@NonNull final DataTable dataTable)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
@@ -108,6 +108,7 @@ import java.util.function.Supplier;
 import static de.metas.cucumber.stepdefs.StepDefConstants.TABLECOLUMN_IDENTIFIER;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 public class PP_Order_StepDef
 {
@@ -220,6 +221,45 @@ public class PP_Order_StepDef
 
 			ppOrderTable.put(row.getAsIdentifier(I_PP_Order.COLUMNNAME_PP_Order_ID), ppOrder);
 		});
+	}
+
+	/**
+	 * Creates a manufacturing order and asserts it is rejected at save time by the {@link org.eevolution.model.validator.PP_Order}
+	 * model interceptor's product life-cycle (BBS-status) guard, exposing the resulting {@link AdempiereException#getErrorCode()}.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>PP_Order_ID</b> — (required, identifier-ref) alias for the order that must NOT be created<br>
+	 *   <b>DocBaseType</b> — (required) PP_Order doc-base-type, e.g. {@code MOP}<br>
+	 *   <b>M_Product_ID</b> — (required, identifier-ref) the finished-good product being manufactured<br>
+	 *   <b>QtyEntered</b> — (required) quantity to manufacture<br>
+	 *   <b>S_Resource_ID</b> — (required, identifier-ref) the plant/resource<br>
+	 *   <b>DateOrdered</b> — (required) order date<br>
+	 *   <b>DatePromised</b> — (required) promised date<br>
+	 *   <b>DateStartSchedule</b> — (required) schedule start date<br>
+	 *   <b>ErrorCode</b> — (required) the expected {@link AdempiereException#getErrorCode()}, e.g. {@code M_Product_BBSStatus_ActionBlocked}<br>
+	 * @cucumber.depends StepDefData: M_Product_StepDefData, S_Resource_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And create PP_Order expecting error:
+	 *   | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | ErrorCode                         |
+	 *   | ppOrder_blocked        | MOP         | blocked                 | 10         | testResource             | 2022-01-05T23:59:00.00Z | 2022-01-05T23:59:00.00Z | 2022-01-05T23:59:00.00Z | M_Product_BBSStatus_ActionBlocked |
+	 * </pre>
+	 */
+	@And("create PP_Order expecting error:")
+	public void create_pp_order_expecting_error(@NonNull final DataTable dataTable)
+	{
+		final DataTableRow row = DataTableRows.of(dataTable).singleRow();
+		final String expectedErrorCode = row.getAsString("ErrorCode");
+		try
+		{
+			compute_PPOrderCreateRequest_to_create_pp_order(dataTable);
+			fail("Creating the PP_Order should have been rejected with error code " + expectedErrorCode);
+		}
+		catch (final AdempiereException exception)
+		{
+			assertThat(exception.getErrorCode()).isEqualTo(expectedErrorCode);
+		}
 	}
 
 	@And("complete planning for PP_Order:")

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/productLifeCycleStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/productLifeCycleStatus.feature
@@ -26,7 +26,7 @@ Feature: product life-cycle status enforcement on order lines
       | Identifier    | Name        | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
       | endcustomer_1 | Endcustomer | N            | Y              | ps_1                          |
 
-  @Id:S31039
+  @Id:S31039_TC1
   Scenario: the life-cycle status gates whether a product can be sold on an order
     # two products: one blocked (Gesperrt), one OK
     And metasfresh contains M_Products:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/productLifeCycleStatus_manufacturing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/productLifeCycleStatus_manufacturing.feature
@@ -1,0 +1,39 @@
+@from:cucumber
+@allure.label.epic:E0380_Masterdata_Products
+@allure.label.feature:F6000_Maintain_Product_Data
+@ghActions:run_on_executor4
+Feature: product life-cycle status enforcement on manufacturing orders
+## F6000: Maintain Product Data
+# A product's life-cycle status (BBS-Status) gates whether it may be manufactured:
+# - "G" (Gesperrt) blocks manufacturing.
+# The PP_Order model interceptor rejects the order at creation, before it is ever saved.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2021-04-16T13:30:13+01:00[Europe/Berlin]
+
+  @Id:S31039
+  Scenario: a Gesperrt product's manufacturing order is rejected at creation
+    # a blocked finished good plus its component
+    And metasfresh contains M_Products:
+      | Identifier    | ProductLifeCycleStatus |
+      | finishedGood  | G                      |
+      | component     |                        |
+
+    And metasfresh contains PP_Product_BOM
+      | Identifier | M_Product_ID.Identifier | ValidFrom  |
+      | bom        | finishedGood            | 2021-01-02 |
+    And metasfresh contains PP_Product_BOMLines
+      | Identifier | PP_Product_BOM_ID.Identifier | M_Product_ID.Identifier | ValidFrom  | QtyBatch |
+      | bom_line   | bom                          | component               | 2021-01-02 | 10       |
+    And the PP_Product_BOM identified by bom is completed
+
+    And load S_Resource:
+      | S_Resource_ID.Identifier | S_Resource_ID |
+      | testResource             | 540006        |
+
+    # the completed BOM lets createOrder reach the save; the interceptor's life-cycle guard then rejects it
+    And create PP_Order expecting error:
+      | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | ErrorCode                         |
+      | ppOrder_blocked        | MOP         | finishedGood            | 10         | testResource             | 2021-04-17T23:59:00.00Z | 2021-04-17T23:59:00.00Z | 2021-04-17T23:59:00.00Z | M_Product_BBSStatus_ActionBlocked |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/productLifeCycleStatus_manufacturing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/productLifeCycleStatus_manufacturing.feature
@@ -13,7 +13,7 @@ Feature: product life-cycle status enforcement on manufacturing orders
     And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
     And metasfresh has date and time 2021-04-16T13:30:13+01:00[Europe/Berlin]
 
-  @Id:S31039
+  @Id:S31039_TC2
   Scenario: a Gesperrt product's manufacturing order is rejected at creation
     # a blocked finished good plus its component
     And metasfresh contains M_Products:

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/model/validator/PP_Cost_Collector.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/model/validator/PP_Cost_Collector.java
@@ -33,16 +33,26 @@ public class PP_Cost_Collector
 	}
 
 	/**
-	 * Product life-cycle (BBS-status) manufacturing guard on the finished-good receipt: a product whose
-	 * {@code ProductLifeCycleStatus} blocks MANUFACTURE (e.g. G/Gesperrt) must not be received from a
-	 * production order. Covers both the webUI classic receipt and the mobile HU receipt, which both
-	 * create a {@code MaterialReceipt} {@link I_PP_Cost_Collector} through {@code IPPCostCollectorBL.createReceipt}.
+	 * Product life-cycle (BBS-status) manufacturing guard on the finished-good (and co/by-product) receipt:
+	 * a product whose {@code ProductLifeCycleStatus} blocks MANUFACTURE (e.g. G/Gesperrt) must not be
+	 * received from a production order. Covers both the webUI classic receipt and the mobile HU receipt,
+	 * which both create a {@code MaterialReceipt} {@link I_PP_Cost_Collector} through
+	 * {@link org.eevolution.api.IPPCostCollectorBL#createReceipt}.
 	 */
 	@ModelChange(timings = ModelValidator.TYPE_BEFORE_NEW)
 	public void assertManufacturingAllowedOnReceipt(final I_PP_Cost_Collector cc)
 	{
+		// A reversal/void of an already-completed receipt copies the original's CostCollectorType +
+		// M_Product_ID onto a NEW row (MPPCostCollector.reverseCorrectIt). Never retroactively block
+		// undoing a document that was legitimately completed while the product was still allowed
+		// (mirrors de.metas.product.model.interceptor.M_InOut's reversal exemption).
+		if (cc.getReversal_ID() > 0)
+		{
+			return;
+		}
+
 		final CostCollectorType costCollectorType = CostCollectorType.ofCode(cc.getCostCollectorType());
-		if (costCollectorType.isMaterialReceipt() && cc.getM_Product_ID() > 0)
+		if (costCollectorType.isMaterialReceiptOrCoProduct() && cc.getM_Product_ID() > 0)
 		{
 			productBL.assertAllowed(ProductId.ofRepoId(cc.getM_Product_ID()), ProductLifeCycleAction.MANUFACTURE);
 		}

--- a/backend/de.metas.manufacturing/src/main/java/org/eevolution/model/validator/PP_Cost_Collector.java
+++ b/backend/de.metas.manufacturing/src/main/java/org/eevolution/model/validator/PP_Cost_Collector.java
@@ -2,6 +2,9 @@ package org.eevolution.model.validator;
 
 import de.metas.material.planning.pporder.IPPOrderBOMBL;
 import de.metas.material.planning.pporder.LiberoException;
+import de.metas.product.IProductBL;
+import de.metas.product.ProductId;
+import de.metas.product.ProductLifeCycleAction;
 import de.metas.uom.UomId;
 import de.metas.util.Services;
 import org.adempiere.ad.callout.spi.IProgramaticCalloutProvider;
@@ -21,11 +24,28 @@ import org.eevolution.model.I_PP_Cost_Collector;
 public class PP_Cost_Collector
 {
 	private final IPPOrderBOMBL orderBOMBL = Services.get(IPPOrderBOMBL.class);
+	private final IProductBL productBL = Services.get(IProductBL.class);
 
 	@Init
 	public void init()
 	{
 		Services.get(IProgramaticCalloutProvider.class).registerAnnotatedCallout(new org.eevolution.callout.PP_Cost_Collector());
+	}
+
+	/**
+	 * Product life-cycle (BBS-status) manufacturing guard on the finished-good receipt: a product whose
+	 * {@code ProductLifeCycleStatus} blocks MANUFACTURE (e.g. G/Gesperrt) must not be received from a
+	 * production order. Covers both the webUI classic receipt and the mobile HU receipt, which both
+	 * create a {@code MaterialReceipt} {@link I_PP_Cost_Collector} through {@code IPPCostCollectorBL.createReceipt}.
+	 */
+	@ModelChange(timings = ModelValidator.TYPE_BEFORE_NEW)
+	public void assertManufacturingAllowedOnReceipt(final I_PP_Cost_Collector cc)
+	{
+		final CostCollectorType costCollectorType = CostCollectorType.ofCode(cc.getCostCollectorType());
+		if (costCollectorType.isMaterialReceipt() && cc.getM_Product_ID() > 0)
+		{
+			productBL.assertAllowed(ProductId.ofRepoId(cc.getM_Product_ID()), ProductLifeCycleAction.MANUFACTURE);
+		}
 	}
 
 	/**

--- a/backend/de.metas.manufacturing/src/test/java/org/eevolution/model/validator/PP_Cost_CollectorTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/org/eevolution/model/validator/PP_Cost_CollectorTest.java
@@ -110,4 +110,30 @@ public class PP_Cost_CollectorTest
 		assertThatCode(() -> interceptor.assertManufacturingAllowedOnReceipt(cc))
 				.doesNotThrowAnyException();
 	}
+
+	@Test
+	public void blockedProduct_coProductReceipt_isRejected()
+	{
+		// A co/by-product receipt (MixVariance) materialises a manufactured product too, so a Blocked
+		// co-product must also be rejected.
+		final I_PP_Cost_Collector cc = receiptCostCollector(createProduct(X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked));
+		cc.setCostCollectorType(X_PP_Cost_Collector.COSTCOLLECTORTYPE_MixVariance);
+
+		assertThatThrownBy(() -> interceptor.assertManufacturingAllowedOnReceipt(cc))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("M_Product_BBSStatus_ActionBlocked");
+	}
+
+	@Test
+	public void blockedProduct_reversalReceipt_isAllowed()
+	{
+		// A reversal/void of an already-completed receipt (Reversal_ID set) must NEVER be retroactively
+		// blocked, even if the product is now Blocked — otherwise a legitimately-completed receipt could
+		// not be undone. Mirrors the M_InOut reversal exemption.
+		final I_PP_Cost_Collector cc = receiptCostCollector(createProduct(X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked));
+		cc.setReversal_ID(1_000_000); // any existing receipt — POJO does not enforce the FK
+
+		assertThatCode(() -> interceptor.assertManufacturingAllowedOnReceipt(cc))
+				.doesNotThrowAnyException();
+	}
 }

--- a/backend/de.metas.manufacturing/src/test/java/org/eevolution/model/validator/PP_Cost_CollectorTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/org/eevolution/model/validator/PP_Cost_CollectorTest.java
@@ -1,0 +1,113 @@
+package org.eevolution.model.validator;
+
+import de.metas.ad_reference.ADReferenceService;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_M_Product;
+import org.compiere.model.X_M_Product;
+import org.eevolution.model.I_PP_Cost_Collector;
+import org.eevolution.model.X_PP_Cost_Collector;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.save;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/*
+ * #%L
+ * de.metas.manufacturing
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * Tests the product life-cycle (BBS-status) manufacturing guard on the finished-good RECEIPT
+ * ({@link PP_Cost_Collector#assertManufacturingAllowedOnReceipt(I_PP_Cost_Collector)}). A product whose
+ * {@code ProductLifeCycleStatus} blocks MANUFACTURE (G/Gesperrt) must not be received from a production
+ * order — closing the gap where the {@code PP_Order} guard fires only at order creation, not at receipt
+ * (so a product blocked AFTER its order was created could still be received, in both webUI and mobile).
+ * <p>
+ * Direct-method approach, as in {@link PP_OrderTest}: the guard reads the product's status through the
+ * real {@code IProductBL} from the test {@code POJOLookupMap}, so the product's status drives the outcome.
+ */
+public class PP_Cost_CollectorTest
+{
+	private PP_Cost_Collector interceptor;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+		SpringContextHolder.registerJUnitBean(ADReferenceService.newMocked());
+		interceptor = new PP_Cost_Collector();
+	}
+
+	private int createProduct(final String lifeCycleStatus)
+	{
+		final I_M_Product product = newInstance(I_M_Product.class);
+		product.setValue("P1");
+		product.setName("P1");
+		product.setProductLifeCycleStatus(lifeCycleStatus);
+		save(product);
+		return product.getM_Product_ID();
+	}
+
+	private I_PP_Cost_Collector receiptCostCollector(final int productId)
+	{
+		final I_PP_Cost_Collector cc = newInstance(I_PP_Cost_Collector.class);
+		cc.setCostCollectorType(X_PP_Cost_Collector.COSTCOLLECTORTYPE_MaterialReceipt);
+		cc.setM_Product_ID(productId);
+		return cc;
+	}
+
+	@Test
+	public void blockedProduct_receipt_isRejected()
+	{
+		// PRODUCTLIFECYCLESTATUS_Blocked = "G" = BLOCKED (blocks every action, incl. MANUFACTURE)
+		final I_PP_Cost_Collector cc = receiptCostCollector(createProduct(X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked));
+
+		assertThatThrownBy(() -> interceptor.assertManufacturingAllowedOnReceipt(cc))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("M_Product_BBSStatus_ActionBlocked");
+	}
+
+	@Test
+	public void okProduct_receipt_isAllowed()
+	{
+		// PRODUCTLIFECYCLESTATUS_OK = "O" = fully permissive => guard must NOT fire.
+		final I_PP_Cost_Collector cc = receiptCostCollector(createProduct(X_M_Product.PRODUCTLIFECYCLESTATUS_OK));
+
+		assertThatCode(() -> interceptor.assertManufacturingAllowedOnReceipt(cc))
+				.doesNotThrowAnyException();
+	}
+
+	@Test
+	public void blockedProduct_componentIssue_isAllowed()
+	{
+		// The guard fires only on the finished-good MaterialReceipt, never on a component ISSUE
+		// (which consumes a different product carrying its own status).
+		final I_PP_Cost_Collector cc = receiptCostCollector(createProduct(X_M_Product.PRODUCTLIFECYCLESTATUS_Blocked));
+		cc.setCostCollectorType(X_PP_Cost_Collector.COSTCOLLECTORTYPE_ComponentIssue);
+
+		assertThatCode(() -> interceptor.assertManufacturingAllowedOnReceipt(cc))
+				.doesNotThrowAnyException();
+	}
+}


### PR DESCRIPTION
## What

UAT follow-up on the Product Life Cycle Status ("BBS-Status") feature — two enforcement gaps.

**1. Finished-good receipt was unguarded.** The `MANUFACTURE` life-cycle guard was only on `PP_Order` (fires at manufacturing-order creation). The finished-good **receipt** is a separate document — a `PP_Cost_Collector` of type `MaterialReceipt`, created by **both** the webUI classic receipt and the mobile HU receipt via `IPPCostCollectorBL.createReceipt` — and it was unguarded. So a product set to `G` (Gesperrt) **after** its manufacturing order was created could still have its manufactured good received, in both UIs.

Fix: a `BEFORE_NEW` guard in the `PP_Cost_Collector` interceptor — on a `MaterialReceipt` (or co/by-product) cost collector, `assertAllowed(product, MANUFACTURE)`. One choke point covers both UIs. **Reversals are exempted** (`Reversal_ID > 0`, mirroring the `M_InOut` guard) so a legitimately-completed receipt can always be undone.

**2. No end-to-end proof that a manufacturing order is blocked at creation.** Added a cucumber scenario so the candidate→order path (which hits the same interceptor) is demonstrably blocked for a `G` product.

## Tests

- `PP_Cost_CollectorTest` (unit): blocked receipt rejected, OK receipt allowed, component-issue not blocked, **co-product receipt blocked**, **reversal receipt allowed**.
- `productLifeCycleStatus_manufacturing.feature` (cucumber, ran green locally): a `G` product's manufacturing order is rejected at creation with `M_Product_BBSStatus_ActionBlocked`, through the real `PP_Order` interceptor.
