### PR TITLE
Cucumber: quiesce the shipment-schedule recompute queue before the batching fixture seeds

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -367,8 +367,8 @@ public class M_ShipmentSchedule_StepDef
 	 * <p>
 	 * The wait closes a real race: a recompute pass enqueued by an earlier scenario claims markers through the
 	 * same DB function this feature asserts on, and that claiming SQL is unconditionally global. Both processors
-	 * are checked in ONE predicate so they are zero at the same poll — a create-missing run enqueues a recompute
-	 * pass.
+	 * are checked in ONE predicate so they are zero at the same poll: a create-missing run enqueues a recompute
+	 * pass, so checking them one after the other could pass on a queue that is not quiet.
 	 * <p>
 	 * Do NOT widen {@link WorkPackageQueueUtil#countPendingWorkPackages(String)} to not-ready workpackages: one
 	 * bound to a rolled-back transaction never becomes ready, so waiting on it would turn this intermittent flake

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -361,39 +361,18 @@ public class M_ShipmentSchedule_StepDef
 	}
 
 	/**
-	 * Isolation cleanup: waits until the shipment-schedule work queue is drained, then removes any leftover untagged
-	 * {@code M_ShipmentSchedule_Recompute} markers ({@code AD_PInstance_ID IS NULL}) that a prior scenario sharing
-	 * this DB may have left behind, so a whole-product recompute-batching scenario starts from a known, empty
-	 * recompute backlog that stays empty. Belongs at the start of the Background.
+	 * Isolation cleanup: waits until the shipment-schedule work queue is drained, then deletes any leftover
+	 * untagged {@code M_ShipmentSchedule_Recompute} markers ({@code AD_PInstance_ID IS NULL}). Belongs at the
+	 * start of the Background.
 	 * <p>
-	 * <b>Why the wait — the concrete failure it prevents.</b> A REAL recompute pass enqueued by an earlier scenario
-	 * on this executor is picked up by the background queue planner (500ms poll interval, see
-	 * {@code CucumberLifeCycleSupport}) and can still be in flight while this feature seeds its fixture and counts
-	 * markers GLOBALLY. That pass claims markers through the same {@code M_ShipmentSchedule_TagToRecompute} DB
-	 * function the feature asserts on, and the claiming SQL is unconditionally global — it tags whatever untagged
-	 * markers exist, so the fixture cannot be made invisible to it and draining first is the only test-side fix.
-	 * Reproduced 3 red out of 10 runs with a pass enqueued in the Background, in both variants:
-	 * <ul>
-	 *   <li>the concurrent pass tag-claimed the seeded markers —
-	 *       {@code [Number of untagged M_ShipmentSchedule_Recompute markers remaining] expected: 6 but was: 1}</li>
-	 *   <li>it had already claimed (and its recompute deleted) them before the scenario's own tagging call —
-	 *       {@code [Number of M_ShipmentSchedule_Recompute markers tagged for selection recomputePass (the count the
-	 *       DB function returns)] Expected size: 2 but was: 0 in: []}</li>
-	 * </ul>
-	 * <b>Both</b> processors in {@link #RECOMPUTE_QUEUE_PROCESSOR_SHORT_NAMES} must be quiet, checked in ONE
-	 * predicate so they are zero at the same poll — a create-missing run enqueues a recompute pass, so clearing them
-	 * one after the other could pass on a queue that is not quiet. Once quiet, the queue stays quiet for the rest of
-	 * the scenario: a pass is only ever enqueued on transaction commit
-	 * ({@code UpdateInvalidShipmentSchedulesWorkpackageProcessorScheduler} extends
-	 * {@code WorkpackagesOnCommitSchedulerTemplate}), this feature completes no document, and
-	 * {@link #seedShipmentSchedulesWithUntaggedRecomputeMarker} inserts its rows with raw SQL, enqueueing nothing.
+	 * The wait closes a real race: a recompute pass enqueued by an earlier scenario claims markers through the
+	 * same DB function this feature asserts on, and that claiming SQL is unconditionally global. Both processors
+	 * are checked in ONE predicate so they are zero at the same poll — a create-missing run enqueues a recompute
+	 * pass.
 	 * <p>
-	 * <b>Do not widen the pending-workpackage filter.</b> {@link WorkPackageQueueUtil#countPendingWorkPackages(String)}
-	 * deliberately counts only {@code IsReadyForProcessing=Y} rows. A workpackage bound to a rolled-back transaction
-	 * never becomes ready, so including not-ready rows would trade this intermittent flake for a DETERMINISTIC
-	 * {@value #RECOMPUTE_QUEUE_DRAIN_TIMEOUT_SEC}s timeout on every run where an earlier scenario rolled back. A
-	 * workpackage that is currently BEING processed is still counted (the queue clears {@code IsReadyForProcessing}
-	 * only while building the workpackage, never during processing), so an in-flight pass is waited for, not missed.
+	 * Do NOT widen {@link WorkPackageQueueUtil#countPendingWorkPackages(String)} to not-ready workpackages: one
+	 * bound to a rolled-back transaction never becomes ready, so waiting on it would turn this intermittent flake
+	 * into a deterministic timeout.
 	 *
 	 * @cucumber.stepdef
 	 * @cucumber.example
@@ -417,9 +396,7 @@ public class M_ShipmentSchedule_StepDef
 
 	/**
 	 * Waits until no {@link #RECOMPUTE_QUEUE_PROCESSOR_SHORT_NAMES} workpackage is pending any more; see
-	 * {@link #deleteAllUntaggedRecomputeMarkers()} for the race this closes. On an already-quiet queue — the
-	 * expected case — the underlying executor's first optimistic try returns immediately, so the step costs two
-	 * count queries and no sleep.
+	 * {@link #deleteAllUntaggedRecomputeMarkers()} for the race this closes.
 	 */
 	private void waitForRecomputeWorkQueueToDrain() throws InterruptedException
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -60,6 +60,7 @@ import de.metas.cucumber.stepdefs.shipper.Carrier_Product_StepDefData;
 import de.metas.cucumber.stepdefs.shipper.Carrier_Service_StepDefData;
 import de.metas.cucumber.stepdefs.shipper.M_Shipper_StepDefData;
 import de.metas.cucumber.stepdefs.warehouse.M_Warehouse_StepDefData;
