### PR TITLE
WebUI: stop a malformed document id from failing as a server error

### DIFF
--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentCollection.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/DocumentCollection.java
@@ -49,6 +49,7 @@ import de.metas.ui.web.window.datatypes.WindowId;
 import de.metas.ui.web.window.descriptor.DetailId;
 import de.metas.ui.web.window.descriptor.DocumentDescriptor;
 import de.metas.ui.web.window.descriptor.DocumentEntityDescriptor;
+import de.metas.ui.web.window.descriptor.DocumentFieldDescriptor;
 import de.metas.ui.web.window.descriptor.factory.DocumentDescriptorFactory;
 import de.metas.ui.web.window.events.DocumentWebsocketPublisher;
 import de.metas.ui.web.window.exceptions.DocumentNotFoundException;
@@ -375,6 +376,15 @@ public class DocumentCollection
 			throw new InvalidDocumentPathException("documentId cannot be NEW");
 		}
 
+		final DocumentFieldDescriptor singleIdField = entityDescriptor.getSingleIdFieldOrNull();
+		if (!documentIdCanMatchKey(
+				singleIdField != null,
+				singleIdField != null && String.class.equals(singleIdField.getValueClass()),
+				documentKey.getDocumentId().isInt()))
+		{
+			throw new DocumentNotFoundException(documentKey.getDocumentPath());
+		}
+
 		final Document document = DocumentQuery.ofRecordId(entityDescriptor, documentKey.getDocumentId())
 				.setChangesCollector(NullDocumentChangesCollector.instance)
 				.retriveDocumentOrNull();
@@ -384,6 +394,32 @@ public class DocumentCollection
 		}
 
 		return document;
+	}
+
+	/**
+	 * Tells whether a document id can address a record of the entity at all.
+	 * <p>
+	 * A non-numeric id cannot match a single-column integer key, so the record does not exist. Answering that here
+	 * keeps a stale or malformed id — the frontend emits both a {@code notfound} sentinel and, when a route parameter
+	 * is unset, the literal {@code undefined} — from reaching the SQL layer, where it surfaces as a server error
+	 * instead of a 404.
+	 *
+	 * @param hasSingleIdField           the entity is keyed by exactly one column; a composed key is left alone
+	 * @param singleIdFieldIsStringTyped that single key column is string-typed, so a non-numeric id is legitimate
+	 * @param documentIdIsInt            the incoming id is numeric
+	 */
+	static boolean documentIdCanMatchKey(
+			final boolean hasSingleIdField,
+			final boolean singleIdFieldIsStringTyped,
+			final boolean documentIdIsInt)
+	{
+		if (documentIdIsInt)
+		{
+			return true;
+		}
+
+		// Only the single-key path converts the id to an int, so a composed key is unaffected.
+		return !hasSingleIdField || singleIdFieldIsStringTyped;
 	}
 
 	public String cacheReset(final boolean forgetNotSavedDocuments)

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/sql/SqlDocumentQueryBuilder.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/sql/SqlDocumentQueryBuilder.java
@@ -384,8 +384,8 @@ public class SqlDocumentQueryBuilder
 			}
 
 			// Single primary key
-			// NOTE: DocumentCollection.documentIdCanMatchKey rejects a non-numeric id before it reaches this
-			// conversion; keep the two in step if the branch below ever starts converting too.
+			// NOTE: for a root document loaded via DocumentCollection, documentIdCanMatchKey rejects a non-numeric
+			// id before it reaches this conversion; keep the two in step if the branch below ever starts converting too.
 			if (keyFields.size() == 1)
 			{
 				final String singleKeyColumnName = keyFields.get(0).getColumnName();

--- a/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/sql/SqlDocumentQueryBuilder.java
+++ b/backend/de.metas.ui.web.base/src/main/java/de/metas/ui/web/window/model/sql/SqlDocumentQueryBuilder.java
@@ -384,6 +384,8 @@ public class SqlDocumentQueryBuilder
 			}
 
 			// Single primary key
