### PR TITLE
Merge: intensive_care_release -> new_dawn_uat (sales order packing instruction)

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818060_sys_Mobile_Application_Access_UC.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5818060_sys_Mobile_Application_Access_UC.sql
@@ -1,0 +1,46 @@
+-- Enforce "at most one ACTIVE access record per Mobile Application and Role" on
+-- Mobile_Application_Access. A duplicate makes the role's mobile-application permissions
+-- ambiguous and degrades the whole instance.
+-- The index is declared in the application dictionary (AD_Index_Table / AD_Index_Column) so
+-- that a violation surfaces as the translatable ErrorMsg below (HTTP 422) instead of a raw
+-- database error: DBUniqueConstraintException maps the violated index name back to its
+-- AD_Index_Table row via MIndexTable.getByNameIgnoringCase(). Therefore the physical index
+-- name MUST stay equal to AD_Index_Table.Name.
+-- Existing duplicates are deactivated by
+-- 5818050_sys_Mobile_Application_Access_deactivate_duplicates.sql (lower prefix, runs first).
+
+INSERT INTO AD_Index_Table (AD_Client_ID,AD_Index_Table_ID,AD_Org_ID,AD_Table_ID,Created,CreatedBy,Description,EntityType,ErrorMsg,IsActive,IsUnique,Name,Processing,Updated,UpdatedBy,WhereClause) VALUES (0,540867 /*From ID Server*/,0,542446,TO_TIMESTAMP('2026-08-10 09:10:00','YYYY-MM-DD HH24:MI:SS'),100,'Ensures there is at most one active access record per Mobile Application and Role.','D','Für diese Mobile Application und Rolle gibt es bereits einen aktiven Eintrag. Bitte bearbeiten Sie den bestehenden Eintrag.','Y','Y','Mobile_Application_Access_UC','N',TO_TIMESTAMP('2026-08-10 09:10:00','YYYY-MM-DD HH24:MI:SS'),100,'IsActive=''Y''')
+;
+
+INSERT INTO AD_Index_Table_Trl (AD_Language,AD_Index_Table_ID, ErrorMsg, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy) SELECT l.AD_Language, t.AD_Index_Table_ID, t.ErrorMsg, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy FROM AD_Language l, AD_Index_Table t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y') AND t.AD_Index_Table_ID=540867 AND NOT EXISTS (SELECT 1 FROM AD_Index_Table_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Index_Table_ID=t.AD_Index_Table_ID)
+;
+
+UPDATE AD_Index_Table_Trl SET ErrorMsg='An active entry for this Mobile Application and Role already exists. Please edit the existing entry.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-10 09:10:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Index_Table_ID=540867
+;
+
+UPDATE AD_Index_Table_Trl SET ErrorMsg='Für diese Mobile Application und Rolle gibt es bereits einen aktiven Eintrag. Bitte bearbeiten Sie den bestehenden Eintrag.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-10 09:10:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Index_Table_ID=540867
+;
+
+UPDATE AD_Index_Table_Trl SET ErrorMsg='Für diese Mobile Application und Rolle gibt es bereits einen aktiven Eintrag. Bitte bearbeiten Sie den bestehenden Eintrag.',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-10 09:10:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Index_Table_ID=540867
+;
+
+INSERT INTO AD_Index_Column (AD_Client_ID,AD_Column_ID,AD_Index_Column_ID,AD_Index_Table_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,SeqNo,Updated,UpdatedBy) VALUES (0,589278,541535 /*From ID Server*/,540867,0,TO_TIMESTAMP('2026-08-10 09:11:00','YYYY-MM-DD HH24:MI:SS'),100,'D','Y',10,TO_TIMESTAMP('2026-08-10 09:11:00','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+INSERT INTO AD_Index_Column (AD_Client_ID,AD_Column_ID,AD_Index_Column_ID,AD_Index_Table_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,SeqNo,Updated,UpdatedBy) VALUES (0,589279,541536 /*From ID Server*/,540867,0,TO_TIMESTAMP('2026-08-10 09:11:10','YYYY-MM-DD HH24:MI:SS'),100,'D','Y',20,TO_TIMESTAMP('2026-08-10 09:11:10','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- IF NOT EXISTS: the index was already created manually on the affected production instance
+-- under exactly this name and definition; there it stays untouched.
+CREATE UNIQUE INDEX IF NOT EXISTS Mobile_Application_Access_UC ON Mobile_Application_Access (Mobile_Application_ID, AD_Role_ID) WHERE IsActive = 'Y'
+;
+
+-- When this migration script fails on CREATE UNIQUE INDEX, the instance still holds duplicate
+-- active rows. Inspect them with:
+/*
+SELECT Mobile_Application_ID, AD_Role_ID, count(*), array_agg(Mobile_Application_Access_ID)
+FROM Mobile_Application_Access
+WHERE IsActive = 'Y'
+GROUP BY Mobile_Application_ID, AD_Role_ID
+HAVING count(*) > 1;
+*/

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreatePackingInstructionsCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreatePackingInstructionsCommand.java
@@ -21,13 +21,10 @@ import de.metas.handlingunits.model.I_M_HU_PI_GRAI;
 import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
-import de.metas.handlingunits.model.I_M_ProductPrice;
 import de.metas.logging.LogManager;
 import de.metas.manufacturing.workflows_api.activity_handlers.generateHUQRCodes.GenerateHUQRCodesActivityHandler;
 import de.metas.manufacturing.workflows_api.activity_handlers.receive.MaterialReceiptActivityHandler;
 import de.metas.pricing.PriceListVersionId;
-import de.metas.pricing.service.IPriceListDAO;
-import de.metas.pricing.service.ProductPrices;
 import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
 import de.metas.uom.UomId;
@@ -42,14 +39,12 @@ import lombok.Value;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
-import org.compiere.model.I_M_PriceList_Version;
 import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
-import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
@@ -64,7 +59,7 @@ public class CreatePackingInstructionsCommand
 	@NonNull private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
 	@NonNull private final IAttributeDAO attributeDAO = Services.get(IAttributeDAO.class);
 	@NonNull private final HUPIGraiRepository huPIGraiRepository = new HUPIGraiRepository();
-	@NonNull private final IPriceListDAO priceListDAO = Services.get(IPriceListDAO.class);
+	@NonNull private final ProductPricePackingInstructionRepository productPricePackingInstructionRepository = new ProductPricePackingInstructionRepository();
 	@NonNull private final MasterdataContext context;
 	@NonNull private final JsonPackingInstructionsRequest request;
 	@NonNull private final Identifier identifier;
@@ -406,21 +401,13 @@ public class CreatePackingInstructionsCommand
 		// Fails with "No identifier found for PriceListVersionId" when the request has no bpartners section:
 		// the price list version is created as a side effect of creating a bpartner.
 		final PriceListVersionId priceListVersionId = context.getIdOfType(PriceListVersionId.class);
-		final I_M_PriceList_Version priceListVersion = priceListDAO.getPriceListVersionById(priceListVersionId);
 
-		final List<I_M_ProductPrice> productPrices = ProductPrices.newQuery(priceListVersion)
-				.setProductId(productId)
-				.list(I_M_ProductPrice.class);
+		final int updatedCount = productPricePackingInstructionRepository
+				.pointProductPricesAt(priceListVersionId, productId, piItemProduct);
 
-		Check.assumeNotEmpty(productPrices,
+		Check.assume(updatedCount > 0,
 				"referencedByProductPrice needs product {} to have a price on price list version {} — give the product a price in the same request",
 				productId, priceListVersionId);
-
-		for (final I_M_ProductPrice productPrice : productPrices)
-		{
-			productPrice.setM_HU_PI_Item_Product(piItemProduct);
-			saveRecord(productPrice);
-		}
 	}
 
 	private void renamePreviousEANs()

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreatePackingInstructionsCommand.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/CreatePackingInstructionsCommand.java
@@ -17,22 +17,29 @@ import de.metas.handlingunits.model.I_M_HU_PI;
 import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
+import de.metas.handlingunits.model.I_M_ProductPrice;
 import de.metas.logging.LogManager;
 import de.metas.manufacturing.workflows_api.activity_handlers.generateHUQRCodes.GenerateHUQRCodesActivityHandler;
 import de.metas.manufacturing.workflows_api.activity_handlers.receive.MaterialReceiptActivityHandler;
+import de.metas.pricing.PriceListVersionId;
+import de.metas.pricing.service.IPriceListDAO;
+import de.metas.pricing.service.ProductPrices;
 import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
 import de.metas.uom.UomId;
+import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.compiere.model.I_M_PriceList_Version;
 import org.slf4j.Logger;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.util.List;
 
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 
@@ -43,6 +50,7 @@ public class CreatePackingInstructionsCommand
 	@NonNull private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	@NonNull private final IProductBL productBL = Services.get(IProductBL.class);
 	@NonNull private final IHandlingUnitsBL handlingUnitsBL = Services.get(IHandlingUnitsBL.class);
+	@NonNull private final IPriceListDAO priceListDAO = Services.get(IPriceListDAO.class);
 	@NonNull private final MasterdataContext context;
 	@NonNull private final JsonPackingInstructionsRequest request;
 	@NonNull private final Identifier identifier;
@@ -212,13 +220,51 @@ public class CreatePackingInstructionsCommand
 		record.setC_UOM_ID(uomId.getRepoId());
 		record.setValidFrom(Timestamp.from(MasterdataContext.DEFAULT_ValidFrom.atStartOfDay(SystemTime.zoneId()).toInstant()));
 		record.setEAN_TU(request.getTu_ean() != null ? request.getTu_ean().getAsString() : null);
+		record.setIsDefaultForProduct(request.isDefaultForProduct());
 		saveRecord(record);
 		final HUPIItemProductId piItemProductId = HUPIItemProductId.ofRepoId(record.getM_HU_PI_Item_Product_ID());
+
+		if (request.isReferencedByProductPrice())
+		{
+			pointProductPricesAt(productId, record);
+		}
 
 		context.putIdentifierIfAbsent(tuIdentifier, piItemProductId);
 		context.putIdentifier(Identifier.ofString(tuIdentifier.getAsString() + "_" + productIdentifier.getAsString()), piItemProductId);
 
 		return MaterialReceiptActivityHandler.extractNewTUTargetTestId(record);
+	}
+
+	/**
+	 * Makes the product's price(s) on the current price list version reference the given CU-TU allocation,
+	 * so the packing instruction is one a product price actually points at.
+	 * <p>
+	 * Links <em>every</em> price row the product has on that price list version. Fixtures create one price
+	 * per product, so that is the same thing in practice — but a fixture that creates several (e.g.
+	 * attribute-dependent variants) would get them all pointed at this allocation.
+	 */
+	private void pointProductPricesAt(
+			@NonNull final ProductId productId,
+			@NonNull final I_M_HU_PI_Item_Product piItemProduct)
+	{
+		// Fails with "No identifier found for PriceListVersionId" when the request has no bpartners section:
+		// the price list version is created as a side effect of creating a bpartner.
+		final PriceListVersionId priceListVersionId = context.getIdOfType(PriceListVersionId.class);
+		final I_M_PriceList_Version priceListVersion = priceListDAO.getPriceListVersionById(priceListVersionId);
+
+		final List<I_M_ProductPrice> productPrices = ProductPrices.newQuery(priceListVersion)
+				.setProductId(productId)
+				.list(I_M_ProductPrice.class);
+
+		Check.assumeNotEmpty(productPrices,
+				"referencedByProductPrice needs product {} to have a price on price list version {} — give the product a price in the same request",
+				productId, priceListVersionId);
+
+		for (final I_M_ProductPrice productPrice : productPrices)
+		{
+			productPrice.setM_HU_PI_Item_Product(piItemProduct);
+			saveRecord(productPrice);
+		}
 	}
 
 	private void renamePreviousEANs()

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonPackingInstructionsRequest.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/JsonPackingInstructionsRequest.java
@@ -31,6 +31,27 @@ public class JsonPackingInstructionsRequest
 	@Nullable Identifier lu;
 	int qtyTUsPerLU;
 
+	/**
+	 * Sets {@code M_HU_PI_Item_Product.IsDefaultForProduct} on the created CU-TU allocation — the
+	 * "Standard-Packvorschrift" that gets auto-defaulted onto document lines for this product.
+	 * <p>
+	 * TU requests only — a {@code cu} request creates no CU-TU allocation, so this has no effect there.
+	 */
+	boolean isDefaultForProduct;
+
+	/**
+	 * Points the product's existing product price(s) on the current price list version at the created
+	 * CU-TU allocation, i.e. makes the packing instruction one that a price references. Requires the same
+	 * request to give that product a price.
+	 * <p>
+	 * The link is expressed here rather than on the product request because products are created before
+	 * packing instructions ({@code CreateMasterdataCommand}), so at price-creation time the packing
+	 * instruction does not exist yet.
+	 * <p>
+	 * TU requests only — a {@code cu} request creates no CU-TU allocation, so this has no effect there.
+	 */
+	boolean referencedByProductPrice;
+
 	public Identifier getTuNotNull() {return Check.assumeNotNull(tu, "tu must be set");}
 
 	public Identifier getProductNotNull() {return Check.assumeNotNull(product, "product must be set");}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/ProductPricePackingInstructionRepository.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/ProductPricePackingInstructionRepository.java
@@ -1,0 +1,56 @@
+package de.metas.frontend_testing.masterdata.hu;
+
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.handlingunits.model.I_M_ProductPrice;
+import de.metas.pricing.PriceListVersionId;
+import de.metas.pricing.service.IPriceListDAO;
+import de.metas.pricing.service.ProductPrices;
+import de.metas.product.ProductId;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.compiere.model.I_M_PriceList_Version;
+
+import java.util.List;
+
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+
+/**
+ * Persistence for the {@code M_ProductPrice.M_HU_PI_Item_Product_ID} link that the masterdata API sets.
+ * <p>
+ * Separate from {@link CreatePackingInstructionsCommand} because persistence primitives
+ * ({@code InterfaceWrapperHelper.saveRecord}) belong in a {@code *Repository}/{@code *DAO} rather than in a
+ * command — see {@code docs/coding-rules/service-injection.md} §4. An ArchUnit rule enforces this.
+ * <p>
+ * The HU-flavoured {@code de.metas.handlingunits.model.I_M_ProductPrice} is used deliberately: only it exposes
+ * {@code setM_HU_PI_Item_Product}, because {@code de.metas.business} cannot depend on the handling-units module.
+ */
+public class ProductPricePackingInstructionRepository
+{
+	@NonNull private final IPriceListDAO priceListDAO = Services.get(IPriceListDAO.class);
+
+	/**
+	 * Points every product price of {@code productId} on the given price list version at {@code piItemProduct}.
+	 *
+	 * @return how many product prices were updated — zero means the product has no price on that price list
+	 *         version, which the caller is expected to treat as a masterdata-request error.
+	 */
+	public int pointProductPricesAt(
+			@NonNull final PriceListVersionId priceListVersionId,
+			@NonNull final ProductId productId,
+			@NonNull final I_M_HU_PI_Item_Product piItemProduct)
+	{
+		final I_M_PriceList_Version priceListVersion = priceListDAO.getPriceListVersionById(priceListVersionId);
+
+		final List<I_M_ProductPrice> productPrices = ProductPrices.newQuery(priceListVersion)
+				.setProductId(productId)
+				.list(I_M_ProductPrice.class);
+
+		for (final I_M_ProductPrice productPrice : productPrices)
+		{
+			productPrice.setM_HU_PI_Item_Product(piItemProduct);
+			saveRecord(productPrice);
+		}
+
+		return productPrices.size();
+	}
+}

--- a/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/ProductPricePackingInstructionRepository.java
+++ b/backend/de.metas.frontend-testing/src/main/java/de/metas/frontend_testing/masterdata/hu/ProductPricePackingInstructionRepository.java
@@ -23,6 +23,11 @@ import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
  * <p>
  * The HU-flavoured {@code de.metas.handlingunits.model.I_M_ProductPrice} is used deliberately: only it exposes
  * {@code setM_HU_PI_Item_Product}, because {@code de.metas.business} cannot depend on the handling-units module.
+ * That is also why this is a second writer of {@code M_ProductPrice} alongside
+ * {@code de.metas.pricing.productprice.ProductPriceRepository}: this one is scoped to the HU column only.
+ * <p>
+ * Repository Tables: M_ProductPrice
+ * Repository Cluster: ProductPricePackingInstructionRepository
  */
 public class ProductPricePackingInstructionRepository
 {

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductBL.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductBL.java
@@ -50,6 +50,15 @@ import java.util.List;
 
 public interface IHUPIItemProductBL extends ISingletonService
 {
+	/**
+	 * Legacy key. The setting predates this accessor and is still named after the WebUI quick-input helper
+	 * that first read it; it is now read from here too, because the same rule applies to the order line
+	 * interceptor. The string must NOT change — {@code AD_SysConfig} rows on live instances key on it
+	 * verbatim.
+	 */
+	String SYSCONFIG_EnforcePrecisePricePerHUItemProduct =
+			"de.metas.ui.web.quickinput.field.PackingItemProductFieldHelper.EnforcePrecisePricePerHUItemProduct";
+
 	HUPIItemProduct getById(@NonNull HUPIItemProductId id);
 
 	I_M_HU_PI_Item_Product getRecordById(HUPIItemProductId id);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/IHUPIItemProductDAO.java
@@ -28,6 +28,7 @@ import de.metas.handlingunits.model.I_M_HU;
 import de.metas.handlingunits.model.I_M_HU_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.pricing.PriceListVersionId;
 import de.metas.product.ProductId;
 import de.metas.util.ISingletonService;
 import lombok.NonNull;
@@ -141,7 +142,34 @@ public interface IHUPIItemProductDAO extends ISingletonService
 
 	Optional<I_M_HU_PI_Item_Product> retrieveDefaultForProduct(ProductId productId, BPartnerId bpartnerId, ZonedDateTime date);
 
+	/**
+	 * Like {@link #retrieveDefaultForProduct(ProductId, BPartnerId, ZonedDateTime)}, but when
+	 * {@code priceListVersionId} is not {@code null}, only a packing instruction that an
+	 * {@code M_ProductPrice} of that price list version references is returned.
+	 * <p>
+	 * Use this from a pricing-aware caller: a packing instruction that no product price references cannot
+	 * be priced, so defaulting it onto a document line makes that line uncompletable.
+	 * <p>
+	 * Unlike the older overloads, {@code date} is nullable here and means "no validity filter" — a
+	 * pre-save callout or interceptor can legitimately run before any date column is populated, and must
+	 * not be made to blow up over it.
+	 */
+	Optional<I_M_HU_PI_Item_Product> retrieveDefaultForProduct(
+			ProductId productId,
+			@Nullable BPartnerId bpartnerId,
+			@Nullable ZonedDateTime date,
+			@Nullable PriceListVersionId priceListVersionId);
+
 	Optional<HUPIItemProductId> retrieveDefaultIdForProduct(ProductId productId, BPartnerId bpartnerId, ZonedDateTime date);
+
+	/**
+	 * @see #retrieveDefaultForProduct(ProductId, BPartnerId, ZonedDateTime, PriceListVersionId)
+	 */
+	Optional<HUPIItemProductId> retrieveDefaultIdForProduct(
+			ProductId productId,
+			@Nullable BPartnerId bpartnerId,
+			@Nullable ZonedDateTime date,
+			@Nullable PriceListVersionId priceListVersionId);
 
 	@Nullable
 	I_M_HU_PI_Item_Product retrieveDefaultForProduct(@NonNull ProductId productId, @NonNull ZonedDateTime date);

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductDAO.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/impl/HUPIItemProductDAO.java
@@ -45,6 +45,7 @@ import de.metas.handlingunits.model.I_M_ProductPrice;
 import de.metas.handlingunits.model.X_M_HU_PI_Item;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
 import de.metas.i18n.IModelTranslationMap;
+import de.metas.pricing.PriceListVersionId;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantitys;
 import de.metas.uom.UomId;
@@ -860,11 +861,23 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 			@Nullable final BPartnerId bpartnerId,
 			@NonNull final ZonedDateTime date)
 	{
+		return retrieveDefaultForProduct(productId, bpartnerId, date, null);
+	}
+
+	@Override
+	public Optional<I_M_HU_PI_Item_Product> retrieveDefaultForProduct(
+			@NonNull final ProductId productId,
+			@Nullable final BPartnerId bpartnerId,
+			@Nullable final ZonedDateTime date,
+			@Nullable final PriceListVersionId priceListVersionId)
+	{
 		final IHUPIItemProductQuery query = createHUPIItemProductQuery();
 		query.setBPartnerId(bpartnerId);
 		query.setProductId(productId);
 		query.setDate(date);
 		query.setDefaultForProduct(true);
+		// null means "don't restrict"; the filter in buildQueryFilters is guarded by a null check
+		query.setPriceListVersionId(priceListVersionId);
 
 		final I_M_HU_PI_Item_Product huPIItemProduct = retrieveFirst(Env.getCtx(), query, ITrx.TRXNAME_None);
 		return Optional.ofNullable(huPIItemProduct);
@@ -876,7 +889,17 @@ public class HUPIItemProductDAO implements IHUPIItemProductDAO
 			@Nullable final BPartnerId bpartnerId,
 			@NonNull final ZonedDateTime date)
 	{
-		return retrieveDefaultForProduct(productId, bpartnerId, date)
+		return retrieveDefaultIdForProduct(productId, bpartnerId, date, null);
+	}
+
+	@Override
+	public Optional<HUPIItemProductId> retrieveDefaultIdForProduct(
+			@NonNull final ProductId productId,
+			@Nullable final BPartnerId bpartnerId,
+			@Nullable final ZonedDateTime date,
+			@Nullable final PriceListVersionId priceListVersionId)
+	{
+		return retrieveDefaultForProduct(productId, bpartnerId, date, priceListVersionId)
 				.map(huPiItemProduct -> HUPIItemProductId.ofRepoIdOrNull(huPiItemProduct.getM_HU_PI_Item_Product_ID()));
 	}
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pricing/spi/impl/HUPricing.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/pricing/spi/impl/HUPricing.java
@@ -209,7 +209,12 @@ public class HUPricing extends AttributePricing
 
 		//
 		// Make sure the default product price attribute is matching our pricing context packing material,
-		// or it has no packing material set.
+		// or the pricing CONTEXT has no packing material set.
+		//
+		// Note the exemption is on the context side only: once the context carries a packing material, a
+		// default price without one does NOT qualify, because its M_HU_PI_Item_Product_ID reads as "None"
+		// and therefore compares unequal. So a packing instruction that no product price references cannot
+		// be rescued by a packing-material-less default price here.
 		if (!isProductPriceMatchingContextPackingMaterial(defaultPrice, pricingCtx))
 		{
 			return null;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -1,10 +1,16 @@
 package de.metas.handlingunits.reservation.interceptor;
 
 import de.metas.bpartner.BPartnerId;
+import de.metas.common.util.CoalesceUtil;
 import de.metas.handlingunits.HUPIItemProductId;
+import de.metas.handlingunits.IHUPIItemProductBL;
 import de.metas.handlingunits.IHUPIItemProductDAO;
 import de.metas.handlingunits.model.I_C_Order;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.order.IOrderDAO;
+import de.metas.order.IOrderLineBL;
+import de.metas.order.OrderId;
+import de.metas.pricing.PriceListVersionId;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -14,12 +20,17 @@ import org.adempiere.ad.callout.spi.IProgramaticCalloutProvider;
 import org.adempiere.ad.modelvalidator.annotations.Init;
 import org.adempiere.ad.modelvalidator.annotations.Interceptor;
 import org.adempiere.ad.modelvalidator.annotations.ModelChange;
+import org.adempiere.service.ClientId;
+import org.adempiere.service.ISysConfigBL;
 import org.compiere.model.I_C_OrderLine;
+import org.compiere.model.I_M_PriceList_Version;
 import org.compiere.model.ModelValidator;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Nullable;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -51,6 +62,9 @@ import java.util.Properties;
 public class C_OrderLine
 {
 	private final IHUPIItemProductDAO hupiItemProductDAO = Services.get(IHUPIItemProductDAO.class);
+	private final IOrderDAO ordersRepo = Services.get(IOrderDAO.class);
+	private final IOrderLineBL orderLineBL = Services.get(IOrderLineBL.class);
+	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 
 	@Init
 	public void registerCallouts()
@@ -70,11 +84,99 @@ public class C_OrderLine
 	@CalloutMethod(columnNames = de.metas.interfaces.I_C_OrderLine.COLUMNNAME_M_Product_ID)
 	public void onProductSetOrChanged(final de.metas.interfaces.I_C_OrderLine orderLine)
 	{
-		final Optional<HUPIItemProductId> huPiItemProductId = hupiItemProductDAO.retrieveDefaultIdForProduct(ProductId.ofRepoId(orderLine.getM_Product_ID()),
+		final org.compiere.model.I_C_Order order = ordersRepo.getById(OrderId.ofRepoId(orderLine.getC_Order_ID()));
+
+		final ZonedDateTime date = extractPriceDate(orderLine, order);
+
+		final Optional<HUPIItemProductId> huPiItemProductId = hupiItemProductDAO.retrieveDefaultIdForProduct(
+				ProductId.ofRepoId(orderLine.getM_Product_ID()),
 				BPartnerId.ofRepoId(orderLine.getC_BPartner_ID()),
-				TimeUtil.asZonedDateTime(orderLine.getDatePromised()));
+				date,
+				getPriceListVersionIdOrNull(orderLine, order, date));
 		final Properties ctx = Env.getCtx();
 		final I_M_HU_PI_Item_Product noPackingItemProduct = hupiItemProductDAO.retrieveVirtualPIMaterialItemProduct(ctx);
 		orderLine.setM_HU_PI_Item_Product_ID(HUPIItemProductId.toRepoId(huPiItemProductId.orElse(HUPIItemProductId.ofRepoId(noPackingItemProduct.getM_HU_PI_Item_Product_ID()))));
+	}
+
+	/**
+	 * The packing instruction's validity date, DatePromised-based for sales and purchase alike.
+	 * <p>
+	 * {@code C_OrderLine.DatePromised} is nullable — a line whose date has not been set yet is normal — so
+	 * coalesce to the order header, mirroring the sales branch of {@code OrderLineBL}'s own price-date
+	 * resolution. Both being unset is possible too: this runs as a pre-save interceptor and callout, and
+	 * an AD {@code Mandatory} flag is only enforced when the record is persisted, not while it is being
+	 * edited. That case returns {@code null}, meaning "no validity filter" — never an exception, because
+	 * refusing to default a packing instruction must not break product selection.
+	 */
+	@Nullable
+	private static ZonedDateTime extractPriceDate(
+			@NonNull final de.metas.interfaces.I_C_OrderLine orderLine,
+			@NonNull final org.compiere.model.I_C_Order order)
+	{
+		return CoalesceUtil.coalesce(
+				TimeUtil.asZonedDateTime(orderLine.getDatePromised()),
+				TimeUtil.asZonedDateTime(order.getDatePromised()));
+	}
+
+	/**
+	 * @return the order's price list version, which restricts the default lookup to packing instructions
+	 *         that a product price references — or {@code null} to leave the lookup unrestricted.
+	 *         <p>
+	 *         Null is returned when the document is not a sales order, when the rule is not enforced, and
+	 *         when there is no price list to resolve one from: an order that has no price list yet must
+	 *         keep today's behaviour rather than silently lose its packing instruction.
+	 *         <p>
+	 *         Note this site cannot simply skip the lookup the way the quick-input helper does. That
+	 *         helper has a price-list step ahead of the fallback which has already returned any priced
+	 *         packing instruction; here the {@code IsDefaultForProduct} lookup is the only source, so
+	 *         skipping it would also strip the default where a product price legitimately references it.
+	 */
+	@Nullable
+	private PriceListVersionId getPriceListVersionIdOrNull(
+			@NonNull final de.metas.interfaces.I_C_OrderLine orderLine,
+			@NonNull final org.compiere.model.I_C_Order order,
+			@Nullable final ZonedDateTime date)
+	{
+		if (date == null)
+		{
+			// No date anywhere on the line or its order, so there is no price list version to speak of.
+			// orderLineBL.getPriceListVersion would throw on exactly this input; stay unrestricted.
+			//
+			// This deliberately also gives up on a line that carries an explicit M_PriceList_Version_ID
+			// override, which could in principle be resolved without any date. That combination only
+			// makes us less restrictive, never wrong, and keeping one guard is worth more here than
+			// adding a branch no test exercises.
+			return null;
+		}
+
+		if (!order.isSOTrx())
+		{
+			// Sales only, matching the quick-input helper, which reaches its IsDefaultForProduct fallback
+			// under an SOTrx.SALES guard. Purchase order lines keep today's behaviour untouched. Whether
+			// purchase should follow the same rule is a separate question, deliberately not decided here.
+			return null;
+		}
+
+		if (!sysConfigBL.getBooleanValue(
+				IHUPIItemProductBL.SYSCONFIG_EnforcePrecisePricePerHUItemProduct,
+				false,
+				ClientId.ofRepoId(orderLine.getAD_Client_ID()).getRepoId()))
+		{
+			return null;
+		}
+
+		// orderLineBL.getPriceListVersion throws when there is neither a line-level override nor an order
+		// price list, so bail out to "unrestricted" first rather than let an incomplete order fail here.
+		if (orderLine.getM_PriceList_Version_ID() <= 0 && order.getM_PriceList_ID() <= 0)
+		{
+			return null;
+		}
+
+		// Deliberately the shared BL rather than a local re-resolution: it honours the line-level price
+		// list version override and resolves the price date in the order's org timezone.
+		final I_M_PriceList_Version priceListVersion = orderLineBL.getPriceListVersion(orderLine);
+		return priceListVersion == null
+				? null
+				: PriceListVersionId.ofRepoId(priceListVersion.getM_PriceList_Version_ID());
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUPIItemProductDAOTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/impl/HUPIItemProductDAOTest.java
@@ -20,6 +20,7 @@ import org.adempiere.test.AdempiereTestHelper;
 import org.adempiere.test.AdempiereTestWatcher;
 import org.assertj.core.api.OptionalAssert;
 import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_M_PriceList_Version;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,12 +42,17 @@ import de.metas.handlingunits.model.I_M_HU_PI_Item;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
 import de.metas.handlingunits.model.I_M_HU_PI_Version;
 import de.metas.handlingunits.model.I_M_HU_PackingMaterial;
+import de.metas.handlingunits.model.I_M_ProductPrice;
 import de.metas.handlingunits.model.X_M_HU_PI_Item;
 import de.metas.handlingunits.model.X_M_HU_PI_Version;
+import de.metas.pricing.PriceListVersionId;
 import de.metas.product.IProductDAO;
 import de.metas.product.ProductId;
 import de.metas.util.Services;
 import lombok.Builder;
+import lombok.NonNull;
+
+import javax.annotation.Nullable;
 
 @ExtendWith(AdempiereTestWatcher.class)
 public class HUPIItemProductDAOTest
@@ -406,6 +412,81 @@ public class HUPIItemProductDAOTest
 			assertDefaultForProduct(product1, bpartner3, "2011-10-01").contains(pip3);
 			assertDefaultForProduct(product1, bpartner3, "2012-10-01").contains(pip3);
 		}
+
+		/**
+		 * A packing instruction that no product price of the given price list version references must not be
+		 * offered as a default — it cannot be priced, so a document line carrying it cannot be completed.
+		 */
+		@Test
+		public void priceListVersionGiven_noProductPriceReferencesIt_returnsEmpty()
+		{
+			final I_M_HU_PI_Item_Product pip = huPIItemProduct()
+					.productId(product1).bpartnerId(null).validFrom("2011-10-01")
+					.huUnitType(X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit).defaultForProduct(true).build();
+			final PriceListVersionId plvId = createPriceListVersion();
+			createProductPrice(plvId, product1, null); // a price, but with no packing instruction
+
+			assertThat(dao.retrieveDefaultForProduct(product1, bpartner1, date("2011-10-01"), plvId)).isEmpty();
+			assertThat(dao.retrieveDefaultIdForProduct(product1, bpartner1, date("2011-10-01"), plvId)).isEmpty();
+
+			// the unrestricted overloads are unchanged
+			assertThat(dao.retrieveDefaultForProduct(product1, bpartner1, date("2011-10-01"))).contains(pip);
+			assertThat(dao.retrieveDefaultForProduct(product1, bpartner1, date("2011-10-01"), null)).contains(pip);
+		}
+
+		@Test
+		public void priceListVersionGiven_aProductPriceReferencesIt_returnsIt()
+		{
+			final I_M_HU_PI_Item_Product pip = huPIItemProduct()
+					.productId(product1).bpartnerId(null).validFrom("2011-10-01")
+					.huUnitType(X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit).defaultForProduct(true).build();
+			final PriceListVersionId plvId = createPriceListVersion();
+			createProductPrice(plvId, product1, pip);
+
+			assertThat(dao.retrieveDefaultForProduct(product1, bpartner1, date("2011-10-01"), plvId)).contains(pip);
+			assertThat(dao.retrieveDefaultIdForProduct(product1, bpartner1, date("2011-10-01"), plvId))
+					.contains(HUPIItemProductId.ofRepoId(pip.getM_HU_PI_Item_Product_ID()));
+		}
+
+		/**
+		 * The price of a <em>different</em> price list version must not qualify a packing instruction.
+		 */
+		@Test
+		public void priceListVersionGiven_onlyAnotherVersionsPriceReferencesIt_returnsEmpty()
+		{
+			final I_M_HU_PI_Item_Product pip = huPIItemProduct()
+					.productId(product1).bpartnerId(null).validFrom("2011-10-01")
+					.huUnitType(X_M_HU_PI_Version.HU_UNITTYPE_TransportUnit).defaultForProduct(true).build();
+			final PriceListVersionId plvId = createPriceListVersion();
+			final PriceListVersionId otherPlvId = createPriceListVersion();
+			createProductPrice(otherPlvId, product1, pip);
+
+			assertThat(dao.retrieveDefaultForProduct(product1, bpartner1, date("2011-10-01"), plvId)).isEmpty();
+			assertThat(dao.retrieveDefaultForProduct(product1, bpartner1, date("2011-10-01"), otherPlvId)).contains(pip);
+		}
+	}
+
+	private PriceListVersionId createPriceListVersion()
+	{
+		final I_M_PriceList_Version plv = newInstance(I_M_PriceList_Version.class);
+		plv.setIsActive(true);
+		saveRecord(plv);
+		return PriceListVersionId.ofRepoId(plv.getM_PriceList_Version_ID());
+	}
+
+	private void createProductPrice(
+			@NonNull final PriceListVersionId priceListVersionId,
+			@NonNull final ProductId productId,
+			@Nullable final I_M_HU_PI_Item_Product huPiItemProduct)
+	{
+		final I_M_ProductPrice productPrice = newInstance(I_M_ProductPrice.class);
+		productPrice.setM_PriceList_Version_ID(priceListVersionId.getRepoId());
+		productPrice.setM_Product_ID(productId.getRepoId());
+		if (huPiItemProduct != null)
+		{
+			productPrice.setM_HU_PI_Item_Product(huPiItemProduct);
+		}
+		saveRecord(productPrice);
 	}
 
 	@Nested

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
@@ -1,0 +1,405 @@
+/*
+ * #%L
+ * de.metas.handlingunits.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.handlingunits.reservation.interceptor;
+
+import de.metas.handlingunits.HUPIItemProductId;
+import de.metas.handlingunits.HuPackingInstructionsId;
+import de.metas.handlingunits.HuPackingInstructionsItemId;
+import de.metas.handlingunits.HuPackingInstructionsVersionId;
+import de.metas.handlingunits.IHUPIItemProductBL;
+import de.metas.handlingunits.model.I_M_HU_PI;
+import de.metas.handlingunits.model.I_M_HU_PI_Item;
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.handlingunits.model.I_M_HU_PI_Version;
+import de.metas.handlingunits.model.I_M_ProductPrice;
+import de.metas.handlingunits.model.X_M_HU_PI_Item;
+import de.metas.pricing.PriceListId;
+import de.metas.product.ProductId;
+import lombok.NonNull;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.model.I_AD_SysConfig;
+import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_C_Order;
+import org.compiere.model.I_M_PriceList;
+import org.compiere.model.I_M_PriceList_Version;
+import org.compiere.model.I_M_Product;
+import org.compiere.util.TimeUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.adempiere.model.InterfaceWrapperHelper.load;
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the manual sales order line path: setting or changing the product on an order line must only
+ * default a Standard-Packvorschrift ({@code M_HU_PI_Item_Product.IsDefaultForProduct}) when a product
+ * price of the order's price list version references it. When none does, the line gets the Virtual PI
+ * ("no packing"), which prices correctly.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class C_OrderLineTest
+{
+	private static final ZonedDateTime DATE = LocalDate.of(2026, 8, 12).atStartOfDay(ZoneId.of("UTC"));
+
+	private C_OrderLine interceptor;
+
+	private ProductId productId;
+	private I_M_PriceList_Version priceListVersion;
+	private de.metas.interfaces.I_C_OrderLine orderLine;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		interceptor = new C_OrderLine();
+
+		createVirtualPackingInstruction();
+
+		productId = createProduct();
+		final PriceListId priceListId = createPriceList();
+		priceListVersion = createPriceListVersion(priceListId);
+		orderLine = createOrderLine(priceListId);
+	}
+
+	//
+	// Tests
+	//
+
+	@Test
+	public void enforceOn_noProductPriceReferencesTheDefault_setsNoPacking()
+	{
+		setEnforcePrecisePrice(true);
+		createDefaultForProductPackingInstruction();
+		createProductPrice(null); // a price for the product, but with no packing instruction
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(HUPIItemProductId.VIRTUAL_HU.getRepoId());
+	}
+
+	/**
+	 * The regression a blanket skip would have caused: this site has no price-list step in front of it, so
+	 * suppressing the lookup outright would strip the default from an installation whose product price
+	 * legitimately references the Standard-Packvorschrift.
+	 */
+	@Test
+	public void enforceOn_aProductPriceReferencesTheDefault_setsThatDefault()
+	{
+		setEnforcePrecisePrice(true);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(piip);
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	@Test
+	public void enforceOff_noProductPriceReferencesTheDefault_setsThatDefault()
+	{
+		setEnforcePrecisePrice(false);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	/**
+	 * Not an acceptance criterion — it pins a deliberate choice: when the price list version cannot be
+	 * resolved we leave the lookup unrestricted rather than silently strip the packing instruction, so an
+	 * incomplete order keeps today's behaviour.
+	 */
+	@Test
+	public void enforceOn_orderHasNoPriceList_keepsTodaysBehaviour()
+	{
+		setEnforcePrecisePrice(true);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+		clearOrderPriceList();
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	/**
+	 * {@code C_OrderLine.DatePromised} is nullable and a freshly created line commonly has none yet, so
+	 * reading it unguarded blew up here — for every caller, whether or not the rule is enforced. The date
+	 * falls back to the order header, as the shared price-date resolution does.
+	 */
+	@Test
+	public void lineHasNoDatePromised_enforceOn_fallsBackToTheOrderHeaderDate()
+	{
+		setEnforcePrecisePrice(true);
+		createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+		clearOrderLineDatePromised();
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(HUPIItemProductId.VIRTUAL_HU.getRepoId());
+	}
+
+	@Test
+	public void lineHasNoDatePromised_enforceOff_fallsBackToTheOrderHeaderDate()
+	{
+		setEnforcePrecisePrice(false);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+		clearOrderLineDatePromised();
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	/**
+	 * The price requirement is scoped to sales order lines — the same scope the quick-input helper applies,
+	 * where the IsDefaultForProduct fallback sits behind an {@code SOTrx.SALES} guard. A purchase order line
+	 * must keep today's behaviour even with the rule enforced and no product price referencing the default.
+	 */
+	@Test
+	public void purchaseOrder_enforceOn_noProductPriceReferencesTheDefault_stillSetsThatDefault()
+	{
+		setEnforcePrecisePrice(true);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+		makeOrderAPurchaseOrder();
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	/**
+	 * Neither the line nor the order header carries a DatePromised. An AD {@code Mandatory} flag is only
+	 * enforced on persist, so a pre-save interceptor/callout can genuinely see both unset — and must not
+	 * throw. With no date there is no price list version to restrict against either, so this falls back
+	 * to today's unrestricted behaviour rather than stripping the packing instruction.
+	 */
+	@Test
+	public void noDatePromisedAnywhere_enforceOn_doesNotThrowAndKeepsTodaysBehaviour()
+	{
+		setEnforcePrecisePrice(true);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+		clearOrderLineDatePromised();
+		clearOrderDatePromised();
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	@Test
+	public void noDatePromisedAnywhere_purchaseOrder_doesNotThrowAndKeepsTodaysBehaviour()
+	{
+		setEnforcePrecisePrice(true);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+		clearOrderLineDatePromised();
+		clearOrderDatePromised();
+		makeOrderAPurchaseOrder();
+
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	//
+	// Fixture
+	//
+
+	private void clearOrderDatePromised()
+	{
+		final I_C_Order order = load(orderLine.getC_Order_ID(), I_C_Order.class);
+		order.setDatePromised(null);
+		saveRecord(order);
+	}
+
+	private void makeOrderAPurchaseOrder()
+	{
+		final I_C_Order order = load(orderLine.getC_Order_ID(), I_C_Order.class);
+		order.setIsSOTrx(false);
+		saveRecord(order);
+	}
+
+	private void clearOrderLineDatePromised()
+	{
+		orderLine.setDatePromised(null);
+		saveRecord(orderLine);
+	}
+
+	private void setEnforcePrecisePrice(final boolean value)
+	{
+		final I_AD_SysConfig sysConfig = newInstance(I_AD_SysConfig.class);
+		sysConfig.setName(IHUPIItemProductBL.SYSCONFIG_EnforcePrecisePricePerHUItemProduct);
+		sysConfig.setValue(value ? "Y" : "N");
+		sysConfig.setIsActive(true);
+		saveRecord(sysConfig);
+	}
+
+	private ProductId createProduct()
+	{
+		final I_M_Product product = newInstance(I_M_Product.class);
+		product.setValue("TestProduct");
+		product.setName("Test Product");
+		saveRecord(product);
+		return ProductId.ofRepoId(product.getM_Product_ID());
+	}
+
+	private PriceListId createPriceList()
+	{
+		final I_M_PriceList priceList = newInstance(I_M_PriceList.class);
+		priceList.setName("Test Sales Price List");
+		priceList.setIsSOPriceList(true);
+		saveRecord(priceList);
+		return PriceListId.ofRepoId(priceList.getM_PriceList_ID());
+	}
+
+	private I_M_PriceList_Version createPriceListVersion(@NonNull final PriceListId priceListId)
+	{
+		final I_M_PriceList_Version plv = newInstance(I_M_PriceList_Version.class);
+		plv.setM_PriceList_ID(priceListId.getRepoId());
+		plv.setValidFrom(TimeUtil.asTimestamp(DATE.minusYears(1)));
+		plv.setIsActive(true);
+		saveRecord(plv);
+		return plv;
+	}
+
+	private de.metas.interfaces.I_C_OrderLine createOrderLine(@NonNull final PriceListId priceListId)
+	{
+		final I_C_BPartner bpartner = newInstance(I_C_BPartner.class);
+		bpartner.setName("Test Partner");
+		saveRecord(bpartner);
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(bpartner.getC_BPartner_ID());
+		order.setM_PriceList_ID(priceListId.getRepoId());
+		order.setIsSOTrx(true);
+		order.setDatePromised(TimeUtil.asTimestamp(DATE));
+		saveRecord(order);
+
+		final de.metas.interfaces.I_C_OrderLine line = newInstance(de.metas.interfaces.I_C_OrderLine.class);
+		line.setC_Order_ID(order.getC_Order_ID());
+		line.setC_BPartner_ID(bpartner.getC_BPartner_ID());
+		line.setM_Product_ID(productId.getRepoId());
+		line.setDatePromised(TimeUtil.asTimestamp(DATE));
+		saveRecord(line);
+		return line;
+	}
+
+	private void clearOrderPriceList()
+	{
+		final I_C_Order order = load(orderLine.getC_Order_ID(), I_C_Order.class);
+		order.setM_PriceList_ID(0);
+		saveRecord(order);
+	}
+
+	/**
+	 * The Virtual PI ("no packing") that {@code retrieveVirtualPIMaterialItemProduct} resolves by its fixed
+	 * id — the interceptor falls back to it whenever no Standard-Packvorschrift applies.
+	 */
+	private void createVirtualPackingInstruction()
+	{
+		final I_M_HU_PI huPI = newInstance(I_M_HU_PI.class);
+		huPI.setM_HU_PI_ID(HuPackingInstructionsId.VIRTUAL.getRepoId());
+		huPI.setName("VirtualPI");
+		saveRecord(huPI);
+
+		final I_M_HU_PI_Version huPIVersion = newInstance(I_M_HU_PI_Version.class);
+		huPIVersion.setM_HU_PI_Version_ID(HuPackingInstructionsVersionId.VIRTUAL.getRepoId());
+		huPIVersion.setM_HU_PI_ID(huPI.getM_HU_PI_ID());
+		huPIVersion.setIsCurrent(true);
+		saveRecord(huPIVersion);
+
+		final I_M_HU_PI_Item huPIItem = newInstance(I_M_HU_PI_Item.class);
+		huPIItem.setM_HU_PI_Item_ID(HuPackingInstructionsItemId.VIRTUAL.getRepoId());
+		huPIItem.setM_HU_PI_Version_ID(huPIVersion.getM_HU_PI_Version_ID());
+		huPIItem.setItemType(X_M_HU_PI_Item.ITEMTYPE_Material);
+		saveRecord(huPIItem);
+
+		final I_M_HU_PI_Item_Product piip = newInstance(I_M_HU_PI_Item_Product.class);
+		piip.setM_HU_PI_Item_Product_ID(HUPIItemProductId.VIRTUAL_HU.getRepoId());
+		piip.setM_HU_PI_Item_ID(huPIItem.getM_HU_PI_Item_ID());
+		piip.setIsInfiniteCapacity(true);
+		piip.setIsAllowAnyProduct(true);
+		saveRecord(piip);
+	}
+
+	/**
+	 * The reported shape: a Standard-Packvorschrift with infinite capacity and no business partner,
+	 * created so that mobileUI production works.
+	 */
+	private I_M_HU_PI_Item_Product createDefaultForProductPackingInstruction()
+	{
+		final I_M_HU_PI huPI = newInstance(I_M_HU_PI.class);
+		huPI.setName("Test Frame PI");
+		saveRecord(huPI);
+
+		final I_M_HU_PI_Version huPIVersion = newInstance(I_M_HU_PI_Version.class);
+		huPIVersion.setM_HU_PI_ID(huPI.getM_HU_PI_ID());
+		huPIVersion.setIsCurrent(true);
+		saveRecord(huPIVersion);
+
+		final I_M_HU_PI_Item huPIItem = newInstance(I_M_HU_PI_Item.class);
+		huPIItem.setM_HU_PI_Version_ID(huPIVersion.getM_HU_PI_Version_ID());
+		huPIItem.setItemType(X_M_HU_PI_Item.ITEMTYPE_Material);
+		saveRecord(huPIItem);
+
+		final I_M_HU_PI_Item_Product piip = newInstance(I_M_HU_PI_Item_Product.class);
+		piip.setM_Product_ID(productId.getRepoId());
+		piip.setM_HU_PI_Item_ID(huPIItem.getM_HU_PI_Item_ID());
+		piip.setIsDefaultForProduct(true);
+		piip.setIsInfiniteCapacity(true);
+		piip.setQty(BigDecimal.ZERO);
+		piip.setValidFrom(TimeUtil.asTimestamp(DATE.minusYears(1)));
+		saveRecord(piip);
+		return piip;
+	}
+
+	private void createProductPrice(@Nullable final I_M_HU_PI_Item_Product huPiItemProduct)
+	{
+		final I_M_ProductPrice productPrice = newInstance(I_M_ProductPrice.class);
+		productPrice.setM_PriceList_Version_ID(priceListVersion.getM_PriceList_Version_ID());
+		productPrice.setM_Product_ID(productId.getRepoId());
+		if (huPiItemProduct != null)
+		{
+			productPrice.setM_HU_PI_Item_Product(huPiItemProduct);
+		}
+		saveRecord(productPrice);
+	}
+}

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/field/PackingItemProductFieldHelper.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/quickinput/field/PackingItemProductFieldHelper.java
@@ -34,6 +34,7 @@ import org.compiere.model.I_M_PriceList_Version;
 import org.compiere.util.Env;
 import org.springframework.stereotype.Component;
 
+import de.metas.handlingunits.IHUPIItemProductBL;
 import de.metas.handlingunits.IHUPIItemProductDAO;
 import de.metas.handlingunits.IHUPIItemProductQuery;
 import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
@@ -50,8 +51,6 @@ public class PackingItemProductFieldHelper
 	private final IHUPIItemProductDAO huPIItemProductsRepo = Services.get(IHUPIItemProductDAO.class);
 	private final IPriceListDAO priceListsRepo = Services.get(IPriceListDAO.class);
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
-	
-	private static final String SYSCONFIG_EnforcePrecisePricePerHUItemProduct = "de.metas.ui.web.quickinput.field.PackingItemProductFieldHelper.EnforcePrecisePricePerHUItemProduct";
 
 	public Optional<I_M_HU_PI_Item_Product> getDefaultPackingMaterial(@NonNull final DefaultPackingItemCriteria defaultPackingItemCriteria)
 	{
@@ -62,18 +61,26 @@ public class PackingItemProductFieldHelper
 			return defaultPIProduct;
 		}
 
-		if (SOTrx.SALES.equals(defaultPackingItemCriteria.getSoTrx()))
-		{
-			// Sales Orders: if no Packing Instruction is set on Product Price, check the default Packing Item for Product (set in CU-TU Allocations)
-			return huPIItemProductsRepo.retrieveDefaultForProduct(defaultPackingItemCriteria.getProductId(),
-					defaultPackingItemCriteria.getBPartnerLocationId().getBpartnerId(), defaultPackingItemCriteria.getDate());
-		}
-		else
+		if (!SOTrx.SALES.equals(defaultPackingItemCriteria.getSoTrx()))
 		{
 			// Purchase Orders: only the Packing Instructions which are set on Purchase Product Prices are used.
 			// Therefore at this step we return nothing.
 			return Optional.empty();
 		}
+
+		if (isEnforcePrecisePricePerHUItemProduct(defaultPackingItemCriteria.getClientId()))
+		{
+			// The price list step above already returned every packing instruction that a product price of
+			// this price list version references. So the IsDefaultForProduct fallback below could only ever
+			// yield one that no product price references -- which is exactly what this setting forbids, and
+			// such a packing instruction makes the order line uncompletable ("Produkt ist nicht auf der
+			// Preisliste"), because pricing matches on it.
+			return Optional.empty();
+		}
+
+		// Sales Orders: if no Packing Instruction is set on Product Price, check the default Packing Item for Product (set in CU-TU Allocations)
+		return huPIItemProductsRepo.retrieveDefaultForProduct(defaultPackingItemCriteria.getProductId(),
+				defaultPackingItemCriteria.getBPartnerLocationId().getBpartnerId(), defaultPackingItemCriteria.getDate());
 	}
 
 	private Optional<I_M_HU_PI_Item_Product> getDefaultPackingMaterialFromPriceList(@NonNull final DefaultPackingItemCriteria defaultPackingItemCriteria)
@@ -96,11 +103,10 @@ public class PackingItemProductFieldHelper
 		}
 
 		final ClientId clientId = defaultPackingItemCriteria.getClientId();
-		final boolean enforcePrecisePricePerHUItemProduct = sysConfigBL.getBooleanValue(SYSCONFIG_EnforcePrecisePricePerHUItemProduct, false, clientId.getRepoId());
-		
+		final boolean enforcePrecisePricePerHUItemProduct = isEnforcePrecisePricePerHUItemProduct(clientId);
+
 		// TODO: check ASI too
-		final IHUPIItemProductDAO piItemProductDAO = Services.get(IHUPIItemProductDAO.class);
-		final IHUPIItemProductQuery queryVO = piItemProductDAO.createHUPIItemProductQuery();
+		final IHUPIItemProductQuery queryVO = huPIItemProductsRepo.createHUPIItemProductQuery();
 		queryVO.setM_Product_ID(defaultPackingItemCriteria.getProductId().getRepoId());
 		queryVO.setBPartnerId(defaultPackingItemCriteria.getBPartnerLocationId().getBpartnerId());
 		queryVO.setAllowVirtualPI(false);
@@ -111,8 +117,18 @@ public class PackingItemProductFieldHelper
 		{
 			queryVO.setPriceListVersionId(PriceListVersionId.ofRepoId(priceListVersion.getM_PriceList_Version_ID()));
 		}
-		final List<I_M_HU_PI_Item_Product> itemProducts = piItemProductDAO.retrieveHUItemProducts(Env.getCtx(), queryVO, ITrx.TRXNAME_ThreadInherited);
+		final List<I_M_HU_PI_Item_Product> itemProducts = huPIItemProductsRepo.retrieveHUItemProducts(Env.getCtx(), queryVO, ITrx.TRXNAME_ThreadInherited);
 		return itemProducts.stream().findFirst();
+	}
+
+	/**
+	 * @return {@code true} if a packing instruction may only be auto-defaulted when a product price of the
+	 *         relevant price list version references it. Defaults to {@code false} when unset.
+	 */
+	private boolean isEnforcePrecisePricePerHUItemProduct(@NonNull final ClientId clientId)
+	{
+		return sysConfigBL.getBooleanValue(
+				IHUPIItemProductBL.SYSCONFIG_EnforcePrecisePricePerHUItemProduct, false, clientId.getRepoId());
 	}
 
 	@Nullable

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/quickinput/field/PackingItemProductFieldHelperTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/quickinput/field/PackingItemProductFieldHelperTest.java
@@ -1,0 +1,269 @@
+/*
+ * #%L
+ * metasfresh-webui-api
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ui.web.quickinput.field;
+
+import de.metas.bpartner.BPartnerLocationAndCaptureId;
+import de.metas.handlingunits.IHUPIItemProductBL;
+import de.metas.handlingunits.model.I_M_HU_PI;
+import de.metas.handlingunits.model.I_M_HU_PI_Item;
+import de.metas.handlingunits.model.I_M_HU_PI_Item_Product;
+import de.metas.handlingunits.model.I_M_HU_PI_Version;
+import de.metas.handlingunits.model.I_M_ProductPrice;
+import de.metas.handlingunits.model.X_M_HU_PI_Item;
+import de.metas.lang.SOTrx;
+import de.metas.pricing.PriceListId;
+import de.metas.product.ProductId;
+import lombok.NonNull;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.model.I_AD_SysConfig;
+import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_C_BPartner_Location;
+import org.compiere.model.I_M_PriceList;
+import org.compiere.model.I_M_PriceList_Version;
+import org.compiere.model.I_M_Product;
+import org.compiere.util.TimeUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the rule that a Standard-Packvorschrift ({@code M_HU_PI_Item_Product.IsDefaultForProduct}) is
+ * only offered as the sales order line quick-entry default when a product price of the order's price list
+ * version references it.
+ * <p>
+ * Note on the fixture: the criteria carry an explicit {@code priceListId}. Resolving a price list from the
+ * pricing system + partner country is a separate concern of {@code IPriceListDAO} and is not what these
+ * tests are about — the branch under test sits downstream of that resolution.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class PackingItemProductFieldHelperTest
+{
+	private static final ZonedDateTime DATE = LocalDate.of(2026, 8, 12).atStartOfDay(ZoneId.of("UTC"));
+
+	private PackingItemProductFieldHelper helper;
+
+	private ClientId clientId;
+	private ProductId productId;
+	private BPartnerLocationAndCaptureId bpartnerLocationId;
+	private PriceListId priceListId;
+	private I_M_PriceList_Version priceListVersion;
+
+	@BeforeEach
+	public void init()
+	{
+		AdempiereTestHelper.get().init();
+
+		helper = new PackingItemProductFieldHelper();
+
+		clientId = ClientId.ofRepoId(1000000);
+		productId = createProduct();
+		bpartnerLocationId = createBPartnerLocation();
+		priceListId = createPriceList();
+		priceListVersion = createPriceListVersion(priceListId);
+	}
+
+	//
+	// Tests
+	//
+
+	@Test
+	public void salesOrder_enforceOn_noProductPriceReferencesTheDefault_returnsEmpty()
+	{
+		setEnforcePrecisePrice(true);
+		createDefaultForProductPackingInstruction();
+		createProductPrice(null); // a price for the product, but with no packing instruction
+
+		assertThat(helper.getDefaultPackingMaterial(criteria(SOTrx.SALES))).isEmpty();
+	}
+
+	@Test
+	public void salesOrder_enforceOff_noProductPriceReferencesTheDefault_returnsTheDefault()
+	{
+		setEnforcePrecisePrice(false);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+
+		assertThat(helper.getDefaultPackingMaterial(criteria(SOTrx.SALES)))
+				.get()
+				.extracting(I_M_HU_PI_Item_Product::getM_HU_PI_Item_Product_ID)
+				.isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	@Test
+	public void salesOrder_enforceOn_aProductPriceReferencesThePackingInstruction_returnsIt()
+	{
+		setEnforcePrecisePrice(true);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(piip);
+
+		assertThat(helper.getDefaultPackingMaterial(criteria(SOTrx.SALES)))
+				.get()
+				.extracting(I_M_HU_PI_Item_Product::getM_HU_PI_Item_Product_ID)
+				.isEqualTo(piip.getM_HU_PI_Item_Product_ID());
+	}
+
+	@Test
+	public void purchaseOrder_enforceOn_neverReachesTheDefaultForProductFallback()
+	{
+		setEnforcePrecisePrice(true);
+		createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+
+		assertThat(helper.getDefaultPackingMaterial(criteria(SOTrx.PURCHASE))).isEmpty();
+	}
+
+	/**
+	 * The shape used by the invoice line and distribution order line quick inputs: they build their
+	 * criteria without a {@code soTrx}, so they never reach the sales-only fallback.
+	 */
+	@Test
+	public void noSoTrx_enforceOn_neverReachesTheDefaultForProductFallback()
+	{
+		setEnforcePrecisePrice(true);
+		createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+
+		assertThat(helper.getDefaultPackingMaterial(criteria(null))).isEmpty();
+	}
+
+	//
+	// Fixture
+	//
+
+	private DefaultPackingItemCriteria criteria(@Nullable final SOTrx soTrx)
+	{
+		return DefaultPackingItemCriteria.builder()
+				.productId(productId)
+				.bPartnerLocationId(bpartnerLocationId)
+				.date(DATE)
+				.priceListId(priceListId)
+				.soTrx(soTrx)
+				.clientId(clientId)
+				.build();
+	}
+
+	private void setEnforcePrecisePrice(final boolean value)
+	{
+		final I_AD_SysConfig sysConfig = newInstance(I_AD_SysConfig.class);
+		sysConfig.setName(IHUPIItemProductBL.SYSCONFIG_EnforcePrecisePricePerHUItemProduct);
+		sysConfig.setValue(value ? "Y" : "N");
+		sysConfig.setIsActive(true);
+		saveRecord(sysConfig);
+	}
+
+	private ProductId createProduct()
+	{
+		final I_M_Product product = newInstance(I_M_Product.class);
+		product.setValue("TestProduct");
+		product.setName("Test Product");
+		saveRecord(product);
+		return ProductId.ofRepoId(product.getM_Product_ID());
+	}
+
+	private BPartnerLocationAndCaptureId createBPartnerLocation()
+	{
+		final I_C_BPartner bpartner = newInstance(I_C_BPartner.class);
+		bpartner.setName("Test Partner");
+		saveRecord(bpartner);
+
+		final I_C_BPartner_Location bpLocation = newInstance(I_C_BPartner_Location.class);
+		bpLocation.setC_BPartner_ID(bpartner.getC_BPartner_ID());
+		saveRecord(bpLocation);
+
+		return BPartnerLocationAndCaptureId.ofRepoId(bpartner.getC_BPartner_ID(), bpLocation.getC_BPartner_Location_ID());
+	}
+
+	private PriceListId createPriceList()
+	{
+		final I_M_PriceList priceList = newInstance(I_M_PriceList.class);
+		priceList.setName("Test Sales Price List");
+		priceList.setIsSOPriceList(true);
+		saveRecord(priceList);
+		return PriceListId.ofRepoId(priceList.getM_PriceList_ID());
+	}
+
+	private I_M_PriceList_Version createPriceListVersion(@NonNull final PriceListId priceListId)
+	{
+		final I_M_PriceList_Version plv = newInstance(I_M_PriceList_Version.class);
+		plv.setM_PriceList_ID(priceListId.getRepoId());
+		plv.setValidFrom(TimeUtil.asTimestamp(DATE.minusYears(1)));
+		plv.setIsActive(true);
+		saveRecord(plv);
+		return plv;
+	}
+
+	/**
+	 * The reported shape: a Standard-Packvorschrift with infinite capacity and no business partner,
+	 * created so that mobileUI production works.
+	 */
+	private I_M_HU_PI_Item_Product createDefaultForProductPackingInstruction()
+	{
+		final I_M_HU_PI huPI = newInstance(I_M_HU_PI.class);
+		huPI.setName("Test Frame PI");
+		saveRecord(huPI);
+
+		final I_M_HU_PI_Version huPIVersion = newInstance(I_M_HU_PI_Version.class);
+		huPIVersion.setM_HU_PI_ID(huPI.getM_HU_PI_ID());
+		huPIVersion.setIsCurrent(true);
+		saveRecord(huPIVersion);
+
+		final I_M_HU_PI_Item huPIItem = newInstance(I_M_HU_PI_Item.class);
+		huPIItem.setM_HU_PI_Version_ID(huPIVersion.getM_HU_PI_Version_ID());
+		huPIItem.setItemType(X_M_HU_PI_Item.ITEMTYPE_Material);
+		saveRecord(huPIItem);
+
+		final I_M_HU_PI_Item_Product piip = newInstance(I_M_HU_PI_Item_Product.class);
+		piip.setM_Product_ID(productId.getRepoId());
+		piip.setM_HU_PI_Item_ID(huPIItem.getM_HU_PI_Item_ID());
+		piip.setIsDefaultForProduct(true);
+		piip.setIsInfiniteCapacity(true);
+		piip.setQty(BigDecimal.ZERO);
+		piip.setValidFrom(TimeUtil.asTimestamp(DATE.minusYears(1)));
+		saveRecord(piip);
+		return piip;
+	}
+
+	private void createProductPrice(@Nullable final I_M_HU_PI_Item_Product huPiItemProduct)
+	{
+		final I_M_ProductPrice productPrice = newInstance(I_M_ProductPrice.class);
+		productPrice.setM_PriceList_Version_ID(priceListVersion.getM_PriceList_Version_ID());
+		productPrice.setM_Product_ID(productId.getRepoId());
+		if (huPiItemProduct != null)
+		{
+			productPrice.setM_HU_PI_Item_Product(huPiItemProduct);
+		}
+		saveRecord(productPrice);
+	}
+}

--- a/e2e/frontend-webui/tests/spec/sales-order-default-packing-instruction.spec.js
+++ b/e2e/frontend-webui/tests/spec/sales-order-default-packing-instruction.spec.js
@@ -1,0 +1,134 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { Backend } from '../utils/Backend';
+import { LoginPage } from '../utils/pages/LoginPage';
+import { SalesOrderPage } from '../utils/pages/SalesOrderPage';
+import { getFieldData, getValidationStatus } from '../utils/WebAPIValidation';
+import { SALES_ORDER_WINDOW_ID } from '../utils/WindowIds';
+
+/**
+ * A product's Standard-Packvorschrift (`M_HU_PI_Item_Product.IsDefaultForProduct`) must only be
+ * pre-filled into the sales order line quick entry when a product price of the order's price list
+ * version references it.
+ *
+ * Pricing matches on the packing instruction, so a pre-filled one that no price references makes the
+ * line unpriceable and the order impossible to complete ("Produkt ist nicht auf der Preisliste").
+ *
+ * Both cases run under the seeded default of
+ * `de.metas.ui.web.quickinput.field.PackingItemProductFieldHelper.EnforcePrecisePricePerHUItemProduct`,
+ * which is `Y` — the value real installations run — so the specs deliberately do NOT write it.
+ */
+
+/**
+ * @param {boolean} priceReferencesPackingInstruction
+ *   false → the product has a price, but nothing references the Standard-Packvorschrift (the reported case)
+ *   true  → the product's price references it
+ */
+const createFixture = async (priceReferencesPackingInstruction) =>
+  Backend.createMasterdata({
+    request: {
+      login: { user: { language: 'en_US' } },
+      bpartners: {
+        CUSTOMER: {
+          isVendor: false,
+          isCustomer: true,
+          isSoPriceList: true,
+          name: 'Customer',
+        },
+      },
+      products: {
+        PROD: {
+          name: 'PROD',
+          type: 'Item',
+          prices: [{ price: 17.35, currencyCode: 'EUR' }],
+        },
+      },
+      packingInstructions: {
+        // No qtyCUsPerTU => infinite capacity, and no bpartner: the shape a product carries when the
+        // packing instruction exists for mobileUI production rather than for selling.
+        DEFAULT_PI: {
+          tu: 'TU_DEFAULT',
+          product: 'PROD',
+          isDefaultForProduct: true,
+          referencedByProductPrice: priceReferencesPackingInstruction,
+        },
+      },
+    },
+  });
+
+test.describe('Sales order quick entry - default packing instruction', () => {
+  test.beforeEach(() => {
+    // The custom `test` fixture in playwright.config.js already publishes the page globally.
+    allure.epic('E0100: Sales');
+    allure.tag('F00101.10: Sales Order Quick Entry packing instruction');
+    allure.tag('F00101.10');
+  });
+
+  // `page` is destructured but not referenced: the page objects and Backend read the page the custom
+  // fixture in playwright.config.js publishes as `global.currentPage`, and Playwright only runs that
+  // fixture for a test that actually requests `page`. Omitting it leaves the global unset.
+  // eslint-disable-next-line no-unused-vars
+  test('no product price references the Standard-Packvorschrift - not defaulted, order completes', async ({ page }) => {
+    const masterdata = await createFixture(false);
+    const customer = masterdata.bpartners.CUSTOMER.bpartnerCode;
+    const product = masterdata.products.PROD.productName;
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+
+    await SalesOrderPage.goto();
+    await SalesOrderPage.clickNew();
+    const recordId = await SalesOrderPage.selectCustomer(customer);
+
+    await SalesOrderPage.openQuickEntryAndSelectProduct({ product, recordId });
+
+    // The defect: the Standard-Packvorschrift was pre-filled here even though no price references it.
+    const packingInstruction = await SalesOrderPage.getQuickEntryPackingInstruction();
+    console.log(`[TC1] packing instruction after product select: "${packingInstruction}"`);
+    expect(packingInstruction).toBe('');
+
+    await SalesOrderPage.submitQuickEntryLine({ quantity: 1 });
+
+    // End result, read back from the server - not merely "the field looked empty".
+    const validation = await getValidationStatus(SALES_ORDER_WINDOW_ID, recordId);
+    expect(validation.valid, `order ${recordId} must be saveable: ${validation.reason}`).toBe(true);
+
+    await SalesOrderPage.complete();
+
+    const docStatus = await getFieldData(SALES_ORDER_WINDOW_ID, recordId, 'DocStatus');
+    expect(docStatus.value?.key ?? docStatus.value).toBe('CO');
+  });
+
+  // eslint-disable-next-line no-unused-vars
+  test('a product price references the packing instruction - still defaulted, order completes', async ({ page }) => {
+    const masterdata = await createFixture(true);
+    const customer = masterdata.bpartners.CUSTOMER.bpartnerCode;
+    const product = masterdata.products.PROD.productName;
+
+    await LoginPage.goto();
+    await LoginPage.login(masterdata.login.user);
+
+    await SalesOrderPage.goto();
+    await SalesOrderPage.clickNew();
+    const recordId = await SalesOrderPage.selectCustomer(customer);
+
+    await SalesOrderPage.openQuickEntryAndSelectProduct({ product, recordId });
+
+    // The other half of the rule: a priced packing instruction must still be offered, otherwise the
+    // fix would have stripped a legitimate default.
+    const packingInstruction = await SalesOrderPage.getQuickEntryPackingInstruction();
+    console.log(`[TC2] packing instruction after product select: "${packingInstruction}"`);
+    expect(packingInstruction).not.toBe('');
+
+    await SalesOrderPage.submitQuickEntryLine({ quantity: 1 });
+
+    const validation = await getValidationStatus(SALES_ORDER_WINDOW_ID, recordId);
+    expect(validation.valid, `order ${recordId} must be saveable: ${validation.reason}`).toBe(true);
+
+    await SalesOrderPage.complete();
+
+    const docStatus = await getFieldData(SALES_ORDER_WINDOW_ID, recordId, 'DocStatus');
+    expect(docStatus.value?.key ?? docStatus.value).toBe('CO');
+  });
+});

--- a/e2e/frontend-webui/tests/utils/pages/SalesOrderPage.js
+++ b/e2e/frontend-webui/tests/utils/pages/SalesOrderPage.js
@@ -203,6 +203,25 @@ export class SalesOrderPage {
    */
   static async addOrderLine({ product, quantity, recordId }) {
     return await test.step(`SalesOrderPage - Add order line: ${product} x ${quantity}`, async () => {
+      await this.openQuickEntryAndSelectProduct({ product, recordId });
+      await this.submitQuickEntryLine({ quantity });
+    });
+  }
+
+  /**
+   * Open the batch-entry (quick input) form and select a product, then STOP — leaving the form open so
+   * the caller can inspect what the backend defaulted into it.
+   *
+   * This is the first half of {@link addOrderLine}, which submits and closes the form and so cannot be
+   * used to read a defaulted field. Keeping it as the single implementation means both callers get the
+   * same spinner handling rather than two copies drifting apart.
+   *
+   * @param {Object} params
+   * @param {string} params.product - Product code or name
+   * @param {string} params.recordId - Optional record ID (extracted from the URL if not provided)
+   */
+  static async openQuickEntryAndSelectProduct({ product, recordId }) {
+    return await test.step(`SalesOrderPage - Open quick entry and select: ${product}`, async () => {
       const page = getPage();
 
       // Get record ID if not provided
@@ -273,24 +292,40 @@ export class SalesOrderPage {
       // This avoids clicking on "Search for more..." or other non-record options
       await page.locator('.input-dropdown-list-option').getByText(product).first().click();
 
-      // Wait for product to be selected and form to update
-      await page.waitForTimeout(500);
+      // The product callout runs server-side and patches the quick-input document; give it time to
+      // come back before the caller reads any field it may have defaulted.
+      await page.waitForTimeout(1500);
+    });
+  }
 
-      // Fill quantity using spinbutton role (language-independent)
+  /**
+   * @returns {Promise<string>} the displayed value of the packing-instruction
+   *   (`M_HU_PI_Item_Product_ID`) field in the open quick-entry form — empty string when unset.
+   *   Call after {@link openQuickEntryAndSelectProduct}.
+   */
+  static async getQuickEntryPackingInstruction() {
+    return await test.step('SalesOrderPage - Read quick-entry packing instruction', async () => {
+      const page = getPage();
+
+      const field = page.locator('.quick-input-container #lookup_M_HU_PI_Item_Product_ID input.input-field');
+      await field.waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+      return (await field.inputValue()).trim();
+    });
+  }
+
+  /**
+   * Submit the order line from the quick-entry form opened by
+   * {@link openQuickEntryAndSelectProduct}, then close the form.
+   */
+  static async submitQuickEntryLine({ quantity }) {
+    return await test.step(`SalesOrderPage - Submit quick-entry line qty ${quantity}`, async () => {
+      const page = getPage();
+
       await page.getByRole('spinbutton').fill(quantity.toString());
-
-      // Press Enter to add the line (as instructed by the UI: "Press 'Enter' to add")
       await page.keyboard.press('Enter');
-
-      // Wait for the line to be added
       await page.waitForTimeout(500);
 
-      // Close the batch entry modal
-      // Language-independent: Use data-testid from TableFilter.js
-      const closeButton = page.getByTestId('batch-entry-toggle');
-      await closeButton.click();
-
-      // Wait for the modal to close
+      await page.getByTestId('batch-entry-toggle').click();
       await page.waitForTimeout(500);
     });
   }


### PR DESCRIPTION
Forward-merge of the whole `intensive_care_release` line into `new_dawn_uat`, completing the propagation of the sales-order packing-instruction fix (hop 2 of 2; hop 1 was https://github.com/metasfresh/metasfresh/pull/25531).

A packing instruction is only auto-defaulted onto a sales order line when a product price of the order's price list version references it — gated by the existing `EnforcePrecisePricePerHUItemProduct` SysConfig. Includes its JUnit and Playwright coverage.

## Conflicts resolved (4)

All four are places where **both** branches had extended the same file, so each was resolved as a union rather than a choice:

| File | Both sides added | Resolution |
|---|---|---|
| `C_OrderLine` | `new_dawn_uat`: receipt-schedule cleanup (`IOrderBL`, `IReceiptScheduleDAO`) · release line: price-aware default (`IOrderDAO`, `IOrderLineBL`, `ISysConfigBL`) | Union of imports + fields; `beforeOrderLineDeleted` and the price-aware default both kept |
| `SalesOrderPage` | `new_dawn_uat`: `addOrderLine` rewritten as a retry loop with a page reload · release line: split into `openQuickEntryAndSelectProduct` + `submitQuickEntryLine` | **Kept `new_dawn_uat`'s `addOrderLine`**; added the release line's helpers alongside |
| `JsonPackingInstructionsRequest` | GRAI-mapping fields · packing-instruction fields | Union |
| `CreatePackingInstructionsCommand` | `IAttributeDAO` + `HUPIGraiRepository` · `IPriceListDAO` | Union (imports ordered) |

### Note on `SalesOrderPage`

`addOrderLine` is deliberately **not** composed from the two new helpers on this branch, even though it is on the release line. Its retry loop reloads the page, which would discard the freshly-defaulted field state that `openQuickEntryAndSelectProduct` exists to expose. Composing them would also have meant dropping this branch's retry hardening — a deletion that a forward-merge would carry upstream. The helper's javadoc is adapted to state this.

## Verification

- No DDL or migration scripts in this merge.
- Spec dependencies confirmed present on `new_dawn_uat`: `getValidationStatus`, `getFieldData`, `SALES_ORDER_WINDOW_ID`, and `complete()` still resolves against this branch's `complete({ maxAttempts = 3 } = {})`.
- The gate for this PR is CI (a merge-through carries commits already reviewed on their own PRs).
