### PR TITLE
Cover the invoicing timing of freight-cost and service order lines with cucumber

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -558,6 +558,9 @@ public class C_Invoice_Candidate_StepDef
 	 *   <li>{@code Reason} (optional)</li>
 	 *   <li>{@code IsAutoInvoice} (optional) — expected auto-invoice flag</li>
 	 *   <li>{@code InvoiceRule} (optional) — expected invoice-rule code (e.g. {@code D} = AfterDelivery, {@code I} = Immediate)</li>
+	 *   <li>{@code InvoiceRule_Override} (optional, null-allowed) — expected invoice-rule override; pass {@code null} to assert that no override is set</li>
+	 *   <li>{@code IsFreightCost} (optional) — expected freight-cost flag, derived from the product's ProductType</li>
+	 *   <li>{@code DeliveryDate} (optional) — expected delivery date</li>
 	 * </ul>
 	 *
 	 * <p>Example:
@@ -693,6 +696,17 @@ public class C_Invoice_Candidate_StepDef
 
 						row.getAsOptionalString(I_C_Invoice_Candidate.COLUMNNAME_InvoiceRule)
 								.ifPresent(invoiceRule -> softly.assertThat(finalInvoiceCandidate.getInvoiceRule()).as("InvoiceRule").isEqualTo(invoiceRule));
+
+						row.getAsOptionalString(I_C_Invoice_Candidate.COLUMNNAME_InvoiceRule_Override)
+								.ifPresent(invoiceRuleOverride -> softly.assertThat(finalInvoiceCandidate.getInvoiceRule_Override())
+										.as("InvoiceRule_Override")
+										.isEqualTo(DataTableUtil.nullToken2Null(invoiceRuleOverride)));
+
+						row.getAsOptionalBoolean(I_C_Invoice_Candidate.COLUMNNAME_IsFreightCost)
+								.ifPresent(isFreightCost -> softly.assertThat(finalInvoiceCandidate.isFreightCost()).as("IsFreightCost").isEqualTo(isFreightCost));
+
+						row.getAsOptionalLocalDate(I_C_Invoice_Candidate.COLUMNNAME_DeliveryDate)
+								.ifPresent(deliveryDate -> softly.assertThat(TimeUtil.asLocalDate(finalInvoiceCandidate.getDeliveryDate())).as("DeliveryDate").isEqualTo(deliveryDate));
 
 						softly.assertAll();
 					}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoiceRules.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoiceRules.feature
@@ -1,7 +1,6 @@
 @from:cucumber
 @allure.label.epic:E0340_Invoicing
 @allure.label.feature:F00703_Invoice_Rule
-@F00703
 @ghActions:run_on_executor5
 Feature: invoice rules
 ## F00703: Invoice Rule
@@ -12,10 +11,6 @@ Feature: invoice rules
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
     And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
 
-  @from:cucumber
-@allure.label.epic:E0340_Invoicing
-@allure.label.feature:F00703_Invoice_Rule
-@F00703
   Scenario: we can invoice a sales order with invoice rule after delivery
     Given metasfresh has date and time 2021-04-16T13:30:13+01:00[Europe/Berlin]
     And metasfresh contains M_Products:
@@ -71,10 +66,6 @@ Feature: invoice rules
       | C_InvoiceLine_ID.Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | Processed |
       | invoiceLine_1               | invoice_1               | p_1                     | 10          | true      |
 
-  @from:cucumber
-@allure.label.epic:E0340_Invoicing
-@allure.label.feature:F00703_Invoice_Rule
-@F00703
   Scenario: we can invoice a sales order with invoice rule after pick
     Given metasfresh has date and time 2021-04-16T13:30:13+01:00[Europe/Berlin]
     And metasfresh contains M_Products:
@@ -133,10 +124,6 @@ Feature: invoice rules
       | C_InvoiceLine_ID.Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | Processed |
       | invoiceLine_2               | invoice_2               | p_2                     | 6           | true      |
 
-  @from:cucumber
-@allure.label.epic:E0340_Invoicing
-@allure.label.feature:F00703_Invoice_Rule
-@F00703
   Scenario: we can invoice a sales order with invoice rule after pick and over-picked quantity
     Given metasfresh has date and time 2021-04-16T13:30:13+01:00[Europe/Berlin]
     And metasfresh contains M_Products:
@@ -205,10 +192,6 @@ Feature: invoice rules
       | shipmentLine1_1           | shipment              | p_3                     | 12          | true      |
 
 
