### PR TITLE
MobileUI Picking: catch-weight un-pack records the leaf CU and its own QR

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/candidate/commands/PackToHUsProducer.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/candidate/commands/PackToHUsProducer.java
@@ -111,6 +111,15 @@ public class PackToHUsProducer
 		@NonNull TableRecordReference documentRef;
 		boolean checkIfAlreadyPacked;
 		boolean createInventoryForMissingQty;
+
+		/**
+		 * When {@code true}, the packed CU(s) are recorded as CU parts of their (top-level, no-LU) TU so
+		 * downstream records the leaf CU instead of the container TU — required only when the picked unit is a
+		 * CU packed into a TU pick target (so a later unpick-to-floor can extract that CU). Leave {@code false}
+		 * for a whole-TU pick, where the TU itself is the picked unit and must be recorded as a full TU
+		 * (otherwise a spurious VHU is materialized on the shipment-schedule QtyPicked).
+		 */
+		boolean recordLeafCUsAsTUParts;
 	}
 
 	public LUTUResult packToHU(@NonNull final PackToHURequest request)
@@ -200,6 +209,9 @@ public class PackToHUsProducer
 			}
 			weightUpdater.updatePackToHU(pickFromHU);
 
+			// Intentionally independent of request.isRecordLeafCUsAsTUParts(): here the source HU already IS a
+			// TU at the exact qty + packing instructions, so no CU is split out and packed INTO a container —
+			// there is no distinct leaf CU to record, and a later unpick has nothing nested to strand.
 			return LUTUResult.ofSingleTopLevelTU(pickFromHU);
 		}
 		//
@@ -222,7 +234,14 @@ public class PackToHUsProducer
 			final I_M_HU luRecord = handlingUnitsBL.getLoadingUnitHU(tuRecord);
 			if (luRecord == null)
 			{
-				return LUTUResult.ofSingleTopLevelTU(tuRecord);
+				// A CU-into-TU pick (picked unit is the CU): record the just-packed CU as a CU part of the
+				// (top-level) TU — NOT the bare container TU. Recording only the container makes a later
+				// unpick's extract-to-top-level a no-op (the TU is already top-level) and strands the picked CU
+				// (Picked, still nested) inside the TU.
+				// A whole-TU pick (picked unit is the TU) records the full TU as before (no spurious leaf VHU).
+				return request.isRecordLeafCUsAsTUParts()
+						? LUTUResult.ofTopLevelTUs(LUTUResult.TUsList.of(LUTUResult.TU.ofSingleTU(tuRecord, cuRecord)))
+						: LUTUResult.ofSingleTopLevelTU(tuRecord);
 			}
 			else if(handlingUnitsBL.isAggregateHU(tuRecord))
 			{
@@ -257,7 +276,15 @@ public class PackToHUsProducer
 			final LUTUResult result;
 			if (packToDestination instanceof ILUTUProducerAllocationDestination)
 			{
-				result = ((ILUTUProducerAllocationDestination)packToDestination).getResult();
+				final LUTUResult producerResult = ((ILUTUProducerAllocationDestination)packToDestination).getResult();
+				// For a CU-into-TU pick (picked unit is the CU) the LU/TU producer returns freshly-created
+				// top-level TUs as "full" TUs (no CU parts tracked); record the packed CU(s) as CU parts so
+				// downstream records the leaf CU, not the container TU (otherwise a later unpick strands the
+				// picked CU inside the TU). For a whole-TU pick (picked unit is the TU) the full TUs are kept
+				// as-is, so downstream records the TU and no spurious leaf VHU is materialized.
+				result = request.isRecordLeafCUsAsTUParts()
+						? recordPackedCUsAsParts(producerResult)
+						: producerResult;
 			}
 			else if (packToDestination instanceof IHUProducerAllocationDestination)
 			{
@@ -288,6 +315,47 @@ public class PackToHUsProducer
 			weightUpdater.updatePackToHUs(result);
 			return result;
 		}
+	}
+
+	/**
+	 * For a CU-into-TU pick, re-wraps each fresh top-level TU to carry its packed CU(s) as CU parts, so
+	 * downstream records the leaf CU (not the container TU) and a later unpick can extract it instead of
+	 * leaving it Picked inside the TU. Reached only via {@link PackToHURequest#isRecordLeafCUsAsTUParts()}
+	 * (set solely by {@code PickingJobPickCommand}, one pack per {@code PackToInfo}), so {@code getVHUs(tuRecord)}
+	 * returns exactly this pick's CU(s).
+	 */
+	private LUTUResult recordPackedCUsAsParts(@NonNull final LUTUResult result)
+	{
+		if (!result.getLus().isEmpty() || result.getTopLevelTUs().isEmpty())
+		{
+			return result;
+		}
+
+		final ImmutableList.Builder<LUTUResult.TU> tus = ImmutableList.builder();
+		for (final LUTUResult.TU tu : result.getTopLevelTUs())
+		{
+			// Only enrich a real single TU that carries no CU parts yet; aggregates / already-parted TUs stay as-is.
+			if (tu.isAggregate() || !tu.isFullTU())
+			{
+				tus.add(tu);
+				continue;
+			}
+
+			final I_M_HU tuRecord = tu.toHU();
+			final List<I_M_HU> vhus = handlingUnitsBL.getVHUs(tuRecord);
+			if (vhus.isEmpty())
+			{
+				tus.add(tu);
+			}
+			else
+			{
+				// Record ALL of this TU's VHUs as its CU parts (a pick may split into >1 CU) — not just one;
+				// the loop likewise enriches every top-level TU. "ofSingleTU" means a non-aggregate TU, not one CU.
+				tus.add(LUTUResult.TU.ofSingleTU(tuRecord, vhus.toArray(new I_M_HU[0])));
+			}
+		}
+
+		return LUTUResult.ofTopLevelTUs(LUTUResult.TUsList.of(tus.build()));
 	}
 
 	private PickFromHU.PickFromHUBuilder newPickFromHU()

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/service/commands/pick/PickingJobPickCommand.java
@@ -710,7 +710,8 @@ public class PickingJobPickCommand
 			final I_M_HU pickFromHURecord = huService.getById(pickFromHU.getId());
 			if (huService.isVirtual(pickFromHURecord))
 			{
-				packedHUs = pickCUsAndPackTo(productId, pickFromHU.getId(), packToInfo);
+				// Whole-TU pick (picked unit is the TU): pack CUs into full TUs and record the TUs, not leaf CUs.
+				packedHUs = pickCUsAndPackTo(productId, pickFromHU.getId(), packToInfo, /*recordLeafCUsAsTUParts*/false);
 			}
 			else
 			{
@@ -728,7 +729,9 @@ public class PickingJobPickCommand
 			}
 			else
 			{
-				packedHUs = pickCUsAndPackTo(productId, pickFromHU.getId(), packToInfo);
+				// CU pick into a TU pick target (picked unit is the CU): record the leaf CU as a CU part so a
+				// later unpick-to-floor can extract & re-activate it.
+				packedHUs = pickCUsAndPackTo(productId, pickFromHU.getId(), packToInfo, /*recordLeafCUsAsTUParts*/true);
 			}
 		}
 
