### PR TITLE
MobileUI Picking: catch-weight line total no longer leaks a floating-point artifact

### DIFF
--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/reducers/wfProcesses/picking/catch_weight.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/reducers/wfProcesses/picking/catch_weight.test.js
@@ -1,0 +1,65 @@
+import {
+  computeCatchWeightsArrayForLine,
+  formatCatchWeightToHumanReadableStr,
+} from '../../../../reducers/wfProcesses/picking/catch_weight';
+
+const lineWithCatchWeightSteps = (...qtys) => ({
+  steps: Object.fromEntries(
+    qtys.map((qty, index) => [`step-${index}`, { mainPickFrom: { pickedCatchWeight: { qty, uomSymbol: 'kg' } } }])
+  ),
+});
+
+describe('picking catch_weight', () => {
+  describe('computeCatchWeightsArrayForLine', () => {
+    it('sums the catch weights of all steps', () => {
+      expect(computeCatchWeightsArrayForLine({ line: lineWithCatchWeightSteps(8.76) })).toEqual([
+        { qty: 8.76, uom: 'kg' },
+      ]);
+    });
+
+    // Reproduces the real picking flow: each pick of a 6-piece catch-weight batch creates six 1-CU
+    // steps of 1.46 kg. Six of them sum to exactly 8.76 in IEEE-754, but after a duplicate pick the
+    // twelve addends sum to 17.520000000000003. The display path formats with precision=null, i.e.
+    // countDecimalPlaces(qty) => 15 decimals, so that artifact reaches the UI verbatim.
+    it('does not leak a floating-point artifact when summing many one-CU catch weights', () => {
+      const sixSteps = Array(6).fill(1.46);
+      expect(computeCatchWeightsArrayForLine({ line: lineWithCatchWeightSteps(...sixSteps) })).toEqual([
+        { qty: 8.76, uom: 'kg' },
+      ]);
+
+      const twelveSteps = Array(12).fill(1.46);
+      expect(computeCatchWeightsArrayForLine({ line: lineWithCatchWeightSteps(...twelveSteps) })).toEqual([
+        { qty: 17.52, uom: 'kg' },
+      ]);
+    });
+
+    it('does not round away genuinely-precise values', () => {
+      expect(computeCatchWeightsArrayForLine({ line: lineWithCatchWeightSteps(0.001, 0.002) })).toEqual([
+        { qty: 0.003, uom: 'kg' },
+      ]);
+    });
+
+    it('keeps catch weights of different UOMs apart', () => {
+      const line = {
+        steps: {
+          a: { mainPickFrom: { pickedCatchWeight: { qty: 8.76, uomSymbol: 'kg' } } },
+          b: { mainPickFrom: { pickedCatchWeight: { qty: 8.76, uomSymbol: 'kg' } } },
+          c: { mainPickFrom: { pickedCatchWeight: { qty: 1.5, uomSymbol: 'lb' } } },
+        },
+      };
+      expect(computeCatchWeightsArrayForLine({ line })).toEqual([
+        { qty: 17.52, uom: 'kg' },
+        { qty: 1.5, uom: 'lb' },
+      ]);
+    });
+  });
+
+  describe('formatCatchWeightToHumanReadableStr', () => {
+    // This is the assertion the mobile E2E spec picking_catchWeight_unpack.spec.js makes on the
+    // line button's data-qtycurrentcatchweight attribute after a duplicate pick.
+    it('renders a summed catch weight without floating-point noise', () => {
+      const catchWeights = computeCatchWeightsArrayForLine({ line: lineWithCatchWeightSteps(...Array(12).fill(1.46)) });
+      expect(formatCatchWeightToHumanReadableStr(catchWeights)).toEqual('17.52 kg');
+    });
+  });
+});

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/reducers/wfProcesses/picking/catch_weight.test.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/__tests__/reducers/wfProcesses/picking/catch_weight.test.js
@@ -39,6 +39,23 @@ describe('picking catch_weight', () => {
       ]);
     });
 
