### PR TITLE
Frontend WebUI quick actions — stop the list view jumping when the pointer crosses the actions bar

### DIFF
--- a/e2e/frontend-webui/tests/spec/quick-actions.spec.js
+++ b/e2e/frontend-webui/tests/spec/quick-actions.spec.js
@@ -1,0 +1,188 @@
+import { expect } from '@playwright/test';
+import { test } from '../../playwright.config';
+import { allure } from 'allure-playwright';
+import { FRONTEND_BASE_URL, SLOW_ACTION_TIMEOUT, step } from '../utils/common';
+import { SHIPMENT_CANDIDATES_WINDOW_ID } from '../utils/WindowIds';
+
+/**
+ * Quick-actions bar of a list view.
+ *
+ * Features tested:
+ * - F50000: Frontend WebUI
+ *
+ * The quick-actions bar is shared by every list view (DocumentList.js), so these tests use a
+ * plain list view and need no masterdata.
+ *
+ * Layout stability: hovering the quick-actions dropdown-toggle button used to render a tooltip that
+ * reached past the right edge of `.document-list-wrapper` (an `overflow: auto` box). That gave the
+ * wrapper a horizontal scrollbar, which — where scrollbars consume layout space — cascaded into a
+ * vertical scrollbar as well and shifted the whole grid sideways, so the grid appeared to resize
+ * whenever the pointer crossed the quick-action button operators use all day.
+ *
+ * These tests assert on the *overflow*, not on the visible shift: the overflow is the defect and is
+ * observable everywhere, whereas whether it visibly moves the grid depends on the platform drawing
+ * classic rather than overlay scrollbars.
+ */
+
+const TOOLTIP_DELAY = 1500; // the tooltip is revealed after a 1s delay (Tooltips.js + buttons.scss)
+
+/**
+ * Every scroll container on the page that currently overflows, with the amount.
+ * A stable layout means this set is identical before, during and after hovering.
+ */
+const overflowingScrollContainers = async (page) =>
+  await page.evaluate(() => {
+    const found = [];
+    for (const el of document.querySelectorAll('*')) {
+      const cs = getComputedStyle(el);
+      const scrollsX = cs.overflowX === 'auto' || cs.overflowX === 'scroll';
+      const scrollsY = cs.overflowY === 'auto' || cs.overflowY === 'scroll';
+      if (!scrollsX && !scrollsY) continue;
+      const dx = el.scrollWidth - el.clientWidth;
+      const dy = el.scrollHeight - el.clientHeight;
+      if (dx === 0 && dy === 0) continue;
+      const classes = String(el.className).trim().split(/\s+/).filter(Boolean).join('.');
+      found.push(`${el.tagName.toLowerCase()}${classes ? '.' + classes : ''} dx=${dx} dy=${dy}`);
+    }
+    return found.sort();
+  });
+
+const gridBox = async (page) =>
+  await page.evaluate(() => {
+    const g = document.querySelector('.document-list-table');
+    if (!g) return null;
+    const b = g.getBoundingClientRect();
+    return {
+      x: Math.round(b.x),
+      y: Math.round(b.y),
+      w: Math.round(b.width),
+      h: Math.round(b.height),
+    };
+  });
+
+/**
+ * Inline login — see claude-docs/selectors-and-gotchas.md "Default Login — Role Selection".
+ * LoginPage.login() is deliberately not used: its waitForResponse can miss the second
+ * authenticate call of the role-selection step.
+ */
+const login = async (page) => {
+  await page.goto(`${FRONTEND_BASE_URL}/login`);
+  await page
+    .locator('.login-container')
+    .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+  await page.locator('input[name="username"]').fill('metasfresh');
+  await page.locator('input[name="password"]').fill('metasfresh');
+  await page.locator('.btn-meta-success').click();
+
+  await page.waitForTimeout(1000);
+  if (page.url().includes('/login')) {
+    const sendButton = page.locator('.btn-meta-success');
+    if (await sendButton.isVisible()) {
+      await sendButton.click();
+    }
+  }
+  await page.waitForURL((url) => !url.toString().includes('/login'), {
+    timeout: SLOW_ACTION_TIMEOUT,
+  });
+};
+
+const openListView = async (page) => {
+  await login(page);
+  await page.goto(`${FRONTEND_BASE_URL}/window/${SHIPMENT_CANDIDATES_WINDOW_ID}`);
+  await page
+    .locator('.document-list-wrapper')
+    .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+  await page
+    .getByTestId('quick-action-dropdown-toggle')
+    .waitFor({ state: 'visible', timeout: SLOW_ACTION_TIMEOUT });
+  // the grid settles its column widths shortly after the layout+data arrive
+  await page.waitForTimeout(1500);
+};
+
+/** Park the pointer far from the quick-actions area so no hover state is active. */
+const restPointer = async (page) => {
+  const vp = page.viewportSize();
+  await page.mouse.move(5, Math.round(vp.height / 2));
+  await page.waitForTimeout(600);
+};
+
+const hoverTargets = [
+  { testId: 'quick-action-dropdown-toggle', label: 'dropdown toggle' },
+  { testId: 'quick-action-button', label: 'green quick-action button' },
+];
+
+test.describe('Quick actions', () => {
+  hoverTargets.forEach(({ testId, label }) => {
+    test(`Hovering the ${label} leaves the list view layout untouched`, async ({ page }) => {
+      allure.tag('F50000: Frontend WebUI');
+      allure.tag('F50000'); // Standalone tag for Tags section
+      allure.story('Quick-actions bar does not disturb the list view layout on hover');
+      allure.description(
+        `Moving the pointer onto the ${label} must not make any scroll container overflow and ` +
+          'must not move the grid — otherwise scrollbars flicker on and off and the grid appears ' +
+          'to resize under the pointer.'
+      );
+
+      await openListView(page);
+
+      const [restOverflow, restGrid] = await step('Measure the resting layout', async () => {
+        await restPointer(page);
+        return [await overflowingScrollContainers(page), await gridBox(page)];
+      });
+
+      await step(`Hover the ${label}`, async () => {
+        await page.getByTestId(testId).hover();
+        await page.waitForTimeout(TOOLTIP_DELAY);
+      });
+
+      await step('No scroll container gained overflow and the grid did not move', async () => {
+        expect(await overflowingScrollContainers(page)).toEqual(restOverflow);
+        expect(await gridBox(page)).toEqual(restGrid);
+      });
+
+      await step('Layout is still unchanged after the pointer leaves', async () => {
+        await restPointer(page);
+        expect(await overflowingScrollContainers(page)).toEqual(restOverflow);
+        expect(await gridBox(page)).toEqual(restGrid);
+      });
+    });
+  });
+
+  test('The dropdown-toggle tooltip is shown and fits inside the list view', async ({ page }) => {
+    allure.tag('F50000: Frontend WebUI');
+    allure.tag('F50000'); // Standalone tag for Tags section
+    allure.story('Quick-actions bar does not disturb the list view layout on hover');
+    allure.description(
+      'Guards against removing the hover feedback to fix the layout: the tooltip must still be ' +
+        'shown, and must fit inside the scroll container it lives in.'
+    );
+
+    await openListView(page);
+    await restPointer(page);
+
+    await step('Hover the dropdown toggle', async () => {
+      await page.getByTestId('quick-action-dropdown-toggle').hover();
+      await page.waitForTimeout(TOOLTIP_DELAY);
+    });
+
+    await step('The tooltip is visible', async () => {
+      await expect(page.locator('.tooltip-wrapp')).toBeVisible();
+    });
+
+    await step('The tooltip fits inside .document-list-wrapper', async () => {
+      const outside = await page.evaluate(() => {
+        const t = document.querySelector('.tooltip-wrapp').getBoundingClientRect();
+        const w = document.querySelector('.document-list-wrapper').getBoundingClientRect();
+        return {
+          pastRight: Math.round(t.right - w.right),
+          pastLeft: Math.round(w.left - t.left),
+          pastBottom: Math.round(t.bottom - w.bottom),
+        };
+      });
+      console.log('[INFO] tooltip outside .document-list-wrapper by', JSON.stringify(outside));
+      expect(outside.pastRight).toBeLessThanOrEqual(0);
+      expect(outside.pastLeft).toBeLessThanOrEqual(0);
+      expect(outside.pastBottom).toBeLessThanOrEqual(0);
+    });
+  });
+});

