### PR TITLE
BPartner REST API: stop leaking a CacheMgt group per API call

### DIFF
--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v1/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKey.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v1/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKey.java
@@ -43,15 +43,26 @@ import java.util.function.Function;
 
 public final class BPartnerCompositeCacheByLookupKey
 {
+	/**
+	 * Must be a CONSTANT, and must follow the {@code TableName#by#...} convention.
+	 * <p>
+	 * One instance of this class is created per REST API call. {@link de.metas.cache.CacheMgt} derives the cache's
+	 * {@code CacheLabel} from this name and keeps one {@code CachesGroup} per distinct label for the lifetime of the
+	 * JVM — the group holds its caches weakly, but the group itself is never removed. An instance-specific name would
+	 * therefore leak one group per API call. The {@code #} matters: without it the whole name (not the table name)
+	 * becomes the label.
+	 */
+	private static final String CACHE_NAME = I_C_BPartner.Table_Name + "#by#BPartnerCompositeLookupKey";
+
 	private final transient CCache<OrgAndBPartnerCompositeLookupKey, BPartnerComposite> cache;
 
-	public BPartnerCompositeCacheByLookupKey(@NonNull final String identifier)
+	public BPartnerCompositeCacheByLookupKey()
 	{
 		final CacheIndex<BPartnerId/* RK */, OrgAndBPartnerCompositeLookupKey/* CK */, BPartnerComposite/* V */> //
 				cacheIndex = CacheIndex.of(new BPartnerCompositeCacheIndex());
 
 		cache = CCache.<OrgAndBPartnerCompositeLookupKey, BPartnerComposite>builder()
-				.cacheName("BPartnerComposite_by_LookupKey" + "_" + identifier)
+				.cacheName(CACHE_NAME)
 				.additionalTableNameToResetFor(I_AD_User.Table_Name)
 				.additionalTableNameToResetFor(I_C_BPartner.Table_Name)
 				.additionalTableNameToResetFor(I_C_BPartner_Location.Table_Name)

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v1/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKey.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v1/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKey.java
@@ -50,9 +50,10 @@ public final class BPartnerCompositeCacheByLookupKey
 	 * {@code CacheLabel} from this name and keeps one {@code CachesGroup} per distinct label for the lifetime of the
 	 * JVM — the group holds its caches weakly, but the group itself is never removed. An instance-specific name would
 	 * therefore leak one group per API call. The {@code #} matters: without it the whole name (not the table name)
-	 * becomes the label.
+	 * becomes the label. The suffix keeps v1 and v2 distinguishable in cache stats while leaving the label
+	 * (everything before the first {@code #}) identical.
 	 */
-	private static final String CACHE_NAME = I_C_BPartner.Table_Name + "#by#BPartnerCompositeLookupKey";
+	private static final String CACHE_NAME = I_C_BPartner.Table_Name + "#by#BPartnerCompositeLookupKey_v1";
 
 	private final transient CCache<OrgAndBPartnerCompositeLookupKey, BPartnerComposite> cache;
 

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v1/bpartner/bpartnercomposite/JsonRetrieverService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v1/bpartner/bpartnercomposite/JsonRetrieverService.java
@@ -206,7 +206,7 @@ public class JsonRetrieverService
 		this.greetingRepository = greetingRepository;
 		this.identifier = identifier;
 
-		this.cache = new BPartnerCompositeCacheByLookupKey(identifier);
+		this.cache = new BPartnerCompositeCacheByLookupKey();
 	}
 
 	public Optional<JsonResponseComposite> getJsonBPartnerComposite(@NonNull final OrgId orgId, @NonNull final IdentifierString bpartnerIdentifier)

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKey.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKey.java
@@ -52,9 +52,10 @@ public final class BPartnerCompositeCacheByLookupKey
 	 * {@code CacheLabel} from this name and keeps one {@code CachesGroup} per distinct label for the lifetime of the
 	 * JVM — the group holds its caches weakly, but the group itself is never removed. An instance-specific name would
 	 * therefore leak one group per API call. The {@code #} matters: without it the whole name (not the table name)
-	 * becomes the label.
+	 * becomes the label. The suffix keeps v1 and v2 distinguishable in cache stats while leaving the label
+	 * (everything before the first {@code #}) identical.
 	 */
-	private static final String CACHE_NAME = I_C_BPartner.Table_Name + "#by#BPartnerCompositeLookupKey";
+	private static final String CACHE_NAME = I_C_BPartner.Table_Name + "#by#BPartnerCompositeLookupKey_v2";
 
 	private final transient CCache<OrgAndBPartnerCompositeLookupKey, BPartnerComposite> cache;
 

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKey.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKey.java
@@ -45,15 +45,26 @@ import java.util.function.Function;
 
 public final class BPartnerCompositeCacheByLookupKey
 {
+	/**
+	 * Must be a CONSTANT, and must follow the {@code TableName#by#...} convention.
+	 * <p>
+	 * One instance of this class is created per REST API call. {@link de.metas.cache.CacheMgt} derives the cache's
+	 * {@code CacheLabel} from this name and keeps one {@code CachesGroup} per distinct label for the lifetime of the
+	 * JVM — the group holds its caches weakly, but the group itself is never removed. An instance-specific name would
+	 * therefore leak one group per API call. The {@code #} matters: without it the whole name (not the table name)
+	 * becomes the label.
+	 */
+	private static final String CACHE_NAME = I_C_BPartner.Table_Name + "#by#BPartnerCompositeLookupKey";
+
 	private final transient CCache<OrgAndBPartnerCompositeLookupKey, BPartnerComposite> cache;
 
-	public BPartnerCompositeCacheByLookupKey(@NonNull final String identifier)
+	public BPartnerCompositeCacheByLookupKey()
 	{
 		final CacheIndex<BPartnerId/* RK */, OrgAndBPartnerCompositeLookupKey/* CK */, BPartnerComposite/* V */> //
 				cacheIndex = CacheIndex.of(new BPartnerCompositeCacheIndex());
 
 		cache = CCache.<OrgAndBPartnerCompositeLookupKey, BPartnerComposite>builder()
-				.cacheName("BPartnerComposite_by_LookupKey" + "_" + identifier)
+				.cacheName(CACHE_NAME)
 				.additionalTableNameToResetFor(I_AD_User.Table_Name)
 				.additionalTableNameToResetFor(I_C_BPartner.Table_Name)
 				.additionalTableNameToResetFor(I_C_BPartner_Location.Table_Name)

--- a/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/JsonRetrieverService.java
+++ b/backend/de.metas.business.rest-api-impl/src/main/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/JsonRetrieverService.java
@@ -259,7 +259,7 @@ public class JsonRetrieverService
 		this.externalReferenceService = externalReferenceService;
 		this.identifier = identifier;
 
-		this.cache = new BPartnerCompositeCacheByLookupKey(identifier);
+		this.cache = new BPartnerCompositeCacheByLookupKey();
 	}
 
 	public Optional<JsonResponseComposite> getJsonBPartnerComposite(

--- a/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v1/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKeyTest.java
+++ b/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v1/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKeyTest.java
@@ -1,0 +1,83 @@
+package de.metas.rest_api.v1.bpartner.bpartnercomposite;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.cache.CCacheStats;
+import de.metas.cache.CacheLabel;
+import de.metas.cache.CacheMgt;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * #%L
+ * de.metas.business.rest-api-impl
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+class BPartnerCompositeCacheByLookupKeyTest
+{
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+	}
+
+	/**
+	 * One of these caches is created per {@code JsonRetrieverService}, i.e. once per BPartner REST API call.
+	 * <p>
+	 * {@link CacheMgt} keeps one {@code CachesGroup} per distinct {@link CacheLabel} for the lifetime of the JVM: the
+	 * group holds its caches weakly, so a dead cache is collected, but the group itself is a strong value in
+	 * {@code cachesByLabel} and is never removed. Therefore the label must NOT depend on the instance — otherwise
+	 * every API call leaks one group (~1kB of guava-map scaffolding) that nothing can ever reclaim.
+	 */
+	@Test
+	void cacheLabels_doNotGrow_whenManyInstancesAreCreated()
+	{
+		// the first instance legitimately introduces this cache's labels; measure from there
+		final List<BPartnerCompositeCacheByLookupKey> held = new ArrayList<>();
+		held.add(new BPartnerCompositeCacheByLookupKey());
+		final Set<CacheLabel> labelsAfterFirstInstance = distinctLabelsOfLiveCaches();
+
+		for (int i = 0; i < 100; i++)
+		{
+			// keep them reachable: CacheMgt holds its caches weakly, and a collected cache would hide the leak
+			held.add(new BPartnerCompositeCacheByLookupKey());
+		}
+
+		assertThat(distinctLabelsOfLiveCaches())
+				.as("creating further instances must not introduce additional cache labels")
+				.isEqualTo(labelsAfterFirstInstance);
+		assertThat(held).hasSize(101); // keep `held` strongly referenced until the assertions are done
+	}
+
+	private static Set<CacheLabel> distinctLabelsOfLiveCaches()
+	{
+		return CacheMgt.get()
+				.streamStats()
+				.map(CCacheStats::getLabels)
+				.flatMap(Set::stream)
+				.collect(ImmutableSet.toImmutableSet());
+	}
+}

--- a/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v1/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKeyTest.java
+++ b/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v1/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKeyTest.java
@@ -1,15 +1,11 @@
 package de.metas.rest_api.v1.bpartner.bpartnercomposite;
 
-import com.google.common.collect.ImmutableSet;
-import de.metas.cache.CCacheStats;
 import de.metas.cache.CacheLabel;
 import de.metas.cache.CacheMgt;
 import org.adempiere.test.AdempiereTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,28 +52,18 @@ class BPartnerCompositeCacheByLookupKeyTest
 	void cacheLabels_doNotGrow_whenManyInstancesAreCreated()
 	{
 		// the first instance legitimately introduces this cache's labels; measure from there
-		final List<BPartnerCompositeCacheByLookupKey> held = new ArrayList<>();
-		held.add(new BPartnerCompositeCacheByLookupKey());
-		final Set<CacheLabel> labelsAfterFirstInstance = distinctLabelsOfLiveCaches();
+		new BPartnerCompositeCacheByLookupKey();
+		final Set<CacheLabel> labelsAfterFirstInstance = CacheMgt.get().getCacheLabels();
 
 		for (int i = 0; i < 100; i++)
 		{
-			// keep them reachable: CacheMgt holds its caches weakly, and a collected cache would hide the leak
-			held.add(new BPartnerCompositeCacheByLookupKey());
+			new BPartnerCompositeCacheByLookupKey();
 		}
 
-		assertThat(distinctLabelsOfLiveCaches())
+		// getCacheLabels() returns the keys of CacheMgt's label map, i.e. exactly what leaked: those keys survive
+		// even after the caches they hold have been collected, so no instance needs to be kept alive here.
+		assertThat(CacheMgt.get().getCacheLabels())
 				.as("creating further instances must not introduce additional cache labels")
 				.isEqualTo(labelsAfterFirstInstance);
-		assertThat(held).hasSize(101); // keep `held` strongly referenced until the assertions are done
-	}
-
-	private static Set<CacheLabel> distinctLabelsOfLiveCaches()
-	{
-		return CacheMgt.get()
-				.streamStats()
-				.map(CCacheStats::getLabels)
-				.flatMap(Set::stream)
-				.collect(ImmutableSet.toImmutableSet());
 	}
 }

--- a/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKeyTest.java
+++ b/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKeyTest.java
@@ -1,15 +1,11 @@
 package de.metas.rest_api.v2.bpartner.bpartnercomposite;
 
-import com.google.common.collect.ImmutableSet;
-import de.metas.cache.CCacheStats;
 import de.metas.cache.CacheLabel;
 import de.metas.cache.CacheMgt;
 import org.adempiere.test.AdempiereTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,28 +52,18 @@ class BPartnerCompositeCacheByLookupKeyTest
 	void cacheLabels_doNotGrow_whenManyInstancesAreCreated()
 	{
 		// the first instance legitimately introduces this cache's labels; measure from there
-		final List<BPartnerCompositeCacheByLookupKey> held = new ArrayList<>();
-		held.add(new BPartnerCompositeCacheByLookupKey());
-		final Set<CacheLabel> labelsAfterFirstInstance = distinctLabelsOfLiveCaches();
+		new BPartnerCompositeCacheByLookupKey();
+		final Set<CacheLabel> labelsAfterFirstInstance = CacheMgt.get().getCacheLabels();
 
 		for (int i = 0; i < 100; i++)
 		{
-			// keep them reachable: CacheMgt holds its caches weakly, and a collected cache would hide the leak
-			held.add(new BPartnerCompositeCacheByLookupKey());
+			new BPartnerCompositeCacheByLookupKey();
 		}
 
-		assertThat(distinctLabelsOfLiveCaches())
+		// getCacheLabels() returns the keys of CacheMgt's label map, i.e. exactly what leaked: those keys survive
+		// even after the caches they hold have been collected, so no instance needs to be kept alive here.
+		assertThat(CacheMgt.get().getCacheLabels())
 				.as("creating further instances must not introduce additional cache labels")
 				.isEqualTo(labelsAfterFirstInstance);
-		assertThat(held).hasSize(101); // keep `held` strongly referenced until the assertions are done
-	}
-
-	private static Set<CacheLabel> distinctLabelsOfLiveCaches()
-	{
-		return CacheMgt.get()
-				.streamStats()
-				.map(CCacheStats::getLabels)
-				.flatMap(Set::stream)
-				.collect(ImmutableSet.toImmutableSet());
 	}
 }

--- a/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKeyTest.java
+++ b/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKeyTest.java
@@ -1,9 +1,16 @@
 package de.metas.rest_api.v2.bpartner.bpartnercomposite;
 
+import com.google.common.collect.ImmutableSet;
+import de.metas.cache.CCacheStats;
+import de.metas.cache.CacheLabel;
 import de.metas.cache.CacheMgt;
 import org.adempiere.test.AdempiereTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,27 +47,37 @@ class BPartnerCompositeCacheByLookupKeyTest
 	/**
 	 * One of these caches is created per {@code JsonRetrieverService}, i.e. once per BPartner REST API call.
 	 * <p>
-	 * {@link CacheMgt} keeps one {@code CachesGroup} per distinct {@link de.metas.cache.CacheLabel} for the lifetime of
-	 * the JVM: the group holds its caches weakly, so a dead cache is collected, but the group itself is a strong value
-	 * in {@code cachesByLabel} and is never removed. Therefore the label must NOT depend on the instance — otherwise
+	 * {@link CacheMgt} keeps one {@code CachesGroup} per distinct {@link CacheLabel} for the lifetime of the JVM: the
+	 * group holds its caches weakly, so a dead cache is collected, but the group itself is a strong value in
+	 * {@code cachesByLabel} and is never removed. Therefore the label must NOT depend on the instance — otherwise
 	 * every API call leaks one group (~1kB of guava-map scaffolding) that nothing can ever reclaim.
 	 */
 	@Test
 	void cacheLabels_doNotGrow_whenManyInstancesAreCreated()
 	{
-		final CacheMgt cacheMgt = CacheMgt.get();
-
 		// the first instance legitimately introduces this cache's labels; measure from there
-		new BPartnerCompositeCacheByLookupKey();
-		final int labelsAfterFirstInstance = cacheMgt.getCacheLabels().size();
+		final List<BPartnerCompositeCacheByLookupKey> held = new ArrayList<>();
+		held.add(new BPartnerCompositeCacheByLookupKey());
+		final Set<CacheLabel> labelsAfterFirstInstance = distinctLabelsOfLiveCaches();
 
 		for (int i = 0; i < 100; i++)
 		{
-			new BPartnerCompositeCacheByLookupKey();
+			// keep them reachable: CacheMgt holds its caches weakly, and a collected cache would hide the leak
+			held.add(new BPartnerCompositeCacheByLookupKey());
 		}
 
-		assertThat(cacheMgt.getCacheLabels())
-				.as("creating further instances must not register additional cache labels")
-				.hasSize(labelsAfterFirstInstance);
+		assertThat(distinctLabelsOfLiveCaches())
+				.as("creating further instances must not introduce additional cache labels")
+				.isEqualTo(labelsAfterFirstInstance);
+		assertThat(held).hasSize(101); // keep `held` strongly referenced until the assertions are done
+	}
+
+	private static Set<CacheLabel> distinctLabelsOfLiveCaches()
+	{
+		return CacheMgt.get()
+				.streamStats()
+				.map(CCacheStats::getLabels)
+				.flatMap(Set::stream)
+				.collect(ImmutableSet.toImmutableSet());
 	}
 }

--- a/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKeyTest.java
+++ b/backend/de.metas.business.rest-api-impl/src/test/java/de/metas/rest_api/v2/bpartner/bpartnercomposite/BPartnerCompositeCacheByLookupKeyTest.java
@@ -1,0 +1,66 @@
+package de.metas.rest_api.v2.bpartner.bpartnercomposite;
+
+import de.metas.cache.CacheMgt;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * #%L
+ * de.metas.business.rest-api-impl
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+class BPartnerCompositeCacheByLookupKeyTest
+{
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+	}
+
+	/**
+	 * One of these caches is created per {@code JsonRetrieverService}, i.e. once per BPartner REST API call.
+	 * <p>
+	 * {@link CacheMgt} keeps one {@code CachesGroup} per distinct {@link de.metas.cache.CacheLabel} for the lifetime of
+	 * the JVM: the group holds its caches weakly, so a dead cache is collected, but the group itself is a strong value
+	 * in {@code cachesByLabel} and is never removed. Therefore the label must NOT depend on the instance — otherwise
+	 * every API call leaks one group (~1kB of guava-map scaffolding) that nothing can ever reclaim.
+	 */
+	@Test
+	void cacheLabels_doNotGrow_whenManyInstancesAreCreated()
+	{
+		final CacheMgt cacheMgt = CacheMgt.get();
+
+		// the first instance legitimately introduces this cache's labels; measure from there
+		new BPartnerCompositeCacheByLookupKey();
+		final int labelsAfterFirstInstance = cacheMgt.getCacheLabels().size();
+
+		for (int i = 0; i < 100; i++)
+		{
+			new BPartnerCompositeCacheByLookupKey();
+		}
+
+		assertThat(cacheMgt.getCacheLabels())
+				.as("creating further instances must not register additional cache labels")
+				.hasSize(labelsAfterFirstInstance);
+	}
+}


### PR DESCRIPTION
Port of https://github.com/metasfresh/metasfresh/pull/25468 to `big_coconut_uat`.

This branch is an isolated fork — it does not receive `new_dawn_uat` merges — so the fix does not reach it via the normal merge train and needs its own PR. The instance that surfaced this defect in production runs this branch.

## The defect

`BPartnerCompositeCacheByLookupKey` names its `CCache`:

```java
.cacheName("BPartnerComposite_by_LookupKey" + "_" + identifier)
```

`identifier` is minted fresh on **every** call to `JsonServiceFactory.createPersister()` / `createRetriever()` (`"persister_" + UIDStringUtil.createNext()`). That name contains no `#`, so `CCache.extractTableNameForCacheName()` returns `null` — it assumes `TableName#by#Column1#…` — and the fallback takes the **whole unique name** as the table name, hence the `CacheLabel`.

`CacheMgt.getCachesGroup()` then does `cachesByLabel.computeIfAbsent(label, CachesGroup::new)`, and nothing ever removes an entry. The group holds its caches *weakly*, so a dead `CCache` is collected — but the group itself is a strong map value, ~968 bytes of Guava scaffolding, retained for the life of the JVM.

**So every BPartner REST API call permanently leaked one `CachesGroup`.** In the production heap dump: **1,367,015** groups for **215** live caches, 1.32 GB, reached over ~2.5 weeks of normal API traffic and ending in an `OutOfMemoryError`.

## The fix

Name the cache by the convention the extractor expects, so the label is the table name and the key space is bounded:

```java
// v1
private static final String CACHE_NAME = I_C_BPartner.Table_Name + "#by#BPartnerCompositeLookupKey_v1";
// v2
private static final String CACHE_NAME = I_C_BPartner.Table_Name + "#by#BPartnerCompositeLookupKey_v2";
```

The `_v1` / `_v2` suffix sits after the first `#`, so both derive the identical label `C_BPartner`; it only keeps the two API versions distinguishable in cache-stats output.

The unique label served no purpose — nothing ever invalidated by it; the cache is already reset via `additionalTableNameToResetFor(...)`, which already includes `C_BPartner`. Cache semantics are unchanged: each `JsonRetrieverService` still gets its **own** `CCache`, only the label it registers under is now shared. The now-unused constructor parameter is dropped.

## Difference from the upstream PR

Production changes are identical (cherry-picked cleanly). Only the **test** differs: this branch has `CacheMgt.getCacheLabels()` but not `streamStats()` / `CCacheStats`, so the test reads the label set directly.

That is actually a closer measurement of the defect — `getCacheLabels()` returns the keys of `cachesByLabel`, which are precisely what leaked, and those keys survive after the caches they held have been collected. So unlike upstream, no instance has to be kept alive to observe the growth.

## Validation status

**Not validated locally.** `repo.metasfresh.com` is returning **502** for every request and is the only public host for several build dependencies (`net.dev.java:pdf-renderer:0.9.0`, `org.jpedal:jpedal:1.0` — neither on Maven Central), so no local module chain can be built. CI is the first real verdict. Flagging this rather than implying a local green.

## Not addressed here

`CacheMgt` accepting an unbounded label key space with no eviction is the underlying hazard that made this possible, and the `#`-convention fallback will silently turn any other dynamic `#`-less cache name into a permanent label. Deliberately out of scope — it is a separate change to a very widely used class.
