### PR TITLE
Material events: stop the self-perpetuating completion-tracker cycle

### DIFF
--- a/backend/de.metas.material/event/src/main/java/de/metas/material/event/MaterialEventHandlerRegistry.java
+++ b/backend/de.metas.material/event/src/main/java/de/metas/material/event/MaterialEventHandlerRegistry.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableListMultimap;
 import de.metas.event.log.EventLogUserService;
 import de.metas.event.log.EventLogUserService.InvokeHandlerAndLogRequest;
 import de.metas.logging.LogManager;
+import de.metas.material.event.tracking.AllEventsProcessedEvent;
 import lombok.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
@@ -94,7 +95,11 @@ public class MaterialEventHandlerRegistry
 			}
 		}
 
-		if (!handlersForEventClass.isEmpty())
+		// AllEventsProcessedEvent is a bookkeeping signal, not tracked work: it was never enqueue()d for its trace,
+		// so counting it as "processed" here would add a spurious entry to that trace's EventProgress (see
+		// MaterialEventObserver.reportEventProcessed). Handler dispatch above is unaffected -- this only skips the
+		// tracking side-effect for this one event type.
+		if (!handlersForEventClass.isEmpty() && !(event instanceof AllEventsProcessedEvent))
 		{
 			materialEventObserver.reportEventProcessed(event);
 		}

--- a/backend/de.metas.material/event/src/main/java/de/metas/material/event/MaterialEventObserver.java
+++ b/backend/de.metas.material/event/src/main/java/de/metas/material/event/MaterialEventObserver.java
@@ -103,14 +103,18 @@ public class MaterialEventObserver
 			return;
 		}
 
-		if (traceId2EventProgress.get(traceId) == null)
-		{
-			observe(traceId);
-		}
-
 		final EventProgress eventProgress = traceId2EventProgress.get(traceId);
 
-		Check.assumeNotNull(eventProgress, "EventProgress cannot be null at this point! It is initialized on `observe(traceId)`");
+		if (eventProgress == null)
+		{
+			// A tracking entry exists only while some caller is awaiting that trace via awaitProcessing(traceId).
+			// There is none here, so nobody is waiting and there is nothing to track.
+			// Registering the trace at this point would be actively harmful: the freshly created EventProgress would
+			// immediately look "all processed", we would post an AllEventsProcessedEvent for a trace nobody asked
+			// about, and that event comes back in as yet another processed event for an unobserved trace -- a cycle
+			// that keeps the material-events queue busy until the awaiting caller times out.
+			return;
+		}
 
 		eventProgress.markAsProcessed(event.getEventId());
 

--- a/backend/de.metas.material/event/src/main/java/de/metas/material/event/tracking/EventProgress.java
+++ b/backend/de.metas.material/event/src/main/java/de/metas/material/event/tracking/EventProgress.java
@@ -57,8 +57,11 @@ public class EventProgress
 
 	public boolean areAllEventsProcessed()
 	{
-		return eventId2Status.values()
-				.stream()
-				.allMatch(PROCESSED::equals);
+		// eventId2Status.values().stream().allMatch(..) is vacuously true on an empty map; a trace for which
+		// nothing was ever enqueue()d must not be reported as "all processed".
+		return !eventId2Status.isEmpty()
+				&& eventId2Status.values()
+						.stream()
+						.allMatch(PROCESSED::equals);
 	}
 }