@@ -766,16 +769,40 @@ public class PickingJobPickCommand
 				}
 				else
 				{
+					// Decouple the two recordings for a CU-into-TU pick (the TU now carries leaf CU parts):
+					// - Shipment schedule (M_ShipmentSchedule_QtyPicked): for a CU-into-BARE-TU pick (no LU)
+					//   record the destination TU (VHU_ID stays NULL; expanded into per-VHU COO candidates at
+					//   shipment time), NOT the leaf CU (which would materialise a spurious VHU and change
+					//   downstream shipment/reversal/DESADV handling). An LU pick keeps recording the leaf CU.
+					// - Picking-job step: ALWAYS record the leaf CU(s), so a later unpick-to-floor can extract
+					//   and re-activate them.
+					final boolean recordTUOnShipmentSchedule = packedHUs.getLURecords().isEmpty();
+
 					final ImmutableList<TUPart> cus = tu.getCUsNotEmpty();
 					final List<Quantity> catchWeights = getCatchWeight() != null ? getCatchWeight().spreadEqually(cus.size()) : null;
+
+					Quantity qtyPickedThisTU = null;
 					for (int i = 0; i < cus.size(); i++)
 					{
 						final TUPart cu = cus.get(i);
 						final Quantity catchWeightPerCU = catchWeights != null ? catchWeights.get(i) : null;
 						final Quantity qtyPicked = huStorageFactory.getStorage(cu.toHU()).getQuantity(productId, uom);
-						addShipmentScheduleQtyPicked(cu, qtyPicked);
+						qtyPickedThisTU = qtyPickedThisTU == null ? qtyPicked : qtyPickedThisTU.add(qtyPicked);
+						if (!recordTUOnShipmentSchedule)
+						{
+							addShipmentScheduleQtyPicked(cu, qtyPicked);
+						}
 
-						result.addAll(toPickingJobStepPickedToHU(tu, cu, qtyPicked, catchWeightPerCU, pickFrom));
+						result.addAll(toPickingJobStepPickedToHU(cu, qtyPicked, catchWeightPerCU, pickFrom));
+					}
+
+					if (recordTUOnShipmentSchedule && qtyPickedThisTU != null)
+					{
+						// Record THIS pick's qty (sum of its CU parts), NOT the container TU's cumulative
+						// product storage: picking the same product more than once into one bare TU would
+						// otherwise record the running total, which the shipment-schedule expansion over-counts
+						// into a spurious extra per-COO line (nShiftShipment COO "mixed TUs" scenarios).
+						addShipmentScheduleQtyPicked(tu, qtyPickedThisTU);
 					}
 				}
 			}
@@ -844,7 +871,10 @@ public class PickingJobPickCommand
 	{
 
 		final List<HUQRCode> huQRCodes = huService.getOrCreateQRCodesByHuId(tu.getId());
-		if (huQRCodes.size() != tu.getQtyTU().toInt())
+		// An aggregate HU can accumulate more active QR-code assignments than its current TU count (generated
+		// one-per-TU and not trimmed on split/pick-out). Only the first N are used below, so tolerate a surplus;
+		// error only on a deficit.
+		if (huQRCodes.size() < tu.getQtyTU().toInt())
 		{
 			throw new AdempiereException(INVALID_NUMBER_QR_CODES_ERROR_MSG, tu.getQtyTU(), huQRCodes.size());
 		}
@@ -869,15 +899,21 @@ public class PickingJobPickCommand
 	}
 
 	private List<PickingJobStepPickedToHU> toPickingJobStepPickedToHU(
-			@NonNull final TU tu1,
 			@NonNull final TUPart cu,
 			@NonNull final Quantity qtyPicked,
 			@Nullable final Quantity catchWeight,
 			@NonNull final PickingJobStepPickFrom pickFrom)
 	{
 
-		final List<HUQRCode> huQRCodes = huService.getOrCreateQRCodesByHuId(tu1.getId());
-		if (huQRCodes.size() != 1)
+		// Record the CU's OWN QR code (not the container TU's): the recorded HU here IS the leaf CU, so a
+		// later unpick extracts THIS CU to top-level (extractToTopLevel asserts the QR is on the extracted
+		// HU) and, on a move-to-target, re-derives the QR from the extracted CU. Recording the container
+		// TU's QR left the CU un-QR'd → the unpick's extract asserted the wrong HU and the CU was stranded
+		// Picked inside the TU.
+		final List<HUQRCode> huQRCodes = huService.getOrCreateQRCodesByHuId(cu.getId());
+		// Same surplus tolerance as the aggregate-TU path: this path uses only the first code (get(0) below),
+		// so a surplus is fine; error only when there are zero codes.
+		if (huQRCodes.size() < 1)
 		{
 			throw new AdempiereException(INVALID_NUMBER_QR_CODES_ERROR_MSG, 1, huQRCodes.size());
 		}
@@ -984,7 +1020,8 @@ public class PickingJobPickCommand
 	private LUTUResult pickCUsAndPackTo(
 			@NonNull final ProductId productId,
 			@NonNull final HuId pickFromVHUId,
-			@NonNull final PackToHUsProducer.PackToInfo packToInfo)
+			@NonNull final PackToHUsProducer.PackToInfo packToInfo,
+			final boolean recordLeafCUsAsTUParts)
 	{
 		return packToHUsProducer.packToHU(
 				PackToHUsProducer.PackToHURequest.builder()
@@ -997,6 +1034,7 @@ public class PickingJobPickCommand
 						.documentRef(getLineId().toTableRecordReference())
 						.checkIfAlreadyPacked(checkIfAlreadyPacked)
 						.createInventoryForMissingQty(createInventoryForMissingQty)
+						.recordLeafCUsAsTUParts(recordLeafCUsAsTUParts)
 						.build()
 		);
 	}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/PickingJobTestHelper.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/PickingJobTestHelper.java
