### PR TITLE
Port: ESRDataLoaderUtilTest - register IESRImportBL so the class no longer depends on test order

### DIFF
--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtilTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/dataimporter/ESRDataLoaderUtilTest.java
@@ -1,6 +1,10 @@
 package de.metas.payment.esr.dataimporter;
 
 import de.metas.payment.esr.model.I_ESR_ImportLine;
+import de.metas.attachments.AttachmentEntryService;
+import de.metas.payment.esr.api.IESRImportBL;
+import de.metas.payment.esr.api.impl.ESRImportBL;
+import de.metas.util.Services;
 import org.adempiere.test.AdempiereTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,6 +27,14 @@ public class ESRDataLoaderUtilTest
 	void init()
 	{
 		AdempiereTestHelper.get().init();
+
+		// ESRDataLoaderUtil is a @UtilityClass, so its Services.get(...) fields run in the static
+		// initializer the first time the class is touched. IESRImportBL cannot be auto-instantiated
+		// (ESRImportBL has no default constructor), so without this registration the initializer
+		// throws -- and because a failed <clinit> is cached per JVM, every later test that touches
+		// ESRDataLoaderUtil then fails with NoClassDefFoundError. Registering it here is what makes
+		// this class independent of whether some other test registered the service first.
+		Services.registerService(IESRImportBL.class, new ESRImportBL(AttachmentEntryService.createInstanceForUnitTesting()));
 	}
 
 	private I_ESR_ImportLine newLine()


### PR DESCRIPTION
## Summary

Port of https://github.com/metasfresh/metasfresh/pull/25650 to `inner_silence_uat`. Cherry-pick applied **without conflict**; the patch is line-for-line identical to the source commit.

`ESRDataLoaderUtil` is a Lombok **`@UtilityClass`**, so its `Services.get(...)` fields run in the **static initializer** the first time the class is touched. `IESRImportBL` cannot be auto-instantiated — `ESRImportBL` has no default constructor — so that initializer **throws** unless something has already registered the service in the same JVM.

`ESRDataLoaderUtilTest` registered nothing, so it only passed when an `ESRTestBase` subclass happened to run first. Run alone, or first in its module, it failed with `ExceptionInInitializerError` — and because a failed `<clinit>` is **cached per JVM**, every later test touching `ESRDataLoaderUtil` then failed with `NoClassDefFoundError`. On the source branch that cascaded to **51 failures + 48 errors across 175 tests** from one static initializer.

This branch carries the same fragile test, via https://github.com/metasfresh/metasfresh/pull/25629.

## Port safety checks against this branch

- The constructor the fix calls exists here unchanged: `ESRTestBase:101-102` on this branch already does `AttachmentEntryService.createInstanceForUnitTesting()` → `new ESRImportBL(attachmentEntryService)`, so the registration compiles against the same signature.
- No conflict and no adaptation needed, unlike the earlier port on this branch (https://github.com/metasfresh/metasfresh/pull/25629), where the test helper had to keep its single-argument form because this line has no exact-`DateTrx` condition.

## Test plan

- [x] On the source branch, over an identical patch: the class alone **5 errors → 5 passing**; full `de.metas.payment.esr` module suite **175 run / 51 failures / 48 errors → 175 run / 0 failures / 0 errors**, 1 pre-existing skip.
- [ ] **Not run locally on this branch.** This branch's module targets Java 17 and its worktree has no populated `.m2-local`, so a local run would either not compile or link against artifacts built for a different branch. Since the patch is identical and the constructor signature is verified present, **CI's `test (java)` is the gate here.**

Worth noting for the reviewer: `test (java)` does genuinely gate test failures — `docker-builds/Dockerfile.junit` runs `mvn surefire:test --fail-never` and derives `junit.mvn.exit-code` by grepping for `BUILD SUCCESS`, and `cicd.yaml` exits 1 when that code is non-zero. It stayed green on the fragile test only because CI runs the whole backend in shared JVMs, where an `ESRTestBase` subclass registers the service first.
