### PR TITLE
Merge: intensive_care_release → new_dawn_uat

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/DocLine_Allocation.java
@@ -371,6 +371,34 @@ class DocLine_Allocation extends DocLine<Doc_AllocationHdr>
 		Check.assume(added, "Line should not be already compensated: {}", this);
 	}
 
+	/**
+	 * @return true if this line is a <b>sales</b> credit memo whose counter-line is a sales invoice.
+	 * <p>
+	 * For such a pair, the credit memo's receivable is cleared by
+	 * {@code Doc_AllocationHdr.createCreditMemoCompensationFacts()} while the <i>invoice</i> line is iterated,
+	 * so all that is left to book on this line is its own discount / write-off.
+	 * <p>
+	 * Unlike {@link #isInvoiceWithCreditMemoCounterLine(AcctSchemaId)} this is purely structural, i.e. it does not
+	 * depend on the order in which the allocation's lines are iterated.
+	 */
+	public boolean isSalesCreditMemoWithInvoiceCounterLine()
+	{
+		if (!hasInvoiceDocument() || !isCreditMemoInvoice() || !isSOTrxInvoice())
+		{
+			return false;
+		}
+
+		final DocLine_Allocation counterLine = getCounterDocLine();
+		if (counterLine == null || !counterLine.hasInvoiceDocument())
+		{
+			return false;
+		}
+
+		// Same SOTrx, counter is a regular invoice
+		return counterLine.isSOTrxInvoice()
+				&& !counterLine.isCreditMemoInvoice();
+	}
+
 	public boolean hasInvoiceDocument()
 	{
 		return getC_Invoice() != null;

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_AllocationHdr.java
@@ -820,6 +820,17 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			return;
 		}
 
+		// A sales credit memo which is matched against a sales invoice: its receivable is cleared in full by
+		// createCreditMemoCompensationFacts, while the invoice line is iterated. What is left here is this line's own
+		// discount/write-off, which is already booked by createInvoiceDiscountFacts/createInvoiceWriteOffFacts and
+		// which that clearing entry already absorbs (see below). Booking it again would post the credit memo's
+		// receivable a second time, on the same side as the discount leg, so the fact would not balance in source
+		// currency and Fact.balanceSource() would push the difference onto the suspense balancing account.
+		if (line.isSalesCreditMemoWithInvoiceCounterLine())
+		{
+			return;
+		}
+
 		final AcctSchema as = fact.getAcctSchema();
 		if (!as.isAccrual())
 		{
@@ -1039,6 +1050,19 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 			currencyConversionCtx = counterLine.getInvoiceCurrencyConversionCtx();
 		}
 
+		// A sales credit memo books its own discount/write-off on the same side as the clearing entry below, while its
+		// own line is iterated (createInvoiceDiscountFacts/createInvoiceWriteOffFacts). The clearing entry must
+		// therefore carry the credit memo's NET amount, so that it absorbs those legs instead of adding to them; the
+		// credit memo's own createInvoiceFacts stands down accordingly, see
+		// DocLine_Allocation.isSalesCreditMemoWithInvoiceCounterLine(). Emitting the absorbed amount as a fact line of
+		// its own is not an option: it would be a second debit line for the same clearing, which
+		// FactTrxLines.extractType rejects.
+		// For a purchase credit memo those legs already land opposite the clearing entry, so there is nothing to absorb.
+		final BigDecimal counterLineAbsorbedAmtSource = counterLine.isSOTrxInvoice()
+				? counterLine.getDiscountAmt().toBigDecimal().add(counterLine.getWriteOffAmt().toBigDecimal())
+				: BigDecimal.ZERO;
+		final BigDecimal clearingAmtSource = compensationAmtSource.subtract(counterLineAbsorbedAmtSource);
+
 		// Create fact line for the counter credit memo
 		final FactLineBuilder factLineBuilder = fact.createLine()
 				.setDocLine(counterLine)
@@ -1052,13 +1076,13 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		{
 			factLineBuilder.setAccount(getCustomerAccount(BPartnerCustomerAccountType.C_Receivable, as));
 			// ARC: DR to clear the credit memo's receivable
-			factLineBuilder.setAmtSource(compensationAmtSource, null);
+			factLineBuilder.setAmtSource(clearingAmtSource, null);
 		}
 		else
 		{
 			factLineBuilder.setAccount(getVendorAccount(BPartnerVendorAccountType.V_Liability, as));
 			// APC: CR to clear the credit memo's liability
-			factLineBuilder.setAmtSource(null, compensationAmtSource.negate());
+			factLineBuilder.setAmtSource(null, clearingAmtSource.negate());
 		}
 
 		final FactLine factLine = factLineBuilder.buildAndAddNotNull();
@@ -1067,7 +1091,25 @@ public class Doc_AllocationHdr extends Doc<DocLine_Allocation>
 		line.markAsCreditMemoInvoiceCompensated(as);
 		counterLine.markAsCreditMemoInvoiceCompensated(as);
 
