### PR TITLE
gh31289: recompute batch skips a handler-less shipment schedule instead of aborting

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -137,8 +137,8 @@ import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
-import java.util.Collection;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -179,8 +179,8 @@ public class M_ShipmentSchedule_StepDef
 	private final Map<String, PInstanceId> recomputeSelectionsByIdentifier = new HashMap<>();
 
 	/**
-	 * gh31289: M_ShipmentSchedule_IDs seeded by {@link #seedShipmentSchedulesWithUntaggedRecomputeMarker}.
-	 * They carry a self-referential AD_Table_ID with no registered handler; {@link #deleteSeededRecomputeSchedules()}
+	 * M_ShipmentSchedule_IDs seeded by {@link #seedShipmentSchedulesWithUntaggedRecomputeMarker}. They carry
+	 * a self-referential AD_Table_ID with no registered handler; {@link #deleteSeededRecomputeSchedules()}
 	 * removes them (markers + rows) after the scenario so they cannot leak into another scenario's recompute
 	 * sweep and jam the whole UpdateInvalidShipmentSchedules batch.
 	 */
@@ -360,11 +360,11 @@ public class M_ShipmentSchedule_StepDef
 	}
 
 	/**
-	 * gh31289: remove the schedules seeded by {@link #seedShipmentSchedulesWithUntaggedRecomputeMarker} (and
-	 * their recompute markers, any tag state) after each scenario. Those rows have a self-referential
-	 * AD_Table_ID with no registered handler; if they survive into a later scenario in the same JVM/DB, the
-	 * always-on UpdateInvalidShipmentSchedulesWorkpackageProcessor sweeps them and (pre-fix) aborts the whole
-	 * recompute batch, so unrelated features' schedules never get recomputed. No-op when nothing was seeded.
+	 * Remove the schedules seeded by {@link #seedShipmentSchedulesWithUntaggedRecomputeMarker} (and their
+	 * recompute markers, any tag state) after each scenario. Those rows have a self-referential AD_Table_ID
+	 * with no registered handler; if they survive into a later scenario in the same JVM/DB, the always-on
+	 * UpdateInvalidShipmentSchedulesWorkpackageProcessor sweeps them and aborts the whole recompute batch, so
+	 * unrelated features' schedules never get recomputed. No-op when nothing was seeded.
 	 */
 	@After
 	public void deleteSeededRecomputeSchedules()

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -96,6 +96,7 @@ import de.metas.util.Services;
 
 import java.time.ZoneId;
 import io.cucumber.datatable.DataTable;
+import io.cucumber.java.After;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -137,6 +138,7 @@ import org.slf4j.Logger;
 import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.util.Collection;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -175,6 +177,14 @@ public class M_ShipmentSchedule_StepDef
 
 	/** Recompute selection ids created by {@link #tagInvalidShipmentSchedulesForRecompute}, keyed by the scenario's selection identifier. */
 	private final Map<String, PInstanceId> recomputeSelectionsByIdentifier = new HashMap<>();
+
+	/**
+	 * gh31289: M_ShipmentSchedule_IDs seeded by {@link #seedShipmentSchedulesWithUntaggedRecomputeMarker}.
+	 * They carry a self-referential AD_Table_ID with no registered handler; {@link #deleteSeededRecomputeSchedules()}
+	 * removes them (markers + rows) after the scenario so they cannot leak into another scenario's recompute
+	 * sweep and jam the whole UpdateInvalidShipmentSchedules batch.
+	 */
+	private final List<Integer> seededRecomputeScheduleIds = new ArrayList<>();
 
 	@NonNull private final AD_User_StepDefData userTable;
 	@NonNull private final C_BPartner_StepDefData bpartnerTable;