@@ -306,6 +306,11 @@ public class PickingJobTestHelper
 		return LocatorId.ofRepoId(warehouseId, locator.getM_Locator_ID());
 	}
 
+	public HUTestHelper getHuTestHelper()
+	{
+		return huTestHelper;
+	}
+
 	public void updateMobileProfile(final UnaryOperator<MobileUIPickingUserProfile> updater)
 	{
 		configService.update(updater);

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/unpick/PickingJobUnpickCatchWeightTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/unpick/PickingJobUnpickCatchWeightTest.java
@@ -47,32 +47,27 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Catch-weight un-pack failure on Mobile-UI picking.
+ * Un-packing a catch-weight CU that was picked into a TU must detach and re-activate the leaf CU.
  * <p>
- * TDD RED for the pre-fix code on {@code intensive_care_hotfix}. This is a backend adaptation of the
- * upstream #24989 regression test ({@code PickingJobUnpickToFloorTest}) to the OLD (pre-refactor) command
- * API present on the customer's branch. The OLD {@code UNPICK} {@link PickingJobStepEvent} unpicks a whole
- * step/pickFrom (no {@code unpickProductId}/{@code qtyToUnpick} — those exist only post-refactor), so the
- * un-pack is driven by {@code (pickingStepId, pickFromKey)} with a {@code null} target (drop to floor).
+ * Backend adaptation of {@code PickingJobUnpickToFloorTest} to the pre-refactor {@code UNPICK}
+ * {@link PickingJobStepEvent} command API, where an un-pack targets a whole step/pickFrom (no
+ * {@code unpickProductId}/{@code qtyToUnpick}) and is driven by {@code (pickingStepId, pickFromKey)} with a
+ * {@code null} target (drop to floor).
  * <p>
- * Structure = the customer's shape: a CU is picked <b>into a TU</b> (a reusable transport crate) under a
- * header-level SALES_ORDER aggregation, then the surplus is un-packed. The root cause reproduced here is
- * #24989: {@code PickingJobPickCommand} records the picked-to HU as
- * {@code HUInfo.ofHuIdAndQRCode(cu.getId(), <the container TU's QR>)} (see the OLD
- * {@code toPickingJobStepPickedToHU(tu, cu, ...)} — the QR comes from {@code getOrCreateQRCodesByHuId(tu.getId())}).
- * Because the step points at the container TU rather than the leaf CU, un-pick operates on the TU instead of
- * extracting the leaf CU: the CU is left <b>Picked and nested inside the TU</b> instead of being dropped as a
- * standalone Active (re-pickable) floor HU. That orphaned-Picked-CU side-effect is the root cause and is exactly
- * what this test asserts against (and what the upstream {@code PickingJobUnpickToFloorTest} guards).
+ * Scenario: a CU is picked <b>into a TU</b> (a reusable transport crate) under header-level
+ * {@code SALES_ORDER} aggregation, then un-packed to the floor. The bug this guards against: when the
+ * picking-job step records the picked-to HU as the container TU plus the TU's QR
+ * ({@code HUInfo.ofHuIdAndQRCode(cu.getId(), <the TU's QR>)} via {@code toPickingJobStepPickedToHU(tu, cu, ...)},
+ * QR from {@code getOrCreateQRCodesByHuId(tu.getId())}), un-pick operates on the TU rather than extracting the
+ * leaf CU, leaving the CU <b>Picked and nested inside the TU</b> instead of dropped as a standalone
+ * {@code Active} (re-pickable) floor HU. The correct behaviour records the leaf CU + its own QR on the step, so
+ * un-pick extracts and re-activates that CU.
  * <p>
- * EXPECTED: RED on {@code intensive_care_hotfix} — the unpicked CU stays {@code HUStatus=Picked} / nested
- * instead of {@code Active} / detached; GREEN once the picking-job step records the leaf CU + its own QR, so
- * un-pick extracts and activates that CU. The blocking runtime throw
- * (<b>"QR Code &lt;n&gt; is not assigned to HU HuId(repoId=&lt;cuId&gt;)"</b>) — driven by the SAME stale TU-QR
- * pair via {@code HUTransformService.extractToTopLevel} → {@code assertQRCodeAssignedToHU} — plus the
- * catch-weight corruption both ride the aggregate-HU + surplus/re-pick path that the in-memory harness cannot
- * model (see class-level note in {@code de.metas.handlingunits.base/CLAUDE.md}); they are covered by the mobile
- * Playwright reproduction. This backend test covers the orphaned-Picked-CU side-effect facet.
+ * This test covers the orphaned-Picked-CU status facet. The related runtime failure
+ * ({@code assertQRCodeAssignedToHU} via {@code HUTransformService.extractToTopLevel}, driven by the same stale
+ * TU-QR pair) and the catch-weight-quantity corruption ride the aggregate-HU + surplus/re-pick path that the
+ * in-memory harness cannot model (it materialises picks as plain real HUs, never aggregate HUs); those are covered by the
+ * mobile Playwright reproduction {@code e2e/mobile-webui/tests/spec/picking/picking_catchWeight_unpack.spec.js}.
  */
 @ExtendWith(AdempiereTestWatcher.class)
 class PickingJobUnpickCatchWeightTest
@@ -166,8 +161,8 @@ class PickingJobUnpickCatchWeightTest
 
 		// UN-PACK the picked CU, SKIPPING the target scan (drop to floor: unpickToTargetQRCode == null).
 		// OLD whole-step UNPICK: identified by (pickingStepId, pickFromKey), not by product/qty.
-		// RED on intensive_care_hotfix: extractToTopLevel(cuId, TU-QR) -> assertQRCodeAssignedToHU throws
-		// "QR Code <n> is not assigned to HU HuId(repoId=<cuId>)".
+		// With the picked-to HU recorded as the container TU + its QR, un-pick operates on the TU rather than
+		// extracting the leaf CU, so the CU stays Picked/nested instead of being dropped Active on the floor.
 		pickingJob = helper.pickingJobService.processStepEvent(pickingJob, PickingJobStepEvent.builder()
 				.pickingLineId(line.getId())
 				.pickingStepId(stepId)
@@ -177,7 +172,7 @@ class PickingJobUnpickCatchWeightTest
 				.unpickToTargetQRCode(null) // floor
 				.build());
 
-		// AC1/AC2: the removed CU must be a standalone ACTIVE floor HU, detached from the TU — no orphan Picked CU left.
+		// The removed CU must be a standalone ACTIVE floor HU, detached from the TU — no orphan Picked CU left.
 		final I_M_HU cuAfter = handlingUnitsBL.getById(cuId);
 		assertThat(cuAfter.getHUStatus())
 				.as("unpicked CU dropped on the floor must be Active (re-pickable), not left Picked")

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/unpick/PickingJobUnpickCatchWeightTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/service/commands/unpick/PickingJobUnpickCatchWeightTest.java
@@ -1,0 +1,194 @@
+package de.metas.handlingunits.picking.job.service.commands.unpick;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.business.BusinessTestHelper;
+import de.metas.handlingunits.HUTestHelper;
+import de.metas.handlingunits.HuId;
+import de.metas.handlingunits.HuPackingInstructionsId;
+import de.metas.handlingunits.IHandlingUnitsBL;
+import de.metas.handlingunits.IHandlingUnitsDAO;
+import de.metas.handlingunits.model.I_M_HU;
+import de.metas.handlingunits.model.I_M_HU_PI;
+import de.metas.handlingunits.model.I_M_HU_PI_Item;
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.handlingunits.model.X_M_HU;
+import de.metas.handlingunits.model.X_M_HU_PI_Version;
+import de.metas.handlingunits.picking.config.mobileui.PickingJobAggregationType;
+import de.metas.handlingunits.picking.job.model.HUInfo;
+import de.metas.handlingunits.picking.job.model.PickingJob;
+import de.metas.handlingunits.picking.job.model.PickingJobLine;
+import de.metas.handlingunits.picking.job.model.PickingJobStep;
+import de.metas.handlingunits.picking.job.model.PickingJobStepEvent;
+import de.metas.handlingunits.picking.job.model.PickingJobStepEventType;
+import de.metas.handlingunits.picking.job.model.PickingJobStepId;
+import de.metas.handlingunits.picking.job.model.PickingJobStepPickFromKey;
+import de.metas.handlingunits.picking.job.model.PickingUnit;
+import de.metas.handlingunits.picking.job.model.TUPickingTarget;
+import de.metas.handlingunits.picking.job.service.commands.PickingJobCreateRequest;
+import de.metas.handlingunits.picking.job.service.commands.PickingJobTestHelper;
+import de.metas.order.OrderAndLineId;
+import de.metas.picking.api.PickingSlotIdAndCaption;
+import de.metas.product.ProductId;
+import de.metas.util.Services;
+import de.metas.util.collections.CollectionUtils;
+import lombok.NonNull;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.model.I_M_Product;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Catch-weight un-pack failure on Mobile-UI picking.
+ * <p>
+ * TDD RED for the pre-fix code on {@code intensive_care_hotfix}. This is a backend adaptation of the
+ * upstream #24989 regression test ({@code PickingJobUnpickToFloorTest}) to the OLD (pre-refactor) command
+ * API present on the customer's branch. The OLD {@code UNPICK} {@link PickingJobStepEvent} unpicks a whole
+ * step/pickFrom (no {@code unpickProductId}/{@code qtyToUnpick} — those exist only post-refactor), so the
+ * un-pack is driven by {@code (pickingStepId, pickFromKey)} with a {@code null} target (drop to floor).
+ * <p>
+ * Structure = the customer's shape: a CU is picked <b>into a TU</b> (a reusable transport crate) under a
+ * header-level SALES_ORDER aggregation, then the surplus is un-packed. The root cause reproduced here is
+ * #24989: {@code PickingJobPickCommand} records the picked-to HU as
+ * {@code HUInfo.ofHuIdAndQRCode(cu.getId(), <the container TU's QR>)} (see the OLD
+ * {@code toPickingJobStepPickedToHU(tu, cu, ...)} — the QR comes from {@code getOrCreateQRCodesByHuId(tu.getId())}).
+ * Because the step points at the container TU rather than the leaf CU, un-pick operates on the TU instead of
+ * extracting the leaf CU: the CU is left <b>Picked and nested inside the TU</b> instead of being dropped as a
+ * standalone Active (re-pickable) floor HU. That orphaned-Picked-CU side-effect is the root cause and is exactly
+ * what this test asserts against (and what the upstream {@code PickingJobUnpickToFloorTest} guards).
+ * <p>
+ * EXPECTED: RED on {@code intensive_care_hotfix} — the unpicked CU stays {@code HUStatus=Picked} / nested
+ * instead of {@code Active} / detached; GREEN once the picking-job step records the leaf CU + its own QR, so
+ * un-pick extracts and activates that CU. The blocking runtime throw
+ * (<b>"QR Code &lt;n&gt; is not assigned to HU HuId(repoId=&lt;cuId&gt;)"</b>) — driven by the SAME stale TU-QR
+ * pair via {@code HUTransformService.extractToTopLevel} → {@code assertQRCodeAssignedToHU} — plus the
+ * catch-weight corruption both ride the aggregate-HU + surplus/re-pick path that the in-memory harness cannot
+ * model (see class-level note in {@code de.metas.handlingunits.base/CLAUDE.md}); they are covered by the mobile
+ * Playwright reproduction. This backend test covers the orphaned-Picked-CU side-effect facet.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+class PickingJobUnpickCatchWeightTest
+{
+	private PickingJobTestHelper helper;
+	private HUTestHelper huTestHelper;
+	private IHandlingUnitsDAO handlingUnitsDAO;
+	private IHandlingUnitsBL handlingUnitsBL;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		helper = new PickingJobTestHelper();
+		huTestHelper = helper.getHuTestHelper();
+		handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
+		handlingUnitsBL = huTestHelper.handlingUnitsBL();
+		Env.setClientId(Env.getCtx(), ClientId.METASFRESH);
+	}
+
+	/** A finite-capacity TU PI for the product, so it can be used as a (new-TU) picking target the CU is packed into. */
+	private HuPackingInstructionsId createTuPI(@NonNull final I_M_Product product, final int capacity)
+	{
+		final I_M_HU_PI tuPI = huTestHelper.createHUDefinition("UNPICK-TU-PI", X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit);
+		final I_M_HU_PI_Item miItem = huTestHelper.createHU_PI_Item_Material(tuPI);
+		final I_M_HU_PI_Item_Product piip = huTestHelper.assignProduct(miItem, product, new BigDecimal(capacity), helper.uomEach);
+		piip.setIsDefaultForProduct(true);
+		InterfaceWrapperHelper.save(piip);
+		return HuPackingInstructionsId.ofRepoId(tuPI.getM_HU_PI_ID());
+	}
+
+	@Test
+	void unpickCuFromTU_toFloor_mustNotFailQRAssignment()
+	{
+		final ProductId productId = BusinessTestHelper.createProductId("P-CW-UNPICK", helper.uomEach);
+		final I_M_Product product = InterfaceWrapperHelper.load(productId, I_M_Product.class);
+		product.setM_Product_Category_ID(BusinessTestHelper.createProductCategory("P-CW-UNPICK-Cat", null).getRepoId());
+		InterfaceWrapperHelper.save(product);
+
+		final HuPackingInstructionsId tuPIId = createTuPI(product, 100);
+
+		final HUInfo pickFromVHU = helper.createVHUInfo(productId, "10", "QR-VHU-CW-UNPICK");
+
+		final OrderAndLineId orderAndLineId = helper.createOrderAndLineId("salesOrderCwUnpick");
+		helper.packageable()
+				.orderAndLineId(orderAndLineId)
+				.productId(productId)
+				.qtyToDeliver("10")
+				.build();
+
+		PickingJob pickingJob = helper.pickingJobService.createPickingJob(
+						PickingJobCreateRequest.builder()
+								.aggregationType(PickingJobAggregationType.SALES_ORDER)
+								.pickerId(de.metas.user.UserId.ofRepoId(1234))
+								.salesOrderId(orderAndLineId.getOrderId())
+								.deliveryBPLocationId(helper.shipToBPLocationId)
+								.isAllowPickingAnyHU(false)
+								.build())
+				.withPickingSlot(PickingSlotIdAndCaption.of(helper.pickingSlotId, "TEST"));
+
+		final PickingJobLine line = CollectionUtils.singleElement(pickingJob.getLines());
+		assertThat(line.getPickingUnit()).as("line must be a CU pick").isEqualTo(PickingUnit.CU);
+
+		// Header-level (SALES_ORDER aggregation) new-TU picking target: the picked CU is packed INTO this TU.
+		pickingJob = helper.pickingJobService.setTUPickingTarget(pickingJob, /*lineId*/ null,
+				TUPickingTarget.ofPackingInstructions(tuPIId, "UNPICK-TU-PI"));
+
+		final PickingJobStepId stepId = CollectionUtils.singleElement(
+				pickingJob.streamSteps().map(PickingJobStep::getId).collect(ImmutableSet.toImmutableSet()));
+
+		// Pick 1 CU into the TU (partial TU -> the picked-to HU is recorded as the leaf CU with the TU's QR).
+		pickingJob = helper.pickingJobService.processStepEvent(pickingJob, PickingJobStepEvent.builder()
+				.pickingLineId(line.getId())
+				.pickingStepId(stepId)
+				.pickFromKey(PickingJobStepPickFromKey.MAIN)
+				.eventType(PickingJobStepEventType.PICK)
+				.qrCode(pickFromVHU.getQrCode().toScannedCode())
+				.qtyPicked(BigDecimal.ONE)
+				.qtyRejectedReasonCode(null)
+				.build());
+
+		// Resolve the physical TU that now holds the picked CU, and the child CU itself.
+		final TUPickingTarget tuTarget = pickingJob.getTuPickingTargetEffective(line.getId()).orElse(null);
+		assertThat(tuTarget).as("TU picking target after pick").isNotNull();
+		assertThat(tuTarget.isExistingTU()).as("after pick the new-TU target must have materialised into a physical TU").isTrue();
+		final HuId tuId = tuTarget.getTuIdNotNull();
+
+		final List<I_M_HU> childrenBefore = handlingUnitsDAO.retrieveIncludedHUs(handlingUnitsBL.getById(tuId));
+		assertThat(childrenBefore).as("the TU must hold exactly one child CU after the pick").hasSize(1);
+		final HuId cuId = HuId.ofRepoId(childrenBefore.get(0).getM_HU_ID());
+		assertThat(childrenBefore.get(0).getHUStatus()).as("child CU is Picked after the pick").isEqualTo(X_M_HU.HUSTATUS_Picked);
+
+		// UN-PACK the picked CU, SKIPPING the target scan (drop to floor: unpickToTargetQRCode == null).
+		// OLD whole-step UNPICK: identified by (pickingStepId, pickFromKey), not by product/qty.
+		// RED on intensive_care_hotfix: extractToTopLevel(cuId, TU-QR) -> assertQRCodeAssignedToHU throws
+		// "QR Code <n> is not assigned to HU HuId(repoId=<cuId>)".
+		pickingJob = helper.pickingJobService.processStepEvent(pickingJob, PickingJobStepEvent.builder()
+				.pickingLineId(line.getId())
+				.pickingStepId(stepId)
+				.pickFromKey(PickingJobStepPickFromKey.MAIN)
+				.eventType(PickingJobStepEventType.UNPICK)
+				.qrCode(pickFromVHU.getQrCode().toScannedCode())
+				.unpickToTargetQRCode(null) // floor
+				.build());
+
+		// AC1/AC2: the removed CU must be a standalone ACTIVE floor HU, detached from the TU — no orphan Picked CU left.
+		final I_M_HU cuAfter = handlingUnitsBL.getById(cuId);
+		assertThat(cuAfter.getHUStatus())
+				.as("unpicked CU dropped on the floor must be Active (re-pickable), not left Picked")
+				.isEqualTo(X_M_HU.HUSTATUS_Active);
+		assertThat(cuAfter.getM_HU_Item_Parent_ID())
+				.as("unpicked CU must be detached from the TU (no parent)")
+				.isLessThanOrEqualTo(0);
+
+		final List<I_M_HU> childrenAfter = handlingUnitsDAO.retrieveIncludedHUs(handlingUnitsBL.getById(tuId));
+		assertThat(childrenAfter)
+				.as("the pick-to TU must hold NO orphan CU after skip-to-floor unpick")
+				.isEmpty();
+	}
+}

--- a/e2e/mobile-webui/tests/spec/picking/picking_catchWeight_unpack.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_catchWeight_unpack.spec.js
@@ -138,13 +138,10 @@ test('Un-pack surplus of a duplicate-picked catch-weight line restores qty AND c
         await PickingJobLineScreen.goBack();
     });
 
-    // === THE DISCRIMINATING ASSERTION ===
     // Required end-state after un-packing the surplus: correct piece quantity (6 Stk) AND correct,
-    // un-corrupted catch-weight (8.76 kg — the ONE remaining batch), reached WITHOUT any "uuups" /
-    // QR-Code-not-assigned error (the surrounding step() wrapper fails on any unexpected error
-    // toast/screen).
-    //   Pre-fix code  -> catch-weight corrupted and/or un-pack throws => RED
-    //   Fixed code    -> qty AND catch-weight restored, no error      => GREEN
+    // un-corrupted catch-weight (8.76 kg — the ONE remaining batch), reached WITHOUT any error toast/screen
+    // (no QR-Code-not-assigned failure — the surrounding step() wrapper fails on any unexpected error).
+    // The bug being guarded against corrupts the remaining catch-weight and/or fails the un-pack.
     await PickingJobScreen.waitForScreen();
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '6 Stk', qtyPickedCatchWeight: '8.76 kg' });
 });

