### PR TITLE
gh30494 Forecast overlay E2E: correct the Allure feature (F19011) and epic (E0155) labels

### DIFF
--- a/e2e/frontend-webui/tests/spec/forecast-overlay-qty.spec.js
+++ b/e2e/frontend-webui/tests/spec/forecast-overlay-qty.spec.js
@@ -124,8 +124,9 @@ async function createIncludedRecord(page, windowId, recordId, detailId, fields) 
 
 test.describe('Forecast overlay — Menge is scoped to the cockpit product', () => {
   test('Sprung zu Prognose shows only the cockpit product\'s forecast quantity', async ({ page }) => {
-    allure.epic('E0300: Planning');
-    allure.tag('F19042');
+    allure.epic('E0155: Material Disposition');
+    allure.tag('F19011: Material Cockpit v2');
+    allure.tag('F19011');
     allure.story('Sprung zu Prognose: per-product Menge in the forecast overlay');
     allure.severity('critical');
     allure.description(`


### PR DESCRIPTION
Corrects the Allure metadata on the forecast-overlay E2E, which carried the wrong feature and a
non-existent epic.

The spec belongs to **Material Cockpit v2 (F19011)**, not the Forecast window (F19042). The overlay
it drives is the cockpit's forecast jump target, and the work behind it changed no part of the
Prognose window (`AD_Window` 328) — every AD change went to the jump-target window `542184`, which
carries no `AD_Menu` entry and is reachable only from a cockpit row.

| | before | after |
|---|---|---|
| feature | `allure.tag('F19042')` | `allure.tag('F19011: Material Cockpit v2')` + bare `allure.tag('F19011')`, the form the sibling specs use |
| epic | `allure.epic('E0300: Planning')` | `allure.epic('E0155: Material Disposition')` |

**`E0300` does not exist in the feature registry at all**, so the Allure report had no epic to group
this test under. `E0155 — Material Disposition` is the registry epic of F19011.

Test-metadata only — no assertions, selectors or behaviour touched.

### Pre-existing, deliberately not fixed here

`e2e/frontend-webui/tests/spec/forecast-generator.spec.js` also carries the non-existent
`E0300: Planning` (three places). That spec belongs to a different feature
(F19050 — Generate Forecasts from Historic Sales Orders, whose registry epic is likewise `E0155`),
so correcting it is another issue's call, not a silent change from this one.
