### PR TITLE
Fix the endless recompute re-enqueue caused by orphaned M_ShipmentSchedule_Recompute markers

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -361,14 +361,17 @@ public class M_ShipmentSchedule_StepDef
 	}
 
 	/**
-	 * Isolation cleanup: waits until the shipment-schedule work queue is drained, then deletes any leftover
-	 * untagged {@code M_ShipmentSchedule_Recompute} markers ({@code AD_PInstance_ID IS NULL}). Belongs at the
-	 * start of the Background.
+	 * Isolation cleanup: deletes any leftover untagged {@code M_ShipmentSchedule_Recompute} markers
+	 * ({@code AD_PInstance_ID IS NULL}), waits until the shipment-schedule work queue is drained, then deletes
+	 * once more. Belongs at the start of the Background.
 	 * <p>
-	 * The wait closes a real race: a recompute pass enqueued by an earlier scenario claims markers through the
-	 * same DB function this feature asserts on, and that claiming SQL is unconditionally global. Both processors
-	 * are checked in ONE predicate so they are zero at the same poll: a create-missing run enqueues a recompute
-	 * pass, so checking them one after the other could pass on a queue that is not quiet.
+	 * Deleting first means the wait no longer depends on the size of the untagged backlog this step removes
+	 * anyway -- it waits only for genuinely in-flight work; the trailing delete catches markers created by a pass
+	 * that completed during the drain. The wait closes a real race: a recompute pass enqueued by an earlier
+	 * scenario claims markers through the same DB function this feature asserts on, and that claiming SQL is
+	 * unconditionally global. Both processors are checked in ONE predicate so they are zero at the same poll: a
+	 * create-missing run enqueues a recompute pass, so checking them one after the other could pass on a queue
+	 * that is not quiet.
 	 * <p>
 	 * Do NOT widen {@link WorkPackageQueueUtil#countPendingWorkPackages(String)} to not-ready workpackages: one
 	 * bound to a rolled-back transaction never becomes ready, so waiting on it would turn this intermittent flake
@@ -383,8 +386,15 @@ public class M_ShipmentSchedule_StepDef
 	@And("all untagged M_ShipmentSchedule_Recompute markers are deleted")
 	public void deleteAllUntaggedRecomputeMarkers() throws InterruptedException
 	{
+		deleteUntaggedRecomputeMarkers();
+
 		waitForRecomputeWorkQueueToDrain();
 
+		deleteUntaggedRecomputeMarkers();
+	}
+
+	private void deleteUntaggedRecomputeMarkers()
+	{
 		// deleteDirectly (bulk filter-based DELETE), NOT delete(): M_ShipmentSchedule_Recompute is a keyless
 		// queue table (no single-column PK), so the PO-by-PO delete() builds an empty WHERE and fails with a
 		// SQL syntax error. deleteDirectly() issues one DELETE FROM ... WHERE AD_PInstance_ID IS NULL.

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -204,7 +204,7 @@ public class M_ShipmentSchedule_StepDef
 	private final Map<String, PInstanceId> recomputeSelectionsByIdentifier = new HashMap<>();
 
 	/**
-	 * gh31502 regression coverage: orphaned {@code M_ShipmentSchedule_ID}s seeded by
+	 * Regression coverage: orphaned {@code M_ShipmentSchedule_ID}s seeded by
 	 * {@link #seedOrphanedUntaggedRecomputeMarker}, keyed by the scenario's identifier, so
 	 * {@link #assertOrphanedRecomputeMarkerReaped} can look the id back up.
 	 */
@@ -369,7 +369,7 @@ public class M_ShipmentSchedule_StepDef
 	}
 
 	/**
-	 * gh31502 regression coverage: seeds one orphaned, untagged {@code M_ShipmentSchedule_Recompute} marker. A
+	 * Regression coverage: seeds one orphaned, untagged {@code M_ShipmentSchedule_Recompute} marker. A
 	 * minimal {@code M_ShipmentSchedule} row is inserted, an untagged marker is inserted for it, then the
 	 * schedule row itself is deleted directly -- leaving the marker behind with no matching schedule. This is
 	 * possible only because {@code M_ShipmentSchedule_Recompute} carries NO FK to {@code M_ShipmentSchedule}
@@ -445,13 +445,22 @@ public class M_ShipmentSchedule_StepDef
 	}
 
 	/**
-	 * gh31502 regression coverage: enqueues one bounded shipment-schedule recompute pass via the real
+	 * Regression coverage: enqueues one bounded shipment-schedule recompute pass via the real
 	 * production entry point, {@link UpdateInvalidShipmentSchedulesWorkpackageProcessor#schedule()} (the same
 	 * static method every real invalidation calls internally). The pass is bounded exactly as in production by
 	 * the {@code UpdateInvalidShipmentSchedulesWorkpackageProcessor.MaxToProcess} sysconfig (default 500 -- a
 	 * real, non-zero limit; nothing in this test module overrides it to unbounded), so
 	 * {@code maxToProcess.isLimited()} is {@code true} and the livelock branch in
 	 * {@code ShipmentScheduleUpdater#updateShipmentSchedules} is reachable.
+	 * <p>
+	 * Two consequences of driving the REAL pipeline (this is the only step in this feature that does):
+	 * the Background's fixture schedules are handler-less (self-referential {@code AD_Table_ID}, no registered
+	 * {@code ShipmentScheduleHandler}), so {@code ShipmentSchedulePA#createOlAndScheds} skips them via its
+	 * defensive report-and-skip path rather than running per-schedule business logic against minimal rows --
+	 * which keeps this pass fast, but also means each run logs one {@code AD_Issue} per skipped fixture
+	 * schedule. Those {@code AD_Issue} rows are an EXPECTED side effect, not a failure. And if that skip path
+	 * were ever removed, this scenario would start failing for a reason unrelated to the orphan it guards --
+	 * look there first before suspecting the reaper or the probe.
 	 *
 	 * @cucumber.stepdef
 	 * @cucumber.example
@@ -466,7 +475,7 @@ public class M_ShipmentSchedule_StepDef
 	}
 
 	/**
-	 * gh31502 regression assertion: waits until no untagged ({@code AD_PInstance_ID IS NULL})
+	 * Regression assertion: waits until no untagged ({@code AD_PInstance_ID IS NULL})
 	 * {@code M_ShipmentSchedule_Recompute} marker remains for the schedule id seeded under {@code identifier}
 	 * by {@link #seedOrphanedUntaggedRecomputeMarker} -- i.e. the orphan was reaped rather than left to
 	 * accumulate forever in the queue table. Polls instead of checking once: the marker is removed
@@ -499,7 +508,7 @@ public class M_ShipmentSchedule_StepDef
 	}
 
 	/**
-	 * gh31502 regression assertion: the strongest available livelock signal -- waits until no
+	 * Regression assertion: the strongest available livelock signal -- waits until no
 	 * {@link #RECOMPUTE_QUEUE_PROCESSOR_SHORT_NAMES} workpackage remains pending, i.e. the shipment-schedule
 	 * recompute queue actually drains to zero within the module's standard wait budget. Before the fix, a
 	 * bounded pass that could never make progress on an untaggable (orphaned) marker kept reporting

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -101,6 +101,7 @@ import java.time.ZoneId;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.After;
 import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import lombok.Builder;
@@ -201,6 +202,13 @@ public class M_ShipmentSchedule_StepDef
 
 	/** Recompute selection ids created by {@link #tagInvalidShipmentSchedulesForRecompute}, keyed by the scenario's selection identifier. */
 	private final Map<String, PInstanceId> recomputeSelectionsByIdentifier = new HashMap<>();
