### PR TITLE
InvoiceCandBL: fail fast on a definitely-errored invoice-candidate recompute instead of polling a full hour

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandDAO.java
@@ -60,6 +60,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -109,6 +110,22 @@ public interface IInvoiceCandDAO extends ISingletonService
 	boolean hasInvalidInvoiceCandidates(@NonNull Collection<InvoiceCandidateId> invoiceCandidateIds);
 
 	boolean hasInvalidInvoiceCandidatesForSelection(@NonNull InvoiceCandidateIdsSelection selectionId);
+
+	/**
+	 * Detects whether the async recompute for the given selection has <b>definitely</b> errored.
+	 * <p>
+	 * The recompute of a selection's ICs runs in an async workpackage that is enqueued under the ICs' {@code C_Async_Batch_ID}.
+	 * This method resolves those batch-ids from the selection's ICs and checks whether there is a
+	 * {@link de.metas.async.model.I_C_Queue_WorkPackage} with {@code IsError='Y'} for any of them.
+	 * <p>
+	 * Conservative on purpose (this feeds a fast-fail on the system-wide enqueue wait-path): it returns a non-empty
+	 * result <b>only</b> when a matching errored workpackage is actually found. If the selection is empty, none of its
+	 * ICs carries a {@code C_Async_Batch_ID}, or no errored workpackage exists, it returns {@link Optional#empty()}.
+	 *
+	 * @return a human-readable error detail (errored workpackage's {@code ErrorMsg} + the still-invalid
+	 * {@code C_Invoice_Candidate_ID}s), or empty when there is no definite recompute error.
+	 */
+	Optional<String> getFailedRecomputeErrorMessage(@NonNull InvoiceCandidateIdsSelection invoiceCandidateIdsSelection);
 
 	List<I_C_InvoiceLine> retrieveIlForIc(I_C_Invoice_Candidate invoiceCand);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -2710,7 +2710,7 @@ public class InvoiceCandBL implements IInvoiceCandBL
 			TryAndWaitUtil.tryAndWait(
 					3600 /*let's wait a full hour*/,
 					1000 /*check once a second*/,
-					() -> !invoiceCandDAO.hasInvalidInvoiceCandidatesForSelection(invoiceCandidateIdsSelection),
+					() -> isSelectionUpdated_failFastOnRecomputeError(invoiceCandidateIdsSelection),
 					null);
 		}
 		catch (final InterruptedException e)
@@ -2723,6 +2723,43 @@ public class InvoiceCandBL implements IInvoiceCandBL
 		{
 			Loggables.withLogger(logger, Level.DEBUG).addLog("InvoiceCandidateEnqueuer - Stop waiting for ICs to be updated async-queue; Selection={}", invoiceCandidateIdsSelection);
 		}
+	}
+
+	/**
+	 * The {@link TryAndWaitUtil#tryAndWait(long, long, java.util.function.Supplier, Runnable) worker} of
+	 * {@link #waitForInvoiceCandidatesUpdated(InvoiceCandidateIdsSelection)}, extracted for unit-testing.
+	 * <p>
+	 * Purely-additive fast-fail: behaves exactly like the former {@code !hasInvalidInvoiceCandidatesForSelection(..)}
+	 * check, except that when there are still-invalid ICs <b>and</b> the async recompute for the selection has
+	 * <b>definitely</b> errored (an errored {@code C_Queue_WorkPackage} exists for the selection's recompute
+	 * {@code C_Async_Batch_ID}s), it throws instead of silently polling for the full hour. When it cannot prove a
+	 * definite error, it keeps waiting exactly as before (returns {@code false}) — so the worst case is unchanged.
+	 *
+	 * @return {@code true} once no invalid IC remains (done); {@code false} while ICs are still invalid but no definite
+	 * recompute error is proven (keep waiting).
+	 * @throws AdempiereException when the recompute has definitely errored.
+	 */
+	@VisibleForTesting
+	boolean isSelectionUpdated_failFastOnRecomputeError(@NonNull final InvoiceCandidateIdsSelection invoiceCandidateIdsSelection)
+	{
+		if (!invoiceCandDAO.hasInvalidInvoiceCandidatesForSelection(invoiceCandidateIdsSelection))
+		{
+			return true; // all ICs updated -> done
+		}
+
+		// There are still-invalid ICs. Keep waiting unless the recompute has *definitely* errored.
+		final Optional<String> recomputeError = invoiceCandDAO.getFailedRecomputeErrorMessage(invoiceCandidateIdsSelection);
+		if (recomputeError.isPresent())
+		{
+			throw new AdempiereException(
+					"The async recompute of invoice candidates failed; aborting the wait early instead of polling for a full hour."
+							+ " " + recomputeError.get()
+							+ " Check AD_Issue for the full stacktrace.")
+					.appendParametersToMessage()
+					.setParameter("InvoiceCandidateIdsSelection (ICs-selection)", invoiceCandidateIdsSelection);
+		}
+
+		return false; // still invalid, but no definite error -> keep waiting exactly as before
 	}
 
 	// TODO: would be nice to use de.metas.ui.web.view.descriptor.SqlAndParams but that is in module webui-api, and here we don't have access to it

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandDAO.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import de.metas.aggregation.model.I_C_Aggregation;
 import de.metas.async.AsyncBatchId;
