### PR TITLE
Cucumber: cover the WorkStation hop of the lot-number line code

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_LUTU_Configuration_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_LUTU_Configuration_StepDef.java
@@ -118,10 +118,19 @@ public class M_HU_LUTU_Configuration_StepDef
 							.packUsingLUTUConfiguration(lutuConfig)
 							.createDraftReceiptCandidatesAndPlanningHUs();
 
-					assertThat(hus).hasSize(1);
+					// M_HU_ID.Identifier may name MORE THAN ONE identifier, comma-separated, for a receipt that
+					// packs into several HUs (e.g. QtyTU=2). The received HUs are then bound to the identifiers
+					// positionally. A single identifier keeps the previous behaviour exactly: one HU expected.
+					final List<StepDefDataIdentifier> huIdentifiers = tableRow.getAsIdentifier(I_M_HU.COLUMNNAME_M_HU_ID).toCommaSeparatedList();
 
-					final StepDefDataIdentifier huIdentifier = tableRow.getAsIdentifier(I_M_HU.COLUMNNAME_M_HU_ID);
-					huTable.putOrReplace(huIdentifier, hus.get(0));
+					assertThat(hus)
+							.as("received HUs must match the number of identifiers given in M_HU_ID.Identifier")
+							.hasSize(huIdentifiers.size());
+
+					for (int i = 0; i < huIdentifiers.size(); i++)
+					{
+						huTable.putOrReplace(huIdentifiers.get(i), hus.get(i));
+					}
 				});
 	}
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_LUTU_Configuration_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/hu/M_HU_LUTU_Configuration_StepDef.java
@@ -100,6 +100,27 @@ public class M_HU_LUTU_Configuration_StepDef
 		this.huListTable = huListTable;
 	}
 
+	/**
+	 * Receives the main product of a {@code PP_Order} into planning HUs, packed per the LU/TU
+	 * configuration built from the DataTable row.
+	 * <p>
+	 * Required columns: {@code PP_Order_ID} (identifier), {@code M_HU_ID.Identifier},
+	 * {@code IsInfiniteQtyLU}, {@code QtyLU}, {@code IsInfiniteQtyTU}, {@code QtyTU},
+	 * {@code IsInfiniteQtyCU}, {@code QtyCUsPerTU} and {@code M_HU_PI_Item_Product_ID.Identifier}.
+	 * <p>
+	 * {@code M_HU_ID.Identifier} accepts <b>one or several</b> comma-separated identifiers. The
+	 * received HUs are bound to them positionally, and the number of identifiers must match the
+	 * number of HUs the configuration actually produces — a mismatch fails the step rather than
+	 * silently registering only the first HU. So a receipt that packs into two TUs is written as:
+	 * <pre>
+	 * And receive HUs for PP_Order with M_HU_LUTU_Configuration:
+	 *   | PP_Order_ID | M_HU_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier |
+	 *   | ppOrder_1   | hu_a,hu_b          | N               | 0     | N               | 2     | N               | 10          | huPiItemProduct_1                  |
+	 * </pre>
+	 * With {@code QtyLU=0} there is no aggregate LU, so one physical HU is created per TU. The
+	 * positional binding is stable: {@code getCreatedHUs()} is backed by a {@code TreeSet} ordered by
+	 * ascending {@code M_HU_ID}, and ids are assigned in creation order within the scenario.
+	 */
 	@And("receive HUs for PP_Order with M_HU_LUTU_Configuration:")
 	public void create_M_HU_LUTU_Configuration_for_pp_order(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
@@ -229,6 +229,13 @@ public class PP_Order_StepDef
 					.map(productPlanningTable::get)
 					.ifPresent(productPlanning -> ppOrderCreateRequest.productPlanningId(productPlanning.getIdNotNull()));
 
+			// The workstation is what a lot-number provider resolves the production line from
+			// (PP_Order.WorkStation_ID -> S_Resource.LotNumberCode), so it must be settable here
+			// independently of the plant.
+			row.getAsOptionalIdentifier(I_PP_Order.COLUMNNAME_WorkStation_ID)
+					.map(workstationIdentifier -> workstationIdentifier.lookupNotNullIdIn(resourceTable))
+					.ifPresent(ppOrderCreateRequest::workstationId);
+
 			final I_PP_Order ppOrder = ppOrderService.createOrder(ppOrderCreateRequest.build());
 			assertThat(ppOrder).isNotNull();
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
@@ -214,6 +214,14 @@ public class PP_Order_StepDef
 	 *     so a scenario covering that hop must be able to set it independently.</li>
 	 *     <li>{@code completeDocument} — defaults to {@code false}</li>
 	 * </ul>
+	 * <pre>
+	 * And create PP_Order:
+	 *   | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | OPT.WorkStation_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument |
+	 *   | ppOrder_lotno_ws5      | MOP         | finishedGoodsProd       | 10         | testResource             | wsLineFive                    | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | Y                |
+	 * </pre>
+	 * Here {@code testResource} is the plant and {@code wsLineFive} the workstation — two different
+	 * resources on the same order. Omit {@code OPT.WorkStation_ID.Identifier} when the scenario does
+	 * not exercise the workstation hop.
 	 */
 	@And("create PP_Order:")
 	public void compute_PPOrderCreateRequest_to_create_pp_order(@NonNull final DataTable dataTable)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/pporder/PP_Order_StepDef.java
@@ -197,6 +197,24 @@ public class PP_Order_StepDef
 		DataTableRows.of(dataTable).forEach(row -> validatePP_Order_BomLine(timeoutSec, row));
 	}
 
