### PR TITLE
mobile E2E: port two known flaky-harness fixes (qty-dialog detach race, HU bulk-move dropped scan) to memorable_shiny_hotfix

### DIFF
--- a/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
@@ -1,4 +1,4 @@
-import { page } from "../common";
+import { page, SLOW_ACTION_TIMEOUT } from "../common";
 import { test } from "../../../playwright.config";
 import { expect } from "@playwright/test";
 import { LoginScreen } from "./LoginScreen";
@@ -11,10 +11,7 @@ const NAME = 'HOME';
 const containerElement = () => page.locator('#ApplicationsListScreen');
 
 export const ApplicationsListScreen = {
-    // `timeout` is optional and passed straight through: callers that omit it keep the
-    // playwright default (bounded only by the test timeout), while a caller landing here after a
-    // known-slow async commit can give the transition its own explicit budget.
-    waitForScreen: async ({ timeout } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
+    waitForScreen: async ({ timeout = SLOW_ACTION_TIMEOUT } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
         await containerElement().waitFor({ timeout });
         await page.locator('.loading').waitFor({ state: 'detached', timeout });
     }),

--- a/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/ApplicationsListScreen.js
@@ -11,9 +11,12 @@ const NAME = 'HOME';
 const containerElement = () => page.locator('#ApplicationsListScreen');
 
 export const ApplicationsListScreen = {
-    waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
-        await containerElement().waitFor();
-        await page.locator('.loading').waitFor({ state: 'detached' });
+    // `timeout` is optional and passed straight through: callers that omit it keep the
+    // playwright default (bounded only by the test timeout), while a caller landing here after a
+    // known-slow async commit can give the transition its own explicit budget.
+    waitForScreen: async ({ timeout } = {}) => await test.step(`${NAME} - Wait for screen`, async () => {
+        await containerElement().waitFor({ timeout });
+        await page.locator('.loading').waitFor({ state: 'detached', timeout });
     }),
 
     expectVisible: async () => await test.step(`${NAME} - Expect to be displayed`, async () => {

--- a/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page } from '../../common';
+import { page, FAST_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../../common';
 import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
@@ -7,6 +7,11 @@ import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponen
 const NAME = 'HUBulkActionsScreen';
 /** @returns {import('@playwright/test').Locator} */
 const containerElement = () => page.locator('#HUBulkActionsScreen');
+
+// A real operator scans the target locator and, if nothing happens, simply scans again.
+// We mirror that: scan the target, and if the bulk-actions screen is still open shortly
+// after, scan once more, up to this many attempts.
+const SCAN_TARGET_MAX_ATTEMPTS = 5;
 
 export const HUBulkActionsScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
@@ -22,8 +27,29 @@ export const HUBulkActionsScreen = {
         // Wait for button text to change to "Close scanner" - ensures React re-render complete
         // and useKeyboardBarcodeReader hook has attached its event listener
         await page.getByTestId('toggle-target-scanner-button').getByText('Close scanner').waitFor();
-        await BarcodeScannerComponent.type(targetLocator);
 
-        await ApplicationsListScreen.waitForScreen();
+        // The keyboard-scanner hook's window listener attaches asynchronously (useEffect after
+        // the React commit), so a single instantaneous scan can be dropped; re-scan until the
+        // screen navigates away — mirroring an operator who scans again when nothing happens.
+        for (let attempt = 1; attempt <= SCAN_TARGET_MAX_ATTEMPTS; attempt++) {
+            await BarcodeScannerComponent.type(targetLocator);
+
+            // Scan accepted → screen navigates away; verify with a bounded wait.
+            try {
+                await containerElement().waitFor({ state: 'detached', timeout: FAST_ACTION_TIMEOUT });
+                break;
+            } catch (e) {
+                if (attempt === SCAN_TARGET_MAX_ATTEMPTS) {
+                    throw e;
+                }
+                // still on the bulk-actions screen — the scan was dropped; scan again
+            }
+        }
+
+        // The bulk move commits via an async REST round-trip (api.moveBulkHUs -> POST /bulk/move);
+        // only once it resolves does the frontend navigate home (history.goHome()). Give that
+        // transition the VERY_SLOW_ACTION_TIMEOUT (40s) budget — the same budget idiom used for
+        // other heavy async-commit flows that return to a list/home screen.
+        await ApplicationsListScreen.waitForScreen({ timeout: VERY_SLOW_ACTION_TIMEOUT });
     }),
 };

--- a/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page, FAST_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../../common';
+import { page, FAST_ACTION_TIMEOUT, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../../common';
 import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
@@ -26,7 +26,7 @@ export const HUBulkActionsScreen = {
         await page.getByTestId('toggle-target-scanner-button').tap();
         // Wait for button text to change to "Close scanner" - ensures React re-render complete
         // and useKeyboardBarcodeReader hook has attached its event listener
-        await page.getByTestId('toggle-target-scanner-button').getByText('Close scanner').waitFor();
+        await page.getByTestId('toggle-target-scanner-button').getByText('Close scanner').waitFor({ timeout: SLOW_ACTION_TIMEOUT });
 
         // The keyboard-scanner hook's window listener attaches asynchronously (useEffect after
         // the React commit), so a single instantaneous scan can be dropped; re-scan until the

--- a/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js
@@ -141,8 +141,16 @@ export const GetQuantityDialog = {
 //
 
 const expectMissingOrDisabled = async (locator) => {
+    // Element should either not exist (dialog already closed) or be disabled (dialog closing).
+    // Race condition: count() > 0 may be true, but by the time toBeDisabled() runs the dialog
+    // may have unmounted. In that case, re-check count — if 0, element is gone (OK).
     if (await locator.count() > 0) {
-        await expect(locator).toBeDisabled();
+        try {
+            await expect(locator).toBeDisabled();
+        } catch (e) {
+            if (await locator.count() === 0) return;
+            throw e;
+        }
     }
 };
 


### PR DESCRIPTION
Ports two **already-root-caused, test-harness-only** mobile-E2E flake fixes from `new_dawn_uat` to `memorable_shiny_hotfix`, which never received them.

## Why

The `mobile test` job is red on this branch family at two seams, with no production cause. Evidence — run https://github.com/metasfresh/metasfresh/actions/runs/31330564488 (backport PR https://github.com/metasfresh/metasfresh/pull/25465, a backend-only `C_BP_Group` change with **zero** `e2e/mobile-webui` files): all 3 attempts ran the identical commit and failed a **different** set of 2-3 specs out of 117 each time, and specs flipped direction across attempts.

| attempt | failing specs | seam |
|---|---|---|
| [1](https://github.com/metasfresh/metasfresh/actions/runs/31330564488/job/93292301289) | `picking/picking_deliveryLocationBasedAggregation.spec.js:101`, `picking/pick_what_was_scheduled_to_workplace.spec.js:82` | `GetQuantityDialog.js:145` |
| [2](https://github.com/metasfresh/metasfresh/actions/runs/31330564488/job/93295390928) | `humanager/huManager.spec.js:154`, `humanager/by_ExternalBarcode_attribute.spec.js:132` | `#ApplicationsListScreen` |
| [3](https://github.com/metasfresh/metasfresh/actions/runs/31330564488/job/93449395689) | `distribution/launchers_dropAllButton.spec.js:79`, `distribution/scan_HU_barcodes.spec.js:103`, `humanager/by_ExternalBarcode_attribute.spec.js:132` | 2x `GetQuantityDialog.js:145`, 1x `#ApplicationsListScreen` |

**Verified (nondeterminism, not a regression):** `gh api repos/metasfresh/metasfresh/actions/jobs/<id>/logs` for the three jobs above, all on the same head commit https://github.com/metasfresh/metasfresh/commit/a69a99a76402300a9cd8d1bae3749a585cf284d3 — `picking_deliveryLocationBasedAggregation.spec.js:101` FAILED in attempt 1 and PASSED (15.3s) in attempt 3; `huManager.spec.js:154` FAILED in attempt 2 and PASSED (4.6s) in attempt 3. Direction change on a fixed commit.
**Verified (diff cannot reach the failures):** `git diff --name-only origin/memorable_shiny_hotfix...origin/memorable_shiny_hotfix_BillBPartnerDeviating | grep -iE "mobile|e2e/|frontend"` -> empty.

## What

**1. `GetQuantityDialog.expectMissingOrDisabled` — check-then-act race on a transient element.** After OK the dialog is unmounting: `count() > 0` observes it attached, then `expect(locator).toBeDisabled()` re-queries and gets `element(s) not found`. A detach *during* the assertion now satisfies the "missing" half of "missing OR disabled". The helper is byte-identical to `new_dawn_uat`'s, which got it via https://github.com/metasfresh/metasfresh/pull/23120.

**Verified:** the attempt-1 and attempt-3 job logs show the failure at exactly this seam — `Error: expect(locator).toBeDisabled() failed` / `Error: element(s) not found` inside `expectMissingOrDisabled (/app/tests/utils/screens/picking/GetQuantityDialog.js:145:31)`, i.e. the assertion re-queried an element that `count()` had just seen. `git show origin/memorable_shiny_hotfix:e2e/mobile-webui/tests/utils/screens/picking/GetQuantityDialog.js` confirms this branch still carries the unguarded helper while `origin/new_dawn_uat` carries the guarded one.

**2. `HUBulkActionsScreen.move` — re-scan the target instead of assuming the first scan landed.** Now re-scans until the bulk-actions screen detaches (max 5 attempts) — what a real operator does when nothing happens. Ported verbatim in behaviour from https://github.com/metasfresh/metasfresh/pull/24615.

**Verified (symptom):** the attempt-2 and attempt-3 logs fail in `HUBulkActionsScreen.move` -> `ApplicationsListScreen.waitForScreen` with `locator.waitFor: Test timeout of 120000ms exceeded` / `waiting for locator('#ApplicationsListScreen') to be visible` — the home screen never appears at all, so the scan's effect never happened.
**Mechanism — upstream diagnosis, not re-verified on this branch (hypothesis here):** https://github.com/metasfresh/metasfresh/pull/24615 attributes it to the keyboard-scanner keydown listener attaching in a `useEffect` after the React commit, so an instantaneous first scan can be dropped. That matches the symptom above (screen never appears rather than appearing late), but this PR does not independently prove the dropped-listener mechanism on `memorable_shiny_hotfix`. The re-scan loop is safe either way: it is a no-op when the first scan lands.

`ApplicationsListScreen.waitForScreen` gains an optional `timeout` (defaulting to `SLOW_ACTION_TIMEOUT`) so the bulk-move path can bound its post-commit home transition at 40s. That block is byte-identical to `new_dawn_uat`'s.

The first push left that default *unset* (pure pass-through), to avoid tightening the other 8 call sites from the 120s global test timeout to 20s. Review round 1 showed that reasoning unsupported: the same port already landed on six other lines — `green_oak_hotfix` (https://github.com/metasfresh/metasfresh/commit/5309b3a9d2a), `task_force_hotfix` (https://github.com/metasfresh/metasfresh/commit/a497dfff2e3), `swift_eagle_hotfix` (https://github.com/metasfresh/metasfresh/commit/e7a20ec7126), `boomerang_signal_hotfix` (https://github.com/metasfresh/metasfresh/commit/7426cef97af), `intensive_care_hotfix` (https://github.com/metasfresh/metasfresh/commit/4bc7c1d4a0c), `deep_tundra_release` (https://github.com/metasfresh/metasfresh/commit/af3ac4c86db) — and **all six default to `SLOW_ACTION_TIMEOUT`** with no reported regression, two of them from this branch's identical bare-`waitFor()` baseline. Leaving it unset also perpetuated the bare `.waitFor()` that `e2e/mobile-webui/CLAUDE.md` flags as a CRITICAL anti-pattern. Of the 8 call sites, six are back-button / navigation waits with no REST commit behind them, one is login (`POST /auth`), and one — `HUDisposalScreen.dispose()` — does follow a REST commit, but a **single-HU** `disposeHU` rather than the N-HU `moveBulkHUs` that motivated the 40s budget (`HUManagerRestController.java:164` vs `:204`). All eight are byte-identical to `new_dawn_uat`, which already ships them on the 20s default with no open flake case. Corrected in the second commit.

A third commit closes the last divergence inside the ported `move()`: the "Close scanner" `waitFor` was left bare where upstream bounds it with `SLOW_ACTION_TIMEOUT`. `move()`'s code is now identical to `new_dawn_uat`'s, comment density aside.

## Scope & verification

Test-harness only — no production code, no specs added, removed, disabled or weakened. All 117 specs still load (`npx playwright test --list`, run in this branch's `e2e/mobile-webui`). A local full-stack reproduction was not possible on this build host (another workspace's stack holds the fixed e2e ports 8282/3000), so the fix verification is this branch's own `mobile test` job.

Both seams are known, internally tracked flaky-CI cases.