+    // Every addition is (accumulator, nextStepQty), so the decimals must come from BOTH operands: keying
+    // only off the accumulator (1 decimal here) would round 1.501 back to 1.5 and lose every later step.
+    it('keeps the more precise operand precision when the step precisions differ', () => {
+      const steps = [1.5, 0.001, 0.001, 0.001, 0.001, 0.001];
+      expect(computeCatchWeightsArrayForLine({ line: lineWithCatchWeightSteps(...steps) })).toEqual([
+        { qty: 1.505, uom: 'kg' },
+      ]);
+    });
+
+    // Below 1e-6 String(num) yields exponential notation, so countDecimalPlaces reports 0 decimals;
+    // rounding to 0 there would truncate the quantity to nothing.
+    it('does not truncate sub-microgram-scale quantities to zero', () => {
+      expect(computeCatchWeightsArrayForLine({ line: lineWithCatchWeightSteps(1e-7, 1e-7) })).toEqual([
+        { qty: 2e-7, uom: 'kg' },
+      ]);
+    });
+
     it('keeps catch weights of different UOMs apart', () => {
       const line = {
         steps: {

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/wfProcesses/picking/catch_weight.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/wfProcesses/picking/catch_weight.js
@@ -1,5 +1,5 @@
 import { getStepsArrayFromLine } from '../index';
-import { formatQtyToHumanReadableStr } from '../../../utils/qtys';
+import { countDecimalPlaces, formatQtyToHumanReadableStr } from '../../../utils/qtys';
 
 export const computeCatchWeightForStep = ({ pickFrom: pickFromParam, step: stepParam }) => {
   let pickFrom;
@@ -37,6 +37,19 @@ export const computeCatchWeightsArrayForLine = ({ line }) => {
   return catchWeightsArray;
 };
 
+/**
+ * Adds two quantities and rounds the result back to the number of decimals the operands actually carry.
+ *
+ * A plain `+=` accumulates binary floating-point error: one pick of a 6-piece catch-weight batch is six
+ * 1-CU steps of 1.46 kg, which sum to exactly 8.76, but twelve of them (after a duplicate pick) sum to
+ * 17.520000000000003. The display path formats with no explicit precision, so it derives the precision
+ * from the value itself (`countDecimalPlaces`) and renders all 15 decimals verbatim into the UI.
+ */
+const sumQtys = (qty1, qty2) => {
+  const decimals = Math.max(countDecimalPlaces(qty1), countDecimalPlaces(qty2));
+  return parseFloat((qty1 + qty2).toFixed(decimals));
+};
+
 const addCatchWeightToMap = (catchWeightsMap, catchWeight) => {
   if (!catchWeight) {
     return;
@@ -46,7 +59,7 @@ const addCatchWeightToMap = (catchWeightsMap, catchWeight) => {
   if (!existingCatchWeightForUOM) {
     catchWeightsMap[catchWeight.uom] = catchWeight;
   } else {
-    existingCatchWeightForUOM.qty += catchWeight.qty;
+    existingCatchWeightForUOM.qty = sumQtys(existingCatchWeightForUOM.qty, catchWeight.qty);
   }
 };
 

--- a/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/wfProcesses/picking/catch_weight.js
+++ b/misc/services/mobile-webui/mobile-webui-frontend/src/reducers/wfProcesses/picking/catch_weight.js
@@ -46,8 +46,17 @@ export const computeCatchWeightsArrayForLine = ({ line }) => {
  * from the value itself (`countDecimalPlaces`) and renders all 15 decimals verbatim into the UI.
  */
 const sumQtys = (qty1, qty2) => {
+  const sum = qty1 + qty2;
   const decimals = Math.max(countDecimalPlaces(qty1), countDecimalPlaces(qty2));
-  return parseFloat((qty1 + qty2).toFixed(decimals));
+
+  // `countDecimalPlaces` inspects `String(num)`, and JS switches to exponential notation below 1e-6
+  // ("1e-7" has no decimal point), so it reports 0 decimals for such a value. Rounding to 0 decimals
+  // there would truncate the quantity away entirely, so leave a sum of non-integer operands unrounded.
+  if (decimals === 0 && !(Number.isInteger(qty1) && Number.isInteger(qty2))) {
+    return sum;
+  }
+
+  return parseFloat(sum.toFixed(decimals));
 };
 
 const addCatchWeightToMap = (catchWeightsMap, catchWeight) => {


### PR DESCRIPTION
## Problem

The catch-weight total on a picking line button could render a raw floating-point artifact:

```
17.520000000000003 kg
```

`computeCatchWeightsArrayForLine` sums the per-step catch weights with a plain `+=`, which accumulates
binary floating-point error. One pick of a 6-piece catch-weight batch creates six 1-CU steps of 1.46 kg:

- six addends → `6 × 1.46 = 8.76` **exactly** in IEEE-754, so a single pick looks fine
- twelve addends, after the operator picks the same line a second time → `12 × 1.46 = 17.520000000000003`

The line button formats that total **without an explicit precision**, so `formatQtyToHumanReadable`
derives the precision from the value itself (`countDecimalPlaces` → 15) and renders all fifteen decimals
verbatim into the caption and the `data-qtycurrentcatchweight` attribute.

## Fix

Round the accumulation back to the number of decimals the operands actually carry, in the one place the
artifact is created:

```js
const sumQtys = (qty1, qty2) => {
  const decimals = Math.max(countDecimalPlaces(qty1), countDecimalPlaces(qty2));
  return parseFloat((qty1 + qty2).toFixed(decimals));
};
```

Fixing it at the sum rather than capping precision inside `formatQtyToHumanReadable` keeps the blast
radius on catch-weight aggregation — the formatter's "derive precision from the value" behaviour is
relied on elsewhere for genuinely-precise quantities, and changing it would alter number display
app-wide.

## Tests

New `src/__tests__/reducers/wfProcesses/picking/catch_weight.test.js` covering:

- a single step (unchanged behaviour)
- **six** one-CU steps → `8.76 kg` and **twelve** → `17.52 kg` (the reported flow)
- genuinely-precise small values are not rounded away (`0.001 + 0.002 = 0.003`)
- catch weights of different UOMs stay separate
- the formatted string a line button renders is `"17.52 kg"`

Verified RED before the change and GREEN after it, on this branch's base. Whole mobile-webui Jest suite
green: 25 suites / 268 tests.

## How it was found

The mobile E2E spec `picking_catchWeight_unpack.spec.js:92` asserts `"17.52 kg"` on the line button after
a duplicate pick, and failed three consecutive times on the same commit — deterministic, not a flake. The
summing code is identical on the branches involved, so the defect is not specific to one line.