+import de.metas.async.model.I_C_Queue_WorkPackage;
 import de.metas.bpartner.BPartnerId;
 import de.metas.bpartner.service.IBPartnerDAO;
 import de.metas.cache.annotation.CacheCtx;
@@ -133,6 +134,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
@@ -1278,6 +1280,13 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 				.andCollectChildren(I_C_Invoice_Candidate_Recompute.COLUMN_C_Invoice_Candidate_ID)
 				.create()
 				.anyMatch();
+	}
+
+	@Override
+	public Optional<String> getFailedRecomputeErrorMessage(@NonNull final InvoiceCandidateIdsSelection invoiceCandidateIdsSelection)
+	{
+		// TODO: implement
+		return Optional.empty();
 	}
 
 	private IQueryBuilder<I_C_Invoice_Candidate> retrieveForBillPartnerQuery(final I_C_BPartner bpartner)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandDAO.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandDAO.java
@@ -1252,9 +1252,22 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 
 		// Without the newOutOfTrx-context, we had InvoiceCandBL.waitForInvoiceCandidatesUpdated consistently hit the 1hr-timeout on one instance,
 		// although multiple UpdateInvalidInvoiceCandidatesWorkpackageProcessors executed successfully during that hour.
+		final IQueryBuilder<I_C_Invoice_Candidate> queryBuilder = createInvoiceCandidateQueryBuilderForSelection(invoiceCandidateIdsSelection);
+
+		return queryBuilder
+				.andCollectChildren(I_C_Invoice_Candidate_Recompute.COLUMN_C_Invoice_Candidate_ID)
+				.create()
+				.anyMatch();
+	}
+
+	/**
+	 * Creates an {@link I_C_Invoice_Candidate} query builder (out-of-trx) restricted to the given selection.
+	 * See {@link #hasInvalidInvoiceCandidatesForSelection(InvoiceCandidateIdsSelection)} for why the out-of-trx context matters.
+	 */
+	private IQueryBuilder<I_C_Invoice_Candidate> createInvoiceCandidateQueryBuilderForSelection(@NonNull final InvoiceCandidateIdsSelection invoiceCandidateIdsSelection)
+	{
 		final IQueryBuilder<I_C_Invoice_Candidate> queryBuilder = queryBL.createQueryBuilder(I_C_Invoice_Candidate.class, PlainContextAware.newOutOfTrx());
 
-		// apply the invoiceCandidateIdsSelection to our queryBuilder
 		invoiceCandidateIdsSelection.apply(new InvoiceCandidateIdsSelection.CaseMapper()
 		{
 			@Override
@@ -1276,17 +1289,73 @@ public class InvoiceCandDAO implements IInvoiceCandDAO
 			}
 		});
 
