### PR TITLE
Sales Order Packing Instruction — require a product price for the auto-defaulted packing instruction

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductBL.java
@@ -39,6 +39,7 @@ import de.metas.util.ISingletonService;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
+import org.adempiere.service.ClientId;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_Product;
@@ -50,6 +51,22 @@ import java.util.List;
 
 public interface IHUPIItemProductBL extends ISingletonService
 {
+	/**
+	 * Legacy key. The setting predates this accessor and is still named after the WebUI quick-input helper
+	 * that first read it; it is now read from here too, because the same rule applies to the order line
+	 * interceptor. The string must NOT change — {@code AD_SysConfig} rows on live instances key on it
+	 * verbatim.
+	 */
+	String SYSCONFIG_EnforcePrecisePricePerHUItemProduct =
+			"de.metas.ui.web.quickinput.field.PackingItemProductFieldHelper.EnforcePrecisePricePerHUItemProduct";
+
+	/**
+	 * @return {@code true} if a packing instruction may only be auto-defaulted onto a document line when a
+	 *         product price of the relevant price list version references it. Defaults to {@code false}
+	 *         when the setting is absent.
+	 */
+	boolean isEnforcePrecisePricePerHUItemProduct(@NonNull ClientId clientId);
+
 	HUPIItemProduct getById(@NonNull HUPIItemProductId id);
 
 	I_M_HU_PI_Item_Product getRecordById(HUPIItemProductId id);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductBL.java
@@ -39,7 +39,6 @@ import de.metas.util.ISingletonService;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.exceptions.AdempiereException;
-import org.adempiere.service.ClientId;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_Product;
@@ -59,13 +58,6 @@ public interface IHUPIItemProductBL extends ISingletonService
 	 */
 	String SYSCONFIG_EnforcePrecisePricePerHUItemProduct =
 			"de.metas.ui.web.quickinput.field.PackingItemProductFieldHelper.EnforcePrecisePricePerHUItemProduct";
-
-	/**
-	 * @return {@code true} if a packing instruction may only be auto-defaulted onto a document line when a
-	 *         product price of the relevant price list version references it. Defaults to {@code false}
-	 *         when the setting is absent.
-	 */
-	boolean isEnforcePrecisePricePerHUItemProduct(@NonNull ClientId clientId);
 
 	HUPIItemProduct getById(@NonNull HUPIItemProductId id);
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductDAO.java
@@ -149,11 +149,15 @@ public interface IHUPIItemProductDAO extends ISingletonService
 	 * <p>
 	 * Use this from a pricing-aware caller: a packing instruction that no product price references cannot
 	 * be priced, so defaulting it onto a document line makes that line uncompletable.
+	 * <p>
+	 * Unlike the older overloads, {@code date} is nullable here and means "no validity filter" — a
+	 * pre-save callout or interceptor can legitimately run before any date column is populated, and must
+	 * not be made to blow up over it.
 	 */
 	Optional<I_M_HU_PI_Item_Product> retrieveDefaultForProduct(
 			ProductId productId,
 			@Nullable BPartnerId bpartnerId,
-			ZonedDateTime date,
+			@Nullable ZonedDateTime date,
 			@Nullable PriceListVersionId priceListVersionId);
 
 	Optional<HUPIItemProductId> retrieveDefaultIdForProduct(ProductId productId, BPartnerId bpartnerId, ZonedDateTime date);
@@ -164,7 +168,7 @@ public interface IHUPIItemProductDAO extends ISingletonService
 	Optional<HUPIItemProductId> retrieveDefaultIdForProduct(
 			ProductId productId,
 			@Nullable BPartnerId bpartnerId,
-			ZonedDateTime date,
+			@Nullable ZonedDateTime date,
 			@Nullable PriceListVersionId priceListVersionId);
 
 	@Nullable

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductDAO.java
@@ -28,6 +28,7 @@ import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.pricing.PriceListVersionId;
 import de.metas.product.ProductId;
 import de.metas.util.ISingletonService;
 import lombok.NonNull;
@@ -141,7 +142,30 @@ public interface IHUPIItemProductDAO extends ISingletonService
 
 	Optional<I_M_HU_PI_Item_Product> retrieveDefaultForProduct(ProductId productId, BPartnerId bpartnerId, ZonedDateTime date);
 
+	/**
+	 * Like {@link #retrieveDefaultForProduct(ProductId, BPartnerId, ZonedDateTime)}, but when
+	 * {@code priceListVersionId} is not {@code null}, only a packing instruction that an
+	 * {@code M_ProductPrice} of that price list version references is returned.
+	 * <p>
+	 * Use this from a pricing-aware caller: a packing instruction that no product price references cannot
+	 * be priced, so defaulting it onto a document line makes that line uncompletable.
+	 */
+	Optional<I_M_HU_PI_Item_Product> retrieveDefaultForProduct(
+			ProductId productId,
+			@Nullable BPartnerId bpartnerId,
+			ZonedDateTime date,
+			@Nullable PriceListVersionId priceListVersionId);
+
 	Optional<HUPIItemProductId> retrieveDefaultIdForProduct(ProductId productId, BPartnerId bpartnerId, ZonedDateTime date);
+
+	/**
+	 * @see #retrieveDefaultForProduct(ProductId, BPartnerId, ZonedDateTime, PriceListVersionId)
+	 */
+	Optional<HUPIItemProductId> retrieveDefaultIdForProduct(
+			ProductId productId,
+			@Nullable BPartnerId bpartnerId,
+			ZonedDateTime date,
+			@Nullable PriceListVersionId priceListVersionId);
 
 	@Nullable
 	I_M_HU_PI_Item_Product retrieveDefaultForProduct(@NonNull ProductId productId, @NonNull ZonedDateTime date);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductBL.java
@@ -48,6 +48,8 @@ import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.service.ISysConfigBL;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_M_Product;
 import org.compiere.util.TimeUtil;
@@ -65,6 +67,13 @@ public class HUPIItemProductBL implements IHUPIItemProductBL
 	@NonNull private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
 	@NonNull private final IOrgDAO orgDAO = Services.get(IOrgDAO.class);
 	@NonNull private final ILUTUConfigurationFactory lutuConfigurationFactory = Services.get(ILUTUConfigurationFactory.class);
+	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+
+	@Override
+	public boolean isEnforcePrecisePricePerHUItemProduct(@NonNull final ClientId clientId)
+	{
+		return sysConfigBL.getBooleanValue(SYSCONFIG_EnforcePrecisePricePerHUItemProduct, false, clientId.getRepoId());
+	}
 
 	@Override
 	public HUPIItemProduct getById(@NonNull final HUPIItemProductId id) {return huPIItemProductDAO.getById(id);}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductBL.java
@@ -48,8 +48,6 @@ import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.model.InterfaceWrapperHelper;
-import org.adempiere.service.ClientId;
-import org.adempiere.service.ISysConfigBL;
 import org.compiere.model.I_C_Order;
 import org.compiere.model.I_M_Product;
 import org.compiere.util.TimeUtil;
@@ -67,13 +65,6 @@ public class HUPIItemProductBL implements IHUPIItemProductBL
 	@NonNull private final IHandlingUnitsDAO handlingUnitsDAO = Services.get(IHandlingUnitsDAO.class);
 	@NonNull private final IOrgDAO orgDAO = Services.get(IOrgDAO.class);
 	@NonNull private final ILUTUConfigurationFactory lutuConfigurationFactory = Services.get(ILUTUConfigurationFactory.class);
-	@NonNull private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
-
-	@Override
-	public boolean isEnforcePrecisePricePerHUItemProduct(@NonNull final ClientId clientId)
-	{
-		return sysConfigBL.getBooleanValue(SYSCONFIG_EnforcePrecisePricePerHUItemProduct, false, clientId.getRepoId());
-	}
 
 	@Override
 	public HUPIItemProduct getById(@NonNull final HUPIItemProductId id) {return huPIItemProductDAO.getById(id);}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductDAO.java
@@ -868,7 +868,7 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 	public Optional<I_M_HU_PI_Item_Product> retrieveDefaultForProduct(
 			@NonNull final ProductId productId,
 			@Nullable final BPartnerId bpartnerId,
-			@NonNull final ZonedDateTime date,
+			@Nullable final ZonedDateTime date,
 			@Nullable final PriceListVersionId priceListVersionId)
 	{
 		final IHUPIItemProductQuery query = createHUPIItemProductQuery();
@@ -896,7 +896,7 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 	public Optional<HUPIItemProductId> retrieveDefaultIdForProduct(
 			@NonNull final ProductId productId,
 			@Nullable final BPartnerId bpartnerId,
-			@NonNull final ZonedDateTime date,
+			@Nullable final ZonedDateTime date,
 			@Nullable final PriceListVersionId priceListVersionId)
 	{
 		return retrieveDefaultForProduct(productId, bpartnerId, date, priceListVersionId)

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductDAO.java
@@ -45,6 +45,7 @@ import de.metas.handlingunits.model.I_M_ProductPrice;
 import de.metas.handlingunits.model.X_M_HU_PI_Item;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
 import de.metas.i18n.IModelTranslationMap;
+import de.metas.pricing.PriceListVersionId;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantitys;
 import de.metas.uom.UomId;
@@ -860,11 +861,23 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 			@Nullable final BPartnerId bpartnerId,
 			@NonNull final ZonedDateTime date)
 	{
+		return retrieveDefaultForProduct(productId, bpartnerId, date, null);
+	}
+
+	@Override
+	public Optional<I_M_HU_PI_Item_Product> retrieveDefaultForProduct(
+			@NonNull final ProductId productId,
+			@Nullable final BPartnerId bpartnerId,
+			@NonNull final ZonedDateTime date,
+			@Nullable final PriceListVersionId priceListVersionId)
+	{
 		final IHUPIItemProductQuery query = createHUPIItemProductQuery();
 		query.setBPartnerId(bpartnerId);
 		query.setProductId(productId);
 		query.setDate(date);
 		query.setDefaultForProduct(true);
+		// null means "don't restrict"; the filter in buildQueryFilters is guarded by a null check
+		query.setPriceListVersionId(priceListVersionId);
 
 		final I_M_HU_PI_Item_Product huPIItemProduct = retrieveFirst(Env.getCtx(), query, ITrx.TRXNAME_None);
 		return Optional.ofNullable(huPIItemProduct);
@@ -876,7 +889,17 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 			@Nullable final BPartnerId bpartnerId,
 			@NonNull final ZonedDateTime date)
 	{
-		return retrieveDefaultForProduct(productId, bpartnerId, date)
+		return retrieveDefaultIdForProduct(productId, bpartnerId, date, null);
+	}
+
+	@Override
+	public Optional<HUPIItemProductId> retrieveDefaultIdForProduct(
+			@NonNull final ProductId productId,
+			@Nullable final BPartnerId bpartnerId,
+			@NonNull final ZonedDateTime date,
+			@Nullable final PriceListVersionId priceListVersionId)
+	{
+		return retrieveDefaultForProduct(productId, bpartnerId, date, priceListVersionId)
 				.map(huPiItemProduct -> HUPIItemProductId.ofRepoIdOrNull(huPiItemProduct.getM_HU_PI_Item_Product_ID()));
 	}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -83,11 +83,13 @@ public class C_OrderLine
 	@CalloutMethod(columnNames = de.metas.interfaces.I_C_OrderLine.COLUMNNAME_M_Product_ID)
 	public void onProductSetOrChanged(final de.metas.interfaces.I_C_OrderLine orderLine)
 	{
+		final org.compiere.model.I_C_Order order = ordersRepo.getById(OrderId.ofRepoId(orderLine.getC_Order_ID()));
+
 		final Optional<HUPIItemProductId> huPiItemProductId = hupiItemProductDAO.retrieveDefaultIdForProduct(
 				ProductId.ofRepoId(orderLine.getM_Product_ID()),
 				BPartnerId.ofRepoId(orderLine.getC_BPartner_ID()),
-				extractPriceDate(orderLine),
-				getPriceListVersionIdOrNull(orderLine));
+				extractPriceDate(orderLine, order),
+				getPriceListVersionIdOrNull(orderLine, order));
 		final Properties ctx = Env.getCtx();
 		final I_M_HU_PI_Item_Product noPackingItemProduct = hupiItemProductDAO.retrieveVirtualPIMaterialItemProduct(ctx);
 		orderLine.setM_HU_PI_Item_Product_ID(HUPIItemProductId.toRepoId(huPiItemProductId.orElse(HUPIItemProductId.ofRepoId(noPackingItemProduct.getM_HU_PI_Item_Product_ID()))));
@@ -95,11 +97,16 @@ public class C_OrderLine
 
 	/**
 	 * {@code C_OrderLine.DatePromised} is nullable — a line whose date has not been set yet is normal, and
-	 * reading that column alone would blow up here. Coalesce to the order header, which is exactly what
-	 * {@code OrderLineBL}'s own price-date resolution does, and for the same reason.
+	 * reading that column alone would blow up here. Coalesce to the order header, mirroring the sales
+	 * branch of {@code OrderLineBL}'s own price-date resolution, and for the same reason.
+	 * <p>
+	 * This is the packing instruction's validity date and is deliberately DatePromised-based for sales and
+	 * purchase alike, exactly as before this change — only the price-list restriction below is scoped.
 	 */
 	@NonNull
-	private ZonedDateTime extractPriceDate(@NonNull final de.metas.interfaces.I_C_OrderLine orderLine)
+	private static ZonedDateTime extractPriceDate(
+			@NonNull final de.metas.interfaces.I_C_OrderLine orderLine,
+			@NonNull final org.compiere.model.I_C_Order order)
 	{
 		final ZonedDateTime lineDatePromised = TimeUtil.asZonedDateTime(orderLine.getDatePromised());
 		if (lineDatePromised != null)
@@ -107,7 +114,6 @@ public class C_OrderLine
 			return lineDatePromised;
 		}
 
-		final org.compiere.model.I_C_Order order = getOrder(orderLine);
 		return Check.assumeNotNull(
 				TimeUtil.asZonedDateTime(order.getDatePromised()),
 				"C_Order {} has a DatePromised", order.getC_Order_ID());
@@ -117,9 +123,9 @@ public class C_OrderLine
 	 * @return the order's price list version, which restricts the default lookup to packing instructions
 	 *         that a product price references — or {@code null} to leave the lookup unrestricted.
 	 *         <p>
-	 *         Null is returned both when the rule is not enforced and when there is no price list to
-	 *         resolve one from: an order that has no price list yet must keep today's behaviour rather
-	 *         than silently lose its packing instruction.
+	 *         Null is returned when the document is not a sales order, when the rule is not enforced, and
+	 *         when there is no price list to resolve one from: an order that has no price list yet must
+	 *         keep today's behaviour rather than silently lose its packing instruction.
 	 *         <p>
 	 *         Note this site cannot simply skip the lookup the way the quick-input helper does. That
 	 *         helper has a price-list step ahead of the fallback which has already returned any priced
@@ -127,8 +133,18 @@ public class C_OrderLine
 	 *         skipping it would also strip the default where a product price legitimately references it.
 	 */
 	@Nullable
-	private PriceListVersionId getPriceListVersionIdOrNull(@NonNull final de.metas.interfaces.I_C_OrderLine orderLine)
+	private PriceListVersionId getPriceListVersionIdOrNull(
+			@NonNull final de.metas.interfaces.I_C_OrderLine orderLine,
+			@NonNull final org.compiere.model.I_C_Order order)
 	{
+		if (!order.isSOTrx())
+		{
+			// Sales only, matching the quick-input helper, which reaches its IsDefaultForProduct fallback
+			// under an SOTrx.SALES guard. Purchase order lines keep today's behaviour untouched. Whether
+			// purchase should follow the same rule is a separate question, deliberately not decided here.
+			return null;
+		}
+
 		if (!hupiItemProductBL.isEnforcePrecisePricePerHUItemProduct(ClientId.ofRepoId(orderLine.getAD_Client_ID())))
 		{
 			return null;
@@ -136,23 +152,16 @@ public class C_OrderLine
 
 		// orderLineBL.getPriceListVersion throws when there is neither a line-level override nor an order
 		// price list, so bail out to "unrestricted" first rather than let an incomplete order fail here.
-		if (orderLine.getM_PriceList_Version_ID() <= 0 && getOrder(orderLine).getM_PriceList_ID() <= 0)
+		if (orderLine.getM_PriceList_Version_ID() <= 0 && order.getM_PriceList_ID() <= 0)
 		{
 			return null;
 		}
 
 		// Deliberately the shared BL rather than a local re-resolution: it honours the line-level price
-		// list version override, picks DatePromised vs DateOrdered by the document's SOTrx, and resolves
-		// the price date in the order's org timezone.
+		// list version override and resolves the price date in the order's org timezone.
 		final I_M_PriceList_Version priceListVersion = orderLineBL.getPriceListVersion(orderLine);
 		return priceListVersion == null
 				? null
 				: PriceListVersionId.ofRepoId(priceListVersion.getM_PriceList_Version_ID());
-	}
-
-	@NonNull
-	private org.compiere.model.I_C_Order getOrder(@NonNull final de.metas.interfaces.I_C_OrderLine orderLine)
-	{
-		return ordersRepo.getById(OrderId.ofRepoId(orderLine.getC_Order_ID()));
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -7,11 +7,11 @@ import de.metas.handlingunits.IHUPIItemProductDAO;
 import de.metas.handlingunits.model.I_C_Order;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.order.IOrderDAO;
+import de.metas.order.IOrderLineBL;
 import de.metas.order.OrderId;
-import de.metas.pricing.PriceListId;
 import de.metas.pricing.PriceListVersionId;
-import de.metas.pricing.service.IPriceListDAO;
 import de.metas.product.ProductId;
+import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.callout.annotations.Callout;
@@ -63,7 +63,7 @@ public class C_OrderLine
 	private final IHUPIItemProductDAO hupiItemProductDAO = Services.get(IHUPIItemProductDAO.class);
 	private final IHUPIItemProductBL hupiItemProductBL = Services.get(IHUPIItemProductBL.class);
 	private final IOrderDAO ordersRepo = Services.get(IOrderDAO.class);
-	private final IPriceListDAO priceListsRepo = Services.get(IPriceListDAO.class);
+	private final IOrderLineBL orderLineBL = Services.get(IOrderLineBL.class);
 
 	@Init
 	public void registerCallouts()
@@ -83,25 +83,43 @@ public class C_OrderLine
 	@CalloutMethod(columnNames = de.metas.interfaces.I_C_OrderLine.COLUMNNAME_M_Product_ID)
 	public void onProductSetOrChanged(final de.metas.interfaces.I_C_OrderLine orderLine)
 	{
-		final ZonedDateTime date = TimeUtil.asZonedDateTime(orderLine.getDatePromised());
-
 		final Optional<HUPIItemProductId> huPiItemProductId = hupiItemProductDAO.retrieveDefaultIdForProduct(
 				ProductId.ofRepoId(orderLine.getM_Product_ID()),
 				BPartnerId.ofRepoId(orderLine.getC_BPartner_ID()),
-				date,
-				getPriceListVersionIdOrNull(orderLine, date));
+				extractPriceDate(orderLine),
+				getPriceListVersionIdOrNull(orderLine));
 		final Properties ctx = Env.getCtx();
 		final I_M_HU_PI_Item_Product noPackingItemProduct = hupiItemProductDAO.retrieveVirtualPIMaterialItemProduct(ctx);
 		orderLine.setM_HU_PI_Item_Product_ID(HUPIItemProductId.toRepoId(huPiItemProductId.orElse(HUPIItemProductId.ofRepoId(noPackingItemProduct.getM_HU_PI_Item_Product_ID()))));
 	}
 
 	/**
+	 * {@code C_OrderLine.DatePromised} is nullable — a line whose date has not been set yet is normal, and
+	 * reading that column alone would blow up here. Coalesce to the order header, which is exactly what
+	 * {@code OrderLineBL}'s own price-date resolution does, and for the same reason.
+	 */
+	@NonNull
+	private ZonedDateTime extractPriceDate(@NonNull final de.metas.interfaces.I_C_OrderLine orderLine)
+	{
+		final ZonedDateTime lineDatePromised = TimeUtil.asZonedDateTime(orderLine.getDatePromised());
+		if (lineDatePromised != null)
+		{
+			return lineDatePromised;
+		}
+
+		final org.compiere.model.I_C_Order order = getOrder(orderLine);
+		return Check.assumeNotNull(
+				TimeUtil.asZonedDateTime(order.getDatePromised()),
+				"C_Order {} has a DatePromised", order.getC_Order_ID());
+	}
+
+	/**
 	 * @return the order's price list version, which restricts the default lookup to packing instructions
 	 *         that a product price references — or {@code null} to leave the lookup unrestricted.
 	 *         <p>
-	 *         Null is returned both when the rule is not enforced and when the price list version cannot
-	 *         be resolved: an order that has no price list yet must keep today's behaviour rather than
-	 *         silently lose its packing instruction.
+	 *         Null is returned both when the rule is not enforced and when there is no price list to
+	 *         resolve one from: an order that has no price list yet must keep today's behaviour rather
+	 *         than silently lose its packing instruction.
 	 *         <p>
 	 *         Note this site cannot simply skip the lookup the way the quick-input helper does. That
 	 *         helper has a price-list step ahead of the fallback which has already returned any priced
@@ -109,25 +127,32 @@ public class C_OrderLine
 	 *         skipping it would also strip the default where a product price legitimately references it.
 	 */
 	@Nullable
-	private PriceListVersionId getPriceListVersionIdOrNull(
-			@NonNull final de.metas.interfaces.I_C_OrderLine orderLine,
-			@NonNull final ZonedDateTime date)
+	private PriceListVersionId getPriceListVersionIdOrNull(@NonNull final de.metas.interfaces.I_C_OrderLine orderLine)
 	{
 		if (!hupiItemProductBL.isEnforcePrecisePricePerHUItemProduct(ClientId.ofRepoId(orderLine.getAD_Client_ID())))
 		{
 			return null;
 		}
 
-		final PriceListId priceListId = PriceListId.ofRepoIdOrNull(
-				ordersRepo.getById(OrderId.ofRepoId(orderLine.getC_Order_ID())).getM_PriceList_ID());
-		if (priceListId == null)
+		// orderLineBL.getPriceListVersion throws when there is neither a line-level override nor an order
+		// price list, so bail out to "unrestricted" first rather than let an incomplete order fail here.
+		if (orderLine.getM_PriceList_Version_ID() <= 0 && getOrder(orderLine).getM_PriceList_ID() <= 0)
 		{
 			return null;
 		}
 
-		final I_M_PriceList_Version priceListVersion = priceListsRepo.retrievePriceListVersionOrNull(priceListId, date, null);
+		// Deliberately the shared BL rather than a local re-resolution: it honours the line-level price
+		// list version override, picks DatePromised vs DateOrdered by the document's SOTrx, and resolves
+		// the price date in the order's org timezone.
+		final I_M_PriceList_Version priceListVersion = orderLineBL.getPriceListVersion(orderLine);
 		return priceListVersion == null
 				? null
 				: PriceListVersionId.ofRepoId(priceListVersion.getM_PriceList_Version_ID());
+	}
+
+	@NonNull
+	private org.compiere.model.I_C_Order getOrder(@NonNull final de.metas.interfaces.I_C_OrderLine orderLine)
+	{
+		return ordersRepo.getById(OrderId.ofRepoId(orderLine.getC_Order_ID()));
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -1,6 +1,7 @@
 package de.metas.handlingunits.reservation.interceptor;
 
 import de.metas.bpartner.BPartnerId;
+import de.metas.common.util.CoalesceUtil;
 import de.metas.handlingunits.HUPIItemProductId;
 import de.metas.handlingunits.IHUPIItemProductBL;
 import de.metas.handlingunits.IHUPIItemProductDAO;
@@ -111,10 +112,9 @@ public class C_OrderLine
 			@NonNull final de.metas.interfaces.I_C_OrderLine orderLine,
 			@NonNull final org.compiere.model.I_C_Order order)
 	{
-		final ZonedDateTime lineDatePromised = TimeUtil.asZonedDateTime(orderLine.getDatePromised());
-		return lineDatePromised != null
-				? lineDatePromised
-				: TimeUtil.asZonedDateTime(order.getDatePromised());
+		return CoalesceUtil.coalesce(
+				TimeUtil.asZonedDateTime(orderLine.getDatePromised()),
+				TimeUtil.asZonedDateTime(order.getDatePromised()));
 	}
 
 	/**
@@ -140,6 +140,11 @@ public class C_OrderLine
 		{
 			// No date anywhere on the line or its order, so there is no price list version to speak of.
 			// orderLineBL.getPriceListVersion would throw on exactly this input; stay unrestricted.
+			//
+			// This deliberately also gives up on a line that carries an explicit M_PriceList_Version_ID
+			// override, which could in principle be resolved without any date. That combination only
+			// makes us less restrictive, never wrong, and keeping one guard is worth more here than
+			// adding a branch no test exercises.
 			return null;
 		}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -21,6 +21,7 @@ import org.adempiere.ad.modelvalidator.annotations.Init;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
 import org.adempiere.service.ClientId;
+import org.adempiere.service.ISysConfigBL;
 import org.compiere.model.I_C_OrderLine;
 import org.compiere.model.I_M_PriceList_Version;
 import org.compiere.model.ModelValidator;
@@ -61,9 +62,9 @@ import java.util.Properties;
 public class C_OrderLine
 {
 	private final IHUPIItemProductDAO hupiItemProductDAO = Services.get(IHUPIItemProductDAO.class);
-	private final IHUPIItemProductBL hupiItemProductBL = Services.get(IHUPIItemProductBL.class);
 	private final IOrderDAO ordersRepo = Services.get(IOrderDAO.class);
 	private final IOrderLineBL orderLineBL = Services.get(IOrderLineBL.class);
+	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 
 	@Init
 	public void registerCallouts()
@@ -156,7 +157,10 @@ public class C_OrderLine
 			return null;
 		}
 
-		if (!hupiItemProductBL.isEnforcePrecisePricePerHUItemProduct(ClientId.ofRepoId(orderLine.getAD_Client_ID())))
+		if (!sysConfigBL.getBooleanValue(
+				IHUPIItemProductBL.SYSCONFIG_EnforcePrecisePricePerHUItemProduct,
+				false,
+				ClientId.ofRepoId(orderLine.getAD_Client_ID()).getRepoId()))
 		{
 			return null;
 		}

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -2,9 +2,15 @@ package de.metas.handlingunits.reservation.interceptor;
 
 import de.metas.bpartner.BPartnerId;
 import de.metas.handlingunits.HUPIItemProductId;
+import de.metas.handlingunits.IHUPIItemProductBL;
 import de.metas.handlingunits.IHUPIItemProductDAO;
 import de.metas.handlingunits.model.I_C_Order;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.order.IOrderDAO;
+import de.metas.order.OrderId;
+import de.metas.pricing.PriceListId;
+import de.metas.pricing.PriceListVersionId;
+import de.metas.pricing.service.IPriceListDAO;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -14,12 +20,16 @@ import org.adempiere.ad.callout.spi.IProgramaticCalloutProvider;
 import org.adempiere.ad.modelvalidator.annotations.Init;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
+import org.adempiere.service.ClientId;
 import org.compiere.model.I_C_OrderLine;
+import org.compiere.model.I_M_PriceList_Version;
 import org.compiere.model.ModelValidator;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Nullable;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -51,6 +61,9 @@ import java.util.Properties;
 public class C_OrderLine
 {
 	private final IHUPIItemProductDAO hupiItemProductDAO = Services.get(IHUPIItemProductDAO.class);
+	private final IHUPIItemProductBL hupiItemProductBL = Services.get(IHUPIItemProductBL.class);
+	private final IOrderDAO ordersRepo = Services.get(IOrderDAO.class);
+	private final IPriceListDAO priceListsRepo = Services.get(IPriceListDAO.class);
 
 	@Init
 	public void registerCallouts()
@@ -70,11 +83,51 @@ public class C_OrderLine
 	@CalloutMethod(columnNames = de.metas.interfaces.I_C_OrderLine.COLUMNNAME_M_Product_ID)
 	public void onProductSetOrChanged(final de.metas.interfaces.I_C_OrderLine orderLine)
 	{
-		final Optional<HUPIItemProductId> huPiItemProductId = hupiItemProductDAO.retrieveDefaultIdForProduct(ProductId.ofRepoId(orderLine.getM_Product_ID()),
+		final ZonedDateTime date = TimeUtil.asZonedDateTime(orderLine.getDatePromised());
+
+		final Optional<HUPIItemProductId> huPiItemProductId = hupiItemProductDAO.retrieveDefaultIdForProduct(
+				ProductId.ofRepoId(orderLine.getM_Product_ID()),
 				BPartnerId.ofRepoId(orderLine.getC_BPartner_ID()),
-				TimeUtil.asZonedDateTime(orderLine.getDatePromised()));
+				date,
+				getPriceListVersionIdOrNull(orderLine, date));
 		final Properties ctx = Env.getCtx();
 		final I_M_HU_PI_Item_Product noPackingItemProduct = hupiItemProductDAO.retrieveVirtualPIMaterialItemProduct(ctx);
 		orderLine.setM_HU_PI_Item_Product_ID(HUPIItemProductId.toRepoId(huPiItemProductId.orElse(HUPIItemProductId.ofRepoId(noPackingItemProduct.getM_HU_PI_Item_Product_ID()))));
+	}
+
+	/**
+	 * @return the order's price list version, which restricts the default lookup to packing instructions
+	 *         that a product price references — or {@code null} to leave the lookup unrestricted.
+	 *         <p>
+	 *         Null is returned both when the rule is not enforced and when the price list version cannot
+	 *         be resolved: an order that has no price list yet must keep today's behaviour rather than
+	 *         silently lose its packing instruction.
+	 *         <p>
+	 *         Note this site cannot simply skip the lookup the way the quick-input helper does. That
+	 *         helper has a price-list step ahead of the fallback which has already returned any priced
+	 *         packing instruction; here the {@code IsDefaultForProduct} lookup is the only source, so
+	 *         skipping it would also strip the default where a product price legitimately references it.
+	 */
+	@Nullable
+	private PriceListVersionId getPriceListVersionIdOrNull(
+			@NonNull final de.metas.interfaces.I_C_OrderLine orderLine,
+			@NonNull final ZonedDateTime date)
+	{
+		if (!hupiItemProductBL.isEnforcePrecisePricePerHUItemProduct(ClientId.ofRepoId(orderLine.getAD_Client_ID())))
+		{
+			return null;
+		}
+
+		final PriceListId priceListId = PriceListId.ofRepoIdOrNull(
+				ordersRepo.getById(OrderId.ofRepoId(orderLine.getC_Order_ID())).getM_PriceList_ID());
+		if (priceListId == null)
+		{
+			return null;
+		}
+
+		final I_M_PriceList_Version priceListVersion = priceListsRepo.retrievePriceListVersionOrNull(priceListId, date, null);
+		return priceListVersion == null
+				? null
+				: PriceListVersionId.ofRepoId(priceListVersion.getM_PriceList_Version_ID());
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -11,7 +11,6 @@ import de.metas.order.IOrderLineBL;
 import de.metas.order.OrderId;
 import de.metas.pricing.PriceListVersionId;
 import de.metas.product.ProductId;
-import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
 import org.adempiere.ad.callout.annotations.Callout;
@@ -85,38 +84,37 @@ public class C_OrderLine
 	{
 		final org.compiere.model.I_C_Order order = ordersRepo.getById(OrderId.ofRepoId(orderLine.getC_Order_ID()));
 
+		final ZonedDateTime date = extractPriceDate(orderLine, order);
+
 		final Optional<HUPIItemProductId> huPiItemProductId = hupiItemProductDAO.retrieveDefaultIdForProduct(
 				ProductId.ofRepoId(orderLine.getM_Product_ID()),
 				BPartnerId.ofRepoId(orderLine.getC_BPartner_ID()),
-				extractPriceDate(orderLine, order),
-				getPriceListVersionIdOrNull(orderLine, order));
+				date,
+				getPriceListVersionIdOrNull(orderLine, order, date));
 		final Properties ctx = Env.getCtx();
 		final I_M_HU_PI_Item_Product noPackingItemProduct = hupiItemProductDAO.retrieveVirtualPIMaterialItemProduct(ctx);
 		orderLine.setM_HU_PI_Item_Product_ID(HUPIItemProductId.toRepoId(huPiItemProductId.orElse(HUPIItemProductId.ofRepoId(noPackingItemProduct.getM_HU_PI_Item_Product_ID()))));
 	}
 
 	/**
-	 * {@code C_OrderLine.DatePromised} is nullable — a line whose date has not been set yet is normal, and
-	 * reading that column alone would blow up here. Coalesce to the order header, mirroring the sales
-	 * branch of {@code OrderLineBL}'s own price-date resolution, and for the same reason.
+	 * The packing instruction's validity date, DatePromised-based for sales and purchase alike.
 	 * <p>
-	 * This is the packing instruction's validity date and is deliberately DatePromised-based for sales and
-	 * purchase alike, exactly as before this change — only the price-list restriction below is scoped.
+	 * {@code C_OrderLine.DatePromised} is nullable — a line whose date has not been set yet is normal — so
+	 * coalesce to the order header, mirroring the sales branch of {@code OrderLineBL}'s own price-date
+	 * resolution. Both being unset is possible too: this runs as a pre-save interceptor and callout, and
+	 * an AD {@code Mandatory} flag is only enforced when the record is persisted, not while it is being
+	 * edited. That case returns {@code null}, meaning "no validity filter" — never an exception, because
+	 * refusing to default a packing instruction must not break product selection.
 	 */
-	@NonNull
+	@Nullable
 	private static ZonedDateTime extractPriceDate(
 			@NonNull final de.metas.interfaces.I_C_OrderLine orderLine,
 			@NonNull final org.compiere.model.I_C_Order order)
 	{
 		final ZonedDateTime lineDatePromised = TimeUtil.asZonedDateTime(orderLine.getDatePromised());
-		if (lineDatePromised != null)
-		{
-			return lineDatePromised;
-		}
-
-		return Check.assumeNotNull(
-				TimeUtil.asZonedDateTime(order.getDatePromised()),
-				"C_Order {} has a DatePromised", order.getC_Order_ID());
+		return lineDatePromised != null
+				? lineDatePromised
+				: TimeUtil.asZonedDateTime(order.getDatePromised());
 	}
 
 	/**
@@ -135,8 +133,16 @@ public class C_OrderLine
 	@Nullable
 	private PriceListVersionId getPriceListVersionIdOrNull(
 			@NonNull final de.metas.interfaces.I_C_OrderLine orderLine,
-			@NonNull final org.compiere.model.I_C_Order order)
+			@NonNull final org.compiere.model.I_C_Order order,
+			@Nullable final ZonedDateTime date)
 	{
+		if (date == null)
+		{
+			// No date anywhere on the line or its order, so there is no price list version to speak of.
+			// orderLineBL.getPriceListVersion would throw on exactly this input; stay unrestricted.
+			return null;
+		}
+
 		if (!order.isSOTrx())
 		{
 			// Sales only, matching the quick-input helper, which reaches its IsDefaultForProduct fallback

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUPIItemProductDAOTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUPIItemProductDAOTest.java
@@ -20,6 +20,7 @@ import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
 import org.assertj.core.api.OptionalAssert;
 import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_M_PriceList_Version;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,12 +42,17 @@ import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
 import de.metas.handlingunits.model.I_M_HU_PackingMaterial;
+import de.metas.handlingunits.model.I_M_ProductPrice;
 import de.metas.handlingunits.model.X_M_HU_PI_Item;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
+import de.metas.pricing.PriceListVersionId;
 import de.metas.product.IProductDAO;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
 import lombok.Builder;
+import lombok.NonNull;
+
+import javax.annotation.Nullable;
 
 @ExtendWith(AdempiereTestWatcher.class)
 public class HUPIItemProductDAOTest
@@ -406,6 +412,81 @@ public class HUPIItemProductDAOTest
 			assertDefaultForProduct(product1, bpartner3, "2011-10-01").contains(pip3);
 			assertDefaultForProduct(product1, bpartner3, "2012-10-01").contains(pip3);
 		}
+
+		/**
+		 * A packing instruction that no product price of the given price list version references must not be
+		 * offered as a default — it cannot be priced, so a document line carrying it cannot be completed.
+		 */
+		@Test
+		public void priceListVersionGiven_noProductPriceReferencesIt_returnsEmpty()
+		{
+			final I_M_HU_PI_Item_Product pip = huPIItemProduct()
+					.productId(product1).bpartnerId(null).validFrom("2011-10-01")
+					.huUnitType(X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit).defaultForProduct(true).build();
+			final PriceListVersionId plvId = createPriceListVersion();
+			createProductPrice(plvId, product1, null); // a price, but with no packing instruction
+
+			assertThat(dao.retrieveDefaultForProduct(product1, bpartner1, date("2011-10-01"), plvId)).isEmpty();
+			assertThat(dao.retrieveDefaultIdForProduct(product1, bpartner1, date("2011-10-01"), plvId)).isEmpty();
+
+			// the unrestricted overloads are unchanged
+			assertThat(dao.retrieveDefaultForProduct(product1, bpartner1, date("2011-10-01"))).contains(pip);
+			assertThat(dao.retrieveDefaultForProduct(product1, bpartner1, date("2011-10-01"), null)).contains(pip);
+		}
+
+		@Test
+		public void priceListVersionGiven_aProductPriceReferencesIt_returnsIt()
+		{
+			final I_M_HU_PI_Item_Product pip = huPIItemProduct()
+					.productId(product1).bpartnerId(null).validFrom("2011-10-01")
+					.huUnitType(X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit).defaultForProduct(true).build();
+			final PriceListVersionId plvId = createPriceListVersion();
+			createProductPrice(plvId, product1, pip);
+
+			assertThat(dao.retrieveDefaultForProduct(product1, bpartner1, date("2011-10-01"), plvId)).contains(pip);
+			assertThat(dao.retrieveDefaultIdForProduct(product1, bpartner1, date("2011-10-01"), plvId))
+					.contains(HUPIItemProductId.ofRepoId(pip.getM_HU_PI_Item_Product_ID()));
+		}
+
+		/**
+		 * The price of a <em>different</em> price list version must not qualify a packing instruction.
+		 */
+		@Test
+		public void priceListVersionGiven_onlyAnotherVersionsPriceReferencesIt_returnsEmpty()
+		{
+			final I_M_HU_PI_Item_Product pip = huPIItemProduct()
+					.productId(product1).bpartnerId(null).validFrom("2011-10-01")
+					.huUnitType(X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit).defaultForProduct(true).build();
+			final PriceListVersionId plvId = createPriceListVersion();
+			final PriceListVersionId otherPlvId = createPriceListVersion();
+			createProductPrice(otherPlvId, product1, pip);
+
+			assertThat(dao.retrieveDefaultForProduct(product1, bpartner1, date("2011-10-01"), plvId)).isEmpty();
+			assertThat(dao.retrieveDefaultForProduct(product1, bpartner1, date("2011-10-01"), otherPlvId)).contains(pip);
+		}
+	}
+
+	private PriceListVersionId createPriceListVersion()
+	{
+		final I_M_PriceList_Version plv = newInstance(I_M_PriceList_Version.class);
+		plv.setIsActive(true);
+		saveRecord(plv);
+		return PriceListVersionId.ofRepoId(plv.getM_PriceList_Version_ID());
+	}
+
+	private void createProductPrice(
+			@NonNull final PriceListVersionId priceListVersionId,
+			@NonNull final ProductId productId,
+			@Nullable final I_M_HU_PI_Item_Product huPiItemProduct)
+	{
+		final I_M_ProductPrice productPrice = newInstance(I_M_ProductPrice.class);
+		productPrice.setM_PriceList_Version_ID(priceListVersionId.getRepoId());
+		productPrice.setM_Product_ID(productId.getRepoId());
+		if (huPiItemProduct != null)
+		{
+			productPrice.setM_HU_PI_Item_Product(huPiItemProduct);
+		}
+		saveRecord(productPrice);
 	}
 
 	@Nested

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
@@ -1,0 +1,301 @@
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.handlingunits.reservation.interceptor;
+
+import de.metas.handlingunits.HUPIItemProductId;
+import de.metas.handlingunits.HuPackingInstructionsId;
+import de.metas.handlingunits.HuPackingInstructionsItemId;
+import de.metas.handlingunits.HuPackingInstructionsVersionId;
+import de.metas.handlingunits.IHUPIItemProductBL;
+import de.metas.handlingunits.model.I_M_HU_PI;
+import de.metas.handlingunits.model.I_M_HU_PI_Item;
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.handlingunits.model.I_M_HU_PI_Version;
+import de.metas.handlingunits.model.I_M_ProductPrice;
+import de.metas.handlingunits.model.X_M_HU_PI_Item;
+import de.metas.pricing.PriceListId;
+import de.metas.product.ProductId;
+import lombok.NonNull;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.model.I_AD_SysConfig;
+import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_M_PriceList;
+import org.compiere.model.I_M_PriceList_Version;
+import org.compiere.model.I_M_Product;
+import org.compiere.util.TimeUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.adempiere.model.InterfaceWrapperHelper.load;
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the manual sales order line path: setting or changing the product on an order line must only
+ * default a Standard-Packvorschrift ({@code M_HU_PI_Item_Product.IsDefaultForProduct}) when a product
+ * price of the order's price list version references it. When none does, the line gets the Virtual PI
+ * ("no packing"), which prices correctly.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class C_OrderLineTest
+{
+	private static final ZonedDateTime DATE = LocalDate.of(2026, 8, 12).atStartOfDay(ZoneId.of("UTC"));
+
+	private C_OrderLine interceptor;
+
+	private ProductId productId;
+	private I_M_PriceList_Version priceListVersion;
+	private de.metas.interfaces.I_C_OrderLine orderLine;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		interceptor = new C_OrderLine();
+
+		createVirtualPackingInstruction();
+
+		productId = createProduct();
+		final PriceListId priceListId = createPriceList();
+		priceListVersion = createPriceListVersion(priceListId);
+		orderLine = createOrderLine(priceListId);
+	}
+
+	//
+	// Tests
+	//
+
+	@Test
+	public void enforceOn_noProductPriceReferencesTheDefault_setsNoPacking()
+	{
+		setEnforcePrecisePrice(true);
+		createDefaultForProductPackingInstruction();
+		createProductPrice(null); // a price for the product, but with no packing instruction
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(HUPIItemProductId.VIRTUAL_HU.getRepoId());
+	}
+
+	/**
+	 * The regression a blanket skip would have caused: this site has no price-list step in front of it, so
+	 * suppressing the lookup outright would strip the default from an installation whose product price
+	 * legitimately references the Standard-Packvorschrift.
+	 */
+	@Test
+	public void enforceOn_aProductPriceReferencesTheDefault_setsThatDefault()
+	{
+		setEnforcePrecisePrice(true);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(piip);
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	@Test
+	public void enforceOff_noProductPriceReferencesTheDefault_setsThatDefault()
+	{
+		setEnforcePrecisePrice(false);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	/**
+	 * Not an acceptance criterion — it pins a deliberate choice: when the price list version cannot be
+	 * resolved we leave the lookup unrestricted rather than silently strip the packing instruction, so an
+	 * incomplete order keeps today's behaviour.
+	 */
+	@Test
+	public void enforceOn_orderHasNoPriceList_keepsTodaysBehaviour()
+	{
+		setEnforcePrecisePrice(true);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+		clearOrderPriceList();
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	//
+	// Fixture
+	//
+
+	private void setEnforcePrecisePrice(final boolean value)
+	{
+		final I_AD_SysConfig sysConfig = newInstance(I_AD_SysConfig.class);
+		sysConfig.setName(IHUPIItemProductBL.SYSCONFIG_EnforcePrecisePricePerHUItemProduct);
+		sysConfig.setValue(value ? "Y" : "N");
+		sysConfig.setIsActive(true);
+		saveRecord(sysConfig);
+	}
+
+	private ProductId createProduct()
+	{
+		final I_M_Product product = newInstance(I_M_Product.class);
+		product.setValue("100024");
+		product.setName("Emmentaler AOP extra");
+		saveRecord(product);
+		return ProductId.ofRepoId(product.getM_Product_ID());
+	}
+
+	private PriceListId createPriceList()
+	{
+		final I_M_PriceList priceList = newInstance(I_M_PriceList.class);
+		priceList.setName("Fromagerie CHF");
+		priceList.setIsSOPriceList(true);
+		saveRecord(priceList);
+		return PriceListId.ofRepoId(priceList.getM_PriceList_ID());
+	}
+
+	private I_M_PriceList_Version createPriceListVersion(@NonNull final PriceListId priceListId)
+	{
+		final I_M_PriceList_Version plv = newInstance(I_M_PriceList_Version.class);
+		plv.setM_PriceList_ID(priceListId.getRepoId());
+		plv.setValidFrom(TimeUtil.asTimestamp(DATE.minusYears(1)));
+		plv.setIsActive(true);
+		saveRecord(plv);
+		return plv;
+	}
+
+	private de.metas.interfaces.I_C_OrderLine createOrderLine(@NonNull final PriceListId priceListId)
+	{
+		final I_C_BPartner bpartner = newInstance(I_C_BPartner.class);
+		bpartner.setName("Fromagerie");
+		saveRecord(bpartner);
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(bpartner.getC_BPartner_ID());
+		order.setM_PriceList_ID(priceListId.getRepoId());
+		order.setIsSOTrx(true);
+		order.setDatePromised(TimeUtil.asTimestamp(DATE));
+		saveRecord(order);
+
+		final de.metas.interfaces.I_C_OrderLine line = newInstance(de.metas.interfaces.I_C_OrderLine.class);
+		line.setC_Order_ID(order.getC_Order_ID());
+		line.setC_BPartner_ID(bpartner.getC_BPartner_ID());
+		line.setM_Product_ID(productId.getRepoId());
+		line.setDatePromised(TimeUtil.asTimestamp(DATE));
+		saveRecord(line);
+		return line;
+	}
+
+	private void clearOrderPriceList()
+	{
+		final I_C_Order order = load(orderLine.getC_Order_ID(), I_C_Order.class);
+		order.setM_PriceList_ID(0);
+		saveRecord(order);
+	}
+
+	/**
+	 * The Virtual PI ("no packing") that {@code retrieveVirtualPIMaterialItemProduct} resolves by its fixed
+	 * id — the interceptor falls back to it whenever no Standard-Packvorschrift applies.
+	 */
+	private void createVirtualPackingInstruction()
+	{
+		final I_M_HU_PI huPI = newInstance(I_M_HU_PI.class);
+		huPI.setM_HU_PI_ID(HuPackingInstructionsId.VIRTUAL.getRepoId());
+		huPI.setName("VirtualPI");
+		saveRecord(huPI);
+
+		final I_M_HU_PI_Version huPIVersion = newInstance(I_M_HU_PI_Version.class);
+		huPIVersion.setM_HU_PI_Version_ID(HuPackingInstructionsVersionId.VIRTUAL.getRepoId());
+		huPIVersion.setM_HU_PI_ID(huPI.getM_HU_PI_ID());
+		huPIVersion.setIsCurrent(true);
+		saveRecord(huPIVersion);
+
+		final I_M_HU_PI_Item huPIItem = newInstance(I_M_HU_PI_Item.class);
+		huPIItem.setM_HU_PI_Item_ID(HuPackingInstructionsItemId.VIRTUAL.getRepoId());
+		huPIItem.setM_HU_PI_Version_ID(huPIVersion.getM_HU_PI_Version_ID());
+		huPIItem.setItemType(X_M_HU_PI_Item.ITEMTYPE_Material);
+		saveRecord(huPIItem);
+
+		final I_M_HU_PI_Item_Product piip = newInstance(I_M_HU_PI_Item_Product.class);
+		piip.setM_HU_PI_Item_Product_ID(HUPIItemProductId.VIRTUAL_HU.getRepoId());
+		piip.setM_HU_PI_Item_ID(huPIItem.getM_HU_PI_Item_ID());
+		piip.setIsInfiniteCapacity(true);
+		piip.setIsAllowAnyProduct(true);
+		saveRecord(piip);
+	}
+
+	/**
+	 * The customer's shape: a Standard-Packvorschrift with infinite capacity and no business partner,
+	 * created so that mobileUI production works.
+	 */
+	private I_M_HU_PI_Item_Product createDefaultForProductPackingInstruction()
+	{
+		final I_M_HU_PI huPI = newInstance(I_M_HU_PI.class);
+		huPI.setName("SBB Rahmen");
+		saveRecord(huPI);
+
+		final I_M_HU_PI_Version huPIVersion = newInstance(I_M_HU_PI_Version.class);
+		huPIVersion.setM_HU_PI_ID(huPI.getM_HU_PI_ID());
+		huPIVersion.setIsCurrent(true);
+		saveRecord(huPIVersion);
+
+		final I_M_HU_PI_Item huPIItem = newInstance(I_M_HU_PI_Item.class);
+		huPIItem.setM_HU_PI_Version_ID(huPIVersion.getM_HU_PI_Version_ID());
+		huPIItem.setItemType(X_M_HU_PI_Item.ITEMTYPE_Material);
+		saveRecord(huPIItem);
+
+		final I_M_HU_PI_Item_Product piip = newInstance(I_M_HU_PI_Item_Product.class);
+		piip.setM_Product_ID(productId.getRepoId());
+		piip.setM_HU_PI_Item_ID(huPIItem.getM_HU_PI_Item_ID());
+		piip.setIsDefaultForProduct(true);
+		piip.setIsInfiniteCapacity(true);
+		piip.setQty(BigDecimal.ZERO);
+		piip.setValidFrom(TimeUtil.asTimestamp(DATE.minusYears(1)));
+		saveRecord(piip);
+		return piip;
+	}
+
+	private void createProductPrice(@Nullable final I_M_HU_PI_Item_Product huPiItemProduct)
+	{
+		final I_M_ProductPrice productPrice = newInstance(I_M_ProductPrice.class);
+		productPrice.setM_PriceList_Version_ID(priceListVersion.getM_PriceList_Version_ID());
+		productPrice.setM_Product_ID(productId.getRepoId());
+		if (huPiItemProduct != null)
+		{
+			productPrice.setM_HU_PI_Item_Product(huPiItemProduct);
+		}
+		saveRecord(productPrice);
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
@@ -186,9 +186,34 @@ public class C_OrderLineTest
 		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
 	}
 
+	/**
+	 * The price requirement is scoped to sales order lines — the same scope the quick-input helper applies,
+	 * where the IsDefaultForProduct fallback sits behind an {@code SOTrx.SALES} guard. A purchase order line
+	 * must keep today's behaviour even with the rule enforced and no product price referencing the default.
+	 */
+	@Test
+	public void purchaseOrder_enforceOn_noProductPriceReferencesTheDefault_stillSetsThatDefault()
+	{
+		setEnforcePrecisePrice(true);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+		makeOrderAPurchaseOrder();
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
 	//
 	// Fixture
 	//
+
+	private void makeOrderAPurchaseOrder()
+	{
+		final I_C_Order order = load(orderLine.getC_Order_ID(), I_C_Order.class);
+		order.setIsSOTrx(false);
+		saveRecord(order);
+	}
 
 	private void clearOrderLineDatePromised()
 	{

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
@@ -204,9 +204,51 @@ public class C_OrderLineTest
 		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
 	}
 
+	/**
+	 * Neither the line nor the order header carries a DatePromised. An AD {@code Mandatory} flag is only
+	 * enforced on persist, so a pre-save interceptor/callout can genuinely see both unset — and must not
+	 * throw. With no date there is no price list version to restrict against either, so this falls back
+	 * to today's unrestricted behaviour rather than stripping the packing instruction.
+	 */
+	@Test
+	public void noDatePromisedAnywhere_enforceOn_doesNotThrowAndKeepsTodaysBehaviour()
+	{
+		setEnforcePrecisePrice(true);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+		clearOrderLineDatePromised();
+		clearOrderDatePromised();
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	@Test
+	public void noDatePromisedAnywhere_purchaseOrder_doesNotThrowAndKeepsTodaysBehaviour()
+	{
+		setEnforcePrecisePrice(true);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+		clearOrderLineDatePromised();
+		clearOrderDatePromised();
+		makeOrderAPurchaseOrder();
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
 	//
 	// Fixture
 	//
+
+	private void clearOrderDatePromised()
+	{
+		final I_C_Order order = load(orderLine.getC_Order_ID(), I_C_Order.class);
+		order.setDatePromised(null);
+		saveRecord(order);
+	}
 
 	private void makeOrderAPurchaseOrder()
 	{

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
@@ -275,8 +275,8 @@ public class C_OrderLineTest
 	private ProductId createProduct()
 	{
 		final I_M_Product product = newInstance(I_M_Product.class);
-		product.setValue("100024");
-		product.setName("Emmentaler AOP extra");
+		product.setValue("TestProduct");
+		product.setName("Test Product");
 		saveRecord(product);
 		return ProductId.ofRepoId(product.getM_Product_ID());
 	}
@@ -284,7 +284,7 @@ public class C_OrderLineTest
 	private PriceListId createPriceList()
 	{
 		final I_M_PriceList priceList = newInstance(I_M_PriceList.class);
-		priceList.setName("Fromagerie CHF");
+		priceList.setName("Test Sales Price List");
 		priceList.setIsSOPriceList(true);
 		saveRecord(priceList);
 		return PriceListId.ofRepoId(priceList.getM_PriceList_ID());
@@ -303,7 +303,7 @@ public class C_OrderLineTest
 	private de.metas.interfaces.I_C_OrderLine createOrderLine(@NonNull final PriceListId priceListId)
 	{
 		final I_C_BPartner bpartner = newInstance(I_C_BPartner.class);
-		bpartner.setName("Fromagerie");
+		bpartner.setName("Test Partner");
 		saveRecord(bpartner);
 
 		final I_C_Order order = newInstance(I_C_Order.class);
@@ -361,13 +361,13 @@ public class C_OrderLineTest
 	}
 
 	/**
-	 * The customer's shape: a Standard-Packvorschrift with infinite capacity and no business partner,
+	 * The reported shape: a Standard-Packvorschrift with infinite capacity and no business partner,
 	 * created so that mobileUI production works.
 	 */
 	private I_M_HU_PI_Item_Product createDefaultForProductPackingInstruction()
 	{
 		final I_M_HU_PI huPI = newInstance(I_M_HU_PI.class);
-		huPI.setName("SBB Rahmen");
+		huPI.setName("Test Frame PI");
 		saveRecord(huPI);
 
 		final I_M_HU_PI_Version huPIVersion = newInstance(I_M_HU_PI_Version.class);

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
@@ -155,9 +155,46 @@ public class C_OrderLineTest
 		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
 	}
 
+	/**
+	 * {@code C_OrderLine.DatePromised} is nullable and a freshly created line commonly has none yet, so
+	 * reading it unguarded blew up here — for every caller, whether or not the rule is enforced. The date
+	 * falls back to the order header, as the shared price-date resolution does.
+	 */
+	@Test
+	public void lineHasNoDatePromised_enforceOn_fallsBackToTheOrderHeaderDate()
+	{
+		setEnforcePrecisePrice(true);
+		createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+		clearOrderLineDatePromised();
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(HUPIItemProductId.VIRTUAL_HU.getRepoId());
+	}
+
+	@Test
+	public void lineHasNoDatePromised_enforceOff_fallsBackToTheOrderHeaderDate()
+	{
+		setEnforcePrecisePrice(false);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+		clearOrderLineDatePromised();
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
 	//
 	// Fixture
 	//
+
+	private void clearOrderLineDatePromised()
+	{
+		orderLine.setDatePromised(null);
+		saveRecord(orderLine);
+	}
 
 	private void setEnforcePrecisePrice(final boolean value)
 	{

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/field/PackingItemProductFieldHelper.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/field/PackingItemProductFieldHelper.java
@@ -104,7 +104,6 @@ public class PackingItemProductFieldHelper
 		final ClientId clientId = defaultPackingItemCriteria.getClientId();
 		final boolean enforcePrecisePricePerHUItemProduct = huPIItemProductBL.isEnforcePrecisePricePerHUItemProduct(clientId);
 
-
 		// TODO: check ASI too
 		final IHUPIItemProductDAO piItemProductDAO = Services.get(IHUPIItemProductDAO.class);
 		final IHUPIItemProductQuery queryVO = piItemProductDAO.createHUPIItemProductQuery();

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/field/PackingItemProductFieldHelper.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/field/PackingItemProductFieldHelper.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.service.ClientId;
+import org.adempiere.service.ISysConfigBL;
 import org.compiere.model.I_M_PriceList_Version;
 import org.compiere.util.Env;
 import org.springframework.stereotype.Component;
@@ -48,8 +49,8 @@ import lombok.NonNull;
 public class PackingItemProductFieldHelper
 {
 	private final IHUPIItemProductDAO huPIItemProductsRepo = Services.get(IHUPIItemProductDAO.class);
-	private final IHUPIItemProductBL huPIItemProductBL = Services.get(IHUPIItemProductBL.class);
 	private final IPriceListDAO priceListsRepo = Services.get(IPriceListDAO.class);
+	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 
 	public Optional<I_M_HU_PI_Item_Product> getDefaultPackingMaterial(@NonNull final DefaultPackingItemCriteria defaultPackingItemCriteria)
 	{
@@ -67,7 +68,7 @@ public class PackingItemProductFieldHelper
 			return Optional.empty();
 		}
 
-		if (huPIItemProductBL.isEnforcePrecisePricePerHUItemProduct(defaultPackingItemCriteria.getClientId()))
+		if (isEnforcePrecisePricePerHUItemProduct(defaultPackingItemCriteria.getClientId()))
 		{
 			// The price list step above already returned every packing instruction that a product price of
 			// this price list version references. So the IsDefaultForProduct fallback below could only ever
@@ -102,11 +103,10 @@ public class PackingItemProductFieldHelper
 		}
 
 		final ClientId clientId = defaultPackingItemCriteria.getClientId();
-		final boolean enforcePrecisePricePerHUItemProduct = huPIItemProductBL.isEnforcePrecisePricePerHUItemProduct(clientId);
+		final boolean enforcePrecisePricePerHUItemProduct = isEnforcePrecisePricePerHUItemProduct(clientId);
 
 		// TODO: check ASI too
-		final IHUPIItemProductDAO piItemProductDAO = Services.get(IHUPIItemProductDAO.class);
-		final IHUPIItemProductQuery queryVO = piItemProductDAO.createHUPIItemProductQuery();
+		final IHUPIItemProductQuery queryVO = huPIItemProductsRepo.createHUPIItemProductQuery();
 		queryVO.setM_Product_ID(defaultPackingItemCriteria.getProductId().getRepoId());
 		queryVO.setBPartnerId(defaultPackingItemCriteria.getBPartnerLocationId().getBpartnerId());
 		queryVO.setAllowVirtualPI(false);
@@ -117,8 +117,18 @@ public class PackingItemProductFieldHelper
 		{
 			queryVO.setPriceListVersionId(PriceListVersionId.ofRepoId(priceListVersion.getM_PriceList_Version_ID()));
 		}
-		final List<I_M_HU_PI_Item_Product> itemProducts = piItemProductDAO.retrieveHUItemProducts(Env.getCtx(), queryVO, ITrx.TRXNAME_ThreadInherited);
+		final List<I_M_HU_PI_Item_Product> itemProducts = huPIItemProductsRepo.retrieveHUItemProducts(Env.getCtx(), queryVO, ITrx.TRXNAME_ThreadInherited);
 		return itemProducts.stream().findFirst();
+	}
+
+	/**
+	 * @return {@code true} if a packing instruction may only be auto-defaulted when a product price of the
+	 *         relevant price list version references it. Defaults to {@code false} when unset.
+	 */
+	private boolean isEnforcePrecisePricePerHUItemProduct(@NonNull final ClientId clientId)
+	{
+		return sysConfigBL.getBooleanValue(
+				IHUPIItemProductBL.SYSCONFIG_EnforcePrecisePricePerHUItemProduct, false, clientId.getRepoId());
 	}
 
 	@Nullable

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/field/PackingItemProductFieldHelper.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/field/PackingItemProductFieldHelper.java
@@ -29,11 +29,11 @@ import javax.annotation.Nullable;
 
 import org.adempiere.ad.trx.api.ITrx;
 import org.adempiere.service.ClientId;
-import org.adempiere.service.ISysConfigBL;
 import org.compiere.model.I_M_PriceList_Version;
 import org.compiere.util.Env;
 import org.springframework.stereotype.Component;
 
+import de.metas.handlingunits.IHUPIItemProductBL;
 import de.metas.handlingunits.IHUPIItemProductDAO;
 import de.metas.handlingunits.IHUPIItemProductQuery;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
@@ -48,10 +48,8 @@ import lombok.NonNull;
 public class PackingItemProductFieldHelper
 {
 	private final IHUPIItemProductDAO huPIItemProductsRepo = Services.get(IHUPIItemProductDAO.class);
+	private final IHUPIItemProductBL huPIItemProductBL = Services.get(IHUPIItemProductBL.class);
 	private final IPriceListDAO priceListsRepo = Services.get(IPriceListDAO.class);
-	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
-	
-	private static final String SYSCONFIG_EnforcePrecisePricePerHUItemProduct = "de.metas.ui.web.quickinput.field.PackingItemProductFieldHelper.EnforcePrecisePricePerHUItemProduct";
 
 	public Optional<I_M_HU_PI_Item_Product> getDefaultPackingMaterial(@NonNull final DefaultPackingItemCriteria defaultPackingItemCriteria)
 	{
@@ -62,18 +60,26 @@ public class PackingItemProductFieldHelper
 			return defaultPIProduct;
 		}
 
-		if (SOTrx.SALES.equals(defaultPackingItemCriteria.getSoTrx()))
-		{
-			// Sales Orders: if no Packing Instruction is set on Product Price, check the default Packing Item for Product (set in CU-TU Allocations)
-			return huPIItemProductsRepo.retrieveDefaultForProduct(defaultPackingItemCriteria.getProductId(),
-					defaultPackingItemCriteria.getBPartnerLocationId().getBpartnerId(), defaultPackingItemCriteria.getDate());
-		}
-		else
+		if (!SOTrx.SALES.equals(defaultPackingItemCriteria.getSoTrx()))
 		{
 			// Purchase Orders: only the Packing Instructions which are set on Purchase Product Prices are used.
 			// Therefore at this step we return nothing.
 			return Optional.empty();
 		}
+
+		if (huPIItemProductBL.isEnforcePrecisePricePerHUItemProduct(defaultPackingItemCriteria.getClientId()))
+		{
+			// The price list step above already returned every packing instruction that a product price of
+			// this price list version references. So the IsDefaultForProduct fallback below could only ever
+			// yield one that no product price references -- which is exactly what this setting forbids, and
+			// such a packing instruction makes the order line uncompletable ("Produkt ist nicht auf der
+			// Preisliste"), because pricing matches on it.
+			return Optional.empty();
+		}
+
+		// Sales Orders: if no Packing Instruction is set on Product Price, check the default Packing Item for Product (set in CU-TU Allocations)
+		return huPIItemProductsRepo.retrieveDefaultForProduct(defaultPackingItemCriteria.getProductId(),
+				defaultPackingItemCriteria.getBPartnerLocationId().getBpartnerId(), defaultPackingItemCriteria.getDate());
 	}
 
 	private Optional<I_M_HU_PI_Item_Product> getDefaultPackingMaterialFromPriceList(@NonNull final DefaultPackingItemCriteria defaultPackingItemCriteria)
@@ -96,8 +102,9 @@ public class PackingItemProductFieldHelper
 		}
 
 		final ClientId clientId = defaultPackingItemCriteria.getClientId();
-		final boolean enforcePrecisePricePerHUItemProduct = sysConfigBL.getBooleanValue(SYSCONFIG_EnforcePrecisePricePerHUItemProduct, false, clientId.getRepoId());
-		
+		final boolean enforcePrecisePricePerHUItemProduct = huPIItemProductBL.isEnforcePrecisePricePerHUItemProduct(clientId);
+
+
 		// TODO: check ASI too
 		final IHUPIItemProductDAO piItemProductDAO = Services.get(IHUPIItemProductDAO.class);
 		final IHUPIItemProductQuery queryVO = piItemProductDAO.createHUPIItemProductQuery();

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/quickinput/field/PackingItemProductFieldHelperTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/quickinput/field/PackingItemProductFieldHelperTest.java
@@ -186,8 +186,8 @@ public class PackingItemProductFieldHelperTest
 	private ProductId createProduct()
 	{
 		final I_M_Product product = newInstance(I_M_Product.class);
-		product.setValue("100024");
-		product.setName("Emmentaler AOP extra");
+		product.setValue("TestProduct");
+		product.setName("Test Product");
 		saveRecord(product);
 		return ProductId.ofRepoId(product.getM_Product_ID());
 	}
@@ -195,7 +195,7 @@ public class PackingItemProductFieldHelperTest
 	private BPartnerLocationAndCaptureId createBPartnerLocation()
 	{
 		final I_C_BPartner bpartner = newInstance(I_C_BPartner.class);
-		bpartner.setName("Fromagerie");
+		bpartner.setName("Test Partner");
 		saveRecord(bpartner);
 
 		final I_C_BPartner_Location bpLocation = newInstance(I_C_BPartner_Location.class);
@@ -208,7 +208,7 @@ public class PackingItemProductFieldHelperTest
 	private PriceListId createPriceList()
 	{
 		final I_M_PriceList priceList = newInstance(I_M_PriceList.class);
-		priceList.setName("Fromagerie CHF");
+		priceList.setName("Test Sales Price List");
 		priceList.setIsSOPriceList(true);
 		saveRecord(priceList);
 		return PriceListId.ofRepoId(priceList.getM_PriceList_ID());
@@ -225,13 +225,13 @@ public class PackingItemProductFieldHelperTest
 	}
 
 	/**
-	 * The customer's shape: a Standard-Packvorschrift with infinite capacity and no business partner,
+	 * The reported shape: a Standard-Packvorschrift with infinite capacity and no business partner,
 	 * created so that mobileUI production works.
 	 */
 	private I_M_HU_PI_Item_Product createDefaultForProductPackingInstruction()
 	{
 		final I_M_HU_PI huPI = newInstance(I_M_HU_PI.class);
-		huPI.setName("SBB Rahmen");
+		huPI.setName("Test Frame PI");
 		saveRecord(huPI);
 
 		final I_M_HU_PI_Version huPIVersion = newInstance(I_M_HU_PI_Version.class);

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/quickinput/field/PackingItemProductFieldHelperTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/quickinput/field/PackingItemProductFieldHelperTest.java
@@ -1,0 +1,269 @@
+/*
+ * #%L
+ * metasfresh-webui-api
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ui.web.quickinput.field;
+
+import de.metas.bpartner.BPartnerLocationAndCaptureId;
+import de.metas.handlingunits.IHUPIItemProductBL;
+import de.metas.handlingunits.model.I_M_HU_PI;
+import de.metas.handlingunits.model.I_M_HU_PI_Item;
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.handlingunits.model.I_M_HU_PI_Version;
+import de.metas.handlingunits.model.I_M_ProductPrice;
+import de.metas.handlingunits.model.X_M_HU_PI_Item;
+import de.metas.lang.SOTrx;
+import de.metas.pricing.PriceListId;
+import de.metas.product.ProductId;
+import lombok.NonNull;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.model.I_AD_SysConfig;
+import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_C_BPartner_Location;
+import org.compiere.model.I_M_PriceList;
+import org.compiere.model.I_M_PriceList_Version;
+import org.compiere.model.I_M_Product;
+import org.compiere.util.TimeUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the rule that a Standard-Packvorschrift ({@code M_HU_PI_Item_Product.IsDefaultForProduct}) is
+ * only offered as the sales order line quick-entry default when a product price of the order's price list
+ * version references it.
+ * <p>
+ * Note on the fixture: the criteria carry an explicit {@code priceListId}. Resolving a price list from the
+ * pricing system + partner country is a separate concern of {@code IPriceListDAO} and is not what these
+ * tests are about — the branch under test sits downstream of that resolution.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class PackingItemProductFieldHelperTest
+{
+	private static final ZonedDateTime DATE = LocalDate.of(2026, 8, 12).atStartOfDay(ZoneId.of("UTC"));
+
+	private PackingItemProductFieldHelper helper;
+
+	private ClientId clientId;
+	private ProductId productId;
+	private BPartnerLocationAndCaptureId bpartnerLocationId;
+	private PriceListId priceListId;
+	private I_M_PriceList_Version priceListVersion;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		helper = new PackingItemProductFieldHelper();
+
+		clientId = ClientId.ofRepoId(1000000);
+		productId = createProduct();
+		bpartnerLocationId = createBPartnerLocation();
+		priceListId = createPriceList();
+		priceListVersion = createPriceListVersion(priceListId);
+	}
+
+	//
+	// Tests
+	//
+
+	@Test
+	public void salesOrder_enforceOn_noProductPriceReferencesTheDefault_returnsEmpty()
+	{
+		setEnforcePrecisePrice(true);
+		createDefaultForProductPackingInstruction();
+		createProductPrice(null); // a price for the product, but with no packing instruction
+
+		assertThat(helper.getDefaultPackingMaterial(criteria(SOTrx.SALES))).isEmpty();
+	}
+
+	@Test
+	public void salesOrder_enforceOff_noProductPriceReferencesTheDefault_returnsTheDefault()
+	{
+		setEnforcePrecisePrice(false);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+
+		assertThat(helper.getDefaultPackingMaterial(criteria(SOTrx.SALES)))
+				.get()
+				.extracting(I_M_HU_PI_Item_Product::getM_HU_PI_Item_Product_ID)
+				.isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	@Test
+	public void salesOrder_enforceOn_aProductPriceReferencesThePackingInstruction_returnsIt()
+	{
+		setEnforcePrecisePrice(true);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(piip);
+
+		assertThat(helper.getDefaultPackingMaterial(criteria(SOTrx.SALES)))
+				.get()
+				.extracting(I_M_HU_PI_Item_Product::getM_HU_PI_Item_Product_ID)
+				.isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	@Test
+	public void purchaseOrder_enforceOn_neverReachesTheDefaultForProductFallback()
+	{
+		setEnforcePrecisePrice(true);
+		createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+
+		assertThat(helper.getDefaultPackingMaterial(criteria(SOTrx.PURCHASE))).isEmpty();
+	}
+
+	/**
+	 * The shape used by the invoice line and distribution order line quick inputs: they build their
+	 * criteria without a {@code soTrx}, so they never reach the sales-only fallback.
+	 */
+	@Test
+	public void noSoTrx_enforceOn_neverReachesTheDefaultForProductFallback()
+	{
+		setEnforcePrecisePrice(true);
+		createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+
+		assertThat(helper.getDefaultPackingMaterial(criteria(null))).isEmpty();
+	}
+
+	//
+	// Fixture
+	//
+
+	private DefaultPackingItemCriteria criteria(@Nullable final SOTrx soTrx)
+	{
+		return DefaultPackingItemCriteria.builder()
+				.productId(productId)
+				.bPartnerLocationId(bpartnerLocationId)
+				.date(DATE)
+				.priceListId(priceListId)
+				.soTrx(soTrx)
+				.clientId(clientId)
+				.build();
+	}
+
+	private void setEnforcePrecisePrice(final boolean value)
+	{
+		final I_AD_SysConfig sysConfig = newInstance(I_AD_SysConfig.class);
+		sysConfig.setName(IHUPIItemProductBL.SYSCONFIG_EnforcePrecisePricePerHUItemProduct);
+		sysConfig.setValue(value ? "Y" : "N");
+		sysConfig.setIsActive(true);
+		saveRecord(sysConfig);
+	}
+
+	private ProductId createProduct()
+	{
+		final I_M_Product product = newInstance(I_M_Product.class);
+		product.setValue("100024");
+		product.setName("Emmentaler AOP extra");
+		saveRecord(product);
+		return ProductId.ofRepoId(product.getM_Product_ID());
+	}
+
+	private BPartnerLocationAndCaptureId createBPartnerLocation()
+	{
+		final I_C_BPartner bpartner = newInstance(I_C_BPartner.class);
+		bpartner.setName("Fromagerie");
+		saveRecord(bpartner);
+
+		final I_C_BPartner_Location bpLocation = newInstance(I_C_BPartner_Location.class);
+		bpLocation.setC_BPartner_ID(bpartner.getC_BPartner_ID());
+		saveRecord(bpLocation);
+
+		return BPartnerLocationAndCaptureId.ofRepoId(bpartner.getC_BPartner_ID(), bpLocation.getC_BPartner_Location_ID());
+	}
+
+	private PriceListId createPriceList()
+	{
+		final I_M_PriceList priceList = newInstance(I_M_PriceList.class);
+		priceList.setName("Fromagerie CHF");
+		priceList.setIsSOPriceList(true);
+		saveRecord(priceList);
+		return PriceListId.ofRepoId(priceList.getM_PriceList_ID());
+	}
+
+	private I_M_PriceList_Version createPriceListVersion(@NonNull final PriceListId priceListId)
+	{
+		final I_M_PriceList_Version plv = newInstance(I_M_PriceList_Version.class);
+		plv.setM_PriceList_ID(priceListId.getRepoId());
+		plv.setValidFrom(TimeUtil.asTimestamp(DATE.minusYears(1)));
+		plv.setIsActive(true);
+		saveRecord(plv);
+		return plv;
+	}
+
+	/**
+	 * The customer's shape: a Standard-Packvorschrift with infinite capacity and no business partner,
+	 * created so that mobileUI production works.
+	 */
+	private I_M_HU_PI_Item_Product createDefaultForProductPackingInstruction()
+	{
+		final I_M_HU_PI huPI = newInstance(I_M_HU_PI.class);
+		huPI.setName("SBB Rahmen");
+		saveRecord(huPI);
+
+		final I_M_HU_PI_Version huPIVersion = newInstance(I_M_HU_PI_Version.class);
+		huPIVersion.setM_HU_PI_ID(huPI.getM_HU_PI_ID());
+		huPIVersion.setIsCurrent(true);
+		saveRecord(huPIVersion);
+
+		final I_M_HU_PI_Item huPIItem = newInstance(I_M_HU_PI_Item.class);
+		huPIItem.setM_HU_PI_Version_ID(huPIVersion.getM_HU_PI_Version_ID());
+		huPIItem.setItemType(X_M_HU_PI_Item.ITEMTYPE_Material);
+		saveRecord(huPIItem);
+
+		final I_M_HU_PI_Item_Product piip = newInstance(I_M_HU_PI_Item_Product.class);
+		piip.setM_Product_ID(productId.getRepoId());
+		piip.setM_HU_PI_Item_ID(huPIItem.getM_HU_PI_Item_ID());
+		piip.setIsDefaultForProduct(true);
+		piip.setIsInfiniteCapacity(true);
+		piip.setQty(BigDecimal.ZERO);
+		piip.setValidFrom(TimeUtil.asTimestamp(DATE.minusYears(1)));
+		saveRecord(piip);
+		return piip;
+	}
+
+	private void createProductPrice(@Nullable final I_M_HU_PI_Item_Product huPiItemProduct)
+	{
+		final I_M_ProductPrice productPrice = newInstance(I_M_ProductPrice.class);
+		productPrice.setM_PriceList_Version_ID(priceListVersion.getM_PriceList_Version_ID());
+		productPrice.setM_Product_ID(productId.getRepoId());
+		if (huPiItemProduct != null)
+		{
+			productPrice.setM_HU_PI_Item_Product(huPiItemProduct);
+		}
+		saveRecord(productPrice);
+	}
+}


### PR DESCRIPTION
## Problem

A product's Standard-Packvorschrift (`M_HU_PI_Item_Product.IsDefaultForProduct`) was auto-defaulted onto a sales order line even when no `M_ProductPrice` of the order's price list version referenced it. Because pricing matches on `M_HU_PI_Item_Product_ID` (`HUPricing`), such a line then cannot be priced and the order cannot be completed — "Produkt ist nicht auf der Preisliste".

This bites any installation that has to maintain a default packing instruction for one purpose (mobileUI production) while selling the same product unpackaged to some partners.

## The rule

With `EnforcePrecisePricePerHUItemProduct` set, a packing instruction is auto-defaulted onto a **sales** order line only if a product price of the order's price list version references it.

**No new setting and no migration** — the behaviour is gated on the pre-existing
`de.metas.ui.web.quickinput.field.PackingItemProductFieldHelper.EnforcePrecisePricePerHUItemProduct`, which now does what its name says. Setting it to `N` restores the previous behaviour; that migration's own description already documents `N` as the escape hatch.

## Two sites, deliberately different

| Site | Behaviour |
|---|---|
| Sales order line **quick entry** (`PackingItemProductFieldHelper`) | **Skips** the `IsDefaultForProduct` fallback. Its price-list step already returns any packing instruction a price references, so the fallback could only ever yield an unpriced one. |
| **Manual entry / product change** (`reservation.interceptor.C_OrderLine`) | **Restricts** the lookup to priced packing instructions via a new `PriceListVersionId` DAO overload. It has no price-list step, so skipping would also strip the default where a price legitimately references it. |

Purchase order lines, invoice line and distribution order line quick entry are unaffected.

## Also fixed on the way

`C_OrderLine.DatePromised` is nullable and the interceptor read it unguarded, so a line without one threw out of the packing-instruction lookup — for every caller, gated or not. This reproduces at the branch point, so it is pre-existing rather than introduced here, but it lives in the method being changed. The date now coalesces to the order header, and nothing on the path throws: an AD `Mandatory` flag is enforced on persist, not while a record is being edited, so a pre-save interceptor/callout can legitimately see no date at all.

## Tests

`de.metas.handlingunits.base` 709 / 0 failures · `de.metas.ui.web.base` 1267 / 0 failures.

New: `C_OrderLineTest` (9), `PackingItemProductFieldHelperTest` (5), plus 3 in `HUPIItemProductDAOTest`. Both new classes were confirmed failing before the fix and passing after.

Browser end-to-end coverage of the quick-entry field follows in a separate PR.
