### PR TITLE
Port: ESR import - cover the three untested no-invoice scenarios

### DIFF
--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
@@ -1842,6 +1842,147 @@ public class ESRImportTest extends ESRTestBase
 	 * re-read from the line's FK
 	 * </ul>
 	 */
+	@Nested
+	class LineWithoutInvoice
+	{
+		/** Scaffolding for a line whose reference resolves to no invoice at all. */
+		private I_ESR_Import importWithUnmatchableLine()
+		{
+			final I_AD_Org org = newInstance(I_AD_Org.class, contextProvider);
+			org.setValue("106");
+			save(org);
+
+			final I_C_ReferenceNo_Type refNoType = newInstance(I_C_ReferenceNo_Type.class, contextProvider);
+			refNoType.setName("InvoiceReference");
+			save(refNoType);
+
+			final CurrencyId currencyEUR = PlainCurrencyDAO.createCurrencyId(CurrencyCode.EUR);
+			final I_C_BP_BankAccount account = createBankAccount(true,
+					org.getAD_Org_ID(),
+					Env.getAD_User_ID(getCtx()),
+					"01-067789-3",
+					currencyEUR);
+
+			// the reference in this line belongs to no invoice in the system
+			final String esrLineText = "01201067789300000001060000000000000000400000050009072  030014040914041014041100001006800000000000090                          ";
+			final I_ESR_Import esrImport = createImport();
+			esrImport.setAD_Org_ID(org.getAD_Org_ID());
+			esrImport.setC_BP_BankAccount_ID(account.getC_BP_BankAccount_ID());
+			save(esrImport);
+
+			esrImportBL.loadAndEvaluateESRImportStream(createImportFile(esrImport), new ByteArrayInputStream(esrLineText.getBytes()));
+			return esrImport;
+		}
+
+		private int createPartner()
+		{
+			final I_C_BPartner bpartner = newInstance(I_C_BPartner.class, contextProvider);
+			bpartner.setValue("payer-without-invoice");
+			save(bpartner);
+			return bpartner.getC_BPartner_ID();
+		}
+
+		/**
+		 * An unmatchable line creates no payment, so nothing can be done with it; setting the partner by
+		 * hand and processing again is the documented recovery, and it is what creates the payment.
+		 */
+		@Test
+		void unknownReference_createsNoPaymentUntilThePartnerIsSetByHand()
+		{
+			final I_ESR_Import esrImport = importWithUnmatchableLine();
+			esrImportBL.process(esrImport);
+
+			final I_ESR_ImportLine line = ESRTestUtil.retrieveSingleLine(esrImport);
+			refresh(line, true);
+			assertThat(line.getC_Payment_ID()).as("no partner, so no payment can be created").isZero();
+			assertThat(line.getC_Invoice_ID()).as("the reference matched no invoice").isZero();
+
+			// the recovery: the accountant sets whoever actually paid
+			line.setC_BPartner_ID(createPartner());
+			line.setESR_IsManual_ReferenceNo(true); // 'Y' by default in the real DB, false in the POJO store
+			save(line);
+			esrImportBL.process(esrImport);
+
+			refresh(line, true);
+			assertThat(line.getC_Payment_ID())
+					.as("processing again after the partner was set is what creates the payment")
+					.isNotZero();
+		}
+
+		/**
+		 * The payment such a line receives: booked for the full amount, but deliberately not allocated and
+		 * with no action chosen, so the accountant still has to decide what happens to the money.
+		 */
+		@Test
+		void theOwnPaymentIsCompletedUnallocatedAndLeavesTheActionOpen()
+		{
+			final I_ESR_Import esrImport = importWithUnmatchableLine();
+			final I_ESR_ImportLine line = ESRTestUtil.retrieveSingleLine(esrImport);
+			line.setC_BPartner_ID(createPartner());
+			line.setESR_IsManual_ReferenceNo(true);
+			save(line);
+
+			esrImportBL.process(esrImport);
+
+			refresh(line, true);
+			final PaymentId paymentId = PaymentId.ofRepoIdOrNull(line.getC_Payment_ID());
+			assertThat(paymentId).as("the line must have got its own payment").isNotNull();
+
+			final I_C_Payment payment = paymentDAO.getById(paymentId);
+			assertThat(payment.getPayAmt())
+					.as("booked for the amount that arrived")
+					.isEqualByComparingTo(line.getAmount());
+			assertThat(payment.getC_Invoice_ID()).as("there is no invoice to link").isZero();
+			assertThat(payment.isAllocated()).as("left unallocated for the accountant").isFalse();
+			assertThat(payment.getDocStatus()).as("completed, so the money is booked").isEqualTo("CO");
+			assertThat(line.getESR_Payment_Action())
+					.as("no action is set for the accountant, so the line stays a visible todo")
+					.isNull();
+			assertThat(line.isProcessed()).as("and the line stays open").isFalse();
+		}
+
+		/**
+		 * The refund branch that only a line WITHOUT an invoice reaches: there is no over-payment to
+		 * compute against, so the whole received amount is what gets transferred back. The sibling test
+		 * in ESRActionHandlerTest covers the with-invoice case, where only the excess is refunded.
+		 */
+		@Test
+		void choosingRefund_transfersBackTheWholeReceivedAmount()
+		{
+			final I_ESR_Import esrImport = importWithUnmatchableLine();
+			final I_ESR_ImportLine line = ESRTestUtil.retrieveSingleLine(esrImport);
+			line.setC_BPartner_ID(createPartner());
+			line.setESR_IsManual_ReferenceNo(true);
+			save(line);
+			esrImportBL.process(esrImport);
+
+			refresh(line, true);
+			final java.math.BigDecimal received = line.getAmount();
+			assertThat(POJOLookupMap.get().getRecords(I_C_Payment.class))
+					.as("guard: the import booked the incoming payment")
+					.hasSize(1);
+
+			line.setESR_Payment_Action(X_ESR_ImportLine.ESR_PAYMENT_ACTION_Money_Was_Transfered_Back_to_Partner);
+			save(line);
+			esrImportBL.registerActionHandler(
+					X_ESR_ImportLine.ESR_PAYMENT_ACTION_Money_Was_Transfered_Back_to_Partner,
+					new MoneyTransferedBackESRActionHandler());
+			esrImportBL.complete(esrImport, "");
+
+			final java.util.List<I_C_Payment> payments = POJOLookupMap.get().getRecords(I_C_Payment.class);
+			assertThat(payments).as("an outbound payment must have been booked for the refund").hasSize(2);
+
+			final I_C_Payment refund = payments.stream()
+					.filter(pmt -> !pmt.isReceipt())
+					.findFirst()
+					.orElse(null);
+			assertThat(refund).as("the refund is an OUTBOUND payment").isNotNull();
+			assertThat(refund.getPayAmt())
+					.as("with no invoice there is no excess to compute, so the whole amount goes back")
+					.isEqualByComparingTo(received);
+		}
+	}
+
 	@Test
 	public void testReprocessSameImport_createsNoSecondPayment()
 	{


### PR DESCRIPTION
## Summary

Port of https://github.com/metasfresh/metasfresh/pull/25651 to `inner_silence_uat`. Auto-merged **without conflict**; the patch is line-for-line identical to the source commit.

Covers the three UAT scenarios for a line that ends up **without an invoice**, which had no automated coverage on either branch:

| test | pins |
|---|---|
| `unknownReference_createsNoPaymentUntilThePartnerIsSetByHand` | an unmatchable reference books nothing; setting the payer by hand **and processing again** is what creates the payment |
| `theOwnPaymentIsCompletedUnallocatedAndLeavesTheActionOpen` | full amount, completed, **not** allocated, no invoice linked, action left empty so the line stays a visible todo |
| `choosingRefund_transfersBackTheWholeReceivedAmount` | *refund the overpayment* on a line **without** an invoice returns the **whole** received amount |

The third closes a genuine blind spot: only a no-invoice line reaches `else { transferedBackAmt = linePayment.getPayAmt(); }` in `MoneyTransferedBackESRActionHandler`. The existing `ESRActionHandlerTest.testMoneyTransferedBackESRAction` covers the with-invoice case, where merely the excess is refunded.

## Port verification against this branch

The two files diverge substantially between branches for unrelated reasons (upstream migrated this test class to AssertJ; `IPeriodBL` moved package), so "it applied cleanly" is not sufficient. Checked statically:

- **No duplicate imports** — the added `org.adempiere.ad.wrapper.POJOLookupMap` import appears exactly once.
- **AssertJ is available here** (`import static org.assertj.core.api.Assertions.assertThat` at line 73). The new tests use the single-argument form; JUnit's `assertThat` is two-argument, so the two static imports don't collide.
- **Every helper the tests use exists on this branch**: `paymentDAO`, `createBankAccount`, `createImport`, `createImportFile`, `ESRTestUtil`, `contextProvider`, `MoneyTransferedBackESRActionHandler`, `de.metas.interfaces.I_C_BPartner`.
- **`setESR_IsManual_ReferenceNo` is present** in this branch's generated `I_ESR_ImportLine`.

## Test-state fidelity

The setup sets exactly one flag by hand: `ESR_IsManual_ReferenceNo`, which is `'Y'` by default in the real database but `false` in the POJO store — the adjustment `testReferenceCompletelyNotFound_T06` already documents in this file. An earlier draft also forced `IsValid(true)`; it was dropped after confirming the tests pass without it, so nothing fabricates a state the running system does not reach on its own.

## Test plan

- [x] On the source branch, over an identical patch: `ESRImportTest` **72 run, 0 failures**; full `de.metas.payment.esr` module suite on merged mainline **175 run, 0 failures, 0 errors**, 1 pre-existing skip.
- [x] The refund test validated by **mutation** on the source branch: neutering the no-invoice branch to use `OverUnderAmt` makes only that test fail, with the refund collapsing to `0`.
- [ ] **Not run locally on this branch** — it targets Java 17 and this worktree has no populated `.m2-local`, so a local run would either not compile or link against artifacts built for another branch. The static checks above stand in for compilation; **CI's `test (java)` is the gate.**

## Note

This branch's whole-module suite additionally needs https://github.com/metasfresh/metasfresh/pull/25652 (the `ESRDataLoaderUtilTest` test-order fix, already merged upstream as https://github.com/metasfresh/metasfresh/pull/25650). Without it, that class's static-initializer failure cascades independently of this change.
