### PR TITLE
C_BP_Group deviating-bill-partner resolution + rename IsAssociation→IsDeviatingBillBPartner (backport of #24777)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_BP_Group.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_C_BP_Group.java
@@ -1,31 +1,8 @@
-/*
- * #%L
- * de.metas.adempiere.adempiere.base
- * %%
- * Copyright (C) 2025 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
-
 package org.compiere.model;
 
-import org.adempiere.model.ModelColumn;
-
-import javax.annotation.Nullable;
 import java.math.BigDecimal;
+import javax.annotation.Nullable;
+import org.adempiere.model.ModelColumn;
 
 /** Generated Interface for C_BP_Group
  *  @author metasfresh (generated) 
@@ -443,27 +420,6 @@ public interface I_C_BP_Group
 	String COLUMNNAME_IsActive = "IsActive";
 
 	/**
-	 * Set Association.
-	 *
-	 * <br>Type: YesNo
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	void setIsAssociation (boolean IsAssociation);
-
-	/**
-	 * Get Association.
-	 *
-	 * <br>Type: YesNo
-	 * <br>Mandatory: true
-	 * <br>Virtual Column: false
-	 */
-	boolean isAssociation();
-
-	ModelColumn<I_C_BP_Group, Object> COLUMN_IsAssociation = new ModelColumn<>(I_C_BP_Group.class, "IsAssociation", null);
-	String COLUMNNAME_IsAssociation = "IsAssociation";
-
-	/**
 	 * Set Auto Invoice.
 	 *
 	 * <br>Type: List
@@ -552,6 +508,27 @@ public interface I_C_BP_Group
 
 	ModelColumn<I_C_BP_Group, Object> COLUMN_IsDefault = new ModelColumn<>(I_C_BP_Group.class, "IsDefault", null);
 	String COLUMNNAME_IsDefault = "IsDefault";
+
+	/**
+	 * Set Association.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsDeviatingBillBPartner (boolean IsDeviatingBillBPartner);
+
+	/**
+	 * Get Association.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isDeviatingBillBPartner();
+
+	ModelColumn<I_C_BP_Group, Object> COLUMN_IsDeviatingBillBPartner = new ModelColumn<>(I_C_BP_Group.class, "IsDeviatingBillBPartner", null);
+	String COLUMNNAME_IsDeviatingBillBPartner = "IsDeviatingBillBPartner";
 
 	/**
 	 * Set Discount Schema.
@@ -645,6 +622,7 @@ public interface I_C_BP_Group
 
 	/**
 	 * Set Exclude from MRP.
+	 * Exclude from MRP calculation
 	 *
 	 * <br>Type: List
 	 * <br>Mandatory: false
@@ -654,6 +632,7 @@ public interface I_C_BP_Group
 
 	/**
 	 * Get Exclude from MRP.
+	 * Exclude from MRP calculation
 	 *
 	 * <br>Type: List
 	 * <br>Mandatory: false
@@ -938,28 +917,6 @@ public interface I_C_BP_Group
 
 	ModelColumn<I_C_BP_Group, Object> COLUMN_PriorityBase = new ModelColumn<>(I_C_BP_Group.class, "PriorityBase", null);
 	String COLUMNNAME_PriorityBase = "PriorityBase";
-
-	/**
-	 * Set Purchaser.
-	 * Purchasing Responsible
-	 *
-	 * <br>Type: Search
-	 * <br>Mandatory: false
-	 * <br>Virtual Column: false
-	 */
-	void setPurchaser_User_ID (int Purchaser_User_ID);
-
-	/**
-	 * Get Purchaser.
-	 * Purchasing Responsible
-	 *
-	 * <br>Type: Search
-	 * <br>Mandatory: false
-	 * <br>Virtual Column: false
-	 */
-	int getPurchaser_User_ID();
-
-	String COLUMNNAME_Purchaser_User_ID = "Purchaser_User_ID";
 
 	/**
 	 * Set Credit Status.

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_BP_Group.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_C_BP_Group.java
@@ -1,32 +1,10 @@
-/*
- * #%L
- * de.metas.adempiere.adempiere.base
- * %%
- * Copyright (C) 2025 metas GmbH
- * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as
- * published by the Free Software Foundation, either version 2 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public
- * License along with this program. If not, see
- * <http://www.gnu.org/licenses/gpl-2.0.html>.
- * #L%
- */
-
 // Generated Model - DO NOT CHANGE
 package org.compiere.model;
 
-import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.Properties;
+import javax.annotation.Nullable;
 
 /** Generated Model for C_BP_Group
  *  @author metasfresh (generated) 
@@ -35,7 +13,7 @@ import java.util.Properties;
 public class X_C_BP_Group extends org.compiere.model.PO implements I_C_BP_Group, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 1353171231L;
+	private static final long serialVersionUID = 766662840L;
 
     /** Standard Constructor */
     public X_C_BP_Group (final Properties ctx, final int C_BP_Group_ID, @Nullable final String trxName)
@@ -329,18 +307,6 @@ public class X_C_BP_Group extends org.compiere.model.PO implements I_C_BP_Group,
 		return get_ValueAsString(COLUMNNAME_InvoiceRule);
 	}
 
-	@Override
-	public void setIsAssociation (final boolean IsAssociation)
-	{
-		set_Value (COLUMNNAME_IsAssociation, IsAssociation);
-	}
-
-	@Override
-	public boolean isAssociation() 
-	{
-		return get_ValueAsBoolean(COLUMNNAME_IsAssociation);
-	}
-
 	/** 
 	 * IsAutoInvoice AD_Reference_ID=319
 	 * Reference name: _YesNo
@@ -396,6 +362,18 @@ public class X_C_BP_Group extends org.compiere.model.PO implements I_C_BP_Group,
 	public boolean isDefault() 
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsDefault);
+	}
+
+	@Override
+	public void setIsDeviatingBillBPartner (final boolean IsDeviatingBillBPartner)
+	{
+		set_Value (COLUMNNAME_IsDeviatingBillBPartner, IsDeviatingBillBPartner);
+	}
+
+	@Override
+	public boolean isDeviatingBillBPartner() 
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsDeviatingBillBPartner);
 	}
 
 	@Override
@@ -761,21 +739,6 @@ public class X_C_BP_Group extends org.compiere.model.PO implements I_C_BP_Group,
 	public java.lang.String getPriorityBase() 
 	{
 		return get_ValueAsString(COLUMNNAME_PriorityBase);
-	}
-
-	@Override
-	public void setPurchaser_User_ID (final int Purchaser_User_ID)
-	{
-		if (Purchaser_User_ID < 1) 
-			set_Value (COLUMNNAME_Purchaser_User_ID, null);
-		else 
-			set_Value (COLUMNNAME_Purchaser_User_ID, Purchaser_User_ID);
-	}
-
-	@Override
-	public int getPurchaser_User_ID() 
-	{
-		return get_ValueAsInt(COLUMNNAME_Purchaser_User_ID);
 	}
 
 	/** 

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/IBPartnerDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/IBPartnerDAO.java
@@ -236,11 +236,14 @@ public interface IBPartnerDAO extends ISingletonService
 	boolean hasMoreLocations(Properties ctx, int bpartnerId, int excludeBPLocationId, @Nullable String trxName);
 
 	/**
-	 * Search the {@link I_C_BP_Relation}s for matching partner and location (note that the link without location is acceptable too)
-	 *
-	 * @return {@link I_C_BP_Relation} first encountered which is used for billing
+	 * @return the single active bill-to {@link I_C_BP_Relation} for the given partner (the relation that
+	 * redirects billing to another partner), or {@code null} if there is none. Shared by
+	 * {@code retrieveBillToLocation} (own-bill-to first, this as fallback) and the effective bill-partner
+	 * resolution. Assumes at most one active {@code IsBillTo} relation per partner; throws (via
+	 * {@code firstOnly}) if several exist.
 	 */
