### PR TITLE
Costing: adopt a zero quantity into the cost's own UOM instead of rejecting it

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/costing/CurrentCost.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/CurrentCost.java
@@ -119,16 +119,46 @@ public final class CurrentCost
 	public void setFrom(final CostDetailPreviousAmounts previousAmounts)
 	{
 		assertCostCurrency(previousAmounts.getCostPrice());
-		assertCostUOM(previousAmounts.getQty());
-
 		assertCostCurrency(previousAmounts.getCumulatedAmt());
-		assertCostUOM(previousAmounts.getCumulatedQty());
+
+		// resolve both quantities BEFORE mutating anything, so a rejected one leaves this cost untouched
+		final Quantity qty = toCostUOM(previousAmounts.getQty());
+		final Quantity cumulatedQty = toCostUOM(previousAmounts.getCumulatedQty());
 
 		this.costPrice = previousAmounts.getCostPrice();
-		this.currentQty = previousAmounts.getQty();
+		this.currentQty = qty;
 
 		this.cumulatedAmt = previousAmounts.getCumulatedAmt();
-		this.cumulatedQty = previousAmounts.getCumulatedQty();
+		this.cumulatedQty = cumulatedQty;
+	}
+
+	/**
+	 * Returns {@code qty} expressed in this cost's own UOM.
+	 * <p>
+	 * A <b>zero</b> quantity carries no unit information — zero metres is zero pieces — so it is adopted into
+	 * this cost's UOM instead of being rejected, and needs no conversion rate. That matters because
+	 * {@code CostRevaluationService#toCostAsOf} restates a live cost from the amounts it carried at an as-of
+	 * date, and those historical amounts can predate a change of the product's stock UOM. Since
+	 * {@code createLines} maps over every product in one pass, rejecting such a zero aborts the entire
+	 * cost-revaluation seed for the client.
+	 * <p>
+	 * A <b>non-zero</b> mismatch is a real inconsistency — converting it would need a rate this class has no
+	 * converter for — so it still throws.
+	 */
+	private Quantity toCostUOM(@NonNull final Quantity qty)
+	{
+		if (UomId.equals(qty.getUomId(), getUomId()))
+		{
+			return qty;
+		}
+		else if (qty.isZero())
+		{
+			return this.currentQty.toZero();
+		}
+		else
+		{
+			throw new AdempiereException("Invalid UOM for `" + qty + "`. Expected: " + getUomId());
+		}
 	}
 
 	public CostElementId getCostElementId()

--- a/backend/de.metas.business/src/main/java/de/metas/costing/CurrentCost.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/CurrentCost.java
@@ -125,7 +125,12 @@ public final class CurrentCost
 		final Quantity qty = toCostUOM(previousAmounts.getQty());
 		final Quantity cumulatedQty = toCostUOM(previousAmounts.getCumulatedQty());
 
-		this.costPrice = toCostUOM(previousAmounts.getCostPrice());
+		// The price's UOM tracks its own amounts — every producer of CostDetailPreviousAmounts builds price and
+		// quantity from the same product UOM — so it is re-labelled exactly when the quantities were, never on its
+		// own. A price tagged independently of its amounts is not something this method may silently rewrite.
+		this.costPrice = UomId.equals(previousAmounts.getCostPrice().getUomId(), previousAmounts.getQty().getUomId())
+				? relabelToCostUOM(previousAmounts.getCostPrice())
+				: previousAmounts.getCostPrice();
 		this.currentQty = qty;
 
 		this.cumulatedAmt = previousAmounts.getCumulatedAmt();
@@ -162,7 +167,9 @@ public final class CurrentCost
 	}
 
 	/**
-	 * Returns {@code costPrice} labelled with this cost's own UOM.
+	 * Returns {@code costPrice} labelled with this cost's own UOM. Unlike {@link #toCostUOM(Quantity)} this
+	 * never rejects a mismatch — it is a pure re-label, which is why it is deliberately NOT an overload of the
+	 * same name; the caller decides when re-labelling is legitimate.
 	 * <p>
 	 * {@code M_Cost} carries no separate UOM for its price: a current cost's price is <b>by definition</b>
 	 * expressed in the cost row's UOM, which is why the constructor stamps {@link #uomId} onto the price on
@@ -173,7 +180,7 @@ public final class CurrentCost
 	 * {@code M_CostRevaluationLine.C_UOM_ID} while writing {@code CurrentQty} in this cost's UOM — a line
 	 * labelled with one unit and quantified in another.
 	 */
