### PR TITLE
ESR_ImportFile: give the table an identifier so its lookup can render

### DIFF
--- a/backend/de.metas.payment.esr/src/main/sql/postgresql/system/70-de.metas.payment.esr/5819170_sys_ESR_ImportFile_IsIdentifier.sql
+++ b/backend/de.metas.payment.esr/src/main/sql/postgresql/system/70-de.metas.payment.esr/5819170_sys_ESR_ImportFile_IsIdentifier.sql
@@ -1,0 +1,27 @@
+-- ESR_ImportFile had no identifier column at all: none of its 20 active AD_Columns carried
+-- IsIdentifier='Y'. Every lookup that has to render an ESR_ImportFile record therefore failed with
+-- "There are no lookup display columns defined for ESR_ImportFile table." The one place this is
+-- reached from is ESR_ImportLine.ESR_ImportFile_ID, a Search reference.
+--
+-- FileName is the identifier a user recognises; Created disambiguates the same file imported twice,
+-- which is the normal ESR re-import path. FileName is nullable, so the display degrades to the
+-- timestamp alone rather than to nothing.
+--
+-- SeqNo is the identifier ordering (a record's display string is built from the IsIdentifier columns
+-- in SeqNo order), so the two values must differ.
+
+UPDATE AD_Column
+SET IsIdentifier = 'Y',
+    SeqNo = 1,
+    Updated = TO_TIMESTAMP('2026-08-14 15:10:00', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Column_ID = 575155  -- ESR_ImportFile.FileName
+;
+
+UPDATE AD_Column
+SET IsIdentifier = 'Y',
+    SeqNo = 2,
+    Updated = TO_TIMESTAMP('2026-08-14 15:10:01', 'YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy = 100
+WHERE AD_Column_ID = 575143  -- ESR_ImportFile.Created
+;


### PR DESCRIPTION
`ESR_ImportFile` has no identifier column — none of its 20 active `AD_Column` rows carries `IsIdentifier='Y'` — so metasfresh cannot build a display string for the table at all.

Found while triaging an `ad_issue` table, alongside the other defects on this branch family. `LookupDisplayInfoRepository.retrieveLookupDisplayInfo` collects the identifier columns and, finding none, throws:

> There are no lookup display columns defined for ESR_ImportFile table.
> HINT: please go to Table and columns, and set IsIdentifier=Y on columns which you want to be part of record's display string.

(`backend/de.metas.adempiere.adempiere/base/src/main/java/org/adempiere/ad/service/impl/LookupDisplayInfoRepository.java:161`)

The reachable path is `ESR_ImportLine.ESR_ImportFile_ID`, the table's only inbound reference and a `Search` reference — exactly the widget that needs a display string to render and to search on.

## What

Sets two identifier columns on the existing `AD_Column` rows:

| SeqNo | Column | Reference | Why |
|---|---|---|---|
| 1 | `FileName` | String | what a user recognises the import by |
| 2 | `Created` | Date+Time | disambiguates the same file imported twice, which is the normal ESR re-import path |

`SeqNo` is the identifier ordering — a record's display string is built from the `IsIdentifier` columns in `SeqNo` order — so the two values must differ. Both rows were at `SeqNo=0`.

`FileName` is nullable, so a row with no file name degrades to the timestamp alone rather than to an empty display string. `Created` as an identifier is established practice, not a novelty: 9 tables already use it (`AD_ChangeLog`, `AD_UserMail`, `M_EDI_Info`, `R_RequestAction`, `C_Recurring_Run`, …) and 55 identifier columns across the dictionary are Date or Date+Time references.

No DDL, no new AD records — two `UPDATE`s on existing dictionary rows, so no ID-server allocation was needed beyond the script's own sequence number.

## How it was verified

Applied against a local `new_dawn_uat` stack via the migration CLI (`workspace_migrate.Main`), then verified by running the exact query `LookupDisplayInfoRepository` issues:

```sql
SELECT c.ColumnName, c.IsTranslated, c.AD_Reference_ID
FROM AD_Table t INNER JOIN AD_Column c ON (t.AD_Table_ID=c.AD_Table_ID)
WHERE t.TableName='ESR_ImportFile' AND (c.IsIdentifier='Y')
ORDER BY c.SeqNo;
```

| | Result |
|---|---|
| Before | **0 rows** → `lookupDisplayColumns.isEmpty()` → the exception above |
| After | `FileName` (ref 10), `Created` (ref 16), in `SeqNo` order → non-empty, exception unreachable |

Registered as applied under project `70-de.metas.payment.esr`.
