### PR TITLE
nShift COO: scope shipment QtyPicked split to shipment-line-config attributes

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -173,6 +173,7 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 	private final IHUPackingAwareBL huPackingAwareBL = Services.get(IHUPackingAwareBL.class);
 	private final IHUCapacityBL huCapacityBL = Services.get(IHUCapacityBL.class);
 	private final IAttributeDAO attributeDAO = Services.get(IAttributeDAO.class);
+	private final IShipmentScheduleHandlerBL shipmentScheduleHandlerBL = Services.get(IShipmentScheduleHandlerBL.class);
 
 	private static final String SYSCONFIG_ShipmentConsolidationPeriod = "de.metas.handlingunits.shipmentschedule.api.impl.HUShipmentScheduleBL.ShipmentConsolidationPeriod";
 	private static final String DEFAULT_ShipmentConsolidationPeriod = null;
@@ -1229,14 +1230,15 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 	/**
 	 * Predicate deciding whether an attribute splits the shipment line, i.e. whether it is whitelisted in
 	 * {@code M_ShipmentSchedule_AttributeConfig} for the schedule's handler — the same rule the M_InOutLine
-	 * aggregation applies. Resolved via {@code getHandlerForOrNull} because this runs eagerly while picking,
-	 * where the schedule may not have a resolvable handler yet; then it falls back to "no restriction" (the
-	 * split is refined at shipment generation, where the handler resolves).
+	 * aggregation applies. Resolved via {@code getHandlerForOrNull}: handlers are registered once at server
+	 * startup ({@code InOutCandidateValidator#onInit}), so during real picking the handler is present and the
+	 * whitelist restricts the split. It is null only in narrow init/test contexts that bypass that
+	 * registration; there we fall back to "no restriction" rather than fail.
 	 */
 	private Predicate<AttributeId> attributeSplitsShipmentLinePredicate(@NonNull final I_M_ShipmentSchedule_QtyPicked qtyPicked)
 	{
 		final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule = qtyPicked.getM_ShipmentSchedule();
-		final ShipmentScheduleHandler handler = Services.get(IShipmentScheduleHandlerBL.class).getHandlerForOrNull(shipmentSchedule);
+		final ShipmentScheduleHandler handler = shipmentScheduleHandlerBL.getHandlerForOrNull(shipmentSchedule);
 		if (handler == null)
 		{
 			return attributeId -> true;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -99,7 +99,6 @@ import org.adempiere.util.lang.IContextAware;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.I_C_UOM;
-import org.compiere.model.I_M_Attribute;
 import org.compiere.model.X_C_DocType;
 import org.compiere.model.X_M_InOut;
 import org.slf4j.Logger;
@@ -116,7 +115,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -173,7 +171,6 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private final IHUPackingAwareBL huPackingAwareBL = Services.get(IHUPackingAwareBL.class);
 	private final IHUCapacityBL huCapacityBL = Services.get(IHUCapacityBL.class);
-	private final IShipmentScheduleHandlerBL shipmentScheduleHandlerBL = Services.get(IShipmentScheduleHandlerBL.class);
 
 	private static final String SYSCONFIG_ShipmentConsolidationPeriod = "de.metas.handlingunits.shipmentschedule.api.impl.HUShipmentScheduleBL.ShipmentConsolidationPeriod";
 	private static final String DEFAULT_ShipmentConsolidationPeriod = null;
@@ -1058,15 +1055,9 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 
 		// The picked-qty allocation may only be split by attributes that are whitelisted for the shipment
 		// line in M_ShipmentSchedule_AttributeConfig — the SAME criterion the downstream M_InOutLine
-		// aggregation applies (see ShipmentScheduleWithHU#computeAttributeValues). Without this filter every
-		// UseInASI attribute splits the allocation, including per-piece measurements such as catch-weight
-		// WeightNet whose values differ only by distribution rounding (e.g. 0.333/0.333/0.334) — producing
-		// extra M_ShipmentSchedule_QtyPicked rows that back no distinct shipment line.
+		// aggregation applies (see ShipmentScheduleWithHU#computeAttributeValues).
 		final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule =
 				InterfaceWrapperHelper.create(qtyPicked.getM_ShipmentSchedule(), de.metas.inoutcandidate.model.I_M_ShipmentSchedule.class);
-		final ShipmentScheduleHandler shipmentScheduleHandler = shipmentScheduleHandlerBL.getHandlerFor(shipmentSchedule);
-		final Predicate<I_M_Attribute> attributeMayBePartOfShipmentLine =
-				attribute -> shipmentScheduleHandler.attributeShallBePartOfShipmentLine(shipmentSchedule, attribute);
 
 		// One pass: for each child VHU compute its UseInASI fingerprint once, then emit one
 		// (fingerprint, productStorage) entry per non-empty product storage of that VHU.
@@ -1078,7 +1069,7 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 				handlingUnitsDAO.retrieveIncludedHUs(huToInspect)
 						.stream()
 						.filter(handlingUnitsBL::isVirtual)
-						.flatMap(vhu -> groupProductStoragesByFingerprint(vhu, productId, storageFactory, attrFactory, attributeMayBePartOfShipmentLine))
+						.flatMap(vhu -> groupProductStoragesByFingerprint(vhu, productId, storageFactory, attrFactory, shipmentSchedule))
 						.collect(ImmutableListMultimap.toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue));
 
 		if (storagesByFingerprint.isEmpty())
@@ -1204,31 +1195,32 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 			@NonNull final ProductId productId,
 			@NonNull final IHUStorageFactory storageFactory,
 			@NonNull final IAttributeStorageFactory attrFactory,
-			@NonNull final Predicate<I_M_Attribute> attributeMayBePartOfShipmentLine)
+			@NonNull final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule)
 	{
 		final IHUProductStorage productStorage = storageFactory.getStorage(vhu).getProductStorageOrNull(productId);
 		if (productStorage == null || productStorage.isEmpty())
 		{
 			return Stream.empty();
 		}
-		final AttributesKey fingerprint = computeUseInASIFingerprint(vhu, attrFactory, attributeMayBePartOfShipmentLine);
+		final AttributesKey fingerprint = computeUseInASIFingerprint(vhu, attrFactory, shipmentSchedule);
 		return Stream.of(Maps.immutableEntry(fingerprint, productStorage));
 	}
 
 	private static AttributesKey computeUseInASIFingerprint(
 			@NonNull final I_M_HU vhu,
 			@NonNull final IAttributeStorageFactory factory,
-			@NonNull final Predicate<I_M_Attribute> attributeMayBePartOfShipmentLine)
+			@NonNull final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule)
 	{
 		// IAttributeStorage does not implement getAttributeValueIdOrNull, so we cannot use
 		// AttributesKeys.createAttributesKeyFromAttributeSet here — list-type attributes
 		// would be silently dropped. Instead, we build the key directly from IAttributeValue,
 		// using the value string for all attribute types (consistent for grouping purposes).
+		final ShipmentScheduleHandler handler = Services.get(IShipmentScheduleHandlerBL.class).getHandlerFor(shipmentSchedule);
 		final ImmutableSet<AttributesKeyPart> parts = factory.getAttributeStorage(vhu)
 				.getAttributeValues()
 				.stream()
 				.filter(av -> av.isUseInASI() && !av.isEmpty())
-				.filter(av -> attributeMayBePartOfShipmentLine.test(av.getM_Attribute()))
+				.filter(av -> handler.attributeShallBePartOfShipmentLine(shipmentSchedule, av.getM_Attribute()))
 				.map(HUShipmentScheduleBL::toAttributesKeyPart)
 				.filter(Objects::nonNull)
 				.collect(ImmutableSet.toImmutableSet());

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -1213,12 +1213,15 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 		// AttributesKeys.createAttributesKeyFromAttributeSet here — list-type attributes
 		// would be silently dropped. Instead, we build the key directly from IAttributeValue,
 		// using the value string for all attribute types (consistent for grouping purposes).
-		final ShipmentScheduleHandler handler = Services.get(IShipmentScheduleHandlerBL.class).getHandlerFor(shipmentSchedule);
+		// getHandlerForOrNull (not getHandlerFor): this runs eagerly while picking, where a schedule may not
+		// have a resolvable handler yet — then fall back to no restriction (the split is refined at shipment
+		// generation, where the handler resolves and the M_ShipmentSchedule_AttributeConfig whitelist applies).
+		final ShipmentScheduleHandler handler = Services.get(IShipmentScheduleHandlerBL.class).getHandlerForOrNull(shipmentSchedule);
 		final ImmutableSet<AttributesKeyPart> parts = factory.getAttributeStorage(vhu)
 				.getAttributeValues()
 				.stream()
 				.filter(av -> av.isUseInASI() && !av.isEmpty())
-				.filter(av -> handler.attributeShallBePartOfShipmentLine(shipmentSchedule, av.getM_Attribute()))
+				.filter(av -> handler == null || handler.attributeShallBePartOfShipmentLine(shipmentSchedule, av.getM_Attribute()))
 				.map(HUShipmentScheduleBL::toAttributesKeyPart)
 				.filter(Objects::nonNull)
 				.collect(ImmutableSet.toImmutableSet());

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -96,6 +96,7 @@ import org.adempiere.util.lang.IContextAware;
 import org.adempiere.warehouse.LocatorId;
 import org.adempiere.warehouse.WarehouseId;
 import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_M_Attribute;
 import org.compiere.model.X_C_DocType;
 import org.compiere.model.X_M_InOut;
 import org.slf4j.Logger;
@@ -112,6 +113,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -1050,6 +1052,19 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 		final IHUStorageFactory storageFactory = huContext.getHUStorageFactory();
 		final IAttributeStorageFactory attrFactory = huContext.getHUAttributeStorageFactory();
 
+		// The picked-qty allocation may only be split by attributes that are whitelisted for the shipment
+		// line in M_ShipmentSchedule_AttributeConfig — the SAME criterion the downstream M_InOutLine
+		// aggregation applies (see ShipmentScheduleWithHU#computeAttributeValues). Without this filter every
+		// UseInASI attribute splits the allocation, including per-piece measurements such as catch-weight
+		// WeightNet whose values differ only by distribution rounding (e.g. 0.333/0.333/0.334) — producing
+		// extra M_ShipmentSchedule_QtyPicked rows that back no distinct shipment line (gh31403).
+		final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule =
+				org.adempiere.model.InterfaceWrapperHelper.create(qtyPicked.getM_ShipmentSchedule(), de.metas.inoutcandidate.model.I_M_ShipmentSchedule.class);
+		final de.metas.inoutcandidate.spi.ShipmentScheduleHandler shipmentScheduleHandler =
+				Services.get(de.metas.inoutcandidate.api.IShipmentScheduleHandlerBL.class).getHandlerFor(shipmentSchedule);
+		final Predicate<I_M_Attribute> attributeMayBePartOfShipmentLine =
+				attribute -> shipmentScheduleHandler.attributeShallBePartOfShipmentLine(shipmentSchedule, attribute);
+
 		// One pass: for each child VHU compute its UseInASI fingerprint once, then emit one
 		// (fingerprint, productStorage) entry per non-empty product storage of that VHU.
 		// Filter by product so VHUs carrying a different product in the same TU are excluded.
@@ -1060,7 +1075,7 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 				handlingUnitsDAO.retrieveIncludedHUs(huToInspect)
 						.stream()
 						.filter(handlingUnitsBL::isVirtual)
-						.flatMap(vhu -> groupProductStoragesByFingerprint(vhu, productId, storageFactory, attrFactory))
+						.flatMap(vhu -> groupProductStoragesByFingerprint(vhu, productId, storageFactory, attrFactory, attributeMayBePartOfShipmentLine))
 						.collect(ImmutableListMultimap.toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue));
 
 		if (storagesByFingerprint.isEmpty())
