### PR TITLE
AD_Table cache: stop flushing the whole table metadata map on every miss

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/table/api/impl/TableIdsCache.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/table/api/impl/TableIdsCache.java
@@ -1,5 +1,6 @@
 package org.adempiere.ad.table.api.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
@@ -31,7 +32,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 /*
  * #%L
@@ -68,6 +72,19 @@ public class TableIdsCache
 			.build();
 
 	private final JUnitGeneratedTableInfoMap junitGeneratedTableInfoMap = new JUnitGeneratedTableInfoMap();
+
+	@NonNull private final Supplier<TableInfoMap> tableInfoMapLoader;
+
+	private TableIdsCache()
+	{
+		this.tableInfoMapLoader = this::retrieveTableInfoMap;
+	}
+
+	@VisibleForTesting
+	TableIdsCache(@NonNull final Supplier<TableInfoMap> tableInfoMapLoader)
+	{
+		this.tableInfoMapLoader = tableInfoMapLoader;
+	}
 
 	public AdTableId getTableIdNotNull(@NonNull final String tableName)
 	{
@@ -155,41 +172,61 @@ public class TableIdsCache
 		}
 	}
 
-	private TableInfo getTableInfo(final String tableName)
+	@VisibleForTesting
+	TableInfo getTableInfo(final String tableName)
 	{
-		TableInfo tableInfo = getTableInfoMap().getTableInfoOrNull(tableName);
+		TableInfoMap tableInfoMap = getTableInfoMap();
+		TableInfo tableInfo = tableInfoMap.getTableInfoOrNull(tableName);
 
 		// Finding no table info for a given table name is pretty unusual,
 		// and when happens it happens when a sysadm user just created the table.
 		// As a solution/workaround we are invalidating the cache and trying it again.
-		if (tableInfo == null)
+		//
+		// We do that at most once per table name and cache generation: resetting flushes the
+		// table metadata of the whole app server, so a name which is *permanently* unknown
+		// (e.g. AD metadata referencing a table that no longer exists) would otherwise flush it
+		// on every single lookup. A name that is still missing right after a reload does not
+		// exist, so we remember it on the freshly loaded map and stop resetting for it.
+		if (tableInfo == null && !tableInfoMap.isKnownMissing(tableName))
 		{
 			tableInfoMapHolder.reset();
-			tableInfo = getTableInfoMap().getTableInfoOrNull(tableName);
+			tableInfoMap = getTableInfoMap();
+			tableInfo = tableInfoMap.getTableInfoOrNull(tableName);
 			if (tableInfo == null)
 			{
-				throw new AdempiereException("No table info found for `" + tableName + "`");
+				tableInfoMap.markMissing(tableName);
 			}
+		}
+
+		if (tableInfo == null)
+		{
+			throw new AdempiereException("No table info found for `" + tableName + "`");
 		}
 
 		return tableInfo;
 	}
 
-	private TableInfo getTableInfo(@NonNull final AdTableId adTableId)
+	@VisibleForTesting
+	TableInfo getTableInfo(@NonNull final AdTableId adTableId)
 	{
-		TableInfo tableInfo = getTableInfoMap().getTableInfoOrNull(adTableId);
+		TableInfoMap tableInfoMap = getTableInfoMap();
+		TableInfo tableInfo = tableInfoMap.getTableInfoOrNull(adTableId);
 
-		// Finding no table info for a given table name is pretty unusual,
-		// and when happens it happens when a sysadm user just created the table.
-		// As a solution/workaround we are invalidating the cache and trying it again.
-		if (tableInfo == null)
+		// See getTableInfo(String) for why we reset at most once per AD_Table_ID and cache generation.
+		if (tableInfo == null && !tableInfoMap.isKnownMissing(adTableId))
 		{
 			tableInfoMapHolder.reset();
-			tableInfo = getTableInfoMap().getTableInfoOrNull(adTableId);
+			tableInfoMap = getTableInfoMap();
+			tableInfo = tableInfoMap.getTableInfoOrNull(adTableId);
 			if (tableInfo == null)
 			{
-				throw new AdempiereException("No table info found for " + adTableId);
+				tableInfoMap.markMissing(adTableId);
 			}
+		}
+
+		if (tableInfo == null)
+		{
+			throw new AdempiereException("No table info found for " + adTableId);
 		}
 
 		return tableInfo;
@@ -197,7 +234,7 @@ public class TableIdsCache
 
 	private TableInfoMap getTableInfoMap()
 	{
-		return tableInfoMapHolder.getOrLoad(0, this::retrieveTableInfoMap);
+		return tableInfoMapHolder.getOrLoad(0, tableInfoMapLoader::get);
 	}
 
 	private TableInfoMap retrieveTableInfoMap()
@@ -274,7 +311,7 @@ public class TableIdsCache
 
 	@Value
 	@Builder
-	private static class TableInfo
+	static class TableInfo
 	{
 		@NonNull
 		AdTableId adTableId;
@@ -289,10 +326,19 @@ public class TableIdsCache
 		TooltipType tooltipType;
 	}
 
-	private static class TableInfoMap
+	static class TableInfoMap
 	{
 		private final ImmutableMap<TableNameKey, TableInfo> tableInfoByTableName;
 		private final ImmutableMap<AdTableId, TableInfo> tableInfoByTableId;
+
+		/**
+		 * Table names/IDs which were confirmed to be missing from THIS snapshot, i.e. they were still
+		 * not found right after this snapshot was loaded. Tracked per snapshot on purpose: as soon as
+		 * the underlying cache is invalidated, a fresh snapshot with an empty set is loaded, so a table
+		 * which was created in the meantime is found again.
+		 */
+		private final Set<TableNameKey> knownMissingTableNames = ConcurrentHashMap.newKeySet();
+		private final Set<AdTableId> knownMissingTableIds = ConcurrentHashMap.newKeySet();
 
 		TableInfoMap(@NonNull final List<TableInfo> list)
 		{
@@ -319,6 +365,26 @@ public class TableIdsCache
 		public TableInfo getTableInfoOrNull(final AdTableId adTableId)
 		{
 			return tableInfoByTableId.get(adTableId);
+		}
+
+		public boolean isKnownMissing(final String tableName)
+		{
+			return knownMissingTableNames.contains(TableNameKey.of(tableName));
+		}
+
+		public void markMissing(final String tableName)
+		{
+			knownMissingTableNames.add(TableNameKey.of(tableName));
+		}
+
+		public boolean isKnownMissing(final AdTableId adTableId)
+		{
+			return knownMissingTableIds.contains(adTableId);
+		}
+
+		public void markMissing(final AdTableId adTableId)
+		{
+			knownMissingTableIds.add(adTableId);
 		}
 	}
 

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/table/api/impl/TableIdsCacheTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/table/api/impl/TableIdsCacheTest.java
@@ -1,0 +1,144 @@
+package org.adempiere.ad.table.api.impl;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.adempiere.service.impl.TooltipType;
+import org.adempiere.ad.table.api.AdTableId;
+import org.adempiere.ad.table.api.impl.TableIdsCache.TableInfo;
+import org.adempiere.ad.table.api.impl.TableIdsCache.TableInfoMap;
+import org.adempiere.exceptions.AdempiereException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/*
+ * #%L
+ * de.metas.adempiere.adempiere.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+class TableIdsCacheTest
+{
+	private static final AdTableId EXISTING_TABLE_ID = AdTableId.ofRepoId(318);
+	private static final String EXISTING_TABLE_NAME = "C_Order";
+	private static final AdTableId MISSING_TABLE_ID = AdTableId.ofRepoId(999_999);
+	private static final String MISSING_TABLE_NAME = "NoSuchTable";
+
+	private static TableInfo tableInfo(final AdTableId adTableId, final String tableName)
+	{
+		return TableInfo.builder()
+				.adTableId(adTableId)
+				.tableName(tableName)
+				.entityType("D")
+				.tooltipType(TooltipType.DEFAULT)
+				.build();
+	}
+
+	private static TableInfoMap mapOf(final TableInfo... tableInfos)
+	{
+		return new TableInfoMap(ImmutableList.copyOf(tableInfos));
+	}
+
+	@Test
+	@DisplayName("repeatedly looking up a missing table name reloads AD_Table only once")
+	void repeatedMissingTableName_reloadsOnlyOnce()
+	{
+		final AtomicInteger loadCount = new AtomicInteger();
+		final TableIdsCache cache = new TableIdsCache(() -> {
+			loadCount.incrementAndGet();
+			return mapOf(tableInfo(EXISTING_TABLE_ID, EXISTING_TABLE_NAME));
+		});
+
+		for (int i = 0; i < 5; i++)
+		{
+			assertThatThrownBy(() -> cache.getTableInfo(MISSING_TABLE_NAME))
+					.isInstanceOf(AdempiereException.class);
+		}
+
+		// initial load + exactly one reset-triggered reload
+		assertThat(loadCount.get()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("repeatedly looking up a missing AD_Table_ID reloads AD_Table only once")
+	void repeatedMissingTableId_reloadsOnlyOnce()
+	{
+		final AtomicInteger loadCount = new AtomicInteger();
+		final TableIdsCache cache = new TableIdsCache(() -> {
+			loadCount.incrementAndGet();
+			return mapOf(tableInfo(EXISTING_TABLE_ID, EXISTING_TABLE_NAME));
+		});
+
+		for (int i = 0; i < 5; i++)
+		{
+			assertThatThrownBy(() -> cache.getTableInfo(MISSING_TABLE_ID))
+					.isInstanceOf(AdempiereException.class);
+		}
+
+		assertThat(loadCount.get()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("a table created after the cache was loaded is still picked up (recovery path kept)")
+	void justCreatedTableName_isFoundAfterReload()
+	{
+		final AtomicInteger loadCount = new AtomicInteger();
+		final TableIdsCache cache = new TableIdsCache(() -> loadCount.incrementAndGet() == 1
+				? mapOf(tableInfo(EXISTING_TABLE_ID, EXISTING_TABLE_NAME))
+				: mapOf(tableInfo(EXISTING_TABLE_ID, EXISTING_TABLE_NAME), tableInfo(MISSING_TABLE_ID, MISSING_TABLE_NAME)));
+
+		assertThat(cache.getTableInfo(MISSING_TABLE_NAME).getTableName()).isEqualTo(MISSING_TABLE_NAME);
+		assertThat(loadCount.get()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("an AD_Table_ID created after the cache was loaded is still picked up (recovery path kept)")
+	void justCreatedTableId_isFoundAfterReload()
+	{
+		final AtomicInteger loadCount = new AtomicInteger();
+		final TableIdsCache cache = new TableIdsCache(() -> loadCount.incrementAndGet() == 1
+				? mapOf(tableInfo(EXISTING_TABLE_ID, EXISTING_TABLE_NAME))
+				: mapOf(tableInfo(EXISTING_TABLE_ID, EXISTING_TABLE_NAME), tableInfo(MISSING_TABLE_ID, MISSING_TABLE_NAME)));
+
+		assertThat(cache.getTableInfo(MISSING_TABLE_ID).getAdTableId()).isEqualTo(MISSING_TABLE_ID);
+		assertThat(loadCount.get()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("an existing table is served from the cache without any reload")
+	void existingTable_noReload()
+	{
+		final AtomicInteger loadCount = new AtomicInteger();
+		final TableIdsCache cache = new TableIdsCache(() -> {
+			loadCount.incrementAndGet();
+			return mapOf(tableInfo(EXISTING_TABLE_ID, EXISTING_TABLE_NAME));
+		});
+
+		for (int i = 0; i < 5; i++)
+		{
+			assertThat(cache.getTableInfo(EXISTING_TABLE_NAME).getAdTableId()).isEqualTo(EXISTING_TABLE_ID);
+			assertThat(cache.getTableInfo(EXISTING_TABLE_ID).getTableName()).isEqualTo(EXISTING_TABLE_NAME);
+		}
+
+		assertThat(loadCount.get()).isEqualTo(1);
+	}
+}

--- a/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/table/api/impl/TableIdsCacheTest.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/test/java/org/adempiere/ad/table/api/impl/TableIdsCacheTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TableIdsCacheTest
 {
-	private static final AdTableId EXISTING_TABLE_ID = AdTableId.ofRepoId(318);
+	private static final AdTableId EXISTING_TABLE_ID = AdTableId.ofRepoId(259);
 	private static final String EXISTING_TABLE_NAME = "C_Order";
 	private static final AdTableId MISSING_TABLE_ID = AdTableId.ofRepoId(999_999);
 	private static final String MISSING_TABLE_NAME = "NoSuchTable";


### PR DESCRIPTION
`TableIdsCache` flushed the app server's entire `AD_Table` metadata map on every lookup that found no table info — not once per unknown name, but on every single lookup of it.

Found while investigating the `ad_issue` table on the instance that motivated this issue: the `No table info found for ...` rows are only the visible tip. Each of those lookups also reset the shared cache, at roughly 820 invalidations per month, and every reset forces the next caller to re-read all of `AD_Table` from the database.

## What

`getTableInfo(String)` and `getTableInfo(AdTableId)` both did:

```java
if (tableInfo == null)
{
    tableInfoMapHolder.reset();                                  // flushes the whole map
    tableInfo = getTableInfoMap().getTableInfoOrNull(tableName);  // reloads all of AD_Table
    if (tableInfo == null) { throw ...; }
}
```

The reset is deliberate and still needed — it is the recovery path for a table a sysadm has just created, whose row the cached snapshot predates. What was missing is a bound. A name that is *permanently* unknown takes that path forever: every lookup flushes, reloads, fails, and throws.

That is not hypothetical here. This issue's own triage found four table names — `BPartner`, `SalesRepIntern`, `R_SalesRep`, `Counterpart_Fact_Acct` — that AD metadata references but that exist in no `AD_Table` row. Every lookup driven by that metadata is a permanent miss, and so a full app-server-wide cache flush.

The fix bounds the reset to **once per name and per cache generation**. A name still missing immediately after the reload does not exist, so it is recorded as known-missing and stops triggering resets.

The recording lives on the `TableInfoMap` snapshot, not on the cache — and that is what preserves the recovery path. Any later invalidation loads a fresh snapshot with an empty known-missing set, so a table created in the meantime is found again. That includes the invalidation `CCache` already performs on its own: the holder is declared `.tableName("AD_Table")`, so a change to `AD_Table` drops the snapshot without anyone asking.

Deliberately unchanged: `getTableId(String)` and `getTableNameIfPresent(AdTableId)` never reset — they return `empty()` on a miss — and stay as they are.

## How it was verified

TDD. `TableIdsCacheTest` was RED against the unchanged code first, reproducing the symptom as a reload count: 5 lookups of a missing name caused **6** loads (one initial + one per lookup) where 2 is correct. Same for the `AdTableId` overload.

To make the reload count observable without a database, the `TableInfoMap` loader is injectable through a `@VisibleForTesting` constructor; the singleton keeps using `retrieveTableInfoMap`. Two nested classes and the two `getTableInfo` overloads widen from private to package-private for the same reason. The only narrowing is `TableIdsCache`'s implicit public constructor becoming private — `new TableIdsCache(` appears nowhere in the repository outside the singleton and this test.

| Suite | Result |
|---|---|
| `TableIdsCacheTest` | 5 tests, 0 failures |
| `de.metas.adempiere.adempiere.base` (full module) | 1452 tests, 0 failures, 6 pre-existing skips |

Two of the five cases are the recovery guard — `justCreatedTableName_isFoundAfterReload` and `justCreatedTableId_isFoundAfterReload` — asserting that a table appearing only in the second load is still found, at a cost of exactly one reload. Both were green before and after the change, so the reset path is provably intact. A fifth case pins that an existing table is served with no reload at all.