+import de.metas.cucumber.stepdefs.workpackage.WorkPackageQueueUtil;
 import de.metas.handlingunits.shipmentschedule.api.GenerateShipmentsForSchedulesRequest;
 import de.metas.handlingunits.shipmentschedule.api.M_ShipmentSchedule_QuantityTypeToUse;
 import de.metas.handlingunits.shipmentschedule.api.ShipmentService;
@@ -70,6 +71,8 @@ import de.metas.inout.ShipmentScheduleId;
 import de.metas.inoutcandidate.CarrierAdviseStatus;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleHandlerBL;
+import de.metas.inoutcandidate.async.CreateMissingShipmentSchedulesWorkpackageProcessor;
+import de.metas.inoutcandidate.async.UpdateInvalidShipmentSchedulesWorkpackageProcessor;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateRepository;
 import de.metas.inoutcandidate.model.I_M_Picking_Job_Schedule;
@@ -163,6 +166,27 @@ public class M_ShipmentSchedule_StepDef
 	private static final String SHIP_BPARTNER = "shipBPartner";
 	private static final String BILL_BPARTNER = "billBPartner";
 
+	/**
+	 * The two workpackage processors that can touch {@code M_ShipmentSchedule_Recompute} behind a scenario's back
+	 * (see {@link #deleteAllUntaggedRecomputeMarkers()}): the recompute pass itself, and the create-missing run
+	 * whose newly created schedules get invalidated — which both INSERTS markers and enqueues a recompute pass.
+	 */
+	private static final ImmutableList<String> RECOMPUTE_QUEUE_PROCESSOR_SHORT_NAMES = ImmutableList.of(
+			UpdateInvalidShipmentSchedulesWorkpackageProcessor.class.getSimpleName(),
+			CreateMissingShipmentSchedulesWorkpackageProcessor.class.getSimpleName());
+
+	/**
+	 * Timeout of the queue drain in {@link #deleteAllUntaggedRecomputeMarkers()}: this module's standard wait budget,
+	 * and ~120 polls of a queue whose planner picks up work every 500ms ({@code CucumberLifeCycleSupport} sets
+	 * {@code QueueProcessorPlanner.SYSCONFIG_POLLINTERVAL_MILLIS=500}), so it expires only when the queue is genuinely
+	 * stuck, never when it is merely slow. When it does expire, {@link #logPendingRecomputeWorkPackages()} names the
+	 * processor that is still busy and its pending count, so the failure is diagnosable rather than just a timeout.
+	 */
+	private static final int RECOMPUTE_QUEUE_DRAIN_TIMEOUT_SEC = 60;
+
+	/** Poll interval of the queue drain — the planner's own poll interval; polling faster only adds queries. */
+	private static final long RECOMPUTE_QUEUE_DRAIN_POLL_MS = 500;
+
 	@NonNull private final JsonAttributeService jsonAttributeService = SpringContextHolder.instance.getBean(JsonAttributeService.class);
 	@NonNull private final ShipmentService shipmentService = SpringContextHolder.instance.getBean(ShipmentService.class);
 	@NonNull private final IShipmentScheduleInvalidateRepository shipmentScheduleInvalidateRepository = Services.get(IShipmentScheduleInvalidateRepository.class);
