### PR TITLE
nShift carrier-service fixes — order-advise service persistence, labels val-rule context, shipment-schedule read-only

### DIFF
--- a/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftOrderAdvisorService.java
+++ b/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftOrderAdvisorService.java
@@ -127,7 +127,7 @@ public class NShiftOrderAdvisorService
 				.build();
 	}
 
-	private static JsonDeliveryAdvisorResponse buildJsonDeliveryAdvisorResponse(@NonNull final JsonOrderAdviceResponse response, @NonNull final String requestId)
+	static JsonDeliveryAdvisorResponse buildJsonDeliveryAdvisorResponse(@NonNull final JsonOrderAdviceResponse response, @NonNull final String requestId)
 	{
 		// OrderAdvice wraps the advised shipment under "Shipment". The carrier PRODUCT IDENTITY is the product
 		// CONCEPT: ProdConceptID (e.g. 9303) — NOT ProdCSID (the carrier-service instance / integration). Reading the
@@ -145,8 +145,7 @@ public class NShiftOrderAdvisorService
 						.name(NShiftUtil.buildCarrierProductName(shipment.getCarrierFullName(), shipment.getProdName(), String.valueOf(prodConceptID)))
 						.build());
 
-		// GoodsType is reported per line (no shipment-level GoodsType / Services in the OrderAdvice response);
-		// the advise carries a single line, so take the GoodsType from the first.
+		// GoodsType is reported per line; the advise carries a single line, so take the GoodsType from the first.
 		final List<JsonLine> lines = shipment.getLines();
 		if (lines != null && !lines.isEmpty() && lines.get(0).getGoodsTypeID() != null)
 		{
@@ -156,6 +155,10 @@ public class NShiftOrderAdvisorService
 					.name(line.getGoodsTypeName())
 					.build());
 		}
+
+		// Services come back at shipment level as bare ids (Shipment.Services), same as the ship response — expose
+		// them as shipperProductServices so the resolved services are persisted onto the shipment schedule.
+		responseBuilder.shipperProductServices(NShiftUtil.extractResolvedServices(shipment));
 
 		return responseBuilder.build();
 	}

--- a/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftOrderAdvisorService.java
+++ b/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftOrderAdvisorService.java
@@ -127,6 +127,7 @@ public class NShiftOrderAdvisorService
 				.build();
 	}
 
+	@VisibleForTesting
 	static JsonDeliveryAdvisorResponse buildJsonDeliveryAdvisorResponse(@NonNull final JsonOrderAdviceResponse response, @NonNull final String requestId)
 	{
 		// OrderAdvice wraps the advised shipment under "Shipment". The carrier PRODUCT IDENTITY is the product

--- a/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftShipmentService.java
+++ b/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftShipmentService.java
@@ -386,5 +386,4 @@ public class NShiftShipmentService
 				})
 				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
-
 }

--- a/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftShipmentService.java
+++ b/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftShipmentService.java
@@ -28,7 +28,6 @@ import de.metas.common.delivery.v1.json.DeliveryMappingConstants;
 import de.metas.common.delivery.v1.json.JsonPackageDimensions;
 import de.metas.common.delivery.v1.json.request.JsonDeliveryOrderParcel;
 import de.metas.common.delivery.v1.json.request.JsonDeliveryRequest;
-import de.metas.common.delivery.v1.json.request.JsonCarrierService;
 import de.metas.common.delivery.v1.json.request.JsonGoodsType;
 import de.metas.common.delivery.v1.json.request.JsonShipperConfig;
 import de.metas.common.delivery.v1.json.request.JsonShipperProduct;
@@ -333,7 +332,7 @@ public class NShiftShipmentService
 				.shipperProduct(extractResolvedShipperProduct(response));
 
 		extractResolvedGoodsTypes(responseLines).forEach(responseBuilder::resolvedGoodsType);
-		extractResolvedServices(response).forEach(responseBuilder::resolvedService);
+		NShiftUtil.extractResolvedServices(response).forEach(responseBuilder::resolvedService);
 
 		return responseBuilder.build();
 	}
@@ -388,18 +387,4 @@ public class NShiftShipmentService
 				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
