### PR TITLE
Merge: soft_panda_hotfix to new_dawn_uat

### DIFF
--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/process/InvokeScriptedImportConversionAction.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/process/InvokeScriptedImportConversionAction.java
@@ -22,6 +22,7 @@
 
 package de.metas.externalsystem.process;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import de.metas.common.externalsystem.JsonExternalSystemName;
 import de.metas.common.externalsystem.JsonExternalSystemRequest;
@@ -40,11 +41,13 @@ import de.metas.externalsystem.scriptedimportconversion.ExternalSystemScriptedIm
 import de.metas.externalsystem.scriptedimportconversion.ExternalSystemScriptedImportConversionConfigId;
 import de.metas.externalsystem.scriptedimportconversion.ExternalSystemScriptedImportConversionService;
 import de.metas.externalsystem.scriptedimportconversion.ExternalSystemScriptedImportConversionService.ResolvedChildCommand;
+import de.metas.externalsystem.scriptedimportconversion.ScriptedImportConversionCommand;
 import de.metas.externalsystem.scriptedimportconversion.ScriptedImportConversionIntent;
 import de.metas.logging.LogManager;
 import de.metas.process.IProcessPreconditionsContext;
 import de.metas.process.PInstanceId;
 import de.metas.process.ProcessPreconditionsResolution;
+import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.SpringContextHolder;
 import org.slf4j.Logger;
@@ -74,7 +77,7 @@ public class InvokeScriptedImportConversionAction extends AlterExternalSystemSer
 	@Override
 	protected String doIt() throws Exception
 	{
-		final ScriptedImportConversionIntent intent = ScriptedImportConversionIntent.ofCode(externalRequest);
+		final ScriptedImportConversionIntent intent = resolveIntent(externalRequest);
 
 		final ImmutableList<ResolvedChildCommand> resolvedCommands = resolveChildCommands(intent);
 		if (resolvedCommands.isEmpty())
@@ -114,6 +117,32 @@ public class InvokeScriptedImportConversionAction extends AlterExternalSystemSer
 		}
 
 		return MSG_OK + " (" + succeeded + "/" + resolvedCommands.size() + ")";
+	}
+
+	/**
+	 * The manual process passes a Start/Stop intent, but the generic infra + {@code ExternalSystem_Service}
+	 * enable/disable commands pass the CONCRETE transport command here — so accept both.
+	 */
+	@VisibleForTesting
+	static ScriptedImportConversionIntent resolveIntent(@NonNull final String externalRequest)
+	{
+		final ScriptedImportConversionIntent intent = ScriptedImportConversionIntent.ofCodeOrNull(externalRequest);
+		if (intent != null)
+		{
+			return intent;
+		}
+
+		final ScriptedImportConversionCommand command = ScriptedImportConversionCommand.ofCodeOrNull(externalRequest);
+		if (command != null)
+		{
+			return command.getIntent();
+		}
+
+		throw new AdempiereException("No ScriptedImportConversion intent or command for External_Request")
+				.appendParametersToMessage()
+				.setParameter("External_Request", externalRequest)
+				.setParameter("acceptedIntents", "start, stop")
+				.setParameter("acceptedCommands", "enableRestAPI, disableRestAPI, enableSftpPolling, disableSftpPolling");
 	}
 
 	private ImmutableList<ResolvedChildCommand> resolveChildCommands(final ScriptedImportConversionIntent intent)

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedimportconversion/ExternalSystemScriptedImportConversionService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedimportconversion/ExternalSystemScriptedImportConversionService.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ENDPOINT_NAME;
+import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ROUTE_KEY;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_SCRIPT_IDENTIFIER;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_TOKEN;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_AUTH_TYPE;
@@ -136,6 +137,10 @@ public class ExternalSystemScriptedImportConversionService
 
 		final ExternalSystemEndpoint endpoint = externalSystemEndpointRepository.getById(config.getExternalSystemEndpointId());
 
+		// Stable per-child identity for the camel SFTP poll-route id. Keyed on the child config id (never on
+		// the endpoint Value/host), so changing this child's endpoint later still lets Stop/disable find and
+		// tear down the previously-started poller instead of orphaning it. endpointName stays for display.
+		parameters.put(PARAM_SCRIPTEDADAPTER_TO_MF_ROUTE_KEY, "ScriptedImportConversion-" + config.getId().getRepoId());
 		parameters.put(PARAM_SCRIPTEDADAPTER_TO_MF_ENDPOINT_NAME, endpoint.getValue());
 		parameters.put(PARAM_SCRIPTEDADAPTER_TO_MF_SCRIPT_IDENTIFIER, config.getScriptIdentifier());
 		parameters.put(PARAM_SCRIPTEDADAPTER_TO_MF_TOKEN, token.getAuthToken());

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedimportconversion/ScriptedImportConversionCommand.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedimportconversion/ScriptedImportConversionCommand.java
@@ -28,6 +28,8 @@ import lombok.Getter;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
 
