### PR TITLE
Fix flaky checkInvoiceCandStatus by waiting for async materialization in the consuming step

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_Candidate_StefDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_Candidate_StefDef.java
@@ -47,6 +47,13 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Step definitions for the invoice-candidate status endpoint {@code POST api/v2/invoices/status}.
+ * <p>
+ * This class owns the wait for the <b>asynchronous</b> invoice-candidate materialization behind that
+ * endpoint, so feature files assert the status response directly and never need their own
+ * "wait for the invoice candidates" steps.
+ */
 @RequiredArgsConstructor
 public class C_Invoice_Candidate_StefDef
 {
@@ -54,6 +61,10 @@ public class C_Invoice_Candidate_StefDef
 	 * The endpoint this step def validates. It is intrinsic to the step (the step is named after that
 	 * endpoint's response), which is what lets this step re-issue the request itself instead of making
 	 * every feature file wait for the invoice candidates beforehand.
+	 * <p>
+	 * Feature files calling {@code validate invoice candidate status response} must POST to this same
+	 * path — the two are not linked mechanically. If this step is ever reused against a second
+	 * endpoint, take the path from the scenario instead of this constant.
 	 */
 	private static final String STATUS_ENDPOINT_PATH = "api/v2/invoices/status";
 	private static final int STATUS_ENDPOINT_EXPECTED_STATUS_CODE = 200;
@@ -98,36 +109,45 @@ public class C_Invoice_Candidate_StefDef
 
 		try
 		{
-			StepDefUtil.tryAndWait(TIMEOUT_SEC, CHECK_INTERVAL_MS, () -> allExpectedItemsArePresent(rows));
+			StepDefUtil.tryAndWait(TIMEOUT_SEC, CHECK_INTERVAL_MS, () -> checkExpectedItemsPresentAndReissueIfNot(rows));
 		}
 		catch (final AssertionError timedOut)
 		{
-			// Deliberately fall through to the assertions below: they name the exact ExternalLineId that is
-			// missing, which is more useful than the generic "worker didn't succeed within the timeout".
+			// Only the poll timeout can reach here: reissueStatusRequest() converts a failed HTTP-status
+			// assertion into an AdempiereException, so a real server error is never mistaken for a timeout.
+			// Falling through lets assertResponseMatches() name the exact missing ExternalLineId, which is
+			// more useful than the generic "worker didn't succeed within the timeout".
 		}
 
 		assertResponseMatches(rows);
 	}
 
 	/**
-	 * @return {@code true} as soon as the last status response holds an item for every expected
-	 *         {@code ExternalLineId}; otherwise re-issues the status request — so the next poll iteration sees a
-	 *         fresh response — and returns {@code false}.
+	 * One poll iteration: checks the last status response and, when it is still incomplete, re-issues the
+	 * request so the next iteration sees a fresh one.
+	 *
+	 * @return {@code true} once the last response holds an item for every expected {@code ExternalLineId}
 	 */
-	private boolean allExpectedItemsArePresent(@NonNull final DataTableRows rows)
+	private boolean checkExpectedItemsPresentAndReissueIfNot(@NonNull final DataTableRows rows)
 	{
-		final Map<String, JsonCheckInvoiceCandidatesStatusResponseItem> responseItemMap = extractResponseItemMap();
-
-		final boolean allPresent = rows.stream()
-				.allMatch(row -> responseItemMap.containsKey(row.getAsString(I_C_Invoice_Candidate.COLUMNNAME_ExternalLineId)));
-
-		if (allPresent)
+		if (allExpectedItemsArePresent(rows))
 		{
 			return true;
 		}
 
 		reissueStatusRequest();
 		return false;
+	}
+
+	/**
+	 * Pure check against the <b>last</b> status response — issues no request and has no side effects.
+	 */
+	private boolean allExpectedItemsArePresent(@NonNull final DataTableRows rows)
+	{
+		final Map<String, JsonCheckInvoiceCandidatesStatusResponseItem> responseItemMap = extractResponseItemMap();
+
+		return rows.stream()
+				.allMatch(row -> responseItemMap.containsKey(row.getAsString(I_C_Invoice_Candidate.COLUMNNAME_ExternalLineId)));
 	}
 
 	private void reissueStatusRequest()
@@ -146,6 +166,13 @@ public class C_Invoice_Candidate_StefDef
 		catch (final IOException e)
 		{
 			throw new AdempiereException("Failed to re-issue the request to " + STATUS_ENDPOINT_PATH, e);
+		}
+		catch (final AssertionError httpStatusMismatch)
+		{
+			// The status assertion inside performHTTPRequest fails with an AssertionError, which the caller
+			// treats as the poll-timeout signal and swallows. Rethrowing as an AdempiereException keeps a
+			// genuine server error (e.g. a 500 during materialization) loud and correctly attributed.
+			throw new AdempiereException("Re-issued request to " + STATUS_ENDPOINT_PATH + " failed: " + httpStatusMismatch.getMessage(), httpStatusMismatch);
 		}
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_Candidate_StefDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_Candidate_StefDef.java
@@ -31,6 +31,7 @@ import de.metas.cucumber.stepdefs.StepDefUtil;
 import de.metas.cucumber.stepdefs.api.REST_API_StepDef;
 import de.metas.cucumber.stepdefs.context.TestContext;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
+import de.metas.logging.LogManager;
 import de.metas.rest_api.invoicecandidates.response.JsonCheckInvoiceCandidatesStatusResponse;
 import de.metas.rest_api.invoicecandidates.response.JsonCheckInvoiceCandidatesStatusResponseItem;
 import io.cucumber.datatable.DataTable;
@@ -39,10 +40,10 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.exceptions.AdempiereException;
 import org.assertj.core.api.SoftAssertions;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -66,6 +67,8 @@ public class C_Invoice_Candidate_StefDef
 	 * path — the two are not linked mechanically. If this step is ever reused against a second
 	 * endpoint, take the path from the scenario instead of this constant.
 	 */
+	private static final Logger logger = LogManager.getLogger(C_Invoice_Candidate_StefDef.class);
+
 	private static final String STATUS_ENDPOINT_PATH = "api/v2/invoices/status";
 	private static final int STATUS_ENDPOINT_EXPECTED_STATUS_CODE = 200;
 	private static final long TIMEOUT_SEC = 60;
@@ -113,10 +116,12 @@ public class C_Invoice_Candidate_StefDef
 		}
 		catch (final AssertionError timedOut)
 		{
-			// Only the poll timeout can reach here: reissueStatusRequest() converts a failed HTTP-status
-			// assertion into an AdempiereException, so a real server error is never mistaken for a timeout.
-			// Falling through lets assertResponseMatches() name the exact missing ExternalLineId, which is
-			// more useful than the generic "worker didn't succeed within the timeout".
+			// Only the poll timeout can reach here: every other AssertionError raised inside the poll body
+			// (a failed HTTP-status assertion in reissueStatusRequest(), an unparseable or null response in
+			// extractResponseItemMap()) is converted to an AdempiereException, so a real error is never
+			// mistaken for a timeout. Falling through lets assertResponseMatches() name the exact missing
+			// ExternalLineId, which is more useful than the generic "worker didn't succeed" message.
+			logger.warn("Invoice-candidate status did not become complete within {}s; asserting the last response", TIMEOUT_SEC, timedOut);
 		}
 
 		assertResponseMatches(rows);
