### PR TITLE
SEPA Payment Export — never group QR-IBAN (QRR) lines so the export produces a valid file

### DIFF
--- a/backend/de.metas.payment.sepa/base/src/main/java/de/metas/payment/sepa/api/impl/CreateSEPAExportFromPaySelectionCommand.java
+++ b/backend/de.metas.payment.sepa/base/src/main/java/de/metas/payment/sepa/api/impl/CreateSEPAExportFromPaySelectionCommand.java
@@ -211,11 +211,32 @@ class CreateSEPAExportFromPaySelectionCommand
 			@NonNull final List<I_C_PaySelectionLine> paySelectionLines,
 			@NonNull final I_SEPA_Export header)
 	{
-		final Map<InvoicePaySelectionLinesAggregationKey, AggregatedInvoicePaySelectionLines> keyToAggregatedPaySelectionLines = getInvoiceKeyToGroupedPaySelectionLines(paySelectionLines);
+		// QR-IBAN (QRR) payments carry a per-invoice QR reference and cannot be aggregated;
+		// export each such line individually, exactly as if grouping were off.
+		final List<I_C_PaySelectionLine> qrIbanLines = paySelectionLines.stream()
+				.filter(this::hasQrIban)
+				.collect(ImmutableList.toImmutableList());
+		final List<I_C_PaySelectionLine> groupableLines = paySelectionLines.stream()
+				.filter(line -> !hasQrIban(line))
+				.collect(ImmutableList.toImmutableList());
+
+		handleUngroupedPaySelectionLines(qrIbanLines, header);
+
+		final Map<InvoicePaySelectionLinesAggregationKey, AggregatedInvoicePaySelectionLines> keyToAggregatedPaySelectionLines = getInvoiceKeyToGroupedPaySelectionLines(groupableLines);
 		final List<I_C_PaySelectionLine> ungroupedPaySelectionLines = getUngroupedPaySelectionLines(keyToAggregatedPaySelectionLines);
 
 		handleUngroupedPaySelectionLines(ungroupedPaySelectionLines, header);
 		handleGroupedPaySelectionLines(keyToAggregatedPaySelectionLines, header);
+	}
+
+	private boolean hasQrIban(@NonNull final I_C_PaySelectionLine line)
+	{
+		final BankAccountId bankAccountId = BankAccountId.ofRepoIdOrNull(line.getC_BP_BankAccount_ID());
+		if (bankAccountId == null)
+		{
+			return false;
+		}
+		return Check.isNotBlank(bankAccountDAO.getById(bankAccountId).getQR_IBAN());
 	}
 
 	private void handleUngroupedPaySelectionLines(

--- a/backend/de.metas.payment.sepa/base/src/test/java/de/metas/payment/sepa/api/impl/CreateSEPAExportFromPaySelectionCommandTest.java
+++ b/backend/de.metas.payment.sepa/base/src/test/java/de/metas/payment/sepa/api/impl/CreateSEPAExportFromPaySelectionCommandTest.java
@@ -1,13 +1,23 @@
 package de.metas.payment.sepa.api.impl;
 
+import de.metas.banking.api.BankAccountService;
 import de.metas.banking.api.BankRepository;
+import de.metas.currency.CurrencyRepository;
+import de.metas.payment.sepa.api.SEPAExportContext;
+import de.metas.payment.sepa.model.I_SEPA_Export;
+import de.metas.payment.sepa.sepamarshaller.impl.SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02;
 import org.adempiere.test.AdempiereTestHelper;
 import org.compiere.SpringContextHolder;
 import org.compiere.model.I_C_PaySelection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
 import static org.adempiere.model.InterfaceWrapperHelper.save;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.compiere.model.X_C_PaySelection.PAYSELECTIONTRXTYPE_DirectDebit;
 
 public class CreateSEPAExportFromPaySelectionCommandTest
@@ -59,5 +69,54 @@ public class CreateSEPAExportFromPaySelectionCommandTest
 		save(paySelection);
 		final CreateSEPAExportFromPaySelectionCommand command = new CreateSEPAExportFromPaySelectionCommand(paySelection, false);
 		sepaTestHelper.assertCommonDebitDirectCases(command.run());
+	}
+
+	@Test
+	public void commandGroupsQrIbanLinesIndividually()
+	{
+		final SEPATestHelper sepaTestHelper = new SEPATestHelper();
+		sepaTestHelper.createQrIbanMockData();
+		final CreateSEPAExportFromPaySelectionCommand command = new CreateSEPAExportFromPaySelectionCommand(sepaTestHelper.getQrIbanPaySelection(), true);
+		sepaTestHelper.assertQrIbanLinesNotGrouped(command.run());
+	}
+
+	@Test
+	public void marshalQrIbanGroupedExport_doesNotThrow() throws Exception
+	{
+		final BankRepository bankRepository = SpringContextHolder.instance.getBean(BankRepository.class);
+		final BankAccountService bankAccountService = new BankAccountService(bankRepository, new CurrencyRepository());
+		SpringContextHolder.registerJUnitBean(bankAccountService);
+
+		final SEPAExportContext exportContext = SEPAExportContext.builder()
+				.referenceAsEndToEndId(false)
+				.build();
+		final SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02 marshaler =
+				new SEPAVendorCreditTransferMarshaler_Pain_001_001_03_CH_02(bankRepository, exportContext, bankAccountService);
+
+		final SEPATestHelper sepaTestHelper = new SEPATestHelper();
+		sepaTestHelper.createQrIbanMockData();
+
+		// sanity check: each QR reference is valid on its own (grouping OFF, so no aggregation happens) - proves the
+		// fixtures are trustworthy before reproducing the grouped-export bug below. `isInvalidQRReference(..)` itself
+		// is package-private to de.metas.payment.sepa.sepamarshaller.impl, so it is exercised here through the public
+		// marshal(..) entry point instead. Running the command twice on the same C_PaySelection is safe - run() only
+		// reads the pay-selection lines, it never mutates them.
+		final I_SEPA_Export ungroupedExport = new CreateSEPAExportFromPaySelectionCommand(sepaTestHelper.getQrIbanPaySelection(), false).run();
+		assertThatCode(() -> marshaler.marshal(ungroupedExport, new ByteArrayOutputStream()))
+				.as("each individual QR reference must be valid before we reproduce the grouping bug")
+				.doesNotThrowAnyException();
+
+		// reproduce the bug: grouping ON aggregates both QR-IBAN lines into one comma-joined, truncated reference
+		// that is no longer a valid 27-digit QRR reference.
+		final I_SEPA_Export groupedExport = new CreateSEPAExportFromPaySelectionCommand(sepaTestHelper.getQrIbanPaySelection(), true).run();
+
+		final ByteArrayOutputStream out = new ByteArrayOutputStream();
+		assertThatCode(() -> marshaler.marshal(groupedExport, out))
+				.as("grouping QR-IBAN lines must not corrupt the QRR reference")
+				.doesNotThrowAnyException();
+
+		final String xml = out.toString(StandardCharsets.UTF_8.name());
+		assertThat(xml).contains(SEPATestHelper.QR_REFERENCE_1);
+		assertThat(xml).contains(SEPATestHelper.QR_REFERENCE_2);
 	}
 }