-	private CostPrice toCostUOM(@NonNull final CostPrice costPrice)
+	private CostPrice relabelToCostUOM(@NonNull final CostPrice costPrice)
 	{
 		return UomId.equals(costPrice.getUomId(), getUomId())
 				? costPrice

--- a/backend/de.metas.business/src/main/java/de/metas/costing/CurrentCost.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/CurrentCost.java
@@ -125,7 +125,7 @@ public final class CurrentCost
 		final Quantity qty = toCostUOM(previousAmounts.getQty());
 		final Quantity cumulatedQty = toCostUOM(previousAmounts.getCumulatedQty());
 
-		this.costPrice = previousAmounts.getCostPrice();
+		this.costPrice = toCostUOM(previousAmounts.getCostPrice());
 		this.currentQty = qty;
 
 		this.cumulatedAmt = previousAmounts.getCumulatedAmt();
@@ -159,6 +159,25 @@ public final class CurrentCost
 		{
 			throw new AdempiereException("Invalid UOM for `" + qty + "`. Expected: " + getUomId());
 		}
+	}
+
+	/**
+	 * Returns {@code costPrice} labelled with this cost's own UOM.
+	 * <p>
+	 * {@code M_Cost} carries no separate UOM for its price: a current cost's price is <b>by definition</b>
+	 * expressed in the cost row's UOM, which is why the constructor stamps {@link #uomId} onto the price on
+	 * every load. A {@link CostDetailPreviousAmounts} however still carries the UOM its amounts were recorded
+	 * under, so the price is re-labelled here to preserve that invariant.
+	 * <p>
+	 * Without this, {@code CostRevaluationRepository.updateRecordFromCopySource} would stamp the stale UOM onto
+	 * {@code M_CostRevaluationLine.C_UOM_ID} while writing {@code CurrentQty} in this cost's UOM — a line
+	 * labelled with one unit and quantified in another.
+	 */
+	private CostPrice toCostUOM(@NonNull final CostPrice costPrice)
+	{
+		return UomId.equals(costPrice.getUomId(), getUomId())
+				? costPrice
+				: costPrice.convertAmounts(getUomId(), amount -> amount);
 	}
 
 	public CostElementId getCostElementId()

--- a/backend/de.metas.business/src/test/java/de/metas/costing/CurrentCostTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/costing/CurrentCostTest.java
@@ -109,8 +109,15 @@ public class CurrentCostTest
 	{
 		private CostDetailPreviousAmounts previousAmounts(final String qty, final I_C_UOM uom)
 		{
+			return previousAmounts(qty, uom, "0");
+		}
+
+		private CostDetailPreviousAmounts previousAmounts(final String qty, final I_C_UOM uom, final String ownCostPrice)
+		{
 			return CostDetailPreviousAmounts.builder()
-					.costPrice(CostPrice.zero(currencyId, UomId.ofRepoId(uom.getC_UOM_ID())))
+					.costPrice(CostPrice.ownCostPrice(
+							CostAmount.of(new BigDecimal(ownCostPrice), currencyId),
+							UomId.ofRepoId(uom.getC_UOM_ID())))
 					.qty(Quantity.of(new BigDecimal(qty), uom))
 					.cumulatedAmt(CostAmount.of(0, currencyId))
 					.cumulatedQty(Quantity.of(new BigDecimal(qty), uom))
@@ -139,6 +146,23 @@ public class CurrentCostTest
 					.isEqualTo(currentCost.getUomId());
 			assertThat(currentCost.getCurrentQty().toBigDecimal()).isEqualByComparingTo("0");
 			assertThat(currentCost.getCumulatedQty().getUomId()).isEqualTo(currentCost.getUomId());
+		}
+
+		@Test
+		public void zeroQtyInAnotherUOM_alsoRelabelsTheCostPrice()
+		{
+			final CurrentCost currentCost = currentCost().build();
+
+			// the live case: no stock left, but the carried price is NOT zero
+			currentCost.setFrom(previousAmounts("0", uomKg, "0.4762"));
+
+			assertThat(currentCost.getCostPrice().getUomId())
+					.as("the price must not keep a foreign UOM — M_Cost has no separate UOM for it, and "
+							+ "CostRevaluationRepository stamps this onto M_CostRevaluationLine.C_UOM_ID")
+					.isEqualTo(currentCost.getUomId());
+			assertThat(currentCost.getCostPrice().getOwnCostPrice().toBigDecimal())
+					.as("re-labelling must not alter the amount")
+					.isEqualByComparingTo("0.4762");
 		}
 
 		@Test

--- a/backend/de.metas.business/src/test/java/de/metas/costing/CurrentCostTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/costing/CurrentCostTest.java
@@ -163,6 +163,28 @@ public class CurrentCostTest
 			assertThat(currentCost.getCostPrice().getOwnCostPrice().toBigDecimal())
 					.as("re-labelling must not alter the amount")
 					.isEqualByComparingTo("0.4762");
+			assertThat(currentCost.getCostPrice().getComponentsCostPrice().toBigDecimal())
+					.as("both price components are re-labelled symmetrically")
+					.isEqualByComparingTo("0");
+		}
+
+		@Test
+		public void zeroQty_butMismatchedNonZeroCumulatedQty_stillThrows()
+		{
+			final CurrentCost currentCost = currentCost().build();
+
+			// qty is zero and could be adopted, but cumulatedQty is a real quantity in a foreign UOM
+			final CostDetailPreviousAmounts amounts = CostDetailPreviousAmounts.builder()
+					.costPrice(CostPrice.zero(currencyId, UomId.ofRepoId(uomKg.getC_UOM_ID())))
+					.qty(Quantity.of(BigDecimal.ZERO, uomKg))
+					.cumulatedAmt(CostAmount.of(0, currencyId))
+					.cumulatedQty(Quantity.of(new BigDecimal("7"), uomKg))
+					.build();
+
+			assertThatThrownBy(() -> currentCost.setFrom(amounts))
+					.as("a non-zero cumulatedQty mismatch is as real as a currentQty one")
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("Invalid UOM");
 		}
 
 		@Test