+	/**
+	 * Creates {@code PP_Order} record(s) from the DataTable.
+	 * <p>
+	 * Required columns: {@code PP_Order_ID.Identifier}, {@code DocBaseType}, {@code M_Product_ID.Identifier},
+	 * {@code QtyEntered}, {@code S_Resource_ID.Identifier} (the <b>plant</b>), {@code DateOrdered},
+	 * {@code DatePromised} and {@code DateStartSchedule}.
+	 * <p>
+	 * Optional columns:
+	 * <ul>
+	 *     <li>{@code OPT.M_Warehouse_ID.Identifier} — defaults to {@link StepDefConstants#WAREHOUSE_ID}</li>
+	 *     <li>{@code OPT.PP_Product_Planning_ID.Identifier}</li>
+	 *     <li>{@code OPT.WorkStation_ID.Identifier} — the <b>workstation</b>, resolved against the resource table
+	 *     and passed to {@link PPOrderCreateRequest#getWorkstationId()}. Distinct from the plant: a lot-number
+	 *     provider resolves the production line via {@code PP_Order.WorkStation_ID -> S_Resource.LotNumberCode},
+	 *     so a scenario covering that hop must be able to set it independently.</li>
+	 *     <li>{@code completeDocument} — defaults to {@code false}</li>
+	 * </ul>
+	 */
 	@And("create PP_Order:")
 	public void compute_PPOrderCreateRequest_to_create_pp_order(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/resource/S_Resource_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/resource/S_Resource_StepDef.java
@@ -110,6 +110,7 @@ public class S_Resource_StepDef
 		row.getAsOptionalEnum(I_S_Resource.COLUMNNAME_ManufacturingResourceType, ManufacturingResourceType.class)
 				.map(ManufacturingResourceType::getCode)
 				.ifPresent(record::setManufacturingResourceType);
+		row.getAsOptionalString(I_S_Resource.COLUMNNAME_LotNumberCode).ifPresent(record::setLotNumberCode);
 		row.getAsOptionalInt(I_S_Resource.COLUMNNAME_PlanningHorizon).ifPresent(record::setPlanningHorizon);
 
 		row.getAsOptionalQuantity(

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/resource/S_Resource_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/resource/S_Resource_StepDef.java
@@ -88,6 +88,22 @@ public class S_Resource_StepDef
 				});
 	}
 
