### PR TITLE
VAT-ID follow-ups: format-invalid to Invalid, report overview, NotSupported relabel, check-log filters

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/vatIdCheckProcess.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/vatIdCheckProcess.feature
@@ -61,6 +61,36 @@ Feature: The VAT-ID check process runs on a selection of Business Partners
     And the VAT-ID check process run reports 1 pending checks
 
   @from:cucumber
+  @Id:S31060_11
+  Scenario: The process marks an already-persisted malformed VAT-ID as Invalid without calling VIES
+  # The partner is created while the format check is OFF, so a malformed value can be persisted at all
+  # (the save-time interceptor would otherwise block it) -- mirroring a value that arrived by import or
+  # predates the format check. With both checks then on, the process must give it a definitive Invalid
+  # from the offline format check alone, never a VIES call, and never leave it 'Ungeprüft'.
+    Given no VATaxID_CheckLog records exist for VATaxID 'BE4258156477'
+    And metasfresh contains VATaxID_Config:
+      | IsFormatCheckEnabled | IsVIESCheckEnabled | RecheckAfterDays | OnServiceUnavailable |
+      | false                | false              | 30               | ServiceUnavailable   |
+    And metasfresh contains C_BPartners:
+      | Identifier | Value          | VATaxID      |
+      | bp_badfmt  | ProcBadFormat1 | BE4258156477 |
+    And metasfresh contains VATaxID_Config:
+      | IsFormatCheckEnabled | IsVIESCheckEnabled | RecheckAfterDays | OnServiceUnavailable |
+      | true                 | true               | 30               | ServiceUnavailable   |
+    And the VAT-ID online checker is stubbed to answer:
+      | VATaxID | VATaxIDStatus |
+    When the C_BPartner_VATaxID_Check process is run for selection with MaxChecksPerRun '0':
+      | C_BPartner_ID |
+      | bp_badfmt     |
+    Then validate C_BPartner VAT-ID status:
+      | C_BPartner_ID | VATaxIDStatus |
+      | bp_badfmt     | Invalid       |
+    And validate VATaxID_CheckLog records of C_BPartner 'bp_badfmt':
+      | VATaxID      | VATaxIDStatus | AD_PInstance_ID |
+      | BE4258156477 | Invalid       | true            |
+    And no unexpected VAT-ID online checks happened
+
+  @from:cucumber
   @Id:S31060_2
   Scenario Outline: An empty or zero limit checks every selected VAT-ID
     Given no VATaxID_CheckLog records exist for VATaxID 'DE136695976'

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/vatIdCheckProcess.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/vatIdCheckProcess.feature
@@ -313,7 +313,7 @@ Feature: The VAT-ID check process runs on a selection of Business Partners
       | IsFormatCheckEnabled | IsVIESCheckEnabled | RecheckAfterDays | OnServiceUnavailable |
       | false                | false              | 30               | ServiceUnavailable   |
     And metasfresh contains C_BPartners:
-      | Identifier | Value          | VATaxID   |
+      | Identifier | Value          | VATaxID    |
       | bp_broken  | ProcStarveBrk1 | IE6433435F |
     Given metasfresh contains VATaxID_Config:
       | IsFormatCheckEnabled | IsVIESCheckEnabled | RecheckAfterDays | OnServiceUnavailable |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/vatIdCheckProcess.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/bpartner/vatIdCheckProcess.feature
@@ -293,10 +293,11 @@ Feature: The VAT-ID check process runs on a selection of Business Partners
   @from:cucumber
   @Id:S31060_8
   Scenario: A persistently-failing check target does not starve the nightly queue on the next run
-    # bp_broken's VATaxID is malformed and bypasses the save-time gate (its organisation's own
-    # VATaxID_Config has the format check switched off just for its creation), so the online check's OWN
-    # format re-validation throws on every single attempt -- the record can never advance past
-    # NotChecked/VATaxIDCheckedAt=null, and would otherwise sort first of every future nightly run forever.
+    # bp_broken's VATaxID is well-formed (it passes the format check) but its organisation's online service
+    # persistently fails: the checker is stubbed to THROW on every attempt, so check() unwinds before
+    # completeCheck() and the record can never advance past NotChecked/VATaxIDCheckedAt=null, and would
+    # otherwise sort first of every future nightly run forever. (A malformed value would NOT serve here: the
+    # offline format check now resolves it to Invalid at once, so it is not a persistently-failing target.)
     # bp_pending is a genuinely healthy, never-yet-checked partner sitting right behind it. The manual
     # selection run below targets ONLY bp_broken -- one attempt, scoped, so this scenario is immune to
     # whatever else the shared database's nightly candidate pool already contains -- and it must fail and
@@ -306,14 +307,14 @@ Feature: The VAT-ID check process runs on a selection of Business Partners
     # Reset any leftover status/attempt state from an earlier run of this same scenario against a
     # never-reset local database: bp_broken/bp_pending are upserted by Value, so without this both
     # VATaxID values could still carry a previous run's final status/attempt timestamp.
-    Given no VATaxID_CheckLog records exist for VATaxID 'NOTAVATID'
+    Given no VATaxID_CheckLog records exist for VATaxID 'IE6433435F'
     And no VATaxID_CheckLog records exist for VATaxID 'LU15027442'
     And metasfresh contains VATaxID_Config:
       | IsFormatCheckEnabled | IsVIESCheckEnabled | RecheckAfterDays | OnServiceUnavailable |
       | false                | false              | 30               | ServiceUnavailable   |
     And metasfresh contains C_BPartners:
       | Identifier | Value          | VATaxID   |
