### PR TITLE
Take the BBS-Status filter off the vanilla Product window too

### DIFF
--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820780_sys_M_Product_ProductLifeCycleStatus_remove_filter_from_vanilla_window.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820780_sys_M_Product_ProductLifeCycleStatus_remove_filter_from_vanilla_window.sql
@@ -1,16 +1,9 @@
--- Product Life Cycle Status (BBS-Status): stop offering the field as a filter in the vanilla Product window.
--- 5820370 hid the field itself on AD_Tab 180 / AD_Window 140 ("Produkt_OLD"), but the filter bar kept
--- listing it, so the window offered a filter for a field it no longer displays.
+-- Product Life Cycle Status (BBS-Status): remove the leftover filter entry from the vanilla Product
+-- window. 5820370 hid the field on AD_Window 140, but the filter bar kept offering it.
 --
--- The filter entry comes from AD_Column.IsSelectionColumn (5819940), which is table-level and must stay
--- 'Y': the customer's own Product window relies on it for its quick filter, and clearing it there would
--- remove the filter from every M_Product tab. AD_Field.IsFilterField is the window-scoped switch, so
--- setting it on this one AD_Field removes the entry from window 140 alone. AD_Field 781859 -- the same
--- column on the customer override window -- is a separate row and is untouched by construction.
---
--- Verified on a local stack carrying every migration of this change: with IsFilterField='N' the window's
--- layout no longer lists ProductLifeCycleStatus among its filter parameters, the grid stays clean, and
--- the column, its ref-list and every backend guard remain untouched.
+-- AD_Field.IsFilterField is window-scoped, so this touches window 140 only. The filter's source,
+-- AD_Column.IsSelectionColumn (5819940), is table-level and stays 'Y' -- clearing it there would also
+-- strip the quick filter from the customer's own Product window.
 
 UPDATE AD_Field
 SET IsFilterField='N',

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820780_sys_M_Product_ProductLifeCycleStatus_remove_filter_from_vanilla_window.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820780_sys_M_Product_ProductLifeCycleStatus_remove_filter_from_vanilla_window.sql
@@ -1,0 +1,20 @@
+-- Product Life Cycle Status (BBS-Status): stop offering the field as a filter in the vanilla Product window.
+-- 5820370 hid the field itself on AD_Tab 180 / AD_Window 140 ("Produkt_OLD"), but the filter bar kept
+-- listing it, so the window offered a filter for a field it no longer displays.
+--
+-- The filter entry comes from AD_Column.IsSelectionColumn (5819940), which is table-level and must stay
+-- 'Y': the customer's own Product window relies on it for its quick filter, and clearing it there would
+-- remove the filter from every M_Product tab. AD_Field.IsFilterField is the window-scoped switch, so
+-- setting it on this one AD_Field removes the entry from window 140 alone. AD_Field 781859 -- the same
+-- column on the customer override window -- is a separate row and is untouched by construction.
+--
+-- Verified on a local stack carrying every migration of this change: with IsFilterField='N' the window's
+-- layout no longer lists ProductLifeCycleStatus among its filter parameters, the grid stays clean, and
+-- the column, its ref-list and every backend guard remain untouched.
+
+UPDATE AD_Field
+SET IsFilterField='N',
+    Updated=TO_TIMESTAMP('2026-08-27 09:15:00','YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy=100
+WHERE AD_Field_ID=781848 /* M_Product.ProductLifeCycleStatus on AD_Tab 180 (AD_Window 140, Produkt_OLD) */
+;

--- a/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
@@ -2,8 +2,9 @@
  * M_Product.ProductLifeCycleStatus (BBS-Status) is NOT rendered in the vanilla Product form
  *
  * Scope: guard the deliberate decision that the life-cycle status field is not offered in the
- * standard Product FORM (AD_Window_ID=140, AD_Tab_ID=180):
+ * standard Product window (AD_Window_ID=140, AD_Tab_ID=180):
  *   1. The field is not rendered in the Product form
+ *   2. The field is not a column of the Product grid
  *
  * WHY THIS TEST INVERTED
  * ----------------------
@@ -14,15 +15,26 @@
  * that customer actually opens. Derivation of the new expectations (per
  * `metasfresh-test-integrity` § "Test Wiring Drift", step 3):
  *   - 5820370 sets AD_UI_Element 652772 IsDisplayed='N' => the form must NOT render the field
+ *   - 5820370 sets AD_UI_Element 652772 IsDisplayedGrid='N' => the grid must NOT list the column
  * The observed CI failure matched that derivation exactly (the old step 1 timed out waiting for a
  * field container that is no longer rendered), so the assertion is updated rather than the change.
  *
- * The grid column and the filter parameter are LOGGED, NOT ASSERTED, because a local run against a
- * DB with 5820370 applied showed the grid layout of window 140 STILL lists ProductLifeCycleStatus
- * even with both IsDisplayedGrid='N' and IsDisplayed='N' on the UI element (and still lists it with
- * that element deactivated). So the grid descriptor is not driven by the flags this migration sets,
- * and the filter is column-driven (AD_Column.IsSelectionColumn, migration 5819940, untouched here).
- * Neither is part of this change's contract; asserting either way would be a guess.
+ * BEWARE WHEN RE-DERIVING THESE EXPECTATIONS FROM A LOCAL RUN
+ * -----------------------------------------------------------
+ * An earlier revision of this spec logged the grid column instead of asserting it, on the strength
+ * of a local run that showed window 140 STILL listing ProductLifeCycleStatus with IsDisplayedGrid='N'
+ * applied. That observation was a stale-cache artifact, not behaviour: ViewLayoutFactory's
+ * "SqlViewLayouts" cache carries no `#<table>` suffix, so CCache.extractTableNameForCacheName derives
+ * no table name and no AD_* reset label ever reaches it, and with expireAfterMinutes=0 it never expires
+ * on its own. A migration applied as raw SQL also never triggers PO.java's save-path invalidation.
+ * After resetting SqlViewLayouts + SqlViewBindings the same probe returned the grid WITHOUT the column.
+ * So: before concluding a layout flag "did not work", reset those caches (or restart the app server)
+ * and re-observe.
+ *
+ * The FILTER parameter is still logged rather than asserted, and that is accurate rather than a guess:
+ * the filter is column-driven (AD_Column.IsSelectionColumn='Y', migration 5819940, untouched here), so
+ * window 140 still offers a BBS-Status filter for a field it no longer displays. Closing that gap is a
+ * separate change (AD_Field.IsFilterField on tab 180) and is not part of this spec's contract yet.
  *
  * WHERE THE REMAINING BEHAVIOUR IS COVERED
  * ----------------------------------------
@@ -114,14 +126,16 @@ removed (migration 5820370).
       );
     });
 
