### PR TITLE
Merge: deep_tundra_release → new_dawn_uat (gh31403 nShift COO QtyPicked split)

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/shipmentschedule/api/impl/HUShipmentScheduleBL.java
@@ -46,6 +46,7 @@ import de.metas.material.event.commons.AttributesKey;
 import de.metas.material.event.commons.AttributesKeyPart;
 import org.adempiere.mm.attributes.AttributeId;
 import org.adempiere.mm.attributes.AttributeValueType;
+import org.adempiere.mm.attributes.api.IAttributeDAO;
 import de.metas.handlingunits.shipmentschedule.api.AddQtyPickedRequest;
 import de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleBL;
 import de.metas.handlingunits.shipmentschedule.api.IHUShipmentScheduleDAO;
@@ -63,11 +64,13 @@ import de.metas.inoutcandidate.api.IInOutCandidateBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleAllocBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleEffectiveBL;
+import de.metas.inoutcandidate.api.IShipmentScheduleHandlerBL;
 import de.metas.inoutcandidate.api.IShipmentSchedulePA;
 import de.metas.inoutcandidate.api.InOutGenerateResult;
 import de.metas.inoutcandidate.api.ShipmentScheduleLoadingCache;
 import de.metas.inoutcandidate.api.impl.HUShipmentScheduleHeaderAggregationKeyBuilder;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
+import de.metas.inoutcandidate.spi.ShipmentScheduleHandler;
 import de.metas.logging.LogManager;
 import de.metas.util.Loggables;
 import de.metas.order.IOrderDAO;
@@ -112,6 +115,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -168,6 +172,8 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private final IHUPackingAwareBL huPackingAwareBL = Services.get(IHUPackingAwareBL.class);
 	private final IHUCapacityBL huCapacityBL = Services.get(IHUCapacityBL.class);
+	private final IAttributeDAO attributeDAO = Services.get(IAttributeDAO.class);
+	private final IShipmentScheduleHandlerBL shipmentScheduleHandlerBL = Services.get(IShipmentScheduleHandlerBL.class);
 
 	private static final String SYSCONFIG_ShipmentConsolidationPeriod = "de.metas.handlingunits.shipmentschedule.api.impl.HUShipmentScheduleBL.ShipmentConsolidationPeriod";
 	private static final String DEFAULT_ShipmentConsolidationPeriod = null;
@@ -1050,6 +1056,10 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 		final IHUStorageFactory storageFactory = huContext.getHUStorageFactory();
 		final IAttributeStorageFactory attrFactory = huContext.getHUAttributeStorageFactory();
 
+		// Split only by attributes whitelisted in M_ShipmentSchedule_AttributeConfig — the same criterion
+		// the M_InOutLine aggregation uses (ShipmentScheduleWithHU#computeAttributeValues).
+		final Predicate<AttributeId> attributeSplitsShipmentLine = attributeSplitsShipmentLinePredicate(qtyPicked);
+
 		// One pass: for each child VHU compute its UseInASI fingerprint once, then emit one
 		// (fingerprint, productStorage) entry per non-empty product storage of that VHU.
 		// Filter by product so VHUs carrying a different product in the same TU are excluded.
@@ -1060,7 +1070,7 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 				handlingUnitsDAO.retrieveIncludedHUs(huToInspect)
 						.stream()
 						.filter(handlingUnitsBL::isVirtual)
-						.flatMap(vhu -> groupProductStoragesByFingerprint(vhu, productId, storageFactory, attrFactory))
+						.flatMap(vhu -> groupProductStoragesByFingerprint(vhu, productId, storageFactory, attrFactory, attributeSplitsShipmentLine))
 						.collect(ImmutableListMultimap.toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue));
 
 		if (storagesByFingerprint.isEmpty())
@@ -1185,20 +1195,22 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 			@NonNull final I_M_HU vhu,
 			@NonNull final ProductId productId,
 			@NonNull final IHUStorageFactory storageFactory,