+
+	/**
+	 * gh31502 regression coverage: orphaned {@code M_ShipmentSchedule_ID}s seeded by
+	 * {@link #seedOrphanedUntaggedRecomputeMarker}, keyed by the scenario's identifier, so
+	 * {@link #assertOrphanedRecomputeMarkerReaped} can look the id back up.
+	 */
+	private final Map<String, Integer> orphanedRecomputeMarkerScheduleIdsByIdentifier = new HashMap<>();
 
 	/**
 	 * M_ShipmentSchedule_IDs seeded by {@link #seedShipmentSchedulesWithUntaggedRecomputeMarker}. They carry
@@ -358,6 +366,166 @@ public class M_ShipmentSchedule_StepDef
 		assertThat(noRecords.get())
 				.as("There are still records in M_ShipmentSchedules_Recompute after %s second timeout -- " + shipmentScheduleIds, timeoutSec)
 				.isTrue();
+	}
+
+	/**
+	 * gh31502 regression coverage: seeds one orphaned, untagged {@code M_ShipmentSchedule_Recompute} marker. A
+	 * minimal {@code M_ShipmentSchedule} row is inserted, an untagged marker is inserted for it, then the
+	 * schedule row itself is deleted directly -- leaving the marker behind with no matching schedule. This is
+	 * possible only because {@code M_ShipmentSchedule_Recompute} carries NO FK to {@code M_ShipmentSchedule}
+	 * (verified against the live local DB); its only FK is to {@code C_Async_Batch}.
+	 * <p>
+	 * Why raw SQL, not the DAO layer: every DAO insertion path for this marker (e.g.
+	 * {@code IShipmentScheduleInvalidateRepository#invalidateShipmentSchedules}) INSERTs
+	 * {@code FROM M_ShipmentSchedule WHERE M_ShipmentSchedule_ID IN (...)}, so it can never produce a marker
+	 * whose schedule does not exist -- the DAO layer is designed to prevent exactly the state this step needs.
+	 * Raw SQL is the only way to create it; this mirrors {@link #seedShipmentSchedulesWithUntaggedRecomputeMarker}'s
+	 * own raw INSERT, plus one raw DELETE to orphan it.
+	 * <p>
+	 * The seeded id is remembered under {@code identifier} for {@link #assertOrphanedRecomputeMarkerReaped}, and
+	 * tracked in {@link #seededRecomputeScheduleIds} so the existing {@link #deleteSeededRecomputeSchedules()}
+	 * cleanup also removes it if it survives the scenario (a harmless no-op once the fix has reaped it).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>identifier</b> — (required) alias to remember the orphaned schedule's id under, for the later
+	 *     "no untagged marker remains" assertion<br>
+	 * @cucumber.example
+	 * <pre>
+	 * Given an orphaned untagged M_ShipmentSchedule_Recompute marker exists for "orphanSchedule"
+	 * </pre>
+	 */
+	@Given("an orphaned untagged M_ShipmentSchedule_Recompute marker exists for {string}")
+	public void seedOrphanedUntaggedRecomputeMarker(@NonNull final String identifier)
+	{
+		final int shipmentScheduleTableId = InterfaceWrapperHelper.getTableId(I_M_ShipmentSchedule.class);
+		final int orphanScheduleId = DB.getNextID(StepDefConstants.CLIENT_ID.getRepoId(), I_M_ShipmentSchedule.Table_Name);
+		final int fillerProductId = DB.getSQLValueEx(ITrx.TRXNAME_None, "SELECT M_Product_ID FROM M_Product ORDER BY M_Product_ID LIMIT 1");
+
+		// Minimal M_ShipmentSchedule row -- same filler pattern as seedShipmentSchedulesWithUntaggedRecomputeMarker.
+		DB.executeUpdateAndThrowExceptionOnFail(
+				"INSERT INTO M_ShipmentSchedule ("
+						+ " M_ShipmentSchedule_ID, AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy,"
+						+ " M_Product_ID, M_Warehouse_ID, C_BPartner_ID, C_BPartner_Location_ID, Bill_BPartner_ID,"
+						+ " DeliveryRule, DeliveryViaRule, BPartnerAddress, AD_Table_ID, Record_ID)"
+						+ " VALUES (?, ?, ?, now(), ?, now(), ?, ?, ?, ?, ?, ?, 'F', 'D', '.', ?, ?)",
+				new Object[] {
+						orphanScheduleId,
+						StepDefConstants.CLIENT_ID.getRepoId(),
+						StepDefConstants.ORG_ID.getRepoId(),
+						UserId.METASFRESH.getRepoId(),
+						UserId.METASFRESH.getRepoId(),
+						fillerProductId,
+						StepDefConstants.WAREHOUSE_ID.getRepoId(),
+						StepDefConstants.METASFRESH_AG_BPARTNER_ID.getRepoId(),
+						StepDefConstants.METASFRESH_AG_BPARTNER_LOCATION_ID.getRepoId(),
+						StepDefConstants.METASFRESH_AG_BPARTNER_ID.getRepoId(),
+						shipmentScheduleTableId,
+						orphanScheduleId },
+				ITrx.TRXNAME_ThreadInherited);
+
+		// One untagged marker for it (keyless queue table -- see seedShipmentSchedulesWithUntaggedRecomputeMarker).
+		DB.executeUpdateAndThrowExceptionOnFail(
+				"INSERT INTO M_ShipmentSchedule_Recompute (M_ShipmentSchedule_ID) VALUES (?)",
+				new Object[] { orphanScheduleId },
+				ITrx.TRXNAME_ThreadInherited);
+
+		// Orphan it: delete the schedule row, leaving the marker with no matching M_ShipmentSchedule. No FK
+		// exists between the two tables, so this delete succeeds and the marker survives untouched.
+		DB.executeUpdateAndThrowExceptionOnFail(
+				"DELETE FROM M_ShipmentSchedule WHERE M_ShipmentSchedule_ID = ?",
+				new Object[] { orphanScheduleId },
+				ITrx.TRXNAME_ThreadInherited);
+
+		orphanedRecomputeMarkerScheduleIdsByIdentifier.put(identifier, orphanScheduleId);
+
+		// Track it so the existing @After cleanup (deleteSeededRecomputeSchedules) removes the leftover marker
+		// too -- the M_ShipmentSchedule delete there is a harmless no-op (the row is already gone).
+		seededRecomputeScheduleIds.add(orphanScheduleId);
+	}
+
+	/**
+	 * gh31502 regression coverage: enqueues one bounded shipment-schedule recompute pass via the real
+	 * production entry point, {@link UpdateInvalidShipmentSchedulesWorkpackageProcessor#schedule()} (the same
+	 * static method every real invalidation calls internally). The pass is bounded exactly as in production by
+	 * the {@code UpdateInvalidShipmentSchedulesWorkpackageProcessor.MaxToProcess} sysconfig (default 500 -- a
+	 * real, non-zero limit; nothing in this test module overrides it to unbounded), so
+	 * {@code maxToProcess.isLimited()} is {@code true} and the livelock branch in
+	 * {@code ShipmentScheduleUpdater#updateShipmentSchedules} is reachable.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * When a shipment-schedule recompute pass is enqueued
+	 * </pre>
+	 */
+	@When("a shipment-schedule recompute pass is enqueued")
+	public void enqueueBoundedRecomputePass()
+	{
+		UpdateInvalidShipmentSchedulesWorkpackageProcessor.schedule();
+	}
+
+	/**
+	 * gh31502 regression assertion: waits until no untagged ({@code AD_PInstance_ID IS NULL})
+	 * {@code M_ShipmentSchedule_Recompute} marker remains for the schedule id seeded under {@code identifier}
+	 * by {@link #seedOrphanedUntaggedRecomputeMarker} -- i.e. the orphan was reaped rather than left to
+	 * accumulate forever in the queue table. Polls instead of checking once: the marker is removed
+	 * asynchronously by the enqueued recompute pass (see the module's async-wait rule).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>identifier</b> — (required) the alias {@link #seedOrphanedUntaggedRecomputeMarker} stored the orphaned schedule's id under<br>
+	 * @cucumber.example
+	 * <pre>
+	 * Then no untagged M_ShipmentSchedule_Recompute marker remains for "orphanSchedule"
+	 * </pre>
+	 */
+	@Then("no untagged M_ShipmentSchedule_Recompute marker remains for {string}")
+	public void assertOrphanedRecomputeMarkerReaped(@NonNull final String identifier) throws InterruptedException
+	{
+		final int orphanScheduleId = getOrphanedRecomputeMarkerScheduleId(identifier);
+
+		final Supplier<Boolean> markerReaped = () -> queryBL.createQueryBuilder(I_M_ShipmentSchedule_Recompute.class)
+				.addEqualsFilter(I_M_ShipmentSchedule_Recompute.COLUMNNAME_M_ShipmentSchedule_ID, orphanScheduleId)
+				.addEqualsFilter(I_M_ShipmentSchedule_Recompute.COLUMNNAME_AD_PInstance_ID, null)
+				.create()
+				.noneMatch();
+
+		StepDefUtil.tryAndWait(RECOMPUTE_QUEUE_DRAIN_TIMEOUT_SEC, RECOMPUTE_QUEUE_DRAIN_POLL_MS, markerReaped);
+
+		assertThat(markerReaped.get())
+				.as("Untagged M_ShipmentSchedule_Recompute marker for orphaned schedule %s (identifier %s) -- expected it to be reaped", orphanScheduleId, identifier)
+				.isTrue();
+	}
+
+	/**
+	 * gh31502 regression assertion: the strongest available livelock signal -- waits until no
+	 * {@link #RECOMPUTE_QUEUE_PROCESSOR_SHORT_NAMES} workpackage remains pending, i.e. the shipment-schedule
+	 * recompute queue actually drains to zero within the module's standard wait budget. Before the fix, a
+	 * bounded pass that could never make progress on an untaggable (orphaned) marker kept reporting
+	 * {@code limitReached=true} and re-enqueueing a follow-up workpackage forever, so this wait would time out
+	 * instead of observing the queue reach zero. Delegates to {@link #waitForRecomputeWorkQueueToDrain()} -- the
+	 * same signal and wait budget the Background's isolation cleanup already relies on.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * And the shipment-schedule recompute work queue drains to zero pending workpackages
+	 * </pre>
+	 */
+	@And("the shipment-schedule recompute work queue drains to zero pending workpackages")
+	public void assertRecomputeWorkQueueDrains() throws InterruptedException
+	{
+		waitForRecomputeWorkQueueToDrain();
+	}
+
+	private int getOrphanedRecomputeMarkerScheduleId(@NonNull final String identifier)
+	{
+		final Integer orphanScheduleId = orphanedRecomputeMarkerScheduleIdsByIdentifier.get(identifier);
+		assertThat(orphanScheduleId)
+				.as("No orphaned M_ShipmentSchedule_Recompute marker was seeded for identifier %s -- call the seeding step first", identifier)
+				.isNotNull();
+		return orphanScheduleId;
 	}
 
 	/**

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -365,13 +365,12 @@ public class M_ShipmentSchedule_StepDef
 	 * ({@code AD_PInstance_ID IS NULL}), waits until the shipment-schedule work queue is drained, then deletes
 	 * once more. Belongs at the start of the Background.
 	 * <p>
-	 * Deleting first means the wait no longer depends on the size of the untagged backlog this step removes
-	 * anyway -- it waits only for genuinely in-flight work; the trailing delete catches markers created by a pass
-	 * that completed during the drain. The wait closes a real race: a recompute pass enqueued by an earlier
-	 * scenario claims markers through the same DB function this feature asserts on, and that claiming SQL is
-	 * unconditionally global. Both processors are checked in ONE predicate so they are zero at the same poll: a
-	 * create-missing run enqueues a recompute pass, so checking them one after the other could pass on a queue
-	 * that is not quiet.
+	 * Deleting first keeps the wait independent of the untagged backlog this step removes anyway; the trailing
+	 * delete catches markers a pass completing during the drain created. The wait closes a real race: a recompute
+	 * pass enqueued by an earlier scenario claims markers through the same DB function this feature asserts on,
+	 * and that claiming SQL is unconditionally global. Both processors are checked in ONE predicate so they are
+	 * zero at the same poll: a create-missing run enqueues a recompute pass, so checking them one after the other
+	 * could pass on a queue that is not quiet.
 	 * <p>
 	 * Do NOT widen {@link WorkPackageQueueUtil#countPendingWorkPackages(String)} to not-ready workpackages: one
 	 * bound to a rolled-back transaction never becomes ready, so waiting on it would turn this intermittent flake

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/updateInvalidShipmentSchedulesRecomputeBatching.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/updateInvalidShipmentSchedulesRecomputeBatching.feature
@@ -131,8 +131,8 @@ Feature: tag invalid shipment schedules for a recompute pass in whole-product ba
   @allure.label.epic:E0100_Sales
   @allure.label.feature:F00130_Shipment_Schedule
   @Id:S31050_TC7
-  Scenario: an orphaned recompute marker is reaped and does not livelock the recompute queue (gh31502)
-  # Regression for gh31502: M_ShipmentSchedule_Recompute has no FK to M_ShipmentSchedule, so a marker can
+  Scenario: an orphaned recompute marker is reaped and does not livelock the recompute queue
+  # M_ShipmentSchedule_Recompute has no FK to M_ShipmentSchedule, so a marker can
   # outlive its schedule. Before the fix, existsUntaggedRecomputeMarkers() counted this untaggable orphan
   # forever, so a bounded recompute pass never saw its backlog reach zero and kept re-enqueueing a follow-up
   # workpackage -- an endless loop. The fix also reaps the orphan so it stops accumulating in the queue table.

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/updateInvalidShipmentSchedulesRecomputeBatching.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/updateInvalidShipmentSchedulesRecomputeBatching.feature
@@ -126,3 +126,17 @@ Feature: tag invalid shipment schedules for a recompute pass in whole-product ba
       | schedA1               |
       | schedA2               |
     And 0 M_ShipmentSchedule_Recompute markers remain untagged
+
+  @from:cucumber
+  @allure.label.epic:E0100_Sales
+  @allure.label.feature:F00130_Shipment_Schedule
+  @Id:S31050_TC7
+  Scenario: an orphaned recompute marker is reaped and does not livelock the recompute queue (gh31502)
+  # Regression for gh31502: M_ShipmentSchedule_Recompute has no FK to M_ShipmentSchedule, so a marker can
+  # outlive its schedule. Before the fix, existsUntaggedRecomputeMarkers() counted this untaggable orphan
+  # forever, so a bounded recompute pass never saw its backlog reach zero and kept re-enqueueing a follow-up
+  # workpackage -- an endless loop. The fix also reaps the orphan so it stops accumulating in the queue table.
+    Given an orphaned untagged M_ShipmentSchedule_Recompute marker exists for "orphanSchedule"
+    When a shipment-schedule recompute pass is enqueued
+    Then no untagged M_ShipmentSchedule_Recompute marker remains for "orphanSchedule"
+    And the shipment-schedule recompute work queue drains to zero pending workpackages

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/IShipmentScheduleInvalidateBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/IShipmentScheduleInvalidateBL.java
@@ -104,4 +104,9 @@ public interface IShipmentScheduleInvalidateBL extends ISingletonService
 	 * Notify the registered listeners that a a bunch of segments changed. Maybe they can gain a performance benefit from processing them all at once.
 	 */
 	void notifySegmentsChanged(Collection<IShipmentScheduleSegment> storageSegments);
