### PR TITLE
Assert the grid too: the life-cycle status field is off the vanilla Product window

### DIFF
--- a/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
@@ -2,8 +2,9 @@
  * M_Product.ProductLifeCycleStatus (BBS-Status) is NOT rendered in the vanilla Product form
  *
  * Scope: guard the deliberate decision that the life-cycle status field is not offered in the
- * standard Product FORM (AD_Window_ID=140, AD_Tab_ID=180):
+ * standard Product window (AD_Window_ID=140, AD_Tab_ID=180):
  *   1. The field is not rendered in the Product form
+ *   2. The field is not a column of the Product grid
  *
  * WHY THIS TEST INVERTED
  * ----------------------
@@ -14,15 +15,26 @@
  * that customer actually opens. Derivation of the new expectations (per
  * `metasfresh-test-integrity` § "Test Wiring Drift", step 3):
  *   - 5820370 sets AD_UI_Element 652772 IsDisplayed='N' => the form must NOT render the field
+ *   - 5820370 sets AD_UI_Element 652772 IsDisplayedGrid='N' => the grid must NOT list the column
  * The observed CI failure matched that derivation exactly (the old step 1 timed out waiting for a
  * field container that is no longer rendered), so the assertion is updated rather than the change.
  *
- * The grid column and the filter parameter are LOGGED, NOT ASSERTED, because a local run against a
- * DB with 5820370 applied showed the grid layout of window 140 STILL lists ProductLifeCycleStatus
- * even with both IsDisplayedGrid='N' and IsDisplayed='N' on the UI element (and still lists it with
- * that element deactivated). So the grid descriptor is not driven by the flags this migration sets,
- * and the filter is column-driven (AD_Column.IsSelectionColumn, migration 5819940, untouched here).
- * Neither is part of this change's contract; asserting either way would be a guess.
+ * BEWARE WHEN RE-DERIVING THESE EXPECTATIONS FROM A LOCAL RUN
+ * -----------------------------------------------------------
+ * An earlier revision of this spec logged the grid column instead of asserting it, on the strength
+ * of a local run that showed window 140 STILL listing ProductLifeCycleStatus with IsDisplayedGrid='N'
+ * applied. That observation was a stale-cache artifact, not behaviour: ViewLayoutFactory's
+ * "SqlViewLayouts" cache carries no `#<table>` suffix, so CCache.extractTableNameForCacheName derives
+ * no table name and no AD_* reset label ever reaches it, and with expireAfterMinutes=0 it never expires
+ * on its own. A migration applied as raw SQL also never triggers PO.java's save-path invalidation.
+ * After resetting SqlViewLayouts + SqlViewBindings the same probe returned the grid WITHOUT the column.
+ * So: before concluding a layout flag "did not work", reset those caches (or restart the app server)
+ * and re-observe.
+ *
+ * The FILTER parameter is still logged rather than asserted, and that is accurate rather than a guess:
+ * the filter is column-driven (AD_Column.IsSelectionColumn='Y', migration 5819940, untouched here), so
+ * window 140 still offers a BBS-Status filter for a field it no longer displays. Closing that gap is a
+ * separate change (AD_Field.IsFilterField on tab 180) and is not part of this spec's contract yet.
  *
  * WHERE THE REMAINING BEHAVIOUR IS COVERED
  * ----------------------------------------
@@ -114,14 +126,16 @@ removed (migration 5820370).
       );
     });
 