-	I_C_BP_Relation retrieveBillBPartnerRelationFirstEncountered(Object contextProvider, I_C_BPartner partner, I_C_BPartner_Location location);
+	@Nullable
+	I_C_BP_Relation retrieveBillToBPartnerRelationOrNull(BPartnerId bPartnerId);
 
 
 	/**

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerDAO.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/bpartner/service/impl/BPartnerDAO.java
@@ -1019,42 +1019,15 @@ public class BPartnerDAO implements IBPartnerDAO
 
 	@Nullable
 	@Override
-	public I_C_BP_Relation retrieveBillBPartnerRelationFirstEncountered(final Object contextProvider, final I_C_BPartner partner, final I_C_BPartner_Location location)
+	public I_C_BP_Relation retrieveBillToBPartnerRelationOrNull(@NonNull final BPartnerId bPartnerId)
 	{
-		Check.assumeNotNull(partner, "partner not null");
-
-		final IQueryBuilder<I_C_BP_Relation> queryBuilder = queryBL.createQueryBuilder(I_C_BP_Relation.class, contextProvider);
-
-		//
-		// Filter by partner
-		queryBuilder.addEqualsFilter(org.compiere.model.I_C_BP_Relation.COLUMNNAME_C_BPartner_ID, partner.getC_BPartner_ID());
-
-		//
-		// Filter by location or null (accept bill relations with no location)
-		final Integer partnerLocationId;
-		if (location != null)
-		{
-			partnerLocationId = location.getC_BPartner_Location_ID();
-		}
-		else
-		{
-			partnerLocationId = null;
-		}
-		queryBuilder.addInArrayOrAllFilter(I_C_BP_Relation.COLUMNNAME_C_BPartner_Location_ID, partnerLocationId, null);
-		queryBuilder.addEqualsFilter(I_C_BP_Relation.COLUMNNAME_IsBillTo, true);
-
-		final IQuery<I_C_BP_Relation> query = queryBuilder
+		return queryBL
+				.createQueryBuilder(I_C_BP_Relation.class)
+				.addEqualsFilter(I_C_BP_Relation.COLUMNNAME_C_BPartner_ID, bPartnerId)
+				.addEqualsFilter(I_C_BP_Relation.COLUMNNAME_IsBillTo, true)
 				.addOnlyActiveRecordsFilter()
-				.create();
-
-		//
-		// Order by BillTo DESC
-		final IQueryOrderBy orderBy = queryBL.createQueryOrderByBuilder(I_C_BPartner_Location.class)
-				.addColumnDescending(I_C_BPartner_Location.COLUMNNAME_IsBillTo)
-				.createQueryOrderBy();
-		query.setOrderBy(orderBy);
-
-		return query.first(I_C_BP_Relation.class);
+				.create()
+				.firstOnly(I_C_BP_Relation.class);
 	}
 
 	private final CCache<ImmutablePair<BPartnerId, Boolean>, I_C_BPartner_Location> billToLocationCache = CCache.<ImmutablePair<BPartnerId, Boolean>, I_C_BPartner_Location>builder()
@@ -1107,18 +1080,7 @@ public class BPartnerDAO implements IBPartnerDAO
 			return ownBillToLocation;
 		}
 
-		final IQueryBuilder<I_C_BP_Relation> bpRelationQueryBuilder = queryBL
-				.createQueryBuilder(I_C_BP_Relation.class)
-				.addEqualsFilter(I_C_BP_Relation.COLUMNNAME_C_BPartner_ID, bPartnerId)
-				.addEqualsFilter(I_C_BP_Relation.COLUMNNAME_IsBillTo, true)
-				.addOnlyActiveRecordsFilter();
-
-		queryBuilder.orderBy()
-				.addColumn(I_C_BP_Relation.COLUMNNAME_C_BP_Relation_ID);
-
-		final I_C_BP_Relation billtoRelation = bpRelationQueryBuilder
-				.create()
-				.firstOnly(I_C_BP_Relation.class); // just added an UC
+		final I_C_BP_Relation billtoRelation = retrieveBillToBPartnerRelationOrNull(bPartnerId);
 		if (billtoRelation != null)
 		{
 			final BPartnerLocationId bPartnerLocationId = BPartnerLocationId.ofRepoId(billtoRelation.getC_BPartnerRelation_ID(), billtoRelation.getC_BPartnerRelation_Location_ID());

--- a/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v1/payment/PaymentRestEndpointTest.java
+++ b/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v1/payment/PaymentRestEndpointTest.java
@@ -25,6 +25,7 @@ package de.metas.rest_api.v1.payment;
 import de.metas.adempiere.model.I_C_Order;
 import de.metas.bpartner.BPartnerSupplierApprovalRepository;
 import de.metas.bpartner.BPartnerSupplierApprovalService;
+import de.metas.bpartner.effective.BPartnerEffectiveBL;
 import de.metas.bpartner.service.impl.BPartnerBL;
 import de.metas.common.rest_api.v1.payment.JsonInboundPaymentInfo;
 import de.metas.currency.CurrencyCode;
@@ -137,6 +138,7 @@ class PaymentRestEndpointTest
 
 		// run the "before_complete" interceptor
 		new C_Order(bpartnerBL,
+				BPartnerEffectiveBL.newInstanceForUnitTesting(),
 				new OrderLineDetailRepository(),
 				documentLocationBL,
 				new BPartnerSupplierApprovalService(new BPartnerSupplierApprovalRepository(), new UserGroupRepository()),

--- a/backend/de.metas.business/src/main/java/de/metas/bpartner/effective/BPartnerEffectiveBL.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner/effective/BPartnerEffectiveBL.java
@@ -24,6 +24,7 @@ package de.metas.bpartner.effective;
 
 import de.metas.bpartner.BPGroupId;
 import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.BPartnerLocationId;
 import de.metas.bpartner.service.IBPGroupDAO;
 import de.metas.bpartner.service.IBPartnerDAO;
 import de.metas.common.util.CoalesceUtil;
@@ -38,6 +39,7 @@ import de.metas.payment.PaymentRule;
 import de.metas.payment.paymentterm.PaymentTermId;
 import de.metas.payment.paymentterm.repository.IPaymentTermRepository;
 import de.metas.pricing.PricingSystemId;
+import de.metas.user.UserId;
 import de.metas.util.Services;
 import de.metas.util.StringUtils;
 import lombok.NonNull;
@@ -46,6 +48,8 @@ import org.adempiere.service.ISysConfigBL;
 import org.compiere.Adempiere;
 import org.compiere.model.I_C_BP_Group;
 import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_C_BP_Relation;
+import org.compiere.model.I_C_BPartner_Location;
 import org.compiere.model.X_C_Order;
 import org.springframework.stereotype.Service;
 
@@ -178,6 +182,54 @@ public class BPartnerEffectiveBL
 				bPartnerBuilder::poIncoterms);
 
 		return bPartnerBuilder.build();
+	}
+
+	/**
+	 * Resolves the effective bill-to partner for a given order partner.
+	 * Precedence: per-partner C_BP_Relation (IsBillTo=Y) → partner's association group Bill_BPartner → parent association group Bill_BPartner → null.
+	 */
+	@Nullable
+	public BillBPartnerResolution getEffectiveBillBPartner(@NonNull final BPartnerId bPartnerId)
+	{
+		final I_C_BPartner bPartnerRecord = bpartnerDAO.getById(bPartnerId);
+
+		final I_C_BP_Relation billRelation = bpartnerDAO.retrieveBillToBPartnerRelationOrNull(bPartnerId);
+		if (billRelation != null)
+		{
+			final BPartnerId billBPartnerId = BPartnerId.ofRepoIdOrNull(billRelation.getC_BPartnerRelation_ID());
+			if (billBPartnerId != null)
+			{
+				final BPartnerLocationId billLocationId = BPartnerLocationId.ofRepoIdOrNull(billBPartnerId, billRelation.getC_BPartnerRelation_Location_ID());
+				// C_BP_Relation has no Bill_User_ID column → no bill user from this path
+				return BillBPartnerResolution.of(billBPartnerId, billLocationId, null);
+			}
+		}
+
+		final I_C_BP_Group bpGroup = bpGroupDAO.getById(BPGroupId.ofRepoId(bPartnerRecord.getC_BP_Group_ID()));
+		if (bpGroup.isDeviatingBillBPartner())
+		{
+			final BPartnerId billBPartnerId = BPartnerId.ofRepoIdOrNull(bpGroup.getBill_BPartner_ID());
+			if (billBPartnerId != null)
+			{
+				final BPartnerLocationId billLocationId = BPartnerLocationId.ofRepoIdOrNull(billBPartnerId, bpGroup.getBill_Location_ID());
+				final UserId billUserId = UserId.ofRepoIdOrNull(bpGroup.getBill_User_ID());
+				return BillBPartnerResolution.of(billBPartnerId, billLocationId, billUserId);
+			}
+		}
+
+		final I_C_BP_Group parentGroup = getParentGroup(bpGroup);
+		if (parentGroup != null && parentGroup.isDeviatingBillBPartner())
+		{
+			final BPartnerId billBPartnerId = BPartnerId.ofRepoIdOrNull(parentGroup.getBill_BPartner_ID());
+			if (billBPartnerId != null)
+			{
+				final BPartnerLocationId billLocationId = BPartnerLocationId.ofRepoIdOrNull(billBPartnerId, parentGroup.getBill_Location_ID());
+				final UserId billUserId = UserId.ofRepoIdOrNull(parentGroup.getBill_User_ID());
+				return BillBPartnerResolution.of(billBPartnerId, billLocationId, billUserId);
+			}
+		}
+
+		return null;
 	}
 
 	@Nullable

--- a/backend/de.metas.business/src/main/java/de/metas/bpartner/effective/BillBPartnerResolution.java
+++ b/backend/de.metas.business/src/main/java/de/metas/bpartner/effective/BillBPartnerResolution.java
@@ -1,0 +1,50 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.bpartner.effective;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.BPartnerLocationId;
+import de.metas.user.UserId;
+import lombok.NonNull;
+import lombok.Value;
+
+import javax.annotation.Nullable;
+
+/**
+ * Resolved bill-to partner, location, and (optionally) user for a sales order.
+ */
+@Value
+public class BillBPartnerResolution
+{
+	@NonNull BPartnerId billBPartnerId;
+	@Nullable BPartnerLocationId billLocationId;
+	@Nullable UserId billUserId;
+
+	public static BillBPartnerResolution of(
+			@NonNull final BPartnerId billBPartnerId,
+			@Nullable final BPartnerLocationId billLocationId,
+			@Nullable final UserId billUserId)
+	{
+		return new BillBPartnerResolution(billBPartnerId, billLocationId, billUserId);
+	}
+}

--- a/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
+++ b/backend/de.metas.business/src/main/java/de/metas/order/model/interceptor/C_Order.java
@@ -25,11 +25,12 @@ package de.metas.order.model.interceptor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import de.metas.adempiere.model.I_C_Order;
-import de.metas.bpartner.BPGroupId;
 import de.metas.bpartner.BPartnerContactId;
 import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.BPartnerLocationId;
 import de.metas.bpartner.BPartnerSupplierApprovalService;
-import de.metas.bpartner.service.IBPGroupDAO;
+import de.metas.bpartner.effective.BillBPartnerResolution;
+import de.metas.bpartner.effective.BPartnerEffectiveBL;
 import de.metas.bpartner.service.IBPartnerBL;
 import de.metas.bpartner.service.IBPartnerDAO;
 import de.metas.common.util.CoalesceUtil;