+import javax.annotation.Nullable;
+
 @AllArgsConstructor
 public enum ScriptedImportConversionCommand
 {
@@ -41,6 +43,50 @@ public enum ScriptedImportConversionCommand
 
 	@Getter
 	private final String value;
+
+	@NonNull
+	public static ScriptedImportConversionCommand ofCode(@NonNull final String value)
+	{
+		final ScriptedImportConversionCommand command = ofCodeOrNull(value);
+		if (command == null)
+		{
+			throw new AdempiereException("No ScriptedImportConversionCommand for code")
+					.appendParametersToMessage()
+					.setParameter("code", value);
+		}
+		return command;
+	}
+
+	@Nullable
+	public static ScriptedImportConversionCommand ofCodeOrNull(@Nullable final String value)
+	{
+		for (final ScriptedImportConversionCommand command : values())
+		{
+			if (command.value.equals(value))
+			{
+				return command;
+			}
+		}
+		return null;
+	}
+
+	@NonNull
+	public ScriptedImportConversionIntent getIntent()
+	{
+		switch (this)
+		{
+			case EnableRestAPI:
+			case EnableSftpPolling:
+				return ScriptedImportConversionIntent.Start;
+			case DisableRestAPI:
+			case DisableSftpPolling:
+				return ScriptedImportConversionIntent.Stop;
+			default:
+				throw new AdempiereException("Unhandled ScriptedImportConversionCommand")
+						.appendParametersToMessage()
+						.setParameter("command", this);
+		}
+	}
 
 	/**
 	 * Derive the concrete command from the user's Start/Stop intent and the child's endpoint

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedimportconversion/ScriptedImportConversionIntent.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedimportconversion/ScriptedImportConversionIntent.java
@@ -27,6 +27,8 @@ import lombok.Getter;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
 
+import javax.annotation.Nullable;
+
 /**
  * User intent for the scripted-import "call" process ({@code AD_Process 585512}, param
  * {@code External_Request} = {@code AD_Reference 541998}): whether to START or STOP the import
@@ -49,6 +51,19 @@ public enum ScriptedImportConversionIntent
 	@NonNull
 	public static ScriptedImportConversionIntent ofCode(@NonNull final String code)
 	{
+		final ScriptedImportConversionIntent intent = ofCodeOrNull(code);
+		if (intent == null)
+		{
+			throw new AdempiereException("No ScriptedImportConversionIntent for code")
+					.appendParametersToMessage()
+					.setParameter("code", code);
+		}
+		return intent;
+	}
+
+	@Nullable
+	public static ScriptedImportConversionIntent ofCodeOrNull(@Nullable final String code)
+	{
 		for (final ScriptedImportConversionIntent intent : values())
 		{
 			if (intent.code.equals(code))
@@ -56,8 +71,6 @@ public enum ScriptedImportConversionIntent
 				return intent;
 			}
 		}
-		throw new AdempiereException("No ScriptedImportConversionIntent for code")
-				.appendParametersToMessage()
-				.setParameter("code", code);
+		return null;
 	}
 }

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5815620_ScriptIdentifier_description_stem_without_js.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5815620_ScriptIdentifier_description_stem_without_js.sql
@@ -1,0 +1,51 @@
+-- Correct the misleading description of the shared ScriptIdentifier element (AD_Element 584103,
+-- ColumnName ScriptIdentifier, label "Skript-Kennung"), used by both the scripted EXPORT
+-- conversion config (AD_Column 591295) and the scripted IMPORT conversion config (AD_Column 591364).
+--
+-- Old text ("Name der JavaScript-Datei ...") wrongly implied the full filename WITH the .js
+-- extension. The loader appends ".js" to the entered value, so the field must hold the file-name
+-- STEM only (e.g. edifact2olcand for the file edifact2olcand.js); entering ".js" breaks loading.
+--
+-- This mutates the SHARED element (the corrected wording is correct in every usage) and lets the
+-- standard AD translation propagation cascade the new text to the two AD_Columns, their AD_Fields
+-- (all AD_Name_ID IS NULL -> inherit from the column) and the _Trl rows of each. AD_UI_Element has
+-- no _Trl and is not covered by the propagation functions, so its Description is corrected directly.
+-- Base AD language on the target stack is de_CH; the German text therefore also lands in the base
+-- Description columns via propagation.
+
+-- 1) AD_Element_Trl: German languages (base de_CH + de_DE) -- authoritative German text
+UPDATE AD_Element_Trl
+SET Description = 'Kennung des JavaScript-Konvertierungsskripts: der Dateiname ohne die Endung .js (z. B. edifact2olcand für die Datei edifact2olcand.js).',
+    IsTranslated = 'Y',
+    Updated = TO_TIMESTAMP('2026-07-22 10:00:00', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy = 100
+WHERE AD_Element_ID = 584103 AND AD_Language IN ('de_DE', 'de_CH');
+
+-- 2) AD_Element_Trl: English
+UPDATE AD_Element_Trl
+SET Description = 'Identifier of the JavaScript conversion script: the file name without the .js extension (e.g. edifact2olcand for the file edifact2olcand.js).',
+    IsTranslated = 'Y',
+    Updated = TO_TIMESTAMP('2026-07-22 10:00:01', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy = 100
+WHERE AD_Element_ID = 584103 AND AD_Language = 'en_US';
+
+-- 3) AD_Element_Trl: fr_CH / it_CH -- German fallback text (fr/it not invented); left IsTranslated='N'
+UPDATE AD_Element_Trl
+SET Description = 'Kennung des JavaScript-Konvertierungsskripts: der Dateiname ohne die Endung .js (z. B. edifact2olcand für die Datei edifact2olcand.js).',
+    IsTranslated = 'N',
+    Updated = TO_TIMESTAMP('2026-07-22 10:00:02', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy = 100
+WHERE AD_Element_ID = 584103 AND AD_Language IN ('fr_CH', 'it_CH');
+
+-- 4) AD_Element base Description (de_CH is the base language -> German text)
+UPDATE AD_Element
+SET Description = 'Kennung des JavaScript-Konvertierungsskripts: der Dateiname ohne die Endung .js (z. B. edifact2olcand für die Datei edifact2olcand.js).',
+    Updated = TO_TIMESTAMP('2026-07-22 10:00:03', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy = 100
+WHERE AD_Element_ID = 584103;
+
+-- 5) Propagate the corrected element text to AD_Column(_Trl) and AD_Field(_Trl) for all languages
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584103);
+
+-- 6) AD_UI_Element has no _Trl companion and is not covered by propagation -> correct directly.
+--    All four UI elements render the ScriptIdentifier field (export tabs + import tabs).
+UPDATE AD_UI_Element
+SET Description = 'Kennung des JavaScript-Konvertierungsskripts: der Dateiname ohne die Endung .js (z. B. edifact2olcand für die Datei edifact2olcand.js).',
+    Updated = TO_TIMESTAMP('2026-07-22 10:00:04', 'YYYY-MM-DD HH24:MI:SS'), UpdatedBy = 100
+WHERE AD_UI_Element_ID IN (637781, 637855, 637874, 637883);

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/process/InvokeScriptedImportConversionActionTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/process/InvokeScriptedImportConversionActionTest.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.process;
+
+import de.metas.externalsystem.scriptedimportconversion.ScriptedImportConversionIntent;
+import org.adempiere.exceptions.AdempiereException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InvokeScriptedImportConversionActionTest
+{
+	@Test
+	void resolveIntent_startStopIntentCodes_areAccepted()
+	{
+		// the manual "call" process (AD_Process 585512, External_Request = AD_Reference 541998) passes the intent code
+		assertThat(InvokeScriptedImportConversionAction.resolveIntent("start")).isEqualTo(ScriptedImportConversionIntent.Start);
+		assertThat(InvokeScriptedImportConversionAction.resolveIntent("stop")).isEqualTo(ScriptedImportConversionIntent.Stop);
+	}
+
+	@Test
+	void resolveIntent_concreteEnableCommands_mapToStart()
+	{
+		// the generic external-system infra (startup reconciler) + ExternalSystem_Service EnableCommand pass the
+		// CONCRETE command code as {externalRequest}; the enable variants must resolve to the Start intent
+		assertThat(InvokeScriptedImportConversionAction.resolveIntent("enableRestAPI")).isEqualTo(ScriptedImportConversionIntent.Start);
+		assertThat(InvokeScriptedImportConversionAction.resolveIntent("enableSftpPolling")).isEqualTo(ScriptedImportConversionIntent.Start);
+	}
+
+	@Test
+	void resolveIntent_concreteDisableCommands_mapToStop()
+	{
+		assertThat(InvokeScriptedImportConversionAction.resolveIntent("disableRestAPI")).isEqualTo(ScriptedImportConversionIntent.Stop);
+		assertThat(InvokeScriptedImportConversionAction.resolveIntent("disableSftpPolling")).isEqualTo(ScriptedImportConversionIntent.Stop);
+	}
+
+	@Test
+	void resolveIntent_unknownCode_throwsClearError()
+	{
+		assertThatThrownBy(() -> InvokeScriptedImportConversionAction.resolveIntent("bogus"))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("bogus");
+	}
+}

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedimportconversion/ExternalSystemScriptedImportConversionServiceTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedimportconversion/ExternalSystemScriptedImportConversionServiceTest.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import org.adempiere.exceptions.AdempiereException;
 
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ENDPOINT_NAME;
+import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ROUTE_KEY;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SFTP_POLLING_INTERVAL_MS;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_PROCESSED_DIR;
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_ERROR_DIR;
@@ -151,6 +152,9 @@ class ExternalSystemScriptedImportConversionServiceTest
 
 		// then
 		assertThat(parameters.get(PARAM_SCRIPTEDADAPTER_TO_MF_ENDPOINT_NAME)).isEqualTo("eddyson-orders");
+		// and the stable per-child route key is derived from the child config id (NOT the endpoint value),
+		// so a later endpoint change cannot orphan the previously-started camel poll route.
+		assertThat(parameters.get(PARAM_SCRIPTEDADAPTER_TO_MF_ROUTE_KEY)).isEqualTo("ScriptedImportConversion-1");
 	}
 
 	@Test

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedimportconversion/ScriptedImportConversionCommandTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedimportconversion/ScriptedImportConversionCommandTest.java
@@ -1,0 +1,72 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedimportconversion;
+
+import org.adempiere.exceptions.AdempiereException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ScriptedImportConversionCommandTest
+{
+	@Test
+	void ofCode_matchesByWireValue()
+	{
+		assertThat(ScriptedImportConversionCommand.ofCode("enableRestAPI")).isEqualTo(ScriptedImportConversionCommand.EnableRestAPI);
+		assertThat(ScriptedImportConversionCommand.ofCode("disableRestAPI")).isEqualTo(ScriptedImportConversionCommand.DisableRestAPI);
+		assertThat(ScriptedImportConversionCommand.ofCode("enableSftpPolling")).isEqualTo(ScriptedImportConversionCommand.EnableSftpPolling);
+		assertThat(ScriptedImportConversionCommand.ofCode("disableSftpPolling")).isEqualTo(ScriptedImportConversionCommand.DisableSftpPolling);
+	}
+
+	@Test
+	void ofCode_unknown_throwsClearError()
+	{
+		assertThatThrownBy(() -> ScriptedImportConversionCommand.ofCode("start"))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("start");
+	}
+
+	@Test
+	void ofCodeOrNull_matchesByWireValue()
+	{
+		assertThat(ScriptedImportConversionCommand.ofCodeOrNull("enableRestAPI")).isEqualTo(ScriptedImportConversionCommand.EnableRestAPI);
+		assertThat(ScriptedImportConversionCommand.ofCodeOrNull("disableSftpPolling")).isEqualTo(ScriptedImportConversionCommand.DisableSftpPolling);
+	}
+
+	@Test
+	void ofCodeOrNull_unknownOrNull_returnsNull()
+	{
+		assertThat(ScriptedImportConversionCommand.ofCodeOrNull("start")).isNull();
+		assertThat(ScriptedImportConversionCommand.ofCodeOrNull(null)).isNull();
+	}
+
+	@Test
+	void getIntent_enableMapsToStart_disableMapsToStop()
+	{
+		assertThat(ScriptedImportConversionCommand.EnableRestAPI.getIntent()).isEqualTo(ScriptedImportConversionIntent.Start);
+		assertThat(ScriptedImportConversionCommand.EnableSftpPolling.getIntent()).isEqualTo(ScriptedImportConversionIntent.Start);
+		assertThat(ScriptedImportConversionCommand.DisableRestAPI.getIntent()).isEqualTo(ScriptedImportConversionIntent.Stop);
+		assertThat(ScriptedImportConversionCommand.DisableSftpPolling.getIntent()).isEqualTo(ScriptedImportConversionIntent.Stop);
+	}
+}

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedimportconversion/ScriptedImportConversionIntentTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedimportconversion/ScriptedImportConversionIntentTest.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.externalsystem.scriptedimportconversion;
+
+import org.adempiere.exceptions.AdempiereException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ScriptedImportConversionIntentTest
+{
+	@Test
+	void ofCode_matchesByCode()
+	{
+		assertThat(ScriptedImportConversionIntent.ofCode("start")).isEqualTo(ScriptedImportConversionIntent.Start);
+		assertThat(ScriptedImportConversionIntent.ofCode("stop")).isEqualTo(ScriptedImportConversionIntent.Stop);
+	}
+
+	@Test
+	void ofCode_unknown_throwsClearError()
+	{
+		assertThatThrownBy(() -> ScriptedImportConversionIntent.ofCode("enableRestAPI"))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining("enableRestAPI");
+	}
+
+	@Test
+	void ofCodeOrNull_matchesByCode()
+	{
+		assertThat(ScriptedImportConversionIntent.ofCodeOrNull("start")).isEqualTo(ScriptedImportConversionIntent.Start);
+		assertThat(ScriptedImportConversionIntent.ofCodeOrNull("stop")).isEqualTo(ScriptedImportConversionIntent.Stop);
+	}
+
+	@Test
+	void ofCodeOrNull_unknownOrNull_returnsNull()
+	{
+		assertThat(ScriptedImportConversionIntent.ofCodeOrNull("enableRestAPI")).isNull();
+		assertThat(ScriptedImportConversionIntent.ofCodeOrNull(null)).isNull();
+	}
+}

--- a/e2e/frontend-webui/tests/spec/externalsystem-scripted-import-create-config.spec.js
+++ b/e2e/frontend-webui/tests/spec/externalsystem-scripted-import-create-config.spec.js
@@ -42,9 +42,13 @@ const SCRIPTED_IMPORT_EXTERNAL_SYSTEM = 'ScriptedImportConversion';
 // An ACTIVE parent ExternalSystem_Config record used by the dedicated-window test to
 // set the config on the root record before binding the endpoint.
 const ACTIVE_PARENT_CONFIG_NAME = 'print-to-remote-folder';
-// Search term for the mandatory "Benutzerimport" (AD_User_Import_ID) field — matches the
-// stable seeded WebUI system user "Admin, Automatik-Benutzer" (has a WebUI auth token).
-const IMPORT_USER_SEARCH = 'Automatik';
+// Search term for the mandatory "Benutzerimport" (AD_User_Import_ID) field. The lookup is filtered to
+// users that can act as an import user (a valid WebUI auth token) — verified against the live stack, it
+// offers only the "metasfresh" login user (the seeded "…, Automatik-Benutzer" system users are NOT
+// offered on the faithful/seed DB → searching for them returns "No results found." and the mandatory
+// field stayed empty). "metasfresh" is the stable, always-present token-holding user on both the local
+// faithful DB and the CI preloaded seed.
+const IMPORT_USER_SEARCH = 'metasfresh';
 const ROLE_CAPTION_REGEX = /^WebUI, metasfresh, metasfresh AG$/;
 
 /** Escape regex metacharacters so a server-generated value (doc sequence) can be
@@ -83,12 +87,18 @@ async function selectLookupValue(page, fieldName, searchText) {
   await input.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
   await input.click();
   await page.waitForTimeout(400);
-  await input.fill(searchText);
-  await page.waitForTimeout(1200);
+  // Type char-by-char so the React typeahead fires its (debounced, backend-querying) search — a direct
+  // .fill() sets the value without the keystroke events a user-lookup needs to populate the option list.
+  await input.pressSequentially(searchText, { delay: 60 });
+  await page.waitForTimeout(1500);
   const dropdown = page.locator('.input-dropdown-list');
   await dropdown.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-  await dropdown.locator('.input-dropdown-list-option').first().click();
-  await page.waitForTimeout(800);
+  // Click the option that actually MATCHES the search, not blindly the first row (which may be a
+  // header / a non-matching entry) — the bare "first option" is what left the mandatory field unset.
+  const matching = dropdown.locator('.input-dropdown-list-option').filter({ hasText: searchText });
+  const target = (await matching.count()) > 0 ? matching.first() : dropdown.locator('.input-dropdown-list-option').first();
+  await target.click();
+  await page.waitForTimeout(1000);
 }
 
 /**
@@ -99,6 +109,8 @@ async function fillTextField(page, fieldName, value) {
   const field = page.locator(`.form-field-${fieldName} input[type="text"]`);
   await field.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
   await field.fill(value);
+  // Commit the edit: the WebUI PATCHes a field only on blur, so an uncommitted .fill() never persists.
+  await field.press('Tab');
   await page.waitForTimeout(300);
 }
 
@@ -316,6 +328,15 @@ asserts the endpoint persists bound after a reload.
         .inputValue();
       expect(boundInModal, 'seeded endpoint must be bound in the child-row form before save').toContain(endpointValue);
 
+      // The mandatory Import User must actually be SELECTED in the modal before saving — a lookup
+      // selection that never landed is the defect this test now guards (the row would save invalid,
+      // "Fill mandatory fields: Import User", while a bound-endpoint-only check stayed green).
+      const importUserInModal = await modal
+        .locator('.form-field-AD_User_Import_ID input')
+        .first()
+        .inputValue();
+      expect(importUserInModal, 'Import User must be selected in the child-row form before save').not.toBe('');
+
       // Save/commit the child row. The WebUI auto-saves each field via PATCH; the modal's
       // Done button commits and closes the "Add new" overlay. Select it by its stable
       // data-testid (Modal.js) — never the localized caption (language-independence rule).
@@ -342,6 +363,15 @@ asserts the endpoint persists bound after a reload.
         childRow,
         'the reloaded child grid row must show the bound endpoint (persisted)'
       ).toContainText(endpointValue, { timeout: SLOW_ACTION_TIMEOUT });
+
+      // OUTCOME check — the create+save produced a VALID, complete record, not just a bound endpoint.
+      // The "Fill mandatory fields" banner appears (and survives reload) whenever a mandatory field
+      // (e.g. Import User) did not persist; its absence proves the whole record saved. This is the
+      // assertion a bound-endpoint-only check lacked (metasfresh-test-integrity: assert the OUTCOME).
+      await expect(
+        page.getByText(/Fill mandatory fields/i),
+        'no mandatory-field error may remain after reload — the saved config must be valid/complete'
+      ).toHaveCount(0, { timeout: SLOW_ACTION_TIMEOUT });
 
       // Reopen the row into its detail form and re-read the bound endpoint — the explicit
       // persisted-save proof (mirrors the reference save test's re-read).
@@ -414,6 +444,10 @@ after a reload.
       await selectListValue(page, 'ExternalSystem_Config_ID', ACTIVE_PARENT_CONFIG_NAME);
       await selectListValue(page, 'ExternalSystem_Endpoint_ID', endpointValue, { exact: true });
       await fillMandatoryConfigFields(page, externalSystemValue);
+
+      // Import User must actually be selected before saving (same guard as the parent-window test).
+      const importUserSet = await page.locator('.form-field-AD_User_Import_ID input').first().inputValue();
+      expect(importUserSet, 'Import User must be selected before save').not.toBe('');
     });
 
     await test.step('Save the record and assert the endpoint persisted bound after a reload', async () => {
@@ -444,6 +478,12 @@ after a reload.
         page.locator('.form-field-ExternalSystemValue input').first(),
         'the Suchschlüssel (ExternalSystemValue) must be persisted after reload'
       ).toHaveValue(externalSystemValue, { timeout: SLOW_ACTION_TIMEOUT });
+
+      // OUTCOME: no mandatory-field error remains after reload — the record saved valid/complete.
+      await expect(
+        page.getByText(/Fill mandatory fields/i),
+        'no mandatory-field error may remain after reload — the saved config must be valid/complete'
+      ).toHaveCount(0, { timeout: SLOW_ACTION_TIMEOUT });
     });
   });
 });

--- a/misc/de-metas-common/de-metas-common-externalsystem/src/main/java/de/metas/common/externalsystem/ExternalSystemConstants.java
+++ b/misc/de-metas-common/de-metas-common-externalsystem/src/main/java/de/metas/common/externalsystem/ExternalSystemConstants.java
@@ -210,6 +210,14 @@ public class ExternalSystemConstants
 	public static final String PARAM_SCRIPTEDADAPTER_TO_MF_ENDPOINT_NAME = "endpointName";
 	public static final String PARAM_SCRIPTEDADAPTER_TO_MF_SCRIPT_IDENTIFIER = "scriptIdentifier";
 	public static final String PARAM_SCRIPTEDADAPTER_TO_MF_TOKEN = "token";
+	/**
+	 * Stable per-child identity used as the dynamic SFTP poll-route id (and the ssh-key temp-file map key).
+	 * Keyed on the child config id — NOT on the endpoint {@code Value} — so that changing the child's
+	 * endpoint (different endpoint record / changed host) does not orphan the previously-started route:
+	 * Stop/disable recomputes the SAME key and tears the running poller down. See
+	 * {@code ScriptedImportConversionSftpRouteBuilder}.
+	 */
+	public static final String PARAM_SCRIPTEDADAPTER_TO_MF_ROUTE_KEY = "scriptedImportRouteKey";
 
 	// SFTP polling parameters (for ScriptedImportConversion inbound polling)
 	public static final String PARAM_SFTP_POLLING_ENDPOINT_HOST = "sftpHost";

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/main/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/from_mf/SftpDeliveryProcessor.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/main/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/from_mf/SftpDeliveryProcessor.java
@@ -28,22 +28,16 @@ import de.metas.common.externalsystem.endpoint.JsonExternalSystemEndpoint;
 import de.metas.common.util.Check;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.Processor;
 import org.apache.camel.RuntimeCamelException;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Map;
-import java.util.Set;
 
 import static de.metas.camel.externalsystems.scriptedadapter.ScriptedAdapterConstants.ROUTE_MSG_FROM_MF_CONTEXT;
 
@@ -56,7 +50,10 @@ import static de.metas.camel.externalsystems.scriptedadapter.ScriptedAdapterCons
  * Supports two authentication modes:
  * <ul>
  *   <li><b>PASSWORD</b> — username + password</li>
- *   <li><b>SSH_KEY</b> — username + SSH private key (written to a temp file)</li>
+ *   <li><b>SSH_KEY</b> — username + SSH private key. The key is kept in memory: its bytes are bound in
+ *       the Camel registry and referenced via {@code &privateKey=#bean:<id>}, so it never lands on a
+ *       temp file on disk; the bean is unbound again once delivery finishes (mirrors the inbound
+ *       {@code ScriptedImportConversionSftpRouteBuilder}).</li>
  * </ul>
  */
 @Slf4j
@@ -108,32 +105,24 @@ public class SftpDeliveryProcessor implements Processor
 			throw new RuntimeCamelException("Script return value is null — nothing to deliver via SFTP!");
 		}
 
-		final String sftpUri = buildSftpUri(endpoint, port, remotePath, username, sftpAuthType, resolvedFilename);
+		// Per-delivery, stable-within-this-exchange bean id for the in-memory SSH key. buildSftpUri binds
+		// the key bytes under this id for SSH_KEY auth; the finally below unbinds it no matter how the
+		// delivery ends (no-op for password auth, where nothing was bound).
+		final String privateKeyBeanId = sshPrivateKeyBeanId(exchange.getExchangeId());
+		final String sftpUri = buildSftpUri(endpoint, port, remotePath, username, sftpAuthType, resolvedFilename, exchange.getContext(), privateKeyBeanId);
 
 		log.info("Delivering file via SFTP: host={}, port={}, path={}, filename={}", host, port, remotePath, resolvedFilename);
 
-		Path tempKeyFile = null;
 		try (final ProducerTemplate producerTemplate = exchange.getContext().createProducerTemplate())
 		{
-			if (AUTH_TYPE_SSH_KEY.equals(sftpAuthType))
-			{
-				tempKeyFile = writeSshKeyToTempFile(endpoint.getSshPrivateKey());
-			}
-
-			final String finalUri = AUTH_TYPE_SSH_KEY.equals(sftpAuthType) && tempKeyFile != null
-					? sftpUri + "&privateKeyFile=" + tempKeyFile.toAbsolutePath()
-					: sftpUri;
-
-			producerTemplate.sendBody(finalUri, body);
+			producerTemplate.sendBody(sftpUri, body);
 
 			log.info("SFTP delivery successful: {}", resolvedFilename);
 		}
 		finally
 		{
-			if (tempKeyFile != null)
-			{
-				deleteTempKeyFileSilently(tempKeyFile);
-			}
+			// Leave no key material behind: drop the in-memory private-key bean (no-op if password auth was used).
+			exchange.getContext().getRegistry().unbind(privateKeyBeanId);
 		}
 	}
 