+			// NOTE: DocumentCollection.documentIdCanMatchKey rejects a non-numeric id before it reaches this
+			// conversion; keep the two in step if the branch below ever starts converting too.
 			if (keyFields.size() == 1)
 			{
 				final String singleKeyColumnName = keyFields.get(0).getColumnName();

--- a/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/window/model/DocumentCollectionDocumentIdCanMatchKeyTest.java
+++ b/backend/de.metas.ui.web.base/src/test/java/de/metas/ui/web/window/model/DocumentCollectionDocumentIdCanMatchKeyTest.java
@@ -1,0 +1,80 @@
+/*
+ * #%L
+ * de.metas.ui.web.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.ui.web.window.model;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins which document ids are answered as "not found" before they reach the SQL layer.
+ */
+class DocumentCollectionDocumentIdCanMatchKeyTest
+{
+	// Signature reminder (positional):
+	// (hasSingleIdField, singleIdFieldIsStringTyped, documentIdIsInt)
+
+	@Nested
+	class DocumentIdCanMatchKey
+	{
+		/**
+		 * The case that reaches production: an ordinary integer-keyed window asked for a non-numeric id. The
+		 * frontend sends both a {@code notfound} sentinel and, when a route parameter is unset, the literal
+		 * {@code undefined}; neither can match an integer primary key.
+		 */
+		@Test
+		void rejectsANonNumericIdOnAnIntegerKeyedEntity()
+		{
+			assertThat(DocumentCollection.documentIdCanMatchKey(true, false, false)).isFalse();
+		}
+
+		@Test
+		void acceptsANumericIdOnAnIntegerKeyedEntity()
+		{
+			assertThat(DocumentCollection.documentIdCanMatchKey(true, false, true)).isTrue();
+		}
+
+		/** A string-typed key column takes a non-numeric id legitimately. */
+		@Test
+		void acceptsANonNumericIdOnAStringKeyedEntity()
+		{
+			assertThat(DocumentCollection.documentIdCanMatchKey(true, true, false)).isTrue();
+		}
+
+		/** A composed key is out of scope — the single-key SQL path is the one that converts to int. */
+		@Test
+		void acceptsANonNumericIdOnAComposedKeyEntity()
+		{
+			assertThat(DocumentCollection.documentIdCanMatchKey(false, false, false)).isTrue();
+		}
+
+		/** A numeric id is always addressable, whatever the key shape. */
+		@Test
+		void acceptsANumericIdRegardlessOfKeyShape()
+		{
+			assertThat(DocumentCollection.documentIdCanMatchKey(false, false, true)).isTrue();
+			assertThat(DocumentCollection.documentIdCanMatchKey(true, true, true)).isTrue();
+		}
+	}
+}

--- a/frontend/src/__tests__/actions/Actions.test.js
+++ b/frontend/src/__tests__/actions/Actions.test.js
@@ -15,6 +15,7 @@ import tablesHandler, {
 import {
   deleteQuickActions,
   fetchQuickActions,
+  fetchTopActions,
   requestQuickActions,
 } from '../../actions/Actions';
 import { createTableData } from '../../actions/TableActions';
@@ -381,6 +382,36 @@ describe('QuickActions', () => {
           ])
         );
 
+      });
+  });
+});
+
+describe('TopActions', () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  it(`does not request top actions without a document`, () => {
+    const store = mockStore(createState());
+
+    // No nock interceptor is registered on purpose: if the guard were missing, the request would be
+    // attempted and this test would fail rather than silently pass.
+    return store
+      .dispatch(fetchTopActions({ windowId: '143', tabId: 'tab1', docId: undefined }))
+      .then(() => {
+        expect(store.getActions()).toEqual([]);
+      });
+  });
+
+  it(`does not request top actions for the 'notfound' sentinel`, () => {
+    const store = mockStore(createState());
+
+    return store
+      .dispatch(
+        fetchTopActions({ windowId: '143', tabId: 'tab1', docId: 'notfound' })
+      )
+      .then(() => {
+        expect(store.getActions()).toEqual([]);
       });
   });
 });

