### PR TITLE
Merge: soft_panda_hotfix -> new_dawn_uat (EDI DESADV terminal status on under-delivery)

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/StepDefUtil.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/StepDefUtil.java
@@ -26,12 +26,19 @@ import com.google.common.collect.ImmutableList;
 import de.metas.i18n.BooleanWithReason;
 import de.metas.i18n.ExplainedOptional;
 import de.metas.logging.LogManager;
+import de.metas.security.IRoleDAO;
+import de.metas.security.Role;
+import de.metas.security.RoleId;
+import de.metas.user.UserId;
+import de.metas.user.api.IUserDAO;
 import de.metas.util.Check;
+import de.metas.util.Services;
 import de.metas.util.NumberUtils;
 import de.metas.util.StringUtils;
 import io.cucumber.java.en.And;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.compiere.Adempiere;
 import org.compiere.model.IQuery;
@@ -45,6 +52,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -57,6 +65,48 @@ public class StepDefUtil
 	private static final Logger logger = LogManager.getLogger(StepDefUtil.class);
 	private static final String SYS_maxWaitSeconds = "maxWaitSeconds";
 	private static ExplainedOptional<Long> _sys_maxWaitSeconds; // lazy
+
+	/**
+	 * @return the {@code AD_User} with the given {@code Login}; fails if there is none.
+	 * Standing masterdata lookup — the login has to exist in the DB the suite runs against.
+	 */
+	@NonNull
+	public static UserId getUserIdByLogin(@NonNull final String userLogin)
+	{
+		final UserId userId = Services.get(IUserDAO.class).retrieveUserIdByLogin(userLogin);
+		if (userId == null)
+		{
+			throw new AdempiereException("Missing AD_User with login " + userLogin);
+		}
+		return userId;
+	}
+
+	/**
+	 * @return the {@code AD_Role} with the given {@code Name} out of the roles assigned to the given user;
+	 * fails if the user has no such role.
+	 *
+	 * @param userLogin only used to identify the user in the failure message — a CI log reader cannot
+	 * resolve a bare {@code AD_User_ID} without DB access.
+	 */
+	@NonNull
+	public static RoleId getRoleIdByName(
+			@NonNull final UserId userId,
+			@NonNull final String userLogin,
+			@NonNull final String roleName)
+	{
+		final List<Role> userRoles = Services.get(IRoleDAO.class).getUserRoles(userId);
+
+		return userRoles.stream()
+				.filter(role -> roleName.equals(role.getName()))
+				.findFirst()
+				.map(Role::getId)
+				// Both halves of the message earn their place: the login identifies WHICH user failed
+				// without a DB lookup, and the assigned-roles list separates a misspelled roleName from a
+				// role that was never assigned. Neither alone tells the CI reader what to fix.
+				.orElseThrow(() -> new AdempiereException("AD_User with login=" + userLogin
+						+ " (AD_User_ID=" + userId.getRepoId() + ") has no AD_Role with name " + roleName
+						+ "; assigned roles: " + userRoles.stream().map(Role::getName).collect(Collectors.joining(", "))));
+	}
 
 	/**
 	 * Waits for the given {@code worker} to supply {@code true}.

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/api/RESTUtil.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/api/RESTUtil.java
@@ -36,13 +36,12 @@ import de.metas.common.rest_api.v2.JsonErrorItem;
 import de.metas.common.rest_api.v2.SyncAdvise;
 import de.metas.common.util.CoalesceUtil;
 import de.metas.common.util.EmptyUtil;
+import de.metas.cucumber.stepdefs.StepDefUtil;
 import de.metas.error.AdIssueId;
 import de.metas.logging.LogManager;
 import de.metas.organization.OrgId;
-import de.metas.security.IRoleDAO;
-import de.metas.security.Role;
+import de.metas.security.RoleId;
 import de.metas.user.UserId;
-import de.metas.user.api.IUserDAO;
 import de.metas.util.Services;
 import de.metas.util.collections.CollectionUtils;
 import de.metas.util.web.security.UserAuthTokenFilter;
@@ -96,24 +95,12 @@ public class RESTUtil
 
 	public String getAuthToken(@NonNull final String userLogin, @NonNull final String roleName)
 	{
-		final IUserDAO userDAO = Services.get(IUserDAO.class);
-		final IRoleDAO roleDAO = Services.get(IRoleDAO.class);
-
-		final UserId userId = userDAO.retrieveUserIdByLogin(userLogin);
-		if (userId == null)
-		{
-			throw new AdempiereException("Missing AD_User with login " + userLogin);
-		}
-		final Role role = roleDAO
-				.getUserRoles(userId)
-				.stream()
-				.filter(r -> r.getName().equals(roleName))
-				.findAny()
-				.orElseThrow(() -> new AdempiereException("User with login=" + userLogin + " and AD_User_ID=" + userId.getRepoId() + " has no role with name " + roleName));
+		final UserId userId = StepDefUtil.getUserIdByLogin(userLogin);
+		final RoleId roleId = StepDefUtil.getRoleIdByName(userId, userLogin, roleName);
 
 		final I_AD_User_AuthToken userAuthTokenRecord = InterfaceWrapperHelper.newInstanceOutOfTrx(I_AD_User_AuthToken.class);
 		userAuthTokenRecord.setAD_User_ID(userId.getRepoId());
-		userAuthTokenRecord.setAD_Role_ID(role.getId().getRepoId());
+		userAuthTokenRecord.setAD_Role_ID(roleId.getRepoId());
 		userAuthTokenRecord.setAD_Org_ID(1000000);
 		InterfaceWrapperHelper.saveRecord(userAuthTokenRecord);
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/api/RESTUtil.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/api/RESTUtil.java
@@ -93,6 +93,7 @@ public class RESTUtil
 {
 	private static final Logger logger = LogManager.getLogger(RESTUtil.class);
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
+	@NonNull private final IRoleDAO roleDAO = Services.get(IRoleDAO.class);
 
 	public String getAuthToken(@NonNull final String userLogin, @NonNull final String roleName)
 	{
@@ -113,7 +114,7 @@ public class RESTUtil
 		// Access.READ-guarded lookup (e.g. OrgDAO.retrieveOrgIdBy) could not see orgs outside the context org.
 		Env.setContext(Env.getCtx(), Env.CTXNAME_AD_Role_ID, roleId.getRepoId());
 		Env.setContext(Env.getCtx(), Env.CTXNAME_AD_Client_ID,
-				Services.get(IRoleDAO.class).getById(roleId).getClientId().getRepoId());
+				roleDAO.getById(roleId).getClientId().getRepoId());
 
 		return userAuthTokenRecord.getAuthToken();
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/api/RESTUtil.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/api/RESTUtil.java
@@ -40,6 +40,7 @@ import de.metas.cucumber.stepdefs.StepDefUtil;
 import de.metas.error.AdIssueId;
 import de.metas.logging.LogManager;
 import de.metas.organization.OrgId;
+import de.metas.security.IRoleDAO;
 import de.metas.security.RoleId;
 import de.metas.user.UserId;
 import de.metas.util.Services;
@@ -110,8 +111,9 @@ public class RESTUtil
 		// under this role's UserRolePermissions. The token alone only authorises HTTP requests (via the
 		// UserAuthTokenFilter); an in-process call would otherwise have no role permissions, so an
 		// Access.READ-guarded lookup (e.g. OrgDAO.retrieveOrgIdBy) could not see orgs outside the context org.
-		Env.setContext(Env.getCtx(), Env.CTXNAME_AD_Role_ID, role.getId().getRepoId());
-		Env.setContext(Env.getCtx(), Env.CTXNAME_AD_Client_ID, role.getClientId().getRepoId());
+		Env.setContext(Env.getCtx(), Env.CTXNAME_AD_Role_ID, roleId.getRepoId());
+		Env.setContext(Env.getCtx(), Env.CTXNAME_AD_Client_ID,
+				Services.get(IRoleDAO.class).getById(roleId).getClientId().getRepoId());
 
 		return userAuthTokenRecord.getAuthToken();
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_DesadvLine_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_DesadvLine_StepDef.java
@@ -82,12 +82,19 @@ public class EDI_DesadvLine_StepDef
 	 *   <li>{@code Line} – narrows the match to the line with this line number</li>
 	 * </ul>
 	 * When no disambiguator is provided the query must return exactly one result.
+	 * <p>
+	 * Optional assertion columns (each asserted only when the column is present):
+	 * <ul>
+	 *   <li>{@code QtyEntered} – expected {@code EDI_DesadvLine.QtyEntered}</li>
+	 *   <li>{@code QtyDeliveredInUOM} – expected {@code EDI_DesadvLine.QtyDeliveredInUOM}</li>
+	 *   <li>{@code QtyDeliveredInStockingUOM} – expected {@code EDI_DesadvLine.QtyDeliveredInStockingUOM}</li>
+	 * </ul>
 	 *
 	 * <p>Example:
 	 * <pre>
 	 * Then EDI_DesadvLine records are found:
-	 *   | EDI_DesadvLine_ID | EDI_Desadv_ID |
-	 *   | desadvLine        | myDesadv      |
+	 *   | EDI_DesadvLine_ID | EDI_Desadv_ID | OPT.QtyDeliveredInStockingUOM |
+	 *   | desadvLine        | myDesadv      | 3                             |
 	 * </pre>
 	 */
 	@Then("EDI_DesadvLine records are found:")
@@ -116,8 +123,33 @@ public class EDI_DesadvLine_StepDef
 
 		final I_EDI_DesadvLine desadvLine = queryBuilder.create().firstOnlyNotNull(I_EDI_DesadvLine.class);
 
+		assertOptionalDesadvLineQtys(row, desadvLine);
+
 		final StepDefDataIdentifier lineIdentifier = row.getAsIdentifier(I_EDI_DesadvLine.COLUMNNAME_EDI_DesadvLine_ID);
 		desadvLineTable.putOrReplace(lineIdentifier, desadvLine);
+	}
+
+	/**
+	 * Asserts the optional {@code QtyEntered} / {@code QtyDeliveredInUOM} /
+	 * {@code QtyDeliveredInStockingUOM} DataTable columns against the given line. A column that is
+	 * absent from the row is skipped entirely, so callers that never supply it keep today's behaviour.
+	 */
+	private static void assertOptionalDesadvLineQtys(@NonNull final DataTableRow row, @NonNull final I_EDI_DesadvLine desadvLine)
+	{
+		row.getAsOptionalBigDecimal(I_EDI_DesadvLine.COLUMNNAME_QtyEntered)
+				.ifPresent(expected -> assertThat(desadvLine.getQtyEntered())
+						.as(I_EDI_DesadvLine.COLUMNNAME_QtyEntered)
+						.isEqualByComparingTo(expected));
+
+		row.getAsOptionalBigDecimal(I_EDI_DesadvLine.COLUMNNAME_QtyDeliveredInUOM)
+				.ifPresent(expected -> assertThat(desadvLine.getQtyDeliveredInUOM())
+						.as(I_EDI_DesadvLine.COLUMNNAME_QtyDeliveredInUOM)
+						.isEqualByComparingTo(expected));
+
+		row.getAsOptionalBigDecimal(I_EDI_DesadvLine.COLUMNNAME_QtyDeliveredInStockingUOM)
+				.ifPresent(expected -> assertThat(desadvLine.getQtyDeliveredInStockingUOM())
+						.as(I_EDI_DesadvLine.COLUMNNAME_QtyDeliveredInStockingUOM)
+						.isEqualByComparingTo(expected));
 	}
 
 	/**

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_Desadv_StepDef.java
@@ -41,6 +41,8 @@ import de.metas.edi.process.export.enqueue.DesadvEnqueuer;
 import de.metas.edi.process.export.enqueue.EnqueueDesadvRequest;
 import de.metas.edi.process.export.enqueue.EnqueueDesadvResult;
 import de.metas.esb.edi.model.I_EDI_Desadv;
+import de.metas.order.IOrderDAO;
+import de.metas.order.OrderId;
 import de.metas.organization.OrgId;
 import de.metas.util.Check;
 import de.metas.util.Services;
@@ -84,6 +86,7 @@ public class EDI_Desadv_StepDef
 	private static final String QTY_TU_TAGNAME = "QtyTU";
 
 	private final IDesadvDAO desadvDAO = Services.get(IDesadvDAO.class);
+	private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 
 	private final DesadvEnqueuer desadvEnqueuer = SpringContextHolder.instance.getBean(DesadvEnqueuer.class);
@@ -133,6 +136,26 @@ public class EDI_Desadv_StepDef
 		}
 	}
 
+	/**
+	 * Resolves the {@code EDI_Desadv} that the given order's shipment(s) were consolidated into
+	 * (found only via its order: {@code C_Order.POReference} + {@code C_Order.C_BPartner_ID}).
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>C_BPartner_ID.Identifier</b> — (required) expected {@code EDI_Desadv.C_BPartner_ID}<br>
+	 *   <b>C_Order_ID.Identifier</b> — (required) the order whose {@code POReference} + {@code C_BPartner_ID} resolve the DESADV<br>
+	 *   <b>EDI_Desadv_ID.Identifier</b> — (required) identifier under which the found record is stored for later steps<br>
+	 *   <b>OPT.Processed</b> — (optional) expected {@code EDI_Desadv.isProcessed()}<br>
+	 *   <b>OPT.FulfillmentPercent</b> — (optional) expected {@code EDI_Desadv.getFulfillmentPercent()}, compared with {@code isEqualByComparingTo}<br>
+	 *   <b>OPT.SumDeliveredInStockingUOM</b> — (optional) expected {@code EDI_Desadv.getSumDeliveredInStockingUOM()}, compared with {@code isEqualByComparingTo}<br>
+	 *   <b>OPT.EDIErrorMsg</b> — (optional) expected {@code EDI_Desadv.getEDIErrorMsg()}; the {@code null} token asserts the column IS null<br>
+	 * @cucumber.example
+	 * <pre>
+	 * Then EDI_Desadv is found:
+	 *   | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_Desadv_ID.Identifier | OPT.Processed | OPT.FulfillmentPercent | OPT.EDIErrorMsg |
+	 *   | bpartner                 | order_1               | desadv_1                 | false         | 100                    | null            |
+	 * </pre>
+	 */
 	@Then("EDI_Desadv is found:")
 	public void find_desadv(@NonNull final DataTable table)
 	{
@@ -140,6 +163,54 @@ public class EDI_Desadv_StepDef
 		for (final Map<String, String> row : dataTable)
 		{
 			findDesadv(row);
+		}
+	}
+
+	/**
+	 * Asserts that neither the given {@code C_Order} nor any of its {@code C_OrderLine}s is wired to a
+	 * DESADV, i.e. {@code C_Order.EDI_Desadv_ID} and every {@code C_OrderLine.EDI_DesadvLine_ID} are unset.
+	 * <p>
+	 * This is the premise of the "POReference filled in after the order was completed" flow: the
+	 * before-complete interceptor on {@code C_Order} skips DESADV creation while {@code POReference} is
+	 * blank, so a DESADV created later — at shipment completion — has to derive the delivered
+	 * quantities on its own. Asserting the absence up front is what makes that later assertion mean
+	 * something.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>C_Order_ID</b> — (required, identifier-ref) the order that must not be linked to a DESADV<br>
+	 * @cucumber.depends StepDefData: C_Order_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * Then C_Order and its C_OrderLines are not linked to any EDI_Desadv:
+	 *   | C_Order_ID |
+	 *   | o_1        |
+	 * </pre>
+	 */
+	@Then("C_Order and its C_OrderLines are not linked to any EDI_Desadv:")
+	public void assert_order_not_linked_to_desadv(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::assertOrderNotLinkedToDesadv);
+	}
+
+	private void assertOrderNotLinkedToDesadv(@NonNull final DataTableRow row)
+	{
+		final I_C_Order order = row.getAsIdentifier(I_C_Order.COLUMNNAME_C_Order_ID).lookupNotNullIn(orderTable);
+		InterfaceWrapperHelper.refresh(order);
+
+		final de.metas.edi.model.I_C_Order ediOrder = InterfaceWrapperHelper.create(order, de.metas.edi.model.I_C_Order.class);
+		assertThat(ediOrder.getEDI_Desadv_ID()).as(de.metas.edi.model.I_C_Order.COLUMNNAME_EDI_Desadv_ID).isZero();
+
+		final List<de.metas.edi.model.I_C_OrderLine> orderLines = orderDAO.retrieveOrderLines(
+				OrderId.ofRepoId(order.getC_Order_ID()),
+				de.metas.edi.model.I_C_OrderLine.class);
+
+		assertThat(orderLines).as("C_OrderLines of the order").isNotEmpty();
+		for (final de.metas.edi.model.I_C_OrderLine orderLine : orderLines)
+		{
+			assertThat(orderLine.getEDI_DesadvLine_ID())
+					.as("%s of C_OrderLine with Line=%s", de.metas.edi.model.I_C_OrderLine.COLUMNNAME_EDI_DesadvLine_ID, orderLine.getLine())
+					.isZero();
 		}
 	}
 