--- a/frontend/src/assets/css/tooltip.scss
+++ b/frontend/src/assets/css/tooltip.scss
@@ -22,6 +22,37 @@
   overflow: visible;
 }
 
+/*
+ * The quick-actions dropdown toggle is the last element in the list-view header, flush against the
+ * right edge of `.document-list-wrapper` — which is `overflow: auto`. A centred tooltip does not fit
+ * there: `left: 50%; margin-left: -40px; width: 80px` reaches 24px past a 32px-wide trigger, so it
+ * spills out of the wrapper, the wrapper gains a horizontal scrollbar, and (where scrollbars take
+ * layout space) that cascades into a vertical one and shifts the whole list view sideways as the
+ * pointer crosses the quick actions.
+ *
+ * Open this tooltip inward instead: right-aligned to its trigger, it can never reach past the
+ * trigger's right edge, so it can never overflow the wrapper. The arrows are re-offset to stay on
+ * the trigger's centre, which sits 15px left of the tooltip's right edge (the trigger's 30px
+ * padding box, halved).
+ */
+.quick-actions-wrapper .tooltip-parent .tooltip-wrapp {
+  left: auto;
+  right: 0;
+  margin-left: 0;
+
+  &:after {
+    left: auto;
+    right: 11px; /* 15px - half of the 8px arrow */
+    margin-left: 0;
+  }
+
+  &:before {
+    left: auto;
+    right: 9px; /* 15px - half of the 12px arrow */
+    margin-left: 0;
+  }
+}
+
 .tooltip-home-menu {
   left: 25px;
 }