--- a/e2e/mobile-webui/tests/spec/picking/picking_catchWeight_unpack.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_catchWeight_unpack.spec.js
@@ -1,0 +1,150 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
+import { PickingJobLineScreen } from "../../utils/screens/picking/PickingJobLineScreen";
+import { PickingJobStepScreen } from "../../utils/screens/picking/PickingJobStepScreen";
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+
+//
+// Mobile-UI: un-packing (Entpacken) a catch-weight product must work correctly, including the
+// real-world path where a line is picked, then picked AGAIN (surplus / duplicate), and the
+// operator un-packs the surplus.
+//
+// SCENARIO DRIVEN (the real mobile flow, end-to-end):
+//   catch-weight product -> pick the line -> pick it AGAIN (duplicate/surplus) -> un-pack the
+//   surplus step (skip scanning a target HU == un-pack to floor).
+//
+// CONTRACT UNDER TEST:
+//   After un-packing ONE of the two identical duplicate picks, the line must show the correct
+//   piece quantity (6 Stk) AND the correct, un-corrupted catch-weight of the ONE remaining batch
+//   (8.76 kg) — reached with NO error toast/screen during the un-pack (no
+//   "QR Code ... is not assigned to HU"). The known failure mode is: the piece quantity reduces
+//   correctly but the catch-weight comes out wrong, and/or a subsequent un-pack throws a
+//   QR-Code-not-assigned error. The fix records the leaf CU + its own QR on the picking-job step,
+//   so the un-pack restores both quantity and catch-weight cleanly.
+//
+// MODELLING NOTES (kept faithful, deliberately robust):
+//   - The duplicate pick is modelled as TWO demand-filling partial picks of 6 CUs each (line
+//     demand = 12). This reproduces the core condition (two aggregate catch-weight picks into the
+//     same pick-to target, then un-pack one) WITHOUT dragging in the over-pick-prompt branch,
+//     which is an unrelated UI surface.
+//   - Both batches are IDENTICAL (6 CUs @ 1.460 kg = 8.76 kg). Un-packing EITHER step therefore
+//     leaves exactly 6 Stk / 8.76 kg, so the assertion is independent of the step ordering.
+//   - Catch-weight is entered via the LMQ catch-weight QR path (multi-CU aggregate) — the path
+//     exercised by the "Leich+Mehl" case in picking_catchWeight.spec.js, and the aggregate-HU
+//     shape the defect lives in.
+//   - The `step()` wrapper used by the screen objects fails the test on any unexpected error
+//     toast/screen, so the "uuups" un-pack failure is caught even if it is transient.
+//
+
+const PER_CU_WEIGHT_KG = '1.460';                                  // one heavy catch-weight piece
+const CATCH_WEIGHT_QR = `LMQ#1#${PER_CU_WEIGHT_KG}#08.11.2025#500`; // 1 piece @ 1.460 kg, lot 500
+const BATCH_QR_CODES = Array(6).fill(CATCH_WEIGHT_QR);             // one batch = 6 pieces = 8.76 kg
+
+const createMasterdata = async () => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: {
+                user: { language: "en_US" },
+            },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU'],
+                    allowCompletingPartialPickingJob: true,
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                "P1": {
+                    uom: 'PCE',
+                    uomConversions: [{ from: 'PCE', to: 'KGM', multiplyRate: 0.10, isCatchUOMForProduct: true }],
+                    prices: [{ price: 5, uom: 'KGM', invoicableQtyBasedOn: 'CatchWeight' }]
+                },
+            },
+            packingInstructions: {
+                "PI": { lu: "LU", qtyTUsPerLU: 20, tu: "TU", product: "P1", qtyCUsPerTU: 4 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', qty: 100, weightNet: 10, lotNo: 'lot1', bestBeforeDate: '2031-11-23' }
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [{ product: 'P1', qty: 12, piItemProduct: 'TU' }]
+                }
+            },
+        }
+    });
+};
+
+// noinspection JSUnusedLocalSymbols
+test('Un-pack surplus of a duplicate-picked catch-weight line restores qty AND catch-weight', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00230: MobileUI Picking');
+    allure.tag('F00230');  // Standalone tag for Tags section
+    allure.story('Catch weight picking - un-pack surplus of a duplicate pick');
+    allure.severity('critical');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    await PickingJobScreen.setTargetLU({ lu: masterdata.packingInstructions.PI.luName });
+    await PickingJobScreen.setTargetTU({ tu: masterdata.packingInstructions.PI.tuName });
+
+    await test.step("Pick the catch-weight line (batch A = 6 Stk / 8.76 kg)", async () => {
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '0 Stk', qtyPickedCatchWeight: '0 kg' });
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.qrCode,
+            catchWeightQRCode: BATCH_QR_CODES,
+        });
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '6 Stk', qtyPickedCatchWeight: '8.76 kg' });
+    });
+
+    await test.step("Erroneously pick the SAME line AGAIN (batch B = surplus, 6 Stk / 8.76 kg)", async () => {
+        await PickingJobScreen.pickHU({
+            qrCode: masterdata.handlingUnits.HU1.qrCode,
+            catchWeightQRCode: BATCH_QR_CODES,
+        });
+        // Both duplicate picks are now aggregated on the line: 12 Stk total, 17.52 kg total.
+        await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '12 Stk', qtyPickedCatchWeight: '17.52 kg' });
+    });
+
+    await test.step("Un-pack the surplus step (skip scanning a target HU == un-pack to floor)", async () => {
+        await PickingJobScreen.clickLineButton({ index: 1 });
+        await PickingJobLineScreen.waitForScreen();
+        // Each on-the-fly pick created its own step; step index 1 is the surplus (second) pick.
+        // (Both steps are identical, so un-packing either leaves exactly one 6 Stk / 8.76 kg batch.)
+        await PickingJobLineScreen.clickStepButton({ index: 1 });
+        await PickingJobStepScreen.unpick();
+        await PickingJobLineScreen.goBack();
+    });
+
+    // === THE DISCRIMINATING ASSERTION ===
+    // Required end-state after un-packing the surplus: correct piece quantity (6 Stk) AND correct,
+    // un-corrupted catch-weight (8.76 kg — the ONE remaining batch), reached WITHOUT any "uuups" /
+    // QR-Code-not-assigned error (the surrounding step() wrapper fails on any unexpected error
+    // toast/screen).
+    //   Pre-fix code  -> catch-weight corrupted and/or un-pack throws => RED
+    //   Fixed code    -> qty AND catch-weight restored, no error      => GREEN
+    await PickingJobScreen.waitForScreen();
+    await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '6 Stk', qtyPickedCatchWeight: '8.76 kg' });
+});

