### PR TITLE
Order line: clearing the product no longer throws from the packing-instruction callout

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/reservation/interceptor/C_OrderLine.java
@@ -99,13 +99,21 @@ public class C_OrderLine
 	@CalloutMethod(columnNames = de.metas.interfaces.I_C_OrderLine.COLUMNNAME_M_Product_ID)
 	public void onProductSetOrChanged(final de.metas.interfaces.I_C_OrderLine orderLine)
 	{
+		// This fires on every change to M_Product_ID, clearing the field included. There is then no product to
+		// default a packing instruction for, so the current one is left for the user to change separately.
+		final ProductId productId = ProductId.ofRepoIdOrNull(orderLine.getM_Product_ID());
+		if (productId == null)
+		{
+			return;
+		}
+
 		final org.compiere.model.I_C_Order order = ordersRepo.getById(OrderId.ofRepoId(orderLine.getC_Order_ID()));
 
 		final ZonedDateTime date = extractPriceDate(orderLine, order);
 
 		final Optional<HUPIItemProductId> huPiItemProductId = hupiItemProductDAO.retrieveDefaultIdForProduct(
-				ProductId.ofRepoId(orderLine.getM_Product_ID()),
-				BPartnerId.ofRepoId(orderLine.getC_BPartner_ID()),
+				productId,
+				BPartnerId.ofRepoIdOrNull(orderLine.getC_BPartner_ID()),
 				date,
 				getPriceListVersionIdOrNull(orderLine, order, date));
 		final Properties ctx = Env.getCtx();

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
@@ -59,6 +59,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.load;
 import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Covers the manual sales order line path: setting or changing the product on an order line must only
@@ -257,6 +258,38 @@ public class C_OrderLineTest
 		saveRecord(order);
 	}
 
+	/**
+	 * Clearing the product on the line fires this callout with {@code M_Product_ID} unset. There is no
+	 * product to default a packing instruction for, and the callout must not throw — an AD
+	 * {@code Mandatory} flag is only enforced on persist, so a pre-save callout genuinely sees the cleared
+	 * value, exactly as it does for an unset DatePromised above.
+	 */
+	@Test
+	public void productCleared_doesNotThrowAndLeavesThePackingInstructionAlone()
+	{
+		setEnforcePrecisePrice(true);
+		createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+		final int packingInstructionBefore = orderLine.getM_HU_PI_Item_Product_ID();
+		clearOrderLineProduct();
+
+		assertThatCode(() -> interceptor.onProductSetOrChanged(orderLine)).doesNotThrowAnyException();
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(packingInstructionBefore);
+	}
+
+	/** The business partner is read on the same lookup call and is just as unset-able while editing. */
+	@Test
+	public void bpartnerCleared_doesNotThrow()
+	{
+		setEnforcePrecisePrice(true);
+		createDefaultForProductPackingInstruction();
+		createProductPrice(null);
+		clearOrderLineBPartner();
+
+		assertThatCode(() -> interceptor.onProductSetOrChanged(orderLine)).doesNotThrowAnyException();
+	}
+
 	private void clearOrderLineDatePromised()
 	{
 		orderLine.setDatePromised(null);
@@ -401,5 +434,17 @@ public class C_OrderLineTest
 			productPrice.setM_HU_PI_Item_Product(huPiItemProduct);
 		}
 		saveRecord(productPrice);
