### PR TITLE
Merge: soft_panda_release to new_dawn_uat (EPCIS resend-Pending propagation)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_ScriptedExportConversion_Status_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/ExternalSystem_ScriptedExportConversion_Status_StepDef.java
@@ -29,11 +29,15 @@ import de.metas.cucumber.stepdefs.StepDefUtil;
 import de.metas.cucumber.stepdefs.api.APIRequest;
 import de.metas.cucumber.stepdefs.api.RESTUtil;
 import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
+import de.metas.edi.api.impl.EpcisExportStatusChangeService;
+import de.metas.externalsystem.ExternalSystemExportStatus;
 import de.metas.externalsystem.model.I_ExternalSystem_Config_ScriptedExportConversion;
 import de.metas.externalsystem.model.I_ExternalSystem_ScriptedExportConversion_Status;
 import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionConfig;
 import de.metas.externalsystem.scriptedexportconversion.process.M_InOut_ReSend_ScriptedExportConversion;
+import de.metas.inout.InOutId;
 import de.metas.process.AdProcessId;
+import de.metas.process.IADPInstanceDAO;
 import de.metas.process.IADProcessDAO;
 import de.metas.process.PInstanceId;
 import de.metas.process.ProcessExecutor;
@@ -46,6 +50,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.table.api.IADTableDAO;
+import org.compiere.SpringContextHolder;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -58,8 +63,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Step definitions for {@code ExternalSystem_ScriptedExportConversion_Status} assertions,
  * scripted-export /ok callback simulation, {@code M_InOut.EPCIS_ExportStatus} roll-up checks,
- * the {@code M_InOut_ReSend_ScriptedExportConversion} process invocation, and deactivating a
- * shipment's status row (the escape-hatch that releases a shipment blocked by an in-flight export).
+ * the {@code M_InOut_ReSend_ScriptedExportConversion} and "Change EPCIS Export Status" process
+ * invocations, and deactivating a shipment's status row (the escape-hatch that releases a shipment
+ * blocked by an in-flight export).
  *
  * <p>The status table holds one row per export ATTEMPT: each enqueue / re-send inserts a fresh
  * row (the per-attempt history), and the transitions of that attempt (Pending → Enqueued →
@@ -74,6 +80,8 @@ public class ExternalSystem_ScriptedExportConversion_Status_StepDef
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	private final IADProcessDAO adProcessDAO = Services.get(IADProcessDAO.class);
 	private final IADTableDAO tableDAO = Services.get(IADTableDAO.class);
+	private final IADPInstanceDAO pInstanceDAO = Services.get(IADPInstanceDAO.class);
+	private final EpcisExportStatusChangeService epcisExportStatusChangeService = SpringContextHolder.instance.getBean(EpcisExportStatusChangeService.class);
 
 	// ------------------------------------------------------------------
 	// Status-row assertion (polling)
@@ -94,6 +102,7 @@ public class ExternalSystem_ScriptedExportConversion_Status_StepDef
 	 *   <b>IsResend</b> — (optional) expected IsResend flag (Y/N)<br>
 	 *   <b>HttpResponseCode</b> — (optional) expected HTTP response code; blank cell = not asserted<br>
 	 *   <b>HasAD_Issue</b> — (optional) Y if AD_Issue_ID must be &gt; 0, N if it must be 0<br>
+	 *   <b>HasAD_PInstance</b> — (optional) Y if AD_PInstance_ID must be &gt; 0 (who/when audit stamp), N if it must be 0<br>
 	 * @cucumber.depends StepDefData: M_InOut_StepDefData, ExternalSystem_Config_ScriptedExportConversion_StepDefData
 	 * @cucumber.example <pre>
 	 * Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
@@ -131,7 +140,8 @@ public class ExternalSystem_ScriptedExportConversion_Status_StepDef
 					// blank cell for an optional column ⇒ that column is not asserted
 					row.getAsOptionalString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_IsResend).map(String::trim).filter(s -> !s.isEmpty()).orElse(null),
 					row.getAsOptionalString(I_ExternalSystem_ScriptedExportConversion_Status.COLUMNNAME_HttpResponseCode).map(String::trim).filter(s -> !s.isEmpty()).orElse(null),
-					row.getAsOptionalString("HasAD_Issue").map(String::trim).filter(s -> !s.isEmpty()).orElse(null)));
+					row.getAsOptionalString("HasAD_Issue").map(String::trim).filter(s -> !s.isEmpty()).orElse(null),
+					row.getAsOptionalString("HasAD_PInstance").map(String::trim).filter(s -> !s.isEmpty()).orElse(null)));
 		}
 
 		StepDefUtil.<Boolean>tryAndWaitForItem()
@@ -168,6 +178,10 @@ public class ExternalSystem_ScriptedExportConversion_Status_StepDef
 						{
 							return Optional.empty();
 						}
+						if (expected.hasPInstance != null && "Y".equals(expected.hasPInstance) != (statusRow.getAD_PInstance_ID() > 0))
+						{
+							return Optional.empty();
+						}
 					}
 					return Optional.of(Boolean.TRUE);
 				})
@@ -183,6 +197,7 @@ public class ExternalSystem_ScriptedExportConversion_Status_StepDef
 		private final String isResend;
 		private final String httpResponseCode;
 		private final String hasIssue;
+		private final String hasPInstance;
 
 		private ExpectedStatusRow(
 				final int inoutId,
@@ -190,7 +205,8 @@ public class ExternalSystem_ScriptedExportConversion_Status_StepDef
 				@NonNull final String exportStatus,
 				final String isResend,
 				final String httpResponseCode,
-				final String hasIssue)
+				final String hasIssue,
+				final String hasPInstance)
 		{
 			this.inoutId = inoutId;
 			this.cfgId = cfgId;
@@ -198,6 +214,7 @@ public class ExternalSystem_ScriptedExportConversion_Status_StepDef
 			this.isResend = isResend;
 			this.httpResponseCode = httpResponseCode;
 			this.hasIssue = hasIssue;
+			this.hasPInstance = hasPInstance;
 		}
 	}
 
@@ -333,6 +350,49 @@ public class ExternalSystem_ScriptedExportConversion_Status_StepDef
 				.buildAndPrepareExecution()
 				.executeSync();
 		executor.getResult().propagateErrorIfAny();