@@ -1185,20 +1200,22 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 			@NonNull final I_M_HU vhu,
 			@NonNull final ProductId productId,
 			@NonNull final IHUStorageFactory storageFactory,
-			@NonNull final IAttributeStorageFactory attrFactory)
+			@NonNull final IAttributeStorageFactory attrFactory,
+			@NonNull final Predicate<I_M_Attribute> attributeMayBePartOfShipmentLine)
 	{
 		final IHUProductStorage productStorage = storageFactory.getStorage(vhu).getProductStorageOrNull(productId);
 		if (productStorage == null || productStorage.isEmpty())
 		{
 			return Stream.empty();
 		}
-		final AttributesKey fingerprint = computeUseInASIFingerprint(vhu, attrFactory);
+		final AttributesKey fingerprint = computeUseInASIFingerprint(vhu, attrFactory, attributeMayBePartOfShipmentLine);
 		return Stream.of(Maps.immutableEntry(fingerprint, productStorage));
 	}
 
 	private static AttributesKey computeUseInASIFingerprint(
 			@NonNull final I_M_HU vhu,
-			@NonNull final IAttributeStorageFactory factory)
+			@NonNull final IAttributeStorageFactory factory,
+			@NonNull final Predicate<I_M_Attribute> attributeMayBePartOfShipmentLine)
 	{
 		// IAttributeStorage does not implement getAttributeValueIdOrNull, so we cannot use
 		// AttributesKeys.createAttributesKeyFromAttributeSet here — list-type attributes
@@ -1208,6 +1225,7 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 				.getAttributeValues()
 				.stream()
 				.filter(av -> av.isUseInASI() && !av.isEmpty())
+				.filter(av -> attributeMayBePartOfShipmentLine.test(av.getM_Attribute()))
 				.map(HUShipmentScheduleBL::toAttributesKeyPart)
 				.filter(Objects::nonNull)
 				.collect(ImmutableSet.toImmutableSet());

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -46,6 +46,7 @@ import de.metas.material.event.commons.AttributesKey;
 import de.metas.material.event.commons.AttributesKeyPart;
 import org.adempiere.mm.attributes.AttributeId;
 import org.adempiere.mm.attributes.AttributeValueType;
+import org.adempiere.mm.attributes.api.IAttributeDAO;
 import de.metas.handlingunits.shipmentschedule.api.AddQtyPickedRequest;
 import de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleBL;
 import de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleDAO;
@@ -114,6 +115,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -170,6 +172,7 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private final IHUPackingAwareBL huPackingAwareBL = Services.get(IHUPackingAwareBL.class);
 	private final IHUCapacityBL huCapacityBL = Services.get(IHUCapacityBL.class);
+	private final IAttributeDAO attributeDAO = Services.get(IAttributeDAO.class);
 
 	private static final String SYSCONFIG_ShipmentConsolidationPeriod = "de.metas.handlingunits.shipmentschedule.api.impl.HUShipmentScheduleBL.ShipmentConsolidationPeriod";
 	private static final String DEFAULT_ShipmentConsolidationPeriod = null;
@@ -1052,10 +1055,9 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 		final IHUStorageFactory storageFactory = huContext.getHUStorageFactory();
 		final IAttributeStorageFactory attrFactory = huContext.getHUAttributeStorageFactory();
 
-		// The picked-qty allocation may only be split by attributes that are whitelisted for the shipment
-		// line in M_ShipmentSchedule_AttributeConfig — the SAME criterion the downstream M_InOutLine
-		// aggregation applies (see ShipmentScheduleWithHU#computeAttributeValues).
-		final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule = qtyPicked.getM_ShipmentSchedule();
+		// Split only by attributes whitelisted in M_ShipmentSchedule_AttributeConfig — the same criterion
+		// the M_InOutLine aggregation uses (ShipmentScheduleWithHU#computeAttributeValues).
+		final Predicate<AttributeId> attributeSplitsShipmentLine = attributeSplitsShipmentLinePredicate(qtyPicked);
 
 		// One pass: for each child VHU compute its UseInASI fingerprint once, then emit one
 		// (fingerprint, productStorage) entry per non-empty product storage of that VHU.
@@ -1067,7 +1069,7 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 				handlingUnitsDAO.retrieveIncludedHUs(huToInspect)
 						.stream()
 						.filter(handlingUnitsBL::isVirtual)
-						.flatMap(vhu -> groupProductStoragesByFingerprint(vhu, productId, storageFactory, attrFactory, shipmentSchedule))
+						.flatMap(vhu -> groupProductStoragesByFingerprint(vhu, productId, storageFactory, attrFactory, attributeSplitsShipmentLine))
 						.collect(ImmutableListMultimap.toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue));
 
 		if (storagesByFingerprint.isEmpty())
