### PR TITLE
nShift: address CustNo via mapping from generic Carrier_Config custom value fields

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_M_Shipper_Mapping_Config.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_M_Shipper_Mapping_Config.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class X_M_Shipper_Mapping_Config extends org.compiere.model.PO implements I_M_Shipper_Mapping_Config, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 1976538100L;
+	private static final long serialVersionUID = 57347542L;
 
     /** Standard Constructor */
     public X_M_Shipper_Mapping_Config (final Properties ctx, final int M_Shipper_Mapping_Config_ID, @Nullable final String trxName)
@@ -90,6 +90,10 @@ public class X_M_Shipper_Mapping_Config extends org.compiere.model.PO implements
 	public static final String MAPPINGATTRIBUTETYPE_DetailGroup = "DetailGroup";
 	/** LineDetailGroup = LineDetailGroup */
 	public static final String MAPPINGATTRIBUTETYPE_LineDetailGroup = "LineDetailGroup";
+	/** SenderCustNo = SenderCustNo */
+	public static final String MAPPINGATTRIBUTETYPE_SenderCustNo = "SenderCustNo";
+	/** ReceiverCustNo = ReceiverCustNo */
+	public static final String MAPPINGATTRIBUTETYPE_ReceiverCustNo = "ReceiverCustNo";
 	@Override
 	public void setMappingAttributeType (final java.lang.String MappingAttributeType)
 	{
@@ -189,8 +193,16 @@ public class X_M_Shipper_Mapping_Config extends org.compiere.model.PO implements
 	public static final String MAPPINGATTRIBUTEVALUE_IncotermsValue = "IncotermsValue";
 	/** ExternalSystemValue = ExternalSystemValue */
 	public static final String MAPPINGATTRIBUTEVALUE_ExternalSystemValue = "ExternalSystemValue";
+	/** IsPreAdviceRequired = IsPreAdviceRequired */
+	public static final String MAPPINGATTRIBUTEVALUE_IsPreAdviceRequired = "IsPreAdviceRequired";
 	/** TopLevelType = TopLevelType */
 	public static final String MAPPINGATTRIBUTEVALUE_TopLevelType = "TopLevelType";
+	/** CustomValueString1 = CustomValueString1 */
+	public static final String MAPPINGATTRIBUTEVALUE_CustomValueString1 = "CustomValueString1";
+	/** CustomValueString2 = CustomValueString2 */
+	public static final String MAPPINGATTRIBUTEVALUE_CustomValueString2 = "CustomValueString2";
+	/** CustomValueString3 = CustomValueString3 */
+	public static final String MAPPINGATTRIBUTEVALUE_CustomValueString3 = "CustomValueString3";
 	@Override
 	public void setMappingAttributeValue (final java.lang.String MappingAttributeValue)
 	{

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5819100_sys_shipper_mapping_custno_reflist.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5819100_sys_shipper_mapping_custno_reflist.sql
@@ -1,0 +1,147 @@
+-- nShift shipper mapping: generic CustNo support.
+-- New mapping ATTRIBUTE TYPES (AD_Reference 541999) SenderCustNo / ReceiverCustNo -> set the nShift address CustNo
+-- of the sender / receiver address from a mapping rule.
+-- New mapping ATTRIBUTE VALUE (AD_Reference 542001) CustomValueString1 -> a generic value read from the shipper
+-- config additional property "CustomValueString1" (carrier-agnostic on purpose: e.g. for DHL Freight the consignee
+-- id is stored there and a ReceiverCustNo rule routes it into the address CustNo).
+-- Ref-list values only; the per-shipper M_Shipper_Mapping_Config rows and the config value are instance data.
+
+-- AD_Ref_List: SenderCustNo (attribute type)
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Ref_List_ID,AD_Reference_ID,
+                         Created,CreatedBy,Description,EntityType,IsActive,Name,
+                         Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,544339 /*From ID Server*/,541999,
+        TO_TIMESTAMP('2026-08-14 10:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        NULL,'D','Y','Lieferant Kundennr.',
+        TO_TIMESTAMP('2026-08-14 10:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        'SenderCustNo','SenderCustNo');
+
+INSERT INTO AD_Ref_List_Trl (AD_Client_ID,AD_Org_ID,AD_Language,AD_Ref_List_ID,
+                             Created,CreatedBy,Description,IsActive,IsTranslated,Name,
+                             Updated,UpdatedBy)
+SELECT 0,0,l.AD_Language,544339 /*From ID Server*/,
+       TO_TIMESTAMP('2026-08-14 10:00:01','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+       NULL,'Y','N','Lieferant Kundennr.',
+       TO_TIMESTAMP('2026-08-14 10:00:01','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100
+FROM AD_Language l WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y'
+  AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Ref_List_ID=544339 AND tt.AD_Language=l.AD_Language);
+
+UPDATE AD_Ref_List_Trl SET Name='Sender Customer No.', IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 10:00:02','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Ref_List_ID=544339 AND AD_Language='en_US';
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 10:00:03','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Ref_List_ID=544339 AND AD_Language IN ('de_DE','de_CH');
+
+-- AD_Ref_List: ReceiverCustNo (attribute type)
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Ref_List_ID,AD_Reference_ID,
+                         Created,CreatedBy,Description,EntityType,IsActive,Name,
+                         Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,544340 /*From ID Server*/,541999,
+        TO_TIMESTAMP('2026-08-14 10:00:04','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        NULL,'D','Y','Empfänger Kundennr.',
+        TO_TIMESTAMP('2026-08-14 10:00:04','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        'ReceiverCustNo','ReceiverCustNo');
+
+INSERT INTO AD_Ref_List_Trl (AD_Client_ID,AD_Org_ID,AD_Language,AD_Ref_List_ID,
+                             Created,CreatedBy,Description,IsActive,IsTranslated,Name,
+                             Updated,UpdatedBy)
+SELECT 0,0,l.AD_Language,544340 /*From ID Server*/,
+       TO_TIMESTAMP('2026-08-14 10:00:05','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+       NULL,'Y','N','Empfänger Kundennr.',
+       TO_TIMESTAMP('2026-08-14 10:00:05','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100
+FROM AD_Language l WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y'
+  AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Ref_List_ID=544340 AND tt.AD_Language=l.AD_Language);
+
+UPDATE AD_Ref_List_Trl SET Name='Receiver Customer No.', IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 10:00:06','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Ref_List_ID=544340 AND AD_Language='en_US';
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 10:00:07','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Ref_List_ID=544340 AND AD_Language IN ('de_DE','de_CH');
+
+-- AD_Ref_List: CustomValueString1 (attribute value; read from shipper-config additional property "CustomValueString1")
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Ref_List_ID,AD_Reference_ID,
+                         Created,CreatedBy,Description,EntityType,IsActive,Name,
+                         Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,544341 /*From ID Server*/,542001,
+        TO_TIMESTAMP('2026-08-14 10:00:08','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        NULL,'D','Y','Benutzerdef. Text 1',
+        TO_TIMESTAMP('2026-08-14 10:00:08','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        'CustomValueString1','CustomValueString1');
+
+INSERT INTO AD_Ref_List_Trl (AD_Client_ID,AD_Org_ID,AD_Language,AD_Ref_List_ID,
+                             Created,CreatedBy,Description,IsActive,IsTranslated,Name,
+                             Updated,UpdatedBy)
+SELECT 0,0,l.AD_Language,544341 /*From ID Server*/,
+       TO_TIMESTAMP('2026-08-14 10:00:09','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+       NULL,'Y','N','Benutzerdef. Text 1',
+       TO_TIMESTAMP('2026-08-14 10:00:09','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100
+FROM AD_Language l WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y'
+  AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Ref_List_ID=544341 AND tt.AD_Language=l.AD_Language);
+
+UPDATE AD_Ref_List_Trl SET Name='Custom Text 1', IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 10:00:10','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Ref_List_ID=544341 AND AD_Language='en_US';
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 10:00:11','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Ref_List_ID=544341 AND AD_Language IN ('de_DE','de_CH');
+
+-- AD_Ref_List: CustomValueString2 (attribute value; read from shipper-config additional property "CustomValueString2")
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Ref_List_ID,AD_Reference_ID,
+                         Created,CreatedBy,Description,EntityType,IsActive,Name,
+                         Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,544342 /*From ID Server*/,542001,
+        TO_TIMESTAMP('2026-08-14 10:00:12','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        NULL,'D','Y','Benutzerdef. Text 2',
+        TO_TIMESTAMP('2026-08-14 10:00:12','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        'CustomValueString2','CustomValueString2');
+
+INSERT INTO AD_Ref_List_Trl (AD_Client_ID,AD_Org_ID,AD_Language,AD_Ref_List_ID,
+                             Created,CreatedBy,Description,IsActive,IsTranslated,Name,
+                             Updated,UpdatedBy)
+SELECT 0,0,l.AD_Language,544342 /*From ID Server*/,
+       TO_TIMESTAMP('2026-08-14 10:00:13','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+       NULL,'Y','N','Benutzerdef. Text 2',
+       TO_TIMESTAMP('2026-08-14 10:00:13','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100
+FROM AD_Language l WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y'
+  AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Ref_List_ID=544342 AND tt.AD_Language=l.AD_Language);
+
+UPDATE AD_Ref_List_Trl SET Name='Custom Text 2', IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 10:00:14','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Ref_List_ID=544342 AND AD_Language='en_US';
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 10:00:15','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Ref_List_ID=544342 AND AD_Language IN ('de_DE','de_CH');
+
+-- AD_Ref_List: CustomValueString3 (attribute value; read from shipper-config additional property "CustomValueString3")
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Ref_List_ID,AD_Reference_ID,
+                         Created,CreatedBy,Description,EntityType,IsActive,Name,
+                         Updated,UpdatedBy,Value,ValueName)
+VALUES (0,0,544343 /*From ID Server*/,542001,
+        TO_TIMESTAMP('2026-08-14 10:00:16','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        NULL,'D','Y','Benutzerdef. Text 3',
+        TO_TIMESTAMP('2026-08-14 10:00:16','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        'CustomValueString3','CustomValueString3');
+
+INSERT INTO AD_Ref_List_Trl (AD_Client_ID,AD_Org_ID,AD_Language,AD_Ref_List_ID,
+                             Created,CreatedBy,Description,IsActive,IsTranslated,Name,
+                             Updated,UpdatedBy)
+SELECT 0,0,l.AD_Language,544343 /*From ID Server*/,
+       TO_TIMESTAMP('2026-08-14 10:00:17','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+       NULL,'Y','N','Benutzerdef. Text 3',
+       TO_TIMESTAMP('2026-08-14 10:00:17','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100
+FROM AD_Language l WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y'
+  AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Ref_List_ID=544343 AND tt.AD_Language=l.AD_Language);
+
+UPDATE AD_Ref_List_Trl SET Name='Custom Text 3', IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 10:00:18','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Ref_List_ID=544343 AND AD_Language='en_US';
+
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 10:00:19','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Ref_List_ID=544343 AND AD_Language IN ('de_DE','de_CH');

--- a/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftUtil.java
+++ b/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftUtil.java
@@ -132,9 +132,9 @@ public class NShiftUtil
 			@NonNull final NShiftMappingConfigs mappingConfigs,
 			@NonNull final Function<String, String> valueProvider)
 	{
-		final String role = kind == JsonAddressKind.SENDER ? "Sender" : "Receiver";
+		final String role = kind.isSender() ? "Sender" : "Receiver";
 
-		final String attentionAttributeType = kind == JsonAddressKind.SENDER
+		final String attentionAttributeType = kind.isSender()
 				? DeliveryMappingConstants.ATTRIBUTE_TYPE_SENDER_ATTENTION
 				: DeliveryMappingConstants.ATTRIBUTE_TYPE_RECEIVER_ATTENTION;
 		final String attention = mappingConfigs.getSingleValue(attentionAttributeType, valueProvider);
@@ -147,7 +147,7 @@ public class NShiftUtil
 
 		// Optional CustNo, resolved from mapping rules (e.g. a CustomValueString1 shipper-config value routed via a
 		// SenderCustNo / ReceiverCustNo rule). Unset -> getSingleValue returns "" -> omitted (JsonAddress is NON_NULL).
-		final String custNoAttributeType = kind == JsonAddressKind.SENDER
+		final String custNoAttributeType = kind.isSender()
 				? DeliveryMappingConstants.ATTRIBUTE_TYPE_SENDER_CUSTNO
 				: DeliveryMappingConstants.ATTRIBUTE_TYPE_RECEIVER_CUSTNO;
 		final String custNo = mappingConfigs.getSingleValue(custNoAttributeType, valueProvider);

--- a/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftUtil.java
+++ b/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/NShiftUtil.java
@@ -145,9 +145,20 @@ public class NShiftUtil
 		Check.assumeNotEmpty(contact != null ? contact.getEmailAddress() : null, IllegalStateException.class,
 				role + " Email is mandatory but is missing or blank.");
 
-		return buildNShiftAddressBuilder(commonAddress, contact, kind)
-				.attention(attention)
-				.build();
+		// Optional CustNo, resolved from mapping rules (e.g. a CustomValueString1 shipper-config value routed via a
+		// SenderCustNo / ReceiverCustNo rule). Unset -> getSingleValue returns "" -> omitted (JsonAddress is NON_NULL).
+		final String custNoAttributeType = kind == JsonAddressKind.SENDER
+				? DeliveryMappingConstants.ATTRIBUTE_TYPE_SENDER_CUSTNO
+				: DeliveryMappingConstants.ATTRIBUTE_TYPE_RECEIVER_CUSTNO;
+		final String custNo = mappingConfigs.getSingleValue(custNoAttributeType, valueProvider);
+
+		final JsonAddress.JsonAddressBuilder addressBuilder = buildNShiftAddressBuilder(commonAddress, contact, kind)
+				.attention(attention);
+		if (Check.isNotBlank(custNo))
+		{
+			addressBuilder.custNo(custNo);
+		}
+		return addressBuilder.build();
 	}
 
 	/**

--- a/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/json/JsonAddressKind.java
+++ b/backend/de.metas.shipper.client.nshift/src/main/java/de/metas/shipper/client/nshift/json/JsonAddressKind.java
@@ -22,6 +22,7 @@
 package de.metas.shipper.client.nshift.json;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -47,5 +48,8 @@ public enum JsonAddressKind
 				.findFirst()
 				.orElse(UNKNOWN);
 	}
+
+	@JsonIgnore
+	public boolean isSender() {return this == SENDER;}
 
 }

--- a/backend/de.metas.shipper.client.nshift/src/test/java/de/metas/shipper/client/nshift/NShiftShipmentServiceTest.java
+++ b/backend/de.metas.shipper.client.nshift/src/test/java/de/metas/shipper/client/nshift/NShiftShipmentServiceTest.java
@@ -52,7 +52,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 import java.math.BigDecimal;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -285,14 +284,17 @@ public class NShiftShipmentServiceTest
 
 		final JsonShipmentRequest shipmentRequest = NShiftShipmentService.buildShipmentRequest(request);
 
-		final List<de.metas.shipper.client.nshift.json.JsonAddress> addresses = shipmentRequest.getData().getAddresses();
-		final de.metas.shipper.client.nshift.json.JsonAddress sender = addresses.stream()
-				.filter(a -> a.getKind() == JsonAddressKind.SENDER).findFirst().orElseThrow(() -> new AssertionError("no sender address"));
-		final de.metas.shipper.client.nshift.json.JsonAddress receiver = addresses.stream()
-				.filter(a -> a.getKind() == JsonAddressKind.RECEIVER).findFirst().orElseThrow(() -> new AssertionError("no receiver address"));
+		assertEquals(consigneeId, custNoOf(shipmentRequest, JsonAddressKind.SENDER), "Sender CustNo must come from the CustomValueString1 config value");
+		assertEquals(consigneeId, custNoOf(shipmentRequest, JsonAddressKind.RECEIVER), "Receiver CustNo must come from the CustomValueString1 config value");
+	}
 
-		assertEquals(consigneeId, sender.getCustNo(), "Sender CustNo must come from the CustomValueString1 config value");
-		assertEquals(consigneeId, receiver.getCustNo(), "Receiver CustNo must come from the CustomValueString1 config value");
+	private static String custNoOf(final JsonShipmentRequest request, final JsonAddressKind kind)
+	{
+		return request.getData().getAddresses().stream()
+				.filter(a -> a.getKind() == kind)
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("no " + kind + " address"))
+				.getCustNo();
 	}
 
 }

--- a/backend/de.metas.shipper.client.nshift/src/test/java/de/metas/shipper/client/nshift/NShiftShipmentServiceTest.java
+++ b/backend/de.metas.shipper.client.nshift/src/test/java/de/metas/shipper/client/nshift/NShiftShipmentServiceTest.java
@@ -288,6 +288,35 @@ public class NShiftShipmentServiceTest
 		assertEquals(consigneeId, custNoOf(shipmentRequest, JsonAddressKind.RECEIVER), "Receiver CustNo must come from the CustomValueString1 config value");
 	}
 
+	@Test
+	void buildShipmentRequest_withoutShipperProduct_skipsProductScopedConfigWithoutNpe()
+	{
+		// Selection-rules booking with no pre-selected product: getValue(ShipperProductExternalId) must be "" (not null),
+		// so isConfigForShipperProduct (@NonNull) skips product-scoped configs instead of throwing an NPE.
+		final JsonMappingConfigList mappingConfigs = JsonMappingConfigList.ofList(ImmutableList.<JsonMappingConfig>builder()
+				.addAll(NShiftTestMappingConfigs.SHARED_TEST.getConfigs())
+				.add(JsonMappingConfig.builder()
+						.seqNo(500)
+						.shipperProductExternalId("10305") // product-scoped -> must be skipped when no product is set
+						.attributeType(DeliveryMappingConstants.ATTRIBUTE_TYPE_RECEIVER_CUSTNO)
+						.attributeValue(DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_1)
+						.build())
+				.build());
+
+		final JsonDeliveryRequest request = DELIVERY_REQUEST.toBuilder()
+				.shipperProduct(null)
+				.shipperConfig(DELIVERY_REQUEST.getShipperConfig()
+						.withAdditionalProperty(NShiftConstants.SELECTION_RULES, "Y")
+						.withAdditionalProperty(DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_1, "DHL-CONSIGNEE-123"))
+				.mappingConfigs(mappingConfigs)
+				.build();
+
+		final JsonShipmentRequest shipmentRequest = NShiftShipmentService.buildShipmentRequest(request);
+		assertNotNull(shipmentRequest);
+		// product-scoped rule skipped (no product selected) -> receiver CustNo stays unset
+		assertNull(custNoOf(shipmentRequest, JsonAddressKind.RECEIVER), "product-scoped CustNo must be skipped when no product is selected");
+	}
+
 	private static String custNoOf(final JsonShipmentRequest request, final JsonAddressKind kind)
 	{
 		return request.getData().getAddresses().stream()

--- a/backend/de.metas.shipper.client.nshift/src/test/java/de/metas/shipper/client/nshift/NShiftShipmentServiceTest.java
+++ b/backend/de.metas.shipper.client.nshift/src/test/java/de/metas/shipper/client/nshift/NShiftShipmentServiceTest.java
@@ -40,6 +40,10 @@ import de.metas.common.delivery.v1.json.request.JsonShipperConfig;
 import de.metas.common.delivery.v1.json.request.JsonShipperProduct;
 import de.metas.common.delivery.v1.json.response.JsonDeliveryResponse;
 import de.metas.shipper.client.nshift.json.request.JsonShipmentRequest;
+import de.metas.shipper.client.nshift.json.JsonAddressKind;
+import de.metas.common.delivery.v1.json.DeliveryMappingConstants;
+import de.metas.common.delivery.v1.json.request.JsonMappingConfig;
+import de.metas.common.delivery.v1.json.request.JsonMappingConfigList;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,6 +52,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -251,6 +256,43 @@ public class NShiftShipmentServiceTest
 		assertEquals(0, shipmentRequest.getData().getProdConceptID(), "ProdConceptID must stay 0 (no resolved product) when rules resolve it");
 		assertTrue(shipmentRequest.getData().getServices().isEmpty(), "Services must not be pre-sent when rules resolve them");
 		assertNull(shipmentRequest.getData().getLines().get(0).getGoodsTypeID(), "Line GoodsTypeID must be omitted when rules resolve it");
+	}
+
+	@Test
+	void buildShipmentRequest_setsCustNoFromCustomValueString1MappingRule()
+	{
+		final String consigneeId = "DHL-CONSIGNEE-123";
+		// SenderCustNo / ReceiverCustNo rules routing the generic CustomValueString1 config value into the address CustNo
+		final JsonMappingConfigList mappingConfigs = JsonMappingConfigList.ofList(ImmutableList.<JsonMappingConfig>builder()
+				.addAll(NShiftTestMappingConfigs.SHARED_TEST.getConfigs())
+				.add(JsonMappingConfig.builder()
+						.seqNo(400)
+						.attributeType(DeliveryMappingConstants.ATTRIBUTE_TYPE_SENDER_CUSTNO)
+						.attributeValue(DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_1)
+						.build())
+				.add(JsonMappingConfig.builder()
+						.seqNo(410)
+						.attributeType(DeliveryMappingConstants.ATTRIBUTE_TYPE_RECEIVER_CUSTNO)
+						.attributeValue(DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_1)
+						.build())
+				.build());
+
+		final JsonDeliveryRequest request = DELIVERY_REQUEST.toBuilder()
+				.shipperConfig(DELIVERY_REQUEST.getShipperConfig()
+						.withAdditionalProperty(DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_1, consigneeId))
+				.mappingConfigs(mappingConfigs)
+				.build();
+
+		final JsonShipmentRequest shipmentRequest = NShiftShipmentService.buildShipmentRequest(request);
+
+		final List<de.metas.shipper.client.nshift.json.JsonAddress> addresses = shipmentRequest.getData().getAddresses();
+		final de.metas.shipper.client.nshift.json.JsonAddress sender = addresses.stream()
+				.filter(a -> a.getKind() == JsonAddressKind.SENDER).findFirst().orElseThrow(() -> new AssertionError("no sender address"));
+		final de.metas.shipper.client.nshift.json.JsonAddress receiver = addresses.stream()
+				.filter(a -> a.getKind() == JsonAddressKind.RECEIVER).findFirst().orElseThrow(() -> new AssertionError("no receiver address"));
+
+		assertEquals(consigneeId, sender.getCustNo(), "Sender CustNo must come from the CustomValueString1 config value");
+		assertEquals(consigneeId, receiver.getCustNo(), "Receiver CustNo must come from the CustomValueString1 config value");
 	}
 
 }

--- a/backend/de.metas.shipper.gateway.commons/src/main/java/de/metas/shipper/gateway/commons/mapping/AttributeType.java
+++ b/backend/de.metas.shipper.gateway.commons/src/main/java/de/metas/shipper/gateway/commons/mapping/AttributeType.java
@@ -23,7 +23,6 @@
 package de.metas.shipper.gateway.commons.mapping;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import de.metas.common.delivery.v1.json.DeliveryMappingConstants;
 import de.metas.util.lang.ReferenceListAwareEnum;
 import de.metas.util.lang.ReferenceListAwareEnums;
 import lombok.Getter;
@@ -37,11 +36,9 @@ public enum AttributeType implements ReferenceListAwareEnum
 	// Keep in sync with de.metas.common.delivery.v1.json.DeliveryMappingConstants
 	SENDER_ATTENTION(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTETYPE_SenderAttention),
 	RECEIVER_ATTENTION(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTETYPE_ReceiverAttention),
-	// CustNo mapping targets (address CustNo of sender / receiver). Value uses DeliveryMappingConstants, not a
-	// generated X_ constant, to avoid a model regeneration — the code is defined once in DeliveryMappingConstants and
-	// seeded as an AD_Ref_List value by migration 5819100.
-	SENDER_CUSTNO(DeliveryMappingConstants.ATTRIBUTE_TYPE_SENDER_CUSTNO),
-	RECEIVER_CUSTNO(DeliveryMappingConstants.ATTRIBUTE_TYPE_RECEIVER_CUSTNO),
+	// CustNo mapping targets (address CustNo of sender / receiver)
+	SENDER_CUSTNO(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTETYPE_SenderCustNo),
+	RECEIVER_CUSTNO(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTETYPE_ReceiverCustNo),
 	REFERENCE(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTETYPE_Reference),
 	LINE_REFERENCE(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTETYPE_LineReference),
 	LINE_DETAIL_GROUP(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTETYPE_LineDetailGroup),

--- a/backend/de.metas.shipper.gateway.commons/src/main/java/de/metas/shipper/gateway/commons/mapping/AttributeType.java
+++ b/backend/de.metas.shipper.gateway.commons/src/main/java/de/metas/shipper/gateway/commons/mapping/AttributeType.java
@@ -22,6 +22,7 @@
 
 package de.metas.shipper.gateway.commons.mapping;
 
+import de.metas.common.delivery.v1.json.DeliveryMappingConstants;
 import de.metas.util.lang.ReferenceListAwareEnum;
 import de.metas.util.lang.ReferenceListAwareEnums;
 import lombok.Getter;
@@ -35,6 +36,11 @@ public enum AttributeType implements ReferenceListAwareEnum
 	// Keep in sync with de.metas.common.delivery.v1.json.DeliveryMappingConstants
 	SENDER_ATTENTION(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTETYPE_SenderAttention),
 	RECEIVER_ATTENTION(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTETYPE_ReceiverAttention),
+	// CustNo mapping targets (address CustNo of sender / receiver). Value uses DeliveryMappingConstants, not a
+	// generated X_ constant, to avoid a model regeneration — the code is defined once in DeliveryMappingConstants and
+	// seeded as an AD_Ref_List value by migration 5819100.
+	SENDER_CUSTNO(DeliveryMappingConstants.ATTRIBUTE_TYPE_SENDER_CUSTNO),
+	RECEIVER_CUSTNO(DeliveryMappingConstants.ATTRIBUTE_TYPE_RECEIVER_CUSTNO),
 	REFERENCE(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTETYPE_Reference),
 	LINE_REFERENCE(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTETYPE_LineReference),
 	LINE_DETAIL_GROUP(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTETYPE_LineDetailGroup),

--- a/backend/de.metas.shipper.gateway.commons/src/main/java/de/metas/shipper/gateway/commons/mapping/AttributeType.java
+++ b/backend/de.metas.shipper.gateway.commons/src/main/java/de/metas/shipper/gateway/commons/mapping/AttributeType.java
@@ -22,6 +22,7 @@
 
 package de.metas.shipper.gateway.commons.mapping;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import de.metas.common.delivery.v1.json.DeliveryMappingConstants;
 import de.metas.util.lang.ReferenceListAwareEnum;
 import de.metas.util.lang.ReferenceListAwareEnums;
@@ -56,4 +57,7 @@ public enum AttributeType implements ReferenceListAwareEnum
 	{
 		return index.ofCode(code);
 	}
+
+	@JsonValue
+	public String toJson() {return getCode();}
 }

--- a/backend/de.metas.shipper.gateway.commons/src/main/java/de/metas/shipper/gateway/commons/mapping/AttributeValue.java
+++ b/backend/de.metas.shipper.gateway.commons/src/main/java/de/metas/shipper/gateway/commons/mapping/AttributeValue.java
@@ -53,6 +53,10 @@ public enum AttributeValue implements ReferenceListAwareEnum
 	IS_PRE_ADVICE_REQUIRED(DeliveryMappingConstants.ATTRIBUTE_VALUE_IS_PRE_ADVICE_REQUIRED),
 	INCOTERMS_VALUE(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTEVALUE_IncotermsValue),
 	EXTERNAL_SYSTEM_VALUE(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTEVALUE_ExternalSystemValue),
+	// Generic values read from Carrier_Config additional properties; seeded as AD_Ref_List values by migration 5819100.
+	CUSTOM_VALUE_STRING_1(DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_1),
+	CUSTOM_VALUE_STRING_2(DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_2),
+	CUSTOM_VALUE_STRING_3(DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_3),
 
 	// From parcel
 	TOP_LEVEL_TYPE(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTEVALUE_TopLevelType),

--- a/backend/de.metas.shipper.gateway.commons/src/main/java/de/metas/shipper/gateway/commons/mapping/AttributeValue.java
+++ b/backend/de.metas.shipper.gateway.commons/src/main/java/de/metas/shipper/gateway/commons/mapping/AttributeValue.java
@@ -22,6 +22,7 @@
 
 package de.metas.shipper.gateway.commons.mapping;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import de.metas.common.delivery.v1.json.DeliveryMappingConstants;
 import de.metas.util.lang.ReferenceListAwareEnum;
 import de.metas.util.lang.ReferenceListAwareEnums;
@@ -97,4 +98,7 @@ public enum AttributeValue implements ReferenceListAwareEnum
 	{
 		return index.ofCode(code);
 	}
+
+	@JsonValue
+	public String toJson() {return getCode();}
 }

--- a/backend/de.metas.shipper.gateway.commons/src/main/java/de/metas/shipper/gateway/commons/mapping/AttributeValue.java
+++ b/backend/de.metas.shipper.gateway.commons/src/main/java/de/metas/shipper/gateway/commons/mapping/AttributeValue.java
@@ -23,7 +23,6 @@
 package de.metas.shipper.gateway.commons.mapping;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import de.metas.common.delivery.v1.json.DeliveryMappingConstants;
 import de.metas.util.lang.ReferenceListAwareEnum;
 import de.metas.util.lang.ReferenceListAwareEnums;
 import lombok.Getter;
@@ -51,13 +50,13 @@ public enum AttributeValue implements ReferenceListAwareEnum
 	SHIPPER_EORI(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTEVALUE_ShipperEORI),
 	RECEIVER_BPARTNER_ATTENTION(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTEVALUE_ReceiverBPartnerAttention),
 	SENDER_BPARTNER_ATTENTION(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTEVALUE_SenderBPartnerAttention),
-	IS_PRE_ADVICE_REQUIRED(DeliveryMappingConstants.ATTRIBUTE_VALUE_IS_PRE_ADVICE_REQUIRED),
+	IS_PRE_ADVICE_REQUIRED(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTEVALUE_IsPreAdviceRequired),
 	INCOTERMS_VALUE(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTEVALUE_IncotermsValue),
 	EXTERNAL_SYSTEM_VALUE(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTEVALUE_ExternalSystemValue),
-	// Generic values read from Carrier_Config additional properties; seeded as AD_Ref_List values by migration 5819100.
-	CUSTOM_VALUE_STRING_1(DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_1),
-	CUSTOM_VALUE_STRING_2(DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_2),
-	CUSTOM_VALUE_STRING_3(DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_3),
+	// Generic values read from Carrier_Config additional properties
+	CUSTOM_VALUE_STRING_1(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTEVALUE_CustomValueString1),
+	CUSTOM_VALUE_STRING_2(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTEVALUE_CustomValueString2),
+	CUSTOM_VALUE_STRING_3(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTEVALUE_CustomValueString3),
 
 	// From parcel
 	TOP_LEVEL_TYPE(X_M_Shipper_Mapping_Config.MAPPINGATTRIBUTEVALUE_TopLevelType),

--- a/backend/de.metas.shipper.gateway.nshift/src/main/sql/postgresql/system/99-de.metas.shipper.gateway.nshift/5819120_sys_Carrier_Config_CustomValueString_fields.sql
+++ b/backend/de.metas.shipper.gateway.nshift/src/main/sql/postgresql/system/99-de.metas.shipper.gateway.nshift/5819120_sys_Carrier_Config_CustomValueString_fields.sql
@@ -1,0 +1,230 @@
+-- nShift shipper config: generic custom value fields.
+-- New Carrier_Config.CustomValueString1..3 columns, surfaced as advanced (non-grid) fields on the nShift
+-- configuration tab (AD_Tab 548455, window 142). ShipperConfigRepository maps every non-excluded Carrier_Config
+-- column to a JsonShipperConfig additional property by column name, so each value is reachable as
+-- additionalProperty("CustomValueStringN") and can be routed into the nShift address CustNo via a SenderCustNo /
+-- ReceiverCustNo mapping rule (e.g. for DHL Freight the operator stores the consignee id here). Carrier-agnostic.
+
+-- 1) physical columns (new columns -> ALTER TABLE ADD COLUMN, nullable)
+ALTER TABLE Carrier_Config ADD COLUMN IF NOT EXISTS CustomValueString1 VARCHAR(60);
+ALTER TABLE Carrier_Config ADD COLUMN IF NOT EXISTS CustomValueString2 VARCHAR(60);
+ALTER TABLE Carrier_Config ADD COLUMN IF NOT EXISTS CustomValueString3 VARCHAR(60);
+
+-- ============================ slot 1 ============================
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,
+                        ColumnName,EntityType,Name,PrintName)
+VALUES (585301 /*From ID Server*/,0,0,'Y',
+        TO_TIMESTAMP('2026-08-14 11:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        TO_TIMESTAMP('2026-08-14 11:00:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        'CustomValueString1','D','Benutzerdef. Text 1','Benutzerdef. Text 1');
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,
+                            Name,PrintName,IsTranslated)
+SELECT l.AD_Language,585301 /*From ID Server*/,0,0,'Y',
+       TO_TIMESTAMP('2026-08-14 11:00:01','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+       TO_TIMESTAMP('2026-08-14 11:00:01','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+       'Benutzerdef. Text 1','Benutzerdef. Text 1','N'
+FROM AD_Language l WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y')
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Element_ID=585301 AND tt.AD_Language=l.AD_Language);
+
+UPDATE AD_Element_Trl SET Name='Custom Text 1', PrintName='Custom Text 1', IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 11:00:02','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Element_ID=585301 AND AD_Language='en_US';
+
+UPDATE AD_Element_Trl SET IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 11:00:03','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Element_ID=585301 AND AD_Language IN ('de_DE','de_CH');
+
+INSERT INTO AD_Column (AD_Column_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,Updated,CreatedBy,UpdatedBy,
+                       Name,Version,EntityType,ColumnName,AD_Table_ID,AD_Reference_ID,FieldLength,
+                       IsKey,IsParent,IsMandatory,IsUpdateable,IsIdentifier,SeqNo,IsTranslated,IsEncrypted,
+                       IsSelectionColumn,AD_Element_ID,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,
+                       IsAdvancedText,IsLazyLoading,IsCalculated,IsGenericZoomOrigin,IsGenericZoomKeyColumn,
+                       IsUseDocSequence,IsStaleable,DDL_NoForeignKey,IsDimension,IsDLMPartitionBoundary,
+                       CacheInvalidateParent,SelectionColumnSeqNo,IsRangeFilter,IsShowFilterIncrementButtons,
+                       IsForceIncludeInGeneratedModel,PersonalDataCategory,IsAutoApplyValidationRule,IsFacetFilter,
+                       MaxFacetsToFetch,FacetFilterSeqNo,IsShowFilterInline,IsExcludeFromZoomTargets,
+                       IsRestApiCustomColumn,CloningStrategy,IsShowFilterInactiveValues)
+VALUES (593311 /*From ID Server*/,0,0,'Y',
+        TO_TIMESTAMP('2026-08-14 11:01:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',
+        TO_TIMESTAMP('2026-08-14 11:01:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,100,
+        'Benutzerdef. Text 1',0,'D','CustomValueString1',542540,10,60,
+        'N','N','N','Y','N',0,'N','N',
+        'N',585301,'N','N','N','Y',
+        'N','N','N','N','N','N','N','N','N','N',
+        'Y',0,'N','N',
+        'N','NP','N','N',
+        0,0,'N','Y',
+        'N','XX','N');
+
+INSERT INTO AD_Field (AD_Field_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,
+                      Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,IsReadOnly,IsSameLine,IsHeading,
+                      IsFieldOnly,IsEncrypted,EntityType,ColumnDisplayLength,IncludedTabHeight,IsDisplayedGrid,
+                      SpanX,SpanY,IsAlwaysUpdateable,IsOverrideFilterDefaultValue,IsHideGridColumnIfEmpty)
+VALUES (782295 /*From ID Server*/,0,0,'Y',
+        TO_TIMESTAMP('2026-08-14 11:02:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        TO_TIMESTAMP('2026-08-14 11:02:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        'Benutzerdef. Text 1',548455,593311,'Y',60,'N','N','N',
+        'N','N','D',0,0,'N',
+        1,1,'N','N','N');
+
+INSERT INTO AD_UI_Element (AD_UI_Element_ID,AD_Client_ID,AD_Org_ID,AD_Field_ID,AD_UI_ElementGroup_ID,AD_Tab_ID,
+                           Created,CreatedBy,Updated,UpdatedBy,IsActive,Name,SeqNo,IsAdvancedField,IsDisplayed,
+                           IsDisplayedGrid,SeqNoGrid,IsDisplayed_SideList,SeqNo_SideList,AD_UI_ElementType,
+                           IsAllowFiltering,IsMultiline,Multiline_LinesCount)
+VALUES (653145 /*From ID Server*/,0,0,782295,553597,548455,
+        TO_TIMESTAMP('2026-08-14 11:02:30','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        TO_TIMESTAMP('2026-08-14 11:02:30','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y',
+        'Benutzerdef. Text 1',100,'Y','Y',
+        'N',0,'N',0,'F',
+        'N','N',0);
+
+-- ============================ slot 2 ============================
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,
+                        ColumnName,EntityType,Name,PrintName)
+VALUES (585302 /*From ID Server*/,0,0,'Y',
+        TO_TIMESTAMP('2026-08-14 11:03:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        TO_TIMESTAMP('2026-08-14 11:03:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        'CustomValueString2','D','Benutzerdef. Text 2','Benutzerdef. Text 2');
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,
+                            Name,PrintName,IsTranslated)
+SELECT l.AD_Language,585302 /*From ID Server*/,0,0,'Y',
+       TO_TIMESTAMP('2026-08-14 11:03:01','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+       TO_TIMESTAMP('2026-08-14 11:03:01','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+       'Benutzerdef. Text 2','Benutzerdef. Text 2','N'
+FROM AD_Language l WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y')
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Element_ID=585302 AND tt.AD_Language=l.AD_Language);
+
+UPDATE AD_Element_Trl SET Name='Custom Text 2', PrintName='Custom Text 2', IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 11:03:02','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Element_ID=585302 AND AD_Language='en_US';
+
+UPDATE AD_Element_Trl SET IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 11:03:03','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Element_ID=585302 AND AD_Language IN ('de_DE','de_CH');
+
+INSERT INTO AD_Column (AD_Column_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,Updated,CreatedBy,UpdatedBy,
+                       Name,Version,EntityType,ColumnName,AD_Table_ID,AD_Reference_ID,FieldLength,
+                       IsKey,IsParent,IsMandatory,IsUpdateable,IsIdentifier,SeqNo,IsTranslated,IsEncrypted,
+                       IsSelectionColumn,AD_Element_ID,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,
+                       IsAdvancedText,IsLazyLoading,IsCalculated,IsGenericZoomOrigin,IsGenericZoomKeyColumn,
+                       IsUseDocSequence,IsStaleable,DDL_NoForeignKey,IsDimension,IsDLMPartitionBoundary,
+                       CacheInvalidateParent,SelectionColumnSeqNo,IsRangeFilter,IsShowFilterIncrementButtons,
+                       IsForceIncludeInGeneratedModel,PersonalDataCategory,IsAutoApplyValidationRule,IsFacetFilter,
+                       MaxFacetsToFetch,FacetFilterSeqNo,IsShowFilterInline,IsExcludeFromZoomTargets,
+                       IsRestApiCustomColumn,CloningStrategy,IsShowFilterInactiveValues)
+VALUES (593312 /*From ID Server*/,0,0,'Y',
+        TO_TIMESTAMP('2026-08-14 11:04:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',
+        TO_TIMESTAMP('2026-08-14 11:04:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,100,
+        'Benutzerdef. Text 2',0,'D','CustomValueString2',542540,10,60,
+        'N','N','N','Y','N',0,'N','N',
+        'N',585302,'N','N','N','Y',
+        'N','N','N','N','N','N','N','N','N','N',
+        'Y',0,'N','N',
+        'N','NP','N','N',
+        0,0,'N','Y',
+        'N','XX','N');
+
+INSERT INTO AD_Field (AD_Field_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,
+                      Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,IsReadOnly,IsSameLine,IsHeading,
+                      IsFieldOnly,IsEncrypted,EntityType,ColumnDisplayLength,IncludedTabHeight,IsDisplayedGrid,
+                      SpanX,SpanY,IsAlwaysUpdateable,IsOverrideFilterDefaultValue,IsHideGridColumnIfEmpty)
+VALUES (782296 /*From ID Server*/,0,0,'Y',
+        TO_TIMESTAMP('2026-08-14 11:05:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        TO_TIMESTAMP('2026-08-14 11:05:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        'Benutzerdef. Text 2',548455,593312,'Y',60,'N','N','N',
+        'N','N','D',0,0,'N',
+        1,1,'N','N','N');
+
+INSERT INTO AD_UI_Element (AD_UI_Element_ID,AD_Client_ID,AD_Org_ID,AD_Field_ID,AD_UI_ElementGroup_ID,AD_Tab_ID,
+                           Created,CreatedBy,Updated,UpdatedBy,IsActive,Name,SeqNo,IsAdvancedField,IsDisplayed,
+                           IsDisplayedGrid,SeqNoGrid,IsDisplayed_SideList,SeqNo_SideList,AD_UI_ElementType,
+                           IsAllowFiltering,IsMultiline,Multiline_LinesCount)
+VALUES (653146 /*From ID Server*/,0,0,782296,553597,548455,
+        TO_TIMESTAMP('2026-08-14 11:05:30','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        TO_TIMESTAMP('2026-08-14 11:05:30','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y',
+        'Benutzerdef. Text 2',110,'Y','Y',
+        'N',0,'N',0,'F',
+        'N','N',0);
+
+-- ============================ slot 3 ============================
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,
+                        ColumnName,EntityType,Name,PrintName)
+VALUES (585303 /*From ID Server*/,0,0,'Y',
+        TO_TIMESTAMP('2026-08-14 11:06:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        TO_TIMESTAMP('2026-08-14 11:06:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        'CustomValueString3','D','Benutzerdef. Text 3','Benutzerdef. Text 3');
+
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,
+                            Name,PrintName,IsTranslated)
+SELECT l.AD_Language,585303 /*From ID Server*/,0,0,'Y',
+       TO_TIMESTAMP('2026-08-14 11:06:01','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+       TO_TIMESTAMP('2026-08-14 11:06:01','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+       'Benutzerdef. Text 3','Benutzerdef. Text 3','N'
+FROM AD_Language l WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y')
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Element_ID=585303 AND tt.AD_Language=l.AD_Language);
+
+UPDATE AD_Element_Trl SET Name='Custom Text 3', PrintName='Custom Text 3', IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 11:06:02','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Element_ID=585303 AND AD_Language='en_US';
+
+UPDATE AD_Element_Trl SET IsTranslated='Y',
+  Updated=TO_TIMESTAMP('2026-08-14 11:06:03','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100
+WHERE AD_Element_ID=585303 AND AD_Language IN ('de_DE','de_CH');
+
+INSERT INTO AD_Column (AD_Column_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,Updated,CreatedBy,UpdatedBy,
+                       Name,Version,EntityType,ColumnName,AD_Table_ID,AD_Reference_ID,FieldLength,
+                       IsKey,IsParent,IsMandatory,IsUpdateable,IsIdentifier,SeqNo,IsTranslated,IsEncrypted,
+                       IsSelectionColumn,AD_Element_ID,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,
+                       IsAdvancedText,IsLazyLoading,IsCalculated,IsGenericZoomOrigin,IsGenericZoomKeyColumn,
+                       IsUseDocSequence,IsStaleable,DDL_NoForeignKey,IsDimension,IsDLMPartitionBoundary,
+                       CacheInvalidateParent,SelectionColumnSeqNo,IsRangeFilter,IsShowFilterIncrementButtons,
+                       IsForceIncludeInGeneratedModel,PersonalDataCategory,IsAutoApplyValidationRule,IsFacetFilter,
+                       MaxFacetsToFetch,FacetFilterSeqNo,IsShowFilterInline,IsExcludeFromZoomTargets,
+                       IsRestApiCustomColumn,CloningStrategy,IsShowFilterInactiveValues)
+VALUES (593313 /*From ID Server*/,0,0,'Y',
+        TO_TIMESTAMP('2026-08-14 11:07:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',
+        TO_TIMESTAMP('2026-08-14 11:07:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,100,
+        'Benutzerdef. Text 3',0,'D','CustomValueString3',542540,10,60,
+        'N','N','N','Y','N',0,'N','N',
+        'N',585303,'N','N','N','Y',
+        'N','N','N','N','N','N','N','N','N','N',
+        'Y',0,'N','N',
+        'N','NP','N','N',
+        0,0,'N','Y',
+        'N','XX','N');
+
+INSERT INTO AD_Field (AD_Field_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,
+                      Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,IsReadOnly,IsSameLine,IsHeading,
+                      IsFieldOnly,IsEncrypted,EntityType,ColumnDisplayLength,IncludedTabHeight,IsDisplayedGrid,
+                      SpanX,SpanY,IsAlwaysUpdateable,IsOverrideFilterDefaultValue,IsHideGridColumnIfEmpty)
+VALUES (782297 /*From ID Server*/,0,0,'Y',
+        TO_TIMESTAMP('2026-08-14 11:08:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        TO_TIMESTAMP('2026-08-14 11:08:00','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        'Benutzerdef. Text 3',548455,593313,'Y',60,'N','N','N',
+        'N','N','D',0,0,'N',
+        1,1,'N','N','N');
+
+INSERT INTO AD_UI_Element (AD_UI_Element_ID,AD_Client_ID,AD_Org_ID,AD_Field_ID,AD_UI_ElementGroup_ID,AD_Tab_ID,
+                           Created,CreatedBy,Updated,UpdatedBy,IsActive,Name,SeqNo,IsAdvancedField,IsDisplayed,
+                           IsDisplayedGrid,SeqNoGrid,IsDisplayed_SideList,SeqNo_SideList,AD_UI_ElementType,
+                           IsAllowFiltering,IsMultiline,Multiline_LinesCount)
+VALUES (653147 /*From ID Server*/,0,0,782297,553597,548455,
+        TO_TIMESTAMP('2026-08-14 11:08:30','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,
+        TO_TIMESTAMP('2026-08-14 11:08:30','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC',100,'Y',
+        'Benutzerdef. Text 3',120,'Y','Y',
+        'N',0,'N',0,'F',
+        'N','N',0);
+
+-- backfill AD_Column_Trl / AD_Field_Trl for all languages, then cascade each element's translations onto them
+SELECT add_missing_translations();
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585301, 'en_US');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585301, 'de_DE');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585301, 'de_CH');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585302, 'en_US');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585302, 'de_DE');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585302, 'de_CH');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585303, 'en_US');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585303, 'de_DE');
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585303, 'de_CH');

--- a/misc/de-metas-common/de-metas-common-delivery/src/main/java/de/metas/common/delivery/v1/json/DeliveryMappingConstants.java
+++ b/misc/de-metas-common/de-metas-common-delivery/src/main/java/de/metas/common/delivery/v1/json/DeliveryMappingConstants.java
@@ -32,6 +32,8 @@ public class DeliveryMappingConstants
 	// attributeTypes
 	public static final String ATTRIBUTE_TYPE_SENDER_ATTENTION = "SenderAttention";
 	public static final String ATTRIBUTE_TYPE_RECEIVER_ATTENTION = "ReceiverAttention";
+	public static final String ATTRIBUTE_TYPE_SENDER_CUSTNO = "SenderCustNo";
+	public static final String ATTRIBUTE_TYPE_RECEIVER_CUSTNO = "ReceiverCustNo";
 	public static final String ATTRIBUTE_TYPE_REFERENCE = "Reference";
 	public static final String ATTRIBUTE_TYPE_LINE_REFERENCE = "LineReference";
 	public static final String ATTRIBUTE_TYPE_DETAIL_GROUP = "DetailGroup";
@@ -58,6 +60,13 @@ public class DeliveryMappingConstants
 	public static final String ATTRIBUTE_VALUE_IS_PRE_ADVICE_REQUIRED = "IsPreAdviceRequired";
 	public static final String ATTRIBUTE_VALUE_INCOTERMS_VALUE = "IncotermsValue";
 	public static final String ATTRIBUTE_VALUE_EXTERNAL_SYSTEM_VALUE = "ExternalSystemValue";
+
+	// Generic pass-through of a shipper-config additional property (the Carrier_Config column of the same name).
+	// Carrier-agnostic on purpose: e.g. for DHL Freight the consignee id is stored here and a SenderCustNo /
+	// ReceiverCustNo mapping rule routes it into the nShift address CustNo. Three interchangeable slots.
+	public static final String ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_1 = "CustomValueString1";
+	public static final String ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_2 = "CustomValueString2";
+	public static final String ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_3 = "CustomValueString3";
 
 	// attributeValuesLine
 	public static final String ATTRIBUTE_VALUE_PARCEL_ID = "ParcelId";

--- a/misc/de-metas-common/de-metas-common-delivery/src/main/java/de/metas/common/delivery/v1/json/request/JsonDeliveryAdvisorRequest.java
+++ b/misc/de-metas-common/de-metas-common-delivery/src/main/java/de/metas/common/delivery/v1/json/request/JsonDeliveryAdvisorRequest.java
@@ -190,6 +190,11 @@ public class JsonDeliveryAdvisorRequest
 						.map(JsonQuantity::getUomCode)
 						.collect(ImmutableSet.toImmutableSet());
 				return uomCodes.size() == 1 ? uomCodes.iterator().next() : null;
+			case DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_1:
+			case DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_2:
+			case DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_3:
+				// the attribute value name IS the Carrier_Config column / shipper-config property key
+				return shipperConfig.getAdditionalProperty(attributeValue);
 			default:
 				return null; // attribute not available at advise time — filtered out by caller
 		}

--- a/misc/de-metas-common/de-metas-common-delivery/src/main/java/de/metas/common/delivery/v1/json/request/JsonDeliveryRequest.java
+++ b/misc/de-metas-common/de-metas-common-delivery/src/main/java/de/metas/common/delivery/v1/json/request/JsonDeliveryRequest.java
@@ -116,7 +116,10 @@ public class JsonDeliveryRequest
 			case DeliveryMappingConstants.ATTRIBUTE_VALUE_SENDER_COUNTRY_CODE:
 				return getPickupAddress().getCountry();
 			case DeliveryMappingConstants.ATTRIBUTE_VALUE_SHIPPER_PRODUCT_EXTERNAL_ID:
-				return getShipperProduct() != null ? getShipperProduct().getCode() : null;
+				// "" (not null) when no product is selected: JsonMappingConfig.isConfigForShipperProduct() takes @NonNull,
+				// so "" means product-scoped configs are skipped while general configs still apply — no NPE. Mirrors
+				// JsonDeliveryAdvisorRequest.getValue().
+				return getShipperProduct() != null ? getShipperProduct().getCode() : "";
 			case DeliveryMappingConstants.ATTRIBUTE_VALUE_SHIPPER_EORI:
 				return getShipperEORI();
 			case DeliveryMappingConstants.ATTRIBUTE_VALUE_RECEIVER_BPARTNER_ATTENTION:

--- a/misc/de-metas-common/de-metas-common-delivery/src/main/java/de/metas/common/delivery/v1/json/request/JsonDeliveryRequest.java
+++ b/misc/de-metas-common/de-metas-common-delivery/src/main/java/de/metas/common/delivery/v1/json/request/JsonDeliveryRequest.java
@@ -129,6 +129,11 @@ public class JsonDeliveryRequest
 				return externalSystemValue;
 			case DeliveryMappingConstants.ATTRIBUTE_VALUE_IS_PRE_ADVICE_REQUIRED:
 				return preAdviceRequired;
+			case DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_1:
+			case DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_2:
+			case DeliveryMappingConstants.ATTRIBUTE_VALUE_CUSTOM_VALUE_STRING_3:
+				// the attribute value name IS the Carrier_Config column / shipper-config property key
+				return shipperConfig.getAdditionalProperty(attributeValue);
 			default:
 				return null; // attribute not available at request level — filtered out by caller
 		}


### PR DESCRIPTION
## What
Generic `SenderCustNo` / `ReceiverCustNo` nShift mapping attribute types that set the nShift address `CustNo` from a mapping rule, sourced from three carrier-agnostic `Carrier_Config.CustomValueString1..3` config fields.

## Why
nShift can require a carrier account / consignee id on the sender or receiver address (`CustNo`). This wires it through the existing mapping-config mechanism instead of a carrier-specific field. For DHL Freight the operator stores the consignee id in one of the custom-value fields and a `ReceiverCustNo` rule routes it into the address `CustNo`.

## How
- `ShipperConfigRepository` already maps every non-excluded `Carrier_Config` column to a `JsonShipperConfig` additional property by column name → the three new `CustomValueStringN` columns become `additionalProperty("CustomValueStringN")` (no `X_` regen needed — the repo reads columns dynamically via `POInfo`).
- `JsonDeliveryRequest` / `JsonDeliveryAdvisorRequest.getValue` resolve `CustomValueStringN` from that property.
- `NShiftUtil.buildAddressWithAttentionFromMappings` sets the address `CustNo` from a `SenderCustNo` / `ReceiverCustNo` mapping rule (optional; omitted when unconfigured).
- New reference-list codes + `AttributeType` / `AttributeValue` enum entries.
- `Carrier_Config.CustomValueString1..3` columns + **advanced, non-grid** fields on the nShift configuration tab (`AD_Tab` 548455), labels "Benutzerdef. Text 1..3" / "Custom Text 1..3".

## Out of scope
The per-shipper `M_Shipper_Mapping_Config` rows and the actual custom values (e.g. the DHL consignee id) are instance configuration/data.

## Tests
`NShiftShipmentServiceTest.buildShipmentRequest_setsCustNoFromCustomValueString1MappingRule` — asserts the address `CustNo` is set from the `CustomValueString1` config value via a mapping rule (verified RED without the change, GREEN with it).