@@ -192,6 +263,28 @@ public class EDI_Desadv_StepDef
 		DataTableRows.of(dataTable).forEach(this::validateEDIExpDesadvElement);
 	}
 
+	/**
+	 * Polls the given {@code EDI_Desadv} records (already resolved via {@code EDI_Desadv is found:}
+	 * or {@code EDI_Desadv is enqueued for export}) until each reaches the expected
+	 * {@code EDI_ExportStatus}, then optionally asserts {@code Processed} / {@code FulfillmentPercent} /
+	 * {@code EDIErrorMsg}.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>EDI_Desadv_ID</b> — (required, identifier-ref) alias from {@code EDI_Desadv_StepDefData}<br>
+	 *   <b>EDI_ExportStatus</b> — (required) the export status to poll for<br>
+	 *   <b>OPT.EDIErrorMsg</b> — (optional) expected {@code EDI_Desadv.getEDIErrorMsg()}; the {@code null} token asserts the column IS null<br>
+	 *   <b>OPT.Processed</b> — (optional) expected {@code EDI_Desadv.isProcessed()}, asserted once the export status matches<br>
+	 *   <b>OPT.FulfillmentPercent</b> — (optional) expected {@code EDI_Desadv.getFulfillmentPercent()}, compared with {@code isEqualByComparingTo}<br>
+	 *   <b>OPT.SumDeliveredInStockingUOM</b> — (optional) expected {@code EDI_Desadv.getSumDeliveredInStockingUOM()}, compared with {@code isEqualByComparingTo}<br>
+	 * @cucumber.depends StepDefData: EDI_Desadv_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * Then after not more than 60s, EDI_Desadv records have the following export status
+	 *   | EDI_Desadv_ID | EDI_ExportStatus | OPT.EDIErrorMsg | OPT.Processed | OPT.FulfillmentPercent |
+	 *   | desadv_1      | Exported         | null            | true          | 100                    |
+	 * </pre>
+	 */
 	@Then("^after not more than (.*)s, EDI_Desadv records have the following export status$")
 	public void validate_export_status(final int timeoutSec, @NonNull final DataTable table) throws InterruptedException
 	{
@@ -373,6 +466,48 @@ public class EDI_Desadv_StepDef
 			InterfaceWrapperHelper.refresh(desadvRecord);
 			return exportStatus.equals(desadvRecord.getEDI_ExportStatus());
 		});
+
+		assertOptionalDesadvFields(tableRow, desadvRecord);
+	}
+
+	/**
+	 * Asserts the optional {@code OPT.Processed} / {@code OPT.FulfillmentPercent} /
+	 * {@code OPT.SumDeliveredInStockingUOM} / {@code OPT.EDIErrorMsg}
+	 * DataTable columns against the given {@code EDI_Desadv} record, shared by {@code EDI_Desadv is found:}
+	 * and {@code after not more than {}s, EDI_Desadv records have the following export status}.
+	 * A column that is absent from {@code tableRow} is skipped entirely, so callers that never
+	 * supply these columns keep today's exact behaviour.
+	 * <p>
+	 * {@code OPT.EDIErrorMsg} is the only one of the three that can assert a NULL: a cell holding the
+	 * {@code null} token (see {@link DataTableUtil#nullToken2Null(String)}) asserts the column IS null,
+	 * any other value is compared literally.
+	 */
+	private void assertOptionalDesadvFields(@NonNull final DataTableRow tableRow, @NonNull final I_EDI_Desadv desadvRecord)
+	{
+		// The column names are given bare: DataTableRow resolves an "OPT." prefix itself.
+		final Boolean processed = tableRow.getAsOptionalBoolean(I_EDI_Desadv.COLUMNNAME_Processed).toBooleanOrNull();
+		if (processed != null)
+		{
+			assertThat(desadvRecord.isProcessed()).as(I_EDI_Desadv.COLUMNNAME_Processed).isEqualTo(processed);
+		}
+
+		tableRow.getAsOptionalBigDecimal(I_EDI_Desadv.COLUMNNAME_FulfillmentPercent)
+				.ifPresent(expected -> assertThat(desadvRecord.getFulfillmentPercent())
+						.as(I_EDI_Desadv.COLUMNNAME_FulfillmentPercent)
+						.isEqualByComparingTo(expected));
+
+		tableRow.getAsOptionalBigDecimal(I_EDI_Desadv.COLUMNNAME_SumDeliveredInStockingUOM)
+				.ifPresent(expected -> assertThat(desadvRecord.getSumDeliveredInStockingUOM())
+						.as(I_EDI_Desadv.COLUMNNAME_SumDeliveredInStockingUOM)
+						.isEqualByComparingTo(expected));
+
+		// getAsOptionalString is empty only when the COLUMN is missing, so a cell that is present and
+		// holds the null token still reaches us — which is what lets this assert an actual SQL NULL
+		// rather than silently skipping.
+		tableRow.getAsOptionalString(I_EDI_Desadv.COLUMNNAME_EDIErrorMsg)
+				.ifPresent(raw -> assertThat(desadvRecord.getEDIErrorMsg())
+						.as(I_EDI_Desadv.COLUMNNAME_EDIErrorMsg)
+						.isEqualTo(DataTableUtil.nullToken2Null(raw)));
 	}
 
 	private void enqueueDesadvForExport(@NonNull final Map<String, String> tableRow)
@@ -409,6 +544,8 @@ public class EDI_Desadv_StepDef
 
 		assertThat(desadvRecord).isNotNull();
 		assertThat(desadvRecord.getC_BPartner_ID()).isEqualTo(bpartnerID);
+
+		assertOptionalDesadvFields(DataTableRow.singleRow(tableRow), desadvRecord);
 
 		final String identifier = DataTableUtil.extractStringForColumnName(tableRow, I_EDI_Desadv.COLUMNNAME_EDI_Desadv_ID + "." + TABLECOLUMN_IDENTIFIER);
 		desadvTable.putOrReplace(identifier, desadvRecord);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_M_InOut_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/edi/EDI_M_InOut_StepDef.java
@@ -28,11 +28,13 @@ import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
 import de.metas.cucumber.stepdefs.StepDefUtil;
 import de.metas.cucumber.stepdefs.shipment.M_InOut_StepDefData;
+import de.metas.edi.api.EDIExportStatus;
 import de.metas.edi.async.spi.impl.EDIWorkpackageProcessor;
 import de.metas.edi.model.I_M_InOut;
 import de.metas.esb.edi.model.I_EDI_Desadv;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -85,5 +87,59 @@ public class EDI_M_InOut_StepDef
 				.addElement(shipment)
 				.bindToThreadInheritedTrx()
 				.buildAndEnqueue();
+	}
+
+	/**
+	 * Sets {@code M_InOut.EDI_ExportStatus} on shipments that already exist.
+	 * <p>
+	 * Stands in for {@code EDIDocumentBL.updateEdiExportStatus}, the production trigger that puts a
+	 * shipment into {@code DontSend} when its ship-to location is not an EDI DESADV recipient (and into
+	 * {@code Pending} when it is).
+	 * <p>
+	 * That trigger cannot produce the state a DESADV-aggregation scenario needs: it writes
+	 * {@code DontSend} only for a ship-to location that is no EDI DESADV recipient, and for such a
+	 * location {@code C_Order.addToDesadv} creates no {@code EDI_Desadv} at all — while a recipient
+	 * location, the only kind that has a DESADV, always gets {@code Pending}.
+	 * <p>
+	 * The one other production writer of {@code DontSend},
+	 * {@code M_InOut.updateEdiExportStatusOnReverse}, is no alternative either: it fires on reverse /
+	 * void, which at the same timing also unlinks the shipment from its DESADV
+	 * ({@code M_InOut.removeFromDesadv}) and undoes its delivered quantity — the very under-delivery
+	 * these scenarios are built on.
+	 * <p>
+	 * "A DESADV whose shipment shall not be sent" is therefore reachable only by writing the status
+	 * onto an already-created shipment of a recipient location. The write survives, because the
+	 * {@code M_InOut} interceptor recomputes the EDI export status only when {@code C_BPartner_ID},
+	 * {@code C_Order_ID} or {@code POReference} change.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_InOut_ID</b> — (required, identifier-ref) the shipment to update<br>
+	 *   <b>EDI_ExportStatus</b> — (required) status code to store, e.g. {@code N} (DontSend), {@code P} (Pending)<br>
+	 * @cucumber.depends StepDefData: M_InOut_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And the EDI export status of the following M_InOut records is set:
+	 *   | M_InOut_ID | EDI_ExportStatus |
+	 *   | s_40       | N                |
+	 * </pre>
+	 */
+	@Given("^the EDI export status of the following M_InOut records is set:$")
+	public void set_export_status(@NonNull final DataTable table)
+	{
+		DataTableRows.of(table).forEach(this::setExportStatus);
+	}
+
+	private void setExportStatus(@NonNull final DataTableRow row)
+	{
+		final I_M_InOut inoutRecord =
+				InterfaceWrapperHelper.create(
+						row.getAsIdentifier(I_M_InOut.COLUMNNAME_M_InOut_ID).lookupNotNullIn(inoutTable),
+						I_M_InOut.class);
+
+		final EDIExportStatus exportStatus = row.getAsEnum(I_M_InOut.COLUMNNAME_EDI_ExportStatus, EDIExportStatus.class);
+
+		inoutRecord.setEDI_ExportStatus(exportStatus.getCode());
+		InterfaceWrapperHelper.save(inoutRecord);
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/MetasfreshToExternalSystemRabbitMQ_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/externalsystem/MetasfreshToExternalSystemRabbitMQ_StepDef.java
@@ -31,6 +31,7 @@ import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.GetResponse;
 import de.metas.CommandLineParser;
 import de.metas.JsonObjectMapperHolder;
 import de.metas.ServerBoot;
@@ -70,6 +71,7 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static de.metas.common.externalsystem.ExternalSystemConstants.PARAM_BPARTNER_ID;
@@ -85,6 +87,9 @@ import static org.assertj.core.api.Assertions.*;
 public class MetasfreshToExternalSystemRabbitMQ_StepDef
 {
 	private final static Logger logger = LogManager.getLogger(MetasfreshToExternalSystemRabbitMQ_StepDef.class);
+
+	/** How long the synchronous {@code basicGet} poll sleeps between empty pulls. */
+	private static final long POLL_INTERVAL_MILLIS = 250L;
 
 	private final ConnectionFactory metasfreshToRabbitMQFactory;
 	private final C_BPartner_StepDefData bpartnerTable;
@@ -126,6 +131,31 @@ public class MetasfreshToExternalSystemRabbitMQ_StepDef
 		final Channel channel = connection.createChannel();
 		final AMQP.Queue.PurgeOk purgeOk = channel.queuePurge(QUEUE_NAME_MF_TO_ES);
 		logger.info("Purged {} messages from queue {}", purgeOk.getMessageCount(), QUEUE_NAME_MF_TO_ES);
+	}
+
+	/**
+	 * Asserts that no message arrives on {@link ExternalSystemConstants#QUEUE_NAME_MF_TO_ES} within the
+	 * given timeout — the negative counterpart of {@code RabbitMQ receives a JsonExternalSystemRequest …}.
+	 * <p>
+	 * Polls synchronously with {@code basicGet} for the whole timeout window, so a message arriving late in
+	 * the window is still seen and still fails the assertion. A message that does not parse as a
+	 * {@link JsonExternalSystemRequest} is acked and skipped rather than failing the step — a leftover or
+	 * another scenario's message must not be reported as the condition under test.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.example
+	 * <pre>
+	 * Then RabbitMQ MF_TO_ExternalSystem receives no message within 5s
+	 * </pre>
+	 */
+	@Then("^RabbitMQ MF_TO_ExternalSystem receives no message within (.*)s$")
+	public void rabbitMQ_receives_no_message(final int timeoutSeconds) throws IOException, TimeoutException
+	{
+		final JsonExternalSystemRequest request = receiveOneRequestOrNull(timeoutSeconds);
+
+		assertThat(request)
+				.as("Expected no JsonExternalSystemRequest on queue=%s within %ss, but received: %s", QUEUE_NAME_MF_TO_ES, timeoutSeconds, request)
+				.isNull();
 	}
 
 	@Then("RabbitMQ receives a JsonExternalSystemRequest with the following external system config and bpartnerId as parameters:")
@@ -254,6 +284,100 @@ public class MetasfreshToExternalSystemRabbitMQ_StepDef
 			if (channel != null)
 			{
 				channel.close();
+			}
+		}
+	}
+
+	/**
+	 * Blocks for up to {@code timeoutSeconds} for a single message on {@link ExternalSystemConstants#QUEUE_NAME_MF_TO_ES},
+	 * returning {@code null} if none arrived in time. Unlike {@link #pollRequestFromQueue(int, Function)} this
+	 * does not fail when nothing is received — the caller ({@code rabbitMQ_receives_no_message}) asserts on that.
+	 */
+	@Nullable
+	private JsonExternalSystemRequest receiveOneRequestOrNull(final int timeoutSeconds) throws IOException, TimeoutException
+	{
+		Connection connection = null;
+		Channel channel = null;
+
+		try
+		{
+			connection = metasfreshToRabbitMQFactory.newConnection();
+			channel = connection.createChannel();
+
+			final long deadline = System.currentTimeMillis() + (timeoutSeconds * 1000L);
+
+			while (System.currentTimeMillis() < deadline)
+			{
+				final GetResponse response = channel.basicGet(QUEUE_NAME_MF_TO_ES, false);
+				if (response == null)
+				{
+					try
+					{
+						Thread.sleep(POLL_INTERVAL_MILLIS);
+					}
+					catch (final InterruptedException e)
+					{
+						Thread.currentThread().interrupt();
+						break;
+					}
+					continue;
+				}
+
+				final long deliveryTag = response.getEnvelope().getDeliveryTag();
+				final String payload = new String(response.getBody(), StandardCharsets.UTF_8);
+
+				logger.info("*** {}: received message: {}", QUEUE_NAME_MF_TO_ES, payload);
+
+				try
+				{
+					final JsonExternalSystemRequest request = objectMapper.readValue(payload, JsonExternalSystemRequest.class);
+					channel.basicAck(deliveryTag, false);
+					return request;
+				}
+				catch (final JsonProcessingException e)
+				{
+					// Foreign message (a leftover, or another scenario's): ack it so it neither blocks this poll
+					// nor reappears, and keep polling. Throwing here would fail the scenario for someone else's
+					// message rather than for the condition under test.
+					channel.basicAck(deliveryTag, false);
+					logger.info("*** {}: skipping unparseable message: {}", QUEUE_NAME_MF_TO_ES, payload, e);
+				}
+			}
+
+			return null;
+		}
+		finally
+		{
+			closeQuietly(channel, connection);
+		}
+	}
+
+	/**
+	 * Closes channel and connection, swallowing close failures — a broker-side close error must not mask
+	 * the assertion result of the step that is closing.
+	 */
+	private void closeQuietly(@Nullable final Channel channel, @Nullable final Connection connection)
+	{
+		if (channel != null)
+		{
+			try
+			{
+				channel.close();
+			}
+			catch (final Exception e)
+			{
+				logger.debug("Ignoring failure while closing the channel", e);
+			}
+		}
+		if (connection != null)
+		{
+			try
+			{
+				connection.close();
+			}
+			catch (final Exception e)
+			{
+				logger.debug("Ignoring failure while closing the connection", e);
 			}
 		}
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
@@ -746,6 +746,31 @@ public class C_Order_StepDef
 				.forEach(this::validateOrder);
 	}
 