--- a/e2e/mobile-webui/tests/spec/picking/picking_catchWeight_unpack.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_catchWeight_unpack.spec.js
@@ -15,16 +15,15 @@ import { LoginScreen } from "../../utils/screens/LoginScreen";
 //
 // SCENARIO DRIVEN (the real mobile flow, end-to-end):
 //   catch-weight product -> pick the line -> pick it AGAIN (duplicate/surplus) -> un-pack the
-//   surplus step (skip scanning a target HU == un-pack to floor).
+//   surplus batch, one 1-CU step at a time (skip scanning a target HU == un-pack to floor).
 //
 // CONTRACT UNDER TEST:
-//   After un-packing ONE of the two identical duplicate picks, the line must show the correct
-//   piece quantity (6 Stk) AND the correct, un-corrupted catch-weight of the ONE remaining batch
-//   (8.76 kg) — reached with NO error toast/screen during the un-pack (no
-//   "QR Code ... is not assigned to HU"). The known failure mode is: the piece quantity reduces
-//   correctly but the catch-weight comes out wrong, and/or a subsequent un-pack throws a
-//   QR-Code-not-assigned error. The fix records the leaf CU + its own QR on the picking-job step,
-//   so the un-pack restores both quantity and catch-weight cleanly.
+//   After un-packing the whole surplus batch (6 of the 12 identical 1-CU picks), the line must show
+//   the correct piece quantity (6 Stk) AND the correct, un-corrupted catch-weight of the 6 remaining
+//   pieces (8.76 kg) — reached with NO error toast/screen during any un-pack (no
+//   "QR Code ... is not assigned to HU"). The known failure mode is: an un-pack throws a
+//   QR-Code-not-assigned error, and/or the remaining catch-weight comes out wrong. The fix records the
+//   leaf CU + its own QR on the picking-job step, so each un-pack restores quantity and catch-weight cleanly.
 //
 // MODELLING NOTES (kept faithful, deliberately robust):
 //   - Each catch-weight QR scan is its own 1-CU pick and creates its own picking-job step, so a