-			@NonNull final IAttributeStorageFactory attrFactory)
+			@NonNull final IAttributeStorageFactory attrFactory,
+			@NonNull final Predicate<AttributeId> attributeSplitsShipmentLine)
 	{
 		final IHUProductStorage productStorage = storageFactory.getStorage(vhu).getProductStorageOrNull(productId);
 		if (productStorage == null || productStorage.isEmpty())
 		{
 			return Stream.empty();
 		}
-		final AttributesKey fingerprint = computeUseInASIFingerprint(vhu, attrFactory);
+		final AttributesKey fingerprint = computeUseInASIFingerprint(vhu, attrFactory, attributeSplitsShipmentLine);
 		return Stream.of(Maps.immutableEntry(fingerprint, productStorage));
 	}
 
 	private static AttributesKey computeUseInASIFingerprint(
 			@NonNull final I_M_HU vhu,
-			@NonNull final IAttributeStorageFactory factory)
+			@NonNull final IAttributeStorageFactory factory,
+			@NonNull final Predicate<AttributeId> attributeSplitsShipmentLine)
 	{
 		// IAttributeStorage does not implement getAttributeValueIdOrNull, so we cannot use
 		// AttributesKeys.createAttributesKeyFromAttributeSet here — list-type attributes
@@ -1208,10 +1220,30 @@ public class HUShipmentScheduleBL implements IHUShipmentScheduleBL
 				.getAttributeValues()
 				.stream()
 				.filter(av -> av.isUseInASI() && !av.isEmpty())
+				.filter(av -> attributeSplitsShipmentLine.test(av.getAttributeId()))
 				.map(HUShipmentScheduleBL::toAttributesKeyPart)
 				.filter(Objects::nonNull)
 				.collect(ImmutableSet.toImmutableSet());
 		return parts.isEmpty() ? AttributesKey.NONE : AttributesKey.ofParts(parts);
+	}
+
+	/**
+	 * Predicate deciding whether an attribute splits the shipment line, i.e. whether it is whitelisted in
+	 * {@code M_ShipmentSchedule_AttributeConfig} for the schedule's handler — the same rule the M_InOutLine
+	 * aggregation applies. Resolved via {@code getHandlerForOrNull}: handlers are registered once at server
+	 * startup ({@code InOutCandidateValidator#onInit}), so during real picking the handler is present and the
+	 * whitelist restricts the split. It is null only in narrow init/test contexts that bypass that
+	 * registration; there we fall back to "no restriction" rather than fail.
+	 */
+	private Predicate<AttributeId> attributeSplitsShipmentLinePredicate(@NonNull final I_M_ShipmentSchedule_QtyPicked qtyPicked)
+	{
+		final de.metas.inoutcandidate.model.I_M_ShipmentSchedule shipmentSchedule = qtyPicked.getM_ShipmentSchedule();
+		final ShipmentScheduleHandler handler = shipmentScheduleHandlerBL.getHandlerForOrNull(shipmentSchedule);
+		if (handler == null)
+		{
+			return attributeId -> true;
+		}
+		return attributeId -> handler.attributeShallBePartOfShipmentLine(shipmentSchedule, attributeDAO.getAttributeRecordById(attributeId));
 	}
 
 	@Nullable

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentScheduleHandlerBL.java
@@ -9,6 +9,8 @@ import de.metas.util.ISingletonService;
 import org.adempiere.ad.dao.QueryLimit;
 import org.compiere.model.I_C_OrderLine;
 
+import javax.annotation.Nullable;
+
 import java.util.Properties;
 import java.util.Set;
 
@@ -76,6 +78,10 @@ public interface IShipmentScheduleHandlerBL extends ISingletonService
 	IDeliverRequest createDeliverRequest(I_M_ShipmentSchedule sched, final I_C_OrderLine salesOrderLine);
 
 	ShipmentScheduleHandler getHandlerFor(I_M_ShipmentSchedule sched);