-    // === STEP 2: record what the list view still exposes (observational) ===
-    await test.step('Record the Product list view grid columns and filter parameters', async () => {
+    // === STEP 2: the grid must not list the column ===
+    await test.step('Assert ProductLifeCycleStatus is absent from the Product grid', async () => {
       const layout = await getViewLayout(PRODUCT_WINDOW_ID, 'grid');
 
-      // Both LOGGED, not asserted — see the header. Verified locally: the grid layout still lists
-      // the column with 5820370 applied, so neither observation is part of this change's contract.
       const columnNames = getViewLayoutColumnNames(layout);
       console.log(`[INFO] Grid columns of window ${PRODUCT_WINDOW_ID}: ${JSON.stringify(columnNames)}`);
+      expect(columnNames, `${FIELD_NAME} must not be a grid column of window ${PRODUCT_WINDOW_ID}`)
+          .not.toContain(FIELD_NAME);
+
+      // Logged, not asserted — the filter is column-driven and outlives this migration. See the header.
       const filterParameterNames = getViewLayoutFilterParameterNames(layout);
       console.log(`[INFO] Filter parameters of window ${PRODUCT_WINDOW_ID}: ${JSON.stringify(filterParameterNames)}`);
     });

--- a/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
@@ -25,8 +25,9 @@
  * of a local run that showed window 140 STILL listing ProductLifeCycleStatus with IsDisplayedGrid='N'
  * applied. That observation was a stale-cache artifact, not behaviour: ViewLayoutFactory's
  * "SqlViewLayouts" cache carries no `#<table>` suffix, so CCache.extractTableNameForCacheName derives
- * no table name and no AD_* reset label ever reaches it, and with expireAfterMinutes=0 it never expires
- * on its own. A migration applied as raw SQL also never triggers PO.java's save-path invalidation.
+ * no real table name and the cache falls back to registering itself under its OWN name — a label no
+ * AD_* save ever resets — and with expireAfterMinutes=0 it never expires on its own. A migration
+ * applied as raw SQL also never triggers PO.java's save-path invalidation.
  * After resetting SqlViewLayouts + SqlViewBindings the same probe returned the grid WITHOUT the column.
  * So: before concluding a layout flag "did not work", reset those caches (or restart the app server)
  * and re-observe.

--- a/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
@@ -1,49 +1,20 @@
 /**
- * M_Product.ProductLifeCycleStatus (BBS-Status) is NOT rendered in the vanilla Product form
+ * M_Product.ProductLifeCycleStatus (BBS-Status) is deliberately NOT part of the vanilla Product
+ * window (AD_Window_ID=140, AD_Tab_ID=180). This spec guards that: the field must be absent from
+ * the form and from the grid.
  *
- * Scope: guard the deliberate decision that the life-cycle status field is not offered in the
- * standard Product window (AD_Window_ID=140, AD_Tab_ID=180):
- *   1. The field is not rendered in the Product form
- *   2. The field is not a column of the Product grid
+ * Migration 5820370 hid it there on purpose -- the window already carries an "Auslaufprodukt"
+ * (M_Product.Discontinued) checkbox that reads like the same control, and the enforcement is wanted
+ * by one customer, whose own repo puts the field on the window that customer actually opens. The
+ * column, its reference list and every backend guard stay in core, covered by de.metas.cucumber
+ * productLifeCycleStatus.feature and ProductBL_assertAllowed_Test / PickHUCommand_LifeCycleStatus_Test.
  *
- * WHY THIS TEST INVERTED
- * ----------------------
- * It previously asserted the opposite — field visible, selectable, persisted, grid column + filter.
- * Migration 5820370 hides the field on window 140 on purpose: the window already carries an
- * "Auslaufprodukt" (M_Product.Discontinued) checkbox that reads like the same control, and the
- * life-cycle enforcement is wanted by one customer, whose own repo adds the field to the window
- * that customer actually opens. Derivation of the new expectations (per
- * `metasfresh-test-integrity` § "Test Wiring Drift", step 3):
- *   - 5820370 sets AD_UI_Element 652772 IsDisplayed='N' => the form must NOT render the field
- *   - 5820370 sets AD_UI_Element 652772 IsDisplayedGrid='N' => the grid must NOT list the column
- * The observed CI failure matched that derivation exactly (the old step 1 timed out waiting for a
- * field container that is no longer rendered), so the assertion is updated rather than the change.
+ * The filter parameter is logged rather than asserted: it comes from AD_Column.IsSelectionColumn
+ * (5819940), which is table-level and stays on for the customer's own window.
  *
- * BEWARE WHEN RE-DERIVING THESE EXPECTATIONS FROM A LOCAL RUN
- * -----------------------------------------------------------
- * An earlier revision of this spec logged the grid column instead of asserting it, on the strength
- * of a local run that showed window 140 STILL listing ProductLifeCycleStatus with IsDisplayedGrid='N'
- * applied. That observation was a stale-cache artifact, not behaviour: ViewLayoutFactory's
- * "SqlViewLayouts" cache carries no `#<table>` suffix, so CCache.extractTableNameForCacheName derives
- * no real table name and the cache falls back to registering itself under its OWN name — a label no
- * AD_* save ever resets — and with expireAfterMinutes=0 it never expires on its own. A migration
- * applied as raw SQL also never triggers PO.java's save-path invalidation.
- * After resetting SqlViewLayouts + SqlViewBindings the same probe returned the grid WITHOUT the column.
- * So: before concluding a layout flag "did not work", reset those caches (or restart the app server)
- * and re-observe.
- *
- * The FILTER parameter is still logged rather than asserted, and that is accurate rather than a guess:
- * the filter is column-driven (AD_Column.IsSelectionColumn='Y', migration 5819940, untouched here), so
- * window 140 still offers a BBS-Status filter for a field it no longer displays. Closing that gap is a
- * separate change (AD_Field.IsFilterField on tab 180) and is not part of this spec's contract yet.
- *
- * WHERE THE REMAINING BEHAVIOUR IS COVERED
- * ----------------------------------------
- * The column, its reference list and every backend guard stay in core, and are exercised by
- * `de.metas.cucumber` productLifeCycleStatus.feature (order-line block + the completion re-checks)
- * and by ProductBL_assertAllowed_Test / PickHUCommand_LifeCycleStatus_Test. The field's visibility
- * in the customer's own Product window cannot be tested here — that window does not exist on a core
- * DB — so no automated core check covers it.
+ * Running this locally: reset the SqlViewLayouts and SqlViewBindings caches first, or the app server
+ * keeps serving the pre-migration layout. Neither cache is keyed to a table, so no AD_* change
+ * invalidates them and an unreset run will contradict the migration.
  */
 
 import { expect } from '@playwright/test';

--- a/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
@@ -5,6 +5,7 @@
  * standard Product window (AD_Window_ID=140, AD_Tab_ID=180):
  *   1. The field is not rendered in the Product form
  *   2. The field is not a column of the Product grid
+ *   3. The field is not offered as a filter of the Product list
  *
  * WHY THIS TEST INVERTED
  * ----------------------
@@ -16,6 +17,7 @@
  * `metasfresh-test-integrity` § "Test Wiring Drift", step 3):
  *   - 5820370 sets AD_UI_Element 652772 IsDisplayed='N' => the form must NOT render the field
  *   - 5820370 sets AD_UI_Element 652772 IsDisplayedGrid='N' => the grid must NOT list the column
+ *   - 5820780 sets AD_Field 781848 IsFilterField='N' => the filter bar must NOT offer the field
  * The observed CI failure matched that derivation exactly (the old step 1 timed out waiting for a
  * field container that is no longer rendered), so the assertion is updated rather than the change.
  *
@@ -32,10 +34,11 @@
  * So: before concluding a layout flag "did not work", reset those caches (or restart the app server)
  * and re-observe.
  *
- * The FILTER parameter is still logged rather than asserted, and that is accurate rather than a guess:
- * the filter is column-driven (AD_Column.IsSelectionColumn='Y', migration 5819940, untouched here), so
- * window 140 still offers a BBS-Status filter for a field it no longer displays. Closing that gap is a
- * separate change (AD_Field.IsFilterField on tab 180) and is not part of this spec's contract yet.
+ * The FILTER parameter needs both migrations to be absent, which is why it is asserted only now. The
+ * filter entry originates from AD_Column.IsSelectionColumn='Y' (5819940), which is table-level and stays
+ * 'Y' so the customer's own Product window keeps its quick filter; 5820780 switches it off for THIS
+ * window alone via AD_Field.IsFilterField. Asserting its absence therefore guards the window-scoped
+ * switch, not the shared column flag.
  *
  * WHERE THE REMAINING BEHAVIOUR IS COVERED
  * ----------------------------------------
@@ -127,8 +130,8 @@ removed (migration 5820370).
       );
     });
 