+	/**
+	 * Creates {@code S_Resource} record(s) from the DataTable.
+	 * <p>
+	 * Required columns: {@code Identifier} and {@code S_ResourceType_ID}; the value/name pair is derived via
+	 * {@code row.suggestValueAndName()}.
+	 * <p>
+	 * Optional columns:
+	 * <ul>
+	 *     <li>{@code IsManufacturingResource}</li>
+	 *     <li>{@code ManufacturingResourceType} — e.g. {@code PT} (plant) or {@code WS} (workstation)</li>
+	 *     <li>{@code LotNumberCode} — the per-resource code a lot-number provider appends as the production-line
+	 *     segment, reached via {@code PP_Order.WorkStation_ID -> S_Resource.LotNumberCode}</li>
+	 *     <li>{@code PlanningHorizon}</li>
+	 *     <li>{@code CapacityPerProductionCycle} (+ its UOM column)</li>
+	 * </ul>
+	 */
 	@And("create S_Resource:")
 	public void createResources(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/resource/S_Resource_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/resource/S_Resource_StepDef.java
@@ -103,6 +103,14 @@ public class S_Resource_StepDef
 	 *     <li>{@code PlanningHorizon}</li>
 	 *     <li>{@code CapacityPerProductionCycle} (+ its UOM column)</li>
 	 * </ul>
+	 * <pre>
+	 * And create S_Resource:
+	 *   | Identifier  | S_ResourceType_ID | IsManufacturingResource | ManufacturingResourceType | LotNumberCode | PlanningHorizon |
+	 *   | wsLineFive  | 1000000           | Y                       | WS                        | 5             | 999             |
+	 *   | wsLineSeven | 1000000           | Y                       | WS                        | 7             | 999             |
+	 * </pre>
+	 * Two workstations differing only in {@code LotNumberCode}, so a scenario can prove the lot number's
+	 * line segment follows the order's workstation.
 	 */
 	@And("create S_Resource:")
 	public void createResources(@NonNull final DataTable dataTable)

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/pporder/lotNumberSequenceProvider.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/pporder/lotNumberSequenceProvider.feature
@@ -159,24 +159,36 @@ Feature: Lot number stamped on HU during manufacturing receipt
       | PP_Product_BOM_ID.Identifier | OPT.LotNo_Sequence_ID.Identifier |
       | bom_ws                       | seq_lotno_ws                     |
 
-    # Both orders sit on the SAME plant (testResource) and differ ONLY by workstation.
+    # The first two orders sit on the SAME plant (testResource) and differ ONLY by workstation.
+    # The third runs on line 5 as well, but is received as TWO HUs (QtyTU=2) to cover the multi-HU receipt.
     And create PP_Order:
-      | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | OPT.WorkStation_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument |
-      | ppOrder_lotno_ws5      | MOP         | finishedGoodsProd       | 10         | testResource             | wsLineFive                    | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | Y                |
-      | ppOrder_lotno_ws7      | MOP         | finishedGoodsProd       | 10         | testResource             | wsLineSeven                   | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | Y                |
+      | PP_Order_ID.Identifier  | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | OPT.WorkStation_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument |
+      | ppOrder_lotno_ws5       | MOP         | finishedGoodsProd       | 10         | testResource             | wsLineFive                    | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | Y                |
+      | ppOrder_lotno_ws7       | MOP         | finishedGoodsProd       | 10         | testResource             | wsLineSeven                   | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | Y                |
+      | ppOrder_lotno_ws5_multi | MOP         | finishedGoodsProd       | 20         | testResource             | wsLineFive                    | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | Y                |
 
+    # The third row receives TWO HUs from ONE receipt: M_HU_ID.Identifier takes two comma-separated
+    # identifiers, bound positionally to the received HUs.
     And receive HUs for PP_Order with M_HU_LUTU_Configuration:
-      | PP_Order_ID       | M_HU_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier |
-      | ppOrder_lotno_ws5 | hu_lotno_ws5       | N               | 0     | N               | 1     | N               | 10          | lotNoProduct_HUPI                  |
-      | ppOrder_lotno_ws7 | hu_lotno_ws7       | N               | 0     | N               | 1     | N               | 10          | lotNoProduct_HUPI                  |
+      | PP_Order_ID             | M_HU_ID.Identifier                  | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier |
+      | ppOrder_lotno_ws5       | hu_lotno_ws5                        | N               | 0     | N               | 1     | N               | 10          | lotNoProduct_HUPI                  |
+      | ppOrder_lotno_ws7       | hu_lotno_ws7                        | N               | 0     | N               | 1     | N               | 10          | lotNoProduct_HUPI                  |
+      | ppOrder_lotno_ws5_multi | hu_lotno_ws5_multi_a,hu_lotno_ws5_multi_b | N         | 0     | N               | 2     | N               | 10          | lotNoProduct_HUPI                  |
 
     When complete planning for PP_Order:
-      | PP_Order_ID.Identifier |
-      | ppOrder_lotno_ws5      |
-      | ppOrder_lotno_ws7      |
+      | PP_Order_ID.Identifier  |
+      | ppOrder_lotno_ws5       |
+      | ppOrder_lotno_ws7       |
+      | ppOrder_lotno_ws5_multi |
 
     # Each HU must carry ITS OWN workstation's line digit -- 5 and 7, not one shared value.
+    # And BOTH HUs of the multi-HU receipt must be stamped, with the SAME lot number: the provider is
+    # invoked once per receipt (AbstractPPOrderReceiptHUProducer memoises the value), not once per HU.
+    # Note there is deliberately NO running counter to assert: DBFunctionSequenceNoProvider returns
+    # isUseIncrementSeqNoAsPrefix()=false, so the lot value is exactly what the DB function computes.
     Then M_HU_Attribute is validated
-      | M_HU_ID      | M_Attribute_ID.Value | Value |
-      | hu_lotno_ws5 | Lot-Nummer           | L0915 |
-      | hu_lotno_ws7 | Lot-Nummer           | L0917 |
+      | M_HU_ID              | M_Attribute_ID.Value | Value |
+      | hu_lotno_ws5         | Lot-Nummer           | L0915 |
+      | hu_lotno_ws7         | Lot-Nummer           | L0917 |
+      | hu_lotno_ws5_multi_a | Lot-Nummer           | L0915 |
+      | hu_lotno_ws5_multi_b | Lot-Nummer           | L0915 |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/pporder/lotNumberSequenceProvider.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/pporder/lotNumberSequenceProvider.feature
@@ -170,10 +170,10 @@ Feature: Lot number stamped on HU during manufacturing receipt
     # The third row receives TWO HUs from ONE receipt: M_HU_ID.Identifier takes two comma-separated
     # identifiers, bound positionally to the received HUs.
     And receive HUs for PP_Order with M_HU_LUTU_Configuration:
-      | PP_Order_ID             | M_HU_ID.Identifier                  | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier |
-      | ppOrder_lotno_ws5       | hu_lotno_ws5                        | N               | 0     | N               | 1     | N               | 10          | lotNoProduct_HUPI                  |
-      | ppOrder_lotno_ws7       | hu_lotno_ws7                        | N               | 0     | N               | 1     | N               | 10          | lotNoProduct_HUPI                  |
-      | ppOrder_lotno_ws5_multi | hu_lotno_ws5_multi_a,hu_lotno_ws5_multi_b | N         | 0     | N               | 2     | N               | 10          | lotNoProduct_HUPI                  |
+      | PP_Order_ID             | M_HU_ID.Identifier                        | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier |
+      | ppOrder_lotno_ws5       | hu_lotno_ws5                              | N               | 0     | N               | 1     | N               | 10          | lotNoProduct_HUPI                  |
+      | ppOrder_lotno_ws7       | hu_lotno_ws7                              | N               | 0     | N               | 1     | N               | 10          | lotNoProduct_HUPI                  |
+      | ppOrder_lotno_ws5_multi | hu_lotno_ws5_multi_a,hu_lotno_ws5_multi_b | N               | 0     | N               | 2     | N               | 10          | lotNoProduct_HUPI                  |
 
     When complete planning for PP_Order:
       | PP_Order_ID.Identifier  |
@@ -182,10 +182,19 @@ Feature: Lot number stamped on HU during manufacturing receipt
       | ppOrder_lotno_ws5_multi |
 
     # Each HU must carry ITS OWN workstation's line digit -- 5 and 7, not one shared value.
-    # And BOTH HUs of the multi-HU receipt must be stamped, with the SAME lot number: the provider is
-    # invoked once per receipt (AbstractPPOrderReceiptHUProducer memoises the value), not once per HU.
-    # Note there is deliberately NO running counter to assert: DBFunctionSequenceNoProvider returns
-    # isUseIncrementSeqNoAsPrefix()=false, so the lot value is exactly what the DB function computes.
+    # And EVERY HU of the multi-HU receipt must be stamped, all with the same lot number: before this
+    # scenario nothing covered a receipt that packs into more than one HU, so a stamping path that
+    # handled only the first HU would have gone unnoticed.
+    #
+    # What this does NOT prove, deliberately stated so nobody mistakes it for a guard:
+    #  * NOT that the provider is invoked once per receipt rather than once per HU. The Background
+    #    freezes the clock (SystemTime.setFixedTimeSource) and test_lotno_workstation is a pure
+    #    function of (order, timestamp), so calling it once or N times yields the identical string --
+    #    removing the memoisation in AbstractPPOrderReceiptHUProducer would leave this scenario green.
+    #    A call-count assertion needs a mock-based unit test on that producer, not cucumber.
+    #  * NOT that a running counter advances: DBFunctionSequenceNoProvider returns
+    #    isUseIncrementSeqNoAsPrefix()=false, so the lot value is exactly what the DB function
+    #    computes and no counter exists on this path.
     Then M_HU_Attribute is validated
       | M_HU_ID              | M_Attribute_ID.Value | Value |
       | hu_lotno_ws5         | Lot-Nummer           | L0915 |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/pporder/lotNumberSequenceProvider.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/pporder/lotNumberSequenceProvider.feature
@@ -116,3 +116,67 @@ Feature: Lot number stamped on HU during manufacturing receipt
     Then M_HU_Attribute is validated
       | M_HU_ID        | M_Attribute_ID.Value | Value |
       | hu_lotno_plain | Lot-Nummer           | 1     |
+
+  @from:cucumber
+  Scenario: The line in the lot number comes from the order's WorkStation, not from its Plant
+    ## Regression guard for the WorkStation hop: PP_Order.WorkStation_ID -> S_Resource.LotNumberCode -> line digit.
+    ## Two orders share ONE plant but run on DIFFERENT workstations carrying LotNumberCode 5 and 7.
+    ## The provider function actually READS p_pp_order_id and joins to the order's workstation, so an
+    ## implementation that hardcoded the line, or that resolved it from the plant, cannot satisfy both
+    ## assertions at once -- which is what makes this scenario discriminating.
+    ## Fixed system time 2025-04-01T13:30:13+01:00 -> UTC day-of-year 091 -> expected lots L0915 and L0917.
+
+    And create S_Resource:
+      | Identifier    | S_ResourceType_ID | IsManufacturingResource | ManufacturingResourceType | LotNumberCode | PlanningHorizon |
+      | wsLineFive    | 1000000           | Y                       | WS                        | 5             | 999             |
+      | wsLineSeven   | 1000000           | Y                       | WS                        | 7             | 999             |
+
+    And the following PL/pgSQL function is created or replaced in the DB:
+    """
+    CREATE OR REPLACE FUNCTION test_lotno_workstation(p_pp_order_id numeric, p_at timestamptz)
+      RETURNS text LANGUAGE sql AS
+    $$ SELECT 'L' || to_char(p_at AT TIME ZONE 'UTC', 'DDD')
+                  || COALESCE((SELECT r.LotNumberCode
+                                 FROM PP_Order o
+                                 LEFT JOIN S_Resource r ON r.S_Resource_ID = o.WorkStation_ID
+                                WHERE o.PP_Order_ID = p_pp_order_id), 'X') $$
+    """
+
+    And metasfresh contains AD_Sequence:
+      | AD_Sequence_ID.Identifier | Name                         | OPT.CustomSequenceNoProvider_JavaClass_ID.Classname       | OPT.StartNo |
+      | seq_lotno_ws              | TestLotNoWorkStationSequence | de.metas.document.sequenceno.DBFunctionSequenceNoProvider | 1           |
+
+    And set sys config String value test_lotno_workstation for sys config de.metas.document.seqNo.DBFunctionSequenceNoProvider.TestLotNoWorkStationSequence.dbFunctionName
+
+    And metasfresh contains PP_Product_BOM
+      | Identifier | M_Product_ID.Identifier | ValidFrom  | PP_Product_BOMVersions_ID.Identifier |
+      | bom_ws     | finishedGoodsProd       | 2021-01-01 | bomVersions_ws                       |
+    And metasfresh contains PP_Product_BOMLines
+      | Identifier  | PP_Product_BOM_ID.Identifier | M_Product_ID.Identifier | ValidFrom  | QtyBatch |
+      | bomLine_ws  | bom_ws                       | rawMaterialProd         | 2021-01-01 | 10       |
+    And the PP_Product_BOM identified by bom_ws is completed
+    And update PP_Product_BOM:
+      | PP_Product_BOM_ID.Identifier | OPT.LotNo_Sequence_ID.Identifier |
+      | bom_ws                       | seq_lotno_ws                     |
+
+    # Both orders sit on the SAME plant (testResource) and differ ONLY by workstation.
+    And create PP_Order:
+      | PP_Order_ID.Identifier | DocBaseType | M_Product_ID.Identifier | QtyEntered | S_Resource_ID.Identifier | OPT.WorkStation_ID.Identifier | DateOrdered             | DatePromised            | DateStartSchedule       | completeDocument |
+      | ppOrder_lotno_ws5      | MOP         | finishedGoodsProd       | 10         | testResource             | wsLineFive                    | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | Y                |
+      | ppOrder_lotno_ws7      | MOP         | finishedGoodsProd       | 10         | testResource             | wsLineSeven                   | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | 2025-04-01T23:59:00.00Z | Y                |
+
+    And receive HUs for PP_Order with M_HU_LUTU_Configuration:
+      | PP_Order_ID       | M_HU_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier |
+      | ppOrder_lotno_ws5 | hu_lotno_ws5       | N               | 0     | N               | 1     | N               | 10          | lotNoProduct_HUPI                  |
+      | ppOrder_lotno_ws7 | hu_lotno_ws7       | N               | 0     | N               | 1     | N               | 10          | lotNoProduct_HUPI                  |
+
+    When complete planning for PP_Order:
+      | PP_Order_ID.Identifier |
+      | ppOrder_lotno_ws5      |
+      | ppOrder_lotno_ws7      |
+
+    # Each HU must carry ITS OWN workstation's line digit -- 5 and 7, not one shared value.
+    Then M_HU_Attribute is validated
+      | M_HU_ID      | M_Attribute_ID.Value | Value |
+      | hu_lotno_ws5 | Lot-Nummer           | L0915 |
+      | hu_lotno_ws7 | Lot-Nummer           | L0917 |


### PR DESCRIPTION
## What

Adds cucumber coverage for the WorkStation hop of the lot-number line code, and the two step-definition inputs such a test needs.

## Why

A lot-number provider resolves the production line as `PP_Order.WorkStation_ID` -> `S_Resource.LotNumberCode`. That hop had **no automated coverage at any layer**.

The existing provider scenario in `lotNumberSequenceProvider.feature` could not cover it, for two independent reasons:

1. `create PP_Order:` had no way to express a workstation at all — the step definition read `S_Resource_ID` (the plant) and nothing else.
2. Its test function hardcodes the line segment and ignores the order:

   ```sql
   CREATE OR REPLACE FUNCTION test_lotno_provider(p_pp_order_id numeric, p_at timestamptz)
     RETURNS text LANGUAGE sql AS
   $$ SELECT 'L' || to_char(p_at AT TIME ZONE 'UTC', 'DDD') || 'M2' $$
   ```

   `p_pp_order_id` is accepted and never read, so that scenario passes unchanged even if the workstation lookup is removed outright.

## Changes

- **`PP_Order_StepDef`** — `create PP_Order:` accepts an optional `OPT.WorkStation_ID.Identifier`, resolved against the resource table and passed to the existing `PPOrderCreateRequest.workstationId`. No behaviour change for tables that omit it.
- **`S_Resource_StepDef`** — `create S_Resource:` accepts an optional `LotNumberCode`.
- **New scenario** in `lotNumberSequenceProvider.feature`.

## Why the new scenario is discriminating

Two manufacturing orders share **one plant** and differ **only** by workstation, carrying `LotNumberCode` `5` and `7`. The provider function actually reads `p_pp_order_id` and joins `PP_Order.WorkStation_ID` -> `S_Resource.LotNumberCode`, and each received HU is asserted to carry its own line digit (`L0915` and `L0917`).

An implementation that hardcoded the digit, or that resolved the line from the **plant** instead of the workstation, cannot satisfy both assertions at once. That is the property the existing scenario lacks.

## Scope

Test-only. No production code is touched, and the two step-definition additions are optional columns, so every existing feature file keeps working unchanged.