@@ -189,12 +194,16 @@ public class C_Invoice_Candidate_StefDef
 			throw new AdempiereException("Failed to parse the " + STATUS_ENDPOINT_PATH + " response", e);
 		}
 
-		assertThat(statusResponse).isNotNull();
+		if (statusResponse == null)
+		{
+			// Must NOT be an assertion: this runs inside the poll body, and an AssertionError here would be
+			// mistaken for the poll timeout and swallowed, ending the retry loop after one iteration.
+			throw new AdempiereException("Got a null response from " + STATUS_ENDPOINT_PATH);
+		}
 
-		final List<JsonCheckInvoiceCandidatesStatusResponseItem> responseItemList = statusResponse.getInvoiceCandidates();
-		assertThat(responseItemList).isNotNull();
-
-		return Maps.uniqueIndex(responseItemList, (item) -> item.getExternalLineId().getValue());
+		// getInvoiceCandidates() cannot be null: the response DTO's @JsonCreator takes a @NonNull list,
+		// so Jackson fails above with a JsonProcessingException before we get here.
+		return Maps.uniqueIndex(statusResponse.getInvoiceCandidates(), (item) -> item.getExternalLineId().getValue());
 	}
 
 	private void assertResponseMatches(@NonNull final DataTableRows rows)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_Candidate_StefDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_Candidate_StefDef.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 import de.metas.JsonObjectMapperHolder;
 import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.StepDefUtil;