--- a/backend/de.metas.material/event/src/main/java/de/metas/material/event/tracking/EventProgress.java
+++ b/backend/de.metas.material/event/src/main/java/de/metas/material/event/tracking/EventProgress.java
@@ -57,8 +57,13 @@ public class EventProgress
 
 	public boolean areAllEventsProcessed()
 	{
-		// eventId2Status.values().stream().allMatch(..) is vacuously true on an empty map; a trace for which
-		// nothing was ever enqueue()d must not be reported as "all processed".
+		// allMatch(..) is vacuously true on an empty map, and an empty map IS reachable here: the completion check
+		// runs from a deferred AFTER_COMMIT handler that re-looks-up the EventProgress by traceId at fire time
+		// (MaterialEventObserver.notifyIfAllEventsProcessed) rather than closing over the instance it was registered
+		// for. So if that traceId was meanwhile removed (awaitProcessing's finally, e.g. on timeout) and then
+		// re-observed -- trace ids do get reused, e.g. via DD_Order_Candidate's persisted DYNATTR_TraceId -- the
+		// lookup finds a FRESH, still-empty progress, and reporting that as "all processed" would announce
+		// completion for work the new trace has not even enqueued yet.
 		return !eventId2Status.isEmpty()
 				&& eventId2Status.values()
 						.stream()

--- a/backend/de.metas.material/event/src/main/java/de/metas/material/event/tracking/EventProgress.java
+++ b/backend/de.metas.material/event/src/main/java/de/metas/material/event/tracking/EventProgress.java
@@ -57,13 +57,13 @@ public class EventProgress
 
 	public boolean areAllEventsProcessed()
 	{
-		// allMatch(..) is vacuously true on an empty map, and an empty map IS reachable here: the completion check
-		// runs from a deferred AFTER_COMMIT handler that re-looks-up the EventProgress by traceId at fire time
-		// (MaterialEventObserver.notifyIfAllEventsProcessed) rather than closing over the instance it was registered
-		// for. So if that traceId was meanwhile removed (awaitProcessing's finally, e.g. on timeout) and then
-		// re-observed -- trace ids do get reused, e.g. via DD_Order_Candidate's persisted DYNATTR_TraceId -- the
-		// lookup finds a FRESH, still-empty progress, and reporting that as "all processed" would announce
-		// completion for work the new trace has not even enqueued yet.
+		// allMatch(..) is vacuously true on an empty map, so without the isEmpty() check a progress with nothing
+		// enqueued would report "all processed". That is reachable because the completion check does not run inline:
+		// it runs from a deferred AFTER_COMMIT handler that re-looks-up the EventProgress by traceId at fire time
+		// (MaterialEventObserver.notifyIfAllEventsProcessed) instead of closing over the instance it was registered
+		// for. If the entry under that traceId is removed (awaitProcessing's finally, e.g. on timeout) and a new one
+		// observed before the handler fires, the lookup finds a FRESH, still-empty progress -- and announcing
+		// completion for it would release an awaiter whose work has not even been enqueued yet.
 		return !eventId2Status.isEmpty()
 				&& eventId2Status.values()
 						.stream()

--- a/backend/de.metas.material/event/src/test/java/de/metas/material/event/MaterialEventObserverTest.java
+++ b/backend/de.metas.material/event/src/test/java/de/metas/material/event/MaterialEventObserverTest.java
@@ -100,7 +100,7 @@ public class MaterialEventObserverTest
 	}
 
 	/**
-	 * TC2: {@link MaterialEventHandlerRegistry#onEvent(MaterialEvent)} calls {@code reportEventProcessed} for every
+	 * {@link MaterialEventHandlerRegistry#onEvent(MaterialEvent)} calls {@code reportEventProcessed} for every
 	 * event class that has at least one registered handler -- including {@link AllEventsProcessedEvent} itself, which
 	 * always has the (real, production) {@link AllEventsProcessedEventHandler} registered. That bookkeeping event is
 	 * not "work" that was ever enqueued for the trace; counting it as processed work pollutes
@@ -110,7 +110,7 @@ public class MaterialEventObserverTest
 	void allEventsProcessedEvent_isNotCountedAsWork()
 	{
 		// given: an observed trace with one ordinary work event still outstanding (enqueued, not yet processed)
-		final String traceId = "tc2-trace-id";
+		final String traceId = "observed-trace-with-outstanding-work";
 		materialEventObserver.observe(traceId);
 
 		final MaterialEvent workEvent = DeactivateAllSimulatedCandidatesEvent.builder()
@@ -144,26 +144,19 @@ public class MaterialEventObserverTest
 	}
 
 	/**
-	 * TC3: {@link EventProgress#areAllEventsProcessed()} is {@code eventId2Status.values().stream().allMatch(...)},
-	 * which is vacuously {@code true} on an empty map. A trace for which nothing was ever enqueued must not be
+	 * {@link EventProgress#areAllEventsProcessed()} is {@code eventId2Status.values().stream().allMatch(...)},
+	 * which is vacuously {@code true} on an empty map. A progress for which nothing was ever enqueued must not be
 	 * reported as "all processed".
 	 */
 	@Test
 	void emptyProgress_isNotAllProcessed()
 	{
-		// given: an observed trace with nothing ever enqueued
-		final String traceId = "tc3-trace-id";
-		materialEventObserver.observe(traceId);
-
-		final EventProgress eventProgress = getTraceId2EventProgress(materialEventObserver).get(traceId);
-		assertThat(eventProgress).isNotNull();
-
-		// then
-		assertThat(eventProgress.areAllEventsProcessed()).isFalse();
+		// a freshly observed trace's progress, before anything was enqueued for it
+		assertThat(new EventProgress().areAllEventsProcessed()).isFalse();
 	}
 
 	/**
-	 * TC4: regression test for the normal completion path. Observes a trace, enqueues two ordinary work events,
+	 * Regression test for the normal completion path. Observes a trace, enqueues two ordinary work events,
 	 * reports both processed, and verifies: exactly one completion signal is posted, the caller awaiting that trace
 	 * is released, and -- since {@link MaterialEventObserver#awaitProcessing(String)} removes the entry in its
 	 * {@code finally} block -- the tracking entry is gone afterwards.
@@ -177,7 +170,7 @@ public class MaterialEventObserverTest
 	void normalCompletionPath_releasesAwaiterAndPostsOnce() throws Exception
 	{
 		// given: an observed trace with two outstanding work events
-		final String traceId = "tc4-trace-id";
+		final String traceId = "observed-trace-two-work-events";
 		materialEventObserver.observe(traceId);
 
 		final MaterialEvent workEvent1 = DeactivateAllSimulatedCandidatesEvent.builder()
@@ -199,6 +192,9 @@ public class MaterialEventObserverTest
 			materialEventObserver.awaitProcessing(traceId);
 			awaiterReleased.countDown();
 		});
+		// daemon: in the very regression this test guards against (awaiter never released) the latch below fails fast,
+		// but this thread would stay blocked in awaitProcessing for the full WaitTimeOutMS (5 min by default).
+		awaiterThread.setDaemon(true);
 		awaiterThread.start();
 
 		// when: both outstanding work events are reported processed

--- a/backend/de.metas.material/event/src/test/java/de/metas/material/event/MaterialEventObserverTest.java
+++ b/backend/de.metas.material/event/src/test/java/de/metas/material/event/MaterialEventObserverTest.java
@@ -48,6 +48,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -158,6 +160,78 @@ public class MaterialEventObserverTest
 
 		// then
 		assertThat(eventProgress.areAllEventsProcessed()).isFalse();
+	}
+
+	/**
+	 * TC4: regression test for the normal completion path. Observes a trace, enqueues two ordinary work events,
+	 * reports both processed, and verifies: exactly one completion signal is posted, the caller awaiting that trace
+	 * is released, and -- since {@link MaterialEventObserver#awaitProcessing(String)} removes the entry in its
+	 * {@code finally} block -- the tracking entry is gone afterwards.
+	 * <p>
+	 * The completion signal ({@link AllEventsProcessedEvent}) only releases the awaiter once it round-trips back
+	 * through {@link MaterialEventHandlerRegistry#onEvent(MaterialEvent)} (as it would via the real, distributed
+	 * event bus in production) and reaches the real {@link AllEventsProcessedEventHandler}. This test simulates that
+	 * round-trip explicitly instead of asserting it away.
+	 */
+	@Test
+	void normalCompletionPath_releasesAwaiterAndPostsOnce() throws Exception
+	{
+		// given: an observed trace with two outstanding work events
+		final String traceId = "tc4-trace-id";
+		materialEventObserver.observe(traceId);
+
+		final MaterialEvent workEvent1 = DeactivateAllSimulatedCandidatesEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientOrgAndTraceId(EventTestHelper.CLIENT_AND_ORG_ID, traceId))
+				.build();
+		final MaterialEvent workEvent2 = DeactivateAllSimulatedCandidatesEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientOrgAndTraceId(EventTestHelper.CLIENT_AND_ORG_ID, traceId))
+				.build();
+
+		materialEventObserver.reportEventEnqueued(workEvent1);
+		materialEventObserver.reportEventEnqueued(workEvent2);
+
+		final EventProgress eventProgress = getTraceId2EventProgress(materialEventObserver).get(traceId);
+		assertThat(eventProgress).isNotNull();
+
+		// and: a caller awaiting that trace's completion, on its own thread (awaitProcessing blocks)
+		final CountDownLatch awaiterReleased = new CountDownLatch(1);
+		final Thread awaiterThread = new Thread(() -> {
+			materialEventObserver.awaitProcessing(traceId);
+			awaiterReleased.countDown();
+		});
+		awaiterThread.start();
+
+		// when: both outstanding work events are reported processed
+		materialEventObserver.reportEventProcessed(workEvent1);
+		materialEventObserver.reportEventProcessed(workEvent2);
+
+		// then: exactly one completion signal was posted to the bus, for this trace
+		final List<MaterialEvent> postedEvents = postMaterialEventService.getPostedEvents();
+		assertThat(postedEvents).hasSize(1);
+		assertThat(postedEvents.get(0)).isInstanceOf(AllEventsProcessedEvent.class);
+		final AllEventsProcessedEvent allEventsProcessedEvent = (AllEventsProcessedEvent)postedEvents.get(0);
+		assertThat(allEventsProcessedEvent.getTraceId()).isEqualTo(traceId);
+
+		// and: the awaiter is NOT released yet -- posting to the bus alone doesn't complete the local future;
+		// only the round-trip delivery back through the registry does (see below)
+		assertThat(eventProgress.getCompletableFuture()).isNotDone();
+
+		// when: the completion signal is delivered back, exactly as the real (distributed) event bus would do
+		final MaterialEventHandlerRegistry registry = new MaterialEventHandlerRegistry(
+				Optional.of(ImmutableList.of(new AllEventsProcessedEventHandler(materialEventObserver))),
+				new EventLogUserService(),
+				materialEventObserver);
+		deliverThroughRegistry(registry, allEventsProcessedEvent);
+
+		// then: the awaiting caller is released
+		assertThat(awaiterReleased.await(10, TimeUnit.SECONDS)).isTrue();
+		awaiterThread.join(TimeUnit.SECONDS.toMillis(10));
+
+		// and: delivering the completion signal back did not cause a repost (still exactly one)
+		assertThat(postMaterialEventService.getPostedEvents()).hasSize(1);
+
+		// and: the tracking entry was removed once awaitProcessing returned
+		assertThat(getTraceId2EventProgress(materialEventObserver)).doesNotContainKey(traceId);
 	}
 
 	/**

--- a/backend/de.metas.material/event/src/test/java/de/metas/material/event/MaterialEventObserverTest.java
+++ b/backend/de.metas.material/event/src/test/java/de/metas/material/event/MaterialEventObserverTest.java
@@ -142,6 +142,25 @@ public class MaterialEventObserverTest
 	}
 
 	/**
+	 * TC3: {@link EventProgress#areAllEventsProcessed()} is {@code eventId2Status.values().stream().allMatch(...)},
+	 * which is vacuously {@code true} on an empty map. A trace for which nothing was ever enqueued must not be
+	 * reported as "all processed".
+	 */
+	@Test
+	void emptyProgress_isNotAllProcessed()
+	{
+		// given: an observed trace with nothing ever enqueued
+		final String traceId = "tc3-trace-id";
+		materialEventObserver.observe(traceId);
+
+		final EventProgress eventProgress = getTraceId2EventProgress(materialEventObserver).get(traceId);
+		assertThat(eventProgress).isNotNull();
+
+		// then
+		assertThat(eventProgress.areAllEventsProcessed()).isFalse();
+	}
+
+	/**
 	 * Delivers {@code event} through {@code registry.onEvent(event)} the same way the real (distributed) event bus
 	 * would: {@link de.metas.event.impl.EventBus} marks a to-be-logged event as "was logged" and wraps delivery with
 	 * an {@link EventLogEntryCollector} thread-local before invoking the listener -- {@link EventLogUserService}

--- a/backend/de.metas.material/event/src/test/java/de/metas/material/event/MaterialEventObserverTest.java
+++ b/backend/de.metas.material/event/src/test/java/de/metas/material/event/MaterialEventObserverTest.java
@@ -1,0 +1,184 @@
+/*
+ * #%L
+ * metasfresh-material-event
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.material.event;
+
+import de.metas.event.IEventBus;
+import de.metas.event.IEventBusFactory;
+import de.metas.event.IEventListener;
+import de.metas.event.Topic;
+import de.metas.material.event.commons.EventDescriptor;
+import de.metas.material.event.eventbus.MaterialEventConverter;
+import de.metas.material.event.eventbus.MetasfreshEventBusService;
+import de.metas.material.event.simulation.DeactivateAllSimulatedCandidatesEvent;
+import de.metas.material.event.tracking.EventProgress;
+import lombok.NonNull;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.SpringContextHolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link MaterialEventObserver}.
+ */
+public class MaterialEventObserverTest
+{
+	private MaterialEventObserver materialEventObserver;
+
+	private RecordingPostMaterialEventService postMaterialEventService;
+
+	@BeforeEach
+	void init()
+	{
+		// needed because MaterialEventObserver resolves ITrxManager/ISysConfigBL via Services.get(..) in its field initializers,
+		// and uses trxManager.getCurrentTrxListenerManagerOrAutoCommit() internally.
+		AdempiereTestHelper.get().init();
+
+		postMaterialEventService = new RecordingPostMaterialEventService();
+		SpringContextHolder.registerJUnitBean(PostMaterialEventService.class, postMaterialEventService);
+
+		materialEventObserver = new MaterialEventObserver();
+	}
+
+	@Test
+	void reportEventProcessed_unobservedTrace_postsNothing()
+	{
+		// given: a traceId that was never passed to observe(traceId)
+		final String traceId = "never-observed-trace-id";
+		final EventDescriptor eventDescriptor = EventDescriptor.ofClientOrgAndTraceId(
+				EventTestHelper.CLIENT_AND_ORG_ID,
+				traceId);
+		// deliberately an ordinary work event, not AllEventsProcessedEvent: this test is about the *unknown trace*,
+		// so it must not pass merely because some particular event type is special-cased.
+		final MaterialEvent processedEvent = DeactivateAllSimulatedCandidatesEvent.builder()
+				.eventDescriptor(eventDescriptor)
+				.build();
+
+		// when
+		materialEventObserver.reportEventProcessed(processedEvent);
+
+		// then: nothing was posted
+		assertThat(postMaterialEventService.getPostedEvents()).isEmpty();
+
+		// and: the tracker holds no entry for that traceId
+		assertThat(getTraceId2EventProgress(materialEventObserver)).doesNotContainKey(traceId);
+	}
+
+	/**
+	 * {@link MaterialEventObserver} does not expose an accessor for its internal {@code traceId2EventProgress} map,
+	 * and we must not add one to production code for this test. We therefore read the private field via reflection,
+	 * following the same pattern already used elsewhere in this codebase's tests (e.g. {@code ServicesTest}).
+	 */
+	@SuppressWarnings("unchecked")
+	private static Map<String, EventProgress> getTraceId2EventProgress(@NonNull final MaterialEventObserver observer)
+	{
+		try
+		{
+			final Field field = MaterialEventObserver.class.getDeclaredField("traceId2EventProgress");
+			field.setAccessible(true);
+			return (Map<String, EventProgress>)field.get(observer);
+		}
+		catch (final ReflectiveOperationException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * A recording fake of {@link PostMaterialEventService}: captures every event that production code would otherwise
+	 * post to the distributed event bus, instead of actually posting it.
+	 * <p>
+	 * We don't use Mockito here (not a test dependency of this module) -- {@link PostMaterialEventService} is a
+	 * non-final class with non-final public methods, so a plain subclass override is enough.
+	 */
+	private static class RecordingPostMaterialEventService extends PostMaterialEventService
+	{
+		private final List<MaterialEvent> postedEvents = new ArrayList<>();
+
+		public RecordingPostMaterialEventService()
+		{
+			super(createDummyMetasfreshEventBusService());
+		}
+
+		@Override
+		public void enqueueEventAfterNextCommit(@NonNull final MaterialEvent event)
+		{
+			postedEvents.add(event);
+		}
+
+		public List<MaterialEvent> getPostedEvents()
+		{
+			return postedEvents;
+		}
+
+		/**
+		 * {@link PostMaterialEventService}'s constructor requires a non-null {@link MetasfreshEventBusService}
+		 * (it's {@code final} with a private constructor, so it can't be subclassed/faked directly). Since we
+		 * override {@link #enqueueEventAfterNextCommit(MaterialEvent)} above and never delegate to the real
+		 * implementation, none of its methods are ever invoked; it merely needs to exist to satisfy the constructor.
+		 */
+		private static MetasfreshEventBusService createDummyMetasfreshEventBusService()
+		{
+			final IEventBusFactory unusedEventBusFactory = new IEventBusFactory()
+			{
+				@Override
+				public IEventBus getEventBus(final Topic topic) {throw new UnsupportedOperationException();}
+
+				@Override
+				public IEventBus getEventBusIfExists(final Topic topic) {throw new UnsupportedOperationException();}
+
+				@Override
+				public List<IEventBus> getAllEventBusInstances() {throw new UnsupportedOperationException();}
+
+				@Override
+				public void initEventBussesWithGlobalListeners() {throw new UnsupportedOperationException();}
+
+				@Override
+				public void destroyAllEventBusses() {throw new UnsupportedOperationException();}
+
+				@Override
+				public void registerGlobalEventListener(final Topic topic, final IEventListener listener) {throw new UnsupportedOperationException();}
+
+				@Override
+				public void addAvailableUserNotificationsTopic(final Topic topic) {throw new UnsupportedOperationException();}
+
+				@Override
+				public void registerUserNotificationsListener(final IEventListener listener) {throw new UnsupportedOperationException();}
+
+				@Override
+				public void unregisterUserNotificationsListener(final IEventListener listener) {throw new UnsupportedOperationException();}
+			};
+
+			return MetasfreshEventBusService.createLocalServiceThatIsReadyToUse(
+					new MaterialEventConverter(),
+					unusedEventBusFactory,
+					new MaterialEventObserver());
+		}
+	}
+}

--- a/backend/de.metas.material/event/src/test/java/de/metas/material/event/MaterialEventObserverTest.java
+++ b/backend/de.metas.material/event/src/test/java/de/metas/material/event/MaterialEventObserverTest.java
@@ -22,14 +22,20 @@
 
 package de.metas.material.event;
 
+import com.google.common.collect.ImmutableList;
+import de.metas.event.Event;
 import de.metas.event.IEventBus;
 import de.metas.event.IEventBusFactory;
 import de.metas.event.IEventListener;
 import de.metas.event.Topic;
+import de.metas.event.log.EventLogEntryCollector;
+import de.metas.event.log.EventLogUserService;
 import de.metas.material.event.commons.EventDescriptor;
 import de.metas.material.event.eventbus.MaterialEventConverter;
 import de.metas.material.event.eventbus.MetasfreshEventBusService;
 import de.metas.material.event.simulation.DeactivateAllSimulatedCandidatesEvent;
+import de.metas.material.event.tracking.AllEventsProcessedEvent;
+import de.metas.material.event.tracking.AllEventsProcessedEventHandler;
 import de.metas.material.event.tracking.EventProgress;
 import lombok.NonNull;
 import org.adempiere.test.AdempiereTestHelper;
@@ -41,6 +47,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -88,6 +95,67 @@ public class MaterialEventObserverTest
 
 		// and: the tracker holds no entry for that traceId
 		assertThat(getTraceId2EventProgress(materialEventObserver)).doesNotContainKey(traceId);
+	}
+
+	/**
+	 * TC2: {@link MaterialEventHandlerRegistry#onEvent(MaterialEvent)} calls {@code reportEventProcessed} for every
+	 * event class that has at least one registered handler -- including {@link AllEventsProcessedEvent} itself, which
+	 * always has the (real, production) {@link AllEventsProcessedEventHandler} registered. That bookkeeping event is
+	 * not "work" that was ever enqueued for the trace; counting it as processed work pollutes
+	 * {@link de.metas.material.event.tracking.EventProgress} with an entry the trace never asked about.
+	 */
+	@Test
+	void allEventsProcessedEvent_isNotCountedAsWork()
+	{
+		// given: an observed trace with one ordinary work event still outstanding (enqueued, not yet processed)
+		final String traceId = "tc2-trace-id";
+		materialEventObserver.observe(traceId);
+
+		final MaterialEvent workEvent = DeactivateAllSimulatedCandidatesEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientOrgAndTraceId(EventTestHelper.CLIENT_AND_ORG_ID, traceId))
+				.build();
+		materialEventObserver.reportEventEnqueued(workEvent);
+
+		// and: a registry with the real AllEventsProcessedEventHandler registered, so dispatch is not vacuous
+		final MaterialEventHandlerRegistry registry = new MaterialEventHandlerRegistry(
+				Optional.of(ImmutableList.of(new AllEventsProcessedEventHandler(materialEventObserver))),
+				new EventLogUserService(),
+				materialEventObserver);
+
+		final AllEventsProcessedEvent allEventsProcessedEvent = AllEventsProcessedEvent.builder()
+				.eventDescriptor(EventDescriptor.ofClientOrgAndTraceId(EventTestHelper.CLIENT_AND_ORG_ID, traceId))
+				.build();
+
+		// when: the bookkeeping event is delivered through the registry, exactly like the real event bus would do
+		deliverThroughRegistry(registry, allEventsProcessedEvent);
+
+		// then: the handler still ran (proves dispatch is unaffected): it completed the trace's future
+		final EventProgress eventProgress = getTraceId2EventProgress(materialEventObserver).get(traceId);
+		assertThat(eventProgress).isNotNull();
+		assertThat(eventProgress.getCompletableFuture()).isDone();
+
+		// and: the bookkeeping event's own eventId was NOT recorded as tracked work for that trace
+		assertThat(eventProgress.getEventId2Status()).doesNotContainKey(allEventsProcessedEvent.getEventId());
+
+		// and: the trace is not treated as complete (the outstanding work event was never processed)
+		assertThat(eventProgress.areAllEventsProcessed()).isFalse();
+	}
+
+	/**
+	 * Delivers {@code event} through {@code registry.onEvent(event)} the same way the real (distributed) event bus
+	 * would: {@link de.metas.event.impl.EventBus} marks a to-be-logged event as "was logged" and wraps delivery with
+	 * an {@link EventLogEntryCollector} thread-local before invoking the listener -- {@link EventLogUserService}
+	 * (used inside {@link MaterialEventHandlerRegistry#onEvent(MaterialEvent)}) requires that thread-local to exist.
+	 */
+	private static void deliverThroughRegistry(
+			@NonNull final MaterialEventHandlerRegistry registry,
+			@NonNull final MaterialEvent event)
+	{
+		final Event busEvent = new MaterialEventConverter().fromMaterialEvent(event).withStatusWasLogged();
+		try (final EventLogEntryCollector ignored = EventLogEntryCollector.createThreadLocalForEvent(busEvent))
+		{
+			registry.onEvent(event);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Problem

The material-events completion tracker could feed itself indefinitely, keeping the `de.metas.material` event topic busy until an awaiting caller timed out with `Queue has not been entirely processed in 5 minutes !`.

The cycle:

1. `MaterialEventObserver.reportEventProcessed` received an event for a trace it had **no tracking entry** for — e.g. one arriving after `awaitProcessing` already removed the entry in its `finally` block.
2. Instead of ignoring it, it called `observe(traceId)`, creating a **fresh** `EventProgress`, then marked the event processed.
3. That progress now trivially satisfied `areAllEventsProcessed()`, so an `AllEventsProcessedEvent` was posted for a trace nobody was awaiting.
4. That bookkeeping event came back through `MaterialEventHandlerRegistry.onEvent`, which reported it as processed work — landing at step 1 again.

Two latent amplifiers made it worse: the bookkeeping event was counted as tracked work even though it was never enqueued, and `areAllEventsProcessed()` was **vacuously true** on an empty progress (`allMatch` over an empty map).

This is a production defect, not a test-only one. It was also the dominant cause of intermittent `test (cucumber) (profile7)` failures.

## Fix

Make the code obey the invariant already documented in prose in `MaterialEventObserver`: **a tracking entry exists only while some caller is awaiting that trace.**

| Change | File |
|---|---|
| `reportEventProcessed` returns early when the trace has no tracking entry, instead of re-registering it | `MaterialEventObserver.java` |
| `AllEventsProcessedEvent` is no longer reported as tracked work (handler dispatch unchanged) | `MaterialEventHandlerRegistry.java` |
| `areAllEventsProcessed()` is false when nothing was ever enqueued | `EventProgress.java` |

Total production change: 3 files, +16/-10.

`reportEventEnqueued`'s auto-registration is deliberately **left intact** — it is load-bearing for a step definition that awaits a trace it never explicitly observed.

## Tests

New `MaterialEventObserverTest` (TDD, one RED->GREEN cycle per change; each RED verified to fail on its assertion, not on a bean-lookup or NPE):

- reporting a processed event for an unobserved trace posts nothing and creates no entry — deliberately uses an *ordinary* work event, so it cannot pass merely because one event type is special-cased;
- the bookkeeping event is not counted as tracked work, while its handler still runs;
- an empty progress is not "all processed";
- **regression test for the normal completion path**: two work events enqueued and processed produce exactly one completion signal, the awaiting caller is released only once that signal round-trips back through the registry (as the real event bus would deliver it), no re-post occurs, and the entry is cleaned up.

The harness uses a hand-written recording fake rather than adding a mocking dependency to this module.

## Verification

- `de.metas.material/event`: 65/65 green.
- All six `de.metas.material` modules (incl. `dispo-service`, `planning`, `cockpit` — the real consumers of this event path): BUILD SUCCESS.
- Cucumber executor group 7 run locally **3 times**, 233 scenarios each: **zero** occurrences of `Queue has not been entirely processed in 5 minutes !`, and all five material-simulation scenarios passed in every run.

Note: CI has not run this branch — GitHub Actions was in a major outage while this was pushed, and no workflow run was created. The local runs above are the evidence until CI recovers.