--- a/frontend/src/actions/Actions.js
+++ b/frontend/src/actions/Actions.js
@@ -276,6 +276,13 @@ export function deleteTopActions({ windowId, tabId, docId }) {
  */
 export function fetchTopActions({ windowId, tabId, docId }) {
   return (dispatch) => {
+    // Without a document there are no top actions to fetch, and the id would reach the backend as the
+    // literal string it stringifies to — `undefined` for an unset route param, or the `notfound`
+    // sentinel — which cannot address a record.
+    if (!windowId || !docId || docId === 'notfound') {
+      return Promise.resolve([]);
+    }
+
     dispatch({
       type: TOP_ACTIONS_LOADING,
       payload: { windowId, tabId, docId },


### PR DESCRIPTION
A malformed document id reached the SQL layer and failed the request as a server error. Two independent defects, one per layer.

## What

**1. The frontend requested top actions without a document**

`fetchTopActions` issued the request whatever `docId` held. `topActionsRequest` interpolates that value straight into `/window/{windowId}/{documentId}/topActions`, so an unset route parameter arrived at the backend as the literal string `undefined`, and the `notfound` sentinel (`WindowActions.js`) arrived verbatim. Neither can address a record, so every affected render produced a failed request.

The guard sits in the action creator rather than at the call sites, so it holds for every caller: `TableFilter` already checked `windowId`, `tabId` and `docId`, while `MasterWindowContainer.refreshActiveTab` guarded only the active tab. `topActionsRequest` itself is deliberately left alone — both of its mappings require the document id, so omitting the segment would only produce an unmapped URL rather than a well-formed request.

**2. The backend answered a server error for an id that cannot address a record**

`DocumentCollection.retrieveRootDocumentFromRepository` passed the id straight to the query, and `SqlDocumentQueryBuilder.buildSqlWhereClause` converted it with `DocumentId.toInt()`, which throws for a string id. A non-numeric id cannot match a single-column integer key, so the record simply does not exist; the method now says so with `DocumentNotFoundException`, which already carries `@ResponseStatus(NOT_FOUND)`.

String-typed and composed keys are exempt: a non-numeric id is legitimate for them, and only the single-key branch converts to int. The guard is a package-private static predicate over primitives with its own test class, matching `shouldInvalidateRootOnChildInvalidation` in the same class.

For the `AD_Reference`/`AD_Ref_List` case flagged by the FIXME above that branch — where the record id is a `Value` string — this turns an existing crash into a 404 for non-numeric values only. Numeric values are unaffected.

## Scope

The backend guard covers root documents loaded through `DocumentCollection`. `SqlDocumentQueryBuilder`'s int conversion is also reachable from `DocumentQuery.retrieveParentDocumentId` via the zoom-into service, but that path cannot carry a string id: `DocumentZoomIntoInfo.recordId` is typed `Integer` and its sole factory takes an `int`, so `DocumentId.of(...)` there always binds to the `int` overload. The cross-reference comment added at the conversion site is scoped accordingly rather than claiming universal coverage.

## How it was verified

TDD on both sides, each RED against unchanged behaviour first.

Frontend: with the guard removed, both new tests fail with a network error — no `nock` interceptor is registered on purpose, so a request that should never happen makes the test fail rather than silently pass.

Backend: five cases cover the decision table; only the integer-key/non-numeric-id case asserts rejection, the rest confirm no over-rejection.

| Suite | Result |
|---|---|
| `de.metas.ui.web.base` (full module) | 1391 tests, 0 failures |
| `frontend` `Actions.test.js` | 9 tests, 0 failures |
| `eslint` on the changed frontend files | clean |

## Not in scope

The `notfound` string is hardcoded here as it already is in four other frontend files, with no shared constant anywhere. Extracting one is worth doing but would touch five files for a concern this change did not introduce.