-	private static Set<JsonCarrierService> extractResolvedServices(@NonNull final JsonShipmentResponse response)
-	{
-		if (response.getServices() == null)
-		{
-			return Collections.emptySet();
-		}
-		// services come back as bare ids; use the id as the name as well
-		return response.getServices().stream()
-				.map(svcId -> {
-					final String id = String.valueOf(svcId);
-					return JsonCarrierService.builder().id(id).name(id).build();
-				})
-				.collect(Collectors.toCollection(LinkedHashSet::new));
-	}
 }

--- a/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftUtil.java
+++ b/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftUtil.java
@@ -24,6 +24,7 @@ package de.metas.shipper.client.nshift;
 
 import de.metas.common.delivery.v1.json.DeliveryMappingConstants;
 import de.metas.common.delivery.v1.json.JsonContact;
+import de.metas.common.delivery.v1.json.request.JsonCarrierService;
 import de.metas.common.delivery.v1.json.request.JsonDeliveryAdvisorRequest;
 import de.metas.common.util.Check;
 import de.metas.shipper.client.nshift.json.JsonAddress;
@@ -32,6 +33,7 @@ import de.metas.shipper.client.nshift.json.JsonDetail;
 import de.metas.shipper.client.nshift.json.JsonDetailGroup;
 import de.metas.shipper.client.nshift.json.JsonDetailRow;
 import de.metas.shipper.client.nshift.json.JsonLine;