-		return factLine.getAmtSourceAndAcctDrOrCr();
+		final AmountSourceAndAcct clearingAmtSourceAndAcct = factLine.getAmtSourceAndAcctDrOrCr();
+		if (counterLineAbsorbedAmtSource.signum() == 0)
+		{
+			return clearingAmtSourceAndAcct;
+		}
+
+		// This compensation settles this line's invoice by its whole allocated amount: partly by the clearing entry
+		// above, and partly by the amount it absorbed from the counter line. Reporting only the clearing entry would
+		// make createInvoiceFacts book this invoice's receivable short by the difference.
+		final BigDecimal currencyRate = factLine.getCurrencyRate();
+		final BigDecimal counterLineAbsorbedAmtAcct = currencyRate.signum() == 0 || currencyRate.compareTo(BigDecimal.ONE) == 0
+				? counterLineAbsorbedAmtSource
+				: factLine.getCurrencyRateFromDocumentToAcctCurrency().convertAmount(counterLineAbsorbedAmtSource);
+
+		return AmountSourceAndAcct.builder()
+				.add(clearingAmtSourceAndAcct)
+				.addAmtSource(counterLineAbsorbedAmtSource)
+				.addAmtAcct(counterLineAbsorbedAmtAcct)
+				.build();
 	}
 
 	/**

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -3348,6 +3348,71 @@ Feature: invoice payment allocation
       | V_Liability_Acct      | 5.95 EUR      |
 
 
+# ############################################################################################################################################
+# ############################################################################################################################################
+# ############################################################################################################################################
+  @Id:S0465_CMA_170
+  @from:cucumber
+  @allure.label.epic:E0340_Invoicing
+  @allure.label.feature:F00700_Invoicing
+  @allure.label.epic:E0225_Accounting
+  @allure.label.feature:F01010_Automatic_Accounting
+  @F00700
+  Scenario: sales credit memo with early-payment discount allocated against sales invoice - allocation must balance
+    # The customer's payment term grants 1% Skonto.
+    # Credit memo GrandTotal = 100.00 EUR (net 84.03 + 19% VAT 15.97), discount = 1.00 EUR.
+    # Allocated amount = GrandTotal + discount = 101.00 EUR.
+    # The discount leg and its receivable counter-leg must land on OPPOSITE sides.
+    # Both on the same side leaves the allocation unbalanced in source currency, and the
+    # residual is then pushed onto the suspense-balancing account.
+    Given metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | salesPLV               | product      | 84.03    | PCE      |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier     | IsCustomer | IsVendor | M_PricingSystem_ID | C_PaymentTerm_ID.Value |
+      | skontoCustomer | Y          | N        | pricingSystem      | 10 Tage 1 %            |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier             | C_BPartner_ID  | IsShipToDefault | IsBillToDefault |
+      | skontoCustomerLocation | skontoCustomer | Y               | Y               |
+
+    # Sales invoice, large enough to absorb the credit memo
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID  | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | invoice    | skontoCustomer | Ausgangsrechnung        | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID | M_Product_ID | QtyInvoiced |
+      | invoice      | product      | 10 PCE      |
+    And the invoice identified by invoice is completed
+
+    # Credit memo: 1 PCE => GrandTotal 100.00 EUR
+    And metasfresh contains C_Invoice:
+      | Identifier | C_BPartner_ID  | C_DocTypeTarget_ID.Name | DateInvoiced | C_ConversionType_ID.Name | IsSOTrx | C_Currency.ISO_Code |
+      | creditMemo | skontoCustomer | Gutschrift              | 2022-05-11   | Spot                     | true    | EUR                 |
+    And metasfresh contains C_InvoiceLines
+      | C_Invoice_ID | M_Product_ID | QtyInvoiced |
+      | creditMemo   | product      | 1 PCE       |
+    And the invoice identified by creditMemo is completed
+
+    And allocate invoices (credit memo/purchase) to invoices
+      | C_Invoice_ID | CreditMemo.C_Invoice_ID |
+      | invoice      | creditMemo              |
+
+    # The credit-memo line carries the discount; the invoice line carries none.
+    And validate C_AllocationLines
+      | C_Invoice_ID | Amount  | DiscountAmt | WriteOffAmt | C_AllocationHdr_ID |
+      | invoice      | 101.00  | 0           | 0           | alloc              |
+      | creditMemo   | -101.00 | 1.00        | 0           | alloc              |
+
+    # The allocation's receivable movements of +101.00 and -101.00 cancel, so the balance is
+    # exactly the discount counter-leg. It must be a DEBIT of -1.00 => balance -1.00 EUR.
+    And Fact_Acct records balances for documents alloc are matching
+      | AccountConceptualName | SourceBalance |
+      | C_Receivable_Acct     | -1.00 EUR     |
+
+
 
 
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/invoicePaymentAllocation.feature
@@ -3357,6 +3357,7 @@ Feature: invoice payment allocation
   @allure.label.feature:F00700_Invoicing
   @allure.label.epic:E0225_Accounting
   @allure.label.feature:F01010_Automatic_Accounting
+  @allure.label.feature:F01010.5_Customer_Invoice_and_Credit_Memo
   @F00700
   Scenario: sales credit memo with early-payment discount allocated against sales invoice - allocation must balance
     # The customer's payment term grants 1% Skonto.
@@ -3408,9 +3409,18 @@ Feature: invoice payment allocation
 
     # The allocation's receivable movements of +101.00 and -101.00 cancel, so the balance is
     # exactly the discount counter-leg. It must be a DEBIT of -1.00 => balance -1.00 EUR.
+    #
+    # The SuspenseBalancing_Acct row is the customer-reported symptom itself: an allocation that
+    # does not balance in source currency gets its residual pushed onto that account by
+    # Fact.balanceSource(). The account is absent from a correctly posted allocation, and an
+    # absent account resolves to a zero balance, so this row passes while the posting is right and
+    # fails the moment a residual reappears. It is asserted explicitly because the balance step
+    # only checks the accounts listed in this table — an extra fact line on an unlisted account
+    # would otherwise go unnoticed.
     And Fact_Acct records balances for documents alloc are matching
-      | AccountConceptualName | SourceBalance |
-      | C_Receivable_Acct     | -1.00 EUR     |
+      | AccountConceptualName  | SourceBalance |
+      | C_Receivable_Acct      | -1.00 EUR     |
+      | SuspenseBalancing_Acct | 0.00 EUR      |
 
 
 


### PR DESCRIPTION
## What

Forward-merge `intensive_care_release` → `new_dawn_uat`, completing the propagation of the credit-memo allocation posting fix (https://github.com/metasfresh/metasfresh/pull/25494) and its cucumber coverage (https://github.com/metasfresh/metasfresh/pull/25553).

Six commits, three files, **no DDL and no migration scripts**:

- `backend/de.metas.acct.base/.../DocLine_Allocation.java`
- `backend/de.metas.acct.base/.../Doc_AllocationHdr.java`
- `backend/de.metas.cucumber/.../invoice/invoicePaymentAllocation.feature`

## ⚠️ Please read before merging — this merge DELETES four scenario copies

The diff shows **54 insertions / 228 deletions** in the feature file. Most of those deletions are **not** propagated content — they remove a pre-existing duplication on `new_dawn_uat`. Since a merge PR gets no diff review, that is spelled out here explicitly.

### The duplication

`new_dawn_uat` carried `S0465_CMA_130`, `S0465_CMA_140`, `S0465_CMA_150` and `S0465_CMA_160` **twice**, under duplicate `@Id`s:

| | first copy (~line 2973) | second copy (~line 3426) |
|---|---|---|
| Title | "standalone credit memo reversed…" | "standalone **sales** credit memo (ARC) reversed… per invoice" |
| DataTable columns | plain (`M_Product_ID`) | `.Identifier`-suffixed |
| Added by | https://github.com/metasfresh/metasfresh/commit/86046dd37d507ae2526c001e1ba81d4138c90062 — "Fix credit memo reversal allocation: correct per-Line_ID DR/CR signs" | https://github.com/metasfresh/metasfresh/commit/1fbb8e945fe930787b03e9d88ec4ab8568bc47f3 — "Align CMA scenarios with soft_panda step defs and fix ARC reversal posting side" |

Both commits are from the same day and **neither is an ancestor of the other** — they were authored on divergent branches and both landed, so the duplication is a merge artifact rather than an intentional pair. Each of the four scenarios has been running twice ever since.

The second copy occupies exactly the position where the incoming `S0465_CMA_170` lands, which is what conflicted.

### What was resolved, and how

Resolving through the conflict markers put `S0465_CMA_170` **inside** one of the duplicated scenarios — the conflict region splits mid-scenario — so the file was rebuilt from its two inputs instead:

- kept `new_dawn_uat`'s content, minus its trailing duplicate block (its `Reversal scenarios ported from IC hotfix …` banner comment and the `.Identifier`-format copies of CMA_130/140/150/160);
- appended `intensive_care_release`'s `S0465_CMA_170` block verbatim.

The `.Identifier` copy is the one dropped because (a) it is the copy that collides, and (b) the surviving plain-column copy is the one `intensive_care_release` also carries — so the two branches converge instead of re-conflicting here on every future merge. Plain columns are also what this file predominantly uses on `new_dawn_uat` (40 plain vs 2 `.Identifier` price-list headers; 102 vs 54 for `C_BPartner_ID`), so the surviving copy is not the odd one out.

The resolution is scripted and re-runnable rather than hand-edited, and it self-verifies.

### Verified end state

- 9 CMA scenarios, each `@Id` **exactly once** (no duplicates remain)
- no conflict markers
- `S0465_CMA_170` present, carrying its `SuspenseBalancing_Acct` assertion
- `@allure.label.feature:F01010.5_Customer_Invoice_and_Credit_Memo` intact
- the posting fix (`isSalesCreditMemoWithInvoiceCounterLine`) present

If you would rather the de-duplication happened in its own reviewed PR, say so and it can be split out — note that de-duplicating first does **not** avoid this conflict (git still reports delete-vs-modify in the same region), so it would be an extra PR rather than a simpler merge.

## Merge mechanics

Merge-commit, **not squash** — squashing a merge-through destroys the parent relationship between the branches and makes every future merge re-conflict on the same already-merged changes.