-  @from:cucumber
-@allure.label.epic:E0340_Invoicing
-@allure.label.feature:F00703_Invoice_Rule
-@F00703
   Scenario: we can double-invoice a sales order with invoice rule after pick, if we pick some quantity and then override the qty to deliver to be equal to qty ordered
     Given metasfresh has date and time 2021-04-16T13:30:13+01:00[Europe/Berlin]
     And metasfresh contains M_Products:
@@ -330,11 +313,7 @@ Feature: invoice rules
       | C_InvoiceLine_ID.Identifier | C_Invoice_ID.Identifier | M_Product_ID.Identifier | QtyInvoiced | Processed |
       | invoiceLine_4_1             | invoice_4               | p_3                     | 10          | true      |
 
-  @from:cucumber
-  @allure.label.epic:E0340_Invoicing
-  @allure.label.feature:F00703_Invoice_Rule
   @Id:S30448_TC1
-  @ghActions:run_on_executor5
   Scenario: MOrder.setBPartner inherits InvoiceRule and IsAutoInvoice from BP group when BP has no direct value
     # Verifies that MOrder.setBPartner (called from beforeSave when no location is set) resolves
     # InvoiceRule and IsAutoInvoice via BPartnerEffectiveBL (group chain), not raw bp.getInvoiceRule().
@@ -389,11 +368,7 @@ Feature: invoice rules
       | C_Invoice_Candidate_ID.Identifier | InvoiceRule | IsAutoInvoice |
       | invoiceCandidate                  | D           | true          |
 
-  @from:cucumber
-  @allure.label.epic:E0340_Invoicing
-  @allure.label.feature:F00703_Invoice_Rule
   @Id:S30448_TC2