@@ -1193,39 +1195,53 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 			@NonNull final ProductId productId,
 			@NonNull final IHUStorageFactory storageFactory,
 			@NonNull final IAttributeStorageFactory attrFactory,
-			@NonNull final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule)
+			@NonNull final Predicate<AttributeId> attributeSplitsShipmentLine)
 	{
 		final IHUProductStorage productStorage = storageFactory.getStorage(vhu).getProductStorageOrNull(productId);
 		if (productStorage == null || productStorage.isEmpty())
 		{
 			return Stream.empty();
 		}
-		final AttributesKey fingerprint = computeUseInASIFingerprint(vhu, attrFactory, shipmentSchedule);
+		final AttributesKey fingerprint = computeUseInASIFingerprint(vhu, attrFactory, attributeSplitsShipmentLine);
 		return Stream.of(Maps.immutableEntry(fingerprint, productStorage));
 	}
 
 	private static AttributesKey computeUseInASIFingerprint(
 			@NonNull final I_M_HU vhu,
 			@NonNull final IAttributeStorageFactory factory,
-			@NonNull final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule)
+			@NonNull final Predicate<AttributeId> attributeSplitsShipmentLine)
 	{
 		// IAttributeStorage does not implement getAttributeValueIdOrNull, so we cannot use
 		// AttributesKeys.createAttributesKeyFromAttributeSet here — list-type attributes
 		// would be silently dropped. Instead, we build the key directly from IAttributeValue,
 		// using the value string for all attribute types (consistent for grouping purposes).
-		// getHandlerForOrNull (not getHandlerFor): this runs eagerly while picking, where a schedule may not
-		// have a resolvable handler yet — then fall back to no restriction (the split is refined at shipment
-		// generation, where the handler resolves and the M_ShipmentSchedule_AttributeConfig whitelist applies).
-		final ShipmentScheduleHandler handler = Services.get(IShipmentScheduleHandlerBL.class).getHandlerForOrNull(shipmentSchedule);
 		final ImmutableSet<AttributesKeyPart> parts = factory.getAttributeStorage(vhu)
 				.getAttributeValues()
 				.stream()
 				.filter(av -> av.isUseInASI() && !av.isEmpty())
-				.filter(av -> handler == null || handler.attributeShallBePartOfShipmentLine(shipmentSchedule, av.getM_Attribute()))
+				.filter(av -> attributeSplitsShipmentLine.test(av.getAttributeId()))
 				.map(HUShipmentScheduleBL::toAttributesKeyPart)
 				.filter(Objects::nonNull)
 				.collect(ImmutableSet.toImmutableSet());
 		return parts.isEmpty() ? AttributesKey.NONE : AttributesKey.ofParts(parts);
+	}
+
+	/**
+	 * Predicate deciding whether an attribute splits the shipment line, i.e. whether it is whitelisted in
+	 * {@code M_ShipmentSchedule_AttributeConfig} for the schedule's handler — the same rule the M_InOutLine
+	 * aggregation applies. Resolved via {@code getHandlerForOrNull} because this runs eagerly while picking,
+	 * where the schedule may not have a resolvable handler yet; then it falls back to "no restriction" (the
+	 * split is refined at shipment generation, where the handler resolves).
+	 */
+	private Predicate<AttributeId> attributeSplitsShipmentLinePredicate(@NonNull final I_M_ShipmentSchedule_QtyPicked qtyPicked)
+	{
+		final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule = qtyPicked.getM_ShipmentSchedule();
+		final ShipmentScheduleHandler handler = Services.get(IShipmentScheduleHandlerBL.class).getHandlerForOrNull(shipmentSchedule);
+		if (handler == null)
+		{
+			return attributeId -> true;
+		}
+		return attributeId -> handler.attributeShallBePartOfShipmentLine(shipmentSchedule, attributeDAO.getAttributeRecordById(attributeId));
 	}
 
 	@Nullable

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -63,11 +63,13 @@ import de.metas.inoutcandidate.api.IInOutCandidateBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleAllocBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleEffectiveBL;
+import de.metas.inoutcandidate.api.IShipmentScheduleHandlerBL;
 import de.metas.inoutcandidate.api.IShipmentSchedulePA;
 import de.metas.inoutcandidate.api.InOutGenerateResult;
 import de.metas.inoutcandidate.api.ShipmentScheduleLoadingCache;
 import de.metas.inoutcandidate.api.impl.HUShipmentScheduleHeaderAggregationKeyBuilder;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
