### PR TITLE
EPCIS scripted export: Re-send picks up a shipment parked in Pending

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
@@ -294,10 +294,9 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
   @Id:S30088_060
   Scenario: S30088_060 — Re-send picks up a shipment parked in Pending (a resting Pending IS resendable)
     ## An operator resets a stuck in-flight EPCIS export to "Not yet sent" (Pending) via the Change EPCIS
-    ## Export Status action, then runs Re-send. Pending is not-in-flight (nothing is being sent), so the
-    ## Re-send MUST pick it up — it is the first send, not a double-send. Before the fix the Re-send
-    ## ignored Pending (it was grouped with the actively-in-flight states), so parking a shipment in
-    ## Pending was a dead end.
+    ## Export Status action, then runs Re-send. An operator-parked Pending is not-in-flight (nothing is
+    ## being sent) and is stamped with the process instance, so Re-send picks it up as the first send —
+    ## not a double-send.
 
     # EPCIS-classified config (its outbound-data process IS the EPCIS export) so the Change EPCIS Export
     # Status action applies; no WhereClause → the export enqueues on any completion (reaches in-flight U).
@@ -337,8 +336,8 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
       | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | HasAD_PInstance |
       | io_060     | scriptedCfg_060                                   | P            | Y               |
 
-    # The fix: Re-send MUST pick up the Pending shipment → a NEW attempt row (IsResend=Y) reaching at
-    # least Enqueued. (Before the fix this process was a no-op on a Pending shipment.)
+    # Re-send picks up the operator-parked Pending shipment → a NEW attempt row (IsResend=Y) reaching at
+    # least Enqueued.
     When M_InOut_ReSend_ScriptedExportConversion process is run for shipment io_060
     Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
       | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | IsResend |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
@@ -291,6 +291,72 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
   @from:cucumber
   @allure.label.epic:E0292_EDI
   @allure.label.feature:F00353_EDI_DESADV_InOut_Link
