### PR TITLE
ESR import: a duplicate incoming payment gets its own C_Payment

### DIFF
--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
@@ -644,11 +644,12 @@ public class ESRImportBL implements IESRImportBL
 		final PaymentId paymentId = fetchDuplicatePaymentIfExists(line);
 		if (paymentId != null)
 		{
+			// Flag the line so the accountant still sees the duplicate, but do not attach the payment we
+			// just found: that payment belongs to the earlier transaction, while this line is money that
+			// arrived a second time and needs its own C_Payment. Falling through to the regular handling
+			// lets processLinesWithPaymentNoInvoice create it (unallocated, since the invoice is paid).
 			line.setESR_Payment_Action(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment);
-			handleUnsupportedTrxType(line);
-			line.setC_Payment_ID(paymentId.getRepoId());
 			esrImportDAO.save(line);
-			return true;
 		}
 		return false;
 	}

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
@@ -129,6 +129,8 @@ public class ESRImportBL implements IESRImportBL
 
 	private static final AdMessageKey ESR_NO_HAS_WRONG_ORG_2P = AdMessageKey.of("de.metas.payment.esr.EsrNoHasWrongOrg");
 
+	private static final AdMessageKey ESR_INVOICE_ALREADY_PAID_1P = AdMessageKey.of("de.metas.payment.esr.InvoiceAlreadyPaid");
+
 	/**
 	 * Filled by {@link #registerActionHandler(String, IESRActionHandler)}.
 	 */
@@ -1178,7 +1180,9 @@ public class ESRImportBL implements IESRImportBL
 	 */
 	private void markInvoiceAlreadyPaid(@NonNull final I_ESR_ImportLine importLine, @NonNull final I_C_Invoice invoice)
 	{
-		ESRDataLoaderUtil.addMatchErrorMsgIfNotPresent(importLine, "Rechnung " + invoice.getDocumentNo() + " wurde im System als bereits bezahlt markiert");
+		final Properties ctx = getCtx(importLine);
+		ESRDataLoaderUtil.addMatchErrorMsgIfNotPresent(importLine,
+														msgBL.getMsg(ctx, ESR_INVOICE_ALREADY_PAID_1P, new Object[] { invoice.getDocumentNo() }));
 		importLine.setESR_Document_Status(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched);
 	}
 

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
@@ -644,10 +644,9 @@ public class ESRImportBL implements IESRImportBL
 		final PaymentId paymentId = fetchDuplicatePaymentIfExists(line);
 		if (paymentId != null)
 		{
-			// Flag the line so the accountant still sees the duplicate, but do not attach the payment we
-			// just found: that payment belongs to the earlier transaction, while this line is money that
-			// arrived a second time and needs its own C_Payment. Falling through to the regular handling
-			// lets processLinesWithPaymentNoInvoice create it (unallocated, since the invoice is paid).
+			// Flag the duplicate for the accountant, but deliberately do NOT attach the payment we found: it
+			// belongs to the earlier transaction, while this line is money that arrived a second time and
+			// needs its own C_Payment. Returning false lets the regular handling create it.
 			line.setESR_Payment_Action(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment);
 			esrImportDAO.save(line);
 		}
@@ -1173,13 +1172,9 @@ public class ESRImportBL implements IESRImportBL
 	}
 
 	/**
-	 * Notes on the given line that its invoice is already flagged as paid, and downgrades the line's document status
-	 * accordingly.
-	 * <p>
-	 * {@link #setInvoice(I_ESR_ImportLine, I_C_Invoice)} is re-entrant for one and the same line: besides being called
-	 * while the line is evaluated, it also runs again from the {@code C_Payment_ID} model interceptor once the line's own
-	 * payment is created. The document status it derives is idempotent, so the note has to be too - otherwise the very
-	 * same sentence ends up in {@code MatchErrorMsg} once per pass.
+	 * {@code setInvoice} runs twice for one line — once while it is evaluated, once from the
+	 * {@code C_Payment_ID} interceptor after the line's payment is created — so this note has to be as
+	 * idempotent as the document status it accompanies.
 	 */
 	private void markInvoiceAlreadyPaid(@NonNull final I_ESR_ImportLine importLine, @NonNull final I_C_Invoice invoice)
 	{

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
@@ -1144,14 +1144,12 @@ public class ESRImportBL implements IESRImportBL
 
 			if (invoice.isPaid() && !paymentBL.isMatchInvoice(payment, invoice))
 			{
-				ESRDataLoaderUtil.addMatchErrorMsg(importLine, "Rechnung " + invoice.getDocumentNo() + " wurde im System als bereits bezahlt markiert");
-				importLine.setESR_Document_Status(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched);
+				markInvoiceAlreadyPaid(importLine, invoice);
 			}
 		}
 		else if (invoice.isPaid())
 		{
-			ESRDataLoaderUtil.addMatchErrorMsg(importLine, "Rechnung " + invoice.getDocumentNo() + " wurde im System als bereits bezahlt markiert");
-			importLine.setESR_Document_Status(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched);
+			markInvoiceAlreadyPaid(importLine, invoice);
 		}
 
 		if (invoice.getAD_Org_ID() != importLine.getAD_Org_ID())
@@ -1172,6 +1170,21 @@ public class ESRImportBL implements IESRImportBL
 
 		importLine.setESR_Invoice_Grandtotal(invoice.getGrandTotal());
 
