### PR TITLE
Sales order quick entry: E2E coverage for the default packing instruction rule

### DIFF
--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreatePackingInstructionsCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreatePackingInstructionsCommand.java
@@ -50,7 +50,7 @@ public class CreatePackingInstructionsCommand
 	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	@NonNull private final IProductBL productBL = Services.get(IProductBL.class);
 	@NonNull private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
-	@NonNull private final IPriceListDAO priceListsRepo = Services.get(IPriceListDAO.class);
+	@NonNull private final IPriceListDAO priceListDAO = Services.get(IPriceListDAO.class);
 	@NonNull private final MasterdataContext context;
 	@NonNull private final JsonPackingInstructionsRequest request;
 	@NonNull private final Identifier identifier;
@@ -250,7 +250,7 @@ public class CreatePackingInstructionsCommand
 		// Fails with "No identifier found for PriceListVersionId" when the request has no bpartners section:
 		// the price list version is created as a side effect of creating a bpartner.
 		final PriceListVersionId priceListVersionId = context.getIdOfType(PriceListVersionId.class);
-		final I_M_PriceList_Version priceListVersion = priceListsRepo.getPriceListVersionById(priceListVersionId);
+		final I_M_PriceList_Version priceListVersion = priceListDAO.getPriceListVersionById(priceListVersionId);
 
 		final List<I_M_ProductPrice> productPrices = ProductPrices.newQuery(priceListVersion)
 				.setProductId(productId)

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreatePackingInstructionsCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreatePackingInstructionsCommand.java
@@ -19,24 +19,23 @@ import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
 import de.metas.handlingunits.model.I_M_ProductPrice;
 import de.metas.logging.LogManager;
+import de.metas.manufacturing.workflows_api.activity_handlers.generateHUQRCodes.GenerateHUQRCodesActivityHandler;
+import de.metas.manufacturing.workflows_api.activity_handlers.receive.MaterialReceiptActivityHandler;
 import de.metas.pricing.PriceListVersionId;
 import de.metas.pricing.service.IPriceListDAO;
 import de.metas.pricing.service.ProductPrices;
-import de.metas.util.Check;
-import de.metas.manufacturing.workflows_api.activity_handlers.generateHUQRCodes.GenerateHUQRCodesActivityHandler;
-import de.metas.manufacturing.workflows_api.activity_handlers.receive.MaterialReceiptActivityHandler;
 import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
 import de.metas.uom.UomId;
+import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.model.InterfaceWrapperHelper;
-import org.slf4j.Logger;
-
 import org.compiere.model.I_M_PriceList_Version;