--- a/backend/de.metas.payment.sepa/base/src/test/java/de/metas/payment/sepa/api/impl/SEPATestHelper.java
+++ b/backend/de.metas.payment.sepa/base/src/test/java/de/metas/payment/sepa/api/impl/SEPATestHelper.java
@@ -49,6 +49,20 @@ public class SEPATestHelper
 	private I_C_PaySelectionLine secondGroupedPaySelectionLine;
 	private I_C_PaySelectionLine ungroupedPaySelectionLine;
 
+	// QR-IBAN (Swiss QRR) fixtures
+	public static final String QR_REFERENCE_1 = "000000000000010360022841297";
+	public static final String QR_REFERENCE_2 = "000000000002015110002913192";
+
+	private I_C_BPartner qrIbanPartner;
+	private I_C_Bank qrIbanBank;
+	private I_C_BP_BankAccount qrIbanBankAccount;
+	private I_C_Invoice qrIbanFirstInvoice;
+	private I_C_Invoice qrIbanSecondInvoice;
+	@Getter
+	private I_C_PaySelection qrIbanPaySelection;
+	private I_C_PaySelectionLine qrIbanFirstPaySelectionLine;
+	private I_C_PaySelectionLine qrIbanSecondPaySelectionLine;
+
 	@NonNull
 	public I_SEPA_Export createSepaExport()
 	{
@@ -381,5 +395,112 @@ public class SEPATestHelper
 		assertThat(ungroupedLine.getRecord_ID()).isEqualTo(ungroupedPaySelectionLine.getC_PaySelectionLine_ID());
 
 		assertThat(ungroupedLine.getNumberOfReferences()).isEqualTo(0);
+	}
+
+	/**
+	 * Builds a dedicated {@link I_C_PaySelection} with two credit-transfer lines paid via the SAME QR-IBAN bank account
+	 * (plain {@code IBAN} left blank, so it is resolved from {@code QR_IBAN}), each with its own valid 27-digit QR reference.
+	 */
+	public void createQrIbanMockData()
+	{
+		final I_C_Currency chfCurrency = newInstance(I_C_Currency.class);
+		chfCurrency.setISO_Code(CurrencyCode.CHF.toThreeLetterCode());
+		save(chfCurrency);
+
+		final I_C_Country country = newInstance(I_C_Country.class);
+		save(country);
+
+		final I_C_Location location = newInstance(I_C_Location.class);
+		location.setC_Country_ID(country.getC_Country_ID());
+		location.setRegionName("qrRegionName");
+		location.setAddress1("qrAddr1");
+		location.setAddress2("qrAddr2");
+		location.setCity("qrCity");
+		location.setPostal("qrPostal");
+		save(location);
+
+		qrIbanPartner = newInstance(I_C_BPartner.class);
+		qrIbanPartner.setName("qrIbanPartnerName");
+		qrIbanPartner.setIsCompany(true);
+		qrIbanPartner.setAD_OrgBP_ID(1000000);
+		save(qrIbanPartner);
+
+		final I_C_BPartner_Location qrIbanPartnerLocation = newInstance(I_C_BPartner_Location.class);
+		qrIbanPartnerLocation.setC_BPartner_ID(qrIbanPartner.getC_BPartner_ID());
+		qrIbanPartnerLocation.setC_Location_ID(location.getC_Location_ID());
+		save(qrIbanPartnerLocation);
+
+		qrIbanBank = newInstance(I_C_Bank.class);
+		qrIbanBank.setName("qrIbanBankName");
+		qrIbanBank.setSwiftCode("qrIbanSwiftCode");
+		save(qrIbanBank);
+
+		qrIbanBankAccount = newInstance(I_C_BP_BankAccount.class);
+		qrIbanBankAccount.setC_BPartner_ID(qrIbanPartner.getC_BPartner_ID());
+		qrIbanBankAccount.setC_Bank_ID(qrIbanBank.getC_Bank_ID());
+		qrIbanBankAccount.setC_Currency_ID(chfCurrency.getC_Currency_ID());
+		qrIbanBankAccount.setQR_IBAN("CH4431999123000889012");
+		qrIbanBankAccount.setIsEsrAccount(true);
+		qrIbanBankAccount.setRoutingNo("qrIbanRoutingNo");
+		qrIbanBankAccount.setSEPA_CreditorIdentifier("qrIbanSepaCreditorIdentifier");
+		save(qrIbanBankAccount);
+
+		qrIbanFirstInvoice = newInstance(I_C_Invoice.class);
+		qrIbanFirstInvoice.setC_BPartner_ID(qrIbanPartner.getC_BPartner_ID());
+		qrIbanFirstInvoice.setC_BPartner_Location_ID(qrIbanPartnerLocation.getC_BPartner_Location_ID());
+		qrIbanFirstInvoice.setDescription("qrIbanFirstInvoiceDescription");
+		save(qrIbanFirstInvoice);
+
+		qrIbanSecondInvoice = newInstance(I_C_Invoice.class);
+		qrIbanSecondInvoice.setC_BPartner_ID(qrIbanPartner.getC_BPartner_ID());
+		qrIbanSecondInvoice.setC_BPartner_Location_ID(qrIbanPartnerLocation.getC_BPartner_Location_ID());
+		qrIbanSecondInvoice.setDescription("qrIbanSecondInvoiceDescription");
+		save(qrIbanSecondInvoice);
+
+		qrIbanPaySelection = newInstance(I_C_PaySelection.class);
+		qrIbanPaySelection.setAD_Org_ID(1000000);
+		qrIbanPaySelection.setPaySelectionTrxType(PAYSELECTIONTRXTYPE_CreditTransfer);
+		qrIbanPaySelection.setC_BP_BankAccount_ID(qrIbanBankAccount.getC_BP_BankAccount_ID());
+		saveRecord(qrIbanPaySelection);
+
+		qrIbanFirstPaySelectionLine = newInstance(I_C_PaySelectionLine.class);
+		qrIbanFirstPaySelectionLine.setC_PaySelection_ID(qrIbanPaySelection.getC_PaySelection_ID());
+		qrIbanFirstPaySelectionLine.setAD_Org_ID(1000000);
+		qrIbanFirstPaySelectionLine.setC_Invoice_ID(qrIbanFirstInvoice.getC_Invoice_ID());
+		qrIbanFirstPaySelectionLine.setC_BP_BankAccount_ID(qrIbanBankAccount.getC_BP_BankAccount_ID());
+		qrIbanFirstPaySelectionLine.setPayAmt(BigDecimal.TEN);
+		qrIbanFirstPaySelectionLine.setC_BPartner_ID(qrIbanPartner.getC_BPartner_ID());
+		qrIbanFirstPaySelectionLine.setReference(QR_REFERENCE_1);
+		save(qrIbanFirstPaySelectionLine);
+
+		qrIbanSecondPaySelectionLine = newInstance(I_C_PaySelectionLine.class);
+		qrIbanSecondPaySelectionLine.setC_PaySelection_ID(qrIbanPaySelection.getC_PaySelection_ID());
+		qrIbanSecondPaySelectionLine.setAD_Org_ID(1000000);
+		qrIbanSecondPaySelectionLine.setC_Invoice_ID(qrIbanSecondInvoice.getC_Invoice_ID());
+		qrIbanSecondPaySelectionLine.setC_BP_BankAccount_ID(qrIbanBankAccount.getC_BP_BankAccount_ID());
+		qrIbanSecondPaySelectionLine.setPayAmt(BigDecimal.ONE);
+		qrIbanSecondPaySelectionLine.setC_BPartner_ID(qrIbanPartner.getC_BPartner_ID());
+		qrIbanSecondPaySelectionLine.setReference(QR_REFERENCE_2);
+		save(qrIbanSecondPaySelectionLine);
+	}
+
+	/**
+	 * Asserts that the two QR-IBAN pay-selection lines created by {@link #createQrIbanMockData()} were exported as two
+	 * individual, non-grouped {@link I_SEPA_Export_Line}s - each keeping its own (valid) QR reference untouched.
+	 */
+	public void assertQrIbanLinesNotGrouped(@NonNull final I_SEPA_Export sepaExport)
+	{
+		final List<I_SEPA_Export_Line> lines = sepaDocumentDAO.retrieveLines(sepaExport);
+		assertThat(lines.size()).isEqualTo(2);
+
+		final I_SEPA_Export_Line firstLine = lines.get(0);
+		assertThat(firstLine.isGroupLine()).isEqualTo(false);
+		assertThat(firstLine.getStructuredRemittanceInfo()).isEqualTo(qrIbanFirstPaySelectionLine.getReference());
+		assertThat(firstLine.getNumberOfReferences()).isEqualTo(0);
+
+		final I_SEPA_Export_Line secondLine = lines.get(1);
+		assertThat(secondLine.isGroupLine()).isEqualTo(false);
+		assertThat(secondLine.getStructuredRemittanceInfo()).isEqualTo(qrIbanSecondPaySelectionLine.getReference());
+		assertThat(secondLine.getNumberOfReferences()).isEqualTo(0);
 	}
 }