+	}
+
+	/**
+	 * Notes on the given line that its invoice is already flagged as paid, and downgrades the line's document status
+	 * accordingly.
+	 * <p>
+	 * {@link #setInvoice(I_ESR_ImportLine, I_C_Invoice)} is re-entrant for one and the same line: besides being called
+	 * while the line is evaluated, it also runs again from the {@code C_Payment_ID} model interceptor once the line's own
+	 * payment is created. The document status it derives is idempotent, so the note has to be too - otherwise the very
+	 * same sentence ends up in {@code MatchErrorMsg} once per pass.
+	 */
+	private void markInvoiceAlreadyPaid(@NonNull final I_ESR_ImportLine importLine, @NonNull final I_C_Invoice invoice)
+	{
+		ESRDataLoaderUtil.addMatchErrorMsgIfNotPresent(importLine, "Rechnung " + invoice.getDocumentNo() + " wurde im System als bereits bezahlt markiert");
+		importLine.setESR_Document_Status(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched);
 	}
 
 	@Override

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtil.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtil.java
@@ -379,6 +379,21 @@ public class ESRDataLoaderUtil
 		importLine.setMatchErrorMsg(addMsgToString(importLine.getMatchErrorMsg(), msg));
 	}
 
+	/**
+	 * Like {@link #addMatchErrorMsg(I_ESR_ImportLine, String)}, but a no-op if the line's {@code MatchErrorMsg} already
+	 * contains the given message. For callers that may run more than once for the same line and would otherwise
+	 * accumulate the very same message again and again.
+	 */
+	public void addMatchErrorMsgIfNotPresent(@NonNull final I_ESR_ImportLine importLine, final String msg)
+	{
+		final String currentMsg = importLine.getMatchErrorMsg();
+		if (!Check.isEmpty(msg, true) && currentMsg != null && currentMsg.contains(msg))
+		{
+			return;
+		}
+		addMatchErrorMsg(importLine, msg);
+	}
+
 	public void addImportErrorMsg(@NonNull final I_ESR_ImportLine importLine, final String msg)
 	{
 		importLine.setImportErrorMsg(addMsgToString(importLine.getImportErrorMsg(), msg));

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtil.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtil.java
@@ -34,6 +34,7 @@ import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_Invoice;
 import org.compiere.util.Env;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /*
@@ -384,7 +385,7 @@ public class ESRDataLoaderUtil
 	 * contains the given message. For callers that may run more than once for the same line and would otherwise
 	 * accumulate the very same message again and again.
 	 */
-	public void addMatchErrorMsgIfNotPresent(@NonNull final I_ESR_ImportLine importLine, final String msg)
+	public void addMatchErrorMsgIfNotPresent(@NonNull final I_ESR_ImportLine importLine, @Nullable final String msg)
 	{
 		final String currentMsg = importLine.getMatchErrorMsg();
 		if (!Check.isEmpty(msg, true) && currentMsg != null && currentMsg.contains(msg))

--- a/backend/de.metas.payment.esr/src/main/sql/postgresql/system/5818570_sys_AD_Message_ESR_InvoiceAlreadyPaid.sql
+++ b/backend/de.metas.payment.esr/src/main/sql/postgresql/system/5818570_sys_AD_Message_ESR_InvoiceAlreadyPaid.sql
@@ -1,5 +1,5 @@
--- AD_Message for ESRImportBL.markInvoiceAlreadyPaid() — the "invoice already paid" note
--- written to ESR_ImportLine.MatchErrorMsg, previously a hardcoded German literal.
+-- AD_Message for the note put on an ESR import line whose invoice is already flagged as paid,
+-- shown to the accountant in ESR_ImportLine.MatchErrorMsg. Previously a hardcoded German literal.
 
 -- 1. the message (base text = German)
 INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)

--- a/backend/de.metas.payment.esr/src/main/sql/postgresql/system/5818570_sys_AD_Message_ESR_InvoiceAlreadyPaid.sql
+++ b/backend/de.metas.payment.esr/src/main/sql/postgresql/system/5818570_sys_AD_Message_ESR_InvoiceAlreadyPaid.sql
@@ -1,0 +1,25 @@
+-- AD_Message for ESRImportBL.markInvoiceAlreadyPaid() — the "invoice already paid" note
+-- written to ESR_ImportLine.MatchErrorMsg, previously a hardcoded German literal.
+
+-- 1. the message (base text = German)
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545795 /*From ID Server*/,0,TO_TIMESTAMP('2026-08-12 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr','Y','Rechnung {0} wurde im System als bereits bezahlt markiert','I',TO_TIMESTAMP('2026-08-12 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr.InvoiceAlreadyPaid')
+;
+
+-- 2. seed AD_Message_Trl for ALL active system languages with the base (DE) text, IsTranslated='N'
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545795
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- 3. en_US override (the real English text) + IsTranslated='Y'
+UPDATE AD_Message_Trl SET MsgText='Invoice {0} was marked as already paid in the system',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-12 10:00:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545795
+;
+
+-- 4. flip de_DE + de_CH to IsTranslated='Y' (their text already equals the DE base)
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-12 10:00:13','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545795
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-12 10:00:14','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545795
+;

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
@@ -5,6 +5,7 @@ package de.metas.payment.esr;
 
 import de.metas.adempiere.model.I_C_Invoice;
 import de.metas.allocation.api.IAllocationDAO;
+import de.metas.bpartner.BPartnerId;
 import de.metas.calendar.standard.IPeriodBL;
 import de.metas.currency.CurrencyCode;
 import de.metas.currency.impl.PlainCurrencyDAO;
@@ -44,6 +45,7 @@ import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.ad.wrapper.POJOLookupMap;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.service.ISysConfigBL;
 import org.adempiere.service.ISysConfigDAO;
 import org.adempiere.util.trxConstraints.api.IOpenTrxBL;
@@ -74,6 +76,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This class tests the entire module of importing ESR
@@ -1827,10 +1830,10 @@ public class ESRImportTest extends ESRTestBase
 
 		// process the very same, already-processed import a second time: the header-level
 		// "Processed=Y" guard in ESRImportBL#processAndCountLines refuses the call outright
-		org.junit.jupiter.api.Assertions.assertThrows(
-				org.adempiere.exceptions.AdempiereException.class,
-				() -> esrImportBL.process(esrImport),
-				"re-processing an already-processed import must be refused by the Processed=Y guard");
+		final AdempiereException thrown = assertThrows(
+				AdempiereException.class,
+				() -> esrImportBL.process(esrImport));
+		assertThat(thrown.getMessage()).contains("Processed");
 
 		// the line must still point to its original payment, not a new one
 		refresh(esrImportLine, true);
@@ -1839,11 +1842,8 @@ public class ESRImportTest extends ESRTestBase
 		// load-bearing assertion: count the partner's actual C_Payment rows, not just the line's FK,
 		// so a stray second payment created for the same partner would be caught even if the line's FK was untouched
 		final int partnerId = esrImportLine.getC_Invoice().getC_BPartner_ID();
-		final List<I_C_Payment> partnerPayments = POJOLookupMap.get().getRecords(I_C_Payment.class)
-				.stream()
-				.filter(payment -> payment.getC_BPartner_ID() == partnerId)
-				.collect(java.util.stream.Collectors.toList());
-		assertThat("exactly one C_Payment must exist for the partner after re-processing", partnerPayments.size(), is(1));
+		final long partnerPaymentCount = paymentDAO.streamPaymentIdsByBPartnerId(BPartnerId.ofRepoId(partnerId)).count();
+		assertThat("exactly one C_Payment must exist for the partner after re-processing", partnerPaymentCount, is(1L));
 	}
 
 }

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
@@ -1792,4 +1792,58 @@ public class ESRImportTest extends ESRTestBase
 		assertThat("the duplicate payment must not be allocated to the invoice", esrLine2Payment.isAllocated(), is(false));
 	}
 
