### PR TITLE
ESRDataLoaderUtilTest: register IESRImportBL so the class no longer depends on test order

### DIFF
--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtilTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtilTest.java
@@ -1,6 +1,10 @@
 package de.metas.payment.esr.dataimporter;
 
 import de.metas.payment.esr.model.I_ESR_ImportLine;
+import de.metas.attachments.AttachmentEntryService;
+import de.metas.payment.esr.api.IESRImportBL;
+import de.metas.payment.esr.api.impl.ESRImportBL;
+import de.metas.util.Services;
 import org.adempiere.test.AdempiereTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +27,14 @@ public class ESRDataLoaderUtilTest
 	void init()
 	{
 		AdempiereTestHelper.get().init();
+
+		// ESRDataLoaderUtil is a @UtilityClass, so its Services.get(...) fields run in the static
+		// initializer the first time the class is touched. IESRImportBL cannot be auto-instantiated
+		// (ESRImportBL has no default constructor), so without this registration the initializer
+		// throws -- and because a failed <clinit> is cached per JVM, every later test that touches
+		// ESRDataLoaderUtil then fails with NoClassDefFoundError. Registering it here is what makes
+		// this class independent of whether some other test registered the service first.
+		Services.registerService(IESRImportBL.class, new ESRImportBL(AttachmentEntryService.createInstanceForUnitTesting()));
 	}
 
 	private I_ESR_ImportLine newLine()


### PR DESCRIPTION
## Summary

Test-only, 12 lines. Makes `ESRDataLoaderUtilTest` independent of test execution order.

`ESRDataLoaderUtil` is a Lombok **`@UtilityClass`**, so its `Services.get(...)` fields run in the **static initializer** the first time the class is touched. `IESRImportBL` cannot be auto-instantiated — `ESRImportBL` has no default constructor — so that initializer **throws** unless something has already registered the service in the same JVM.

`ESRDataLoaderUtilTest` registered nothing. It only passed when an `ESRTestBase` subclass happened to run first and register it (`ESRTestBase:103,137` does exactly that). Run alone, or first in its module, it failed with `ExceptionInInitializerError` — and because a failed `<clinit>` is **cached per JVM**, every later test touching `ESRDataLoaderUtil` then failed with `NoClassDefFoundError`.

The blast radius in this module was **51 failures + 48 errors across 175 tests** from that single static initializer.

## Why CI never caught it

`test (java)` genuinely does gate test failures — I verified the mechanism rather than assuming it: `docker-builds/Dockerfile.junit` runs `mvn surefire:test --fail-never` and derives `junit.mvn.exit-code` by grepping the log for `BUILD SUCCESS`; `cicd.yaml:1427` then exits 1 when that code is non-zero. Reproducing these failures locally under `--fail-never` still prints `BUILD FAILURE`, so the gate would have fired.

It stayed green because CI runs the **whole backend** in shared JVMs, where an `ESRTestBase` subclass registers `IESRImportBL` before this class is reached. That is luck of ordering, not a guarantee — and it is exactly the kind of dependency that breaks silently when classes are added, renamed, or re-partitioned.

## The fix

Register the service in this test's own `@BeforeEach`, mirroring `ESRTestBase` rather than introducing a mocking dependency the module does not otherwise use.

## Test plan

- [x] **The class alone** — the case that was broken: **5 errors before → 5 passing after**.
- [x] **Full `de.metas.payment.esr` module suite** — **before: 175 run, 51 failures, 48 errors. After: 175 run, 0 failures, 0 errors, 1 pre-existing skip.**
- Run with `JAVA_HOME` set to JDK 8 (this module is Java 8; `<metasfresh.java.version>1.8</metasfresh.java.version>`).
