### PR TITLE
Invoice candidates — retry the model lock instead of dying on contention

### DIFF
--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandidateHandlerBL.java
@@ -318,11 +318,16 @@ public class InvoiceCandidateHandlerBL implements IInvoiceCandidateHandlerBL
 		for (final InvoiceCandidateGenerateRequest request : requests)
 		{
 			// Lock the "model" to make sure nobody else would generate invoice candidates for it.
+			// retryOnFailure: two workpackages can legitimately reach the same model concurrently, and the
+			// lock is held only for this one generate-and-save. Without retries the loser dies on the
+			// t_lock_reference_singleowner unique index (LockOwner.newOwner mints a fresh owner per call,
+			// so they can never share the lock), the workpackage fails, and the candidates are never created.
 			final ILock lock = lockManager.lock()
 					.setOwner(lockOwner)
 					.setRecordByModel(model)
 					.setAutoCleanup(true)
 					.setFailIfAlreadyLocked(true)
+					.retryOnFailure(10)
 					.acquire();
 
 			try (final ILockAutoCloseable ignored = lock.asAutoCloseable())


### PR DESCRIPTION
## What

Invoice-candidate generation dies when two async workpackages reach the same model concurrently.
This opts the lock acquisition into the retry mechanism `SqlLockDatabase` already implements.

## The defect

`InvoiceCandidateHandlerBL.createForModel0` acquires the model lock like this:

```java
final ILock lock = lockManager.lock()
        .setOwner(lockOwner)
        .setRecordByModel(model)
        .setAutoCleanup(true)
        .setFailIfAlreadyLocked(true)   // no retry, no wait
        .acquire();
```

Three facts compose the failure:

1. **No retry.** `setFailIfAlreadyLocked(true)` with the default `retryOnFailure = 0` gives
   `maxTrials = 1` — a single attempt.
2. **Owners can never coincide.** `LockOwner.newOwner(prefix)` appends a `UUID.randomUUID()` suffix,
   so two concurrent invocations of the *same* handler hold *different* owners and cannot share a lock.
3. **The database rejects the second inserter.** `t_lock_reference_singleowner` is
   `UNIQUE (record_id, ad_table_id) WHERE isallowmultipleowners = 'N'`.

So the loser of the race cannot serialise, cannot share, and is rejected outright. It dies with

```
de.metas.lock.exceptions.LockFailedException:
    Record was already locked: TableRecordReference{tableName=C_Order, recordId=…}
  Caused by: DBUniqueConstraintException:
    duplicate key value violates unique constraint "t_lock_reference_singleowner"
  at InvoiceCandidateHandlerBL.createMissingCandidatesFor(InvoiceCandidateHandlerBL.java:152)
  at CreateMissingInvoiceCandidatesWorkpackageProcessor.processWorkPackage(…)
```

the workpackage fails, the invoice candidates are never created, and the caller eventually sees a
`400` from `PUT api/v2/orders/sales/candidates/process` — several minutes later, which is what makes
this look like a timeout rather than a lock problem.

Note the `.acquire()` call sits **outside** the surrounding `try/catch`, so the method's own error
logging never sees it either.

## The fix

One line: `.retryOnFailure(10)`.

Nothing new is introduced. `SqlLockDatabase` already implements the retry loop
(`maxTrials = 1 + getRetryOnFailure()`, `sleepBeforeRetry()` at 200 ms); it is simply inert unless a
caller opts in, and this caller never did. `ShipmentScheduleEnqueuer` is the existing precedent and
already uses `retryOnFailure(10)` — the value here matches it rather than inventing a new one.

The lock is held only for one generate-and-save, so contention is transient by construction; 10
attempts across 2 s is far longer than the window.

Retry rather than skip-on-contention: skipping would silently drop the work if the lock holder's
transaction later rolled back, and retry is this codebase's established answer to exactly this
situation.

## Evidence

Surfaced as an intermittent `test (cucumber) (profile3)` failure in
`automateOrderCandToOrderAndShipmentAndInvoice.feature`, where the failing scenario moved between
runs — the classic look of a flaky test.

It is not flaky. Reproduced locally, single machine, no CI involved: **6 failures out of 84
scenarios**, with **102** `t_lock_reference_singleowner` violations and **34** `LockFailedException`
in one run, across many distinct `C_Order` records. That is a higher failure rate than CI produces,
so the contention needs no special infrastructure — ordinary concurrency is enough.

The load-sensitivity explains the intermittency: collision probability rises with parallelism, so the
same commit can pass on a quiet runner and fail on a busy one.

## Scope

Only the main line is fixed here. Older branches that predate the `SqlLockDatabase` retry loop
(the retry mechanism is absent there entirely) need that mechanism ported before this one-liner can
help them.
