### PR TITLE
ESR import: a system-set payment action is not a user decision; field + message fixes

### DIFF
--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
@@ -1085,10 +1085,7 @@ public class ESRImportBL implements IESRImportBL
 
 		final String actionType = line.getESR_Payment_Action();
 
-		// A SYSTEM-SET flag is not a user decision. The import sets some actions itself, and this pass
-		// only tests that ESR_Payment_Action is non-null before running a handler and marking the line
-		// Processed -- so without this guard a later Process run (possibly triggered for a completely
-		// different line) silently closes such a line although nobody decided anything.
+		// A SYSTEM-SET flag is not a user decision:
 		//   Duplicate_Payment: the import flags it, the accountant must still pick an overpayment
 		//     action. It is not even selectable -- ESRPaymentActionValidationRule accepts it in no
 		//     group -- so skipping it here cannot block a deliberate choice.

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportBL.java
@@ -1019,6 +1019,16 @@ public class ESRImportBL implements IESRImportBL
 		}
 	}
 
+	/**
+	 * Actions the IMPORT sets by itself, which therefore must not be treated as a decision by
+	 * {@link #handleEsrImportLine(String, I_ESR_ImportLine)}. See the comment at the guard for why each
+	 * one is in here -- and why {@code Unable_To_Assign_Income} is not.
+	 */
+	private static final ImmutableSet<String> SYSTEM_SET_ACTIONS_AWAITING_DECISION = ImmutableSet.of(
+			X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment,
+			X_ESR_ImportLine.ESR_PAYMENT_ACTION_Control_Line,
+			X_ESR_ImportLine.ESR_PAYMENT_ACTION_Reverse_Booking);
+
 	private void handleEsrImportLine(final String message, final I_ESR_ImportLine line)
 	{
 		if (line.isProcessed())
@@ -1074,6 +1084,24 @@ public class ESRImportBL implements IESRImportBL
 		}
 
 		final String actionType = line.getESR_Payment_Action();
