### PR TITLE
mergify: register the oasis_sun branch group

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -93,6 +93,7 @@ pull_request_rules:
               - base=yoyo_uat
           - or: &PROJECT_BRANCHES_HOTFIX
               # HOTFIX BRANCH. THIS LINE IS A COMMENT FOR NEW CUSTOMER AUTOMATION. DO NOT EDIT THIS LINE IN ANY WAY. The script will insert new branches below this line.
+              - base=oasis_sun_hotfix
               - base=temporary_test202607_hotfix
               - base=speedy_tiger_hotfix
               - base=neon_underwear_hotfix
@@ -127,6 +128,7 @@ pull_request_rules:
               - base=yoyo_hotfix
           - or: &PROJECT_BRANCHES_RELEASE
               # RELEASE BRANCH. THIS LINE IS A COMMENT FOR NEW CUSTOMER AUTOMATION. DO NOT EDIT THIS LINE IN ANY WAY. The script will insert new branches below this line.
+              - base=oasis_sun_release
               - base=temporary_test202607_release
               - base=speedy_tiger_release
               - base=midnight_xylophone_release


### PR DESCRIPTION
Registers the `oasis_sun` branch group in `.mergify.yml`:

- `oasis_sun_release` → `PROJECT_BRANCHES_RELEASE`
- `oasis_sun_hotfix` → `PROJECT_BRANCHES_HOTFIX`

The group had **no** entry in the file at all. Consequences of that gap, for any PR based on either branch:

- no `branch:<base>` label after merge
- no `ops:auto_squash_merge` / `ops:auto_merge_commit` auto-merge — which is what `auto-port.yml` relies on for the `merge/<source>-to-<target>` PRs it creates (it labels them `ops:auto_merge_commit` + `ops:without_review_approval`)
- not covered by the "Block direct merges between protected branches" rule

`oasis_sun_release` is being created now for an upcoming release candidate, which also makes `auto-port.yml` route `oasis_sun_hotfix` to it (`.github/workflows/auto-port.yml:112` picks `${GROUP}_release` when that branch exists) — so both entries are needed for that chain to auto-merge.

No build impact: `.mergify.yml` is in the `paths-ignore` list of the `cicd` push trigger.