+import de.metas.shipper.client.nshift.json.response.JsonShipmentResponse;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 
@@ -40,15 +42,36 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @UtilityClass
 public class NShiftUtil
 {
+	/**
+	 * Extracts the resolved carrier services from an nShift shipment / order-advice response. nShift returns them
+	 * as bare numeric ids under {@code Services}; the id is used as the name as well. Shared by the shipment
+	 * (booking) and order-advise paths so both map the response services identically.
+	 */
+	public static Set<JsonCarrierService> extractResolvedServices(@NonNull final JsonShipmentResponse response)
+	{
+		if (response.getServices() == null)
+		{
+			return Collections.emptySet();
+		}
+		return response.getServices().stream()
+				.map(svcId -> {
+					final String id = String.valueOf(svcId);
+					return JsonCarrierService.builder().id(id).name(id).build();
+				})
+				.collect(Collectors.toCollection(LinkedHashSet::new));
+	}
+
 	/**
 	 * Display name for a carrier product resolved from an nShift response:
 	 * {@code "<CarrierFullName> - <ProdName>"} (e.g. "UPS Rest API - UPS Standard®").

--- a/backend/de.metas.shipper.client.nshift/src/test/java/de/metas/shipper/client/nshift/NShiftOrderAdvisorServiceTest.java
+++ b/backend/de.metas.shipper.client.nshift/src/test/java/de/metas/shipper/client/nshift/NShiftOrderAdvisorServiceTest.java
@@ -29,11 +29,14 @@ import au.com.origin.snapshots.junit5.SnapshotExtension;
 import de.metas.common.delivery.v1.json.JsonAddress;
 import de.metas.common.delivery.v1.json.JsonContact;
 import de.metas.common.delivery.v1.json.JsonPackageDimensions;
+import de.metas.common.delivery.v1.json.request.JsonCarrierService;
 import de.metas.common.delivery.v1.json.request.JsonDeliveryAdvisorRequest;
 import de.metas.common.delivery.v1.json.request.JsonDeliveryAdvisorRequestItem;
 import de.metas.common.delivery.v1.json.request.JsonShipperConfig;
 import de.metas.common.delivery.v1.json.response.JsonDeliveryAdvisorResponse;
 import de.metas.shipper.client.nshift.json.request.JsonShipAdvisorRequest;
+import de.metas.shipper.client.nshift.json.response.JsonOrderAdviceResponse;
+import de.metas.shipper.client.nshift.json.response.JsonShipmentResponse;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,6 +46,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import java.math.BigDecimal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -145,6 +149,26 @@ public class NShiftOrderAdvisorServiceTest
 	{
 		final JsonShipAdvisorRequest request = NShiftOrderAdvisorService.buildRequest(ADVISOR_REQUEST);
 		expect.serializer("orderedJson").toMatchSnapshot(request);
+	}
+
+	@Test
+	void buildResponse_extractsServicesFromShipment()
+	{
+		// nShift returns the resolved services as bare ids under Shipment.Services; the order-advise response must
+		// expose them as shipperProductServices (id used as name) — same as the ship path's resolvedServices.
+		final JsonOrderAdviceResponse response = JsonOrderAdviceResponse.builder()
+				.shipment(JsonShipmentResponse.builder()
+						.prodConceptID(9303)
+						.services(ImmutableList.of(972053, 972054))
+						.build())
+				.build();
+
+		final JsonDeliveryAdvisorResponse advisorResponse =
+				NShiftOrderAdvisorService.buildJsonDeliveryAdvisorResponse(response, "reqId");
+
+		assertThat(advisorResponse.getShipperProductServices())
+				.extracting(JsonCarrierService::getId)
+				.containsExactlyInAnyOrder("972053", "972054");
 	}
 
 	@Test

--- a/backend/de.metas.shipper.client.nshift/src/test/java/de/metas/shipper/client/nshift/NShiftOrderAdvisorServiceTest.java
+++ b/backend/de.metas.shipper.client.nshift/src/test/java/de/metas/shipper/client/nshift/NShiftOrderAdvisorServiceTest.java
@@ -29,11 +29,11 @@ import au.com.origin.snapshots.junit5.SnapshotExtension;
 import de.metas.common.delivery.v1.json.JsonAddress;
 import de.metas.common.delivery.v1.json.JsonContact;
 import de.metas.common.delivery.v1.json.JsonPackageDimensions;
-import de.metas.common.delivery.v1.json.request.JsonCarrierService;
 import de.metas.common.delivery.v1.json.request.JsonDeliveryAdvisorRequest;
 import de.metas.common.delivery.v1.json.request.JsonDeliveryAdvisorRequestItem;
 import de.metas.common.delivery.v1.json.request.JsonShipperConfig;
 import de.metas.common.delivery.v1.json.response.JsonDeliveryAdvisorResponse;
+import de.metas.shipper.client.nshift.json.JsonLine;
 import de.metas.shipper.client.nshift.json.request.JsonShipAdvisorRequest;
 import de.metas.shipper.client.nshift.json.response.JsonOrderAdviceResponse;
 import de.metas.shipper.client.nshift.json.response.JsonShipmentResponse;
@@ -46,8 +46,6 @@ import org.springframework.test.context.TestPropertySource;
 
 import java.math.BigDecimal;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -153,13 +151,20 @@ public class NShiftOrderAdvisorServiceTest
 	}
 
 	@Test
-	void buildResponse_extractsServicesFromShipment()
+	void build_response_test()
 	{
-		// nShift returns the resolved services as bare ids under Shipment.Services; the order-advise response must
-		// expose them as shipperProductServices (id used as name) — same as the ship path's resolvedServices.
+		// The OrderAdvice response wraps the advised shipment; buildJsonDeliveryAdvisorResponse must map the
+		// product (code=ProdConceptID, name=CarrierFullName+ProdName), the goods type (first line), and the
+		// resolved services (bare ids under Shipment.Services, id used as name — same as the ship path).
 		final JsonOrderAdviceResponse response = JsonOrderAdviceResponse.builder()
 				.shipment(JsonShipmentResponse.builder()
 						.prodConceptID(9303)
+						.carrierFullName("UPS Rest API")
+						.prodName("UPS Standard")
+						.lines(ImmutableList.of(JsonLine.builder()
+								.goodsTypeID(5)
+								.goodsTypeName("Packet")
+								.build()))
 						.services(ImmutableList.of(972053, 972054))
 						.build())
 				.build();
@@ -167,9 +172,7 @@ public class NShiftOrderAdvisorServiceTest
 		final JsonDeliveryAdvisorResponse advisorResponse =
 				NShiftOrderAdvisorService.buildJsonDeliveryAdvisorResponse(response, "reqId");
 
-		assertThat(advisorResponse.getShipperProductServices())
-				.extracting(JsonCarrierService::getId, JsonCarrierService::getName)
-				.containsExactlyInAnyOrder(tuple("972053", "972053"), tuple("972054", "972054"));
+		expect.serializer("orderedJson").toMatchSnapshot(advisorResponse);
 	}
 
 	@Test

--- a/backend/de.metas.shipper.client.nshift/src/test/java/de/metas/shipper/client/nshift/NShiftOrderAdvisorServiceTest.java
+++ b/backend/de.metas.shipper.client.nshift/src/test/java/de/metas/shipper/client/nshift/NShiftOrderAdvisorServiceTest.java
@@ -47,6 +47,7 @@ import org.springframework.test.context.TestPropertySource;
 import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -167,8 +168,8 @@ public class NShiftOrderAdvisorServiceTest
 				NShiftOrderAdvisorService.buildJsonDeliveryAdvisorResponse(response, "reqId");
 
 		assertThat(advisorResponse.getShipperProductServices())
-				.extracting(JsonCarrierService::getId)
-				.containsExactlyInAnyOrder("972053", "972054");
+				.extracting(JsonCarrierService::getId, JsonCarrierService::getName)
+				.containsExactlyInAnyOrder(tuple("972053", "972053"), tuple("972054", "972054"));
 	}
 
 	@Test

--- a/backend/de.metas.shipper.client.nshift/src/test/resources/de/metas/shipper/client/nshift/NShiftOrderAdvisorServiceTest.snap
+++ b/backend/de.metas.shipper.client.nshift/src/test/resources/de/metas/shipper/client/nshift/NShiftOrderAdvisorServiceTest.snap
@@ -132,3 +132,28 @@ de.metas.shipper.client.nshift.NShiftOrderAdvisorServiceTest.build_request_test=
     }
   }
 ]
+
+
+de.metas.shipper.client.nshift.NShiftOrderAdvisorServiceTest.build_response_test=[
+  {
+    "goodsType": {
+      "id": "5",
+      "name": "Packet"
+    },
+    "requestId": "reqId",
+    "shipperProduct": {
+      "code": "9303",
+      "name": "UPS Rest API - UPS Standard"
+    },
+    "shipperProductServices": [
+      {
+        "id": "972053",
+        "name": "972053"
+      },
+      {
+        "id": "972054",
+        "name": "972054"
+      }
+    ]
+  }
+]

--- a/backend/de.metas.shipper.gateway.nshift/src/main/sql/postgresql/system/99-de.metas.shipper.gateway.nshift/5818840_sys_C_Order_Carrier_Service_valrule_labels_context.sql
+++ b/backend/de.metas.shipper.gateway.nshift/src/main/sql/postgresql/system/99-de.metas.shipper.gateway.nshift/5818840_sys_C_Order_Carrier_Service_valrule_labels_context.sql
@@ -1,0 +1,12 @@
+-- Fix carrier-service selection on the C_Order "Lieferweg-Services" labels widget.
+-- The services are a Labels widget over the C_Order_Carrier_Service junction. The labels lookup exposes ONLY
+-- the host link column (C_Order_ID) as a validation-rule parameter, so the previous rule keyed on
+-- @Carrier_Product_ID@ never resolved in that context (it fell back to -1) and no services were selectable.
+-- Derive the order's Carrier_Product_ID by joining C_Order on @C_Order_ID@ (the parameter the labels lookup
+-- provides), so the services are again constrained to the selected carrier product's allocations.
+UPDATE AD_Val_Rule
+   SET Code='Carrier_Service_ID IN (SELECT cs.Carrier_Service_ID FROM Carrier_Service cs JOIN Carrier_Product_Service_Alloc a ON a.Carrier_Service_ID = cs.Carrier_Service_ID JOIN C_Order o ON o.C_Order_ID = @C_Order_ID/-1@ WHERE a.IsActive=''Y'' AND a.Carrier_Product_ID = o.Carrier_Product_ID)',
+       Updated=TO_TIMESTAMP('2026-08-13 10:00:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy=100
+ WHERE AD_Val_Rule_ID=540794
+;

--- a/backend/de.metas.shipper.gateway.nshift/src/main/sql/postgresql/system/99-de.metas.shipper.gateway.nshift/5818860_sys_M_ShipmentSchedule_Carrier_Service_detach_valrule.sql
+++ b/backend/de.metas.shipper.gateway.nshift/src/main/sql/postgresql/system/99-de.metas.shipper.gateway.nshift/5818860_sys_M_ShipmentSchedule_Carrier_Service_detach_valrule.sql
@@ -1,0 +1,14 @@
+-- Detach the carrier-service validation rule from the read-only M_ShipmentSchedule "Lieferweg-Services"
+-- labels field. Column M_ShipmentSchedule_Carrier_Service.Carrier_Service_ID carried AD_Val_Rule 540757
+-- (Carrier_Service_ID_for_M_Shipper_ID), which keys on @Carrier_Product_ID@ / @M_Shipper_ID@. That labels
+-- selector lives on the junction tab, whose lookup context only exposes the host link column
+-- (@M_ShipmentSchedule_ID@), so the rule can never resolve there. The field is read-only (the advise code
+-- owns it), so no product filter is needed on it. AD_Val_Rule 540757 itself is left intact -- it is still
+-- referenced by, and resolves correctly for, the M_ShipmentSchedule_Advise_Manual process parameters.
+UPDATE AD_Column
+   SET AD_Val_Rule_ID=NULL,
+       Updated=TO_TIMESTAMP('2026-08-13 10:01:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy=100
+ WHERE AD_Column_ID=591336
+   AND AD_Val_Rule_ID=540757
+;

--- a/backend/de.metas.shipper.gateway.nshift/src/main/sql/postgresql/system/99-de.metas.shipper.gateway.nshift/5818870_sys_M_ShipmentSchedule_CarrierService_field_readonly.sql
+++ b/backend/de.metas.shipper.gateway.nshift/src/main/sql/postgresql/system/99-de.metas.shipper.gateway.nshift/5818870_sys_M_ShipmentSchedule_CarrierService_field_readonly.sql
@@ -1,0 +1,11 @@
+-- Make the M_ShipmentSchedule "Lieferweg-Services" labels field read-only. On the shipment schedule the
+-- carrier services are owned by the carrier-advise code and are not user-edited on this window. AD_Field
+-- 781773 is the labels selector on the hidden tab over M_ShipmentSchedule_Carrier_Service, shown on the
+-- Lieferdisposition window (500221); its position (left column, below the goods-type / carrier-product
+-- fields) stays unchanged.
+UPDATE AD_Field
+   SET IsReadOnly='Y',
+       Updated=TO_TIMESTAMP('2026-08-13 10:02:00','YYYY-MM-DD HH24:MI:SS'),
+       UpdatedBy=100
+ WHERE AD_Field_ID=781773
+;


### PR DESCRIPTION
Follow-up nShift carrier-service fixes found during UAT.

## Order-advise services not persisted
`NShiftOrderAdvisorService` never read the shipment response's `Services`, so services resolved by the order-advise call were dropped — while the ship path already persisted them. Lifted the shared `extractResolvedServices(JsonShipmentResponse)` into `NShiftUtil` and wired it into the order-advise response builder (now sets `shipperProductServices`). + JUnit test.

## Sales-order carrier services not selectable (val rule)
The C_Order carrier-services labels selector's validation rule (`AD_Val_Rule 540794`) keyed on `@Carrier_Product_ID@`, which never resolves in the labels/junction lookup context — `LabelsLookup` exposes only the host link column (`@C_Order_ID@`, because the labels tab has no `Parent_Column_ID` so it falls back to the host key). Rewrote the rule to derive `Carrier_Product_ID` by joining `C_Order` on `@C_Order_ID@`. (Migration `5818840`)

## Shipment-schedule carrier-services labels field
- Detached the same-shaped rule `540757` from the `M_ShipmentSchedule_Carrier_Service.Carrier_Service_ID` column (it can't resolve on the junction tab, and the field is advise-owned / read-only). `540757` is left intact — it stays referenced by, and resolves correctly for, the `M_ShipmentSchedule_Advise_Manual` process parameters. (Migration `5818860`)
- Made the labels field read-only (`AD_Field 781773`). (Migration `5818870`)

Tests: nShift unit suite green (40 tests, 0 failures); all migrations applied + verified on a local stack.