@@ -151,13 +140,15 @@ public class SftpDeliveryProcessor implements Processor
 	}
 
 	@NonNull
-	private static String buildSftpUri(
+	String buildSftpUri(
 			@NonNull final JsonExternalSystemEndpoint endpoint,
 			final int port,
 			@NonNull final String remotePath,
 			@NonNull final String username,
 			@NonNull final String sftpAuthType,
-			@NonNull final String resolvedFilename)
+			@NonNull final String resolvedFilename,
+			@NonNull final CamelContext camelContext,
+			@NonNull final String privateKeyBeanId)
 	{
 		final var sb = new StringBuilder();
 		sb.append("sftp://").append(endpoint.getSftpHost()).append(":").append(port);
@@ -176,11 +167,16 @@ public class SftpDeliveryProcessor implements Processor
 		}
 		else if (AUTH_TYPE_SSH_KEY.equals(sftpAuthType))
 		{
-			if (Check.isBlank(endpoint.getSshPrivateKey()))
+			final String sshPrivateKey = endpoint.getSshPrivateKey();
+			if (Check.isBlank(sshPrivateKey))
 			{
 				throw new RuntimeCamelException("SFTP SSH_KEY auth selected but SSH private key is not configured!");
 			}
-			// privateKeyFile will be appended after temp file is created
+			// Keep the key in memory: bind its bytes in the Camel registry and reference them via
+			// #bean:<id>, so it never lands on a temp file on disk. process()'s finally unbinds the
+			// same id (mirrors the inbound ScriptedImportConversionSftpRouteBuilder).
+			camelContext.getRegistry().bind(privateKeyBeanId, sshPrivateKey.getBytes(StandardCharsets.UTF_8));
+			sb.append("&privateKey=#bean:").append(privateKeyBeanId);
 		}
 		else
 		{
@@ -197,26 +193,8 @@ public class SftpDeliveryProcessor implements Processor
 	}
 
 	@NonNull