+  @Id:S30088_060
+  Scenario: S30088_060 — Re-send picks up a shipment parked in Pending (a resting Pending IS resendable)
+    ## An operator resets a stuck in-flight EPCIS export to "Not yet sent" (Pending) via the Change EPCIS
+    ## Export Status action, then runs Re-send. Pending is not-in-flight (nothing is being sent), so the
+    ## Re-send MUST pick it up — it is the first send, not a double-send. Before the fix the Re-send
+    ## ignored Pending (it was grouped with the actively-in-flight states), so parking a shipment in
+    ## Pending was a dead end.
+
+    # EPCIS-classified config (its outbound-data process IS the EPCIS export) so the Change EPCIS Export
+    # Status action applies; no WhereClause → the export enqueues on any completion (reaches in-flight U).
+    And metasfresh contains ExternalSystem_Config with ScriptedExportConversion and StatusColumn:
+      | ExternalSystem_Config_ID | ExternalSystem_Config_ScriptedExportConversion_ID | AD_Process_OutboundData_ID.Value | TableName |
+      | esConfig_060             | scriptedCfg_060                                   | M_InOut_EPCIS_Export_JSON        | M_InOut   |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference          |
+      | o_060      | true    | bp_es         | 2026-06-09  | PO_S30088_060_@Date@ |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | ol_060     | o_060      | product_es   | 10         | pip_es                  |
+    When the order identified by o_060 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ss_060     | ol_060         | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_060                | D            | true                | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | ss_060                | io_060     |
+
+    # Drain async material/DESADV workpackages from shipment generation.
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # Completion enqueues the EPCIS export → in-flight (U)
+    Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus |
+      | io_060     | scriptedCfg_060                                   | U            |
+
+    # Operator resets it to "Not yet sent" (Pending) via the Change EPCIS Export Status action → a NEW
+    # process-instance-stamped attempt row; the prior in-flight (U) attempt is kept as history.
+    When Change EPCIS Export Status process is run for shipment io_060 with target status Pending
+    Then after not more than 10s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | HasAD_PInstance |
+      | io_060     | scriptedCfg_060                                   | P            | Y               |
+
+    # The fix: Re-send MUST pick up the Pending shipment → a NEW attempt row (IsResend=Y) reaching at
+    # least Enqueued. (Before the fix this process was a no-op on a Pending shipment.)
+    When M_InOut_ReSend_ScriptedExportConversion process is run for shipment io_060
+    Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | IsResend |
+      | io_060     | scriptedCfg_060                                   | U            | Y        |
+
+    # Simulate /ok → the resend attempt reaches Sent.
+    When the scripted-export /ok callback is posted for shipment io_060 with HTTP code 200
+    Then after not more than 10s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | IsResend |
+      | io_060     | scriptedCfg_060                                   | S            | Y        |
+    And after not more than 10s, M_InOut EPCIS_ExportStatus is:
+      | M_InOut_ID | EPCIS_ExportStatus |
+      | io_060     | S                  |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00353_EDI_DESADV_InOut_Link
   @Id:S30279_040
   Scenario: S30279_040 — a WhereClause that depends on the committed-complete state still matches at trigger time
     ## Reproduces the complete-time eligibility timing bug fixed in this change.

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemExportStatus.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemExportStatus.java
@@ -88,16 +88,18 @@ public enum ExternalSystemExportStatus implements ReferenceListAwareEnum
 	public boolean isErrorOrInvalid() {return isError() || isInvalid();}
 
 	/**
-	 * Resendable states: the manual Re-send may re-trigger a config whose latest attempt is a resting
-	 * {@link #Pending} (not yet sent, nothing in flight), a terminal failure ({@link #Error}/{@link
-	 * #Invalid}), or was suppressed as {@link #DontSend} ("shall not be sent" — e.g. every SSCC already
-	 * in the ledger). Re-sending a DontSend re-evaluates relevance, so a record that later has something
-	 * new to export can be sent. {@link #Pending} is resendable because nothing is in flight — the
-	 * re-send is the first send, not a duplicate (an operator can park a shipment in Pending via the
-	 * "Change EPCIS Export Status" action). The actively-in-flight states ({@link #Enqueued}/{@link
-	 * #SendingStarted}) and already-{@link #Sent} are NOT resendable (re-sending would double-send).
+	 * Resendable states (status-only): the manual Re-send may re-trigger a config whose latest attempt is
+	 * a terminal failure ({@link #Error}/{@link #Invalid}) OR was suppressed as {@link #DontSend} ("shall
+	 * not be sent" — e.g. every SSCC already in the ledger). Re-sending a DontSend re-evaluates relevance,
+	 * so a record that later has something new to export can be sent. In-flight ({@link #Pending}/{@link
+	 * #Enqueued}/{@link #SendingStarted}) and already-{@link #Sent} are NOT resendable on status alone.
+	 *
+	 * <p>{@link #Pending} is resendable ONLY when it is an operator-parked attempt (carries an
+	 * {@code AD_PInstance_ID}), never a transient auto-flow Pending awaiting Enqueued. That distinction is
+	 * per-row (the PInstance), not per-status, so it cannot live in this stateless predicate — it is
+	 * applied by {@code ExternalSystemExportStatusService#getResendableConfigsBySourceRecord}.
 	 */
-	public boolean isResendable() {return isPending() || isError() || isInvalid() || isDontSend();}
+	public boolean isResendable() {return isError() || isInvalid() || isDontSend();}
 
 	/** Enqueued OR SendingStarted OR Sent */
 	public boolean isInProgressOrSend() {return isEnqueued() || isSendingStarted() || isSent();}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemExportStatus.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemExportStatus.java
