### PR TITLE
AD_Issue: bound the error-handling recursion that can exhaust the heap

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/error/LoggableWithThrowableUtil.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/error/LoggableWithThrowableUtil.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import de.metas.logging.LogManager;
 import de.metas.util.ILoggable;
 import de.metas.util.Services;
+import org.adempiere.util.lang.IAutoCloseable;
 import de.metas.util.StringUtils;
 import lombok.NonNull;
 import lombok.Value;
@@ -42,6 +43,32 @@ public class LoggableWithThrowableUtil
 
 	private static final Logger logger = LogManager.getLogger(LoggableWithThrowableUtil.class);
 
+	private static final ThreadLocal<Boolean> adIssueCreationSuppressed = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+	/**
+	 * While the returned {@link IAutoCloseable} is open, this class will NOT turn a logged {@link Throwable} into an
+	 * AD_Issue on the current thread; it only logs it.
+	 * <p>
+	 * Needed because persisting an AD_Issue is itself a database write that runs inside the transaction manager. If
+	 * that write fails, the transaction manager logs the failure through the ambient {@link ILoggable} — and if that
+	 * loggable routes throwables back into AD_Issue creation, each failed attempt creates another AD_Issue whose save
+	 * fails the same way. The recursion is unbounded and every level carries the stacktrace of the level below it, so
+	 * the strings grow until the JVM dies with an OutOfMemoryError.
+	 * <p>
+	 * {@code de.metas.error.impl.ErrorManager} opens this region around issue creation, which bounds the depth at one.
+	 */
+	public IAutoCloseable suppressAdIssueCreation()
+	{
+		final Boolean previous = adIssueCreationSuppressed.get();
+		adIssueCreationSuppressed.set(Boolean.TRUE);
+		return () -> adIssueCreationSuppressed.set(previous);
+	}
+
+	public boolean isAdIssueCreationSuppressed()
+	{
+		return Boolean.TRUE.equals(adIssueCreationSuppressed.get());
+	}
+
 	public FormattedMsgWithAdIssueId extractMsgAndAdIssue(@NonNull final String msg, final Object... msgParameters)
 	{
 		final IErrorManager errorManager = Services.get(IErrorManager.class);
@@ -49,7 +76,14 @@ public class LoggableWithThrowableUtil
 		final Throwable exception = LoggableWithThrowableUtil.extractThrowable(msgParameters);
 		Object[] msgParametersEffective = msgParameters;
 		AdIssueId adIssueId = null;
-		if (exception != null)
+		if (exception != null && isAdIssueCreationSuppressed())
+		{
+			// We are already creating an AD_Issue on this thread and something failed while doing so.
+			// Creating another AD_Issue for that failure would recurse into the very code that is failing.
+			logger.warn("Failed while creating an AD_Issue; logging the nested exception instead of creating another AD_Issue.", exception);
+			msgParametersEffective = LoggableWithThrowableUtil.removeLastElement(msgParameters);
+		}
+		else if (exception != null)
 		{
 			try
 			{

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/error/LoggableWithThrowableUtil.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/error/LoggableWithThrowableUtil.java
@@ -3,12 +3,12 @@ package de.metas.error;
 import java.util.Arrays;
 import java.util.Optional;
 
+import org.adempiere.util.lang.IAutoCloseable;
 import org.slf4j.Logger;
 
 import de.metas.logging.LogManager;
 import de.metas.util.ILoggable;
 import de.metas.util.Services;
-import org.adempiere.util.lang.IAutoCloseable;
 import de.metas.util.StringUtils;
 import lombok.NonNull;
 import lombok.Value;
@@ -46,16 +46,12 @@ public class LoggableWithThrowableUtil
 	private static final ThreadLocal<Boolean> adIssueCreationSuppressed = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
 	/**
-	 * While the returned {@link IAutoCloseable} is open, this class will NOT turn a logged {@link Throwable} into an
-	 * AD_Issue on the current thread; it only logs it.
-	 * <p>
-	 * Needed because persisting an AD_Issue is itself a database write that runs inside the transaction manager. If
-	 * that write fails, the transaction manager logs the failure through the ambient {@link ILoggable} — and if that
-	 * loggable routes throwables back into AD_Issue creation, each failed attempt creates another AD_Issue whose save
-	 * fails the same way. The recursion is unbounded and every level carries the stacktrace of the level below it, so
-	 * the strings grow until the JVM dies with an OutOfMemoryError.
-	 * <p>
-	 * {@code de.metas.error.impl.ErrorManager} opens this region around issue creation, which bounds the depth at one.
+	 * While the returned {@link IAutoCloseable} is open, a logged {@link Throwable} is only logged on this thread,
+	 * never turned into an AD_Issue. Opened while an AD_Issue is being persisted, so that a failure of that write
+	 * cannot recurse back into creating another AD_Issue.
+	 *
+	 * @see de.metas.logging.MetasfreshIssueAppender#temporaryDisableIssueReporting() the sibling guard, for the
+	 * Logback-ERROR-log path into AD_Issue creation. It does not cover this path, which logs at WARN.
 	 */
 	public IAutoCloseable suppressAdIssueCreation()
 	{
@@ -78,8 +74,7 @@ public class LoggableWithThrowableUtil
 		AdIssueId adIssueId = null;
 		if (exception != null && isAdIssueCreationSuppressed())
 		{
-			// We are already creating an AD_Issue on this thread and something failed while doing so.
-			// Creating another AD_Issue for that failure would recurse into the very code that is failing.
+			// Already creating an AD_Issue on this thread; another one would recurse into the failing code.
 			logger.warn("Failed while creating an AD_Issue; logging the nested exception instead of creating another AD_Issue.", exception);
 			msgParametersEffective = LoggableWithThrowableUtil.removeLastElement(msgParameters);
 		}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/error/impl/ErrorManager.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/error/impl/ErrorManager.java
@@ -100,11 +100,7 @@ public class ErrorManager implements IErrorManager
 	@Override
 	public AdIssueId createIssue(@NonNull final IssueCreateRequest request)
 	{
-		// Persisting the AD_Issue is itself a DB write inside the trx manager. If it fails, the trx manager logs the
-		// failure through the ambient ILoggable, which — for an audited API request — turns the throwable into yet
-		// another AD_Issue, whose save fails the same way. Suppressing AD_Issue creation for the duration bounds that
-		// recursion at one level; without it the nesting is unbounded and each level carries the stacktrace of the
-		// level below, so the strings grow until the JVM dies with an OutOfMemoryError.
+		// Bounds the recursion when this save fails and the trx manager logs the failure through the ambient loggable.
 		try (final IAutoCloseable ignored = LoggableWithThrowableUtil.suppressAdIssueCreation())
 		{
 			return trxManager.callInNewTrx(() -> createIssueInTrx(request));

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/error/impl/ErrorManager.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/de/metas/error/impl/ErrorManager.java
@@ -8,6 +8,7 @@ import de.metas.error.InsertRemoteIssueRequest;
 import de.metas.error.IssueCategory;
 import de.metas.error.IssueCountersByCategory;
 import de.metas.error.IssueCreateRequest;
+import de.metas.error.LoggableWithThrowableUtil;
 import de.metas.logging.LogManager;
 import de.metas.process.AdProcessId;
 import de.metas.process.PInstanceId;
@@ -23,6 +24,7 @@ import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.exceptions.DBException;
 import org.adempiere.exceptions.IssueReportableExceptions;
+import org.adempiere.util.lang.IAutoCloseable;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.I_AD_Issue;
 import org.compiere.util.DB;
@@ -98,7 +100,15 @@ public class ErrorManager implements IErrorManager
 	@Override
 	public AdIssueId createIssue(@NonNull final IssueCreateRequest request)
 	{
-		return trxManager.callInNewTrx(() -> createIssueInTrx(request));
+		// Persisting the AD_Issue is itself a DB write inside the trx manager. If it fails, the trx manager logs the
+		// failure through the ambient ILoggable, which — for an audited API request — turns the throwable into yet
+		// another AD_Issue, whose save fails the same way. Suppressing AD_Issue creation for the duration bounds that
+		// recursion at one level; without it the nesting is unbounded and each level carries the stacktrace of the
+		// level below, so the strings grow until the JVM dies with an OutOfMemoryError.
+		try (final IAutoCloseable ignored = LoggableWithThrowableUtil.suppressAdIssueCreation())
+		{
+			return trxManager.callInNewTrx(() -> createIssueInTrx(request));
+		}
 	}
 
 	private AdIssueId createIssueInTrx(@NonNull final IssueCreateRequest request)

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/error/CountingErrorManager.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/error/CountingErrorManager.java
@@ -1,0 +1,73 @@
+package de.metas.error;
+
+import org.adempiere.util.lang.impl.TableRecordReference;
+
+import java.util.Collections;
+
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * Test double that only counts how often an AD_Issue would have been created, without touching the database.
+ */
+public class CountingErrorManager implements IErrorManager
+{
+	public int createIssueCount = 0;
+
+	private AdIssueId nextIssueId()
+	{
+		createIssueCount++;
+		return AdIssueId.ofRepoId(createIssueCount);
+	}
+
+	@Override
+	public AdIssueId createIssue(final Throwable t)
+	{
+		return nextIssueId();
+	}
+
+	@Override
+	public AdIssueId createIssue(final IssueCreateRequest request)
+	{
+		return nextIssueId();
+	}
+
+	@Override
+	public AdIssueId insertRemoteIssue(final InsertRemoteIssueRequest request)
+	{
+		return nextIssueId();
+	}
+
+	@Override
+	public void markIssueAcknowledged(final AdIssueId adIssueId)
+	{
+		// nothing
+	}
+
+	@Override
+	public IssueCountersByCategory getIssueCountersByCategory(
+			final TableRecordReference recordRef,
+			final boolean onlyNotAcknowledged)
+	{
+		return IssueCountersByCategory.of(Collections.emptyMap());
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/error/ErrorManagerRecursionGuardTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/error/ErrorManagerRecursionGuardTest.java
@@ -1,0 +1,151 @@
+package de.metas.error;
+
+import de.metas.error.impl.ErrorManager;
+import de.metas.util.ILoggable;
+import de.metas.util.Loggables;
+import de.metas.util.Services;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.util.lang.IAutoCloseable;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * Pins the wiring between {@link ErrorManager} and {@link LoggableWithThrowableUtil}: a failure while an AD_Issue is
+ * being persisted must not produce a second AD_Issue.
+ */
+class ErrorManagerRecursionGuardTest
+{
+	private CountingErrorManagerDecorator errorManager;
+
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		errorManager = new CountingErrorManagerDecorator();
+		Services.registerService(IErrorManager.class, errorManager);
+	}
+
+	/**
+	 * Reproduces the production cycle without a database:
+	 * <ol>
+	 * <li>{@code createIssueInTrx} fails while rendering the summary, because the throwable's message cannot be
+	 * rendered ({@code AdempiereException.extractMessage} calls {@code getLocalizedMessage()} unguarded).</li>
+	 * <li>{@code AbstractTrxManager.call0} catches it and logs it through the ambient {@link ILoggable}, passing the
+	 * throwable as the last parameter.</li>
+	 * <li>The ambient loggable here mimics {@code ApiAuditLoggable}: it routes that throwable back into AD_Issue
+	 * creation.</li>
+	 * </ol>
+	 * Without the guard in {@link ErrorManager#createIssue(IssueCreateRequest)} that second creation proceeds — and in
+	 * production, where each level embeds the stacktrace of the level below, it recurses until the heap is gone.
+	 */
+	@Test
+	void doesNotCreateASecondAdIssue_whenPersistingTheFirstOneFails()
+	{
+		final RuntimeException unrenderableFailure = new RuntimeException("outer")
+		{
+			@Override
+			public String getLocalizedMessage()
+			{
+				throw new IllegalStateException("this message cannot be rendered");
+			}
+		};
+
+		try (final IAutoCloseable ignored = Loggables.temporarySetLoggable(new RecursingLoggable()))
+		{
+			assertThatThrownBy(() -> errorManager.createIssue(IssueCreateRequest.builder()
+					.throwable(unrenderableFailure)
+					.build()))
+					.as("the original failure must still propagate to the caller")
+					.isInstanceOf(Throwable.class);
+		}
+
+		assertThat(errorManager.createIssueCount)
+				.as("only the outer AD_Issue attempt may reach the error manager; the nested one must be suppressed")
+				.isEqualTo(1);
+	}
+
+	/** Mimics {@code ApiAuditLoggable}, which turns a trailing {@link Throwable} into an AD_Issue. */
+	private static class RecursingLoggable implements ILoggable
+	{
+		@Override
+		public ILoggable addLog(final String msg, final Object... msgParameters)
+		{
+			LoggableWithThrowableUtil.extractMsgAndAdIssue(msg, msgParameters);
+			return this;
+		}
+	}
+
+	/**
+	 * Counts the calls that arrive through {@code Services.get(IErrorManager.class)} while delegating to the real
+	 * implementation — a stub would not run the {@code createIssueInTrx} logic under test.
+	 */
+	private static class CountingErrorManagerDecorator implements IErrorManager
+	{
+		private final IErrorManager delegate = new ErrorManager();
+
+		private int createIssueCount = 0;
+
+		@Override
+		public AdIssueId createIssue(final Throwable t)
+		{
+			createIssueCount++;
+			return delegate.createIssue(t);
+		}
+
+		@Override
+		public AdIssueId createIssue(final IssueCreateRequest request)
+		{
+			createIssueCount++;
+			return delegate.createIssue(request);
+		}
+
+		@Override
+		public AdIssueId insertRemoteIssue(final InsertRemoteIssueRequest request)
+		{
+			return delegate.insertRemoteIssue(request);
+		}
+
+		@Override
+		public void markIssueAcknowledged(final AdIssueId adIssueId)
+		{
+			delegate.markIssueAcknowledged(adIssueId);
+		}
+
+		@Override
+		public IssueCountersByCategory getIssueCountersByCategory(
+				final TableRecordReference recordRef,
+				final boolean onlyNotAcknowledged)
+		{
+			return IssueCountersByCategory.of(Collections.emptyMap());
+		}
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/error/LoggableWithThrowableUtilTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/de/metas/error/LoggableWithThrowableUtilTest.java
@@ -1,0 +1,109 @@
+package de.metas.error;
+
+import de.metas.util.Services;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.util.lang.IAutoCloseable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+class LoggableWithThrowableUtilTest
+{
+	private CountingErrorManager errorManager;
+
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		errorManager = new CountingErrorManager();
+		Services.registerService(IErrorManager.class, errorManager);
+	}
+
+	@Test
+	void createsAnAdIssue_whenNotSuppressed()
+	{
+		LoggableWithThrowableUtil.extractMsgAndAdIssue("boom", new RuntimeException("one"));
+
+		assertThat(errorManager.createIssueCount).isEqualTo(1);
+	}
+
+	/**
+	 * Persisting an AD_Issue is itself a DB write; when it fails, the transaction manager logs that failure through
+	 * the ambient loggable, which lands back here. Without the suppression region every failed attempt would create
+	 * another AD_Issue whose save fails the same way — unbounded recursion that ends in an OutOfMemoryError, because
+	 * each level embeds the stacktrace of the level below it.
+	 */
+	@Test
+	void doesNotCreateAnAdIssue_whileSuppressed()
+	{
+		try (final IAutoCloseable ignored = LoggableWithThrowableUtil.suppressAdIssueCreation())
+		{
+			LoggableWithThrowableUtil.extractMsgAndAdIssue("boom", new RuntimeException("nested"));
+		}
+
+		assertThat(errorManager.createIssueCount)
+				.as("a throwable logged while an AD_Issue is being created must not create another AD_Issue")
+				.isZero();
+	}
+
+	@Test
+	void restoresThePreviousState_whenTheRegionIsClosed()
+	{
+		assertThat(LoggableWithThrowableUtil.isAdIssueCreationSuppressed()).isFalse();
+
+		try (final IAutoCloseable ignored = LoggableWithThrowableUtil.suppressAdIssueCreation())
+		{
+			assertThat(LoggableWithThrowableUtil.isAdIssueCreationSuppressed()).isTrue();
+
+			// nested region: closing the inner one must NOT re-enable issue creation
+			try (final IAutoCloseable ignoredInner = LoggableWithThrowableUtil.suppressAdIssueCreation())
+			{
+				assertThat(LoggableWithThrowableUtil.isAdIssueCreationSuppressed()).isTrue();
+			}
+			assertThat(LoggableWithThrowableUtil.isAdIssueCreationSuppressed()).isTrue();
+		}
+
+		assertThat(LoggableWithThrowableUtil.isAdIssueCreationSuppressed()).isFalse();
+
+		// and issue creation works again afterwards
+		LoggableWithThrowableUtil.extractMsgAndAdIssue("boom", new RuntimeException("after"));
+		assertThat(errorManager.createIssueCount).isEqualTo(1);
+	}
+
+	@Test
+	void stillFormatsTheMessage_whileSuppressed()
+	{
+		final LoggableWithThrowableUtil.FormattedMsgWithAdIssueId result;
+		try (final IAutoCloseable ignored = LoggableWithThrowableUtil.suppressAdIssueCreation())
+		{
+			result = LoggableWithThrowableUtil.extractMsgAndAdIssue("value was {}", "42", new RuntimeException("nested"));
+		}
+
+		assertThat(result.getFormattedMessage()).isEqualTo("value was 42");
+		assertThat(result.getAdIsueId()).isEmpty();
+	}
+}


### PR DESCRIPTION
Port of https://github.com/metasfresh/metasfresh/pull/25469 to `big_coconut_uat`.

This branch is an isolated fork — it does not receive `new_dawn_uat` merges — so the fix does not reach it via the normal merge train and needs its own PR. The instance that surfaced this defect in production runs this branch.

## The defect

Persisting an `AD_Issue` is itself a database write that runs inside the transaction manager. When that write fails, `AbstractTrxManager.call0` logs the failure through the ambient `ILoggable`, passing the throwable as the **last** parameter — and `LoggableWithThrowableUtil.extractMsgAndAdIssue` treats a trailing `Throwable` as a request to create an `AD_Issue`. So the cycle closes:

```
ErrorManager.createIssue(Throwable)
 └ createIssueInTrx → InterfaceWrapperHelper.saveRecord(AD_Issue)
    └ PO.saveEx() → AbstractTrxManager.run → call0
       └ catch (Throwable) → loggable.addLog(…, runException)
          └ ApiAuditLoggable.addLog → createLogEntry
             └ LoggableWithThrowableUtil.extractMsgAndAdIssue
                └ errorManager.createIssue(exception)   ← recurses
```

Nothing bounded the depth. `extractMsgAndAdIssue` *does* wrap `createIssue` in `catch (final Exception …)`, but the recursion happens **below** that frame, so the guard never closes the loop. Each level's stacktrace text embeds the level below it, so the strings grow without bound.

From the production heap dump — one Tomcat request thread: **4,222 stack frames**, with **171** `createIssueInTrx` and **170** `extractMsgAndAdIssue` frames, holding **170 `DBException`** (707 MB) and **171 `MIssue`** (228 MB) at roughly **7.9 MB each** — 39.51 % of the heap in one thread's locals. It died inside `MIssue.truncateExceptionsRelatedString`, running a regex replace over the accumulated stacktrace.

## The fix

`ErrorManager` marks the region in which it persists an `AD_Issue`; `LoggableWithThrowableUtil` skips issue creation inside that region and only logs:

```java
try (final IAutoCloseable ignored = LoggableWithThrowableUtil.suppressAdIssueCreation())
{
    return trxManager.callInNewTrx(() -> createIssueInTrx(request));
}
```

This bounds the nesting at one level while preserving the log record and the formatted message. The region is **save/restore** rather than set/clear, so a nested region closing cannot re-enable issue creation early. No public contract changes — the return type and nullability of `createIssue` are untouched, so no call site is affected.

Note there is a sibling guard, `MetasfreshIssueAppender.temporaryDisableIssueReporting()`, for the Logback-ERROR-log path into AD_Issue creation. It cannot cover this path: `call0` logs at WARN and that appender filters on ERROR. The two are now cross-referenced in javadoc.

## Tests

`LoggableWithThrowableUtilTest` pins the ThreadLocal contract (created when not suppressed; not created when suppressed; nested regions restore correctly; the message is still formatted).

`ErrorManagerRecursionGuardTest` pins the **integration point** — the wiring a refactor would silently break:

- the throwable's `getLocalizedMessage()` throws, so `createIssueInTrx` fails while building the summary (`AdempiereException.extractMessage` calls it unguarded) before any save is attempted;
- `AbstractTrxManager.call0` catches it and logs it through the ambient `ILoggable`;
- the installed loggable mimics `ApiAuditLoggable`, routing that throwable back into AD_Issue creation.

The counter **decorates the real `ErrorManager`** rather than stubbing it: a stub never runs `createIssueInTrx`, and counting inside the poisoned throwable cannot distinguish the fixed from the unfixed path, because the nested attempt operates on a different, renderable exception. Counting the calls that arrive via `Services.get` gives **1** with the guard and **2** without.

## Difference from the upstream PR

None — all three commits cherry-picked cleanly, and every symbol the change and its tests rely on was verified present on this branch: `Loggables.temporarySetLoggable`, `ILoggable` being a single-abstract-method interface, the same five `IErrorManager` methods, `IssueCountersByCategory.of(Map)`, `IssueCreateRequest`'s `@Builder` + `throwable` field, `MetasfreshIssueAppender.temporaryDisableIssueReporting()`, `ErrorManager`'s implicit no-arg constructor, and — the one the test depends on — `buildIssueSummary` still being called before `saveRecord`.

## Validation status

**Not validated locally.** `repo.metasfresh.com` is returning **502** for every request and is the only public host for several build dependencies (`net.dev.java:pdf-renderer:0.9.0`, `org.jpedal:jpedal:1.0` — neither on Maven Central), so no local module chain can be built. CI is the first real verdict. Flagging this rather than implying a local green.