-	private static Path writeSshKeyToTempFile(@NonNull final String sshPrivateKey) throws IOException
+	private static String sshPrivateKeyBeanId(@NonNull final String exchangeId)
 	{
-		final Set<PosixFilePermission> ownerOnly = PosixFilePermissions.fromString("rw-------");
-		final FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(ownerOnly);
-		final Path tempFile = Files.createTempFile("sftp_key_", ".pem", attr);
-		Files.writeString(tempFile, sshPrivateKey, StandardCharsets.UTF_8);
-		log.debug("Wrote SSH private key to temp file: {}", tempFile);
-		return tempFile;
-	}
-
-	private static void deleteTempKeyFileSilently(@NonNull final Path tempKeyFile)
-	{
-		try
-		{
-			Files.deleteIfExists(tempKeyFile);
-			log.debug("Deleted temp SSH key file: {}", tempKeyFile);
-		}
-		catch (final IOException e)
-		{
-			log.warn("Failed to delete temp SSH key file: {}", tempKeyFile, e);
-		}
+		return "sftpDeliveryPrivateKey-" + exchangeId;
 	}
 }

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/main/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/to_mf/ScriptedImportConversionSftpDynamicRouteBuilder.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/main/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/to_mf/ScriptedImportConversionSftpDynamicRouteBuilder.java
@@ -41,7 +41,14 @@ public class ScriptedImportConversionSftpDynamicRouteBuilder extends AbstractScr
 {
 	@NonNull private final String sftpUri;
 
+	/**
+	 * Stable per-child route id. Keyed on the child config id (never on the endpoint host/{@code Value}),
+	 * so enable/disable can find and tear down the running poller even after the child's endpoint changed.
+	 */
+	@NonNull private final String routeKey;
+
 	public ScriptedImportConversionSftpDynamicRouteBuilder(
+			@NonNull final String routeKey,
 			@NonNull final String endpointName,
 			@NonNull final String sftpUri,
 			@NonNull final String scriptIdentifier,
@@ -52,6 +59,7 @@ public class ScriptedImportConversionSftpDynamicRouteBuilder extends AbstractScr
 			@NonNull final String errorDir)
 	{
 		super(endpointName, scriptIdentifier, javaScriptRepo, javaScriptExecutorService, producerTemplate, processedDir, errorDir);
+		this.routeKey = routeKey;
 		this.sftpUri = sftpUri;
 	}
 
@@ -70,7 +78,7 @@ public class ScriptedImportConversionSftpDynamicRouteBuilder extends AbstractScr
 
 		//@formatter:off
 		from(sftpUri)
-				.routeId(endpointName)
+				.routeId(routeKey)
 				.group(CamelRoutesGroup.START_ON_DEMAND.getCode())
 				.log("SFTP file received: ${header.CamelFileName}")
 				.convertBodyTo(String.class)

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/main/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/to_mf/ScriptedImportConversionSftpRouteBuilder.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/main/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/to_mf/ScriptedImportConversionSftpRouteBuilder.java
@@ -32,7 +32,6 @@ import de.metas.common.externalsystem.IExternalSystemService;
 import de.metas.common.externalsystem.JsonExternalSystemRequest;
 import de.metas.common.externalsystem.status.JsonExternalStatus;
 import de.metas.common.externalsystem.status.JsonStatusRequest;
-import jakarta.annotation.PreDestroy;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.camel.Exchange;
@@ -40,14 +39,8 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.springframework.stereotype.Component;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static de.metas.camel.externalsystems.common.ExternalSystemCamelConstants.MF_ERROR_ROUTE_ID;
 import static de.metas.camel.externalsystems.scriptedadapter.ScriptedAdapterConstants.DEFAULT_LOCAL_ERROR_DIR;
@@ -74,27 +67,7 @@ public class ScriptedImportConversionSftpRouteBuilder extends RouteBuilder imple
 
 	@NonNull private final ProducerTemplate producerTemplate;
 
-	// Track SSH key temp files for cleanup on disable
-	private final ConcurrentHashMap<String, Path> sshKeyTempFiles = new ConcurrentHashMap<>();
-
 	private JavaScriptExecutorService javaScriptExecutorService;
-
-	@PreDestroy
-	public void cleanupSshKeyTempFiles()
-	{
-		sshKeyTempFiles.forEach((name, path) -> {
-			try
-			{
-				Files.deleteIfExists(path);
-				log.info("Cleaned up SSH key temp file for route '{}': {}", name, path);
-			}
-			catch (final java.io.IOException e)
-			{
-				log.warn("Failed to clean up SSH key temp file for route '{}': {}", name, path, e);
-			}
-		});
-		sshKeyTempFiles.clear();
-	}
 
 	@Override
 	public void configure()
@@ -133,10 +106,40 @@ public class ScriptedImportConversionSftpRouteBuilder extends RouteBuilder imple
 		final JsonExternalSystemRequest request = exchange.getIn().getBody(JsonExternalSystemRequest.class);
 		final Map<String, String> params = request.getParameters();
 
+		// Stable per-child route id (child config id based). The route MUST be keyed on this, not on the
+		// endpoint name/host — otherwise a later endpoint change orphans this poller (disable recomputes a
+		// different key and stops nothing). endpointName is kept only for display / the archive-file fallback.
+		final String routeKey = requireRouteKey(params);
+
+		// Idempotent replace: tear down any poller (and its in-memory ssh-key bean) already running under this
+		// stable key BEFORE (re)creating it — a re-enable after an endpoint/connection change must not leak the
+		// previous route, nor its ssh-key registry bean (which the new enable below would otherwise orphan).
+		removePollingRoute(routeKey);
+
 		final String endpointName = params.get(ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ENDPOINT_NAME);
 		final String scriptIdentifier = params.get(ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_SCRIPT_IDENTIFIER);
 
-		// SFTP connection parameters
+		// LOCAL, transport-agnostic archive folders (never remote — the remote file is consumed by
+		// delete, see below). Default to a container path when the endpoint's dir fields are unset.
+		final String processedDir = params.getOrDefault(ExternalSystemConstants.PARAM_PROCESSED_DIR, DEFAULT_LOCAL_PROCESSED_DIR);
+		final String errorDir = params.getOrDefault(ExternalSystemConstants.PARAM_ERROR_DIR, DEFAULT_LOCAL_ERROR_DIR);
+
+		final String finalSftpUri = buildSftpUri(routeKey, params);
+		// Resolve the script repo path lazily at enable time, not at configure time.
+		final JavaScriptRepo javaScriptRepo = new JavaScriptRepo(
+				getCamelContext().resolvePropertyPlaceholders("{{" + PROPERTY_SCRIPTING_REPO_BASE_DIR + "}}"));
+
+		getCamelContext().addRoutes(new ScriptedImportConversionSftpDynamicRouteBuilder(
+				routeKey, endpointName, finalSftpUri, scriptIdentifier, javaScriptRepo, javaScriptExecutorService, producerTemplate,
+				processedDir, errorDir));
+
+		getCamelContext().getRouteController().startRoute(routeKey);
+		log.info("Dynamic SFTP polling route '{}' started successfully.", routeKey);
+	}
+
+	@NonNull
+	String buildSftpUri(@NonNull final String routeKey, @NonNull final Map<String, String> params)
+	{
 		final String sftpHost = params.get(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_HOST);
 		final String sftpPort = params.get(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_PORT);
 		final String sftpUsername = params.get(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_USERNAME);
@@ -157,12 +160,7 @@ public class ScriptedImportConversionSftpRouteBuilder extends RouteBuilder imple
 		}
 		final String sftpRemotePath = params.getOrDefault(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_REMOTE_PATH, "/");
 		final String pollingIntervalMs = params.getOrDefault(ExternalSystemConstants.PARAM_SFTP_POLLING_INTERVAL_MS, "60000");