+
+	/**
+	 * Deletes the schedule's {@code M_ShipmentSchedule_Recompute} markers, tagged included.
+	 */
+	void deleteRecomputeMarkers(ShipmentScheduleId shipmentScheduleId);
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/IShipmentScheduleInvalidateRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/IShipmentScheduleInvalidateRepository.java
@@ -109,14 +109,8 @@ public interface IShipmentScheduleInvalidateRepository extends ISingletonService
 	void deleteRecomputeMarkersOutOfTrx(PInstanceId adPInstanceId);
 
 	/**
-	 * Delete every M_ShipmentSchedule_Recompute record of the given schedule, tagged or not.
-	 * <p>
-	 * Called when the schedule itself is deleted: there is no FK between the two tables, so a marker left
-	 * behind becomes an ORPHAN that no recompute pass can ever tag (both branches of
-	 * {@code M_ShipmentSchedule_TagToRecompute} require the schedule row to exist). Deleting the markers with
-	 * the schedule stops orphans being created in the first place; {@code m_shipmentschedule_recompute_reap_orphans()}
-	 * remains the backstop for orphans already in the database and for any deletion path that bypasses the
-	 * model layer.
+	 * Deletes every M_ShipmentSchedule_Recompute record of the given schedule, including tagged ones -- once the
+	 * schedule is gone, no marker of it can ever be tagged again, so leaving one behind only creates an orphan.
 	 */
 	void deleteRecomputeMarkers(ShipmentScheduleId shipmentScheduleId);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/IShipmentScheduleInvalidateRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/IShipmentScheduleInvalidateRepository.java