+import de.metas.cucumber.stepdefs.api.REST_API_StepDef;
 import de.metas.cucumber.stepdefs.context.TestContext;
 import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.rest_api.invoicecandidates.response.JsonCheckInvoiceCandidatesStatusResponse;
@@ -34,59 +36,165 @@ import de.metas.rest_api.invoicecandidates.response.JsonCheckInvoiceCandidatesSt
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Then;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.exceptions.AdempiereException;
 import org.assertj.core.api.SoftAssertions;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@RequiredArgsConstructor
 public class C_Invoice_Candidate_StefDef
 {
-	private final TestContext testContext;
+	/**
+	 * The endpoint this step def validates. It is intrinsic to the step (the step is named after that
+	 * endpoint's response), which is what lets this step re-issue the request itself instead of making
+	 * every feature file wait for the invoice candidates beforehand.
+	 */
+	private static final String STATUS_ENDPOINT_PATH = "api/v2/invoices/status";
+	private static final int STATUS_ENDPOINT_EXPECTED_STATUS_CODE = 200;
+	private static final long TIMEOUT_SEC = 60;
+	private static final long CHECK_INTERVAL_MS = 1000;
+
+	@NonNull private final TestContext testContext;
+	@NonNull private final REST_API_StepDef restApiStepDef;
+
 	private final ObjectMapper objectMapper = JsonObjectMapperHolder.newJsonObjectMapper();
 
-	public C_Invoice_Candidate_StefDef(@NonNull final TestContext testContext)
+	/**
+	 * Validates the response of {@code POST api/v2/invoices/status} against the expected invoice-candidate rows.
+	 * <p>
+	 * The invoice candidates behind that endpoint are materialized <b>asynchronously</b> after the order is
+	 * completed, so the first response can legitimately still be missing rows. This step therefore polls: it
+	 * re-issues the same status request (payload taken from {@link TestContext#getRequestPayload()}) every
+	 * {@value #CHECK_INTERVAL_MS}ms for up to {@value #TIMEOUT_SEC}s until an item exists for every expected
+	 * {@code ExternalLineId}, and only then asserts the values.
+	 * <p>
+	 * Because the wait lives here — in the step that <i>consumes</i> the async result — feature files must NOT
+	 * add their own "wait for the invoice candidates" steps before calling this one.
+	 *
+	 * @cucumber.columns
+	 *   <b>ExternalHeaderId</b> — (required) expected external header id of the response item<br>
+	 *   <b>ExternalLineId</b> — (required) expected external line id; also the key the response is matched on<br>
+	 *   <b>QtyEntered</b> — (required) expected ordered quantity<br>
+	 *   <b>QtyToInvoice</b> — (required) expected quantity to invoice<br>
+	 *   <b>QtyInvoiced</b> — (required) expected already-invoiced quantity<br>
+	 *   <b>Processed</b> — (required) expected processed flag<br>
+	 * @cucumber.example
+	 * <pre>
+	 * Then validate invoice candidate status response
+	 *   | ExternalHeaderId | ExternalLineId | QtyEntered | QtyToInvoice | QtyInvoiced | Processed |
+	 *   | ExtHeader_1      | ExtLine_1      | 5          | 0            | 5           | true      |
+	 * </pre>
+	 */
+	@Then("validate invoice candidate status response")
+	public void validateInvoiceCandidateStatusResponse(@NonNull final DataTable table) throws InterruptedException
 	{
-		this.testContext = testContext;
+		final DataTableRows rows = DataTableRows.of(table);
+
+		try
+		{
+			StepDefUtil.tryAndWait(TIMEOUT_SEC, CHECK_INTERVAL_MS, () -> allExpectedItemsArePresent(rows));
+		}
+		catch (final AssertionError timedOut)
+		{
+			// Deliberately fall through to the assertions below: they name the exact ExternalLineId that is
+			// missing, which is more useful than the generic "worker didn't succeed within the timeout".
+		}
+
+		assertResponseMatches(rows);
 	}
 
-	@Then("validate invoice candidate status response")
-	public void validateInvoiceCandidateStatusResponse(@NonNull final DataTable table) throws JsonProcessingException
+	/**
+	 * @return {@code true} as soon as the last status response holds an item for every expected
+	 *         {@code ExternalLineId}; otherwise re-issues the status request — so the next poll iteration sees a
+	 *         fresh response — and returns {@code false}.
+	 */
+	private boolean allExpectedItemsArePresent(@NonNull final DataTableRows rows)
 	{
-		final JsonCheckInvoiceCandidatesStatusResponse statusResponse = objectMapper.readValue(testContext.getApiResponse().getContent(), JsonCheckInvoiceCandidatesStatusResponse.class);
+		final Map<String, JsonCheckInvoiceCandidatesStatusResponseItem> responseItemMap = extractResponseItemMap();
+
+		final boolean allPresent = rows.stream()
+				.allMatch(row -> responseItemMap.containsKey(row.getAsString(I_C_Invoice_Candidate.COLUMNNAME_ExternalLineId)));
+
+		if (allPresent)
+		{
+			return true;
+		}
+
+		reissueStatusRequest();
+		return false;
+	}
+
+	private void reissueStatusRequest()
+	{
+		try
+		{
+			restApiStepDef.performHTTPRequest(
+					restApiStepDef.newAPIRequest()
+							.endpointPath(STATUS_ENDPOINT_PATH)
+							.method("POST")
+							.expectedStatusCode(STATUS_ENDPOINT_EXPECTED_STATUS_CODE)
+							.payload(testContext.getRequestPayload())
+							.build()
+			);
+		}
+		catch (final IOException e)
+		{
+			throw new AdempiereException("Failed to re-issue the request to " + STATUS_ENDPOINT_PATH, e);
+		}
+	}
+
+	@NonNull
+	private Map<String, JsonCheckInvoiceCandidatesStatusResponseItem> extractResponseItemMap()
+	{
+		final JsonCheckInvoiceCandidatesStatusResponse statusResponse;
+		try
+		{
+			statusResponse = objectMapper.readValue(testContext.getApiResponse().getContent(), JsonCheckInvoiceCandidatesStatusResponse.class);
+		}
+		catch (final JsonProcessingException e)
+		{
+			throw new AdempiereException("Failed to parse the " + STATUS_ENDPOINT_PATH + " response", e);
+		}
+
 		assertThat(statusResponse).isNotNull();
 
 		final List<JsonCheckInvoiceCandidatesStatusResponseItem> responseItemList = statusResponse.getInvoiceCandidates();
 		assertThat(responseItemList).isNotNull();
 
-		final Map<String, JsonCheckInvoiceCandidatesStatusResponseItem> responseItemMap = Maps.uniqueIndex(responseItemList,
-				(item) -> item.getExternalLineId().getValue()
-		);
+		return Maps.uniqueIndex(responseItemList, (item) -> item.getExternalLineId().getValue());
+	}
+
+	private void assertResponseMatches(@NonNull final DataTableRows rows)
+	{
+		final Map<String, JsonCheckInvoiceCandidatesStatusResponseItem> responseItemMap = extractResponseItemMap();
 
 		final SoftAssertions softly = new SoftAssertions();
 
-		DataTableRows.of(table)
-				.forEach(row -> {
-							final String externalHeaderId = row.getAsString(I_C_Invoice_Candidate.COLUMNNAME_ExternalHeaderId);
-							final String externalLineId = row.getAsString(I_C_Invoice_Candidate.COLUMNNAME_ExternalLineId);
-							final BigDecimal qtyEntered = row.getAsBigDecimal(I_C_Invoice_Candidate.COLUMNNAME_QtyEntered);
-							final BigDecimal qtyToInvoice = row.getAsBigDecimal(I_C_Invoice_Candidate.COLUMNNAME_QtyToInvoice);
-							final BigDecimal qtyInvoiced = row.getAsBigDecimal(I_C_Invoice_Candidate.COLUMNNAME_QtyInvoiced);
-							final boolean processed = row.getAsBoolean(I_C_Invoice_Candidate.COLUMNNAME_Processed);
+		rows.forEach(row -> {
+					final String externalHeaderId = row.getAsString(I_C_Invoice_Candidate.COLUMNNAME_ExternalHeaderId);
+					final String externalLineId = row.getAsString(I_C_Invoice_Candidate.COLUMNNAME_ExternalLineId);
+					final BigDecimal qtyEntered = row.getAsBigDecimal(I_C_Invoice_Candidate.COLUMNNAME_QtyEntered);
+					final BigDecimal qtyToInvoice = row.getAsBigDecimal(I_C_Invoice_Candidate.COLUMNNAME_QtyToInvoice);
+					final BigDecimal qtyInvoiced = row.getAsBigDecimal(I_C_Invoice_Candidate.COLUMNNAME_QtyInvoiced);
+					final boolean processed = row.getAsBoolean(I_C_Invoice_Candidate.COLUMNNAME_Processed);
 
-							final JsonCheckInvoiceCandidatesStatusResponseItem responseItem = responseItemMap.get(externalLineId);
-							assertThat(responseItem).as("responseItem for externalLineId=%s", externalLineId).isNotNull();
+					final JsonCheckInvoiceCandidatesStatusResponseItem responseItem = responseItemMap.get(externalLineId);
+					assertThat(responseItem).as("responseItem for externalLineId=%s", externalLineId).isNotNull();
 
-							softly.assertThat(responseItem.getExternalHeaderId().getValue()).as("externalHeaderId").isEqualTo(externalHeaderId);
-							softly.assertThat(responseItem.getExternalLineId().getValue()).as("externalLineId").isEqualTo(externalLineId);
-							softly.assertThat(responseItem.getQtyToInvoice()).as("qtyToInvoice").isEqualTo(qtyToInvoice);
-							softly.assertThat(responseItem.getQtyInvoiced()).as("qtyInvoiced").isEqualTo(qtyInvoiced);
-							softly.assertThat(responseItem.getQtyEntered()).as("qtyEntered").isEqualTo(qtyEntered);
-							softly.assertThat(responseItem.isProcessed()).as("processed").isEqualTo(processed);
-						}
-				);
+					softly.assertThat(responseItem.getExternalHeaderId().getValue()).as("externalHeaderId").isEqualTo(externalHeaderId);
+					softly.assertThat(responseItem.getExternalLineId().getValue()).as("externalLineId").isEqualTo(externalLineId);
+					softly.assertThat(responseItem.getQtyToInvoice()).as("qtyToInvoice").isEqualTo(qtyToInvoice);
+					softly.assertThat(responseItem.getQtyInvoiced()).as("qtyInvoiced").isEqualTo(qtyInvoiced);
+					softly.assertThat(responseItem.getQtyEntered()).as("qtyEntered").isEqualTo(qtyEntered);
+					softly.assertThat(responseItem.isProcessed()).as("processed").isEqualTo(processed);
+				}
+		);
 
 		softly.assertAll();
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_Candidate_StefDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoice/C_Invoice_Candidate_StefDef.java
@@ -58,6 +58,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RequiredArgsConstructor
 public class C_Invoice_Candidate_StefDef
 {
+	private static final Logger logger = LogManager.getLogger(C_Invoice_Candidate_StefDef.class);
+
 	/**
 	 * The endpoint this step def validates. It is intrinsic to the step (the step is named after that
 	 * endpoint's response), which is what lets this step re-issue the request itself instead of making
@@ -67,8 +69,6 @@ public class C_Invoice_Candidate_StefDef
 	 * path — the two are not linked mechanically. If this step is ever reused against a second
 	 * endpoint, take the path from the scenario instead of this constant.
 	 */
-	private static final Logger logger = LogManager.getLogger(C_Invoice_Candidate_StefDef.class);
-
 	private static final String STATUS_ENDPOINT_PATH = "api/v2/invoices/status";
 	private static final int STATUS_ENDPOINT_EXPECTED_STATUS_CODE = 200;
 	private static final long TIMEOUT_SEC = 60;

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/checkInvoiceCandStatus.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoice/checkInvoiceCandStatus.feature
@@ -100,7 +100,6 @@ Feature: check invoice candidates status
       | ExternalHeaderId | ExternalLineId | QtyEntered | QtyToInvoice | QtyInvoiced | Processed |
       | ExtHeader_1      | ExtLine_1      | 5          | 0            | 5           | true      |
 
-  #@flaky 2025-11-13-metas-ts: I believe I unflakied it
   @from:cucumber
 @allure.label.epic:E0340_Invoicing
 @allure.label.feature:F00700_Invoicing


### PR DESCRIPTION
## Problem

`checkInvoiceCandStatus.feature` fails intermittently in `test (cucumber) (profile5)`:

```
[responseItem for externalLineId=ExtLine_...] Expecting actual not to be null
  at C_Invoice_Candidate_StefDef.lambda$validateInvoiceCandidateStatusResponse$1(...:80)
```

The invoice candidates behind `api/v2/invoices/status` are materialized **asynchronously** after
the order is completed, so `validate invoice candidate status response` could assert against a
response whose items did not exist yet. Observed on two unrelated branch families, on PRs whose
diffs cannot reach this REST flow.

## Fix (test-only)

`validate invoice candidate status response` now **polls**: it re-issues the same status request
(payload taken from `TestContext`) every second for up to 60s until an item exists for every
expected `ExternalLineId`, and only then asserts the values. On timeout it deliberately falls
through to the assertions, so the failure still names the exact missing `ExternalLineId` rather
than a generic timeout message.

### Why the wait lives in the step def, not the feature file

Per `backend/de.metas.cucumber/CLAUDE.md`, the consuming step waits for exactly what it needs and
feature files stay free of technical plumbing. Two further reasons:

- **It closes the race instead of narrowing it.** A wait placed before the POST cannot fully help:
  the response is already captured by the time the assertion step runs, so candidates can still
  change in between. Only retrying the read closes the window.
- **It covers all 4 call sites** of this step rather than the 2 scenarios that happened to fail,
  and any future one.

Also drops a stale commented-out `@flaky ... I believe I unflakied it` note on the affected scenario.

No production code touched.


## Review-fix commits

The three commits after the initial one address code-review findings; they do not change the approach:

- `20c82f5329b` — stop the poll's timeout catch from swallowing a failed HTTP-status assertion on the
  re-issued request (it is rethrown as an `AdempiereException`); split the poll into a driver plus a
  pure predicate (the single method read as a query but issued a request); add the class-level Javadoc.
- `cda1d581769` — close the remaining path: `extractResponseItemMap()` also runs inside the poll body,
  and its null-response assertion could be mistaken for the timeout and swallowed, ending the retry
  after one iteration. It now throws an `AdempiereException`, and the timeout catch logs the throwable.
  Also drops a dead `isNotNull()` check (the response DTO's `@JsonCreator` takes a `@NonNull` list, so
  Jackson fails earlier).
- `01e244d0914` — reattach the endpoint-constant Javadoc that the new logger field had displaced.