@@ -88,13 +88,16 @@ public enum ExternalSystemExportStatus implements ReferenceListAwareEnum
 	public boolean isErrorOrInvalid() {return isError() || isInvalid();}
 
 	/**
-	 * Resendable states: the manual Re-send may re-trigger a config whose latest attempt is a terminal
-	 * failure ({@link #Error}/{@link #Invalid}) OR was suppressed as {@link #DontSend} ("shall not be
-	 * sent" — e.g. every SSCC already in the ledger). Re-sending a DontSend re-evaluates relevance, so a
-	 * record that later has something new to export can be sent. In-flight (Pending/Enqueued/
-	 * SendingStarted) and already-{@link #Sent} are NOT resendable.
+	 * Resendable states: the manual Re-send may re-trigger a config whose latest attempt is a resting
+	 * {@link #Pending} (not yet sent, nothing in flight), a terminal failure ({@link #Error}/{@link
+	 * #Invalid}), or was suppressed as {@link #DontSend} ("shall not be sent" — e.g. every SSCC already
+	 * in the ledger). Re-sending a DontSend re-evaluates relevance, so a record that later has something
+	 * new to export can be sent. {@link #Pending} is resendable because nothing is in flight — the
+	 * re-send is the first send, not a duplicate (an operator can park a shipment in Pending via the
+	 * "Change EPCIS Export Status" action). The actively-in-flight states ({@link #Enqueued}/{@link
+	 * #SendingStarted}) and already-{@link #Sent} are NOT resendable (re-sending would double-send).
 	 */
-	public boolean isResendable() {return isError() || isInvalid() || isDontSend();}
+	public boolean isResendable() {return isPending() || isError() || isInvalid() || isDontSend();}
 
 	/** Enqueued OR SendingStarted OR Sent */
 	public boolean isInProgressOrSend() {return isEnqueued() || isSendingStarted() || isSent();}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
