### PR TITLE
Port: de-flake productMaturing — run maturing-candidate recompute synchronously

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/manufacturing.maturing/productMaturing.feature
@@ -78,7 +78,7 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     Then after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -86,6 +86,11 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
+    # Intentionally NOT converted to the generic "AD_Process ... is run" step (unlike
+    # CreateMaturingCandidates above):
+    # - A synchronous run only enqueues its selection.
+    # - Its close chain needs the scheduler's own async RUN_ONCE dispatch to flip IsClosed.
+    # - Run synchronously, the candidate stays unclosed. Do not convert this line.
     And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_AlreadyMaturedForOrdering' is ran once
 
     And after not more than 60s, PP_Order_Candidates are found
@@ -151,7 +156,7 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -163,7 +168,7 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     Then after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -206,7 +211,7 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     And after not more than 60s, PP_Order_Candidates are found
       | Identifier | Processed | M_Product_ID | PP_Product_BOM_ID | PP_Product_Planning_ID | S_Resource_ID | QtyEntered | QtyToProcess | QtyProcessed | DatePromised         | DateStartSchedule    | IsClosed | IsMaturing | M_Maturing_Configuration_ID | M_Maturing_Configuration_Line_ID | Issue_HU_ID   |
@@ -218,6 +223,6 @@ Feature: Maturing scenarios
 
     And wait until all rabbitMQ queues are empty or throw exception after 5 minutes
 
-    And AD_Scheduler for classname 'org.eevolution.productioncandidate.process.PP_Order_Candidate_CreateMaturingCandidates' is ran once
+    And the AD_Process with value 'PP_Order_Candidate_CreateMaturingCandidates' is run
 
     Then after not more than 60s, no PP_Order_Candidates are found for Issue_HU_ID: 'rawgood_hu_30'


### PR DESCRIPTION
Straight port of https://github.com/metasfresh/metasfresh/pull/25175 (merged to `new_dawn_uat` 2026-07-16) to `deep_tundra_release`. Cherry-pick of https://github.com/metasfresh/metasfresh/commit/f4ca93b4d3077ac2d369ccc67f60a427c741ab72, applied cleanly; the resulting file is byte-identical to the `new_dawn_uat` version.

## Why

Two scenarios in `manufacturing.maturing/productMaturing.feature` flake on this branch:

- `:123` "Maturing candidate created, then HU qty is adjusted. Maturing candidate is updated"
- `:178` "Maturing candidate created, then HU is disposed. Maturing candidate is deleted."

Both fail as `after not more than 60s, PP_Order_Candidates are found` timing out (121 tries, `No item found for SELECT * FROM PP_Order_Candidate … IsMaturing='Y'`) — the maturing candidate is never created.

Root cause, confirmed: when `CreateMaturingCandidates` is triggered through the event-bus `RUN_ONCE` path, `Scheduler.doWork0` lazily calls `m_model.getAD_Process()` on a scheduler PO bound to a `TrxRun_…` transaction that is already closed on the async scheduler thread → `No transaction was found for TrxRun_… tableName=AD_Process` → the run aborts. Intermittent because it depends on whether that transaction is still open when the async thread does the lazy load.

The failures are reproducible on the diff-free base branch itself, most recently on runs of `deep_tundra_release` on 2026-07-28, and they are still hitting unrelated PRs today.

## What this changes

Feature file only — no production code, no step-def code.

Five of the six `AD_Scheduler … is ran once` triggers (the `PP_Order_Candidate_CreateMaturingCandidates` runs) become the synchronous generic step `the AD_Process with value '<value>' is run`, which goes through `ProcessInfo.executeSync()` and takes the async scheduler `RUN_ONCE` out of the test path entirely, so the race cannot occur. The business logic under test is unchanged — it is the same process the scheduler's `doIt()` runs.

The sixth trigger (`…AlreadyMaturedForOrdering`) deliberately stays on the scheduler path; its close chain needs the async dispatch.

Verified on this branch: `1` remaining `is ran once` and `5` synchronous runs, matching `new_dawn_uat`; and `AD_Process_Run_StepDef` (`@When("the AD_Process with value {string} is run")`) exists here, so all five ported steps resolve.

## Not fixed here

The underlying scheduler `RUN_ONCE` / `RESTART` transaction defect is a real production bug — the same path backs the "run scheduler now" / restart action in `AD_Scheduler_Controller`, so a user can hit the same intermittent failure. That is tracked separately and is deliberately out of scope for de-flaking.
