### PR TITLE
Traffic Management: add C_Order -> Traffic Management related-documents relation

### DIFF
--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5819810_sys_RelationType_C_Order_to_TrafficManagement.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5819810_sys_RelationType_C_Order_to_TrafficManagement.sql
@@ -2,7 +2,8 @@
 -- (C_Order, IsSOTrx='Y') the user can jump to the order's Traffic Management (Picking Job Schedule)
 -- rows. Reuses the standard C_Order(SO) source reference 540666; the target opens the Picking Job
 -- Schedule window (541929) on the M_Picking_Job_Schedule_view (542514), filtered to the current order
--- via M_ShipmentSchedule.C_Order_ID. Generic (EntityType de.metas.handlingunits), one direction only.
+-- via the view's C_OrderSO_ID column (the sales order the shipment schedule belongs to). Generic
+-- (EntityType de.metas.handlingunits), one direction only.
 --
 -- IDs allocated from idserver.metas.de on 2026-08-21:
 --   AD_Reference    542133 (target reference "Traffic Management Target for C_Order")
@@ -15,26 +16,23 @@ VALUES (0,0,542133 /*From ID Server*/,TO_TIMESTAMP('2026-08-21 10:00:00','YYYY-M
 ;
 
 -- Translations for the target reference (copies the base name into every system language)
-INSERT INTO AD_Reference_Trl (AD_Language,AD_Reference_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
-SELECT l.AD_Language,t.AD_Reference_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+INSERT INTO AD_Reference_Trl (AD_Language,AD_Reference_ID, Description,Help,Name, IsTranslated,IsActive,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Reference_ID, t.Description,t.Help,t.Name, 'N','Y',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
 FROM AD_Language l, AD_Reference t
-WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Reference_ID=542133
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Reference_ID=542133
   AND NOT EXISTS (SELECT * FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
 ;
 
 -- Target ref-table: the Picking Job Schedule view, opening window 541929, filtered to the source order.
 -- AD_Key = M_ShipmentSchedule_ID (AD_Column 590664): non-null on every view row (the synthetic
 -- to-be-scheduled row carries M_Picking_Job_Schedule_ID=0, so that column is unsuitable as the zoom key).
--- The where-clause joins the view to the current order via M_ShipmentSchedule.C_Order_ID.
+-- WhereClause matches the view's own C_OrderSO_ID column against the source order's context value
+-- (@C_Order_ID/-1@); C_OrderSO_ID is the sales order the shipment schedule belongs to.
 INSERT INTO AD_Ref_Table (AD_Client_ID,AD_Key,AD_Org_ID,AD_Reference_ID,AD_Table_ID,AD_Window_ID,Created,CreatedBy,EntityType,IsActive,IsValueDisplayed,Updated,UpdatedBy,WhereClause)
-VALUES (0,590664,0,542133,542514,541929,TO_TIMESTAMP('2026-08-21 10:00:01','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','N',TO_TIMESTAMP('2026-08-21 10:00:01','YYYY-MM-DD HH24:MI:SS'),100,'exists (
-	select 1 from M_ShipmentSchedule s
-	where s.M_ShipmentSchedule_ID = M_Picking_Job_Schedule_view.M_ShipmentSchedule_ID
-	  and s.C_Order_ID = @C_Order_ID/-1@
-)')
+VALUES (0,590664,0,542133,542514,541929,TO_TIMESTAMP('2026-08-21 10:00:01','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','N',TO_TIMESTAMP('2026-08-21 10:00:01','YYYY-MM-DD HH24:MI:SS'),100,'M_Picking_Job_Schedule_view.C_OrderSO_ID = @C_Order_ID/-1@')
 ;
 
 -- The directed relation itself: reuse the standard C_Order(SO) source (540666) -> the new target (542133).
-INSERT INTO AD_RelationType (AD_Client_ID,AD_Org_ID,AD_RelationType_ID,Created,CreatedBy,Updated,UpdatedBy,EntityType,IsActive,IsDirected,IsTableRecordIDTarget,Name,InternalName,AD_Reference_Source_ID,AD_Reference_Target_ID)
-VALUES (0,0,540504 /*From ID Server*/,TO_TIMESTAMP('2026-08-21 10:00:02','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 10:00:02','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','Y','N','C_Order (SO) -> Traffic Management','C_Order_to_TrafficManagement',540666,542133)
+INSERT INTO AD_RelationType (AD_Client_ID,AD_Org_ID,AD_RelationType_ID,Created,CreatedBy,Updated,UpdatedBy,EntityType,IsActive,IsTableRecordIDTarget,Name,InternalName,AD_Reference_Source_ID,AD_Reference_Target_ID)
+VALUES (0,0,540504 /*From ID Server*/,TO_TIMESTAMP('2026-08-21 10:00:02','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 10:00:02','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','N','C_Order (SO) -> Traffic Management','C_Order_to_TrafficManagement',540666,542133)
 ;

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5819810_sys_RelationType_C_Order_to_TrafficManagement.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5819810_sys_RelationType_C_Order_to_TrafficManagement.sql
@@ -1,4 +1,4 @@
--- me03 31628: add a directed "Related Documents" (zoom-across) relation so that from a sales order
+-- Add a directed "Related Documents" (zoom-across) relation so that from a sales order
 -- (C_Order, IsSOTrx='Y') the user can jump to the order's Traffic Management (Picking Job Schedule)
 -- rows. Reuses the standard C_Order(SO) source reference 540666; the target opens the Picking Job
 -- Schedule window (541929) on the M_Picking_Job_Schedule_view (542514), filtered to the current order

--- a/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5819810_sys_me03_31628_RelationType_C_Order_to_TrafficManagement.sql
+++ b/backend/de.metas.handlingunits.base/src/main/sql/postgresql/system/70-de.metas.handlingunits/5819810_sys_me03_31628_RelationType_C_Order_to_TrafficManagement.sql
@@ -1,0 +1,40 @@
+-- me03 31628: add a directed "Related Documents" (zoom-across) relation so that from a sales order
+-- (C_Order, IsSOTrx='Y') the user can jump to the order's Traffic Management (Picking Job Schedule)
+-- rows. Reuses the standard C_Order(SO) source reference 540666; the target opens the Picking Job
+-- Schedule window (541929) on the M_Picking_Job_Schedule_view (542514), filtered to the current order
+-- via M_ShipmentSchedule.C_Order_ID. Generic (EntityType de.metas.handlingunits), one direction only.
+--
+-- IDs allocated from idserver.metas.de on 2026-08-21:
+--   AD_Reference    542133 (target reference "Traffic Management Target for C_Order")
+--   AD_RelationType 540504 (C_Order (SO) -> Traffic Management)
+--   (AD_Ref_Table shares AD_Reference_ID = 542133 as its key; no separate id)
+
+-- Target reference (ValidationType 'T' = Table)
+INSERT INTO AD_Reference (AD_Client_ID,AD_Org_ID,AD_Reference_ID,Created,CreatedBy,EntityType,IsActive,IsOrderByValue,Name,Updated,UpdatedBy,ValidationType)
+VALUES (0,0,542133 /*From ID Server*/,TO_TIMESTAMP('2026-08-21 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','N','Traffic Management Target for C_Order',TO_TIMESTAMP('2026-08-21 10:00:00','YYYY-MM-DD HH24:MI:SS'),100,'T')
+;
+
+-- Translations for the target reference (copies the base name into every system language)
+INSERT INTO AD_Reference_Trl (AD_Language,AD_Reference_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy)
+SELECT l.AD_Language,t.AD_Reference_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy
+FROM AD_Language l, AD_Reference t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.AD_Reference_ID=542133
+  AND NOT EXISTS (SELECT * FROM AD_Reference_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Reference_ID=t.AD_Reference_ID)
+;
+
+-- Target ref-table: the Picking Job Schedule view, opening window 541929, filtered to the source order.
+-- AD_Key = M_ShipmentSchedule_ID (AD_Column 590664): non-null on every view row (the synthetic
+-- to-be-scheduled row carries M_Picking_Job_Schedule_ID=0, so that column is unsuitable as the zoom key).
+-- The where-clause joins the view to the current order via M_ShipmentSchedule.C_Order_ID.
+INSERT INTO AD_Ref_Table (AD_Client_ID,AD_Key,AD_Org_ID,AD_Reference_ID,AD_Table_ID,AD_Window_ID,Created,CreatedBy,EntityType,IsActive,IsValueDisplayed,Updated,UpdatedBy,WhereClause)
+VALUES (0,590664,0,542133,542514,541929,TO_TIMESTAMP('2026-08-21 10:00:01','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','N',TO_TIMESTAMP('2026-08-21 10:00:01','YYYY-MM-DD HH24:MI:SS'),100,'exists (
+	select 1 from M_ShipmentSchedule s
+	where s.M_ShipmentSchedule_ID = M_Picking_Job_Schedule_view.M_ShipmentSchedule_ID
+	  and s.C_Order_ID = @C_Order_ID/-1@
+)')
+;
+
+-- The directed relation itself: reuse the standard C_Order(SO) source (540666) -> the new target (542133).
+INSERT INTO AD_RelationType (AD_Client_ID,AD_Org_ID,AD_RelationType_ID,Created,CreatedBy,Updated,UpdatedBy,EntityType,IsActive,IsDirected,IsTableRecordIDTarget,Name,InternalName,AD_Reference_Source_ID,AD_Reference_Target_ID)
+VALUES (0,0,540504 /*From ID Server*/,TO_TIMESTAMP('2026-08-21 10:00:02','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 10:00:02','YYYY-MM-DD HH24:MI:SS'),100,'de.metas.handlingunits','Y','Y','N','C_Order (SO) -> Traffic Management','C_Order_to_TrafficManagement',540666,542133)
+;


### PR DESCRIPTION
## What

Adds a directed "Related Documents" (zoom-across) relation so that from a sales order
(`C_Order`, `IsSOTrx='Y'`) the user can jump to that order's **Traffic Management**
(Picking Job Schedule) rows.

## How

Single AD-metadata migration script
(`5819810_sys_RelationType_C_Order_to_TrafficManagement.sql`):

- New `AD_RelationType` (`540504`, `IsDirected='Y'`), reusing the standard C_Order(SO) source
  reference `540666`.
- New target `AD_Reference` (`542133`, `ValidationType='T'`) + `AD_Ref_Table`:
  - `AD_Table_ID = 542514` (`M_Picking_Job_Schedule_view`, the view the Traffic Management tab uses)
  - `AD_Window_ID = 541929` (Picking Job Schedule window)
  - `AD_Key = 590664` (`M_ShipmentSchedule_ID`; non-null on every view row, unlike the synthetic
    `M_Picking_Job_Schedule_ID = 0` rows)
  - WhereClause filters to the current order via
    `M_ShipmentSchedule.C_Order_ID = @C_Order_ID/-1@`.

No Java, no new column, no process, no action button, no reverse relation. Generic
(`EntityType = de.metas.handlingunits`), so it is available for all customers.

All new AD IDs are allocated from the central ID server.