-		// LOCAL, transport-agnostic archive folders (never remote — the remote file is consumed by
-		// delete, see below). Default to a container path when the endpoint's dir fields are unset.
-		final String processedDir = params.getOrDefault(ExternalSystemConstants.PARAM_PROCESSED_DIR, DEFAULT_LOCAL_PROCESSED_DIR);
-		final String errorDir = params.getOrDefault(ExternalSystemConstants.PARAM_ERROR_DIR, DEFAULT_LOCAL_ERROR_DIR);
 
-		// Build SFTP URI
 		final StringBuilder sftpUri = new StringBuilder();
 		sftpUri.append("sftp://").append(sftpHost);
 		if (sftpPort != null && !sftpPort.isEmpty())
@@ -176,12 +174,12 @@ public class ScriptedImportConversionSftpRouteBuilder extends RouteBuilder imple
 		if (ExternalSystemConstants.SFTP_AUTH_TYPE_SSH_KEY.equals(sftpAuthType))
 		{
 			final String sshPrivateKey = params.get(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_PRIVATE_KEY);
-			final Set<PosixFilePermission> ownerOnly = PosixFilePermissions.fromString("rw-------");
-			final FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(ownerOnly);
-			final Path tempKeyFile = Files.createTempFile("sftp_key_" + endpointName + "_", ".pem", attr);
-			Files.writeString(tempKeyFile, sshPrivateKey);
-			sshKeyTempFiles.put(endpointName, tempKeyFile);
-			sftpUri.append("&privateKeyFile=").append(tempKeyFile.toAbsolutePath());
+			// Keep the key in memory: bind its bytes in the Camel registry (keyed on the STABLE route key,
+			// mirroring the route id) and reference them via #bean:<id>, so it never lands on disk.
+			// removePollingRoute unbinds the same id on disable/replace.
+			final String privateKeyBeanId = sshPrivateKeyBeanId(routeKey);
+			getCamelContext().getRegistry().bind(privateKeyBeanId, sshPrivateKey.getBytes(StandardCharsets.UTF_8));
+			sftpUri.append("&privateKey=#bean:").append(privateKeyBeanId);
 		}
 		else
 		{
@@ -191,7 +189,7 @@ public class ScriptedImportConversionSftpRouteBuilder extends RouteBuilder imple
 
 		sftpUri.append("&delay=").append(pollingIntervalMs);
 		// Consume the remote file by DELETE (never a remote move/mkdir) — no remote .done/.error
-		// folders. The payload is instead archived to the LOCAL processedDir/errorDir below (see
+		// folders. The payload is instead archived to the LOCAL processedDir/errorDir (see
 		// ScriptedImportConversionSftpDynamicRouteBuilder, whose onException is handled(true) so this
 		// delete still applies even when the transform fails).
 		sftpUri.append("&delete=true");
@@ -201,34 +199,58 @@ public class ScriptedImportConversionSftpRouteBuilder extends RouteBuilder imple
 		sftpUri.append("&strictHostKeyChecking=no");
 		sftpUri.append("&useUserKnownHostsFile=false");
 
-		// Add the dynamic route (resolve script repo path lazily at enable time, not at configure time)
-		final String finalSftpUri = sftpUri.toString();
-		final JavaScriptRepo javaScriptRepo = new JavaScriptRepo(
-				getCamelContext().resolvePropertyPlaceholders("{{" + PROPERTY_SCRIPTING_REPO_BASE_DIR + "}}"));
-		getCamelContext().addRoutes(new ScriptedImportConversionSftpDynamicRouteBuilder(
-				endpointName, finalSftpUri, scriptIdentifier, javaScriptRepo, javaScriptExecutorService, producerTemplate,
-				processedDir, errorDir));
+		return sftpUri.toString();
+	}
 