+	/**
+	 * Re-processing the SAME already-processed ESR import must be idempotent.
+	 * <ul>
+	 * <li>invoice 50, one ESR line pays it in full
+	 * <li>{@code esrImportBL.process(esrImport)} is called a SECOND time on the very same, already-processed import
+	 * <li>production code refuses the second call (the header's {@code Processed=Y} guard throws
+	 * {@code AdempiereException}) -- that guard IS the idempotency protection this test pins
+	 * <li>the line must keep its original payment (no new {@code C_Payment_ID})
+	 * <li>exactly ONE {@code C_Payment} must exist for the partner, counted from the actual table, not merely
+	 * re-read from the line's FK
+	 * </ul>
+	 */
+	@Test
+	public void testReprocessSameImport_createsNoSecondPayment()
+	{
+		final String grandTotal = "50";
+		final String esrLineText = "01201067789300000001060012345600654321400000050009072  030014040914041014041100001006800000000000090                          ";
+		final String completeRef = ESRTransactionLineMatcherUtil.extractReferenceNumberStr(esrLineText);
+
+		final String partnerValue = "123456";
+		final String invDocNo = "654321";
+		final String ESR_Rendered_AccountNo = "01-067789-3";
+
+		final I_ESR_ImportLine esrImportLine = setupESR_ImportLine(invDocNo, grandTotal, false, completeRef, /* refNo, */ ESR_Rendered_AccountNo, partnerValue, "50", false);
+		final I_ESR_Import esrImport = esrImportLine.getESR_Import();
+
+		esrImportBL.process(esrImport);
+
+		refresh(esrImportLine, true);
+		assertThat(esrImportLine.isProcessed(), is(true));
+		final int originalPaymentId = esrImportLine.getC_Payment_ID();
+		assertThat("first processing must have created a payment", originalPaymentId, is(not(0)));
+
+		// process the very same, already-processed import a second time: the header-level
+		// "Processed=Y" guard in ESRImportBL#processAndCountLines refuses the call outright
+		org.junit.jupiter.api.Assertions.assertThrows(
+				org.adempiere.exceptions.AdempiereException.class,
+				() -> esrImportBL.process(esrImport),
+				"re-processing an already-processed import must be refused by the Processed=Y guard");
+
+		// the line must still point to its original payment, not a new one
+		refresh(esrImportLine, true);
+		assertThat("re-processing must not swap in a new payment", esrImportLine.getC_Payment_ID(), is(originalPaymentId));
+
+		// load-bearing assertion: count the partner's actual C_Payment rows, not just the line's FK,
+		// so a stray second payment created for the same partner would be caught even if the line's FK was untouched
+		final int partnerId = esrImportLine.getC_Invoice().getC_BPartner_ID();
+		final List<I_C_Payment> partnerPayments = POJOLookupMap.get().getRecords(I_C_Payment.class)
+				.stream()
+				.filter(payment -> payment.getC_BPartner_ID() == partnerId)
+				.collect(java.util.stream.Collectors.toList());
+		assertThat("exactly one C_Payment must exist for the partner after re-processing", partnerPayments.size(), is(1));
+	}
+
 }

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
@@ -1734,4 +1734,62 @@ public class ESRImportTest extends ESRTestBase
 		assertThat("the duplicate payment must not be allocated to the invoice", esrLine2Payment.isAllocated(), is(false));
 	}
 
