### PR TITLE
ESR import: a duplicate incoming payment gets its own C_Payment

### DIFF
--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
@@ -127,6 +127,8 @@ public class ESRImportBL implements IESRImportBL
 
 	private static final AdMessageKey ESR_NO_HAS_WRONG_ORG_2P = AdMessageKey.of("de.metas.payment.esr.EsrNoHasWrongOrg");
 
+	private static final AdMessageKey ESR_INVOICE_ALREADY_PAID_1P = AdMessageKey.of("de.metas.payment.esr.InvoiceAlreadyPaid");
+
 	/**
 	 * Filled by {@link #registerActionHandler(String, IESRActionHandler)}.
 	 */
@@ -660,11 +662,11 @@ public class ESRImportBL implements IESRImportBL
 		final PaymentId paymentId = fetchDuplicatePaymentIfExists(line);
 		if (paymentId != null)
 		{
+			// Flag the duplicate for the accountant, but deliberately do NOT attach the payment we found: it
+			// belongs to the earlier transaction, while this line is money that arrived a second time and
+			// needs its own C_Payment. Returning false lets the regular handling create it.
 			line.setESR_Payment_Action(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment);
-			handleUnsupportedTrxType(line);
-			line.setC_Payment_ID(paymentId.getRepoId());
 			esrImportDAO.save(line);
-			return true;
 		}
 		return false;
 	}
@@ -1157,14 +1159,12 @@ public class ESRImportBL implements IESRImportBL
 
 			if (invoice.isPaid() && !paymentBL.isMatchInvoice(payment, invoice))
 			{
-				ESRDataLoaderUtil.addMatchErrorMsg(importLine, "Rechnung " + invoice.getDocumentNo() + " wurde im System als bereits bezahlt markiert");
-				importLine.setESR_Document_Status(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched);
+				markInvoiceAlreadyPaid(importLine, invoice);
 			}
 		}
 		else if (invoice.isPaid())
 		{
-			ESRDataLoaderUtil.addMatchErrorMsg(importLine, "Rechnung " + invoice.getDocumentNo() + " wurde im System als bereits bezahlt markiert");
-			importLine.setESR_Document_Status(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched);
+			markInvoiceAlreadyPaid(importLine, invoice);
 		}
 
 		if (invoice.getAD_Org_ID() != importLine.getAD_Org_ID())
@@ -1185,6 +1185,19 @@ public class ESRImportBL implements IESRImportBL
 
 		importLine.setESR_Invoice_Grandtotal(invoice.getGrandTotal());
 
+	}
+
+	/**
+	 * {@code setInvoice} runs twice for one line — once while it is evaluated, once from the
+	 * {@code C_Payment_ID} interceptor after the line's payment is created — so this note has to be as
+	 * idempotent as the document status it accompanies.
+	 */
+	private void markInvoiceAlreadyPaid(@NonNull final I_ESR_ImportLine importLine, @NonNull final I_C_Invoice invoice)
+	{
+		final Properties ctx = getCtx(importLine);
+		ESRDataLoaderUtil.addMatchErrorMsgIfNotPresent(importLine,
+														msgBL.getMsg(ctx, ESR_INVOICE_ALREADY_PAID_1P, new Object[] { invoice.getDocumentNo() }));
+		importLine.setESR_Document_Status(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched);
 	}
 
 	@Override

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtil.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtil.java
@@ -38,6 +38,7 @@ import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_Invoice;
 import org.compiere.util.Env;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /*
@@ -401,6 +402,21 @@ public class ESRDataLoaderUtil
 	public void addMatchErrorMsg(@NonNull final I_ESR_ImportLine importLine, final String msg)
 	{
 		importLine.setMatchErrorMsg(addMsgToString(importLine.getMatchErrorMsg(), msg));
+	}
+
+	/**
+	 * Like {@link #addMatchErrorMsg(I_ESR_ImportLine, String)}, but a no-op if the line's {@code MatchErrorMsg} already
+	 * contains the given message. For callers that may run more than once for the same line and would otherwise
+	 * accumulate the very same message again and again.
+	 */
+	public void addMatchErrorMsgIfNotPresent(@NonNull final I_ESR_ImportLine importLine, @Nullable final String msg)
+	{
+		final String currentMsg = importLine.getMatchErrorMsg();
+		if (!Check.isEmpty(msg, true) && currentMsg != null && currentMsg.contains(msg))
+		{
+			return;
+		}
+		addMatchErrorMsg(importLine, msg);
 	}
 
 	public void addImportErrorMsg(@NonNull final I_ESR_ImportLine importLine, final String msg)