--- a/e2e/mobile-webui/tests/spec/picking/picking_catchWeight_unpack.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/picking_catchWeight_unpack.spec.js
@@ -27,12 +27,12 @@ import { LoginScreen } from "../../utils/screens/LoginScreen";
 //   so the un-pack restores both quantity and catch-weight cleanly.
 //
 // MODELLING NOTES (kept faithful, deliberately robust):
-//   - The duplicate pick is modelled as TWO demand-filling partial picks of 6 CUs each (line
-//     demand = 12). This reproduces the core condition (two aggregate catch-weight picks into the
-//     same pick-to target, then un-pack one) WITHOUT dragging in the over-pick-prompt branch,
-//     which is an unrelated UI surface.
-//   - Both batches are IDENTICAL (6 CUs @ 1.460 kg = 8.76 kg). Un-packing EITHER step therefore
-//     leaves exactly 6 Stk / 8.76 kg, so the assertion is independent of the step ordering.
+//   - Each catch-weight QR scan is its own 1-CU pick and creates its own picking-job step, so a
+//     6-QR pickHU produces 6 one-CU steps. Two 6-QR picks = 12 identical 1-CU steps (line demand 12).
+//     This reproduces the core condition (duplicate catch-weight picks into the same pick-to target,
+//     then un-pack the surplus) WITHOUT dragging in the over-pick-prompt branch (an unrelated surface).
+//   - Un-packing one step returns exactly 1 CU (1.460 kg) to the floor. To un-pack the whole surplus
+//     "batch" of 6 pieces, un-pack 6 steps; all 12 steps are identical, so this lands on 6 Stk / 8.76 kg.
 //   - Catch-weight is entered via the LMQ catch-weight QR path (multi-CU aggregate) — the path
 //     exercised by the "Leich+Mehl" case in picking_catchWeight.spec.js, and the aggregate-HU
 //     shape the defect lives in.