@@ -60,6 +61,7 @@ import de.metas.pricing.service.IPriceListDAO;
 import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
 import de.metas.shipping.PurchaseOrderToShipperTransportationService;
+import de.metas.user.UserId;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import de.metas.util.lang.ExternalId;
@@ -76,7 +78,6 @@ import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ISysConfigBL;
 import org.compiere.SpringContextHolder;
-import org.compiere.model.I_C_BP_Group;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_Payment;
 import org.compiere.model.I_M_PriceList;
@@ -108,8 +109,8 @@ public class C_Order
 	@NonNull private final IPaymentDAO paymentDAO = Services.get(IPaymentDAO.class);
 	@NonNull private final IProductBL productBL = Services.get(IProductBL.class);
 	@NonNull private final IOrgDAO orgDAO = Services.get(IOrgDAO.class);
-	@NonNull private final IBPGroupDAO groupDAO = Services.get(IBPGroupDAO.class);
 	@NonNull private final IBPartnerBL bpartnerBL;
+	@NonNull private final BPartnerEffectiveBL bpartnerEffectiveBL;
 	@NonNull private final OrderLineDetailRepository orderLineDetailRepository;
 	@NonNull private final BPartnerSupplierApprovalService partnerSupplierApprovalService;
 	@NonNull private final IDocumentLocationBL documentLocationBL;
@@ -123,6 +124,7 @@ public class C_Order
 
 	public C_Order(
 			@NonNull final IBPartnerBL bpartnerBL,
+			@NonNull final BPartnerEffectiveBL bpartnerEffectiveBL,
 			@NonNull final OrderLineDetailRepository orderLineDetailRepository,
 			@NonNull final IDocumentLocationBL documentLocationBL,
 			@NonNull final BPartnerSupplierApprovalService partnerSupplierApprovalService,
@@ -130,6 +132,7 @@ public class C_Order
 			@NonNull final OrderPayScheduleService orderPayScheduleService)
 	{
 		this.bpartnerBL = bpartnerBL;
+		this.bpartnerEffectiveBL = bpartnerEffectiveBL;
 		this.orderLineDetailRepository = orderLineDetailRepository;
 		this.partnerSupplierApprovalService = partnerSupplierApprovalService;
 		this.documentLocationBL = documentLocationBL;
@@ -597,29 +600,33 @@ public class C_Order
 		}
 	}
 
-	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE }, ifColumnsChanged = { I_C_Order.COLUMNNAME_C_BPartner_ID })
-	public void setBillBPartnerIdIfAssociation(final I_C_Order order)
+	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_NEW, ModelValidator.TYPE_BEFORE_CHANGE }, ifColumnsChanged = { I_C_Order.COLUMNNAME_C_BPartner_ID }, skipIfCopying = true)
+	public void setBillBPartnerIdFromEffectiveResolution(final I_C_Order order)
 	{
-		final I_C_BP_Group bpartnerGroup = groupDAO.getByBPartnerId(BPartnerId.ofRepoId(order.getC_BPartner_ID()));
-		if (bpartnerGroup.isAssociation())
+		final BPartnerId bPartnerId = BPartnerId.ofRepoIdOrNull(order.getC_BPartner_ID());
+		if (bPartnerId == null)
 		{
-			order.setBill_BPartner_ID(bpartnerGroup.getBill_BPartner_ID());
-			order.setBill_Location_ID(bpartnerGroup.getBill_Location_ID());
-			order.setBill_User_ID(bpartnerGroup.getBill_User_ID());
+			return;
 		}
-		else
+
+		// Preserve a bill partner that was explicitly provided programmatically (e.g. by OLCandOrderFactory) —
+		// i.e. a bill partner DIFFERENT from the order's own partner. The standard own-bill-to default
+		// (Bill_BPartner == C_BPartner, set by setBillLocation) is NOT a "provided" value and is still
+		// (re)resolved. On a UI action we always (re)resolve.
+		final BPartnerId providedBillBPartnerId = BPartnerId.ofRepoIdOrNull(order.getBill_BPartner_ID());
+		if (!InterfaceWrapperHelper.isUIAction(order)
+				&& providedBillBPartnerId != null
+				&& !BPartnerId.equals(providedBillBPartnerId, bPartnerId))
 		{
-			final BPGroupId parentGroupId = BPGroupId.ofRepoIdOrNull(bpartnerGroup.getParent_BP_Group_ID());
-			if (parentGroupId != null)
-			{
-				final I_C_BP_Group parentGroup = groupDAO.getById(parentGroupId);
-				if (parentGroup.isAssociation())
-				{
-					order.setBill_BPartner_ID(parentGroup.getBill_BPartner_ID());
-					order.setBill_Location_ID(parentGroup.getBill_Location_ID());
-					order.setBill_User_ID(parentGroup.getBill_User_ID());
-				}
-			}
+			return;
+		}
+
+		final BillBPartnerResolution resolution = bpartnerEffectiveBL.getEffectiveBillBPartner(bPartnerId);
+		if (resolution != null)
+		{
+			order.setBill_BPartner_ID(resolution.getBillBPartnerId().getRepoId());
+			order.setBill_Location_ID(BPartnerLocationId.toRepoId(resolution.getBillLocationId()));
+			order.setBill_User_ID(UserId.toRepoId(resolution.getBillUserId()));
 		}
 	}
 

--- a/backend/de.metas.business/src/test/java/de/metas/bpartner/effective/BPartnerEffectiveBLTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/bpartner/effective/BPartnerEffectiveBLTest.java
@@ -23,6 +23,7 @@
 package de.metas.bpartner.effective;
 
 import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.BPartnerLocationId;
 import de.metas.incoterms.Incoterms;
 import de.metas.incoterms.IncotermsId;
 import de.metas.lang.SOTrx;
@@ -36,7 +37,9 @@ import lombok.Builder;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
 import org.compiere.model.I_C_BP_Group;
+import org.compiere.model.I_C_BP_Relation;
 import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_C_BPartner_Location;
 import org.compiere.model.I_C_Incoterms;
 import org.compiere.model.I_C_PaymentTerm;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,8 +49,6 @@ import javax.annotation.Nullable;
 
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class BPartnerEffectiveBLTest
 {
@@ -57,7 +58,7 @@ public class BPartnerEffectiveBLTest
 	public void init()
 	{
 		AdempiereTestHelper.get().init();
-        bpartnerEffectiveBL = BPartnerEffectiveBL.newInstanceForUnitTesting();
+		bpartnerEffectiveBL = BPartnerEffectiveBL.newInstanceForUnitTesting();
 	}
 
 	@Test
@@ -98,18 +99,18 @@ public class BPartnerEffectiveBLTest
 		assertThat(PaymentTermId.equals(bPartnerEffectiveAfterDefaultSetup.getPaymentTermId(SOTrx.PURCHASE), paymentTermId)).isTrue();
 
 		final Incoterms incoterms = bPartnerEffectiveAfterDefaultSetup.getIncoterms(SOTrx.SALES);
-		assertNotNull(incoterms);
+		assertThat(incoterms).isNotNull();
 		assertThat(IncotermsId.equals(incoterms.getId(), incotermsId)).isTrue();
-		assertEquals("TestIncoterms", incoterms.getName());
-		assertEquals("TestIncotermsValue", incoterms.getValue());
-		assertEquals("TestIncotermsDefaultLocation", incoterms.getLocationEffective());
+		assertThat(incoterms.getName()).isEqualTo("TestIncoterms");
+		assertThat(incoterms.getValue()).isEqualTo("TestIncotermsValue");
+		assertThat(incoterms.getLocationEffective()).isEqualTo("TestIncotermsDefaultLocation");
 
 		final Incoterms poIncoterms = bPartnerEffectiveAfterDefaultSetup.getIncoterms(SOTrx.PURCHASE);
-		assertNotNull(poIncoterms);
+		assertThat(poIncoterms).isNotNull();
 		assertThat(IncotermsId.equals(poIncoterms.getId(), incotermsId)).isTrue();
-		assertEquals("TestIncoterms", poIncoterms.getName());
-		assertEquals("TestIncotermsValue", poIncoterms.getValue());
-		assertEquals("TestIncotermsDefaultLocation", poIncoterms.getLocationEffective());
+		assertThat(poIncoterms.getName()).isEqualTo("TestIncoterms");
+		assertThat(poIncoterms.getValue()).isEqualTo("TestIncotermsValue");
+		assertThat(poIncoterms.getLocationEffective()).isEqualTo("TestIncotermsDefaultLocation");
 	}
 
 	@Test
@@ -153,18 +154,18 @@ public class BPartnerEffectiveBLTest
 		assertThat(bPartnerEffective.isAutoInvoice(SOTrx.PURCHASE)).isFalse();
 
 		final Incoterms incoterms = bPartnerEffective.getIncoterms(SOTrx.SALES);
-		assertNotNull(incoterms);
+		assertThat(incoterms).isNotNull();
 		assertThat(IncotermsId.equals(incoterms.getId(), IncotermsId.ofRepoId(5))).isTrue();
-		assertEquals("TestIncoterms", incoterms.getName());
-		assertEquals("TestIncotermsValue", incoterms.getValue());
-		assertEquals("TestIncotermsLocation", incoterms.getLocationEffective());
+		assertThat(incoterms.getName()).isEqualTo("TestIncoterms");
+		assertThat(incoterms.getValue()).isEqualTo("TestIncotermsValue");
+		assertThat(incoterms.getLocationEffective()).isEqualTo("TestIncotermsLocation");
 
 		final Incoterms poIncoterms = bPartnerEffective.getIncoterms(SOTrx.PURCHASE);
-		assertNotNull(poIncoterms);
+		assertThat(poIncoterms).isNotNull();
 		assertThat(IncotermsId.equals(poIncoterms.getId(), IncotermsId.ofRepoId(6))).isTrue();
