### PR TITLE
MobileUI Picking: name every product of a picking job in the launcher caption

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/de/metas/picking/model/X_PickingProfile_PickingJobConfig.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/de/metas/picking/model/X_PickingProfile_PickingJobConfig.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class X_PickingProfile_PickingJobConfig extends org.compiere.model.PO implements I_PickingProfile_PickingJobConfig, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 578159988L;
+	private static final long serialVersionUID = -1386016706L;
 
     /** Standard Constructor */
     public X_PickingProfile_PickingJobConfig (final Properties ctx, final int PickingProfile_PickingJobConfig_ID, @Nullable final String trxName)
@@ -108,6 +108,8 @@ public class X_PickingProfile_PickingJobConfig extends org.compiere.model.PO imp
 	public static final String PICKINGJOBFIELD_QtyToDeliver = "QtyToDeliver";
 	/** ProductNo = ProductNo */
 	public static final String PICKINGJOBFIELD_ProductNo = "ProductNo";
+	/** ProductNames = ProductNames */
+	public static final String PICKINGJOBFIELD_ProductNames = "ProductNames";
 	@Override
 	public void setPickingJobField (final java.lang.String PickingJobField)
 	{

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5819660_PickingJobField_Options_ProductNames.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5819660_PickingJobField_Options_ProductNames.sql
@@ -11,42 +11,42 @@ INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTra
 ;
 
 -- Reference Item: PickingJobField_Options -> ProductNames_ProductNames
-UPDATE AD_Ref_List_Trl SET IsTranslated='Y' WHERE AD_Language='de_CH' AND AD_Ref_List_ID=544344
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-19 19:04:39','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Ref_List_ID=544344
 ;
 
 -- Reference Item: PickingJobField_Options -> ProductNames_ProductNames
-UPDATE AD_Ref_List_Trl SET IsTranslated='Y' WHERE AD_Language='de_DE' AND AD_Ref_List_ID=544344
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-19 19:04:40','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Ref_List_ID=544344
 ;
 
 -- Reference Item: PickingJobField_Options -> ProductNames_ProductNames
-UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Product names (all)' WHERE AD_Language='en_US' AND AD_Ref_List_ID=544344
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Product names (all)', Updated=TO_TIMESTAMP('2026-08-19 19:04:41','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Ref_List_ID=544344
 ;
 
 UPDATE AD_Ref_List base SET Name=trl.Name, Updated=trl.Updated, UpdatedBy=trl.UpdatedBy FROM AD_Ref_List_Trl trl WHERE trl.AD_Ref_List_ID=base.AD_Ref_List_ID AND trl.AD_Language='en_US' AND trl.AD_Language=getBaseLanguage()
 ;
 
 -- Description for the new value ProductNames (AD_Ref_List_ID=544344)
-UPDATE AD_Ref_List SET Description='Alle Produktnamen des Auftrags, durch Komma getrennt.' WHERE AD_Ref_List_ID=544344
+UPDATE AD_Ref_List SET Description='Alle Produktnamen des Auftrags, durch Komma getrennt.', Updated=TO_TIMESTAMP('2026-08-19 19:04:42','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Ref_List_ID=544344
 ;
 
-UPDATE AD_Ref_List_Trl SET Description='Alle Produktnamen des Auftrags, durch Komma getrennt.' WHERE AD_Ref_List_ID=544344 AND AD_Language='de_DE'
+UPDATE AD_Ref_List_Trl SET Description='Alle Produktnamen des Auftrags, durch Komma getrennt.', Updated=TO_TIMESTAMP('2026-08-19 19:04:43','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Ref_List_ID=544344 AND AD_Language='de_DE'
 ;
 
-UPDATE AD_Ref_List_Trl SET Description='Alle Produktnamen des Auftrags, durch Komma getrennt.' WHERE AD_Ref_List_ID=544344 AND AD_Language='de_CH'
+UPDATE AD_Ref_List_Trl SET Description='Alle Produktnamen des Auftrags, durch Komma getrennt.', Updated=TO_TIMESTAMP('2026-08-19 19:04:44','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Ref_List_ID=544344 AND AD_Language='de_CH'
 ;
 
-UPDATE AD_Ref_List_Trl SET Description='All product names of the job, comma separated.' WHERE AD_Ref_List_ID=544344 AND AD_Language='en_US'
+UPDATE AD_Ref_List_Trl SET Description='All product names of the job, comma separated.', Updated=TO_TIMESTAMP('2026-08-19 19:04:45','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Ref_List_ID=544344 AND AD_Language='en_US'
 ;
 
 -- Description for the existing value Product (AD_Ref_List_ID=543862)
-UPDATE AD_Ref_List SET Description='Der Produktname — nur wenn der Auftrag genau ein Produkt enthält, sonst leer.' WHERE AD_Ref_List_ID=543862
+UPDATE AD_Ref_List SET Description='Der Produktname — nur wenn der Auftrag genau ein Produkt enthält, sonst leer.', Updated=TO_TIMESTAMP('2026-08-19 19:04:46','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Ref_List_ID=543862
 ;
 
-UPDATE AD_Ref_List_Trl SET Description='Der Produktname — nur wenn der Auftrag genau ein Produkt enthält, sonst leer.' WHERE AD_Ref_List_ID=543862 AND AD_Language='de_DE'
+UPDATE AD_Ref_List_Trl SET Description='Der Produktname — nur wenn der Auftrag genau ein Produkt enthält, sonst leer.', Updated=TO_TIMESTAMP('2026-08-19 19:04:47','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Ref_List_ID=543862 AND AD_Language='de_DE'
 ;
 
-UPDATE AD_Ref_List_Trl SET Description='Der Produktname — nur wenn der Auftrag genau ein Produkt enthält, sonst leer.' WHERE AD_Ref_List_ID=543862 AND AD_Language='de_CH'
+UPDATE AD_Ref_List_Trl SET Description='Der Produktname — nur wenn der Auftrag genau ein Produkt enthält, sonst leer.', Updated=TO_TIMESTAMP('2026-08-19 19:04:48','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Ref_List_ID=543862 AND AD_Language='de_CH'
 ;
 
-UPDATE AD_Ref_List_Trl SET Description='The product name — only when the job holds exactly one product, otherwise empty.' WHERE AD_Ref_List_ID=543862 AND AD_Language='en_US'
+UPDATE AD_Ref_List_Trl SET Description='The product name — only when the job holds exactly one product, otherwise empty.', Updated=TO_TIMESTAMP('2026-08-19 19:04:49','YYYY-MM-DD HH24:MI:SS')::timestamp without time zone AT TIME ZONE 'UTC', UpdatedBy=100 WHERE AD_Ref_List_ID=543862 AND AD_Language='en_US'
 ;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5819660_PickingJobField_Options_ProductNames.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5819660_PickingJobField_Options_ProductNames.sql
@@ -1,0 +1,52 @@
+-- IDs allocated from idserver.metas.de on 2026-08-19:
+--   AD_Ref_List 544344 (PickingJobField_Options -> ProductNames)
+
+-- Reference: PickingJobField_Options
+-- Value: ProductNames
+-- ValueName: ProductNames
+INSERT INTO AD_Ref_List (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Ref_List_ID,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,Value,ValueName) VALUES (0,0,541850,544344 /*From ID Server*/,TO_TIMESTAMP('2026-08-19 19:04:38.667253','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'de.metas.picking','Y','Produktnamen (alle)',TO_TIMESTAMP('2026-08-19 19:04:38.667253','YYYY-MM-DD HH24:MI:SS.US')::timestamp without time zone AT TIME ZONE 'UTC',100,'ProductNames','ProductNames')
+;
+
+INSERT INTO AD_Ref_List_Trl (AD_Language,AD_Ref_List_ID, Description,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive) SELECT l.AD_Language, t.AD_Ref_List_ID, t.Description,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y' FROM AD_Language l, AD_Ref_List t WHERE l.IsActive='Y'AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Ref_List_ID=544344 AND NOT EXISTS (SELECT 1 FROM AD_Ref_List_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Ref_List_ID=t.AD_Ref_List_ID)
+;
+
+-- Reference Item: PickingJobField_Options -> ProductNames_ProductNames
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y' WHERE AD_Language='de_CH' AND AD_Ref_List_ID=544344
+;
+
+-- Reference Item: PickingJobField_Options -> ProductNames_ProductNames
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y' WHERE AD_Language='de_DE' AND AD_Ref_List_ID=544344
+;
+
+-- Reference Item: PickingJobField_Options -> ProductNames_ProductNames
+UPDATE AD_Ref_List_Trl SET IsTranslated='Y', Name='Product names (all)' WHERE AD_Language='en_US' AND AD_Ref_List_ID=544344
+;
+
+UPDATE AD_Ref_List base SET Name=trl.Name, Updated=trl.Updated, UpdatedBy=trl.UpdatedBy FROM AD_Ref_List_Trl trl WHERE trl.AD_Ref_List_ID=base.AD_Ref_List_ID AND trl.AD_Language='en_US' AND trl.AD_Language=getBaseLanguage()
+;
+
+-- Description for the new value ProductNames (AD_Ref_List_ID=544344)
+UPDATE AD_Ref_List SET Description='Alle Produktnamen des Auftrags, durch Komma getrennt.' WHERE AD_Ref_List_ID=544344
+;
+
+UPDATE AD_Ref_List_Trl SET Description='Alle Produktnamen des Auftrags, durch Komma getrennt.' WHERE AD_Ref_List_ID=544344 AND AD_Language='de_DE'
+;
+
+UPDATE AD_Ref_List_Trl SET Description='Alle Produktnamen des Auftrags, durch Komma getrennt.' WHERE AD_Ref_List_ID=544344 AND AD_Language='de_CH'
+;
+
+UPDATE AD_Ref_List_Trl SET Description='All product names of the job, comma separated.' WHERE AD_Ref_List_ID=544344 AND AD_Language='en_US'
+;
+
+-- Description for the existing value Product (AD_Ref_List_ID=543862)
+UPDATE AD_Ref_List SET Description='Der Produktname — nur wenn der Auftrag genau ein Produkt enthält, sonst leer.' WHERE AD_Ref_List_ID=543862
+;
+
+UPDATE AD_Ref_List_Trl SET Description='Der Produktname — nur wenn der Auftrag genau ein Produkt enthält, sonst leer.' WHERE AD_Ref_List_ID=543862 AND AD_Language='de_DE'
+;
+
+UPDATE AD_Ref_List_Trl SET Description='Der Produktname — nur wenn der Auftrag genau ein Produkt enthält, sonst leer.' WHERE AD_Ref_List_ID=543862 AND AD_Language='de_CH'
+;
+
+UPDATE AD_Ref_List_Trl SET Description='The product name — only when the job holds exactly one product, otherwise empty.' WHERE AD_Ref_List_ID=543862 AND AD_Language='en_US'
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5819670_sys_PickingProfile_PickingJobConfig_Options_Translations.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5819670_sys_PickingProfile_PickingJobConfig_Options_Translations.sql
@@ -1,0 +1,135 @@
+-- Translate the picking-profile / picking-job-options labels that are still
+-- shown in English on the "Mobile UI Kommissionierprofil" window (tab
+-- "Feld" = PickingProfile_PickingJobConfig) and the "Mobile UI
+-- Kommissionieraufgabe Optionen" window. System base language is de_DE, so
+-- AD_Element.Name is the German label; these 10 elements still held their
+-- untranslated English original in the base column. en_US keeps the
+-- original English text as an explicit translation override. de_CH mirrors
+-- de_DE. fr_CH is intentionally left untouched (falls back to the new
+-- German base) -- no fr_CH translation done here.
+--
+-- FormatPattern (53687) is a shared element (5 AD_Column usages across
+-- other tables/windows too) -- translating it also fixes the label on
+-- those other windows, which is the correct root-cause fix for a shared
+-- element. Its Description was also still English and is corrected here
+-- too, since it is shown as the field's tooltip.
+
+-- === 583513 PickingJobAggregationType : "Aggregation Type" -> "Aggregationstyp" ===
+UPDATE AD_Element SET Name='Aggregationstyp', Updated=TO_TIMESTAMP('2026-08-20 09:30:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513
+;
+UPDATE AD_Element_Trl SET Name='Aggregationstyp', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513 AND AD_Language='de_DE'
+;
+UPDATE AD_Element_Trl SET Name='Aggregationstyp', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513 AND AD_Language='de_CH'
+;
+UPDATE AD_Element_Trl SET Name='Aggregation Type', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:03','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513 AND AD_Language='en_US'
+;
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583513)
+;
+
+-- === 584219 IsAllowQuickPackAll : "Allow Quick Pack All" -> "Schnellverpackung für alle erlauben" ===
+UPDATE AD_Element SET Name='Schnellverpackung für alle erlauben', Updated=TO_TIMESTAMP('2026-08-20 09:30:04','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219
+;
+UPDATE AD_Element_Trl SET Name='Schnellverpackung für alle erlauben', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:05','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219 AND AD_Language='de_DE'
+;
+UPDATE AD_Element_Trl SET Name='Schnellverpackung für alle erlauben', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:06','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219 AND AD_Language='de_CH'
+;
+UPDATE AD_Element_Trl SET Name='Allow Quick Pack All', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:07','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219 AND AD_Language='en_US'
+;
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584219)
+;
+
+-- === 577441 IsAnonymousHuPickedOnTheFly : "Anonymous HU Picked On the Fly" -> "Anonyme HU im Lauf kommissioniert" ===
+UPDATE AD_Element SET Name='Anonyme HU im Lauf kommissioniert', Updated=TO_TIMESTAMP('2026-08-20 09:30:08','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441
+;
+UPDATE AD_Element_Trl SET Name='Anonyme HU im Lauf kommissioniert', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:09','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441 AND AD_Language='de_DE'
+;
+UPDATE AD_Element_Trl SET Name='Anonyme HU im Lauf kommissioniert', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:10','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441 AND AD_Language='de_CH'
+;
+UPDATE AD_Element_Trl SET Name='Anonymous HU Picked On the Fly', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:11','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441 AND AD_Language='en_US'
+;
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(577441)
+;
+
+-- === 583887 IsConsideredOnlyScheduledJobs : "Consider only scheduled jobs" -> "Nur eingeplante Kommissionieraufgaben berücksichtigen" ===
+UPDATE AD_Element SET Name='Nur eingeplante Kommissionieraufgaben berücksichtigen', Updated=TO_TIMESTAMP('2026-08-20 09:30:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887
+;
+UPDATE AD_Element_Trl SET Name='Nur eingeplante Kommissionieraufgaben berücksichtigen', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:13','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887 AND AD_Language='de_DE'
+;
+UPDATE AD_Element_Trl SET Name='Nur eingeplante Kommissionieraufgaben berücksichtigen', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:14','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887 AND AD_Language='de_CH'
+;
+UPDATE AD_Element_Trl SET Name='Consider only scheduled jobs', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:15','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887 AND AD_Language='en_US'
+;
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583887)
+;
+
+-- === 583565 IsFilterByBarcode : "Filter by Barcode" -> "Nach Barcode filtern" ===
+UPDATE AD_Element SET Name='Nach Barcode filtern', Updated=TO_TIMESTAMP('2026-08-20 09:30:16','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565
+;
+UPDATE AD_Element_Trl SET Name='Nach Barcode filtern', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:17','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565 AND AD_Language='de_DE'
+;
+UPDATE AD_Element_Trl SET Name='Nach Barcode filtern', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:18','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565 AND AD_Language='de_CH'
+;
+UPDATE AD_Element_Trl SET Name='Filter by Barcode', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:19','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565 AND AD_Language='en_US'
+;
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583565)
+;
+
+-- === 53687 FormatPattern : "Format Pattern" -> "Format-Muster" (Name + Description; shared element, see header) ===
+UPDATE AD_Element SET Name='Format-Muster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', Updated=TO_TIMESTAMP('2026-08-20 09:30:20','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687
+;
+UPDATE AD_Element_Trl SET Name='Format-Muster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:21','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687 AND AD_Language='de_DE'
+;
+UPDATE AD_Element_Trl SET Name='Format-Muster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:22','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687 AND AD_Language='de_CH'
+;
+UPDATE AD_Element_Trl SET Name='Format Pattern', Description='The pattern used to format a number or date.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:23','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687 AND AD_Language='en_US'
+;
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(53687)
+;
+
+-- === 583942 AllowPickToStructure_LU_TU : "Pick to LU/TU structure" -> "Kommissionierung zu LU/TU-Struktur" ===
+UPDATE AD_Element SET Name='Kommissionierung zu LU/TU-Struktur', Updated=TO_TIMESTAMP('2026-08-20 09:30:24','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942
+;
+UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/TU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:25','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942 AND AD_Language='de_DE'
+;
+UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/TU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:26','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942 AND AD_Language='de_CH'
+;
+UPDATE AD_Element_Trl SET Name='Pick to LU/TU structure', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:27','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942 AND AD_Language='en_US'
+;
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583942)
+;
+
+-- === 583943 AllowPickToStructure_LU_CU : "Pick to LU/CU structure" -> "Kommissionierung zu LU/CU-Struktur" ===
+UPDATE AD_Element SET Name='Kommissionierung zu LU/CU-Struktur', Updated=TO_TIMESTAMP('2026-08-20 09:30:28','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943
+;
+UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/CU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:29','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943 AND AD_Language='de_DE'
+;
+UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/CU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:30','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943 AND AD_Language='de_CH'
+;
+UPDATE AD_Element_Trl SET Name='Pick to LU/CU structure', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:31','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943 AND AD_Language='en_US'
+;
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583943)
+;
+
+-- === 583944 AllowPickToStructure_TU : "Pick to top level TU structure" -> "Kommissionierung zur obersten TU-Struktur" ===
+UPDATE AD_Element SET Name='Kommissionierung zur obersten TU-Struktur', Updated=TO_TIMESTAMP('2026-08-20 09:30:32','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944
+;
+UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten TU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:33','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944 AND AD_Language='de_DE'
+;
+UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten TU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:34','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944 AND AD_Language='de_CH'
+;
+UPDATE AD_Element_Trl SET Name='Pick to top level TU structure', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:35','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944 AND AD_Language='en_US'
+;
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583944)
+;
+
+-- === 583945 AllowPickToStructure_CU : "Pick to top level CU structure" -> "Kommissionierung zur obersten CU-Struktur" ===
+UPDATE AD_Element SET Name='Kommissionierung zur obersten CU-Struktur', Updated=TO_TIMESTAMP('2026-08-20 09:30:36','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945
+;
+UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten CU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:37','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945 AND AD_Language='de_DE'
+;
+UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten CU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:38','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945 AND AD_Language='de_CH'
+;
+UPDATE AD_Element_Trl SET Name='Pick to top level CU structure', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:39','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945 AND AD_Language='en_US'
+;
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583945)
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5819670_sys_PickingProfile_PickingJobConfig_Options_Translations.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5819670_sys_PickingProfile_PickingJobConfig_Options_Translations.sql
@@ -8,73 +8,106 @@
 -- de_DE. fr_CH is intentionally left untouched (falls back to the new
 -- German base) -- no fr_CH translation done here.
 --
+-- Names below are human-approved abbreviations (some elements shortened to
+-- fit the Name column comfortably); every one of the 9 renamed/kept elements
+-- also gets a German Description carrying the meaning the short Name can no
+-- longer hold, based on read-only behavioural analysis of the actual code
+-- paths (see ai-work/31391/label-semantics-review.md). English Descriptions
+-- are added as translation overrides; en_US Name/Description stay ENGLISH.
+--
 -- FormatPattern (53687) is a shared element (5 AD_Column usages across
 -- other tables/windows too) -- translating it also fixes the label on
 -- those other windows, which is the correct root-cause fix for a shared
 -- element. Its Description was also still English and is corrected here
--- too, since it is shown as the field's tooltip.
+-- too, since it is shown as the field's tooltip. This element is NOT
+-- further touched below: it keeps "Formatmuster" and its number/date
+-- Description, which remain correct for its 4 other usages (AD_Column,
+-- PA_ReportColumn, AD_PrintFormatItem, DATEV_ExportFormatColumn).
+--
+-- On PickingProfile_PickingJobConfig specifically, FormatPattern (AD_Column
+-- 587947, AD_Field 725184) is NOT a number/date format -- it is an
+-- address-component display-order token string, consumed via
+-- AddressDisplaySequence.ofNullable(field.getPattern()) in
+-- DisplayValueProvider.java:277-280,331-338. Per the "meaning inconsistent
+-- across usages -> new AD_Element + AD_Field.AD_Name_ID" rule, a dedicated
+-- AD_Element (585377, "Adressformat (Anzeige)") is created below and linked
+-- onto AD_Field 725184 via AD_Name_ID, leaving the shared element 53687
+-- untouched for its other 4 usages.
 
--- === 583513 PickingJobAggregationType : "Aggregation Type" -> "Aggregationstyp" ===
-UPDATE AD_Element SET Name='Aggregationstyp', Updated=TO_TIMESTAMP('2026-08-20 09:30:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513
+-- === 583513 PickingJobAggregationType : "Aggregation Type" -> "Aggregationstyp" (+ Description) ===
+UPDATE AD_Element SET Name='Aggregationstyp', Description='Legt fest, wie Positionen zu einer Kommissionieraufgabe zusammengefasst werden: pro Auftrag (mit einer gemeinsamen LU für den ganzen Auftrag), pro Produkt (mit Kommissionierziel auf Zeilenebene) oder pro Lieferadresse.', Updated=TO_TIMESTAMP('2026-08-23 10:00:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513
 ;
-UPDATE AD_Element_Trl SET Name='Aggregationstyp', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Aggregationstyp', Description='Legt fest, wie Positionen zu einer Kommissionieraufgabe zusammengefasst werden: pro Auftrag (mit einer gemeinsamen LU für den ganzen Auftrag), pro Produkt (mit Kommissionierziel auf Zeilenebene) oder pro Lieferadresse.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Aggregationstyp', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Aggregationstyp', Description='Legt fest, wie Positionen zu einer Kommissionieraufgabe zusammengefasst werden: pro Auftrag (mit einer gemeinsamen LU für den ganzen Auftrag), pro Produkt (mit Kommissionierziel auf Zeilenebene) oder pro Lieferadresse.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513 AND AD_Language='de_CH'
 ;
-UPDATE AD_Element_Trl SET Name='Aggregation Type', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:03','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513 AND AD_Language='en_US'
+UPDATE AD_Element_Trl SET Name='Aggregation Type', Description='Defines how lines are grouped into one picking job: by order (with one shared LU for the whole order), by product (with the pick target at line level), or by delivery location.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-23 10:00:03','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513 AND AD_Language='en_US'
 ;
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583513)
 ;
 
--- === 584219 IsAllowQuickPackAll : "Allow Quick Pack All" -> "Schnellverpackung für alle erlauben" ===
-UPDATE AD_Element SET Name='Schnellverpackung für alle erlauben', Updated=TO_TIMESTAMP('2026-08-20 09:30:04','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219
+-- === 584219 IsAllowQuickPackAll : "Schnellverpackung für alle erlauben" -> "Schnelldruck erlauben" (+ Description) ===
+-- Enables the on-screen "Schnelldruck" button (PickProductsActivity.jsx / translations_de.js:178);
+-- PickingJobPickAllCommand picks every line of the job to its remaining qty, then completes it --
+-- no printing is actually performed despite the button caption.
+UPDATE AD_Element SET Name='Schnelldruck erlauben', Description='Blendet auf dem Kommissionierauftrag die Schaltfläche „Schnelldruck“ ein: sie kommissioniert alle noch offenen Positionen vollständig und schließt den Auftrag ab. Es wird dabei nichts gedruckt.', Updated=TO_TIMESTAMP('2026-08-23 10:00:04','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219
 ;
-UPDATE AD_Element_Trl SET Name='Schnellverpackung für alle erlauben', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:05','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Schnelldruck erlauben', Description='Blendet auf dem Kommissionierauftrag die Schaltfläche „Schnelldruck“ ein: sie kommissioniert alle noch offenen Positionen vollständig und schließt den Auftrag ab. Es wird dabei nichts gedruckt.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:05','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Schnellverpackung für alle erlauben', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:06','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Schnelldruck erlauben', Description='Blendet auf dem Kommissionierauftrag die Schaltfläche „Schnelldruck“ ein: sie kommissioniert alle noch offenen Positionen vollständig und schließt den Auftrag ab. Es wird dabei nichts gedruckt.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:06','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219 AND AD_Language='de_CH'
 ;
-UPDATE AD_Element_Trl SET Name='Allow Quick Pack All', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:07','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219 AND AD_Language='en_US'
+UPDATE AD_Element_Trl SET Name='Allow Quick Pack All', Description='Shows the "Schnelldruck" (quick-pack) button on the picking job: it fully picks all remaining open lines and completes the job. Despite its caption, nothing is printed.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-23 10:00:07','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219 AND AD_Language='en_US'
 ;
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584219)
 ;
 
--- === 577441 IsAnonymousHuPickedOnTheFly : "Anonymous HU Picked On the Fly" -> "Anonyme HU im Lauf kommissioniert" ===
-UPDATE AD_Element SET Name='Anonyme HU im Lauf kommissioniert', Updated=TO_TIMESTAMP('2026-08-20 09:30:08','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441
+-- === 577441 IsAnonymousHuPickedOnTheFly : "Anonyme HU im Lauf kommissioniert" -> "Kommiss. ohne HU-Scan erl." (+ Description) ===
+-- Lets the picker enter a packed qty without scanning a source HU; PickingJobPickCommand
+-- (createPickFromHUOnTheFly) creates a new anonymous HU on the fly to receive it. Such picks are
+-- excluded from transport-order assignment unless explicitly allowed
+-- (InOutToTransportationOrderService.java:130).
+UPDATE AD_Element SET Name='Kommiss. ohne HU-Scan erl.', Description='Erlaubt das Kommissionieren einer Menge, ohne vorher eine Quell-HU zu scannen; das System legt dafür automatisch eine neue, anonyme HU an. Solche Kommissionierungen werden von der automatischen Zuordnung zu Transportaufträgen ausgeschlossen, sofern dies nicht ausdrücklich erlaubt ist.', Updated=TO_TIMESTAMP('2026-08-23 10:00:08','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441
 ;
-UPDATE AD_Element_Trl SET Name='Anonyme HU im Lauf kommissioniert', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:09','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Kommiss. ohne HU-Scan erl.', Description='Erlaubt das Kommissionieren einer Menge, ohne vorher eine Quell-HU zu scannen; das System legt dafür automatisch eine neue, anonyme HU an. Solche Kommissionierungen werden von der automatischen Zuordnung zu Transportaufträgen ausgeschlossen, sofern dies nicht ausdrücklich erlaubt ist.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:09','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Anonyme HU im Lauf kommissioniert', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:10','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Kommiss. ohne HU-Scan erl.', Description='Erlaubt das Kommissionieren einer Menge, ohne vorher eine Quell-HU zu scannen; das System legt dafür automatisch eine neue, anonyme HU an. Solche Kommissionierungen werden von der automatischen Zuordnung zu Transportaufträgen ausgeschlossen, sofern dies nicht ausdrücklich erlaubt ist.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:10','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441 AND AD_Language='de_CH'
 ;
-UPDATE AD_Element_Trl SET Name='Anonymous HU Picked On the Fly', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:11','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441 AND AD_Language='en_US'
+UPDATE AD_Element_Trl SET Name='Anonymous HU Picked On the Fly', Description='Allows picking a quantity without first scanning a source HU; the system automatically creates a new anonymous HU for it. Such picks are excluded from automatic transport-order assignment unless explicitly allowed.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-23 10:00:11','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441 AND AD_Language='en_US'
 ;
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(577441)
 ;
 
--- === 583887 IsConsideredOnlyScheduledJobs : "Consider only scheduled jobs" -> "Nur eingeplante Kommissionieraufgaben berücksichtigen" ===
-UPDATE AD_Element SET Name='Nur eingeplante Kommissionieraufgaben berücksichtigen', Updated=TO_TIMESTAMP('2026-08-20 09:30:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887
+-- === 583887 IsConsideredOnlyScheduledJobs : "Nur eingeplante Kommissionieraufgaben berücksichtigen" -> "Nur zugewiesene Aufgaben" (+ Description) ===
+-- Only usage is MassPrintingService.java:115 (mass-printing feature): restricts candidate picking
+-- jobs to those assigned to the operator's current workplace via Traffic Management (AD_Element
+-- 584131 -- kept identical in DE/EN, used verbatim here). Distinct from the neighbouring
+-- IsActiveWorkplaceRequired ("Aktiver Arbeitsplatz erforderlich").
+UPDATE AD_Element SET Name='Nur zugewiesene Aufgaben', Description='Zeigt beim Massendruck nur Kommissionieraufgaben an, die über das Traffic Management dem aktuellen Arbeitsplatz des Bedieners zugewiesen wurden. Zu unterscheiden von „Aktiver Arbeitsplatz erforderlich“.', Updated=TO_TIMESTAMP('2026-08-23 10:00:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887
 ;
-UPDATE AD_Element_Trl SET Name='Nur eingeplante Kommissionieraufgaben berücksichtigen', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:13','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Nur zugewiesene Aufgaben', Description='Zeigt beim Massendruck nur Kommissionieraufgaben an, die über das Traffic Management dem aktuellen Arbeitsplatz des Bedieners zugewiesen wurden. Zu unterscheiden von „Aktiver Arbeitsplatz erforderlich“.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:13','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Nur eingeplante Kommissionieraufgaben berücksichtigen', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:14','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Nur zugewiesene Aufgaben', Description='Zeigt beim Massendruck nur Kommissionieraufgaben an, die über das Traffic Management dem aktuellen Arbeitsplatz des Bedieners zugewiesen wurden. Zu unterscheiden von „Aktiver Arbeitsplatz erforderlich“.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:14','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887 AND AD_Language='de_CH'
 ;
-UPDATE AD_Element_Trl SET Name='Consider only scheduled jobs', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:15','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887 AND AD_Language='en_US'
+UPDATE AD_Element_Trl SET Name='Consider only scheduled jobs', Description='When mass printing, only considers picking jobs that have been assigned to the operator''s current workplace via Traffic Management. Distinct from "Active workplace required".', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-23 10:00:15','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887 AND AD_Language='en_US'
 ;
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583887)
 ;
 
--- === 583565 IsFilterByBarcode : "Filter by Barcode" -> "Nach Barcode filtern" ===
-UPDATE AD_Element SET Name='Nach Barcode filtern', Updated=TO_TIMESTAMP('2026-08-20 09:30:16','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565
+-- === 583565 IsFilterByBarcode : "Filter by Barcode" -> "Nach Barcode filtern" (+ Description) ===
+UPDATE AD_Element SET Name='Nach Barcode filtern', Description='Blendet in der Liste der Kommissionieraufgaben eine Schaltfläche ein, mit der die Liste durch Scannen eines Barcodes gefiltert werden kann.', Updated=TO_TIMESTAMP('2026-08-23 10:00:16','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565
 ;
-UPDATE AD_Element_Trl SET Name='Nach Barcode filtern', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:17','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Nach Barcode filtern', Description='Blendet in der Liste der Kommissionieraufgaben eine Schaltfläche ein, mit der die Liste durch Scannen eines Barcodes gefiltert werden kann.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:17','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Nach Barcode filtern', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:18','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Nach Barcode filtern', Description='Blendet in der Liste der Kommissionieraufgaben eine Schaltfläche ein, mit der die Liste durch Scannen eines Barcodes gefiltert werden kann.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:18','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565 AND AD_Language='de_CH'
 ;
-UPDATE AD_Element_Trl SET Name='Filter by Barcode', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:19','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565 AND AD_Language='en_US'
+UPDATE AD_Element_Trl SET Name='Filter by Barcode', Description='Shows a button in the picking-jobs list that lets the list be filtered by scanning a barcode.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-23 10:00:19','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565 AND AD_Language='en_US'
 ;
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583565)
 ;
 
 -- === 53687 FormatPattern : "Format Pattern" -> "Formatmuster" (Name + Description; shared element, see header) ===
+-- NOT touched further for the PickingProfile_PickingJobConfig usage -- see the new AD_Element
+-- 585377 further below, linked via AD_Field.AD_Name_ID instead.
 UPDATE AD_Element SET Name='Formatmuster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', Updated=TO_TIMESTAMP('2026-08-20 09:30:20','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687
 ;
 UPDATE AD_Element_Trl SET Name='Formatmuster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:21','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687 AND AD_Language='de_DE'
@@ -86,50 +119,106 @@ UPDATE AD_Element_Trl SET Name='Format Pattern', Description='The pattern used t
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(53687)
 ;
 
--- === 583942 AllowPickToStructure_LU_TU : "Pick to LU/TU structure" -> "Kommissionierung zu LU/TU-Struktur" ===
-UPDATE AD_Element SET Name='Kommissionierung zu LU/TU-Struktur', Updated=TO_TIMESTAMP('2026-08-20 09:30:24','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942
+-- === 583942 AllowPickToStructure_LU_TU : "Kommissionierung zu LU/TU-Struktur" -> "Kommiss. zu LU/TU erlauben" (+ Description) ===
+UPDATE AD_Element SET Name='Kommiss. zu LU/TU erlauben', Description='Erlaubt das Kommissionieren in eine geschachtelte LU/TU-Struktur (Palette mit Kartons/TUs).', Updated=TO_TIMESTAMP('2026-08-23 10:00:20','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/TU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:25','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Kommiss. zu LU/TU erlauben', Description='Erlaubt das Kommissionieren in eine geschachtelte LU/TU-Struktur (Palette mit Kartons/TUs).', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:21','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/TU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:26','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Kommiss. zu LU/TU erlauben', Description='Erlaubt das Kommissionieren in eine geschachtelte LU/TU-Struktur (Palette mit Kartons/TUs).', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:22','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942 AND AD_Language='de_CH'
 ;
-UPDATE AD_Element_Trl SET Name='Pick to LU/TU structure', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:27','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942 AND AD_Language='en_US'
+UPDATE AD_Element_Trl SET Name='Pick to LU/TU structure', Description='Allows picking into a nested LU/TU structure (pallet with cartons/TUs).', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-23 10:00:23','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942 AND AD_Language='en_US'
 ;
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583942)
 ;
 
--- === 583943 AllowPickToStructure_LU_CU : "Pick to LU/CU structure" -> "Kommissionierung zu LU/CU-Struktur" ===
-UPDATE AD_Element SET Name='Kommissionierung zu LU/CU-Struktur', Updated=TO_TIMESTAMP('2026-08-20 09:30:28','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943
+-- === 583943 AllowPickToStructure_LU_CU : "Kommissionierung zu LU/CU-Struktur" -> "Kommiss. zu LU/CU erlauben" (+ Description) ===
+UPDATE AD_Element SET Name='Kommiss. zu LU/CU erlauben', Description='Erlaubt das Kommissionieren direkt in eine LU, die CUs ohne zwischengeschaltete TU enthält (Palette ohne Kartons).', Updated=TO_TIMESTAMP('2026-08-23 10:00:24','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/CU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:29','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Kommiss. zu LU/CU erlauben', Description='Erlaubt das Kommissionieren direkt in eine LU, die CUs ohne zwischengeschaltete TU enthält (Palette ohne Kartons).', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:25','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/CU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:30','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Kommiss. zu LU/CU erlauben', Description='Erlaubt das Kommissionieren direkt in eine LU, die CUs ohne zwischengeschaltete TU enthält (Palette ohne Kartons).', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:26','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943 AND AD_Language='de_CH'
 ;
-UPDATE AD_Element_Trl SET Name='Pick to LU/CU structure', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:31','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943 AND AD_Language='en_US'
+UPDATE AD_Element_Trl SET Name='Pick to LU/CU structure', Description='Allows picking directly into an LU that holds CUs without an intermediate TU (pallet without cartons).', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-23 10:00:27','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943 AND AD_Language='en_US'
 ;
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583943)
 ;
 
--- === 583944 AllowPickToStructure_TU : "Pick to top level TU structure" -> "Kommissionierung zur obersten TU-Struktur" ===
-UPDATE AD_Element SET Name='Kommissionierung zur obersten TU-Struktur', Updated=TO_TIMESTAMP('2026-08-20 09:30:32','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944
+-- === 583944 AllowPickToStructure_TU : "Kommissionierung zur obersten TU-Struktur" -> "Kommiss. zu oberster TU erl." (+ Description) ===
+UPDATE AD_Element SET Name='Kommiss. zu oberster TU erl.', Description='Erlaubt das Kommissionieren in eine eigenständige TU ohne übergeordnete LU (TU als oberste Verpackungsebene).', Updated=TO_TIMESTAMP('2026-08-23 10:00:28','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten TU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:33','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Kommiss. zu oberster TU erl.', Description='Erlaubt das Kommissionieren in eine eigenständige TU ohne übergeordnete LU (TU als oberste Verpackungsebene).', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:29','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten TU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:34','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Kommiss. zu oberster TU erl.', Description='Erlaubt das Kommissionieren in eine eigenständige TU ohne übergeordnete LU (TU als oberste Verpackungsebene).', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:30','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944 AND AD_Language='de_CH'
 ;
-UPDATE AD_Element_Trl SET Name='Pick to top level TU structure', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:35','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944 AND AD_Language='en_US'
+UPDATE AD_Element_Trl SET Name='Pick to top level TU structure', Description='Allows picking into a standalone TU with no parent LU (TU as the top packaging level).', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-23 10:00:31','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944 AND AD_Language='en_US'
 ;
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583944)
 ;
 
--- === 583945 AllowPickToStructure_CU : "Pick to top level CU structure" -> "Kommissionierung zur obersten CU-Struktur" ===
-UPDATE AD_Element SET Name='Kommissionierung zur obersten CU-Struktur', Updated=TO_TIMESTAMP('2026-08-20 09:30:36','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945
+-- === 583945 AllowPickToStructure_CU : "Kommissionierung zur obersten CU-Struktur" -> "Kommiss. zu oberster CU erl." (+ Description) ===
+UPDATE AD_Element SET Name='Kommiss. zu oberster CU erl.', Description='Erlaubt das Kommissionieren in eine lose CU ohne LU- oder TU-Verpackung (CU als oberste Ebene).', Updated=TO_TIMESTAMP('2026-08-23 10:00:32','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten CU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:37','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Kommiss. zu oberster CU erl.', Description='Erlaubt das Kommissionieren in eine lose CU ohne LU- oder TU-Verpackung (CU als oberste Ebene).', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:33','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten CU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:38','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Kommiss. zu oberster CU erl.', Description='Erlaubt das Kommissionieren in eine lose CU ohne LU- oder TU-Verpackung (CU als oberste Ebene).', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:34','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945 AND AD_Language='de_CH'
 ;
-UPDATE AD_Element_Trl SET Name='Pick to top level CU structure', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:39','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945 AND AD_Language='en_US'
+UPDATE AD_Element_Trl SET Name='Pick to top level CU structure', Description='Allows picking into a loose CU with no LU or TU packaging (CU as the top level).', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-23 10:00:35','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945 AND AD_Language='en_US'
 ;
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583945)
+;
+
+-- === Part B: dedicated AD_Element for PickingProfile_PickingJobConfig.FormatPattern ===
+-- On this one table (AD_Column 587947, AD_Field 725184) the shared element 53687's meaning does
+-- NOT apply -- the column holds an address-component display-order token string
+-- (AddressDisplaySequence.ofNullable(field.getPattern()), DisplayValueProvider.java:277-280,
+-- 331-338), not a number/date format pattern. Per the "meaning inconsistent across usages -> new
+-- AD_Element + AD_Field.AD_Name_ID" rule: create a new element and link it onto this ONE field,
+-- leaving 53687 untouched for its other 4 usages.
+INSERT INTO AD_Element (AD_Element_ID, AD_Client_ID, AD_Org_ID, IsActive, Created, CreatedBy, Updated, UpdatedBy,
+                        ColumnName, EntityType, Name, PrintName, Description)
+VALUES (585377 /*From ID Server*/, 0, 0, 'Y',
+        TO_TIMESTAMP('2026-08-23 10:00:36','YYYY-MM-DD HH24:MI:SS'), 100,
+        TO_TIMESTAMP('2026-08-23 10:00:36','YYYY-MM-DD HH24:MI:SS'), 100,
+        'PickingJobConfig_AddressDisplaySequence', 'D',
+        'Adressformat (Anzeige)', 'Adressformat (Anzeige)',
+        'Legt bei einem Adressfeld (z. B. Übergabeadresse) fest, welche Adressbestandteile in welcher Reihenfolge angezeigt werden. Kein Zahlen- oder Datumsformat.')
+;
+
+-- Skeleton _Trl rows for all active system languages
+INSERT INTO AD_Element_Trl (AD_Language, AD_Element_ID, Name, PrintName, Description, IsTranslated,
+                            AD_Client_ID, AD_Org_ID, Created, CreatedBy, Updated, UpdatedBy, IsActive)
+SELECT l.AD_Language, e.AD_Element_ID, e.Name, e.PrintName, e.Description, 'N',
+       e.AD_Client_ID, e.AD_Org_ID, e.Created, e.CreatedBy,
+       TO_TIMESTAMP('2026-08-23 10:00:37','YYYY-MM-DD HH24:MI:SS'), 100, 'Y'
+FROM AD_Language l, AD_Element e
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND e.AD_Element_ID=585377
+  AND NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=e.AD_Element_ID)
+;
+
+-- de_DE / de_CH: German, IsTranslated='N' (base-language convention)
+UPDATE AD_Element_Trl SET Name='Adressformat (Anzeige)', Description='Legt bei einem Adressfeld (z. B. Übergabeadresse) fest, welche Adressbestandteile in welcher Reihenfolge angezeigt werden. Kein Zahlen- oder Datumsformat.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:38','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=585377 AND AD_Language='de_DE'
+;
+UPDATE AD_Element_Trl SET Name='Adressformat (Anzeige)', Description='Legt bei einem Adressfeld (z. B. Übergabeadresse) fest, welche Adressbestandteile in welcher Reihenfolge angezeigt werden. Kein Zahlen- oder Datumsformat.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-23 10:00:39','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=585377 AND AD_Language='de_CH'
+;
+
+-- en_US: English override, IsTranslated='Y'
+UPDATE AD_Element_Trl SET Name='Address format (display)', Description='For an address-type field (e.g. handover address), defines which address components are shown and in what order. Not a number or date format.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-23 10:00:40','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=585377 AND AD_Language='en_US'
+;
+
+SELECT update_TRL_Tables_On_AD_Element_TRL_Update(585377)
+;
+
+-- Link AD_Field 725184 (FormatPattern field on PickingProfile_PickingJobConfig / AD_Column 587947)
+-- to the new element via AD_Name_ID -- the shared element 53687 is NOT touched for this usage.
+UPDATE AD_Field SET AD_Name_ID=585377, Updated=TO_TIMESTAMP('2026-08-23 10:00:41','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Field_ID=725184
+;
+
+-- Propagate the new element's translations onto AD_Field_Trl / AD_Field via the AD_Name_ID path
+SELECT update_FieldTranslation_From_AD_Name_Element(585377)
+;
+
+-- Rebuild the element link so dictionary tooling reflects the new AD_Name_ID override
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=725184
+;
+SELECT AD_Element_Link_Create_Missing_Field(725184)
 ;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5819670_sys_PickingProfile_PickingJobConfig_Options_Translations.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5819670_sys_PickingProfile_PickingJobConfig_Options_Translations.sql
@@ -17,9 +17,9 @@
 -- === 583513 PickingJobAggregationType : "Aggregation Type" -> "Aggregationstyp" ===
 UPDATE AD_Element SET Name='Aggregationstyp', Updated=TO_TIMESTAMP('2026-08-20 09:30:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513
 ;
-UPDATE AD_Element_Trl SET Name='Aggregationstyp', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Aggregationstyp', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Aggregationstyp', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Aggregationstyp', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513 AND AD_Language='de_CH'
 ;
 UPDATE AD_Element_Trl SET Name='Aggregation Type', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:03','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583513 AND AD_Language='en_US'
 ;
@@ -29,9 +29,9 @@ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583513)
 -- === 584219 IsAllowQuickPackAll : "Allow Quick Pack All" -> "Schnellverpackung für alle erlauben" ===
 UPDATE AD_Element SET Name='Schnellverpackung für alle erlauben', Updated=TO_TIMESTAMP('2026-08-20 09:30:04','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219
 ;
-UPDATE AD_Element_Trl SET Name='Schnellverpackung für alle erlauben', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:05','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Schnellverpackung für alle erlauben', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:05','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Schnellverpackung für alle erlauben', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:06','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Schnellverpackung für alle erlauben', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:06','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219 AND AD_Language='de_CH'
 ;
 UPDATE AD_Element_Trl SET Name='Allow Quick Pack All', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:07','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=584219 AND AD_Language='en_US'
 ;
@@ -41,9 +41,9 @@ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(584219)
 -- === 577441 IsAnonymousHuPickedOnTheFly : "Anonymous HU Picked On the Fly" -> "Anonyme HU im Lauf kommissioniert" ===
 UPDATE AD_Element SET Name='Anonyme HU im Lauf kommissioniert', Updated=TO_TIMESTAMP('2026-08-20 09:30:08','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441
 ;
-UPDATE AD_Element_Trl SET Name='Anonyme HU im Lauf kommissioniert', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:09','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Anonyme HU im Lauf kommissioniert', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:09','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Anonyme HU im Lauf kommissioniert', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:10','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Anonyme HU im Lauf kommissioniert', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:10','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441 AND AD_Language='de_CH'
 ;
 UPDATE AD_Element_Trl SET Name='Anonymous HU Picked On the Fly', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:11','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=577441 AND AD_Language='en_US'
 ;
@@ -53,9 +53,9 @@ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(577441)
 -- === 583887 IsConsideredOnlyScheduledJobs : "Consider only scheduled jobs" -> "Nur eingeplante Kommissionieraufgaben berücksichtigen" ===
 UPDATE AD_Element SET Name='Nur eingeplante Kommissionieraufgaben berücksichtigen', Updated=TO_TIMESTAMP('2026-08-20 09:30:12','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887
 ;
-UPDATE AD_Element_Trl SET Name='Nur eingeplante Kommissionieraufgaben berücksichtigen', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:13','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Nur eingeplante Kommissionieraufgaben berücksichtigen', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:13','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Nur eingeplante Kommissionieraufgaben berücksichtigen', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:14','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Nur eingeplante Kommissionieraufgaben berücksichtigen', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:14','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887 AND AD_Language='de_CH'
 ;
 UPDATE AD_Element_Trl SET Name='Consider only scheduled jobs', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:15','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583887 AND AD_Language='en_US'
 ;
@@ -65,9 +65,9 @@ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583887)
 -- === 583565 IsFilterByBarcode : "Filter by Barcode" -> "Nach Barcode filtern" ===
 UPDATE AD_Element SET Name='Nach Barcode filtern', Updated=TO_TIMESTAMP('2026-08-20 09:30:16','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565
 ;
-UPDATE AD_Element_Trl SET Name='Nach Barcode filtern', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:17','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Nach Barcode filtern', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:17','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Nach Barcode filtern', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:18','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Nach Barcode filtern', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:18','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565 AND AD_Language='de_CH'
 ;
 UPDATE AD_Element_Trl SET Name='Filter by Barcode', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:19','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583565 AND AD_Language='en_US'
 ;
@@ -77,9 +77,9 @@ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583565)
 -- === 53687 FormatPattern : "Format Pattern" -> "Formatmuster" (Name + Description; shared element, see header) ===
 UPDATE AD_Element SET Name='Formatmuster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', Updated=TO_TIMESTAMP('2026-08-20 09:30:20','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687
 ;
-UPDATE AD_Element_Trl SET Name='Formatmuster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:21','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Formatmuster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:21','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Formatmuster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:22','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Formatmuster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:22','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687 AND AD_Language='de_CH'
 ;
 UPDATE AD_Element_Trl SET Name='Format Pattern', Description='The pattern used to format a number or date.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:23','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687 AND AD_Language='en_US'
 ;
@@ -89,9 +89,9 @@ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(53687)
 -- === 583942 AllowPickToStructure_LU_TU : "Pick to LU/TU structure" -> "Kommissionierung zu LU/TU-Struktur" ===
 UPDATE AD_Element SET Name='Kommissionierung zu LU/TU-Struktur', Updated=TO_TIMESTAMP('2026-08-20 09:30:24','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/TU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:25','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/TU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:25','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/TU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:26','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/TU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:26','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942 AND AD_Language='de_CH'
 ;
 UPDATE AD_Element_Trl SET Name='Pick to LU/TU structure', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:27','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583942 AND AD_Language='en_US'
 ;
@@ -101,9 +101,9 @@ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583942)
 -- === 583943 AllowPickToStructure_LU_CU : "Pick to LU/CU structure" -> "Kommissionierung zu LU/CU-Struktur" ===
 UPDATE AD_Element SET Name='Kommissionierung zu LU/CU-Struktur', Updated=TO_TIMESTAMP('2026-08-20 09:30:28','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/CU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:29','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/CU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:29','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/CU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:30','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Kommissionierung zu LU/CU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:30','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943 AND AD_Language='de_CH'
 ;
 UPDATE AD_Element_Trl SET Name='Pick to LU/CU structure', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:31','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583943 AND AD_Language='en_US'
 ;
@@ -113,9 +113,9 @@ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583943)
 -- === 583944 AllowPickToStructure_TU : "Pick to top level TU structure" -> "Kommissionierung zur obersten TU-Struktur" ===
 UPDATE AD_Element SET Name='Kommissionierung zur obersten TU-Struktur', Updated=TO_TIMESTAMP('2026-08-20 09:30:32','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten TU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:33','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten TU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:33','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten TU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:34','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten TU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:34','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944 AND AD_Language='de_CH'
 ;
 UPDATE AD_Element_Trl SET Name='Pick to top level TU structure', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:35','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583944 AND AD_Language='en_US'
 ;
@@ -125,9 +125,9 @@ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583944)
 -- === 583945 AllowPickToStructure_CU : "Pick to top level CU structure" -> "Kommissionierung zur obersten CU-Struktur" ===
 UPDATE AD_Element SET Name='Kommissionierung zur obersten CU-Struktur', Updated=TO_TIMESTAMP('2026-08-20 09:30:36','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten CU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:37','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten CU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:37','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten CU-Struktur', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:38','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Kommissionierung zur obersten CU-Struktur', IsTranslated='N', Updated=TO_TIMESTAMP('2026-08-20 09:30:38','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945 AND AD_Language='de_CH'
 ;
 UPDATE AD_Element_Trl SET Name='Pick to top level CU structure', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:39','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=583945 AND AD_Language='en_US'
 ;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5819670_sys_PickingProfile_PickingJobConfig_Options_Translations.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5819670_sys_PickingProfile_PickingJobConfig_Options_Translations.sql
@@ -74,12 +74,12 @@ UPDATE AD_Element_Trl SET Name='Filter by Barcode', IsTranslated='Y', Updated=TO
 SELECT update_TRL_Tables_On_AD_Element_TRL_Update(583565)
 ;
 
--- === 53687 FormatPattern : "Format Pattern" -> "Format-Muster" (Name + Description; shared element, see header) ===
-UPDATE AD_Element SET Name='Format-Muster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', Updated=TO_TIMESTAMP('2026-08-20 09:30:20','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687
+-- === 53687 FormatPattern : "Format Pattern" -> "Formatmuster" (Name + Description; shared element, see header) ===
+UPDATE AD_Element SET Name='Formatmuster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', Updated=TO_TIMESTAMP('2026-08-20 09:30:20','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687
 ;
-UPDATE AD_Element_Trl SET Name='Format-Muster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:21','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687 AND AD_Language='de_DE'
+UPDATE AD_Element_Trl SET Name='Formatmuster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:21','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687 AND AD_Language='de_DE'
 ;
-UPDATE AD_Element_Trl SET Name='Format-Muster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:22','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687 AND AD_Language='de_CH'
+UPDATE AD_Element_Trl SET Name='Formatmuster', Description='Das Muster, das zur Formatierung einer Zahl oder eines Datums verwendet wird.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:22','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687 AND AD_Language='de_CH'
 ;
 UPDATE AD_Element_Trl SET Name='Format Pattern', Description='The pattern used to format a number or date.', IsTranslated='Y', Updated=TO_TIMESTAMP('2026-08-20 09:30:23','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100 WHERE AD_Element_ID=53687 AND AD_Language='en_US'
 ;

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/PickingJobFieldType.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/config/mobileui/PickingJobFieldType.java
@@ -44,6 +44,7 @@ import static de.metas.picking.model.X_PickingProfile_PickingJobConfig.PICKINGJO
 import static de.metas.picking.model.X_PickingProfile_PickingJobConfig.PICKINGJOBFIELD_DocumentNo;
 import static de.metas.picking.model.X_PickingProfile_PickingJobConfig.PICKINGJOBFIELD_HandoverLocation;
 import static de.metas.picking.model.X_PickingProfile_PickingJobConfig.PICKINGJOBFIELD_ProductName;
+import static de.metas.picking.model.X_PickingProfile_PickingJobConfig.PICKINGJOBFIELD_ProductNames;
 import static de.metas.picking.model.X_PickingProfile_PickingJobConfig.PICKINGJOBFIELD_ProductNo;
 import static de.metas.picking.model.X_PickingProfile_PickingJobConfig.PICKINGJOBFIELD_QtyToDeliver;
 import static de.metas.picking.model.X_PickingProfile_PickingJobConfig.PICKINGJOBFIELD_RuestplatzNr;
@@ -60,6 +61,7 @@ public enum PickingJobFieldType implements ReferenceListAwareEnum
 	RUESTPLATZ_NR(PICKINGJOBFIELD_RuestplatzNr),
 	PRODUCT_NO(PICKINGJOBFIELD_ProductNo),
 	PRODUCT_NAME(PICKINGJOBFIELD_ProductName),
+	PRODUCT_NAMES(PICKINGJOBFIELD_ProductNames),
 	QTY_TO_DELIVER(PICKINGJOBFIELD_QtyToDeliver),
 	;
 

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJob.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJob.java
@@ -34,6 +34,8 @@ import de.metas.bpartner.BPartnerLocationId;
 import de.metas.handlingunits.HuId;
 import de.metas.handlingunits.picking.PackToSpec;
 import de.metas.handlingunits.picking.config.mobileui.PickingJobAggregationType;
+import de.metas.i18n.ITranslatableString;
+import de.metas.i18n.TranslatableStrings;
 import de.metas.picking.api.PickingSlotId;
 import de.metas.picking.api.PickingSlotIdAndCaption;
 import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
@@ -576,6 +578,18 @@ public final class PickingJob implements PickingJobHeaderOrLine
 		}
 
 		return productValueAndName;
+	}
+
+	@NonNull
+	public ITranslatableString getProductNamesJoined()
+	{
+		final ImmutableList<ITranslatableString> names = lines.stream()
+				.collect(ImmutableMap.toImmutableMap(
+						PickingJobLine::getProductId,
+						line -> line.getProductValueAndName().getName(),
+						(first, duplicate) -> first))   // same product on several lines -> named once
+				.values().asList();
+		return TranslatableStrings.join(", ", names);
 	}
 
 	@Nullable

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJob.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJob.java
@@ -48,6 +48,7 @@ import de.metas.uom.UomId;
 import de.metas.user.UserId;
 import de.metas.util.Check;
 import de.metas.util.Optionals;
+import de.metas.util.StreamUtils;
 import de.metas.util.collections.CollectionUtils;
 import lombok.Builder;
 import lombok.Getter;
@@ -583,13 +584,12 @@ public final class PickingJob implements PickingJobHeaderOrLine
 	@NonNull
 	public ITranslatableString getProductNamesJoined()
 	{
-		final ImmutableList<ITranslatableString> names = lines.stream()
-				.collect(ImmutableMap.toImmutableMap(
-						PickingJobLine::getProductId,
-						line -> line.getProductValueAndName().getName(),
-						(first, duplicate) -> first))   // same product on several lines -> named once
-				.values().asList();
-		return TranslatableStrings.join(", ", names);
+		// distinct by ProductId (never by displayed text, so two distinct products sharing a name both appear);
+		// filter preserves encounter order, so the names read in line order.
+		return lines.stream()
+				.filter(StreamUtils.distinctByKey(PickingJobLine::getProductId))
+				.map(line -> line.getProductValueAndName().getName())
+				.collect(TranslatableStrings.joining(", "));
 	}
 
 	@Nullable

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobCandidateProducts.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobCandidateProducts.java
@@ -1,6 +1,5 @@
 package de.metas.handlingunits.picking.job.model;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import de.metas.i18n.ITranslatableString;
@@ -133,9 +132,8 @@ public class PickingJobCandidateProducts implements Iterable<PickingJobCandidate
 	{
 		// No deduplication is needed on this path: byProductId is keyed by ProductId and built with Maps.uniqueIndex,
 		// so a repeated product cannot exist here.
-		return TranslatableStrings.join(", ",
-				byProductId.values().stream()
-						.map(product -> product.getProductValueAndName().getName())
-						.collect(ImmutableList.toImmutableList()));
+		return byProductId.values().stream()
+				.map(product -> product.getProductValueAndName().getName())
+				.collect(TranslatableStrings.joining(", "));
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobCandidateProducts.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/model/PickingJobCandidateProducts.java
@@ -1,7 +1,10 @@
 package de.metas.handlingunits.picking.job.model;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import de.metas.i18n.ITranslatableString;
+import de.metas.i18n.TranslatableStrings;
 import de.metas.product.ProductId;
 import de.metas.product.ProductValueAndName;
 import de.metas.quantity.Quantity;
@@ -123,5 +126,16 @@ public class PickingJobCandidateProducts implements Iterable<PickingJobCandidate
 	public ProductValueAndName getSingleProductValueAndNameOrNull()
 	{
 		return singleProduct != null ? singleProduct.getProductValueAndName() : null;
+	}
+
+	@NonNull
+	public ITranslatableString getProductNamesJoined()
+	{
+		// No deduplication is needed on this path: byProductId is keyed by ProductId and built with Maps.uniqueIndex,
+		// so a repeated product cannot exist here.
+		return TranslatableStrings.join(", ",
+				byProductId.values().stream()
+						.map(product -> product.getProductValueAndName().getName())
+						.collect(ImmutableList.toImmutableList()));
 	}
 }

--- a/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaver.java
+++ b/backend/de.metas.handlingunits.base/src/main/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaver.java
@@ -862,7 +862,13 @@ class PickingJobLoaderAndSaver extends PickingJobSaver
 	private PickingJobCandidateProducts extractProducts(final PickingJobId pickingJobId)
 	{
 		final PickingJobCandidateProductsCollector collector = new PickingJobCandidateProductsCollector();
-		for (final I_M_Picking_Job_Line line : this.pickingJobLines.get(pickingJobId))
+		// Sorted for the same reason loadPickingJob sorts its lines: this collection's iteration order becomes the
+		// order of the launcher caption's product names, so an unordered scan would render them differently run to run.
+		final ImmutableList<I_M_Picking_Job_Line> linesInPredictableOrder = this.pickingJobLines.get(pickingJobId)
+				.stream()
+				.sorted(Comparator.comparingInt(I_M_Picking_Job_Line::getM_Picking_Job_Line_ID))
+				.collect(ImmutableList.toImmutableList());
+		for (final I_M_Picking_Job_Line line : linesInPredictableOrder)
 		{
 			final ProductId productId = extractProductId(line);
 			collector.collect(

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaverProductOrderTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaverProductOrderTest.java
@@ -1,0 +1,100 @@
+package de.metas.handlingunits.picking.job.repository;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import de.metas.business.BusinessTestHelper;
+import de.metas.handlingunits.model.I_M_Picking_Job;
+import de.metas.handlingunits.model.I_M_Picking_Job_Line;
+import de.metas.handlingunits.picking.config.mobileui.PickingJobAggregationType;
+import de.metas.handlingunits.picking.job.model.PickingJobDocStatus;
+import de.metas.handlingunits.picking.job.model.PickingJobId;
+import de.metas.handlingunits.picking.job.model.PickingJobReference;
+import de.metas.organization.OrgId;
+import org.adempiere.ad.wrapper.POJOLookupMap;
+import org.adempiere.ad.wrapper.POJONextIdSuppliers;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The launcher caption of an already-started picking job joins the job's product names, and that
+ * order is the order {@code extractProducts} iterates the job's lines in. The lines arrive from a
+ * query with no {@code ORDER BY}, so the loader has to impose the order itself — otherwise the same
+ * job renders its products differently from one load to the next.
+ */
+class PickingJobLoaderAndSaverProductOrderTest
+{
+	private final OrgId orgId = OrgId.ofRepoId(1);
+	private MockedPickingJobLoaderSupportingServices loadingSupportServices;
+	private I_C_UOM uomEach;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		POJOLookupMap.setNextIdSupplier(POJONextIdSuppliers.newPerTableSequence());
+
+		// registers PickingJobLineCarrierServiceRepository in the JUnit bean registry, which
+		// PickingJobSaver resolves when PickingJobLoaderAndSaver is constructed
+		PickingJobLineCarrierServiceRepository.newInstanceForUnitTesting();
+
+		loadingSupportServices = new MockedPickingJobLoaderSupportingServices();
+		uomEach = BusinessTestHelper.createUomEach();
+	}
+
+	private I_M_Picking_Job createJob()
+	{
+		final I_M_Picking_Job job = InterfaceWrapperHelper.newInstance(I_M_Picking_Job.class);
+		job.setAD_Org_ID(orgId.getRepoId());
+		job.setDocStatus(PickingJobDocStatus.Drafted.getCode());
+		job.setPickingJobAggregationType(PickingJobAggregationType.SALES_ORDER.getCode());
+		job.setIsActive(true);
+		InterfaceWrapperHelper.saveRecord(job);
+		return job;
+	}
+
+	private I_M_Picking_Job_Line createLine(final I_M_Picking_Job job, final int productRepoId, final int shipmentScheduleRepoId)
+	{
+		final I_M_Picking_Job_Line line = InterfaceWrapperHelper.newInstance(I_M_Picking_Job_Line.class);
+		line.setAD_Org_ID(orgId.getRepoId());
+		line.setM_Picking_Job_ID(job.getM_Picking_Job_ID());
+		line.setM_Product_ID(productRepoId);
+		line.setM_ShipmentSchedule_ID(shipmentScheduleRepoId);
+		line.setC_UOM_ID(uomEach.getC_UOM_ID());
+		line.setQtyToPick(BigDecimal.ONE);
+		line.setIsActive(true);
+		InterfaceWrapperHelper.saveRecord(line);
+		return line;
+	}
+
+	@Test
+	void productNames_followLineIdOrder_whateverOrderTheLinesWereLoadedIn()
+	{
+		final I_M_Picking_Job job = createJob();
+		// created ascending, so line id order and product id order agree
+		final ImmutableList<I_M_Picking_Job_Line> linesInIdOrder = ImmutableList.of(
+				createLine(job, 101, 201),
+				createLine(job, 102, 202),
+				createLine(job, 103, 203));
+
+		final PickingJobLoaderAndSaver loader = PickingJobLoaderAndSaver.forLoading(loadingSupportServices);
+		loader.addAlreadyLoadedFromDB(job);
+		// fed in REVERSE: this is what an unordered query may hand back, and it is exactly what an
+		// unsorted implementation would leak into the caption
+		linesInIdOrder.reverse().forEach(loader::addAlreadyLoadedFromDB);
+
+		final PickingJobId pickingJobId = PickingJobId.ofRepoId(job.getM_Picking_Job_ID());
+		final PickingJobReference reference = loader.streamPickingJobReferences(ImmutableSet.of(pickingJobId))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("no PickingJobReference loaded"));
+
+		assertThat(reference.getProducts().getProductNamesJoined().getDefaultValue())
+				.isEqualTo("productName-101, productName-102, productName-103");
+	}
+}

--- a/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaverProductOrderTest.java
+++ b/backend/de.metas.handlingunits.base/src/test/java/de/metas/handlingunits/picking/job/repository/PickingJobLoaderAndSaverProductOrderTest.java
@@ -27,6 +27,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * order is the order {@code extractProducts} iterates the job's lines in. The lines arrive from a
  * query with no {@code ORDER BY}, so the loader has to impose the order itself — otherwise the same
  * job renders its products differently from one load to the next.
+ * <p>
+ * JUnit is the right tier here rather than Playwright or Cucumber: the invariant is a pure in-memory
+ * ordering contract of the loader, reachable without a database because {@code addAlreadyLoadedFromDB}
+ * populates the line map directly. The mobile Playwright spec covers the user-visible caption and owns
+ * that layer; this test owns the ordering contract underneath it, so the two do not duplicate.
  */
 class PickingJobLoaderAndSaverProductOrderTest
 {
@@ -77,11 +82,13 @@ class PickingJobLoaderAndSaverProductOrderTest
 	void productNames_followLineIdOrder_whateverOrderTheLinesWereLoadedIn()
 	{
 		final I_M_Picking_Job job = createJob();
-		// created ascending, so line id order and product id order agree
+		// Product ids deliberately do NOT ascend with the line ids, so the expected string below is
+		// reached only by sorting on the LINE id: a sort on ProductId would yield 101,102,103 and a
+		// sort on nothing would yield the reversed feed order, and both differ from it.
 		final ImmutableList<I_M_Picking_Job_Line> linesInIdOrder = ImmutableList.of(
-				createLine(job, 101, 201),
-				createLine(job, 102, 202),
-				createLine(job, 103, 203));
+				createLine(job, 103, 201),
+				createLine(job, 101, 202),
+				createLine(job, 102, 203));
 
 		final PickingJobLoaderAndSaver loader = PickingJobLoaderAndSaver.forLoading(loadingSupportServices);
 		loader.addAlreadyLoadedFromDB(job);
@@ -95,6 +102,6 @@ class PickingJobLoaderAndSaverProductOrderTest
 				.orElseThrow(() -> new AssertionError("no PickingJobReference loaded"));
 
 		assertThat(reference.getProducts().getProductNamesJoined().getDefaultValue())
-				.isEqualTo("productName-101, productName-102, productName-103");
+				.isEqualTo("productName-103, productName-101, productName-102");
 	}
 }

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/DisplayValueProvider.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/DisplayValueProvider.java
@@ -215,6 +215,7 @@ public class DisplayValueProvider
 				.handoverLocationId(pickingJob.getHandoverLocationId())
 				.productValueAndName(pickingJob.getSingleProductValueAndName())
 				.qtyToDeliver(pickingJob.getSingleQtyToPickOrNull())
+				.productNames(pickingJob.getProductNamesJoined())
 				.build();
 	}
 
@@ -229,6 +230,7 @@ public class DisplayValueProvider
 				// .handoverLocationId(pickingJobLine.getHandoverLocationId())
 				.productValueAndName(pickingJobLine.getProductValueAndName())
 				.qtyToDeliver(pickingJobLine.getQtyToPick())
+				.productNames(pickingJobLine.getProductValueAndName().getName())
 				.build();
 	}
 

--- a/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/DisplayValueProvider.java
+++ b/backend/de.metas.picking.rest-api/src/main/java/de/metas/picking/workflow/DisplayValueProvider.java
@@ -185,6 +185,7 @@ public class DisplayValueProvider
 				.handoverLocationId(pickingJobCandidate.getHandoverLocationId())
 				.productValueAndName(pickingJobCandidate.getProductValueAndName())
 				.qtyToDeliver(pickingJobCandidate.getQtyToDeliver())
+				.productNames(pickingJobCandidate.getProducts().getProductNamesJoined())
 				.build();
 	}
 
@@ -199,6 +200,7 @@ public class DisplayValueProvider
 				.handoverLocationId(pickingJobReference.getHandoverLocationId())
 				.productValueAndName(pickingJobReference.getProductValueAndName())
 				.qtyToDeliver(pickingJobReference.getQtyToDeliver())
+				.productNames(pickingJobReference.getProducts().getProductNamesJoined())
 				.build();
 	}
 
@@ -284,6 +286,11 @@ public class DisplayValueProvider
 			{
 				final ProductValueAndName productValueAndName = context.getProductValueAndName();
 				return productValueAndName != null ? productValueAndName.getName() : TranslatableStrings.empty();
+			}
+			case PRODUCT_NAMES:
+			{
+				final ITranslatableString productNames = context.getProductNames();
+				return productNames != null ? productNames : TranslatableStrings.empty();
 			}
 			case QTY_TO_DELIVER:
 			{
@@ -382,6 +389,7 @@ public class DisplayValueProvider
 		@Nullable BPartnerLocationId handoverLocationId;
 		@Nullable ProductValueAndName productValueAndName;
 		@Nullable Quantity qtyToDeliver;
+		@Nullable ITranslatableString productNames;
 
 		@Nullable
 		public BPartnerLocationId getHandoverLocationIdWithFallback()

--- a/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/DisplayValueProviderProductNamesDetailTest.java
+++ b/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/DisplayValueProviderProductNamesDetailTest.java
@@ -155,6 +155,21 @@ class DisplayValueProviderProductNamesDetailTest
 	}
 
 	@Test
+	void job_productNames_namesTwoDistinctProductsSharingANameTwice()
+	{
+		final DisplayValueProvider provider = displayValueProvider();
+		// two genuinely different products that happen to carry the same name:
+		// deduplication is by ProductId, so neither may swallow the other
+		final PickingJobLine lineA = line(1, "Gouda");
+		final PickingJobLine lineB = line(2, "Gouda");
+		final PickingJob job = job(lineA, lineB);
+
+		final String caption = provider.getDisplayValue(productNamesField(), job).translate("en_US");
+
+		assertThat(caption).isEqualTo("Gouda, Gouda");
+	}
+
+	@Test
 	void line_productNames_namesOnlyItsOwnProduct()
 	{
 		final DisplayValueProvider provider = displayValueProvider();

--- a/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/DisplayValueProviderProductNamesDetailTest.java
+++ b/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/DisplayValueProviderProductNamesDetailTest.java
@@ -158,9 +158,10 @@ class DisplayValueProviderProductNamesDetailTest
 	void line_productNames_namesOnlyItsOwnProduct()
 	{
 		final DisplayValueProvider provider = displayValueProvider();
+		// a line resolves its own product independently of any job it belongs to,
+		// so no job is constructed here
 		final PickingJobLine lineA = line(1, "ProductA");
 		final PickingJobLine lineB = line(2, "ProductB");
-		job(lineA, lineB); // the job the lines belong to; only the line itself is passed below
 
 		final String captionA = provider.getDisplayValue(productNamesField(), lineA).translate("en_US");
 		final String captionB = provider.getDisplayValue(productNamesField(), lineB).translate("en_US");

--- a/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/DisplayValueProviderProductNamesDetailTest.java
+++ b/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/DisplayValueProviderProductNamesDetailTest.java
@@ -54,6 +54,7 @@ import de.metas.quantity.Quantity;
 import org.adempiere.test.AdempiereTestHelper;
 import org.compiere.model.I_C_UOM;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -140,33 +141,37 @@ class DisplayValueProviderProductNamesDetailTest
 				.build();
 	}
 
-	@Test
-	void job_productNames_namesEachDistinctProductOnceInFirstOccurrenceOrder()
+	@Nested
+	class JobProductNames
 	{
-		final DisplayValueProvider provider = displayValueProvider();
-		final PickingJobLine lineA1 = line(1, "ProductA");
-		final PickingJobLine lineB = line(2, "ProductB");
-		final PickingJobLine lineA2 = line(1, "ProductA"); // same product again, on a different line
-		final PickingJob job = job(lineA1, lineB, lineA2);
+		@Test
+		void namesEachDistinctProductOnceInFirstOccurrenceOrder()
+		{
+			final DisplayValueProvider provider = displayValueProvider();
+			final PickingJobLine lineA1 = line(1, "ProductA");
+			final PickingJobLine lineB = line(2, "ProductB");
+			final PickingJobLine lineA2 = line(1, "ProductA"); // same product again, on a different line
+			final PickingJob job = job(lineA1, lineB, lineA2);
 
-		final String caption = provider.getDisplayValue(productNamesField(), job).translate("en_US");
+			final String caption = provider.getDisplayValue(productNamesField(), job).translate("en_US");
 
-		assertThat(caption).isEqualTo("ProductA, ProductB");
-	}
+			assertThat(caption).isEqualTo("ProductA, ProductB");
+		}
 
-	@Test
-	void job_productNames_namesTwoDistinctProductsSharingANameTwice()
-	{
-		final DisplayValueProvider provider = displayValueProvider();
-		// two genuinely different products that happen to carry the same name:
-		// deduplication is by ProductId, so neither may swallow the other
-		final PickingJobLine lineA = line(1, "Gouda");
-		final PickingJobLine lineB = line(2, "Gouda");
-		final PickingJob job = job(lineA, lineB);
+		@Test
+		void namesTwoDistinctProductsSharingANameTwice()
+		{
+			final DisplayValueProvider provider = displayValueProvider();
+			// two genuinely different products that happen to carry the same name:
+			// deduplication is by ProductId, so neither may swallow the other
+			final PickingJobLine lineA = line(1, "Gouda");
+			final PickingJobLine lineB = line(2, "Gouda");
+			final PickingJob job = job(lineA, lineB);
 
-		final String caption = provider.getDisplayValue(productNamesField(), job).translate("en_US");
+			final String caption = provider.getDisplayValue(productNamesField(), job).translate("en_US");
 
-		assertThat(caption).isEqualTo("Gouda, Gouda");
+			assertThat(caption).isEqualTo("Gouda, Gouda");
+		}
 	}
 
 	@Test

--- a/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/DisplayValueProviderProductNamesDetailTest.java
+++ b/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/DisplayValueProviderProductNamesDetailTest.java
@@ -62,7 +62,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Covers the {@code PRODUCT_NAMES} launcher field type on the DETAIL surfaces (AC6, AC7, AC8): the started-job
+ * Covers the {@code PRODUCT_NAMES} launcher field type on the DETAIL surfaces: the started-job
  * header names every distinct product of the job (deduplicated by {@code ProductId}, first-occurrence order),
  * while an opened line names only its own product, never the job's others.
  */

--- a/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/DisplayValueProviderProductNamesDetailTest.java
+++ b/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/DisplayValueProviderProductNamesDetailTest.java
@@ -1,0 +1,183 @@
+/*
+ * #%L
+ * de.metas.picking.rest-api
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.picking.workflow;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import de.metas.bpartner.BPartnerLocationId;
+import de.metas.business.BusinessTestHelper;
+import de.metas.document.location.RenderedAddressProvider;
+import de.metas.handlingunits.HUPIItemProduct;
+import de.metas.handlingunits.HUPIItemProductId;
+import de.metas.handlingunits.HuPackingInstructionsItemId;
+import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfile;
+import de.metas.handlingunits.picking.config.mobileui.PickingJobAggregationType;
+import de.metas.handlingunits.picking.config.mobileui.PickingJobField;
+import de.metas.handlingunits.picking.config.mobileui.PickingJobFieldType;
+import de.metas.handlingunits.picking.job.model.PickingJob;
+import de.metas.handlingunits.picking.job.model.PickingJobDocStatus;
+import de.metas.handlingunits.picking.job.model.PickingJobHeader;
+import de.metas.handlingunits.picking.job.model.PickingJobId;
+import de.metas.handlingunits.picking.job.model.PickingJobLine;
+import de.metas.handlingunits.picking.job.model.PickingJobLineId;
+import de.metas.handlingunits.picking.job.model.PickingUnit;
+import de.metas.handlingunits.picking.job.service.external.bpartner.PickingJobBPartnerService;
+import de.metas.i18n.TranslatableStrings;
+import de.metas.inout.ShipmentScheduleId;
+import de.metas.order.OrderAndLineId;
+import de.metas.organization.IOrgDAO;
+import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
+import de.metas.product.ProductCategoryId;
+import de.metas.product.ProductId;
+import de.metas.product.ProductValueAndName;
+import de.metas.quantity.Quantity;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the {@code PRODUCT_NAMES} launcher field type on the DETAIL surfaces (AC6, AC7, AC8): the started-job
+ * header names every distinct product of the job (deduplicated by {@code ProductId}, first-occurrence order),
+ * while an opened line names only its own product, never the job's others.
+ */
+class DisplayValueProviderProductNamesDetailTest
+{
+	private I_C_UOM each;
+	private int nextRepoId;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		each = BusinessTestHelper.createUomEach();
+		nextRepoId = 1;
+	}
+
+	private DisplayValueProvider displayValueProvider()
+	{
+		final IOrgDAO orgDAO = mock(IOrgDAO.class);
+		final PickingJobBPartnerService bpartnerService = mock(PickingJobBPartnerService.class);
+		when(bpartnerService.newRenderedAddressProvider()).thenReturn(mock(RenderedAddressProvider.class));
+
+		return DisplayValueProvider.builder()
+				.orgDAO(orgDAO)
+				.bpartnerService(bpartnerService)
+				.profile(MobileUIPickingUserProfile.DEFAULT)
+				.build();
+	}
+
+	private PickingJobField productNamesField()
+	{
+		return PickingJobField.builder().seqNo(10).field(PickingJobFieldType.PRODUCT_NAMES).isShowInSummary(false).isShowInDetailed(true).build();
+	}
+
+	private PickingJobLine line(final int productRepoId, final String name)
+	{
+		final int lineRepoId = nextRepoId++;
+		final ProductId productId = ProductId.ofRepoId(productRepoId);
+
+		return PickingJobLine.builder()
+				.id(PickingJobLineId.ofRepoId(lineRepoId))
+				.caption(TranslatableStrings.anyLanguage("line-" + lineRepoId))
+				.productId(productId)
+				.productNo("value-" + productRepoId)
+				.productCategoryId(ProductCategoryId.ofRepoId(1))
+				.productValueAndName(ProductValueAndName.of("value-" + productRepoId, TranslatableStrings.anyLanguage(name)))
+				.packingInfo(HUPIItemProduct.builder()
+						.id(HUPIItemProductId.VIRTUAL_HU)
+						.name(TranslatableStrings.anyLanguage("packing"))
+						.piItemId(HuPackingInstructionsItemId.VIRTUAL)
+						.build())
+				.qtyToPick(Quantity.of("1", each))
+				.salesOrderAndLineId(OrderAndLineId.ofRepoIds(1, lineRepoId))
+				.salesOrderDocumentNo("SO1")
+				.orderLineSeqNo(lineRepoId * 10)
+				.deliveryBPLocationId(BPartnerLocationId.ofRepoId(1, 1))
+				.scheduleId(ShipmentScheduleAndJobScheduleId.ofShipmentScheduleId(ShipmentScheduleId.ofRepoId(lineRepoId)))
+				.steps(ImmutableList.of())
+				.pickingUnit(PickingUnit.CU)
+				.build();
+	}
+
+	private PickingJob job(final PickingJobLine... lines)
+	{
+		return PickingJob.builder()
+				.id(PickingJobId.ofRepoId(1))
+				.header(PickingJobHeader.builder()
+						.aggregationType(PickingJobAggregationType.SALES_ORDER)
+						.salesOrderDocumentNo("SO1")
+						.customerName("Acme")
+						.build())
+				.lines(ImmutableList.copyOf(lines))
+				.pickFromAlternatives(ImmutableSet.of())
+				.docStatus(PickingJobDocStatus.Drafted)
+				.build();
+	}
+
+	@Test
+	void job_productNames_namesEachDistinctProductOnceInFirstOccurrenceOrder()
+	{
+		final DisplayValueProvider provider = displayValueProvider();
+		final PickingJobLine lineA1 = line(1, "ProductA");
+		final PickingJobLine lineB = line(2, "ProductB");
+		final PickingJobLine lineA2 = line(1, "ProductA"); // same product again, on a different line
+		final PickingJob job = job(lineA1, lineB, lineA2);
+
+		final String caption = provider.getDisplayValue(productNamesField(), job).translate("en_US");
+
+		assertThat(caption).isEqualTo("ProductA, ProductB");
+	}
+
+	@Test
+	void line_productNames_namesOnlyItsOwnProduct()
+	{
+		final DisplayValueProvider provider = displayValueProvider();
+		final PickingJobLine lineA = line(1, "ProductA");
+		final PickingJobLine lineB = line(2, "ProductB");
+		job(lineA, lineB); // the job the lines belong to; only the line itself is passed below
+
+		final String captionA = provider.getDisplayValue(productNamesField(), lineA).translate("en_US");
+		final String captionB = provider.getDisplayValue(productNamesField(), lineB).translate("en_US");
+
+		assertThat(captionA).isEqualTo("ProductA");
+		assertThat(captionB).isEqualTo("ProductB");
+	}
+
+	@Test
+	void neitherJobNorLineCallThrows()
+	{
+		final DisplayValueProvider provider = displayValueProvider();
+		final PickingJobLine lineA = line(1, "ProductA");
+		final PickingJobLine lineB = line(2, "ProductB");
+		final PickingJob job = job(lineA, lineB);
+
+		assertThatCode(() -> provider.getDisplayValue(productNamesField(), job)).doesNotThrowAnyException();
+		assertThatCode(() -> provider.getDisplayValue(productNamesField(), lineA)).doesNotThrowAnyException();
+	}
+}

--- a/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/DisplayValueProviderProductNamesTest.java
+++ b/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/DisplayValueProviderProductNamesTest.java
@@ -1,0 +1,161 @@
+/*
+ * #%L
+ * de.metas.picking.rest-api
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.picking.workflow;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.business.BusinessTestHelper;
+import de.metas.document.location.RenderedAddressProvider;
+import de.metas.handlingunits.picking.config.mobileui.MobileUIPickingUserProfile;
+import de.metas.handlingunits.picking.config.mobileui.PickingJobAggregationType;
+import de.metas.handlingunits.picking.config.mobileui.PickingJobField;
+import de.metas.handlingunits.picking.config.mobileui.PickingJobFieldType;
+import de.metas.handlingunits.picking.job.model.PickingJobCandidate;
+import de.metas.handlingunits.picking.job.model.PickingJobCandidateProduct;
+import de.metas.handlingunits.picking.job.model.PickingJobCandidateProducts;
+import de.metas.handlingunits.picking.job.service.external.bpartner.PickingJobBPartnerService;
+import de.metas.i18n.TranslatableStrings;
+import de.metas.organization.IOrgDAO;
+import de.metas.product.ProductId;
+import de.metas.product.ProductValueAndName;
+import de.metas.quantity.Quantity;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the {@code PRODUCT_NAMES} launcher field type (AC2, AC3, AC4, AC5, AC8, AC9): a job-list
+ * caption listing every product of a multi-product job, joined by {@code ", "}, while the existing
+ * {@code PRODUCT_NAME} / {@code QTY_TO_DELIVER} fields stay blank for a multi-product job as before.
+ */
+class DisplayValueProviderProductNamesTest
+{
+	private I_C_UOM each;
+	private DisplayValueProvider displayValueProvider;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		each = BusinessTestHelper.createUomEach();
+	}
+
+	private DisplayValueProvider displayValueProvider(final PickingJobFieldType productFieldType)
+	{
+		final IOrgDAO orgDAO = mock(IOrgDAO.class);
+		final PickingJobBPartnerService bpartnerService = mock(PickingJobBPartnerService.class);
+		when(bpartnerService.newRenderedAddressProvider()).thenReturn(mock(RenderedAddressProvider.class));
+
+		final MobileUIPickingUserProfile profile = MobileUIPickingUserProfile.DEFAULT.toBuilder()
+				.fields(ImmutableList.of(
+						PickingJobField.builder().seqNo(10).field(PickingJobFieldType.DOCUMENT_NO).isShowInSummary(true).isShowInDetailed(true).build(),
+						PickingJobField.builder().seqNo(20).field(PickingJobFieldType.CUSTOMER).isShowInSummary(true).isShowInDetailed(true).build(),
+						PickingJobField.builder().seqNo(30).field(productFieldType).isShowInSummary(true).isShowInDetailed(true).build(),
+						PickingJobField.builder().seqNo(40).field(PickingJobFieldType.QTY_TO_DELIVER).isShowInSummary(true).isShowInDetailed(true).build()
+				))
+				.build();
+
+		return DisplayValueProvider.builder()
+				.orgDAO(orgDAO)
+				.bpartnerService(bpartnerService)
+				.profile(profile)
+				.build();
+	}
+
+	private PickingJobCandidateProduct product(final int productRepoId, final String name, final String qtyToDeliver)
+	{
+		final ProductId productId = ProductId.ofRepoId(productRepoId);
+		return PickingJobCandidateProduct.builder()
+				.productId(productId)
+				.productValueAndName(ProductValueAndName.of("value-" + productRepoId, TranslatableStrings.anyLanguage(name)))
+				.qtyToDeliver(qtyToDeliver != null ? Quantity.of(qtyToDeliver, each) : null)
+				.build();
+	}
+
+	private PickingJobCandidate candidate(final PickingJobCandidateProduct... products)
+	{
+		return PickingJobCandidate.builder()
+				.aggregationType(PickingJobAggregationType.SALES_ORDER)
+				.salesOrderDocumentNo("SO1")
+				.customerName("Acme")
+				.products(PickingJobCandidateProducts.ofList(ImmutableList.copyOf(products)))
+				.build();
+	}
+
+	@Test
+	void multiProduct_productNames_joinsAllNamesInOrder()
+	{
+		final DisplayValueProvider provider = displayValueProvider(PickingJobFieldType.PRODUCT_NAMES);
+		final PickingJobCandidate candidate = candidate(
+				product(1, "ProductA", null),
+				product(2, "ProductB", null),
+				product(3, "ProductC", null));
+
+		final String caption = provider.computeLauncherCaption(candidate).translate("en_US");
+
+		assertThat(caption).isEqualTo("SO1 | Acme | ProductA, ProductB, ProductC");
+	}
+
+	@Test
+	void singleProduct_productNames_isExactlyThatName()
+	{
+		final DisplayValueProvider provider = displayValueProvider(PickingJobFieldType.PRODUCT_NAMES);
+		final PickingJobCandidate candidate = candidate(product(1, "OnlyProduct", null));
+
+		final String caption = provider.computeLauncherCaption(candidate).translate("en_US");
+
+		assertThat(caption).isEqualTo("SO1 | Acme | OnlyProduct");
+	}
+
+	@Test
+	void multiProduct_existingProductNameField_staysBlank()
+	{
+		final DisplayValueProvider provider = displayValueProvider(PickingJobFieldType.PRODUCT_NAME);
+		final PickingJobCandidate candidate = candidate(
+				product(1, "ProductA", null),
+				product(2, "ProductB", null),
+				product(3, "ProductC", null));
+
+		final String caption = provider.computeLauncherCaption(candidate).translate("en_US");
+
+		assertThat(caption).isEqualTo("SO1 | Acme");
+	}
+
+	@Test
+	void multiProduct_qtyToDeliver_staysBlankEvenWhenEachProductHasAQty()
+	{
+		final DisplayValueProvider provider = displayValueProvider(PickingJobFieldType.PRODUCT_NAMES);
+		final PickingJobCandidate candidate = candidate(
+				product(1, "ProductA", "5"),
+				product(2, "ProductB", "10"),
+				product(3, "ProductC", "3"));
+
+		final String caption = provider.computeLauncherCaption(candidate).translate("en_US");
+
+		assertThat(caption).isEqualTo("SO1 | Acme | ProductA, ProductB, ProductC");
+	}
+}

--- a/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/DisplayValueProviderProductNamesTest.java
+++ b/backend/de.metas.picking.rest-api/src/test/java/de/metas/picking/workflow/DisplayValueProviderProductNamesTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Covers the {@code PRODUCT_NAMES} launcher field type (AC2, AC3, AC4, AC5, AC8, AC9): a job-list
+ * Covers the {@code PRODUCT_NAMES} launcher field type: a job-list
  * caption listing every product of a multi-product job, joined by {@code ", "}, while the existing
  * {@code PRODUCT_NAME} / {@code QTY_TO_DELIVER} fields stay blank for a multi-product job as before.
  */

--- a/e2e/mobile-webui/tests/spec/picking/productNames.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/productNames.spec.js
@@ -11,12 +11,12 @@ import { LoginScreen } from "../../utils/screens/LoginScreen";
  * exactly like before, and the existing PRODUCT_NAME field type stays untouched for a multi-product
  * order (blank, as before this feature existed).
  */
-const createMasterdata = async ({ productField, lines }) => {
+const createMasterdata = async ({ productField, lines, workplace }) => {
     return await Backend.createMasterdata({
         language: "en_US",
         request: {
             login: {
-                user: { language: "en_US" },
+                user: { language: "en_US", workplace },
             },
             mobileConfig: {
                 picking: {
@@ -27,6 +27,11 @@ const createMasterdata = async ({ productField, lines }) => {
                     shipOnCloseLU: false,
                     pickTo: ['LU_TU'],
                     allowCompletingPartialPickingJob: false,
+                    // Scope the job list to this test's own workplace so it never sees jobs created
+                    // by other tests sharing the same picking job list (each test gets its own
+                    // distinct workplace — see the `workplace` param below).
+                    activeWorkplaceRequired: true,
+                    considerOnlyJobScheduledToWorkplace: true,
                     fields: [
                         { field: 'DOCUMENT_NO' },
                         { field: 'CUSTOMER' },
@@ -37,6 +42,7 @@ const createMasterdata = async ({ productField, lines }) => {
             },
             bpartners: { "BP1": {} },
             warehouses: { "wh": {} },
+            workplaces: { [workplace]: {} },
             products: {
                 "P1": { price: 1 },
                 "P2": { price: 1 },
@@ -47,7 +53,7 @@ const createMasterdata = async ({ productField, lines }) => {
                     bpartner: 'BP1',
                     warehouse: 'wh',
                     datePromised: '2025-03-01T00:00:00.000+02:00',
-                    lines,
+                    lines: lines.map(line => ({ ...line, workplace })),
                 }
             },
         }
@@ -69,6 +75,7 @@ test('Multi-product order lists all product names', async ({ page }) => {
             { product: 'P2', qty: 3 },
             { product: 'P3', qty: 2 },
         ],
+        workplace: 'workplace1',
     });
 
     await LoginScreen.login(masterdata.login.user);
@@ -100,6 +107,7 @@ test('Single-product order looks unchanged', async ({ page }) => {
         lines: [
             { product: 'P1', qty: 5 },
         ],
+        workplace: 'workplace2',
     });
 
     await LoginScreen.login(masterdata.login.user);
@@ -134,6 +142,7 @@ test('The existing PRODUCT_NAME field type is untouched', async ({ page }) => {
             { product: 'P2', qty: 3 },
             { product: 'P3', qty: 2 },
         ],
+        workplace: 'workplace3',
     });
 
     await LoginScreen.login(masterdata.login.user);

--- a/e2e/mobile-webui/tests/spec/picking/productNames.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/productNames.spec.js
@@ -1,0 +1,152 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+
+/**
+ * Covers the PRODUCT_NAMES picking-launcher field type on the job LIST: a multi-product order's
+ * caption lists every product name (joined by ", ", no quantity), a single-product order looks
+ * exactly like before, and the existing PRODUCT_NAME field type stays untouched for a multi-product
+ * order (blank, as before this feature existed).
+ */
+const createMasterdata = async ({ productField, lines }) => {
+    return await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: {
+                user: { language: "en_US" },
+            },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    shipOnCloseLU: false,
+                    pickTo: ['LU_TU'],
+                    allowCompletingPartialPickingJob: false,
+                    fields: [
+                        { field: 'DOCUMENT_NO' },
+                        { field: 'CUSTOMER' },
+                        { field: productField, isShowInDetailed: false },
+                        { field: 'QTY_TO_DELIVER' },
+                    ],
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            products: {
+                "P1": { price: 1 },
+                "P2": { price: 1 },
+                "P3": { price: 1 },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines,
+                }
+            },
+        }
+    });
+}
+
+// noinspection JSUnusedLocalSymbols
+test('Multi-product order lists all product names', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00240');
+    allure.story('Picking launcher product names');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({
+        productField: 'PRODUCT_NAMES',
+        lines: [
+            { product: 'P1', qty: 5 },
+            { product: 'P2', qty: 3 },
+            { product: 'P3', qty: 2 },
+        ],
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+
+    const caption = [
+        masterdata.salesOrders.SO1.documentNo,
+        masterdata.bpartners.BP1.bpartnerCode,
+        [masterdata.products.P1.productName, masterdata.products.P2.productName, masterdata.products.P3.productName].join(", "),
+    ].join(" | ");
+
+    await PickingJobsListScreen.expectJobButtons([
+        { salesOrderId: masterdata.salesOrders.SO1.id, caption },
+    ]);
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Single-product order looks unchanged', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00240');
+    allure.story('Picking launcher product names');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({
+        productField: 'PRODUCT_NAMES',
+        lines: [
+            { product: 'P1', qty: 5 },
+        ],
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+
+    const caption = [
+        masterdata.salesOrders.SO1.documentNo,
+        masterdata.bpartners.BP1.bpartnerCode,
+        masterdata.products.P1.productName,
+        "5 Stk",
+    ].join(" | ");
+
+    await PickingJobsListScreen.expectJobButtons([
+        { salesOrderId: masterdata.salesOrders.SO1.id, caption },
+    ]);
+});
+
+// noinspection JSUnusedLocalSymbols
+test('The existing PRODUCT_NAME field type is untouched', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00240');
+    allure.story('Picking launcher product names');
+    allure.severity('normal');
+
+    const masterdata = await createMasterdata({
+        productField: 'PRODUCT_NAME',
+        lines: [
+            { product: 'P1', qty: 5 },
+            { product: 'P2', qty: 3 },
+            { product: 'P3', qty: 2 },
+        ],
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+
+    const caption = [
+        masterdata.salesOrders.SO1.documentNo,
+        masterdata.bpartners.BP1.bpartnerCode,
+    ].join(" | ");
+
+    await PickingJobsListScreen.expectJobButtons([
+        { salesOrderId: masterdata.salesOrders.SO1.id, caption },
+    ]);
+});

--- a/e2e/mobile-webui/tests/spec/picking/productNamesDetail.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/productNamesDetail.spec.js
@@ -124,7 +124,10 @@ test('Detail surfaces name the right subject', async ({ page }) => {
                     // configuration this customer will not use on the launcher, exercised here because
                     // the field type is available to any profile, not only the one this customer runs.
                     fields: [
+                        { field: 'DOCUMENT_NO' },
+                        { field: 'CUSTOMER' },
                         { field: 'PRODUCT_NAMES', isShowInDetailed: true },
+                        { field: 'QTY_TO_DELIVER' },
                     ],
                 }
             },

--- a/e2e/mobile-webui/tests/spec/picking/productNamesDetail.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/productNamesDetail.spec.js
@@ -1,0 +1,169 @@
+import { test } from "../../../playwright.config";
+import { allure } from 'allure-playwright';
+import { ApplicationsListScreen } from "../../utils/screens/ApplicationsListScreen";
+import { PickingJobsListScreen } from "../../utils/screens/picking/PickingJobsListScreen";
+import { PickingJobScreen } from "../../utils/screens/picking/PickingJobScreen";
+import { PickingJobLineScreen } from "../../utils/screens/picking/PickingJobLineScreen";
+import { Backend } from "../../utils/screens/Backend";
+import { LoginScreen } from "../../utils/screens/LoginScreen";
+
+// noinspection JSUnusedLocalSymbols
+test('Already-started job still lists its products', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00240');
+    allure.story('Picking launcher product names');
+    allure.severity('normal');
+
+    const masterdata = await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: {
+                user: { language: "en_US" },
+            },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    shipOnCloseLU: false,
+                    pickTo: ['LU_TU'],
+                    allowCompletingPartialPickingJob: false,
+                    fields: [
+                        { field: 'DOCUMENT_NO' },
+                        { field: 'CUSTOMER' },
+                        { field: 'PRODUCT_NAMES', isShowInDetailed: false },
+                        { field: 'QTY_TO_DELIVER' },
+                    ],
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            products: {
+                "P1": { price: 1 },
+                "P2": { price: 1 },
+                "P3": { price: 1 },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    lines: [
+                        { product: 'P1', qty: 5 },
+                        { product: 'P2', qty: 3 },
+                        { product: 'P3', qty: 2 },
+                    ],
+                }
+            },
+        }
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+
+    const caption = [
+        masterdata.salesOrders.SO1.documentNo,
+        masterdata.bpartners.BP1.bpartnerCode,
+        [masterdata.products.P1.productName, masterdata.products.P2.productName, masterdata.products.P3.productName].join(", "),
+    ].join(" | ");
+
+    await PickingJobsListScreen.expectJobButtons([
+        { salesOrderId: masterdata.salesOrders.SO1.id, caption, alreadyStarted: false },
+    ]);
+
+    await PickingJobsListScreen.startJob({ documentNo: masterdata.salesOrders.SO1.documentNo });
+    await PickingJobScreen.goBack();
+
+    await PickingJobsListScreen.expectJobButtons([
+        { salesOrderId: masterdata.salesOrders.SO1.id, caption, alreadyStarted: true },
+    ]);
+});
+
+// noinspection JSUnusedLocalSymbols
+test('Detail surfaces name the right subject', async ({ page }) => {
+    // === ALLURE METADATA ===
+    allure.epic('E0105: Picking');
+    allure.tag('F00240');
+    allure.story('Picking launcher product names');
+    allure.severity('normal');
+
+    const masterdata = await Backend.createMasterdata({
+        language: "en_US",
+        request: {
+            login: {
+                user: { language: "en_US" },
+            },
+            mobileConfig: {
+                picking: {
+                    aggregationType: "sales_order",
+                    allowPickingAnyCustomer: true,
+                    createShipmentPolicy: 'CL',
+                    allowPickingAnyHU: true,
+                    pickTo: ['LU_TU', 'TU', 'LU_CU', 'CU'],
+                    shipOnCloseLU: false,
+                    anonymousPickHUsOnTheFly: false,
+                    readAttributes: [],
+                    // ProductNames configured for the DETAIL surfaces only (isShowInDetailed) — a
+                    // configuration this customer will not use on the launcher, exercised here because
+                    // the field type is available to any profile, not only the one this customer runs.
+                    fields: [
+                        { field: 'PRODUCT_NAMES', isShowInDetailed: true },
+                    ],
+                }
+            },
+            bpartners: { "BP1": {} },
+            warehouses: { "wh": {} },
+            pickingSlots: { slot1: {} },
+            products: {
+                "P1": { price: 1 },
+                "P2": { price: 1 },
+            },
+            packingInstructions: {
+                "LU_CU": { cu: true, lu: "LU", qtyTUsPerLU: 1 },
+            },
+            handlingUnits: {
+                "HU1": { product: 'P1', warehouse: 'wh', qty: 1000, packingInstructions: 'LU_CU' },
+                "HU2": { product: 'P2', warehouse: 'wh', qty: 1000, packingInstructions: 'LU_CU' },
+            },
+            salesOrders: {
+                "SO1": {
+                    bpartner: 'BP1',
+                    warehouse: 'wh',
+                    datePromised: '2025-03-01T00:00:00.000+02:00',
+                    // P1 appears on two separate lines, P2 on one — the job holds two distinct products.
+                    lines: [
+                        { product: 'P1', qty: 3 },
+                        { product: 'P2', qty: 2 },
+                        { product: 'P1', qty: 1 },
+                    ],
+                }
+            },
+        }
+    });
+
+    await LoginScreen.login(masterdata.login.user);
+    await ApplicationsListScreen.expectVisible();
+    await ApplicationsListScreen.startApplication('picking');
+    await PickingJobsListScreen.waitForScreen();
+    await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
+    await PickingJobsListScreen.startJob({ index: 1 });
+
+    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+
+    // Job header: each of the job's distinct products named once, in first-occurrence (line) order.
+    // PickingJobScreen has no expectHeaderProperty of its own (every sibling screen — jobs list, job
+    // line, material-receipt line, workplace manager — defines one over the same shared page-global
+    // `.view-header` row); reusing PickingJobLineScreen's existing, unmodified implementation here.
+    const jobHeaderProductNames = [masterdata.products.P1.productName, masterdata.products.P2.productName].join(", ");
+    await PickingJobLineScreen.expectHeaderProperty({ caption: 'Product names (all)', value: jobHeaderProductNames });
+
+    // Opened line (the P2 line, index 2): names only its own product, never the job's other product(s).
+    await PickingJobScreen.clickLineButton({ index: 2 });
+    await PickingJobLineScreen.waitForScreen();
+    await PickingJobLineScreen.expectHeaderProperty({ caption: 'Product names (all)', value: masterdata.products.P2.productName });
+    await PickingJobLineScreen.goBack();
+});

--- a/e2e/mobile-webui/tests/spec/picking/productNamesDetail.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/productNamesDetail.spec.js
@@ -15,11 +15,15 @@ test('Already-started job still lists its products', async ({ page }) => {
     allure.story('Picking launcher product names');
     allure.severity('normal');
 
+    // Own workplace so this test's job list is scoped to jobs it created itself, isolating it
+    // from jobs created by other tests sharing the same picking job list.
+    const workplace = 'workplace1';
+
     const masterdata = await Backend.createMasterdata({
         language: "en_US",
         request: {
             login: {
-                user: { language: "en_US" },
+                user: { language: "en_US", workplace },
             },
             mobileConfig: {
                 picking: {
@@ -30,6 +34,8 @@ test('Already-started job still lists its products', async ({ page }) => {
                     shipOnCloseLU: false,
                     pickTo: ['LU_TU'],
                     allowCompletingPartialPickingJob: false,
+                    activeWorkplaceRequired: true,
+                    considerOnlyJobScheduledToWorkplace: true,
                     fields: [
                         { field: 'DOCUMENT_NO' },
                         { field: 'CUSTOMER' },
@@ -40,6 +46,7 @@ test('Already-started job still lists its products', async ({ page }) => {
             },
             bpartners: { "BP1": {} },
             warehouses: { "wh": {} },
+            workplaces: { [workplace]: {} },
             products: {
                 "P1": { price: 1 },
                 "P2": { price: 1 },
@@ -51,9 +58,9 @@ test('Already-started job still lists its products', async ({ page }) => {
                     warehouse: 'wh',
                     datePromised: '2025-03-01T00:00:00.000+02:00',
                     lines: [
-                        { product: 'P1', qty: 5 },
-                        { product: 'P2', qty: 3 },
-                        { product: 'P3', qty: 2 },
+                        { product: 'P1', qty: 5, workplace },
+                        { product: 'P2', qty: 3, workplace },
+                        { product: 'P3', qty: 2, workplace },
                     ],
                 }
             },
@@ -91,11 +98,15 @@ test('Detail surfaces name the right subject', async ({ page }) => {
     allure.story('Picking launcher product names');
     allure.severity('normal');
 
+    // Own workplace so this test's job list is scoped to jobs it created itself, isolating it
+    // from jobs created by other tests sharing the same picking job list.
+    const workplace = 'workplace2';
+
     const masterdata = await Backend.createMasterdata({
         language: "en_US",
         request: {
             login: {
-                user: { language: "en_US" },
+                user: { language: "en_US", workplace },
             },
             mobileConfig: {
                 picking: {
@@ -107,6 +118,8 @@ test('Detail surfaces name the right subject', async ({ page }) => {
                     shipOnCloseLU: false,
                     anonymousPickHUsOnTheFly: false,
                     readAttributes: [],
+                    activeWorkplaceRequired: true,
+                    considerOnlyJobScheduledToWorkplace: true,
                     // ProductNames configured for the DETAIL surfaces only (isShowInDetailed) — a
                     // configuration this customer will not use on the launcher, exercised here because
                     // the field type is available to any profile, not only the one this customer runs.
@@ -117,6 +130,7 @@ test('Detail surfaces name the right subject', async ({ page }) => {
             },
             bpartners: { "BP1": {} },
             warehouses: { "wh": {} },
+            workplaces: { [workplace]: {} },
             pickingSlots: { slot1: {} },
             products: {
                 "P1": { price: 1 },
@@ -136,9 +150,9 @@ test('Detail surfaces name the right subject', async ({ page }) => {
                     datePromised: '2025-03-01T00:00:00.000+02:00',
                     // P1 appears on two separate lines, P2 on one — the job holds two distinct products.
                     lines: [
-                        { product: 'P1', qty: 3 },
-                        { product: 'P2', qty: 2 },
-                        { product: 'P1', qty: 1 },
+                        { product: 'P1', qty: 3, workplace },
+                        { product: 'P2', qty: 2, workplace },
+                        { product: 'P1', qty: 1, workplace },
                     ],
                 }
             },
@@ -152,7 +166,15 @@ test('Detail surfaces name the right subject', async ({ page }) => {
     await PickingJobsListScreen.filterByDocumentNo(masterdata.salesOrders.SO1.documentNo);
     await PickingJobsListScreen.startJob({ index: 1 });
 
-    await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
+    // This picking profile is HU-level (pickTo includes LU/TU/CU targets), so scanning the
+    // picking slot auto-navigates straight into the first eligible line's scan screen (real app
+    // behavior — see PickingMobileApplication.openFirstEligiblePickingLineScanner). Go back to the
+    // job screen from there, same as a real operator would, before checking the job header.
+    await PickingJobScreen.scanPickingSlot({
+        qrCode: masterdata.pickingSlots.slot1.qrCode,
+        expectNextScreen: 'PickLineScanScreen',
+        gotoPickingJobScreen: true,
+    });
 
     // Job header: each of the job's distinct products named once, in first-occurrence (line) order.
     const jobHeaderProductNames = [masterdata.products.P1.productName, masterdata.products.P2.productName].join(", ");

--- a/e2e/mobile-webui/tests/spec/picking/productNamesDetail.spec.js
+++ b/e2e/mobile-webui/tests/spec/picking/productNamesDetail.spec.js
@@ -155,11 +155,8 @@ test('Detail surfaces name the right subject', async ({ page }) => {
     await PickingJobScreen.scanPickingSlot({ qrCode: masterdata.pickingSlots.slot1.qrCode });
 
     // Job header: each of the job's distinct products named once, in first-occurrence (line) order.
-    // PickingJobScreen has no expectHeaderProperty of its own (every sibling screen — jobs list, job
-    // line, material-receipt line, workplace manager — defines one over the same shared page-global
-    // `.view-header` row); reusing PickingJobLineScreen's existing, unmodified implementation here.
     const jobHeaderProductNames = [masterdata.products.P1.productName, masterdata.products.P2.productName].join(", ");
-    await PickingJobLineScreen.expectHeaderProperty({ caption: 'Product names (all)', value: jobHeaderProductNames });
+    await PickingJobScreen.expectHeaderProperty({ caption: 'Product names (all)', value: jobHeaderProductNames });
 
     // Opened line (the P2 line, index 2): names only its own product, never the job's other product(s).
     await PickingJobScreen.clickLineButton({ index: 2 });

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobScreen.js
@@ -26,6 +26,13 @@ export const PickingJobScreen = {
         await page.locator('.loading').waitFor({ state: 'detached', timeout: SLOW_ACTION_TIMEOUT });
     }),
 
+    // The job header and the line header are rendered by the same page-global markup, so this
+    // delegates rather than duplicating the locator — mirroring how DistributionJobScreen defers
+    // to DistributionUtils. Gives job-header assertions a call site on the screen they belong to.
+    expectHeaderProperty: async ({ caption, value }) => await step(`${NAME} - Check header property '${caption}'='${value}'`, async () => {
+        await PickingJobLineScreen.expectHeaderProperty({ caption, value });
+    }),
+
     getPickingJobId: async () => {
         const currentUrl = await page.url();
 

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
@@ -247,5 +247,9 @@ const expectJobButton = async ({ name, button, expectation }) => await test.step
             await expect(indicatorLocator).toHaveCount(0);
         }
     }
+
+    if (expectation.caption != null) {
+        await expect(button).toHaveText(expectation.caption);
+    }
 });
 

--- a/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/picking/PickingJobsListScreen.js
@@ -229,7 +229,7 @@ const locateJobButtons = ({ documentNo, index, salesOrderId, customerId, qtyToDe
 };
 
 const expectJobButton = async ({ name, button, expectation }) => await test.step(`Expect job button ${name}`, async () => {
-    await button.waitFor({ state: 'attached' });
+    await button.waitFor({ state: 'visible', timeout: VERY_FAST_ACTION_TIMEOUT });
     await expect(button).toHaveCount(1);
 
     if (expectation.indicator != null) {


### PR DESCRIPTION
## What

Adds a picking-profile launcher field type **`ProductNames`** that names every product of a picking job, so a multi-product order shows its products on the mobile picking job list instead of collapsing to document number + customer.

## Why

The existing `Product` field type renders the job's *single* product name, and is deliberately empty when a job holds more than one product. On a multi-product order the launcher entry therefore shows only document number and customer, and a picker has to open the job to find out what is in it.

## How

- New value in the existing `PickingJobField_Options` reference list, plus a description on **both** product-name values so a configurator can tell them apart in the field-type list (previously neither had one).
- New enum constant `PickingJobFieldType.PRODUCT_NAMES`.
- `PickingJobCandidateProducts#getProductNamesJoined()` serves the job **list**; `PickingJob#getProductNamesJoined()` serves the job **header**; a job **line** resolves to its own product only. All three subjects are served by a single `case PRODUCT_NAMES` in `DisplayValueProvider`, reading a `@Nullable ITranslatableString` on `Context`.
- Names are joined with `", "`, deduplicated by `ProductId` (never by displayed text, so two distinct products sharing a name both appear) and kept in first-occurrence order.
- The launcher caption stays a single flat string: **the launcher JSON contract and all frontend code are untouched.**

A second migration translates ten picking-profile labels that were still displayed to German users as their untranslated English originals (e.g. `Consider only scheduled jobs`, `Pick to LU/TU structure`). German wording was taken from the glossary where it exists and otherwise grounded on sibling AD elements. Per `docs/REVIEW.md`, `en_US` keeps the English text with `IsTranslated='Y'` while the base-language `de_DE`/`de_CH` rows carry the German text with `IsTranslated='N'`.

## Tests

- **JUnit** — two new classes, 7 tests, covering the joined list on the job list, the single-product case, the untouched singular field type, the empty-quantity case, per-product deduplication across lines, and line-level resolution. Both were written test-first and observed failing before implementation. Full `de.metas.picking.rest-api` module suite green (53 tests).
- **Playwright (`e2e/mobile-webui`)** — two new specs, 5 tests, covering the multi-product caption, the single-product caption, the untouched `PRODUCT_NAME` behaviour, an already-started job, and the job-header vs job-line distinction. Verified 5/5 passing twice back-to-back with no database reset, against a stack running this branch's own CI images.
- Each Playwright test declares its **own workplace** and logs into it, so the job list is scoped to the job that test created. Without this the exact job-button count assertions see every earlier test's job and are order-dependent.
- `PickingJobScreen` gained an `expectHeaderProperty` helper: seven sibling screens define one, this one did not, so a job-header assertion previously had to borrow the job-*line* screen's method.

## Notes for the reviewer

- `FormatPattern` is a **shared** AD element (5 windows: `AD_Column`, `PA_ReportColumn`, `AD_PrintFormatItem`, `DATEV_ExportFormatColumn`, and the picking profile). It was still English on the picking window, and an `AD_Element` is defined once and reused by design — so translating it necessarily corrects all five. All uses were checked to be the same column with the same reference type and meaning, so one German term is correct everywhere.
- The `test (cucumber) (profile3)` job fails on the VAT-ID suite (`vatIdCheckProcess`, `vatIdOnlineCheck`). That is a known, tracked flake — a process-wide stub singleton racing async work-package checks — and is unrelated to this branch: the same scenarios were already failing and passing across adjacent commits before this branch's migrations existed, the assertions are DB-record-count checks with no label involvement, and the diff contains no VAT-ID or bpartner code.