@@ -92,7 +92,10 @@ public interface IShipmentScheduleInvalidateRepository extends ISingletonService
 
 	/**
 	 * @return {@code true} if at least one {@code M_ShipmentSchedule_Recompute} row is still untagged
-	 *         (i.e. {@code AD_PInstance_ID IS NULL}) -- i.e. there is more backlog pending a recompute pass.
+	 *         (i.e. {@code AD_PInstance_ID IS NULL}) <b>and taggable</b> (its {@code M_ShipmentSchedule} still
+	 *         exists, which is what {@link #markAllToRecomputeOutOfTrx(PInstanceId, QueryLimit)} requires) --
+	 *         i.e. there is more backlog a follow-up recompute pass could actually pick up. An orphaned marker
+	 *         (no schedule row; there is no FK) can never be tagged and is deliberately not counted.
 	 *         This is the correct signal for "should a follow-up bounded run be enqueued", as opposed to
 	 *         comparing a pass's recomputed count against its {@code maxToProcess} (which, because the tag
 	 *         unit is a whole product, is not reliable: a pass can recompute more or fewer schedules than

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/IShipmentScheduleInvalidateRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/IShipmentScheduleInvalidateRepository.java
@@ -109,6 +109,18 @@ public interface IShipmentScheduleInvalidateRepository extends ISingletonService
 	void deleteRecomputeMarkersOutOfTrx(PInstanceId adPInstanceId);
 
 	/**
+	 * Delete every M_ShipmentSchedule_Recompute record of the given schedule, tagged or not.
+	 * <p>
+	 * Called when the schedule itself is deleted: there is no FK between the two tables, so a marker left
+	 * behind becomes an ORPHAN that no recompute pass can ever tag (both branches of
+	 * {@code M_ShipmentSchedule_TagToRecompute} require the schedule row to exist). Deleting the markers with
+	 * the schedule stops orphans being created in the first place; {@code m_shipmentschedule_recompute_reap_orphans()}
+	 * remains the backstop for orphans already in the database and for any deletion path that bypasses the
+	 * model layer.
+	 */
+	void deleteRecomputeMarkers(ShipmentScheduleId shipmentScheduleId);
+
+	/**
 	 * Untag M_ShipmentSchedule_Recompute records which were tagged with given tag
 	 */
 	void releaseRecomputeMarkerOutOfTrx(PInstanceId adPInstanceId);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateBL.java
@@ -373,6 +373,12 @@ public class ShipmentScheduleInvalidateBL implements IShipmentScheduleInvalidate
 		}
 	}
 
