### PR TITLE
Product Tag - M_Tag + M_Product_Tag core tables, Product Tag window, Labels tab on Product window

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_M_Product_Tag.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_M_Product_Tag.java
@@ -1,0 +1,188 @@
+package org.compiere.model;
+
+import org.adempiere.model.ModelColumn;
+
+/** Generated Interface for M_Product_Tag
+ *  @author metasfresh (generated) 
+ */
+@SuppressWarnings("unused")
+public interface I_M_Product_Tag 
+{
+
+	String Table_Name = "M_Product_Tag";
+
+//	/** AD_Table_ID=542637 */
+//	int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
+
+
+	/**
+	 * Get Client.
+	 * Client/Tenant for this installation.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Client_ID();
+
+	String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+
+	/**
+	 * Set Organisation.
+	 * Organisational entity within client
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setAD_Org_ID (int AD_Org_ID);
+
+	/**
+	 * Get Organisation.
+	 * Organisational entity within client
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Org_ID();
+
+	String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/**
+	 * Get Created.
+	 * Date this record was created
+	 *
+	 * <br>Type: DateTime
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.sql.Timestamp getCreated();
+
+	ModelColumn<I_M_Product_Tag, Object> COLUMN_Created = new ModelColumn<>(I_M_Product_Tag.class, "Created", null);
+	String COLUMNNAME_Created = "Created";
+
+	/**
+	 * Get Created By.
+	 * User who created this records
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getCreatedBy();
+
+	String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/**
+	 * Set Active.
+	 * The record is active in the system
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsActive (boolean IsActive);
+
+	/**
+	 * Get Active.
+	 * The record is active in the system
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isActive();
+
+	ModelColumn<I_M_Product_Tag, Object> COLUMN_IsActive = new ModelColumn<>(I_M_Product_Tag.class, "IsActive", null);
+	String COLUMNNAME_IsActive = "IsActive";
+
+	/**
+	 * Set Product.
+	 * Product, Service, Item
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setM_Product_ID (int M_Product_ID);
+
+	/**
+	 * Get Product.
+	 * Product, Service, Item
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getM_Product_ID();
+
+	String COLUMNNAME_M_Product_ID = "M_Product_ID";
+
+	/**
+	 * Set Product Tag Assignment.
+	 *
+	 * <br>Type: ID
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setM_Product_Tag_ID (int M_Product_Tag_ID);
+
+	/**
+	 * Get Product Tag Assignment.
+	 *
+	 * <br>Type: ID
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getM_Product_Tag_ID();
+
+	ModelColumn<I_M_Product_Tag, Object> COLUMN_M_Product_Tag_ID = new ModelColumn<>(I_M_Product_Tag.class, "M_Product_Tag_ID", null);
+	String COLUMNNAME_M_Product_Tag_ID = "M_Product_Tag_ID";
+
+	/**
+	 * Set Product Tag.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setM_Tag_ID (int M_Tag_ID);
+
+	/**
+	 * Get Product Tag.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getM_Tag_ID();
+
+	ModelColumn<I_M_Product_Tag, org.compiere.model.I_M_Tag> COLUMN_M_Tag_ID = new ModelColumn<>(I_M_Product_Tag.class, "M_Tag_ID", org.compiere.model.I_M_Tag.class);
+	String COLUMNNAME_M_Tag_ID = "M_Tag_ID";
+
+	/**
+	 * Get Updated.
+	 * Date this record was updated
+	 *
+	 * <br>Type: DateTime
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.sql.Timestamp getUpdated();
+
+	ModelColumn<I_M_Product_Tag, Object> COLUMN_Updated = new ModelColumn<>(I_M_Product_Tag.class, "Updated", null);
+	String COLUMNNAME_Updated = "Updated";
+
+	/**
+	 * Get Updated By.
+	 * User who updated this records
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getUpdatedBy();
+
+	String COLUMNNAME_UpdatedBy = "UpdatedBy";
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_M_Tag.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_M_Tag.java
@@ -1,0 +1,211 @@
+package org.compiere.model;
+
+import javax.annotation.Nullable;
+import org.adempiere.model.ModelColumn;
+
+/** Generated Interface for M_Tag
+ *  @author metasfresh (generated) 
+ */
+@SuppressWarnings("unused")
+public interface I_M_Tag 
+{
+
+	String Table_Name = "M_Tag";
+
+//	/** AD_Table_ID=542636 */
+//	int Table_ID = org.compiere.model.MTable.getTable_ID(Table_Name);
+
+
+	/**
+	 * Get Client.
+	 * Client/Tenant for this installation.
+	 *
+	 * <br>Type: TableDir
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Client_ID();
+
+	String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+
+	/**
+	 * Set Organisation.
+	 * Organisational entity within client
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setAD_Org_ID (int AD_Org_ID);
+
+	/**
+	 * Get Organisation.
+	 * Organisational entity within client
+	 *
+	 * <br>Type: Search
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getAD_Org_ID();
+
+	String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/**
+	 * Get Created.
+	 * Date this record was created
+	 *
+	 * <br>Type: DateTime
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.sql.Timestamp getCreated();
+
+	ModelColumn<I_M_Tag, Object> COLUMN_Created = new ModelColumn<>(I_M_Tag.class, "Created", null);
+	String COLUMNNAME_Created = "Created";
+
+	/**
+	 * Get Created By.
+	 * User who created this records
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getCreatedBy();
+
+	String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/**
+	 * Set Description.
+	 *
+	 * <br>Type: Text
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setDescription (@Nullable java.lang.String Description);
+
+	/**
+	 * Get Description.
+	 *
+	 * <br>Type: Text
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	@Nullable java.lang.String getDescription();
+
+	ModelColumn<I_M_Tag, Object> COLUMN_Description = new ModelColumn<>(I_M_Tag.class, "Description", null);
+	String COLUMNNAME_Description = "Description";
+
+	/**
+	 * Set Active.
+	 * The record is active in the system
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsActive (boolean IsActive);
+
+	/**
+	 * Get Active.
+	 * The record is active in the system
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isActive();
+
+	ModelColumn<I_M_Tag, Object> COLUMN_IsActive = new ModelColumn<>(I_M_Tag.class, "IsActive", null);
+	String COLUMNNAME_IsActive = "IsActive";
+
+	/**
+	 * Set Product Tag.
+	 *
+	 * <br>Type: ID
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setM_Tag_ID (int M_Tag_ID);
+
+	/**
+	 * Get Product Tag.
+	 *
+	 * <br>Type: ID
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getM_Tag_ID();
+
+	ModelColumn<I_M_Tag, Object> COLUMN_M_Tag_ID = new ModelColumn<>(I_M_Tag.class, "M_Tag_ID", null);
+	String COLUMNNAME_M_Tag_ID = "M_Tag_ID";
+
+	/**
+	 * Set Name.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setName (java.lang.String Name);
+
+	/**
+	 * Get Name.
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.lang.String getName();
+
+	ModelColumn<I_M_Tag, Object> COLUMN_Name = new ModelColumn<>(I_M_Tag.class, "Name", null);
+	String COLUMNNAME_Name = "Name";
+
+	/**
+	 * Get Updated.
+	 * Date this record was updated
+	 *
+	 * <br>Type: DateTime
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.sql.Timestamp getUpdated();
+
+	ModelColumn<I_M_Tag, Object> COLUMN_Updated = new ModelColumn<>(I_M_Tag.class, "Updated", null);
+	String COLUMNNAME_Updated = "Updated";
+
+	/**
+	 * Get Updated By.
+	 * User who updated this records
+	 *
+	 * <br>Type: Table
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	int getUpdatedBy();
+
+	String COLUMNNAME_UpdatedBy = "UpdatedBy";
+
+	/**
+	 * Set Search Key.
+	 * Search key for the record in the format required - must be unique
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setValue (java.lang.String Value);
+
+	/**
+	 * Get Search Key.
+	 * Search key for the record in the format required - must be unique
+	 *
+	 * <br>Type: String
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	java.lang.String getValue();
+
+	ModelColumn<I_M_Tag, Object> COLUMN_Value = new ModelColumn<>(I_M_Tag.class, "Value", null);
+	String COLUMNNAME_Value = "Value";
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_M_Product_Tag.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_M_Product_Tag.java
@@ -1,0 +1,81 @@
+// Generated Model - DO NOT CHANGE
+package org.compiere.model;
+
+import java.sql.ResultSet;
+import java.util.Properties;
+import javax.annotation.Nullable;
+
+/** Generated Model for M_Product_Tag
+ *  @author metasfresh (generated) 
+ */
+@SuppressWarnings("unused")
+public class X_M_Product_Tag extends org.compiere.model.PO implements I_M_Product_Tag, org.compiere.model.I_Persistent 
+{
+
+	private static final long serialVersionUID = 1531766429L;
+
+    /** Standard Constructor */
+    public X_M_Product_Tag (final Properties ctx, final int M_Product_Tag_ID, @Nullable final String trxName)
+    {
+      super (ctx, M_Product_Tag_ID, trxName);
+    }
+
+    /** Load Constructor */
+    public X_M_Product_Tag (final Properties ctx, final ResultSet rs, @Nullable final String trxName)
+    {
+      super (ctx, rs, trxName);
+    }
+
+
+	/** Load Meta Data */
+	@Override
+	protected org.compiere.model.POInfo initPO(final Properties ctx)
+	{
+		return org.compiere.model.POInfo.getPOInfo(Table_Name);
+	}
+
+	@Override
+	public void setM_Product_ID (final int M_Product_ID)
+	{
+		if (M_Product_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_M_Product_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_M_Product_ID, M_Product_ID);
+	}
+
+	@Override
+	public int getM_Product_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_M_Product_ID);
+	}
+
+	@Override
+	public void setM_Product_Tag_ID (final int M_Product_Tag_ID)
+	{
+		if (M_Product_Tag_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_M_Product_Tag_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_M_Product_Tag_ID, M_Product_Tag_ID);
+	}
+
+	@Override
+	public int getM_Product_Tag_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_M_Product_Tag_ID);
+	}
+
+	@Override
+	public void setM_Tag_ID (final int M_Tag_ID)
+	{
+		if (M_Tag_ID < 1) 
+			set_Value (COLUMNNAME_M_Tag_ID, null);
+		else 
+			set_Value (COLUMNNAME_M_Tag_ID, M_Tag_ID);
+	}
+
+	@Override
+	public int getM_Tag_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_M_Tag_ID);
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_M_Tag.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_M_Tag.java
@@ -1,0 +1,87 @@
+// Generated Model - DO NOT CHANGE
+package org.compiere.model;
+
+import java.sql.ResultSet;
+import java.util.Properties;
+import javax.annotation.Nullable;
+
+/** Generated Model for M_Tag
+ *  @author metasfresh (generated) 
+ */
+@SuppressWarnings("unused")
+public class X_M_Tag extends org.compiere.model.PO implements I_M_Tag, org.compiere.model.I_Persistent 
+{
+
+	private static final long serialVersionUID = 1735077641L;
+
+    /** Standard Constructor */
+    public X_M_Tag (final Properties ctx, final int M_Tag_ID, @Nullable final String trxName)
+    {
+      super (ctx, M_Tag_ID, trxName);
+    }
+
+    /** Load Constructor */
+    public X_M_Tag (final Properties ctx, final ResultSet rs, @Nullable final String trxName)
+    {
+      super (ctx, rs, trxName);
+    }
+
+
+	/** Load Meta Data */
+	@Override
+	protected org.compiere.model.POInfo initPO(final Properties ctx)
+	{
+		return org.compiere.model.POInfo.getPOInfo(Table_Name);
+	}
+
+	@Override
+	public void setDescription (final @Nullable java.lang.String Description)
+	{
+		set_Value (COLUMNNAME_Description, Description);
+	}
+
+	@Override
+	public java.lang.String getDescription() 
+	{
+		return get_ValueAsString(COLUMNNAME_Description);
+	}
+
+	@Override
+	public void setM_Tag_ID (final int M_Tag_ID)
+	{
+		if (M_Tag_ID < 1) 
+			set_ValueNoCheck (COLUMNNAME_M_Tag_ID, null);
+		else 
+			set_ValueNoCheck (COLUMNNAME_M_Tag_ID, M_Tag_ID);
+	}
+
+	@Override
+	public int getM_Tag_ID() 
+	{
+		return get_ValueAsInt(COLUMNNAME_M_Tag_ID);
+	}
+
+	@Override
+	public void setName (final java.lang.String Name)
+	{
+		set_Value (COLUMNNAME_Name, Name);
+	}
+
+	@Override
+	public java.lang.String getName() 
+	{
+		return get_ValueAsString(COLUMNNAME_Name);
+	}
+
+	@Override
+	public void setValue (final java.lang.String Value)
+	{
+		set_Value (COLUMNNAME_Value, Value);
+	}
+
+	@Override
+	public java.lang.String getValue() 
+	{
+		return get_ValueAsString(COLUMNNAME_Value);
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818080_sys_gh31399_M_Tag_table.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818080_sys_gh31399_M_Tag_table.sql
@@ -1,0 +1,125 @@
+-- Product Tag registry (M_Tag)
+-- General product-tag registry — a Name / unique Value / Description entity
+-- that a product can be tagged with via the M_Product_Tag many-to-many table.
+-- Complements the existing single-text M_Product.CustomerLabelName field.
+--
+-- IDs allocated from idserver.metas.de:
+--   AD_Table 542636
+--   AD_Elements: 585159 (M_Tag_ID key column), 585160 (Value business column)
+--   Reused existing AD_Elements: 102 AD_Client_ID, 113 AD_Org_ID, 245 Created, 246 CreatedBy,
+--     275 Description, 348 IsActive, 469 Name, 607 Updated, 608 UpdatedBy
+--   AD_Columns 593110..593120
+
+-- AD_Table -------------------------------------------------------------------
+INSERT INTO AD_Table (AccessLevel,ACTriggerLength,AD_Client_ID,AD_Org_ID,AD_Table_ID,CopyColumnsFromTable,Created,CreatedBy,Description,EntityType,ImportTable,IsActive,IsAutocomplete,IsChangeLog,IsDeleteable,IsDLM,IsEnableRemoteCacheInvalidation,IsHighVolume,IsSecurityEnabled,IsView,LoadSeq,Name,PersonalDataCategory,ReplicationType,TableName,Updated,UpdatedBy) VALUES ('4',0,0,0,542636 /*From ID Server*/,'N',TO_TIMESTAMP('2026-08-10 15:20:00','YYYY-MM-DD HH24:MI:SS'),100,'Produkt-Label Registry','D','N','Y','Y','N','Y','N','N','N','N','N',0,'Product Tag','NP','L','M_Tag',TO_TIMESTAMP('2026-08-10 15:20:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Table_Trl (AD_Language,AD_Table_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Table_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Table t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Table_ID=542636 AND NOT EXISTS (SELECT 1 FROM AD_Table_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Table_ID=t.AD_Table_ID)
+;
+
+-- No AD_Sequence row: the native PK sequence m_tag_seq is auto-created by dba_seq_check_native() after migration.
+
+-- Key column element (M_Tag_ID) --------------------------------------------
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,585159 /*From ID Server*/,0,'M_Tag_ID',TO_TIMESTAMP('2026-08-10 15:20:01','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Produkt-Label','Produkt-Label',TO_TIMESTAMP('2026-08-10 15:20:01','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585159 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+-- English via en_US override
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Product Tag', PrintName='Product Tag',Updated=TO_TIMESTAMP('2026-08-10 15:20:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585159 AND AD_Language='en_US'
+;
+-- Swiss German (de_CH) explicit override with Swiss conventions (already same as de_DE — no ß)
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Produkt-Label', PrintName='Produkt-Label',Updated=TO_TIMESTAMP('2026-08-10 15:20:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585159 AND AD_Language='de_CH'
+;
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585159,'en_US')
+;
+
+-- Value column element (Value) ---------------------------------------------
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,585160 /*From ID Server*/,0,'Value',TO_TIMESTAMP('2026-08-10 15:20:03','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Suchschlüssel','Suchschlüssel',TO_TIMESTAMP('2026-08-10 15:20:03','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585160 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Search Key', PrintName='Search Key',Updated=TO_TIMESTAMP('2026-08-10 15:20:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585160 AND AD_Language='en_US'
+;
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Suchschlüssel', PrintName='Suchschlüssel',Updated=TO_TIMESTAMP('2026-08-10 15:20:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585160 AND AD_Language='de_CH'
+;
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585160,'en_US')
+;
+
+-- Standard columns -----------------------------------------------------------
+-- AD_Client_ID
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593110 /*From ID Server*/,102,0,19,542636,'AD_Client_ID',TO_TIMESTAMP('2026-08-10 15:20:05','YYYY-MM-DD HH24:MI:SS'),100,'Mandant für diese Installation.','D',10,'Ein Mandant ist eine Firma oder eine juristische Person.','Y','Y','N','N','N','N','Y','N','N','Y','N','N','Mandant','NP',0,TO_TIMESTAMP('2026-08-10 15:20:05','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593110 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- AD_Org_ID
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593111 /*From ID Server*/,113,0,30,542636,'AD_Org_ID',TO_TIMESTAMP('2026-08-10 15:20:06','YYYY-MM-DD HH24:MI:SS'),100,'Organisatorische Einheit des Mandanten','D',10,'Eine Organisation ist ein Bereich ihres Mandanten.','Y','Y','N','N','N','N','Y','N','Y','Y','N','N','Sektion','NP',0,TO_TIMESTAMP('2026-08-10 15:20:06','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593111 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Created
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593112 /*From ID Server*/,245,0,16,542636,'Created',TO_TIMESTAMP('2026-08-10 15:20:07','YYYY-MM-DD HH24:MI:SS'),100,'Datum, an dem dieser Eintrag erstellt wurde','D',29,'Das Feld Erstellt zeigt an, zu welchem Datum dieser Eintrag erstellt wurde.','Y','N','N','N','N','N','Y','N','N','Y','N','N','Erstellt','NP',0,TO_TIMESTAMP('2026-08-10 15:20:07','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593112 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- CreatedBy
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593113 /*From ID Server*/,246,0,18,110,542636,'CreatedBy',TO_TIMESTAMP('2026-08-10 15:20:08','YYYY-MM-DD HH24:MI:SS'),100,'Nutzer, der diesen Eintrag erstellt hat','D',10,'Das Feld Erstellt durch zeigt an, welcher Nutzer diesen Eintrag erstellt hat.','Y','N','N','N','N','N','Y','N','N','Y','N','N','Erstellt durch','NP',0,TO_TIMESTAMP('2026-08-10 15:20:08','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593113 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- IsActive
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593114 /*From ID Server*/,348,0,20,542636,'IsActive',TO_TIMESTAMP('2026-08-10 15:20:09','YYYY-MM-DD HH24:MI:SS'),100,'Der Eintrag ist im System aktiv','D',1,'Es gibt zwei Möglichkeiten, einen Datensatz nicht mehr verfügbar zu machen: einer ist, ihn zu löschen; der andere, ihn zu deaktivieren.','Y','Y','N','N','N','N','Y','N','N','Y','N','Y','Aktiv','NP',0,TO_TIMESTAMP('2026-08-10 15:20:09','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593114 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Updated
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593115 /*From ID Server*/,607,0,16,542636,'Updated',TO_TIMESTAMP('2026-08-10 15:20:10','YYYY-MM-DD HH24:MI:SS'),100,'Datum, an dem dieser Eintrag aktualisiert wurde','D',29,'Aktualisiert zeigt an, wann dieser Eintrag aktualisiert wurde.','Y','N','N','N','N','N','Y','N','N','Y','N','N','Aktualisiert','NP',0,TO_TIMESTAMP('2026-08-10 15:20:10','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593115 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- UpdatedBy
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593116 /*From ID Server*/,608,0,18,110,542636,'UpdatedBy',TO_TIMESTAMP('2026-08-10 15:20:11','YYYY-MM-DD HH24:MI:SS'),100,'Nutzer, der diesen Eintrag aktualisiert hat','D',10,'Aktualisiert durch zeigt an, welcher Nutzer diesen Eintrag aktualisiert hat.','Y','N','N','N','N','N','Y','N','N','Y','N','N','Aktualisiert durch','NP',0,TO_TIMESTAMP('2026-08-10 15:20:11','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593116 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Key column: M_Tag_ID (ID, reference 13) ---------------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593117 /*From ID Server*/,585159,0,13,542636,'M_Tag_ID',TO_TIMESTAMP('2026-08-10 15:20:12','YYYY-MM-DD HH24:MI:SS'),100,'D',10,'Y','N','N','N','N','Y','Y','N','N','Y','N','N','Produkt-Label','NP',0,TO_TIMESTAMP('2026-08-10 15:20:12','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593117 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Business column: Name (String, reference 10) ; reuse element 469 --------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593118 /*From ID Server*/,469,0,10,542636,'Name',TO_TIMESTAMP('2026-08-10 15:20:13','YYYY-MM-DD HH24:MI:SS'),100,'Alphanumerischer Identifikator dieses Eintrags','D',60,'Der Name des Eintrags wird zusätzlich zur Ordnungszahl bzw. dem Suchschlüssel verwendet.','Y','Y','N','N','Y','N','Y','N','Y','Y','N','Y','Name','NP',0,TO_TIMESTAMP('2026-08-10 15:20:13','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593118 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Business column: Value (String, reference 10, unique per client) --------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593119 /*From ID Server*/,585160,0,10,542636,'Value',TO_TIMESTAMP('2026-08-10 15:20:14','YYYY-MM-DD HH24:MI:SS'),100,'D',60,'Y','Y','N','N','Y','N','Y','N','Y','Y','N','Y','Suchschlüssel','NP',0,TO_TIMESTAMP('2026-08-10 15:20:14','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593119 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Business column: Description (String, reference 14 text) ; reuse element 275
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593120 /*From ID Server*/,275,0,14,542636,'Description',TO_TIMESTAMP('2026-08-10 15:20:15','YYYY-MM-DD HH24:MI:SS'),100,'Zusätzliche kurze Beschreibung','D',255,'Eine Beschreibung ist auf 255 Zeichen begrenzt.','Y','Y','N','N','N','N','N','N','N','Y','N','Y','Beschreibung','NP',0,TO_TIMESTAMP('2026-08-10 15:20:15','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593120 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Physical table -------------------------------------------------------------
+/* DDL */ CREATE TABLE public.M_Tag (AD_Client_ID NUMERIC(10) NOT NULL, AD_Org_ID NUMERIC(10) NOT NULL, Created TIMESTAMP WITH TIME ZONE NOT NULL, CreatedBy NUMERIC(10) NOT NULL, Description VARCHAR(255), IsActive CHAR(1) CHECK (IsActive IN ('Y','N')) NOT NULL, M_Tag_ID NUMERIC(10) NOT NULL, Name VARCHAR(60) NOT NULL, Updated TIMESTAMP WITH TIME ZONE NOT NULL, UpdatedBy NUMERIC(10) NOT NULL, Value VARCHAR(60) NOT NULL, CONSTRAINT M_Tag_Key PRIMARY KEY (M_Tag_ID))
+;
+
+-- Unique index on Value per client, active rows only -------------------------
+/* DDL */ CREATE UNIQUE INDEX M_Tag_Value_uc ON public.M_Tag (AD_Client_ID, LOWER(Value)) WHERE IsActive='Y'
+;
+
+-- Propagate any still-missing translations for the new table/columns.
+SELECT add_missing_translations()
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818080_sys_gh31399_M_Tag_table.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818080_sys_gh31399_M_Tag_table.sql
@@ -5,9 +5,11 @@
 --
 -- IDs allocated from idserver.metas.de:
 --   AD_Table 542636
---   AD_Elements: 585159 (M_Tag_ID key column), 585160 (Value business column)
+--   AD_Elements: 585159 (M_Tag_ID key column). 585160 (originally for Value) skipped —
+--     AD_Element.ColumnName has a unique constraint and element 620 already covers 'Value'
+--     (Name='Suchschlüssel', en_US='Search Key'), so we reuse it instead.
 --   Reused existing AD_Elements: 102 AD_Client_ID, 113 AD_Org_ID, 245 Created, 246 CreatedBy,
---     275 Description, 348 IsActive, 469 Name, 607 Updated, 608 UpdatedBy
+--     275 Description, 348 IsActive, 469 Name, 607 Updated, 608 UpdatedBy, 620 Value
 --   AD_Columns 593110..593120
 
 -- AD_Table -------------------------------------------------------------------
@@ -35,19 +37,8 @@ UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Produkt-Label', PrintName='Pro
 /* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585159,'de_CH')
 ;
 
--- Value column element (Value) ---------------------------------------------
-INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,585160 /*From ID Server*/,0,'Value',TO_TIMESTAMP('2026-08-10 15:20:03','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Suchschlüssel','Suchschlüssel',TO_TIMESTAMP('2026-08-10 15:20:03','YYYY-MM-DD HH24:MI:SS'),100)
-;
-INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585160 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
-;
-UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Search Key', PrintName='Search Key',Updated=TO_TIMESTAMP('2026-08-10 15:20:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585160 AND AD_Language='en_US'
-;
-UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Suchschlüssel', PrintName='Suchschlüssel',Updated=TO_TIMESTAMP('2026-08-10 15:20:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585160 AND AD_Language='de_CH'
-;
-/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585160,'en_US')
-;
-/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585160,'de_CH')
-;
+-- Value column reuses existing AD_Element 620 (ColumnName='Value', Name='Suchschlüssel', en='Search Key').
+-- AD_Element.ColumnName has a unique constraint, so we MUST reuse.
 
 -- Standard columns -----------------------------------------------------------
 -- AD_Client_ID
@@ -104,8 +95,8 @@ INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Refe
 INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593118 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
 ;
 
--- Business column: Value (String, reference 10, unique per client) --------
-INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593119 /*From ID Server*/,585160,0,10,542636,'Value',TO_TIMESTAMP('2026-08-10 15:20:14','YYYY-MM-DD HH24:MI:SS'),100,'D',60,'Y','Y','N','N','Y','N','Y','N','Y','Y','N','Y','Suchschlüssel','NP',0,TO_TIMESTAMP('2026-08-10 15:20:14','YYYY-MM-DD HH24:MI:SS'),100,0)
+-- Business column: Value (String, reference 10, unique per client) — reuses existing AD_Element 620
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593119 /*From ID Server*/,620,0,10,542636,'Value',TO_TIMESTAMP('2026-08-10 15:20:14','YYYY-MM-DD HH24:MI:SS'),100,'D',60,'Y','Y','N','N','Y','N','Y','N','Y','Y','N','Y','Suchschlüssel','NP',0,TO_TIMESTAMP('2026-08-10 15:20:14','YYYY-MM-DD HH24:MI:SS'),100,0)
 ;
 INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593119 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
 ;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818080_sys_gh31399_M_Tag_table.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818080_sys_gh31399_M_Tag_table.sql
@@ -114,7 +114,3 @@ INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Clien
 -- Unique index on Value per client, active rows only -------------------------
 /* DDL */ CREATE UNIQUE INDEX M_Tag_Value_uc ON public.M_Tag (AD_Client_ID, LOWER(Value)) WHERE IsActive='Y'
 ;
-
--- Propagate any still-missing translations for the new table/columns.
-SELECT add_missing_translations()
-;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818080_sys_gh31399_M_Tag_table.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818080_sys_gh31399_M_Tag_table.sql
@@ -32,6 +32,8 @@ UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Produkt-Label', PrintName='Pro
 ;
 /* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585159,'en_US')
 ;
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585159,'de_CH')
+;
 
 -- Value column element (Value) ---------------------------------------------
 INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,585160 /*From ID Server*/,0,'Value',TO_TIMESTAMP('2026-08-10 15:20:03','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Suchschlüssel','Suchschlüssel',TO_TIMESTAMP('2026-08-10 15:20:03','YYYY-MM-DD HH24:MI:SS'),100)
@@ -43,6 +45,8 @@ UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Search Key', PrintName='Search
 UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Suchschlüssel', PrintName='Suchschlüssel',Updated=TO_TIMESTAMP('2026-08-10 15:20:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585160 AND AD_Language='de_CH'
 ;
 /* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585160,'en_US')
+;
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585160,'de_CH')
 ;
 
 -- Standard columns -----------------------------------------------------------

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818090_sys_gh31399_M_Product_Tag_table.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818090_sys_gh31399_M_Product_Tag_table.sql
@@ -8,7 +8,7 @@
 --   AD_Element: 585162 (M_Product_Tag_ID key column)
 --   Reused existing AD_Elements: 102 AD_Client_ID, 113 AD_Org_ID, 245 Created, 246 CreatedBy,
 --     348 IsActive, 454 M_Product_ID, 607 Updated, 608 UpdatedBy, 585159 M_Tag_ID (from 5818080)
---   AD_Columns 593122..593130
+--   AD_Columns 593121..593130 (593121 = M_Tag_ID FK, inserted last in file but allocated earlier from server block; std cols + PK + M_Product_ID = 593122..593130)
 
 -- AD_Table -------------------------------------------------------------------
 INSERT INTO AD_Table (AccessLevel,ACTriggerLength,AD_Client_ID,AD_Org_ID,AD_Table_ID,CopyColumnsFromTable,Created,CreatedBy,Description,EntityType,ImportTable,IsActive,IsAutocomplete,IsChangeLog,IsDeleteable,IsDLM,IsEnableRemoteCacheInvalidation,IsHighVolume,IsSecurityEnabled,IsView,LoadSeq,Name,PersonalDataCategory,ReplicationType,TableName,Updated,UpdatedBy) VALUES ('4',0,0,0,542637 /*From ID Server*/,'N',TO_TIMESTAMP('2026-08-10 15:25:00','YYYY-MM-DD HH24:MI:SS'),100,'Produkt-Label Zuordnung','D','N','Y','N','N','Y','N','N','N','N','N',0,'Product Tag Assignment','NP','L','M_Product_Tag',TO_TIMESTAMP('2026-08-10 15:25:00','YYYY-MM-DD HH24:MI:SS'),100)
@@ -27,6 +27,8 @@ UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Product Tag Assignment', Print
 UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Produkt-Label Zuordnung', PrintName='Produkt-Label Zuordnung',Updated=TO_TIMESTAMP('2026-08-10 15:25:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585162 AND AD_Language='de_CH'
 ;
 /* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585162,'en_US')
+;
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585162,'de_CH')
 ;
 
 -- Standard columns -----------------------------------------------------------

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818090_sys_gh31399_M_Product_Tag_table.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818090_sys_gh31399_M_Product_Tag_table.sql
@@ -1,0 +1,103 @@
+-- Product ↔ Tag assignment table (M_Product_Tag)
+-- Many-to-many link table between M_Product and M_Tag. Uniqueness enforced on
+-- (AD_Client_ID, M_Product_ID, M_Tag_ID) so a product can be tagged with a
+-- given tag at most once per client.
+--
+-- IDs allocated from idserver.metas.de:
+--   AD_Table 542637
+--   AD_Element: 585162 (M_Product_Tag_ID key column)
+--   Reused existing AD_Elements: 102 AD_Client_ID, 113 AD_Org_ID, 245 Created, 246 CreatedBy,
+--     348 IsActive, 454 M_Product_ID, 607 Updated, 608 UpdatedBy, 585159 M_Tag_ID (from 5818080)
+--   AD_Columns 593122..593130
+
+-- AD_Table -------------------------------------------------------------------
+INSERT INTO AD_Table (AccessLevel,ACTriggerLength,AD_Client_ID,AD_Org_ID,AD_Table_ID,CopyColumnsFromTable,Created,CreatedBy,Description,EntityType,ImportTable,IsActive,IsAutocomplete,IsChangeLog,IsDeleteable,IsDLM,IsEnableRemoteCacheInvalidation,IsHighVolume,IsSecurityEnabled,IsView,LoadSeq,Name,PersonalDataCategory,ReplicationType,TableName,Updated,UpdatedBy) VALUES ('4',0,0,0,542637 /*From ID Server*/,'N',TO_TIMESTAMP('2026-08-10 15:25:00','YYYY-MM-DD HH24:MI:SS'),100,'Produkt-Label Zuordnung','D','N','Y','N','N','Y','N','N','N','N','N',0,'Product Tag Assignment','NP','L','M_Product_Tag',TO_TIMESTAMP('2026-08-10 15:25:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Table_Trl (AD_Language,AD_Table_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Table_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Table t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Table_ID=542637 AND NOT EXISTS (SELECT 1 FROM AD_Table_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Table_ID=t.AD_Table_ID)
+;
+
+-- Key column element (M_Product_Tag_ID) ------------------------------------
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,585162 /*From ID Server*/,0,'M_Product_Tag_ID',TO_TIMESTAMP('2026-08-10 15:25:01','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','Produkt-Label Zuordnung','Produkt-Label Zuordnung',TO_TIMESTAMP('2026-08-10 15:25:01','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585162 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Product Tag Assignment', PrintName='Product Tag Assignment',Updated=TO_TIMESTAMP('2026-08-10 15:25:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585162 AND AD_Language='en_US'
+;
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Produkt-Label Zuordnung', PrintName='Produkt-Label Zuordnung',Updated=TO_TIMESTAMP('2026-08-10 15:25:02','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=585162 AND AD_Language='de_CH'
+;
+/* DDL */ select update_TRL_Tables_On_AD_Element_TRL_Update(585162,'en_US')
+;
+
+-- Standard columns -----------------------------------------------------------
+-- AD_Client_ID
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593122 /*From ID Server*/,102,0,19,542637,'AD_Client_ID',TO_TIMESTAMP('2026-08-10 15:25:03','YYYY-MM-DD HH24:MI:SS'),100,'Mandant für diese Installation.','D',10,'Ein Mandant ist eine Firma oder eine juristische Person.','Y','Y','N','N','N','N','Y','N','N','Y','N','N','Mandant','NP',0,TO_TIMESTAMP('2026-08-10 15:25:03','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593122 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- AD_Org_ID
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593123 /*From ID Server*/,113,0,30,542637,'AD_Org_ID',TO_TIMESTAMP('2026-08-10 15:25:04','YYYY-MM-DD HH24:MI:SS'),100,'Organisatorische Einheit des Mandanten','D',10,'Eine Organisation ist ein Bereich ihres Mandanten.','Y','Y','N','N','N','N','Y','N','Y','Y','N','N','Sektion','NP',0,TO_TIMESTAMP('2026-08-10 15:25:04','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593123 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Created
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593124 /*From ID Server*/,245,0,16,542637,'Created',TO_TIMESTAMP('2026-08-10 15:25:05','YYYY-MM-DD HH24:MI:SS'),100,'Datum, an dem dieser Eintrag erstellt wurde','D',29,'Das Feld Erstellt zeigt an, zu welchem Datum dieser Eintrag erstellt wurde.','Y','N','N','N','N','N','Y','N','N','Y','N','N','Erstellt','NP',0,TO_TIMESTAMP('2026-08-10 15:25:05','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593124 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- CreatedBy
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593125 /*From ID Server*/,246,0,18,110,542637,'CreatedBy',TO_TIMESTAMP('2026-08-10 15:25:06','YYYY-MM-DD HH24:MI:SS'),100,'Nutzer, der diesen Eintrag erstellt hat','D',10,'Das Feld Erstellt durch zeigt an, welcher Nutzer diesen Eintrag erstellt hat.','Y','N','N','N','N','N','Y','N','N','Y','N','N','Erstellt durch','NP',0,TO_TIMESTAMP('2026-08-10 15:25:06','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593125 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- IsActive
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593126 /*From ID Server*/,348,0,20,542637,'IsActive',TO_TIMESTAMP('2026-08-10 15:25:07','YYYY-MM-DD HH24:MI:SS'),100,'Der Eintrag ist im System aktiv','D',1,'Es gibt zwei Möglichkeiten, einen Datensatz nicht mehr verfügbar zu machen: einer ist, ihn zu löschen; der andere, ihn zu deaktivieren.','Y','Y','N','N','N','N','Y','N','N','Y','N','Y','Aktiv','NP',0,TO_TIMESTAMP('2026-08-10 15:25:07','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593126 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Updated
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593127 /*From ID Server*/,607,0,16,542637,'Updated',TO_TIMESTAMP('2026-08-10 15:25:08','YYYY-MM-DD HH24:MI:SS'),100,'Datum, an dem dieser Eintrag aktualisiert wurde','D',29,'Aktualisiert zeigt an, wann dieser Eintrag aktualisiert wurde.','Y','N','N','N','N','N','Y','N','N','Y','N','N','Aktualisiert','NP',0,TO_TIMESTAMP('2026-08-10 15:25:08','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593127 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- UpdatedBy
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,ColumnName,Created,CreatedBy,Description,EntityType,FieldLength,Help,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593128 /*From ID Server*/,608,0,18,110,542637,'UpdatedBy',TO_TIMESTAMP('2026-08-10 15:25:09','YYYY-MM-DD HH24:MI:SS'),100,'Nutzer, der diesen Eintrag aktualisiert hat','D',10,'Aktualisiert durch zeigt an, welcher Nutzer diesen Eintrag aktualisiert hat.','Y','N','N','N','N','N','Y','N','N','Y','N','N','Aktualisiert durch','NP',0,TO_TIMESTAMP('2026-08-10 15:25:09','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593128 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Key column: M_Product_Tag_ID (ID, reference 13) --------------------------
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593129 /*From ID Server*/,585162,0,13,542637,'M_Product_Tag_ID',TO_TIMESTAMP('2026-08-10 15:25:10','YYYY-MM-DD HH24:MI:SS'),100,'D',10,'Y','N','N','N','N','Y','Y','N','N','Y','N','N','Produkt-Label Zuordnung','NP',0,TO_TIMESTAMP('2026-08-10 15:25:10','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593129 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Parent: M_Product_ID (TableDir 19, IsParent='Y') ; reuse element 454 -----
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593130 /*From ID Server*/,454,0,19,542637,'M_Product_ID',TO_TIMESTAMP('2026-08-10 15:25:11','YYYY-MM-DD HH24:MI:SS'),100,'D',10,'Y','Y','N','N','N','N','Y','Y','N','Y','N','N','Produkt','NP',0,TO_TIMESTAMP('2026-08-10 15:25:11','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593130 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Value: M_Tag_ID (TableDir 19, IsSelectionColumn='Y') ; reuse element 585159 (from 5818080)
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,ColumnName,Created,CreatedBy,EntityType,FieldLength,IsActive,IsAllowLogging,IsAlwaysUpdateable,IsEncrypted,IsIdentifier,IsKey,IsMandatory,IsParent,IsSelectionColumn,IsSyncDatabase,IsTranslated,IsUpdateable,Name,PersonalDataCategory,SeqNo,Updated,UpdatedBy,Version) VALUES (0,593121 /*From ID Server*/,585159,0,19,542637,'M_Tag_ID',TO_TIMESTAMP('2026-08-10 15:25:12','YYYY-MM-DD HH24:MI:SS'),100,'D',10,'Y','Y','N','N','Y','N','Y','N','Y','Y','N','Y','Produkt-Label','NP',0,TO_TIMESTAMP('2026-08-10 15:25:12','YYYY-MM-DD HH24:MI:SS'),100,0)
+;
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Column_ID=593121 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- Physical table -------------------------------------------------------------
+/* DDL */ CREATE TABLE public.M_Product_Tag (AD_Client_ID NUMERIC(10) NOT NULL, AD_Org_ID NUMERIC(10) NOT NULL, Created TIMESTAMP WITH TIME ZONE NOT NULL, CreatedBy NUMERIC(10) NOT NULL, IsActive CHAR(1) CHECK (IsActive IN ('Y','N')) NOT NULL, M_Product_ID NUMERIC(10) NOT NULL, M_Product_Tag_ID NUMERIC(10) NOT NULL, M_Tag_ID NUMERIC(10) NOT NULL, Updated TIMESTAMP WITH TIME ZONE NOT NULL, UpdatedBy NUMERIC(10) NOT NULL, CONSTRAINT M_Product_Tag_Key PRIMARY KEY (M_Product_Tag_ID), CONSTRAINT MProduct_MProductTag FOREIGN KEY (M_Product_ID) REFERENCES public.M_Product DEFERRABLE INITIALLY DEFERRED, CONSTRAINT MTag_MProductTag FOREIGN KEY (M_Tag_ID) REFERENCES public.M_Tag DEFERRABLE INITIALLY DEFERRED)
+;
+
+-- Unique index: one row per (Product, Tag) per Client, active only ---------
+/* DDL */ CREATE UNIQUE INDEX M_Product_Tag_uc ON public.M_Product_Tag (AD_Client_ID, M_Product_ID, M_Tag_ID) WHERE IsActive='Y'
+;
+
+-- Propagate any still-missing translations for the new table/columns.
+SELECT add_missing_translations()
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818090_sys_gh31399_M_Product_Tag_table.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818090_sys_gh31399_M_Product_Tag_table.sql
@@ -100,6 +100,3 @@ INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Clien
 /* DDL */ CREATE UNIQUE INDEX M_Product_Tag_uc ON public.M_Product_Tag (AD_Client_ID, M_Product_ID, M_Tag_ID) WHERE IsActive='Y'
 ;
 
--- Propagate any still-missing translations for the new table/columns.
-SELECT add_missing_translations()
-;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818100_sys_gh31399_M_Tag_window.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818100_sys_gh31399_M_Tag_window.sql
@@ -1,0 +1,215 @@
+-- Product Tag registry window (M_Tag)
+-- Creates the "Produkt-Label" / "Product Tag" AD_Window over M_Tag (AD_Table_ID=542636).
+-- Single tab, grid-first CRUD, 3 user-facing fields: Name, Value, Description.
+--
+-- IDs allocated from idserver.metas.de:
+--   AD_MigrationScript prefix : 5818100
+--   AD_Window_ID              : 542180
+--   AD_Tab_ID                 : 549361
+--   AD_UI_Section_ID          : 547866
+--   AD_UI_Column_ID           : 549615
+--   AD_UI_ElementGroup_ID     : 555536
+--   AD_UI_Element_ID (Name)   : 652810
+--   AD_UI_Element_ID (Value)  : 652811
+--   AD_UI_Element_ID (Desc)   : 652812
+--   AD_Field_ID (Name)        : 781897
+--   AD_Field_ID (Value)       : 781898
+--   AD_Field_ID (Desc)        : 781899
+--   AD_Menu_ID                : 542354
+--
+-- Reused AD_Column_IDs from T2 migration (5818080_sys_gh31399_M_Tag_table.sql):
+--   593118 = Name, 593119 = Value, 593120 = Description
+-- Reused AD_Element_IDs:
+--   585159 = M_Tag_ID / Produkt-Label (window element)
+--   469    = Name, 620 = Value (Suchschlüssel), 275 = Description
+
+-- ===========================================================================
+-- AD_Window
+-- ===========================================================================
+
+-- Window: Produkt-Label
+INSERT INTO AD_Window (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Window_ID,Created,CreatedBy,EntityType,IsActive,IsBetaFunctionality,IsDefault,IsEnableRemoteCacheInvalidation,IsOneInstanceOnly,IsSOTrx,Name,Processing,Updated,UpdatedBy,WindowType,WinHeight,WinWidth)
+VALUES (0,585159 /*M_Tag_ID element*/,0,542180 /*From ID Server*/,TO_TIMESTAMP('2026-08-10 16:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','N','N','N','N','Y','Produkt-Label','N',TO_TIMESTAMP('2026-08-10 16:00:00','YYYY-MM-DD HH24:MI:SS'),100,'M',0,0)
+;
+
+INSERT INTO AD_Window_Trl (AD_Language,AD_Window_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Window_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Window t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Window_ID=542180
+AND NOT EXISTS (SELECT 1 FROM AD_Window_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Window_ID=t.AD_Window_ID)
+;
+
+/* DDL */ select update_window_translation_from_ad_element(585159)
+;
+
+DELETE FROM AD_Element_Link WHERE AD_Window_ID=542180
+;
+
+/* DDL */ select AD_Element_Link_Create_Missing_Window(542180)
+;
+
+-- ===========================================================================
+-- AD_Tab
+-- ===========================================================================
+
+-- Tab: Product Tag (grid-first, TabLevel=0)
+INSERT INTO AD_Tab (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Tab_ID,AD_Table_ID,AD_Window_ID,AllowQuickInput,Created,CreatedBy,EntityType,HasTree,ImportFields,InternalName,IsActive,IsAdvancedTab,IsCheckParentsChanged,IsGenericZoomTarget,IsGridModeOnly,IsInfoTab,IsInsertRecord,IsQueryOnLoad,IsReadOnly,IsRefreshAllOnActivate,IsRefreshViewOnChangeEvents,IsSearchActive,IsSearchCollapsed,IsSingleRow,IsSortTab,IsTranslationTab,MaxQueryRecords,Name,Processing,SeqNo,TabLevel,Updated,UpdatedBy)
+VALUES (0,585159 /*M_Tag_ID element*/,0,549361 /*From ID Server*/,542636 /*M_Tag*/,542180,'Y',TO_TIMESTAMP('2026-08-10 16:00:01','YYYY-MM-DD HH24:MI:SS'),100,'D','N','N','M_Tag','Y','N','Y','N','N','N','Y','Y','N','N','N','Y','Y','N','N','N',0,'Produkt-Label','N',10,0,TO_TIMESTAMP('2026-08-10 16:00:01','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Tab_Trl (AD_Language,AD_Tab_ID, CommitWarning,Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Tab_ID, t.CommitWarning,t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Tab t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Tab_ID=549361
+AND NOT EXISTS (SELECT 1 FROM AD_Tab_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Tab_ID=t.AD_Tab_ID)
+;
+
+/* DDL */ select update_tab_translation_from_ad_element(585159)
+;
+
+/* DDL */ select AD_Element_Link_Create_Missing_Tab(549361)
+;
+
+-- ===========================================================================
+-- AD_Field rows (required by convention — one per user-facing column)
+-- ===========================================================================
+
+-- Field: Name
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,Description,DisplayLength,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,Updated,UpdatedBy)
+VALUES (0,593118 /*Name col*/,781897 /*From ID Server*/,0,549361,TO_TIMESTAMP('2026-08-10 16:00:10','YYYY-MM-DD HH24:MI:SS'),100,'Alphanumerischer Identifikator dieses Eintrags',60,'D','Y','Y','Y','N','N','N','N','N','Name',TO_TIMESTAMP('2026-08-10 16:00:10','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Field_ID=781897
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+/* DDL */ select update_FieldTranslation_From_AD_Name_Element(469 /*Name element*/)
+;
+
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781897
+;
+
+/* DDL */ select AD_Element_Link_Create_Missing_Field(781897)
+;
+
+-- Field: Value (Suchschlüssel)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,DisplayLength,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,Updated,UpdatedBy)
+VALUES (0,593119 /*Value col*/,781898 /*From ID Server*/,0,549361,TO_TIMESTAMP('2026-08-10 16:00:11','YYYY-MM-DD HH24:MI:SS'),100,60,'D','Y','Y','Y','N','N','N','N','N','Suchschlüssel',TO_TIMESTAMP('2026-08-10 16:00:11','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Field_ID=781898
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+/* DDL */ select update_FieldTranslation_From_AD_Name_Element(620 /*Value/Suchschlüssel element*/)
+;
+
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781898
+;
+
+/* DDL */ select AD_Element_Link_Create_Missing_Field(781898)
+;
+
+-- Field: Description
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,Description,DisplayLength,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,Updated,UpdatedBy)
+VALUES (0,593120 /*Description col*/,781899 /*From ID Server*/,0,549361,TO_TIMESTAMP('2026-08-10 16:00:12','YYYY-MM-DD HH24:MI:SS'),100,'Zusätzliche kurze Beschreibung',255,'D','Y','Y','Y','N','N','N','N','N','Beschreibung',TO_TIMESTAMP('2026-08-10 16:00:12','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Field_ID=781899
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+/* DDL */ select update_FieldTranslation_From_AD_Name_Element(275 /*Description element*/)
+;
+
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781899
+;
+
+/* DDL */ select AD_Element_Link_Create_Missing_Field(781899)
+;
+
+-- ===========================================================================
+-- UI Layout: AD_UI_Section → AD_UI_Column → AD_UI_ElementGroup → AD_UI_Element
+-- Single main section, single column, single "default" group.
+-- Grid ordering: Name(10), Value(20), Description(30).
+-- ===========================================================================
+
+-- UI Section: main
+INSERT INTO AD_UI_Section (AD_Client_ID,AD_Org_ID,AD_Tab_ID,AD_UI_Section_ID,Created,CreatedBy,IsActive,SeqNo,Updated,UpdatedBy,Value)
+VALUES (0,0,549361,547866 /*From ID Server*/,TO_TIMESTAMP('2026-08-10 16:00:20','YYYY-MM-DD HH24:MI:SS'),100,'Y',10,TO_TIMESTAMP('2026-08-10 16:00:20','YYYY-MM-DD HH24:MI:SS'),100,'main')
+;
+
+INSERT INTO AD_UI_Section_Trl (AD_Language,AD_UI_Section_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_UI_Section_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_UI_Section t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_UI_Section_ID=547866
+AND NOT EXISTS (SELECT 1 FROM AD_UI_Section_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_UI_Section_ID=t.AD_UI_Section_ID)
+;
+
+-- UI Column: 10 (single column)
+INSERT INTO AD_UI_Column (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_Section_ID,Created,CreatedBy,IsActive,SeqNo,Updated,UpdatedBy)
+VALUES (0,0,549615 /*From ID Server*/,547866,TO_TIMESTAMP('2026-08-10 16:00:21','YYYY-MM-DD HH24:MI:SS'),100,'Y',10,TO_TIMESTAMP('2026-08-10 16:00:21','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- UI ElementGroup: default (primary style)
+INSERT INTO AD_UI_ElementGroup (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_ElementGroup_ID,Created,CreatedBy,IsActive,Name,SeqNo,UIStyle,Updated,UpdatedBy)
+VALUES (0,0,549615,555536 /*From ID Server*/,TO_TIMESTAMP('2026-08-10 16:00:22','YYYY-MM-DD HH24:MI:SS'),100,'Y','default',10,'primary',TO_TIMESTAMP('2026-08-10 16:00:22','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- UI Element: Name (SeqNo=10, IsDisplayedGrid=Y, SeqNoGrid=10)
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781897,0,549361,555536,652810 /*From ID Server*/,'F',TO_TIMESTAMP('2026-08-10 16:00:30','YYYY-MM-DD HH24:MI:SS'),100,'Alphanumerischer Identifikator dieses Eintrags','Y','N','Y','Y','N','Name',10,10,0,TO_TIMESTAMP('2026-08-10 16:00:30','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- UI Element: Value / Suchschlüssel (SeqNo=20, IsDisplayedGrid=Y, SeqNoGrid=20)
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781898,0,549361,555536,652811 /*From ID Server*/,'F',TO_TIMESTAMP('2026-08-10 16:00:31','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Suchschlüssel',20,20,0,TO_TIMESTAMP('2026-08-10 16:00:31','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- UI Element: Description (SeqNo=30, IsDisplayedGrid=Y, SeqNoGrid=30)
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781899,0,549361,555536,652812 /*From ID Server*/,'F',TO_TIMESTAMP('2026-08-10 16:00:32','YYYY-MM-DD HH24:MI:SS'),100,'Zusätzliche kurze Beschreibung','Y','N','Y','Y','N','Beschreibung',30,30,0,TO_TIMESTAMP('2026-08-10 16:00:32','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- ===========================================================================
+-- AD_Menu + tree placement
+-- Parent: 167 (Einstellungen Materialwirtschaft)
+-- ===========================================================================
+
+INSERT INTO AD_Menu (Action,AD_Client_ID,AD_Element_ID,AD_Menu_ID,AD_Org_ID,AD_Window_ID,Created,CreatedBy,EntityType,InternalName,IsActive,IsCreateNew,IsReadOnly,IsSOTrx,IsSummary,Name,Updated,UpdatedBy)
+VALUES ('W',0,585159,542354 /*From ID Server*/,0,542180,TO_TIMESTAMP('2026-08-10 16:00:40','YYYY-MM-DD HH24:MI:SS'),100,'D','M_Tag','Y','N','N','N','N','Produkt-Label',TO_TIMESTAMP('2026-08-10 16:00:40','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Menu_Trl (AD_Language,AD_Menu_ID, Description,Name,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Menu_ID, t.Description,t.Name,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Menu t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Menu_ID=542354
+AND NOT EXISTS (SELECT 1 FROM AD_Menu_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Menu_ID=t.AD_Menu_ID)
+;
+
+-- Place in menu tree under parent 167 (Einstellungen Materialwirtschaft), last position
+INSERT INTO AD_TreeNodeMM (AD_Client_ID,AD_Org_ID, IsActive,Created,CreatedBy,Updated,UpdatedBy, AD_Tree_ID, Node_ID, Parent_ID, SeqNo)
+SELECT t.AD_Client_ID,0, 'Y', now(), 100, now(), 100,t.AD_Tree_ID, 542354, 167, 999
+FROM AD_Tree t
+WHERE t.AD_Client_ID=0 AND t.IsActive='Y' AND t.IsAllNodes='Y' AND t.AD_Table_ID=116
+AND NOT EXISTS (SELECT * FROM AD_TreeNodeMM e WHERE e.AD_Tree_ID=t.AD_Tree_ID AND Node_ID=542354)
+;
+
+/* DDL */ select update_menu_translation_from_ad_element(585159)
+;
+
+-- ===========================================================================
+-- Propagate any still-missing translations
+-- ===========================================================================
+
+SELECT add_missing_translations()
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818100_sys_gh31399_M_Tag_window.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818100_sys_gh31399_M_Tag_window.sql
@@ -207,9 +207,3 @@ AND NOT EXISTS (SELECT * FROM AD_TreeNodeMM e WHERE e.AD_Tree_ID=t.AD_Tree_ID AN
 /* DDL */ select update_menu_translation_from_ad_element(585159)
 ;
 
--- ===========================================================================
--- Propagate any still-missing translations
--- ===========================================================================
-
-SELECT add_missing_translations()
-;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818120_sys_gh31399_ProductWindow_LabelsTab.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818120_sys_gh31399_ProductWindow_LabelsTab.sql
@@ -1,0 +1,139 @@
+-- Product window (AD_Window_ID=140) — add "Labels" child tab over M_Product_Tag
+-- Satisfies AC4: users can manage product–tag assignments from the core Product window.
+--
+-- IDs allocated from idserver.metas.de:
+--   AD_MigrationScript prefix : 5818120
+--   AD_Tab_ID                 : 549362
+--   AD_UI_Section_ID          : 547867
+--   AD_UI_Column_ID           : 549616
+--   AD_UI_ElementGroup_ID     : 555537
+--   AD_UI_Element_ID (M_Tag_ID)  : 652813
+--   AD_UI_Element_ID (IsActive)  : 652814
+--   AD_Field_ID (M_Tag_ID)    : 781900
+--   AD_Field_ID (IsActive)    : 781901
+--
+-- Reused IDs (from T2/T3 migrations — do NOT recreate):
+--   AD_Table_ID  M_Product_Tag          : 542637
+--   AD_Column_ID M_Product_Tag_ID       : 593129
+--   AD_Column_ID M_Product_ID (FK/parent): 593130   ← Parent_Column_ID
+--   AD_Column_ID M_Tag_ID               : 593121
+--   AD_Column_ID IsActive               : 593126
+--   AD_Element_ID M_Tag_ID (Produkt-Label): 585159
+--   AD_Element_ID IsActive              : 348
+--   AD_Element_ID Labels (tab name)     : 577701   (existing, columnname='')
+--
+-- Parent window context:
+--   AD_Window_ID=140 (Produkt), EntityType='D', max existing tab SeqNo=360 → this tab SeqNo=370
+
+-- ===========================================================================
+-- AD_Tab
+-- ===========================================================================
+
+-- Tab: Labels (child of Product, TabLevel=1, grid-only, insert allowed)
+INSERT INTO AD_Tab (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Tab_ID,AD_Table_ID,AD_Window_ID,AD_Column_ID,Parent_Column_ID,AllowQuickInput,Created,CreatedBy,EntityType,HasTree,ImportFields,InternalName,IsActive,IsAdvancedTab,IsCheckParentsChanged,IsGenericZoomTarget,IsGridModeOnly,IsInfoTab,IsInsertRecord,IsQueryOnLoad,IsReadOnly,IsRefreshAllOnActivate,IsRefreshViewOnChangeEvents,IsSearchActive,IsSearchCollapsed,IsSingleRow,IsSortTab,IsTranslationTab,MaxQueryRecords,Name,Processing,SeqNo,TabLevel,Updated,UpdatedBy)
+VALUES (0,577701 /*Labels element*/,0,549362 /*From ID Server*/,542637 /*M_Product_Tag*/,140 /*Produkt window*/,NULL /*AD_Column_ID=NULL for child tab*/,593130 /*Parent_Column_ID=M_Product_Tag.M_Product_ID*/,'Y',TO_TIMESTAMP('2026-08-11 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','N','N','M_Product_Tag','Y','N','Y','N','N','N','Y','Y','N','N','N','Y','Y','N','N','N',0,'Labels','N',370,1,TO_TIMESTAMP('2026-08-11 10:00:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Tab_Trl (AD_Language,AD_Tab_ID, CommitWarning,Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Tab_ID, t.CommitWarning,t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Tab t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Tab_ID=549362
+AND NOT EXISTS (SELECT 1 FROM AD_Tab_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Tab_ID=t.AD_Tab_ID)
+;
+
+/* DDL */ select update_tab_translation_from_ad_element(577701)
+;
+
+/* DDL */ select AD_Element_Link_Create_Missing_Tab(549362)
+;
+
+-- ===========================================================================
+-- AD_Field rows (one per user-facing column shown in this tab)
+-- ===========================================================================
+
+-- Field: M_Tag_ID (Produkt-Label)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,DisplayLength,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,Updated,UpdatedBy)
+VALUES (0,593121 /*M_Tag_ID col*/,781900 /*From ID Server*/,0,549362,TO_TIMESTAMP('2026-08-11 10:00:10','YYYY-MM-DD HH24:MI:SS'),100,60,'D','Y','Y','Y','N','N','N','N','N','Produkt-Label',TO_TIMESTAMP('2026-08-11 10:00:10','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Field_ID=781900
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+/* DDL */ select update_FieldTranslation_From_AD_Name_Element(585159 /*M_Tag_ID element*/)
+;
+
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781900
+;
+
+/* DDL */ select AD_Element_Link_Create_Missing_Field(781900)
+;
+
+-- Field: IsActive (Aktiv)
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,DisplayLength,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,Updated,UpdatedBy)
+VALUES (0,593126 /*IsActive col*/,781901 /*From ID Server*/,0,549362,TO_TIMESTAMP('2026-08-11 10:00:11','YYYY-MM-DD HH24:MI:SS'),100,1,'D','Y','Y','Y','N','N','N','N','N','Aktiv',TO_TIMESTAMP('2026-08-11 10:00:11','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_Field_ID=781901
+AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+/* DDL */ select update_FieldTranslation_From_AD_Name_Element(348 /*IsActive element*/)
+;
+
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781901
+;
+
+/* DDL */ select AD_Element_Link_Create_Missing_Field(781901)
+;
+
+-- ===========================================================================
+-- UI Layout: AD_UI_Section → AD_UI_Column → AD_UI_ElementGroup → AD_UI_Element
+-- Single main section, single column, single "default" group.
+-- Grid ordering: M_Tag_ID(10), IsActive(20).
+-- ===========================================================================
+
+-- UI Section: main
+INSERT INTO AD_UI_Section (AD_Client_ID,AD_Org_ID,AD_Tab_ID,AD_UI_Section_ID,Created,CreatedBy,IsActive,SeqNo,Updated,UpdatedBy,Value)
+VALUES (0,0,549362,547867 /*From ID Server*/,TO_TIMESTAMP('2026-08-11 10:00:20','YYYY-MM-DD HH24:MI:SS'),100,'Y',10,TO_TIMESTAMP('2026-08-11 10:00:20','YYYY-MM-DD HH24:MI:SS'),100,'main')
+;
+
+INSERT INTO AD_UI_Section_Trl (AD_Language,AD_UI_Section_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language, t.AD_UI_Section_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_UI_Section t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N') AND t.AD_UI_Section_ID=547867
+AND NOT EXISTS (SELECT 1 FROM AD_UI_Section_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_UI_Section_ID=t.AD_UI_Section_ID)
+;
+
+-- UI Column: 10 (single column)
+INSERT INTO AD_UI_Column (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_Section_ID,Created,CreatedBy,IsActive,SeqNo,Updated,UpdatedBy)
+VALUES (0,0,549616 /*From ID Server*/,547867,TO_TIMESTAMP('2026-08-11 10:00:21','YYYY-MM-DD HH24:MI:SS'),100,'Y',10,TO_TIMESTAMP('2026-08-11 10:00:21','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- UI ElementGroup: default (primary style)
+INSERT INTO AD_UI_ElementGroup (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_ElementGroup_ID,Created,CreatedBy,IsActive,Name,SeqNo,UIStyle,Updated,UpdatedBy)
+VALUES (0,0,549616,555537 /*From ID Server*/,TO_TIMESTAMP('2026-08-11 10:00:22','YYYY-MM-DD HH24:MI:SS'),100,'Y','default',10,'primary',TO_TIMESTAMP('2026-08-11 10:00:22','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- UI Element: M_Tag_ID / Produkt-Label (SeqNo=10, IsDisplayedGrid=Y, SeqNoGrid=10)
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781900,0,549362,555537,652813 /*From ID Server*/,'F',TO_TIMESTAMP('2026-08-11 10:00:30','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Produkt-Label',10,10,0,TO_TIMESTAMP('2026-08-11 10:00:30','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- UI Element: IsActive / Aktiv (SeqNo=20, IsDisplayedGrid=Y, SeqNoGrid=20)
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,781901,0,549362,555537,652814 /*From ID Server*/,'F',TO_TIMESTAMP('2026-08-11 10:00:31','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Aktiv',20,20,0,TO_TIMESTAMP('2026-08-11 10:00:31','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- ===========================================================================
+-- Propagate any still-missing translations
+-- ===========================================================================
+
+SELECT add_missing_translations()
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818120_sys_gh31399_ProductWindow_LabelsTab.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818120_sys_gh31399_ProductWindow_LabelsTab.sql
@@ -131,9 +131,3 @@ INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_El
 VALUES (0,781901,0,549362,555537,652814 /*From ID Server*/,'F',TO_TIMESTAMP('2026-08-11 10:00:31','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','Y','N','Aktiv',20,20,0,TO_TIMESTAMP('2026-08-11 10:00:31','YYYY-MM-DD HH24:MI:SS'),100)
 ;
 
--- ===========================================================================
--- Propagate any still-missing translations
--- ===========================================================================
-
-SELECT add_missing_translations()
-;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818170_sys_gh31399_FixProductWindowAndLabelsTab.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818170_sys_gh31399_FixProductWindowAndLabelsTab.sql
@@ -1,0 +1,489 @@
+-- Run mode: SWING_CLIENT
+
+
+-- Reordering children of `webUI`
+-- Node name: `Product Tag`
+-- 2026-08-11T06:45:28.265Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=0, Updated=now(), UpdatedBy=100 WHERE  Node_ID=542354 AND AD_Tree_ID=10
+;
+
+-- Node name: `CRM`
+-- 2026-08-11T06:45:28.313Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=1, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000008 AND AD_Tree_ID=10
+;
+
+-- Node name: `Marketing`
+-- 2026-08-11T06:45:28.353Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=2, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541091 AND AD_Tree_ID=10
+;
+
+-- Node name: `Product Management`
+-- 2026-08-11T06:45:28.393Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=3, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000009 AND AD_Tree_ID=10
+;
+
+-- Node name: `Sales`
+-- 2026-08-11T06:45:28.433Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=4, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000010 AND AD_Tree_ID=10
+;
+
+-- Node name: `BOM Management`
+-- 2026-08-11T06:45:28.514Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=5, Updated=now(), UpdatedBy=100 WHERE  Node_ID=542294 AND AD_Tree_ID=10
+;
+
+-- Node name: `Purchase`
+-- 2026-08-11T06:45:28.554Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=6, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000011 AND AD_Tree_ID=10
+;
+
+-- Node name: `Pricing`
+-- 2026-08-11T06:45:28.594Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=7, Updated=now(), UpdatedBy=100 WHERE  Node_ID=540752 AND AD_Tree_ID=10
+;
+
+-- Node name: `Warehouse Management`
+-- 2026-08-11T06:45:28.642Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=8, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000012 AND AD_Tree_ID=10
+;
+
+-- Node name: `Contract Management`
+-- 2026-08-11T06:45:28.685Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=9, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000013 AND AD_Tree_ID=10
+;
+
+-- Node name: `Manufacturing`
+-- 2026-08-11T06:45:28.727Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=10, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000014 AND AD_Tree_ID=10
+;
+
+-- Node name: `Material Receipt`
+-- 2026-08-11T06:45:28.766Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=11, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000017 AND AD_Tree_ID=10
+;
+
+-- Node name: `Billing`
+-- 2026-08-11T06:45:28.807Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=12, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000018 AND AD_Tree_ID=10
+;
+
+-- Node name: `Finance`
+-- 2026-08-11T06:45:28.852Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=13, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000015 AND AD_Tree_ID=10
+;
+
+-- Node name: `Logistics`
+-- 2026-08-11T06:45:28.891Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=14, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000016 AND AD_Tree_ID=10
+;
+
+-- Node name: `Shipment`
+-- 2026-08-11T06:45:28.931Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=15, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000019 AND AD_Tree_ID=10
+;
+
+-- Node name: `Pharma`
+-- 2026-08-11T06:45:28.973Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=16, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541012 AND AD_Tree_ID=10
+;
+
+-- Node name: `Project Management`
+-- 2026-08-11T06:45:29.024Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=17, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541329 AND AD_Tree_ID=10
+;
+
+-- Node name: `Forum Datenaustausch`
+-- 2026-08-11T06:45:29.065Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=18, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541229 AND AD_Tree_ID=10
+;
+
+-- Node name: `Seminar-Verwaltung`
+-- 2026-08-11T06:45:29.105Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=19, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541340 AND AD_Tree_ID=10
+;
+
+-- Node name: `Client/ Organisation`
+-- 2026-08-11T06:45:29.144Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=20, Updated=now(), UpdatedBy=100 WHERE  Node_ID=540833 AND AD_Tree_ID=10
+;
+
+-- Node name: `Service delivery`
+-- 2026-08-11T06:45:29.187Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=21, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541428 AND AD_Tree_ID=10
+;
+
+-- Node name: `System`
+-- 2026-08-11T06:45:29.228Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000007, SeqNo=22, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000098 AND AD_Tree_ID=10
+;
+
+-- Reordering children of `Product Management`
+-- Node name: `Product Tag`
+-- 2026-08-11T06:45:33.954Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=0, Updated=now(), UpdatedBy=100 WHERE  Node_ID=542354 AND AD_Tree_ID=10
+;
+
+-- Node name: `Replenishment`
+-- 2026-08-11T06:45:34.028Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=1, Updated=now(), UpdatedBy=100 WHERE  Node_ID=542202 AND AD_Tree_ID=10
+;
+
+-- Node name: `Product Data Capture (Jasper)`
+-- 2026-08-11T06:45:34.070Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=2, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541293 AND AD_Tree_ID=10
+;
+
+-- Node name: `Product`
+-- 2026-08-11T06:45:34.112Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=3, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000034 AND AD_Tree_ID=10
+;
+
+-- Node name: `Customs Tariff`
+-- 2026-08-11T06:45:34.152Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=4, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541391 AND AD_Tree_ID=10
+;
+
+-- Node name: `Commodity Number`
+-- 2026-08-11T06:45:34.191Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=5, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541468 AND AD_Tree_ID=10
+;
+
+-- Node name: `Discount Schema`
+-- 2026-08-11T06:45:34.233Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=6, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000093 AND AD_Tree_ID=10
+;
+
+-- Node name: `Discount Rows`
+-- 2026-08-11T06:45:34.275Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=7, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541230 AND AD_Tree_ID=10
+;
+
+-- Node name: `Lot control`
+-- 2026-08-11T06:45:34.317Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=8, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541062 AND AD_Tree_ID=10
+;
+
+-- Node name: `BPartner Product statistics`
+-- 2026-08-11T06:45:34.357Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=9, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541194 AND AD_Tree_ID=10
+;
+
+-- Node name: `Hazard Symbol`
+-- 2026-08-11T06:45:34.399Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=10, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541870 AND AD_Tree_ID=10
+;
+
+-- Node name: `Product Certification`
+-- 2026-08-11T06:45:34.440Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=11, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541904 AND AD_Tree_ID=10
+;
+
+-- Node name: `Hazard Symbol Trl`
+-- 2026-08-11T06:45:34.480Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=12, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541871 AND AD_Tree_ID=10
+;
+
+-- Node name: `Download Partner Products`
+-- 2026-08-11T06:45:34.521Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=13, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541411 AND AD_Tree_ID=10
+;
+
+-- Node name: `Actions`
+-- 2026-08-11T06:45:34.564Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=14, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000044 AND AD_Tree_ID=10
+;
+
+-- Node name: `Settings`
+-- 2026-08-11T06:45:34.610Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=15, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000037 AND AD_Tree_ID=10
+;
+
+-- Node name: `Package-Licensing`
+-- 2026-08-11T06:45:34.652Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=16, Updated=now(), UpdatedBy=100 WHERE  Node_ID=542248 AND AD_Tree_ID=10
+;
+
+-- Node name: `Reports`
+-- 2026-08-11T06:45:34.692Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=17, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000035 AND AD_Tree_ID=10
+;
+
+-- Node name: `Produkt Marktpläze`
+-- 2026-08-11T06:45:34.733Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=18, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541864 AND AD_Tree_ID=10
+;
+
+-- Node name: `Additives translation`
+-- 2026-08-11T06:45:34.773Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=19, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541873 AND AD_Tree_ID=10
+;
+
+-- Node name: `Waste Management`
+-- 2026-08-11T06:45:34.813Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=20, Updated=now(), UpdatedBy=100 WHERE  Node_ID=542270 AND AD_Tree_ID=10
+;
+
+-- Node name: `Food`
+-- 2026-08-11T06:45:34.858Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=21, Updated=now(), UpdatedBy=100 WHERE  Node_ID=542272 AND AD_Tree_ID=10
+;
+
+-- Reordering children of `Product Management`
+-- Node name: `Replenishment`
+-- 2026-08-11T06:45:41.134Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=0, Updated=now(), UpdatedBy=100 WHERE  Node_ID=542202 AND AD_Tree_ID=10
+;
+
+-- Node name: `Product Data Capture (Jasper)`
+-- 2026-08-11T06:45:41.178Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=1, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541293 AND AD_Tree_ID=10
+;
+
+-- Node name: `Product`
+-- 2026-08-11T06:45:41.218Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=2, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000034 AND AD_Tree_ID=10
+;
+
+-- Node name: `Customs Tariff`
+-- 2026-08-11T06:45:41.258Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=3, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541391 AND AD_Tree_ID=10
+;
+
+-- Node name: `Product Tag`
+-- 2026-08-11T06:45:41.299Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=4, Updated=now(), UpdatedBy=100 WHERE  Node_ID=542354 AND AD_Tree_ID=10
+;
+
+-- Node name: `Commodity Number`
+-- 2026-08-11T06:45:41.339Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=5, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541468 AND AD_Tree_ID=10
+;
+
+-- Node name: `Discount Schema`
+-- 2026-08-11T06:45:41.382Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=6, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000093 AND AD_Tree_ID=10
+;
+
+-- Node name: `Discount Rows`
+-- 2026-08-11T06:45:41.424Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=7, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541230 AND AD_Tree_ID=10
+;
+
+-- Node name: `Lot control`
+-- 2026-08-11T06:45:41.464Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=8, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541062 AND AD_Tree_ID=10
+;
+
+-- Node name: `BPartner Product statistics`
+-- 2026-08-11T06:45:41.505Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=9, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541194 AND AD_Tree_ID=10
+;
+
+-- Node name: `Hazard Symbol`
+-- 2026-08-11T06:45:41.548Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=10, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541870 AND AD_Tree_ID=10
+;
+
+-- Node name: `Product Certification`
+-- 2026-08-11T06:45:41.592Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=11, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541904 AND AD_Tree_ID=10
+;
+
+-- Node name: `Hazard Symbol Trl`
+-- 2026-08-11T06:45:41.632Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=12, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541871 AND AD_Tree_ID=10
+;
+
+-- Node name: `Download Partner Products`
+-- 2026-08-11T06:45:41.672Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=13, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541411 AND AD_Tree_ID=10
+;
+
+-- Node name: `Actions`
+-- 2026-08-11T06:45:41.711Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=14, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000044 AND AD_Tree_ID=10
+;
+
+-- Node name: `Settings`
+-- 2026-08-11T06:45:41.752Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=15, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000037 AND AD_Tree_ID=10
+;
+
+-- Node name: `Package-Licensing`
+-- 2026-08-11T06:45:41.795Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=16, Updated=now(), UpdatedBy=100 WHERE  Node_ID=542248 AND AD_Tree_ID=10
+;
+
+-- Node name: `Reports`
+-- 2026-08-11T06:45:41.835Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=17, Updated=now(), UpdatedBy=100 WHERE  Node_ID=1000035 AND AD_Tree_ID=10
+;
+
+-- Node name: `Produkt Marktpläze`
+-- 2026-08-11T06:45:41.874Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=18, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541864 AND AD_Tree_ID=10
+;
+
+-- Node name: `Additives translation`
+-- 2026-08-11T06:45:41.914Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=19, Updated=now(), UpdatedBy=100 WHERE  Node_ID=541873 AND AD_Tree_ID=10
+;
+
+-- Node name: `Waste Management`
+-- 2026-08-11T06:45:41.960Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=20, Updated=now(), UpdatedBy=100 WHERE  Node_ID=542270 AND AD_Tree_ID=10
+;
+
+-- Node name: `Food`
+-- 2026-08-11T06:45:42Z
+UPDATE AD_TreeNodeMM SET Parent_ID=1000009, SeqNo=21, Updated=now(), UpdatedBy=100 WHERE  Node_ID=542272 AND AD_Tree_ID=10
+;
+
+-- UI Element: Produkt(140,D) -> Produkt(180,D) -> main -> 10 -> Divers.Tag
+-- 2026-08-11T06:50:36.516Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,Labels_Selector_Field_ID,Labels_Tab_ID,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,0,180,1000039,1000528,'L',TO_TIMESTAMP('2026-08-11 06:50:36.096000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y','N','N','Y','N','N','N',781900,549362,0,'Tag',20,0,0,TO_TIMESTAMP('2026-08-11 06:50:36.096000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- Field: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> Aktiv
+-- Column: M_Tag.IsActive
+-- 2026-08-11T08:34:00.488Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,FacetFilterSeqNo,Help,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,593114,1000008,0,549361,0,TO_TIMESTAMP('2026-08-11 08:33:59.789000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Der Eintrag ist im System aktiv',0,'D',0,'Es gibt zwei Möglichkeiten, einen Datensatz nicht mehr verfügbar zu machen: einer ist, ihn zu löschen; der andere, ihn zu deaktivieren. Ein deaktivierter Eintrag ist nicht mehr für eine Auswahl verfügbar, aber verfügbar für die Verwendung in Berichten. Es gibt zwei Gründe, Datensätze zu deaktivieren und nicht zu löschen: (1) Das System braucht den Datensatz für Revisionszwecke. (2) Der Datensatz wird von anderen Datensätzen referenziert. Z.B. können Sie keinen Geschäftspartner löschen, wenn es Rechnungen für diesen Geschäftspartner gibt. Sie deaktivieren den Geschäftspartner und verhindern, dass dieser Eintrag in zukünftigen Vorgängen verwendet wird.',0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Aktiv',0,0,10,0,1,1,TO_TIMESTAMP('2026-08-11 08:33:59.789000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-08-11T08:34:00.531Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=1000008 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-08-11T08:34:00.604Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(348)
+;
+
+-- 2026-08-11T08:34:00.717Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=1000008
+;
+
+-- 2026-08-11T08:34:00.763Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(1000008)
+;
+
+-- Field: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> Sektion
+-- Column: M_Tag.AD_Org_ID
+-- 2026-08-11T08:34:34.618Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,FacetFilterSeqNo,Help,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,593111,1000009,0,549361,0,TO_TIMESTAMP('2026-08-11 08:34:33.942000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Organisatorische Einheit des Mandanten',0,'D',0,'Eine Organisation ist ein Bereich ihres Mandanten - z.B. Laden oder Abteilung. Sie können Daten über Organisationen hinweg gemeinsam verwenden.',0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Sektion',0,0,20,0,1,1,TO_TIMESTAMP('2026-08-11 08:34:33.942000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-08-11T08:34:34.662Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=1000009 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-08-11T08:34:34.703Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(113)
+;
+
+-- 2026-08-11T08:34:34.780Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=1000009
+;
+
+-- 2026-08-11T08:34:34.824Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(1000009)
+;
+
+-- UI Section: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main
+-- UI Column: 20
+-- 2026-08-11T08:34:59.708Z
+INSERT INTO AD_UI_Column (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_Section_ID,Created,CreatedBy,IsActive,SeqNo,Updated,UpdatedBy) VALUES (0,0,1000033,547866,TO_TIMESTAMP('2026-08-11 08:34:59.316000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y',20,TO_TIMESTAMP('2026-08-11 08:34:59.316000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- UI Column: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 20
+-- UI Element Group: main
+-- 2026-08-11T08:35:10.444Z
+INSERT INTO AD_UI_ElementGroup (AD_Client_ID,AD_Org_ID,AD_UI_Column_ID,AD_UI_ElementGroup_ID,Created,CreatedBy,IsActive,Name,SeqNo,Updated,UpdatedBy) VALUES (0,0,1000033,1000047,TO_TIMESTAMP('2026-08-11 08:35:10.060000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y','main',10,TO_TIMESTAMP('2026-08-11 08:35:10.060000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 20 -> main.Aktiv
+-- Column: M_Tag.IsActive
+-- 2026-08-11T08:35:39.193Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,1000008,0,549361,1000047,1000529,'F',TO_TIMESTAMP('2026-08-11 08:35:38.765000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Der Eintrag ist im System aktiv','Es gibt zwei Möglichkeiten, einen Datensatz nicht mehr verfügbar zu machen: einer ist, ihn zu löschen; der andere, ihn zu deaktivieren. Ein deaktivierter Eintrag ist nicht mehr für eine Auswahl verfügbar, aber verfügbar für die Verwendung in Berichten. Es gibt zwei Gründe, Datensätze zu deaktivieren und nicht zu löschen: (1) Das System braucht den Datensatz für Revisionszwecke. (2) Der Datensatz wird von anderen Datensätzen referenziert. Z.B. können Sie keinen Geschäftspartner löschen, wenn es Rechnungen für diesen Geschäftspartner gibt. Sie deaktivieren den Geschäftspartner und verhindern, dass dieser Eintrag in zukünftigen Vorgängen verwendet wird.','Y','N','N','Y','N','N','N',0,'Aktiv',10,0,0,TO_TIMESTAMP('2026-08-11 08:35:38.765000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 20 -> main.Sektion
+-- Column: M_Tag.AD_Org_ID
+-- 2026-08-11T08:35:57.039Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,1000009,0,549361,1000047,1000530,'F',TO_TIMESTAMP('2026-08-11 08:35:56.602000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Organisatorische Einheit des Mandanten','Eine Organisation ist ein Bereich ihres Mandanten - z.B. Laden oder Abteilung. Sie können Daten über Organisationen hinweg gemeinsam verwenden.','Y','N','N','Y','N','N','N',0,'Sektion',20,0,0,TO_TIMESTAMP('2026-08-11 08:35:56.602000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- Field: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> Mandant
+-- Column: M_Tag.AD_Client_ID
+-- 2026-08-11T08:36:24.226Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,ColumnDisplayLength,Created,CreatedBy,Description,DisplayLength,EntityType,FacetFilterSeqNo,Help,IncludedTabHeight,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsHideGridColumnIfEmpty,IsOverrideFilterDefaultValue,IsReadOnly,IsSameLine,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,SeqNoGrid,SortNo,SpanX,SpanY,Updated,UpdatedBy) VALUES (0,593110,1000010,0,549361,0,TO_TIMESTAMP('2026-08-11 08:36:23.679000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Mandant für diese Installation.',0,'D',0,'Ein Mandant ist eine Firma oder eine juristische Person. Sie können keine Daten über Mandanten hinweg verwenden. .',0,'Y','Y','Y','N','N','N','N','N','N','N',0,'Mandant',0,0,30,0,1,1,TO_TIMESTAMP('2026-08-11 08:36:23.679000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-08-11T08:36:24.267Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=1000010 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-08-11T08:36:24.309Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(102)
+;
+
+-- 2026-08-11T08:36:24.399Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=1000010
+;
+
+-- 2026-08-11T08:36:24.439Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(1000010)
+;
+
+-- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 20 -> main.Mandant
+-- Column: M_Tag.AD_Client_ID
+-- 2026-08-11T08:36:46.669Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,Description,Help,IsActive,IsAdvancedField,IsAllowFiltering,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,IsMultiLine,MultiLine_LinesCount,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,1000010,0,549361,1000047,1000531,'F',TO_TIMESTAMP('2026-08-11 08:36:46.160000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Mandant für diese Installation.','Ein Mandant ist eine Firma oder eine juristische Person. Sie können keine Daten über Mandanten hinweg verwenden. .','Y','N','N','Y','N','N','N',0,'Mandant',30,0,0,TO_TIMESTAMP('2026-08-11 08:36:46.160000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 10 -> default.Beschreibung
+-- Column: M_Tag.Description
+-- 2026-08-11T08:37:01.759Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='N', SeqNoGrid=0,Updated=TO_TIMESTAMP('2026-08-11 08:37:01.759000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=652812
+;
+
+-- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 10 -> default.Suchschlüssel
+-- Column: M_Tag.Value
+-- 2026-08-11T08:37:02.011Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=10,Updated=TO_TIMESTAMP('2026-08-11 08:37:02.011000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=652811
+;
+
+-- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 10 -> default.Name
+-- Column: M_Tag.Name
+-- 2026-08-11T08:37:02.262Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=20,Updated=TO_TIMESTAMP('2026-08-11 08:37:02.262000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=652810
+;
+
+-- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 20 -> main.Aktiv
+-- Column: M_Tag.IsActive
+-- 2026-08-11T08:37:02.524Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=30,Updated=TO_TIMESTAMP('2026-08-11 08:37:02.524000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=1000529
+;
+
+-- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 20 -> main.Sektion
+-- Column: M_Tag.AD_Org_ID
+-- 2026-08-11T08:37:02.779Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=40,Updated=TO_TIMESTAMP('2026-08-11 08:37:02.779000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=1000530
+;
+
+-- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 20 -> main.Mandant
+-- Column: M_Tag.AD_Client_ID
+-- 2026-08-11T08:37:03.032Z
+UPDATE AD_UI_Element SET IsDisplayedGrid='Y', SeqNoGrid=50,Updated=TO_TIMESTAMP('2026-08-11 08:37:03.032000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=1000531
+;
+
+-- Table: M_Tag
+-- 2026-08-11T08:41:41.154Z
+UPDATE AD_Table SET AccessLevel='3',Updated=TO_TIMESTAMP('2026-08-11 08:41:41.029000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Table_ID=542636
+;
+
+-- UI Element: Produkt-Label(542180,D) -> Produkt-Label(549361,D) -> main -> 10 -> default.Suchschlüssel
+-- Column: M_Tag.Value
+-- 2026-08-11T08:42:29.106Z
+UPDATE AD_UI_Element SET SeqNo=5,Updated=TO_TIMESTAMP('2026-08-11 08:42:29.106000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_UI_Element_ID=652811
+;
+


### PR DESCRIPTION
Adds the core product-tag concept:

- New `M_Tag` registry table (Name / unique Value / Description) + AD_Window "Product Tag" for CRUD.
- New `M_Product_Tag` many-to-many table binding `M_Product` <-> `M_Tag`.
- Regenerated model classes `I_M_Tag` / `X_M_Tag` / `I_M_Product_Tag` / `X_M_Product_Tag`.
- New "Labels" child tab on the Product window (`AD_Window_ID=140`) over `M_Product_Tag`, bound via `AD_Tab.Parent_Column_ID=M_Product_Tag.M_Product_ID`.
- Fills missing `de_DE` + `de_CH` translations on the Product / Product Category windows.

## Test plan

- Open the new "Product Tag" window from the menu -> create/edit/delete a tag (Name, Value, Description); verify Value uniqueness per client.
- Open a product on the Product window -> new "Labels" child tab -> add/remove tag assignments; verify persistence via `M_Product_Tag`.
- Product Category window shows a proper German translation for `Parent Product Category` (no longer English in the DE UI).