+	/**
+	 * Updates fields of a {@code C_Order} previously registered under an identifier.
+	 *
+	 * <p>Required column:
+	 * <ul>
+	 *   <li>{@code C_Order_ID} – identifier of the order to update</li>
+	 * </ul>
+	 * Optional field columns (each applied only when present):
+	 * <ul>
+	 *   <li>{@code DocBaseType} + {@code DocSubType} – both together select a new C_DocType / C_DocTypeTarget</li>
+	 *   <li>{@code PaymentRule}</li>
+	 *   <li>{@code PreparationDate}</li>
+	 *   <li>{@code LC_Date}</li>
+	 *   <li>{@code POReference} – the customer's purchase-order reference; a {@code @Date@} placeholder
+	 *       in the value is resolved to the current timestamp, so a scenario can keep it unique across
+	 *       repeated local runs</li>
+	 * </ul>
+	 *
+	 * <p>Example:
+	 * <pre>
+	 * When update order
+	 *   | C_Order_ID | POReference    |
+	 *   | o_1        | PO_1234_@Date@ |
+	 * </pre>
+	 */
 	@And("update order")
 	public void update_order(@NonNull final DataTable dataTable)
 	{
@@ -781,6 +806,9 @@ public class C_Order_StepDef
 				.ifPresent(expected -> order.setPreparationDate(Timestamp.from(expected)));
 		tableRow.getAsOptionalInstant(I_C_Order.COLUMNNAME_LC_Date)
 				.ifPresent(expected -> order.setLC_Date(Timestamp.from(expected)));
+		// getAsOptionalName (not ...String) so that a @Date@ placeholder in the value is resolved
+		tableRow.getAsOptionalName(COLUMNNAME_POReference)
+				.ifPresent(order::setPOReference);
 		saveRecord(order);
 
 		orderTable.putOrReplace(tableRow.getAsIdentifier(), order);

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipment/M_InOut_StepDef.java
@@ -287,7 +287,10 @@ public class M_InOut_StepDef
 	 * <b>QuantityType</b> — (required) "D" (delivery), "O" (ordered), etc.<br>
 	 * <b>IsCompleteShipments</b> — (required) true/false — auto-complete the generated shipment<br>
 	 * <b>IsShipmentDateToday</b> — (required) true/false — use today as shipment date<br>
-	 * <b>QtyToDeliver_Override</b> — (optional) override quantity to deliver<br>
+	 * <b>QtyToDeliver_Override_For_M_ShipmentSchedule_ID</b> — (optional) override quantity to deliver.
+	 * The column name really is that long: it is the workpackage parameter
+	 * {@link ShipmentScheduleWorkPackageParameters#PARAM_QtyToDeliver_Override}, and a cell headed with the
+	 * short name {@code QtyToDeliver_Override} is silently ignored — the full quantity ships instead.<br>
 	 * @cucumber.depends StepDefData: M_ShipmentSchedule_StepDefData
 	 * @cucumber.example <pre>
 	 * And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
@@ -344,7 +347,10 @@ public class M_InOut_StepDef
 	 *
 	 * @cucumber.stepdef
 	 * @cucumber.columns <b>M_ShipmentSchedule_ID</b> — (required, identifier-ref) shipment schedule alias<br>
-	 * <b>QtyToDeliver_Override</b> — (optional) override quantity to deliver<br>
+	 * <b>QtyToDeliver_Override_For_M_ShipmentSchedule_ID</b> — (optional) override quantity to deliver.
+	 * The column name really is that long: it is the workpackage parameter
+	 * {@link ShipmentScheduleWorkPackageParameters#PARAM_QtyToDeliver_Override}, and a cell headed with the
+	 * short name {@code QtyToDeliver_Override} is silently ignored — the full quantity ships instead.<br>
 	 * @cucumber.depends StepDefData: M_ShipmentSchedule_StepDefData
 	 * @cucumber.example <pre>
 	 * And 'generate shipments' process is invoked with QuantityType=D, IsCompleteShipments=true and IsShipToday=false

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -73,18 +73,26 @@ import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateRepositor
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule_ExportAudit;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule_Recompute;
+import de.metas.inoutcandidate.process.M_ShipmentSchedule_CloseShipmentSchedules;
 import de.metas.logging.LogManager;
 import de.metas.material.event.commons.AttributesKey;
 import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
+import de.metas.process.IADProcessDAO;
+import de.metas.process.ProcessCalledFrom;
+import de.metas.process.ProcessExecutionResult;
+import de.metas.process.ProcessInfo;
 import de.metas.rest_api.v2.attributes.JsonAttributeService;
+import de.metas.security.RoleId;
 import de.metas.shipper.gateway.commons.process.CarrierAdviseProcessService;
 import de.metas.shipping.ShipperId;
+import de.metas.user.UserId;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -112,6 +120,7 @@ import org.compiere.model.I_M_AttributeSetInstance;
 import org.compiere.model.I_M_InOut;
 import org.compiere.model.I_M_Product;
 import org.compiere.model.I_M_Shipper;
+import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.Trx;
 import org.slf4j.Logger;
@@ -122,6 +131,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -142,6 +152,16 @@ public class M_ShipmentSchedule_StepDef
 	private static final String SHIP_BPARTNER = "shipBPartner";
 	private static final String BILL_BPARTNER = "billBPartner";
 
+	/**
+	 * Name of the {@code AD_Role} the selection process is run under. It is STANDING masterdata: the
+	 * {@code metasfresh} user has this role in the DB the suite runs against, independently of which steps ran
+	 * before — nothing has to create it, and this step-def is not coupled to the API-token step that happens to
+	 * name the same pair. Chosen because that role is defined on the cucumber client with
+	 * {@code IsAccessAllOrgs='Y'} (verified on the local stack), so a process running under it may write the
+	 * records the other steps of a scenario created.
+	 */
+	private static final String PROCESS_ROLE_NAME = "WebUI";
+
 	@NonNull private final JsonAttributeService jsonAttributeService = SpringContextHolder.instance.getBean(JsonAttributeService.class);
 	@NonNull private final ShipmentService shipmentService = SpringContextHolder.instance.getBean(ShipmentService.class);
 	@NonNull private final IShipmentScheduleInvalidateRepository shipmentScheduleInvalidateRepository = Services.get(IShipmentScheduleInvalidateRepository.class);
@@ -151,6 +171,7 @@ public class M_ShipmentSchedule_StepDef
 	@NonNull private final IInputDataSourceDAO inputDataSourceDAO = Services.get(IInputDataSourceDAO.class);
 	@NonNull private final IShipmentScheduleBL shipmentScheduleBL = Services.get(IShipmentScheduleBL.class);
 	@NonNull private final CarrierAdviseProcessService carrierAdviseProcessService = SpringContextHolder.instance.getBean(CarrierAdviseProcessService.class);
+	@NonNull private final IADProcessDAO adProcessDAO = Services.get(IADProcessDAO.class);
 
 	@NonNull private final AD_User_StepDefData userTable;
 	@NonNull private final C_BPartner_StepDefData bpartnerTable;
@@ -575,6 +596,90 @@ public class M_ShipmentSchedule_StepDef
 						.appendParametersToMessage()
 						.setParameter("action:", action);
 		}
+	}
+
+	/**
+	 * Closes ALL the given {@code M_ShipmentSchedule}s in ONE run of the real
+	 * {@code M_ShipmentSchedule_CloseShipmentSchedules} AD_Process — the way an operator closes a multi-row
+	 * selection from the shipment-disposition view. Use this instead of repeating
+	 * {@code the M_ShipmentSchedule identified by … is closed} whenever a scenario has to prove something
+	 * about a single close <i>operation</i> that spans several schedules (e.g. that a once-per-schedule model
+	 * interceptor does not produce repeated writes).
+	 * <p>
+	 * The selection is handed over exactly the way the WebUI hands it over: as the {@code ProcessInfo}
+	 * where-clause {@code M_ShipmentSchedule.M_ShipmentSchedule_ID IN (…)} that
+	 * {@code SqlViewSelectionQueryBuilder.buildSqlWhereClause(…)} builds for the selected rows; the process turns
+	 * it back into a query via {@code ProcessInfo.getQueryFilterOrElseFalse()}. Because that method additionally
+	 * restricts to the client(s)/org(s) the acting role may write, the process is run under the
+	 * {@link #PROCESS_ROLE_NAME} role of the {@code metasfresh} user rather than under the ambient (role-less)
+	 * context.
+	 * <p>
+	 * Any process error fails the step — including the process' own {@code @NoSelection@} guard, which fires when
+	 * the where-clause matched no open, unpicked schedule. So a silently empty selection cannot pass unnoticed.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_ShipmentSchedule_ID</b> — (required, identifier-ref) one row per {@code M_ShipmentSchedule} to close;
+	 *   ALL rows are closed by a single process run<br>
+	 * @cucumber.depends StepDefData: M_ShipmentSchedule_StepDefData
+	 * @cucumber.example
+	 * <pre>{@code
+	 * When the M_ShipmentSchedule_CloseShipmentSchedules process is run for selection:
+	 *   | M_ShipmentSchedule_ID |
+	 *   | s_s_60_1              |
+	 *   | s_s_60_2              |
+	 *   | s_s_60_3              |
+	 * }</pre>
+	 */
+	@When("the M_ShipmentSchedule_CloseShipmentSchedules process is run for selection:")
+	public void M_ShipmentSchedule_CloseShipmentSchedules_forSelection(@NonNull final DataTable dataTable)
+	{
+		final ImmutableSet<Integer> shipmentScheduleRepoIds = DataTableRows.of(dataTable)
+				.stream()
+				.map(row -> row.getAsIdentifier(COLUMNNAME_M_ShipmentSchedule_ID))
+				.map(shipmentScheduleTable::getId)
+				.map(ShipmentScheduleId::getRepoId)
+				.collect(ImmutableSet.toImmutableSet());
+
+		final String selectionWhereClause = DB.buildSqlList(
+				I_M_ShipmentSchedule.Table_Name + "." + COLUMNNAME_M_ShipmentSchedule_ID,
+				shipmentScheduleRepoIds);
+
+		final ProcessExecutionResult result = ProcessInfo.builder()
+				.setCtx(createProcessCtx())
+				.setProcessCalledFrom(ProcessCalledFrom.WebUI)
+				.setAD_Process_ID(adProcessDAO.retrieveProcessIdByClass(M_ShipmentSchedule_CloseShipmentSchedules.class))
+				.setWhereClause(selectionWhereClause)
+				.buildAndPrepareExecution()
+				.executeSync()
+				.getResult();
+
+		result.propagateErrorIfAny();
+
+		logger.info("Ran M_ShipmentSchedule_CloseShipmentSchedules with AD_PInstance_ID={} for selection {}: {}",
+				result.getPinstanceId(), selectionWhereClause, result.getSummary());
+	}
+
+	/**
+	 * @return a context that carries the {@link #PROCESS_ROLE_NAME} role of the {@code metasfresh} user,
+	 * so that a process reading {@code ProcessInfo.getQueryFilterOrElseFalse()} sees a role which may write the
+	 * cucumber client's records.
+	 */
+	private Properties createProcessCtx()
+	{
+		final UserId userId = StepDefUtil.getUserIdByLogin(StepDefConstants.METASFRESH_VALUE);
+		final RoleId roleId = StepDefUtil.getRoleIdByName(userId, StepDefConstants.METASFRESH_VALUE, PROCESS_ROLE_NAME);
+
+		// copyCtx (not deriveCtx): the process ctx has to carry the values itself.
+		// The ambient cucumber ctx reaches the process only as Properties-defaults otherwise, and
+		// ContextClientQueryFilter then fails with "No #AD_Client_ID found in context".
+		final Properties processCtx = Env.copyCtx(Env.getCtx());
+		Env.setClientId(processCtx, StepDefConstants.CLIENT_ID);
+		Env.setOrgId(processCtx, StepDefConstants.ORG_ID);
+		Env.setLoggedUserId(processCtx, userId);
+		Env.setContext(processCtx, Env.CTXNAME_AD_Role_ID, roleId.getRepoId());
+
+		return processCtx;
 	}
 
 	private void validateNoShipmentScheduleCreatedForOrder(@NonNull final OrderId orderId)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -79,7 +79,6 @@ import de.metas.inoutcandidate.model.I_M_Picking_Job_Schedule;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule_ExportAudit;
 import de.metas.inoutcandidate.model.I_M_ShipmentSchedule_Recompute;
-import de.metas.inoutcandidate.process.M_ShipmentSchedule_CloseShipmentSchedules;
 import de.metas.logging.LogManager;
 import de.metas.material.event.commons.AttributesKey;
 import de.metas.order.OrderId;
@@ -88,13 +87,8 @@ import de.metas.picking.api.PickingJobScheduleId;
 import de.metas.picking.api.ShipmentScheduleAndJobScheduleId;
 import de.metas.picking.api.ShipmentScheduleAndJobScheduleIdSet;
 import de.metas.process.IADPInstanceDAO;
-import de.metas.process.IADProcessDAO;
 import de.metas.process.PInstanceId;
-import de.metas.process.ProcessCalledFrom;
-import de.metas.process.ProcessExecutionResult;
-import de.metas.process.ProcessInfo;
 import de.metas.rest_api.v2.attributes.JsonAttributeService;
-import de.metas.security.RoleId;
 import de.metas.shipper.gateway.commons.process.CarrierAdviseProcessService;
 import de.metas.shipping.ShipperId;
 import de.metas.util.Check;
@@ -153,7 +147,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -195,16 +188,6 @@ public class M_ShipmentSchedule_StepDef
 	/** Poll interval of the queue drain — the planner's own poll interval; polling faster only adds queries. */
 	private static final long RECOMPUTE_QUEUE_DRAIN_POLL_MS = 500;
 
-	/**
-	 * Name of the {@code AD_Role} the selection process is run under. It is STANDING masterdata: the
-	 * {@code metasfresh} user has this role in the DB the suite runs against, independently of which steps ran
-	 * before — nothing has to create it, and this step-def is not coupled to the API-token step that happens to
-	 * name the same pair. Chosen because that role is defined on the cucumber client with
-	 * {@code IsAccessAllOrgs='Y'} (verified on the local stack), so a process running under it may write the
-	 * records the other steps of a scenario created.
-	 */
-	private static final String PROCESS_ROLE_NAME = "WebUI";
-
 	@NonNull private final JsonAttributeService jsonAttributeService = SpringContextHolder.instance.getBean(JsonAttributeService.class);
 	@NonNull private final ShipmentService shipmentService = SpringContextHolder.instance.getBean(ShipmentService.class);
 	@NonNull private final IShipmentScheduleInvalidateRepository shipmentScheduleInvalidateRepository = Services.get(IShipmentScheduleInvalidateRepository.class);
@@ -216,7 +199,6 @@ public class M_ShipmentSchedule_StepDef
 	@NonNull private final IOrgDAO orgDAO = Services.get(IOrgDAO.class);
 	@NonNull private final IADPInstanceDAO adPInstanceDAO = Services.get(IADPInstanceDAO.class);
 	@NonNull private final CarrierAdviseProcessService carrierAdviseProcessService = SpringContextHolder.instance.getBean(CarrierAdviseProcessService.class);
-	@NonNull private final IADProcessDAO adProcessDAO = Services.get(IADProcessDAO.class);
 
 	/** Recompute selection ids created by {@link #tagInvalidShipmentSchedulesForRecompute}, keyed by the scenario's selection identifier. */
 	private final Map<String, PInstanceId> recomputeSelectionsByIdentifier = new HashMap<>();
@@ -1153,90 +1135,6 @@ public class M_ShipmentSchedule_StepDef
 		final I_M_ShipmentSchedule schedule = shipmentScheduleTable.get(shipmentScheduleIdentifier);
 		schedule.setIsActive(false);
 		saveRecord(schedule);
-	}
-
-	/**
-	 * Closes ALL the given {@code M_ShipmentSchedule}s in ONE run of the real
-	 * {@code M_ShipmentSchedule_CloseShipmentSchedules} AD_Process — the way an operator closes a multi-row
-	 * selection from the shipment-disposition view. Use this instead of repeating
-	 * {@code the M_ShipmentSchedule identified by … is closed} whenever a scenario has to prove something
-	 * about a single close <i>operation</i> that spans several schedules (e.g. that a once-per-schedule model
-	 * interceptor does not produce repeated writes).
-	 * <p>
-	 * The selection is handed over exactly the way the WebUI hands it over: as the {@code ProcessInfo}
-	 * where-clause {@code M_ShipmentSchedule.M_ShipmentSchedule_ID IN (…)} that
-	 * {@code SqlViewSelectionQueryBuilder.buildSqlWhereClause(…)} builds for the selected rows; the process turns
-	 * it back into a query via {@code ProcessInfo.getQueryFilterOrElseFalse()}. Because that method additionally
-	 * restricts to the client(s)/org(s) the acting role may write, the process is run under the
-	 * {@link #PROCESS_ROLE_NAME} role of the {@code metasfresh} user rather than under the ambient (role-less)
-	 * context.
-	 * <p>
-	 * Any process error fails the step — including the process' own {@code @NoSelection@} guard, which fires when
-	 * the where-clause matched no open, unpicked schedule. So a silently empty selection cannot pass unnoticed.
-	 *
-	 * @cucumber.stepdef
-	 * @cucumber.columns
-	 *   <b>M_ShipmentSchedule_ID</b> — (required, identifier-ref) one row per {@code M_ShipmentSchedule} to close;
-	 *   ALL rows are closed by a single process run<br>
-	 * @cucumber.depends StepDefData: M_ShipmentSchedule_StepDefData
-	 * @cucumber.example
-	 * <pre>{@code
-	 * When the M_ShipmentSchedule_CloseShipmentSchedules process is run for selection:
-	 *   | M_ShipmentSchedule_ID |
-	 *   | s_s_60_1              |
-	 *   | s_s_60_2              |
-	 *   | s_s_60_3              |
-	 * }</pre>
-	 */
-	@When("the M_ShipmentSchedule_CloseShipmentSchedules process is run for selection:")
-	public void M_ShipmentSchedule_CloseShipmentSchedules_forSelection(@NonNull final DataTable dataTable)
-	{
-		final ImmutableSet<Integer> shipmentScheduleRepoIds = DataTableRows.of(dataTable)
-				.stream()
-				.map(row -> row.getAsIdentifier(COLUMNNAME_M_ShipmentSchedule_ID))
-				.map(shipmentScheduleTable::getId)
-				.map(ShipmentScheduleId::getRepoId)
-				.collect(ImmutableSet.toImmutableSet());
-
-		final String selectionWhereClause = DB.buildSqlList(
-				I_M_ShipmentSchedule.Table_Name + "." + COLUMNNAME_M_ShipmentSchedule_ID,
-				shipmentScheduleRepoIds);
-
-		final ProcessExecutionResult result = ProcessInfo.builder()
-				.setCtx(createProcessCtx())
-				.setProcessCalledFrom(ProcessCalledFrom.WebUI)
-				.setAD_Process_ID(adProcessDAO.retrieveProcessIdByClass(M_ShipmentSchedule_CloseShipmentSchedules.class))
-				.setWhereClause(selectionWhereClause)
-				.buildAndPrepareExecution()
-				.executeSync()
-				.getResult();
-
-		result.propagateErrorIfAny();
-
-		logger.info("Ran M_ShipmentSchedule_CloseShipmentSchedules with AD_PInstance_ID={} for selection {}: {}",
-				result.getPinstanceId(), selectionWhereClause, result.getSummary());
-	}
-
-	/**
-	 * @return a context that carries the {@link #PROCESS_ROLE_NAME} role of the {@code metasfresh} user,
-	 * so that a process reading {@code ProcessInfo.getQueryFilterOrElseFalse()} sees a role which may write the
-	 * cucumber client's records.
-	 */
-	private Properties createProcessCtx()
-	{
-		final UserId userId = StepDefUtil.getUserIdByLogin(StepDefConstants.METASFRESH_VALUE);
-		final RoleId roleId = StepDefUtil.getRoleIdByName(userId, StepDefConstants.METASFRESH_VALUE, PROCESS_ROLE_NAME);
-
-		// copyCtx (not deriveCtx): the process ctx has to carry the values itself.
-		// The ambient cucumber ctx reaches the process only as Properties-defaults otherwise, and
-		// ContextClientQueryFilter then fails with "No #AD_Client_ID found in context".
-		final Properties processCtx = Env.copyCtx(Env.getCtx());
-		Env.setClientId(processCtx, StepDefConstants.CLIENT_ID);
-		Env.setOrgId(processCtx, StepDefConstants.ORG_ID);
-		Env.setLoggedUserId(processCtx, userId);
-		Env.setContext(processCtx, Env.CTXNAME_AD_Role_ID, roleId.getRepoId());
-
-		return processCtx;
 	}
 
 	private void validateNoShipmentScheduleCreatedForOrder(@NonNull final OrderId orderId)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -97,7 +97,6 @@ import de.metas.rest_api.v2.attributes.JsonAttributeService;
 import de.metas.security.RoleId;
 import de.metas.shipper.gateway.commons.process.CarrierAdviseProcessService;
 import de.metas.shipping.ShipperId;