+import de.metas.inoutcandidate.spi.ShipmentScheduleHandler;
 import de.metas.logging.LogManager;
 import de.metas.util.Loggables;
 import de.metas.order.IOrderDAO;
@@ -90,6 +92,7 @@ import org.adempiere.ad.dao.IQueryOrderBy.Nulls;
 import org.adempiere.ad.dao.impl.DateTruncQueryFilterModifier;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ISysConfigBL;
 import org.adempiere.util.agg.key.IAggregationKeyBuilder;
 import org.adempiere.util.lang.IContextAware;
@@ -170,6 +173,7 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private final IHUPackingAwareBL huPackingAwareBL = Services.get(IHUPackingAwareBL.class);
 	private final IHUCapacityBL huCapacityBL = Services.get(IHUCapacityBL.class);
+	private final IShipmentScheduleHandlerBL shipmentScheduleHandlerBL = Services.get(IShipmentScheduleHandlerBL.class);
 
 	private static final String SYSCONFIG_ShipmentConsolidationPeriod = "de.metas.handlingunits.shipmentschedule.api.impl.HUShipmentScheduleBL.ShipmentConsolidationPeriod";
 	private static final String DEFAULT_ShipmentConsolidationPeriod = null;
@@ -1057,11 +1061,10 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 		// aggregation applies (see ShipmentScheduleWithHU#computeAttributeValues). Without this filter every
 		// UseInASI attribute splits the allocation, including per-piece measurements such as catch-weight
 		// WeightNet whose values differ only by distribution rounding (e.g. 0.333/0.333/0.334) — producing