-    // === STEP 2: the grid must not list the column ===
-    await test.step('Assert ProductLifeCycleStatus is absent from the Product grid', async () => {
+    // === STEP 2: the grid must not list the column, the filter bar must not offer it ===
+    await test.step('Assert ProductLifeCycleStatus is absent from the Product grid and filters', async () => {
       const layout = await getViewLayout(PRODUCT_WINDOW_ID, 'grid');
 
       const columnNames = getViewLayoutColumnNames(layout);
@@ -136,9 +139,10 @@ removed (migration 5820370).
       expect(columnNames, `${FIELD_NAME} must not be a grid column of window ${PRODUCT_WINDOW_ID}`)
           .not.toContain(FIELD_NAME);
 
-      // Logged, not asserted — the filter is column-driven and outlives this migration. See the header.
       const filterParameterNames = getViewLayoutFilterParameterNames(layout);
       console.log(`[INFO] Filter parameters of window ${PRODUCT_WINDOW_ID}: ${JSON.stringify(filterParameterNames)}`);
+      expect(filterParameterNames, `${FIELD_NAME} must not be a filter of window ${PRODUCT_WINDOW_ID}`)
+          .not.toContain(FIELD_NAME);
     });
 
     console.log('[PASS] ProductLifeCycleStatus is not rendered in the vanilla Product form.');


### PR DESCRIPTION
Completes the "take BBS-Status off the vanilla Product window" job that migration 5820370 started.

### The gap

5820370 hid the field on window 140, but the filter bar kept listing it — so the window advertised a filter for a field it no longer displays. This was reviewer feedback on the earlier round.

### Why a window-scoped flag and not the column flag

The filter entry originates from `AD_Column.IsSelectionColumn='Y'` (migration 5819940), which is **table-level**. Clearing it there would strip the filter from every `M_Product` tab — including the customer's own Product window, which relies on it for its quick filter.

`AD_Field.IsFilterField` is the window-scoped switch. Setting it on `AD_Field 781848` removes the entry from window 140 alone. `AD_Field 781859` — the same column on the customer override window — is a separate row, so the change cannot reach it by construction, not merely by observation.

### Evidence

Verified against a local from-source stack whose DB carries every migration of this change, applied through the migration CLI (`AD_MigrationScript` in sync — no raw psql):

| Step | Filter parameters of window 140 |
|---|---|
| Before the migration | include `ProductLifeCycleStatus` — spec **RED** |
| After the migration | `ProductLifeCycleStatus` absent — spec **GREEN** |

`AD_Field 781848` ends at `IsFilterField='N'`; `781859` unchanged. Grid columns stay clean throughout.

### Spec change

`product-life-cycle-status.spec.js` now **asserts** the filter's absence instead of logging it. It logged before because the observation was not deterministic until this migration existed; the header comment is updated to say exactly that, so the assertion documents which switch it guards (the window-scoped flag, not the shared column flag).

Stacked on the branch of the preceding round; that PR's commit appears in the diff until it merges.