--- a/backend/de.metas.payment.esr/src/main/sql/postgresql/system/5818570_sys_AD_Message_ESR_InvoiceAlreadyPaid.sql
+++ b/backend/de.metas.payment.esr/src/main/sql/postgresql/system/5818570_sys_AD_Message_ESR_InvoiceAlreadyPaid.sql
@@ -1,0 +1,25 @@
+-- AD_Message for the note put on an ESR import line whose invoice is already flagged as paid,
+-- shown to the accountant in ESR_ImportLine.MatchErrorMsg. Previously a hardcoded German literal.
+
+-- 1. the message (base text = German)
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545795 /*From ID Server*/,0,TO_TIMESTAMP('2026-08-12 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr','Y','Rechnung {0} wurde im System als bereits bezahlt markiert','I',TO_TIMESTAMP('2026-08-12 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.payment.esr.InvoiceAlreadyPaid')
+;
+
+-- 2. seed AD_Message_Trl for ALL active system languages with the base (DE) text, IsTranslated='N'
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID,MsgText,MsgTip,IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID,t.MsgText,t.MsgTip,'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545795
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- 3. en_US override (the real English text) + IsTranslated='Y'
+UPDATE AD_Message_Trl SET MsgText='Invoice {0} was marked as already paid in the system',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-12 10:00:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545795
+;
+
+-- 4. flip de_DE + de_CH to IsTranslated='Y' (their text already equals the DE base)
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-12 10:00:13','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545795
+;
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-12 10:00:14','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545795
+;

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
@@ -5,6 +5,7 @@ package de.metas.payment.esr;
 
 import de.metas.adempiere.model.I_C_Invoice;
 import de.metas.allocation.api.IAllocationDAO;
+import de.metas.bpartner.BPartnerId;
 import de.metas.calendar.IPeriodBL;
 import de.metas.currency.CurrencyCode;
 import de.metas.currency.impl.PlainCurrencyDAO;
@@ -45,6 +46,7 @@ import org.adempiere.ad.dao.IQueryBL;
 import org.adempiere.ad.table.api.IADTableDAO;
 import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.ad.wrapper.POJOLookupMap;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.service.ISysConfigBL;
 import org.adempiere.service.ISysConfigDAO;
 import org.adempiere.util.trxConstraints.api.IOpenTrxBL;
@@ -55,11 +57,14 @@ import org.compiere.model.I_C_AllocationLine;
 import org.compiere.model.I_C_Payment;
 import org.compiere.model.X_C_DocType;
 import org.compiere.util.Env;
+import org.compiere.util.TimeUtil;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -68,6 +73,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.refresh;
 import static org.adempiere.model.InterfaceWrapperHelper.save;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This class tests the entire module of importing ESR
@@ -1617,6 +1623,10 @@ public class ESRImportTest extends ESRTestBase
 		assertThat(esrImportLine3.isProcessed()).isTrue();
 	}
 