@@ -203,6 +227,7 @@ public class M_ShipmentSchedule_StepDef
 	@NonNull private final Carrier_Service_StepDefData carrierServiceTable;
 	@NonNull private final C_Project_StepDefData projectTable;
 	@NonNull private final M_Picking_Job_Schedule_StepDefData pickingJobScheduleTable;
+	@NonNull private final WorkPackageQueueUtil workPackageQueueUtil;
 
 	private final TestContext testContext;
 
@@ -336,10 +361,39 @@ public class M_ShipmentSchedule_StepDef
 	}
 
 	/**
-	 * Isolation cleanup: removes any leftover untagged {@code M_ShipmentSchedule_Recompute} markers
-	 * ({@code AD_PInstance_ID IS NULL}) that a prior scenario sharing this DB may have left behind, so a
-	 * whole-product recompute-batching scenario starts from a known, empty recompute backlog. Belongs at the
-	 * start of the Background.
+	 * Isolation cleanup: waits until the shipment-schedule work queue is drained, then removes any leftover untagged
+	 * {@code M_ShipmentSchedule_Recompute} markers ({@code AD_PInstance_ID IS NULL}) that a prior scenario sharing
+	 * this DB may have left behind, so a whole-product recompute-batching scenario starts from a known, empty
+	 * recompute backlog that stays empty. Belongs at the start of the Background.
+	 * <p>
+	 * <b>Why the wait — the concrete failure it prevents.</b> A REAL recompute pass enqueued by an earlier scenario
+	 * on this executor is picked up by the background queue planner (500ms poll interval, see
+	 * {@code CucumberLifeCycleSupport}) and can still be in flight while this feature seeds its fixture and counts
+	 * markers GLOBALLY. That pass claims markers through the same {@code M_ShipmentSchedule_TagToRecompute} DB
+	 * function the feature asserts on, and the claiming SQL is unconditionally global — it tags whatever untagged
+	 * markers exist, so the fixture cannot be made invisible to it and draining first is the only test-side fix.
+	 * Reproduced 3 red out of 10 runs with a pass enqueued in the Background, in both variants:
+	 * <ul>
+	 *   <li>the concurrent pass tag-claimed the seeded markers —
+	 *       {@code [Number of untagged M_ShipmentSchedule_Recompute markers remaining] expected: 6 but was: 1}</li>
+	 *   <li>it had already claimed (and its recompute deleted) them before the scenario's own tagging call —
+	 *       {@code [Number of M_ShipmentSchedule_Recompute markers tagged for selection recomputePass (the count the
+	 *       DB function returns)] Expected size: 2 but was: 0 in: []}</li>
+	 * </ul>
+	 * <b>Both</b> processors in {@link #RECOMPUTE_QUEUE_PROCESSOR_SHORT_NAMES} must be quiet, checked in ONE
+	 * predicate so they are zero at the same poll — a create-missing run enqueues a recompute pass, so clearing them
+	 * one after the other could pass on a queue that is not quiet. Once quiet, the queue stays quiet for the rest of
+	 * the scenario: a pass is only ever enqueued on transaction commit
+	 * ({@code UpdateInvalidShipmentSchedulesWorkpackageProcessorScheduler} extends
+	 * {@code WorkpackagesOnCommitSchedulerTemplate}), this feature completes no document, and
+	 * {@link #seedShipmentSchedulesWithUntaggedRecomputeMarker} inserts its rows with raw SQL, enqueueing nothing.
+	 * <p>
+	 * <b>Do not widen the pending-workpackage filter.</b> {@link WorkPackageQueueUtil#countPendingWorkPackages(String)}
+	 * deliberately counts only {@code IsReadyForProcessing=Y} rows. A workpackage bound to a rolled-back transaction
+	 * never becomes ready, so including not-ready rows would trade this intermittent flake for a DETERMINISTIC
+	 * {@value #RECOMPUTE_QUEUE_DRAIN_TIMEOUT_SEC}s timeout on every run where an earlier scenario rolled back. A
+	 * workpackage that is currently BEING processed is still counted (the queue clears {@code IsReadyForProcessing}
+	 * only while building the workpackage, never during processing), so an in-flight pass is waited for, not missed.
 	 *
 	 * @cucumber.stepdef
 	 * @cucumber.example
@@ -348,8 +402,10 @@ public class M_ShipmentSchedule_StepDef
 	 * </pre>
 	 */
 	@And("all untagged M_ShipmentSchedule_Recompute markers are deleted")