--- a/backend/de.metas.business/src/test/java/de/metas/costing/CurrentCostTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/costing/CurrentCostTest.java
@@ -8,7 +8,9 @@ import de.metas.organization.OrgId;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
 import de.metas.quantity.QuantityUOMConverters;
+import de.metas.uom.UomId;
 import lombok.Builder;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.mm.attributes.AttributeSetInstanceId;
 import org.adempiere.service.ClientId;
 import org.adempiere.test.AdempiereTestHelper;
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /*
  * #%L
@@ -47,6 +50,7 @@ public class CurrentCostTest
 {
 	private final CurrencyId currencyId = CurrencyId.ofRepoId(1);
 	private I_C_UOM uomEach;
+	private I_C_UOM uomKg;
 
 	@BeforeEach
 	public void beforeEach()
@@ -54,6 +58,7 @@ public class CurrentCostTest
 		AdempiereTestHelper.get().init();
 
 		uomEach = BusinessTestHelper.createUomEach();
+		uomKg = BusinessTestHelper.createUomKg();
 	}
 
 	private static BigDecimal toBigDecimalOrNull(final String str)
@@ -89,6 +94,63 @@ public class CurrentCostTest
 				.ownCostPrice(toBigDecimalOrNull(ownCostPrice))
 				.currentQty(toBigDecimalOrNull(currentQty))
 				.build();
+	}
+
+	/**
+	 * The CopyFromCostElement seed restates a live CurrentCost from the amounts it carried at
+	 * an as-of date ({@code CostRevaluationService#toCostAsOf}). Those historical amounts may legitimately
+	 * predate a product UOM change, so they can arrive in a different UOM than the live cost row.
+	 *
+	 * A ZERO quantity is unambiguous in any UOM -- zero metres is zero pieces -- and needs no conversion
+	 * rate. Rejecting it aborts the whole seed for every product. A NON-zero mismatch stays a hard error.
+	 */
+	@Nested
+	public class setFrom
+	{
+		private CostDetailPreviousAmounts previousAmounts(final String qty, final I_C_UOM uom)
+		{
+			return CostDetailPreviousAmounts.builder()
+					.costPrice(CostPrice.zero(currencyId, UomId.ofRepoId(uom.getC_UOM_ID())))
+					.qty(Quantity.of(new BigDecimal(qty), uom))
+					.cumulatedAmt(CostAmount.of(0, currencyId))
+					.cumulatedQty(Quantity.of(new BigDecimal(qty), uom))
+					.build();
+		}
+
+		@Test
+		public void sameUOM_isAccepted()
+		{
+			final CurrentCost currentCost = currentCost().build();
+
+			currentCost.setFrom(previousAmounts("0", uomEach));
+
+			assertThat(currentCost.getCurrentQty().toBigDecimal()).isEqualByComparingTo("0");
+		}
+
+		@Test
+		public void zeroQtyInAnotherUOM_isAccepted()
+		{
+			final CurrentCost currentCost = currentCost().build();
+
+			currentCost.setFrom(previousAmounts("0", uomKg));
+
+			assertThat(currentCost.getCurrentQty().getUomId())
+					.as("a zero quantity must be adopted into the cost's own UOM, not rejected")
+					.isEqualTo(currentCost.getUomId());
+			assertThat(currentCost.getCurrentQty().toBigDecimal()).isEqualByComparingTo("0");
+			assertThat(currentCost.getCumulatedQty().getUomId()).isEqualTo(currentCost.getUomId());
+		}
+
+		@Test
+		public void nonZeroQtyInAnotherUOM_stillThrows()
+		{
+			final CurrentCost currentCost = currentCost().build();
+
+			assertThatThrownBy(() -> currentCost.setFrom(previousAmounts("5", uomKg)))
+					.as("a non-zero mismatch is a real inconsistency and must stay loud")
+					.isInstanceOf(AdempiereException.class)
+					.hasMessageContaining("Invalid UOM");
+		}
 	}
 
 	@Nested