+	/**
+	 * Cross-import duplicate with NO PaymentDate on either line (the fixture default): the second line
+	 * must still get its own payment, and the "invoice already paid" note must appear exactly once.
+	 */
 	@Test
 	public void testDuplicatePayments()
 	{
@@ -1653,11 +1663,204 @@ public class ESRImportTest extends ESRTestBase
 
 		refresh(esrImportLine2, true);
 		assertThat(esrImportLine2.getESR_Payment_Action()).isEqualTo(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment);
+		assertThat(esrImportLine2.isProcessed()).as("the duplicate line must stay unprocessed so the accountant still sees it").isFalse();
+		assertThat(esrImportLine2.getESR_Document_Status()).isEqualTo(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched);
 		assertThat(esrImportLine2.getImportErrorMsg()).isNull();
-		assertThat(esrImportLine2.getMatchErrorMsg()).isEqualTo("Rechnung " + invDocNo + " wurde im System als bereits bezahlt markiert");
+		// note text now comes from msgBL.getMsg(ESR_INVOICE_ALREADY_PAID_1P, ...); in this no-DB test env
+		// an AD_Message with no registered row resolves to "<key>_[<params>]" (see ESRImportBLTest#test_setInvoice_wrongOrg
+		// for the same fallback shape with 2 params)
+		assertThat(esrImportLine2.getMatchErrorMsg()).isEqualTo("de.metas.payment.esr.InvoiceAlreadyPaid_[" + invDocNo + "]");
 
-		// check the payment
-		assertThat(esrImportLine2.getC_Payment_ID()).isEqualTo(esrImportLine2.getC_Payment_ID());
+		// check the payment: the duplicate-flagged line must have its OWN payment, not the first line's
+		assertThat(esrImportLine2.getC_Payment_ID()).as("the duplicate line must not carry the first line's C_Payment_ID").isNotEqualTo(esrImportLine1.getC_Payment_ID());
+
+		final PaymentId esrImportLine2PaymentId = PaymentId.ofRepoIdOrNull(esrImportLine2.getC_Payment_ID());
+		final I_C_Payment esrLine2Payment = esrImportLine2PaymentId == null ? null
+				: paymentDAO.getById(esrImportLine2PaymentId);
+		assertThat(esrLine2Payment).as("the duplicate-flagged line must have created its own payment").isNotNull();
+		assertThat(esrLine2Payment.getPayAmt()).isEqualByComparingTo("50");
+		assertThat(esrLine2Payment.isAllocated()).as("the duplicate payment must not be allocated to the invoice").isFalse();
+		assertThat(esrLine2Payment.getC_Invoice_ID()).as("the duplicate payment must not be linked to the invoice").isEqualTo(0);
+	}
+
+	/**
+	 * Same ESR reference and same amount arrive again after the first, already fully-matched payment,
+	 * either on the same day or a later day.
+	 * <ul>
+	 * <li>invoice 50, first ESR line pays it in full on D1
+	 * <li>second ESR line: same reference, same amount 50, PaymentDate D1 or a later D2
+	 * <li>on the same day, the second line must still be flagged as a duplicate payment and remain unprocessed
+	 * <li>either way it must get its OWN payment (not the first line's), for PayAmt 50, not allocated or linked to the invoice
+	 * </ul>
+	 */
+	@Nested
+	class DuplicatePaymentGetsOwnPayment
+	{
+		@Test
+		void arrivingOnTheSameDay()
+		{
+			assertDuplicateGetsOwnPayment(0);
+		}
+
+		/**
+		 * On this branch, {@code AbstractPaymentDAO#retrievePaymentIds} filters candidate payments on an exact
+		 * {@code DateTrx} match, so a receipt arriving one day after the first payment never matches it and is
+		 * therefore not flagged as {@code Duplicate_Payment} here -- it still receives its own payment, which is
+		 * the money-is-booked guarantee this test pins.
+		 */
+		@Test
+		void arrivingOnALaterDay()
+		{
+			final String grandTotal = "50";
+			final String esrLineText = "01201067789300000001060012345600654321400000050009072  030014040914041014041100001006800000000000090                          ";
+			final String completeRef = ESRTransactionLineMatcherUtil.extractReferenceNumberStr(esrLineText);
+
+			final String partnerValue = "123456";
+			final String invDocNo = "654321";
+			final String ESR_Rendered_AccountNo = "01-067789-3";
+
+			final I_ESR_ImportLine esrImportLine1 = setupESR_ImportLine(invDocNo, grandTotal, false, completeRef, /* refNo, */ ESR_Rendered_AccountNo, partnerValue, "50", false);
+			esrImportLine1.setESRLineText(esrLineText);
+			final Timestamp paymentDate1 = TimeUtil.getDay(2024, 1, 10);
+			esrImportLine1.setPaymentDate(paymentDate1);
+			save(esrImportLine1);
+
+			final I_ESR_Import esrImport = esrImportLine1.getESR_Import();
+
+			esrImportBL.process(esrImport);
+
+			final I_ESR_ImportLine esrImportLine2 = createESR_ImportLineFromOtherLine(esrImportLine1);
+			esrImportLine2.setESRLineText(esrLineText);
+			final Timestamp paymentDate2 = TimeUtil.addDays(paymentDate1, 1);
+			esrImportLine2.setPaymentDate(paymentDate2);
+			save(esrImportLine2);
+			final I_ESR_Import esrImport2 = esrImportLine2.getESR_Import();
+			esrImportBL.process(esrImport2);
+
+			// check first import line: unaffected, still fully matched and paid
+			refresh(esrImportLine1, true);
+			assertThat(esrImportLine1.isProcessed()).isTrue();
+			assertThat(esrImportLine1.getESR_Payment_Action()).isEqualTo(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Fit_Amounts);
+
+			// check second import line: the cross-day duplicate search misses the earlier payment, so no
+			// Duplicate_Payment flag is set here -- this is the known, branch-specific gap
+			refresh(esrImportLine2, true);
+			assertThat(esrImportLine2.getESR_Payment_Action()).isNull();
+
+			// ... but the line must still have its OWN payment, not the first line's -- the money that
+			// arrived a second time is booked, which is the guarantee this port exists to provide
+			assertThat(esrImportLine2.getC_Payment_ID()).as("the cross-day line must not carry the first line's C_Payment_ID").isNotEqualTo(esrImportLine1.getC_Payment_ID());
+
+			final PaymentId esrImportLine2PaymentId = PaymentId.ofRepoIdOrNull(esrImportLine2.getC_Payment_ID());
+			final I_C_Payment esrLine2Payment = esrImportLine2PaymentId == null ? null
+					: paymentDAO.getById(esrImportLine2PaymentId);
+			assertThat(esrLine2Payment).as("the cross-day line must have created its own payment").isNotNull();
+			assertThat(esrLine2Payment.getPayAmt()).isEqualByComparingTo("50");
+			assertThat(esrLine2Payment.isAllocated()).as("the payment must not be allocated to the invoice").isFalse();
+			assertThat(esrLine2Payment.getC_Invoice_ID()).as("the payment must not be linked to the invoice").isEqualTo(0);
+		}
+
+		private void assertDuplicateGetsOwnPayment(final int daysAfterFirstPayment)
+		{
+			final String grandTotal = "50";
+			final String esrLineText = "01201067789300000001060012345600654321400000050009072  030014040914041014041100001006800000000000090                          ";
+			final String completeRef = ESRTransactionLineMatcherUtil.extractReferenceNumberStr(esrLineText);
+
+			final String partnerValue = "123456";
+			final String invDocNo = "654321";
+			final String ESR_Rendered_AccountNo = "01-067789-3";
+
+			final I_ESR_ImportLine esrImportLine1 = setupESR_ImportLine(invDocNo, grandTotal, false, completeRef, /* refNo, */ ESR_Rendered_AccountNo, partnerValue, "50", false);
+			esrImportLine1.setESRLineText(esrLineText);
+			final Timestamp paymentDate1 = TimeUtil.getDay(2024, 1, 10);
+			esrImportLine1.setPaymentDate(paymentDate1);
+			save(esrImportLine1);
+
+			final I_ESR_Import esrImport = esrImportLine1.getESR_Import();
+
+			esrImportBL.process(esrImport);
+
+			final I_ESR_ImportLine esrImportLine2 = createESR_ImportLineFromOtherLine(esrImportLine1);
+			esrImportLine2.setESRLineText(esrLineText);
+			final Timestamp paymentDate2 = TimeUtil.addDays(paymentDate1, daysAfterFirstPayment);
+			esrImportLine2.setPaymentDate(paymentDate2);
+			save(esrImportLine2);
+			final I_ESR_Import esrImport2 = esrImportLine2.getESR_Import();
+			esrImportBL.process(esrImport2);
+
+			// check first import line: unaffected, still fully matched and paid
+			refresh(esrImportLine1, true);
+			assertThat(esrImportLine1.isProcessed()).isTrue();
+			assertThat(esrImportLine1.getESR_Payment_Action()).isEqualTo(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Fit_Amounts);
+
+			// check second import line: flagged as a duplicate payment, and remains unprocessed for the accountant
+			refresh(esrImportLine2, true);
+			assertThat(esrImportLine2.getESR_Payment_Action()).isEqualTo(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment);
+			assertThat(esrImportLine2.isProcessed()).as("the duplicate line must stay unprocessed so the accountant still sees it").isFalse();
+			assertThat(esrImportLine2.getESR_Document_Status()).isEqualTo(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched);
+
+			// ... but it must have its OWN payment, not the first line's
+			assertThat(esrImportLine2.getC_Payment_ID()).as("the duplicate line must not carry the first line's C_Payment_ID").isNotEqualTo(esrImportLine1.getC_Payment_ID());
+
+			final PaymentId esrImportLine2PaymentId = PaymentId.ofRepoIdOrNull(esrImportLine2.getC_Payment_ID());
+			final I_C_Payment esrLine2Payment = esrImportLine2PaymentId == null ? null
+					: paymentDAO.getById(esrImportLine2PaymentId);
+			assertThat(esrLine2Payment).as("the duplicate-flagged line must have created its own payment").isNotNull();
+			assertThat(esrLine2Payment.getPayAmt()).isEqualByComparingTo("50");
+			assertThat(esrLine2Payment.isAllocated()).as("the duplicate payment must not be allocated to the invoice").isFalse();
+			assertThat(esrLine2Payment.getC_Invoice_ID()).as("the duplicate payment must not be linked to the invoice").isEqualTo(0);
+		}
+	}
+
+	/**
+	 * Re-processing the SAME already-processed ESR import must be idempotent.
+	 * <ul>
+	 * <li>invoice 50, one ESR line pays it in full
+	 * <li>{@code esrImportBL.process(esrImport)} is called a SECOND time on the very same, already-processed import
+	 * <li>production code refuses the second call (the header's {@code Processed=Y} guard throws
+	 * {@code AdempiereException}) -- that guard IS the idempotency protection this test pins
+	 * <li>the line must keep its original payment (no new {@code C_Payment_ID})
+	 * <li>exactly ONE {@code C_Payment} must exist for the partner, counted from the actual table, not merely
+	 * re-read from the line's FK
+	 * </ul>
+	 */
+	@Test
+	public void testReprocessSameImport_createsNoSecondPayment()
+	{
+		final String grandTotal = "50";
+		final String esrLineText = "01201067789300000001060012345600654321400000050009072  030014040914041014041100001006800000000000090                          ";
+		final String completeRef = ESRTransactionLineMatcherUtil.extractReferenceNumberStr(esrLineText);
+
+		final String partnerValue = "123456";
+		final String invDocNo = "654321";
+		final String ESR_Rendered_AccountNo = "01-067789-3";
+
+		final I_ESR_ImportLine esrImportLine = setupESR_ImportLine(invDocNo, grandTotal, false, completeRef, /* refNo, */ ESR_Rendered_AccountNo, partnerValue, "50", false);
+		final I_ESR_Import esrImport = esrImportLine.getESR_Import();
+
+		esrImportBL.process(esrImport);
+
+		refresh(esrImportLine, true);
+		assertThat(esrImportLine.isProcessed()).isTrue();
+		final int originalPaymentId = esrImportLine.getC_Payment_ID();
+		assertThat(originalPaymentId).as("first processing must have created a payment").isNotEqualTo(0);
+
+		// process the very same, already-processed import a second time: the header-level
+		// "Processed=Y" guard in ESRImportBL#processAndCountLines refuses the call outright
+		final AdempiereException thrown = assertThrows(
+				AdempiereException.class,
+				() -> esrImportBL.process(esrImport));
+		assertThat(thrown.getMessage()).contains("Processed");
+
+		// the line must still point to its original payment, not a new one
+		refresh(esrImportLine, true);
+		assertThat(esrImportLine.getC_Payment_ID()).as("re-processing must not swap in a new payment").isEqualTo(originalPaymentId);
+
+		// load-bearing assertion: count the partner's actual C_Payment rows, not just the line's FK,
+		// so a stray second payment created for the same partner would be caught even if the line's FK was untouched
+		final int partnerId = esrImportLine.getC_Invoice().getC_BPartner_ID();
+		final long partnerPaymentCount = paymentDAO.streamPaymentIdsByBPartnerId(BPartnerId.ofRepoId(partnerId)).count();
+		assertThat(partnerPaymentCount).as("exactly one C_Payment must exist for the partner after re-processing").isEqualTo(1L);
 	}
 
 }

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
@@ -1699,7 +1699,7 @@ public class ESRImportTest extends ESRTestBase
 		@Test
 		void arrivingOnTheSameDay()
 		{
-			assertDuplicateGetsOwnPayment(0);
+			assertDuplicateGetsOwnPayment(0, X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment);
 		}
 
 		/**
@@ -1711,56 +1711,14 @@ public class ESRImportTest extends ESRTestBase
 		@Test
 		void arrivingOnALaterDay()
 		{
-			final String grandTotal = "50";
-			final String esrLineText = "01201067789300000001060012345600654321400000050009072  030014040914041014041100001006800000000000090                          ";
-			final String completeRef = ESRTransactionLineMatcherUtil.extractReferenceNumberStr(esrLineText);
-
-			final String partnerValue = "123456";
-			final String invDocNo = "654321";
-			final String ESR_Rendered_AccountNo = "01-067789-3";
-
-			final I_ESR_ImportLine esrImportLine1 = setupESR_ImportLine(invDocNo, grandTotal, false, completeRef, /* refNo, */ ESR_Rendered_AccountNo, partnerValue, "50", false);
-			esrImportLine1.setESRLineText(esrLineText);
-			final Timestamp paymentDate1 = TimeUtil.getDay(2024, 1, 10);
-			esrImportLine1.setPaymentDate(paymentDate1);
-			save(esrImportLine1);
-
-			final I_ESR_Import esrImport = esrImportLine1.getESR_Import();
-
-			esrImportBL.process(esrImport);
-
-			final I_ESR_ImportLine esrImportLine2 = createESR_ImportLineFromOtherLine(esrImportLine1);
-			esrImportLine2.setESRLineText(esrLineText);
-			final Timestamp paymentDate2 = TimeUtil.addDays(paymentDate1, 1);
-			esrImportLine2.setPaymentDate(paymentDate2);
-			save(esrImportLine2);
-			final I_ESR_Import esrImport2 = esrImportLine2.getESR_Import();
-			esrImportBL.process(esrImport2);
-
-			// check first import line: unaffected, still fully matched and paid
-			refresh(esrImportLine1, true);
-			assertThat(esrImportLine1.isProcessed()).isTrue();
-			assertThat(esrImportLine1.getESR_Payment_Action()).isEqualTo(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Fit_Amounts);
-
-			// check second import line: the cross-day duplicate search misses the earlier payment, so no
-			// Duplicate_Payment flag is set here -- this is the known, branch-specific gap
-			refresh(esrImportLine2, true);
-			assertThat(esrImportLine2.getESR_Payment_Action()).isNull();
-
-			// ... but the line must still have its OWN payment, not the first line's -- the money that
-			// arrived a second time is booked, which is the guarantee this port exists to provide
-			assertThat(esrImportLine2.getC_Payment_ID()).as("the cross-day line must not carry the first line's C_Payment_ID").isNotEqualTo(esrImportLine1.getC_Payment_ID());
-
-			final PaymentId esrImportLine2PaymentId = PaymentId.ofRepoIdOrNull(esrImportLine2.getC_Payment_ID());
-			final I_C_Payment esrLine2Payment = esrImportLine2PaymentId == null ? null
-					: paymentDAO.getById(esrImportLine2PaymentId);
-			assertThat(esrLine2Payment).as("the cross-day line must have created its own payment").isNotNull();
-			assertThat(esrLine2Payment.getPayAmt()).isEqualByComparingTo("50");
-			assertThat(esrLine2Payment.isAllocated()).as("the payment must not be allocated to the invoice").isFalse();
-			assertThat(esrLine2Payment.getC_Invoice_ID()).as("the payment must not be linked to the invoice").isEqualTo(0);
+			assertDuplicateGetsOwnPayment(1, null);
 		}
 