@@ -350,6 +360,35 @@ public class M_ShipmentSchedule_StepDef
 	}
 
 	/**
+	 * gh31289: remove the schedules seeded by {@link #seedShipmentSchedulesWithUntaggedRecomputeMarker} (and
+	 * their recompute markers, any tag state) after each scenario. Those rows have a self-referential
+	 * AD_Table_ID with no registered handler; if they survive into a later scenario in the same JVM/DB, the
+	 * always-on UpdateInvalidShipmentSchedulesWorkpackageProcessor sweeps them and (pre-fix) aborts the whole
+	 * recompute batch, so unrelated features' schedules never get recomputed. No-op when nothing was seeded.
+	 */
+	@After
+	public void deleteSeededRecomputeSchedules()
+	{
+		if (seededRecomputeScheduleIds.isEmpty())
+		{
+			return;
+		}
+
+		// markers first (they reference M_ShipmentSchedule), then the schedule rows; deleteDirectly issues a
+		// single bulk DELETE (M_ShipmentSchedule_Recompute is a keyless queue table -- see the sibling method).
+		queryBL.createQueryBuilder(I_M_ShipmentSchedule_Recompute.class)
+				.addInArrayFilter(I_M_ShipmentSchedule_Recompute.COLUMNNAME_M_ShipmentSchedule_ID, seededRecomputeScheduleIds)
+				.create()
+				.deleteDirectly();
+		queryBL.createQueryBuilder(I_M_ShipmentSchedule.class)
+				.addInArrayFilter(I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID, seededRecomputeScheduleIds)
+				.create()
+				.deleteDirectly();
+
+		seededRecomputeScheduleIds.clear();
+	}
+
+	/**
 	 * Seeds the whole-product recompute-batching fixture DIRECTLY: each DataTable row inserts one minimal
 	 * {@code M_ShipmentSchedule} for the given product plus exactly one UNTAGGED
 	 * {@code M_ShipmentSchedule_Recompute} marker ({@code AD_PInstance_ID IS NULL}), and stores the schedule
@@ -434,6 +473,7 @@ public class M_ShipmentSchedule_StepDef
 					.firstOnlyNotNull(I_M_ShipmentSchedule.class);
 
 			shipmentScheduleTable.put(row.getAsIdentifier(), schedule);
+			seededRecomputeScheduleIds.add(shipmentScheduleId);
 		});
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA.java
@@ -9,10 +9,13 @@ import de.metas.cache.CacheMgt;
 import de.metas.cache.model.CacheInvalidateMultiRequest;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.inout.model.I_M_InOutLine;
+import de.metas.error.IErrorManager;
 import de.metas.inoutcandidate.api.IShipmentScheduleAllocDAO;
+import de.metas.inoutcandidate.api.IShipmentScheduleHandlerBL;
 import de.metas.inoutcandidate.api.IShipmentSchedulePA;
 import de.metas.inoutcandidate.api.OlAndSched;
 import de.metas.inoutcandidate.exportaudit.APIExportStatus;
+import com.google.common.annotations.VisibleForTesting;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateRepository;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.interfaces.I_C_OrderLine;
@@ -301,7 +304,8 @@ public class ShipmentSchedulePA implements IShipmentSchedulePA
 		return OrderAndLineId.ofRepoIdsOrNull(shipmentSchedule.getC_Order_ID(), shipmentSchedule.getC_OrderLine_ID());
 	}
 
-	private List<OlAndSched> createOlAndScheds(final List<I_M_ShipmentSchedule> shipmentSchedules)
+	@VisibleForTesting
+	List<OlAndSched> createOlAndScheds(final List<I_M_ShipmentSchedule> shipmentSchedules)
 	{
 		final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
 
@@ -318,8 +322,20 @@ public class ShipmentSchedulePA implements IShipmentSchedulePA
 
 		final List<OlAndSched> result = new ArrayList<>();
 
+		final IShipmentScheduleHandlerBL shipmentScheduleHandlerBL = Services.get(IShipmentScheduleHandlerBL.class);
+
 		for (final I_M_ShipmentSchedule schedule : shipmentSchedules)
 		{
+			// gh31289: a schedule whose AD_Table_ID has no registered handler cannot be recomputed. Skip it
+			// (surfaced as an AD_Issue) instead of letting OlAndSched -> getHandlerFor throw and abort the
+			// WHOLE batch -- one such row (a #25200 self-referential test-seed row, or genuine data
+			// corruption) would otherwise jam every other schedule in the recompute queue.
+			if (shipmentScheduleHandlerBL.getHandlerForOrNull(schedule) == null)
+			{
+				reportHandlerlessScheduleAndSkip(schedule);
+				continue;
+			}
+
 			final OrderAndLineId orderLineId = extractOrderAndLineId(schedule);
 			final I_C_OrderLine orderLine;
 			final I_C_Order order;
@@ -342,6 +358,32 @@ public class ShipmentSchedulePA implements IShipmentSchedulePA
 			result.add(olAndSched);
 		}
 		return result;
+	}
+
+	/**
+	 * gh31289: report (as an AD_Issue) a shipment schedule whose {@code AD_Table_ID} has no registered
+	 * {@link de.metas.inoutcandidate.spi.ShipmentScheduleHandler}, so it stays visible while the recompute
+	 * batch continues. Its {@code M_ShipmentSchedule_Recompute} marker is cleared with the rest of the batch
+	 * (tagged with this pass's selection) at the end of the pass, so it is not re-swept forever.
+	 */
+	private void reportHandlerlessScheduleAndSkip(@NonNull final I_M_ShipmentSchedule schedule)
+	{
+		final AdempiereException issue = new AdempiereException(
+				"Skipping M_ShipmentSchedule with no registered ShipmentScheduleHandler for its AD_Table_ID"
+						+ " (it cannot be recomputed): " + schedule);
+		logger.warn(issue.getLocalizedMessage(), issue);
+
+		// Before gh31289 the thrown exception aborted the workpackage and was recorded as an AD_Issue by the
+		// async error handler; now that we no longer abort, raise the AD_Issue explicitly. Best-effort:
+		// creating the issue must never itself break the recompute pass.
+		try
+		{
+			Services.get(IErrorManager.class).createIssue(issue);
+		}
+		catch (final Exception issueCreationFailed)
+		{
+			logger.warn("Failed to create AD_Issue for handler-less M_ShipmentSchedule", issueCreationFailed);
+		}
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA.java
@@ -1,5 +1,6 @@
 package de.metas.inoutcandidate.api.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -7,15 +8,14 @@ import com.google.common.collect.Maps;
 import de.metas.bpartner.BPartnerId;
 import de.metas.cache.CacheMgt;
 import de.metas.cache.model.CacheInvalidateMultiRequest;
+import de.metas.error.IErrorManager;
 import de.metas.inout.ShipmentScheduleId;
 import de.metas.inout.model.I_M_InOutLine;
-import de.metas.error.IErrorManager;
 import de.metas.inoutcandidate.api.IShipmentScheduleAllocDAO;
 import de.metas.inoutcandidate.api.IShipmentScheduleHandlerBL;
 import de.metas.inoutcandidate.api.IShipmentSchedulePA;
 import de.metas.inoutcandidate.api.OlAndSched;
 import de.metas.inoutcandidate.exportaudit.APIExportStatus;
-import com.google.common.annotations.VisibleForTesting;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateRepository;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.interfaces.I_C_OrderLine;
@@ -326,10 +326,10 @@ public class ShipmentSchedulePA implements IShipmentSchedulePA
 
 		for (final I_M_ShipmentSchedule schedule : shipmentSchedules)
 		{
-			// gh31289: a schedule whose AD_Table_ID has no registered handler cannot be recomputed. Skip it
-			// (surfaced as an AD_Issue) instead of letting OlAndSched -> getHandlerFor throw and abort the
-			// WHOLE batch -- one such row (a #25200 self-referential test-seed row, or genuine data
-			// corruption) would otherwise jam every other schedule in the recompute queue.
+			// A schedule whose AD_Table_ID has no registered handler cannot be recomputed. Skip it (surfaced
+			// as an AD_Issue) instead of letting OlAndSched -> getHandlerFor throw and abort the WHOLE batch --
+			// one such row (a self-referential test-seed row, or genuine data corruption) would otherwise jam
+			// every other schedule in the recompute queue.
 			if (shipmentScheduleHandlerBL.getHandlerForOrNull(schedule) == null)
 			{
 				reportHandlerlessScheduleAndSkip(schedule);
@@ -361,7 +361,7 @@ public class ShipmentSchedulePA implements IShipmentSchedulePA
 	}
 
 	/**
-	 * gh31289: report (as an AD_Issue) a shipment schedule whose {@code AD_Table_ID} has no registered
+	 * Report (as an AD_Issue) a shipment schedule whose {@code AD_Table_ID} has no registered
 	 * {@link de.metas.inoutcandidate.spi.ShipmentScheduleHandler}, so it stays visible while the recompute
 	 * batch continues. Its {@code M_ShipmentSchedule_Recompute} marker is cleared with the rest of the batch
 	 * (tagged with this pass's selection) at the end of the pass, so it is not re-swept forever.
@@ -373,9 +373,9 @@ public class ShipmentSchedulePA implements IShipmentSchedulePA
 						+ " (it cannot be recomputed): " + schedule);
 		logger.warn(issue.getLocalizedMessage(), issue);
 
-		// Before gh31289 the thrown exception aborted the workpackage and was recorded as an AD_Issue by the
-		// async error handler; now that we no longer abort, raise the AD_Issue explicitly. Best-effort:
-		// creating the issue must never itself break the recompute pass.
+		// A handler-less schedule cannot be recomputed; since the pass no longer aborts on it, raise the
+		// AD_Issue explicitly to keep it visible. Best-effort: creating the issue must never itself break
+		// the recompute pass.
 		try
 		{
 			Services.get(IErrorManager.class).createIssue(issue);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA.java
@@ -67,6 +67,8 @@ public class ShipmentSchedulePA implements IShipmentSchedulePA
 {
 	private final static Logger logger = LogManager.getLogger(ShipmentSchedulePA.class);
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	private final IShipmentScheduleHandlerBL shipmentScheduleHandlerBL = Services.get(IShipmentScheduleHandlerBL.class);
+	private final IErrorManager errorManager = Services.get(IErrorManager.class);
 
 	/**
 	 * When mass cache invalidation, above this threshold we will invalidate ALL shipment schedule records instead of particular IDS
@@ -322,8 +324,6 @@ public class ShipmentSchedulePA implements IShipmentSchedulePA
 
 		final List<OlAndSched> result = new ArrayList<>();
 
-		final IShipmentScheduleHandlerBL shipmentScheduleHandlerBL = Services.get(IShipmentScheduleHandlerBL.class);
-
 		for (final I_M_ShipmentSchedule schedule : shipmentSchedules)
 		{
 			// A schedule whose AD_Table_ID has no registered handler cannot be recomputed. Skip it (surfaced
@@ -378,7 +378,7 @@ public class ShipmentSchedulePA implements IShipmentSchedulePA
 		// the recompute pass.
 		try
 		{
-			Services.get(IErrorManager.class).createIssue(issue);
+			errorManager.createIssue(issue);
 		}
 		catch (final Exception issueCreationFailed)
 		{

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA_createOlAndScheds_handlerlessSchedule_Test.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA_createOlAndScheds_handlerlessSchedule_Test.java
@@ -1,5 +1,27 @@
 package de.metas.inoutcandidate.api.impl;
 
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,37 +47,13 @@ import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.inoutcandidate.spi.ShipmentScheduleHandler;
 import de.metas.util.Services;
 
-/*
- * #%L
- * de.metas.swat.base
- * %%
- * Copyright (C) 2026 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
-
 /**
- * gh31289: a single {@link I_M_ShipmentSchedule} whose {@code AD_Table_ID} has no registered
- * {@link ShipmentScheduleHandler} must NOT abort the whole recompute batch.
- * <p>
- * Before the fix {@link ShipmentSchedulePA#createOlAndScheds(List)} let the "No shipment schedule handler
- * defined for ..." exception propagate, so one bad row (the self-referential test-seed rows from #25200, or
- * genuine data corruption) rolled back the entire {@code UpdateInvalidShipmentSchedules} batch and jammed
- * every other schedule in the recompute queue. After the fix the handler-less schedule is skipped (and
- * surfaced as an {@code AD_Issue}) while the resolvable schedules are still processed.
+ * A single {@link I_M_ShipmentSchedule} whose {@code AD_Table_ID} has no registered
+ * {@link ShipmentScheduleHandler} must NOT abort the whole recompute batch:
+ * {@link ShipmentSchedulePA#createOlAndScheds(List)} must skip the handler-less schedule (surfaced as an
+ * {@code AD_Issue}) and still process the resolvable schedules in the same batch, rather than letting the
+ * "No shipment schedule handler defined for ..." exception propagate and roll back the entire
+ * {@code UpdateInvalidShipmentSchedules} batch (which would jam every other schedule in the recompute queue).
  */
 class ShipmentSchedulePA_createOlAndScheds_handlerlessSchedule_Test
 {
@@ -88,7 +86,7 @@ class ShipmentSchedulePA_createOlAndScheds_handlerlessSchedule_Test
 		final I_M_ShipmentSchedule sched = newInstance(I_M_ShipmentSchedule.class);
 		sched.setAD_Table_ID(adTableId);
 		saveRecord(sched);
-		// self-referential Record_ID, exactly like the #25200 seed step (not read by createOlAndScheds)
+		// self-referential Record_ID, like the recompute-batching seed fixture (not read by createOlAndScheds)
 		sched.setRecord_ID(sched.getM_ShipmentSchedule_ID());
 		saveRecord(sched);
 		return sched;
@@ -103,7 +101,7 @@ class ShipmentSchedulePA_createOlAndScheds_handlerlessSchedule_Test
 		final I_M_ShipmentSchedule resolvable = createScheduleFor(resolvableTableId);
 
 		// handler-less: a self-referential M_ShipmentSchedule table id with NO registered handler
-		// (mirrors the #25200 seedShipmentSchedulesWithUntaggedRecomputeMarker poison row)
+		// (mirrors the seedShipmentSchedulesWithUntaggedRecomputeMarker poison row)
 		final int handlerlessTableId = createTable(I_M_ShipmentSchedule.Table_Name);
 		final I_M_ShipmentSchedule handlerless = createScheduleFor(handlerlessTableId);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA_createOlAndScheds_handlerlessSchedule_Test.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA_createOlAndScheds_handlerlessSchedule_Test.java
@@ -1,0 +1,167 @@
+package de.metas.inoutcandidate.api.impl;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+
+import org.adempiere.ad.dao.QueryLimit;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_AD_Table;
+import org.compiere.model.I_C_OrderLine;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import de.metas.inoutcandidate.api.IDeliverRequest;
+import de.metas.inoutcandidate.api.IShipmentScheduleHandlerBL;
+import de.metas.inoutcandidate.api.OlAndSched;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.inoutcandidate.spi.ShipmentScheduleHandler;
+import de.metas.util.Services;
+
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * gh31289: a single {@link I_M_ShipmentSchedule} whose {@code AD_Table_ID} has no registered
+ * {@link ShipmentScheduleHandler} must NOT abort the whole recompute batch.
+ * <p>
+ * Before the fix {@link ShipmentSchedulePA#createOlAndScheds(List)} let the "No shipment schedule handler
+ * defined for ..." exception propagate, so one bad row (the self-referential test-seed rows from #25200, or
+ * genuine data corruption) rolled back the entire {@code UpdateInvalidShipmentSchedules} batch and jammed
+ * every other schedule in the recompute queue. After the fix the handler-less schedule is skipped (and
+ * surfaced as an {@code AD_Issue}) while the resolvable schedules are still processed.
+ */
+class ShipmentSchedulePA_createOlAndScheds_handlerlessSchedule_Test
+{
+	private ShipmentSchedulePA shipmentSchedulePA;
+	private ShipmentScheduleHandlerBL shipmentScheduleHandlerBL;
+
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		shipmentScheduleHandlerBL = new ShipmentScheduleHandlerBL();
+		Services.registerService(IShipmentScheduleHandlerBL.class, shipmentScheduleHandlerBL);
+
+		shipmentSchedulePA = new ShipmentSchedulePA();
+	}
+
+	private int createTable(final String tableName)
+	{
+		final I_AD_Table table = newInstance(I_AD_Table.class);
+		table.setTableName(tableName);
+		table.setName(tableName);
+		table.setEntityType("D");
+		saveRecord(table);
+		return table.getAD_Table_ID();
+	}
+
+	private I_M_ShipmentSchedule createScheduleFor(final int adTableId)
+	{
+		final I_M_ShipmentSchedule sched = newInstance(I_M_ShipmentSchedule.class);
+		sched.setAD_Table_ID(adTableId);
+		saveRecord(sched);
+		// self-referential Record_ID, exactly like the #25200 seed step (not read by createOlAndScheds)
+		sched.setRecord_ID(sched.getM_ShipmentSchedule_ID());
+		saveRecord(sched);
+		return sched;
+	}
+
+	@Test
+	void createOlAndScheds_skipsHandlerlessSchedule_insteadOfAbortingTheBatch()
+	{
+		// resolvable: a table WITH a registered handler
+		final int resolvableTableId = createTable(I_C_OrderLine.Table_Name);
+		shipmentScheduleHandlerBL.registerHandler(new StubHandler(I_C_OrderLine.Table_Name));
+		final I_M_ShipmentSchedule resolvable = createScheduleFor(resolvableTableId);
+
+		// handler-less: a self-referential M_ShipmentSchedule table id with NO registered handler
+		// (mirrors the #25200 seedShipmentSchedulesWithUntaggedRecomputeMarker poison row)
+		final int handlerlessTableId = createTable(I_M_ShipmentSchedule.Table_Name);
+		final I_M_ShipmentSchedule handlerless = createScheduleFor(handlerlessTableId);
+
+		// handler-less schedule first, so the old code aborts before ever reaching the resolvable one
+		final List<OlAndSched> result = shipmentSchedulePA.createOlAndScheds(
+				ImmutableList.of(handlerless, resolvable));
+
+		assertThat(result)
+				.as("the handler-less schedule is skipped; the resolvable one is still processed (batch not aborted)")
+				.hasSize(1);
+		assertThat(result.get(0).getShipmentScheduleId().getRepoId())
+				.isEqualTo(resolvable.getM_ShipmentSchedule_ID());
+	}
+
+	/** Minimal handler: resolves for its source table and returns a trivial deliver-request. */
+	private static class StubHandler extends ShipmentScheduleHandler
+	{
+		private final String sourceTable;
+
+		StubHandler(final String sourceTable)
+		{
+			this.sourceTable = sourceTable;
+		}
+
+		@Override
+		public String getSourceTable()
+		{
+			return sourceTable;
+		}
+
+		@Override
+		public IDeliverRequest createDeliverRequest(final I_M_ShipmentSchedule sched, final I_C_OrderLine salesOrderLine)
+		{
+			return () -> BigDecimal.ZERO;
+		}
+
+		@Override
+		public Iterator<?> retrieveModelsWithMissingCandidates(final Properties ctx, final String trxName, final QueryLimit limit)
+		{
+			throw new UnsupportedOperationException("not exercised by this test");
+		}
+
+		@Override
+		public List<I_M_ShipmentSchedule> createCandidatesFor(final Object model)
+		{
+			throw new UnsupportedOperationException("not exercised by this test");
+		}
+
+		@Override
+		public void updateShipmentScheduleFromReferencedRecord(final I_M_ShipmentSchedule shipmentSchedule)
+		{
+			// not exercised by this test
+		}
+
+		@Override
+		public void invalidateCandidatesFor(final Object model)
+		{
+			// not exercised by this test
+		}
+	}
+}


### PR DESCRIPTION
## What

A cucumber seed fixture (`M_ShipmentSchedule_StepDef.seedShipmentSchedulesWithUntaggedRecomputeMarker`, from https://github.com/metasfresh/metasfresh/pull/25200) raw-INSERTs `M_ShipmentSchedule` rows with a **self-referential `AD_Table_ID`** (= the `M_ShipmentSchedule` table itself) plus an untagged recompute marker. The always-on `UpdateInvalidShipmentSchedulesWorkpackageProcessor` sweeps those markers DB-wide in one-transaction batches; the handler-less row makes `ShipmentScheduleHandlerBL.getHandlerFor` throw, which **aborts the whole batch** — so no schedule in the recompute queue gets recomputed. Symptom: profile6/profile7 picking scenarios time out on `M_ShipmentSchedules are found: | IsToRecompute | N |` (their schedule's recompute never settles); orphan rows + `AD_Issue`s were also observed accumulating on the base branch.

## Fix — two parts

1. **Product robustness — `ShipmentSchedulePA.createOlAndScheds`.** Resolve each schedule's handler via `getHandlerForOrNull`; a handler-less schedule is logged + recorded as an `AD_Issue` and **skipped** instead of aborting the batch. One bad row (test poison, or genuine data corruption / a schedule whose source-module handler is not loaded) can no longer jam the whole recompute queue.
2. **Fixture hermeticity — `M_ShipmentSchedule_StepDef`.** Track the seeded IDs; an `@After` deletes their recompute markers (any tag state) then the schedule rows, so the poison cannot leak into another scenario's recompute sweep. The https://github.com/metasfresh/metasfresh/pull/25200 direct-seed design (deliberately not using the order pipeline, to keep the tag-count assertions deterministic) is otherwise untouched.

## Test

New JUnit `ShipmentSchedulePA_createOlAndScheds_handlerlessSchedule_Test`: a handler-less schedule + a resolvable schedule in the same batch. **RED** before (throws `No shipment schedule handler defined for M_ShipmentSchedule`, aborting the batch); **GREEN** after (handler-less skipped, resolvable still processed). Run locally (JDK 8) — 1 run, 0 failures.

## Why it was intermittent (not branch-specific)

https://github.com/metasfresh/metasfresh/pull/25200 is an ancestor of **both** this base branch and `new_dawn_uat` (byte-identical fixture). It only fails when CI's per-run **profile partitioning** places the batching feature in the same profile as picking scenarios (shared JVM/DB) — which is why a green run and a red run can share the same code.