+	/**
+	 * Same ESR reference and same amount arrive on the SAME DAY as the first, already fully-matched payment.
+	 * <ul>
+	 * <li>invoice 50, first ESR line pays it in full on D1
+	 * <li>second ESR line: same reference, same amount 50, same PaymentDate D1
+	 * <li>the second line must still be flagged as a duplicate payment
+	 * <li>but it must get its OWN payment (not the first line's), for PayAmt 50, not allocated to the invoice
+	 * </ul>
+	 */
+	@Test
+	public void testDuplicatePayment_sameDay_createsOwnPayment()
+	{
+		final String grandTotal = "50";
+		final String esrLineText = "01201067789300000001060012345600654321400000050009072  030014040914041014041100001006800000000000090                          ";
+		final String completeRef = ESRTransactionLineMatcherUtil.extractReferenceNumberStr(esrLineText);
+
+		final String partnerValue = "123456";
+		final String invDocNo = "654321";
+		final String ESR_Rendered_AccountNo = "01-067789-3";
+
+		final I_ESR_ImportLine esrImportLine1 = setupESR_ImportLine(invDocNo, grandTotal, false, completeRef, /* refNo, */ ESR_Rendered_AccountNo, partnerValue, "50", false);
+		esrImportLine1.setESRLineText(esrLineText);
+		final Timestamp paymentDate1 = TimeUtil.getDay(2024, 1, 10);
+		esrImportLine1.setPaymentDate(paymentDate1);
+		save(esrImportLine1);
+
+		final I_ESR_Import esrImport = esrImportLine1.getESR_Import();
+
+		esrImportBL.process(esrImport);
+
+		final I_ESR_ImportLine esrImportLine2 = createESR_ImportLineFromOtherLine(esrImportLine1);
+		esrImportLine2.setESRLineText(esrLineText);
+		esrImportLine2.setPaymentDate(paymentDate1);
+		save(esrImportLine2);
+		final I_ESR_Import esrImport2 = esrImportLine2.getESR_Import();
+		esrImportBL.process(esrImport2);
+
+		// check first import line: unaffected, still fully matched and paid
+		refresh(esrImportLine1, true);
+		assertThat(esrImportLine1.isProcessed(), is(true));
+		assertThat(esrImportLine1.getESR_Payment_Action(), is(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Fit_Amounts));
+
+		// check second import line: flagged as a duplicate payment ...
+		refresh(esrImportLine2, true);
+		assertThat(esrImportLine2.getESR_Payment_Action(), is(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment));
+
+		// ... but it must have its OWN payment, not the first line's
+		assertThat("the second line arriving on the same day must not carry the first line's C_Payment_ID",
+				   esrImportLine2.getC_Payment_ID(), is(not(esrImportLine1.getC_Payment_ID())));
+
+		final PaymentId esrImportLine2PaymentId = PaymentId.ofRepoIdOrNull(esrImportLine2.getC_Payment_ID());
+		final I_C_Payment esrLine2Payment = esrImportLine2PaymentId == null ? null
+				: paymentDAO.getById(esrImportLine2PaymentId);
+		assertThat("the duplicate-flagged line must have created its own payment", esrLine2Payment, notNullValue());
+		assertThat(esrLine2Payment.getPayAmt(), comparesEqualTo(new BigDecimal("50")));
+		assertThat("the duplicate payment must not be allocated to the invoice", esrLine2Payment.isAllocated(), is(false));
+	}
+
 }

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
@@ -1674,8 +1674,16 @@ public class ESRImportTest extends ESRTestBase
 		assertThat(esrImportLine2.getImportErrorMsg(), nullValue());
 		assertThat(esrImportLine2.getMatchErrorMsg(), is("Rechnung " + invDocNo + " wurde im System als bereits bezahlt markiert"));
 
