### PR TITLE
MobileUI picking: defined filter order, null-safe delivery date, and an option to offer every filter group at once

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_MobileUI_UserProfile_Picking.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_MobileUI_UserProfile_Picking.java
@@ -491,7 +491,7 @@ public interface I_MobileUI_UserProfile_Picking
 	String COLUMNNAME_IsConsiderSalesOrderCapacity = "IsConsiderSalesOrderCapacity";
 
 	/**
-	 * Set Show Picking Slot Suggestions.
+	 * Set Show Picking Tray Suggestions.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
@@ -500,7 +500,7 @@ public interface I_MobileUI_UserProfile_Picking
 	void setIsDisplayPickingSlotSuggestions (boolean IsDisplayPickingSlotSuggestions);
 
 	/**
-	 * Get Show Picking Slot Suggestions.
+	 * Get Show Picking Tray Suggestions.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
@@ -556,7 +556,7 @@ public interface I_MobileUI_UserProfile_Picking
 	String COLUMNNAME_IsMassPrinting = "IsMassPrinting";
 
 	/**
-	 * Set Picking Slot required.
+	 * Set Kommissionierfach erforderlich.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
@@ -565,7 +565,7 @@ public interface I_MobileUI_UserProfile_Picking
 	void setIsPickingSlotRequired (boolean IsPickingSlotRequired);
 
 	/**
-	 * Get Picking Slot required.
+	 * Get Kommissionierfach erforderlich.
 	 *
 	 * <br>Type: YesNo
 	 * <br>Mandatory: true
@@ -596,6 +596,27 @@ public interface I_MobileUI_UserProfile_Picking
 
 	ModelColumn<I_MobileUI_UserProfile_Picking, Object> COLUMN_IsShipOnCloseLU = new ModelColumn<>(I_MobileUI_UserProfile_Picking.class, "IsShipOnCloseLU", null);
 	String COLUMNNAME_IsShipOnCloseLU = "IsShipOnCloseLU";
+
+	/**
+	 * Set Show all filter groups at once.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	void setIsShowAllFilterGroups (boolean IsShowAllFilterGroups);
+
+	/**
+	 * Get Show all filter groups at once.
+	 *
+	 * <br>Type: YesNo
+	 * <br>Mandatory: true
+	 * <br>Virtual Column: false
+	 */
+	boolean isShowAllFilterGroups();
+
+	ModelColumn<I_MobileUI_UserProfile_Picking, Object> COLUMN_IsShowAllFilterGroups = new ModelColumn<>(I_MobileUI_UserProfile_Picking.class, "IsShowAllFilterGroups", null);
+	String COLUMNNAME_IsShowAllFilterGroups = "IsShowAllFilterGroups";
 
 	/**
 	 * Set Allow over-pick with prompt.

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_MobileUI_UserProfile_Picking.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_MobileUI_UserProfile_Picking.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class X_MobileUI_UserProfile_Picking extends org.compiere.model.PO implements I_MobileUI_UserProfile_Picking, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 899214859L;
+	private static final long serialVersionUID = -657563801L;
 
     /** Standard Constructor */
     public X_MobileUI_UserProfile_Picking (final Properties ctx, final int MobileUI_UserProfile_Picking_ID, @Nullable final String trxName)
@@ -321,6 +321,18 @@ public class X_MobileUI_UserProfile_Picking extends org.compiere.model.PO implem
 	public boolean isShipOnCloseLU() 
 	{
 		return get_ValueAsBoolean(COLUMNNAME_IsShipOnCloseLU);
+	}
+
+	@Override
+	public void setIsShowAllFilterGroups (final boolean IsShowAllFilterGroups)
+	{
+		set_Value (COLUMNNAME_IsShowAllFilterGroups, IsShowAllFilterGroups);
+	}
+
+	@Override
+	public boolean isShowAllFilterGroups() 
+	{
+		return get_ValueAsBoolean(COLUMNNAME_IsShowAllFilterGroups);
 	}
 
 	@Override

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818150_sys_MobileUI_UserProfile_Picking_IsShowAllFilterGroups.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818150_sys_MobileUI_UserProfile_Picking_IsShowAllFilterGroups.sql
@@ -21,7 +21,7 @@ INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description
 
 -- Element: IsShowAllFilterGroups (de_CH)
 -- 2026-08-11T08:40:31.000Z