-    // === STEP 2: record what the list view still exposes (observational) ===
-    await test.step('Record the Product list view grid columns and filter parameters', async () => {
+    // === STEP 2: the grid must not list the column ===
+    await test.step('Assert ProductLifeCycleStatus is absent from the Product grid', async () => {
       const layout = await getViewLayout(PRODUCT_WINDOW_ID, 'grid');
 
-      // Both LOGGED, not asserted — see the header. Verified locally: the grid layout still lists
-      // the column with 5820370 applied, so neither observation is part of this change's contract.
       const columnNames = getViewLayoutColumnNames(layout);
       console.log(`[INFO] Grid columns of window ${PRODUCT_WINDOW_ID}: ${JSON.stringify(columnNames)}`);
+      expect(columnNames, `${FIELD_NAME} must not be a grid column of window ${PRODUCT_WINDOW_ID}`)
+          .not.toContain(FIELD_NAME);
+
+      // Logged, not asserted — the filter is column-driven and outlives this migration. See the header.
       const filterParameterNames = getViewLayoutFilterParameterNames(layout);
       console.log(`[INFO] Filter parameters of window ${PRODUCT_WINDOW_ID}: ${JSON.stringify(filterParameterNames)}`);
     });

--- a/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
@@ -25,8 +25,9 @@
  * of a local run that showed window 140 STILL listing ProductLifeCycleStatus with IsDisplayedGrid='N'
  * applied. That observation was a stale-cache artifact, not behaviour: ViewLayoutFactory's
  * "SqlViewLayouts" cache carries no `#<table>` suffix, so CCache.extractTableNameForCacheName derives
- * no table name and no AD_* reset label ever reaches it, and with expireAfterMinutes=0 it never expires
- * on its own. A migration applied as raw SQL also never triggers PO.java's save-path invalidation.
+ * no real table name and the cache falls back to registering itself under its OWN name — a label no
+ * AD_* save ever resets — and with expireAfterMinutes=0 it never expires on its own. A migration
+ * applied as raw SQL also never triggers PO.java's save-path invalidation.
  * After resetting SqlViewLayouts + SqlViewBindings the same probe returned the grid WITHOUT the column.
  * So: before concluding a layout flag "did not work", reset those caches (or restart the app server)
  * and re-observe.

--- a/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
@@ -1,49 +1,20 @@
 /**
- * M_Product.ProductLifeCycleStatus (BBS-Status) is NOT rendered in the vanilla Product form
+ * M_Product.ProductLifeCycleStatus (BBS-Status) is deliberately NOT part of the vanilla Product
+ * window (AD_Window_ID=140, AD_Tab_ID=180). This spec guards that: the field must be absent from
+ * the form and from the grid.
  *
- * Scope: guard the deliberate decision that the life-cycle status field is not offered in the
- * standard Product window (AD_Window_ID=140, AD_Tab_ID=180):
- *   1. The field is not rendered in the Product form
- *   2. The field is not a column of the Product grid
+ * Migration 5820370 hid it there on purpose -- the window already carries an "Auslaufprodukt"
+ * (M_Product.Discontinued) checkbox that reads like the same control, and the enforcement is wanted
+ * by one customer, whose own repo puts the field on the window that customer actually opens. The
+ * column, its reference list and every backend guard stay in core, covered by de.metas.cucumber
+ * productLifeCycleStatus.feature and ProductBL_assertAllowed_Test / PickHUCommand_LifeCycleStatus_Test.
  *
- * WHY THIS TEST INVERTED
- * ----------------------
- * It previously asserted the opposite — field visible, selectable, persisted, grid column + filter.
- * Migration 5820370 hides the field on window 140 on purpose: the window already carries an
- * "Auslaufprodukt" (M_Product.Discontinued) checkbox that reads like the same control, and the
- * life-cycle enforcement is wanted by one customer, whose own repo adds the field to the window
- * that customer actually opens. Derivation of the new expectations (per
- * `metasfresh-test-integrity` § "Test Wiring Drift", step 3):
- *   - 5820370 sets AD_UI_Element 652772 IsDisplayed='N' => the form must NOT render the field
- *   - 5820370 sets AD_UI_Element 652772 IsDisplayedGrid='N' => the grid must NOT list the column
- * The observed CI failure matched that derivation exactly (the old step 1 timed out waiting for a
- * field container that is no longer rendered), so the assertion is updated rather than the change.
+ * The filter parameter is logged rather than asserted: it comes from AD_Column.IsSelectionColumn
+ * (5819940), which is table-level and stays on for the customer's own window.
  *
- * BEWARE WHEN RE-DERIVING THESE EXPECTATIONS FROM A LOCAL RUN
- * -----------------------------------------------------------
- * An earlier revision of this spec logged the grid column instead of asserting it, on the strength
- * of a local run that showed window 140 STILL listing ProductLifeCycleStatus with IsDisplayedGrid='N'
- * applied. That observation was a stale-cache artifact, not behaviour: ViewLayoutFactory's
- * "SqlViewLayouts" cache carries no `#<table>` suffix, so CCache.extractTableNameForCacheName derives
- * no real table name and the cache falls back to registering itself under its OWN name — a label no
- * AD_* save ever resets — and with expireAfterMinutes=0 it never expires on its own. A migration
- * applied as raw SQL also never triggers PO.java's save-path invalidation.
- * After resetting SqlViewLayouts + SqlViewBindings the same probe returned the grid WITHOUT the column.
- * So: before concluding a layout flag "did not work", reset those caches (or restart the app server)
- * and re-observe.
- *
- * The FILTER parameter is still logged rather than asserted, and that is accurate rather than a guess:
- * the filter is column-driven (AD_Column.IsSelectionColumn='Y', migration 5819940, untouched here), so
- * window 140 still offers a BBS-Status filter for a field it no longer displays. Closing that gap is a
- * separate change (AD_Field.IsFilterField on tab 180) and is not part of this spec's contract yet.
- *
- * WHERE THE REMAINING BEHAVIOUR IS COVERED
- * ----------------------------------------
- * The column, its reference list and every backend guard stay in core, and are exercised by
- * `de.metas.cucumber` productLifeCycleStatus.feature (order-line block + the completion re-checks)
- * and by ProductBL_assertAllowed_Test / PickHUCommand_LifeCycleStatus_Test. The field's visibility
- * in the customer's own Product window cannot be tested here — that window does not exist on a core
- * DB — so no automated core check covers it.
+ * Running this locally: reset the SqlViewLayouts and SqlViewBindings caches first, or the app server
+ * keeps serving the pre-migration layout. Neither cache is keyed to a table, so no AD_* change
+ * invalidates them and an unreset run will contradict the migration.
  */
 
 import { expect } from '@playwright/test';


### PR DESCRIPTION
Restores the grid-column assertion that a previous revision of this spec removed, and corrects the source comment that justified removing it.

### What was wrong

The prior revision downgraded the grid check to a `console.log` and recorded, as fact, that window 140 still lists `ProductLifeCycleStatus` with `IsDisplayedGrid='N'` applied — concluding that "the grid descriptor is not driven by the flags this migration sets".

That observation was a stale-cache artifact:

- `ViewLayoutFactory`'s `SqlViewLayouts` cache name carries no `#<table>` suffix, so `CCache.extractTableNameForCacheName` derives no *real* table name; the constructor then falls back to registering the cache under its own name (`CCache.java:249`), a label no `AD_*` save ever resets.
- `expireAfterMinutes=0` means it never expires on its own.
- A migration applied as raw SQL never triggers `PO.java`'s save-path invalidation.

So the app server kept serving the pre-migration layout indefinitely.

### Evidence

Verified against a local from-source stack on a DB carrying every migration of this change:

| Step | Result |
|---|---|
| Reset `SqlViewLayouts` + `SqlViewBindings`, run the spec | Grid columns come back **without** `ProductLifeCycleStatus` |
| Flip `AD_UI_Element 652772` `IsDisplayedGrid='Y'`, reset, re-run | Restored assertion **FAILS** — the column reappears |
| Flip back to `'N'`, reset, re-run | **PASSES** |

So the flag does drive the grid descriptor, contrary to the old comment, and the restored assertion is meaningful rather than vacuous.

### Not changed

The filter parameter stays logged rather than asserted, and that is now documented as accurate rather than as a guess: the filter is column-driven (`AD_Column.IsSelectionColumn`, migration 5819940), so the window still offers a life-cycle-status filter for a field it no longer displays. Closing that gap is a separate change on `AD_Field.IsFilterField` for tab 180.

Test-only change — no production, functional or DB change.
