### PR TITLE
fix flaky HttpCallSchedulerTest async race (test-only)

### DIFF
--- a/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
+++ b/backend/de.metas.util.web/src/test/java/de/metas/util/web/audit/HttpCallSchedulerTest.java
@@ -7,9 +7,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class HttpCallSchedulerTest
 {
@@ -113,8 +115,15 @@ class HttpCallSchedulerTest
 			throw new RuntimeException("test error");
 		}));
 
-		// Should complete exceptionally
-		assertThat(failingFuture).isCompletedExceptionally();
+		// Should complete exceptionally.
+		// The supplier throws on the scheduler's pool thread, so completion happens
+		// asynchronously. Block until the future settles (up to 5s) instead of checking
+		// isCompletedExceptionally() synchronously: that check was racy and failed
+		// intermittently on CPU-contended CI runners where the pool thread had not yet
+		// run the throwing supplier at the instant the assertion was evaluated.
+		assertThatThrownBy(() -> failingFuture.get(5, TimeUnit.SECONDS))
+				.isInstanceOf(ExecutionException.class)
+				.hasCauseInstanceOf(RuntimeException.class);
 
 		// Wait a bit for scheduler to settle
 		Thread.sleep(500);


### PR DESCRIPTION
Fix a flaky test (test-only) so this branch's `test (java)` stops failing intermittently on CI.

`HttpCallSchedulerTest.exceptionInRequestDoesNotBreakScheduler` asserted `assertThat(failingFuture).isCompletedExceptionally()` synchronously, before the async `CompletableFuture` (executed on the scheduler's pool thread) had settled — racy on CPU-contended CI runners. Replaced with the accepted new_dawn_uat form that blocks up to 5s:
`assertThatThrownBy(() -> failingFuture.get(5, TimeUnit.SECONDS)).isInstanceOf(ExecutionException.class).hasCauseInstanceOf(RuntimeException.class)`.

Byte-identical port of the fix already applied on the allure branches. Test-only; +11/-2 (one file + 2 imports). new_dawn_uat already carries this fix.