-import de.metas.user.UserId;
 import de.metas.util.Check;
 import de.metas.organization.IOrgDAO;
 import de.metas.organization.OrgId;

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/externalSystemBased/ediDesadvExportViaExternalSystem.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/externalSystemBased/ediDesadvExportViaExternalSystem.feature
@@ -371,3 +371,631 @@ Feature: EDI DESADV export via External System
     And after not more than 5s, EDI_Desadv records have the following export status
       | EDI_Desadv_ID.Identifier | EDI_ExportStatus |
       | d_repl_150               | P                |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00350_EDI
+  @Id:S30013_10
+  Scenario: S30013_10 — under-delivery, remaining M_ShipmentSchedule closed -> DESADV reaches Sent
+  ## An order for 100 PCE is only delivered 70 PCE; that one shipment is exported successfully.
+  ## Intermediate state: the DESADV is under-delivered (FulfillmentPercent=70) and therefore
+  ## still Pending — nothing may close it while more M_InOutLines could still arrive.
+  ## Closing the remaining M_ShipmentSchedule is the statement "no more will ever be delivered",
+  ## so the DESADV must reach its terminal status S / Processed on its own, without running the
+  ## EDI_Desadv_Close process.  FulfillmentPercent must stay 70 — it is an EXP_FormatLine, i.e.
+  ## transmitted content, and auto-closing may not change what the recipient receives.
+    And RabbitMQ MF_TO_ExternalSystem queue is purged
+
+    # @Date@ suffix keeps the POReference unique across local repeat runs: the DESADV is resolved
+    # by POReference + C_BPartner_ID, so a fixed value would re-use a previous run's DESADV.
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | POReference           |
+      | o_10       | true    | customer1     | 2025-04-17  | 2025-04-18Z  | PO_S30013_10_@Date@   |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID | QtyEntered |
+      | ol_10_1    | o_10                  | product      | 100        |
+
+    And the order identified by o_10 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_10     | ol_10_1                   | N             |
+
+    # Deliver only 70 of the 100 ordered, so a remainder stays open.
+    # QtyToDeliver_Override_For_M_ShipmentSchedule_ID is the workpackage-parameter name that
+    # ShipmentScheduleWorkPackageParameters.PARAM_QtyToDeliver_Override resolves to; the short
+    # alias "QtyToDeliver_Override" does NOT match and the full 100 would be shipped.
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
+      | s_s_10                           | D            | true                | false       | 70                                              |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | s_s_10                           | s_10                  |
+
+    And EDI_Desadv is found:
+      | EDI_Desadv_ID.Identifier | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_ExportStatus |
+      | d_10                     | customer1                | o_10                  | P                |
+
+    And M_InOut is enqueued for EDI export
+      | M_InOut_ID |
+      | s_10       |
+
+    Then after not more than 120s, M_InOut records have the following export status
+      | M_InOut_ID.Identifier | EDI_ExportStatus |
+      | s_10                  | S                |
+
+    # Intermediate state: everything that was shipped is exported, but the DESADV is under-delivered
+    And after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.Processed | OPT.FulfillmentPercent |
+      | d_10          | P                | false         | 70                     |
+
+    When the M_ShipmentSchedule identified by s_s_10 is closed
+
+    # ─── CORE ASSERTION ────────────────────────────────────────────────────────
+    # OPT.EDIErrorMsg=null: the auto-close is a clean terminal state, not an error state.
+    Then after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.EDIErrorMsg | OPT.Processed | OPT.FulfillmentPercent |
+      | d_10          | S                | null            | true          | 70                     |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00350_EDI
+  @Id:S30013_20
+  Scenario: S30013_20 — under-delivery, M_ShipmentSchedule left open -> DESADV stays Pending
+  ## The unchanged case, and the signal disposition relies on: as long as the remaining
+  ## M_ShipmentSchedule is open, more M_InOutLines can still arrive, so the under-delivered
+  ## DESADV must stay P / not Processed even though every shipment it has is exported.
+    And RabbitMQ MF_TO_ExternalSystem queue is purged
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | POReference           |
+      | o_20       | true    | customer1     | 2025-04-17  | 2025-04-18Z  | PO_S30013_20_@Date@   |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID | QtyEntered |
+      | ol_20_1    | o_20                  | product      | 100        |
+
+    And the order identified by o_20 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_20     | ol_20_1                   | N             |
+
+    # Deliver only 70 of the 100 ordered, so a remainder stays open (see S30013_10 on the column name).
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
+      | s_s_20                           | D            | true                | false       | 70                                              |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | s_s_20                           | s_20                  |
+
+    And EDI_Desadv is found:
+      | EDI_Desadv_ID.Identifier | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_ExportStatus |
+      | d_20                     | customer1                | o_20                  | P                |
+
+    And M_InOut is enqueued for EDI export
+      | M_InOut_ID |
+      | s_20       |
+
+    Then after not more than 120s, M_InOut records have the following export status
+      | M_InOut_ID.Identifier | EDI_ExportStatus |
+      | s_20                  | S                |
+
+    # ─── CORE ASSERTION ────────────────────────────────────────────────────────
+    # The schedule is deliberately NOT closed — this is the signal disposition relies on.
+    Then after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.Processed | OPT.FulfillmentPercent |
+      | d_20          | P                | false         | 70                     |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00350_EDI
+  @Id:S30013_30
+  Scenario: S30013_30 — M_ShipmentSchedule closed after the DESADV was already exported -> DESADV reaches Sent
+  ## The production ordering: the export finished first, the close came later.
+  ## An order for 2 x 100 PCE is delivered and exported for the first line only, so the DESADV is
+  ## under-delivered (FulfillmentPercent=50) and stays Pending even though its only shipment is
+  ## already Sent.  Closing the second line's M_ShipmentSchedule afterwards is the statement "the
+  ## other 100 will never be delivered", so the already-exported DESADV must reach S on its own.
+  ## FulfillmentPercent must stay 50 — it is an EXP_FormatLine, i.e. transmitted content.
+    And RabbitMQ MF_TO_ExternalSystem queue is purged
+
+    # @Date@ suffix keeps the POReference unique across local repeat runs (see S30013_10).
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | POReference         |
+      | o_30       | true    | customer1     | 2025-04-17  | 2025-04-18Z  | PO_S30013_30_@Date@ |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID | QtyEntered |
+      | ol_30_1    | o_30                  | product      | 100        |
+      | ol_30_2    | o_30                  | product      | 100        |
+
+    And the order identified by o_30 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_30_1   | ol_30_1                   | N             |
+      | s_s_30_2   | ol_30_2                   | N             |
+
+    # Only the first line is shipped; the second line's schedule stays open with nothing delivered.
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_30_1                         | D            | true                | false       |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | s_s_30_1                         | s_30                  |
+
+    And EDI_Desadv is found:
+      | EDI_Desadv_ID.Identifier | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_ExportStatus |
+      | d_30                     | customer1                | o_30                  | P                |
+
+    And M_InOut is enqueued for EDI export
+      | M_InOut_ID |
+      | s_30       |
+
+    Then after not more than 120s, M_InOut records have the following export status
+      | M_InOut_ID.Identifier | EDI_ExportStatus |
+      | s_30                  | S                |
+
+    # The export is finished — and the DESADV is still Pending because line ol_30_2 is undelivered.
+    And after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.EDIErrorMsg | OPT.Processed | OPT.FulfillmentPercent |
+      | d_30          | P                | null            | false         | 50                     |
+
+    When the M_ShipmentSchedule identified by s_s_30_2 is closed
+
+    # ─── CORE ASSERTION ────────────────────────────────────────────────────────
+    # The close arrives after the export already completed, and still closes the DESADV.
+    Then after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.EDIErrorMsg | OPT.Processed | OPT.FulfillmentPercent |
+      | d_30          | S                | null            | true          | 50                     |
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00350_EDI
+  @Id:S30013_40
+  Scenario: S30013_40 — nothing was sent and everything is closed -> DESADV reaches DontSend
+  ## The branch that must yield DontSend rather than Sent, matching what the EDI_Desadv_Close process
+  ## writes.  An order for 100 PCE is delivered 70 PCE, but that shipment is not transmitted at all —
+  ## it carries DontSend, the status a shipment gets when its ship-to location is no EDI DESADV
+  ## recipient.  Closing the remaining M_ShipmentSchedule then says "the other 30 will never be
+  ## delivered", so the DESADV reaches its terminal status too — and since not one of its shipments
+  ## was ever sent, that terminal status is DontSend, not Sent.
+    And RabbitMQ MF_TO_ExternalSystem queue is purged
+
+    # @Date@ suffix keeps the POReference unique across local repeat runs (see S30013_10).
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | POReference         |
+      | o_40       | true    | customer1     | 2025-04-17  | 2025-04-18Z  | PO_S30013_40_@Date@ |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID | QtyEntered |
+      | ol_40_1    | o_40                  | product      | 100        |
+
+    And the order identified by o_40 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_40     | ol_40_1                   | N             |
+
+    # Deliver only 70 of the 100 ordered, so a remainder stays open (see S30013_10 on the column name).
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
+      | s_s_40                           | D            | true                | false       | 70                                              |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | s_s_40                           | s_40                  |
+
+    And EDI_Desadv is found:
+      | EDI_Desadv_ID.Identifier | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_ExportStatus |
+      | d_40                     | customer1                | o_40                  | P                |
+
+    # The shipment is never enqueued for export; it is marked as one that shall not be sent at all.
+    And the EDI export status of the following M_InOut records is set:
+      | M_InOut_ID | EDI_ExportStatus |
+      | s_40       | N                |
+
+    When the M_ShipmentSchedule identified by s_s_40 is closed
+
+    # ─── CORE ASSERTION ────────────────────────────────────────────────────────
+    # No shipment of this DESADV was ever sent, so the terminal status is DontSend (N), not Sent.
+    Then after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.EDIErrorMsg | OPT.Processed | OPT.FulfillmentPercent |
+      | d_40          | N                | null            | true          | 70                     |
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00350_EDI
+  @Id:S30013_50
+  Scenario: S30013_50 — the automatic close of the DESADV transmits nothing
+  ## Closing itself sends nothing.  An order for 100 PCE is delivered 70 PCE and that shipment is
+  ## exported, which puts one JsonExternalSystemRequest on the queue — the positive control that
+  ## proves this scenario can see a transmission.  That message is consumed, the queue is emptied,
+  ## and only then is the remaining M_ShipmentSchedule closed.  The DESADV reaches its terminal
+  ## status S, and nothing new leaves the system: no further message on the queue, and the shipment
+  ## still sits at S rather than having been walked through Enqueued / SendingStarted again.
+    And RabbitMQ MF_TO_ExternalSystem queue is purged
+
+    # @Date@ suffix keeps the POReference unique across local repeat runs (see S30013_10).
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | POReference         |
+      | o_50       | true    | customer1     | 2025-04-17  | 2025-04-18Z  | PO_S30013_50_@Date@ |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID | QtyEntered |
+      | ol_50_1    | o_50                  | product      | 100        |
+
+    And the order identified by o_50 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_50     | ol_50_1                   | N             |
+
+    # Deliver only 70 of the 100 ordered, so a remainder stays open (see S30013_10 on the column name).
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
+      | s_s_50                           | D            | true                | false       | 70                                              |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | s_s_50                           | s_50                  |
+
+    And EDI_Desadv is found:
+      | EDI_Desadv_ID.Identifier | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_ExportStatus |
+      | d_50                     | customer1                | o_50                  | P                |
+
+    And M_InOut is enqueued for EDI export
+      | M_InOut_ID |
+      | s_50       |
+
+    Then after not more than 120s, M_InOut records have the following export status
+      | M_InOut_ID.Identifier | EDI_ExportStatus |
+      | s_50                  | S                |
+
+    # Positive control: the export DID put a message on the queue, and this step consumes it.
+    # Whatever the close does afterwards is therefore measured against a queue known to work.
+    Then RabbitMQ receives a JsonExternalSystemRequest with the following external system config and parameter:
+      | ExternalSystem_Config_ID.Identifier | ConfigIDOnly |
+      | externalSystemConfig_1              | true         |
+
+    And RabbitMQ MF_TO_ExternalSystem queue is purged
+
+    And after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.Processed | OPT.FulfillmentPercent |
+      | d_50          | P                | false         | 70                     |
+
+    When the M_ShipmentSchedule identified by s_s_50 is closed
+
+    Then after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.EDIErrorMsg | OPT.Processed | OPT.FulfillmentPercent |
+      | d_50          | S                | null            | true          | 70                     |
+
+    # ─── CORE ASSERTION ────────────────────────────────────────────────────────
+    # Nothing was transmitted by the close: no message on the queue, and the shipment was not
+    # re-exported (a re-export would have moved it through Enqueued / SendingStarted).
+    Then RabbitMQ MF_TO_ExternalSystem receives no message within 30s
+    And after not more than 5s, M_InOut records have the following export status
+      | M_InOut_ID.Identifier | EDI_ExportStatus |
+      | s_50                  | S                |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00350_EDI
+  @Id:S30013_60
+  Scenario: S30013_60 — closing all M_ShipmentSchedules of a three-line order -> DESADV reaches Sent
+  ## The close fires the DESADV recompute once per closed M_ShipmentSchedule, so a three-line order
+  ## runs it three times.  An order for 3 x 100 PCE is delivered 70 PCE per line in one shipment,
+  ## which is exported; the DESADV is under-delivered at 70% and stays Pending.  Closing all three
+  ## remaining M_ShipmentSchedules must leave it at exactly one terminal state, S / Processed, with
+  ## the transmitted FulfillmentPercent untouched.
+    And RabbitMQ MF_TO_ExternalSystem queue is purged
+
+    # @Date@ suffix keeps the POReference unique across local repeat runs (see S30013_10).
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | POReference         |
+      | o_60       | true    | customer1     | 2025-04-17  | 2025-04-18Z  | PO_S30013_60_@Date@ |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID | QtyEntered |
+      | ol_60_1    | o_60                  | product      | 100        |
+      | ol_60_2    | o_60                  | product      | 100        |
+      | ol_60_3    | o_60                  | product      | 100        |
+
+    And the order identified by o_60 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_60_1   | ol_60_1                   | N             |
+      | s_s_60_2   | ol_60_2                   | N             |
+      | s_s_60_3   | ol_60_3                   | N             |
+
+    # All three schedules go into ONE workpackage, so one shipment covers the whole order;
+    # each line delivers 70 of its 100 (see S30013_10 on the override column name).
+    And 'generate shipments' process is invoked with QuantityType=D, IsCompleteShipments=true and IsShipToday=false
+      | M_ShipmentSchedule_ID | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
+      | s_s_60_1              | 70                                              |
+      | s_s_60_2              | 70                                              |
+      | s_s_60_3              | 70                                              |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | s_s_60_1                         | s_60                  |
+
+    And EDI_Desadv is found:
+      | EDI_Desadv_ID.Identifier | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_ExportStatus |
+      | d_60                     | customer1                | o_60                  | P                |
+
+    And M_InOut is enqueued for EDI export
+      | M_InOut_ID |
+      | s_60       |
+
+    Then after not more than 120s, M_InOut records have the following export status
+      | M_InOut_ID.Identifier | EDI_ExportStatus |
+      | s_60                  | S                |
+
+    # 210 of 300 ordered delivered => 70%: every one of the three lines is short.
+    And after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.Processed | OPT.FulfillmentPercent |
+      | d_60          | P                | false         | 70                     |
+
+    # TC8 requires ONE operation: the real M_ShipmentSchedule_CloseShipmentSchedules AD_Process is run once
+    # over a three-row selection, so the interceptor fires once per line inside a single close operation.
+    When the M_ShipmentSchedule_CloseShipmentSchedules process is run for selection:
+      | M_ShipmentSchedule_ID |
+      | s_s_60_1              |
+      | s_s_60_2              |
+      | s_s_60_3              |
+
+    # ─── CORE ASSERTION ────────────────────────────────────────────────────────
+    # The DESADV is closed only once the LAST line can no longer receive anything.
+    Then after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.EDIErrorMsg | OPT.Processed | OPT.FulfillmentPercent |
+      | d_60          | S                | null            | true          | 70                     |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00350_EDI
+  @Id:S30013_70
+  Scenario: S30013_70 — reopening the M_ShipmentSchedule returns the DESADV to Pending without re-sending
+  ## The close is reversible.  An order for 100 PCE is delivered 70 PCE, exported, and auto-closed to
+  ## S by closing the remaining M_ShipmentSchedule.  Reopening that schedule says "more may still be
+  ## delivered after all", so the DESADV must return to P / not Processed and accept further
+  ## M_InOutLines again — and reopening must not re-transmit anything: no message on the queue, and
+  ## the shipment stays at S instead of being walked through Enqueued / SendingStarted a second time.
+    And RabbitMQ MF_TO_ExternalSystem queue is purged
+
+    # @Date@ suffix keeps the POReference unique across local repeat runs (see S30013_10).
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | POReference         |
+      | o_70       | true    | customer1     | 2025-04-17  | 2025-04-18Z  | PO_S30013_70_@Date@ |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID | QtyEntered |
+      | ol_70_1    | o_70                  | product      | 100        |
+
+    And the order identified by o_70 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_70     | ol_70_1                   | N             |
+
+    # Deliver only 70 of the 100 ordered, so a remainder stays open (see S30013_10 on the column name).
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
+      | s_s_70                           | D            | true                | false       | 70                                              |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | s_s_70                           | s_70                  |
+
+    And EDI_Desadv is found:
+      | EDI_Desadv_ID.Identifier | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_ExportStatus |
+      | d_70                     | customer1                | o_70                  | P                |
+
+    And M_InOut is enqueued for EDI export
+      | M_InOut_ID |
+      | s_70       |
+
+    Then after not more than 120s, M_InOut records have the following export status
+      | M_InOut_ID.Identifier | EDI_ExportStatus |
+      | s_70                  | S                |
+
+    # Positive control: the export DID put a message on the queue, and this step consumes it, so the
+    # "no message" assertion after the reopen is measured against a queue known to deliver.
+    Then RabbitMQ receives a JsonExternalSystemRequest with the following external system config and parameter:
+      | ExternalSystem_Config_ID.Identifier | ConfigIDOnly |
+      | externalSystemConfig_1              | true         |
+
+    When the M_ShipmentSchedule identified by s_s_70 is closed
+
+    Then after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.EDIErrorMsg | OPT.Processed | OPT.FulfillmentPercent |
+      | d_70          | S                | null            | true          | 70                     |
+
+    And RabbitMQ MF_TO_ExternalSystem queue is purged
+
+    When the M_ShipmentSchedule identified by s_s_70 is reactivated
+
+    # ─── CORE ASSERTION ────────────────────────────────────────────────────────
+    # Back to Pending because the reopened schedule can deliver again — and nothing was re-sent:
+    # no message on the queue, and the shipment was not re-exported.
+    Then after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.EDIErrorMsg | OPT.Processed | OPT.FulfillmentPercent |
+      | d_70          | P                | null            | false         | 70                     |
+
+    Then RabbitMQ MF_TO_ExternalSystem receives no message within 30s
+    And after not more than 5s, M_InOut records have the following export status
+      | M_InOut_ID.Identifier | EDI_ExportStatus |
+      | s_70                  | S                |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00350_EDI
+  @Id:S30013_80
+  Scenario: S30013_80 — POReference filled in after the order was completed -> the retro-created DESADV carries the delivered quantities
+  ## The second failure the customer reported.  The clerk completed the order before the customer's
+  ## purchase-order reference was known, so C_Order's before-complete interceptor skipped DESADV
+  ## creation (it returns early on a blank POReference) and no EDI_Desadv / EDI_DesadvLine existed.
+  ## The reference is then filled in on the already-completed order, and the DESADV is created later,
+  ## at shipment completion, by DesadvBL.addToDesadvCreateForInOutIfNotExist via its C_Order fallback.
+  ## That fallback creates the EDI_DesadvLines only at that moment, so the delivered quantities have to
+  ## be derived AFTER they exist — otherwise the recipient receives a DESADV announcing zero delivered.
+    And RabbitMQ MF_TO_ExternalSystem queue is purged
+
+    # POReference is deliberately absent here: that is what keeps the order out of the DESADV at
+    # completion time and sets up the whole scenario.
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised |
+      | o_80       | true    | customer1     | 2025-04-17  | 2025-04-18Z  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID | QtyEntered |
+      | ol_80_1    | o_80                  | product      | 3          |
+
+    And the order identified by o_80 is completed
+
+    # The premise: with a blank POReference the completion created neither a DESADV header nor any
+    # DESADV line, so nothing is wired up yet.
+    Then C_Order and its C_OrderLines are not linked to any EDI_Desadv:
+      | C_Order_ID |
+      | o_80       |
+
+    # The real-world action: the clerk fills the customer's purchase-order reference in on the
+    # already-completed order.
+    # @Date@ suffix keeps the POReference unique across local repeat runs (see S30013_10).
+    When update order
+      | C_Order_ID | POReference         |
+      | o_80       | PO_S30013_80_@Date@ |
+
+    # Updating the order re-invalidates its M_ShipmentSchedule, so wait for the recompute to land
+    # before generating from it.
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_80     | ol_80_1                   | N             |
+
+    # Deliver all 3 ordered, so the DESADV is fully delivered.
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday |
+      | s_s_80                           | D            | true                | false       |
+
+    # DocStatus=CO: the DESADV is created in the shipment's before-complete interceptor, so the wait
+    # has to land on the COMPLETED shipment before anything reads the DESADV.
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier | DocStatus |
+      | s_s_80                           | s_80                  | CO        |
+
+    # ─── CORE ASSERTION ────────────────────────────────────────────
+    # The DESADV was created from the order at shipment completion and must already carry the shipped
+    # quantities — header sums included — not the zeros a freshly created, un-walked line would have.
+    And EDI_Desadv is found:
+      | EDI_Desadv_ID.Identifier | C_BPartner_ID.Identifier | C_Order_ID.Identifier | OPT.SumDeliveredInStockingUOM | OPT.FulfillmentPercent |
+      | d_80                     | customer1                | o_80                  | 3                             | 100                    |
+
+    And EDI_DesadvLine records are found:
+      | EDI_DesadvLine_ID | EDI_Desadv_ID | M_Product_ID | OPT.QtyEntered | OPT.QtyDeliveredInUOM | OPT.QtyDeliveredInStockingUOM |
+      | d_l_80            | d_80          | product        | 3              | 3                     | 3                             |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00350_EDI
+  @Id:S30013_100
+  Scenario: S30013_100 — location-level 'E' routing outranks the partner's 'R' default -> the under-delivery still auto-closes
+  ## The routing shape a production instance actually runs.  Every other scenario in this file inherits
+  ## the Background's single partner-level C_BPartner_EDI_Setting with EdiDESADVSendingMode=E and no
+  ## location, so per-M_InOut export mode is reached trivially.  In production the
+  ## de.metas.edi.OneDesadvPerShipment sysconfig route is off and the mode comes from a
+  ## location-bound 'E' row that outranks the partner's own 'R' default on SeqNo — see
+  ## EDIBPartnerConfigRepository.resolve(): among the rows whose C_BPartner_Location_ID is null or
+  ## matches exactly, the minimum SeqNo wins, then the minimum ID.
+  ## This scenario builds that shape (partner-level 'R' at SeqNo 20, location-bound 'E' at SeqNo 10)
+  ## and then runs S30013_10's flow on top of it: deliver 70 of the 100 ordered, export that shipment,
+  ## close the remaining M_ShipmentSchedule, and the DESADV must auto-close to S on its own.
+  ## S30189_150 covers location-driven routing in isolation; this is the only scenario that composes it
+  ## with an under-delivery close, i.e. the combination the fix has to survive at the customer.
+    And RabbitMQ MF_TO_ExternalSystem queue is purged
+
+    # A partner of its own is required: the Background already owns the (customer1, no location) row,
+    # and this step upserts on (C_BPartner_ID, C_BPartner_Location_ID), so giving customer1 a
+    # partner-level 'R' default would overwrite that row and break every sibling scenario.
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | Value                | Name                | IsCustomer | IsVendor | M_PricingSystem_ID |
+      | customer2  | desadvReceiver2Value | desadvReceiver2Name | Y          | N        | pricingSystem      |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier          | C_BPartner_ID | IsShipTo | IsBillTo | IsShipToDefault | IsBillToDefault | GLN           |
+      | bpartner_location_2 | customer2     | Y        | Y        | Y               | Y               | 2234567890123 |
+
+    # The tie-break under test: for bpartner_location_2 the location-bound 'E' row (SeqNo 10) beats the
+    # partner's own ReplicationInterface default (SeqNo 20), so this order runs in per-M_InOut mode and
+    # is exported through externalSystemConfig_1.  The blank C_BPartner_Location_ID cell on the first
+    # row is what makes it the partner-level default (the column is optional in this step).
+    And metasfresh contains C_BPartner_EDI_Setting:
+      | Identifier                      | C_BPartner_ID | C_BPartner_Location_ID | IsEdiDesadvRecipient | EdiDesadvRecipientGLN | EdiDESADVSendingMode | EdiDESADV_ExternalSystem_Config_ID | SeqNo |
+      | edi_setting_desadv_repl_cust2   | customer2     |                        | true                 | 2234567890            | R                    |                                    | 20    |
+      | edi_setting_desadv_extSys_cust2 | customer2     | bpartner_location_2    | true                 | 2234567891            | E                    | externalSystemConfig_1             | 10    |
+
+    # @Date@ suffix keeps the POReference unique across local repeat runs (see S30013_10).
+    # DeliveryRule=F is mandatory here and NOT an arbitrary extra: MOrder.beforeSave copies the
+    # partner's DeliveryRule onto the order only while C_BPartner_Location_ID is still unset, and this
+    # order must name its location explicitly to hit the location-bound EDI setting.  Without it the
+    # order keeps the column default 'A' (Availability), there is no stock in the test DB, and
+    # 'generate shipments' aborts with "nothing left to deliver".  S30189_150 — the other scenario that
+    # names the location — passes F for the same reason.
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | C_BPartner_Location_ID | DeliveryRule | DateOrdered | DatePromised | POReference          |
+      | o_100      | true    | customer2     | bpartner_location_2    | F            | 2025-04-17  | 2025-04-18Z  | PO_S30013_100_@Date@ |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID | QtyEntered |
+      | ol_100_1   | o_100                 | product      | 100        |
+
+    And the order identified by o_100 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_100    | ol_100_1                  | N             |
+
+    # Deliver only 70 of the 100 ordered, so a remainder stays open (see S30013_10 on the column name).
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
+      | s_s_100                          | D            | true                | false       | 70                                              |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | s_s_100                          | s_100                 |
+
+    And EDI_Desadv is found:
+      | EDI_Desadv_ID.Identifier | C_BPartner_ID.Identifier | C_Order_ID.Identifier |
+      | d_100                    | customer2                | o_100                 |
+
+    And M_InOut is enqueued for EDI export
+      | M_InOut_ID |
+      | s_100      |
+
+    Then after not more than 120s, M_InOut records have the following export status
+      | M_InOut_ID.Identifier | EDI_ExportStatus |
+      | s_100                 | S                |
+
+    # ─── ROUTING ASSERTION ─────────────────────────────────────────────────────
+    # Only the external-system route puts a message on MF_TO_ExternalSystem.  Had the partner-level 'R'
+    # row won the SeqNo tie-break, the export would have taken the ReplicationInterface route and this
+    # step would time out — which is exactly the production precondition being asserted here.
+    Then RabbitMQ receives a JsonExternalSystemRequest with the following external system config and parameter:
+      | ExternalSystem_Config_ID.Identifier | ConfigIDOnly |
+      | externalSystemConfig_1              | true         |
+
+    # Intermediate state: everything that was shipped is exported, but the DESADV is under-delivered
+    And after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.Processed | OPT.FulfillmentPercent |
+      | d_100         | P                | false         | 70                     |
+
+    When the M_ShipmentSchedule identified by s_s_100 is closed
+
+    # ─── CORE ASSERTION ────────────────────────────────────────────────────────
+    # Same terminal state as S30013_10, reached under the production routing shape.
+    # OPT.EDIErrorMsg=null: the auto-close is a clean terminal state, not an error state.
+    Then after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.EDIErrorMsg | OPT.Processed | OPT.FulfillmentPercent |
+      | d_100         | S                | null            | true          | 70                     |