### PR DESCRIPTION
## What

`CurrentCost.setFrom()` asserted that the incoming amounts already carried this cost's UOM. The
cost-revaluation seed (`CostRevaluationService.toCostAsOf`) restates a live cost from the amounts it
held at an as-of date, and those historical amounts can predate a change of the product's stock UOM —
so the assert fires on data that is perfectly consistent.

Two things are now normalised into the cost's own UOM:

- **Quantities** (`currentQty`, `cumulatedQty`). A **zero** quantity carries no unit information —
  zero metres is zero pieces — and needs no conversion rate, so it is adopted. A **non-zero** mismatch
  is a real inconsistency, would need a rate this class has no converter for, and still throws exactly
  as before.
- **The cost price.** `M_Cost` carries no separate UOM for its price — a current cost's price is by
  definition expressed in the cost row's UOM, which is why the constructor stamps `uomId` onto the
  price on every load. Left verbatim, the price kept the UOM the historical amounts were recorded
  under, and `CostRevaluationRepository.updateRecordFromCopySource` writes
  `record.setC_UOM_ID(costPrice.getUomId())` right beside `record.setCurrentQty(...)` — persisting a
  revaluation line labelled with one unit and quantified in another.

The price re-label is caller-decided: it fires only when the price's UOM tracked the incoming
quantities (the invariant every producer of `CostDetailPreviousAmounts` maintains). A price tagged
independently of its own amounts is left alone rather than silently rewritten. The two helpers are
named apart on purpose — `toCostUOM(Quantity)` rejects a non-zero mismatch, `relabelToCostUOM` never
rejects anything.

## Why it matters

`createLines` maps over every product of the client in one pass, so a **single** zero-quantity product
sitting in a stale UOM aborted the **entire** cost-revaluation seed for that client. Observed on a
customer instance: two products, both zero-quantity at the anchor date, blocked the whole seed with

```
Invalid UOM for `0 LFM`. Expected: UomId(repoId=100)
  CurrentCost.assertCostUOM <- CurrentCost.setFrom <- CostRevaluationService.toCostAsOf
  <- createLinesFromCopyFromCostElement <- createLines
```

The WebUI swallows this — the action appears to do nothing and the document keeps 0 lines.

## Scope notes

- `assertCostUOM()` is deliberately **left untouched**. Its other caller, `addCumulatedAmtAndQty()`,
  sits on the forward path where the caller has already converted, and has no reason to become more
  permissive. This change narrows the guard for one call site; it does not weaken it.
- `setFrom()` resolves every amount *before* mutating any field, so a rejected quantity leaves the
  cost untouched.
- Amounts are never altered — only labels.

## Tests

`CurrentCostTest` gains a `setFrom` nested class, 5 cases:

| case | without the fix | with it |
|---|---|---|
| same UOM accepted (control) | pass | pass |
| **zero qty in another UOM accepted** | **fail** — `Invalid UOM` | pass |
| **zero qty re-labels a NON-zero price** (`0.4762`, both price components) | **fail** | pass |
| zero qty + non-zero mismatched `cumulatedQty` still throws | pass | pass |
| non-zero qty in another UOM still throws | pass | pass |

The two failing-without-the-fix cases are the genuine RED — they fail with the same exception, at the
same line, as the customer instance. The two "still throws" cases pass both before and after: that is
what makes this a narrowing rather than a weakening.

Locally: `CurrentCostTest` 9/9 green; full unfiltered `de.metas.business` module **547/547** green;
`CostRevaluationServiceTest` 14/14 green.