+import org.slf4j.Logger;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -239,11 +238,17 @@ public class CreatePackingInstructionsCommand
 	/**
 	 * Makes the product's price(s) on the current price list version reference the given CU-TU allocation,
 	 * so the packing instruction is one a product price actually points at.
+	 * <p>
+	 * Links <em>every</em> price row the product has on that price list version. Fixtures create one price
+	 * per product, so that is the same thing in practice — but a fixture that creates several (e.g.
+	 * attribute-dependent variants) would get them all pointed at this allocation.
 	 */
 	private void pointProductPricesAt(
 			@NonNull final ProductId productId,
 			@NonNull final I_M_HU_PI_Item_Product piItemProduct)
 	{
+		// Fails with "No identifier found for PriceListVersionId" when the request has no bpartners section:
+		// the price list version is created as a side effect of creating a bpartner.
 		final PriceListVersionId priceListVersionId = context.getIdOfType(PriceListVersionId.class);
 		final I_M_PriceList_Version priceListVersion = priceListsRepo.getPriceListVersionById(priceListVersionId);
 
@@ -251,7 +256,8 @@ public class CreatePackingInstructionsCommand
 				.setProductId(productId)
 				.list(I_M_ProductPrice.class);
 
-		Check.assumeNotEmpty(productPrices, "product {} has at least one product price on {} to reference the packing instruction from",
+		Check.assumeNotEmpty(productPrices,
+				"referencedByProductPrice needs product {} to have a price on price list version {} — give the product a price in the same request",
 				productId, priceListVersionId);
 
 		for (final I_M_ProductPrice productPrice : productPrices)

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreatePackingInstructionsCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreatePackingInstructionsCommand.java
@@ -17,7 +17,12 @@ import de.metas.handlingunits.model.I_M_HU_PI;
 import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
+import de.metas.handlingunits.model.I_M_ProductPrice;
 import de.metas.logging.LogManager;
+import de.metas.pricing.PriceListVersionId;
+import de.metas.pricing.service.IPriceListDAO;
+import de.metas.pricing.service.ProductPrices;
+import de.metas.util.Check;
 import de.metas.manufacturing.workflows_api.activity_handlers.generateHUQRCodes.GenerateHUQRCodesActivityHandler;
 import de.metas.manufacturing.workflows_api.activity_handlers.receive.MaterialReceiptActivityHandler;
 import de.metas.product.IProductBL;
@@ -31,8 +36,11 @@ import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.slf4j.Logger;
 
+import org.compiere.model.I_M_PriceList_Version;
+
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.util.List;
 
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 
@@ -43,6 +51,7 @@ public class CreatePackingInstructionsCommand
 	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	@NonNull private final IProductBL productBL = Services.get(IProductBL.class);
 	@NonNull private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
+	@NonNull private final IPriceListDAO priceListsRepo = Services.get(IPriceListDAO.class);
 	@NonNull private final MasterdataContext context;
 	@NonNull private final JsonPackingInstructionsRequest request;
 	@NonNull private final Identifier identifier;
@@ -212,13 +221,44 @@ public class CreatePackingInstructionsCommand
 		record.setC_UOM_ID(uomId.getRepoId());
 		record.setValidFrom(Timestamp.from(MasterdataContext.DEFAULT_ValidFrom.atStartOfDay(SystemTime.zoneId()).toInstant()));
 		record.setEAN_TU(request.getTu_ean() != null ? request.getTu_ean().getAsString() : null);
+		record.setIsDefaultForProduct(request.isDefaultForProduct());
 		saveRecord(record);
 		final HUPIItemProductId piItemProductId = HUPIItemProductId.ofRepoId(record.getM_HU_PI_Item_Product_ID());
+
+		if (request.isReferencedByProductPrice())
+		{
+			pointProductPricesAt(productId, record);
+		}
 
 		context.putIdentifierIfAbsent(tuIdentifier, piItemProductId);
 		context.putIdentifier(Identifier.ofString(tuIdentifier.getAsString() + "_" + productIdentifier.getAsString()), piItemProductId);
 
 		return MaterialReceiptActivityHandler.extractNewTUTargetTestId(record);
+	}
+
+	/**
+	 * Makes the product's price(s) on the current price list version reference the given CU-TU allocation,
+	 * so the packing instruction is one a product price actually points at.
+	 */
+	private void pointProductPricesAt(
+			@NonNull final ProductId productId,
+			@NonNull final I_M_HU_PI_Item_Product piItemProduct)
+	{
+		final PriceListVersionId priceListVersionId = context.getIdOfType(PriceListVersionId.class);
+		final I_M_PriceList_Version priceListVersion = priceListsRepo.getPriceListVersionById(priceListVersionId);
+
+		final List<I_M_ProductPrice> productPrices = ProductPrices.newQuery(priceListVersion)
+				.setProductId(productId)
+				.list(I_M_ProductPrice.class);
+
+		Check.assumeNotEmpty(productPrices, "product {} has at least one product price on {} to reference the packing instruction from",
+				productId, priceListVersionId);
+
+		for (final I_M_ProductPrice productPrice : productPrices)
+		{
+			productPrice.setM_HU_PI_Item_Product(piItemProduct);
+			saveRecord(productPrice);
+		}
 	}
 
 	private void renamePreviousEANs()

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonPackingInstructionsRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonPackingInstructionsRequest.java
@@ -31,6 +31,22 @@ public class JsonPackingInstructionsRequest
 	@Nullable Identifier lu;
 	int qtyTUsPerLU;
 
+	/**
+	 * Sets {@code M_HU_PI_Item_Product.IsDefaultForProduct} on the created CU-TU allocation — the
+	 * "Standard-Packvorschrift" that gets auto-defaulted onto document lines for this product.
+	 */
+	boolean isDefaultForProduct;
+
+	/**
+	 * Points the product's existing product price(s) on the current price list version at the created
+	 * CU-TU allocation, i.e. makes the packing instruction one that a price references.
+	 * <p>
+	 * The link is expressed here rather than on the product request because products are created before
+	 * packing instructions ({@code CreateMasterdataCommand}), so at price-creation time the packing
+	 * instruction does not exist yet.
+	 */
+	boolean referencedByProductPrice;
+
 	public Identifier getTuNotNull() {return Check.assumeNotNull(tu, "tu must be set");}
 
 	public Identifier getProductNotNull() {return Check.assumeNotNull(product, "product must be set");}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonPackingInstructionsRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonPackingInstructionsRequest.java
@@ -34,16 +34,21 @@ public class JsonPackingInstructionsRequest
 	/**
 	 * Sets {@code M_HU_PI_Item_Product.IsDefaultForProduct} on the created CU-TU allocation — the
 	 * "Standard-Packvorschrift" that gets auto-defaulted onto document lines for this product.
+	 * <p>
+	 * TU requests only — a {@code cu} request creates no CU-TU allocation, so this has no effect there.
 	 */
 	boolean isDefaultForProduct;
 
 	/**
 	 * Points the product's existing product price(s) on the current price list version at the created
-	 * CU-TU allocation, i.e. makes the packing instruction one that a price references.
+	 * CU-TU allocation, i.e. makes the packing instruction one that a price references. Requires the same
+	 * request to give that product a price.
 	 * <p>
 	 * The link is expressed here rather than on the product request because products are created before
 	 * packing instructions ({@code CreateMasterdataCommand}), so at price-creation time the packing
 	 * instruction does not exist yet.
+	 * <p>
+	 * TU requests only — a {@code cu} request creates no CU-TU allocation, so this has no effect there.
 	 */
 	boolean referencedByProductPrice;
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pricing/spi/impl/HUPricing.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pricing/spi/impl/HUPricing.java
@@ -209,7 +209,12 @@ public class HUPricing extends AttributePricing
 
 		//
 		// Make sure the default product price attribute is matching our pricing context packing material,
-		// or it has no packing material set.
+		// or the pricing CONTEXT has no packing material set.
+		//
+		// Note the exemption is on the context side only: once the context carries a packing material, a
+		// default price without one does NOT qualify, because its M_HU_PI_Item_Product_ID reads as "None"
+		// and therefore compares unequal. So a packing instruction that no product price references cannot
+		// be rescued by a packing-material-less default price here.
 		if (!isProductPriceMatchingContextPackingMaterial(defaultPrice, pricingCtx))
 		{
 			return null;

--- a/e2e/frontend-webui/tests/spec/sales-order-default-packing-instruction.spec.js
+++ b/e2e/frontend-webui/tests/spec/sales-order-default-packing-instruction.spec.js
@@ -1,0 +1,129 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { LoginPage } from '../utils/pages/LoginPage';
+import { SalesOrderPage } from '../utils/pages/SalesOrderPage';
+import { getFieldData, getValidationStatus } from '../utils/WebAPIValidation';
+import { SALES_ORDER_WINDOW_ID } from '../utils/WindowIds';
+
+/**
+ * A product's Standard-Packvorschrift (`M_HU_PI_Item_Product.IsDefaultForProduct`) must only be
+ * pre-filled into the sales order line quick entry when a product price of the order's price list
+ * version references it.
+ *
+ * Pricing matches on the packing instruction, so a pre-filled one that no price references makes the
+ * line unpriceable and the order impossible to complete ("Produkt ist nicht auf der Preisliste").
+ *
+ * Both cases run under the seeded default of
+ * `de.metas.ui.web.quickinput.field.PackingItemProductFieldHelper.EnforcePrecisePricePerHUItemProduct`,
+ * which is `Y` — the value real installations run — so the specs deliberately do NOT write it.
+ */
+
+/**
+ * @param {boolean} priceReferencesPackingInstruction
+ *   false → the product has a price, but nothing references the Standard-Packvorschrift (the reported case)
+ *   true  → the product's price references it
+ */
+const createFixture = async (priceReferencesPackingInstruction) =>
+  Backend.createMasterdata({
+    request: {
+      login: { user: { language: 'en_US' } },
+      bpartners: {
+        CUSTOMER: {
+          isVendor: false,
+          isCustomer: true,
+          isSoPriceList: true,
+          name: 'Customer',
+        },
+      },
+      products: {
+        PROD: {
+          name: 'PROD',
+          type: 'Item',
+          prices: [{ price: 17.35, currencyCode: 'EUR' }],
+        },
+      },
+      packingInstructions: {
+        // No qtyCUsPerTU => infinite capacity, and no bpartner: the shape a product carries when the
+        // packing instruction exists for mobileUI production rather than for selling.
+        DEFAULT_PI: {
+          tu: 'TU_DEFAULT',
+          product: 'PROD',
+          isDefaultForProduct: true,
+          referencedByProductPrice: priceReferencesPackingInstruction,
+        },
+      },
+    },
+  });
+
+test.describe('Sales order quick entry - default packing instruction', () => {
+  test.beforeEach(() => {
+    // The custom `test` fixture in playwright.config.js already publishes the page globally.
+    allure.epic('E0100: Sales');
+    allure.tag('F00101.10: Sales Order Quick Entry packing instruction');
+    allure.tag('F00101.10');
+  });
+
+  test('no product price references the Standard-Packvorschrift - not defaulted, order completes', async () => {
+    const masterdata = await createFixture(false);
+    const customer = masterdata.bpartners.CUSTOMER.bpartnerCode;
+    const product = masterdata.products.PROD.productName;
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+
+    await SalesOrderPage.goto();
+    await SalesOrderPage.clickNew();
+    const recordId = await SalesOrderPage.selectCustomer(customer);
+
+    await SalesOrderPage.openQuickEntryAndSelectProduct({ product, recordId });
+
+    // The defect: the Standard-Packvorschrift was pre-filled here even though no price references it.
+    const packingInstruction = await SalesOrderPage.getQuickEntryPackingInstruction();
+    console.log(`[TC1] packing instruction after product select: "${packingInstruction}"`);
+    expect(packingInstruction).toBe('');
+
+    await SalesOrderPage.submitQuickEntryLine({ quantity: 1 });
+
+    // End result, read back from the server - not merely "the field looked empty".
+    const validation = await getValidationStatus(SALES_ORDER_WINDOW_ID, recordId);
+    expect(validation.valid, `order ${recordId} must be saveable: ${validation.reason}`).toBe(true);
+
+    await SalesOrderPage.complete();
+
+    const docStatus = await getFieldData(SALES_ORDER_WINDOW_ID, recordId, 'DocStatus');
+    expect(docStatus.value?.key ?? docStatus.value).toBe('CO');
+  });
+
+  test('a product price references the packing instruction - still defaulted, order completes', async () => {
+    const masterdata = await createFixture(true);
+    const customer = masterdata.bpartners.CUSTOMER.bpartnerCode;
+    const product = masterdata.products.PROD.productName;
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+
+    await SalesOrderPage.goto();
+    await SalesOrderPage.clickNew();
+    const recordId = await SalesOrderPage.selectCustomer(customer);
+
+    await SalesOrderPage.openQuickEntryAndSelectProduct({ product, recordId });
+
+    // The other half of the rule: a priced packing instruction must still be offered, otherwise the
+    // fix would have stripped a legitimate default.
+    const packingInstruction = await SalesOrderPage.getQuickEntryPackingInstruction();
+    console.log(`[TC2] packing instruction after product select: "${packingInstruction}"`);
+    expect(packingInstruction).not.toBe('');
+
+    await SalesOrderPage.submitQuickEntryLine({ quantity: 1 });
+
+    const validation = await getValidationStatus(SALES_ORDER_WINDOW_ID, recordId);
+    expect(validation.valid, `order ${recordId} must be saveable: ${validation.reason}`).toBe(true);
+
+    await SalesOrderPage.complete();
+
+    const docStatus = await getFieldData(SALES_ORDER_WINDOW_ID, recordId, 'DocStatus');
+    expect(docStatus.value?.key ?? docStatus.value).toBe('CO');
+  });
+});

--- a/e2e/frontend-webui/tests/spec/sales-order-default-packing-instruction.spec.js
+++ b/e2e/frontend-webui/tests/spec/sales-order-default-packing-instruction.spec.js
@@ -65,7 +65,11 @@ test.describe('Sales order quick entry - default packing instruction', () => {
     allure.tag('F00101.10');
   });
 
-  test('no product price references the Standard-Packvorschrift - not defaulted, order completes', async () => {
+  // `page` is destructured but not referenced: the page objects and Backend read the page the custom
+  // fixture in playwright.config.js publishes as `global.currentPage`, and Playwright only runs that
+  // fixture for a test that actually requests `page`. Omitting it leaves the global unset.
+  // eslint-disable-next-line no-unused-vars
+  test('no product price references the Standard-Packvorschrift - not defaulted, order completes', async ({ page }) => {
     const masterdata = await createFixture(false);
     const customer = masterdata.bpartners.CUSTOMER.bpartnerCode;
     const product = masterdata.products.PROD.productName;
@@ -96,7 +100,8 @@ test.describe('Sales order quick entry - default packing instruction', () => {
     expect(docStatus.value?.key ?? docStatus.value).toBe('CO');
   });
 
-  test('a product price references the packing instruction - still defaulted, order completes', async () => {
+  // eslint-disable-next-line no-unused-vars
+  test('a product price references the packing instruction - still defaulted, order completes', async ({ page }) => {
     const masterdata = await createFixture(true);
     const customer = masterdata.bpartners.CUSTOMER.bpartnerCode;
     const product = masterdata.products.PROD.productName;

--- a/e2e/frontend-webui/tests/utils/pages/SalesOrderPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/SalesOrderPage.js
@@ -296,6 +296,83 @@ export class SalesOrderPage {
   }
 
   /**
+   * Open the batch-entry (quick input) form and select a product, then STOP — leaving the form open so
+   * the caller can inspect what the backend defaulted into it.
+   *
+   * `addOrderLine` submits and closes the form, so it cannot be used to read a defaulted field.
+   *
+   * @param {Object} params
+   * @param {string} params.product - Product code or name
+   * @param {string} params.recordId - Optional record ID (extracted from the URL if not provided)
+   */
+  static async openQuickEntryAndSelectProduct({ product, recordId }) {
+    return await test.step(`SalesOrderPage - Open quick entry and select: ${product}`, async () => {
+      const page = getPage();
+
+      const effectiveRecordId = recordId || this.getRecordId();
+      await waitForTabAllowsNew(SALES_ORDER_WINDOW_ID, effectiveRecordId, 'AD_Tab-187', {
+        maxRetries: 15,
+        retryDelayMs: 1000,
+      });
+
+      const batchEntryButton = page.getByTestId('batch-entry-toggle');
+      await batchEntryButton.scrollIntoViewIfNeeded();
+      await batchEntryButton.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await batchEntryButton.click();
+
+      await page.locator('.quick-input-container').waitFor({
+        state: 'visible',
+        timeout: SLOW_ACTION_TIMEOUT,
+      });
+
+      const productInput = page.locator('#lookup_M_Product_ID input.input-field');
+      await productInput.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      await productInput.click();
+      await page.waitForTimeout(300);
+      await productInput.fill(product);
+      await page.waitForTimeout(500);
+
+      await page.locator('.input-dropdown-list-option').getByText(product).first().click();
+
+      // The product callout runs server-side and patches the quick-input document; give it time to
+      // come back before the caller reads any field it may have defaulted.
+      await page.waitForTimeout(1500);
+    });
+  }
+
+  /**
+   * @returns {Promise<string>} the displayed value of the packing-instruction
+   *   (`M_HU_PI_Item_Product_ID`) field in the open quick-entry form — empty string when unset.
+   *   Call after {@link openQuickEntryAndSelectProduct}.
+   */
+  static async getQuickEntryPackingInstruction() {
+    return await test.step('SalesOrderPage - Read quick-entry packing instruction', async () => {
+      const page = getPage();
+
+      const field = page.locator('.quick-input-container #lookup_M_HU_PI_Item_Product_ID input.input-field');
+      await field.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      return (await field.inputValue()).trim();
+    });
+  }
+
+  /**
+   * Submit the order line from the quick-entry form opened by
+   * {@link openQuickEntryAndSelectProduct}, then close the form.
+   */
+  static async submitQuickEntryLine({ quantity }) {
+    return await test.step(`SalesOrderPage - Submit quick-entry line qty ${quantity}`, async () => {
+      const page = getPage();
+
+      await page.getByRole('spinbutton').fill(quantity.toString());
+      await page.keyboard.press('Enter');
+      await page.waitForTimeout(500);
+
+      await page.getByTestId('batch-entry-toggle').click();
+      await page.waitForTimeout(500);
+    });
+  }
+
+  /**
    * Complete the sales order.
    */
   static async complete() {

--- a/e2e/frontend-webui/tests/utils/pages/SalesOrderPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/SalesOrderPage.js
@@ -203,6 +203,25 @@ export class SalesOrderPage {
    */
   static async addOrderLine({ product, quantity, recordId }) {
     return await test.step(`SalesOrderPage - Add order line: ${product} x ${quantity}`, async () => {
+      await this.openQuickEntryAndSelectProduct({ product, recordId });
+      await this.submitQuickEntryLine({ quantity });
+    });
+  }
+
+  /**
+   * Open the batch-entry (quick input) form and select a product, then STOP — leaving the form open so
+   * the caller can inspect what the backend defaulted into it.
+   *
+   * This is the first half of {@link addOrderLine}, which submits and closes the form and so cannot be
+   * used to read a defaulted field. Keeping it as the single implementation means both callers get the
+   * same spinner handling rather than two copies drifting apart.
+   *
+   * @param {Object} params
+   * @param {string} params.product - Product code or name
+   * @param {string} params.recordId - Optional record ID (extracted from the URL if not provided)
+   */
+  static async openQuickEntryAndSelectProduct({ product, recordId }) {
+    return await test.step(`SalesOrderPage - Open quick entry and select: ${product}`, async () => {
       const page = getPage();
 
       // Get record ID if not provided
@@ -271,67 +290,6 @@ export class SalesOrderPage {
 
       // Click the option by text - finds element containing the product code
       // This avoids clicking on "Search for more..." or other non-record options
-      await page.locator('.input-dropdown-list-option').getByText(product).first().click();
-
-      // Wait for product to be selected and form to update
-      await page.waitForTimeout(500);
-
-      // Fill quantity using spinbutton role (language-independent)
-      await page.getByRole('spinbutton').fill(quantity.toString());
-
-      // Press Enter to add the line (as instructed by the UI: "Press 'Enter' to add")
-      await page.keyboard.press('Enter');
-
-      // Wait for the line to be added
-      await page.waitForTimeout(500);
-
-      // Close the batch entry modal
-      // Language-independent: Use data-testid from TableFilter.js
-      const closeButton = page.getByTestId('batch-entry-toggle');
-      await closeButton.click();
-
-      // Wait for the modal to close
-      await page.waitForTimeout(500);
-    });
-  }
-
-  /**
-   * Open the batch-entry (quick input) form and select a product, then STOP — leaving the form open so
-   * the caller can inspect what the backend defaulted into it.
-   *
-   * `addOrderLine` submits and closes the form, so it cannot be used to read a defaulted field.
-   *
-   * @param {Object} params
-   * @param {string} params.product - Product code or name
-   * @param {string} params.recordId - Optional record ID (extracted from the URL if not provided)
-   */
-  static async openQuickEntryAndSelectProduct({ product, recordId }) {
-    return await test.step(`SalesOrderPage - Open quick entry and select: ${product}`, async () => {
-      const page = getPage();
-
-      const effectiveRecordId = recordId || this.getRecordId();
-      await waitForTabAllowsNew(SALES_ORDER_WINDOW_ID, effectiveRecordId, 'AD_Tab-187', {
-        maxRetries: 15,
-        retryDelayMs: 1000,
-      });
-
-      const batchEntryButton = page.getByTestId('batch-entry-toggle');
-      await batchEntryButton.scrollIntoViewIfNeeded();
-      await batchEntryButton.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-      await batchEntryButton.click();
-
-      await page.locator('.quick-input-container').waitFor({
-        state: 'visible',
-        timeout: SLOW_ACTION_TIMEOUT,
-      });
-
-      const productInput = page.locator('#lookup_M_Product_ID input.input-field');
-      await productInput.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
-      await productInput.click();
-      await page.waitForTimeout(300);
-      await productInput.fill(product);
-      await page.waitForTimeout(500);
-
       await page.locator('.input-dropdown-list-option').getByText(product).first().click();
 
       // The product callout runs server-side and patches the quick-input document; give it time to


### PR DESCRIPTION
Playwright coverage for the sales-order quick-entry packing-instruction rule shipped in #25515, plus the masterdata-API fixtures it needs.

## What the tests prove

A product's default packing instruction (`M_HU_PI_Item_Product.IsDefaultForProduct`) must only be pre-filled into the sales order line quick entry when a product price of the order's price list version references it. Pricing matches on the packing instruction, so a pre-filled one that no price references makes the line unpriceable and the order impossible to complete.

| Case | Fixture | Expected |
|---|---|---|
| TC1 | product has a price, nothing references the default packing instruction | quick-entry packing instruction stays empty; order completes |
| TC2 | a product price references the packing instruction | packing instruction is still offered; order completes |

Both run under the seeded default of `de.metas.ui.web.quickinput.field.PackingItemProductFieldHelper.EnforcePrecisePricePerHUItemProduct` (`Y`) — the value real installations run — so the spec deliberately does not write it.

Each case asserts the end result read back from the server, not merely the on-screen field: the record's validation status and `DocStatus == 'CO'` after completion.

## Verified locally

Run against a from-source stack (app, webapi and frontend built from this branch):

- `2 passed` — TC1 reads `""`, TC2 reads the packing instruction name.
- **Negative control**: with the gate SysConfig flipped to `N`, TC1 fails with `Expected: "" / Received: "TU_DEFAULT_…"` — i.e. it reproduces the original defect exactly. The green is therefore evidence the fix works, not an artefact of the test setup. The SysConfig was restored and the suite re-confirmed green.

## Changes

**Masterdata API** (`de.metas.frontend-testing`)
- `JsonPackingInstructionsRequest`: new `isDefaultForProduct` and `referencedByProductPrice` flags (TU requests only).
- `CreatePackingInstructionsCommand`: sets `IsDefaultForProduct`, and can point the product's existing prices at the created packing instruction so the priced case can be set up through the API.

**E2E**
- New spec `sales-order-default-packing-instruction.spec.js`.
- `SalesOrderPage`: `addOrderLine` is split into `openQuickEntryAndSelectProduct` + `submitQuickEntryLine` and now composes them. The split is what lets a test inspect a field the backend defaulted before the line is submitted; composing rather than copying keeps one implementation, so both callers keep the spinner-detached waits around the product dropdown.

## Notes for the reviewer

- No new SysConfig and no migration — this rides on the existing `EnforcePrecisePricePerHUItemProduct` setting.
- `shipment-schedule.spec.js` (a caller of the refactored `addOrderLine`) fails on a local from-source stack with `PDF parsing failed: Invalid PDF structure`. This was checked against the pre-refactor helper and fails identically there, so it is a local Jasper-rendering limitation, not a regression from this change.

## Also included

`HUPricing` — a comment-only correction, no behaviour change. The comment at the `findDefaultPriceAttributeOrNull` call site read *"or it has no packing material set"*, where "it" parses as the product price. The code exempts only the **context** side: once the pricing context carries a packing material, a default price without one reads as `None` and compares unequal. The misreading matters here because it suggests a packing-material-less default price can rescue a packing instruction that no product price references — it cannot, which is precisely the failure mode this issue is about.