--- a/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/DesadvBL.java
+++ b/backend/de.metas.edi/src/main/java/de/metas/edi/api/impl/DesadvBL.java
@@ -61,10 +61,12 @@ import de.metas.uom.UOMConversionContext;
 import de.metas.uom.UomId;
 import de.metas.util.Check;
 import de.metas.util.Services;
+import de.metas.util.StringUtils;
 import de.metas.util.lang.Percent;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.adempiere.ad.trx.api.ITrx;
+import org.adempiere.ad.trx.api.ITrxManager;
 import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ClientId;
@@ -86,6 +88,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -120,6 +123,7 @@ public class DesadvBL
 	private final IShipmentSchedulePA shipmentSchedulePA = Services.get(IShipmentSchedulePA.class);
 	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
 	private final IHUPIItemProductBL hupiItemProductBL = Services.get(IHUPIItemProductBL.class);
+	@NonNull private final ITrxManager trxManager = Services.get(ITrxManager.class);
 
 	@NonNull private final transient EDIDesadvPackService ediDesadvPackService;
 	@NonNull private final EDIDesadvInOutLineDAO desadvInOutLineDAO;
@@ -374,29 +378,7 @@ public class DesadvBL
 		final Map<EDIDesadvId, EDIDesadvPackService.Sequences> sequencesByDesadv = new HashMap<>();
 
 		final List<I_M_InOutLine> inOutLines = inOutDAO.retrieveLines(inOut, I_M_InOutLine.class);