-      | bp_broken  | ProcStarveBrk1 | NOTAVATID |
+      | bp_broken  | ProcStarveBrk1 | IE6433435F |
     Given metasfresh contains VATaxID_Config:
       | IsFormatCheckEnabled | IsVIESCheckEnabled | RecheckAfterDays | OnServiceUnavailable |
       | true                 | false              | 30               | ServiceUnavailable   |
@@ -323,11 +324,12 @@ Feature: The VAT-ID check process runs on a selection of Business Partners
     And metasfresh contains VATaxID_Config:
       | IsFormatCheckEnabled | IsVIESCheckEnabled | RecheckAfterDays | OnServiceUnavailable |
       | true                 | true               | 30               | ServiceUnavailable   |
-    # No online-service stub needed for bp_broken's own attempt below: the malformed value throws
-    # during VATaxIDValidationUtil's format re-check, strictly before the online service is ever reached.
-    # Stubbed unreachable purely so the availability pre-filter's getUnavailableCountryCodes() call has a
-    # definite (empty) answer rather than an unprogrammed one.
-    Given the VAT-ID online checker is stubbed to be unreachable
+    # bp_broken's own attempt below fails AT the online service: the checker is stubbed to THROW, so
+    # check() unwinds before completeCheck() and the status stays NotChecked while the attempt is still
+    # stamped (VATaxIDLastAttemptedAt) -- exactly the persistently-failing shape this scenario needs. A
+    # well-formed value is required for this: a malformed one would be resolved to Invalid by the offline
+    # format check before the service is ever reached.
+    Given the VAT-ID online checker is stubbed to throw an exception
     When the C_BPartner_VATaxID_Check process is run for selection with MaxChecksPerRun '':
       | C_BPartner_ID |
       | bp_broken     |

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/export/bpartner/ExportBPartnerToExternalSystem.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/export/bpartner/ExportBPartnerToExternalSystem.java
@@ -92,7 +92,7 @@ public abstract class ExportBPartnerToExternalSystem extends ExportToExternalSys
 	 */
 	public void enqueueBPartnerSync(@NonNull final BPartnerId bPartnerId)
 	{
-		Loggables.withLogger(logger, Level.DEBUG).addLog("BPartnerId: {} enqueued to be synced.", bPartnerId);
+		Loggables.withLogger(logger, Level.DEBUG).addLog("ExportBPartnerToExternalSystem - C_BPartner_ID: {} enqueued to be synced.", bPartnerId.getRepoId());
 
 		syncBPartnerDebouncer.add(bPartnerId);
 	}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/export/externalreference/ExportExternalReferenceToExternalSystem.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/export/externalreference/ExportExternalReferenceToExternalSystem.java
@@ -93,7 +93,7 @@ public abstract class ExportExternalReferenceToExternalSystem extends ExportToEx
 	 */
 	public void enqueueExternalReferenceSync(@NonNull final ExternalReferenceId externalReferenceId)
 	{
-		Loggables.withLogger(logger, Level.DEBUG).addLog("ExternalReferenceId: {} enqueued to be synced.", externalReferenceId);
+		Loggables.withLogger(logger, Level.DEBUG).addLog("ExportExternalReferenceToExternalSystem - ExternalReferenceId: {} enqueued to be synced.", externalReferenceId);
 
 		syncExternalReferenceDebouncer.add(externalReferenceId);
 	}

--- a/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/export/hu/ExportHUToExternalSystemService.java
+++ b/backend/de.metas.externalsystem/src/main/java/de/metas/externalsystem/export/hu/ExportHUToExternalSystemService.java
@@ -88,7 +88,7 @@ public abstract class ExportHUToExternalSystemService extends ExportToExternalSy
 
 	public void enqueueHUExport(@NonNull final ExportHUCandidate exportHUCandidate)
 	{
-		Loggables.withLogger(logger, Level.DEBUG).addLog("exportHUCandidate: {} enqueued to be synced.", exportHUCandidate);
+		Loggables.withLogger(logger, Level.DEBUG).addLog("ExportHUToExternalSystemService - exportHUCandidate: {} enqueued to be synced.", exportHUCandidate);
 
 		syncHuDebouncer.add(exportHUCandidate);
 	}