@@ -128,20 +128,25 @@ test('Un-pack surplus of a duplicate-picked catch-weight line restores qty AND c
         await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '12 Stk', qtyPickedCatchWeight: '17.52 kg' });
     });
 
-    await test.step("Un-pack the surplus step (skip scanning a target HU == un-pack to floor)", async () => {
+    await test.step("Un-pack the whole surplus batch (6 pieces = 6 one-CU steps; skip scanning a target HU == un-pack to floor)", async () => {
         await PickingJobScreen.clickLineButton({ index: 1 });
-        await PickingJobLineScreen.waitForScreen();
-        // Each on-the-fly pick created its own step; step index 1 is the surplus (second) pick.
-        // (Both steps are identical, so un-packing either leaves exactly one 6 Stk / 8.76 kg batch.)
-        await PickingJobLineScreen.clickStepButton({ index: 1 });
-        await PickingJobStepScreen.unpick();
+        // Each pick created its own 1-CU step (12 total). Un-packing a step removes it and re-indexes
+        // the list, so un-pack index 0 six times to return the 6 surplus pieces to the floor. All steps
+        // are identical, so this leaves exactly 6 Stk / 8.76 kg regardless of which six are removed.
+        // On the OLD (unfixed) code the FIRST un-pack already throws "QR Code not assigned to HU".
+        for (let i = 0; i < 6; i++) {
+            await PickingJobLineScreen.waitForScreen();
+            await PickingJobLineScreen.clickStepButton({ index: 0 });
+            await PickingJobStepScreen.unpick();
+        }
         await PickingJobLineScreen.goBack();
     });
 
-    // Required end-state after un-packing the surplus: correct piece quantity (6 Stk) AND correct,
-    // un-corrupted catch-weight (8.76 kg — the ONE remaining batch), reached WITHOUT any error toast/screen
-    // (no QR-Code-not-assigned failure — the surrounding step() wrapper fails on any unexpected error).
-    // The bug being guarded against corrupts the remaining catch-weight and/or fails the un-pack.
+    // Required end-state after un-packing the whole surplus batch (6 of 12 pieces): correct piece
+    // quantity (6 Stk) AND correct, un-corrupted catch-weight (8.76 kg for the 6 remaining pieces),
+    // reached WITHOUT any error toast/screen (no QR-Code-not-assigned failure — the surrounding step()
+    // wrapper fails on any unexpected error). The bug guarded against throws on the FIRST un-pack and/or
+    // corrupts the remaining catch-weight.
     await PickingJobScreen.waitForScreen();
     await PickingJobScreen.expectLineButton({ index: 1, qtyToPick: '12 Stk', qtyPicked: '6 Stk', qtyPickedCatchWeight: '8.76 kg' });
 });