-		// check the payment
-		assertThat(esrImportLine2.getC_Payment_ID(), is(esrImportLine2.getC_Payment_ID()));
+		// check the payment: the duplicate-flagged line must have its OWN payment, not the first line's
+		assertThat("the duplicate line must not carry the first line's C_Payment_ID",
+				   esrImportLine2.getC_Payment_ID(), is(not(esrImportLine1.getC_Payment_ID())));
+
+		final PaymentId esrImportLine2PaymentId = PaymentId.ofRepoIdOrNull(esrImportLine2.getC_Payment_ID());
+		final I_C_Payment esrLine2Payment = esrImportLine2PaymentId == null ? null
+				: paymentDAO.getById(esrImportLine2PaymentId);
+		assertThat("the duplicate-flagged line must have created its own payment", esrLine2Payment, notNullValue());
+		assertThat(esrLine2Payment.getPayAmt(), comparesEqualTo(new BigDecimal("50")));
+		assertThat("the duplicate payment must not be allocated to the invoice", esrLine2Payment.isAllocated(), is(false));
 	}
 
 	/**

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
@@ -56,6 +56,7 @@ import org.compiere.model.I_C_Payment;
 import org.compiere.model.X_C_DocType;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
@@ -1633,6 +1634,10 @@ public class ESRImportTest extends ESRTestBase
 		assertThat(esrImportLine3.isProcessed(), is(true));
 	}
 
+	/**
+	 * Cross-import duplicate with NO PaymentDate on either line (the fixture default): the second line
+	 * must still get its own payment, and the "invoice already paid" note must appear exactly once.
+	 */
 	@Test
 	public void testDuplicatePayments()
 	{
@@ -1671,6 +1676,9 @@ public class ESRImportTest extends ESRTestBase
 
 		refresh(esrImportLine2, true);
 		assertThat(esrImportLine2.getESR_Payment_Action(), is(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment));
+		assertThat("the duplicate line must stay unprocessed so the accountant still sees it",
+				   esrImportLine2.isProcessed(), is(false));
+		assertThat(esrImportLine2.getESR_Document_Status(), is(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched));
 		assertThat(esrImportLine2.getImportErrorMsg(), nullValue());
 		assertThat(esrImportLine2.getMatchErrorMsg(), is("Rechnung " + invDocNo + " wurde im System als bereits bezahlt markiert"));
 
@@ -1684,123 +1692,86 @@ public class ESRImportTest extends ESRTestBase
 		assertThat("the duplicate-flagged line must have created its own payment", esrLine2Payment, notNullValue());
 		assertThat(esrLine2Payment.getPayAmt(), comparesEqualTo(new BigDecimal("50")));
 		assertThat("the duplicate payment must not be allocated to the invoice", esrLine2Payment.isAllocated(), is(false));
+		assertThat("the duplicate payment must not be linked to the invoice", esrLine2Payment.getC_Invoice_ID(), is(0));
 	}
 
 	/**
-	 * Same ESR reference and same amount arrive on a LATER DAY than the first, already fully-matched payment.
+	 * Same ESR reference and same amount arrive again after the first, already fully-matched payment,
+	 * either on the same day or a later day.
 	 * <ul>
 	 * <li>invoice 50, first ESR line pays it in full on D1
-	 * <li>second ESR line: same reference, same amount 50, but PaymentDate D2 != D1
-	 * <li>the second line must still be flagged as a duplicate payment
-	 * <li>but it must get its OWN payment (not the first line's), for PayAmt 50, not allocated to the invoice
+	 * <li>second ESR line: same reference, same amount 50, PaymentDate D1 or a later D2
+	 * <li>the second line must still be flagged as a duplicate payment and remain unprocessed
+	 * <li>but it must get its OWN payment (not the first line's), for PayAmt 50, not allocated or linked to the invoice
 	 * </ul>
 	 */