-		getCamelContext().getRouteController().startRoute(endpointName);
-		log.info("Dynamic SFTP polling route '{}' started successfully.", endpointName);
+	@NonNull
+	private static String sshPrivateKeyBeanId(@NonNull final String routeKey)
+	{
+		return "sftpPrivateKey-" + routeKey;
 	}
 
 	private void disableSftpPollingProcessor(@NonNull final Exchange exchange) throws Exception
 	{
 		final JsonExternalSystemRequest request = exchange.getIn().getBody(JsonExternalSystemRequest.class);
-		final String endpointName = request.getParameters().get(ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ENDPOINT_NAME);
+		// Stop by the SAME stable key the route was started with — matches the running poller regardless of
+		// whether the child's endpoint (host/Value) has since changed.
+		final String routeKey = requireRouteKey(request.getParameters());
 
-		getCamelContext().getRouteController().stopRoute(endpointName);
-		getCamelContext().removeRoute(endpointName);
+		removePollingRoute(routeKey);
 
-		// Cleanup SSH key temp file if any
-		final Path tempKeyFile = sshKeyTempFiles.remove(endpointName);
-		if (tempKeyFile != null)
+		log.info("Dynamic SFTP polling route '{}' stopped and removed.", routeKey);
+	}
+
+	/**
+	 * The stable per-child route key ({@link ExternalSystemConstants#PARAM_SCRIPTEDADAPTER_TO_MF_ROUTE_KEY})
+	 * is mandatory — the backend always supplies it for both enable and disable. A missing key would mean
+	 * the poller could not be reliably torn down, so fail loudly rather than leak a route.
+	 */
+	@NonNull
+	private static String requireRouteKey(@NonNull final Map<String, String> params)
+	{
+		final String routeKey = params.get(ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ROUTE_KEY);
+		if (routeKey == null || routeKey.isBlank())
 		{
-			Files.deleteIfExists(tempKeyFile);
+			throw new org.apache.camel.RuntimeCamelException("Parameter '" + ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ROUTE_KEY + "' is required!");
+		}
+		return routeKey;
+	}
+
+	/**
+	 * Tears down the dynamic SFTP poll route for {@code routeKey}: stops and removes the route if present,
+	 * and unbinds its in-memory ssh-key registry bean if one was bound. Idempotent — safe to call when
+	 * nothing is running (used both by disable and by enable's idempotent-replace pre-clean).
+	 */
+	void removePollingRoute(@NonNull final String routeKey) throws Exception
+	{
+		if (getCamelContext().getRoute(routeKey) != null)
+		{
+			getCamelContext().getRouteController().stopRoute(routeKey);
+			getCamelContext().removeRoute(routeKey);
 		}
 
-		log.info("Dynamic SFTP polling route '{}' stopped and removed.", endpointName);
+		// Leave no key material behind: drop the in-memory private-key bean (no-op if password auth was used).
+		getCamelContext().getRegistry().unbind(sshPrivateKeyBeanId(routeKey));
 	}
 
 	private void prepareExternalStatusCreateRequest(@NonNull final Exchange exchange, @NonNull final JsonExternalStatus externalStatus)

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/test/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/from_mf/SftpDeliveryProcessorTest.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/test/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/from_mf/SftpDeliveryProcessorTest.java
@@ -31,6 +31,7 @@ import org.apache.camel.support.DefaultExchange;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -38,11 +39,14 @@ import java.util.stream.Stream;
 
 import static de.metas.camel.externalsystems.scriptedadapter.ScriptedAdapterConstants.ROUTE_MSG_FROM_MF_CONTEXT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SftpDeliveryProcessorTest
 {
 	private static final String SFTP_USER = "testuser";
 	private static final String SFTP_PASS = "testpass";
+	private static final String PRIVATE_KEY =
+			"-----BEGIN OPENSSH PRIVATE KEY-----\nZm9vYmFyYmF6cXV4\n-----END OPENSSH PRIVATE KEY-----\n";
 
 	@TempDir
 	Path sftpRootDir;
@@ -148,6 +152,115 @@ class SftpDeliveryProcessorTest
 
 			final String fileContent = Files.readString(expectedFile);
 			assertThat(fileContent).isEqualTo("<transformed-order/>");
+		}
+	}
+
+	@Test
+	void sshKeyAuth_buildSftpUri_bindsKeyBytesInRegistry_andReferencesBean_notTempFile() throws Exception
+	{
+		try (final CamelContext camelContext = new DefaultCamelContext())
+		{
+			camelContext.start();
+
+			final JsonExternalSystemEndpoint endpoint = JsonExternalSystemEndpoint.builder()
+					.value("test-endpoint")
+					.transportType("SFTP")
+					.sftpHost("localhost")
+					.sftpPort(22)
+					.sftpUsername(SFTP_USER)
+					.sftpAuthType("SSH_KEY")
+					.sshPrivateKey(PRIVATE_KEY)
+					.sftpRemotePath("outgoing")
+					.sftpFilenamePattern("delivery.json")
+					.build();
+
+			final String beanId = "sftpDeliveryPrivateKey-test";
+			final SftpDeliveryProcessor processor = new SftpDeliveryProcessor();
+
+			final String uri = processor.buildSftpUri(endpoint, 22, "outgoing", SFTP_USER, "SSH_KEY", "delivery.json", camelContext, beanId);
+
+			// the key is referenced in-memory via #bean:<id> — never written to a temp file on disk
+			assertThat(uri).contains("&privateKey=#bean:" + beanId);
+			assertThat(uri).doesNotContain("privateKeyFile");
+			assertThat(uri).doesNotContain(".pem");
+
+			// the key bytes are bound in the Camel registry under the given id
+			final byte[] bound = camelContext.getRegistry().lookupByNameAndType(beanId, byte[].class);
+			assertThat(bound).isEqualTo(PRIVATE_KEY.getBytes(StandardCharsets.UTF_8));
+		}
+	}
+
+	@Test
+	void passwordAuth_buildSftpUri_usesPasswordInUri_andBindsNoKeyBean() throws Exception
+	{
+		try (final CamelContext camelContext = new DefaultCamelContext())
+		{
+			camelContext.start();
+
+			final JsonExternalSystemEndpoint endpoint = JsonExternalSystemEndpoint.builder()
+					.value("test-endpoint")
+					.transportType("SFTP")
+					.sftpHost("localhost")
+					.sftpPort(22)
+					.sftpUsername(SFTP_USER)
+					.sftpAuthType("PASSWORD")
+					.password(SFTP_PASS)
+					.sftpRemotePath("outgoing")
+					.sftpFilenamePattern("delivery.json")
+					.build();
+
+			final String beanId = "sftpDeliveryPrivateKey-test";
+			final SftpDeliveryProcessor processor = new SftpDeliveryProcessor();
+
+			final String uri = processor.buildSftpUri(endpoint, 22, "outgoing", SFTP_USER, "PASSWORD", "delivery.json", camelContext, beanId);
+
+			assertThat(uri).doesNotContain("privateKey");
+			assertThat(camelContext.getRegistry().lookupByNameAndType(beanId, byte[].class)).isNull();
+		}
+	}
+
+	@Test
+	void sshKeyAuth_process_alwaysUnbindsKeyBean_evenWhenDeliveryFails() throws Exception
+	{
+		// The embedded server only accepts PASSWORD auth, so an SSH_KEY delivery to it fails at send time.
+		// The point of the test is the finally-block guarantee: however process() ends, it must leave NO
+		// private-key bytes behind in the registry (no key-material leak on the error path either).
+		try (final EmbeddedSftpServer sftpServer = new EmbeddedSftpServer(sftpRootDir, SFTP_USER, SFTP_PASS);
+			 final CamelContext camelContext = new DefaultCamelContext())
+		{
+			camelContext.start();
+
+			final JsonExternalSystemEndpoint endpoint = JsonExternalSystemEndpoint.builder()
+					.value("test-endpoint")
+					.transportType("SFTP")
+					.sftpHost("localhost")
+					.sftpPort(sftpServer.getPort())
+					.sftpUsername(SFTP_USER)
+					.sftpAuthType("SSH_KEY")
+					.sshPrivateKey(PRIVATE_KEY)
+					.sftpRemotePath("")
+					.sftpFilenamePattern("delivery.json")
+					.build();
+
+			final MsgFromMfContext context = MsgFromMfContext.builder()
+					.orgCode("testOrg")
+					.scriptingRequestBody("{}")
+					.scriptIdentifier("testScript")
+					.endpointParameters(endpoint)
+					.outboundRecordTableName("C_Order")
+					.outboundRecordId("789")
+					.build();
+			context.setScriptReturnValue("{\"transformed\": \"output\"}");
+
+			final Exchange exchange = new DefaultExchange(camelContext);
+			exchange.setProperty(ROUTE_MSG_FROM_MF_CONTEXT, context);
+
+			final SftpDeliveryProcessor processor = new SftpDeliveryProcessor();
+
+			assertThatThrownBy(() -> processor.process(exchange)).isInstanceOf(Exception.class);
+
+			final String beanId = "sftpDeliveryPrivateKey-" + exchange.getExchangeId();
+			assertThat(camelContext.getRegistry().lookupByNameAndType(beanId, byte[].class)).isNull();
 		}
 	}
 }

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/test/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/to_mf/InboundSftpIntegrationTest.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/test/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/to_mf/InboundSftpIntegrationTest.java
@@ -46,8 +46,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import static de.metas.camel.externalsystems.common.ExternalSystemCamelConstants.MF_ERROR_ROUTE_ID;
 import static de.metas.camel.externalsystems.common.ExternalSystemCamelConstants.MF_PUSH_OL_CANDIDATES_ROUTE_ID;
@@ -84,6 +86,12 @@ public class InboundSftpIntegrationTest extends CamelTestSupport
 	private static final String SFTP_USERNAME = "testuser";
 	private static final String SFTP_PASSWORD = "testpass";
 	private static final String ENDPOINT_NAME = "sftpIntegrationTestEndpoint";
+	/**
+	 * Stable per-child route key — the dynamic SFTP poll route is keyed on THIS (the child config id),
+	 * NOT on {@link #ENDPOINT_NAME} (the endpoint Value), so that changing the endpoint does not leak the
+	 * old poller. This is the value the backend puts under {@code PARAM_SCRIPTEDADAPTER_TO_MF_ROUTE_KEY}.
+	 */
+	private static final String ROUTE_KEY = "ScriptedImportConversion-100";
 	private static final String SCRIPT_IDENTIFIER = "inbound_sftp_test_noop";
 	private static final String SCRIPT_IDENTIFIER_OLCAND = "inbound_sftp_test_olcand";
 	private static final String TEST_FILE_NAME = "test_order.json";