-UPDATE AD_Element_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-11 08:40:31.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=585163 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET IsTranslated='N',Updated=TO_TIMESTAMP('2026-08-11 08:40:31.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=585163 AND AD_Language='de_CH'
 ;
 
 -- 2026-08-11T08:40:31.010Z
@@ -34,7 +34,7 @@ UPDATE AD_Element_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-11 08:4
 
 -- Element: IsShowAllFilterGroups (de_DE, base language)
 -- 2026-08-11T08:40:32.000Z
-UPDATE AD_Element_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-11 08:40:32.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=585163 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET IsTranslated='N',Updated=TO_TIMESTAMP('2026-08-11 08:40:32.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=585163 AND AD_Language='de_DE'
 ;
 
 -- 2026-08-11T08:40:32.100Z

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818150_sys_MobileUI_UserProfile_Picking_IsShowAllFilterGroups.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818150_sys_MobileUI_UserProfile_Picking_IsShowAllFilterGroups.sql
@@ -1,0 +1,100 @@
+-- Run mode: SWING_CLIENT
+
+-- Adds the picking-profile setting that decides how the packing launcher offers its filter groups:
+-- unset (the default, and today's behaviour) the groups are revealed progressively, one at a time as
+-- the operator narrows down; set, every configured group is offered right away.
+
+-- IDs allocated from idserver.metas.de on 2026-08-11:
+--   AD_Element    585163 (new IsShowAllFilterGroups label for MobileUI_UserProfile_Picking)
+--   AD_Column     593131 (MobileUI_UserProfile_Picking.IsShowAllFilterGroups, default 'N', NOT NULL)
+--   AD_Field      781902 (picking-profile window 541743 / tab 547258)
+--   AD_UI_Element 652815 (header, group 551252 "flags", SeqNo 200)
+
+-- Element: IsShowAllFilterGroups
+-- 2026-08-11T08:40:30.000Z
+INSERT INTO AD_Element (AD_Client_ID,AD_Element_ID,AD_Org_ID,ColumnName,Created,CreatedBy,EntityType,IsActive,Name,PrintName,Updated,UpdatedBy) VALUES (0,585163 /*From ID Server*/,0,'IsShowAllFilterGroups',TO_TIMESTAMP('2026-08-11 08:40:30.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'D','Y','Alle Filtergruppen gleichzeitig anzeigen','Alle Filtergruppen gleichzeitig anzeigen',TO_TIMESTAMP('2026-08-11 08:40:30.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-08-11T08:40:30.100Z
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, CommitWarning,Description,Help,Name,PO_Description,PO_Help,PO_Name,PO_PrintName,PrintName,WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Element_ID, t.CommitWarning,t.Description,t.Help,t.Name,t.PO_Description,t.PO_Help,t.PO_Name,t.PO_PrintName,t.PrintName,t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Element t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Element_ID=585163 AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- Element: IsShowAllFilterGroups (de_CH)
+-- 2026-08-11T08:40:31.000Z
+UPDATE AD_Element_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-11 08:40:31.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=585163 AND AD_Language='de_CH'
+;
+
+-- 2026-08-11T08:40:31.010Z
+/* DDL */  select update_ad_element_on_ad_element_trl_update(585163,'de_CH')
+;
+
+-- 2026-08-11T08:40:31.100Z
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(585163,'de_CH')
+;
+
+-- Element: IsShowAllFilterGroups (de_DE, base language)
+-- 2026-08-11T08:40:32.000Z
+UPDATE AD_Element_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-11 08:40:32.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=585163 AND AD_Language='de_DE'
+;
+
+-- 2026-08-11T08:40:32.100Z
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(585163,'de_DE')
+;
+
+-- Element: IsShowAllFilterGroups (en_US)
+-- 2026-08-11T08:40:33.000Z
+UPDATE AD_Element_Trl SET IsTranslated='Y', Name='Show all filter groups at once', PrintName='Show all filter groups at once',Updated=TO_TIMESTAMP('2026-08-11 08:40:33.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',UpdatedBy=100 WHERE AD_Element_ID=585163 AND AD_Language='en_US'
+;
+
+-- 2026-08-11T08:40:33.010Z
+UPDATE AD_Element base SET Name=trl.Name, PrintName=trl.PrintName, Updated=trl.Updated, UpdatedBy=trl.UpdatedBy FROM AD_Element_Trl trl  WHERE trl.AD_Element_ID=base.AD_Element_ID AND trl.AD_Language='en_US' AND trl.AD_Language=getBaseLanguage()
+;
+
+-- 2026-08-11T08:40:33.100Z
+/* DDL */  select update_TRL_Tables_On_AD_Element_TRL_Update(585163,'en_US')
+;
+
+-- Column: MobileUI_UserProfile_Picking.IsShowAllFilterGroups
+-- 2026-08-11T08:40:34.000Z
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Table_ID,CloningStrategy,ColumnName,Created,CreatedBy,DDL_NoForeignKey,DefaultValue,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,PersonalDataCategory,Version) VALUES (0,593131 /*From ID Server*/,585163,0,20,542373,'XX','IsShowAllFilterGroups',TO_TIMESTAMP('2026-08-11 08:40:34.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'N','N','D',0,1,'Y','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','N','Y','N',0,'Alle Filtergruppen gleichzeitig anzeigen',0,0,TO_TIMESTAMP('2026-08-11 08:40:34.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'NP',0)
+;
+
+-- 2026-08-11T08:40:34.100Z
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Column t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=593131 AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 2026-08-11T08:40:34.200Z
+/* DDL */  select update_Column_Translation_From_AD_Element(585163)
+;
+
+-- 2026-08-11T08:40:35.000Z
+/* DDL */ SELECT public.db_alter_table('MobileUI_UserProfile_Picking','ALTER TABLE public.MobileUI_UserProfile_Picking ADD COLUMN IsShowAllFilterGroups CHAR(1) DEFAULT ''N'' CHECK (IsShowAllFilterGroups IN (''Y'',''N'')) NOT NULL')
+;
+
+-- Field: Mobile UI Kommissionierprofil(541743,D) -> Mobile UI Kommissionierprofil(547258,D) -> Alle Filtergruppen gleichzeitig anzeigen
+-- Column: MobileUI_UserProfile_Picking.IsShowAllFilterGroups
+-- 2026-08-11T08:40:36.000Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,DisplayLength,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,Updated,UpdatedBy) VALUES (0,593131,781902 /*From ID Server*/,0,547258,TO_TIMESTAMP('2026-08-11 08:40:36.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,1,'D','Y','N','N','N','N','N','N','N','Alle Filtergruppen gleichzeitig anzeigen',TO_TIMESTAMP('2026-08-11 08:40:36.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;
+
+-- 2026-08-11T08:40:36.100Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Field t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=781902 AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-08-11T08:40:36.200Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(585163)
+;
+
+-- 2026-08-11T08:40:36.300Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=781902
+;
+
+-- 2026-08-11T08:40:36.400Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(781902)
+;
+
+-- UI Element: Mobile UI Kommissionierprofil(541743,D) -> Mobile UI Kommissionierprofil(547258,D) -> main -> 20 -> flags.Alle Filtergruppen gleichzeitig anzeigen
+-- Column: MobileUI_UserProfile_Picking.IsShowAllFilterGroups
+-- 2026-08-11T08:40:37.000Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy) VALUES (0,781902,0,547258,551252,652815 /*From ID Server*/,'F',TO_TIMESTAMP('2026-08-11 08:40:37.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y','N','Y','N','N','Alle Filtergruppen gleichzeitig anzeigen',200,0,0,TO_TIMESTAMP('2026-08-11 08:40:37.000000','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100)
+;

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/JsonMobileConfigRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/JsonMobileConfigRequest.java
@@ -63,6 +63,7 @@ public class JsonMobileConfigRequest
 		@Nullable Boolean massPrinting;
 		@Nullable Boolean showQtyAvailableForLines;
 		@Nullable Boolean showPromptWhenOverPicking;
+		@Nullable Boolean showAllFilterGroups;
 
 		@Nullable List<Customer> customers;
 		

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigPickingCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/mobile_configuration/MobileConfigPickingCommand.java
@@ -51,7 +51,8 @@ class MobileConfigPickingCommand
 					.isConsiderOnlyJobScheduledToWorkplace(request.getConsiderOnlyJobScheduledToWorkplace() != null ? request.getConsiderOnlyJobScheduledToWorkplace() : false)
 					.isAllowQuickPackAll(request.getAllowQuickPackAll() != null ? request.getAllowQuickPackAll() : false)
 					.isMassPrinting(request.getMassPrinting() != null ? request.getMassPrinting() : false)
-					.isShowQtyAvailableForLines(request.getShowQtyAvailableForLines() != null ? request.getShowQtyAvailableForLines() : false);
+					.isShowQtyAvailableForLines(request.getShowQtyAvailableForLines() != null ? request.getShowQtyAvailableForLines() : false)
+					.isShowAllFilterGroups(request.getShowAllFilterGroups() != null ? request.getShowAllFilterGroups() : false);
 
 			if (request.getAllowPickingAnyCustomer() != null)
 			{

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfile.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfile.java
@@ -46,6 +46,7 @@ public class MobileUIPickingUserProfile
 			.isAllowPickingAnyCustomer(true)
 			.isMassPrinting(false)
 			.isShowQtyAvailableForLines(false)
+			.isShowAllFilterGroups(false)
 			.defaultPickingJobOptions(PickingJobOptions.builder()
 					.aggregationType(PickingJobAggregationType.DEFAULT)
 					.allowedPickToStructures(AllowedPickToStructures.DEFAULT)
@@ -69,6 +70,8 @@ public class MobileUIPickingUserProfile
 	boolean isAllowQuickPackAll;
 	boolean isMassPrinting;
 	boolean isShowQtyAvailableForLines;
+	/** offer every configured filter group at once instead of revealing them as the operator narrows down */
+	boolean isShowAllFilterGroups;
 	@Getter @NonNull PickingCustomerConfigsCollection customerConfigs;
 	@NonNull PickingJobOptions defaultPickingJobOptions;
 	@Getter(AccessLevel.NONE) @NonNull PickingFiltersList filters;
@@ -87,6 +90,7 @@ public class MobileUIPickingUserProfile
 			final boolean isAllowQuickPackAll,
 			final boolean isMassPrinting,
 			final boolean isShowQtyAvailableForLines,
+			final boolean isShowAllFilterGroups,
 			final @Nullable PickingCustomerConfigsCollection customerConfigs,
 			final @NonNull PickingJobOptions defaultPickingJobOptions,
 			final @Nullable PickingFiltersList filters,
@@ -100,6 +104,7 @@ public class MobileUIPickingUserProfile
 		this.isAllowQuickPackAll = isAllowQuickPackAll;
 		this.isMassPrinting = isMassPrinting;
 		this.isShowQtyAvailableForLines = isShowQtyAvailableForLines;
+		this.isShowAllFilterGroups = isShowAllFilterGroups;
 		this.customerConfigs = customerConfigs != null ? customerConfigs : PickingCustomerConfigsCollection.EMPTY;
 		this.defaultPickingJobOptions = defaultPickingJobOptions;
 		this.filters = filters != null ? filters : PickingFiltersList.EMPTY;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepository.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepository.java
@@ -395,6 +395,8 @@ public class MobileUIPickingUserProfileRepository
 		return queryBL.createQueryBuilder(I_PickingProfile_Filter.class)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_PickingProfile_Filter.COLUMNNAME_MobileUI_UserProfile_Picking_ID, profileId)
+				.orderBy(I_PickingProfile_Filter.COLUMNNAME_SeqNo)
+				.orderBy(I_PickingProfile_Filter.COLUMNNAME_PickingProfile_Filter_ID)
 				.create()
 				.stream();
 	}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepository.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepository.java
@@ -113,6 +113,7 @@ public class MobileUIPickingUserProfileRepository
 				.isAllowQuickPackAll(profileRecord.isAllowQuickPackAll())
 				.isMassPrinting(profileRecord.isMassPrinting())
 				.isShowQtyAvailableForLines(profileRecord.isShowQtyAvailableForLines())
+				.isShowAllFilterGroups(profileRecord.isShowAllFilterGroups())
 				.customerConfigs(retrievePickingCustomerConfigsCollection(profileId))
 				.defaultPickingJobOptions(extractPickingJobOptions(profileRecord))
 				.filters(retrieveFilters(profileId))
@@ -337,6 +338,7 @@ public class MobileUIPickingUserProfileRepository
 		record.setIsAllowQuickPackAll(from.isAllowQuickPackAll());
 		record.setIsMassPrinting(from.isMassPrinting());
 		record.setIsShowQtyAvailableForLines(from.isShowQtyAvailableForLines());
+		record.setIsShowAllFilterGroups(from.isShowAllFilterGroups());
 		updateRecord(record, from.getDefaultPickingJobOptions());
 	}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepository.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepository.java
@@ -395,8 +395,8 @@ public class MobileUIPickingUserProfileRepository
 		return queryBL.createQueryBuilder(I_PickingProfile_Filter.class)
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_PickingProfile_Filter.COLUMNNAME_MobileUI_UserProfile_Picking_ID, profileId)
-				.orderBy(I_PickingProfile_Filter.COLUMNNAME_SeqNo)
-				.orderBy(I_PickingProfile_Filter.COLUMNNAME_PickingProfile_Filter_ID)
+				// deliberately unordered: both callers are order-insensitive (retrieveFilters re-sorts via
+				// PickingFiltersList, save_Filters collects into a map keyed by facet group)
 				.create()
 				.stream();
 	}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/PickingFiltersList.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/PickingFiltersList.java
@@ -39,6 +39,21 @@ import java.util.stream.Collector;
 @EqualsAndHashCode
 public class PickingFiltersList
 {
+	/**
+	 * Sequence number first, then the group itself in its declaration order.
+	 * <p>
+	 * The secondary key is what makes the order a property of the configuration rather than of the order
+	 * the rows happen to be stored in: sequence numbers are only assigned automatically when the profile is
+	 * saved through the repository, so rows entered by hand in the profile window all keep the column
+	 * default of 0 and tie.
+	 * <p>
+	 * Declared before {@link #EMPTY} / {@link #DEFAULT} on purpose — those call the constructor from their
+	 * own static initializers, so a comparator declared below them would still be null by then.
+	 */
+	private static final Comparator<PickingFilter> ORDERING = Comparator
+			.comparingInt(PickingFilter::getSeqNo)
+			.thenComparing(PickingFilter::getOption);
+
 	public static final PickingFiltersList EMPTY = new PickingFiltersList(ImmutableList.of());
 
 	public static final PickingFiltersList DEFAULT = new PickingFiltersList(ImmutableList.of(
@@ -51,7 +66,7 @@ public class PickingFiltersList
 
 	private PickingFiltersList(@NonNull final List<PickingFilter> list)
 	{
-		this.groupsInOrder = list.stream().sorted(Comparator.comparing(PickingFilter::getSeqNo)).map(PickingFilter::getOption).distinct().collect(ImmutableList.toImmutableList());
+		this.groupsInOrder = list.stream().sorted(ORDERING).map(PickingFilter::getOption).distinct().collect(ImmutableList.toImmutableList());
 		this.filtersByGroup = Maps.uniqueIndex(list, PickingFilter::getOption);
 
 	}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/facets/CollectingParameters.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/facets/CollectingParameters.java
@@ -14,4 +14,6 @@ public class CollectingParameters
 	@NonNull RenderedAddressProvider addressProvider;
 	@NonNull ImmutableList<PickingJobFacetGroup> groupsInOrder;
 	@NonNull PickingJobQuery.Facets activeFacets;
+	/** offer every configured group at once instead of revealing them as the operator narrows down */
+	boolean isShowAllFilterGroups;
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/facets/PickingJobFacetsAccumulator.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/facets/PickingJobFacetsAccumulator.java
@@ -143,7 +143,11 @@ class PickingJobFacetsAccumulator
 			//
 			// If user didn't activate any facet on this group, stop collecting facets here.
 			// Let him/her active some facets on this group, and then we can continue collecting for next groups
-			if (collectedGroupFacets.stream().noneMatch(PickingJobFacet::isActive))
+			// ...unless the profile asks for every configured group to be offered right away, in which case we
+			// keep going. Note this only skips the early exit: activeFacetsOfPreviousGroups below still
+			// accumulates, so ticking a facet in one group keeps narrowing the ones offered in the others.
+			if (!parameters.isShowAllFilterGroups()
+					&& collectedGroupFacets.stream().noneMatch(PickingJobFacet::isActive))
 			{
 				break;
 			}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/facets/delivery_day/DeliveryDayFacetHandler.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/facets/delivery_day/DeliveryDayFacetHandler.java
@@ -68,6 +68,13 @@ public class DeliveryDayFacetHandler implements PickingJobFacetHandler
 	public List<DeliveryDayFacet> extractFacets(@NonNull final Packageable packageable, @NonNull final CollectingParameters parameters)
 	{
 		final InstantAndOrgId deliveryDate = packageable.getDeliveryDate();
+		if (deliveryDate == null)
+		{
+			// the shipment schedule carries no delivery date; the order contributes no delivery-day option
+			// and stays pickable, rather than taking the whole filter list down with it
+			return ImmutableList.of();
+		}
+
 		//final ZoneId timeZone = orgDAO.getTimeZone(deliveryDate.getOrgId());
 		final ZoneId timeZone = SystemTime.zoneId();
 		final LocalDate deliveryDay = deliveryDate.toZonedDateTime(timeZone).toLocalDate();

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepositoryTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepositoryTest.java
@@ -22,6 +22,7 @@
 
 package de.metas.handlingunits.picking.config.mobileui;
 
+import com.google.common.collect.ImmutableList;
 import de.metas.handlingunits.picking.job.model.facets.PickingJobFacetGroup;
 import de.metas.picking.model.I_PickingProfile_Filter;
 import de.metas.picking.model.X_PickingProfile_Filter;
@@ -112,6 +113,24 @@ class MobileUIPickingUserProfileRepositoryTest
 
 			assertThat(profile.getFilterGroupsInOrder())
 					.containsExactly(PickingJobFacetGroup.CUSTOMER, PickingJobFacetGroup.DELIVERY_DATE);
+		}
+
+		/**
+		 * TC1's second half: the order must still hold once the profile has been saved back, which
+		 * deletes and recreates the filter rows and resets their sequence numbers.
+		 */
+		@Test
+		void tiedSeqNo_survivesAProfileEdit()
+		{
+			final I_MobileUI_UserProfile_Picking profileRecord = newProfileRecord();
+			saveRecord(profileRecord);
+			newFilterRecord(profileRecord, X_PickingProfile_Filter.FILTERTYPE_DeliveryDate, 0);
+			newFilterRecord(profileRecord, X_PickingProfile_Filter.FILTERTYPE_Customer, 0);
+			final ImmutableList<PickingJobFacetGroup> before = repository.getProfile().getFilterGroupsInOrder();
+
+			repository.update(profile -> profile.toBuilder().isMassPrinting(true).build());
+
+			assertThat(repository.getProfile().getFilterGroupsInOrder()).isEqualTo(before);
 		}
 
 		@Test

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepositoryTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepositoryTest.java
@@ -149,6 +149,48 @@ class MobileUIPickingUserProfileRepositoryTest
 	}
 
 	@Nested
+	class IsShowAllFilterGroups
+	{
+		@Test
+		void set_returnsTrue()
+		{
+			final I_MobileUI_UserProfile_Picking record = newProfileRecord();
+			record.setIsShowAllFilterGroups(true);
+			saveRecord(record);
+
+			assertThat(repository.getProfile().isShowAllFilterGroups()).isTrue();
+		}
+
+		@Test
+		void unset_returnsFalse()
+		{
+			final I_MobileUI_UserProfile_Picking record = newProfileRecord();
+			record.setIsShowAllFilterGroups(false);
+			saveRecord(record);
+
+			assertThat(repository.getProfile().isShowAllFilterGroups()).isFalse();
+		}
+
+		@Test
+		void noProfileRecord_returnsFalse()
+		{
+			// the default profile keeps today's progressive-narrowing behaviour
+			assertThat(repository.getProfile().isShowAllFilterGroups()).isFalse();
+		}
+
+		@Test
+		void roundTripsThroughSave()
+		{
+			final I_MobileUI_UserProfile_Picking record = newProfileRecord();
+			saveRecord(record);
+
+			repository.update(profile -> profile.toBuilder().isShowAllFilterGroups(true).build());
+
+			assertThat(repository.getProfile().isShowAllFilterGroups()).isTrue();
+		}
+	}
+
+	@Nested
 	class IsMassPrinting
 	{
 		@Test

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepositoryTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/config/mobileui/MobileUIPickingUserProfileRepositoryTest.java
@@ -22,6 +22,10 @@
 
 package de.metas.handlingunits.picking.config.mobileui;
 
+import de.metas.handlingunits.picking.job.model.facets.PickingJobFacetGroup;
+import de.metas.picking.model.I_PickingProfile_Filter;
+import de.metas.picking.model.X_PickingProfile_Filter;
+import lombok.NonNull;
 import org.adempiere.ad.wrapper.POJOLookupMap;
 import org.adempiere.ad.wrapper.POJONextIdSuppliers;
 import org.adempiere.test.AdempiereTestHelper;
@@ -59,6 +63,70 @@ class MobileUIPickingUserProfileRepositoryTest
 		record.setPickingJobAggregationType(X_MobileUI_UserProfile_Picking.PICKINGJOBAGGREGATIONTYPE_Sales_order);
 		record.setCreateShipmentPolicy(X_MobileUI_UserProfile_Picking.CREATESHIPMENTPOLICY_DO_NOT_CREATE);
 		return record;
+	}
+
+	private void newFilterRecord(
+			@NonNull final I_MobileUI_UserProfile_Picking profileRecord,
+			@NonNull final String filterType,
+			final int seqNo)
+	{
+		final I_PickingProfile_Filter record = newInstance(I_PickingProfile_Filter.class);
+		record.setIsActive(true);
+		record.setMobileUI_UserProfile_Picking_ID(profileRecord.getMobileUI_UserProfile_Picking_ID());
+		record.setFilterType(filterType);
+		record.setSeqNo(seqNo);
+		saveRecord(record);
+	}
+
+	@Nested
+	class FilterGroupOrder
+	{
+		/**
+		 * Two filter rows sharing a sequence number must not let the order in which they happen to be
+		 * stored decide the order the operator sees. Both saving orders must produce the same result,
+		 * i.e. the tie is broken by the group itself, in its declaration order.
+		 */
+		@Test
+		void tiedSeqNo_customerStoredFirst_ordersByGroup()
+		{
+			final I_MobileUI_UserProfile_Picking profileRecord = newProfileRecord();
+			saveRecord(profileRecord);
+			newFilterRecord(profileRecord, X_PickingProfile_Filter.FILTERTYPE_Customer, 0);
+			newFilterRecord(profileRecord, X_PickingProfile_Filter.FILTERTYPE_DeliveryDate, 0);
+
+			final MobileUIPickingUserProfile profile = repository.getProfile();
+
+			assertThat(profile.getFilterGroupsInOrder())
+					.containsExactly(PickingJobFacetGroup.CUSTOMER, PickingJobFacetGroup.DELIVERY_DATE);
+		}
+
+		@Test
+		void tiedSeqNo_deliveryDateStoredFirst_ordersByGroup()
+		{
+			final I_MobileUI_UserProfile_Picking profileRecord = newProfileRecord();
+			saveRecord(profileRecord);
+			newFilterRecord(profileRecord, X_PickingProfile_Filter.FILTERTYPE_DeliveryDate, 0);
+			newFilterRecord(profileRecord, X_PickingProfile_Filter.FILTERTYPE_Customer, 0);
+
+			final MobileUIPickingUserProfile profile = repository.getProfile();
+
+			assertThat(profile.getFilterGroupsInOrder())
+					.containsExactly(PickingJobFacetGroup.CUSTOMER, PickingJobFacetGroup.DELIVERY_DATE);
+		}
+
+		@Test
+		void distinctSeqNo_ordersBySeqNo()
+		{
+			final I_MobileUI_UserProfile_Picking profileRecord = newProfileRecord();
+			saveRecord(profileRecord);
+			newFilterRecord(profileRecord, X_PickingProfile_Filter.FILTERTYPE_Customer, 20);
+			newFilterRecord(profileRecord, X_PickingProfile_Filter.FILTERTYPE_DeliveryDate, 10);
+
+			final MobileUIPickingUserProfile profile = repository.getProfile();
+
+			assertThat(profile.getFilterGroupsInOrder())
+					.containsExactly(PickingJobFacetGroup.DELIVERY_DATE, PickingJobFacetGroup.CUSTOMER);
+		}
 	}
 
 	@Nested

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/model/facets/PickingJobFacetsAccumulatorTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/model/facets/PickingJobFacetsAccumulatorTest.java
@@ -1,0 +1,166 @@
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.handlingunits.picking.job.model.facets;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.BPartnerLocationId;
+import de.metas.bpartner.ShipmentAllocationBestBeforePolicy;
+import de.metas.document.location.IDocumentLocationBL;
+import de.metas.document.location.RenderedAddressProvider;
+import de.metas.handlingunits.picking.job.model.PickingJobQuery;
+import de.metas.handlingunits.picking.job.model.facets.customer.CustomerFacet;
+import de.metas.handlingunits.picking.job.model.facets.delivery_day.DeliveryDayFacet;
+import de.metas.i18n.TranslatableStrings;
+import de.metas.inout.ShipmentScheduleId;
+import de.metas.organization.InstantAndOrgId;
+import de.metas.organization.OrgId;
+import de.metas.picking.api.Packageable;
+import de.metas.product.ProductId;
+import de.metas.product.ProductValueAndName;
+import de.metas.quantity.Quantity;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static de.metas.common.util.time.SystemTime.zoneId;
+import static org.adempiere.model.InterfaceWrapperHelper.newInstanceOutOfTrx;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(AdempiereTestWatcher.class)
+class PickingJobFacetsAccumulatorTest
+{
+	private static final OrgId ORG_ID = OrgId.ofRepoId(1);
+
+	private static final BPartnerId CUSTOMER_1 = BPartnerId.ofRepoId(1_000_001);
+	private static final BPartnerId CUSTOMER_2 = BPartnerId.ofRepoId(1_000_002);
+	private static final LocalDate DAY_1 = LocalDate.of(2026, 8, 11);
+	private static final LocalDate DAY_2 = LocalDate.of(2026, 8, 12);
+
+	private static final ImmutableList<PickingJobFacetGroup> CUSTOMER_THEN_DELIVERY_DATE =
+			ImmutableList.of(PickingJobFacetGroup.CUSTOMER, PickingJobFacetGroup.DELIVERY_DATE);
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+	}
+
+	@Test
+	void byDefault_onlyTheFirstGroupIsOffered()
+	{
+		final PickingJobFacets facets = collect(parameters(false, PickingJobQuery.Facets.EMPTY));
+
+		assertThat(customerIdsOf(facets)).containsExactlyInAnyOrder(CUSTOMER_1, CUSTOMER_2);
+		assertThat(deliveryDaysOf(facets)).isEmpty();
+	}
+
+	@Test
+	void showAllFilterGroups_everyGroupIsOfferedUpFront()
+	{
+		final PickingJobFacets facets = collect(parameters(true, PickingJobQuery.Facets.EMPTY));
+
+		assertThat(customerIdsOf(facets)).containsExactlyInAnyOrder(CUSTOMER_1, CUSTOMER_2);
+		assertThat(deliveryDaysOf(facets)).containsExactlyInAnyOrder(DAY_1, DAY_2);
+	}
+
+	@Test
+	void showAllFilterGroups_selectingACustomerStillNarrowsTheOthers()
+	{
+		final PickingJobQuery.Facets customer1Selected = PickingJobQuery.Facets.builder().customerId(CUSTOMER_1).build();
+
+		final PickingJobFacets facets = collect(parameters(true, customer1Selected));
+
+		assertThat(customerIdsOf(facets)).containsExactlyInAnyOrder(CUSTOMER_1, CUSTOMER_2);
+		assertThat(deliveryDaysOf(facets)).containsExactly(DAY_1);
+	}
+
+	private PickingJobFacets collect(final CollectingParameters parameters)
+	{
+		return Stream.of(
+						packageable(CUSTOMER_1, DAY_1),
+						packageable(CUSTOMER_2, DAY_2))
+				.collect(PickingJobFacetsAccumulator.collect(parameters));
+	}
+
+	private static CollectingParameters parameters(final boolean isShowAllFilterGroups, final PickingJobQuery.Facets activeFacets)
+	{
+		return CollectingParameters.builder()
+				.addressProvider(RenderedAddressProvider.builder().documentLocationBL(mock(IDocumentLocationBL.class)).build())
+				.groupsInOrder(CUSTOMER_THEN_DELIVERY_DATE)
+				.activeFacets(activeFacets)
+				.isShowAllFilterGroups(isShowAllFilterGroups)
+				.build();
+	}
+
+	private static Iterable<BPartnerId> customerIdsOf(final PickingJobFacets facets)
+	{
+		return facets.toList(CustomerFacet.class, CustomerFacet::getBpartnerId);
+	}
+
+	private static Iterable<LocalDate> deliveryDaysOf(final PickingJobFacets facets)
+	{
+		return facets.toList(DeliveryDayFacet.class, DeliveryDayFacet::getDeliveryDate);
+	}
+
+	private static Packageable packageable(final BPartnerId customerId, final LocalDate deliveryDay)
+	{
+		final I_C_UOM uomRecord = newInstanceOutOfTrx(I_C_UOM.class);
+		uomRecord.setUOMSymbol("PCE");
+		final Quantity zero = Quantity.zero(uomRecord);
+
+		return Packageable.builder()
+				.orgId(ORG_ID)
+				.shipmentScheduleId(ShipmentScheduleId.ofRepoId(customerId.getRepoId()))
+				.qtyOrdered(zero)
+				.qtyToDeliver(zero)
+				.qtyDelivered(zero)
+				.qtyPickedAndDelivered(zero)
+				.qtyPickedNotDelivered(zero)
+				.qtyPickedPlanned(zero)
+				.customerId(customerId)
+				.customerBPValue("BP" + customerId.getRepoId())
+				.customerName("Customer " + customerId.getRepoId())
+				.customerLocationId(BPartnerLocationId.ofRepoId(customerId.getRepoId(), 1))
+				.handoverLocationId(BPartnerLocationId.ofRepoId(customerId.getRepoId(), 1))
+				.warehouseId(WarehouseId.ofRepoId(1))
+				.bestBeforePolicy(Optional.of(ShipmentAllocationBestBeforePolicy.Expiring_First))
+				.productId(ProductId.ofRepoId(1))
+				.productValueAndName(ProductValueAndName.of("P1", TranslatableStrings.constant("Product 1")))
+				.asiId(AttributeSetInstanceId.NONE)
+				.deliveryDate(InstantAndOrgId.ofInstant(
+						Objects.requireNonNull(deliveryDay).atStartOfDay(zoneId()).toInstant(), ORG_ID))
+				.build();
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/model/facets/delivery_day/DeliveryDayFacetHandlerTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/model/facets/delivery_day/DeliveryDayFacetHandlerTest.java
@@ -1,0 +1,131 @@
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.handlingunits.picking.job.model.facets.delivery_day;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.bpartner.BPartnerId;
+import de.metas.bpartner.BPartnerLocationId;
+import de.metas.document.location.IDocumentLocationBL;
+import de.metas.document.location.RenderedAddressProvider;
+import de.metas.i18n.TranslatableStrings;
+import de.metas.handlingunits.picking.job.model.PickingJobQuery;
+import de.metas.handlingunits.picking.job.model.facets.CollectingParameters;
+import de.metas.handlingunits.picking.job.model.facets.PickingJobFacetGroup;
+import de.metas.inout.ShipmentScheduleId;
+import de.metas.organization.InstantAndOrgId;
+import de.metas.organization.OrgId;
+import de.metas.picking.api.Packageable;
+import de.metas.product.ProductId;
+import de.metas.product.ProductValueAndName;
+import de.metas.quantity.Quantity;
+import de.metas.bpartner.ShipmentAllocationBestBeforePolicy;
+import de.metas.uom.UomId;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.adempiere.warehouse.WarehouseId;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstanceOutOfTrx;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(AdempiereTestWatcher.class)
+class DeliveryDayFacetHandlerTest
+{
+	private static final OrgId ORG_ID = OrgId.ofRepoId(1);
+
+	private final DeliveryDayFacetHandler handler = new DeliveryDayFacetHandler();
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+	}
+
+	/**
+	 * An order line whose delivery date was never set must not take the whole filter bar down with it.
+	 * {@code PackagingDAO} leaves the field null whenever the shipment schedule carries no delivery date.
+	 */
+	@Test
+	void noDeliveryDate_contributesNoOption()
+	{
+		assertThat(handler.extractFacets(packageable(null), collectingParameters())).isEmpty();
+	}
+
+	@Test
+	void withDeliveryDate_contributesThatDay()
+	{
+		final Instant deliveryDate = LocalDate.of(2026, 8, 11).atStartOfDay(de.metas.common.util.time.SystemTime.zoneId()).toInstant();
+
+		assertThat(handler.extractFacets(packageable(InstantAndOrgId.ofInstant(deliveryDate, ORG_ID)), collectingParameters()))
+				.extracting(DeliveryDayFacet::getDeliveryDate)
+				.containsExactly(LocalDate.of(2026, 8, 11));
+	}
+
+	private static CollectingParameters collectingParameters()
+	{
+		return CollectingParameters.builder()
+				// never consulted by this handler; the parameters object insists on one
+				.addressProvider(RenderedAddressProvider.builder().documentLocationBL(mock(IDocumentLocationBL.class)).build())
+				.groupsInOrder(ImmutableList.of(PickingJobFacetGroup.DELIVERY_DATE))
+				.activeFacets(PickingJobQuery.Facets.builder().build())
+				.build();
+	}
+
+	private static Packageable packageable(@Nullable final InstantAndOrgId deliveryDate)
+	{
+		final I_C_UOM uomRecord = newInstanceOutOfTrx(I_C_UOM.class);
+		uomRecord.setUOMSymbol("PCE");
+		final Quantity zero = Quantity.zero(uomRecord);
+
+		return Packageable.builder()
+				.orgId(ORG_ID)
+				.shipmentScheduleId(ShipmentScheduleId.ofRepoId(1))
+				.qtyOrdered(zero)
+				.qtyToDeliver(zero)
+				.qtyDelivered(zero)
+				.qtyPickedAndDelivered(zero)
+				.qtyPickedNotDelivered(zero)
+				.qtyPickedPlanned(zero)
+				.customerId(BPartnerId.ofRepoId(1))
+				.customerLocationId(BPartnerLocationId.ofRepoId(1, 1))
+				.handoverLocationId(BPartnerLocationId.ofRepoId(1, 1))
+				.warehouseId(WarehouseId.ofRepoId(1))
+				.bestBeforePolicy(Optional.of(ShipmentAllocationBestBeforePolicy.Expiring_First))
+				.productId(ProductId.ofRepoId(1))
+				.productValueAndName(ProductValueAndName.of("P1", TranslatableStrings.constant("Product 1")))
+				.asiId(AttributeSetInstanceId.NONE)
+				.deliveryDate(deliveryDate)
+				.build();
+	}
+}

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/lauchers/PickingWorkflowLaunchersProvider.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/lauchers/PickingWorkflowLaunchersProvider.java
@@ -308,6 +308,7 @@ public class PickingWorkflowLaunchersProvider
 						.addressProvider(bpartnerService.newRenderedAddressProvider())
 						.groupsInOrder(groups)
 						.activeFacets(activeFacets)
+						.isShowAllFilterGroups(profile.isShowAllFilterGroups())
 						.build());
 
 		return PickingJobFacetHandlers.toWorkflowLaunchersFacetGroupList(pickingFacets, profile);

--- a/e2e/mobile-webui/tests/spec/picking/filters_allAtOnce.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/filters_allAtOnce.spec.js
@@ -1,0 +1,112 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { Backend } from '../../utils/screens/Backend';
+import { LoginScreen } from '../../utils/screens/LoginScreen';
+import { ApplicationsListScreen } from '../../utils/screens/ApplicationsListScreen';
+import { PickingJobsListScreen } from '../../utils/screens/picking/PickingJobsListScreen';
+import { PickingJobsListFiltersScreen } from '../../utils/screens/picking/PickingJobsListFiltersScreen';
+
+const DELIVERY_DATE = '2025-03-01';
+
+const createMasterdata = async () => {
+    const salesOrderOf = (bpartner, datePromised) => ({
+        bpartner,
+        warehouse: 'wh',
+        datePromised,
+        lines: [{ product: 'P1', qty: 10, workplace: 'workplace1' }]
+    });
+
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: {
+                user1: { language: "en_US", workplace: "workplace1" },
+            },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU', 'TU', 'LU_CU', 'CU'],
+                    activeWorkplaceRequired: true,
+                    considerOnlyJobScheduledToWorkplace: true,
+                    allowPickingAnyCustomer: false,
+                    customers: [
+                        { customer: "customer1" },
+                        { customer: "customer2" },
+                    ],
+                    filters: ['Customer', 'DeliveryDate'],
+                    showAllFilterGroups: true,
+                }
+            },
+            bpartners: {
+                "customer1": {},
+                "customer2": {},
+            },
+            warehouses: { "wh": {} },
+            workplaces: { workplace1: {} },
+            pickingSlots: { slot1: {} },
+            products: { "P1": { price: 1 } },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', qty: 1000 },
+            },
+            salesOrders: {
+                'SO1': salesOrderOf('customer1', `${DELIVERY_DATE}T05:00:00.000+02:00`),
+                'SO2': salesOrderOf('customer2', `${DELIVERY_DATE}T05:00:00.000+02:00`),
+            },
+        }
+    })
+}
+
+// noinspection JSUnusedLocalSymbols
+test('Check facets when all filter groups are offered at once', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00240');
+    allure.story('Picking facets');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata();
+
+    await LoginScreen.login(masterdata.login.user1);
+
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startPickingApplication();
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.clickFilterButton();
+
+    await test.step('The delivery date is offered without picking a customer first', async () => {
+        await PickingJobsListFiltersScreen.expectFacets([
+            { facetId: 'Customer_' + masterdata.bpartners.customer1.id, isChecked: false },
+            { facetId: 'Customer_' + masterdata.bpartners.customer2.id, isChecked: false },
+            { facetId: 'DeliveryDate_' + DELIVERY_DATE, isChecked: false },
+        ]);
+        await PickingJobsListFiltersScreen.expectShowResults({ hitCount: 2 });
+    });
+
+    await test.step('Tick the delivery date straight away', async () => {
+        await PickingJobsListFiltersScreen.clickFacet({ facetId: 'DeliveryDate_' + DELIVERY_DATE });
+        await PickingJobsListFiltersScreen.expectFacets([
+            { facetId: 'Customer_' + masterdata.bpartners.customer1.id, isChecked: false },
+            { facetId: 'Customer_' + masterdata.bpartners.customer2.id, isChecked: false },
+            { facetId: 'DeliveryDate_' + DELIVERY_DATE, isChecked: true },
+        ]);
+        await PickingJobsListFiltersScreen.expectShowResults({ hitCount: 2 });
+    });
+
+    await test.step('Tick one customer and see the other options narrow', async () => {
+        await PickingJobsListFiltersScreen.clickFacet({ facetId: 'Customer_' + masterdata.bpartners.customer1.id });
+        await PickingJobsListFiltersScreen.expectFacets([
+            { facetId: 'Customer_' + masterdata.bpartners.customer1.id, isChecked: true },
+            { facetId: 'Customer_' + masterdata.bpartners.customer2.id, isChecked: false },
+            { facetId: 'DeliveryDate_' + DELIVERY_DATE, isChecked: true },
+        ]);
+        await PickingJobsListFiltersScreen.expectShowResults({ hitCount: 1 });
+    });
+
+    await test.step('Go back and logout', async () => {
+        await PickingJobsListFiltersScreen.goBack();
+        await PickingJobsListScreen.goBack();
+        await ApplicationsListScreen.logout();
+    });
+});


