### PR TITLE
Port: ESR import - re-word two payment actions and hide paid invoices from the line invoice picker

### DIFF
--- a/backend/de.metas.payment.esr/src/main/sql/postgresql/system/70-de.metas.payment.esr/5820330_sys_ESR_Payment_Action_labels_D_B.sql
+++ b/backend/de.metas.payment.esr/src/main/sql/postgresql/system/70-de.metas.payment.esr/5820330_sys_ESR_Payment_Action_labels_D_B.sql
@@ -1,0 +1,52 @@
+-- Re-word two ESR payment actions after a customer review of the labels shipped by 5819900.
+--
+-- 'D' (Keep for dunning): the label and description described only what happens to the REMAINDER
+--   ("Betrag mahnen" / "Offenen Restbetrag ... in den Mahnlauf geben"), so the thing the accountant
+--   was actually looking for -- that the incoming PARTIAL payment gets allocated to the invoice --
+--   was invisible, and the action was not found when a debtor underpaid. The allocation is what the
+--   action really does: the shared base handler allocates the payment and records the over/under
+--   amount, and the dunning handler itself adds nothing on top. Whether the remainder is then
+--   actually dunned depends on dunning configuration this action does not control, so the new text
+--   deliberately promises only the allocation.
+--
+-- 'B' (Money was transferred back): both name and description asserted the refund had ALREADY
+--   happened, but the action is what BOOKS the refund (it creates the outbound payment). Users hit
+--   the case where the money had not yet been transferred and had no action to choose. Renamed to
+--   the forward form and the description now states plainly that the bank transfer itself is manual.
+--
+-- Base row carries German (base language); en_US carries the English override.
+
+-- 1. Base rows: German.
+UPDATE AD_Ref_List rl SET Name=v.de_name, Description=v.de_desc,
+       Updated=TO_TIMESTAMP('2026-08-26 14:10:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+FROM (VALUES
+  (540538,'Teilzahlung zuordnen','Die eingegangene Teilzahlung wird der Rechnung zugeordnet.'),
+  (540535,'Überzahlbetrag zurückerstatten','metasfresh bucht eine Auszahlung über den Überzahlbetrag und verrechnet sie mit der eingegangenen Zahlung. Die Banküberweisung selbst erfolgt ausserhalb von metasfresh und muss separat ausgelöst werden.')
+) AS v(id, de_name, de_desc)
+WHERE rl.AD_Ref_List_ID = v.id
+;
+
+-- 2. Push the German text into every non-en_US translation row.
+--    IsTranslated='Y' only where the German text IS the final text (de_DE, de_CH); any other
+--    language honestly stays 'N' -- correct German, still awaiting its own translation.
+--    The IsTranslated guard protects a real translation somebody may have made since 5819900:
+--    only de_DE/de_CH are overwritten unconditionally.
+UPDATE AD_Ref_List_Trl t SET Name=rl.Name, Description=rl.Description,
+       IsTranslated = CASE WHEN t.AD_Language IN ('de_DE','de_CH') THEN 'Y' ELSE 'N' END,
+       Updated=TO_TIMESTAMP('2026-08-26 14:10:01','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+FROM   AD_Ref_List rl
+WHERE  rl.AD_Ref_List_ID = t.AD_Ref_List_ID
+  AND  rl.AD_Ref_List_ID IN (540538, 540535)
+  AND  t.AD_Language <> 'en_US'
+  AND  (t.AD_Language IN ('de_DE','de_CH') OR coalesce(t.IsTranslated,'N') <> 'Y')
+;
+
+-- 3. English override.
+UPDATE AD_Ref_List_Trl t SET Name=v.en_name, Description=v.en_desc, IsTranslated='Y',
+       Updated=TO_TIMESTAMP('2026-08-26 14:10:02','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+FROM (VALUES
+  (540538,'Assign partial payment','The incoming partial payment is allocated to the invoice.'),
+  (540535,'Refund the overpayment','metasfresh books an outbound payment for the overpaid amount and allocates it against the incoming payment. The bank transfer itself happens outside metasfresh and must be triggered separately.')
+) AS v(id, en_name, en_desc)
+WHERE t.AD_Ref_List_ID = v.id AND t.AD_Language = 'en_US'
+;

--- a/backend/de.metas.payment.esr/src/main/sql/postgresql/system/70-de.metas.payment.esr/5820340_sys_ESR_ImportLine_Invoice_ValRule_NotPaid.sql
+++ b/backend/de.metas.payment.esr/src/main/sql/postgresql/system/70-de.metas.payment.esr/5820340_sys_ESR_ImportLine_Invoice_ValRule_NotPaid.sql
@@ -1,0 +1,19 @@
+-- Hide fully-paid invoices from the invoice picker on an ESR import line.
+--
+-- The rule filtered on organisation only, so every invoice of the org was offered -- including ones
+-- already settled (IsPaid='Y'). Those are noise the accountant has to scroll past, and picking one
+-- achieves nothing: the shared action handler only allocates when the invoice is NOT paid, so a paid
+-- invoice on a line is silently inert. Selecting a settled invoice is never the right answer, not
+-- even for a second payment against it -- such a payment is booked as its own unallocated payment
+-- and needs no invoice on the line at all.
+--
+-- C_Invoice.IsPaid is NOT NULL with default 'N', so a plain comparison needs no COALESCE.
+--
+-- Sole consumer is AD_Column 547647 (ESR_ImportLine.C_Invoice_ID), so this cannot affect any other
+-- lookup. The rule is renamed because its name no longer describes what it filters.
+UPDATE AD_Val_Rule
+   SET Name='ESR_Invoice_Same_Org_NotPaid',
+       Code='C_Invoice.AD_Org_ID = @AD_Org_ID@ AND C_Invoice.IsPaid=''N''',
+       Updated=TO_TIMESTAMP('2026-08-26 14:20:00','YYYY-MM-DD HH24:MI:SS'), UpdatedBy=100
+ WHERE AD_Val_Rule_ID=540186
+;


### PR DESCRIPTION
## Summary

Port of https://github.com/metasfresh/metasfresh/pull/25628 to `inner_silence_uat`. Cherry-pick applied **without conflict** — both files are new.

### `5820330` — re-word two payment actions

**Keep for dunning** (`D`) described only what happens to the **remainder**, so the thing an accountant looks for when a debtor underpays — that the incoming **partial payment gets allocated to the invoice** — was invisible, and the action went unfound. The allocation is what it really does: `AbstractESRActionHandler.process` allocates the payment and records the over/under amount, while `DunningESRActionHandler.process` adds nothing on top. Whether the remainder is then dunned depends on dunning configuration this action does not control, so the new text promises **only** the allocation.

- `Teilzahlung zuordnen` — *Die eingegangene Teilzahlung wird der Rechnung zugeordnet.*

**Money was transferred back** (`B`) asserted in both name and description that the refund had **already happened** — but the action is what **books** it (`MoneyTransferedBackESRActionHandler` creates the outbound payment). Users hit the case where the money had not yet been transferred and had no action to pick.

- `Überzahlbetrag zurückerstatten` — *metasfresh bucht eine Auszahlung über den Überzahlbetrag und verrechnet sie mit der eingegangenen Zahlung. Die Banküberweisung selbst erfolgt ausserhalb von metasfresh und muss separat ausgelöst werden.*

### `5820340` — hide paid invoices from the line's invoice picker

Val rule `540186` filtered on organisation only, so every invoice of the org was offered, settled ones included. Picking a paid invoice achieves nothing — the shared handler only allocates when the invoice is **not** paid, so it is silently inert — and it is never the right answer, not even for a second payment against that invoice, which is booked as its own unallocated payment and needs no invoice on the line.

`C_Invoice.AD_Org_ID = @AD_Org_ID@` → `C_Invoice.AD_Org_ID = @AD_Org_ID@ AND C_Invoice.IsPaid='N'`

## Port safety checks against this branch

- **No customer override of the touched records.** Val rule `540186` is not redefined by any migration on this branch (checked every script mentioning the id for an accompanying `AD_Val_Rule` statement), so the blanket `SET Code=…` cannot clobber a branch-specific variant.
- The two ref-list rows are already in sync with core here: `5819900` landed on this branch via https://github.com/metasfresh/metasfresh/pull/25606, so these UPDATEs re-word exactly the texts that script installed.
- The prerequisite for the picker change holds: `C_Invoice.IsPaid` is `NOT NULL DEFAULT 'N'`, so a plain comparison needs no `COALESCE`.

## Test plan

- [x] Both scripts dry-applied against a live metasfresh DB inside `BEGIN … ROLLBACK` (on the core PR, over byte-identical scripts): they apply clean, hit exactly the intended rows, German lands in the base column with umlauts intact, `en_US` is overridden, `de_DE`/`de_CH` end `IsTranslated='Y'`, and the resulting val-rule fragment was parse-checked as a real `WHERE` clause.
- No Java touched. `migration-cli` in CI is the authoritative apply gate for this branch.

## Notes for the reviewer

Deliberately **not** included, as they go beyond what was asked and want their own decision: a `DocStatus IN ('CO','CL')` filter (drafted invoices are selectable today), and restricting the picker to the line's BPartner.
