### PR TITLE
Merge: intensive_care_hotfix → intensive_care_release

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -3357,6 +3357,7 @@ Feature: invoice payment allocation
   @allure.label.feature:F00700_Invoicing
   @allure.label.epic:E0225_Accounting
   @allure.label.feature:F01010_Automatic_Accounting
+  @allure.label.feature:F01010.5_Customer_Invoice_and_Credit_Memo
   @F00700
   Scenario: sales credit memo with early-payment discount allocated against sales invoice - allocation must balance
     # The customer's payment term grants 1% Skonto.
@@ -3408,9 +3409,18 @@ Feature: invoice payment allocation
 
     # The allocation's receivable movements of +101.00 and -101.00 cancel, so the balance is
     # exactly the discount counter-leg. It must be a DEBIT of -1.00 => balance -1.00 EUR.
+    #
+    # The SuspenseBalancing_Acct row is the customer-reported symptom itself: an allocation that
+    # does not balance in source currency gets its residual pushed onto that account by
+    # Fact.balanceSource(). The account is absent from a correctly posted allocation, and an
+    # absent account resolves to a zero balance, so this row passes while the posting is right and
+    # fails the moment a residual reappears. It is asserted explicitly because the balance step
+    # only checks the accounts listed in this table — an extra fact line on an unlisted account
+    # would otherwise go unnoticed.
     And Fact_Acct records balances for documents alloc are matching
-      | AccountConceptualName | SourceBalance |
-      | C_Receivable_Acct     | -1.00 EUR     |
+      | AccountConceptualName  | SourceBalance |
+      | C_Receivable_Acct      | -1.00 EUR     |
+      | SuspenseBalancing_Acct | 0.00 EUR      |
 
 
 


### PR DESCRIPTION
## What

Forward-merge `intensive_care_hotfix` → `intensive_care_release`.

Carries a single commit: the merge of https://github.com/metasfresh/metasfresh/pull/25553 (test-only), which strengthens the cucumber scenario `@Id:S0465_CMA_170` so it fails if a fact line lands on the suspense-balancing account, and attributes the scenario to its own Allure feature.

The posting fix this scenario covers (https://github.com/metasfresh/metasfresh/pull/25494) is already on `intensive_care_release`.

## Scope

One commit, one file, no DDL and no migration scripts:

- `backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature`

## Merge mechanics

Merge-commit, not squash — this is a branch merge-through, so squashing would destroy the parent relationship between the two branches and make every future merge re-conflict on the same already-merged changes.