@@ -176,13 +184,13 @@ public class InboundSftpIntegrationTest extends CamelTestSupport
 	@AfterEach
 	void tearDown() throws Exception
 	{
-		// Stop the dynamic route if still running
-		if (context.getRoute(ENDPOINT_NAME) != null)
+		// Stop the dynamic route if still running (keyed on the stable route key, not the endpoint name)
+		if (context.getRoute(ROUTE_KEY) != null)
 		{
 			try
 			{
-				context.getRouteController().stopRoute(ENDPOINT_NAME);
-				context.removeRoute(ENDPOINT_NAME);
+				context.getRouteController().stopRoute(ROUTE_KEY);
+				context.removeRoute(ROUTE_KEY);
 			}
 			catch (final Exception ignored)
 			{
@@ -249,7 +257,7 @@ public class InboundSftpIntegrationTest extends CamelTestSupport
 		template.sendBody("direct:" + ScriptedImportConversionSftpRouteBuilder.ENABLE_SFTP_POLLING_ROUTE_ID, enableRequest);
 
 		// The dynamic route should now be registered
-		assertThat(context.getRouteController().getRouteStatus(ENDPOINT_NAME)).isNotNull();
+		assertThat(context.getRouteController().getRouteStatus(ROUTE_KEY)).isNotNull();
 
 		// Wait for the payload to be archived to the LOCAL processed folder (up to 10 seconds)
 		final Path localDoneFile = localProcessedDir.resolve(TEST_FILE_NAME);
@@ -276,7 +284,7 @@ public class InboundSftpIntegrationTest extends CamelTestSupport
 		template.sendBody("direct:" + ScriptedImportConversionSftpRouteBuilder.DISABLE_SFTP_POLLING_ROUTE_ID, disableRequest);
 
 		// Then: route should be removed
-		assertThat(context.getRoute(ENDPOINT_NAME)).isNull();
+		assertThat(context.getRoute(ROUTE_KEY)).isNull();
 	}
 
 	@Test
@@ -301,7 +309,7 @@ public class InboundSftpIntegrationTest extends CamelTestSupport
 		// Act: fire the enable SFTP polling route, using the real (non-no-op) OLCand-producing transform
 		final JsonExternalSystemRequest enableRequest = buildEnableRequest(SCRIPT_IDENTIFIER_OLCAND);
 		template.sendBody("direct:" + ScriptedImportConversionSftpRouteBuilder.ENABLE_SFTP_POLLING_ROUTE_ID, enableRequest);
-		assertThat(context.getRouteController().getRouteStatus(ENDPOINT_NAME)).isNotNull();
+		assertThat(context.getRouteController().getRouteStatus(ROUTE_KEY)).isNotNull();
 
 		// Wait for the payload to be archived to the LOCAL processed folder (up to 10 seconds)
 		final Path localDoneFile = localProcessedDir.resolve(TEST_FILE_NAME);
@@ -324,7 +332,7 @@ public class InboundSftpIntegrationTest extends CamelTestSupport
 		// Act: disable the polling route
 		final JsonExternalSystemRequest disableRequest = buildDisableRequest();
 		template.sendBody("direct:" + ScriptedImportConversionSftpRouteBuilder.DISABLE_SFTP_POLLING_ROUTE_ID, disableRequest);
-		assertThat(context.getRoute(ENDPOINT_NAME)).isNull();
+		assertThat(context.getRoute(ROUTE_KEY)).isNull();
 	}
 
 	@Test
@@ -349,7 +357,7 @@ public class InboundSftpIntegrationTest extends CamelTestSupport
 		// Act: fire the enable SFTP polling route
 		final JsonExternalSystemRequest enableRequest = buildEnableRequest(SCRIPT_IDENTIFIER_OLCAND);
 		template.sendBody("direct:" + ScriptedImportConversionSftpRouteBuilder.ENABLE_SFTP_POLLING_ROUTE_ID, enableRequest);
-		assertThat(context.getRouteController().getRouteStatus(ENDPOINT_NAME)).isNotNull();
+		assertThat(context.getRouteController().getRouteStatus(ROUTE_KEY)).isNotNull();
 
 		// Wait for the payload to be archived to the LOCAL error folder (up to 10 seconds) — it must
 		// not be silently lost
@@ -375,7 +383,69 @@ public class InboundSftpIntegrationTest extends CamelTestSupport
 		// Act: disable the polling route
 		final JsonExternalSystemRequest disableRequest = buildDisableRequest();
 		template.sendBody("direct:" + ScriptedImportConversionSftpRouteBuilder.DISABLE_SFTP_POLLING_ROUTE_ID, disableRequest);
-		assertThat(context.getRoute(ENDPOINT_NAME)).isNull();
+		assertThat(context.getRoute(ROUTE_KEY)).isNull();
+	}
+
+	/**
+	 * Reproduces the production leak: a child's SFTP endpoint is changed (pointed at a different endpoint
+	 * record — different host / {@code Value}) and the poller is re-started. The previously-started route
+	 * must be torn down; only ONE poller — the new one — may remain.
+	 * <p>
+	 * The dynamic route is keyed on the STABLE per-child route key ({@link #ROUTE_KEY}), not on the endpoint
+	 * name/host, so the second enable idempotently REPLACES the first. On the pre-fix code (route keyed on
+	 * the endpoint name) the two enables produced two distinct routes and the old host kept being polled.
+	 */
+	@Test
+	void endpointChanged_previousPollerTornDown_onlyNewPollerRemains() throws Exception
+	{
+		interceptExternalStatusEndpoints();
+		registerDummyErrorRoute();
+
+		context.start();
+
+		// Two remote locations on the SFTP server — "before" and "after" the endpoint change.
+		Files.createDirectories(sftpRootDir.resolve("inboundA"));
+		Files.createDirectories(sftpRootDir.resolve("inboundB"));
+
+		// Enable pointing at endpoint A (Value "endpointA", remote path inboundA).
+		template.sendBody("direct:" + ScriptedImportConversionSftpRouteBuilder.ENABLE_SFTP_POLLING_ROUTE_ID,
+				buildEnableRequest(SCRIPT_IDENTIFIER, "endpointA", ROUTE_KEY, "inboundA"));
+
+		// The child's endpoint is changed to a DIFFERENT endpoint record (Value "endpointB", remote path
+		// inboundB) and Start is pressed again — SAME child, SAME stable route key, different host/path.
+		template.sendBody("direct:" + ScriptedImportConversionSftpRouteBuilder.ENABLE_SFTP_POLLING_ROUTE_ID,
+				buildEnableRequest(SCRIPT_IDENTIFIER, "endpointB", ROUTE_KEY, "inboundB"));
+
+		// Exactly ONE SFTP poll route must remain — the old endpoint-A poller must have been removed.
+		assertThat(countSftpPollRoutes())
+				.as("Changing the child's endpoint must not leak the old SFTP poller")
+				.isEqualTo(1);
+
+		// And the surviving route must poll the NEW location, never the old one.
+		final String survivingUri = sftpPollRouteUris().stream().findFirst().orElse("");
+		assertThat(survivingUri).contains("inboundB");
+		assertThat(survivingUri).doesNotContain("inboundA");
+
+		// Disable via the stable key removes the poller entirely.
+		template.sendBody("direct:" + ScriptedImportConversionSftpRouteBuilder.DISABLE_SFTP_POLLING_ROUTE_ID,
+				buildDisableRequest("endpointB", ROUTE_KEY));
+		assertThat(countSftpPollRoutes())
+				.as("Disable must remove the SFTP poller")
+				.isZero();
+		assertThat(context.getRoute(ROUTE_KEY)).isNull();
+	}
+
+	private long countSftpPollRoutes()
+	{
+		return sftpPollRouteUris().size();
+	}
+
+	private List<String> sftpPollRouteUris()
+	{
+		return context.getRoutes().stream()
+				.map(route -> route.getEndpoint().getEndpointUri())
+				.filter(uri -> uri.startsWith("sftp://"))
+				.collect(Collectors.toList());
 	}
 
 	private void interceptExternalStatusEndpoints() throws Exception
@@ -428,15 +498,25 @@ public class InboundSftpIntegrationTest extends CamelTestSupport
 
 	private JsonExternalSystemRequest buildEnableRequest(@NonNull final String scriptIdentifier)
 	{
+		return buildEnableRequest(scriptIdentifier, ENDPOINT_NAME, ROUTE_KEY, "inbound");
+	}
+
+	private JsonExternalSystemRequest buildEnableRequest(
+			@NonNull final String scriptIdentifier,
+			@NonNull final String endpointName,
+			@NonNull final String routeKey,
+			@NonNull final String remotePath)
+	{
 		final Map<String, String> params = new HashMap<>();
-		params.put(ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ENDPOINT_NAME, ENDPOINT_NAME);
+		params.put(ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ENDPOINT_NAME, endpointName);
+		params.put(ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ROUTE_KEY, routeKey);
 		params.put(ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_SCRIPT_IDENTIFIER, scriptIdentifier);
 		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_HOST, "localhost");
 		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_PORT, String.valueOf(sftpServer.getPort()));
 		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_USERNAME, SFTP_USERNAME);
 		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_PASSWORD, SFTP_PASSWORD);
 		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_AUTH_TYPE, "PASSWORD");
-		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_REMOTE_PATH, "inbound");
+		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_REMOTE_PATH, remotePath);
 		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_INTERVAL_MS, "500");
 		// LOCAL, transport-agnostic archive folders (never remote — see class javadoc)
 		params.put(ExternalSystemConstants.PARAM_PROCESSED_DIR, localProcessedDir.toAbsolutePath().toString());