-		// extra M_ShipmentSchedule_QtyPicked rows that back no distinct shipment line (gh31403).
+		// extra M_ShipmentSchedule_QtyPicked rows that back no distinct shipment line.
 		final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule =
-				org.adempiere.model.InterfaceWrapperHelper.create(qtyPicked.getM_ShipmentSchedule(), de.metas.inoutcandidate.model.I_M_ShipmentSchedule.class);
-		final de.metas.inoutcandidate.spi.ShipmentScheduleHandler shipmentScheduleHandler =
-				Services.get(de.metas.inoutcandidate.api.IShipmentScheduleHandlerBL.class).getHandlerFor(shipmentSchedule);
+				InterfaceWrapperHelper.create(qtyPicked.getM_ShipmentSchedule(), de.metas.inoutcandidate.model.I_M_ShipmentSchedule.class);
+		final ShipmentScheduleHandler shipmentScheduleHandler = shipmentScheduleHandlerBL.getHandlerFor(shipmentSchedule);
 		final Predicate<I_M_Attribute> attributeMayBePartOfShipmentLine =
 				attribute -> shipmentScheduleHandler.attributeShallBePartOfShipmentLine(shipmentSchedule, attribute);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -92,7 +92,6 @@ import org.adempiere.ad.dao.IQueryOrderBy.Nulls;
 import org.adempiere.ad.dao.impl.DateTruncQueryFilterModifier;
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ISysConfigBL;
 import org.adempiere.util.agg.key.IAggregationKeyBuilder;
 import org.adempiere.util.lang.IContextAware;
@@ -1056,8 +1055,7 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 		// The picked-qty allocation may only be split by attributes that are whitelisted for the shipment
 		// line in M_ShipmentSchedule_AttributeConfig — the SAME criterion the downstream M_InOutLine
 		// aggregation applies (see ShipmentScheduleWithHU#computeAttributeValues).
-		final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule =
-				InterfaceWrapperHelper.create(qtyPicked.getM_ShipmentSchedule(), de.metas.inoutcandidate.model.I_M_ShipmentSchedule.class);
+		final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule = qtyPicked.getM_ShipmentSchedule();
 
 		// One pass: for each child VHU compute its UseInASI fingerprint once, then emit one
 		// (fingerprint, productStorage) entry per non-empty product storage of that VHU.

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleHandlerBL.java
@@ -9,6 +9,8 @@ import de.metas.util.ISingletonService;
 import org.adempiere.ad.dao.QueryLimit;
 import org.compiere.model.I_C_OrderLine;
 
+import javax.annotation.Nullable;
+
 import java.util.Properties;
 import java.util.Set;
 
@@ -76,6 +78,10 @@ public interface IShipmentScheduleHandlerBL extends ISingletonService
 	IDeliverRequest createDeliverRequest(I_M_ShipmentSchedule sched, final I_C_OrderLine salesOrderLine);
 
 	ShipmentScheduleHandler getHandlerFor(I_M_ShipmentSchedule sched);