-  @ghActions:run_on_executor5
   Scenario: OLCand explicit invoiceRule and isAutoInvoice win over BP-group defaults
     # Guard scenario: when an OLCand request explicitly sets invoiceRule=I (Immediate) and isAutoInvoice=false,
     # those values must be preserved on the resulting order even though the BP's group has InvoiceRule=D/IsAutoInvoice=Y.

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/freightCostAndServiceInvoicing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/freightCostAndServiceInvoicing.feature
@@ -1,0 +1,158 @@
+@from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00703_Invoice_Rule
+@F00703
+@ghActions:run_on_executor6
+Feature: Invoicing of non-item lines on a sales order with invoice rule "after delivery"
+## F00703: Invoice Rule
+##
+## A sales order may carry non-item lines beside the goods. They are treated differently:
+## - freight cost (product type Frachtkosten) keeps the order's invoice rule and is invoiced with the first delivery
+## - a service (product type Dienstleistung) is overridden to "immediate" and is invoiced without any delivery
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2021-04-17T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
+
+    When load M_Warehouse:
+      | M_Warehouse_ID.Identifier | Value        |
+      | warehouse                 | StdWarehouse |
+    And metasfresh contains M_PricingSystems
+      | Identifier    |
+      | pricingSystem |
+    And metasfresh contains C_BPartners:
+      | Identifier  | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | endcustomer | N            | Y              | pricingSystem                 |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier          | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | endcustomerLocation | 0123456789011 | endcustomer              | Y                   | Y                   |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | SOTrx | IsTaxIncluded | PricePrecision |
+      | priceList  | pricingSystem                 | DE                        | EUR                 | true  | false         | 2              |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier       | M_PriceList_ID.Identifier | ValidFrom  |
+      | priceListVersion | priceList                 | 2021-04-01 |
+
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00703_Invoice_Rule
+@F00703
+  @Id:S31036_10
+  Scenario: Freight cost is not invoiced before the goods are delivered and lands on the invoice of the first delivery
+    Given metasfresh contains M_Products:
+      | Identifier  | ProductType | IsStocked |
+      | goods       | I           | Y         |
+      | freightCost | F           | N         |
+    And metasfresh contains M_ProductPrices
+      | Identifier       | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | goodsPrice       | priceListVersion                  | goods                   | 10.0     | PCE               | Normal                        |
+      | freightCostPrice | priceListVersion                  | freightCost             | 25.0     | PCE               | Normal                        |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | InvoiceRule |
+      | order      | true    | endcustomer              | 2021-04-17  | D           |
+    And metasfresh contains C_OrderLines:
+      | Identifier      | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | goodsLine       | order                 | goods                   | 100        |
+      | freightCostLine | order                 | freightCost             | 1          |
+
+    When the order identified by order is completed
+
+    Then after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID | C_OrderLine_ID  | QtyToInvoice |
+      | goodsCandidate         | goodsLine       | 0            |
+      | freightCostCandidate   | freightCostLine | 0            |
+    # A non-item line is never delivered — only product type Artikel gets a shipment schedule — so its
+    # quantity to invoice is the ORDERED quantity from the start. The freight cost is nevertheless held
+    # back at zero while the goods of the same order are not invoiceable yet; a service is not (see below).
+    And validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID | IsFreightCost | InvoiceRule | InvoiceRule_Override | QtyOrdered | QtyDelivered | QtyToInvoice |
+      | goodsCandidate         | false         | D           | null                 | 100        | 0            | 0            |
+      | freightCostCandidate   | true          | D           | null                 | 1          | 0            | 0            |
+    And invoice candidates are not billable
+      | C_Invoice_Candidate_ID.Identifier |
+      | freightCostCandidate              |
+      | goodsCandidate                    |
+
+    When after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier    | C_OrderLine_ID | IsToRecompute |
+      | goodsSchedule | goodsLine      | N             |
+    # the first delivery covers 40 of the 100 ordered goods
+    And 'generate shipments' process is invoked with QuantityType=D, IsCompleteShipments=true and IsShipToday=false
+      | M_ShipmentSchedule_ID | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
+      | goodsSchedule         | 40                                              |
+    Then after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID | M_InOut_ID    | DocStatus |
+      | goodsSchedule         | firstShipment | CO        |
+    And validate the created shipment lines
+      | M_InOut_ID    | M_Product_ID | C_OrderLine_ID | movementqty | processed |
+      | firstShipment | goods        | goodsLine      | 40          | true      |
+    # the goods became invoiceable, so the freight cost is released and takes over their delivery date
+    And validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID | QtyDelivered | QtyToInvoice | DeliveryDate |
+      | goodsCandidate         | 40           | 40           | 2021-04-17   |
+      | freightCostCandidate   | 0            | 1            | 2021-04-17   |
+
+    When process invoice candidates together and wait 600s for C_Invoice_Candidate to be processed
+      | C_Invoice_Candidate_ID |
+      | goodsCandidate         |
+      | freightCostCandidate   |
+    Then after not more than 60s, C_Invoice are found:
+      | C_Invoice_Candidate_ID.Identifier | C_Invoice_ID.Identifier | OPT.DocStatus |
+      | goodsCandidate                    | firstInvoice            | CO            |
+      | freightCostCandidate              | firstInvoice            | CO            |
+    # goods and freight cost end up on one and the same invoice
+    And validate created invoice lines
+      | C_Invoice_ID | M_Product_ID | QtyInvoiced |
+      | firstInvoice | goods        | 40          |
+      | firstInvoice | freightCost  | 1           |
+
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00703_Invoice_Rule
+@F00703
+  @Id:S31036_20
+  Scenario: A service line is invoiced immediately, without waiting for the goods to be delivered
+    Given metasfresh contains M_Products:
+      | Identifier | ProductType | IsStocked |
+      | goods      | I           | Y         |
+      | seminar    | S           | N         |
+    And metasfresh contains M_ProductPrices
+      | Identifier   | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | goodsPrice   | priceListVersion                  | goods                   | 10.0     | PCE               | Normal                        |
+      | seminarPrice | priceListVersion                  | seminar                 | 80.0     | PCE               | Normal                        |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered | InvoiceRule |
+      | order      | true    | endcustomer              | 2021-04-17  | D           |
+    And metasfresh contains C_OrderLines:
+      | Identifier  | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | goodsLine   | order                 | goods                   | 100        |
+      | seminarLine | order                 | seminar                 | 1          |
+
+    When the order identified by order is completed
+
+    Then after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID | C_OrderLine_ID | QtyToInvoice |
+      | goodsCandidate         | goodsLine      | 0            |
+      | seminarCandidate       | seminarLine    | 1            |
+    # the service candidate is overridden to "immediate" and — not being held back like a freight cost —
+    # carries its full ordered quantity while the goods of the same order are still undelivered
+    And validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID | IsFreightCost | InvoiceRule | InvoiceRule_Override | QtyOrdered | QtyDelivered | QtyToInvoice |
+      | goodsCandidate         | false         | D           | null                 | 100        | 0            | 0            |
+      | seminarCandidate       | false         | D           | I                    | 1          | 0            | 1            |
+    And invoice candidates are not billable
+      | C_Invoice_Candidate_ID.Identifier |
+      | goodsCandidate                    |
+
+    When process invoice candidates and wait 600s for C_Invoice_Candidate to be processed
+      | C_Invoice_Candidate_ID |
+      | seminarCandidate       |
+    Then after not more than 60s, C_Invoice are found:
+      | C_Invoice_Candidate_ID.Identifier | C_Invoice_ID.Identifier | OPT.DocStatus |
+      | seminarCandidate                  | seminarInvoice          | CO            |
+    And validate created invoice lines
+      | C_Invoice_ID   | M_Product_ID | QtyInvoiced |
+      | seminarInvoice | seminar      | 1           |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/freightCostAndServiceInvoicing.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/freightCostAndServiceInvoicing.feature
@@ -1,7 +1,6 @@
 @from:cucumber
 @allure.label.epic:E0340_Invoicing
 @allure.label.feature:F00703_Invoice_Rule