### PR DESCRIPTION
## Problem

In any list view, moving the mouse onto the quick-actions dropdown-toggle button (the small caret
next to the green quick-action button) changed the page layout: scrollbars appeared, and the whole
view — actions bar, grid, pagination — shifted sideways. Moving the pointer away reversed it. Because
the shift moves the button out from under the pointer, it oscillates, so the grid appears to resize
repeatedly while the user is simply moving the mouse near the action they use all day.

## Root cause

The tooltip rendered on hover is `position: absolute; left: 50%; margin-left: -40px; width: 80px`,
i.e. an 80px box centred on its trigger. The toggle button is 32px wide, so the tooltip reaches 24px
past the button's right edge. That button is the last element in the list-view header, only 21px from
the content edge of `.document-list-wrapper` — which is `overflow: auto`
(`frontend/src/assets/css/styles.scss:400`). So the tooltip overflowed the wrapper by **3px**,
measured:

| | `.document-list-wrapper` clientWidth | scrollWidth |
|---|---|---|
| pointer away | 1814 | 1814 |
| hovering the toggle | 1814 | **1817** |
| hovering, with the tooltip element hidden | 1814 | 1814 |

Verified: measured in a real browser on a running stack, by reading
`el.scrollWidth - el.clientWidth` for every `overflow: auto`/`scroll` element on the page with the
pointer parked away, then hovering `[data-testid="quick-action-dropdown-toggle"]` and re-reading —
the wrapper's `scrollWidth` goes 1814 -> 1817. Confirmed via the causal isolation in the third row
above: injecting `.tooltip-wrapp { display: none }` while the hover state is otherwise unchanged
takes it straight back to 1814, so the tooltip element is the sole contributor. The only other hover
effect in range is a background-colour change (`frontend/src/assets/css/buttons.scss:198`).

3px of overflow is enough for the wrapper to show a horizontal scrollbar. Where scrollbars consume
layout space, that scrollbar takes ~15px of height — and the layout has **zero** vertical slack,
because the grid's height is pinned to the viewport with `max-height: calc(100vh - 210px)`
(`frontend/src/assets/css/table.scss:757`) and `vh` ignores scrollbars. So a vertical scrollbar
follows immediately, costing another ~15px of width, and everything shifts left.

Verified (zero slack): measured `clientHeight == scrollHeight` on the wrapper (850 == 850) and on the
document at 1910x905, 1920x1080, 1600x900, 1366x768 and 1280x800 — no viewport size has spare
height. The 15px cascade itself is a platform consequence, not reproduced locally: this Chromium
draws overlay scrollbars that take no layout space, so locally the 3px overflow appears and
disappears without moving anything, while the classic scrollbars visible in the reported recording do
take space. That step of the chain is therefore *inference from the measured overflow plus the
measured zero slack*, not a local observation.

## Fix

Right-align that tooltip to its trigger instead of centring it, so it opens inward and can never
reach past the trigger's right edge — hence never past the wrapper. Scoped to
`.quick-actions-wrapper .tooltip-parent`, so the other `.tooltip-wrapp` call sites are untouched. The
arrow pseudo-elements are re-offset to stay on the trigger's centre.

## Verification

Verified via `npx playwright test tests/spec/quick-actions.spec.js` and
`npx playwright test tests/spec/shipment-schedule.spec.js` in `e2e/frontend-webui`, plus `yarn lint`
and `yarn test` in `frontend`, all executed on 2026-08-23 against a local stack on
`http://localhost:3000` built from `5.175-memorable-shiny-hotfix.40333`:

- New spec `e2e/frontend-webui/tests/spec/quick-actions.spec.js` — 3 tests. Before the fix: 2 failed
  (the tooltip test reporting exactly `pastRight: 3`); after: 3 passed with the spec unmodified. The
  tooltip now sits 22px *inside* the wrapper.
- The spec asserts on the **overflow**, not on the visible shift, because whether the overflow
  visibly moves the grid depends on the platform drawing classic rather than overlay scrollbars — the
  overflow is the defect and is observable everywhere.
- Swept all 30 hover targets on the list view (every `.tooltip-parent`, the green quick-action
  button, filter widgets, breadcrumb, outline-secondary buttons, grid header and body cells, the
  three-dot menu, the bookmark star): **0** change the set of overflowing scroll containers, so no
  other tooltip call site has the same defect and the fix introduced none.
- Existing `shipment-schedule.spec.js` (which invokes a quick action): 2/2 passed, en_US + de_DE.
- `frontend`: `yarn lint` 0 errors, `yarn test` 323 passed.