+	@Override
+	public void deleteRecomputeMarkers(@NonNull final ShipmentScheduleId shipmentScheduleId)
+	{
+		invalidSchedulesRepo.deleteRecomputeMarkers(shipmentScheduleId);
+	}
+
 	@VisibleForTesting
 	Stream<IShipmentScheduleSegment> explodeByPickingBOMs(final IShipmentScheduleSegment segment)
 	{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateRepository.java
@@ -656,14 +656,11 @@ public class ShipmentScheduleInvalidateRepository implements IShipmentScheduleIn
 		// deleteDirectly (bulk filter-based DELETE), NOT delete(): M_ShipmentSchedule_Recompute is a keyless
 		// queue table, so the PO-by-PO delete() builds an empty WHERE and fails.
 		//
-		// Deliberately NOT restricted to untagged markers: there is no FK between the two tables, so any marker
-		// left behind after the schedule row is gone becomes an ORPHAN that no recompute pass can ever tag
-		// (both branches of M_ShipmentSchedule_TagToRecompute require the schedule row to exist) -- that orphan
-		// then keeps existsUntaggedRecomputeMarkers() answering "yes", so every bounded pass reports limit-reached,
-		// enqueues a follow-up, tags nothing, and repeats: an endless re-enqueue loop (observed at ~2
-		// workpackages/second until the marker was removed by hand). m_shipmentschedule_recompute_reap_orphans()
-		// remains the backstop for orphans already in the database and for any deletion path that bypasses the
-		// model layer.
+		// Deliberately NOT restricted to untagged markers: with no FK between the two tables, a marker outliving
+		// its schedule is an ORPHAN that M_ShipmentSchedule_TagToRecompute can never tag (both branches require
+		// the schedule row), so existsUntaggedRecomputeMarkers() reports work remaining forever and every bounded
+		// pass re-enqueues a follow-up. m_shipmentschedule_recompute_reap_orphans() backstops orphans already in
+		// the database and any deletion path bypassing the model layer.
 		queryBL.createQueryBuilder(I_M_ShipmentSchedule_Recompute.class)
 				.addEqualsFilter(I_M_ShipmentSchedule_Recompute.COLUMNNAME_M_ShipmentSchedule_ID, shipmentScheduleId)
 				.create()

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateRepository.java
@@ -656,9 +656,14 @@ public class ShipmentScheduleInvalidateRepository implements IShipmentScheduleIn
 		// deleteDirectly (bulk filter-based DELETE), NOT delete(): M_ShipmentSchedule_Recompute is a keyless
 		// queue table, so the PO-by-PO delete() builds an empty WHERE and fails.
 		//
-		// Deliberately NOT restricted to untagged markers. The schedule row is going away, so no marker of it
-		// can ever be meaningful again -- a tagged one would only be dropped later anyway, by its own pass's
-		// deleteRecomputeMarkersOutOfTrx. Leaving any behind is what creates the orphan.
+		// Deliberately NOT restricted to untagged markers: there is no FK between the two tables, so any marker
+		// left behind after the schedule row is gone becomes an ORPHAN that no recompute pass can ever tag
+		// (both branches of M_ShipmentSchedule_TagToRecompute require the schedule row to exist) -- that orphan
+		// then keeps existsUntaggedRecomputeMarkers() answering "yes", so every bounded pass reports limit-reached,
+		// enqueues a follow-up, tags nothing, and repeats: an endless re-enqueue loop (observed at ~2
+		// workpackages/second until the marker was removed by hand). m_shipmentschedule_recompute_reap_orphans()
+		// remains the backstop for orphans already in the database and for any deletion path that bypasses the
+		// model layer.
 		queryBL.createQueryBuilder(I_M_ShipmentSchedule_Recompute.class)
 				.addEqualsFilter(I_M_ShipmentSchedule_Recompute.COLUMNNAME_M_ShipmentSchedule_ID, shipmentScheduleId)
 				.create()

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateRepository.java
@@ -651,6 +651,21 @@ public class ShipmentScheduleInvalidateRepository implements IShipmentScheduleIn
 	}
 
 	@Override
+	public void deleteRecomputeMarkers(@NonNull final ShipmentScheduleId shipmentScheduleId)
+	{
+		// deleteDirectly (bulk filter-based DELETE), NOT delete(): M_ShipmentSchedule_Recompute is a keyless
+		// queue table, so the PO-by-PO delete() builds an empty WHERE and fails.
+		//
+		// Deliberately NOT restricted to untagged markers. The schedule row is going away, so no marker of it
+		// can ever be meaningful again -- a tagged one would only be dropped later anyway, by its own pass's
+		// deleteRecomputeMarkersOutOfTrx. Leaving any behind is what creates the orphan.
+		queryBL.createQueryBuilder(I_M_ShipmentSchedule_Recompute.class)
+				.addEqualsFilter(I_M_ShipmentSchedule_Recompute.COLUMNNAME_M_ShipmentSchedule_ID, shipmentScheduleId)
+				.create()
+				.deleteDirectly();
+	}
+
+	@Override
 	public void deleteRecomputeMarkersOutOfTrx(@NonNull final PInstanceId pinstanceId)
 	{
 		final String sql = "DELETE FROM " + M_SHIPMENT_SCHEDULE_RECOMPUTE + " WHERE AD_Pinstance_ID=? RETURNING M_ShipmentSchedule_ID";

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateRepository.java
@@ -579,15 +579,30 @@ public class ShipmentScheduleInvalidateRepository implements IShipmentScheduleIn
 		return whereClause.toString();
 	}
 
-	// ::int: the DB function RETURNS bigint; getSQLValueEx reads via ResultSet.getInt. The explicit narrowing
-	// documents that dedup counts stay within int range (bounded by the recompute-table size).
+	// ::int: the DB functions RETURN bigint; getSQLValueEx reads via ResultSet.getInt. The explicit narrowing
+	// documents that dedup/reap counts stay within int range (bounded by the recompute-table size).
 	private static final String SQL_DEDUP_RECOMPUTE = "SELECT m_shipmentschedule_recompute_dedup()::int";
+	private static final String SQL_REAP_ORPHANED_RECOMPUTE = "SELECT m_shipmentschedule_recompute_reap_orphans()::int";
 	private static final String SQL_TAG_TO_RECOMPUTE = "SELECT M_ShipmentSchedule_TagToRecompute(p_selection_id => ?, p_batchsize => ?)";
 
 	@Override
 	public void markAllToRecomputeOutOfTrx(@NonNull final PInstanceId pinstanceId, @NonNull final QueryLimit maxToProcess)
 	{
-		// Dedup the untagged (unclaimed) recompute markers first: multiple untagged rows for the same
+		// Reap the orphaned untagged markers: there is no FK from M_ShipmentSchedule_Recompute to
+		// M_ShipmentSchedule, so a marker can outlive its schedule, and M_ShipmentSchedule_TagToRecompute can never
+		// tag such a marker -- it would sit in this high-churn queue table forever. Same best-effort contract as the
+		// dedup below (see there): out-of-trx, 5s lock_timeout in the DB function, warn and fall through on failure.
+		try
+		{
+			final int countReaped = DB.getSQLValueEx(ITrx.TRXNAME_None, SQL_REAP_ORPHANED_RECOMPUTE);
+			logger.debug("Reaped {} orphaned untagged recompute marker(s) before tagging for {}", countReaped, pinstanceId);
+		}
+		catch (final Exception ex)
+		{
+			logger.warn("Failed to reap orphaned untagged recompute markers before tagging for {}; proceeding with tagging anyway", pinstanceId, ex);
+		}
+
+		// Dedup the untagged (unclaimed) recompute markers next: multiple untagged rows for the same
 		// M_ShipmentSchedule_ID would skew the distinct-schedule batch counting in the whole-product batching
 		// performed by M_ShipmentSchedule_TagToRecompute below. m_shipmentschedule_recompute_dedup keeps one
 		// unclaimed marker per schedule; it is idempotent and a no-op when there are no duplicates. Runs out-of-trx
@@ -621,7 +636,17 @@ public class ShipmentScheduleInvalidateRepository implements IShipmentScheduleIn
 	@Override
 	public boolean existsUntaggedRecomputeMarkers()
 	{
-		final String sql = "SELECT 1 FROM " + M_SHIPMENT_SCHEDULE_RECOMPUTE + " WHERE AD_PInstance_ID IS NULL LIMIT 1";
+		// The EXISTS is the taggability condition of M_ShipmentSchedule_TagToRecompute (both of its branches
+		// require the M_ShipmentSchedule row to still exist). M_ShipmentSchedule_Recompute has no FK to
+		// M_ShipmentSchedule, so an ORPHANED untagged marker -- one whose schedule was deleted -- can exist and can
+		// never be tagged. Counting it here would answer a looser question than the tagging can deliver on: the
+		// pass tags nothing, still reports limit-reached, and enqueues a follow-up pass, forever.
+		final String sql = "SELECT 1"
+				+ " FROM " + M_SHIPMENT_SCHEDULE_RECOMPUTE + " sr"
+				+ " WHERE sr.AD_PInstance_ID IS NULL"
+				+ "   AND EXISTS (SELECT 1 FROM " + I_M_ShipmentSchedule.Table_Name + " s"
+				+ "               WHERE s." + COLUMNNAME_M_ShipmentSchedule_ID + "=sr." + COLUMNNAME_M_ShipmentSchedule_ID + ")"
+				+ " LIMIT 1";
 		return DB.getSQLValueEx(ITrx.TRXNAME_None, sql) == 1;
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule.java
@@ -32,7 +32,6 @@ import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleEffectiveBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleUpdater;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
-import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateRepository;
 import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
 import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleSegments;
 import de.metas.inoutcandidate.model.I_M_IolCandHandler_Log;
@@ -142,20 +141,12 @@ public class M_ShipmentSchedule
 	}
 
 	/**
-	 * Deletes the schedule's {@code M_ShipmentSchedule_Recompute} markers along with the schedule.
-	 * <p>
-	 * The concrete failure this prevents: there is no FK between the two tables, so a marker that outlives its
-	 * schedule becomes an ORPHAN which no recompute pass can tag (both branches of
-	 * {@code M_ShipmentSchedule_TagToRecompute} require the schedule row). Before this, such a marker kept
-	 * {@code existsUntaggedRecomputeMarkers()} answering "yes, there is more to do", so every bounded pass
-	 * reported limit-reached, enqueued a follow-up, tagged nothing, and repeated -- an endless re-enqueue loop
-	 * (observed at ~2 workpackages/second until the marker was removed by hand).
+	 * Deletes the schedule's {@code M_ShipmentSchedule_Recompute} markers so none survive the schedule as orphans.
 	 */
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_DELETE })
 	public void deleteRecomputeMarkers(final I_M_ShipmentSchedule schedule)
 	{
-		Services.get(IShipmentScheduleInvalidateRepository.class)
-				.deleteRecomputeMarkers(ShipmentScheduleId.ofRepoId(schedule.getM_ShipmentSchedule_ID()));
+		invalidSchedulesService.deleteRecomputeMarkers(ShipmentScheduleId.ofRepoId(schedule.getM_ShipmentSchedule_ID()));
 	}
 
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_DELETE })

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule.java
@@ -26,11 +26,13 @@ import com.google.common.collect.ImmutableList;
 import de.metas.bpartner.BPartnerId;
 import de.metas.document.engine.DocStatus;
 import de.metas.i18n.AdMessageKey;
