### PR TITLE
Credit memo allocation — assert the suspense-balancing account stays empty in S0465_CMA_170

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -3408,9 +3408,18 @@ Feature: invoice payment allocation
 
     # The allocation's receivable movements of +101.00 and -101.00 cancel, so the balance is
     # exactly the discount counter-leg. It must be a DEBIT of -1.00 => balance -1.00 EUR.
+    #
+    # The SuspenseBalancing_Acct row is the customer-reported symptom itself: an allocation that
+    # does not balance in source currency gets its residual pushed onto that account by
+    # Fact.balanceSource(). The account is absent from a correctly posted allocation, and an
+    # absent account resolves to a zero balance, so this row passes while the posting is right and
+    # fails the moment a residual reappears. It is asserted explicitly because the balance step
+    # only checks the accounts listed in this table — an extra fact line on an unlisted account
+    # would otherwise go unnoticed.
     And Fact_Acct records balances for documents alloc are matching
-      | AccountConceptualName | SourceBalance |
-      | C_Receivable_Acct     | -1.00 EUR     |
+      | AccountConceptualName  | SourceBalance |
+      | C_Receivable_Acct      | -1.00 EUR     |
+      | SuspenseBalancing_Acct | 0.00 EUR      |
 
 
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -3357,6 +3357,7 @@ Feature: invoice payment allocation
   @allure.label.feature:F00700_Invoicing
   @allure.label.epic:E0225_Accounting
   @allure.label.feature:F01010_Automatic_Accounting
+  @allure.label.feature:F01010.5_Customer_Invoice_and_Credit_Memo
   @F00700
   Scenario: sales credit memo with early-payment discount allocated against sales invoice - allocation must balance
     # The customer's payment term grants 1% Skonto.


### PR DESCRIPTION
## What

Follow-up to https://github.com/metasfresh/metasfresh/pull/25494. Test-only.

`@Id:S0465_CMA_170` — the regression scenario for the discounted sales credit memo — asserted only the `C_Receivable_Acct` balance. That assertion does discriminate the fix (the pre-fix posting left `+1.00` where the fix leaves `-1.00`), but it cannot see the reported symptom: a fact line on the **suspense-balancing account**.

`FactAcctBalanceMatchers.assertValid()` iterates only the matchers listed in the table and never asserts the absence of other accounts, so an allocation that posts an extra line onto `SuspenseBalancing_Acct` passes the scenario silently.

## The change

One row added to the existing balance table:

```gherkin
| AccountConceptualName  | SourceBalance |
| C_Receivable_Acct      | -1.00 EUR     |
| SuspenseBalancing_Acct | 0.00 EUR      |
```

This works because:
- the suspense account is built with the conceptual name `SuspenseBalancing_Acct` — `AcctSchemaDAO.toAcctSchemaGeneralLedger()` does `Account.of(accountId, I_C_AcctSchema_GL.COLUMNNAME_SuspenseBalancing_Acct)`, and `FactLineBuilder.setAccount(Account)` carries that name onto the fact line;
- an account with **no** matching fact rows resolves to a zero balance in `FactAcctBalanceMacher.assertMatching()` (`toNoneOrSingleValue().orElseGet(...::toZero)`), so the row passes while the allocation posts correctly and fails the moment `Fact.balanceSource()` plants a residual again.

## What is deliberately NOT asserted

- **The discount account's balance.** A discount tax correction posts to the same account (`PayDiscount_Rev_Acct`), so its expected balance depends on the accounting-schema configuration of the environment, not on the behaviour under test. Pinning it would make the scenario fragile for a reason unrelated to this fix.
- **An exhaustive `Fact_Acct records are matching` table.** That step *is* exhaustive per document (`FactAcctDocMatcher` fails any unmatched record with "Fact_Acct record was not expected"), which would be the strongest form — but it requires enumerating the tax-correction rows too, and those are environment-dependent as above.

## Scope note

If the cucumber environment's accounting schema has `IsUseSuspenseBalancing = N`, a source-currency imbalance surfaces as a posting exception rather than a suspense line, and the scenario already fails at `waitUtilPosted`. In that case this row is a harmless no-op guard; in an environment where suspense balancing is on, it is the direct symptom check. Either way it cannot produce a false RED.