-		assertEquals("TestPoIncoterms", poIncoterms.getName());
-		assertEquals("TestPoIncotermsValue", poIncoterms.getValue());
-		assertEquals("TestPoIncotermsLocation", poIncoterms.getLocationEffective());
+		assertThat(poIncoterms.getName()).isEqualTo("TestPoIncoterms");
+		assertThat(poIncoterms.getValue()).isEqualTo("TestPoIncotermsValue");
+		assertThat(poIncoterms.getLocationEffective()).isEqualTo("TestPoIncotermsLocation");
 	}
 
 	@Test
@@ -230,18 +231,18 @@ public class BPartnerEffectiveBLTest
 		assertThat(bPartnerEffective.isAutoInvoice(SOTrx.PURCHASE)).isFalse();
 
 		final Incoterms incoterms = bPartnerEffective.getIncoterms(SOTrx.SALES);
-		assertNotNull(incoterms);
+		assertThat(incoterms).isNotNull();
 		assertThat(IncotermsId.equals(incoterms.getId(), IncotermsId.ofRepoId(11))).isTrue();
-		assertEquals("TestIncoterms2", incoterms.getName());
-		assertEquals("TestIncotermsValue2", incoterms.getValue());
-		assertEquals("TestIncotermsLocation2", incoterms.getLocationEffective());
+		assertThat(incoterms.getName()).isEqualTo("TestIncoterms2");
+		assertThat(incoterms.getValue()).isEqualTo("TestIncotermsValue2");
+		assertThat(incoterms.getLocationEffective()).isEqualTo("TestIncotermsLocation2");
 
 		final Incoterms poIncoterms = bPartnerEffective.getIncoterms(SOTrx.PURCHASE);
-		assertNotNull(poIncoterms);
+		assertThat(poIncoterms).isNotNull();
 		assertThat(IncotermsId.equals(poIncoterms.getId(), IncotermsId.ofRepoId(12))).isTrue();
-		assertEquals("TestPoIncoterms2", poIncoterms.getName());
-		assertEquals("TestPoIncotermsValue2", poIncoterms.getValue());
-		assertEquals("TestPoIncotermsLocation2", poIncoterms.getLocationEffective());
+		assertThat(poIncoterms.getName()).isEqualTo("TestPoIncoterms2");
+		assertThat(poIncoterms.getValue()).isEqualTo("TestPoIncotermsValue2");
+		assertThat(poIncoterms.getLocationEffective()).isEqualTo("TestPoIncotermsLocation2");
 	}
 
 	@Test
@@ -330,18 +331,157 @@ public class BPartnerEffectiveBLTest
 		assertThat(bPartnerEffective.isAutoInvoice(SOTrx.PURCHASE)).isFalse();
 
 		final Incoterms incoterms = bPartnerEffective.getIncoterms(SOTrx.SALES);
-		assertNotNull(incoterms);
+		assertThat(incoterms).isNotNull();
 		assertThat(IncotermsId.equals(incoterms.getId(), IncotermsId.ofRepoId(17))).isTrue();
-		assertEquals("TestIncoterms3", incoterms.getName());
-		assertEquals("TestIncotermsValue3", incoterms.getValue());
-		assertEquals("TestIncotermsLocation3", incoterms.getLocationEffective());
+		assertThat(incoterms.getName()).isEqualTo("TestIncoterms3");
+		assertThat(incoterms.getValue()).isEqualTo("TestIncotermsValue3");
+		assertThat(incoterms.getLocationEffective()).isEqualTo("TestIncotermsLocation3");
 
 		final Incoterms poIncoterms = bPartnerEffective.getIncoterms(SOTrx.PURCHASE);
-		assertNotNull(poIncoterms);
+		assertThat(poIncoterms).isNotNull();
 		assertThat(IncotermsId.equals(poIncoterms.getId(), IncotermsId.ofRepoId(18))).isTrue();
-		assertEquals("TestPoIncoterms3", poIncoterms.getName());
-		assertEquals("TestPoIncotermsValue3", poIncoterms.getValue());
-		assertEquals("TestPoIncotermsLocation3", poIncoterms.getLocationEffective());
+		assertThat(poIncoterms.getName()).isEqualTo("TestPoIncoterms3");
+		assertThat(poIncoterms.getValue()).isEqualTo("TestPoIncotermsValue3");
+		assertThat(poIncoterms.getLocationEffective()).isEqualTo("TestPoIncotermsLocation3");
+	}
+
+	// ------- getEffectiveBillBPartner tests -------
+
+	@Test
+	public void getEffectiveBillBPartner_relationWinsOverAssociationGroup()
+	{
+		// central billing BP (association group bill-to)
+		final I_C_BPartner centralBillingBP = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		saveRecord(centralBillingBP);
+		final BPartnerId centralBillingId = BPartnerId.ofRepoId(centralBillingBP.getC_BPartner_ID());
+
+		// association group pointing to centralBillingBP
+		final I_C_BP_Group assocGroup = InterfaceWrapperHelper.newInstance(I_C_BP_Group.class);
+		assocGroup.setIsDeviatingBillBPartner(true);
+		assocGroup.setBill_BPartner_ID(centralBillingId.getRepoId());
+		saveRecord(assocGroup);
+
+		// member BP in the association group
+		final I_C_BPartner memberBP = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		memberBP.setC_BP_Group_ID(assocGroup.getC_BP_Group_ID());
+		saveRecord(memberBP);
+		final BPartnerId memberBPId = BPartnerId.ofRepoId(memberBP.getC_BPartner_ID());
+
+		// per-member-BP bill-to location
+		final I_C_BPartner_Location memberBillToLoc = InterfaceWrapperHelper.newInstance(I_C_BPartner_Location.class);
+		memberBillToLoc.setC_BPartner_ID(memberBP.getC_BPartner_ID());
+		saveRecord(memberBillToLoc);
+
+		// per-member-BP bill-to partner (separate from centralBilling)
+		final I_C_BPartner memberBillToBP = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		saveRecord(memberBillToBP);
+		final BPartnerId memberBillToBPId = BPartnerId.ofRepoId(memberBillToBP.getC_BPartner_ID());
+
+		// per-member-BP bill-to location on the target BP
+		final I_C_BPartner_Location memberBillToBPLoc = InterfaceWrapperHelper.newInstance(I_C_BPartner_Location.class);
+		memberBillToBPLoc.setC_BPartner_ID(memberBillToBP.getC_BPartner_ID());
+		saveRecord(memberBillToBPLoc);
+
+		// C_BP_Relation: memberBP → memberBillToBP (IsBillTo=Y)
+		final I_C_BP_Relation relation = InterfaceWrapperHelper.newInstance(I_C_BP_Relation.class);
+		relation.setC_BPartner_ID(memberBP.getC_BPartner_ID());
+		relation.setC_BPartner_Location_ID(memberBillToLoc.getC_BPartner_Location_ID());
+		relation.setC_BPartnerRelation_ID(memberBillToBP.getC_BPartner_ID());
+		relation.setC_BPartnerRelation_Location_ID(memberBillToBPLoc.getC_BPartner_Location_ID());
+		relation.setIsBillTo(true);
+		relation.setIsActive(true);
+		saveRecord(relation);
+
+		final BillBPartnerResolution resolution = bpartnerEffectiveBL.getEffectiveBillBPartner(memberBPId);
+
+		final BPartnerLocationId expectedBillLocId = BPartnerLocationId.ofRepoId(memberBillToBPId, memberBillToBPLoc.getC_BPartner_Location_ID());
+		assertThat(resolution).isNotNull();
+		assertThat(resolution.getBillBPartnerId()).isEqualTo(memberBillToBPId);
+		assertThat(resolution.getBillLocationId()).isEqualTo(expectedBillLocId);
+	}
+
+	@Test
+	public void getEffectiveBillBPartner_associationGroupUsedWhenNoRelation()
+	{
+		final I_C_BPartner centralBillingBP = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		saveRecord(centralBillingBP);
+		final BPartnerId centralBillingId = BPartnerId.ofRepoId(centralBillingBP.getC_BPartner_ID());
+
+		final I_C_BPartner_Location centralLoc = InterfaceWrapperHelper.newInstance(I_C_BPartner_Location.class);
+		centralLoc.setC_BPartner_ID(centralBillingBP.getC_BPartner_ID());
+		saveRecord(centralLoc);
+
+		final I_C_BP_Group assocGroup = InterfaceWrapperHelper.newInstance(I_C_BP_Group.class);
+		assocGroup.setIsDeviatingBillBPartner(true);
+		assocGroup.setBill_BPartner_ID(centralBillingId.getRepoId());
+		assocGroup.setBill_Location_ID(centralLoc.getC_BPartner_Location_ID());
+		saveRecord(assocGroup);
+
+		final I_C_BPartner memberBP = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		memberBP.setC_BP_Group_ID(assocGroup.getC_BP_Group_ID());
+		saveRecord(memberBP);
+		final BPartnerId memberBPId = BPartnerId.ofRepoId(memberBP.getC_BPartner_ID());
+
+		final BillBPartnerResolution resolution = bpartnerEffectiveBL.getEffectiveBillBPartner(memberBPId);
+
+		final BPartnerLocationId expectedBillLocId = BPartnerLocationId.ofRepoId(centralBillingId, centralLoc.getC_BPartner_Location_ID());
+		assertThat(resolution).isNotNull();
+		assertThat(resolution.getBillBPartnerId()).isEqualTo(centralBillingId);
+		assertThat(resolution.getBillLocationId()).isEqualTo(expectedBillLocId);
+	}
+
+	@Test
+	public void getEffectiveBillBPartner_parentAssociationGroupUsedWhenMemberGroupIsNotAssociation()
+	{
+		final I_C_BPartner centralBillingBP = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		saveRecord(centralBillingBP);
+		final BPartnerId centralBillingId = BPartnerId.ofRepoId(centralBillingBP.getC_BPartner_ID());
+
+		final I_C_BPartner_Location centralLoc = InterfaceWrapperHelper.newInstance(I_C_BPartner_Location.class);
+		centralLoc.setC_BPartner_ID(centralBillingBP.getC_BPartner_ID());
+		saveRecord(centralLoc);
+
+		// parent group is the association
+		final I_C_BP_Group parentAssocGroup = InterfaceWrapperHelper.newInstance(I_C_BP_Group.class);
+		parentAssocGroup.setIsDeviatingBillBPartner(true);
+		parentAssocGroup.setBill_BPartner_ID(centralBillingId.getRepoId());
+		parentAssocGroup.setBill_Location_ID(centralLoc.getC_BPartner_Location_ID());
+		saveRecord(parentAssocGroup);
+
+		// member's direct group is NOT an association
+		final I_C_BP_Group childGroup = InterfaceWrapperHelper.newInstance(I_C_BP_Group.class);
+		childGroup.setIsDeviatingBillBPartner(false);
+		childGroup.setParent_BP_Group_ID(parentAssocGroup.getC_BP_Group_ID());
+		saveRecord(childGroup);
+
+		final I_C_BPartner memberBP = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		memberBP.setC_BP_Group_ID(childGroup.getC_BP_Group_ID());
+		saveRecord(memberBP);
+		final BPartnerId memberBPId = BPartnerId.ofRepoId(memberBP.getC_BPartner_ID());
+
+		final BillBPartnerResolution resolution = bpartnerEffectiveBL.getEffectiveBillBPartner(memberBPId);
+
+		final BPartnerLocationId expectedBillLocId = BPartnerLocationId.ofRepoId(centralBillingId, centralLoc.getC_BPartner_Location_ID());
+		assertThat(resolution).isNotNull();
+		assertThat(resolution.getBillBPartnerId()).isEqualTo(centralBillingId);
+		assertThat(resolution.getBillLocationId()).isEqualTo(expectedBillLocId);
+	}
+
+	@Test
+	public void getEffectiveBillBPartner_neitherRelationNorAssociationGroup_returnsNull()
+	{
+		final I_C_BP_Group plainGroup = InterfaceWrapperHelper.newInstance(I_C_BP_Group.class);
+		plainGroup.setIsDeviatingBillBPartner(false);
+		saveRecord(plainGroup);
+
+		final I_C_BPartner memberBP = InterfaceWrapperHelper.newInstance(I_C_BPartner.class);
+		memberBP.setC_BP_Group_ID(plainGroup.getC_BP_Group_ID());
+		saveRecord(memberBP);
+		final BPartnerId memberBPId = BPartnerId.ofRepoId(memberBP.getC_BPartner_ID());
+
+		final BillBPartnerResolution resolution = bpartnerEffectiveBL.getEffectiveBillBPartner(memberBPId);
+
+		assertThat(resolution).isNull();
 	}
 
 	@Builder(builderMethodName = "setup", builderClassName = "$SetupBuilder")