-		for (final I_M_InOutLine inOutLine : inOutLines)
-		{
-			if (inOutLine.getC_OrderLine_ID() <= 0)
-			{
-				continue; // the DESADV-Line needs to relate to an orderline to make sense
-			}
-
-			// Resolve the DESADV for this inOutLine via its order line → desadv line → desadv header.
-			// When the order line has no EDI_DesadvLine_ID set, this line cannot contribute to any
-			// source DESADV (addInOutLine would early-return anyway), so we skip it here.
-			final I_C_OrderLine orderLineRecord = InterfaceWrapperHelper.create(inOutLine.getC_OrderLine(), I_C_OrderLine.class);
-			final EDIDesadvLineId desadvLineId = EDIDesadvLineId.ofRepoIdOrNull(orderLineRecord.getEDI_DesadvLine_ID());
-			if (desadvLineId == null)
-			{
-				continue;
-			}
-			final I_EDI_DesadvLine desadvLineRecord = desadvDAO.retrieveLineById(desadvLineId);
-			final EDIDesadvId lineDesadvId = EDIDesadvId.ofRepoId(desadvLineRecord.getEDI_Desadv_ID());
-
-			final EDIDesadvPackService.Sequences lineSequences = sequencesByDesadv.computeIfAbsent(lineDesadvId, ediDesadvPackService::createSequences);
-
-			addInOutLine(inOutLine, recipientBPartnerId, lineSequences, desadvLineRecord);
-		}
+		addInOutLinesToDesadvLines(inOutLines, recipientBPartnerId, sequencesByDesadv);
 
 		// If the line walk found source DESADVs, the lowest EDI_Desadv_ID wins as the "primary"
 		// written to M_InOut.EDI_Desadv (legacy single-DESADV header link); the junction table
@@ -425,6 +407,11 @@ public class DesadvBL
 			{
 				primary = addToDesadvCreateForOrderIfNotExist(order);
 				InterfaceWrapperHelper.save(order);
+
+				// The fallback has just created the EDI_DesadvLines and wired C_OrderLine.EDI_DesadvLine_ID.
+				// The first walk skipped every line because those links did not exist yet, so the shipped
+				// quantities would stay at zero. Walk again now that the lines are there.
+				addInOutLinesToDesadvLines(inOutLines, recipientBPartnerId, sequencesByDesadv);
 			}
 		}
 		else if (Check.isNotBlank(inOut.getPOReference()))
@@ -459,6 +446,45 @@ public class DesadvBL
 			ediDesadvInOutRepository.assignDesadvToInOut(perLineDesadvId, inOutId);
 		}
 		return primary;
+	}
+
+	/**
+	 * Adds each of {@code inOutLines} to the {@code EDI_DesadvLine} its order line points to, and
+	 * records the DESADVs it touched in {@code sequencesByDesadv}.
+	 * <p>
+	 * Order lines are re-read by id rather than via {@code inOutLine.getC_OrderLine()} because this
+	 * runs a second time after {@link #addToDesadvCreateForOrderIfNotExist(I_C_Order)} has just
+	 * written {@code EDI_DesadvLine_ID} onto its own order-line instances.
+	 */
+	private void addInOutLinesToDesadvLines(
+			@NonNull final List<I_M_InOutLine> inOutLines,
+			@NonNull final BPartnerId recipientBPartnerId,
+			@NonNull final Map<EDIDesadvId, EDIDesadvPackService.Sequences> sequencesByDesadv)
+	{
+		for (final I_M_InOutLine inOutLine : inOutLines)
+		{
+			if (inOutLine.getC_OrderLine_ID() <= 0)
+			{
+				continue; // the DESADV-Line needs to relate to an orderline to make sense
+			}
+
+			// Resolve the DESADV for this inOutLine via its order line → desadv line → desadv header.
+			// When the order line has no EDI_DesadvLine_ID set, this line cannot contribute to any
+			// source DESADV (addInOutLine would early-return anyway), so we skip it here.
+			final I_C_OrderLine orderLineRecord = orderDAO.getOrderLineById(
+					OrderLineId.ofRepoId(inOutLine.getC_OrderLine_ID()), I_C_OrderLine.class);
+			final EDIDesadvLineId desadvLineId = EDIDesadvLineId.ofRepoIdOrNull(orderLineRecord.getEDI_DesadvLine_ID());
+			if (desadvLineId == null)
+			{
+				continue;
+			}
+			final I_EDI_DesadvLine desadvLineRecord = desadvDAO.retrieveLineById(desadvLineId);
+			final EDIDesadvId lineDesadvId = EDIDesadvId.ofRepoId(desadvLineRecord.getEDI_Desadv_ID());
+
+			final EDIDesadvPackService.Sequences lineSequences = sequencesByDesadv.computeIfAbsent(lineDesadvId, ediDesadvPackService::createSequences);
+
+			addInOutLine(inOutLine, recipientBPartnerId, lineSequences, desadvLineRecord);
+		}
 	}
 
 	private void addInOutLine(
@@ -798,6 +824,13 @@ public class DesadvBL
 		final BigDecimal qtyOrdered_Override = getQtyOrdered_Override(schedule);
 		desadvLineRecord.setQtyOrdered_Override(qtyOrdered_Override);
 		desadvDAO.save(desadvLineRecord);
+
+		// The override we just wrote can complete (or re-open) the DESADV's last open line, so the
+		// header status has to be re-derived. This is stated here rather than in any close process
+		// because every close route goes through ShipmentScheduleBL.closeShipmentSchedule and thus
+		// through this interceptor-driven method — which is also why the recompute is deferred to the
+		// end of the transaction: one close operation spanning N lines re-derives the header once.
+		recomputeDesadvStatusFromInOutsBeforeCommit(EDIDesadvId.ofRepoId(desadvLineRecord.getEDI_Desadv_ID()));
 	}
 
 	public void propagateEDIStatus(@NonNull final I_EDI_Desadv desadv)
@@ -1065,6 +1098,43 @@ public class DesadvBL
 		return desadvDAO.retrieveAllDesadvLines(desadv);
 	}
 
