### PR TITLE
ESR import: offer the overpayment actions on a line without an invoice

### DIFF
--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/validationRule/ESRPaymentActionValidationRule.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/validationRule/ESRPaymentActionValidationRule.java
@@ -109,11 +109,21 @@ public class ESRPaymentActionValidationRule extends AbstractJavaValidationRule
 		overPaymentGroup.add(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Money_Was_Transfered_Back_to_Partner);
 		overPaymentGroup.add(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Unable_To_Assign_Income); // metas-tsa: added per Mark request
 
+		// Actions for when there is a payment but no invoice to settle it against.
+		// Such a line is money sitting on the partner, so the accountant faces the same three-way
+		// decision as on an overpayment: park it, offset it against the next invoice, or refund it.
+		// The overPaymentGroup above cannot serve that case, because it is gated on a NEGATIVE
+		// ESR_Invoice_Openamt and a line without an invoice keeps the column at zero -- only
+		// ESRImportBL.updateOpenAmtAndStatusDontSave writes it, and that runs per invoice group.
+		// Every handler behind these actions supports a line without an invoice: the refund one
+		// branches on it explicitly ("there is no invoice, so we transfer back all the money"),
+		// and the next-invoice one only needs the payment to set IsAutoAllocateAvailableAmt.
 		final List<String> noActionGroup = new ArrayList<String>();
-		// only show <code>X_ESR_ImportLine.ESR_PAYMENT_ACTION_Unable_To_Assign_Income</code> action when c_invoice_id is empty
 		if (invoiceId <= 0)
 		{
 			noActionGroup.add(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Unable_To_Assign_Income);
+			noActionGroup.add(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Money_Was_Transfered_Back_to_Partner);
+			noActionGroup.add(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Allocate_Payment_With_Next_Invoice);
 		}
 
 		// Actions for when we have Payment < Open amount

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/validationRule/ESRPaymentActionValidationRuleTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/validationRule/ESRPaymentActionValidationRuleTest.java
@@ -97,17 +97,69 @@ public class ESRPaymentActionValidationRuleTest
 		plainValidationCtx.setValue(paymentIdStr, paymentIDStr);
 		plainValidationCtx.setValue(invoiceIdStr, "-1");
 
+		// A line that has a payment but no invoice is money sitting on the partner with nothing to
+		// settle. The accountant faces the same three-way decision as on an overpayment, so all
+		// three overpayment actions must be offered -- see the comment in noActionGroup.
 		boolean accepted = ESRValidationRuleTools.evaluatePaymentAction(ESR_PAYMENT_ACTION_Allocate_Payment_With_Next_Invoice, plainValidationCtx);
-		assertThat(accepted).as("accepted").isFalse();
+		assertThat(accepted).as("accepted").isTrue();
 
 		accepted = ESRValidationRuleTools.evaluatePaymentAction(ESR_PAYMENT_ACTION_Money_Was_Transfered_Back_to_Partner, plainValidationCtx);
-		assertThat(accepted).as("accepted").isFalse();
+		assertThat(accepted).as("accepted").isTrue();
 
 		accepted = ESRValidationRuleTools.evaluatePaymentAction(ESR_PAYMENT_ACTION_Unable_To_Assign_Income, plainValidationCtx);
 		assertThat(accepted).as("accepted").isTrue();
 
 		accepted = ESRValidationRuleTools.evaluatePaymentAction(ESR_PAYMENT_ACTION_Control_Line, plainValidationCtx);
 		assertThat(accepted).as("accepted").isFalse();