### PR DESCRIPTION
The mobile packing launcher's filter bar had three problems, all fixed here.

**Filter group order was undefined when sequence numbers tie.** Sequence numbers are only
assigned automatically when a profile is saved through the repository, so filter rows entered by
hand in the profile window all keep the column default of `0` — and the group order then came down
to whatever order the rows were returned in. The order is now sequence number first, then the facet
group in its declaration order: defined, and stable across a profile edit (which deletes and
recreates the rows).

**An order with no delivery date broke the whole filter list.** `PackagingDAO` leaves
`Packageable.deliveryDate` null when the shipment schedule has none, and `DeliveryDayFacetHandler`
dereferenced it unconditionally. Such an order now contributes no delivery-day option and stays
pickable.

**Only the first configured filter group was ever offered.** The collector stops at the first group
with no active facet, so the operator had to tick a customer before any other filter appeared. That
is deliberate behaviour specified by `e2e/mobile-webui/tests/spec/picking/facets.spec.js`, so it is
unchanged by default. A new profile setting — `MobileUI_UserProfile_Picking.IsShowAllFilterGroups`,
defaulting to `'N'` — opts a profile into having every configured group offered right away. Only the
early exit is skipped; the cross-group narrowing is untouched, so ticking a customer still narrows
the delivery dates on offer.

## Tests

- `MobileUIPickingUserProfileRepositoryTest` — filter group order under tied sequence numbers, in
  both storage orders and across a profile edit; the new setting's round trip.
- `DeliveryDayFacetHandlerTest` (new) — an order with and without a delivery date.
- `PickingJobFacetsAccumulatorTest` (new) — the default still reveals one group at a time; the opt-in
  offers every group up front and still narrows across groups.
- `facets.spec.js` passes **unmodified**, proving the default behaviour is untouched.
- `filters_allAtOnce.spec.js` (new) — the opt-in path through the real mobile UI.

Whole `de.metas.handlingunits.base` suite: 1041 tests, 0 failures.