-	@Test
-	public void testDuplicatePayment_differentDay_createsOwnPayment()
+	@Nested
+	class DuplicatePaymentGetsOwnPayment
 	{
-		final String grandTotal = "50";
-		final String esrLineText = "01201067789300000001060012345600654321400000050009072  030014040914041014041100001006800000000000090                          ";
-		final String completeRef = ESRTransactionLineMatcherUtil.extractReferenceNumberStr(esrLineText);
+		@Test
+		void arrivingOnTheSameDay()
+		{
+			assertDuplicateGetsOwnPayment(0);
+		}
 
-		final String partnerValue = "123456";
-		final String invDocNo = "654321";
-		final String ESR_Rendered_AccountNo = "01-067789-3";
+		@Test
+		void arrivingOnALaterDay()
+		{
+			assertDuplicateGetsOwnPayment(1);
+		}
 
-		final I_ESR_ImportLine esrImportLine1 = setupESR_ImportLine(invDocNo, grandTotal, false, completeRef, /* refNo, */ ESR_Rendered_AccountNo, partnerValue, "50", false);
-		esrImportLine1.setESRLineText(esrLineText);
-		final Timestamp paymentDate1 = TimeUtil.getDay(2024, 1, 10);
-		esrImportLine1.setPaymentDate(paymentDate1);
-		save(esrImportLine1);
+		private void assertDuplicateGetsOwnPayment(final int daysAfterFirstPayment)
+		{
+			final String grandTotal = "50";
+			final String esrLineText = "01201067789300000001060012345600654321400000050009072  030014040914041014041100001006800000000000090                          ";
+			final String completeRef = ESRTransactionLineMatcherUtil.extractReferenceNumberStr(esrLineText);
 
-		final I_ESR_Import esrImport = esrImportLine1.getESR_Import();
+			final String partnerValue = "123456";
+			final String invDocNo = "654321";
+			final String ESR_Rendered_AccountNo = "01-067789-3";
 
-		esrImportBL.process(esrImport);
+			final I_ESR_ImportLine esrImportLine1 = setupESR_ImportLine(invDocNo, grandTotal, false, completeRef, /* refNo, */ ESR_Rendered_AccountNo, partnerValue, "50", false);
+			esrImportLine1.setESRLineText(esrLineText);
+			final Timestamp paymentDate1 = TimeUtil.getDay(2024, 1, 10);
+			esrImportLine1.setPaymentDate(paymentDate1);
+			save(esrImportLine1);
 
-		final I_ESR_ImportLine esrImportLine2 = createESR_ImportLineFromOtherLine(esrImportLine1);
-		esrImportLine2.setESRLineText(esrLineText);
-		final Timestamp paymentDate2 = TimeUtil.addDays(paymentDate1, 1);
-		esrImportLine2.setPaymentDate(paymentDate2);
-		save(esrImportLine2);
-		final I_ESR_Import esrImport2 = esrImportLine2.getESR_Import();
-		esrImportBL.process(esrImport2);
+			final I_ESR_Import esrImport = esrImportLine1.getESR_Import();
 
-		// check first import line: unaffected, still fully matched and paid
-		refresh(esrImportLine1, true);
-		assertThat(esrImportLine1.isProcessed(), is(true));
-		assertThat(esrImportLine1.getESR_Payment_Action(), is(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Fit_Amounts));
+			esrImportBL.process(esrImport);
 
-		// check second import line: flagged as a duplicate payment ...
-		refresh(esrImportLine2, true);
-		assertThat(esrImportLine2.getESR_Payment_Action(), is(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment));
+			final I_ESR_ImportLine esrImportLine2 = createESR_ImportLineFromOtherLine(esrImportLine1);
+			esrImportLine2.setESRLineText(esrLineText);
+			final Timestamp paymentDate2 = TimeUtil.addDays(paymentDate1, daysAfterFirstPayment);
+			esrImportLine2.setPaymentDate(paymentDate2);
+			save(esrImportLine2);
+			final I_ESR_Import esrImport2 = esrImportLine2.getESR_Import();
+			esrImportBL.process(esrImport2);
 
-		// ... but it must have its OWN payment, not the first line's
-		assertThat("the second line arriving on a later day must not carry the first line's C_Payment_ID",
-				   esrImportLine2.getC_Payment_ID(), is(not(esrImportLine1.getC_Payment_ID())));
+			// check first import line: unaffected, still fully matched and paid
+			refresh(esrImportLine1, true);
+			assertThat(esrImportLine1.isProcessed(), is(true));
+			assertThat(esrImportLine1.getESR_Payment_Action(), is(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Fit_Amounts));
 
-		final PaymentId esrImportLine2PaymentId = PaymentId.ofRepoIdOrNull(esrImportLine2.getC_Payment_ID());
-		final I_C_Payment esrLine2Payment = esrImportLine2PaymentId == null ? null
-				: paymentDAO.getById(esrImportLine2PaymentId);
-		assertThat("the duplicate-flagged line must have created its own payment", esrLine2Payment, notNullValue());
-		assertThat(esrLine2Payment.getPayAmt(), comparesEqualTo(new BigDecimal("50")));
-		assertThat("the duplicate payment must not be allocated to the invoice", esrLine2Payment.isAllocated(), is(false));
-	}
+			// check second import line: flagged as a duplicate payment, and remains unprocessed for the accountant
+			refresh(esrImportLine2, true);
+			assertThat(esrImportLine2.getESR_Payment_Action(), is(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment));
+			assertThat("the duplicate line must stay unprocessed so the accountant still sees it",
+					   esrImportLine2.isProcessed(), is(false));
+			assertThat(esrImportLine2.getESR_Document_Status(), is(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched));
 
-	/**
-	 * Same ESR reference and same amount arrive on the SAME DAY as the first, already fully-matched payment.
-	 * <ul>
-	 * <li>invoice 50, first ESR line pays it in full on D1
-	 * <li>second ESR line: same reference, same amount 50, same PaymentDate D1
-	 * <li>the second line must still be flagged as a duplicate payment
-	 * <li>but it must get its OWN payment (not the first line's), for PayAmt 50, not allocated to the invoice
-	 * </ul>
-	 */
-	@Test
-	public void testDuplicatePayment_sameDay_createsOwnPayment()
-	{
-		final String grandTotal = "50";
-		final String esrLineText = "01201067789300000001060012345600654321400000050009072  030014040914041014041100001006800000000000090                          ";
-		final String completeRef = ESRTransactionLineMatcherUtil.extractReferenceNumberStr(esrLineText);
+			// ... but it must have its OWN payment, not the first line's
+			assertThat("the duplicate line must not carry the first line's C_Payment_ID",
+					   esrImportLine2.getC_Payment_ID(), is(not(esrImportLine1.getC_Payment_ID())));
 
-		final String partnerValue = "123456";
-		final String invDocNo = "654321";
-		final String ESR_Rendered_AccountNo = "01-067789-3";
-
-		final I_ESR_ImportLine esrImportLine1 = setupESR_ImportLine(invDocNo, grandTotal, false, completeRef, /* refNo, */ ESR_Rendered_AccountNo, partnerValue, "50", false);
-		esrImportLine1.setESRLineText(esrLineText);
-		final Timestamp paymentDate1 = TimeUtil.getDay(2024, 1, 10);
-		esrImportLine1.setPaymentDate(paymentDate1);
-		save(esrImportLine1);
-
-		final I_ESR_Import esrImport = esrImportLine1.getESR_Import();
-
-		esrImportBL.process(esrImport);
-
-		final I_ESR_ImportLine esrImportLine2 = createESR_ImportLineFromOtherLine(esrImportLine1);
-		esrImportLine2.setESRLineText(esrLineText);
-		esrImportLine2.setPaymentDate(paymentDate1);
-		save(esrImportLine2);
-		final I_ESR_Import esrImport2 = esrImportLine2.getESR_Import();
-		esrImportBL.process(esrImport2);
-
-		// check first import line: unaffected, still fully matched and paid
-		refresh(esrImportLine1, true);
-		assertThat(esrImportLine1.isProcessed(), is(true));
-		assertThat(esrImportLine1.getESR_Payment_Action(), is(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Fit_Amounts));
-
-		// check second import line: flagged as a duplicate payment ...
-		refresh(esrImportLine2, true);
-		assertThat(esrImportLine2.getESR_Payment_Action(), is(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment));
-
-		// ... but it must have its OWN payment, not the first line's
-		assertThat("the second line arriving on the same day must not carry the first line's C_Payment_ID",
-				   esrImportLine2.getC_Payment_ID(), is(not(esrImportLine1.getC_Payment_ID())));
-
-		final PaymentId esrImportLine2PaymentId = PaymentId.ofRepoIdOrNull(esrImportLine2.getC_Payment_ID());
-		final I_C_Payment esrLine2Payment = esrImportLine2PaymentId == null ? null
-				: paymentDAO.getById(esrImportLine2PaymentId);
-		assertThat("the duplicate-flagged line must have created its own payment", esrLine2Payment, notNullValue());
-		assertThat(esrLine2Payment.getPayAmt(), comparesEqualTo(new BigDecimal("50")));
-		assertThat("the duplicate payment must not be allocated to the invoice", esrLine2Payment.isAllocated(), is(false));
+			final PaymentId esrImportLine2PaymentId = PaymentId.ofRepoIdOrNull(esrImportLine2.getC_Payment_ID());
+			final I_C_Payment esrLine2Payment = esrImportLine2PaymentId == null ? null
+					: paymentDAO.getById(esrImportLine2PaymentId);
+			assertThat("the duplicate-flagged line must have created its own payment", esrLine2Payment, notNullValue());
+			assertThat(esrLine2Payment.getPayAmt(), comparesEqualTo(new BigDecimal("50")));
+			assertThat("the duplicate payment must not be allocated to the invoice", esrLine2Payment.isAllocated(), is(false));
+			assertThat("the duplicate payment must not be linked to the invoice", esrLine2Payment.getC_Invoice_ID(), is(0));
+		}
 	}
 
 	/**

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
@@ -1680,7 +1680,10 @@ public class ESRImportTest extends ESRTestBase
 				   esrImportLine2.isProcessed(), is(false));
 		assertThat(esrImportLine2.getESR_Document_Status(), is(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched));
 		assertThat(esrImportLine2.getImportErrorMsg(), nullValue());
-		assertThat(esrImportLine2.getMatchErrorMsg(), is("Rechnung " + invDocNo + " wurde im System als bereits bezahlt markiert"));
+		// note text now comes from msgBL.getMsg(ESR_INVOICE_ALREADY_PAID_1P, ...); in this no-DB test env
+		// an AD_Message with no registered row resolves to "<key>_[<params>]" (see ESRImportBLTest#test_setInvoice_wrongOrg
+		// for the same fallback shape with 2 params)
+		assertThat(esrImportLine2.getMatchErrorMsg(), is("de.metas.payment.esr.InvoiceAlreadyPaid_[" + invDocNo + "]"));
 
 		// check the payment: the duplicate-flagged line must have its OWN payment, not the first line's
 		assertThat("the duplicate line must not carry the first line's C_Payment_ID",

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
@@ -53,11 +53,13 @@ import org.compiere.model.I_C_AllocationLine;
 import org.compiere.model.I_C_Payment;
 import org.compiere.model.X_C_DocType;
 import org.compiere.util.Env;
+import org.compiere.util.TimeUtil;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -68,6 +70,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.save;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
@@ -1670,6 +1673,65 @@ public class ESRImportTest extends ESRTestBase
 
 		// check the payment
 		assertThat(esrImportLine2.getC_Payment_ID(), is(esrImportLine2.getC_Payment_ID()));
+	}
+
+	/**
+	 * Same ESR reference and same amount arrive on a LATER DAY than the first, already fully-matched payment.
+	 * <ul>
+	 * <li>invoice 50, first ESR line pays it in full on D1
+	 * <li>second ESR line: same reference, same amount 50, but PaymentDate D2 != D1
+	 * <li>the second line must still be flagged as a duplicate payment
+	 * <li>but it must get its OWN payment (not the first line's), for PayAmt 50, not allocated to the invoice
+	 * </ul>
+	 */
+	@Test
+	public void testDuplicatePayment_differentDay_createsOwnPayment()
+	{
+		final String grandTotal = "50";
+		final String esrLineText = "01201067789300000001060012345600654321400000050009072  030014040914041014041100001006800000000000090                          ";
+		final String completeRef = ESRTransactionLineMatcherUtil.extractReferenceNumberStr(esrLineText);
+
+		final String partnerValue = "123456";
+		final String invDocNo = "654321";
+		final String ESR_Rendered_AccountNo = "01-067789-3";
+
+		final I_ESR_ImportLine esrImportLine1 = setupESR_ImportLine(invDocNo, grandTotal, false, completeRef, /* refNo, */ ESR_Rendered_AccountNo, partnerValue, "50", false);
+		esrImportLine1.setESRLineText(esrLineText);
+		final Timestamp paymentDate1 = TimeUtil.getDay(2024, 1, 10);
+		esrImportLine1.setPaymentDate(paymentDate1);
+		save(esrImportLine1);
+
+		final I_ESR_Import esrImport = esrImportLine1.getESR_Import();
+
+		esrImportBL.process(esrImport);
+
+		final I_ESR_ImportLine esrImportLine2 = createESR_ImportLineFromOtherLine(esrImportLine1);
+		esrImportLine2.setESRLineText(esrLineText);
+		final Timestamp paymentDate2 = TimeUtil.addDays(paymentDate1, 1);
+		esrImportLine2.setPaymentDate(paymentDate2);
+		save(esrImportLine2);
+		final I_ESR_Import esrImport2 = esrImportLine2.getESR_Import();
+		esrImportBL.process(esrImport2);
+
+		// check first import line: unaffected, still fully matched and paid
+		refresh(esrImportLine1, true);
+		assertThat(esrImportLine1.isProcessed(), is(true));
+		assertThat(esrImportLine1.getESR_Payment_Action(), is(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Fit_Amounts));
+
+		// check second import line: flagged as a duplicate payment ...
+		refresh(esrImportLine2, true);
+		assertThat(esrImportLine2.getESR_Payment_Action(), is(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment));
+
+		// ... but it must have its OWN payment, not the first line's
+		assertThat("the second line arriving on a later day must not carry the first line's C_Payment_ID",
+				   esrImportLine2.getC_Payment_ID(), is(not(esrImportLine1.getC_Payment_ID())));
+
+		final PaymentId esrImportLine2PaymentId = PaymentId.ofRepoIdOrNull(esrImportLine2.getC_Payment_ID());
+		final I_C_Payment esrLine2Payment = esrImportLine2PaymentId == null ? null
+				: paymentDAO.getById(esrImportLine2PaymentId);
+		assertThat("the duplicate-flagged line must have created its own payment", esrLine2Payment, notNullValue());
+		assertThat(esrLine2Payment.getPayAmt(), comparesEqualTo(new BigDecimal("50")));
+		assertThat("the duplicate payment must not be allocated to the invoice", esrLine2Payment.isAllocated(), is(false));
 	}
 
 }