-	public void deleteAllUntaggedRecomputeMarkers()
+	public void deleteAllUntaggedRecomputeMarkers() throws InterruptedException
 	{
+		waitForRecomputeWorkQueueToDrain();
+
 		// deleteDirectly (bulk filter-based DELETE), NOT delete(): M_ShipmentSchedule_Recompute is a keyless
 		// queue table (no single-column PK), so the PO-by-PO delete() builds an empty WHERE and fails with a
 		// SQL syntax error. deleteDirectly() issues one DELETE FROM ... WHERE AD_PInstance_ID IS NULL.
@@ -357,6 +413,38 @@ public class M_ShipmentSchedule_StepDef
 				.addEqualsFilter(I_M_ShipmentSchedule_Recompute.COLUMNNAME_AD_PInstance_ID, null)
 				.create()
 				.deleteDirectly();
+	}
+
+	/**
+	 * Waits until no {@link #RECOMPUTE_QUEUE_PROCESSOR_SHORT_NAMES} workpackage is pending any more; see
+	 * {@link #deleteAllUntaggedRecomputeMarkers()} for the race this closes. On an already-quiet queue — the
+	 * expected case — the underlying executor's first optimistic try returns immediately, so the step costs two
+	 * count queries and no sleep.
+	 */
+	private void waitForRecomputeWorkQueueToDrain() throws InterruptedException
+	{
+		StepDefUtil.tryAndWait(
+				RECOMPUTE_QUEUE_DRAIN_TIMEOUT_SEC,
+				RECOMPUTE_QUEUE_DRAIN_POLL_MS,
+				() -> countPendingRecomputeWorkPackages() == 0,
+				this::logPendingRecomputeWorkPackages);
+	}
+
+	private int countPendingRecomputeWorkPackages()
+	{
+		return RECOMPUTE_QUEUE_PROCESSOR_SHORT_NAMES.stream()
+				.mapToInt(workPackageQueueUtil::countPendingWorkPackages)
+				.sum();
+	}
+
+	private void logPendingRecomputeWorkPackages()
+	{
+		final StringBuilder message = new StringBuilder();
+		RECOMPUTE_QUEUE_PROCESSOR_SHORT_NAMES.forEach(processorShortName -> message
+				.append(processorShortName).append(" : ").append(workPackageQueueUtil.countPendingWorkPackages(processorShortName))
+				.append(" pending C_Queue_WorkPackage(s)").append("\n"));
+
+		logger.error("*** Error while waiting for the shipment-schedule work queue to drain, see current context: \n" + message);
 	}
 
 	/**

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workpackage/C_Queue_WorkPackage_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workpackage/C_Queue_WorkPackage_StepDef.java
@@ -44,7 +44,6 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBL;
-import org.adempiere.ad.dao.IQueryBuilder;
 import org.adempiere.ad.dao.IQueryFilter;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrx;
@@ -71,7 +70,6 @@ public class C_Queue_WorkPackage_StepDef
 	private final IWorkpackageProcessorFactory workpackageProcessorFactory = Services.get(IWorkpackageProcessorFactory.class);
 
 	private static final String MAIL_WP_PROCESSOR_INTERNAL_NAME = "MailWorkpackageProcessor";
-	private static final String WORKPACKAGE_PROCESSOR_CLASS_SUFFIX = "WorkpackageProcessor";
 
 	@NonNull private final C_Queue_Processor_StepDefData processorTable;
 	@NonNull private final C_Queue_WorkPackage_StepDefData workPackageTable;
@@ -412,7 +410,7 @@ public class C_Queue_WorkPackage_StepDef
 	@And("^there (?:is|are) (\\d+) pending \"(.*)\" workpackages?$")
 	public void assert_pending_workpackage_count(final int expectedCount, @NonNull final String processorShortName)
 	{
-		final int actualCount = countPendingWorkPackages(processorShortName);
+		final int actualCount = WorkPackageQueueUtil.countPendingWorkPackages(processorShortName);
 		assertThat(actualCount)
 				.as("Number of pending C_Queue_WorkPackage for processor %s", processorShortName)
 				.isEqualTo(expectedCount);
@@ -420,58 +418,15 @@ public class C_Queue_WorkPackage_StepDef
 
 	private Optional<I_C_Queue_WorkPackage> retrieveOldestPendingWorkPackage(@NonNull final String processorShortName)
 	{
-		final ImmutableSet<Integer> packageProcessorIds = resolvePackageProcessorIds(processorShortName);
+		final ImmutableSet<Integer> packageProcessorIds = WorkPackageQueueUtil.resolvePackageProcessorIds(processorShortName);
 		if (packageProcessorIds.isEmpty())
 		{
 			return Optional.empty();
 		}
 
-		return pendingWorkPackagesQuery(packageProcessorIds)
+		return WorkPackageQueueUtil.pendingWorkPackagesQuery(packageProcessorIds)
 				.orderBy(I_C_Queue_WorkPackage.COLUMNNAME_C_Queue_WorkPackage_ID)
 				.create()
 				.firstOptional(I_C_Queue_WorkPackage.class);
-	}
-
-	private int countPendingWorkPackages(@NonNull final String processorShortName)
-	{
-		final ImmutableSet<Integer> packageProcessorIds = resolvePackageProcessorIds(processorShortName);
-		if (packageProcessorIds.isEmpty())
-		{
-			return 0;
-		}
-
-		return pendingWorkPackagesQuery(packageProcessorIds)
-				.create()
-				.count();
-	}
-
-	private IQueryBuilder<I_C_Queue_WorkPackage> pendingWorkPackagesQuery(@NonNull final ImmutableSet<Integer> packageProcessorIds)
-	{
-		return queryBL.createQueryBuilder(I_C_Queue_WorkPackage.class)
-				.addInArrayFilter(I_C_Queue_WorkPackage.COLUMNNAME_C_Queue_PackageProcessor_ID, packageProcessorIds)
-				.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_Processed, false)
-				.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_IsError, false)
-				.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_IsReadyForProcessing, true);
-	}
-
-	/**
-	 * Resolves the {@code C_Queue_PackageProcessor_ID}s whose {@code Classname} simple name matches the given
-	 * short name (with a {@value WORKPACKAGE_PROCESSOR_CLASS_SUFFIX} suffix appended if not already present) —
-	 * e.g. {@code CreateMissingShipmentSchedules} resolves {@code CreateMissingShipmentSchedulesWorkpackageProcessor}.
-	 */
-	private ImmutableSet<Integer> resolvePackageProcessorIds(@NonNull final String processorShortName)
-	{
-		final String processorSimpleClassName = processorShortName.endsWith(WORKPACKAGE_PROCESSOR_CLASS_SUFFIX)
-				? processorShortName
-				: processorShortName + WORKPACKAGE_PROCESSOR_CLASS_SUFFIX;
-		final String classnameSuffix = "." + processorSimpleClassName;
-
-		return queryBL.createQueryBuilder(I_C_Queue_PackageProcessor.class)
-				.addOnlyActiveRecordsFilter()
-				.create()
-				.stream()
-				.filter(packageProcessor -> packageProcessor.getClassname() != null && packageProcessor.getClassname().endsWith(classnameSuffix))
-				.map(I_C_Queue_PackageProcessor::getC_Queue_PackageProcessor_ID)
-				.collect(ImmutableSet.toImmutableSet());
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workpackage/C_Queue_WorkPackage_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workpackage/C_Queue_WorkPackage_StepDef.java
@@ -76,19 +76,22 @@ public class C_Queue_WorkPackage_StepDef
 	@NonNull private final C_Queue_Element_StepDefData queueElementTable;
 	@NonNull private final C_OLCand_StepDefData candidateTable;
 	@NonNull private final IdentifiersResolver identifiersResolver;
+	@NonNull private final WorkPackageQueueUtil workPackageQueueUtil;
 
 	public C_Queue_WorkPackage_StepDef(
 			@NonNull final C_Queue_Processor_StepDefData processorTable,
 			@NonNull final C_Queue_WorkPackage_StepDefData workPackageTable,
 			@NonNull final C_Queue_Element_StepDefData queueElementTable,
 			@NonNull final C_OLCand_StepDefData candidateTable,
-			@NonNull final IdentifiersResolver identifiersResolver)
+			@NonNull final IdentifiersResolver identifiersResolver,
+			@NonNull final WorkPackageQueueUtil workPackageQueueUtil)
 	{
 		this.processorTable = processorTable;
 		this.workPackageTable = workPackageTable;
 		this.queueElementTable = queueElementTable;
 		this.candidateTable = candidateTable;
 		this.identifiersResolver = identifiersResolver;
+		this.workPackageQueueUtil = workPackageQueueUtil;
 	}
 
 	@And("locate last C_Queue_WorkPackage by enqueued element")