+	}
+
+	private void clearOrderLineProduct()
+	{
+		orderLine.setM_Product_ID(0);
+		saveRecord(orderLine);
+	}
+
+	private void clearOrderLineBPartner()
+	{
+		orderLine.setC_BPartner_ID(0);
+		saveRecord(orderLine);
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/reservation/interceptor/C_OrderLineTest.java
@@ -268,26 +268,32 @@ public class C_OrderLineTest
 	public void productCleared_doesNotThrowAndLeavesThePackingInstructionAlone()
 	{
 		setEnforcePrecisePrice(true);
-		createDefaultForProductPackingInstruction();
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
 		createProductPrice(null);
-		final int packingInstructionBefore = orderLine.getM_HU_PI_Item_Product_ID();
+		givenTheLineAlreadyHasPackingInstruction(piip);
 		clearOrderLineProduct();
 
 		assertThatCode(() -> interceptor.onProductSetOrChanged(orderLine)).doesNotThrowAnyException();
 
-		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(packingInstructionBefore);
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
 	}
 
-	/** The business partner is read on the same lookup call and is just as unset-able while editing. */
+	/**
+	 * The business partner is read on the same lookup call and is just as unset-able while editing. Unlike the
+	 * product it needs no early return — the lookup accepts no partner and simply drops that filter — so the
+	 * default must still be applied rather than merely not throwing.
+	 */
 	@Test
-	public void bpartnerCleared_doesNotThrow()
+	public void bpartnerCleared_stillAppliesTheDefault()
 	{
 		setEnforcePrecisePrice(true);
-		createDefaultForProductPackingInstruction();
-		createProductPrice(null);
+		final I_M_HU_PI_Item_Product piip = createDefaultForProductPackingInstruction();
+		createProductPrice(piip);
 		clearOrderLineBPartner();
 
-		assertThatCode(() -> interceptor.onProductSetOrChanged(orderLine)).doesNotThrowAnyException();
+		interceptor.onProductSetOrChanged(orderLine);
+
+		assertThat(orderLine.getM_HU_PI_Item_Product_ID()).isEqualTo(piip.getM_HU_PI_Item_Product_ID());
 	}
 
 	private void clearOrderLineDatePromised()
@@ -434,6 +440,12 @@ public class C_OrderLineTest
 			productPrice.setM_HU_PI_Item_Product(huPiItemProduct);
 		}
 		saveRecord(productPrice);
+	}
+
+	private void givenTheLineAlreadyHasPackingInstruction(@NonNull final I_M_HU_PI_Item_Product piip)
+	{
+		orderLine.setM_HU_PI_Item_Product_ID(piip.getM_HU_PI_Item_Product_ID());
+		saveRecord(orderLine);
 	}
 
 	private void clearOrderLineProduct()


### PR DESCRIPTION
Clearing the product on an order line threw an assumption failure out of the packing-instruction callout, and the message asked the user to forward it to metas.

## What

`C_OrderLine.onProductSetOrChanged` in `de.metas.handlingunits.reservation.interceptor` is annotated `@CalloutMethod(columnNames = M_Product_ID)` and `@ModelChange(BEFORE_CHANGE, ifColumnsChanged = M_Product_ID)`, so it fires on **every** change to the product — including clearing it. It then called `ProductId.ofRepoId(orderLine.getM_Product_ID())` with `0`, and `Check.assumeGreaterThanZero` threw. What the user saw was *"Ihr Test hat einen bisher unentdeckten Fehler offengelegt. Bitte leiten Sie diese Meldung an metas weiter"* — the product literally asking to be reported.

The callout now returns early when there is no product. There is nothing to default a packing instruction for, and the one already on the line is left for the user to change separately. That matches `HUOrderBL.updateOrderLine`, reached from the other `M_Product_ID`-watching interceptor on the same table, which already does `if (productId == null) { return; }` without clearing.

The business partner was read on the same lookup call with the same exposure, but it needed no early return: `IHUPIItemProductDAO.retrieveDefaultIdForProduct` declares that parameter `@Nullable`, and a null partner is honoured all the way down — `BPartnerId.toRepoId(null)` yields `-1`, and `HUPIItemProductDAO.buildQueryFilters` only applies the partner filter when `getC_BPartner_ID() > 0`. So it is passed as `ofRepoIdOrNull` and the lookup still runs.

## How it was verified

TDD — both tests were RED against the unchanged code, failing at `Check.assumeGreaterThanZero`, the same frame as the production stack.

The first version of the "leaves the packing instruction alone" test was **vacuous** and this was caught in review: the fixture never assigns `M_HU_PI_Item_Product_ID`, so the captured before-value was always `0` and the assertion held whether the guard preserved the value or cleared it. The line now starts with a real packing instruction. Confirmed by mutation: injecting `orderLine.setM_HU_PI_Item_Product_ID(0)` into the guard makes the test fail, and removing it makes it pass.

The partner test likewise asserted only that nothing was thrown, which would have hidden a wrong-default regression; it now asserts the default is applied, which the bpartner-agnostic fixture makes deterministic.

| Suite | Result |
|---|---|
| `de.metas.handlingunits.base` (full module) | 1107 tests, 0 failures, 22 pre-existing skips |
| `C_OrderLineTest` (the touched class) | 11 tests, 0 failures |
