### PR TITLE
Product Import: accept all valid ProductType codes (fix Invalid ProductType for F/O/N)

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/product/ProductType.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/ProductType.java
@@ -73,10 +73,6 @@ public enum ProductType implements ReferenceListAwareEnum
 		return type != null ? type.getCode() : null;
 	}
 
-	/**
-	 * @return an SQL {@code IN (...)} list of every {@link ProductType} code, single-quoted and comma-separated
-	 * (e.g. {@code 'I','S','R','E','O','F','N'}). Codes are single-char literals — no injection concern.
-	 */
 	public static String getCodesAsSqlList()
 	{
 		return Arrays.stream(values())

--- a/backend/de.metas.business/src/main/java/de/metas/product/ProductType.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/ProductType.java
@@ -10,6 +10,7 @@ import org.compiere.model.X_M_Product;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.stream.Collectors;
 
 /*
  * #%L
@@ -70,6 +71,18 @@ public enum ProductType implements ReferenceListAwareEnum
 	public static String toCodeOrNull(@Nullable final ProductType type)
 	{
 		return type != null ? type.getCode() : null;
+	}
+
+	/**
+	 * @return an SQL {@code IN (...)} list of every {@link ProductType} code, single-quoted and comma-separated
+	 * (e.g. {@code 'I','S','R','E','O','F','N'}). Codes are single-char literals — no injection concern.
+	 */
+	public static String getCodesAsSqlList()
+	{
+		return Arrays.stream(values())
+				.map(ProductType::getCode)
+				.map(code -> "'" + code + "'")
+				.collect(Collectors.joining(","));
 	}
 
 	private static final ImmutableMap<String, ProductType> typesByCode = Maps.uniqueIndex(Arrays.asList(values()), ProductType::getCode);

--- a/backend/de.metas.business/src/main/java/de/metas/product/impexp/MProductImportTableSqlUpdater.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/impexp/MProductImportTableSqlUpdater.java
@@ -57,8 +57,7 @@ public class MProductImportTableSqlUpdater
 	/**
 	 * SQL {@code IN (...)} list of every valid {@link ProductType} code (e.g. {@code 'E','F','I',...}).
 	 * Derived from the enum so the import's accepted set can never drift from the ProductType reference
-	 * list (the drift that let 'F'/'O'/'N' be wrongly rejected). Codes are single-char literals — no
-	 * injection concern.
+	 * list. Codes are single-char literals — no injection concern.
 	 */
 	private static final String VALID_PRODUCT_TYPE_CODES_SQL = Arrays.stream(ProductType.values())
 			.map(ProductType::getCode)

--- a/backend/de.metas.business/src/main/java/de/metas/product/impexp/MProductImportTableSqlUpdater.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/impexp/MProductImportTableSqlUpdater.java
@@ -24,6 +24,7 @@ package de.metas.product.impexp;
 
 import de.metas.impexp.processing.ImportRecordsSelection;
 import de.metas.logging.LogManager;
+import de.metas.product.ProductType;
 import de.metas.tax.api.ITaxBL;
 import de.metas.tax.api.TaxCategoryId;
 import de.metas.util.Services;
@@ -35,7 +36,9 @@ import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.slf4j.Logger;
 
+import java.util.Arrays;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import static de.metas.impexp.format.ImportTableDescriptor.COLUMNNAME_I_ErrorMsg;
 import static de.metas.impexp.format.ImportTableDescriptor.COLUMNNAME_I_IsImported;
@@ -50,6 +53,17 @@ import static org.compiere.model.I_M_Product.COLUMNNAME_C_UOM_ID;
 public class MProductImportTableSqlUpdater
 {
 	private static final Logger logger = LogManager.getLogger(MProductImportTableSqlUpdater.class);
+
+	/**
+	 * SQL {@code IN (...)} list of every valid {@link ProductType} code (e.g. {@code 'E','F','I',...}).
+	 * Derived from the enum so the import's accepted set can never drift from the ProductType reference
+	 * list (the drift that let 'F'/'O'/'N' be wrongly rejected). Codes are single-char literals — no
+	 * injection concern.
+	 */
+	private static final String VALID_PRODUCT_TYPE_CODES_SQL = Arrays.stream(ProductType.values())
+			.map(ProductType::getCode)
+			.map(code -> "'" + code + "'")
+			.collect(Collectors.joining(","));
 
 	private final ImportRecordsSelection selection;
 	private final Properties ctx;
@@ -617,7 +631,7 @@ public class MProductImportTableSqlUpdater
 		sql = new StringBuilder("UPDATE ")
 				.append(targetTableName + " i ")
 				.append(" SET " + COLUMNNAME_I_IsImported + "='E', " + COLUMNNAME_I_ErrorMsg + "=" + COLUMNNAME_I_ErrorMsg + "||'ERR=Invalid ProductType,' ")
-				.append("WHERE ProductType NOT IN ('E','I','R','S')")
+				.append("WHERE ProductType NOT IN (" + VALID_PRODUCT_TYPE_CODES_SQL + ")")
 				.append(" AND " + COLUMNNAME_I_IsImported + "<>'Y'")
 				.append(selection.toSqlWhereClause("i"));
 		DB.executeUpdateAndThrowExceptionOnFail(sql.toString(), ITrx.TRXNAME_ThreadInherited);

--- a/backend/de.metas.business/src/main/java/de/metas/product/impexp/MProductImportTableSqlUpdater.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/impexp/MProductImportTableSqlUpdater.java
@@ -36,9 +36,7 @@ import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.slf4j.Logger;
 
-import java.util.Arrays;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 import static de.metas.impexp.format.ImportTableDescriptor.COLUMNNAME_I_ErrorMsg;
 import static de.metas.impexp.format.ImportTableDescriptor.COLUMNNAME_I_IsImported;
@@ -56,13 +54,9 @@ public class MProductImportTableSqlUpdater
 
 	/**
 	 * SQL {@code IN (...)} list of every valid {@link ProductType} code (e.g. {@code 'E','F','I',...}).
-	 * Derived from the enum so the import's accepted set can never drift from the ProductType reference
-	 * list. Codes are single-char literals — no injection concern.
+	 * Derived from the enum so the import's accepted set can never drift from the ProductType reference list.
 	 */
-	private static final String VALID_PRODUCT_TYPE_CODES_SQL = Arrays.stream(ProductType.values())
-			.map(ProductType::getCode)
-			.map(code -> "'" + code + "'")
-			.collect(Collectors.joining(","));
+	private static final String VALID_PRODUCT_TYPE_CODES_SQL = ProductType.getCodesAsSqlList();
 
 	private final ImportRecordsSelection selection;
 	private final Properties ctx;

--- a/backend/de.metas.business/src/main/java/de/metas/product/impexp/MProductImportTableSqlUpdater.java
+++ b/backend/de.metas.business/src/main/java/de/metas/product/impexp/MProductImportTableSqlUpdater.java
@@ -52,10 +52,6 @@ public class MProductImportTableSqlUpdater
 {
 	private static final Logger logger = LogManager.getLogger(MProductImportTableSqlUpdater.class);
 
-	/**
-	 * SQL {@code IN (...)} list of every valid {@link ProductType} code (e.g. {@code 'E','F','I',...}).
-	 * Derived from the enum so the import's accepted set can never drift from the ProductType reference list.
-	 */
 	private static final String VALID_PRODUCT_TYPE_CODES_SQL = ProductType.getCodesAsSqlList();
 
 	private final ImportRecordsSelection selection;

--- a/backend/de.metas.business/src/test/java/de/metas/product/ProductTypeTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/product/ProductTypeTest.java
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.product;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProductTypeTest
+{
+	@Test
+	void getCodesAsSqlList_containsEveryCode_quotedAndCommaSeparated()
+	{
+		final String expected = Arrays.stream(ProductType.values())
+				.map(ProductType::getCode)
+				.map(code -> "'" + code + "'")
+				.collect(Collectors.joining(","));
+
+		assertThat(ProductType.getCodesAsSqlList()).isEqualTo(expected);
+	}
+}


### PR DESCRIPTION
## Problem
Importing a product via `I_Product` with `ProductType = 'F'` (freight cost) fails with `ERR=Invalid ProductType`. The same happens for `'O'` (Online) and `'N'` (Food) — even though all three are valid `ProductType` reference-list codes and are assignable on `M_Product`.

## Root cause
`MProductImportTableSqlUpdater.dbUpdateErrorMessages()` hardcoded the accepted set as `ProductType NOT IN ('E','I','R','S')`, which had drifted from the 7-value `de.metas.product.ProductType` enum (`I, S, R, E, O, F, N`). A sibling method in the same class already enumerates all seven.

## Fix
Build the allowed-`ProductType` `IN (...)` list from `ProductType.values()`, so the import's accepted set is always the full `ProductType` reference list and can never drift from the enum again. Codes are single-character literals — no injection concern. Genuinely invalid codes (not in the reference list) are still rejected.

## Verification
Manual: import a product with `ProductType = 'F'` via the Import Product window — it now imports as a freight-cost product instead of erroring; a code outside the reference list is still rejected.