@@ -410,7 +413,7 @@ public class C_Queue_WorkPackage_StepDef
 	@And("^there (?:is|are) (\\d+) pending \"(.*)\" workpackages?$")
 	public void assert_pending_workpackage_count(final int expectedCount, @NonNull final String processorShortName)
 	{
-		final int actualCount = WorkPackageQueueUtil.countPendingWorkPackages(processorShortName);
+		final int actualCount = workPackageQueueUtil.countPendingWorkPackages(processorShortName);
 		assertThat(actualCount)
 				.as("Number of pending C_Queue_WorkPackage for processor %s", processorShortName)
 				.isEqualTo(expectedCount);
@@ -418,13 +421,13 @@ public class C_Queue_WorkPackage_StepDef
 
 	private Optional<I_C_Queue_WorkPackage> retrieveOldestPendingWorkPackage(@NonNull final String processorShortName)
 	{
-		final ImmutableSet<Integer> packageProcessorIds = WorkPackageQueueUtil.resolvePackageProcessorIds(processorShortName);
+		final ImmutableSet<Integer> packageProcessorIds = workPackageQueueUtil.resolvePackageProcessorIds(processorShortName);
 		if (packageProcessorIds.isEmpty())
 		{
 			return Optional.empty();
 		}
 
-		return WorkPackageQueueUtil.pendingWorkPackagesQuery(packageProcessorIds)
+		return workPackageQueueUtil.pendingWorkPackagesQuery(packageProcessorIds)
 				.orderBy(I_C_Queue_WorkPackage.COLUMNNAME_C_Queue_WorkPackage_ID)
 				.create()
 				.firstOptional(I_C_Queue_WorkPackage.class);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workpackage/WorkPackageQueueUtil.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workpackage/WorkPackageQueueUtil.java
@@ -27,7 +27,6 @@ import de.metas.async.model.I_C_Queue_PackageProcessor;
 import de.metas.async.model.I_C_Queue_WorkPackage;
 import de.metas.util.Services;
 import lombok.NonNull;
-import lombok.experimental.UtilityClass;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.dao.IQueryBuilder;
 
@@ -35,11 +34,14 @@ import org.adempiere.ad.dao.IQueryBuilder;
  * Shared queries over {@link I_C_Queue_WorkPackage} for cucumber step defs that need to know how many
  * workpackages are still pending for a given {@link I_C_Queue_PackageProcessor}, identified by its short name
  * (e.g. {@code CreateMissingShipmentSchedules} for {@code CreateMissingShipmentSchedulesWorkpackageProcessor}).
+ * <p>
+ * A plain PicoContainer-managed instance (see {@code cucumber-picocontainer}), constructor-injected into step
+ * defs the same way {@link de.metas.cucumber.stepdefs.util.IdentifiersResolver} is — never a
+ * {@code @UtilityClass}/static-field shape (forbidden by {@code docs/coding-rules/service-injection.md} §2).
  */
-@UtilityClass
 public class WorkPackageQueueUtil
 {
-	private static final IQueryBL queryBL = Services.get(IQueryBL.class);
+	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
 
 	private static final String WORKPACKAGE_PROCESSOR_CLASS_SUFFIX = "WorkpackageProcessor";
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workpackage/WorkPackageQueueUtil.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workpackage/WorkPackageQueueUtil.java
@@ -53,7 +53,9 @@ public class WorkPackageQueueUtil
 	 * <p>
 	 * Deliberately excludes not-ready workpackages ({@code IsReadyForProcessing=false}): a workpackage bound to
 	 * a rolled-back transaction never becomes ready, so counting/waiting on it would turn an intermittent flake
-	 * into a deterministic timeout.
+	 * into a deterministic timeout. A workpackage that is currently BEING processed IS still counted — the queue
+	 * clears {@code IsReadyForProcessing} only while building the workpackage, never during processing — so a
+	 * caller waiting for this count to reach zero really does wait out an in-flight run. Keep it that way.
 	 *
 	 * @param processorShortName e.g. {@code CreateMissingShipmentSchedules} or {@code UpdateInvalidShipmentSchedules}
 	 */

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workpackage/WorkPackageQueueUtil.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/workpackage/WorkPackageQueueUtil.java
@@ -1,0 +1,100 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.workpackage;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.async.model.I_C_Queue_PackageProcessor;
+import de.metas.async.model.I_C_Queue_WorkPackage;
+import de.metas.util.Services;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.dao.IQueryBuilder;
+
+/**
+ * Shared queries over {@link I_C_Queue_WorkPackage} for cucumber step defs that need to know how many
+ * workpackages are still pending for a given {@link I_C_Queue_PackageProcessor}, identified by its short name
+ * (e.g. {@code CreateMissingShipmentSchedules} for {@code CreateMissingShipmentSchedulesWorkpackageProcessor}).
+ */
+@UtilityClass
+public class WorkPackageQueueUtil
+{
+	private static final IQueryBL queryBL = Services.get(IQueryBL.class);
+
+	private static final String WORKPACKAGE_PROCESSOR_CLASS_SUFFIX = "WorkpackageProcessor";
+
+	/**
+	 * Counts how many {@code C_Queue_WorkPackage} rows are currently pending (not yet processed, not errored,
+	 * ready for processing) for the workpackage processor identified by its short name — i.e. how many runs of
+	 * that processor are still waiting to happen, whether because none has run yet or because a run re-enqueued
+	 * a follow-up workpackage for the remaining work.
+	 * <p>
+	 * Deliberately excludes not-ready workpackages ({@code IsReadyForProcessing=false}): a workpackage bound to
+	 * a rolled-back transaction never becomes ready, so counting/waiting on it would turn an intermittent flake
+	 * into a deterministic timeout.
+	 *
+	 * @param processorShortName e.g. {@code CreateMissingShipmentSchedules} or {@code UpdateInvalidShipmentSchedules}
+	 */
+	public int countPendingWorkPackages(@NonNull final String processorShortName)
+	{
+		final ImmutableSet<Integer> packageProcessorIds = resolvePackageProcessorIds(processorShortName);
+		if (packageProcessorIds.isEmpty())
+		{
+			return 0;
+		}
+
+		return pendingWorkPackagesQuery(packageProcessorIds)
+				.create()
+				.count();
+	}
+
+	IQueryBuilder<I_C_Queue_WorkPackage> pendingWorkPackagesQuery(@NonNull final ImmutableSet<Integer> packageProcessorIds)
+	{
+		return queryBL.createQueryBuilder(I_C_Queue_WorkPackage.class)
+				.addInArrayFilter(I_C_Queue_WorkPackage.COLUMNNAME_C_Queue_PackageProcessor_ID, packageProcessorIds)
+				.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_Processed, false)
+				.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_IsError, false)
+				.addEqualsFilter(I_C_Queue_WorkPackage.COLUMNNAME_IsReadyForProcessing, true);
+	}
+
+	/**
+	 * Resolves the {@code C_Queue_PackageProcessor_ID}s whose {@code Classname} simple name matches the given
+	 * short name (with a {@value WORKPACKAGE_PROCESSOR_CLASS_SUFFIX} suffix appended if not already present) —
+	 * e.g. {@code CreateMissingShipmentSchedules} resolves {@code CreateMissingShipmentSchedulesWorkpackageProcessor}.
+	 */
+	ImmutableSet<Integer> resolvePackageProcessorIds(@NonNull final String processorShortName)
+	{
+		final String processorSimpleClassName = processorShortName.endsWith(WORKPACKAGE_PROCESSOR_CLASS_SUFFIX)
+				? processorShortName
+				: processorShortName + WORKPACKAGE_PROCESSOR_CLASS_SUFFIX;
+		final String classnameSuffix = "." + processorSimpleClassName;
+
+		return queryBL.createQueryBuilder(I_C_Queue_PackageProcessor.class)
+				.addOnlyActiveRecordsFilter()
+				.create()
+				.stream()
+				.filter(packageProcessor -> packageProcessor.getClassname() != null && packageProcessor.getClassname().endsWith(classnameSuffix))
+				.map(I_C_Queue_PackageProcessor::getC_Queue_PackageProcessor_ID)
+				.collect(ImmutableSet.toImmutableSet());
+	}
+}


### PR DESCRIPTION
## Problem

`updateInvalidShipmentSchedulesRecomputeBatching.feature` is flaky on `test (cucumber) (profile7)`.

Its scenarios assert on **global** counts in `M_ShipmentSchedule_Recompute`, while a real
`UpdateInvalidShipmentSchedules` recompute pass — enqueued on commit by some earlier scenario sharing the
executor's DB, and picked up by the 500 ms background queue planner — can still be in flight. That pass
claims markers through the same `M_ShipmentSchedule_TagToRecompute` DB function the feature asserts on, and
the claiming SQL is unconditionally global: it tags whatever untagged markers exist. The fixture therefore
cannot be made invisible to a concurrent pass, and draining the queue first is the only test-side fix.

Two failure shapes, both reproduced:

```
✘ And 6 M_ShipmentSchedule_Recompute markers remain untagged
    [Number of untagged M_ShipmentSchedule_Recompute markers remaining]
    expected: 6
     but was: 1
```
```
✘ Then 2 M_ShipmentSchedule_Recompute markers are tagged for recompute selection recomputePass:
    [Number of M_ShipmentSchedule_Recompute markers tagged for selection recomputePass …]
    Expected size: 2 but was: 0 in: []
```

## Fix

Test-side only — no production code, no feature-file change, no assertion change.

`M_ShipmentSchedule_StepDef.deleteAllUntaggedRecomputeMarkers()` — the Background's isolation step, i.e. the
step that *consumes* a quiet queue — now waits until neither `UpdateInvalidShipmentSchedules` nor
`CreateMissingShipmentSchedules` has a pending workpackage before it deletes untagged markers and the fixture
seeds. Once the queue is quiet it stays quiet for the rest of the scenario: a pass is only ever enqueued on
transaction commit (`WorkpackagesOnCommitSchedulerTemplate`), this feature completes no document, and the
seeding step inserts its rows with raw SQL.

Both processors are checked in **one** predicate so they are zero at the same poll — a create-missing run
enqueues a recompute pass, so clearing them one after the other could pass on a queue that is not quiet.

The pending-workpackage query is deliberately **not** widened to include not-ready workpackages: a
workpackage bound to a rolled-back transaction never becomes ready, so waiting on those would trade an
intermittent flake for a deterministic 60 s timeout. A workpackage currently *being processed* is still
counted — the queue clears `IsReadyForProcessing` only while building the workpackage, never during
processing — so an in-flight pass is waited for, not missed.

The query itself already existed in `C_Queue_WorkPackage_StepDef`; the first commit lifts it into
`WorkPackageQueueUtil` (unchanged semantics) so both step defs can share it. cucumber-picocontainer hands
both step-def classes the same per-scenario instance.

## Evidence

Reproduced with a temporary harness (never committed) that enqueues a real recompute pass into the
`Background`, so every scenario starts with a pass already queued:

| | runs | result |
|---|---|---|
| harness, no fix | 10 | **3 red** — both signatures above |
| harness + fix | 10 | **10 green** |
| fix only, harness reverted | 1 | 5/5 green |

Judged from the full maven logs, not the reports — the suite executes twice per run and only the second
execution writes reports. Zero `timeout` / `tryAndWait` occurrences across the ten green runs, so the drain
never approaches its deadline and is not masking the race behind a stall.

## Scope

Three files, all under `backend/de.metas.cucumber/src/test/`:

- `stepdefs/workpackage/WorkPackageQueueUtil.java` — new, shared pending-workpackage query
- `stepdefs/workpackage/C_Queue_WorkPackage_StepDef.java` — delegates to it
- `stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java` — the drain wait