### PR DESCRIPTION
## Problem

When pay-selection **grouping** is enabled and a vendor is paid via a Swiss **QR-IBAN (QRR)**, the SEPA credit-transfer export fails.

Grouping aggregates the pay-selection lines of one invoice-key into a single export line whose structured remittance info becomes the member references comma-joined and truncated to 35 characters (`AggregatedInvoicePaySelectionLines#getAggregatedRemittanceInfo`). For a QR-IBAN account the Swiss marshaller (`pain.001.001.03.ch.02`) validates that remittance as a 27-digit QR reference (exact length + mod-10 check) and throws `SEPA_Export_InvalidReference` on the aggregate — so no file is produced.

## Fix

In `CreateSEPAExportFromPaySelectionCommand#handleInvoicePaySelectionLines`, partition the lines before grouping:

- **QR-IBAN lines** are routed through the existing single-line (ungrouped) path, so each keeps its own valid 27-digit QR reference.
- **All other lines** keep the existing grouped/ungrouped behaviour, byte-for-byte.

QR-IBAN detection (`hasQrIban`) uses the same signal the marshaller itself uses to trigger QR-reference validation: the line's `C_BP_BankAccount` has a non-blank `QR_IBAN`.

No AD/migration changes; no marshaller changes; the aggregation logic itself is untouched.

## Tests

`de.metas.payment.sepa/base` — `CreateSEPAExportFromPaySelectionCommandTest`:

- `commandGroupsQrIbanLinesIndividually` — two QR-IBAN lines with grouping ON produce two individual export lines, each retaining its own QR reference (not one aggregated line).
- `marshalQrIbanGroupedExport_doesNotThrow` — the grouped export marshals to a valid file (two `QRR` references) instead of throwing `SEPA_Export_InvalidReference`.

Both were written first as failing (RED) against the unfixed code, then turn green with the fix. The four pre-existing tests (non-QR grouped + ungrouped paths) stay green — `Tests run: 6, Failures: 0`.