@@ -155,11 +155,15 @@ public class ExternalSystemExportStatusService
 	}
 
 	/**
-	 * Returns the config IDs whose latest status row for the given source record is re-sendable
-	 * ({@link ExternalSystemExportStatus#isResendable()} — {@link ExternalSystemExportStatus#Error},
-	 * {@link ExternalSystemExportStatus#Invalid} or {@link ExternalSystemExportStatus#DontSend}). A
-	 * DontSend row is included so a suppressed record can be re-evaluated on re-send. Sent and in-flight
-	 * rows (Pending, Enqueued, SendingStarted) are excluded to prevent double-sending.
+	 * Returns the config IDs whose latest status row for the given source record is re-sendable:
+	 * a terminal {@link ExternalSystemExportStatus#Error}/{@link ExternalSystemExportStatus#Invalid} or a
+	 * suppressed {@link ExternalSystemExportStatus#DontSend} (re-offered so a suppressed record can be
+	 * re-evaluated), OR an operator-parked {@link ExternalSystemExportStatus#Pending} — a Pending row that
+	 * carries an {@code AD_PInstance_ID}, i.e. was set deliberately via the "Change EPCIS Export Status"
+	 * action. {@link ExternalSystemExportStatus#Sent} and the actively-in-flight
+	 * {@link ExternalSystemExportStatus#Enqueued}/{@link ExternalSystemExportStatus#SendingStarted} rows —
+	 * and a transient auto-flow Pending (no PInstance, momentarily awaiting Enqueued) — are excluded to
+	 * prevent double-sending.
 	 */
 	@NonNull
 	public List<ExternalSystemScriptedExportConversionConfigId> getResendableConfigsBySourceRecord(
@@ -167,10 +171,9 @@ public class ExternalSystemExportStatusService
 	{
 		// Reduce the per-attempt history to the LATEST attempt per config (getLatestBySourceRecord
 		// returns ALL rows newest-first, so putIfAbsent keeps the newest), then offer only configs whose
-		// latest attempt is resendable — Error/Invalid OR DontSend (a suppressed attempt is re-offered so
-		// a re-send can re-evaluate relevance). Without the latest-per-config dedup a config whose latest
-		// attempt already SUCCEEDED would still be offered because an OLDER attempt errored — re-triggering
-		// an already-delivered export. Mirrors getConfigsWithNonSentAttemptBySourceRecord's dedup.
+		// latest attempt is resendable (see isResendableAttempt). Without the latest-per-config dedup a
+		// config whose latest attempt already SUCCEEDED would still be offered because an OLDER attempt
+		// errored — re-triggering an already-delivered export. Mirrors getConfigsWithNonSentAttemptBySourceRecord's dedup.
 		final LinkedHashMap<ExternalSystemScriptedExportConversionConfigId, ScriptedExportConversionStatus> latestPerConfig =
 				new LinkedHashMap<>();
 		for (final ScriptedExportConversionStatus entry : repo.getLatestBySourceRecord(sourceRecord))
@@ -179,9 +182,23 @@ public class ExternalSystemExportStatusService
 		}
 
 		return latestPerConfig.values().stream()
-				.filter(s -> s.getStatus().isResendable())
+				.filter(ExternalSystemExportStatusService::isResendableAttempt)
 				.map(ScriptedExportConversionStatus::getConfigId)
 				.collect(ImmutableList.toImmutableList());
+	}
+
+	/**
+	 * Whether a config's LATEST attempt row may be re-sent. Terminal Error/Invalid/DontSend qualify on
+	 * status alone ({@link ExternalSystemExportStatus#isResendable()}). A {@link ExternalSystemExportStatus#Pending}
+	 * row qualifies ONLY when it carries an {@code AD_PInstance_ID} — an operator-parked attempt set via
+	 * the "Change EPCIS Export Status" action. A Pending row WITHOUT a PInstance is a transient auto-flow
+	 * attempt momentarily awaiting the Pending→Enqueued transition; re-sending it would double-send, so it
+	 * is excluded.
+	 */
+	private static boolean isResendableAttempt(@NonNull final ScriptedExportConversionStatus latest)
+	{
+		return latest.getStatus().isResendable()
+				|| (latest.getStatus().isPending() && latest.getPInstanceId() != null);
 	}
 
 	/**

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemExportStatusTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemExportStatusTest.java
@@ -220,21 +220,19 @@ class ExternalSystemExportStatusTest
 	}
 
 	/**
-	 * isResendable() — the manual Re-send may re-trigger a config whose latest attempt is a resting
-	 * Pending (not-yet-sent, nothing in flight), a terminal failure (Error/Invalid), or a suppressed
-	 * DontSend. Pending IS resendable: nothing is in flight, so re-sending it is the first send, not a
-	 * duplicate — an operator can park a shipment in Pending via the "Change EPCIS Export Status"
-	 * action, and Re-send must then pick it up. The actively-in-flight states (Enqueued/SendingStarted)
-	 * and already-Sent are NOT resendable (re-sending would double-send / re-deliver).
+	 * isResendable() is status-only: Error/Invalid/DontSend qualify. Pending is NOT resendable on status
+	 * alone — an operator-parked Pending becomes resendable only via the per-row PInstance gate in
+	 * ExternalSystemExportStatusService#getResendableConfigsBySourceRecord (see its test), never here.
+	 * The in-flight Enqueued/SendingStarted and already-Sent are never resendable.
 	 */
 	@Test
 	void testIsResendable()
 	{
-		assertThat(ExternalSystemExportStatus.Pending.isResendable()).isTrue();
 		assertThat(ExternalSystemExportStatus.Error.isResendable()).isTrue();
 		assertThat(ExternalSystemExportStatus.Invalid.isResendable()).isTrue();
 		assertThat(ExternalSystemExportStatus.DontSend.isResendable()).isTrue();
 
+		assertThat(ExternalSystemExportStatus.Pending.isResendable()).isFalse();
 		assertThat(ExternalSystemExportStatus.Enqueued.isResendable()).isFalse();
 		assertThat(ExternalSystemExportStatus.SendingStarted.isResendable()).isFalse();
 		assertThat(ExternalSystemExportStatus.Sent.isResendable()).isFalse();

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemExportStatusTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemExportStatusTest.java
@@ -219,6 +219,27 @@ class ExternalSystemExportStatusTest
 		assertThat(ExternalSystemExportStatus.DontSend.isInProgressOrSend()).isFalse();
 	}
 