--- a/backend/de.metas.vatid/base/src/main/java/de/metas/vatid/VATaxIDCheckService.java
+++ b/backend/de.metas.vatid/base/src/main/java/de/metas/vatid/VATaxIDCheckService.java
@@ -103,8 +103,8 @@ public class VATaxIDCheckService
 		{
 			// A malformed value is definitively not a valid VAT-ID, and the offline format check can say so
 			// without VIES — so it is recorded as Invalid rather than sent to the service, and never left
-			// forever NotChecked. Runs regardless of IsVIESCheckEnabled (AC13: format and VIES checks are
-			// independent), and on the SAME predicate the save-time interceptor uses to BLOCK such a value —
+			// forever NotChecked. Runs regardless of IsVIESCheckEnabled (the format and VIES checks toggle
+			// independently), and on the SAME predicate the save-time interceptor uses to BLOCK such a value —
 			// so the save gate and the process agree on what "malformed" means. The save-time path still
 			// throws to reject at entry; this path exists for a value that was imported or predates the
 			// format check, which the process must be able to verdict rather than silently skip.

--- a/backend/de.metas.vatid/base/src/main/java/de/metas/vatid/VATaxIDCheckService.java
+++ b/backend/de.metas.vatid/base/src/main/java/de/metas/vatid/VATaxIDCheckService.java
@@ -69,6 +69,14 @@ public class VATaxIDCheckService
 {
 	private static final Logger logger = LogManager.getLogger(VATaxIDCheckService.class);
 
+	/**
+	 * {@code RawResponse} written for an {@link VATaxIDStatus#Invalid} produced by the OFFLINE format check
+	 * rather than by VIES. It deliberately carries no {@code valid:false}, which is the one thing that
+	 * separates it from a real VIES rejection (see the class javadoc); no VIES request was made, so the row's
+	 * {@code RequestIdentifier} also stays null.
+	 */
+	private static final String RAWRESPONSE_OFFLINE_FORMAT_INVALID = "offline format check: malformed VAT-ID, no VIES request sent";
+
 	@NonNull private final VATaxIDConfigRepository configRepository;
 	@NonNull private final VATaxIDCheckRepository checkRepository;
 	@NonNull private final VATaxIDParentStatusRepository parentStatusRepository;
@@ -91,11 +99,20 @@ public class VATaxIDCheckService
 		final VATaxIDParentStatus parentStatus = parentStatusRepository.getParentStatus(request);
 		final VATaxIDConfig config = configRepository.getByOrgId(parentStatus.getOrgId());
 
-		if (config.isFormatCheckEnabled())
+		if (config.isFormatCheckEnabled() && !VATaxIDValidationUtil.isFormatValid(vataxID))
 		{
-			// Throws for a malformed value, exactly as the save-time check does — a value the format check
-			// rejects must not reach the online service, and must not be recorded as if it had been checked.
-			VATaxIDValidationUtil.validate(vataxID);
+			// A malformed value is definitively not a valid VAT-ID, and the offline format check can say so
+			// without VIES — so it is recorded as Invalid rather than sent to the service, and never left
+			// forever NotChecked. Runs regardless of IsVIESCheckEnabled (AC13: format and VIES checks are
+			// independent), and on the SAME predicate the save-time interceptor uses to BLOCK such a value —
+			// so the save gate and the process agree on what "malformed" means. The save-time path still
+			// throws to reject at entry; this path exists for a value that was imported or predates the
+			// format check, which the process must be able to verdict rather than silently skip.
+			final VATaxIDCheckLogId checkLogId = checkRepository.writeRequestSent(request);
+			return completeCheckAndStoreVerdict(request, parentStatus, VATaxIDCheckResult.builder()
+					.status(VATaxIDStatus.Invalid)
+					.rawResponse(RAWRESPONSE_OFFLINE_FORMAT_INVALID)
+					.build(), checkLogId);
 		}
 
 		if (!config.isViesCheckEnabled())
@@ -123,8 +140,26 @@ public class VATaxIDCheckService
 		}
 
 		final VATaxIDCheckLogId checkLogId = checkRepository.writeRequestSent(request);
-
 		final VATaxIDCheckResult result = applyOnServiceUnavailable(onlineChecker.check(vataxID, config), config);
+		return completeCheckAndStoreVerdict(request, parentStatus, result, checkLogId);
+	}
+
+	/**
+	 * Completes the {@code RequestSent} log row with {@code result}, stores the verdict on the parent —
+	 * refreshing the partner's open orders' tax when the status actually changed — and logs a genuine re-check
+	 * flip. Shared by the online path and the offline format-invalid path so the two cannot drift on how a
+	 * verdict, once obtained, is recorded.
+	 *
+	 * @return the status the RECORD now has: the verdict when it was stored, or the unchanged stored status
+	 * when {@link #updateParentStatusIfStillCurrent(VATaxIDCheckRequest, VATaxIDLastCheck)} abandoned it.
+	 */
+	@NonNull
+	private VATaxIDStatus completeCheckAndStoreVerdict(
+			@NonNull final VATaxIDCheckRequest request,
+			@NonNull final VATaxIDParentStatus parentStatus,
+			@NonNull final VATaxIDCheckResult result,
+			@NonNull final VATaxIDCheckLogId checkLogId)
+	{
 		checkRepository.completeCheck(checkLogId, result);
 
 		if (!storeVerdictAndRefreshOrderTax(request, parentStatus.getStatus(), VATaxIDLastCheck.builder()
@@ -143,7 +178,8 @@ public class VATaxIDCheckService
 		// re-check flip (Valid -> Invalid, ServiceUnavailable -> Valid, ...) still logs.
 		if (result.getStatus() != parentStatus.getStatus() && parentStatus.getStatus() != VATaxIDStatus.NotChecked)
 		{
-			Loggables.addLog("VAT-ID {}: status {} -> {}", vataxID.getAsString(), parentStatus.getStatus(), result.getStatus());
+			Loggables.addLog("VAT-ID {}: status {} -> {}",
+					request.getVataxID().getAsString(), parentStatus.getStatus(), result.getStatus());
 		}
 
 		return result.getStatus();

--- a/backend/de.metas.vatid/base/src/main/java/de/metas/vatid/VATaxIDMassCheckService.java
+++ b/backend/de.metas.vatid/base/src/main/java/de/metas/vatid/VATaxIDMassCheckService.java
@@ -172,9 +172,16 @@ public class VATaxIDMassCheckService
 	 *
 	 * <p>Due-ness and ordering are the query's ({@code IBPartnerDAO}), evaluated per organisation with that
 	 * organisation's own recheck window — organisations with the online check switched off are never queried
-	 * at all (only VIES-enabled organisations are swept — {@code getRecheckAfterDaysByViesEnabledOrgId}). By
-	 * design that means the nightly does NOT auto-detect a pre-existing / imported malformed VAT-ID on a
-	 * format-check-only organisation: there the manual {@code C_BPartner_VATaxID_Check} process is the path
+	 * at all (only VIES-enabled organisations are swept — {@code getRecheckAfterDaysByViesEnabledOrgId}).
+	 * <b>Why skip them:</b> the nightly exists solely to keep the <i>time-varying</i> VIES verdict current — a
+	 * VAT registration can be withdrawn or turned invalid after it was first checked, which is the whole
+	 * reason an online check is repeated at all. An organisation with VIES off has no such time-varying result
+	 * to refresh: its only validation is the offline format check, which is deterministic and already applied
+	 * at save time (and re-applied by the manual process), so a value's format verdict never changes on its
+	 * own between nights. Sweeping a VIES-off organisation would therefore re-examine values whose verdict
+	 * cannot have moved — pure work for no possible status change — so it is excluded by construction.
+	 * By design that also means the nightly does NOT auto-detect a pre-existing / imported malformed VAT-ID on
+	 * a format-check-only organisation: there the manual {@code C_BPartner_VATaxID_Check} process is the path
 	 * that gives such a value its offline {@code Invalid} verdict. The two grains run one after the other,
 	 * headers then locations, each oldest-attempt-first; a single combined ordering across both would need a
 	 * merge, and raising {@code MaxChecksPerRun} is the cheaper answer now that nothing is loaded up front.

--- a/backend/de.metas.vatid/base/src/main/java/de/metas/vatid/VATaxIDMassCheckService.java
+++ b/backend/de.metas.vatid/base/src/main/java/de/metas/vatid/VATaxIDMassCheckService.java
@@ -171,10 +171,13 @@ public class VATaxIDMassCheckService
 	 * The nightly sweep. Uses {@link VATaxIDMassCheckRequest#getMaxChecksPerRun()} and builds no selection.
 	 *
 	 * <p>Due-ness and ordering are the query's ({@code IBPartnerDAO}), evaluated per organisation with that
-	 * organisation's own recheck window — organisations with the check switched off are never queried at
-	 * all. The two grains run one after the other, headers then locations, each oldest-attempt-first; a
-	 * single combined ordering across both would need a merge, and raising {@code MaxChecksPerRun} is the
-	 * cheaper answer now that nothing is loaded up front.
+	 * organisation's own recheck window — organisations with the online check switched off are never queried
+	 * at all (only VIES-enabled organisations are swept — {@code getRecheckAfterDaysByViesEnabledOrgId}). By
+	 * design that means the nightly does NOT auto-detect a pre-existing / imported malformed VAT-ID on a
+	 * format-check-only organisation: there the manual {@code C_BPartner_VATaxID_Check} process is the path
+	 * that gives such a value its offline {@code Invalid} verdict. The two grains run one after the other,
+	 * headers then locations, each oldest-attempt-first; a single combined ordering across both would need a
+	 * merge, and raising {@code MaxChecksPerRun} is the cheaper answer now that nothing is loaded up front.
      */
 	@NonNull
 	private VATaxIDMassCheckResult runNightly(@NonNull final VATaxIDMassCheckRequest request)

--- a/backend/de.metas.vatid/base/src/main/java/de/metas/vatid/VATaxIDValidationUtil.java
+++ b/backend/de.metas.vatid/base/src/main/java/de/metas/vatid/VATaxIDValidationUtil.java
@@ -48,11 +48,14 @@ public final class VATaxIDValidationUtil
 	 */
 	public static void validate(@Nullable final VATIdentifier vatId)
 	{
-		final String vatIdString = VATIdentifier.toString(vatId);
-		if (!EUVatIdValidator.isValid(vatIdString))
+		// Delegates to isFormatValid so the throwing and non-throwing forms share ONE predicate by
+		// construction — the offline check in VATaxIDCheckService and this save-time gate must never
+		// diverge on what "malformed" means. The extra VATIdentifier.toString on the throw path is a
+		// negligible cost worth that guarantee; do not "optimise" it by inlining the check here.
+		if (!isFormatValid(vatId))
 		{
 			// AdempiereException(AdMessageKey, …) is already flagged userValidationError=true — no .markAsUserValidationError() needed.
-			throw new AdempiereException(MSG_VATaxID_Invalid_Format, vatIdString);
+			throw new AdempiereException(MSG_VATaxID_Invalid_Format, VATIdentifier.toString(vatId));
 		}
 	}
 

--- a/backend/de.metas.vatid/base/src/main/java/de/metas/vatid/VATaxIDValidationUtil.java
+++ b/backend/de.metas.vatid/base/src/main/java/de/metas/vatid/VATaxIDValidationUtil.java
@@ -48,11 +48,25 @@ public final class VATaxIDValidationUtil
 	 */
 	public static void validate(@Nullable final VATIdentifier vatId)
 	{
-		final String vatIdString = VATIdentifier.toString(vatId);
-		if (!EUVatIdValidator.isValid(vatIdString))
+		if (!isFormatValid(vatId))
 		{
 			// AdempiereException(AdMessageKey, …) is already flagged userValidationError=true — no .markAsUserValidationError() needed.
-			throw new AdempiereException(MSG_VATaxID_Invalid_Format, vatIdString);
+			throw new AdempiereException(MSG_VATaxID_Invalid_Format, VATIdentifier.toString(vatId));
 		}
+	}
+
+	/**
+	 * The non-throwing counterpart of {@link #validate(VATIdentifier)}, for a caller that must RECORD a
+	 * verdict for a malformed value rather than abort on it. Same rule set: null, and values whose prefix is
+	 * outside the supported country set... see {@link EUVatIdValidator#isValid(String)} for the exact
+	 * acceptance rule (null / too-short accepted; a supported prefix must pass its structure and check digit;
+	 * an unsupported prefix is rejected). The caller is responsible for checking whether the format check
+	 * should run at all.
+	 *
+	 * @return {@code true} if {@code vatId} passes the offline format check.
+	 */
+	public static boolean isFormatValid(@Nullable final VATIdentifier vatId)
+	{
+		return EUVatIdValidator.isValid(VATIdentifier.toString(vatId));
 	}
 }

--- a/backend/de.metas.vatid/base/src/main/java/de/metas/vatid/VATaxIDValidationUtil.java
+++ b/backend/de.metas.vatid/base/src/main/java/de/metas/vatid/VATaxIDValidationUtil.java
@@ -48,10 +48,11 @@ public final class VATaxIDValidationUtil
 	 */
 	public static void validate(@Nullable final VATIdentifier vatId)
 	{
-		if (!isFormatValid(vatId))
+		final String vatIdString = VATIdentifier.toString(vatId);
+		if (!EUVatIdValidator.isValid(vatIdString))
 		{
 			// AdempiereException(AdMessageKey, …) is already flagged userValidationError=true — no .markAsUserValidationError() needed.
-			throw new AdempiereException(MSG_VATaxID_Invalid_Format, VATIdentifier.toString(vatId));
+			throw new AdempiereException(MSG_VATaxID_Invalid_Format, vatIdString);
 		}
 	}
 

--- a/backend/de.metas.vatid/base/src/main/sql/postgresql/system/45-de.metas.vatid/5820300_sys_VATaxID_Config_Report_Overview_Section.sql
+++ b/backend/de.metas.vatid/base/src/main/sql/postgresql/system/45-de.metas.vatid/5820300_sys_VATaxID_Config_Report_Overview_Section.sql
@@ -1,3 +1,7 @@
+-- VATaxID_Config_Report: add an overview section counting how many partners / addresses carry a
+-- VAT-ID at all (with / without), so the per-status counts are read against the real population.
+-- Body kept in sync with ddl/functions/VATaxID_Config_Report.sql.
+
 DROP FUNCTION IF EXISTS VATaxID_Config_Report(NUMERIC);
 
 CREATE OR REPLACE FUNCTION VATaxID_Config_Report(p_VATaxID_Config_ID NUMERIC)

--- a/backend/de.metas.vatid/base/src/main/sql/postgresql/system/45-de.metas.vatid/5820310_sys_VATaxID_Status_NotSupported_Relabel.sql
+++ b/backend/de.metas.vatid/base/src/main/sql/postgresql/system/45-de.metas.vatid/5820310_sys_VATaxID_Status_NotSupported_Relabel.sql
@@ -1,0 +1,24 @@
+-- Relabel the VATaxIDStatus 'NotSupported' entry (AD_Ref_List 544333, AD_Reference 542125).
+-- The internal Value / ValueName stays 'NotSupported'; only the displayed label changes. "Nicht
+-- unterstützt" read as a feature limitation or an error, when the status actually means the VAT-ID's
+-- country prefix (CH / GB / NO / non-EU) is outside VIES coverage: the offline format check is its only
+-- validation and it still counts as holding a tax certificate.
+--   de_DE: Außerhalb VIES-Abdeckung
+--   de_CH: Ausserhalb VIES-Abdeckung   (Swiss spelling, ß -> ss)
+--   en_US: Outside VIES coverage
+
+UPDATE AD_Ref_List
+SET Name = 'Außerhalb VIES-Abdeckung', Updated = now(), UpdatedBy = 100
+WHERE AD_Ref_List_ID = 544333;
+
+UPDATE AD_Ref_List_Trl
+SET Name = 'Außerhalb VIES-Abdeckung', IsTranslated = 'Y', Updated = now(), UpdatedBy = 100
+WHERE AD_Ref_List_ID = 544333 AND AD_Language = 'de_DE';
+
+UPDATE AD_Ref_List_Trl
+SET Name = 'Ausserhalb VIES-Abdeckung', IsTranslated = 'Y', Updated = now(), UpdatedBy = 100
+WHERE AD_Ref_List_ID = 544333 AND AD_Language = 'de_CH';
+
+UPDATE AD_Ref_List_Trl
+SET Name = 'Outside VIES coverage', IsTranslated = 'Y', Updated = now(), UpdatedBy = 100
+WHERE AD_Ref_List_ID = 544333 AND AD_Language = 'en_US';

--- a/backend/de.metas.vatid/base/src/main/sql/postgresql/system/45-de.metas.vatid/5820320_sys_VATaxID_CheckLog_Window_Filters.sql
+++ b/backend/de.metas.vatid/base/src/main/sql/postgresql/system/45-de.metas.vatid/5820320_sys_VATaxID_CheckLog_Window_Filters.sql
@@ -1,0 +1,30 @@
+-- USt-IdNr.-Prüfprotokoll window (AD_Window 542183, AD_Tab 549365, AD_Table VATaxID_CheckLog 542639).
+-- Three grid/filter tweaks. AD_Column ids from the table's creation migration:
+--   VATaxID 593174, RequestDate 593176, ResponseDate 593177, IsActive 593167.
+
+-- (1) VATaxID becomes a filter column.
+UPDATE AD_Column SET IsSelectionColumn = 'Y', Updated = now(), UpdatedBy = 100
+WHERE AD_Column_ID = 593174;
+
+-- (2) The two existing date filters become date-RANGE (from / to) filters. The WebUI switch is
+--     AD_Column.FilterOperator = 'B' (Between) -> a from/to widget in the filter panel. (IsRangeFilter is
+--     inert in the WebUI -- no read-site -- so it is deliberately NOT used here.)
+UPDATE AD_Column SET FilterOperator = 'B', Updated = now(), UpdatedBy = 100
+WHERE AD_Column_ID IN (593176, 593177);
+
+-- (3) IsActive: move the grid column to the far right (grid order = AD_UI_Element.SeqNoGrid, mirrored on
+--     AD_Field.SeqNoGrid), and move its filter to the bottom of the filter panel.
+--     Filter-panel order is governed by AD_Column.SelectionColumnSeqNo (all filter columns on this tab
+--     leave it NULL today, so order only tie-breaks on AD_Field.SeqNo); set it explicitly so IsActive is
+--     deterministically last rather than by accidental tie-break. SelectionColumnSeqNo lives on the
+--     table's OWN IsActive column (VATaxID_CheckLog.IsActive = 593167), so this touches only this window.
+--     Deliberate deviation from the "Organisation last in the grid" convention: the change was explicitly
+--     requested -- Aktiv is to sit at the far right.
+UPDATE AD_Field SET SeqNo = 200, SeqNoGrid = 200, Updated = now(), UpdatedBy = 100
+WHERE AD_Column_ID = 593167 AND AD_Tab_ID = 549365;
+
+UPDATE AD_UI_Element SET SeqNoGrid = 200, Updated = now(), UpdatedBy = 100
+WHERE AD_Field_ID IN (SELECT AD_Field_ID FROM AD_Field WHERE AD_Column_ID = 593167 AND AD_Tab_ID = 549365);
+
+UPDATE AD_Column SET SelectionColumnSeqNo = 200, Updated = now(), UpdatedBy = 100
+WHERE AD_Column_ID = 593167;

--- a/backend/de.metas.vatid/base/src/main/sql/postgresql/system/45-de.metas.vatid/5820320_sys_VATaxID_CheckLog_Window_Filters.sql
+++ b/backend/de.metas.vatid/base/src/main/sql/postgresql/system/45-de.metas.vatid/5820320_sys_VATaxID_CheckLog_Window_Filters.sql
@@ -14,10 +14,11 @@ WHERE AD_Column_ID IN (593176, 593177);
 
 -- (3) IsActive: move the grid column to the far right (grid order = AD_UI_Element.SeqNoGrid, mirrored on
 --     AD_Field.SeqNoGrid), and move its filter to the bottom of the filter panel.
---     Filter-panel order is governed by AD_Column.SelectionColumnSeqNo (all filter columns on this tab
---     leave it NULL today, so order only tie-breaks on AD_Field.SeqNo); set it explicitly so IsActive is
---     deterministically last rather than by accidental tie-break. SelectionColumnSeqNo lives on the
---     table's OWN IsActive column (VATaxID_CheckLog.IsActive = 593167), so this touches only this window.
+--     Filter-panel order sorts on AD_Column.SelectionColumnSeqNo, where a NULL is treated as
+--     Integer.MAX_VALUE (i.e. sorts LAST); every filter column on this tab leaves it NULL, so they all
+--     tie at MAX and the order falls through to AD_Field.SeqNo. Setting AD_Field.SeqNo = 200 (below) is
+--     therefore exactly what puts IsActive last. SelectionColumnSeqNo is deliberately NOT set: a finite
+--     value there would sort BEFORE the NULL siblings and push IsActive FIRST -- the opposite of intended.
 --     Deliberate deviation from the "Organisation last in the grid" convention: the change was explicitly
 --     requested -- Aktiv is to sit at the far right.
 UPDATE AD_Field SET SeqNo = 200, SeqNoGrid = 200, Updated = now(), UpdatedBy = 100
@@ -25,6 +26,3 @@ WHERE AD_Column_ID = 593167 AND AD_Tab_ID = 549365;
 
 UPDATE AD_UI_Element SET SeqNoGrid = 200, Updated = now(), UpdatedBy = 100
 WHERE AD_Field_ID IN (SELECT AD_Field_ID FROM AD_Field WHERE AD_Column_ID = 593167 AND AD_Tab_ID = 549365);
-
-UPDATE AD_Column SET SelectionColumnSeqNo = 200, Updated = now(), UpdatedBy = 100
-WHERE AD_Column_ID = 593167;

--- a/backend/de.metas.vatid/base/src/test/java/de/metas/vatid/VATaxIDCheckServiceTest.java
+++ b/backend/de.metas.vatid/base/src/test/java/de/metas/vatid/VATaxIDCheckServiceTest.java
@@ -382,6 +382,49 @@ class VATaxIDCheckServiceTest
 	 * {@code vatIdCheckProcessCorrectsOrderTax.feature} — that own whether the resulting {@code C_Tax_ID} is
 	 * right.
 	 */
+	/**
+	 * A syntactically-invalid VAT-ID on a SUPPORTED prefix (here a Belgian number that fails the {@code BE}
+	 * structure) must not leave the record forever {@code NotChecked}. The offline format check is
+	 * authoritative when enabled, so the check records {@link VATaxIDStatus#Invalid} straight away and never
+	 * calls VIES — the same predicate the save-time interceptor uses to block such a value, applied to one
+	 * that was imported or predates the format check. Regression for the danthermuat finding where an
+	 * imported malformed VAT-ID stayed "Ungeprüft".
+	 */
+	@Test
+	void aMalformedVATaxID_isRecordedInvalidOffline_withoutCallingVIES()
+	{
+		givenConfig(0);
+		final VATIdentifier malformed = VATIdentifier.of("BE4258156477"); // BE prefix, fails BE[01]\d{9}
+		final BPartnerId bpartnerId = givenBPartnerWithVATaxID(malformed);
+
+		final VATaxIDStatus returnedStatus = checkService.check(VATaxIDCheckRequest.builder()
+				.bpartnerId(bpartnerId)
+				.vataxID(malformed)
+				.build());
+
+		assertThat(returnedStatus).as("returned status").isEqualTo(VATaxIDStatus.Invalid);
+
+		final I_C_BPartner record = reload(bpartnerId);
+		assertThat(record.getVATaxIDStatus()).as("VATaxIDStatus").isEqualTo(VATaxIDStatus.Invalid.getCode());
+		assertThat(record.getVATaxIDCheckedAt()).as("VATaxIDCheckedAt").isNotNull();
+		assertThat(record.getVATaxID_CheckLog_ID()).as("VATaxID_CheckLog_ID").isGreaterThan(0);
+
+		// The offline format check is definitive on its own — VIES is never asked about a malformed value.
+		verify(onlineChecker, never()).check(any(VATIdentifier.class), any(VATaxIDConfig.class));
+
+		// The log row is Invalid and distinguishable from a VIES 'valid:false' rejection: no requestIdentifier,
+		// and a RawResponse that marks it as an offline format rejection (see the class javadoc on the point).
+		assertThat(allCheckLogs())
+				.as("VATaxID_CheckLog rows")
+				.hasSize(1)
+				.allSatisfy(log -> {
+					assertThat(log.getVATaxID()).isEqualTo(malformed.getAsString());
+					assertThat(log.getVATaxIDStatus()).isEqualTo(VATaxIDStatus.Invalid.getCode());
+					assertThat(log.getRequestIdentifier()).isNull();
+					assertThat(log.getRawResponse()).contains("offline format check");
+				});
+	}
+
 	@Test
 	void aSaveTriggeredCheckThatChangesTheStoredStatus_refreshesTheOpenOrdersTax()
 	{

--- a/backend/de.metas.vatid/base/src/test/java/de/metas/vatid/VATaxIDCheckServiceTest.java
+++ b/backend/de.metas.vatid/base/src/test/java/de/metas/vatid/VATaxIDCheckServiceTest.java
@@ -387,8 +387,8 @@ class VATaxIDCheckServiceTest
 	 * structure) must not leave the record forever {@code NotChecked}. The offline format check is
 	 * authoritative when enabled, so the check records {@link VATaxIDStatus#Invalid} straight away and never
 	 * calls VIES — the same predicate the save-time interceptor uses to block such a value, applied to one
-	 * that was imported or predates the format check. Regression for the danthermuat finding where an
-	 * imported malformed VAT-ID stayed "Ungeprüft".
+	 * that was imported or predates the format check. Regression: such a value must not stay
+	 * {@code NotChecked} ("Ungeprüft") forever.
 	 */
 	@Test
 	void aMalformedVATaxID_isRecordedInvalidOffline_withoutCallingVIES()
@@ -423,6 +423,39 @@ class VATaxIDCheckServiceTest
 					assertThat(log.getRequestIdentifier()).isNull();
 					assertThat(log.getRawResponse()).contains("offline format check");
 				});
+	}
+
+	/**
+	 * The offline format check is independent of the online check: a malformed VAT-ID is recorded
+	 * {@link VATaxIDStatus#Invalid} even when VIES is switched OFF for the organisation. Contrast
+	 * {@link #aCheckWithTheOnlineCheckDisabled_writesNothingAndDoesNotRefreshTheOrderTax()}, where a
+	 * WELL-FORMED value with VIES off writes nothing — the difference is exactly that the offline check has a
+	 * verdict of its own to record, so a value that can never be checked online is not left {@code NotChecked}
+	 * forever on a VIES-disabled organisation.
+	 */
+	@Test
+	void aMalformedVATaxID_isRecordedInvalidOffline_evenWithVIESDisabled()
+	{
+		when(configRepository.getByOrgId(any(OrgId.class))).thenReturn(VATaxIDConfig.builder()
+				.id(VATaxIDConfigId.ofRepoId(1_000_000))
+				.formatCheckEnabled(true)
+				.viesCheckEnabled(false)
+				.restApiBaseURL("https://ec.europa.eu/taxation_customs/vies/rest-api")
+				.recheckAfterDays(0)
+				.onServiceUnavailable(VATaxIDOnServiceUnavailableAction.ServiceUnavailable)
+				.build());
+		final VATIdentifier malformed = VATIdentifier.of("BE4258156477"); // BE prefix, fails BE[01]\d{9}
+		final BPartnerId bpartnerId = givenBPartnerWithVATaxID(malformed);
+
+		final VATaxIDStatus returnedStatus = checkService.check(VATaxIDCheckRequest.builder()
+				.bpartnerId(bpartnerId)
+				.vataxID(malformed)
+				.build());
+
+		assertThat(returnedStatus).as("returned status").isEqualTo(VATaxIDStatus.Invalid);
+		assertThat(reload(bpartnerId).getVATaxIDStatus()).as("VATaxIDStatus").isEqualTo(VATaxIDStatus.Invalid.getCode());
+		verify(onlineChecker, never()).check(any(VATIdentifier.class), any(VATaxIDConfig.class));
+		assertThat(allCheckLogs()).as("VATaxID_CheckLog rows").hasSize(1);
 	}
 
 	@Test

--- a/e2e/frontend-webui/tests/spec/vatid-check-log-window.spec.js
+++ b/e2e/frontend-webui/tests/spec/vatid-check-log-window.spec.js
@@ -305,6 +305,20 @@ true today without fabricating a row the real system cannot yet produce.
       }
     });
 