@@ -395,7 +535,6 @@ public class BPartnerEffectiveBLTest
 		saveRecord(bpGroupParent);
 
 		final I_C_BP_Group bpGroup = InterfaceWrapperHelper.newInstance(I_C_BP_Group.class);
-		bpGroup.setC_BP_Group_ID(3);
 		bpGroup.setParent_BP_Group_ID(bpGroupParent.getC_BP_Group_ID());
 		bpGroup.setM_PricingSystem_ID(PricingSystemId.toRepoId(bpGroup_PricingSystemId));
 		bpGroup.setPO_PricingSystem_ID(PricingSystemId.toRepoId(bpGroup_poPricingSystemId));

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/C_BPartner_StepDef.java
@@ -33,6 +33,7 @@ import de.metas.common.util.CoalesceUtil;
 import de.metas.common.util.EmptyUtil;
 import de.metas.contracts.bpartner.process.C_BPartner_MoveToAnotherOrg;
 import de.metas.cucumber.stepdefs.aggregation.C_Aggregation_StepDefData;
+import de.metas.cucumber.stepdefs.bpgroup.C_BP_Group_StepDefData;
 import de.metas.cucumber.stepdefs.context.TestContext;
 import de.metas.cucumber.stepdefs.discountschema.M_DiscountSchema_StepDefData;
 import de.metas.cucumber.stepdefs.dunning.C_Dunning_StepDefData;
@@ -120,6 +121,7 @@ public class C_BPartner_StepDef
 	public static final int BP_GROUP_ID = BPGroupId.ofRepoId(1000000).getRepoId();
 
 	@NonNull private final C_BPartner_StepDefData bPartnerTable;
+	@NonNull private final C_BP_Group_StepDefData bpGroupTable;
 	@NonNull private final C_BPartner_Location_StepDefData bPartnerLocationTable;
 	@NonNull private final M_PricingSystem_StepDefData pricingSystemTable;
 	@NonNull private final M_Product_StepDefData productTable;