+	/**
+	 * isResendable() — the manual Re-send may re-trigger a config whose latest attempt is a resting
+	 * Pending (not-yet-sent, nothing in flight), a terminal failure (Error/Invalid), or a suppressed
+	 * DontSend. Pending IS resendable: nothing is in flight, so re-sending it is the first send, not a
+	 * duplicate — an operator can park a shipment in Pending via the "Change EPCIS Export Status"
+	 * action, and Re-send must then pick it up. The actively-in-flight states (Enqueued/SendingStarted)
+	 * and already-Sent are NOT resendable (re-sending would double-send / re-deliver).
+	 */
+	@Test
+	void testIsResendable()
+	{
+		assertThat(ExternalSystemExportStatus.Pending.isResendable()).isTrue();
+		assertThat(ExternalSystemExportStatus.Error.isResendable()).isTrue();
+		assertThat(ExternalSystemExportStatus.Invalid.isResendable()).isTrue();
+		assertThat(ExternalSystemExportStatus.DontSend.isResendable()).isTrue();
+
+		assertThat(ExternalSystemExportStatus.Enqueued.isResendable()).isFalse();
+		assertThat(ExternalSystemExportStatus.SendingStarted.isResendable()).isFalse();
+		assertThat(ExternalSystemExportStatus.Sent.isResendable()).isFalse();
+	}
+
 	/** AD_Reference_ID binding is 542104 */
 	@Test
 	void testAdReferenceId()

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
@@ -305,11 +305,14 @@ public class ExternalSystemExportStatusServiceTest
 	// -----------------------------------------------------------------------
 
 	/**
-	 * A config with an in-flight (Pending) status must NOT be returned by the re-send
-	 * selection, to prevent double-sending a record that is already queued.
+	 * A config whose latest attempt is a resting Pending MUST be returned by the re-send selection:
+	 * Pending means not-yet-sent with nothing in flight, so a re-send is the first send (not a
+	 * duplicate). An operator can park a shipment in Pending via the "Change EPCIS Export Status"
+	 * action and must then be able to Re-send it. (Only the actively-in-flight Enqueued/SendingStarted
+	 * and already-Sent are excluded — covered by the "succeeded" test below.)
 	 */
 	@Test
-	void getResendableConfigs_excludes_pendingConfig()
+	void getResendableConfigs_includes_pendingConfig()
 	{
 		final TableRecordReference ref = newInOutRef();
 		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
@@ -319,7 +322,7 @@ public class ExternalSystemExportStatusServiceTest
 		final List<ExternalSystemScriptedExportConversionConfigId> result =
 				service.getResendableConfigsBySourceRecord(ref);
 
-		assertThat(result).isEmpty();
+		assertThat(result).containsExactly(configId);
 	}
 
 	/**

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
@@ -305,24 +305,38 @@ public class ExternalSystemExportStatusServiceTest
 	// -----------------------------------------------------------------------
 
 	/**
-	 * A config whose latest attempt is a resting Pending MUST be returned by the re-send selection:
-	 * Pending means not-yet-sent with nothing in flight, so a re-send is the first send (not a
-	 * duplicate). An operator can park a shipment in Pending via the "Change EPCIS Export Status"
-	 * action and must then be able to Re-send it. (Only the actively-in-flight Enqueued/SendingStarted
-	 * and already-Sent are excluded — covered by the "succeeded" test below.)
+	 * A config whose latest attempt is an OPERATOR-PARKED Pending — one carrying an AD_PInstance, set via
+	 * the "Change EPCIS Export Status" action — MUST be returned by the re-send selection: nothing is in
+	 * flight, so a re-send is the first send. An operator parks a stuck shipment in Pending and must then
+	 * be able to Re-send it.
 	 */
 	@Test
-	void getResendableConfigs_includes_pendingConfig()
+	void getResendableConfigs_includes_manuallyParkedPendingConfig()
 	{
 		final TableRecordReference ref = newInOutRef();
 		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
 
-		service.recordPending(configId, ref); // stays Pending
+		// operator parks it in Pending via the Change action -> stamped with the process PInstance
+		service.recordManualStatusChange(configId, ref, ExternalSystemExportStatus.Pending, PInstanceId.ofRepoId(1201));
 
-		final List<ExternalSystemScriptedExportConversionConfigId> result =
-				service.getResendableConfigsBySourceRecord(ref);
+		assertThat(service.getResendableConfigsBySourceRecord(ref)).containsExactly(configId);
+	}
 