+    await test.step('IsActive is the right-most grid column (moved to the far right — migration 5820320)', async () => {
+      // Grid columns render in AD_UI_Element.SeqNoGrid order; migration 5820320 gives IsActive the highest
+      // SeqNoGrid (200), so its header must sit to the RIGHT of AD_Org_ID (previously the last data column).
+      // Compared by horizontal position, reusing the two data-testid selectors already asserted above.
+      const isActiveBox = await page.locator('[data-testid="column-IsActive"]').boundingBox();
+      const orgBox = await page.locator('[data-testid="column-AD_Org_ID"]').boundingBox();
+      expect(isActiveBox, 'IsActive column header must have a bounding box').toBeTruthy();
+      expect(orgBox, 'AD_Org_ID column header must have a bounding box').toBeTruthy();
+      expect(
+        isActiveBox.x,
+        'IsActive grid column must render to the right of AD_Org_ID after the grid-order change',
+      ).toBeGreaterThan(orgBox.x);
+    });
+
     await test.step('Assert the list-view "add new" affordance is absent (AD_Tab.IsInsertRecord=N)', async () => {
       // TableFilter.js renders the "add new" button as
       // `<button class="btn btn-meta-outline-secondary btn-distance btn-sm">`


### PR DESCRIPTION
## What this PR does

Follow-up fixes to the VAT-ID online-check feature.

**Format-invalid VAT-IDs are now recorded as `Invalid`.** A syntactically-invalid VAT-ID reaching `VATaxIDCheckService.check()` previously threw at the format-check gate and the throw was swallowed, leaving the record `NotChecked` forever. When the format check is enabled and the value fails it, the check now records `Invalid` offline — no VIES call — via a check-log row marked as an offline format rejection (distinct from a VIES `valid:false`), flowing through the same store-and-refresh path so an open order's tax follows. The save-time interceptor still throws to block such a value at entry; this path handles values that were imported or predate the format check.

**Report `VATaxID_Config_Report`: new overview section** counting, per partner and per address, how many carry a VAT-ID versus none — so the per-status counts are read against the population that actually has a VAT-ID (a record that never had one reads as `NotChecked`, which otherwise dominates the count).

**`VATaxIDStatus` `NotSupported` relabelled** to "Außerhalb VIES-Abdeckung" / "Outside VIES coverage" (internal code unchanged) — the old "Nicht unterstützt" read like an error, when it means the country prefix is outside VIES coverage and the offline format check is its only validation.

**VATaxID_CheckLog window filter/grid tweaks:** VATaxID becomes filterable; the two date filters become from/to range filters (`AD_Column.FilterOperator='B'`); the Active column moves to the far right of the grid with its filter last.

**Also:** the external-system "enqueued to be synced" debug log lines now name their source class.

## Migrations
- `5820300` — report overview section (function replace; canonical `ddl/functions/VATaxID_Config_Report.sql` kept in sync)
- `5820310` — `NotSupported` relabel (de_DE / de_CH / en_US)
- `5820320` — check-log window filter/grid

## Verification
- `de.metas.vatid` unit tests green (170), including a new test pinning format-invalid → `Invalid` with no VIES call.
- Cucumber scenario added for the process path (an already-persisted malformed VAT-ID → `Invalid`).
- Migrations applied and verified on a customer-faithful DB; the check-log window layout was rule-checked and its Playwright spec extended for the grid-order change.