+	}
+
+	/**
+	 * The production shape of a line without an invoice: {@code ESR_Invoice_Openamt} is ZERO, because
+	 * {@code ESRImportBL.updateOpenAmtAndStatusDontSave} only ever runs per invoice group and therefore
+	 * never touches such a line. With a zero open amount neither the over- nor the underpayment group
+	 * can fire, so the "no invoice" branch is the ONLY thing that can offer an action here.
+	 * <p>
+	 * Before the fix this left {@code Unable_To_Assign_Income} as the single choice, which cannot record
+	 * a refund -- even though {@code MoneyTransferedBackESRActionHandler} explicitly implements the
+	 * no-invoice case ("there is no invoice, so we transfer back all the money").
+	 */
+	@Test
+	public void esrPaymentActionValidationRule_noInvoice_zeroOpenAmt_offersAllOverpaymentActions()
+	{
+		final I_C_Payment payment = db.newInstance(I_C_Payment.class);
+		payment.setPayAmt(new BigDecimal("110"));
+		db.save(payment);
+
+		plainValidationCtx.setValue(openAmtStr, "0.00");
+		plainValidationCtx.setValue(paymentIdStr, Integer.toString(payment.getC_Payment_ID()));
+		plainValidationCtx.setValue(invoiceIdStr, "-1");
+
+		ESRValidationRuleTools.assertAccepted(ESR_PAYMENT_ACTION_Money_Was_Transfered_Back_to_Partner, plainValidationCtx);
+		ESRValidationRuleTools.assertAccepted(ESR_PAYMENT_ACTION_Allocate_Payment_With_Next_Invoice, plainValidationCtx);
+		ESRValidationRuleTools.assertAccepted(ESR_PAYMENT_ACTION_Unable_To_Assign_Income, plainValidationCtx);
+
+		// unchanged: an underpayment action makes no sense without an invoice, and the import sets
+		// Duplicate_Payment itself -- it must never become manually selectable.
+		ESRValidationRuleTools.assertRejected(ESR_PAYMENT_ACTION_Write_Off_Amount, plainValidationCtx);
+		ESRValidationRuleTools.assertRejected(ESR_PAYMENT_ACTION_Keep_For_Dunning, plainValidationCtx);
+		ESRValidationRuleTools.assertRejected(ESR_PAYMENT_ACTION_Duplicate_Payment, plainValidationCtx);
+		ESRValidationRuleTools.assertRejected(ESR_PAYMENT_ACTION_Control_Line, plainValidationCtx);
+	}
+
+	/**
+	 * A line with NO payment must stay locked down even without an invoice: nothing can be done with
+	 * money that was never booked.
+	 */
+	@Test
+	public void esrPaymentActionValidationRule_noInvoice_noPayment_offersNothing()
+	{
+		plainValidationCtx.setValue(openAmtStr, "0.00");
+		plainValidationCtx.setValue(paymentIdStr, "-1");
+		plainValidationCtx.setValue(invoiceIdStr, "-1");
+
+		ESRValidationRuleTools.assertRejected(ESR_PAYMENT_ACTION_Money_Was_Transfered_Back_to_Partner, plainValidationCtx);
+		ESRValidationRuleTools.assertRejected(ESR_PAYMENT_ACTION_Allocate_Payment_With_Next_Invoice, plainValidationCtx);
+		ESRValidationRuleTools.assertRejected(ESR_PAYMENT_ACTION_Unable_To_Assign_Income, plainValidationCtx);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

A line that has a payment but **no invoice** could only be set to *unable to assign income*. The other two overpayment actions — *money was transferred back to partner* and *allocate payment with next invoice* — were unreachable.

Cause: both live only in `overPaymentGroup`, which is gated on a **negative** `ESR_Invoice_Openamt`. A line without an invoice keeps that column at **zero**, because the only writer is `ESRImportBL.updateOpenAmtAndStatusDontSave` and that runs per invoice group — so it never touches such a line. Neither the over- nor the underpayment group can fire, leaving the single-entry "no invoice" branch as the only source of actions.

Both handlers behind the unreachable actions already support a line without an invoice:

- `MoneyTransferedBackESRActionHandler` branches on it explicitly — *"there is no invoice, so we transfer back all the money"* — and creates the outbound payment for the full `PayAmt`.
- `WithNextInvoiceESRActionHandler` only needs the payment, to set `IsAutoAllocateAvailableAmt`.

So the capability existed and the dropdown simply withheld it: the accountant could not record a refund on such a line and had to create the outbound payment by hand.

## What changed

The "no invoice" branch now offers all three overpayment actions instead of one. Unchanged: the underpayment actions stay rejected (nothing to settle without an invoice), `Duplicate_Payment` remains never manually selectable, and a line with **no payment** still offers nothing.

## Reviewer note — an existing test's assertions are inverted

This **deliberately inverts two assertions** in `ESRPaymentActionValidationRule_NoInvoice_test`, which pinned the old behaviour. That test is the reason this is a conscious behaviour change rather than a bug fix to unspecified code. Its fixture also sets `ESR_Invoice_Openamt=100` on a line with no invoice, which cannot occur in production, so a second test covers the real shape (`openAmt=0`), plus one pinning the no-payment case.

Blame predates the 2019 monorepo move, so no original rationale is recoverable beyond the code comment.

## Test plan
- [x] `ESRPaymentActionValidationRuleTest` — RED first (2 failures at the new assertions), then GREEN: 13 run, 0 failures
- [x] Full `de.metas.payment.esr` module suite — 168 run, 0 failures, 1 pre-existing skip unrelated to this change
- Run locally with `JAVA_HOME` set to JDK 8; JDK 17 fails this module on Lombok/`IllegalAccessError`.