+
+	/** @return the handler for the given schedule, or {@code null} if none is registered for its table (e.g. a schedule that carries no handler context yet). */
+	@Nullable
+	ShipmentScheduleHandler getHandlerForOrNull(I_M_ShipmentSchedule sched);
 
 	void updateShipmentScheduleFromReferencedRecord(I_M_ShipmentSchedule shipmentScheduleRecord);
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentScheduleHandlerBL.java
@@ -379,14 +379,21 @@ public class ShipmentScheduleHandlerBL implements IShipmentScheduleHandlerBL
 	@Override
 	public ShipmentScheduleHandler getHandlerFor(@NonNull final I_M_ShipmentSchedule sched)
 	{
-		final String tableName = adTableDAO.retrieveTableName(sched.getAD_Table_ID());
-
-		final ShipmentScheduleHandler shipmentScheduleHandler = tableName2Handler.get(tableName);
+		final ShipmentScheduleHandler shipmentScheduleHandler = getHandlerForOrNull(sched);
 		if (shipmentScheduleHandler == null)
 		{
+			final String tableName = adTableDAO.retrieveTableName(sched.getAD_Table_ID());
 			throw new AdempiereException("No shipment schedule handler defined for " + tableName + " (" + sched + ")");
 		}
 
 		return shipmentScheduleHandler;
+	}
+
+	@Override
+	@Nullable
+	public ShipmentScheduleHandler getHandlerForOrNull(@NonNull final I_M_ShipmentSchedule sched)
+	{
+		final String tableName = adTableDAO.retrieveTableName(sched.getAD_Table_ID());
+		return tableName2Handler.get(tableName);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5817360_sys_gh31403_HUAggregation_M_Attribute_field_description.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5817360_sys_gh31403_HUAggregation_M_Attribute_field_description.sql
@@ -1,0 +1,70 @@
+-- gh31403: clarify the "Merkmal" (M_Attribute) field description in the HU-Aggregation tab
+-- (Window 540150 "Lieferkandidaten - Handler" -> tab M_ShipmentSchedule_AttributeConfig, AD_Field 563057).
+--
+-- The field reuses the generic shared element 2015 ("Produkt-Merkmal / Product Attribute like Color, Size"),
+-- which says nothing about what listing an attribute here actually does. Give the field a dedicated
+-- description/help via AD_Field.AD_Name_ID -> a NEW AD_Element (585152), leaving the shared element 2015
+-- untouched (it backs every M_Attribute field system-wide).
+--
+-- Behaviour documented (kept technical HERE, plain-language in the user-facing text below):
+-- an attribute listed here splits the picked-qty allocation (M_ShipmentSchedule_QtyPicked) and the shipment
+-- line (M_InOutLine) per distinct value; it makes NO statement about whether the attribute is carried on the
+-- HU/stock (that is M_HU_PI_Attribute.UseInASI, an independent setting).
+
+-- 1. New name-only AD_Element (ColumnName NULL; overrides only this field's name/description/help)
+INSERT INTO AD_Element (AD_Client_ID, AD_Element_ID, AD_Org_ID, ColumnName, Created, CreatedBy,
+                        Description, EntityType, IsActive, Name, PrintName, Updated, UpdatedBy)
+VALUES (0, 585152 /*From ID Server*/, 0, NULL,
+        TO_TIMESTAMP('2026-08-04 09:01:00', 'YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', 100,
+        'Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen und Mengenbuchungen gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus.',
+        'de.metas.inoutcandidate', 'Y',
+        'Merkmal', 'Merkmal',
+        TO_TIMESTAMP('2026-08-04 09:01:00', 'YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', 100);
+
+-- 2. AD_Element_Trl skeleton rows for all system + base languages
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, CommitWarning, Description, Help, Name,
+                            PO_Description, PO_Help, PO_Name, PO_PrintName, PrintName,
+                            WEBUI_NameBrowse, WEBUI_NameNew, WEBUI_NameNewBreadcrumb,
+                            IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning, t.Description, t.Help, t.Name,
+       t.PO_Description, t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName,
+       t.WEBUI_NameBrowse, t.WEBUI_NameNew, t.WEBUI_NameNewBreadcrumb,
+       'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive = 'Y' AND (l.IsSystemLanguage = 'Y' OR l.IsBaseLanguage = 'Y')
+  AND t.AD_Element_ID = 585152
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt
+                  WHERE tt.AD_Language = l.AD_Language AND tt.AD_Element_ID = t.AD_Element_ID);
+
+-- 3. Per-language text (de_DE + de_CH = German, en_US = English). Later timestamp than the element INSERT
+--    so the propagation guard (f.updated <> e_trl.updated) always fires.
+UPDATE AD_Element_Trl SET Name='Merkmal',
+    Description='Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen und Mengenbuchungen gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus.',
+    Help='Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen und Mengenbuchungen gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus. Ob ein Merkmal am Bestand geführt wird, wird dagegen in der Packvorschrift eingestellt und ist von dieser Konfiguration unabhängig.',
+    IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-04 09:01:30','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Element_ID = 585152 AND AD_Language IN ('de_DE','de_CH');
+
+UPDATE AD_Element_Trl SET Name='Attribute',
+    Description='Attributes that split shipment lines. Picked goods that differ in a listed attribute (e.g. Country of Origin, Lot) are booked to separate shipment lines and picked-quantity allocations. Attributes not listed here do not cause a shipment-line split.',
+    Help='Attributes that split shipment lines. Picked goods that differ in a listed attribute (e.g. Country of Origin, Lot) are booked to separate shipment lines and picked-quantity allocations. Attributes not listed here do not cause a shipment-line split. Whether an attribute is carried on stock is configured separately in the packing instruction and is independent of this configuration.',
+    IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-04 09:01:30','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Element_ID = 585152 AND AD_Language = 'en_US';
+
+-- 4. Propagate element translations
+/* DDL */ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585152, 'de_DE');
+/* DDL */ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585152, 'en_US');
+
+-- 5. Point the field at the new element (earlier timestamp than the element, so the propagation guard fires)
+UPDATE AD_Field
+SET AD_Name_ID = 585152,
+    Description = 'Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen und Mengenbuchungen gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus.',
+    Help        = 'Merkmale, die Lieferpositionen aufteilen. Kommissionierte Waren, die sich in einem hier aufgeführten Merkmal unterscheiden (z. B. Herkunftsland, Los), werden auf getrennte Lieferpositionen und Mengenbuchungen gebucht. Nicht hier aufgeführte Merkmale lösen keine Aufteilung aus. Ob ein Merkmal am Bestand geführt wird, wird dagegen in der Packvorschrift eingestellt und ist von dieser Konfiguration unabhängig.',
+    Updated = TO_TIMESTAMP('2026-08-04 09:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy = 100
+WHERE AD_Field_ID = 563057;
+
+-- 6. Propagate the new name element to the field's translations
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(585152);
+
+-- 7. Recreate the element link for the field
+DELETE FROM AD_Element_Link WHERE AD_Field_ID = 563057;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(563057);


### PR DESCRIPTION
## What

Propagates `deep_tundra_release` → `new_dawn_uat` (merge-through), carrying up the nShift-COO QtyPicked-split fix (https://github.com/metasfresh/metasfresh/pull/25416) plus all other `deep_tundra_release` commits not yet on `new_dawn_uat`.

## Conflict resolution

One conflict — `backend/de.metas.handlingunits.base/.../HUShipmentScheduleBL.java`, an **imports** block. `new_dawn_uat` already carries the same `createCandidatesForQtyPicked`/`computeUseInASIFingerprint` code (the buggy unfiltered fingerprint this fix corrects) and its imports; the incoming side re-added 9 imports at a different position. Resolved by keeping `new_dawn_uat`'s existing imports and adding only the one genuinely-new import the fix needs (`org.adempiere.mm.attributes.api.IAttributeDAO`); the other 8 were already present (or comment-only). The fix's method bodies (`attributeSplitsShipmentLinePredicate`, the `M_ShipmentSchedule_AttributeConfig` filter, the null-safe `getHandlerForOrNull`) auto-merged cleanly onto `new_dawn_uat`'s version — verified present.

## Merge type

**Merge commit — NOT squash** (branch-through PR; squashing would destroy the parent relationship and re-conflict future merges).

## Migration / DDL

Carries migration `5817360` (AD field-description override) — auto-merge is disabled; a developer verifies/merges manually.