@@ -456,8 +536,16 @@ public class InboundSftpIntegrationTest extends CamelTestSupport
 
 	private JsonExternalSystemRequest buildDisableRequest()
 	{
+		return buildDisableRequest(ENDPOINT_NAME, ROUTE_KEY);
+	}
+
+	private JsonExternalSystemRequest buildDisableRequest(
+			@NonNull final String endpointName,
+			@NonNull final String routeKey)
+	{
 		final Map<String, String> params = new HashMap<>();
-		params.put(ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ENDPOINT_NAME, ENDPOINT_NAME);
+		params.put(ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ENDPOINT_NAME, endpointName);
+		params.put(ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ROUTE_KEY, routeKey);
 
 		return JsonExternalSystemRequest.builder()
 				.externalSystemName(JsonExternalSystemName.of("ScriptedImportConversion"))

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/test/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/to_mf/ScriptedImportConversionSftpRouteBuilderTest.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/test/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/to_mf/ScriptedImportConversionSftpRouteBuilderTest.java
@@ -43,6 +43,7 @@ import java.io.InputStream;
 import java.util.Properties;
 
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ENDPOINT_NAME;
+import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_SCRIPTEDADAPTER_TO_MF_ROUTE_KEY;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class ScriptedImportConversionSftpRouteBuilderTest extends CamelTestSupport
@@ -131,21 +132,22 @@ public class ScriptedImportConversionSftpRouteBuilderTest extends CamelTestSuppo
 		final JsonExternalSystemRequest invokeExternalSystemRequest = objectMapper
 				.readValue(invokeExternalSystemRequestIS, JsonExternalSystemRequest.class);
 
-		final String endpointName = invokeExternalSystemRequest.getParameters().get(PARAM_SCRIPTEDADAPTER_TO_MF_ENDPOINT_NAME);
+		// The dynamic route is keyed on the STABLE route key (child config id), not the endpoint name.
+		final String routeKey = invokeExternalSystemRequest.getParameters().get(PARAM_SCRIPTEDADAPTER_TO_MF_ROUTE_KEY);
 
-		// Pre-register a dynamic SFTP route so disable can stop it.
+		// Pre-register a dynamic SFTP route (keyed on the stable route key) so disable can stop it.
 		// We use a mock "direct:" route to avoid needing an actual SFTP server.
 		context.addRoutes(new RouteBuilder()
 		{
 			@Override
 			public void configure()
 			{
-				from("direct:" + endpointName)
-						.routeId(endpointName)
+				from("direct:" + routeKey)
+						.routeId(routeKey)
 						.log("mock dynamic sftp route");
 			}
 		});
-		context.getRouteController().startRoute(endpointName);
+		context.getRouteController().startRoute(routeKey);
 
 		// when fire the route
 		template.sendBody("direct:" + ScriptedImportConversionSftpRouteBuilder.DISABLE_SFTP_POLLING_ROUTE_ID, invokeExternalSystemRequest);
@@ -155,7 +157,7 @@ public class ScriptedImportConversionSftpRouteBuilderTest extends CamelTestSuppo
 		assertThat(mockStoreExternalStatusEP.called).isEqualTo(1);
 
 		// route should have been removed
-		assertThat(context.getRoute(endpointName)).isNull();
+		assertThat(context.getRoute(routeKey)).isNull();
 	}
 
 	private void prepareEnableRouteForTesting(@NonNull final MockStoreExternalStatusEP mockStoreExternalStatusEP) throws Exception

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/test/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/to_mf/ScriptedImportConversionSftpSshKeyBindingTest.java
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/test/java/de/metas/camel/externalsystems/scriptedadapter/convertmsg/to_mf/ScriptedImportConversionSftpSshKeyBindingTest.java
@@ -1,0 +1,113 @@
+/*
+ * #%L
+ * de-metas-camel-scriptedadapter
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.camel.externalsystems.scriptedadapter.convertmsg.to_mf;
+
+import de.metas.common.externalsystem.ExternalSystemConstants;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the SSH-key SFTP auth path keeps the private key in memory (Camel registry {@code byte[]} bean
+ * referenced via {@code &privateKey=#bean:<id>}) instead of writing it to a temp file on disk, and that the
+ * bean is removed again when the poll route is disabled/replaced.
+ */
+public class ScriptedImportConversionSftpSshKeyBindingTest extends CamelTestSupport
+{
+	private static final String ROUTE_KEY = "ScriptedImportConversion-100";
+	private static final String PRIVATE_KEY =
+			"-----BEGIN OPENSSH PRIVATE KEY-----\nZm9vYmFyYmF6cXV4\n-----END OPENSSH PRIVATE KEY-----\n";
+	private static final String PRIVATE_KEY_BEAN_ID = "sftpPrivateKey-" + ROUTE_KEY;
+
+	private ScriptedImportConversionSftpRouteBuilder routeBuilder;
+
+	@Override
+	protected RouteBuilder createRouteBuilder()
+	{
+		routeBuilder = new ScriptedImportConversionSftpRouteBuilder(Mockito.mock(ProducerTemplate.class));
+		return routeBuilder;
+	}
+
+	private static Map<String, String> sshKeyParams()
+	{
+		final Map<String, String> params = new HashMap<>();
+		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_HOST, "localhost");
+		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_PORT, "22");
+		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_USERNAME, "testuser");
+		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_AUTH_TYPE, ExternalSystemConstants.SFTP_AUTH_TYPE_SSH_KEY);
+		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_PRIVATE_KEY, PRIVATE_KEY);
+		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_REMOTE_PATH, "/inbound");
+		return params;
+	}
+
+	@Test
+	void sshKeyAuth_bindsPrivateKeyBytesInRegistry_andReferencesBeanInUri() throws Exception
+	{
+		final String uri = routeBuilder.buildSftpUri(ROUTE_KEY, sshKeyParams());
+
+		// the key is referenced in-memory via #bean:<id> — never written to a temp file on disk
+		assertThat(uri).contains("&privateKey=#bean:" + PRIVATE_KEY_BEAN_ID);
+		assertThat(uri).doesNotContain("privateKeyFile");
+		assertThat(uri).doesNotContain(".pem");
+
+		// the key bytes are bound in the Camel registry under the route-key-derived id
+		final byte[] bound = context.getRegistry().lookupByNameAndType(PRIVATE_KEY_BEAN_ID, byte[].class);
+		assertThat(bound).isEqualTo(PRIVATE_KEY.getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Test
+	void disableOrReplace_unbindsPrivateKeyBean() throws Exception
+	{
+		routeBuilder.buildSftpUri(ROUTE_KEY, sshKeyParams());
+		assertThat(context.getRegistry().lookupByNameAndType(PRIVATE_KEY_BEAN_ID, byte[].class)).isNotNull();
+
+		// disable/replace must leave no key material behind in the registry
+		routeBuilder.removePollingRoute(ROUTE_KEY);
+
+		assertThat(context.getRegistry().lookupByNameAndType(PRIVATE_KEY_BEAN_ID, byte[].class)).isNull();
+	}
+
+	@Test
+	void passwordAuth_usesPasswordInUri_andBindsNoKeyBean() throws Exception
+	{
+		final Map<String, String> params = new HashMap<>();
+		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_HOST, "localhost");
+		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_USERNAME, "testuser");
+		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_AUTH_TYPE, ExternalSystemConstants.SFTP_AUTH_TYPE_PASSWORD);
+		params.put(ExternalSystemConstants.PARAM_SFTP_POLLING_ENDPOINT_PASSWORD, "testpass");
+
+		final String uri = routeBuilder.buildSftpUri(ROUTE_KEY, params);
+
+		assertThat(uri).contains("&password=RAW(testpass)");
+		assertThat(uri).doesNotContain("privateKey");
+		assertThat(context.getRegistry().lookupByNameAndType(PRIVATE_KEY_BEAN_ID, byte[].class)).isNull();
+	}
+}

--- a/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/test/resources/de/metas/camel/externalsystems/scriptedadapter/convertmsg/to_mf/sftp/1_SftpExternalSystemRequest.json
+++ b/misc/services/camel/de-metas-camel-externalsystems/de-metas-camel-scriptedadapter/src/test/resources/de/metas/camel/externalsystems/scriptedadapter/convertmsg/to_mf/sftp/1_SftpExternalSystemRequest.json
@@ -8,6 +8,7 @@
   "traceId": "123",
   "parameters": {
     "endpointName": "sftpEndpoint",
+    "scriptedImportRouteKey": "ScriptedImportConversion-1",
     "scriptIdentifier": "scriptIdentifier",
     "sftpHost": "localhost",
     "sftpPort": "22",


### PR DESCRIPTION
Forward merge-through of `soft_panda_hotfix` into `new_dawn_uat` (DoD up-propagation).

Carries the two externalsystem scripted-import fixes merged onto `soft_panda_hotfix`:
- https://github.com/metasfresh/metasfresh/pull/25294 — post-rollout follow-up fixes (invoke-500 fix, stale-SFTP-route-on-endpoint-change, Skript-Kennung help text, SSH key kept in memory inbound + outbound)
- https://github.com/metasfresh/metasfresh/pull/25415 — harden the scripted-import create-save E2E to prove a real persisted, valid save

Both commits are already reviewed + merged on the source branch. Includes one brand-new additive migration (`5815620_ScriptIdentifier_description_stem_without_js.sql`).

**Merge with a MERGE COMMIT, never squash** (a squash of a merge-through re-conflicts every future merge between these branches).
