### PR TITLE
e2e mobile: port the scan-retry loop to fix the intermittent ApplicationsListScreen timeout

### DIFF
--- a/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
+++ b/e2e/mobile-webui/tests/utils/screens/huManager/HUBulkActionsScreen.js
@@ -1,5 +1,5 @@
 import { test } from '../../../../playwright.config';
-import { page, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../../common';
+import { page, FAST_ACTION_TIMEOUT, SLOW_ACTION_TIMEOUT, VERY_SLOW_ACTION_TIMEOUT } from '../../common';
 import { expect } from '@playwright/test';
 import { ApplicationsListScreen } from '../ApplicationsListScreen';
 import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponent';
@@ -7,6 +7,11 @@ import { BarcodeScannerComponent } from '../../components/BarcodeScannerComponen
 const NAME = 'HUBulkActionsScreen';
 /** @returns {import('@playwright/test').Locator} */
 const containerElement = () => page.locator('#HUBulkActionsScreen');
+
+// A real operator scans the target locator and, if nothing happens, simply scans again.
+// We mirror that: scan the target, and if the bulk-actions screen is still open shortly
+// after, scan once more, up to this many attempts.
+const SCAN_TARGET_MAX_ATTEMPTS = 5;
 
 export const HUBulkActionsScreen = {
     waitForScreen: async () => await test.step(`${NAME} - Wait for screen`, async () => {
@@ -20,9 +25,25 @@ export const HUBulkActionsScreen = {
     move: async ({ targetLocator }) => await test.step(`${NAME} - Move HU`, async () => {
         await page.getByTestId('toggle-target-scanner-button').tap();
         // Wait for button text to change to "Close scanner" - ensures React re-render complete
-        // and useKeyboardBarcodeReader hook has attached its event listener
         await page.getByTestId('toggle-target-scanner-button').getByText('Close scanner').waitFor({ timeout: SLOW_ACTION_TIMEOUT });
-        await BarcodeScannerComponent.type(targetLocator);
+
+        // The keyboard-scanner hook's window listener attaches asynchronously (useEffect after
+        // the React commit), so a single instantaneous scan can be dropped; re-scan until the
+        // screen navigates away — mirroring an operator who scans again when nothing happens.
+        for (let attempt = 1; attempt <= SCAN_TARGET_MAX_ATTEMPTS; attempt++) {
+            await BarcodeScannerComponent.type(targetLocator);
+
+            // Scan accepted → screen navigates away; verify with a bounded wait.
+            try {
+                await containerElement().waitFor({ state: 'detached', timeout: FAST_ACTION_TIMEOUT });
+                break;
+            } catch (e) {
+                if (attempt === SCAN_TARGET_MAX_ATTEMPTS) {
+                    throw e;
+                }
+                // still on the bulk-actions screen — the scan was dropped; scan again
+            }
+        }
 
         // The bulk move commits via an async REST round-trip (api.moveBulkHUs -> POST /bulk/move);
         // only once it resolves does the frontend navigate home (history.goHome()). The home screen


### PR DESCRIPTION
## What

Ports the `SCAN_TARGET_MAX_ATTEMPTS` re-scan loop in `HUBulkActionsScreen.move()` from https://github.com/metasfresh/metasfresh/pull/24615 onto this branch. Test-harness only — one file under `e2e/mobile-webui/`, no production code.

## Why

`mobile test` fails intermittently on this branch. The failure alternates between two sibling specs on an **identical commit** — each passes on a run where the other fails:

| attempt | `huManager.spec.js:155` | `by_ExternalBarcode_attribute.spec.js:123` |
| :--- | :--- | :--- |
| 1 | pass | fail |
| 2 | fail | pass |
| 3 | pass | fail |
| 4 | fail | pass |

Always 247/248 passing, always the same error:

```
TimeoutError: locator.waitFor: Timeout 40000ms exceeded
  waiting for locator('#ApplicationsListScreen')
  at tests/utils/screens/ApplicationsListScreen.js:15
```

**Root cause** — a dropped-first-scan race. The keyboard-scanner `keydown` listener attaches in a `useEffect`, i.e. *after* the React commit, so a scan issued immediately can be dropped and the screen never navigates. The existing comment claiming the "Close scanner" text-wait proves the listener is attached is precisely the wrong assumption, and is removed.

This branch already received the rest of that file's evolution (the `VERY_SLOW_ACTION_TIMEOUT` bump and its rationale comment) but never the re-scan loop — the only actually-effective part of the fix. The same port was merged to a sibling hotfix branch as https://github.com/metasfresh/metasfresh/pull/25495 and verified green there.

## Change

- import `FAST_ACTION_TIMEOUT` alongside the existing timeouts
- add `const SCAN_TARGET_MAX_ATTEMPTS = 5`
- `move()` wraps the target scan in a 1..5 loop; each attempt bounded-waits for `#HUBulkActionsScreen` to become `detached` (`FAST_ACTION_TIMEOUT`), breaks on success, re-scans otherwise, and rethrows the original Playwright error on the final attempt
- no fixed sleeps are introduced

After the port, this file is **byte-identical** to the `new_dawn_uat` version.

## Verification

- Cherry-pick of the upstream commit; the only conflict was the import line (this branch already carried `VERY_SLOW_ACTION_TIMEOUT`), resolved by keeping all four constants.
- `git diff --name-only` against the base returns exactly the one file; `node --check` passes.
- Deliberately narrower than https://github.com/metasfresh/metasfresh/pull/25495, which also carried an `ApplicationsListScreen` timeout parameterization and a `GetQuantityDialog` race fix that this branch already has via other commits.
