### PR TITLE
webui: stop the column-resize handle from swallowing context-menu clicks

### DIFF
--- a/frontend/src/assets/css/layers.scss
+++ b/frontend/src/assets/css/layers.scss
@@ -10,6 +10,12 @@
 * - 400 - screen-freeze
 */
 
+/* Over static content, so a row context menu is never occluded by a table's own
+ * in-content overlays -- notably `.column-resize-handle` (table.scss), a full-height 5px
+ * strip at z-index 3 on every header-cell boundary. Both used to sit at 3, which left the
+ * hit test to DOM order and let the invisible handle swallow clicks on menu items. */
+$z-index-context-menu: 50;
+
 $z-index-backdrop: 200;
 $z-index-spinner-overlay: 200;
 $z-index-header-menu: 201;

--- a/frontend/src/assets/css/layers.scss
+++ b/frontend/src/assets/css/layers.scss
@@ -10,11 +10,19 @@
 * - 400 - screen-freeze
 */
 
-/* Over static content, so a row context menu is never occluded by a table's own
- * in-content overlays -- notably `.column-resize-handle` (table.scss), a full-height 5px
- * strip at z-index 3 on every header-cell boundary. Both used to sit at 3, which left the
- * hit test to DOM order and let the invisible handle swallow clicks on menu items. */
-$z-index-context-menu: 50;
+/* Over static content, so a row context menu is never occluded by an overlay that can be
+ * open at the same time. It must outrank, in the <100 band:
+ *   3  `.column-resize-handle` (table.scss) - a full-height 5px strip on every header-cell
+ *      boundary; both sat at 3, so the hit test fell to DOM order and the invisible handle
+ *      swallowed clicks on menu items. That is the bug this value exists to prevent.
+ *   50 `.attributes-dropdown` (attributes.scss) - rendered INSIDE table cells, so it can be
+ *      open in the same subtree as the menu.
+ *   50 `.click-overlay` (screen-freeze.scss) - the outside-click catcher of a raw modal, which
+ *      can host a grid; below it, a click on the menu would close the modal instead.
+ * and stay under 99 (spinner / tabs / inputs / status-list) and 100 (header). 51-98 is
+ * otherwise unoccupied - keep it that way rather than reusing 50, or the equal-z-index /
+ * DOM-order coin flip simply moves to a different pair of elements. */
+$z-index-context-menu: 60;
 
 $z-index-backdrop: 200;
 $z-index-spinner-overlay: 200;

--- a/frontend/src/assets/css/layers.scss
+++ b/frontend/src/assets/css/layers.scss
@@ -4,24 +4,35 @@
 * Layers
 * - 0 - default - all static elements like tables or forms
 * - < 100 - elements that are over static content (order list)
-* - 100 - header
 * - 200 - backdrop
-* - 200 < - elements that are over backdrop (header expanded)
+* - 200 < - elements that are over backdrop (header expanded), incl. the header itself at 201
 * - 400 - screen-freeze
+*
+* The "100 - header" line that used to sit in this list was stale and has been removed: the
+* header is `$z-index-header-menu` (201, below), and the literal 100s in the codebase belong to
+* unrelated elements (`.panel-size-button`, `.draggable-widget-menu`, `.react-tagsinput--focused`,
+* `.modal-content-wrapper`). It is removed rather than corrected in place because it was read as
+* ground truth when choosing a value below and produced a wrong constraint.
 */
 
-/* Over static content, so a row context menu is never occluded by an overlay that can be
- * open at the same time. It must outrank, in the <100 band:
+/* Over static content, so a row context menu is never occluded by an overlay that can be open
+ * at the same time and in the same stacking context. It must outrank:
  *   3  `.column-resize-handle` (table.scss) - a full-height 5px strip on every header-cell
  *      boundary; both sat at 3, so the hit test fell to DOM order and the invisible handle
  *      swallowed clicks on menu items. That is the bug this value exists to prevent.
  *   50 `.attributes-dropdown` (attributes.scss) - rendered INSIDE table cells, so it can be
  *      open in the same subtree as the menu.
- *   50 `.click-overlay` (screen-freeze.scss) - the outside-click catcher of a raw modal, which
- *      can host a grid; below it, a click on the menu would close the modal instead.
- * and stay under 99 (spinner / tabs / inputs / status-list) and 100 (header). 51-98 is
- * otherwise unoccupied - keep it that way rather than reusing 50, or the equal-z-index /
- * DOM-order coin flip simply moves to a different pair of elements. */
+ * Ceiling: stay under 99 (`.spinner .icon`, `.tabs-fullscreen`, `.input-dropdown-list`,
+ * `.dropdown-status-list`), which should stay above the menu. 51-98 is otherwise unoccupied -
+ * keep it that way rather than reusing an in-use value, or the equal-z-index / DOM-order coin
+ * flip simply moves to a different pair of elements.
+ *
+ * NOT a constraint, recorded so it is not "helpfully" added back: `.click-overlay`
+ * (screen-freeze.scss, z-index 50), a raw modal's outside-click catcher. A raw modal can host a
+ * grid, but `.screen-freeze` is `display: flex` and its `.modal-content-wrapper` child carries
+ * `z-index: 100` with no `position`; per CSS Flexbox 5.4 a flex item with a non-auto z-index
+ * forms a stacking context even when statically positioned, so the wrapper paints atomically
+ * above `.click-overlay` and every descendant menu wins there regardless of its own value. */
 $z-index-context-menu: 60;
 
 $z-index-backdrop: 200;

--- a/frontend/src/assets/css/styles.scss
+++ b/frontend/src/assets/css/styles.scss
@@ -162,7 +162,7 @@ body {
   font-weight: normal;
   color: $brand-font-color;
   box-shadow: 0 0 6px rgba(0, 0, 0, .1);
-  z-index: 3;
+  z-index: $z-index-context-menu;
   overflow: hidden;
 }
 


### PR DESCRIPTION
`.context-menu` and `.column-resize-handle` both declared `z-index: 3`. At equal stacking level the hit test falls to DOM order, so the resize handle can win over a context menu that is visually on top.

The handle is `position: absolute; top: 0; bottom: 0; width: 5px` — a **full-height, invisible 5px strip at every header-cell boundary**. When a row context menu opens over a grid header, any menu item whose clicked point lands on such a boundary is silently dead: the click reaches the handle and the menu's `onClick` never fires.

It is narrow, so a user usually clicks elsewhere on the item and never notices — which is why it has gone unreported since the handle was introduced. An automated click always targets the element **centre**, so it hits the strip reliably.

## The fix

`layers.scss` already documents the intended bands:

```
* - 0 - default - all static elements like tables or forms
* - < 100 - elements that are over static content (order list)
* - 100 - header
```

A context menu is exactly "an element over static content", but it was sitting in the static band. It now gets a named layer (`$z-index-context-menu: 50`) instead of another bare number. The resize handle keeps `z-index: 3`, which is correct for in-table content — nothing about resizing changes.

## Verification

Reproduced and fixed against a running local stack, using an existing E2E scenario that clicks a reference in the order-line context menu:

- **before:** failed 3x — standalone, with neighbouring specs preceding it, and again after clearing the AD metadata caches (ruling out both test-ordering and stale-metadata explanations)
- **after:** passes

Regression-checked the two things this could plausibly break, both green:

- `column-resize.spec.js` — drag-to-resize, width persistence across reload, double-click reset
- `zoom-into.spec.js` — right-click zoom, i.e. the context-menu path itself

plus `subheader-actions.spec.js` and a windowed grid spec. `yarn lint` clean.