-		return queryBuilder
-				.andCollectChildren(I_C_Invoice_Candidate_Recompute.COLUMN_C_Invoice_Candidate_ID)
-				.create()
-				.anyMatch();
+		return queryBuilder;
 	}
 
 	@Override
 	public Optional<String> getFailedRecomputeErrorMessage(@NonNull final InvoiceCandidateIdsSelection invoiceCandidateIdsSelection)
 	{
-		// TODO: implement
-		return Optional.empty();
+		if (invoiceCandidateIdsSelection.isEmpty())
+		{
+			return Optional.empty();
+		}
+
+		// The recompute of these ICs runs in an async workpackage that is enqueued under the ICs' C_Async_Batch_ID
+		// (UpdateInvalidInvoiceCandidatesWorkpackageProcessorScheduler#extractAsyncBatchFromItem). Resolve those batch-ids
+		// from the selection's ICs. If none of them carries a *real* batch-id, we cannot attribute any error to this
+		// selection -> return empty -> the wait keeps its unchanged behaviour.
+		final ImmutableSet<AsyncBatchId> asyncBatchIds = retrieveRealAsyncBatchIdsForSelection(invoiceCandidateIdsSelection);
+		if (asyncBatchIds.isEmpty())
+		{
+			return Optional.empty();
+		}
+
+		// Conservative on purpose (feeds a system-wide fast-fail): only report an error when a matching errored
+		// workpackage is actually found for one of the selection's recompute batch-ids.
+		final I_C_Queue_WorkPackage erroredWorkPackage = queryBL.createQueryBuilder(I_C_Queue_WorkPackage.class, PlainContextAware.newOutOfTrx())
+				.addInArrayFilter(I_C_Queue_WorkPackage.COLUMNNAME_C_Async_Batch_ID, asyncBatchIds)
+				.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_IsError, true)
+				.orderBy(I_C_Queue_WorkPackage.COLUMNNAME_C_Queue_WorkPackage_ID)
+				.create()
+				.first();
+		if (erroredWorkPackage == null)
+		{
+			return Optional.empty();
+		}
+
+		final List<Integer> stillInvalidInvoiceCandidateIds = retrieveInvalidInvoiceCandidateIdsForSelection(invoiceCandidateIdsSelection);
+
+		final String errorMsg = erroredWorkPackage.getErrorMsg();
+		final String detail = "Errored recompute C_Queue_WorkPackage_ID=" + erroredWorkPackage.getC_Queue_WorkPackage_ID()
+				+ " (C_Async_Batch_ID=" + erroredWorkPackage.getC_Async_Batch_ID() + ")"
+				+ "; ErrorMsg=" + (Check.isBlank(errorMsg) ? "<none>" : errorMsg)
+				+ "; still-invalid C_Invoice_Candidate_IDs=" + stillInvalidInvoiceCandidateIds;
+		return Optional.of(detail);
+	}
+
+	/**
+	 * @return the distinct <b>real</b> {@code C_Async_Batch_ID}s of the selection's ICs, i.e. excluding {@code null}/{@code 0}
+	 * and the {@link AsyncBatchId#NONE_ASYNC_BATCH_ID} sentinel (an errored workpackage under the shared NONE-batch cannot be
+	 * reliably attributed to this selection, so we never fast-fail on it).
+	 */
+	private ImmutableSet<AsyncBatchId> retrieveRealAsyncBatchIdsForSelection(@NonNull final InvoiceCandidateIdsSelection invoiceCandidateIdsSelection)
+	{
+		return createInvoiceCandidateQueryBuilderForSelection(invoiceCandidateIdsSelection)
+				.create()
+				.listDistinct(I_C_Invoice_Candidate.COLUMNNAME_C_Async_Batch_ID, Integer.class)
+				.stream()
+				.map(AsyncBatchId::ofRepoIdOrNull)
+				.filter(Objects::nonNull)
+				.filter(asyncBatchId -> !AsyncBatchId.NONE_ASYNC_BATCH_ID.equals(asyncBatchId))
+				.collect(ImmutableSet.toImmutableSet());
+	}
+
+	private List<Integer> retrieveInvalidInvoiceCandidateIdsForSelection(@NonNull final InvoiceCandidateIdsSelection invoiceCandidateIdsSelection)
+	{
+		return createInvoiceCandidateQueryBuilderForSelection(invoiceCandidateIdsSelection)
+				.andCollectChildren(I_C_Invoice_Candidate_Recompute.COLUMN_C_Invoice_Candidate_ID)
+				.create()
+				.listDistinct(I_C_Invoice_Candidate_Recompute.COLUMNNAME_C_Invoice_Candidate_ID, Integer.class);
 	}
 
 	private IQueryBuilder<I_C_Invoice_Candidate> retrieveForBillPartnerQuery(final I_C_BPartner bpartner)

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLRecomputeFastFailTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLRecomputeFastFailTest.java
@@ -1,0 +1,178 @@
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2024 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.invoicecandidate.api.impl;
+
+import de.metas.async.model.I_C_Queue_WorkPackage;
+import de.metas.invoicecandidate.InvoiceCandidateId;
+import de.metas.invoicecandidate.api.IInvoiceCandDAO;
+import de.metas.invoicecandidate.api.InvoiceCandidateIdsSelection;
+import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
+import de.metas.invoicecandidate.model.I_C_Invoice_Candidate_Recompute;
+import de.metas.util.Services;
+import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Covers the purely-additive fast-fail on a definitely-errored async recompute, added to
+ * {@link InvoiceCandBL#isSelectionUpdated_failFastOnRecomputeError(InvoiceCandidateIdsSelection)} and its detection
+ * seam {@link IInvoiceCandDAO#getFailedRecomputeErrorMessage(InvoiceCandidateIdsSelection)}.
+ */
+public class InvoiceCandBLRecomputeFastFailTest
+{
+	private static final int ASYNC_BATCH_ID = 555;
+	private static final String ERROR_MSG = "boom - transaction poisoned in UpdateInvalidInvoiceCandidatesWorkpackageProcessor";
+
+	private IInvoiceCandDAO invoiceCandDAO;
+	private InvoiceCandBL invoiceCandBL;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+		invoiceCandDAO = Services.get(IInvoiceCandDAO.class);
+		invoiceCandBL = new InvoiceCandBL();
+	}
+
+	private InvoiceCandidateId createInvoiceCandidate(final int asyncBatchId)
+	{
+		final I_C_Invoice_Candidate ic = newInstance(I_C_Invoice_Candidate.class);
+		if (asyncBatchId > 0)
+		{
+			ic.setC_Async_Batch_ID(asyncBatchId);
+		}
+		saveRecord(ic);
+		return InvoiceCandidateId.ofRepoId(ic.getC_Invoice_Candidate_ID());
+	}
+
+	/** Marks the given IC invalid, i.e. makes {@code hasInvalidInvoiceCandidatesForSelection} return true. */
+	private void tagInvalid(final InvoiceCandidateId invoiceCandidateId, final int asyncBatchId)
+	{
+		final I_C_Invoice_Candidate_Recompute recompute = newInstance(I_C_Invoice_Candidate_Recompute.class);
+		recompute.setC_Invoice_Candidate_ID(invoiceCandidateId.getRepoId());
+		if (asyncBatchId > 0)
+		{
+			recompute.setC_Async_Batch_ID(asyncBatchId);
+		}
+		saveRecord(recompute);
+	}
+
+	private void createWorkPackage(final int asyncBatchId, final boolean isError, @Nullable final String errorMsg)
+	{
+		final I_C_Queue_WorkPackage wp = newInstance(I_C_Queue_WorkPackage.class);
+		wp.setC_Async_Batch_ID(asyncBatchId);
+		wp.setIsError(isError);
+		wp.setErrorMsg(errorMsg);
+		saveRecord(wp);
+	}
+
+	@Test
+	public void getFailedRecomputeErrorMessage_erroredWorkPackage_returnsErrorMsg()
+	{
+		final InvoiceCandidateId icId = createInvoiceCandidate(ASYNC_BATCH_ID);
+		tagInvalid(icId, ASYNC_BATCH_ID);
+		createWorkPackage(ASYNC_BATCH_ID, true, ERROR_MSG);
+
+		final Optional<String> result = invoiceCandDAO.getFailedRecomputeErrorMessage(
+				InvoiceCandidateIdsSelection.ofIdsSet(java.util.Collections.singleton(icId)));
+
+		assertThat(result).isPresent();
+		assertThat(result.get())
+				.contains(ERROR_MSG)
+				.contains(String.valueOf(icId.getRepoId()));
+	}
+
+	@Test
+	public void getFailedRecomputeErrorMessage_noErroredWorkPackage_empty()
+	{
+		final InvoiceCandidateId icId = createInvoiceCandidate(ASYNC_BATCH_ID);
+		tagInvalid(icId, ASYNC_BATCH_ID);
+		// a non-errored WP for the batch: must NOT trigger a fast-fail
+		createWorkPackage(ASYNC_BATCH_ID, false, null);
+
+		final Optional<String> result = invoiceCandDAO.getFailedRecomputeErrorMessage(
+				InvoiceCandidateIdsSelection.ofIdsSet(java.util.Collections.singleton(icId)));
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	public void getFailedRecomputeErrorMessage_icHasNoAsyncBatch_empty()
+	{
+		final InvoiceCandidateId icId = createInvoiceCandidate(0 /*no async batch*/);
+		tagInvalid(icId, 0);
+		// even an errored WP under an unrelated batch must NOT be attributed to this selection
+		createWorkPackage(ASYNC_BATCH_ID, true, ERROR_MSG);
+
+		final Optional<String> result = invoiceCandDAO.getFailedRecomputeErrorMessage(
+				InvoiceCandidateIdsSelection.ofIdsSet(java.util.Collections.singleton(icId)));
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	public void isSelectionUpdated_stillInvalidAndErrored_throws()
+	{
+		final InvoiceCandidateId icId = createInvoiceCandidate(ASYNC_BATCH_ID);
+		tagInvalid(icId, ASYNC_BATCH_ID);
+		createWorkPackage(ASYNC_BATCH_ID, true, ERROR_MSG);
+
+		final InvoiceCandidateIdsSelection selection = InvoiceCandidateIdsSelection.ofIdsSet(java.util.Collections.singleton(icId));
+
+		assertThatThrownBy(() -> invoiceCandBL.isSelectionUpdated_failFastOnRecomputeError(selection))
+				.isInstanceOf(AdempiereException.class)
+				.hasMessageContaining(ERROR_MSG);
+	}
+
+	@Test
+	public void isSelectionUpdated_stillInvalidButNoError_keepsWaiting()
+	{
+		final InvoiceCandidateId icId = createInvoiceCandidate(ASYNC_BATCH_ID);
+		tagInvalid(icId, ASYNC_BATCH_ID);
+		// no errored WP -> must keep waiting (return false), NOT throw
+
+		final InvoiceCandidateIdsSelection selection = InvoiceCandidateIdsSelection.ofIdsSet(java.util.Collections.singleton(icId));
+
+		assertThat(invoiceCandBL.isSelectionUpdated_failFastOnRecomputeError(selection)).isFalse();
+	}
+
+	@Test
+	public void isSelectionUpdated_noInvalidIcs_done()
+	{
+		final InvoiceCandidateId icId = createInvoiceCandidate(ASYNC_BATCH_ID);
+		// no recompute tag -> IC is valid -> done
+
+		final InvoiceCandidateIdsSelection selection = InvoiceCandidateIdsSelection.ofIdsSet(java.util.Collections.singleton(icId));
+
+		assertThat(invoiceCandBL.isSelectionUpdated_failFastOnRecomputeError(selection)).isTrue();
+	}
+}


### PR DESCRIPTION
## Problem
`InvoiceCandBL.waitForInvoiceCandidatesUpdated(...)` waits for a selection's invoice candidates to be recomputed by polling `hasInvalidInvoiceCandidatesForSelection` once a second for up to **one hour** (`TryAndWaitUtil.tryAndWait(3600, 1000, ...)`).

Normally the async `UpdateInvalidInvoiceCandidatesWorkpackageProcessor` clears the invalid ("to recompute") tag within seconds. But when that recompute workpackage fails with a hard, transaction-poisoning error, the per-IC error handler's own save also fails — so the invalid tag is never cleared **and** the IC is never flagged `IsError`. The poll then runs the full hour with no progress, and in CI the job is subsequently killed at a 120-minute hard timeout, producing an opaque, undiagnosable hang.

## Fix (purely additive, conservative)
Add an early-exit to the wait's poll worker: when there are still-invalid ICs **and** the async recompute for the selection has *definitely* errored, throw immediately — surfacing the errored workpackage's `ErrorMsg` + the still-invalid `C_Invoice_Candidate_ID`s + a hint to check `AD_Issue` — instead of polling to the 1-hour timeout.

Detection is deliberately conservative, because this wait runs in **every** invoice-candidate enqueue flow:
- It reports an error **only** when a matching errored `C_Queue_WorkPackage` (`IsError='Y'`) is actually found for one of the selection's recompute `C_Async_Batch_ID`s.
- It requires a **real** batch id (excludes null/`0` and the shared `NONE` sentinel), so an unrelated errored workpackage under the shared batch can never be misattributed to this selection.
- The timeout path is **unchanged** — the worst case is exactly today's behaviour; the only new behaviour is a fast, diagnosable failure on a *definite* recompute error.

The `hasInvalidInvoiceCandidatesForSelection` selection→query-builder logic is extracted into a shared private helper (behaviour-preserving) and reused by the new detection method.

## Tests
New `InvoiceCandBLRecomputeFastFailTest` (6 unit tests): detection (errored WP → error surfaced; non-errored WP → none; IC without a real batch → none) and the decision helper (still-invalid + errored → throws; still-invalid + no error → keeps waiting; no invalid → done). Existing `InvoiceCandDAOTest` + `InvoiceCandBLUpdateInvalidCandidatesTest` remain green (14 tests total).