@@ -224,7 +226,10 @@ public class C_BPartner_StepDef
 	{
 		final ValueAndName valueAndName = row.suggestValueAndName();
 
-		final int bpGroupId = row.getAsOptionalInt(COLUMNNAME_C_BP_Group_ID).orElse(BP_GROUP_ID);
+		final int bpGroupId = row.getAsOptionalIdentifier(COLUMNNAME_C_BP_Group_ID)
+				.flatMap(bpGroupTable::getIdOptional)
+				.map(BPGroupId::getRepoId)
+				.orElseGet(() -> row.getAsOptionalInt(COLUMNNAME_C_BP_Group_ID).orElse(BP_GROUP_ID));
 
 		final int orgId = row.getAsOptionalIdentifier(I_C_BPartner.COLUMNNAME_AD_Org_ID)
 				.map(orgTable::get)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/bpartner/C_BP_Relation_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/bpartner/C_BP_Relation_StepDef.java
@@ -1,0 +1,99 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.bpartner;
+
+import de.metas.bpartner.BPartnerId;
+import de.metas.cucumber.stepdefs.C_BPartner_Location_StepDefData;
+import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
+import de.metas.cucumber.stepdefs.DataTableRow;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.StepDefConstants;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_C_BP_Relation;
+import org.compiere.model.I_C_BPartner;
+
+/**
+ * Responsible for creating {@code C_BP_Relation} (business-partner relation) records.
+ */
+@RequiredArgsConstructor
+public class C_BP_Relation_StepDef
+{
+	@NonNull private final C_BP_Relation_StepDefData bpRelationTable;
+	@NonNull private final C_BPartner_StepDefData bpartnerTable;
+	@NonNull private final C_BPartner_Location_StepDefData bpartnerLocationTable;
+
+	/**
+	 * Creates {@code C_BP_Relation} records linking a source partner to a target (relation) partner.
+	 *
+	 * @cucumber.stepdef Creates {@code C_BP_Relation} records.
+	 * @cucumber.columns
+	 *   <b>Identifier</b> — (optional) alias for cross-step reference<br>
+	 *   <b>C_BPartner_ID</b> — (required, identifier-ref) the source business partner<br>
+	 *   <b>C_BPartnerRelation_ID</b> — (required, identifier-ref) the related (target) business partner<br>
+	 *   <b>C_BPartnerRelation_Location_ID</b> — (optional, identifier-ref) the location of the related partner<br>
+	 *   <b>IsBillTo</b> — (optional, default false) whether the relation is used for bill-to<br>
+	 *   <b>Name</b> — (optional) relation name; auto-generated from the partner IDs when omitted<br>
+	 * @cucumber.depends StepDefData: C_BPartner_StepDefData, C_BPartner_Location_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And metasfresh contains C_BP_Relations:
+	 *   | Identifier  | C_BPartner_ID | C_BPartnerRelation_ID | IsBillTo |
+	 *   | rel_billTo  | memberBP      | memberBillToBP        | Y        |
+	 * </pre>
+	 */
+	@Given("metasfresh contains C_BP_Relations:")
+	public void createBPRelations(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable)
+				.setAdditionalRowIdentifierColumnName(I_C_BP_Relation.COLUMNNAME_C_BP_Relation_ID)
+				.forEach(this::createBPRelation);
+	}
+
+	private void createBPRelation(@NonNull final DataTableRow row)
+	{
+		final BPartnerId sourceBPartnerId = row.getAsIdentifier(I_C_BPartner.COLUMNNAME_C_BPartner_ID).lookupNotNullIdIn(bpartnerTable);
+		final BPartnerId relationBPartnerId = row.getAsIdentifier(I_C_BP_Relation.COLUMNNAME_C_BPartnerRelation_ID).lookupNotNullIdIn(bpartnerTable);
+
+		final I_C_BP_Relation bpRelation = InterfaceWrapperHelper.newInstance(I_C_BP_Relation.class);
+		bpRelation.setAD_Org_ID(StepDefConstants.ORG_ID.getRepoId());
+		bpRelation.setC_BPartner_ID(sourceBPartnerId.getRepoId());
+		bpRelation.setC_BPartnerRelation_ID(relationBPartnerId.getRepoId());
+		bpRelation.setName(row.getAsOptionalString(I_C_BP_Relation.COLUMNNAME_Name)
+				.orElseGet(() -> "BP relation " + sourceBPartnerId.getRepoId() + "-" + relationBPartnerId.getRepoId()));
+		bpRelation.setIsActive(true);
+
+		row.getAsOptionalIdentifier(I_C_BP_Relation.COLUMNNAME_C_BPartnerRelation_Location_ID)
+				.map(bpartnerLocationTable::get)
+				.ifPresent(loc -> bpRelation.setC_BPartnerRelation_Location_ID(loc.getC_BPartner_Location_ID()));
+
+		bpRelation.setIsBillTo(row.getAsOptionalBoolean(I_C_BP_Relation.COLUMNNAME_IsBillTo).orElseFalse());
+
+		InterfaceWrapperHelper.saveRecord(bpRelation);
+
+		row.getAsOptionalIdentifier().ifPresent(identifier -> bpRelationTable.putOrReplace(identifier, bpRelation));
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/bpartner/C_BP_Relation_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/bpartner/C_BP_Relation_StepDefData.java
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.bpartner;
+
+import de.metas.bpartner.service.BPRelationId;
+import de.metas.cucumber.stepdefs.StepDefData;
+import de.metas.cucumber.stepdefs.StepDefDataGetIdAware;
+import org.compiere.model.I_C_BP_Relation;
+
+/** Holds created {@code C_BP_Relation} records for cross-step reference. */
+public class C_BP_Relation_StepDefData extends StepDefData<I_C_BP_Relation>
+		implements StepDefDataGetIdAware<BPRelationId, I_C_BP_Relation>
+{
+	public C_BP_Relation_StepDefData()
+	{
+		super(I_C_BP_Relation.class);
+	}
+
+	@Override
+	public BPRelationId extractIdFromRecord(final I_C_BP_Relation record)
+	{
+		return BPRelationId.ofRepoId(record.getC_BP_Relation_ID());
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/bpgroup/C_BP_Group_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/bpgroup/C_BP_Group_StepDef.java
@@ -1,0 +1,100 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.bpgroup;
+
+import de.metas.bpartner.service.IBPGroupDAO;
+import de.metas.cucumber.stepdefs.C_BPartner_Location_StepDefData;
+import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
+import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.ValueAndName;
+import de.metas.util.Services;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_C_BP_Group;
+
+/**
+ * Responsible for creating {@code C_BP_Group} (business-partner group) records.
+ */
+@RequiredArgsConstructor
+public class C_BP_Group_StepDef
+{
+	@NonNull private final C_BP_Group_StepDefData bpGroupTable;
+	@NonNull private final C_BPartner_StepDefData bpartnerTable;
+	@NonNull private final C_BPartner_Location_StepDefData bpartnerLocationTable;
+
+	private final IBPGroupDAO bpGroupDAO = Services.get(IBPGroupDAO.class);
+
+	/**
+	 * @cucumber.stepdef Creates {@code C_BP_Group} records, optionally nested under a parent group.
+	 * @cucumber.columns
+	 *   <b>Identifier</b> — (required) alias for cross-step reference<br>
+	 *   <b>Name</b> — (optional) group name; auto-generated when omitted<br>
+	 *   <b>Parent_BP_Group_ID</b> — (optional, identifier-ref) parent business-partner group<br>
+	 *   <b>IsDeviatingBillBPartner</b> — (optional, default false) redirects the order's bill-partner to this group's Bill_BPartner<br>
+	 *   <b>Bill_BPartner_ID</b> — (optional, identifier-ref) deviating bill-to partner for the group<br>
+	 *   <b>Bill_Location_ID</b> — (optional, identifier-ref) deviating bill-to location for the group<br>
+	 * @cucumber.depends StepDefData: C_BP_Group_StepDefData, C_BPartner_StepDefData, C_BPartner_Location_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And metasfresh contains C_BP_Groups:
+	 *   | Identifier       | IsDeviatingBillBPartner | Bill_BPartner_ID  |
+	 *   | deviatingBillGrp | Y                       | centralBillingBP  |
+	 * </pre>
+	 */
+	@Given("metasfresh contains C_BP_Groups:")
+	public void createBPGroups(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable)
+				.setAdditionalRowIdentifierColumnName(I_C_BP_Group.COLUMNNAME_C_BP_Group_ID)
+				.forEach(row -> {
+					final ValueAndName valueAndName = row.suggestValueAndName();
+
+					final I_C_BP_Group bpGroupRecord = InterfaceWrapperHelper.newInstance(I_C_BP_Group.class);
+					bpGroupRecord.setIsActive(true);
+					bpGroupRecord.setValue(valueAndName.getValue());
+					bpGroupRecord.setName(valueAndName.getName());
+
+					row.getAsOptionalIdentifier(I_C_BP_Group.COLUMNNAME_Parent_BP_Group_ID)
+							.map(bpGroupTable::getId)
+							.ifPresent(parentId -> bpGroupRecord.setParent_BP_Group_ID(parentId.getRepoId()));
+
+					row.getAsOptionalBoolean(I_C_BP_Group.COLUMNNAME_IsDeviatingBillBPartner)
+							.ifPresent(bpGroupRecord::setIsDeviatingBillBPartner);
+
+					row.getAsOptionalIdentifier(I_C_BP_Group.COLUMNNAME_Bill_BPartner_ID)
+							.map(id -> id.lookupNotNullIdIn(bpartnerTable))
+							.ifPresent(bpId -> bpGroupRecord.setBill_BPartner_ID(bpId.getRepoId()));
+
+					row.getAsOptionalIdentifier(I_C_BP_Group.COLUMNNAME_Bill_Location_ID)
+							.map(bpartnerLocationTable::get)
+							.ifPresent(loc -> bpGroupRecord.setBill_Location_ID(loc.getC_BPartner_Location_ID()));
+
+					bpGroupDAO.save(bpGroupRecord);
+
+					row.getAsOptionalIdentifier().ifPresent(identifier -> bpGroupTable.putOrReplace(identifier, bpGroupRecord));
+				});
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/bpgroup/C_BP_Group_StepDefData.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/bpgroup/C_BP_Group_StepDefData.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * de.metas.cucumber
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.cucumber.stepdefs.bpgroup;
+
+import de.metas.bpartner.BPGroupId;
+import de.metas.cucumber.stepdefs.StepDefData;
+import de.metas.cucumber.stepdefs.StepDefDataGetIdAware;
+import org.compiere.model.I_C_BP_Group;
+
+public class C_BP_Group_StepDefData extends StepDefData<I_C_BP_Group> implements StepDefDataGetIdAware<BPGroupId, I_C_BP_Group>
+{
+	public C_BP_Group_StepDefData()
+	{
+		super(I_C_BP_Group.class);
+	}
+
+	@Override
+	public BPGroupId extractIdFromRecord(final I_C_BP_Group record)
+	{
+		return BPGroupId.ofRepoId(record.getC_BP_Group_ID());
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/billBPartnerAssociationVsRelation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/salesOrder/billBPartnerAssociationVsRelation.feature
@@ -1,0 +1,41 @@
+@from:cucumber
+@allure.label.epic:E0100_Sales
+@allure.label.feature:F00100_Sales_Order
+@ghActions:run_on_executor1
+Feature: Bill-to partner resolution: per-partner C_BP_Relation (IsBillTo=Y) beats the group's deviating bill-partner
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-05-17T13:30:13+01:00[Europe/Berlin]
+
+  @Id:S30351_10
+  Scenario: Per-partner bill-to relation takes precedence over the group's deviating bill partner
+    Given metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx |
+      | pl         | ps                 | DE                    | EUR                 | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv        | pl             |
+    And metasfresh contains C_BPartners:
+      | Identifier     |
+      | centralBilling |
+      | memberBillTo   |
+    And metasfresh contains C_BP_Groups:
+      | Identifier       | IsDeviatingBillBPartner | Bill_BPartner_ID |
+      | deviatingBillGrp | Y                       | centralBilling   |
+    And metasfresh contains C_BPartners:
+      | Identifier | IsCustomer | C_BP_Group_ID    | M_PricingSystem_ID |
+      | memberBP   | Y          | deviatingBillGrp | ps                 |
+    And metasfresh contains C_BP_Relations:
+      | Identifier | C_BPartner_ID | C_BPartnerRelation_ID | C_BPartnerRelation_Location_ID | IsBillTo |
+      | rel1       | memberBP      | memberBillTo          | memberBillTo                   | Y        |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered |
+      | salesOrder | true    | memberBP      | 2022-05-17  |
+    Then validate the created orders
+      | C_Order_ID.Identifier | Bill_BPartner_ID.Identifier |
+      | salesOrder            | memberBillTo                |

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5809360_sys_rename_C_BP_Group_IsAssociation_to_IsDeviatingBillBPartner.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5809360_sys_rename_C_BP_Group_IsAssociation_to_IsDeviatingBillBPartner.sql
@@ -1,0 +1,25 @@
+-- Rename C_BP_Group.IsAssociation → IsDeviatingBillBPartner
+-- Renames the physical column and its check constraint, and updates the AD dictionary
+-- (ColumnName only; display Name/PrintName/Trl are unchanged — that is a separate task).
+
+-- 1. Rename the physical column (db_alter_table drops/recreates dependent views; pass the full ALTER TABLE statement)
+/* DDL */ SELECT public.db_alter_table('C_BP_Group', 'ALTER TABLE C_BP_Group RENAME COLUMN IsAssociation TO IsDeviatingBillBPartner');
+
+-- 2. Rename the check constraint
+/* DDL */ SELECT public.db_alter_table('C_BP_Group', 'ALTER TABLE C_BP_Group RENAME CONSTRAINT c_bp_group_isassociation_check TO c_bp_group_isdeviatingbillbpartner_check');
+
+-- 3. Update AD_Column ColumnName
+UPDATE AD_Column
+SET    ColumnName = 'IsDeviatingBillBPartner',
+       Updated    = TO_TIMESTAMP('2026-06-23 10:00:01', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy  = 100
+WHERE  AD_Column_ID = 590706
+;
+
+-- 4. Update AD_Element ColumnName (Name/PrintName/Trl unchanged — Task D)
+UPDATE AD_Element
+SET    ColumnName = 'IsDeviatingBillBPartner',
+       Updated    = TO_TIMESTAMP('2026-06-23 10:00:02', 'YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy  = 100
+WHERE  AD_Element_ID = 583888
+;

--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5809510_sys_BPGroup_paymentterm_labels_and_Verband_rename.sql
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/sql/postgresql/system/70-de.metas.fresh/5809510_sys_BPGroup_paymentterm_labels_and_Verband_rename.sql
@@ -1,0 +1,83 @@
+-- BP-Group window: disambiguate the two payment-term field labels + rename "Verband".
+-- Operates on the core window 192 (all customers). The element-583888 rename below propagates
+-- via update_TRL_Tables_On_AD_Element_TRL_Update to every AD_Field referencing that element,
+-- so any customer override window that reuses it is updated by the same call.
+--
+-- AFFECTED RECORDS
+-- =====================================================================
+-- 1) NEW AD_Element 585048 (name-only override for the C_PaymentTerm_ID field):
+--      de_DE 'Zahlungsbedingung (Kunde)' | de_CH 'Zahlungskondition (Kunde)' | en_US 'Payment Term (Customer)'
+-- 2) NEW AD_Element 585049 (name-only override for the PO_PaymentTerm_ID field):
+--      de_DE 'Zahlungskondition (Lieferant)' | de_CH 'Zahlungskondition (Lieferant)' | en_US 'PO Payment Term (Vendor)'
+-- 3) AD_Field 753506 (C_PaymentTerm_ID, window 192 tab 322) -> AD_Name_ID=585048
+--    AD_Field 753505 (PO_PaymentTerm_ID, window 192 tab 322) -> AD_Name_ID=585049
+-- 4) AD_Element 583888 (the IsDeviatingBillBPartner column label) renamed:
+--      'Verband'/'Association' -> de_DE/de_CH 'Abweichender Rechnungsempfaenger' | en_US 'Alternate Invoice Recipient'
+--
+-- NOT AFFECTED: shared elements 204 (C_PaymentTerm_ID) / 1576 (PO_PaymentTerm_ID) stay untouched --
+-- they are context-dependent on ~50 / ~16 other windows where a (Kunde)/(Lieferant) suffix would be
+-- wrong; only the two BP-Group fields get the suffixed label via AD_Field.AD_Name_ID.
+
+-- ============================================================================
+-- 1) AD_Element 585048 — C_PaymentTerm_ID label "(Kunde)"
+-- ============================================================================
+INSERT INTO AD_Element (AD_Client_ID, AD_Element_ID, AD_Org_ID, ColumnName, Created, CreatedBy, Description, EntityType, IsActive, Name, PrintName, Updated, UpdatedBy)
+VALUES (0, 585048 /*From ID Server*/, 0, NULL,
+        TO_TIMESTAMP('2026-06-24 10:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', 100,
+        NULL, 'D', 'Y', 'Zahlungsbedingung (Kunde)', 'Zahlungsbedingung (Kunde)',
+        TO_TIMESTAMP('2026-06-24 10:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', 100);
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, CommitWarning, Description, Help, Name, PO_Description, PO_Help, PO_Name, PO_PrintName, PrintName, WEBUI_NameBrowse, WEBUI_NameNew, WEBUI_NameNewBreadcrumb, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning, t.Description, t.Help, t.Name, t.PO_Description, t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName, t.WEBUI_NameBrowse, t.WEBUI_NameNew, t.WEBUI_NameNewBreadcrumb, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585048
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID);
+
+UPDATE AD_Element_Trl SET Name='Zahlungsbedingung (Kunde)', PrintName='Zahlungsbedingung (Kunde)', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-24 10:00:01','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Element_ID=585048 AND AD_Language='de_DE';
+UPDATE AD_Element_Trl SET Name='Zahlungskondition (Kunde)', PrintName='Zahlungskondition (Kunde)', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-24 10:00:02','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Element_ID=585048 AND AD_Language='de_CH';
+UPDATE AD_Element_Trl SET Name='Payment Term (Customer)', PrintName='Payment Term (Customer)', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-24 10:00:03','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Element_ID=585048 AND AD_Language='en_US';
+
+-- ============================================================================
+-- 2) AD_Element 585049 — PO_PaymentTerm_ID label "(Lieferant)"
+-- ============================================================================
+INSERT INTO AD_Element (AD_Client_ID, AD_Element_ID, AD_Org_ID, ColumnName, Created, CreatedBy, Description, EntityType, IsActive, Name, PrintName, Updated, UpdatedBy)
+VALUES (0, 585049 /*From ID Server*/, 0, NULL,
+        TO_TIMESTAMP('2026-06-24 10:00:04','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', 100,
+        NULL, 'D', 'Y', 'Zahlungskondition (Lieferant)', 'Zahlungskondition (Lieferant)',
+        TO_TIMESTAMP('2026-06-24 10:00:04','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', 100);
+
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, CommitWarning, Description, Help, Name, PO_Description, PO_Help, PO_Name, PO_PrintName, PrintName, WEBUI_NameBrowse, WEBUI_NameNew, WEBUI_NameNewBreadcrumb, IsTranslated, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning, t.Description, t.Help, t.Name, t.PO_Description, t.PO_Help, t.PO_Name, t.PO_PrintName, t.PrintName, t.WEBUI_NameBrowse, t.WEBUI_NameNew, t.WEBUI_NameNewBreadcrumb, 'N', t.AD_Client_ID, t.AD_Org_ID, t.Created, t.CreatedBy, t.Updated, t.UpdatedBy, 'Y'
+FROM AD_Language l, AD_Element t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585049
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID);
+
+UPDATE AD_Element_Trl SET Name='Zahlungskondition (Lieferant)', PrintName='Zahlungskondition (Lieferant)', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-24 10:00:05','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Element_ID=585049 AND AD_Language='de_DE';
+UPDATE AD_Element_Trl SET Name='Zahlungskondition (Lieferant)', PrintName='Zahlungskondition (Lieferant)', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-24 10:00:06','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Element_ID=585049 AND AD_Language='de_CH';
+UPDATE AD_Element_Trl SET Name='PO Payment Term (Vendor)', PrintName='PO Payment Term (Vendor)', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-24 10:00:07','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Element_ID=585049 AND AD_Language='en_US';
+
+-- ============================================================================
+-- 3) Point the two displayed core fields (window 192 tab 322) at the override elements
+--    (earlier timestamp than the element_trl rows so the propagation guard fires)
+-- ============================================================================
+UPDATE AD_Field SET AD_Name_ID=585048, Updated=TO_TIMESTAMP('2026-06-24 09:59:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Field_ID=753506;
+UPDATE AD_Field SET AD_Name_ID=585049, Updated=TO_TIMESTAMP('2026-06-24 09:59:01','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Field_ID=753505;
+
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(585048);
+/* DDL */ SELECT update_FieldTranslation_From_AD_Name_Element(585049);
+
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=753506;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(753506);
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=753505;
+/* DDL */ SELECT AD_Element_Link_Create_Missing_Field(753505);
+
+-- ============================================================================
+-- 4) Rename element 583888 (column IsDeviatingBillBPartner): Verband -> Abweichender Rechnungsempfaenger
+--    Single-use element (only AD_Column 590706). Propagation updates AD_Column + every AD_Field that
+--    references it (core window 192 field 752676, plus any customer override window reusing it).
+-- ============================================================================
+UPDATE AD_Element_Trl SET Name='Abweichender Rechnungsempfänger', PrintName='Abweichender Rechnungsempfänger', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-24 10:00:10','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Element_ID=583888 AND AD_Language='de_DE';
+UPDATE AD_Element_Trl SET Name='Abweichender Rechnungsempfänger', PrintName='Abweichender Rechnungsempfänger', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-24 10:00:11','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Element_ID=583888 AND AD_Language='de_CH';
+UPDATE AD_Element_Trl SET Name='Alternate Invoice Recipient', PrintName='Alternate Invoice Recipient', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-06-24 10:00:12','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Element_ID=583888 AND AD_Language='en_US';
+
+/* DDL */ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583888);

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/interceptor/OrderTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/interceptor/OrderTest.java
@@ -26,6 +26,7 @@ import de.metas.adempiere.model.I_C_Order;
 import de.metas.bpartner.BPartnerLocationId;
 import de.metas.bpartner.BPartnerSupplierApprovalRepository;
 import de.metas.bpartner.BPartnerSupplierApprovalService;
+import de.metas.bpartner.effective.BPartnerEffectiveBL;
 import de.metas.bpartner.service.impl.BPartnerBL;
 import de.metas.common.util.time.SystemTime;
 import de.metas.doctype.CopyDescriptionAndDocumentNote;
@@ -76,12 +77,13 @@ public class OrderTest
 		SpringContextHolder.registerJUnitBean(BPartnerOrderParamsRepository.newInstanceForUnitTesting());
 
 		final BPartnerBL bpartnerBL = new BPartnerBL(new UserRepository());
+		final BPartnerEffectiveBL bpartnerEffectiveBL = BPartnerEffectiveBL.newInstanceForUnitTesting();
 		final DocumentLocationBL documentLocationBL = DocumentLocationBL.newInstanceForUnitTesting();
 		final OrderLineDetailRepository orderLineDetailRepository = new OrderLineDetailRepository();
 		final BPartnerSupplierApprovalService partnerSupplierApprovalService = new BPartnerSupplierApprovalService(new BPartnerSupplierApprovalRepository(), new UserGroupRepository());
 		final PurchaseOrderToShipperTransportationService purchaseOrderToShipperTransportationService = PurchaseOrderToShipperTransportationService.newInstanceForUnitTesting();
 		final OrderPayScheduleService orderPayScheduleService = OrderPayScheduleService.newInstanceForUnitTesting();
-		Services.get(IModelInterceptorRegistry.class).addModelInterceptor(new C_Order(bpartnerBL, orderLineDetailRepository, documentLocationBL, partnerSupplierApprovalService, purchaseOrderToShipperTransportationService, orderPayScheduleService));
+		Services.get(IModelInterceptorRegistry.class).addModelInterceptor(new C_Order(bpartnerBL, bpartnerEffectiveBL, orderLineDetailRepository, documentLocationBL, partnerSupplierApprovalService, purchaseOrderToShipperTransportationService, orderPayScheduleService));
 
 		defaultIncoterm = newInstance(I_C_Incoterms.class);
 		defaultIncoterm.setName("System Default Incoterm");
@@ -243,6 +245,144 @@ public class OrderTest
 
 		Assertions.assertEquals(incoterms.getC_Incoterms_ID(), order.getC_Incoterms_ID());
 		Assertions.assertEquals("City", order.getIncotermLocation());
+	}
+
+	/**
+	 * A programmatically created order (e.g. from an OLCand) that already carries a provided Bill_BPartner
+	 * must NOT have it overwritten by the deviating-bill-partner group resolution.
+	 */
+	@Test
+	public void setBillBPartner_doesNotOverwriteProvidedBillBPartner_whenNotUIAction()
+	{
+		final I_C_BP_Group plainGroup = createPlainBPGroup();
+
+		final I_C_BPartner centralBilling = createBPartnerInGroup("CentralBilling", plainGroup);
+		final I_C_BPartner providedBill = createBPartnerInGroup("ProvidedBill", plainGroup);
+
+		final I_C_BP_Group deviatingGroup = newInstance(I_C_BP_Group.class);
+		deviatingGroup.setName("DeviatingBillGroup");
+		deviatingGroup.setValue("DeviatingBillGroup");
+		deviatingGroup.setIsDeviatingBillBPartner(true);
+		deviatingGroup.setBill_BPartner_ID(centralBilling.getC_BPartner_ID());
+		save(deviatingGroup);
+
+		final I_C_BPartner member = createBPartnerInGroup("Member", deviatingGroup);
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(member.getC_BPartner_ID());
+		order.setBill_BPartner_ID(providedBill.getC_BPartner_ID());
+		order.setIsSOTrx(true);
+		save(order);
+
+		Assertions.assertEquals(providedBill.getC_BPartner_ID(), order.getBill_BPartner_ID());
+	}
+
+	/**
+	 * When no Bill_BPartner is provided, the deviating-bill-partner group resolution still applies.
+	 */
+	@Test
+	public void setBillBPartner_appliesGroupBill_whenNoBillBPartnerProvided()
+	{
+		final I_C_BP_Group plainGroup = createPlainBPGroup();
+		final I_C_BPartner centralBilling = createBPartnerInGroup("CentralBilling", plainGroup);
+
+		final I_C_BP_Group deviatingGroup = newInstance(I_C_BP_Group.class);
+		deviatingGroup.setName("DeviatingBillGroup");
+		deviatingGroup.setValue("DeviatingBillGroup");
+		deviatingGroup.setIsDeviatingBillBPartner(true);
+		deviatingGroup.setBill_BPartner_ID(centralBilling.getC_BPartner_ID());
+		save(deviatingGroup);
+
+		final I_C_BPartner member = createBPartnerInGroup("Member", deviatingGroup);
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(member.getC_BPartner_ID());
+		order.setIsSOTrx(true);
+		save(order);
+
+		Assertions.assertEquals(centralBilling.getC_BPartner_ID(), order.getBill_BPartner_ID());
+	}
+
+	/**
+	 * On a programmatic BEFORE_CHANGE (C_BPartner_ID changed on an order that already carries a provided
+	 * bill partner), the provided Bill_BPartner is preserved — not re-resolved from the new partner's group.
+	 */
+	@Test
+	public void setBillBPartner_doesNotOverwriteProvidedBillBPartner_onProgrammaticChange()
+	{
+		final I_C_BP_Group plainGroup = createPlainBPGroup();
+		final I_C_BPartner centralBilling = createBPartnerInGroup("CentralBilling", plainGroup);
+		final I_C_BPartner providedBill = createBPartnerInGroup("ProvidedBill", plainGroup);
+
+		final I_C_BP_Group deviatingGroup = newInstance(I_C_BP_Group.class);
+		deviatingGroup.setName("DeviatingBillGroup");
+		deviatingGroup.setValue("DeviatingBillGroup");
+		deviatingGroup.setIsDeviatingBillBPartner(true);
+		deviatingGroup.setBill_BPartner_ID(centralBilling.getC_BPartner_ID());
+		save(deviatingGroup);
+
+		final I_C_BPartner member1 = createBPartnerInGroup("Member1", deviatingGroup);
+		final I_C_BPartner member2 = createBPartnerInGroup("Member2", deviatingGroup);
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(member1.getC_BPartner_ID());
+		order.setBill_BPartner_ID(providedBill.getC_BPartner_ID());
+		order.setIsSOTrx(true);
+		save(order);
+
+		// a programmatic partner change must not re-resolve the already-provided bill partner
+		order.setC_BPartner_ID(member2.getC_BPartner_ID());
+		save(order);
+
+		Assertions.assertEquals(providedBill.getC_BPartner_ID(), order.getBill_BPartner_ID());
+	}
+
+	/**
+	 * The standard own-bill-to default (Bill_BPartner == C_BPartner, as set by setBillLocation before this
+	 * interceptor) is NOT a "provided" bill partner — the deviating-group resolution still overwrites it.
+	 * Guards against the OLCand guard being too broad and suppressing the feature for programmatic orders.
+	 */
+	@Test
+	public void setBillBPartner_overwritesOwnBillToDefault_withGroupBill()
+	{
+		final I_C_BP_Group plainGroup = createPlainBPGroup();
+		final I_C_BPartner centralBilling = createBPartnerInGroup("CentralBilling", plainGroup);
+
+		final I_C_BP_Group deviatingGroup = newInstance(I_C_BP_Group.class);
+		deviatingGroup.setName("DeviatingBillGroup");
+		deviatingGroup.setValue("DeviatingBillGroup");
+		deviatingGroup.setIsDeviatingBillBPartner(true);
+		deviatingGroup.setBill_BPartner_ID(centralBilling.getC_BPartner_ID());
+		save(deviatingGroup);
+
+		final I_C_BPartner member = createBPartnerInGroup("Member", deviatingGroup);
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(member.getC_BPartner_ID());
+		// simulate the own-bill-to default that setBillLocation sets before this interceptor
+		order.setBill_BPartner_ID(member.getC_BPartner_ID());
+		order.setIsSOTrx(true);
+		save(order);
+
+		Assertions.assertEquals(centralBilling.getC_BPartner_ID(), order.getBill_BPartner_ID());
+	}
+
+	private I_C_BP_Group createPlainBPGroup()
+	{
+		final I_C_BP_Group group = newInstance(I_C_BP_Group.class);
+		group.setName("PlainGroup");
+		group.setValue("PlainGroup");
+		save(group);
+		return group;
+	}
+
+	private I_C_BPartner createBPartnerInGroup(final String name, final I_C_BP_Group group)
+	{
+		final I_C_BPartner bpartner = newInstance(I_C_BPartner.class);
+		bpartner.setName(name);
+		bpartner.setC_BP_Group(group);
+		save(bpartner);
+		return bpartner;
 	}
 
 	@Test


### PR DESCRIPTION
## What

Backports the `C_BP_Group` deviating-bill-partner rework to `memorable_shiny_hotfix`:

1. **Centralizes sales/purchase-order bill-partner resolution** in `BPartnerEffectiveBL` (`BillBPartnerResolution`) with an explicit precedence: per-partner bill-to `C_BP_Relation` → the group's deviating bill-partner → the parent group → default. The `C_Order` interceptor is rewired to the resolver and now carries `skipIfCopying = true`, so **cloning an order preserves the explicitly-set invoice partner** instead of overwriting it with the group's.
2. **Renames the column** `C_BP_Group.IsAssociation` → `IsDeviatingBillBPartner` (physical column + check constraint + `AD_Column`/`AD_Element` ColumnName), regenerates `I_/X_C_BP_Group`.
3. **Payment-term field labels** on the BP-Group window: disambiguates the customer/vendor payment-term fields and renames the "Verband" element to "Abweichender Rechnungsempfänger".

## Why

On the target line, cloning a purchase order overwrote the invoice partner that had been set on the source order with the group's standard invoicing partner. The old save-time association interceptor re-derived the bill partner on every create (clone included); the resolver + `skipIfCopying` guard fix that.

## Source

Cherry-pick of the already-merged https://github.com/metasfresh/metasfresh/pull/24777 (present on `new_dawn_uat`). Conflict/completeness adaptations for this older base:
- added the missing `import de.metas.user.UserId` in `BPartnerEffectiveBL` (auto-merge gap),
- added `C_BP_Group_StepDefData` and identifier-resolution for `C_BP_Group_ID` in `C_BPartner_StepDef` (test-infra this base lacked),
- dropped two out-of-scope `getPurchaseTransportDays` tests (a different feature, absent on this base),
- scrubbed the two migration scripts' comments to generic English.

## Test

- All cucumber profiles green, incl. `salesOrder/billBPartnerAssociationVsRelation.feature` (`@Id:S30351_10`) proving the relation-wins-over-group precedence end-to-end.
- `BPartnerEffectiveBLTest` (incl. the 4 `getEffectiveBillBPartner_*` cases) and `OrderTest` green.
- The `mobile test` red is the pre-existing `Bulk actions - Move` HU-manager breakage (also red on `new_dawn_uat`), unrelated to this backport — the diff contains no mobile-webui files.