+	}
+
+	// ------------------------------------------------------------------
+	// Change-export-status process invocation
+	// ------------------------------------------------------------------
+
+	/**
+	 * Marks a shipment's EPCIS scripted-export status via the "Change EPCIS Export Status" shipment action —
+	 * writing a new, process-instance-stamped attempt row per EPCIS config (prior attempts kept as history).
+	 *
+	 * <p><b>Direct-service invocation (documented exemption).</b> In production this fires when an operator
+	 * runs the "Change EPCIS Export Status" process from the shipment action menu (the
+	 * {@code ChangeEpcisExportStatus_M_InOut_SingleView} AD_Process). That process class lives in
+	 * {@code de.metas.ui.web.base}, which this cucumber module does not (and should not) depend on.
+	 * The process is a thin parameter-reader that delegates to {@link EpcisExportStatusChangeService#changeStatus},
+	 * so invoking that service directly exercises the same transition + who/when-audit behaviour. A real
+	 * {@code AD_PInstance} for the actual process (resolved by its AD_Process Value) is created and passed,
+	 * so the audit stamp on the written row is faithful to production.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData
+	 * @cucumber.example <pre>
+	 * When Change EPCIS Export Status process is run for shipment io_050 with target status DontSend
+	 * </pre>
+	 */
+	@When("^Change EPCIS Export Status process is run for shipment (.*) with target status (.*)$")
+	public void runChangeEpcisExportStatusProcess(final String inoutIdentifierStr, final String targetStatusStr)
+	{
+		final org.compiere.model.I_M_InOut inout = inoutTable.get(StepDefDataIdentifier.ofString(inoutIdentifierStr));
+		assertThat(inout).isNotNull();
+
+		final ExternalSystemExportStatus targetStatus = ExternalSystemExportStatus.valueOf(targetStatusStr.trim());
+
+		final AdProcessId processId = adProcessDAO.retrieveProcessIdByValue("ChangeEpcisExportStatus_M_InOut_SingleView");
+		assertThat(processId).as("AD_Process not found for Value=ChangeEpcisExportStatus_M_InOut_SingleView").isNotNull();
+
+		final PInstanceId pInstanceId = PInstanceId.ofRepoId(
+				pInstanceDAO.createAD_PInstance(processId).getAD_PInstance_ID());
+
+		epcisExportStatusChangeService.changeStatus(
+				InOutId.ofRepoId(inout.getM_InOut_ID()),
+				targetStatus,
+				pInstanceId);
 	}
 
 	/**

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
@@ -291,6 +291,71 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
   @from:cucumber
   @allure.label.epic:E0292_EDI
   @allure.label.feature:F00353_EDI_DESADV_InOut_Link
+  @Id:S30088_060
+  Scenario: S30088_060 — Re-send picks up a shipment parked in Pending (a resting Pending IS resendable)
+    ## An operator resets a stuck in-flight EPCIS export to "Not yet sent" (Pending) via the Change EPCIS
+    ## Export Status action, then runs Re-send. An operator-parked Pending is not-in-flight (nothing is
+    ## being sent) and is stamped with the process instance, so Re-send picks it up as the first send —
+    ## not a double-send.
+
+    # EPCIS-classified config (its outbound-data process IS the EPCIS export) so the Change EPCIS Export
+    # Status action applies; no WhereClause → the export enqueues on any completion (reaches in-flight U).
+    And metasfresh contains ExternalSystem_Config with ScriptedExportConversion and StatusColumn:
+      | ExternalSystem_Config_ID | ExternalSystem_Config_ScriptedExportConversion_ID | AD_Process_OutboundData_ID.Value | TableName |
+      | esConfig_060             | scriptedCfg_060                                   | M_InOut_EPCIS_Export_JSON        | M_InOut   |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference          |
+      | o_060      | true    | bp_es         | 2026-06-09  | PO_S30088_060_@Date@ |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | ol_060     | o_060      | product_es   | 10         | pip_es                  |
+    When the order identified by o_060 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ss_060     | ol_060         | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_060                | D            | true                | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | ss_060                | io_060     |
+
+    # Drain async material/DESADV workpackages from shipment generation.
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # Completion enqueues the EPCIS export → in-flight (U)
+    Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus |
+      | io_060     | scriptedCfg_060                                   | U            |
+
+    # Operator resets it to "Not yet sent" (Pending) via the Change EPCIS Export Status action → a NEW
+    # process-instance-stamped attempt row; the prior in-flight (U) attempt is kept as history.
+    When Change EPCIS Export Status process is run for shipment io_060 with target status Pending
+    Then after not more than 10s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | HasAD_PInstance |
+      | io_060     | scriptedCfg_060                                   | P            | Y               |
+
+    # Re-send picks up the operator-parked Pending shipment → a NEW attempt row (IsResend=Y) reaching at
+    # least Enqueued.
+    When M_InOut_ReSend_ScriptedExportConversion process is run for shipment io_060
+    Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | IsResend |
+      | io_060     | scriptedCfg_060                                   | U            | Y        |
+
+    # Simulate /ok → the resend attempt reaches Sent.
+    When the scripted-export /ok callback is posted for shipment io_060 with HTTP code 200
+    Then after not more than 10s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | IsResend |
+      | io_060     | scriptedCfg_060                                   | S            | Y        |
+    And after not more than 10s, M_InOut EPCIS_ExportStatus is:
+      | M_InOut_ID | EPCIS_ExportStatus |
+      | io_060     | S                  |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00353_EDI_DESADV_InOut_Link
   @Id:S30279_040
   Scenario: S30279_040 — a WhereClause that depends on the committed-complete state still matches at trigger time
     ## Reproduces the complete-time eligibility timing bug fixed in this change.

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/epcisScriptedExportStatus.feature
@@ -227,6 +227,70 @@ Feature: EPCIS scripted-export status — success, error and re-send flows
   @from:cucumber
   @allure.label.epic:E0292_EDI
   @allure.label.feature:F00353_EDI_DESADV_InOut_Link
+  @Id:S30088_050
+  Scenario: S30088_050 — Change-EPCIS-Export-Status action writes a new audited DontSend attempt and releases the in-flight reverse block
+    ## An operator uses the shipment "Change EPCIS Export Status" action to mark a stuck in-flight export as
+    ## DontSend. This writes a NEW, process-instance-stamped attempt row (who/when audit; the prior in-flight
+    ## attempt is kept as history). Because the shipment's LATEST EPCIS status is then no longer in-flight, the
+    ## reverse/reactivate guard that was blocking the shipment (in-flight → SSCC may already be at the receiver)
+    ## is released and the shipment can be reversed.
+
+    # EPCIS-classified scripted-export config: its outbound-data process IS the EPCIS export
+    # (M_InOut_EPCIS_Export_JSON), so EpcisExportConfigMatcher classifies it as an EPCIS config — which
+    # both the reverse guard and the Change-EPCIS-Export-Status service require. No restrictive WhereClause
+    # → the export enqueues on any completion (reaches in-flight U). Overrides the Background's non-EPCIS
+    # scriptedCfg_es for M_InOut (table-scoped takeover).
+    And metasfresh contains ExternalSystem_Config with ScriptedExportConversion and StatusColumn:
+      | ExternalSystem_Config_ID | ExternalSystem_Config_ScriptedExportConversion_ID | AD_Process_OutboundData_ID.Value | TableName |
+      | esConfig_050             | scriptedCfg_050                                   | M_InOut_EPCIS_Export_JSON        | M_InOut   |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | POReference          |
+      | o_050      | true    | bp_es         | 2026-06-09  | PO_S30088_050_@Date@ |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | M_HU_PI_Item_Product_ID |
+      | ol_050     | o_050      | product_es   | 10         | pip_es                  |
+    When the order identified by o_050 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | ss_050     | ol_050         | N             |
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID | QuantityType | IsCompleteShipments | IsShipToday |
+      | ss_050                | D            | true                | false       |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID |
+      | ss_050                | io_050     |
+
+    # Drain async material/DESADV workpackages from shipment generation (avoid spilling into sibling executor tests).
+    And wait until de.metas.material rabbitMQ queue is empty or throw exception after 5 minutes
+
+    # Shipment completion enqueues the EPCIS export → the attempt row is Enqueued (U, in-flight)
+    Then after not more than 30s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus |
+      | io_050     | scriptedCfg_050                                   | U            |
+
+    # In-flight → reversing the shipment is blocked (re-completing could re-transmit an SSCC already at the receiver)
+    And the shipment identified by io_050 is reversed expecting error
+      | AD_Message_ID |
+      |               |
+
+    # Operator marks it DontSend via the shipment "Change EPCIS Export Status" action
+    When Change EPCIS Export Status process is run for shipment io_050 with target status DontSend
+
+    # A NEW attempt row (DontSend=N) is now the latest, stamped with the process AD_PInstance_ID (who/when audit);
+    # the prior in-flight (U) attempt is retained as history (per-attempt history, newest-first).
+    Then after not more than 10s, ExternalSystem_ScriptedExportConversion_Status is found:
+      | M_InOut_ID | ExternalSystem_Config_ScriptedExportConversion_ID | ExportStatus | HasAD_PInstance |
+      | io_050     | scriptedCfg_050                                   | N            | Y               |
+      | io_050     | scriptedCfg_050                                   | U            |                 |
+
+    # Latest EPCIS status is no longer in-flight → the reverse guard releases; the shipment can now be reversed.
+    And the shipment identified by io_050 is reversed
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00353_EDI_DESADV_InOut_Link
   @Id:S30279_040
   Scenario: S30279_040 — a WhereClause that depends on the committed-complete state still matches at trigger time
     ## Reproduces the complete-time eligibility timing bug fixed in this change.

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/EpcisExportStatusChangeService.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/EpcisExportStatusChangeService.java
@@ -1,0 +1,96 @@
+/*
+ * #%L
+ * de.metas.edi
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.edi.api.impl;
+
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.externalsystem.scriptedexportconversion.ExternalSystemExportStatusService;
+import de.metas.externalsystem.scriptedexportconversion.ExternalSystemScriptedExportConversionRepository;
+import de.metas.externalsystem.scriptedexportconversion.ScriptedExportConversionStatus;
+import de.metas.inout.InOutId;
+import de.metas.process.PInstanceId;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.util.lang.impl.TableRecordReference;
+import org.compiere.model.I_M_InOut;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Backs the "Change EPCIS Export Status" WebUI process. Resolves a shipment's EPCIS scripted-export
+ * config(s) and changes their export status by recording a new, process-instance-stamped attempt row
+ * (who/when audit) — mirroring the {@code ChangeEDI_ExportStatus_*} pattern, adapted to the
+ * per-attempt-row EPCIS status model. Sits next to {@link EpcisReverseGuardService} and reuses its exact
+ * EPCIS-config resolution (latest-status rows filtered by {@link EpcisExportConfigMatcher}).
+ */
+@Service
+@RequiredArgsConstructor
+public class EpcisExportStatusChangeService
+{
+	@NonNull private final ExternalSystemExportStatusService exportStatusService;
+	@NonNull private final ExternalSystemScriptedExportConversionRepository scriptedExportConversionRepository;
+	@NonNull private final EpcisExportConfigMatcher epcisExportConfigMatcher;
+
+	private static TableRecordReference toSourceRecord(@NonNull final InOutId inOutId)
+	{
+		return TableRecordReference.of(I_M_InOut.Table_Name, inOutId.getRepoId());
+	}
+
+	/** Latest EPCIS status rows (one per EPCIS config) for the shipment. Empty if the shipment has no EPCIS export. */
+	@NonNull
+	public List<ScriptedExportConversionStatus> getEpcisStatuses(@NonNull final InOutId inOutId)
+	{
+		return exportStatusService.getLatestStatusesBySourceRecord(toSourceRecord(inOutId)).stream()
+				.filter(st -> epcisExportConfigMatcher.isEpcisExportConfig(scriptedExportConversionRepository.getById(st.getConfigId())))
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * The shipment's single current EPCIS export status (for the transition matrix / parameter lookup), or
+	 * {@code null} if it has no EPCIS status row or its EPCIS configs are in mixed states.
+	 */
+	@Nullable
+	public ExternalSystemExportStatus getFromStatus(@NonNull final InOutId inOutId)
+	{
+		final List<ExternalSystemExportStatus> distinct = getEpcisStatuses(inOutId).stream()
+				.map(ScriptedExportConversionStatus::getStatus)
+				.distinct()
+				.collect(Collectors.toList());
+		return distinct.size() == 1 ? distinct.get(0) : null;
+	}
+
+	/** Records a manual status change (a new, process-instance-stamped attempt row) for every EPCIS config of the shipment. */
+	public void changeStatus(
+			@NonNull final InOutId inOutId,
+			@NonNull final ExternalSystemExportStatus targetStatus,
+			@NonNull final PInstanceId pInstanceId)
+	{
+		final TableRecordReference sourceRecord = toSourceRecord(inOutId);
+		for (final ScriptedExportConversionStatus st : getEpcisStatuses(inOutId))
+		{
+			exportStatusService.recordManualStatusChange(st.getConfigId(), sourceRecord, targetStatus, pInstanceId);
+		}
+	}
+}

--- a/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5817460_sys_EPCIS_StatusTab_IsActive_GridEditable_revert.sql
+++ b/backend/de.metas.edi/src/main/sql/postgresql/system/80-de.metas.edi/5817460_sys_EPCIS_StatusTab_IsActive_GridEditable_revert.sql
@@ -1,0 +1,16 @@
+-- Revert 5814640: unset ViewEditMode on the EPCIS-Exportstatus tab's IsActive AD_UI_Element (652656).
+--
+-- 5814640 set ViewEditMode='D' hoping to make the IsActive switch inline-editable in the GRID. That is
+-- INERT: WebUI enables inline grid editing only for the MAIN record view (mainTable=true, set only in
+-- DocumentList.js); an included/detail tab renders with mainTable falsy, so TableRow.js never makes a
+-- field inline-editable there regardless of the backend viewEditorRenderMode. Changing a shipment's
+-- EPCIS export status is instead done via the new "Change EPCIS Export Status" M_InOut process
+-- (AD_Process 585645/585646). Restore the element to its original no-ViewEditMode state so the tab does
+-- not carry misleading dead config; the single-row-form IsActive escape-hatch (5813870 + 5814320,
+-- IsAlwaysUpdateable='Y') is unaffected.
+UPDATE AD_UI_Element
+SET    ViewEditMode = NULL,
+       Updated = TO_TIMESTAMP('2026-07-21 09:01:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy = 100
+WHERE  AD_UI_Element_ID = 652656
+  AND  ViewEditMode = 'D'
+;

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemExportStatus.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/ExternalSystemExportStatus.java
@@ -88,11 +88,16 @@ public enum ExternalSystemExportStatus implements ReferenceListAwareEnum
 	public boolean isErrorOrInvalid() {return isError() || isInvalid();}
 
 	/**
-	 * Resendable states: the manual Re-send may re-trigger a config whose latest attempt is a terminal
-	 * failure ({@link #Error}/{@link #Invalid}) OR was suppressed as {@link #DontSend} ("shall not be
-	 * sent" — e.g. every SSCC already in the ledger). Re-sending a DontSend re-evaluates relevance, so a
-	 * record that later has something new to export can be sent. In-flight (Pending/Enqueued/
-	 * SendingStarted) and already-{@link #Sent} are NOT resendable.
+	 * Resendable states (status-only): the manual Re-send may re-trigger a config whose latest attempt is
+	 * a terminal failure ({@link #Error}/{@link #Invalid}) OR was suppressed as {@link #DontSend} ("shall
+	 * not be sent" — e.g. every SSCC already in the ledger). Re-sending a DontSend re-evaluates relevance,
+	 * so a record that later has something new to export can be sent. In-flight ({@link #Pending}/{@link
+	 * #Enqueued}/{@link #SendingStarted}) and already-{@link #Sent} are NOT resendable on status alone.
+	 *
+	 * <p>{@link #Pending} is resendable ONLY when it is an operator-parked attempt (carries an
+	 * {@code AD_PInstance_ID}), never a transient auto-flow Pending awaiting Enqueued. That distinction is
+	 * per-row (the PInstance), not per-status, so it cannot live in this stateless predicate — it is
+	 * applied by {@code ExternalSystemExportStatusService#getResendableConfigsBySourceRecord}.
 	 */
 	public boolean isResendable() {return isError() || isInvalid() || isDontSend();}
 

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusRepository.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusRepository.java
@@ -251,6 +251,26 @@ public class ExternalSystemExportStatusRepository
 	}
 
 	/**
+	 * Returns the LATEST attempt row PER config for the given source record (one row per config, all
+	 * states). {@link #getLatestBySourceRecord} returns ALL historical rows newest-first, so
+	 * {@code putIfAbsent} keeps the newest per config — the same latest-per-config reduction used by
+	 * {@link #getConfigsWithNonSentAttemptBySourceRecord} / {@link #getInflightConfigsBySourceRecord}.
+	 * Callers that want "the current status" MUST use this, not the raw {@link #getLatestBySourceRecord}
+	 * (which would surface stale earlier attempts once a config has &gt;=2 rows, e.g. after a re-send).
+	 */
+	@NonNull
+	public List<ScriptedExportConversionStatus> getLatestPerConfigBySourceRecord(@NonNull final TableRecordReference sourceRecord)
+	{
+		final LinkedHashMap<ExternalSystemScriptedExportConversionConfigId, ScriptedExportConversionStatus> latestPerConfig =
+				new LinkedHashMap<>();
+		for (final ScriptedExportConversionStatus entry : getLatestBySourceRecord(sourceRecord))
+		{
+			latestPerConfig.putIfAbsent(entry.getConfigId(), entry);
+		}
+		return ImmutableList.copyOf(latestPerConfig.values());
+	}
+
+	/**
 	 * Returns all status rows for the given source record, ordered newest-first.
 	 */
 	@NonNull

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
@@ -155,11 +155,15 @@ public class ExternalSystemExportStatusService
 	}
 
 	/**
-	 * Returns the config IDs whose latest status row for the given source record is re-sendable
-	 * ({@link ExternalSystemExportStatus#isResendable()} — {@link ExternalSystemExportStatus#Error},
-	 * {@link ExternalSystemExportStatus#Invalid} or {@link ExternalSystemExportStatus#DontSend}). A
-	 * DontSend row is included so a suppressed record can be re-evaluated on re-send. Sent and in-flight
-	 * rows (Pending, Enqueued, SendingStarted) are excluded to prevent double-sending.
+	 * Returns the config IDs whose latest status row for the given source record is re-sendable:
+	 * a terminal {@link ExternalSystemExportStatus#Error}/{@link ExternalSystemExportStatus#Invalid} or a
+	 * suppressed {@link ExternalSystemExportStatus#DontSend} (re-offered so a suppressed record can be
+	 * re-evaluated), OR an operator-parked {@link ExternalSystemExportStatus#Pending} — a Pending row that
+	 * carries an {@code AD_PInstance_ID}, i.e. was set deliberately via the "Change EPCIS Export Status"
+	 * action. {@link ExternalSystemExportStatus#Sent} and the actively-in-flight
+	 * {@link ExternalSystemExportStatus#Enqueued}/{@link ExternalSystemExportStatus#SendingStarted} rows —
+	 * and a transient auto-flow Pending (no PInstance, momentarily awaiting Enqueued) — are excluded to
+	 * prevent double-sending.
 	 */
 	@NonNull
 	public List<ExternalSystemScriptedExportConversionConfigId> getResendableConfigsBySourceRecord(
@@ -167,10 +171,9 @@ public class ExternalSystemExportStatusService
 	{
 		// Reduce the per-attempt history to the LATEST attempt per config (getLatestBySourceRecord
 		// returns ALL rows newest-first, so putIfAbsent keeps the newest), then offer only configs whose
-		// latest attempt is resendable — Error/Invalid OR DontSend (a suppressed attempt is re-offered so
-		// a re-send can re-evaluate relevance). Without the latest-per-config dedup a config whose latest
-		// attempt already SUCCEEDED would still be offered because an OLDER attempt errored — re-triggering
-		// an already-delivered export. Mirrors getConfigsWithNonSentAttemptBySourceRecord's dedup.
+		// latest attempt is resendable (see isResendableAttempt). Without the latest-per-config dedup a
+		// config whose latest attempt already SUCCEEDED would still be offered because an OLDER attempt
+		// errored — re-triggering an already-delivered export. Mirrors getConfigsWithNonSentAttemptBySourceRecord's dedup.
 		final LinkedHashMap<ExternalSystemScriptedExportConversionConfigId, ScriptedExportConversionStatus> latestPerConfig =
 				new LinkedHashMap<>();
 		for (final ScriptedExportConversionStatus entry : repo.getLatestBySourceRecord(sourceRecord))
@@ -179,9 +182,23 @@ public class ExternalSystemExportStatusService
 		}
 
 		return latestPerConfig.values().stream()
-				.filter(s -> s.getStatus().isResendable())
+				.filter(ExternalSystemExportStatusService::isResendableAttempt)
 				.map(ScriptedExportConversionStatus::getConfigId)
 				.collect(ImmutableList.toImmutableList());
+	}
+
+	/**
+	 * Whether a config's LATEST attempt row may be re-sent. Terminal Error/Invalid/DontSend qualify on
+	 * status alone ({@link ExternalSystemExportStatus#isResendable()}). A {@link ExternalSystemExportStatus#Pending}
+	 * row qualifies ONLY when it carries an {@code AD_PInstance_ID} — an operator-parked attempt set via
+	 * the "Change EPCIS Export Status" action. A Pending row WITHOUT a PInstance is a transient auto-flow
+	 * attempt momentarily awaiting the Pending→Enqueued transition; re-sending it would double-send, so it
+	 * is excluded.
+	 */
+	private static boolean isResendableAttempt(@NonNull final ScriptedExportConversionStatus latest)
+	{
+		return latest.getStatus().isResendable()
+				|| (latest.getStatus().isPending() && latest.getPInstanceId() != null);
 	}
 
 	/**

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusService.java
@@ -92,6 +92,37 @@ public class ExternalSystemExportStatusService
 	}
 
 	/**
+	 * Manually changes the export status of (config, sourceRecord) to {@code targetStatus} by recording a
+	 * NEW attempt row, stamped with the triggering process instance ({@code pInstanceId}) for a who/when
+	 * audit trail. Prior attempt rows are kept as history. Used by the "Change EPCIS Export Status" process.
+	 */
+	public void recordManualStatusChange(
+			@NonNull final ExternalSystemScriptedExportConversionConfigId configId,
+			@NonNull final TableRecordReference sourceRecord,
+			@NonNull final ExternalSystemExportStatus targetStatus,
+			@NonNull final PInstanceId pInstanceId)
+	{
+		repo.insertNewAttempt(ScriptedExportConversionStatusCreateRequest.builder()
+				.configId(configId)
+				.sourceRecord(sourceRecord)
+				.status(targetStatus)
+				.pInstanceId(pInstanceId)
+				.build());
+	}
+
+	/**
+	 * The current status per config for the given source record: the LATEST attempt row per config
+	 * (one row per config, all states). Deduped via {@link ExternalSystemExportStatusRepository#getLatestPerConfigBySourceRecord}
+	 * — NOT the raw per-attempt history, so a config that has been re-sent (>=2 rows) reports only its
+	 * newest attempt, never a stale earlier one.
+	 */
+	@NonNull
+	public List<ScriptedExportConversionStatus> getLatestStatusesBySourceRecord(@NonNull final TableRecordReference sourceRecord)
+	{
+		return repo.getLatestPerConfigBySourceRecord(sourceRecord);
+	}
+
+	/**
 	 * Records that the source record was included by the config WhereClause.
 	 * Status {@link ExternalSystemExportStatus#Pending}, no PInstance yet.
 	 */