+	/**
+	 * @return {@code true} if this line has already received everything it will ever receive, i.e.
+	 *         {@code QtyDeliveredInStockingUOM >= COALESCE(QtyOrdered_Override, QtyOrdered)}.
+	 *         This is the java equivalent of the SQL {@code IsDeliveryClosed} in
+	 *         {@code M_InOut_DesadvLine_V.sql} / {@code get_desadv_packs_json_fn.sql}.
+	 *         <p>
+	 *         Note: {@code getQtyOrdered_Override()} returns {@code ZERO} for a SQL NULL, so the
+	 *         "no override" case has to be detected with {@code InterfaceWrapperHelper.isNull} —
+	 *         otherwise every line without an override would look delivery-closed.
+	 */
+	@VisibleForTesting
+	static boolean isDesadvLineDeliveryClosed(@NonNull final I_EDI_DesadvLine desadvLineRecord)
+	{
+		final BigDecimal effectiveQtyOrdered =
+				InterfaceWrapperHelper.isNull(desadvLineRecord, I_EDI_DesadvLine.COLUMNNAME_QtyOrdered_Override)
+						? desadvLineRecord.getQtyOrdered()
+						: desadvLineRecord.getQtyOrdered_Override();
+
+		return desadvLineRecord.getQtyDeliveredInStockingUOM().compareTo(effectiveQtyOrdered) >= 0;
+	}
+
+	/**
+	 * @return {@code true} if no further {@code M_InOutLine} can arrive for this DESADV, because every
+	 *         one of its lines is delivery-closed. A DESADV without lines returns {@code false}:
+	 *         "nothing to deliver" is not the same statement as "everything delivered", and letting it
+	 *         return {@code true} would auto-close freshly created, still-empty DESADVs.
+	 */
+	private boolean areAllDesadvLinesDeliveryClosed(@NonNull final I_EDI_Desadv desadv)
+	{
+		final List<I_EDI_DesadvLine> desadvLines = desadvDAO.retrieveAllDesadvLines(desadv);
+		if (desadvLines.isEmpty())
+		{
+			return false;
+		}
+		return desadvLines.stream().allMatch(DesadvBL::isDesadvLineDeliveryClosed);
+	}
+
 	@NonNull
 	public List<I_C_Order> retrieveAllOrders(final I_EDI_Desadv desadv)
 	{
@@ -1089,6 +1159,37 @@ public class DesadvBL
 	}
 
 	/**
+	 * Accumulates {@code desadvId} and re-derives the DESADV status <b>once per distinct DESADV at the end
+	 * of the current transaction</b> instead of once per call, via
+	 * {@link #recomputeDesadvStatusFromInOuts(EDIDesadvId)}.
+	 * <p>
+	 * Closing the {@code M_ShipmentSchedule}s of an order fires the interceptor once per record, and each
+	 * recompute costs three to four uncached round-trips (the header, the per-shipment routing config, the
+	 * linked-shipment junction, and all DESADV lines). An N-line order therefore paid N times over for a
+	 * verdict only the last pass can reach. Deferring costs nothing semantically: a recompute at the end of
+	 * the transaction sees the final state of every line, which is precisely what the discarded earlier
+	 * passes were trying to establish.
+	 * <p>
+	 * {@code BEFORE_COMMIT} rather than {@code AFTER_COMMIT} on purpose — the recompute <i>writes</i> the
+	 * {@code EDI_Desadv}, so it must be part of the same transaction. That keeps the new status visible to
+	 * whoever reads the DESADV once the close returns (no asynchronous window to wait on), and lets a
+	 * failure fail the close instead of being logged and dropped. With no active transaction the shared
+	 * helper runs the recompute immediately, so a single stand-alone close behaves exactly as before.
+	 */
+	public void recomputeDesadvStatusFromInOutsBeforeCommit(@NonNull final EDIDesadvId desadvId)
+	{
+		trxManager.accumulateAndProcessBeforeCommit(
+				"DesadvBL.recomputeDesadvStatusFromInOutsBeforeCommit",
+				ImmutableSet.of(desadvId),
+				this::recomputeDesadvStatusFromInOutsNow);
+	}
+
+	private void recomputeDesadvStatusFromInOutsNow(@NonNull final Collection<EDIDesadvId> desadvIds)
+	{
+		ImmutableSet.copyOf(desadvIds).forEach(this::recomputeDesadvStatusFromInOuts);
+	}
+
+	/**
 	 * Recomputes the DESADV export status based on the statuses of all linked shipments (M_InOut).
 	 * <p>
 	 * This applies only when {@link #isOneDesadvPerShipment(I_EDI_Desadv)} returns true
@@ -1100,9 +1201,22 @@ public class DesadvBL
 	 * <ol>
 	 *   <li>Any linked InOut is Invalid → DESADV Invalid + aggregated error message</li>
 	 *   <li>Any linked InOut is Error (and none Invalid) → DESADV Error + aggregated error message</li>
-	 *   <li>All linked InOuts are Sent or DontSend AND FulfillmentPercent >= 100% → DESADV Sent, clear error message</li>
-	 *   <li>Any linked InOut is Pending, Enqueued, or SendingStarted, OR FulfillmentPercent < 100% → DESADV Pending, clear error message</li>
+	 *   <li>All linked InOuts are Sent or DontSend AND no further delivery is expected → DESADV Sent
+	 *       if at least one InOut is Sent, else DontSend; error message cleared.
+	 *       "No further delivery expected" means FulfillmentPercent &gt;= 100%, <b>or</b> every
+	 *       {@code EDI_DesadvLine} is delivery-closed
+	 *       ({@code QtyDeliveredInStockingUOM >= COALESCE(QtyOrdered_Override, QtyOrdered)}), which is
+	 *       what closing the line's {@code M_ShipmentSchedule} expresses. This is what lets an
+	 *       under-delivered DESADV reach its terminal status without running the
+	 *       {@code EDI_Desadv_Close} process.</li>
+	 *   <li>Otherwise → DESADV Pending, error message cleared</li>
 	 * </ol>
+	 * The computed status is written only when it (or the error message) actually differs from the stored
+	 * value: several linked shipments changing status within one transaction each reach this method.
+	 * <p>
+	 * Callers on the shipment-schedule close route must use
+	 * {@link #recomputeDesadvStatusFromInOutsBeforeCommit(EDIDesadvId)} instead, which collapses one close
+	 * operation's N per-line invocations into a single recompute.
 	 */
 	public void recomputeDesadvStatusFromInOuts(@NonNull final EDIDesadvId desadvId)
 	{
@@ -1134,9 +1248,7 @@ public class DesadvBL
 		if (!invalidInOuts.isEmpty())
 		{
 			final String aggregatedError = buildAggregatedErrorMessage(invalidInOuts);
-			desadv.setEDI_ExportStatus(EDIExportStatus.Invalid.getCode());
-			desadv.setEDIErrorMsg(aggregatedError);
-			desadvDAO.save(desadv);
+			setDesadvStatusAndSaveIfChanged(desadv, EDIExportStatus.Invalid, aggregatedError);
 			logger.info("DESADV {} set to Invalid due to {} invalid InOuts: {}", desadvId, invalidInOuts.size(), aggregatedError);
 			return;
 		}
@@ -1144,9 +1256,7 @@ public class DesadvBL
 		if (!errorInOuts.isEmpty())
 		{
 			final String aggregatedError = buildAggregatedErrorMessage(errorInOuts);
-			desadv.setEDI_ExportStatus(EDIExportStatus.Error.getCode());
-			desadv.setEDIErrorMsg(aggregatedError);
-			desadvDAO.save(desadv);
+			setDesadvStatusAndSaveIfChanged(desadv, EDIExportStatus.Error, aggregatedError);
 			logger.info("DESADV {} set to Error due to {} error InOuts: {}", desadvId, errorInOuts.size(), aggregatedError);
 			return;
 		}
@@ -1156,21 +1266,65 @@ public class DesadvBL
 
 		final BigDecimal fulfillmentPercent = desadv.getFulfillmentPercent();
 
-		if (allProcessed && fulfillmentPercent.compareTo(BigDecimal.valueOf(100)) >= 0)
+		// No further M_InOutLine can arrive if the DESADV is fully fulfilled, or if every line has
+		// already received everything it will ever receive (which is what closing the line's
+		// M_ShipmentSchedule expresses, via EDI_DesadvLine.QtyOrdered_Override).
+		// allProcessed is evaluated first only because it is in-memory over the already-loaded allInOuts.
+		// It does NOT spare the areAllDesadvLinesDeliveryClosed query on the close path this feature
+		// exists for: a schedule is normally closed only once its shipments are already Sent/DontSend, so
+		// allProcessed is true throughout a mass-close and the line query would fire every single time.
+		// What holds that query count to one per transaction is the accumulation in
+		// recomputeDesadvStatusFromInOutsBeforeCommit, not this ordering.
+		final boolean noFurtherDeliveryExpected = allProcessed
+				&& (fulfillmentPercent.compareTo(BigDecimal.valueOf(100)) >= 0
+						|| areAllDesadvLinesDeliveryClosed(desadv));
+
+		if (noFurtherDeliveryExpected)
 		{
 			final boolean containsSentInOuts = allInOuts.stream().anyMatch(inOut -> EDIExportStatus.ofCode(inOut.getEDI_ExportStatus()).isSent());
 			final EDIExportStatus ediExportStatus = containsSentInOuts ? EDIExportStatus.Sent : EDIExportStatus.DontSend;
-			desadv.setEDI_ExportStatus(ediExportStatus.getCode());
-			desadv.setEDIErrorMsg(null);
-			desadvDAO.save(desadv);
-			logger.info("DESADV {} auto-closed to Sent (all InOuts sent/don't send, fulfillment {}%)", desadvId, fulfillmentPercent);
+			setDesadvStatusAndSaveIfChanged(desadv, ediExportStatus, null);
+			logger.info("DESADV {} auto-closed to {} (all InOuts sent/don't send, no further delivery expected, fulfillment {}%)",
+					desadvId, ediExportStatus, fulfillmentPercent);
 			return;
 		}
 
-		desadv.setEDI_ExportStatus(EDIExportStatus.Pending.getCode());
-		desadv.setEDIErrorMsg(null);
-		desadvDAO.save(desadv);
+		setDesadvStatusAndSaveIfChanged(desadv, EDIExportStatus.Pending, null);
 		logger.debug("DESADV {} set to Pending (fulfillment {}%, allProcessed={})", desadvId, fulfillmentPercent, allProcessed);
+	}
+
+	/**
+	 * @return {@code true} if writing {@code targetStatus} / {@code targetErrorMsg} onto {@code desadv} would
+	 *         actually change either value. Blank-vs-{@code null} error messages compare as equal.
+	 */
+	@VisibleForTesting
+	static boolean isDesadvStatusChanged(
+			@NonNull final I_EDI_Desadv desadv,
+			@NonNull final EDIExportStatus targetStatus,
+			@Nullable final String targetErrorMsg)
+	{
+		return !Objects.equals(desadv.getEDI_ExportStatus(), targetStatus.getCode())
+				|| !Objects.equals(StringUtils.trimBlankToNull(desadv.getEDIErrorMsg()),
+						StringUtils.trimBlankToNull(targetErrorMsg));
+	}
+
+	/**
+	 * The recompute still runs more than once per transaction whenever several of the DESADV's linked
+	 * shipments change their EDI_ExportStatus, and the earlier passes typically conclude "still open".
+	 * Saving only on an actual change keeps that to at most one write per transition.
+	 */
+	private void setDesadvStatusAndSaveIfChanged(
+			@NonNull final I_EDI_Desadv desadv,
+			@NonNull final EDIExportStatus targetStatus,
+			@Nullable final String targetErrorMsg)
+	{
+		if (!isDesadvStatusChanged(desadv, targetStatus, targetErrorMsg))
+		{
+			return;
+		}
+		desadv.setEDI_ExportStatus(targetStatus.getCode());
+		desadv.setEDIErrorMsg(targetErrorMsg);
+		desadvDAO.save(desadv);
 	}
 
 	/**

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_addToDesadvCreateForInOutIfNotExist_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_addToDesadvCreateForInOutIfNotExist_Test.java
@@ -48,6 +48,8 @@ import org.adempiere.model.InterfaceWrapperHelper;
 import org.adempiere.service.ClientId;
 import org.adempiere.service.ISysConfigBL;
 import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.model.I_C_BPartner;
+import org.compiere.model.I_C_BPartner_Location;
 import org.compiere.model.I_C_UOM;
 import org.compiere.model.I_M_Attribute;
 import org.compiere.model.I_M_Product;
@@ -683,6 +685,79 @@ class DesadvBL_addToDesadvCreateForInOutIfNotExist_Test
 				.extracting(I_EDI_Desadv_M_InOut::getM_InOut_ID)
 				.as("All junction rows must point to the same shipment")
 				.containsOnly(inOutRecord.getM_InOut_ID());
+	}
+
+	/**
+	 * The order was completed while POReference was still empty, so no EDI_Desadv and no
+	 * C_OrderLine.EDI_DesadvLine_ID existed. When the shipment completes, the DESADV is created
+	 * from the order as a fallback — and used to end up with QtyDelivered* = 0 because the
+	 * M_InOutLine walk had already finished before those lines existed.
+	 */
+	@Test
+	void addToDesadvCreateForInOutIfNotExist_orderWithoutDesadvLines_getsDeliveredQtys()
+	{
+		final I_C_UOM stockUOM = InterfaceWrapperHelper.load(stockUomId, I_C_UOM.class);
+
+		// a real bpartner + location is needed because the fallback creates a brand-new EDI_Desadv
+		// header, and that requires resolving a bill-to location (OrderBL.getBillToLocationId)
+		final I_C_BPartner recipientBPartner = BusinessTestHelper.createBPartner("recipient-30013");
+		final I_C_BPartner_Location recipientLocation = BusinessTestHelper.createBPartnerLocation(recipientBPartner);
+
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setC_BPartner_ID(recipientBPartner.getC_BPartner_ID());
+		order.setC_BPartner_Location_ID(recipientLocation.getC_BPartner_Location_ID());
+		order.setPOReference("PO-30013-LATE");   // set only after the order was completed
+		saveRecord(order);
+
+		final I_C_OrderLine orderLine = newInstance(I_C_OrderLine.class);
+		orderLine.setC_Order_ID(order.getC_Order_ID());
+		orderLine.setC_BPartner_ID(recipientBPartner.getC_BPartner_ID());
+		orderLine.setM_Product_ID(huPIItemProductRecord.getM_Product_ID());
+		orderLine.setC_UOM_ID(stockUOM.getC_UOM_ID());
+		orderLine.setQtyEntered(new BigDecimal("3"));
+		orderLine.setQtyOrdered(new BigDecimal("3"));
+		orderLine.setLine(10);
+		saveRecord(orderLine);
+		assertThat(orderLine.getEDI_DesadvLine_ID())
+				.as("precondition: the order line is not wired to any DESADV line")
+				.isZero();
+
+		final I_M_InOut shipment = newInstance(I_M_InOut.class);
+		shipment.setC_Order_ID(order.getC_Order_ID());
+		shipment.setC_BPartner_ID(recipientBPartner.getC_BPartner_ID());
+		saveRecord(shipment);
+
+		final I_M_InOutLine shipmentLine = newInstance(I_M_InOutLine.class);
+		shipmentLine.setM_InOut_ID(shipment.getM_InOut_ID());
+		shipmentLine.setC_OrderLine_ID(orderLine.getC_OrderLine_ID());
+		shipmentLine.setM_Product_ID(huPIItemProductRecord.getM_Product_ID());
+		shipmentLine.setC_UOM_ID(stockUOM.getC_UOM_ID());
+		shipmentLine.setMovementQty(new BigDecimal("3"));
+		shipmentLine.setQtyEntered(new BigDecimal("3"));
+		saveRecord(shipmentLine);
+
+		// ── invoke ──
+		final I_EDI_Desadv result = desadvBL.addToDesadvCreateForInOutIfNotExist(shipment);
+
+		// ── assert ──
+		assertThat(result).as("a DESADV must have been created from the order").isNotNull();
+
+		InterfaceWrapperHelper.refresh(orderLine);
+		assertThat(orderLine.getEDI_DesadvLine_ID())
+				.as("the fallback must have wired the order line to a DESADV line")
+				.isPositive();
+
+		final I_EDI_DesadvLine createdLine = InterfaceWrapperHelper.load(
+				orderLine.getEDI_DesadvLine_ID(), I_EDI_DesadvLine.class);
+		assertThat(createdLine.getQtyEntered()).isEqualByComparingTo("3");
+		assertThat(createdLine.getQtyDeliveredInUOM())
+				.as("the shipped quantity must reach the freshly created DESADV line")
+				.isEqualByComparingTo("3");
+		assertThat(createdLine.getQtyDeliveredInStockingUOM()).isEqualByComparingTo("3");
+
+		InterfaceWrapperHelper.refresh(result);
+		assertThat(result.getSumDeliveredInStockingUOM()).isEqualByComparingTo("3");
+		assertThat(result.getFulfillmentPercent()).isEqualByComparingTo("100");
 	}
 
 	private void changeDesadvLineToCOLIasUOM()