+
+		// A SYSTEM-SET flag is not a user decision. The import sets some actions itself, and this pass
+		// only tests that ESR_Payment_Action is non-null before running a handler and marking the line
+		// Processed -- so without this guard a later Process run (possibly triggered for a completely
+		// different line) silently closes such a line although nobody decided anything.
+		//   Duplicate_Payment: the import flags it, the accountant must still pick an overpayment
+		//     action. It is not even selectable -- ESRPaymentActionValidationRule accepts it in no
+		//     group -- so skipping it here cannot block a deliberate choice.
+		//   Control_Line / Reverse_Booking: no handler is registered for either, so this pass would
+		//     only append a "not supported" message to the line on every run. Reverse bookings are
+		//     documented as something the admin deals with manually.
+		// Unable_To_Assign_Income is deliberately NOT in this set: it IS offered in the dropdown, so
+		// it can be a genuine user choice and must keep being processed.
+		if (SYSTEM_SET_ACTIONS_AWAITING_DECISION.contains(actionType))
+		{
+			return;
+		}
+
 		if (Check.isEmpty(actionType, true))
 		{
 			final AdempiereException ex = AdempiereException.newWithTranslatableMessage("@" + ESRConstants.ERR_ESR_LINE_WITH_NO_PAYMENT_ACTION + "@");
@@ -1195,7 +1223,7 @@ public class ESRImportBL implements IESRImportBL
 	private void markInvoiceAlreadyPaid(@NonNull final I_ESR_ImportLine importLine, @NonNull final I_C_Invoice invoice)
 	{
 		final Properties ctx = getCtx(importLine);
-		ESRDataLoaderUtil.addMatchErrorMsgIfNotPresent(importLine,
+		ESRDataLoaderUtil.addMatchErrorMsg(importLine,
 														msgBL.getMsg(ctx, ESR_INVOICE_ALREADY_PAID_1P, new Object[] { invoice.getDocumentNo() }));
 		importLine.setESR_Document_Status(X_ESR_ImportLine.ESR_DOCUMENT_STATUS_PartiallyMatched);
 	}

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtil.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtil.java
@@ -407,6 +407,12 @@ public class ESRDataLoaderUtil
 	 * second Process run evaluates it once more -- so an unconditional append shows the accountant the
 	 * same sentence two or three times over. It is idempotent per message, so a genuinely different
 	 * message is still appended.
+	 * <p>
+	 * Known limitation, deliberately kept: the check is {@code contains}, so a shorter message that
+	 * happens to sit inside one already stored is treated as present and dropped. Matching whole
+	 * messages instead (splitting on the {@code "; "} that {@link #addMsgToString(String, String)}
+	 * joins with) would only trade this for the opposite bug -- a message that itself contains
+	 * {@code "; "} would then duplicate again. Pinned by ESRDataLoaderUtilTest.
 	 */
 	public void addMatchErrorMsg(@NonNull final I_ESR_ImportLine importLine, @Nullable final String msg)
 	{

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtil.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtil.java
@@ -399,24 +399,23 @@ public class ESRDataLoaderUtil
 		}
 	}
 
-	public void addMatchErrorMsg(@NonNull final I_ESR_ImportLine importLine, final String msg)
-	{
-		importLine.setMatchErrorMsg(addMsgToString(importLine.getMatchErrorMsg(), msg));
-	}
-
 	/**
-	 * Like {@link #addMatchErrorMsg(I_ESR_ImportLine, String)}, but a no-op if the line's {@code MatchErrorMsg} already
-	 * contains the given message. For callers that may run more than once for the same line and would otherwise
-	 * accumulate the very same message again and again.
+	 * Appends {@code msg} to the line's {@code MatchErrorMsg}, unless it is already there.
+	 * <p>
+	 * The de-duplication is not a nicety: every {@code evaluate*} entry point here is re-runnable by
+	 * design -- the import evaluates a line, a {@code @ModelChange} interceptor evaluates it again, and a
+	 * second Process run evaluates it once more -- so an unconditional append shows the accountant the
+	 * same sentence two or three times over. It is idempotent per message, so a genuinely different
+	 * message is still appended.
 	 */
-	public void addMatchErrorMsgIfNotPresent(@NonNull final I_ESR_ImportLine importLine, @Nullable final String msg)
+	public void addMatchErrorMsg(@NonNull final I_ESR_ImportLine importLine, @Nullable final String msg)
 	{
 		final String currentMsg = importLine.getMatchErrorMsg();
 		if (!Check.isEmpty(msg, true) && currentMsg != null && currentMsg.contains(msg))
 		{
 			return;
 		}
-		addMatchErrorMsg(importLine, msg);
+		importLine.setMatchErrorMsg(addMsgToString(currentMsg, msg));
 	}
 
 	public void addImportErrorMsg(@NonNull final I_ESR_ImportLine importLine, final String msg)

--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtil.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtil.java
@@ -401,18 +401,6 @@ public class ESRDataLoaderUtil
 
 	/**
 	 * Appends {@code msg} to the line's {@code MatchErrorMsg}, unless it is already there.
-	 * <p>
-	 * The de-duplication is not a nicety: every {@code evaluate*} entry point here is re-runnable by
-	 * design -- the import evaluates a line, a {@code @ModelChange} interceptor evaluates it again, and a
-	 * second Process run evaluates it once more -- so an unconditional append shows the accountant the
-	 * same sentence two or three times over. It is idempotent per message, so a genuinely different
-	 * message is still appended.
-	 * <p>
-	 * Known limitation, deliberately kept: the check is {@code contains}, so a shorter message that
-	 * happens to sit inside one already stored is treated as present and dropped. Matching whole
-	 * messages instead (splitting on the {@code "; "} that {@link #addMsgToString(String, String)}
-	 * joins with) would only trade this for the opposite bug -- a message that itself contains
-	 * {@code "; "} would then duplicate again. Pinned by ESRDataLoaderUtilTest.
 	 */
 	public void addMatchErrorMsg(@NonNull final I_ESR_ImportLine importLine, @Nullable final String msg)
 	{

--- a/backend/de.metas.payment.esr/src/main/sql/postgresql/system/70-de.metas.payment.esr/5819910_sys_ESR_Payment_Action_element.sql
+++ b/backend/de.metas.payment.esr/src/main/sql/postgresql/system/70-de.metas.payment.esr/5819910_sys_ESR_Payment_Action_element.sql
@@ -1,0 +1,73 @@
+-- ESR_ImportLine.ESR_Payment_Action: give the FIELD a real label, description and help.
+--
+-- WHY. AD_Element 542031 (ColumnName ESR_Payment_Action) still carries the raw column name as its
+-- Name, so the WebUI shows the technical string "ESR_Payment_Action" as the field label:
+--   AD_Element.Name        = 'ESR_Payment_Action',  Description = NULL, Help = NULL
+--   AD_Element_Trl de_DE   = 'ESR_Payment_Action',  IsTranslated = 'N'
+--   AD_Element_Trl de_CH   = 'ESR_Payment_Action',  IsTranslated = 'N'
+--   AD_Element_Trl en_US   = 'Action',              IsTranslated = 'Y'   (vague, no description)
+-- So a German user reads a Java-ish identifier and an English user reads an unqualified "Action";
+-- neither gets any description or help, on the one field that decides how an incoming payment is
+-- handled and that BLOCKS the import while it is empty.
+--
+-- The Help deliberately documents why the list can come up empty (no payment on the line), because
+-- that is a dead end users otherwise hit with no explanation.
+--
+-- SCOPE. Element 542031 is used by exactly ONE AD_Column (548689, ESR_ImportLine) and by no AD_Field
+-- via AD_Name_ID, so this rename cannot leak into an unrelated field's label.
+--
+-- Base language is German, so the German text is written to AD_Element_Trl (never to AD_Element
+-- directly) and pushed outward by update_TRL_Tables_On_AD_Element_TRL_Update, which also refreshes
+-- AD_Element itself and the dependent AD_Column/AD_Field translations.
+
+-- 1. make sure every active system language has a row to update (a language added after the element
+--    was created would otherwise have none). No IsActive filter in the guard: AD_Element_Trl's key is
+--    (AD_Element_ID, AD_Language), so filtering it would hide a deactivated row and the INSERT would
+--    then violate that key.
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, Name,PrintName,Description,Help, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.Name,t.PrintName,t.Description,t.Help, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM   AD_Language l, AD_Element t
+WHERE  l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Element_ID=542031
+  AND  NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
+;
+
+-- 2. German (base language) — de_DE and de_CH share the text.
+UPDATE AD_Element_Trl SET
+       Name='Zahlungsaktion',
+       PrintName='Zahlungsaktion',
+       Description='Legt fest, wie mit dem Zahlungseingang dieser Importzeile verfahren wird. Muss gesetzt sein, damit der Import abgeschlossen werden kann.',
+       Help='Die Auswahl richtet sich nach Rechnung und offenem Betrag der Zeile: Überzahlung, Unterzahlung oder keine Rechnung. Ist der Zeile keine Zahlung zugeordnet, steht keine Aktion zur Auswahl.',
+       IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-08-25 16:10:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE  AD_Element_ID=542031 AND AD_Language IN ('de_DE','de_CH')
+;
+
+-- 3. English.
+UPDATE AD_Element_Trl SET
+       Name='Payment action',
+       PrintName='Payment action',
+       Description='Determines how the incoming payment on this import line is handled. Must be set before the import can be completed.',
+       Help='The available choices depend on the line''s invoice and open amount: overpayment, underpayment, or no invoice. If the line has no payment, no action can be selected.',
+       IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-08-25 16:10:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE  AD_Element_ID=542031 AND AD_Language='en_US'
+;
+
+-- 3b. any OTHER active system language: take the corrected German text, honestly flagged as not yet
+--     translated. Needed because statement 1 seeds from the base AD_Element row, which still holds the
+--     old raw name at that point -- the same seed-before-rename ordering that left 5741590's rows stale.
+--     A language that already claims a finished translation is left alone.
+UPDATE AD_Element_Trl t SET
+       Name=de.Name, PrintName=de.PrintName, Description=de.Description, Help=de.Help,
+       IsTranslated='N',
+       Updated=TO_TIMESTAMP('2026-08-25 16:10:03','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+FROM   AD_Element_Trl de
+WHERE  de.AD_Element_ID=542031 AND de.AD_Language='de_DE'
+  AND  t.AD_Element_ID=542031
+  AND  t.AD_Language NOT IN ('de_DE','de_CH','en_US')
+  AND  coalesce(t.IsTranslated,'N') <> 'Y'
+;
+
+-- 4. push AD_Element_Trl outward: refreshes AD_Element itself plus the dependent AD_Column/AD_Field
+--    translations. Without this the field keeps showing its old label.
+/* DDL */ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(542031);

--- a/backend/de.metas.payment.esr/src/main/sql/postgresql/system/70-de.metas.payment.esr/5819910_sys_ESR_Payment_Action_element.sql
+++ b/backend/de.metas.payment.esr/src/main/sql/postgresql/system/70-de.metas.payment.esr/5819910_sys_ESR_Payment_Action_element.sql
@@ -59,8 +59,10 @@ UPDATE AD_Element_Trl SET
 WHERE  AD_Element_ID=542031 AND AD_Language='en_US'
 ;
 
--- 3b. any OTHER active system language: take the corrected German text, honestly flagged as not yet
---     translated. Needed because statement 1 seeds from the base AD_Element row, which still holds the
+-- 3b. any OTHER language that already HAS a row: take the corrected German text, honestly flagged as
+--     not yet translated. Unlike statement 1 this deliberately has no IsActive/IsSystemLanguage filter:
+--     it only rewrites rows that already exist, so it cannot create exposure for an inactive language.
+--     Needed because statement 1 seeds from the base AD_Element row, which still holds the
 --     old raw name at that point -- the same seed-before-rename ordering that left 5741590's rows stale.
 --     A language that already claims a finished translation is left alone.
 UPDATE AD_Element_Trl t SET

--- a/backend/de.metas.payment.esr/src/main/sql/postgresql/system/70-de.metas.payment.esr/5819910_sys_ESR_Payment_Action_element.sql
+++ b/backend/de.metas.payment.esr/src/main/sql/postgresql/system/70-de.metas.payment.esr/5819910_sys_ESR_Payment_Action_element.sql
@@ -24,8 +24,14 @@
 --    was created would otherwise have none). No IsActive filter in the guard: AD_Element_Trl's key is
 --    (AD_Element_ID, AD_Language), so filtering it would hide a deactivated row and the INSERT would
 --    then violate that key.
-INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, Name,PrintName,Description,Help, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
-SELECT l.AD_Language, t.AD_Element_ID, t.Name,t.PrintName,t.Description,t.Help, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+INSERT INTO AD_Element_Trl (AD_Language,AD_Element_ID, Name,PrintName,Description,Help,
+                            PO_Name,PO_PrintName,PO_Description,PO_Help,CommitWarning,
+                            WEBUI_NameBrowse,WEBUI_NameNew,WEBUI_NameNewBreadcrumb,
+                            IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Element_ID, t.Name,t.PrintName,t.Description,t.Help,
+       t.PO_Name,t.PO_PrintName,t.PO_Description,t.PO_Help,t.CommitWarning,
+       t.WEBUI_NameBrowse,t.WEBUI_NameNew,t.WEBUI_NameNewBreadcrumb,
+       'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
 FROM   AD_Language l, AD_Element t
 WHERE  l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Element_ID=542031
   AND  NOT EXISTS (SELECT 1 FROM AD_Element_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Element_ID=t.AD_Element_ID)
@@ -71,3 +77,20 @@ WHERE  de.AD_Element_ID=542031 AND de.AD_Language='de_DE'
 -- 4. push AD_Element_Trl outward: refreshes AD_Element itself plus the dependent AD_Column/AD_Field
 --    translations. Without this the field keeps showing its old label.
 /* DDL */ SELECT update_TRL_Tables_On_AD_Element_TRL_Update(542031);
+
+-- 5. AD_Field.Help is NOT covered by the propagation above: update_FieldTranslation_From_AD_Name_Element
+--    sets Name and Description on the base AD_Field row (and Help only on AD_Field_Trl), so the field's
+--    own Help stays stale. Verified by reading the function body, and a documented pitfall with a prior
+--    incident. Since the Help IS half of what this migration delivers, write it directly -- set-based via
+--    the element, so no AD_Field id is hardcoded, and covering BOTH routes the function itself covers.
+UPDATE AD_Field f SET
+       Help=(SELECT t.Help FROM AD_Element_Trl t WHERE t.AD_Element_ID=542031 AND t.AD_Language='de_DE'),
+       Updated=TO_TIMESTAMP('2026-08-25 16:10:04','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+WHERE  (
+         -- route 1: the field inherits from its column's element
+         (f.AD_Name_ID IS NULL AND EXISTS (SELECT 1 FROM AD_Column c
+                                            WHERE c.AD_Column_ID=f.AD_Column_ID AND c.AD_Element_ID=542031))
+         -- route 2: the field overrides with this element directly
+         OR f.AD_Name_ID=542031
+       )
+;

--- a/backend/de.metas.payment.esr/src/main/sql/postgresql/system/70-de.metas.payment.esr/5819910_sys_ESR_Payment_Action_element.sql
+++ b/backend/de.metas.payment.esr/src/main/sql/postgresql/system/70-de.metas.payment.esr/5819910_sys_ESR_Payment_Action_element.sql
@@ -93,4 +93,9 @@ WHERE  (
          -- route 2: the field overrides with this element directly
          OR f.AD_Name_ID=542031
        )
+--    Guard: if the de_DE row were somehow missing (an install where de_DE is not an active system
+--    language), the scalar subquery above would yield NULL and this statement would silently BLANK the
+--    fields' Help instead of skipping them. Only run when there is a German text to copy.
+  AND  EXISTS (SELECT 1 FROM AD_Element_Trl t
+                WHERE t.AD_Element_ID=542031 AND t.AD_Language='de_DE' AND t.Help IS NOT NULL)
 ;

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
@@ -1718,6 +1718,61 @@ public class ESRImportTest extends ESRTestBase
 		 * @param expectedPaymentAction the second line's expected {@code ESR_Payment_Action}, or {@code null} if it
 		 * is expected to stay unflagged (see {@link #arrivingOnALaterDay()}).
 		 */
+		/**
+		 * A later "Process ESR" run must NOT close a line the import flagged Duplicate_Payment.
+		 * <p>
+		 * The action pass ({@code ESRImportBL.handleEsrImportLine(String, I_ESR_ImportLine)}) only checks that
+		 * ESR_Payment_Action is non-null before running a handler and setting Processed. Since the import sets
+		 * Duplicate_Payment itself, that flag would otherwise be read as "the accountant decided" and the line
+		 * would be closed -- observed in UAT, where completing the import for an unrelated line silently closed
+		 * a duplicate line. Duplicate_Payment is not offered in the action dropdown at all, so the accountant
+		 * must still pick one of the overpayment actions; the line has to stay open until then.
+		 */
+		@Test
+		void completingTheImportMustNotCloseTheFlaggedDuplicate()
+		{
+			final String grandTotal = "50";
+			final String esrLineText = "01201067789300000001060012345600654321400000050009072  030014040914041014041100001006800000000000090                          ";
+			final String completeRef = ESRTransactionLineMatcherUtil.extractReferenceNumberStr(esrLineText);
+
+			final String partnerValue = "123456";
+			final String invDocNo = "654321";
+			final String ESR_Rendered_AccountNo = "01-067789-3";
+
+			final I_ESR_ImportLine esrImportLine1 = setupESR_ImportLine(invDocNo, grandTotal, false, completeRef, ESR_Rendered_AccountNo, partnerValue, "50", false);
+			esrImportLine1.setESRLineText(esrLineText);
+			final Timestamp paymentDate = TimeUtil.getDay(2024, 1, 10);
+			esrImportLine1.setPaymentDate(paymentDate);
+			save(esrImportLine1);
+			esrImportBL.process(esrImportLine1.getESR_Import());
+
+			final I_ESR_ImportLine esrImportLine2 = createESR_ImportLineFromOtherLine(esrImportLine1);
+			esrImportLine2.setESRLineText(esrLineText);
+			esrImportLine2.setPaymentDate(paymentDate);
+			save(esrImportLine2);
+			final I_ESR_Import esrImport2 = esrImportLine2.getESR_Import();
+			esrImportBL.process(esrImport2);
+
+			refresh(esrImportLine2, true);
+			assertThat(esrImportLine2.getESR_Payment_Action()).isEqualTo(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment);
+			assertThat(esrImportLine2.isProcessed()).as("precondition: the import leaves the flagged duplicate open").isFalse();
+			final int paymentIdAfterImport = esrImportLine2.getC_Payment_ID();
+
+			// the accountant completes the import without having chosen an overpayment action
+			esrImportBL.complete(esrImport2, "completing the import");
+
+			refresh(esrImportLine2, true);
+			assertThat(esrImportLine2.isProcessed())
+					.as("a flagged duplicate must stay OPEN until an overpayment action is chosen")
+					.isFalse();
+			assertThat(esrImportLine2.getESR_Payment_Action())
+					.as("the flag itself must survive, so the accountant still sees why the line is open")
+					.isEqualTo(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Duplicate_Payment);
+			assertThat(esrImportLine2.getC_Payment_ID())
+					.as("and its own payment must not be swapped or dropped")
+					.isEqualTo(paymentIdAfterImport);
+		}
+
 		private void assertDuplicateGetsOwnPayment(final int daysAfterFirstPayment, final String expectedPaymentAction)
 		{
 			final String grandTotal = "50";

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
@@ -1715,10 +1715,6 @@ public class ESRImportTest extends ESRTestBase
 		}
 
 		/**
-		 * @param expectedPaymentAction the second line's expected {@code ESR_Payment_Action}, or {@code null} if it
-		 * is expected to stay unflagged (see {@link #arrivingOnALaterDay()}).
-		 */
-		/**
 		 * A later "Process ESR" run must NOT close a line the import flagged Duplicate_Payment.
 		 * <p>
 		 * The action pass ({@code ESRImportBL.handleEsrImportLine(String, I_ESR_ImportLine)}) only checks that
@@ -1773,6 +1769,10 @@ public class ESRImportTest extends ESRTestBase
 					.isEqualTo(paymentIdAfterImport);
 		}
 
+		/**
+		 * @param expectedPaymentAction the second line's expected {@code ESR_Payment_Action}, or {@code null} if it
+		 * is expected to stay unflagged (see {@link #arrivingOnALaterDay()}).
+		 */
 		private void assertDuplicateGetsOwnPayment(final int daysAfterFirstPayment, final String expectedPaymentAction)
 		{
 			final String grandTotal = "50";

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtilTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtilTest.java
@@ -1,0 +1,90 @@
+package de.metas.payment.esr.dataimporter;
+
+import de.metas.payment.esr.model.I_ESR_ImportLine;
+import org.adempiere.test.AdempiereTestHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The match-error messages on an ESR import line must not accumulate duplicates.
+ * <p>
+ * Every {@code evaluate*} entry point of {@link ESRDataLoaderUtil} is re-runnable by design -- the import
+ * evaluates a line, and a later {@code @ModelChange} interceptor evaluates it again -- so an unconditional
+ * append produces the same sentence twice in {@code MatchErrorMsg}, which is what the accountant reads.
+ */
+public class ESRDataLoaderUtilTest
+{
+	@BeforeEach
+	void init()
+	{
+		AdempiereTestHelper.get().init();
+	}
+
+	private I_ESR_ImportLine newLine()
+	{
+		return newInstance(I_ESR_ImportLine.class);
+	}
+
+	@Nested
+	@DisplayName("addMatchErrorMsg is idempotent per message")
+	class Idempotent
+	{
+		@Test
+		void sameMessageTwice_storedOnce()
+		{
+			final I_ESR_ImportLine line = newLine();
+			final String msg = "Die importierte ESR-Referenznummer 000000000202183482010101694 wurde nicht in der Datenbank gefunden";
+
+			ESRDataLoaderUtil.addMatchErrorMsg(line, msg);
+			ESRDataLoaderUtil.addMatchErrorMsg(line, msg);
+
+			assertThat(line.getMatchErrorMsg())
+					.as("the same match error must be stored once, however often the line is evaluated")
+					.isEqualTo(msg);
+		}
+
+		@Test
+		void differentMessages_bothKept()
+		{
+			final I_ESR_ImportLine line = newLine();
+
+			ESRDataLoaderUtil.addMatchErrorMsg(line, "first problem");
+			ESRDataLoaderUtil.addMatchErrorMsg(line, "second problem");
+
+			assertThat(line.getMatchErrorMsg())
+					.as("de-duplication must not swallow a genuinely different message")
+					.contains("first problem")
+					.contains("second problem");
+		}
+
+		@Test
+		void repeatedAcrossManyEvaluations_stillOnce()
+		{
+			final I_ESR_ImportLine line = newLine();
+			final String msg = "Rechnung 103439 wurde im System als bereits bezahlt markiert";
+
+			for (int i = 0; i < 5; i++)
+			{
+				ESRDataLoaderUtil.addMatchErrorMsg(line, msg);
+			}
+
+			assertThat(line.getMatchErrorMsg()).isEqualTo(msg);
+		}
+
+		@Test
+		void blankMessage_doesNotCrashAndAddsNothingMeaningful()
+		{
+			final I_ESR_ImportLine line = newLine();
+
+			ESRDataLoaderUtil.addMatchErrorMsg(line, "a real problem");
+			ESRDataLoaderUtil.addMatchErrorMsg(line, "a real problem");
+
+			assertThat(line.getMatchErrorMsg()).isEqualTo("a real problem");
+		}
+	}
+}

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtilTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtilTest.java
@@ -77,14 +77,35 @@ public class ESRDataLoaderUtilTest
 		}
 
 		@Test
-		void blankMessage_doesNotCrashAndAddsNothingMeaningful()
+		void blankOrNullMessage_isANoOpAndDoesNotCrash()
 		{
 			final I_ESR_ImportLine line = newLine();
 
-			ESRDataLoaderUtil.addMatchErrorMsg(line, "a real problem");
-			ESRDataLoaderUtil.addMatchErrorMsg(line, "a real problem");
+			// on an empty line
+			ESRDataLoaderUtil.addMatchErrorMsg(line, null);
+			ESRDataLoaderUtil.addMatchErrorMsg(line, "");
+			ESRDataLoaderUtil.addMatchErrorMsg(line, "   ");
+			assertThat(line.getMatchErrorMsg()).as("nothing meaningful may be stored").isNullOrEmpty();
 
+			// and on a line that already carries a real message, which must survive untouched
+			ESRDataLoaderUtil.addMatchErrorMsg(line, "a real problem");
+			ESRDataLoaderUtil.addMatchErrorMsg(line, null);
+			ESRDataLoaderUtil.addMatchErrorMsg(line, "  ");
 			assertThat(line.getMatchErrorMsg()).isEqualTo("a real problem");
+		}
+
+		@Test
+		void aMessageThatIsASubstringOfAStoredOne_isSwallowed_knownTradeoff()
+		{
+			// Pins the documented limitation of the contains()-based de-duplication, so the behaviour is a
+			// recorded decision rather than a surprise: a shorter message that happens to sit inside an
+			// already-stored longer one is treated as already present.
+			final I_ESR_ImportLine line = newLine();
+
+			ESRDataLoaderUtil.addMatchErrorMsg(line, "Rechnung 103439 wurde nicht gefunden");
+			ESRDataLoaderUtil.addMatchErrorMsg(line, "Rechnung 103439");
+
+			assertThat(line.getMatchErrorMsg()).isEqualTo("Rechnung 103439 wurde nicht gefunden");
 		}
 	}
 }


### PR DESCRIPTION
## What

Follow-up to https://github.com/metasfresh/metasfresh/pull/25605, which was squash-merged while this work was still in progress and therefore carried only the ref-list migration (`5819900`). This PR holds the rest.

Two independent fixes plus one migration, all on `ESR_ImportLine.ESR_Payment_Action`.

## 1. A system-set payment action is not a user decision

Found in UAT: a line the import had flagged `Duplicate_Payment` was **silently closed** by a later "Process ESR" run that the accountant triggered for a completely *different* line.

`ESRImportBL.handleEsrImportLine(String, I_ESR_ImportLine)` only tested that `ESR_Payment_Action` is non-null before running a handler and calling `setProcessed(true)`. Since the import sets some actions itself, that test cannot tell a system flag from an accountant's decision.

Now skipped in that pass:

| Action | Why |
|---|---|
| `Duplicate_Payment` | the import flags it; the accountant must still choose an overpayment action. It is **not selectable at all** (`ESRPaymentActionValidationRule` accepts it in no group), so skipping it cannot block a deliberate choice |
| `Control_Line`, `Reverse_Booking` | no handler is registered for either, so the pass only appended a `NotSupported` message on every run. Reverse bookings are documented as admin-handled |

`Unable_To_Assign_Income` is deliberately **not** skipped — it *is* offered in the dropdown, so it can be a genuine choice. `Fit_Amounts` needs no guard: those lines are already `Processed`, so the method returns early.

Money was never at risk: `AbstractESRActionHandler`'s guard (`!isAllocated && !isPaid`) is false for a settled invoice, so nothing was allocated even via the old path. What was lost was the accountant's prompt — a real overpayment left with no open todo.

## 2. Match-error messages no longer accumulate duplicates

`ESRDataLoaderUtil.addMatchErrorMsg` is now idempotent per message, and the separate `addMatchErrorMsgIfNotPresent` is gone (its single caller repointed). Every `evaluate*` entry point is re-runnable by design — import, a `@ModelChange` interceptor, then a second Process run — so the unconditional append showed the same sentence two or three times. UAT saw exactly that.

Fixing the one helper covers **all** call sites rather than patching most of them and leaving the trap for the next one. Known limitation, documented and pinned by a test: the check is `contains`, so a shorter message sitting inside a stored one is treated as present. Whole-message matching was considered and rejected — it only trades this for the mirror bug, since a message containing `"; "` would then duplicate again.

## 3. The field itself had no label, description or help

`AD_Element` 542031 still carried the raw column name, so the WebUI showed **`ESR_Payment_Action`** as the field label; Description/Help were NULL; `de_DE`/`de_CH` were untranslated; `en_US` said only "Action".

Now **Zahlungsaktion / Payment action**, with a description saying what the field decides and that it must be set before the import can complete. The Help documents why the action list can come up **empty** — a line with no payment offers nothing — because that is a dead end users otherwise hit with no explanation.

Notable: the propagation function `update_FieldTranslation_From_AD_Name_Element` sets `Name`/`Description` on the base `AD_Field` row but **never `Help`** (Help only reaches `AD_Field_Trl`), so the migration writes `AD_Field.Help` directly, set-based via the element, covering both routes the function itself covers.

## Testing

- `ESRImportTest#completingTheImportMustNotCloseTheFlaggedDuplicate` pins the exact UAT regression: `complete()` must leave a flagged duplicate open, keep its flag, and keep its own payment.
- `ESRDataLoaderUtilTest` pins de-duplication, null/blank safety, and the documented substring tradeoff.
- The migration was validated on a throwaway PostgreSQL reproducing live state — including a propagation stub that deliberately omits `Help` exactly as the real function does, and one `AD_Field` per route.

**The Java tests have not been executed locally** — this module does not compile in my environment (the generated `camt054` sources need `javax.xml.bind`). CI is their first run.