+
+	/** @return the handler for the given schedule, or {@code null} if none is registered for its table (e.g. a schedule that carries no handler context yet). */
+	@Nullable
+	ShipmentScheduleHandler getHandlerForOrNull(I_M_ShipmentSchedule sched);
 
 	void updateShipmentScheduleFromReferencedRecord(I_M_ShipmentSchedule shipmentScheduleRecord);
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
@@ -379,14 +379,21 @@ public class ShipmentScheduleHandlerBL implements IShipmentScheduleHandlerBL
 	@Override
 	public ShipmentScheduleHandler getHandlerFor(@NonNull final I_M_ShipmentSchedule sched)
 	{
-		final String tableName = adTableDAO.retrieveTableName(sched.getAD_Table_ID());
-
-		final ShipmentScheduleHandler shipmentScheduleHandler = tableName2Handler.get(tableName);
+		final ShipmentScheduleHandler shipmentScheduleHandler = getHandlerForOrNull(sched);
 		if (shipmentScheduleHandler == null)
 		{
+			final String tableName = adTableDAO.retrieveTableName(sched.getAD_Table_ID());
 			throw new AdempiereException("No shipment schedule handler defined for " + tableName + " (" + sched + ")");
 		}
 
 		return shipmentScheduleHandler;
+	}
+
+	@Override
+	@Nullable
+	public ShipmentScheduleHandler getHandlerForOrNull(@NonNull final I_M_ShipmentSchedule sched)
+	{
+		final String tableName = adTableDAO.retrieveTableName(sched.getAD_Table_ID());
+		return tableName2Handler.get(tableName);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5817360_sys_gh31403_HUAggregation_M_Attribute_field_description.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5817360_sys_gh31403_HUAggregation_M_Attribute_field_description.sql
@@ -6,16 +6,17 @@
 -- description/help via AD_Field.AD_Name_ID -> a NEW AD_Element (585152), leaving the shared element 2015
 -- untouched (it backs every M_Attribute field system-wide).
 --
--- The config controls ONLY shipment-line splitting: an attribute listed here splits the picked-qty
--- allocation + M_InOutLine per distinct value; it makes NO statement about whether the attribute is carried
--- on the HU/stock (that is M_HU_PI_Attribute.UseInASI, an independent setting).
+-- Behaviour documented (kept technical HERE, plain-language in the user-facing text below):
+-- an attribute listed here splits the picked-qty allocation (M_ShipmentSchedule_QtyPicked) and the shipment
+-- line (M_InOutLine) per distinct value; it makes NO statement about whether the attribute is carried on the
+-- HU/stock (that is M_HU_PI_Attribute.UseInASI, an independent setting).
 
 -- 1. New name-only AD_Element (ColumnName NULL; overrides only this field's name/description/help)
 INSERT INTO AD_Element (AD_Client_ID, AD_Element_ID, AD_Org_ID, ColumnName, Created, CreatedBy,
                         Description, EntityType, IsActive, Name, PrintName, Updated, UpdatedBy)
-VALUES (0, 585152, 0, NULL,
+VALUES (0, 585152 /*From ID Server*/, 0, NULL,
         TO_TIMESTAMP('2026-08-04 09:01:00', 'YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', 100,
-        'Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen (M_InOutLine) und Mengenbuchungen (M_ShipmentSchedule_QtyPicked) gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus.',
+        'Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen und Mengenbuchungen gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus.',
         'de.metas.inoutcandidate', 'Y',
         'Merkmal', 'Merkmal',
         TO_TIMESTAMP('2026-08-04 09:01:00', 'YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', 100);
@@ -35,17 +36,18 @@ WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
   AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt
                   WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID);
 
--- 3. Per-language text (de_DE + de_CH = German, en_US = English)
+-- 3. Per-language text (de_DE + de_CH = German, en_US = English). Later timestamp than the element INSERT
+--    so the propagation guard (f.updated <> e_trl.updated) always fires.
 UPDATE AD_Element_Trl SET Name='Merkmal',
-    Description='Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen (M_InOutLine) und Mengenbuchungen (M_ShipmentSchedule_QtyPicked) gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus.',
-    Help='Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen (M_InOutLine) und Mengenbuchungen (M_ShipmentSchedule_QtyPicked) gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus. Ob ein Merkmal am HU/Bestand geführt wird, steuert dagegen M_HU_PI_Attribute.UseInASI und ist von dieser Konfiguration unabhängig.',
-    IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-04 09:01:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+    Description='Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen und Mengenbuchungen gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus.',
+    Help='Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen und Mengenbuchungen gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus. Ob ein Merkmal am Bestand geführt wird, wird dagegen in der Packvorschrift eingestellt und ist von dieser Konfiguration unabhängig.',
+    IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-04 09:01:30','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
 WHERE AD_Element_ID = 585152 AND AD_Language IN ('de_DE','de_CH');
 
 UPDATE AD_Element_Trl SET Name='Attribute',
-    Description='Attributes that split shipment lines. Picked goods that differ in a listed attribute (e.g. Country of Origin, Lot) are booked to separate shipment lines (M_InOutLine) and picked-qty allocations (M_ShipmentSchedule_QtyPicked). Attributes not listed here do not cause a shipment-line split.',
-    Help='Attributes that split shipment lines. Picked goods that differ in a listed attribute (e.g. Country of Origin, Lot) are booked to separate shipment lines (M_InOutLine) and picked-qty allocations (M_ShipmentSchedule_QtyPicked). Attributes not listed here do not cause a shipment-line split. Whether an attribute is carried on the HU/stock is controlled separately by M_HU_PI_Attribute.UseInASI and is independent of this configuration.',
-    IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-04 09:01:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+    Description='Attributes that split shipment lines. Picked goods that differ in a listed attribute (e.g. Country of Origin, Lot) are booked to separate shipment lines and picked-quantity allocations. Attributes not listed here do not cause a shipment-line split.',
+    Help='Attributes that split shipment lines. Picked goods that differ in a listed attribute (e.g. Country of Origin, Lot) are booked to separate shipment lines and picked-quantity allocations. Attributes not listed here do not cause a shipment-line split. Whether an attribute is carried on stock is configured separately in the packing instruction and is independent of this configuration.',
+    IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-04 09:01:30','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
 WHERE AD_Element_ID = 585152 AND AD_Language = 'en_US';
 
 -- 4. Propagate element translations
@@ -55,8 +57,8 @@ WHERE AD_Element_ID = 585152 AND AD_Language = 'en_US';
 -- 5. Point the field at the new element (earlier timestamp than the element, so the propagation guard fires)
 UPDATE AD_Field
 SET AD_Name_ID = 585152,
-    Description = 'Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen (M_InOutLine) und Mengenbuchungen (M_ShipmentSchedule_QtyPicked) gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus.',
-    Help        = 'Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen (M_InOutLine) und Mengenbuchungen (M_ShipmentSchedule_QtyPicked) gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus. Ob ein Merkmal am HU/Bestand geführt wird, steuert dagegen M_HU_PI_Attribute.UseInASI und ist von dieser Konfiguration unabhängig.',
+    Description = 'Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen und Mengenbuchungen gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus.',
+    Help        = 'Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen und Mengenbuchungen gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus. Ob ein Merkmal am Bestand geführt wird, wird dagegen in der Packvorschrift eingestellt und ist von dieser Konfiguration unabhängig.',
     Updated = TO_TIMESTAMP('2026-08-04 09:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy = 100
 WHERE AD_Field_ID = 563057;
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5817360_sys_gh31403_HUAggregation_M_Attribute_field_description.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5817360_sys_gh31403_HUAggregation_M_Attribute_field_description.sql
@@ -1,0 +1,68 @@
+-- gh31403: clarify the "Merkmal" (M_Attribute) field description in the HU-Aggregation tab
+-- (Window 540150 "Lieferkandidaten - Handler" -> tab M_ShipmentSchedule_AttributeConfig, AD_Field 563057).
+--
+-- The field reuses the generic shared element 2015 ("Produkt-Merkmal / Product Attribute like Color, Size"),
+-- which says nothing about what listing an attribute here actually does. Give the field a dedicated
+-- description/help via AD_Field.AD_Name_ID -> a NEW AD_Element (585152), leaving the shared element 2015
+-- untouched (it backs every M_Attribute field system-wide).
+--
+-- The config controls ONLY shipment-line splitting: an attribute listed here splits the picked-qty
+-- allocation + M_InOutLine per distinct value; it makes NO statement about whether the attribute is carried
+-- on the HU/stock (that is M_HU_PI_Attribute.UseInASI, an independent setting).
+
+-- 1. New name-only AD_Element (ColumnName NULL; overrides only this field's name/description/help)
+INSERT INTO AD_Element (AD_Client_ID, AD_Element_ID, AD_Org_ID, ColumnName, Created, CreatedBy,
+                        Description, EntityType, IsActive, Name, PrintName, Updated, UpdatedBy)
+VALUES (0, 585152, 0, NULL,
+        TO_TIMESTAMP('2026-08-04 09:01:00', 'YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', 100,
+        'Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen (M_InOutLine) und Mengenbuchungen (M_ShipmentSchedule_QtyPicked) gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus.',
+        'de.metas.inoutcandidate', 'Y',
+        'Merkmal', 'Merkmal',
+        TO_TIMESTAMP('2026-08-04 09:01:00', 'YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', 100);
+
+-- 2. AD_Element_Trl skeleton rows for all system + base languages
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, CommitWarning, Description, Help, Name,
+                            PO_Description, PO_Help, PO_Name, PO_PrintName, PrintName,
+                            WEBUI_NameBrowse, WEBUI_NameNew, WEBUI_NameNewBreadcrumb,
+                            IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning, t.Description, t.Help, t.Name,
+       t.PO_Description, t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName,
+       t.WEBUI_NameBrowse, t.WEBUI_NameNew, t.WEBUI_NameNewBreadcrumb,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Element_ID = 585152
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID);
+
+-- 3. Per-language text (de_DE + de_CH = German, en_US = English)
+UPDATE AD_Element_Trl SET Name='Merkmal',
+    Description='Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen (M_InOutLine) und Mengenbuchungen (M_ShipmentSchedule_QtyPicked) gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus.',
+    Help='Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen (M_InOutLine) und Mengenbuchungen (M_ShipmentSchedule_QtyPicked) gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus. Ob ein Merkmal am HU/Bestand geführt wird, steuert dagegen M_HU_PI_Attribute.UseInASI und ist von dieser Konfiguration unabhängig.',
+    IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-04 09:01:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Element_ID = 585152 AND AD_Language IN ('de_DE','de_CH');
+
+UPDATE AD_Element_Trl SET Name='Attribute',
+    Description='Attributes that split shipment lines. Picked goods that differ in a listed attribute (e.g. Country of Origin, Lot) are booked to separate shipment lines (M_InOutLine) and picked-qty allocations (M_ShipmentSchedule_QtyPicked). Attributes not listed here do not cause a shipment-line split.',
+    Help='Attributes that split shipment lines. Picked goods that differ in a listed attribute (e.g. Country of Origin, Lot) are booked to separate shipment lines (M_InOutLine) and picked-qty allocations (M_ShipmentSchedule_QtyPicked). Attributes not listed here do not cause a shipment-line split. Whether an attribute is carried on the HU/stock is controlled separately by M_HU_PI_Attribute.UseInASI and is independent of this configuration.',
+    IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-04 09:01:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Element_ID = 585152 AND AD_Language = 'en_US';
+
+-- 4. Propagate element translations
+/* DDL */ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585152, 'de_DE');
+/* DDL */ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585152, 'en_US');
+
+-- 5. Point the field at the new element (earlier timestamp than the element, so the propagation guard fires)
+UPDATE AD_Field
+SET AD_Name_ID = 585152,
+    Description = 'Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen (M_InOutLine) und Mengenbuchungen (M_ShipmentSchedule_QtyPicked) gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus.',
+    Help        = 'Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen (M_InOutLine) und Mengenbuchungen (M_ShipmentSchedule_QtyPicked) gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus. Ob ein Merkmal am HU/Bestand geführt wird, steuert dagegen M_HU_PI_Attribute.UseInASI und ist von dieser Konfiguration unabhängig.',
+    Updated = TO_TIMESTAMP('2026-08-04 09:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy = 100
+WHERE AD_Field_ID = 563057;
+
+-- 6. Propagate the new name element to the field's translations
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(585152);
+
+-- 7. Recreate the element link for the field
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 563057;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(563057);


### PR DESCRIPTION
## What

Fixes a `deep_tundra_release` / `new_dawn_uat` build red: the mobile E2E `e2e/mobile-webui/tests/spec/picking/overPickingPrompt_wholeHU.spec.js` fails deterministically — a catch-weight whole-HU pick books **two** `M_ShipmentSchedule_QtyPicked` rows where **one** is expected (`Expected qty picked records size to be <1> but was <2>`).

## Root cause

`HUShipmentScheduleBL.createCandidatesForQtyPicked` splits the picked-qty allocation into one `M_ShipmentSchedule_QtyPicked` row per distinct **`UseInASI` attribute fingerprint** (`computeUseInASIFingerprint`). That fingerprint used the **full** `UseInASI` attribute set — diverging from the downstream `M_InOutLine` aggregation in `ShipmentScheduleWithHU#computeAttributeValues`, which groups only by attributes **whitelisted in `M_ShipmentSchedule_AttributeConfig`** (via `ShipmentScheduleHandler#attributeShallBePartOfShipmentLine`).

`WeightNet` is `UseInASI` **and** a per-piece **measurement** (`LinearDistribution` splitter + `Sum` aggregation): when a whole HU of N catch-weight pieces is split, the total weight is distributed with rounding, so the pieces carry unequal values (e.g. `0.333 / 0.333 / 0.334`). Two distinct values → two fingerprint groups → two `QtyPicked` rows — even though the InOutLine aggregation correctly ignores weight and merges them back into a single line. The extra `QtyPicked` row backs no distinct shipment line.

Introduced by the nShift Country-of-Origin work (https://github.com/metasfresh/metasfresh/pull/24363), whose per-attribute expansion of `createCandidatesForQtyPicked` used the raw `UseInASI` flag instead of the shipment-line attribute config.

## Fix

Apply the **same** `attributeShallBePartOfShipmentLine` (`M_ShipmentSchedule_AttributeConfig`) filter to `computeUseInASIFingerprint` that the InOutLine aggregation already uses. The QtyPicked split now uses the **identical criterion** as the InOutLine aggregation:
- classification attributes (country of origin, lot, best-before, …) still split — as configured;
- measurement attributes (weight) no longer do.

Whether a customer wants per-attribute lines stays a config decision in `M_ShipmentSchedule_AttributeConfig` — the fix makes the QtyPicked layer honor that config, like the rest of the pipeline.

## Test

Covered by the existing E2E `e2e/mobile-webui/tests/spec/picking/overPickingPrompt_wholeHU.spec.js` — RED before this change (it asserts the `QtyPicked` row count that fails), GREEN after. Reproduced locally: the three picked VHUs carry `WeightNet` `0.333 / 0.333 / 0.334`, producing the two-row split the spec rejects.

## AD metadata

None — pure Java change, no `AD_*` migration or new field.