--- a/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_recomputeDesadvStatusFromInOuts_Test.java
+++ b/backend/de.metas.edi/src/test/java/de/metas/edi/api/impl/DesadvBL_recomputeDesadvStatusFromInOuts_Test.java
@@ -1,0 +1,387 @@
+package de.metas.edi.api.impl;
+
+import de.metas.async.model.I_C_Queue_WorkPackage;
+import de.metas.edi.api.EDIDesadvId;
+import de.metas.edi.api.EDIExportStatus;
+import de.metas.edi.api.impl.pack.EDIDesadvPackService;
+import de.metas.edi.async.spi.impl.EDIWorkpackageProcessor;
+import de.metas.esb.edi.model.I_EDI_Desadv;
+import de.metas.esb.edi.model.I_EDI_DesadvLine;
+import de.metas.esb.edi.model.I_EDI_Desadv_M_InOut;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.organization.OrgId;
+import de.metas.product.asidata.ProductASIDataRepository;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.ad.dao.IQueryBL;
+import org.adempiere.ad.trx.api.ITrxManager;
+import org.adempiere.ad.wrapper.POJOLookupMap;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.service.ISysConfigBL;
+import org.adempiere.test.AdempiereTestHelper;
+import de.metas.edi.model.I_C_OrderLine;
+import de.metas.edi.model.I_M_InOut;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DesadvBL_recomputeDesadvStatusFromInOuts_Test
+{
+	private DesadvBL desadvBL;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		// DesadvBL.isOneDesadvPerShipment reads this via the no-context sysConfigBL.getBooleanValue(name, default)
+		// overload, which is scoped to ClientAndOrgId.SYSTEM (AD_Client_ID=0) regardless of the current test
+		// client set up by AdempiereTestHelper — so the value must be written at ClientId.SYSTEM, not the test's
+		// own client (and not ClientId.METASFRESH, which is a different, real client with repoId 1000000).
+		Services.get(ISysConfigBL.class).setValue(
+				EDIWorkpackageProcessor.SYS_CONFIG_OneDesadvPerShipment,
+				true,
+				ClientId.SYSTEM,
+				OrgId.ANY);
+		desadvBL = DesadvBL.newInstanceForUnitTesting();
+	}
+
+	private I_EDI_Desadv createDesadv(final String fulfillmentPercent, final String exportStatus)
+	{
+		final I_EDI_Desadv desadv = newInstance(I_EDI_Desadv.class);
+		desadv.setFulfillmentPercent(new BigDecimal(fulfillmentPercent));
+		desadv.setEDI_ExportStatus(exportStatus);
+		saveRecord(desadv);
+		return desadv;
+	}
+
+	/** @param qtyOrderedOverride {@code null} means the column stays SQL NULL — the case that must NOT be read as zero */
+	private void createDesadvLine(
+			final I_EDI_Desadv desadv,
+			final String qtyOrdered,
+			final String qtyOrderedOverride,
+			final String qtyDeliveredInStockingUOM)
+	{
+		createDesadvLineRecord(desadv, qtyOrdered, qtyOrderedOverride, qtyDeliveredInStockingUOM);
+	}
+
+	/** Same as {@link #createDesadvLine(I_EDI_Desadv, String, String, String)} but returns the created record. */
+	private I_EDI_DesadvLine createDesadvLineRecord(
+			final I_EDI_Desadv desadv,
+			final String qtyOrdered,
+			final String qtyOrderedOverride,
+			final String qtyDeliveredInStockingUOM)
+	{
+		final I_EDI_DesadvLine line = newInstance(I_EDI_DesadvLine.class);
+		line.setEDI_Desadv_ID(desadv.getEDI_Desadv_ID());
+		line.setQtyOrdered(new BigDecimal(qtyOrdered));
+		line.setQtyOrdered_Override(qtyOrderedOverride == null ? null : new BigDecimal(qtyOrderedOverride));
+		line.setQtyDeliveredInStockingUOM(new BigDecimal(qtyDeliveredInStockingUOM));
+		saveRecord(line);
+		return line;
+	}
+
+	private I_M_ShipmentSchedule createShipmentSchedule(
+			final I_C_OrderLine orderLine,
+			final String qtyDelivered,
+			final boolean closed)
+	{
+		final I_M_ShipmentSchedule schedule = newInstance(I_M_ShipmentSchedule.class);
+		schedule.setC_OrderLine_ID(orderLine.getC_OrderLine_ID());
+		schedule.setQtyDelivered(new BigDecimal(qtyDelivered));
+		schedule.setIsClosed(closed);
+		saveRecord(schedule);
+		return schedule;
+	}
+
+	private I_M_InOut createLinkedInOut(final I_EDI_Desadv desadv, final EDIExportStatus inOutStatus)
+	{
+		final I_M_InOut inOut = newInstance(I_M_InOut.class);
+		inOut.setEDI_ExportStatus(inOutStatus.getCode());
+		inOut.setEDI_Desadv_ID(desadv.getEDI_Desadv_ID());
+		saveRecord(inOut);
+
+		final I_EDI_Desadv_M_InOut junction = newInstance(I_EDI_Desadv_M_InOut.class);
+		junction.setEDI_Desadv_ID(desadv.getEDI_Desadv_ID());
+		junction.setM_InOut_ID(inOut.getM_InOut_ID());
+		saveRecord(junction);
+		return inOut;
+	}
+
+	@Test
+	void allLinesDeliveryClosed_and_allInOutsSent_flipsToSent()
+	{
+		// under-delivery: ordered 100, the closed shipment schedule wrote QtyOrdered_Override=70, delivered 70
+		final I_EDI_Desadv desadv = createDesadv("70", EDIExportStatus.Pending.getCode());
+		createDesadvLine(desadv, "100", "70", "70");
+		createLinkedInOut(desadv, EDIExportStatus.Sent);
+
+		desadvBL.recomputeDesadvStatusFromInOuts(EDIDesadvId.ofRepoId(desadv.getEDI_Desadv_ID()));
+
+		InterfaceWrapperHelper.refresh(desadv);
+		assertThat(desadv.getEDI_ExportStatus()).isEqualTo(EDIExportStatus.Sent.getCode());
+		assertThat(desadv.getEDIErrorMsg()).isNull();
+	}
+
+	@Test
+	void oneLineStillOpen_staysPending()
+	{
+		final I_EDI_Desadv desadv = createDesadv("70", EDIExportStatus.Pending.getCode());
+		createDesadvLine(desadv, "100", "70", "70");   // delivery-closed
+		createDesadvLine(desadv, "100", null, "70");   // still open: no override, delivered 70 < ordered 100
+		createLinkedInOut(desadv, EDIExportStatus.Sent);
+
+		desadvBL.recomputeDesadvStatusFromInOuts(EDIDesadvId.ofRepoId(desadv.getEDI_Desadv_ID()));
+
+		InterfaceWrapperHelper.refresh(desadv);
+		assertThat(desadv.getEDI_ExportStatus()).isEqualTo(EDIExportStatus.Pending.getCode());
+	}
+
+	@Test
+	void allLinesDeliveryClosed_and_nothingSent_flipsToDontSend()
+	{
+		final I_EDI_Desadv desadv = createDesadv("0", EDIExportStatus.Pending.getCode());
+		createDesadvLine(desadv, "100", "0", "0");
+		createLinkedInOut(desadv, EDIExportStatus.DontSend);
+
+		desadvBL.recomputeDesadvStatusFromInOuts(EDIDesadvId.ofRepoId(desadv.getEDI_Desadv_ID()));
+
+		InterfaceWrapperHelper.refresh(desadv);
+		assertThat(desadv.getEDI_ExportStatus()).isEqualTo(EDIExportStatus.DontSend.getCode());
+	}
+
+	/**
+	 * Guards the nullability trap: a NULL QtyOrdered_Override must fall back to QtyOrdered,
+	 * NOT be read as zero (X_EDI_DesadvLine.getQtyOrdered_Override returns ZERO for NULL).
+	 * Without the guard, delivered 0 >= "override" 0 would make this line delivery-closed
+	 * and the DESADV would auto-close although nothing was delivered.
+	 */
+	@Test
+	void nullQtyOrderedOverride_isNotTreatedAsZero_staysPending()
+	{
+		final I_EDI_Desadv desadv = createDesadv("0", EDIExportStatus.Pending.getCode());
+		createDesadvLine(desadv, "100", null, "0");
+		createLinkedInOut(desadv, EDIExportStatus.Sent);
+
+		desadvBL.recomputeDesadvStatusFromInOuts(EDIDesadvId.ofRepoId(desadv.getEDI_Desadv_ID()));
+
+		InterfaceWrapperHelper.refresh(desadv);
+		assertThat(desadv.getEDI_ExportStatus()).isEqualTo(EDIExportStatus.Pending.getCode());
+	}
+
+	@Test
+	void isDesadvStatusChanged_detectsEqualStatusAndErrorMsg()
+	{
+		final I_EDI_Desadv desadv = createDesadv("100", EDIExportStatus.Sent.getCode());
+		desadv.setEDIErrorMsg(null);
+		saveRecord(desadv);
+
+		assertThat(DesadvBL.isDesadvStatusChanged(desadv, EDIExportStatus.Sent, null))
+				.as("same status, same (null) error message -> nothing to write")
+				.isFalse();
+		assertThat(DesadvBL.isDesadvStatusChanged(desadv, EDIExportStatus.Pending, null))
+				.as("different status -> must write")
+				.isTrue();
+		assertThat(DesadvBL.isDesadvStatusChanged(desadv, EDIExportStatus.Sent, "boom"))
+				.as("same status but a new error message -> must write")
+				.isTrue();
+	}
+
+	@Test
+	void recompute_isIdempotent_whenAlreadySent()
+	{
+		final I_EDI_Desadv desadv = createDesadv("70", EDIExportStatus.Pending.getCode());
+		createDesadvLine(desadv, "100", "70", "70");
+		createLinkedInOut(desadv, EDIExportStatus.Sent);
+		final EDIDesadvId desadvId = EDIDesadvId.ofRepoId(desadv.getEDI_Desadv_ID());
+
+		desadvBL.recomputeDesadvStatusFromInOuts(desadvId);
+		desadvBL.recomputeDesadvStatusFromInOuts(desadvId);
+		desadvBL.recomputeDesadvStatusFromInOuts(desadvId);
+
+		InterfaceWrapperHelper.refresh(desadv);
+		assertThat(desadv.getEDI_ExportStatus()).isEqualTo(EDIExportStatus.Sent.getCode());
+		assertThat(desadv.getEDIErrorMsg()).isNull();
+	}
+
+	/**
+	 * Pins the empty-lines guard in {@code areAllDesadvLinesDeliveryClosed}. {@code Stream.allMatch}
+	 * is vacuously {@code true} on an empty stream, so dropping that guard would auto-close every
+	 * freshly created, still-empty DESADV — and would do so while passing every other test here.
+	 */
+	@Test
+	void desadvWithoutLines_isNotDeliveryClosed_staysPending()
+	{
+		final I_EDI_Desadv desadv = createDesadv("0", EDIExportStatus.Pending.getCode());
+		// deliberately no EDI_DesadvLine at all
+		createLinkedInOut(desadv, EDIExportStatus.Sent);
+
+		desadvBL.recomputeDesadvStatusFromInOuts(EDIDesadvId.ofRepoId(desadv.getEDI_Desadv_ID()));
+
+		InterfaceWrapperHelper.refresh(desadv);
+		assertThat(desadv.getEDI_ExportStatus()).isEqualTo(EDIExportStatus.Pending.getCode());
+	}
+
+	@Test
+	void closingTheShipmentSchedule_flipsTheDesadvToSent()
+	{
+		final I_EDI_Desadv desadv = createDesadv("70", EDIExportStatus.Pending.getCode());
+		final I_EDI_DesadvLine desadvLine = createDesadvLineRecord(desadv, "100", null, "70");
+		createLinkedInOut(desadv, EDIExportStatus.Sent);
+
+		final I_C_OrderLine orderLine = newInstance(I_C_OrderLine.class);
+		orderLine.setEDI_DesadvLine_ID(desadvLine.getEDI_DesadvLine_ID());
+		saveRecord(orderLine);
+
+		// nothing has flipped yet: the line is still open
+		desadvBL.recomputeDesadvStatusFromInOuts(EDIDesadvId.ofRepoId(desadv.getEDI_Desadv_ID()));
+		InterfaceWrapperHelper.refresh(desadv);
+		assertThat(desadv.getEDI_ExportStatus())
+				.as("precondition: still Pending while the schedule is open")
+				.isEqualTo(EDIExportStatus.Pending.getCode());
+
+		final I_M_ShipmentSchedule closedSchedule = createShipmentSchedule(orderLine, "70", true);
+		desadvBL.updateQtyOrdered_OverrideFromShipSchedAndSave(closedSchedule);
+
+		InterfaceWrapperHelper.refresh(desadvLine);
+		assertThat(desadvLine.getQtyOrdered_Override()).isEqualByComparingTo("70");
+		InterfaceWrapperHelper.refresh(desadv);
+		assertThat(desadv.getEDI_ExportStatus())
+				.as("closing the schedule must flip the DESADV without any further call")
+				.isEqualTo(EDIExportStatus.Sent.getCode());
+	}
+
+	/**
+	 * Reopening a closed shipment schedule must return the DESADV to Pending, and reaching a terminal
+	 * status must not re-send anything.
+	 * <p>
+	 * The assertions below pin what this tier can actually observe: the recompute's own code path
+	 * writes only the {@code EDI_Desadv}, so it leaves the shipment's {@code EDI_ExportStatus} alone
+	 * and enqueues no export work package. They do <b>not</b> cover interceptor wiring — a plain JUnit
+	 * test never runs the {@code ModelValidationEngine}, so no {@code @ModelChange} handler fires here.
+	 * Whether a status change can re-trigger an export through
+	 * {@code EDI_Desadv.onDesadvStatusChanged} is an integration-tier statement and is covered by the
+	 * Cucumber scenarios instead.
+	 */
+	@Test
+	void reopeningTheShipmentSchedule_returnsTheDesadvToPending_andNeverReTransmits()
+	{
+		final I_EDI_Desadv desadv = createDesadv("70", EDIExportStatus.Pending.getCode());
+		final I_EDI_DesadvLine desadvLine = createDesadvLineRecord(desadv, "100", null, "70");
+		final I_M_InOut inOut = createLinkedInOut(desadv, EDIExportStatus.Sent);
+
+		final I_C_OrderLine orderLine = newInstance(I_C_OrderLine.class);
+		orderLine.setEDI_DesadvLine_ID(desadvLine.getEDI_DesadvLine_ID());
+		saveRecord(orderLine);
+
+		final I_M_ShipmentSchedule schedule = createShipmentSchedule(orderLine, "70", true);
+		desadvBL.updateQtyOrdered_OverrideFromShipSchedAndSave(schedule);
+		InterfaceWrapperHelper.refresh(desadv);
+		assertThat(desadv.getEDI_ExportStatus()).isEqualTo(EDIExportStatus.Sent.getCode());
+
+		schedule.setIsClosed(false);
+		saveRecord(schedule);
+		desadvBL.updateQtyOrdered_OverrideFromShipSchedAndSave(schedule);
+
+		InterfaceWrapperHelper.refresh(desadvLine);
+		// Probed via isNull, not getQtyOrdered_Override() == null: the generated getter maps SQL NULL
+		// to BigDecimal.ZERO, so an .isNull() assertion here could never hold and a .isZero() one
+		// could not tell "override cleared" from "override set to zero" — the distinction the whole
+		// delivery-closed predicate turns on.
+		assertThat(InterfaceWrapperHelper.isNull(desadvLine, I_EDI_DesadvLine.COLUMNNAME_QtyOrdered_Override))
+				.as("reopening clears the override back to SQL NULL, which is what re-opens the line")
+				.isTrue();
+
+		InterfaceWrapperHelper.refresh(desadv);
+		assertThat(desadv.getEDI_ExportStatus())
+				.as("reopening must return the DESADV to Pending — more may ship after all")
+				.isEqualTo(EDIExportStatus.Pending.getCode());
+
+		InterfaceWrapperHelper.refresh(inOut);
+		assertThat(inOut.getEDI_ExportStatus())
+				.as("the shipment's own export status must be untouched — nothing is re-sent")
+				.isEqualTo(EDIExportStatus.Sent.getCode());
+		assertThat(POJOLookupMap.get().getRecords(I_C_Queue_WorkPackage.class))
+				.as("no export work package may be enqueued by a close or a reopen")
+				.isEmpty();
+	}
+
+	/**
+	 * Pins the per-transaction dedupe of the close route: closing every {@code M_ShipmentSchedule} of one
+	 * order inside a single transaction must re-derive the DESADV header exactly <b>once</b>, not once per
+	 * schedule.
+	 * <p>
+	 * The {@code M_ShipmentSchedule} interceptor fires per record and each recompute costs three to four
+	 * uncached round-trips (the header, the per-shipment routing config, the linked-shipment junction, and
+	 * all DESADV lines), so an un-deduped close of an N-line order pays N times over for a verdict only the
+	 * last pass can reach. What is counted here is recompute <em>invocations</em>: {@code POJOLookupMap}
+	 * exposes no query counter, and {@code setDesadvStatusAndSaveIfChanged} guards the write only — so the
+	 * repetition is invisible to every record-state assertion, which is exactly why it needs its own test.
+	 */
+	@Test
+	void closingEveryScheduleOfOneDesadv_inOneTrx_recomputesTheHeaderOnlyOnce()
+	{
+		final I_EDI_Desadv desadv = createDesadv("70", EDIExportStatus.Pending.getCode());
+		createLinkedInOut(desadv, EDIExportStatus.Sent);
+
+		// three lines, each under-delivered 70 of 100, each with its own order line and shipment schedule
+		final List<I_M_ShipmentSchedule> closedSchedules = new ArrayList<>();
+		for (int i = 0; i < 3; i++)
+		{
+			final I_EDI_DesadvLine desadvLine = createDesadvLineRecord(desadv, "100", null, "70");
+			final I_C_OrderLine orderLine = newInstance(I_C_OrderLine.class);
+			orderLine.setEDI_DesadvLine_ID(desadvLine.getEDI_DesadvLine_ID());
+			saveRecord(orderLine);
+			closedSchedules.add(createShipmentSchedule(orderLine, "70", true));
+		}
+
+		final CountingDesadvBL countingDesadvBL = new CountingDesadvBL();
+
+		// one transaction = one close operation, the way M_ShipmentSchedule_CloseShipmentSchedules runs it
+		Services.get(ITrxManager.class).runInThreadInheritedTrx(
+				() -> closedSchedules.forEach(countingDesadvBL::updateQtyOrdered_OverrideFromShipSchedAndSave));
+
+		assertThat(countingDesadvBL.recomputeInvocations)
+				.as("three schedules of the same DESADV, closed in one transaction, must cost ONE recompute")
+				.isEqualTo(1);
+
+		InterfaceWrapperHelper.refresh(desadv);
+		assertThat(desadv.getEDI_ExportStatus())
+				.as("and the single deduped recompute must still reach the same terminal status")
+				.isEqualTo(EDIExportStatus.Sent.getCode());
+	}
+
+	/**
+	 * Counts how often the recompute entry point actually runs. Constructed the same way
+	 * {@link DesadvBL#newInstanceForUnitTesting()} does, but as a subclass rather than via
+	 * {@code SpringContextHolder} so that the override is in place: a Mockito spy would not see
+	 * {@code DesadvBL}'s own internal call to the method.
+	 */
+	private static final class CountingDesadvBL extends DesadvBL
+	{
+		private int recomputeInvocations = 0;
+
+		private CountingDesadvBL()
+		{
+			super(EDIDesadvPackService.newInstanceForUnitTesting(),
+					EDIDesadvInOutLineDAO.newInstanceForUnitTesting(),
+					EDIBPartnerConfigService.newInstanceForUnitTesting(),
+					new ProductASIDataRepository(Services.get(IQueryBL.class)),
+					new EDIDesadvInOutRepository());
+		}
+
+		@Override
+		public void recomputeDesadvStatusFromInOuts(@NonNull final EDIDesadvId desadvId)
+		{
+			recomputeInvocations++;
+			super.recomputeDesadvStatusFromInOuts(desadvId);
+		}
+	}
+}


### PR DESCRIPTION
Forward merge-through (up-propagation) of `soft_panda_hotfix` into `new_dawn_uat`.

Carries exactly one commit, already reviewed and merged on the source branch:
https://github.com/metasfresh/metasfresh/commit/9d6bbaa649119ad3abdcc7e8b19c8f2022f11129 — "EDI DESADV: reach a terminal status on an under-delivery, and populate a retro-created DESADV", from https://github.com/metasfresh/metasfresh/pull/25612.

`soft_panda_hotfix` was 1 commit ahead of `new_dawn_uat`, so nothing else is swept in. Merge commit only (never squash) per branch-propagation policy: the two-parent topology is what keeps the commit SHA reachable from `new_dawn_uat` for `git branch --contains`, auto-port dedup and cherry-pick dedup.

Scope: one production file (`backend/de.metas.edi/.../DesadvBL.java`), two JUnit test classes, nine cucumber scenarios in `edi/externalSystemBased/ediDesadvExportViaExternalSystem.feature`, and the step-defs they need. No migration script, no `AD_*` change, no sysconfig.

## Conflict resolution

Four conflicts, all in cucumber step-defs, all resolved as a union of the two sides. No production code was touched by any resolution — `DesadvBL.java` and the feature file are byte-identical to the source branch.

- **`EDI_DesadvLine_StepDef`** — add/add of two unrelated members at one insertion point: kept both (the target's SSCC-label step, and the incoming optional-quantity assertion helper that the already-merged finder body calls). The incoming javadoc re-documented the disambiguator columns the target already documents in its newer `OPT.`-prefixed form, so only the new "optional assertion columns" list was carried over, written with the `OPT.` prefix the target file and the feature files actually use.
- **`MetasfreshToExternalSystemRabbitMQ_StepDef`** — import-block conflict. The target had independently rewritten `pollRequestFromQueue` from a `basicConsume` push consumer to a synchronous `basicGet` pull-loop — the same fix the incoming commit applied to its own new step — so `DefaultConsumer` and `Envelope` are no longer referenced anywhere in the file and their imports were not re-added. The incoming side contributes only the new "receives no message" step and its helper.
- **`M_InOut_StepDef`** — conflicting `@cucumber.columns` documentation, resolved against the constants: `PARAM_IsShipmentDateToday = "IsShipToday"`, so the target's column name is the correct one; `PARAM_QtyToDeliver_Override = "QtyToDeliver_Override_For_M_ShipmentSchedule_ID"`, so the incoming long name and its explanation are the correct ones. Kept one of each.
- **`M_ShipmentSchedule_StepDef`** — three add/add conflicts (imports, constants, methods) between unrelated features: union in all three, imports sorted.

Checks run on the resolved tree: no conflict markers, balanced braces, every import used, no duplicate cucumber step expression, every one of the 38 step texts added by the propagated commit resolves to a step definition, and every line the commit added is present except the four javadoc lines deliberately restyled above.

## Expected red checks

These are red on `soft_panda_hotfix` independently of this merge and are tracked as known flakes:

| Check | Failure |
|---|---|
| `mobile test` | `by_ExternalBarcode_attribute.spec.js` / `hu_consolidation_grai.spec.js` |
| `test (cucumber) (profile5)` | `ediExport.feature:277` |
| `test (cucumber) (profile6)` | `multipleProductionCandidates.feature:223` |

`test (cucumber) (profile3)` is the job that runs the changed feature and must be green.
