### PR TITLE
Cucumber: cover closing the M_ShipmentSchedule BEFORE the DESADV export

### DIFF
--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/externalSystemBased/ediDesadvExportViaExternalSystem.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/edi/externalSystemBased/ediDesadvExportViaExternalSystem.feature
@@ -999,3 +999,69 @@ Feature: EDI DESADV export via External System
     Then after not more than 120s, EDI_Desadv records have the following export status
       | EDI_Desadv_ID | EDI_ExportStatus | OPT.EDIErrorMsg | OPT.Processed | OPT.FulfillmentPercent |
       | d_100         | S                | null            | true          | 70                     |
+
+
+  @from:cucumber
+  @allure.label.epic:E0292_EDI
+  @allure.label.feature:F00350_EDI
+  @Id:S30013_110
+  Scenario: S30013_110 — M_ShipmentSchedule closed before the DESADV was exported -> DESADV reaches Sent
+  ## The customer's own agreed sequence, and the mirror image of S30013_30.
+  ## An order for 100 PCE is delivered 70 PCE, and the remaining M_ShipmentSchedule is closed straight
+  ## away — while the shipment is still waiting to be exported.
+  ## Closing alone cannot finish the DESADV: its own recompute still sees an unexported M_InOut, so the
+  ## DESADV stays Pending.  The export then flips that shipment to Sent, and it is that status change
+  ## which carries the already-closed DESADV to its terminal status S / Processed.
+  ## FulfillmentPercent must stay 70 — it is an EXP_FormatLine, i.e. transmitted content.
+    And RabbitMQ MF_TO_ExternalSystem queue is purged
+
+    # @Date@ suffix keeps the POReference unique across local repeat runs (see S30013_10).
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DateOrdered | DatePromised | POReference          |
+      | o_110      | true    | customer1     | 2025-04-17  | 2025-04-18Z  | PO_S30013_110_@Date@ |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID | QtyEntered |
+      | ol_110_1   | o_110                 | product      | 100        |
+
+    And the order identified by o_110 is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID.Identifier | IsToRecompute |
+      | s_s_110    | ol_110_1                  | N             |
+
+    # Deliver only 70 of the 100 ordered, so a remainder stays open (see S30013_10 on the column name).
+    And 'generate shipments' process is invoked individually for each M_ShipmentSchedule
+      | M_ShipmentSchedule_ID.Identifier | QuantityType | IsCompleteShipments | IsShipToday | QtyToDeliver_Override_For_M_ShipmentSchedule_ID |
+      | s_s_110                          | D            | true                | false       | 70                                              |
+
+    And after not more than 60s, M_InOut is found:
+      | M_ShipmentSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | s_s_110                          | s_110                 |
+
+    And EDI_Desadv is found:
+      | EDI_Desadv_ID.Identifier | C_BPartner_ID.Identifier | C_Order_ID.Identifier | EDI_ExportStatus |
+      | d_110                    | customer1                | o_110                 | P                |
+
+    # The ordering under test: the close comes FIRST, while the shipment is still unexported.
+    When the M_ShipmentSchedule identified by s_s_110 is closed
+
+    # Intermediate state: the close on its own may not finish the DESADV — nothing has been transmitted
+    # yet, so it stays Pending and carries no error.
+    Then after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.EDIErrorMsg | OPT.Processed | OPT.FulfillmentPercent |
+      | d_110         | P                | null            | false         | 70                     |
+
+    And M_InOut is enqueued for EDI export
+      | M_InOut_ID |
+      | s_110      |
+
+    Then after not more than 120s, M_InOut records have the following export status
+      | M_InOut_ID.Identifier | EDI_ExportStatus |
+      | s_110                 | S                |
+
+    # ─── CORE ASSERTION ────────────────────────────────────────────────────────
+    # The export lands on an already-closed schedule, and the DESADV still reaches its terminal status.
+    # OPT.EDIErrorMsg=null: the auto-close is a clean terminal state, not an error state.
+    Then after not more than 120s, EDI_Desadv records have the following export status
+      | EDI_Desadv_ID | EDI_ExportStatus | OPT.EDIErrorMsg | OPT.Processed | OPT.FulfillmentPercent |
+      | d_110         | S                | null            | true          | 70                     |


### PR DESCRIPTION
Adds one Cucumber scenario, `@Id:S30013_110`, to `ediDesadvExportViaExternalSystem.feature`. Test-only — no production code, no migration script, no behaviour change.

### What ordering it covers

The `EDI_Desadv` status flip must be reached in **both** orderings of "close the remaining `M_ShipmentSchedule`" vs "export the DESADV"; the requirements for this work state both explicitly. Only one of them was tested: the eight existing `S30013_*` scenarios all close the schedule **after** the DESADV has already been exported. Closing **before** the export — the sequence agreed with the customer — had no coverage.

`S30013_110` is the mirror image of `S30013_30`: an order for 100 PCE is delivered 70 PCE and the remaining schedule is closed while the shipment is still unexported.

- The close alone does not finish the DESADV: its own recompute still sees an unexported `M_InOut`, so the DESADV stays `P` (Pending), `Processed=N`.
- The later export flips that shipment to `S`, and it is that status change which carries the already-closed DESADV to its terminal `S` / `Processed=Y`.
- `FulfillmentPercent` stays `70` — it is an `EXP_FormatLine`, i.e. transmitted content, so it must not move.

### Local test result

Run at 2026-08-26 23:22 CEST against a local `soft_panda_uat_2` Docker stack in provided-infrastructure mode (PostgreSQL on 32632, RabbitMQ, PostgREST):

```
run-cucumber-feature.sh @Id:S30013_110 <env-file selecting that stack>
```

Result: **PASS** — 1 scenario, 28 steps, all passed, 0 failures / 0 errors (`backend/de.metas.cucumber/target/cucumber-junit.xml`: `<testsuite tests="1" skipped="0" failures="0" errors="0">`).

DB ground truth after the run: `EDI_Desadv` 1000089 = `EDI_ExportStatus='S'`, `Processed='Y'`, `FulfillmentPercent=70`; `M_ShipmentSchedule` 1000119 = `IsClosed='Y'`, 100 ordered / 70 delivered; `M_InOut` 1000084 = `EDI_ExportStatus='S'`, `DocStatus='CO'`.