+import de.metas.inout.ShipmentScheduleId;
 import de.metas.inoutcandidate.api.IShipmentScheduleAllocDAO;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleEffectiveBL;
 import de.metas.inoutcandidate.api.IShipmentScheduleUpdater;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
+import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateRepository;
 import de.metas.inoutcandidate.invalidation.segments.IShipmentScheduleSegment;
 import de.metas.inoutcandidate.invalidation.segments.ShipmentScheduleSegments;
 import de.metas.inoutcandidate.model.I_M_IolCandHandler_Log;
@@ -137,6 +139,23 @@ public class M_ShipmentSchedule
 				.addEqualsFilter(I_M_IolCandHandler_Log.COLUMNNAME_AD_Table_ID, shipmentSchedule.getAD_Table_ID())
 				.addEqualsFilter(I_M_IolCandHandler_Log.COLUMN_Record_ID, shipmentSchedule.getRecord_ID())
 				.create();
+	}
+
+	/**
+	 * Deletes the schedule's {@code M_ShipmentSchedule_Recompute} markers along with the schedule.
+	 * <p>
+	 * The concrete failure this prevents: there is no FK between the two tables, so a marker that outlives its
+	 * schedule becomes an ORPHAN which no recompute pass can tag (both branches of
+	 * {@code M_ShipmentSchedule_TagToRecompute} require the schedule row). Before this, such a marker kept
+	 * {@code existsUntaggedRecomputeMarkers()} answering "yes, there is more to do", so every bounded pass
+	 * reported limit-reached, enqueued a follow-up, tagged nothing, and repeated -- an endless re-enqueue loop
+	 * (observed at ~2 workpackages/second until the marker was removed by hand).
+	 */
+	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_DELETE })
+	public void deleteRecomputeMarkers(final I_M_ShipmentSchedule schedule)
+	{
+		Services.get(IShipmentScheduleInvalidateRepository.class)
+				.deleteRecomputeMarkers(ShipmentScheduleId.ofRepoId(schedule.getM_ShipmentSchedule_ID()));
 	}
 
 	@ModelChange(timings = { ModelValidator.TYPE_BEFORE_DELETE })

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/de_metas_inoutcandidate/m_shipmentschedule_recompute_reap_orphans.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/de_metas_inoutcandidate/m_shipmentschedule_recompute_reap_orphans.sql
@@ -1,0 +1,34 @@
+-- Purpose: delete ORPHANED enqueued recompute flags -- unclaimed rows whose M_ShipmentSchedule no longer exists.
+-- Context: M_ShipmentSchedule_Recompute has no FK to M_ShipmentSchedule, so deleting a schedule leaves its flag
+-- behind. M_ShipmentSchedule_TagToRecompute can never tag such a flag (both of its branches require the schedule
+-- row), so it stays enqueued forever: it bloats this high-churn queue table and keeps every "is there untagged
+-- work left?" probe answering yes.
+
+DROP FUNCTION IF EXISTS m_shipmentschedule_recompute_reap_orphans();
+
+CREATE OR REPLACE FUNCTION m_shipmentschedule_recompute_reap_orphans()
+RETURNS bigint
+LANGUAGE plpgsql
+AS $func$
+DECLARE
+    v_deleted bigint;
+BEGIN
+    -- Fail fast rather than hang/deadlock behind a running recompute batch's bulk UPDATE.
+    SET LOCAL lock_timeout = '5s';
+
+    -- Only UNCLAIMED rows (AD_PInstance_ID IS NULL): never removes a row an in-flight
+    -- batch has claimed and is processing.
+    DELETE FROM M_ShipmentSchedule_Recompute sr
+     WHERE sr.AD_PInstance_ID IS NULL
+       AND NOT EXISTS (SELECT 1
+                         FROM M_ShipmentSchedule s
+                        WHERE s.M_ShipmentSchedule_ID = sr.M_ShipmentSchedule_ID);
+
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    RAISE NOTICE 'm_shipmentschedule_recompute_reap_orphans: deleted % orphaned flag(s)', v_deleted;
+    RETURN v_deleted;
+END;
+$func$;
+
+COMMENT ON FUNCTION m_shipmentschedule_recompute_reap_orphans() IS
+'Deletes orphaned M_ShipmentSchedule_Recompute rows: unclaimed rows (AD_PInstance_ID IS NULL) whose M_ShipmentSchedule no longer exists and which therefore can never be tagged. Returns the number of orphaned flags deleted. Idempotent; run on demand or periodically.';

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5818180_sys_M_ShipmentSchedule_Recompute_reap_orphans_function.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5818180_sys_M_ShipmentSchedule_Recompute_reap_orphans_function.sql
@@ -1,0 +1,30 @@
+-- Source DDL: backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/ddl/de_metas_inoutcandidate/m_shipmentschedule_recompute_reap_orphans.sql
+
+DROP FUNCTION IF EXISTS m_shipmentschedule_recompute_reap_orphans();
+
+CREATE OR REPLACE FUNCTION m_shipmentschedule_recompute_reap_orphans()
+RETURNS bigint
+LANGUAGE plpgsql
+AS $func$
+DECLARE
+    v_deleted bigint;
+BEGIN
+    -- Fail fast rather than hang/deadlock behind a running recompute batch's bulk UPDATE.
+    SET LOCAL lock_timeout = '5s';
+
+    -- Only UNCLAIMED rows (AD_PInstance_ID IS NULL): never removes a row an in-flight
+    -- batch has claimed and is processing.
+    DELETE FROM M_ShipmentSchedule_Recompute sr
+     WHERE sr.AD_PInstance_ID IS NULL
+       AND NOT EXISTS (SELECT 1
+                         FROM M_ShipmentSchedule s
+                        WHERE s.M_ShipmentSchedule_ID = sr.M_ShipmentSchedule_ID);
+
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    RAISE NOTICE 'm_shipmentschedule_recompute_reap_orphans: deleted % orphaned flag(s)', v_deleted;
+    RETURN v_deleted;
+END;
+$func$;
+
+COMMENT ON FUNCTION m_shipmentschedule_recompute_reap_orphans() IS
+'Deletes orphaned M_ShipmentSchedule_Recompute rows: unclaimed rows (AD_PInstance_ID IS NULL) whose M_ShipmentSchedule no longer exists and which therefore can never be tagged. Returns the number of orphaned flags deleted. Idempotent; run on demand or periodically.';

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule_DeleteRecomputeMarkersTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule_DeleteRecomputeMarkersTest.java
@@ -35,7 +35,6 @@ import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.wrapper.POJOLookupMap;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.test.AdempiereTestHelper;
-import org.compiere.SpringContextHolder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -93,20 +92,21 @@ class M_ShipmentSchedule_DeleteRecomputeMarkersTest
 	}
 
 	/**
-	 * IShipmentScheduleInvalidateBL and IShipmentScheduleUpdater are Spring beans with constructor-injected
-	 * collaborators, so Services.get(...) cannot reflectively default-construct them in this no-Spring-context
-	 * test; register real instances (their own collaborators either self-construct or are irrelevant to the
-	 * path under test) so the interceptor's field initializers resolve, then register the interceptor itself.
+	 * Registers the interceptor's collaborators via {@link Services#registerService}, which writes straight into
+	 * the service cache, and NOT via {@code SpringContextHolder.registerJUnitBean}.
+	 * <p>
+	 * Both are Spring beans with constructor-injected collaborators, so {@code Services.get(...)} cannot
+	 * reflectively default-construct them here. The JUnit-bean fallback would normally cover that, but it is
+	 * reached only through Services' external provider -- and any {@code @SpringBootTest} elsewhere in this
+	 * module permanently replaces that provider with one bound to its own throwaway context, which
+	 * {@code AdempiereTestHelper.init()} does not restore. So the fallback works when this class runs alone and
+	 * silently stops working once the full module suite runs it after such a test. Registering the instances
+	 * directly bypasses the provider entirely and behaves the same either way.
 	 */
 	private static void registerInterceptorUnderTest()
 	{
-		SpringContextHolder.registerJUnitBean(IShipmentScheduleInvalidateBL.class, new ShipmentScheduleInvalidateBL(new PickingBOMService()));
-		SpringContextHolder.registerJUnitBean(IShipmentScheduleUpdater.class, ShipmentScheduleUpdater.newInstanceForUnitTesting());
-
-		System.out.println("DEBUG unitTestMode=" + org.compiere.Adempiere.isUnitTestMode()
-				+ " appCtx=" + SpringContextHolder.instance.getApplicationContext()
-				+ " beanFound=" + SpringContextHolder.instance.getBeanOr(IShipmentScheduleInvalidateBL.class, null));
-		System.out.println("DEBUG servicesGet=" + Services.get(IShipmentScheduleInvalidateBL.class));
+		Services.registerService(IShipmentScheduleInvalidateBL.class, new ShipmentScheduleInvalidateBL(new PickingBOMService()));
+		Services.registerService(IShipmentScheduleUpdater.class, ShipmentScheduleUpdater.newInstanceForUnitTesting());
 
 		POJOLookupMap.get().addModelValidator(new M_ShipmentSchedule());
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule_DeleteRecomputeMarkersTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule_DeleteRecomputeMarkersTest.java
@@ -92,16 +92,9 @@ class M_ShipmentSchedule_DeleteRecomputeMarkersTest
 	}
 
 	/**
-	 * Registers the interceptor's collaborators via {@link Services#registerService}, which writes straight into
-	 * the service cache, and NOT via {@code SpringContextHolder.registerJUnitBean}.
-	 * <p>
-	 * Both are Spring beans with constructor-injected collaborators, so {@code Services.get(...)} cannot
-	 * reflectively default-construct them here. The JUnit-bean fallback would normally cover that, but it is
-	 * reached only through Services' external provider -- and any {@code @SpringBootTest} elsewhere in this
-	 * module permanently replaces that provider with one bound to its own throwaway context, which
-	 * {@code AdempiereTestHelper.init()} does not restore. So the fallback works when this class runs alone and
-	 * silently stops working once the full module suite runs it after such a test. Registering the instances
-	 * directly bypasses the provider entirely and behaves the same either way.
+	 * Registers the collaborators via {@link Services#registerService} -- NOT
+	 * {@code SpringContextHolder.registerJUnitBean}, which is silently inert here once any
+	 * {@code @SpringBootTest} has run earlier in the same fork.
 	 */
 	private static void registerInterceptorUnderTest()
 	{

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule_DeleteRecomputeMarkersTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule_DeleteRecomputeMarkersTest.java
@@ -1,0 +1,113 @@
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.inoutcandidate.modelvalidator;
+
+import de.metas.inoutcandidate.api.IShipmentScheduleUpdater;
+import de.metas.inoutcandidate.api.impl.ShipmentScheduleUpdater;
+import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
+import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateRepository;
+import de.metas.inoutcandidate.invalidation.impl.ShipmentScheduleInvalidateBL;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule_Recompute;
+import de.metas.inoutcandidate.picking_bom.PickingBOMService;
+import de.metas.util.Services;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.wrapper.POJOLookupMap;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.SpringContextHolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that deleting an {@link I_M_ShipmentSchedule} through the model layer also deletes every
+ * {@code M_ShipmentSchedule_Recompute} marker of that schedule -- tagged ones included, per the deliberate
+ * design decision in {@link IShipmentScheduleInvalidateRepository#deleteRecomputeMarkers}. A test that only
+ * covers the untagged row would not guard that decision.
+ */
+class M_ShipmentSchedule_DeleteRecomputeMarkersTest
+{
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+	}
+
+	@Test
+	void deletingScheduleThroughModelLayer_deletesUntaggedAndTaggedRecomputeMarkers()
+	{
+		// given: the schedule + its markers, created with the interceptor NOT YET registered -- so only the
+		// TYPE_BEFORE_DELETE methods under test fire later, not the unrelated TYPE_BEFORE_NEW defaulting chain
+		// (which needs a full Spring context this plain unit test doesn't have).
+		final I_M_ShipmentSchedule schedule = newInstance(I_M_ShipmentSchedule.class);
+		saveRecord(schedule);
+
+		final I_M_ShipmentSchedule_Recompute untaggedMarker = newInstance(I_M_ShipmentSchedule_Recompute.class);
+		untaggedMarker.setM_ShipmentSchedule_ID(schedule.getM_ShipmentSchedule_ID());
+		saveRecord(untaggedMarker);
+
+		final I_M_ShipmentSchedule_Recompute taggedMarker = newInstance(I_M_ShipmentSchedule_Recompute.class);
+		taggedMarker.setM_ShipmentSchedule_ID(schedule.getM_ShipmentSchedule_ID());
+		taggedMarker.setAD_PInstance_ID(1000001); // tagged: AD_PInstance_ID set (vs. the untagged marker's NULL)
+		saveRecord(taggedMarker);
+
+		registerInterceptorUnderTest();
+
+		// when: deleted through the model layer, so the @ModelChange(TYPE_BEFORE_DELETE) interceptor fires
+		InterfaceWrapperHelper.delete(schedule);
+
+		// then: both the untagged AND the tagged marker are gone
+		final List<I_M_ShipmentSchedule_Recompute> remainingMarkers = Services.get(IQueryBL.class)
+				.createQueryBuilder(I_M_ShipmentSchedule_Recompute.class)
+				.addEqualsFilter(I_M_ShipmentSchedule_Recompute.COLUMNNAME_M_ShipmentSchedule_ID, schedule.getM_ShipmentSchedule_ID())
+				.create()
+				.list();
+
+		assertThat(remainingMarkers).isEmpty();
+	}
+
+	/**
+	 * IShipmentScheduleInvalidateBL and IShipmentScheduleUpdater are Spring beans with constructor-injected
+	 * collaborators, so Services.get(...) cannot reflectively default-construct them in this no-Spring-context
+	 * test; register real instances (their own collaborators either self-construct or are irrelevant to the
+	 * path under test) so the interceptor's field initializers resolve, then register the interceptor itself.
+	 */
+	private static void registerInterceptorUnderTest()
+	{
+		SpringContextHolder.registerJUnitBean(IShipmentScheduleInvalidateBL.class, new ShipmentScheduleInvalidateBL(new PickingBOMService()));
+		SpringContextHolder.registerJUnitBean(IShipmentScheduleUpdater.class, ShipmentScheduleUpdater.newInstanceForUnitTesting());
+
+		System.out.println("DEBUG unitTestMode=" + org.compiere.Adempiere.isUnitTestMode()
+				+ " appCtx=" + SpringContextHolder.instance.getApplicationContext()
+				+ " beanFound=" + SpringContextHolder.instance.getBeanOr(IShipmentScheduleInvalidateBL.class, null));
+		System.out.println("DEBUG servicesGet=" + Services.get(IShipmentScheduleInvalidateBL.class));
+
+		POJOLookupMap.get().addModelValidator(new M_ShipmentSchedule());
+	}
+}


### PR DESCRIPTION
Follow-up to https://github.com/metasfresh/metasfresh/pull/25463, which fixed a cucumber flake but introduced a deadlock on `new_dawn_uat`'s profile7. This fixes the underlying **production** defect that made the deadlock possible.

> **Not a test-only PR.** It changes production code and ships a migration script, so it needs genuinely green CI, and the propagation merge will hit the DDL-review gate.

## The defect

`M_ShipmentSchedule_Recompute` has **no foreign key** to `M_ShipmentSchedule`, so a marker can outlive its schedule and become an *orphan*. Then:

| | |
|---|---|
| `existsUntaggedRecomputeMarkers()` | `SELECT 1 … WHERE AD_PInstance_ID IS NULL LIMIT 1` — **no join**, so it counted the orphan |
| `M_ShipmentSchedule_TagToRecompute` | can never tag it — `EXISTS (…M_ShipmentSchedule…)` in the unbounded branch, `JOIN M_ShipmentSchedule` in the bounded one |
| `ShipmentScheduleUpdater` | `limitReached = maxToProcess.isLimited() && existsUntaggedRecomputeMarkers()` → tags 0, still reports limit-reached, enqueues a follow-up. Forever. |

The probe answered a **looser** question than the tagging could ever deliver on. Observed in one CI run: 803 workpackages enqueued at ~2/second, each logging `Found 0 invalid shipment schedules and tagged them` / `Limit reached; enqueued a follow-up workpackage`.

This is a production defect, not just a CI one: any orphan in a live database spins the async processor indefinitely.

## The fix

**1 — Make the probe honest.** `existsUntaggedRecomputeMarkers()` now applies the tagging function's own existence condition, so it counts only markers a pass could actually claim.

**2 — Reap existing orphans.** New DB function `m_shipmentschedule_recompute_reap_orphans()`, called next to the existing dedup call in `markAllToRecomputeOutOfTrx` — out-of-trx, `lock_timeout = '5s'`, unclaimed rows only, best-effort so a lock timeout can never abort the mandatory tagging. This is what cleans up orphans already sitting in live databases.

**3 — Stop creating them.** The `M_ShipmentSchedule` `BEFORE_DELETE` interceptor now deletes the schedule's recompute markers, alongside the two sibling tables it already cleaned up. Prevention at the known creation point.

2 and 3 are complements, not alternatives: the interceptor prevents new orphans, the reaper clears existing ones and backstops any deletion path that bypasses the model layer (support/ops SQL, bulk deletes).

**4 — Regression test.** New cucumber scenario `@Id:S31050_TC7` seeds an orphan and asserts both that it gets reaped and that the queue drains to zero pending workpackages.

**5 — Test-side ordering.** The cucumber isolation step now deletes untagged markers → drains → deletes again. **This is not what fixes the livelock** — with the honest probe, `limitReached` resolves correctly even with an orphan present. It is separately justified: the step deletes untagged markers anyway, so deleting first keeps the wait independent of the size of an unrelated backlog it is about to remove.

## Evidence

Reproduced deterministically before the fix, by seeding an orphan:

| | scenarios | 60s timeouts | `Limit reached` loop iterations |
|---|---|---|---|
| orphan seeded, no fix | **5 failed** (×2 runs) | 10 | **561** per run |
| orphan seeded, with fix | **5 passed** (×3 runs) | 0 | **0** |

The new regression scenario was verified to actually guard: with the production fix reverted and the module jar reinstalled, `@Id:S31050_TC7` fails on `Then no untagged M_ShipmentSchedule_Recompute marker remains` with the 60s timeout and 112 loop iterations; with the fix it passes.

## Notes for review

- Migration `5818180` (ID server), DDL reference file and migration script are byte-identical.
- The reaper deletes queue rows without `backup_table()` — it is a runtime maintenance function, not a data migration; the existing `m_shipmentschedule_recompute_dedup()` migration sets the same precedent.
- `existsUntaggedRecomputeMarkers()` has exactly one production caller (the `limitReached` decision).