-@F00703
 @ghActions:run_on_executor6
 Feature: Invoicing of non-item lines on a sales order with invoice rule "after delivery"
 ## F00703: Invoice Rule
@@ -36,10 +35,6 @@ Feature: Invoicing of non-item lines on a sales order with invoice rule "after d
       | Identifier       | M_PriceList_ID.Identifier | ValidFrom  |
       | priceListVersion | priceList                 | 2021-04-01 |
 
-  @from:cucumber
-@allure.label.epic:E0340_Invoicing
-@allure.label.feature:F00703_Invoice_Rule
-@F00703
   @Id:S31036_10
   Scenario: Freight cost is not invoiced before the goods are delivered and lands on the invoice of the first delivery
     Given metasfresh contains M_Products:
@@ -109,10 +104,6 @@ Feature: Invoicing of non-item lines on a sales order with invoice rule "after d
       | firstInvoice | goods        | 40          |
       | firstInvoice | freightCost  | 1           |
 
-  @from:cucumber
-@allure.label.epic:E0340_Invoicing
-@allure.label.feature:F00703_Invoice_Rule
-@F00703
   @Id:S31036_20
   Scenario: A service line is invoiced immediately, without waiting for the goods to be delivered
     Given metasfresh contains M_Products:


### PR DESCRIPTION
## What

Two cucumber scenarios covering how a sales order with invoice rule *after delivery* invoices its **non-item** lines, plus the three assertion columns the existing invoice-candidate validation step was missing for them.

## Why

Neither a freight-cost (`ProductType=F`) nor a service (`ProductType=S`) order line ever gets a shipment schedule — only `ProductType=I` lines do, per the `C_OrderLine_ID_With_Missing_ShipmentSchedule_v` view. So for both, `InvoiceCandidate.computeToInvoiceExclOverride` takes the `computeDeliveredOrOrdered()` branch and the candidate is quantity-wise invoiceable the moment the order is completed. What happens next differs sharply, and nothing covered it end to end:

- **freight cost** — `InvoiceCandBL.setQtyAndDateForFreightCost` holds `QtyToInvoice` at `0` while a non-freight-cost candidate of the same order is not yet invoiceable; once the goods become invoiceable it is released and takes over their `DeliveryDate`, so goods and freight cost land on the same invoice.
- **service** — `AbstractInvoiceCandidateHandler.isNotReceivableService` forces `InvoiceRule_Override = Immediate` (freight cost is explicitly exempted), and nothing holds it back, so it is invoiced while the goods are still undelivered.

Before this PR the only coverage was three JUnit tests calling `setQtyAndDateForFreightCost` directly on hand-built records with `IsFreightCost` set by hand — bypassing the `ProductType` → `IsFreightCost` mapping, the immediate-override exemption, the DAO wait-for query and the invoicing itself. No `.feature` file mentioned freight cost.

## Changes

- `features/invoicecandidate/freightCostAndServiceInvoicing.feature` — the two scenarios, executor6.
- `C_Invoice_Candidate_StepDef.validate_C_Invoice_Candidate` — three additive **optional** assertion columns: `IsFreightCost`, `InvoiceRule_Override` (pass `null` to assert that no override is set) and `DeliveryDate`. No existing column or behaviour changes.
- `features/invoiceRules.feature` — tag hygiene only: drops a bare `@F00703` tag, which is not in the closed allowed-tag set documented in `backend/de.metas.cucumber/CLAUDE.md`, plus the per-scenario duplication of the four tags already carried at feature level. Cucumber unions a feature's tags into every scenario before the CI executor filter and the Allure adapter see them, so attribution and selection are unchanged.

Test-only change: no production code, no migration.

## Verification

Green locally on 2026-08-13 against a dedicated isolated infra stack with the branch's migrations applied. The final run filtered on the feature label rather than on scenario ids — `-Dgroups=allure.label.feature:F00703_Invoice_Rule` — so it also proves that the scenarios left with no tags of their own are still selected through feature-level inheritance: 11/11 scenarios passed across `invoiceRules.feature` (6), `invoiceRule_Manual.feature` (3) and `freightCostAndServiceInvoicing.feature` (2).

Result read from `backend/de.metas.cucumber/target/cucumber.json` — surefire's `Tests run: 0` is the known cucumber/surefire counting artifact, not a skipped run.
