### PR TITLE
Credit memo allocation — discounted credit memo matched against invoice must balance

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -371,6 +371,34 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 		Check.assume(added, "Line should not be already compensated: {}", this);
 	}
 
+	/**
+	 * @return true if this line is a <b>sales</b> credit memo whose counter-line is a sales invoice.
+	 * <p>
+	 * For such a pair, the credit memo's receivable is cleared by
+	 * {@code Doc_AllocationHdr.createCreditMemoCompensationFacts()} while the <i>invoice</i> line is iterated,
+	 * so all that is left to book on this line is its own discount / write-off.
+	 * <p>
+	 * Unlike {@link #isInvoiceWithCreditMemoCounterLine(AcctSchemaId)} this is purely structural, i.e. it does not
+	 * depend on the order in which the allocation's lines are iterated.
+	 */
+	public boolean isSalesCreditMemoWithInvoiceCounterLine()
+	{
+		if (!hasInvoiceDocument() || !isCreditMemoInvoice() || !isSOTrxInvoice())
+		{
+			return false;
+		}
+
+		final DocLine_Allocation counterLine = getCounterDocLine();
+		if (counterLine == null || !counterLine.hasInvoiceDocument())
+		{
+			return false;
+		}
+
+		// Same SOTrx, counter is a regular invoice
+		return counterLine.isSOTrxInvoice()
+				&& !counterLine.isCreditMemoInvoice();
+	}
+
 	public boolean hasInvoiceDocument()
 	{
 		return getC_Invoice() != null;

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -856,15 +856,14 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		{
 			factLineBuilder.setAccount(getCustomerAccount(BPartnerCustomerAccountType.C_Receivable, as));
 
-			// ARC: a credit memo reduces the receivable, so its allocation leg is a DEBIT —
-			// whether or not it is matched against another invoice. Qualifying this on
-			// "no counter line" put the ARC leg of a matched pair on the credit side, which
-			// made it add to the discount leg instead of offsetting it (mirrors the APC branch below).
-			if (line.isCreditMemoInvoice())
+			final DocLine_Allocation counterLine = line.getCounterDocLine();
+
+			// ARC that is not allocated against another invoice
+			if (line.isCreditMemoInvoice() && counterLine == null)
 			{
 				factLineBuilder.setAmtSource(allocationSource, null);
 			}
-			// ARI
+			// ARI or ARC that is allocated against the other invoice
 			else
 			{
 				factLineBuilder.setAmtSource(null, allocationSource);

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -820,6 +820,17 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			return;
 		}
 
+		// A sales credit memo which is matched against a sales invoice: its receivable is cleared in full by
+		// createCreditMemoCompensationFacts, while the invoice line is iterated. What is left here is this line's own
+		// discount/write-off, which is already booked by createInvoiceDiscountFacts/createInvoiceWriteOffFacts and
+		// which that clearing entry already absorbs (see below). Booking it again would post the credit memo's
+		// receivable a second time, on the same side as the discount leg, so the fact would not balance in source
+		// currency and Fact.balanceSource() would push the difference onto the suspense balancing account.
+		if (line.isSalesCreditMemoWithInvoiceCounterLine())
+		{
+			return;
+		}
+
 		final AcctSchema as = fact.getAcctSchema();
 		if (!as.isAccrual())
 		{
@@ -1039,6 +1050,19 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			currencyConversionCtx = counterLine.getInvoiceCurrencyConversionCtx();
 		}
 
+		// A sales credit memo books its own discount/write-off on the same side as the clearing entry below, while its
+		// own line is iterated (createInvoiceDiscountFacts/createInvoiceWriteOffFacts). The clearing entry must
+		// therefore carry the credit memo's NET amount, so that it absorbs those legs instead of adding to them; the
+		// credit memo's own createInvoiceFacts stands down accordingly, see
+		// DocLine_Allocation.isSalesCreditMemoWithInvoiceCounterLine(). Emitting the absorbed amount as a fact line of
+		// its own is not an option: it would be a second debit line for the same clearing, which
+		// FactTrxLines.extractType rejects.
+		// For a purchase credit memo those legs already land opposite the clearing entry, so there is nothing to absorb.
+		final BigDecimal counterLineAbsorbedAmtSource = counterLine.isSOTrxInvoice()
+				? counterLine.getDiscountAmt().toBigDecimal().add(counterLine.getWriteOffAmt().toBigDecimal())
+				: BigDecimal.ZERO;
+		final BigDecimal clearingAmtSource = compensationAmtSource.subtract(counterLineAbsorbedAmtSource);
+
 		// Create fact line for the counter credit memo
 		final FactLineBuilder factLineBuilder = fact.createLine()
 				.setDocLine(counterLine)
@@ -1052,13 +1076,13 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		{
 			factLineBuilder.setAccount(getCustomerAccount(BPartnerCustomerAccountType.C_Receivable, as));
 			// ARC: DR to clear the credit memo's receivable
-			factLineBuilder.setAmtSource(compensationAmtSource, null);
+			factLineBuilder.setAmtSource(clearingAmtSource, null);
 		}
 		else
 		{
 			factLineBuilder.setAccount(getVendorAccount(BPartnerVendorAccountType.V_Liability, as));
 			// APC: CR to clear the credit memo's liability
-			factLineBuilder.setAmtSource(null, compensationAmtSource.negate());
+			factLineBuilder.setAmtSource(null, clearingAmtSource.negate());
 		}
 
 		final FactLine factLine = factLineBuilder.buildAndAddNotNull();
@@ -1067,7 +1091,25 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		line.markAsCreditMemoInvoiceCompensated(as);
 		counterLine.markAsCreditMemoInvoiceCompensated(as);
 
-		return factLine.getAmtSourceAndAcctDrOrCr();
+		final AmountSourceAndAcct clearingAmtSourceAndAcct = factLine.getAmtSourceAndAcctDrOrCr();
+		if (counterLineAbsorbedAmtSource.signum() == 0)
+		{
+			return clearingAmtSourceAndAcct;
+		}
+
+		// This compensation settles this line's invoice by its whole allocated amount: partly by the clearing entry
+		// above, and partly by the amount it absorbed from the counter line. Reporting only the clearing entry would
+		// make createInvoiceFacts book this invoice's receivable short by the difference.
+		final BigDecimal currencyRate = factLine.getCurrencyRate();
+		final BigDecimal counterLineAbsorbedAmtAcct = currencyRate.signum() == 0 || currencyRate.compareTo(BigDecimal.ONE) == 0
+				? counterLineAbsorbedAmtSource
+				: factLine.getCurrencyRateFromDocumentToAcctCurrency().convertAmount(counterLineAbsorbedAmtSource);
+
+		return AmountSourceAndAcct.builder()
+				.add(clearingAmtSourceAndAcct)
+				.addAmtSource(counterLineAbsorbedAmtSource)
+				.addAmtAcct(counterLineAbsorbedAmtAcct)
+				.build();
 	}
 
 	/**

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -856,14 +856,15 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		{
 			factLineBuilder.setAccount(getCustomerAccount(BPartnerCustomerAccountType.C_Receivable, as));
 
-			final DocLine_Allocation counterLine = line.getCounterDocLine();
-
-			// ARC that is not allocated against another invoice
-			if (line.isCreditMemoInvoice() && counterLine == null)
+			// ARC: a credit memo reduces the receivable, so its allocation leg is a DEBIT —
+			// whether or not it is matched against another invoice. Qualifying this on
+			// "no counter line" put the ARC leg of a matched pair on the credit side, which
+			// made it add to the discount leg instead of offsetting it (mirrors the APC branch below).
+			if (line.isCreditMemoInvoice())
 			{
 				factLineBuilder.setAmtSource(allocationSource, null);
 			}
-			// ARI or ARC that is allocated against the other invoice
+			// ARI
 			else
 			{
 				factLineBuilder.setAmtSource(null, allocationSource);

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -3355,6 +3355,8 @@ Feature: invoice payment allocation
   @from:cucumber
   @allure.label.epic:E0340_Invoicing
   @allure.label.feature:F00700_Invoicing
+  @allure.label.epic:E0225_Accounting
+  @allure.label.feature:F01010_Automatic_Accounting
   @F00700
   Scenario: sales credit memo with early-payment discount allocated against sales invoice - allocation must balance
     # The customer's payment term grants 1% Skonto.

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -3348,6 +3348,69 @@ Feature: invoice payment allocation
       | V_Liability_Acct      | 5.95 EUR      |
 
 
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_CMA_170
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @F00700
+  Scenario: sales credit memo with early-payment discount allocated against sales invoice - allocation must balance
+    # The customer's payment term grants 1% Skonto.
+    # Credit memo GrandTotal = 100.00 EUR (net 84.03 + 19% VAT 15.97), discount = 1.00 EUR.
+    # Allocated amount = GrandTotal + discount = 101.00 EUR.
+    # The discount leg and its receivable counter-leg must land on OPPOSITE sides.
+    # Both on the same side leaves the allocation unbalanced in source currency, and the
+    # residual is then pushed onto the suspense-balancing account.
+    Given metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | salesPLV               | product      | 84.03    | PCE      |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier     | IsCustomer | IsVendor | M_PricingSystem_ID | C_PaymentTerm_ID.Value |
+      | skontoCustomer | Y          | N        | pricingSystem      | 10 Tage 1 %            |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier             | C_BPartner_ID  | IsShipToDefault | IsBillToDefault |
+      | skontoCustomerLocation | skontoCustomer | Y               | Y               |
+
+    # Sales invoice, large enough to absorb the credit memo
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID  | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | invoice    | skontoCustomer | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID | M_Product_ID | QtyInvoiced |
+      | invoice      | product      | 10 PCE      |
+    And the invoice identified by invoice is completed
+
+    # Credit memo: 1 PCE => GrandTotal 100.00 EUR
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID  | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | creditMemo | skontoCustomer | Gutschrift              | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID | M_Product_ID | QtyInvoiced |
+      | creditMemo   | product      | 1 PCE       |
+    And the invoice identified by creditMemo is completed
+
+    And allocate invoices (credit memo/purchase) to invoices
+      | C_Invoice_ID | CreditMemo.C_Invoice_ID |
+      | invoice      | creditMemo              |
+
+    # The credit-memo line carries the discount; the invoice line carries none.
+    And validate C_AllocationLines
+      | C_Invoice_ID | Amount  | DiscountAmt | WriteOffAmt | C_AllocationHdr_ID |
+      | invoice      | 101.00  | 0           | 0           | alloc              |
+      | creditMemo   | -101.00 | 1.00        | 0           | alloc              |
+
+    # The allocation's receivable movements of +101.00 and -101.00 cancel, so the balance is
+    # exactly the discount counter-leg. It must be a DEBIT of -1.00 => balance -1.00 EUR.
+    And Fact_Acct records balances for documents alloc are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | -1.00 EUR     |
+
+
 
 
 


### PR DESCRIPTION
## What

A sales credit memo (`ARC`) carrying an early-payment discount (Skonto), allocated against a sales invoice (`ARI`), posted its receivable **twice**. The allocation therefore did not balance in source currency, and `Fact.balanceSource()` pushed the residual onto the suspense-balancing account.

This PR fixes the posting and adds the covering scenario `S0465_CMA_170`.

## The defect

For a two-line, cross-linked invoice-to-credit-memo allocation:

1. `createCreditMemoCompensationFacts` books the credit memo's receivable for the **gross** allocated amount, while the *invoice* line is iterated.
2. The credit-memo line's own `createInvoiceFacts` then emits what is left in its collector — the discount — as a **second** entry on the same account. The `ARC` branch's `counterLine == null` guard does not hold for a matched credit memo, so that entry lands on the **same side** as the discount leg.

The two legs add up instead of offsetting, and the residual — always exactly **twice the discount** — ends up on the suspense account.

## The fix

The correct posting is **three** lines, not four:

| line | side | amount |
|---|---|---|
| receivable — invoice line | CR | the full allocated amount |
| receivable — credit-memo line | DR | allocated **minus** the credit memo's own discount/write-off |
| discount | CR | the discount |

The clearing entry now carries the credit memo's **net** amount, and reports the full settled amount back to the invoice line so that the invoice's receivable is still cleared in full. The credit-memo line's own `createInvoiceFacts` stands down, via the new structural predicate `DocLine_Allocation.isSalesCreditMemoWithInvoiceCounterLine()`.

Absorbing the amount into the clearing entry rather than posting it separately is not cosmetic: a separate line would be a second debit line for the same clearing, which `FactTrxLines.extractType` rejects outright (`2 DR lines, 2 CR lines`). This is the same division of labour that `createDirectInvoiceAllocationFacts` already documents — the specialised method emits the final line and `createInvoiceFacts` does not add a duplicate.

The predicate is deliberately structural rather than based on the already-compensated flag, so the result does not depend on the order in which the allocation's lines are iterated.

## Scope

Sales credit memos only. For a **purchase** credit memo the discount leg already lands opposite the clearing entry, so there is nothing to absorb — consistent with the field data, where only sales credit memos are affected. The guard for a credit memo matched against an **opposite-transaction** counter-invoice (the API/ARC compensation covered by `S0465_CMA_200` and `ral30_alloc1`) is untouched, and scenarios without a discount (`S0465_CMA_110`, `S0465_CMA_120`) are unaffected because the netting term is then zero.

## Verification

`S0465_CMA_170` fails on both commits preceding the fix and passes on the fix commit — full green run: https://github.com/metasfresh/metasfresh/actions/runs/31690888609

A real discounted credit-memo allocation was also re-posted on a dev instance, before and after the fix:

| account | before | after |
|---|---|---|
| receivable — credit memo | DR 64.46 | **DR 59.67** |
| receivable — invoice | CR 64.46 | CR 64.46 |
| discount | CR −4.79 | CR −4.79 |
| receivable — duplicate leg | CR −4.79 | **gone** |
| suspense balancing | CR 9.58 | **gone** |

After the fix: DR 59.67 against CR (64.46 − 4.79) = 59.67. The document balances and nothing lands on the suspense account. The tax-correction pair is a dedicated fact and is unchanged.

## The scenario

```gherkin
And Fact_Acct records balances for documents alloc are matching
  | AccountConceptualName | SourceBalance |
  | C_Receivable_Acct     | -1.00 EUR     |
```

One product at `84.03`, invoice `10 PCE`, credit memo `1 PCE`, so the credit memo GrandTotal is `100.00 EUR` (net 84.03 plus 19 % VAT 15.97); payment term `10 Tage 1 %` gives a discount of `1.00`, and the allocated amount is `101.00`. The receivable movements are then `DR 100.00` and `CR 101.00`, i.e. `SourceBalance -1.00 EUR`. Before the fix the duplicate leg made it `+1.00`.

## Coverage gap this closes

| condition | existing scenario | asserts `Fact_Acct`? |
|---|---|---|
| sales credit memo, payment, discount | yes | yes |
| credit memo matched against invoice, **no** discount | `S0465_CMA_110` | yes |
| credit memo matched against invoice **with** discount | `S0132_280` builds exactly this shape | **no** — only `C_AllocationLines` |

An existing scenario already produced the broken state and could not see it, because it never looked at the accounting facts. `S0132_280` is deliberately left untouched.
