### PR TITLE
Product Life Cycle: fix ArchUnit violation in SetProductLifeCycleStatusCommand (use IProductDAO)

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/product/SetProductLifeCycleStatusCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/product/SetProductLifeCycleStatusCommand.java
@@ -3,10 +3,11 @@ package de.metas.frontend_testing.masterdata.product;
 import de.metas.frontend_testing.masterdata.Identifier;
 import de.metas.frontend_testing.masterdata.MasterdataContext;
 import de.metas.product.BBSStatus;
+import de.metas.product.IProductDAO;
 import de.metas.product.ProductId;
+import de.metas.util.Services;
 import lombok.Builder;
 import lombok.NonNull;
-import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.model.I_M_Product;
 
 /**
@@ -19,9 +20,8 @@ import org.compiere.model.I_M_Product;
  * those documents exist — typically issued as its own {@code productLifeCycleStatuses} masterdata
  * request once the order/picking-job setup is in place.
  * <p>
- * Mirrors the {@code M_Product} load+save done by
- * {@code CreateMasterdataCommand#linkProductsToCompensationGroupSchemas} (no dedicated DAO method
- * exists for this single-column update).
+ * Loads and saves via {@link IProductDAO} rather than raw {@code InterfaceWrapperHelper}, per this module's
+ * "create/query through DAOs" rule.
  */
 @Builder
 public class SetProductLifeCycleStatusCommand
@@ -35,9 +35,11 @@ public class SetProductLifeCycleStatusCommand
 		// Validate the code against the BBS-Status reference list (fails loudly on a typo).
 		final BBSStatus status = BBSStatus.ofCode(statusCode);
 
+		final IProductDAO productsRepo = Services.get(IProductDAO.class);
+
 		final ProductId productId = context.getId(identifier, ProductId.class);
-		final I_M_Product product = InterfaceWrapperHelper.load(productId, I_M_Product.class);
+		final I_M_Product product = productsRepo.getById(productId);
 		product.setProductLifeCycleStatus(status.getCode());
-		InterfaceWrapperHelper.save(product);
+		productsRepo.save(product);
 	}
 }


### PR DESCRIPTION
## Problem

The `deep_tundra_release` -> `new_dawn_uat` merge build fails in the `test (java)` job with a **new ArchUnit violation**:

```
[de.metas.frontend-testing] InterfaceWrapperHelper.save/saveRecord/load must only be
called from *Repository / *DAO classes  (violated 2 times)

SetProductLifeCycleStatusCommand.execute() calls InterfaceWrapperHelper.load(...)  (line 39)
SetProductLifeCycleStatusCommand.execute() calls InterfaceWrapperHelper.save(...)  (line 41)
```

Failing job: https://github.com/metasfresh/metasfresh/actions/runs/30749297221/job/91503089494

## Why it was not caught on `deep_tundra_release`

`backend/de.metas.architecture-tests` is wired on `new_dawn_uat` but **not** on `deep_tundra_release`, so the rule is only evaluated at merge-up time. Fixing it here, at the source branch, rather than only on the merge branch.

## Fix

`SetProductLifeCycleStatusCommand` now loads and saves the `M_Product` record through `IProductDAO.getById(...)` / `IProductDAO.save(...)` instead of calling `InterfaceWrapperHelper` directly. No behaviour change.

## Verification

- `compile-module.sh backend/de.metas.frontend-testing` -> BUILD SUCCESS (JDK 8, local, 2026-08-02)
- The ArchUnit rule (`MetasfreshArchRules.persistencePrimitivesConfinedToRepositoryOrDao`) matches only direct `InterfaceWrapperHelper.save/saveRecord/load` call sites; both are removed, so the module returns to its frozen baseline.