--- a/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5817450_sys_M_InOut_ChangeEpcisExportStatus_process.sql
+++ b/backend/de.metas.externalsystem/src/main/sql/postgresql/system/80-de.metas.externalsystem/5817450_sys_M_InOut_ChangeEpcisExportStatus_process.sql
@@ -1,0 +1,103 @@
+/*
+ * #%L
+ * de.metas.externalsystem
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+-- "Change EPCIS Export Status" shipment-header process on M_InOut, mirroring the EDI
+-- ChangeEDI_ExportStatus_M_InOut_{Grid,Single}View pair. Lets an operator change a shipment's EPCIS
+-- scripted-export status (target: "Noch nicht gesendet" P / "Soll nicht gesendet werden" N) from any
+-- current state by writing a new, process-instance-stamped attempt row (who/when audit); setting P/N
+-- clears the effective in-flight status so the reverse/reactivate guard releases as a consequence.
+--   * GridView  (AD_Process 585645): multi-select shipments in the M_InOut view  -> WEBUI_ViewAction
+--   * SingleView(AD_Process 585646): single shipment document                    -> WEBUI_DocumentAction
+-- Target-status parameter uses the existing EPCIS ExportStatus ref-list (AD_Reference 542104) and the
+-- shared "ExportStatus" element (AD_Element 577791) -- no new list value, no new element.
+
+------------------------------------------------------------------------------------------------------
+-- 1) GridView process (multi-select, view action)
+------------------------------------------------------------------------------------------------------
+INSERT INTO AD_Process (AccessLevel,AD_Client_ID,AD_Org_ID,AD_Process_ID,AllowProcessReRun,Classname,CopyFromProcess,Created,CreatedBy,EntityType,IsActive,IsApplySecuritySettings,IsBetaFunctionality,IsDirectPrint,IsFormatExcelFile,IsLogWarning,IsNotifyUserAfterExecution,IsOneInstanceOnly,IsReport,IsTranslateExcelHeaders,IsUpdateExportDate,IsUseBPartnerLanguage,LockWaitTimeout,Name,PostgrestResponseFormat,RefreshAllAfterExecution,ShowHelp,SpreadsheetFormat,Type,Updated,UpdatedBy,Value)
+VALUES ('3',0,0,585645 /*From ID Server*/,'Y','de.metas.ui.web.externalsystem.ChangeEpcisExportStatus_M_InOut_GridView','N',TO_TIMESTAMP('2026-07-21 09:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.externalsystem','Y','N','N','N','Y','N','N','N','N','Y','N','Y',0,'EPCIS-Status ändern','json','N','N','xls','Java',TO_TIMESTAMP('2026-07-21 09:00:00','YYYY-MM-DD HH24:MI:SS'),100,'ChangeEpcisExportStatus_M_InOut_GridView')
+;
+
+INSERT INTO AD_Process_Trl (AD_Language,AD_Process_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Process t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_ID=585645
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_ID=t.AD_Process_ID)
+;
+
+UPDATE AD_Process_Trl SET Name='Change EPCIS Export Status', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-21 09:00:05','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Process_ID=585645 AND AD_Language='en_US'
+;
+UPDATE AD_Process_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-21 09:00:06','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Process_ID=585645 AND AD_Language IN ('de_DE','de_CH')
+;
+
+------------------------------------------------------------------------------------------------------
+-- 2) SingleView process (single shipment, document action)
+------------------------------------------------------------------------------------------------------
+INSERT INTO AD_Process (AccessLevel,AD_Client_ID,AD_Org_ID,AD_Process_ID,AllowProcessReRun,Classname,CopyFromProcess,Created,CreatedBy,EntityType,IsActive,IsApplySecuritySettings,IsBetaFunctionality,IsDirectPrint,IsFormatExcelFile,IsLogWarning,IsNotifyUserAfterExecution,IsOneInstanceOnly,IsReport,IsTranslateExcelHeaders,IsUpdateExportDate,IsUseBPartnerLanguage,LockWaitTimeout,Name,PostgrestResponseFormat,RefreshAllAfterExecution,ShowHelp,SpreadsheetFormat,Type,Updated,UpdatedBy,Value)
+VALUES ('3',0,0,585646 /*From ID Server*/,'Y','de.metas.ui.web.externalsystem.ChangeEpcisExportStatus_M_InOut_SingleView','N',TO_TIMESTAMP('2026-07-21 09:00:10','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.externalsystem','Y','N','N','N','Y','N','N','N','N','Y','N','Y',0,'EPCIS-Status ändern','json','N','N','xls','Java',TO_TIMESTAMP('2026-07-21 09:00:10','YYYY-MM-DD HH24:MI:SS'),100,'ChangeEpcisExportStatus_M_InOut_SingleView')
+;
+
+INSERT INTO AD_Process_Trl (AD_Language,AD_Process_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Process t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_ID=585646
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_ID=t.AD_Process_ID)
+;
+
+UPDATE AD_Process_Trl SET Name='Change EPCIS Export Status', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-21 09:00:15','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Process_ID=585646 AND AD_Language='en_US'
+;
+UPDATE AD_Process_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-07-21 09:00:16','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE AD_Process_ID=585646 AND AD_Language IN ('de_DE','de_CH')
+;
+
+------------------------------------------------------------------------------------------------------
+-- 3) Target-status parameter (List, EPCIS ExportStatus ref-list 542104) -- one per process
+--    ColumnName 'ExportStatus' matches the @Param parameterName; centrally maintained from element 577791.
+------------------------------------------------------------------------------------------------------
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,AD_Reference_Value_ID,ColumnName,Created,CreatedBy,EntityType,FieldLength,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,ShowInactiveValues,Updated,UpdatedBy)
+VALUES (0,577791,0,585645,543271 /*From ID Server*/,17,542104,'ExportStatus',TO_TIMESTAMP('2026-07-21 09:00:20','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.externalsystem',1,'Y','N','Y','N','Y','N','Export Status',10,'N',TO_TIMESTAMP('2026-07-21 09:00:20','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Process_Para t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_Para_ID=543271
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+INSERT INTO AD_Process_Para (AD_Client_ID,AD_Element_ID,AD_Org_ID,AD_Process_ID,AD_Process_Para_ID,AD_Reference_ID,AD_Reference_Value_ID,ColumnName,Created,CreatedBy,EntityType,FieldLength,IsActive,IsAutocomplete,IsCentrallyMaintained,IsEncrypted,IsMandatory,IsRange,Name,SeqNo,ShowInactiveValues,Updated,UpdatedBy)
+VALUES (0,577791,0,585646,543272 /*From ID Server*/,17,542104,'ExportStatus',TO_TIMESTAMP('2026-07-21 09:00:25','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.externalsystem',1,'Y','N','Y','N','Y','N','Export Status',10,'N',TO_TIMESTAMP('2026-07-21 09:00:25','YYYY-MM-DD HH24:MI:SS'),100)
+;
+INSERT INTO AD_Process_Para_Trl (AD_Language,AD_Process_Para_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Process_Para_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Process_Para t WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Process_Para_ID=543272
+AND NOT EXISTS (SELECT 1 FROM AD_Process_Para_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Process_Para_ID=t.AD_Process_Para_ID)
+;
+
+------------------------------------------------------------------------------------------------------
+-- 4) Attach the processes to the M_InOut (AD_Table 319) view/document actions
+------------------------------------------------------------------------------------------------------
+INSERT INTO AD_Table_Process (AD_Client_ID,AD_Org_ID,AD_Process_ID,AD_Table_ID,AD_Table_Process_ID,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy,WEBUI_DocumentAction,WEBUI_IncludedTabTopAction,WEBUI_ViewAction,WEBUI_ViewQuickAction,WEBUI_ViewQuickAction_Default)
+VALUES (0,0,585645,319,541657 /*From ID Server*/,TO_TIMESTAMP('2026-07-21 09:00:30','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.externalsystem','Y',TO_TIMESTAMP('2026-07-21 09:00:30','YYYY-MM-DD HH24:MI:SS'),100,'N','N','Y','N','N')
+;
+INSERT INTO AD_Table_Process (AD_Client_ID,AD_Org_ID,AD_Process_ID,AD_Table_ID,AD_Table_Process_ID,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy,WEBUI_DocumentAction,WEBUI_IncludedTabTopAction,WEBUI_ViewAction,WEBUI_ViewQuickAction,WEBUI_ViewQuickAction_Default)
+VALUES (0,0,585646,319,541658 /*From ID Server*/,TO_TIMESTAMP('2026-07-21 09:00:35','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.externalsystem','Y',TO_TIMESTAMP('2026-07-21 09:00:35','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','N','N','N')
+;

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemExportStatusTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/ExternalSystemExportStatusTest.java
@@ -219,6 +219,25 @@ class ExternalSystemExportStatusTest
 		assertThat(ExternalSystemExportStatus.DontSend.isInProgressOrSend()).isFalse();
 	}
 
+	/**
+	 * isResendable() is status-only: Error/Invalid/DontSend qualify. Pending is NOT resendable on status
+	 * alone — an operator-parked Pending becomes resendable only via the per-row PInstance gate in
+	 * ExternalSystemExportStatusService#getResendableConfigsBySourceRecord (see its test), never here.
+	 * The in-flight Enqueued/SendingStarted and already-Sent are never resendable.
+	 */
+	@Test
+	void testIsResendable()
+	{
+		assertThat(ExternalSystemExportStatus.Error.isResendable()).isTrue();
+		assertThat(ExternalSystemExportStatus.Invalid.isResendable()).isTrue();
+		assertThat(ExternalSystemExportStatus.DontSend.isResendable()).isTrue();
+
+		assertThat(ExternalSystemExportStatus.Pending.isResendable()).isFalse();
+		assertThat(ExternalSystemExportStatus.Enqueued.isResendable()).isFalse();
+		assertThat(ExternalSystemExportStatus.SendingStarted.isResendable()).isFalse();
+		assertThat(ExternalSystemExportStatus.Sent.isResendable()).isFalse();
+	}
+
 	/** AD_Reference_ID binding is 542104 */
 	@Test
 	void testAdReferenceId()

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
@@ -301,25 +301,43 @@ public class ExternalSystemExportStatusServiceTest
 	}
 
 	// -----------------------------------------------------------------------
-	// getResendableConfigsBySourceRecord — Error/Invalid/DontSend (isResendable) filter
+	// getResendableConfigsBySourceRecord — Error/Invalid/DontSend, plus an operator-parked
+	// (PInstance-stamped) Pending; a transient auto-flow Pending is excluded
 	// -----------------------------------------------------------------------
 
 	/**
-	 * A config with an in-flight (Pending) status must NOT be returned by the re-send
-	 * selection, to prevent double-sending a record that is already queued.
+	 * A config whose latest attempt is an OPERATOR-PARKED Pending — one carrying an AD_PInstance, set via
+	 * the "Change EPCIS Export Status" action — MUST be returned by the re-send selection: nothing is in
+	 * flight, so a re-send is the first send. An operator parks a stuck shipment in Pending and must then
+	 * be able to Re-send it.
 	 */
 	@Test
-	void getResendableConfigs_excludes_pendingConfig()
+	void getResendableConfigs_includes_manuallyParkedPendingConfig()
 	{
 		final TableRecordReference ref = newInOutRef();
 		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
 
-		service.recordPending(configId, ref); // stays Pending
+		// operator parks it in Pending via the Change action -> stamped with the process PInstance
+		service.recordManualStatusChange(configId, ref, ExternalSystemExportStatus.Pending, PInstanceId.ofRepoId(1201));
 
-		final List<ExternalSystemScriptedExportConversionConfigId> result =
-				service.getResendableConfigsBySourceRecord(ref);
+		assertThat(service.getResendableConfigsBySourceRecord(ref)).containsExactly(configId);
+	}
 
-		assertThat(result).isEmpty();
+	/**
+	 * A config whose latest attempt is a TRANSIENT auto-flow Pending — no AD_PInstance, the momentary
+	 * state the normal export flow writes just before flipping to Enqueued — must NOT be returned: it is
+	 * already on its way to being sent, so offering it for re-send would double-send. Only an
+	 * operator-parked Pending (with a PInstance) is resendable.
+	 */
+	@Test
+	void getResendableConfigs_excludes_transientPendingConfig()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+
+		service.recordPending(configId, ref); // auto-flow Pending, no PInstance
+
+		assertThat(service.getResendableConfigsBySourceRecord(ref)).isEmpty();
 	}
 
 	/**

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/ExternalSystemExportStatusServiceTest.java
@@ -401,6 +401,92 @@ public class ExternalSystemExportStatusServiceTest
 		assertThat(result).containsExactly(configId);
 	}
 
+	// -----------------------------------------------------------------------
+	// recordManualStatusChange — writes a NEW, PInstance-stamped attempt row; prior rows are history
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A manual status change (the "Change EPCIS Export Status" process) must append a NEW attempt row
+	 * stamped with the process PInstance (who/when audit) and leave the prior attempt untouched.
+	 */
+	@Test
+	void recordManualStatusChange_appendsNewStampedRow_priorAttemptUntouched()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+		final PInstanceId sendP = PInstanceId.ofRepoId(1301);
+		final PInstanceId manualP = PInstanceId.ofRepoId(1302);
+
+		// a prior, successfully-sent attempt ...
+		service.recordPending(configId, ref);
+		service.markEnqueued(configId, ref, sendP);
+		service.markSent(sendP, HttpStatus.OK);
+
+		// ... then an operator sets it to DontSend via the process
+		service.recordManualStatusChange(configId, ref, ExternalSystemExportStatus.DontSend, manualP);
+
+		final List<ScriptedExportConversionStatus> rows = repo.getByConfigId(configId);
+		assertThat(rows).hasSize(2); // prior Sent + the new DontSend — nothing overwritten
+
+		final ScriptedExportConversionStatus latest = repo.getLatestByConfigAndRecord(configId, ref).get();
+		assertThat(latest.getStatus()).isEqualTo(ExternalSystemExportStatus.DontSend);
+		assertThat(latest.getPInstanceId()).isEqualTo(manualP);
+	}
+
+	// -----------------------------------------------------------------------
+	// getLatestStatusesBySourceRecord — MUST dedupe to the latest attempt PER config
+	// -----------------------------------------------------------------------
+
+	/**
+	 * REGRESSION: getLatestStatusesBySourceRecord must return exactly ONE row per config — the newest
+	 * attempt — not the whole per-attempt history. A config that errored and was then re-sent
+	 * successfully (>=2 rows) must report only its latest (Sent); returning both rows made the WebUI
+	 * "from status" ambiguous (2 distinct statuses -> null) and disabled the change process.
+	 */
+	@Test
+	void getLatestStatusesBySourceRecord_dedupesToLatestAttemptPerConfig()
+	{
+		final TableRecordReference ref = newInOutRef();
+		final ExternalSystemScriptedExportConversionConfigId configId = newConfigId();
+
+		// older attempt errored ...
+		repo.insertNewAttempt(ScriptedExportConversionStatusCreateRequest.builder()
+				.configId(configId).sourceRecord(ref).status(ExternalSystemExportStatus.Error).build());
+		// ... latest attempt (a successful re-send) is Sent
+		repo.insertNewAttempt(ScriptedExportConversionStatusCreateRequest.builder()
+				.configId(configId).sourceRecord(ref).status(ExternalSystemExportStatus.Sent).build());
+
+		final List<ScriptedExportConversionStatus> latest = service.getLatestStatusesBySourceRecord(ref);
+		assertThat(latest).hasSize(1);
+		assertThat(latest.get(0).getStatus()).isEqualTo(ExternalSystemExportStatus.Sent);
+	}
+
+	/**
+	 * With several configs each carrying multiple attempts, getLatestStatusesBySourceRecord returns one
+	 * row per config, each being that config's newest attempt.
+	 */
+	@Test
+	void getLatestStatusesBySourceRecord_onePerConfig_acrossConfigs()
+	{
+		final TableRecordReference ref = newInOutRef();
+
+		// config A: errored then re-sent Sent
+		final ExternalSystemScriptedExportConversionConfigId idA = newConfigId();
+		repo.insertNewAttempt(ScriptedExportConversionStatusCreateRequest.builder()
+				.configId(idA).sourceRecord(ref).status(ExternalSystemExportStatus.Error).build());
+		repo.insertNewAttempt(ScriptedExportConversionStatusCreateRequest.builder()
+				.configId(idA).sourceRecord(ref).status(ExternalSystemExportStatus.Sent).build());
+
+		// config B: single Pending attempt
+		final ExternalSystemScriptedExportConversionConfigId idB = newConfigId();
+		service.recordPending(idB, ref);
+
+		final List<ScriptedExportConversionStatus> latest = service.getLatestStatusesBySourceRecord(ref);
+		assertThat(latest).hasSize(2);
+		assertThat(latest).extracting(ScriptedExportConversionStatus::getStatus)
+				.containsExactlyInAnyOrder(ExternalSystemExportStatus.Sent, ExternalSystemExportStatus.Pending);
+	}
+
 	private int getM_InOutTableId()
 	{
 		return Services.get(IADTableDAO.class).retrieveTableId(I_M_InOut.Table_Name);

--- a/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionTest.java
+++ b/backend/de.metas.externalsystem/src/test/java/de/metas/externalsystem/scriptedexportconversion/M_InOut_ReSend_ScriptedExportConversionTest.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>
  * Covers:
  * <ul>
- *   <li>repo.getConfigsWithNonSentAttemptBySourceRecord: returns distinct config(s) with a non-sent attempt (status not Sent/DontSend); the Error/Invalid/DontSend (isResendable) selection for re-send is covered at the service layer in ExternalSystemExportStatusServiceTest</li>
+ *   <li>repo.getConfigsWithNonSentAttemptBySourceRecord: returns distinct config(s) with a non-sent attempt (status not Sent/DontSend); the re-send selection (Error/Invalid/DontSend, plus an operator-parked PInstance-stamped Pending) is covered at the service layer in ExternalSystemExportStatusServiceTest</li>
  *   <li>recordPendingAsResend: appends a NEW Pending+IsResend=Y attempt row, keeping the prior attempt (per-attempt history)</li>
  *   <li>multi-config: both configs returned when both have Error or Invalid status</li>
  *   <li>sent-only: config not returned when latest attempt is Sent</li>

--- a/backend/de.metas.payment.sepa/base/src/main/sql/postgresql/system/70-de.metas.payment.sepa/5817950_sys_SEPA_IsGroupTransactions_param_description.sql
+++ b/backend/de.metas.payment.sepa/base/src/main/sql/postgresql/system/70-de.metas.payment.sepa/5817950_sys_SEPA_IsGroupTransactions_param_description.sql
@@ -1,0 +1,26 @@
+-- Update the description of the SEPA Export process parameter "IsGroupTransactions"
+-- (AD_Process_Para 543086, process C_PaySelection_SEPA_XmlExport) to state that QR-IBAN
+-- (QRR) payments are NOT aggregated even when grouping is on ("bei nicht QR-Überweisungen"),
+-- and to correct the spelling "SEPA-Gutschiftung" -> "SEPA-Gutschrift".
+-- This parameter has no AD_Element_ID, so its description lives directly on
+-- AD_Process_Para / AD_Process_Para_Trl (direct update is correct here).
+
+UPDATE AD_Process_Para
+SET Description = 'Ermöglicht die Gruppierung mehrerer Rechnungen pro Lieferant zu einer einzigen aggregierten SEPA-Gutschrift. Wenn aktiviert (Standard: Ja), erstellt der SEPA-Export bei nicht QR-Überweisungen eine Transaktion pro Partner statt pro Rechnung, wodurch Bankgebühren und Unübersichtlichkeit in Kontoauszügen reduziert werden. Die interne Nachverfolgbarkeit bleibt in metasfresh vollständig erhalten, ergänzt durch einen detaillierten Excel-Prüfbericht mit rechnungsgenauen Aufschlüsselungen pro Zahlung.',
+    Updated = TO_TIMESTAMP('2026-08-07 10:00:00','YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Process_Para_ID = 543086;
+
+UPDATE AD_Process_Para_Trl
+SET Description = 'Ermöglicht die Gruppierung mehrerer Rechnungen pro Lieferant zu einer einzigen aggregierten SEPA-Gutschrift. Wenn aktiviert (Standard: Ja), erstellt der SEPA-Export bei nicht QR-Überweisungen eine Transaktion pro Partner statt pro Rechnung, wodurch Bankgebühren und Unübersichtlichkeit in Kontoauszügen reduziert werden. Die interne Nachverfolgbarkeit bleibt in metasfresh vollständig erhalten, ergänzt durch einen detaillierten Excel-Prüfbericht mit rechnungsgenauen Aufschlüsselungen pro Zahlung.',
+    Updated = TO_TIMESTAMP('2026-08-07 10:00:01','YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Process_Para_ID = 543086
+  AND AD_Language IN ('de_DE','de_CH');
+
+UPDATE AD_Process_Para_Trl
+SET Description = 'Enables grouping of multiple invoices per vendor into a single aggregated SEPA credit transfer. When checked (default: Yes), the SEPA export creates one transaction per partner instead of one per invoice for non-QR credit transfers, reducing bank fees and statement clutter. Internal traceability remains fully preserved in metasfresh, with a detailed Excel audit report providing invoice-level breakdowns per payment.',
+    Updated = TO_TIMESTAMP('2026-08-07 10:00:02','YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Process_Para_ID = 543086
+  AND AD_Language = 'en_US';

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/externalsystem/ChangeEpcisExportStatusHelper.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/externalsystem/ChangeEpcisExportStatusHelper.java
@@ -1,0 +1,97 @@
+/*
+ * #%L
+ * de.metas.ui.web.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ui.web.externalsystem;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.ad_reference.ADReferenceService;
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.process.IProcessDefaultParametersProvider;
+import de.metas.ui.web.window.datatypes.LookupValue;
+import de.metas.ui.web.window.datatypes.LookupValuesList;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * Shared logic for the "Change EPCIS Export Status" WebUI process (SingleView + GridView).
+ * Mirrors {@code de.metas.ui.web.edi_desadv.ChangeEDI_ExportStatusHelper}, but for the EPCIS
+ * scripted-export status ref-list.
+ */
+@UtilityClass
+public class ChangeEpcisExportStatusHelper
+{
+	@NonNull private final ADReferenceService adReferenceService = ADReferenceService.get();
+
+	private final int AD_Reference_ID = ExternalSystemExportStatus.AD_Reference_ID;
+
+	/**
+	 * Allowed manual target statuses per current status:
+	 * <ul>
+	 *   <li>{@code Pending} ↔ {@code DontSend}</li>
+	 *   <li>{@code Error} / {@code Sent} / {@code Invalid} → both</li>
+	 *   <li>in-flight ({@code Enqueued} / {@code SendingStarted}) → both</li>
+	 * </ul>
+	 */
+	public List<ExternalSystemExportStatus> getAvailableTargetExportStatuses(@Nullable final ExternalSystemExportStatus fromStatus)
+	{
+		if (fromStatus == null)
+		{
+			return ImmutableList.of();
+		}
+		switch (fromStatus)
+		{
+			case Pending:
+				return ImmutableList.of(ExternalSystemExportStatus.DontSend);
+			case DontSend:
+				return ImmutableList.of(ExternalSystemExportStatus.Pending);
+			case Error:
+			case Sent:
+			case Invalid:
+			case Enqueued:
+			case SendingStarted:
+				return ImmutableList.of(ExternalSystemExportStatus.Pending, ExternalSystemExportStatus.DontSend);
+			default:
+				return ImmutableList.of();
+		}
+	}
+
+	public LookupValuesList computeTargetExportStatusLookupValues(@Nullable final ExternalSystemExportStatus fromStatus)
+	{
+		return getAvailableTargetExportStatuses(fromStatus).stream()
+				.map(s -> LookupValue.StringLookupValue.of(s.getCode(), adReferenceService.retrieveListNameTranslatableString(AD_Reference_ID, s.getCode())))
+				.collect(LookupValuesList.collect());
+	}
+
+	public Object computeParameterDefaultValue(@Nullable final ExternalSystemExportStatus fromStatus)
+	{
+		final List<ExternalSystemExportStatus> availableTargetStatuses = getAvailableTargetExportStatuses(fromStatus);
+		if (!availableTargetStatuses.isEmpty())
+		{
+			final String code = availableTargetStatuses.get(0).getCode();
+			return LookupValue.StringLookupValue.of(code, adReferenceService.retrieveListNameTranslatableString(AD_Reference_ID, code));
+		}
+		return IProcessDefaultParametersProvider.DEFAULT_VALUE_NOTAVAILABLE;
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/externalsystem/ChangeEpcisExportStatus_M_InOut_GridView.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/externalsystem/ChangeEpcisExportStatus_M_InOut_GridView.java
@@ -1,0 +1,123 @@
+/*
+ * #%L
+ * de.metas.ui.web.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ui.web.externalsystem;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.edi.api.impl.EpcisExportStatusChangeService;
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.inout.IInOutDAO;
+import de.metas.inout.InOutId;
+import de.metas.process.IProcessDefaultParameter;
+import de.metas.process.IProcessDefaultParametersProvider;
+import de.metas.process.IProcessPrecondition;
+import de.metas.process.Param;
+import de.metas.process.ProcessPreconditionsResolution;
+import de.metas.ui.web.process.adprocess.ViewBasedProcessTemplate;
+import de.metas.ui.web.window.datatypes.DocumentIdsSelection;
+import de.metas.util.Services;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_M_InOut;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * WebUI process to change the EPCIS scripted-export status of multiple shipments (M_InOut grid view).
+ * Mirrors {@code ChangeEDI_ExportStatus_M_InOut_GridView}. All selected shipments must share the same
+ * current EPCIS status so the offered transitions are consistent.
+ */
+public class ChangeEpcisExportStatus_M_InOut_GridView
+		extends ViewBasedProcessTemplate
+		implements IProcessPrecondition, IProcessDefaultParametersProvider
+{
+	private final IInOutDAO inOutDAO = Services.get(IInOutDAO.class);
+	private final EpcisExportStatusChangeService changeService = SpringContextHolder.instance.getBean(EpcisExportStatusChangeService.class);
+
+	protected static final String PARAM_TargetExportStatus = "ExportStatus";
+	@Param(parameterName = PARAM_TargetExportStatus, mandatory = true)
+	private String p_TargetExportStatus;
+
+	@Override
+	public ProcessPreconditionsResolution checkPreconditionsApplicable()
+	{
+		final ImmutableSet<InOutId> inOutIds = getSelectedInOutIds();
+		if (inOutIds.isEmpty())
+		{
+			return ProcessPreconditionsResolution.rejectBecauseNoSelection();
+		}
+
+		// getFromStatus issues one status query per selected shipment. Acceptable for a view action
+		// (operators multi-select a handful of shipments); if bulk multi-selects appear, add a batched
+		// getLatestStatusesBySourceRecords accessor. getFromStatus already dedups to the latest attempt
+		// per config, so there is no per-attempt-row query here.
+		final Set<ExternalSystemExportStatus> statuses = inOutDAO.getByIds(inOutIds, I_M_InOut.class).stream()
+				.filter(I_M_InOut::isSOTrx)
+				.map(inOut -> changeService.getFromStatus(InOutId.ofRepoId(inOut.getM_InOut_ID())))
+				.collect(Collectors.toSet());
+
+		if (statuses.isEmpty())
+		{
+			return ProcessPreconditionsResolution.rejectWithInternalReason("No Shipments");
+		}
+		if (statuses.size() > 1)
+		{
+			return ProcessPreconditionsResolution.rejectWithInternalReason("All selected shipments must have the same EPCIS export status");
+		}
+
+		final ExternalSystemExportStatus fromStatus = statuses.iterator().next();
+		if (ChangeEpcisExportStatusHelper.getAvailableTargetExportStatuses(fromStatus).isEmpty())
+		{
+			return ProcessPreconditionsResolution.rejectWithInternalReason("Cannot change EPCIS export status from the current one: " + fromStatus);
+		}
+
+		return ProcessPreconditionsResolution.accept();
+	}
+
+	@Override
+	protected String doIt() throws Exception
+	{
+		final ExternalSystemExportStatus targetStatus = ExternalSystemExportStatus.ofCode(p_TargetExportStatus);
+		final ImmutableSet<InOutId> selectedIds = getSelectedInOutIds();
+		if (selectedIds.isEmpty())
+		{
+			return MSG_OK;
+		}
+		selectedIds.forEach(inOutId -> changeService.changeStatus(inOutId, targetStatus, getPinstanceId()));
+		return MSG_OK;
+	}
+
+	@Override
+	@Nullable
+	public Object getParameterDefaultValue(final IProcessDefaultParameter parameter)
+	{
+		return ChangeEpcisExportStatusHelper.computeParameterDefaultValue(
+				changeService.getFromStatus(getSelectedInOutIds().iterator().next()));
+	}
+
+	private ImmutableSet<InOutId> getSelectedInOutIds()
+	{
+		final DocumentIdsSelection selectedRowIds = getSelectedRowIds();
+		return selectedRowIds.toIds(InOutId::ofRepoId);
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/externalsystem/ChangeEpcisExportStatus_M_InOut_SingleView.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/externalsystem/ChangeEpcisExportStatus_M_InOut_SingleView.java
@@ -1,0 +1,112 @@
+/*
+ * #%L
+ * de.metas.ui.web.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ui.web.externalsystem;
+
+import de.metas.edi.api.impl.EpcisExportStatusChangeService;
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import de.metas.inout.IInOutDAO;
+import de.metas.inout.InOutId;
+import de.metas.process.IProcessDefaultParameter;
+import de.metas.process.IProcessDefaultParametersProvider;
+import de.metas.process.IProcessPrecondition;
+import de.metas.process.IProcessPreconditionsContext;
+import de.metas.process.JavaProcess;
+import de.metas.process.Param;
+import de.metas.process.ProcessPreconditionsResolution;
+import de.metas.ui.web.process.descriptor.ProcessParamLookupValuesProvider;
+import de.metas.ui.web.window.datatypes.LookupValuesList;
+import de.metas.ui.web.window.descriptor.DocumentLayoutElementFieldDescriptor.LookupSource;
+import de.metas.ui.web.window.model.lookup.LookupDataSourceContext;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.compiere.SpringContextHolder;
+import org.compiere.model.I_M_InOut;
+
+import javax.annotation.Nullable;
+
+/**
+ * WebUI process to change the EPCIS scripted-export status of a single shipment (M_InOut). Mirrors
+ * {@code ChangeEDI_ExportStatus_M_InOut_SingleView}. Writes a new, process-instance-stamped status
+ * attempt row per EPCIS config of the shipment (who/when audit).
+ */
+public class ChangeEpcisExportStatus_M_InOut_SingleView
+		extends JavaProcess
+		implements IProcessPrecondition, IProcessDefaultParametersProvider
+{
+	private final IInOutDAO inOutDAO = Services.get(IInOutDAO.class);
+	private final EpcisExportStatusChangeService changeService = SpringContextHolder.instance.getBean(EpcisExportStatusChangeService.class);
+
+	protected static final String PARAM_TargetExportStatus = "ExportStatus";
+	@Param(parameterName = PARAM_TargetExportStatus, mandatory = true)
+	private String p_TargetExportStatus;
+
+	@Override
+	public ProcessPreconditionsResolution checkPreconditionsApplicable(final @NonNull IProcessPreconditionsContext context)
+	{
+		if (context.isNoSelection())
+		{
+			return ProcessPreconditionsResolution.rejectBecauseNoSelection();
+		}
+		if (!context.isSingleSelection())
+		{
+			return ProcessPreconditionsResolution.rejectBecauseNotSingleSelection();
+		}
+
+		final I_M_InOut inOut = inOutDAO.getById(InOutId.ofRepoId(context.getSingleSelectedRecordId()), I_M_InOut.class);
+		if (!inOut.isSOTrx())
+		{
+			return ProcessPreconditionsResolution.rejectWithInternalReason("No Shipment");
+		}
+
+		final ExternalSystemExportStatus fromStatus = changeService.getFromStatus(InOutId.ofRepoId(inOut.getM_InOut_ID()));
+		if (ChangeEpcisExportStatusHelper.getAvailableTargetExportStatuses(fromStatus).isEmpty())
+		{
+			return ProcessPreconditionsResolution.rejectWithInternalReason("Cannot change EPCIS export status from the current one: " + fromStatus);
+		}
+
+		return ProcessPreconditionsResolution.accept();
+	}
+
+	@ProcessParamLookupValuesProvider(parameterName = PARAM_TargetExportStatus, numericKey = false, lookupSource = LookupSource.list)
+	private LookupValuesList getTargetExportStatusLookupValues(final LookupDataSourceContext context)
+	{
+		return ChangeEpcisExportStatusHelper.computeTargetExportStatusLookupValues(changeService.getFromStatus(InOutId.ofRepoId(getRecord_ID())));
+	}
+
+	@Override
+	@Nullable
+	public Object getParameterDefaultValue(final IProcessDefaultParameter parameter)
+	{
+		return ChangeEpcisExportStatusHelper.computeParameterDefaultValue(changeService.getFromStatus(InOutId.ofRepoId(getRecord_ID())));
+	}
+
+	@Override
+	protected String doIt() throws Exception
+	{
+		changeService.changeStatus(
+				InOutId.ofRepoId(getRecord_ID()),
+				ExternalSystemExportStatus.ofCode(p_TargetExportStatus),
+				getPinstanceId());
+		return MSG_OK;
+	}
+}

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/externalsystem/ChangeEpcisExportStatusHelperTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/externalsystem/ChangeEpcisExportStatusHelperTest.java
@@ -1,0 +1,124 @@
+/*
+ * #%L
+ * de.metas.ui.web.base
+ * %%
+ * Copyright (C) 2025 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ui.web.externalsystem;
+
+import de.metas.ad_reference.ADReferenceService;
+import de.metas.externalsystem.ExternalSystemExportStatus;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.SpringContextHolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static de.metas.externalsystem.ExternalSystemExportStatus.DontSend;
+import static de.metas.externalsystem.ExternalSystemExportStatus.Enqueued;
+import static de.metas.externalsystem.ExternalSystemExportStatus.Error;
+import static de.metas.externalsystem.ExternalSystemExportStatus.Invalid;
+import static de.metas.externalsystem.ExternalSystemExportStatus.Pending;
+import static de.metas.externalsystem.ExternalSystemExportStatus.SendingStarted;
+import static de.metas.externalsystem.ExternalSystemExportStatus.Sent;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChangeEpcisExportStatusHelperTest
+{
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+		// the helper resolves AD_Reference_ID via ADReferenceService at class-init; a mocked one is enough
+		// for the pure transition-matrix assertions here (they never hit the lookup-value methods).
+		SpringContextHolder.registerJUnitBean(ADReferenceService.newMocked());
+	}
+
+	// Transition matrix (see ChangeEpcisExportStatusHelper javadoc):
+	//   Pending  -> DontSend            (suppress a not-yet-sent record)
+	//   DontSend -> Pending             (un-suppress -> re-queue)
+	//   Error / Sent / Invalid / Enqueued / SendingStarted -> both (Pending, DontSend)
+
+	@Test
+	void pending_offersOnly_dontSend()
+	{
+		assertThat(ChangeEpcisExportStatusHelper.getAvailableTargetExportStatuses(Pending))
+				.containsExactly(DontSend);
+	}
+
+	@Test
+	void dontSend_offersOnly_pending()
+	{
+		assertThat(ChangeEpcisExportStatusHelper.getAvailableTargetExportStatuses(DontSend))
+				.containsExactly(Pending);
+	}
+
+	@Test
+	void error_offersBoth()
+	{
+		assertThat(ChangeEpcisExportStatusHelper.getAvailableTargetExportStatuses(Error))
+				.containsExactly(Pending, DontSend);
+	}
+
+	@Test
+	void sent_offersBoth()
+	{
+		assertThat(ChangeEpcisExportStatusHelper.getAvailableTargetExportStatuses(Sent))
+				.containsExactly(Pending, DontSend);
+	}
+
+	@Test
+	void invalid_offersBoth()
+	{
+		assertThat(ChangeEpcisExportStatusHelper.getAvailableTargetExportStatuses(Invalid))
+				.containsExactly(Pending, DontSend);
+	}
+
+	@Test
+	void inflight_enqueued_offersBoth()
+	{
+		assertThat(ChangeEpcisExportStatusHelper.getAvailableTargetExportStatuses(Enqueued))
+				.containsExactly(Pending, DontSend);
+	}
+
+	@Test
+	void inflight_sendingStarted_offersBoth()
+	{
+		assertThat(ChangeEpcisExportStatusHelper.getAvailableTargetExportStatuses(SendingStarted))
+				.containsExactly(Pending, DontSend);
+	}
+
+	@Test
+	void nullFrom_offersNothing()
+	{
+		assertThat(ChangeEpcisExportStatusHelper.getAvailableTargetExportStatuses(null))
+				.isEmpty();
+	}
+
+	// A target status is never a no-op self-transition: the "from" value must not appear in its own targets.
+	@Test
+	void noTargetIsASelfTransition()
+	{
+		for (final ExternalSystemExportStatus from : ExternalSystemExportStatus.values())
+		{
+			assertThat(ChangeEpcisExportStatusHelper.getAvailableTargetExportStatuses(from))
+					.as("targets for %s must not contain %s itself", from, from)
+					.doesNotContain(from);
+		}
+	}
+}


### PR DESCRIPTION
Forward merge-through propagating soft_panda_release into new_dawn_uat (3-hop propagation, hop 2 of 2).

Carries the merged EPCIS "Re-send picks up an operator-parked Pending" fix (https://github.com/metasfresh/metasfresh/pull/25488, via https://github.com/metasfresh/metasfresh/pull/25497) up to the mainline.

- Merge-commit only (never squash — preserves branch parentage).
- One conflict resolved (union) in `ExternalSystemExportStatusService.java`: keep new_dawn_uat's `getMatchingConfigIdsBySourceRecord` (its extra re-trigger selection) AND land soft_panda's `getResendableConfigsBySourceRecord` + `isResendableAttempt` (the operator-parked-Pending resend gate). Both selection methods coexist; the ReSend process chooses between them. Verified: merged module compiles clean locally.
- Gate is green CI (merge-through PRs get no diff review).