### PR DESCRIPTION
## Problem

A **genuinely new** incoming ESR payment is mistaken for one already seen, because the candidate search matches on partner + amount (+ transaction date) only. The typical case is a recurring payment — rent for the following month: same partner, same amount, same invoice reference as last month, but a different transaction and real new money.

Instead of creating a new `C_Payment`, the import pulled out the **previous** payment and attached it to the new line, skipping payment creation entirely. So the second receipt was never booked, the bank statement could not be reconciled, and the import could not be completed.

The same code path also covers the case where money genuinely is sent twice. Either way the outcome must be the same: the line is flagged for the accountant to inspect, **and** the incoming money gets its own payment.

`ESRImportBL.handleEsrImportLine` did three things on a positive duplicate detection: flag the line, attach the payment it had just *found*, and `return true`. That early return marked the line "already handled", so it was excluded from `linesToProcess` and never reached payment creation.

## Fix

The candidate search is deliberately left **unchanged**: it cannot tell a recurring payment apart from a re-sent one (partner, amount, invoice reference and even the raw ESR line text can all be identical), so it must keep flagging the line for the accountant. What changes is the *consequence* of a match.

`handleEsrImportLine` now keeps the `Duplicate_Payment` flag and lets the line fall through to the regular handling, which creates its own payment. Three statements were removed:

- `line.setC_Payment_ID(paymentId.getRepoId())` — the payment found belongs to a **different**, earlier transaction; this line is new money.
- `return true` — it skipped payment creation.
- `handleUnsupportedTrxType(line)` — it can set `Processed=Y` under the `de.metas.payment.esr.ProcessUnspportedTrxTypes` sysconfig, which would defeat the requirement that a duplicate line remain unprocessed for the accountant to act on.

The line then reaches the same machinery a duplicate **within one file** has always used (`processLinesWithPaymentNoInvoice` → `createUnlinkedPaymentForLine`): it gets its own payment, left unallocated because the invoice is already paid. In other words, the cross-import case now converges on the behaviour `ESRImportTest#testDoublePayment_T02` has asserted for the same-file case all along.

Deliberately **not** changed, both considered and rejected with evidence:

- **Narrowing the candidate search** (a day-scoped `DateTrx` filter in `AbstractPaymentDAO.retrievePaymentIds`). Implemented and falsified: removing the candidate means the duplicate is never *detected*, so `ESR_Payment_Action` is never set and the accountant loses the warning.
- **Removing the sibling-line match** in `ESRImportDAO.findExistentPaymentId`. That branch is *detection*, not the defect; removing it leaves the same-day case unflagged.

## Second change — a re-entrancy artefact

`setInvoice` runs twice for one line: once while it is evaluated, and again from the `C_Payment_ID` `@ModelChange` interceptor after the line's payment is created. Everything it derives is idempotent except the appended match-error note, so the "invoice already paid" message was recorded twice once lines started falling through. Added `ESRDataLoaderUtil.addMatchErrorMsgIfNotPresent` and routed both call sites through one `markInvoiceAlreadyPaid` helper.

## Scope boundary — the fix is forward-only

`handleEsrImportLine` returns early for any line that already carries a payment. Import lines that the **old** code already mis-attached therefore keep the wrong payment after deployment, and the money they represent stays unbooked. Repairing existing rows is separate work and is **not** part of this PR.

## Tests

Three new tests, all written and shown RED before the fix:

| Test | Fixture |
|---|---|
| `DuplicatePaymentGetsOwnPayment.arrivingOnALaterDay` | second import one day after the first |
| `DuplicatePaymentGetsOwnPayment.arrivingOnTheSameDay` | both imports on the same payment date |
| `testReprocessSameImport_createsNoSecondPayment` | re-processing the same import header |

Each asserts the duplicate line gets its **own** payment (not the sibling's), for the right amount, unallocated (`C_Invoice_ID == 0`), flagged `Duplicate_Payment`, and left **unprocessed**.

`testReprocessSameImport_createsNoSecondPayment` pins the header-level `Processed=Y` interlock, which refuses re-processing before the duplicate search runs at all.

Also repaired: `testDuplicatePayments` closed with `assertThat(x.getC_Payment_ID(), is(x.getC_Payment_ID()))` — a self-comparison that could never fail. It now asserts which payment the line actually carries, and is the only test covering the null-`PaymentDate` fixture and the exactly-once match-error note.

**Verified locally** (2026-08-12, after a full `mvn_build.sh --skip-tests` reinstall so no stale jar could mask the result):

- `ESRImportTest` — 67 run, 0 failures
- `de.metas.payment.esr` module — 160 run, 0 failures, 1 pre-existing skip
- `de.metas.business` — 622 run, 0 failures
- `de.metas.banking.base` — 97 run, 0 failures, 2 pre-existing skips