-		private void assertDuplicateGetsOwnPayment(final int daysAfterFirstPayment)
+		/**
+		 * @param expectedPaymentAction the second line's expected {@code ESR_Payment_Action}, or {@code null} if it
+		 * is expected to stay unflagged (see {@link #arrivingOnALaterDay()}).
+		 */
+		private void assertDuplicateGetsOwnPayment(final int daysAfterFirstPayment, final String expectedPaymentAction)
 		{
 			final String grandTotal = "50";
 			final String esrLineText = "01201067789300000001060012345600654321400000050009072  030014040914041014041100001006800000000000090                          ";
@@ -1793,22 +1751,32 @@ public class ESRImportTest extends ESRTestBase
 			assertThat(esrImportLine1.isProcessed()).isTrue();
 			assertThat(esrImportLine1.getESR_Payment_Action()).isEqualTo(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Fit_Amounts);
 
-			// check second import line: flagged as a duplicate payment, and remains unprocessed for the accountant
+			// check second import line
 			refresh(esrImportLine2, true);
-			assertThat(esrImportLine2.getESR_Payment_Action()).isEqualTo(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment);
-			assertThat(esrImportLine2.isProcessed()).as("the duplicate line must stay unprocessed so the accountant still sees it").isFalse();
-			assertThat(esrImportLine2.getESR_Document_Status()).isEqualTo(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched);
+			if (expectedPaymentAction == null)
+			{
+				// cross-day: the date-scoped duplicate search misses the earlier payment, so no flag is set
+				assertThat(esrImportLine2.getESR_Payment_Action()).isNull();
+			}
+			else
+			{
+				// same-day: flagged as a duplicate payment, and remains unprocessed for the accountant
+				assertThat(esrImportLine2.getESR_Payment_Action()).isEqualTo(expectedPaymentAction);
+				assertThat(esrImportLine2.isProcessed()).as("the duplicate line must stay unprocessed so the accountant still sees it").isFalse();
+				assertThat(esrImportLine2.getESR_Document_Status()).isEqualTo(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched);
+			}
 
-			// ... but it must have its OWN payment, not the first line's
-			assertThat(esrImportLine2.getC_Payment_ID()).as("the duplicate line must not carry the first line's C_Payment_ID").isNotEqualTo(esrImportLine1.getC_Payment_ID());
+			// ... but it must have its OWN payment, not the first line's -- the money that arrived a second
+			// time is booked either way, which is the guarantee this port exists to provide
+			assertThat(esrImportLine2.getC_Payment_ID()).as("the second line must not carry the first line's C_Payment_ID").isNotEqualTo(esrImportLine1.getC_Payment_ID());
 
 			final PaymentId esrImportLine2PaymentId = PaymentId.ofRepoIdOrNull(esrImportLine2.getC_Payment_ID());
 			final I_C_Payment esrLine2Payment = esrImportLine2PaymentId == null ? null
 					: paymentDAO.getById(esrImportLine2PaymentId);
-			assertThat(esrLine2Payment).as("the duplicate-flagged line must have created its own payment").isNotNull();
+			assertThat(esrLine2Payment).as("the second line must have created its own payment").isNotNull();
 			assertThat(esrLine2Payment.getPayAmt()).isEqualByComparingTo("50");
-			assertThat(esrLine2Payment.isAllocated()).as("the duplicate payment must not be allocated to the invoice").isFalse();
-			assertThat(esrLine2Payment.getC_Invoice_ID()).as("the duplicate payment must not be linked to the invoice").isEqualTo(0);
+			assertThat(esrLine2Payment.isAllocated()).as("the payment must not be allocated to the invoice").isFalse();
+			assertThat(esrLine2Payment.getC_Invoice_ID()).as("the payment must not be linked to the invoice").isEqualTo(0);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Ports the following fix from another branch onto `new_dawn_uat`:

A second ESR line carrying the same reference and amount as an already fully-matched
payment is real money that arrived a second time. Previously, `handleEsrImportLine`
detected the duplicate, attached the **earlier** payment to the new line, and returned
early — so the line was excluded from regular processing and the newly-arrived money
was never booked into its own `C_Payment`.

The fix keeps the `Duplicate_Payment` flag (so the accountant still sees it) but no
longer attaches the earlier payment and no longer short-circuits the line; regular
processing then creates the line's own, unallocated payment for the incoming amount.

A second, related fix makes the "invoice already paid" note idempotent: `setInvoice`
runs twice per line (once during evaluation, once from the `C_Payment_ID` interceptor),
and the note was previously appended on both passes, duplicating the sentence. It is
now added at most once, and the note itself was turned into a translatable `AD_Message`
(previously a hardcoded German literal).

## Known limitation on this branch

`ESRImportDAO.findExistentPaymentId` passes `dateTrx(esrLine.getPaymentDate())` into `PaymentQuery` on
every branch. On `new_dawn_uat`, `AbstractPaymentDAO` honours that parameter (`addEqualsFilter` on
`C_Payment.DateTrx`); on some customer branches the DAO ignores it.

Effect here: the duplicate search only finds an earlier payment made on the **same day**. A receipt
arriving on a **later day** still gets its own correctly-booked payment — right amount, unallocated,
invoice not linked — but carries no `Duplicate_Payment` flag and a null `ESR_Payment_Action`, so it
blocks import completion until the accountant picks an action. The same-day case, the one that was
losing money, is fully fixed. Both are pinned by `arrivingOnALaterDay` / the same-day sibling.

Widening the search is deliberately **not** done here. It would be a one-line, ESR-scoped change
(stop passing `dateTrx` at that single call site — no other caller is affected, the filter is
conditional), but it would flag legitimate repeat payments — same partner, same amount by design —
for every customer.

## Test plan
- [x] `ESRImportTest` (module `de.metas.payment.esr`) — 67 run, 0 failures
- [x] Full `de.metas.payment.esr` module suite — 166 run, 0 failures, 1 pre-existing skip unrelated to this change