### PR DESCRIPTION
## Problem

On mobile picking, un-packing (Entpacken) a **catch-weight** product that was picked into a TU failed: the un-pack threw `QR Code <n> is not assigned to HU HuId(...)` and/or left the remaining catch-weight corrupted.

Root cause: a CU picked into a TU was recorded on the picking-job step as the **container TU** (with the TU's QR). An unpick-to-floor then operated on the TU instead of extracting the leaf CU — a no-op / QR mismatch that stranded the CU (still `Picked`, nested inside the TU) and could corrupt the line's catch-weight.

## Fix

Hand-port of the upstream fix cluster onto the pre-refactor `PickingJobPickCommand` / `PackToHUsProducer`:

- **https://github.com/metasfresh/metasfresh/pull/24989** — record the **leaf CU + its own QR** on the picking step instead of the container TU, so an unpick-to-floor extracts and re-activates the CU. Guarded to CU-into-TU picks via a `recordLeafCUsAsTUParts` flag; whole-TU / single-full-TU / non-catch-weight picks are unchanged. Shipment-schedule recording is decoupled from the picking-step recording (a CU-into-bare-TU pick still records the TU on the schedule to preserve downstream shipment/reversal/DESADV handling).
- **https://github.com/metasfresh/metasfresh/pull/24917** — tolerate surplus `M_HU_QRCode_Assignment` rows on the two picking-time QR-count checks (`!=` -> `<`, "require enough codes, not exactly N").

https://github.com/metasfresh/metasfresh/pull/24772 (move-to-scanned-target stale-QR) is intentionally **not** ported: the failure is at the first extract, before the move path runs, and it is a large refactor out of scope for this hotfix.

## Tests

- **Backend** `PickingJobUnpickCatchWeightTest` (RED->GREEN): a CU picked into a TU and un-packed to the floor must end `Active` / detached, not left `Picked` / nested.
- **Mobile E2E** `e2e/mobile-webui/.../picking_catchWeight_unpack.spec.js` (RED->GREEN on CI): catch-weight line -> duplicate/surplus pick -> un-pack the whole surplus batch -> line quantity and catch-weight restored, no error toast.

**Verified (RED->GREEN, both directions demonstrated):** on the unfixed code the backend test fails `expected: "A" but was: "S"` (the CU is left Picked/nested) — confirmed via `mvn test -pl de.metas.handlingunits.base -Dtest=PickingJobUnpickCatchWeightTest` — and the mobile spec's un-pack raises `QR Code not assigned to HU`; with this change both pass. Mobile GREEN confirmed on CI run https://github.com/metasfresh/metasfresh/actions/runs/30857484888 (job `mobile test` success; `test (java)` success). This grounds both the root cause (leaf-CU-vs-container-TU recording) and the fix direction.