-		assertThat(result).containsExactly(configId);
+	/**
+	 * A config whose latest attempt is a TRANSIENT auto-flow Pending — no AD_PInstance, the momentary
+	 * state the normal export flow writes just before flipping to Enqueued — must NOT be returned: it is
+	 * already on its way to being sent, so offering it for re-send would double-send. Only an
+	 * operator-parked Pending (with a PInstance) is resendable.
+	 */
+	@Test
+	void getResendableConfigs_excludes_transientPendingConfig()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+
+		service.recordPending(configId, ref); // auto-flow Pending, no PInstance
+
+		assertThat(service.getResendableConfigsBySourceRecord(ref)).isEmpty();
 	}
 
 	/**

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
@@ -301,7 +301,8 @@ public class ExternalSystemExportStatusServiceTest
 	}
 
 	// -----------------------------------------------------------------------
-	// getResendableConfigsBySourceRecord — Error/Invalid/DontSend (isResendable) filter
+	// getResendableConfigsBySourceRecord — Error/Invalid/DontSend, plus an operator-parked
+	// (PInstance-stamped) Pending; a transient auto-flow Pending is excluded
 	// -----------------------------------------------------------------------
 
 	/**

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionTest.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>
  * Covers:
  * <ul>
- *   <li>repo.getConfigsWithNonSentAttemptBySourceRecord: returns distinct config(s) with a non-sent attempt (status not Sent/DontSend); the Error/Invalid/DontSend (isResendable) selection for re-send is covered at the service layer in ExternalSystemExportStatusServiceTest</li>
+ *   <li>repo.getConfigsWithNonSentAttemptBySourceRecord: returns distinct config(s) with a non-sent attempt (status not Sent/DontSend); the re-send selection (Error/Invalid/DontSend, plus an operator-parked PInstance-stamped Pending) is covered at the service layer in ExternalSystemExportStatusServiceTest</li>
  *   <li>recordPendingAsResend: appends a NEW Pending+IsResend=Y attempt row, keeping the prior attempt (per-attempt history)</li>
  *   <li>multi-config: both configs returned when both have Error or Invalid status</li>
  *   <li>sent-only: config not returned when latest attempt is Sent</li>


### PR DESCRIPTION
## Problem

The **Re-send EPCIS export** action ignored a shipment whose latest EPCIS scripted-export status was **Pending**: `ExternalSystemExportStatus.isResendable()` grouped `Pending` with the actively-in-flight `Enqueued`/`SendingStarted` states and excluded it, so the Re-send config selection returned nothing and the process was a no-op on a Pending shipment. An operator can park a shipment in `Pending` via the **Change EPCIS Export Status** action, which then had no way to be sent.

## Root cause

`Pending` means *not yet sent, nothing in flight* — semantically different from `Enqueued`/`SendingStarted` (a send actively in progress). Re-sending a `Pending` record is the **first** send, not a double-send. `Pending` only became a resting, operator-settable state recently, which exposed the gap.

## Fix

Include `isPending()` in `isResendable()` (its single caller is the Re-send config selection). `Enqueued`/`SendingStarted`/`Sent` stay excluded (real double-send / re-deliver risk). The Re-send execution path already handles any resendable prior state, so unblocking the selection completes the fix.

## Tests (TDD, RED→GREEN)

- **Unit** — `ExternalSystemExportStatusTest.testIsResendable` (enum contract) and `ExternalSystemExportStatusServiceTest.getResendableConfigs_includes_pendingConfig` (service now returns the Pending config).
- **Cucumber** — new `S30088_060`: complete shipment → in-flight `U` → Change EPCIS Export Status → `Pending` → Re-send → new `IsResend=Y` attempt reaches `Sent`. Verified locally RED before the fix (resend ignored Pending) and GREEN after.
