### PR TITLE
merge/deep_tundra_release-to-new_dawn_uat

### DIFF
--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_M_Shipper.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/I_M_Shipper.java
@@ -318,6 +318,29 @@ public interface I_M_Shipper
 	String COLUMNNAME_PickupTimeTo = "PickupTimeTo";
 
 	/**
+	 * Set Priority.
+	 * Priority of a document
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	void setPriorityRule (@Nullable java.lang.String PriorityRule);
+
+	/**
+	 * Get Priority.
+	 * Priority of a document
+	 *
+	 * <br>Type: List
+	 * <br>Mandatory: false
+	 * <br>Virtual Column: false
+	 */
+	@Nullable java.lang.String getPriorityRule();
+
+	ModelColumn<I_M_Shipper, Object> COLUMN_PriorityRule = new ModelColumn<>(I_M_Shipper.class, "PriorityRule", null);
+	String COLUMNNAME_PriorityRule = "PriorityRule";
+
+	/**
 	 * Set Shipper Gateway.
 	 *
 	 * <br>Type: List

--- a/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_M_Shipper.java
+++ b/backend/de.metas.adempiere.adempiere/base/src/main/java-gen/org/compiere/model/X_M_Shipper.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 public class X_M_Shipper extends org.compiere.model.PO implements I_M_Shipper, org.compiere.model.I_Persistent 
 {
 
-	private static final long serialVersionUID = 764239486L;
+	private static final long serialVersionUID = -1364471192L;
 
     /** Standard Constructor */
     public X_M_Shipper (final Properties ctx, final int M_Shipper_ID, @Nullable final String trxName)
@@ -158,6 +158,33 @@ public class X_M_Shipper extends org.compiere.model.PO implements I_M_Shipper, o
 	public java.sql.Timestamp getPickupTimeTo() 
 	{
 		return get_ValueAsTimestamp(COLUMNNAME_PickupTimeTo);
+	}
+
+	/** 
+	 * PriorityRule AD_Reference_ID=154
+	 * Reference name: _PriorityRule
+	 */
+	public static final int PRIORITYRULE_AD_Reference_ID=154;
+	/** High = 3 */
+	public static final String PRIORITYRULE_High = "3";
+	/** Medium = 5 */
+	public static final String PRIORITYRULE_Medium = "5";
+	/** Low = 7 */
+	public static final String PRIORITYRULE_Low = "7";
+	/** Urgent = 1 */
+	public static final String PRIORITYRULE_Urgent = "1";
+	/** Minor = 9 */
+	public static final String PRIORITYRULE_Minor = "9";
+	@Override
+	public void setPriorityRule (final @Nullable java.lang.String PriorityRule)
+	{
+		set_Value (COLUMNNAME_PriorityRule, PriorityRule);
+	}
+
+	@Override
+	public java.lang.String getPriorityRule() 
+	{
+		return get_ValueAsString(COLUMNNAME_PriorityRule);
 	}
 
 	/** 

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820640_sys_M_Shipper_PriorityRule.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820640_sys_M_Shipper_PriorityRule.sql
@@ -1,0 +1,67 @@
+-- Run mode: SWING_CLIENT
+
+-- Add M_Shipper.PriorityRule (char(1), nullable) + AD metadata; reuses existing AD_Element 522
+--
+-- IDs allocated from idserver.metas.de on 2026-08-27:
+--   AD_Column     593411 (M_Shipper.PriorityRule, nullable)
+--   AD_Field      783022 (Lieferweg window 142 / tab 185)
+--   AD_UI_Element 653671 (main group 541019, SeqNo 50)
+
+-- Column: M_Shipper.PriorityRule
+-- AD_Table_ID=253 (M_Shipper), AD_Reference_ID=17 (List), AD_Reference_Value_ID=154 (_PriorityRule)
+-- 2026-08-27T00:00:00.000Z
+INSERT INTO AD_Column (AD_Client_ID,AD_Column_ID,AD_Element_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_Value_ID,AD_Table_ID,CloningStrategy,ColumnName,Created,CreatedBy,DDL_NoForeignKey,EntityType,FacetFilterSeqNo,FieldLength,IsActive,IsAdvancedText,IsAllowLogging,IsAlwaysUpdateable,IsAutoApplyValidationRule,IsAutocomplete,IsCalculated,IsDimension,IsDLMPartitionBoundary,IsEncrypted,IsExcludeFromZoomTargets,IsFacetFilter,IsForceIncludeInGeneratedModel,IsGenericZoomKeyColumn,IsGenericZoomOrigin,IsIdentifier,IsKey,IsLazyLoading,IsMandatory,IsParent,IsRestAPICustomColumn,IsSelectionColumn,IsShowFilterIncrementButtons,IsShowFilterInline,IsStaleable,IsSyncDatabase,IsTranslated,IsUpdateable,IsUseDocSequence,MaxFacetsToFetch,Name,SelectionColumnSeqNo,SeqNo,Updated,UpdatedBy,PersonalDataCategory,Version)
+VALUES (0,593411 /*From ID Server*/,522,0,17,154,253,'XX','PriorityRule',TO_TIMESTAMP('2026-08-27 00:00:00','YYYY-MM-DD HH24:MI:SS'),100,'N','D',0,1,'Y','N','Y','N','N','N','N','N','N','N','Y','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','N','Y','N',0,'Priorität',0,0,TO_TIMESTAMP('2026-08-27 00:00:00','YYYY-MM-DD HH24:MI:SS'),100,'NP',0)
+;
+
+-- 2026-08-27T00:00:00.100Z
+INSERT INTO AD_Column_Trl (AD_Language,AD_Column_ID, Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Column_ID, t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Column t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Column_ID=593411
+  AND NOT EXISTS (SELECT 1 FROM AD_Column_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Column_ID=t.AD_Column_ID)
+;
+
+-- 2026-08-27T00:00:00.200Z
+/* DDL */  select update_Column_Translation_From_AD_Element(522)
+;
+
+-- Physical column: M_Shipper.PriorityRule CHAR(1)
+-- 2026-08-27T00:00:01.000Z
+/* DDL */ SELECT public.db_alter_table('M_Shipper','ALTER TABLE public.M_Shipper ADD COLUMN PriorityRule CHAR(1)')
+;
+
+-- Field: Lieferweg(142,D) -> Lieferweg(185,D) -> Priorität
+-- Column: M_Shipper.PriorityRule
+-- 2026-08-27T00:00:02.000Z
+INSERT INTO AD_Field (AD_Client_ID,AD_Column_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,Created,CreatedBy,DisplayLength,EntityType,IsActive,IsDisplayed,IsDisplayedGrid,IsEncrypted,IsFieldOnly,IsHeading,IsReadOnly,IsSameLine,Name,Updated,UpdatedBy)
+VALUES (0,593411,783022 /*From ID Server*/,0,185,TO_TIMESTAMP('2026-08-27 00:00:02','YYYY-MM-DD HH24:MI:SS'),100,1,'D','Y','N','N','N','N','N','N','N','Priorität',TO_TIMESTAMP('2026-08-27 00:00:02','YYYY-MM-DD HH24:MI:SS'),100)
+;
+
+-- 2026-08-27T00:00:02.100Z
+INSERT INTO AD_Field_Trl (AD_Language,AD_Field_ID, Description,Help,Name, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language, t.AD_Field_ID, t.Description,t.Help,t.Name, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Field t
+WHERE l.IsActive='Y' AND (l.IsSystemLanguage='Y' OR l.IsBaseLanguage='Y') AND t.AD_Field_ID=783022
+  AND NOT EXISTS (SELECT 1 FROM AD_Field_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Field_ID=t.AD_Field_ID)
+;
+
+-- 2026-08-27T00:00:02.200Z
+/* DDL */  select update_FieldTranslation_From_AD_Name_Element(522)
+;
+
+-- 2026-08-27T00:00:02.300Z
+DELETE FROM AD_Element_Link WHERE AD_Field_ID=783022
+;
+
+-- 2026-08-27T00:00:02.400Z
+/* DDL */ select AD_Element_Link_Create_Missing_Field(783022)
+;
+
+-- UI Element: Lieferweg(142,D) -> Lieferweg(185,D) -> main -> 50 -> Priorität
+-- Column: M_Shipper.PriorityRule
+-- Placed in main group (541019, col 10, sec 10), SeqNo 50
+-- 2026-08-27T00:00:03.000Z
+INSERT INTO AD_UI_Element (AD_Client_ID,AD_Field_ID,AD_Org_ID,AD_Tab_ID,AD_UI_ElementGroup_ID,AD_UI_Element_ID,AD_UI_ElementType,Created,CreatedBy,IsActive,IsAdvancedField,IsDisplayed,IsDisplayedGrid,IsDisplayed_SideList,Name,SeqNo,SeqNoGrid,SeqNo_SideList,Updated,UpdatedBy)
+VALUES (0,783022,0,185,541019,653671 /*From ID Server*/,'F',TO_TIMESTAMP('2026-08-27 00:00:03','YYYY-MM-DD HH24:MI:SS'),100,'Y','N','Y','N','N','Priorität',50,0,0,TO_TIMESTAMP('2026-08-27 00:00:03','YYYY-MM-DD HH24:MI:SS'),100)
+;

--- a/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820780_sys_M_Product_ProductLifeCycleStatus_remove_filter_from_vanilla_window.sql
+++ b/backend/de.metas.adempiere.adempiere/migration/src/main/sql/postgresql/system/10-de.metas.adempiere/5820780_sys_M_Product_ProductLifeCycleStatus_remove_filter_from_vanilla_window.sql
@@ -1,0 +1,13 @@
+-- Product Life Cycle Status (BBS-Status): remove the leftover filter entry from the vanilla Product
+-- window. 5820370 hid the field on AD_Window 140, but the filter bar kept offering it.
+--
+-- AD_Field.IsFilterField is window-scoped, so this touches window 140 only. The filter's source,
+-- AD_Column.IsSelectionColumn (5819940), is table-level and stays 'Y' -- clearing it there would also
+-- strip the quick filter from the customer's own Product window.
+
+UPDATE AD_Field
+SET IsFilterField='N',
+    Updated=TO_TIMESTAMP('2026-08-27 09:15:00','YYYY-MM-DD HH24:MI:SS'),
+    UpdatedBy=100
+WHERE AD_Field_ID=781848 /* M_Product.ProductLifeCycleStatus on AD_Tab 180 (AD_Window 140, Produkt_OLD) */
+;

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java
@@ -237,6 +237,8 @@ public class C_Order_StepDef
 	 *       delivery date (per-line {@code M_Packageable_V.DeliveryDate}) is reached before it may be shipped</li>
 	 *   <li>{@code IsFixedPreparationDate} (optional) — when {@code true}, holds each order line until its own
 	 *       preparation date (per-line {@code M_Packageable_V.PreparationDate}) is reached before it may be picked</li>
+	 *   <li>{@code PriorityRule} (optional) — priority rule code (1=Urgent, 3=High, 5=Medium, 7=Low, 9=Minor);
+	 *       defaults to the AD column default (5, Medium) when omitted</li>
 	 * </ul>
 	 */
 	@Given("metasfresh contains C_Orders:")
@@ -448,6 +450,9 @@ public class C_Order_StepDef
 				.map(shipperTable::extractIdFromRecord)
 				.map(ShipperId::getRepoId)
 				.ifPresent(order::setM_Shipper_ID);
+
+		tableRow.getAsOptionalString(I_C_Order.COLUMNNAME_PriorityRule)
+				.ifPresent(order::setPriorityRule);
 		tableRow.getAsOptionalIdentifier(COLUMNNAME_C_Project_ID)
 				.map(projectTable::get)
 				.map(projectTable::extractIdFromRecord)

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipmentschedule/M_ShipmentSchedule_StepDef.java
@@ -905,6 +905,7 @@ public class M_ShipmentSchedule_StepDef
 	 *     (e.g. {@code 2022-08-10}) compared in the order's time zone<br>
 	 *   <b>DeliveryDate</b> — (optional) expected per-line delivery date (the line's promised delivery date),
 	 *     as a plain calendar date compared in the order's time zone<br>
+	 *   <b>PriorityRule</b> — (optional) expected priority rule code (1=Urgent, 3=High, 5=Medium, 7=Low, 9=Minor)<br>
 	 * @cucumber.depends StepDefData: M_ShipmentSchedule_StepDefData
 	 * @cucumber.example
 	 * <pre>
@@ -1516,6 +1517,9 @@ public class M_ShipmentSchedule_StepDef
 			final I_C_Project project = projectTable.get(projectIdentifier);
 			softly.assertThat(shipmentSchedule.getC_Project_ID()).as("C_Project_ID for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(project.getC_Project_ID());
 		}
+
+		tableRow.getAsOptionalString(I_M_ShipmentSchedule.COLUMNNAME_PriorityRule)
+				.ifPresent(expected -> softly.assertThat(shipmentSchedule.getPriorityRule()).as("PriorityRule for M_ShipmentSchedule_ID.Identifier=%s", shipmentScheduleIdentifier).isEqualTo(expected));
 
 		softly.assertAll();
 	}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipper/M_Shipper_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/shipper/M_Shipper_StepDef.java
@@ -68,6 +68,28 @@ public class M_Shipper_StepDef
 		shipperTable.put(row.getAsIdentifier(), shipperRecord);
 	}
 
+	/**
+	 * Creates or updates {@code M_Shipper} records.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>Identifier</b> — (optional) alias to store the shipper under<br>
+	 *   <b>PickupTimeFrom</b> — (optional) defaults to 08:00<br>
+	 *   <b>PickupTimeTo</b> — (optional) defaults to 17:00<br>
+	 *   <b>InternalName</b> — (optional)<br>
+	 *   <b>ShipperGateway</b> — (optional)<br>
+	 *   <b>IsApiCarrierAdvise</b> — (optional)<br>
+	 *   <b>IsCreateDeliveryPlanning</b> — (optional)<br>
+	 *   <b>PriorityRule</b> — (optional) the shipper's priority rule code (1=Urgent, 3=High, 5=Medium,
+	 *     7=Low, 9=Minor); left empty (the AD column default) when omitted<br>
+	 * @cucumber.depends StepDefData: M_Shipper_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And contains M_Shippers
+	 *   | Identifier | PriorityRule |
+	 *   | express    | 1            |
+	 * </pre>
+	 */
 	@And("contains M_Shippers")
 	public void createOrUpdateShippers(@NonNull final DataTable dataTable)
 	{
@@ -112,10 +134,50 @@ public class M_Shipper_StepDef
 		row.getAsOptionalBoolean(I_M_Shipper.COLUMNNAME_IsCreateDeliveryPlanning)
 				.ifPresent(record::setIsCreateDeliveryPlanning);
 
+		row.getAsOptionalString(I_M_Shipper.COLUMNNAME_PriorityRule)
+				.map(StringUtils::trimBlankToNull)
+				.ifPresent(record::setPriorityRule);
+
 		InterfaceWrapperHelper.save(record);
 
 		row.getAsOptionalIdentifier()
 				.ifPresent(identifier -> shipperTable.put(identifier, record));
+	}
+
+	/**
+	 * Updates an already-known {@code M_Shipper} record — e.g. a carrier-service employee changing the
+	 * shipper's priority in the *Lieferweg* window.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>Identifier</b> — (required, identifier-ref) alias from a prior {@code contains M_Shippers}<br>
+	 *   <b>PriorityRule</b> — (optional) the shipper's new priority rule code (1=Urgent, 3=High, 5=Medium,
+	 *     7=Low, 9=Minor)<br>
+	 * @cucumber.depends StepDefData: M_Shipper_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And update M_Shipper:
+	 *   | Identifier | PriorityRule |
+	 *   | express    | 1            |
+	 * </pre>
+	 */
+	@And("update M_Shipper:")
+	public void updateShipper(@NonNull final DataTable dataTable)
+	{
+		DataTableRows.of(dataTable).forEach(this::updateShipper);
+	}
+
+	private void updateShipper(@NonNull final DataTableRow row)
+	{
+		final I_M_Shipper record = row.getAsIdentifier().lookupNotNullIn(shipperTable);
+
+		row.getAsOptionalString(I_M_Shipper.COLUMNNAME_PriorityRule)
+				.map(StringUtils::trimBlankToNull)
+				.ifPresent(record::setPriorityRule);
+
+		InterfaceWrapperHelper.save(record);
+
+		shipperTable.putOrReplace(row.getAsIdentifier(), record);
 	}
 
 }

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/shipmentSchedulePriorityFromShipper.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/shipmentschedule/shipmentSchedulePriorityFromShipper.feature
@@ -1,0 +1,192 @@
+@from:cucumber
+@allure.label.epic:E0100_Sales
+@allure.label.feature:F00130_Shipment_Schedule
+@ghActions:run_on_executor7
+Feature: Shipment-schedule priority derived from the shipper
+## F00130: Shipment Schedule (Lieferdisposition)
+  A shipment schedule normally takes its priority from its sales order. Behind the
+  M_ShipmentSchedule_PriorityRuleFromShipper sysconfig (default off), it instead takes the
+  priority from its shipper whenever the shipper has one set — the delivery planner uses this
+  to route urgent carriers ahead of standard ones, regardless of what the sales order says.
+  # PriorityRule codes used below: 1 = Urgent, 3 = High, 5 = Medium, 7 = Low, 9 = Minor.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2026-08-27T08:00:00+02:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+
+    And metasfresh contains M_Warehouse:
+      | M_Warehouse_ID |
+      | warehouse      |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country.CountryCode | C_Currency.ISO_Code | SOTrx |
+      | pl         | ps                 | DE                    | EUR                 | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv        | pl             |
+    And metasfresh contains C_TaxCategory
+      | Identifier  |
+      | taxCategory |
+    And metasfresh contains C_Tax
+      | Identifier | C_TaxCategory_ID | Rate | C_Country_ID.CountryCode | To_Country_ID.CountryCode |
+      | tax19      | taxCategory      | 19   | DE                       | DE                        |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID | C_TaxCategory_ID |
+      | plv                    | product      | 10.0     | PCE      | taxCategory      |
+    And metasfresh contains C_BPartners:
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID |
+      | customer   | N        | Y          | ps                 |
+
+  @Id:S31627_TC1
+  Scenario: Switch off — the shipment schedule keeps the order's priority
+
+    And set sys config boolean value false for sys config M_ShipmentSchedule_PriorityRuleFromShipper
+    And contains M_Shippers
+      | Identifier     | PriorityRule |
+      | expressShipper | 1            |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | M_Warehouse_ID | DateOrdered | PriorityRule |
+      | order1     | true    | customer      | warehouse      | 2026-08-27  | 7            |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | OPT.M_Shipper_ID.Identifier |
+      | orderLine1 | order1     | product      | 10         | expressShipper              |
+    When the order identified by order1 is completed
+
+    Then after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | schedule1  | orderLine1     | N             |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID | PriorityRule |
+      | schedule1             | 7            |
+
+  @Id:S31627_TC2
+  Scenario: Switch on — the shipment schedule takes the shipper's priority
+
+    And set sys config boolean value true for sys config M_ShipmentSchedule_PriorityRuleFromShipper
+    And contains M_Shippers
+      | Identifier     | PriorityRule |
+      | expressShipper | 1            |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | M_Warehouse_ID | DateOrdered | PriorityRule |
+      | order1     | true    | customer      | warehouse      | 2026-08-27  | 7            |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | OPT.M_Shipper_ID.Identifier |
+      | orderLine1 | order1     | product      | 10         | expressShipper              |
+    When the order identified by order1 is completed
+
+    Then after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | schedule1  | orderLine1     | N             |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID | PriorityRule |
+      | schedule1             | 1            |
+
+  @Id:S31627_TC3
+  Scenario: Switch on, shipper has no priority set — falls back to the order's priority
+
+    And set sys config boolean value true for sys config M_ShipmentSchedule_PriorityRuleFromShipper
+    And contains M_Shippers
+      | Identifier      |
+      | standardShipper |
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | M_Warehouse_ID | DateOrdered | PriorityRule |
+      | order1     | true    | customer      | warehouse      | 2026-08-27  | 3            |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | OPT.M_Shipper_ID.Identifier |
+      | orderLine1 | order1     | product      | 10         | standardShipper             |
+    When the order identified by order1 is completed
+
+    Then after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | schedule1  | orderLine1     | N             |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID | PriorityRule |
+      | schedule1             | 3            |
+
+  @Id:S31627_TC4
+  Scenario: Switch on, no shipper on the order line — falls back to the order's priority
+
+    And set sys config boolean value true for sys config M_ShipmentSchedule_PriorityRuleFromShipper
+
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | M_Warehouse_ID | DateOrdered | PriorityRule |
+      | order1     | true    | customer      | warehouse      | 2026-08-27  | 3            |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | orderLine1 | order1     | product      | 10         |
+    When the order identified by order1 is completed
+
+    Then after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier | C_OrderLine_ID | IsToRecompute |
+      | schedule1  | orderLine1     | N             |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID | PriorityRule |
+      | schedule1             | 3            |
+
+  @Id:S31627_TC6
+  Scenario: Changing a shipper's priority recomputes its open schedules, but not its processed ones
+
+    And set sys config boolean value true for sys config M_ShipmentSchedule_PriorityRuleFromShipper
+    And contains M_Shippers
+      | Identifier      | PriorityRule |
+      | changingShipper | 7            |
+
+    # Order 1: stays open (never shipped) — this is the one we watch through the recompute.
+    # Its own priority is deliberately Urgent, so the assertion only passes if the derivation
+    # really used the shipper's Low, not the order's.
+    And metasfresh contains C_Orders:
+      | Identifier   | IsSOTrx | C_BPartner_ID | M_Warehouse_ID | DateOrdered | PriorityRule |
+      | pendingOrder | true    | customer      | warehouse      | 2026-08-27  | 1            |
+    And metasfresh contains C_OrderLines:
+      | Identifier       | C_Order_ID   | M_Product_ID | QtyEntered | OPT.M_Shipper_ID.Identifier |
+      | pendingOrderLine | pendingOrder | product      | 10         | changingShipper             |
+    When the order identified by pendingOrder is completed
+
+    Then after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier      | C_OrderLine_ID   | IsToRecompute |
+      | pendingSchedule | pendingOrderLine | N             |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID | PriorityRule |
+      | pendingSchedule       | 7            |
+
+    # Order 2: shipped and completed right away, on the same shipper — its schedule becomes
+    # Processed and must stay untouched by the later shipper-priority change.
+    And metasfresh contains C_Orders:
+      | Identifier   | IsSOTrx | C_BPartner_ID | M_Warehouse_ID | DeliveryRule | DateOrdered | PriorityRule |
+      | shippedOrder | true    | customer      | warehouse      | F            | 2026-08-27  | 1            |
+    And metasfresh contains C_OrderLines:
+      | Identifier       | C_Order_ID   | M_Product_ID | QtyEntered | OPT.M_Shipper_ID.Identifier |
+      | shippedOrderLine | shippedOrder | product      | 10         | changingShipper             |
+    And the order identified by shippedOrder is completed
+
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier      | C_OrderLine_ID   | IsToRecompute |
+      | shippedSchedule | shippedOrderLine | N             |
+    And shipment is generated for the following shipment schedule
+      | M_InOut_ID.Identifier | M_ShipmentSchedule_ID.Identifier | quantityTypeToUse | isCompleteShipment |
+      | shipment              | shippedSchedule                  | D                 | Y                  |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID | OPT.Processed | PriorityRule |
+      | shippedSchedule       | true          | 7            |
+
+    # Raise the shipper's priority — a carrier-service employee editing the Lieferweg window.
+    When update M_Shipper:
+      | Identifier      | PriorityRule |
+      | changingShipper | 1            |
+
+    Then after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID | PriorityRule |
+      | pendingSchedule       | 1            |
+    And after not more than 60s, validate shipment schedules:
+      | M_ShipmentSchedule_ID | OPT.Processed | PriorityRule |
+      | shippedSchedule       | true          | 7            |

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentSchedulePA.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/IShipmentSchedulePA.java
@@ -12,6 +12,7 @@ import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
 import de.metas.process.PInstanceId;
 import de.metas.product.ProductId;
+import de.metas.shipping.ShipperId;
 import de.metas.util.ISingletonService;
 import lombok.NonNull;
 import org.adempiere.ad.dao.IQueryBuilder;
@@ -62,6 +63,8 @@ public interface IShipmentSchedulePA extends ISingletonService
 	boolean existsSheduledForPickingShipmentScheduleForOrder(@NonNull OrderId orderId);
 
 	Set<ShipmentScheduleId> retrieveUnprocessedIdsByOrderId(OrderId orderId);
+
+	Set<ShipmentScheduleId> retrieveUnprocessedIdsByShipperId(@NonNull final ShipperId shipperId);
 
 	/**
 	 * @return the shipment schedule entries that refer to given record

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA.java
@@ -27,6 +27,7 @@ import de.metas.order.OrderId;
 import de.metas.order.OrderLineId;
 import de.metas.process.PInstanceId;
 import de.metas.product.ProductId;
+import de.metas.shipping.ShipperId;
 import de.metas.util.Check;
 import de.metas.util.Services;
 import lombok.NonNull;
@@ -251,6 +252,18 @@ public class ShipmentSchedulePA implements IShipmentSchedulePA
 				.addOnlyActiveRecordsFilter()
 				.addEqualsFilter(I_M_ShipmentSchedule.COLUMN_Processed, false)
 				.addEqualsFilter(I_M_ShipmentSchedule.COLUMN_C_Order_ID, orderId)
+				.create()
+				.idsAsSet(ShipmentScheduleId::ofRepoId);
+	}
+
+	@Override
+	public Set<ShipmentScheduleId> retrieveUnprocessedIdsByShipperId(@NonNull final ShipperId shipperId)
+	{
+		return queryBL
+				.createQueryBuilder(I_M_ShipmentSchedule.class)
+				.addOnlyActiveRecordsFilter()
+				.addEqualsFilter(I_M_ShipmentSchedule.COLUMN_Processed, false)
+				.addEqualsFilter(I_M_ShipmentSchedule.COLUMN_M_Shipper_ID, shipperId)
 				.create()
 				.idsAsSet(ShipmentScheduleId::ofRepoId);
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateRepository.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/invalidation/impl/ShipmentScheduleInvalidateRepository.java
@@ -2,6 +2,7 @@ package de.metas.inoutcandidate.invalidation.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import de.metas.async.AsyncBatchId;
 import de.metas.cache.model.CacheInvalidateMultiRequest;
 import de.metas.cache.model.ModelCacheInvalidationService;
@@ -221,6 +222,10 @@ public class ShipmentScheduleInvalidateRepository implements IShipmentScheduleIn
 		}
 	}
 
+	// PostgreSQL's driver rejects a single "IN (?,?,...)" statement once the parameter count exceeds ~32,765
+	// (DB-08006, "out-of-range integer as a 2-byte value"); chunk well under that cap.
+	private static final int MAX_IDS_PER_CHUNK = 10_000;
+
 	@Override
 	public void invalidateShipmentSchedules(@NonNull final Set<ShipmentScheduleId> shipmentScheduleIds)
 	{
@@ -232,22 +237,26 @@ public class ShipmentScheduleInvalidateRepository implements IShipmentScheduleIn
 		final String description = truncInvalidateDescription("" + shipmentScheduleIds.size() + " shipment schedules: " + shipmentScheduleIds);
 		final String chunkUUID = UUID.randomUUID().toString();
 
-		final List<Object> sqlParams = new ArrayList<>();
-		sqlParams.add(description);
-		sqlParams.add(chunkUUID);
-		final String sqlInWhereClause = DB.buildSqlList(shipmentScheduleIds, sqlParams); // creates the string and fills the sqlParams list
+		int count = 0;
+		for (final List<ShipmentScheduleId> shipmentScheduleIdsChunk : Iterables.partition(shipmentScheduleIds, MAX_IDS_PER_CHUNK))
+		{
+			final List<Object> sqlParams = new ArrayList<>();
+			sqlParams.add(description);
+			sqlParams.add(chunkUUID);
+			final String sqlInWhereClause = DB.buildSqlList(shipmentScheduleIdsChunk, sqlParams); // creates the string and fills the sqlParams list
 
-		final String sql = "INSERT INTO " + M_SHIPMENT_SCHEDULE_RECOMPUTE + " (M_ShipmentSchedule_ID, Description, C_Async_Batch_ID, ChunkUUID) "
-				+ " SELECT " + I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID + ", ?, " + I_M_ShipmentSchedule.COLUMNNAME_C_Async_Batch_ID + " , ?"
-				+ " FROM " + I_M_ShipmentSchedule.Table_Name
-				+ " WHERE "
-				// Only our shipment schedule Ids
-				+ I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID + " IN " + sqlInWhereClause
-				// Only those which were not already added (technically not necessary, but shall reduce unnecessary bloat)
-				+ "   AND NOT EXISTS (select 1 from " + M_SHIPMENT_SCHEDULE_RECOMPUTE + " e where e.AD_PInstance_ID is NULL and e.M_ShipmentSchedule_ID=" + I_M_ShipmentSchedule.Table_Name + "."
-				+ I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID + ")";
+			final String sql = "INSERT INTO " + M_SHIPMENT_SCHEDULE_RECOMPUTE + " (M_ShipmentSchedule_ID, Description, C_Async_Batch_ID, ChunkUUID) "
+					+ " SELECT " + I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID + ", ?, " + I_M_ShipmentSchedule.COLUMNNAME_C_Async_Batch_ID + " , ?"
+					+ " FROM " + I_M_ShipmentSchedule.Table_Name
+					+ " WHERE "
+					// Only our shipment schedule Ids
+					+ I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID + " IN " + sqlInWhereClause
+					// Only those which were not already added (technically not necessary, but shall reduce unnecessary bloat)
+					+ "   AND NOT EXISTS (select 1 from " + M_SHIPMENT_SCHEDULE_RECOMPUTE + " e where e.AD_PInstance_ID is NULL and e.M_ShipmentSchedule_ID=" + I_M_ShipmentSchedule.Table_Name + "."
+					+ I_M_ShipmentSchedule.COLUMNNAME_M_ShipmentSchedule_ID + ")";
 
-		final int count = DB.executeUpdateAndThrowExceptionOnFail(sql, sqlParams.toArray(), ITrx.TRXNAME_ThreadInherited);
+			count += DB.executeUpdateAndThrowExceptionOnFail(sql, sqlParams.toArray(), ITrx.TRXNAME_ThreadInherited);
+		}
 		logger.debug("Invalidated {} shipment schedules for M_ShipmentSchedule_IDs={}", count, shipmentScheduleIds);
 
 		if (count > 0)

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_Shipper_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_Shipper_ShipmentSchedule.java
@@ -1,0 +1,49 @@
+package de.metas.inoutcandidate.modelvalidator;
+
+import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.api.IShipmentSchedulePA;
+import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
+import de.metas.shipping.ShipperId;
+import de.metas.util.Services;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.adempiere.ad.modelvalidator.annotations.Interceptor;
+import org.adempiere.ad.modelvalidator.annotations.ModelChange;
+import org.compiere.model.I_M_Shipper;
+import org.compiere.model.ModelValidator;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+/**
+ * Flags a shipper's unprocessed {@link de.metas.inoutcandidate.model.I_M_ShipmentSchedule}s for recompute
+ * whenever the shipper's {@code PriorityRule} changes -- so that
+ * {@code OrderLineShipmentScheduleHandler#updateShipmentScheduleFromOrder} re-derives their priority from the
+ * (new) shipper value.
+ */
+@Interceptor(I_M_Shipper.class)
+@Component
+@RequiredArgsConstructor
+public class M_Shipper_ShipmentSchedule
+{
+	@NonNull private final IShipmentSchedulePA shipmentSchedulePA = Services.get(IShipmentSchedulePA.class);
+	@NonNull private final IShipmentScheduleInvalidateBL shipmentScheduleInvalidateBL;
+
+	@ModelChange(timings = {
+			ModelValidator.TYPE_AFTER_NEW,
+			ModelValidator.TYPE_AFTER_CHANGE }, ifColumnsChanged = {
+					I_M_Shipper.COLUMNNAME_PriorityRule })
+	public void flagUnprocessedSchedulesForRecompute(final I_M_Shipper shipper)
+	{
+		final ShipperId shipperId = ShipperId.ofRepoId(shipper.getM_Shipper_ID());
+
+		final Set<ShipmentScheduleId> unprocessedScheduleIds = shipmentSchedulePA.retrieveUnprocessedIdsByShipperId(shipperId);
+
+		if (unprocessedScheduleIds.isEmpty())
+		{
+			return;
+		}
+
+		shipmentScheduleInvalidateBL.flagForRecompute(unprocessedScheduleIds);
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/inoutcandidate/OrderLineShipmentScheduleHandler.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/order/inoutcandidate/OrderLineShipmentScheduleHandler.java
@@ -1,5 +1,6 @@
 package de.metas.order.inoutcandidate;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import de.metas.adempiere.model.I_C_Order;
@@ -11,6 +12,7 @@ import de.metas.document.DocBaseAndSubType;
 import de.metas.document.DocTypeId;
 import de.metas.document.IDocTypeDAO;
 import de.metas.document.location.DocumentLocation;
+import de.metas.inout.PriorityRule;
 import de.metas.inoutcandidate.api.IDeliverRequest;
 import de.metas.inoutcandidate.api.IShipmentScheduleBL;
 import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
@@ -20,6 +22,7 @@ import de.metas.inoutcandidate.picking_bom.PickingBOMService;
 import de.metas.inoutcandidate.picking_bom.PickingOrderConfig;
 import de.metas.inoutcandidate.spi.ShipmentScheduleHandler;
 import de.metas.interfaces.I_C_OrderLine;
+import de.metas.logging.LogManager;
 import de.metas.order.DeliveryRule;
 import de.metas.order.IOrderBL;
 import de.metas.order.IOrderDAO;
@@ -33,6 +36,8 @@ import de.metas.product.IProductBL;
 import de.metas.product.ProductId;
 import de.metas.quantity.Quantity;
 import de.metas.quantity.Quantitys;
+import de.metas.shipping.IShipperDAO;
+import de.metas.shipping.ShipperId;
 import de.metas.uom.UomId;
 import de.metas.util.Check;
 import de.metas.util.Services;
@@ -47,6 +52,7 @@ import org.adempiere.mm.attributes.api.IAttributeSetInstanceBL;
 import org.adempiere.mm.attributes.api.ImmutableAttributeSet;
 import org.adempiere.mm.attributes.asi_aware.IAttributeSetInstanceAware;
 import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ISysConfigBL;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.adempiere.warehouse.WarehouseId;
 import org.adempiere.warehouse.spi.IWarehouseAdvisor;
@@ -58,6 +64,7 @@ import org.eevolution.api.IPPOrderBL;
 import org.eevolution.api.PPOrderCreateRequest;
 import org.eevolution.api.PPOrderId;
 import org.eevolution.model.I_PP_Order;
+import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Nullable;
@@ -78,6 +85,7 @@ import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
 @Component
 public class OrderLineShipmentScheduleHandler extends ShipmentScheduleHandler
 {
+	private static final Logger logger = LogManager.getLogger(OrderLineShipmentScheduleHandler.class);
 	private final IQueryBL queryBL = Services.get(IQueryBL.class);
 	private final IOrderBL orderBL = Services.get(IOrderBL.class);
 	private final IOrderDAO orderDAO = Services.get(IOrderDAO.class);
@@ -89,6 +97,8 @@ public class OrderLineShipmentScheduleHandler extends ShipmentScheduleHandler
 	private final IPPOrderBL ppOrderBL = Services.get(IPPOrderBL.class);
 	private final IWarehouseAdvisor warehouseAdvisor = Services.get(IWarehouseAdvisor.class);
 	private final IDocTypeDAO docTypeDAO = Services.get(IDocTypeDAO.class);
+	private final ISysConfigBL sysConfigBL = Services.get(ISysConfigBL.class);
+	private final IShipperDAO shipperDAO = Services.get(IShipperDAO.class);
 	private final PickingBOMService pickingBOMService;
 
 	private final OrderLineShipmentScheduleHandlerExtension extensions;
@@ -259,11 +269,61 @@ public class OrderLineShipmentScheduleHandler extends ShipmentScheduleHandler
 		extensions.updateShipmentScheduleFromOrderLine(shipmentSchedule, orderLine);
 	}
 
+	@VisibleForTesting
+	static final String SYSCONFIG_PriorityRuleFromShipper = "M_ShipmentSchedule_PriorityRuleFromShipper";
+
+	@VisibleForTesting
+	String computePriorityRuleCode(
+			@NonNull final I_C_Order order,
+			@Nullable final ShipperId shipperId,
+			@NonNull final ClientAndOrgId clientAndOrgId)
+	{
+		if (shipperId != null
+				&& sysConfigBL.getBooleanValue(SYSCONFIG_PriorityRuleFromShipper, false, clientAndOrgId))
+		{
+			final PriorityRule shipperPriority = getShipperPriorityOrNull(shipperId);
+			if (shipperPriority != null)
+			{
+				return shipperPriority.getCode();
+			}
+		}
+		return order.getPriorityRule();
+	}
+
+	/**
+	 * @return the shipper's priority, or {@code null} if it has none or its stored code is not in the priority list.
+	 *
+	 * An out-of-list code can reach {@code M_Shipper.PriorityRule} through an import, the REST API or direct SQL —
+	 * the column has no CHECK constraint, the value list is enforced in the UI layer only. It must not propagate as
+	 * an exception: this runs inside {@link de.metas.inoutcandidate.api.impl.ShipmentScheduleUpdater#updateSchedules},
+	 * which iterates a whole recompute batch with no per-item error handling, so throwing here would roll back the
+	 * batch and take unrelated schedules down with it. Falling back also keeps this method symmetric, since the
+	 * order's own priority code is returned unvalidated.
+	 */
+	@Nullable
+	private PriorityRule getShipperPriorityOrNull(@NonNull final ShipperId shipperId)
+	{
+		final String code = shipperDAO.getById(shipperId).getPriorityRule();
+		try
+		{
+			return PriorityRule.ofNullableCode(code);
+		}
+		catch (final RuntimeException ex)
+		{
+			logger.warn("Ignoring unknown PriorityRule code {} on M_Shipper_ID={}; falling back to the order's priority",
+					code, shipperId.getRepoId(), ex);
+			return null;
+		}
+	}
+
 	private void updateShipmentScheduleFromOrder(
 			@NonNull final I_M_ShipmentSchedule shipmentSchedule,
 			@NonNull final I_C_Order order)
 	{
-		shipmentSchedule.setPriorityRule(order.getPriorityRule());
+		shipmentSchedule.setPriorityRule(computePriorityRuleCode(
+				order,
+				ShipperId.ofRepoIdOrNull(shipmentSchedule.getM_Shipper_ID()),
+				ClientAndOrgId.ofClientAndOrg(shipmentSchedule.getAD_Client_ID(), shipmentSchedule.getAD_Org_ID())));
 
 		final BPartnerLocationAndCaptureId billToLocationId = orderBL.getBillToLocationId(order);
 		final BPartnerContactId billToContactId;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5820650_sys_M_ShipmentSchedule_PriorityRuleFromShipper_sysconfig.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/48-de.metas.inoutcandidate/5820650_sys_M_ShipmentSchedule_PriorityRuleFromShipper_sysconfig.sql
@@ -1,0 +1,16 @@
+-- IDs allocated from idserver.metas.de on 2026-08-27:
+--   AD_SysConfig 541850 (M_ShipmentSchedule_PriorityRuleFromShipper switch)
+
+-- 2026-08-27T00:00:00.000Z
+INSERT INTO AD_SysConfig
+(AD_SysConfig_ID, AD_Client_ID, AD_Org_ID, Created, Updated, CreatedBy, UpdatedBy, IsActive,
+ Name, Value, Description, EntityType, ConfigurationLevel)
+VALUES
+(541850 /*From ID Server*/, 0, 0,
+ TO_TIMESTAMP('2026-08-27 00:00:00','YYYY-MM-DD HH24:MI:SS'),
+ TO_TIMESTAMP('2026-08-27 00:00:00','YYYY-MM-DD HH24:MI:SS'),
+ 100, 100, 'Y',
+ 'M_ShipmentSchedule_PriorityRuleFromShipper', 'N',
+ 'By setting this configuration you can switch on and off the derivation of shipment schedule priority from its shipper. If this behaviour is needed, set the value to "Y" otherwise to "N".',
+ 'de.metas.inoutcandidate', 'O')
+;

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA_ByShipperTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/api/impl/ShipmentSchedulePA_ByShipperTest.java
@@ -1,0 +1,83 @@
+package de.metas.inoutcandidate.api.impl;
+
+import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import de.metas.shipping.ShipperId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_M_Shipper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ShipmentSchedulePA_ByShipperTest
+{
+	private ShipmentSchedulePA shipmentSchedulePA;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		shipmentSchedulePA = new ShipmentSchedulePA();
+	}
+
+	@Nested
+	class RetrieveUnprocessedIdsByShipperId
+	{
+		@Test
+		void onlyUnprocessedOnSameShipperReturned()
+		{
+			// Given: two schedules on shipper A (one unprocessed, one processed) and one on shipper B
+			final ShipperId shipperA = createShipper();
+			final ShipperId shipperB = createShipper();
+
+			final I_M_ShipmentSchedule schedA_Unprocessed = createShipmentSchedule(shipperA, false);
+			final ShipmentScheduleId schedA_UnprocessedId = ShipmentScheduleId.ofRepoId(schedA_Unprocessed.getM_ShipmentSchedule_ID());
+
+			final I_M_ShipmentSchedule schedA_Processed = createShipmentSchedule(shipperA, true);
+
+			final I_M_ShipmentSchedule schedB_Unprocessed = createShipmentSchedule(shipperB, false);
+
+			// When
+			final Set<ShipmentScheduleId> result = shipmentSchedulePA.retrieveUnprocessedIdsByShipperId(shipperA);
+
+			// Then: only the unprocessed shipper-A schedule is returned
+			assertThat(result).containsExactly(schedA_UnprocessedId);
+		}
+
+		@Test
+		void unknownShipperReturnsEmptySet()
+		{
+			// Given: an unknown shipper
+			final ShipperId unknownShipper = ShipperId.ofRepoId(999999);
+
+			// When
+			final Set<ShipmentScheduleId> result = shipmentSchedulePA.retrieveUnprocessedIdsByShipperId(unknownShipper);
+
+			// Then: an empty set is returned
+			assertThat(result).isEmpty();
+		}
+	}
+
+	private ShipperId createShipper()
+	{
+		final I_M_Shipper shipper = InterfaceWrapperHelper.newInstance(I_M_Shipper.class);
+		InterfaceWrapperHelper.saveRecord(shipper);
+		return ShipperId.ofRepoId(shipper.getM_Shipper_ID());
+	}
+
+	private I_M_ShipmentSchedule createShipmentSchedule(final ShipperId shipperId, final boolean isProcessed)
+	{
+		final I_M_ShipmentSchedule schedule = InterfaceWrapperHelper.newInstance(I_M_ShipmentSchedule.class);
+		schedule.setM_Shipper_ID(shipperId.getRepoId());
+		schedule.setProcessed(isProcessed);
+		schedule.setAD_Table_ID(0);
+		schedule.setRecord_ID(0);
+		InterfaceWrapperHelper.saveRecord(schedule);
+		return schedule;
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/modelvalidator/M_Shipper_ShipmentScheduleTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/inoutcandidate/modelvalidator/M_Shipper_ShipmentScheduleTest.java
@@ -1,0 +1,139 @@
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.inoutcandidate.modelvalidator;
+
+import com.google.common.collect.ImmutableSet;
+import de.metas.inout.PriorityRule;
+import de.metas.inout.ShipmentScheduleId;
+import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
+import de.metas.inoutcandidate.model.I_M_ShipmentSchedule;
+import lombok.NonNull;
+import org.adempiere.ad.wrapper.POJOLookupMap;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_M_Shipper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verifies that {@link M_Shipper_ShipmentSchedule} flags a shipper's unprocessed {@link I_M_ShipmentSchedule}s
+ * for recompute when the shipper's {@code PriorityRule} changes -- and only then: a processed schedule on the
+ * same shipper, and a change to an unrelated shipper column, must both leave {@link IShipmentScheduleInvalidateBL}
+ * untouched. {@code IShipmentScheduleInvalidateBL} is mocked because its real implementation flags via raw SQL
+ * against a live DB, which this plain unit test does not have.
+ */
+class M_Shipper_ShipmentScheduleTest
+{
+	private IShipmentScheduleInvalidateBL shipmentScheduleInvalidateBL;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		shipmentScheduleInvalidateBL = mock(IShipmentScheduleInvalidateBL.class);
+	}
+
+	@Test
+	void changingShipperPriority_flagsUnprocessedSchedule()
+	{
+		// given: a shipper with an unprocessed schedule, the interceptor registered only AFTER setup so
+		// the priority change below is the only thing that fires it
+		final I_M_Shipper shipper = createShipper();
+		final ShipmentScheduleId scheduleId = createShipmentSchedule(shipper, false);
+
+		registerInterceptorUnderTest(shipmentScheduleInvalidateBL);
+
+		// when: the shipper's PriorityRule changes
+		shipper.setPriorityRule(PriorityRule.High.getCode());
+		saveRecord(shipper);
+
+		// then: the unprocessed schedule is flagged for recompute
+		verify(shipmentScheduleInvalidateBL).flagForRecompute(eq(ImmutableSet.of(scheduleId)));
+	}
+
+	@Test
+	void changingShipperPriority_doesNotFlagProcessedSchedule()
+	{
+		// given: a shipper with a processed schedule
+		final I_M_Shipper shipper = createShipper();
+		createShipmentSchedule(shipper, true);
+
+		registerInterceptorUnderTest(shipmentScheduleInvalidateBL);
+
+		// when: the shipper's PriorityRule changes
+		shipper.setPriorityRule(PriorityRule.High.getCode());
+		saveRecord(shipper);
+
+		// then: nothing is flagged -- the processed schedule was never a candidate
+		verify(shipmentScheduleInvalidateBL, never()).flagForRecompute(org.mockito.ArgumentMatchers.<Set<ShipmentScheduleId>>any());
+	}
+
+	@Test
+	void changingUnrelatedShipperColumn_flagsNothing()
+	{
+		// given: a shipper with an unprocessed schedule
+		final I_M_Shipper shipper = createShipper();
+		createShipmentSchedule(shipper, false);
+
+		registerInterceptorUnderTest(shipmentScheduleInvalidateBL);
+
+		// when: an unrelated column (Name) changes -- PriorityRule stays untouched
+		shipper.setName("Some other name");
+		saveRecord(shipper);
+
+		// then: the interceptor's @ModelChange never fires, so nothing is flagged
+		verify(shipmentScheduleInvalidateBL, never()).flagForRecompute(org.mockito.ArgumentMatchers.<Set<ShipmentScheduleId>>any());
+	}
+
+	private I_M_Shipper createShipper()
+	{
+		final I_M_Shipper shipper = newInstance(I_M_Shipper.class);
+		saveRecord(shipper);
+		return shipper;
+	}
+
+	private ShipmentScheduleId createShipmentSchedule(final I_M_Shipper shipper, final boolean isProcessed)
+	{
+		final I_M_ShipmentSchedule schedule = newInstance(I_M_ShipmentSchedule.class);
+		schedule.setM_Shipper_ID(shipper.getM_Shipper_ID());
+		schedule.setProcessed(isProcessed);
+		schedule.setAD_Table_ID(0);
+		schedule.setRecord_ID(0);
+		saveRecord(schedule);
+		return ShipmentScheduleId.ofRepoId(schedule.getM_ShipmentSchedule_ID());
+	}
+
+	private static void registerInterceptorUnderTest(@NonNull final IShipmentScheduleInvalidateBL shipmentScheduleInvalidateBL)
+	{
+		POJOLookupMap.get().addModelValidator(new M_Shipper_ShipmentSchedule(shipmentScheduleInvalidateBL));
+	}
+}

--- a/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/inoutcandidate/OrderLineShipmentScheduleHandlerPriorityRuleTest.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/test/java/de/metas/order/inoutcandidate/OrderLineShipmentScheduleHandlerPriorityRuleTest.java
@@ -1,0 +1,165 @@
+package de.metas.order.inoutcandidate;
+
+/*
+ * #%L
+ * de.metas.swat.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+import de.metas.adempiere.model.I_C_Order;
+import de.metas.inout.PriorityRule;
+import de.metas.inoutcandidate.invalidation.IShipmentScheduleInvalidateBL;
+import de.metas.inoutcandidate.picking_bom.PickingBOMService;
+import de.metas.organization.ClientAndOrgId;
+import de.metas.organization.OrgId;
+import de.metas.shipping.ShipperId;
+import de.metas.util.Services;
+import org.adempiere.service.ClientId;
+import org.adempiere.service.ISysConfigBL;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_M_Shipper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.annotation.Nullable;
+import java.util.Optional;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.save;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers {@link OrderLineShipmentScheduleHandler#computePriorityRuleCode(I_C_Order, ShipperId, ClientAndOrgId)}.
+ */
+public class OrderLineShipmentScheduleHandlerPriorityRuleTest
+{
+	private static final ClientAndOrgId CLIENT_AND_ORG_ID = ClientAndOrgId.ofClientAndOrg(ClientId.METASFRESH, OrgId.ANY);
+
+	private OrderLineShipmentScheduleHandler handler;
+	private ISysConfigBL sysConfigBL;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+		// computePriorityRuleCode() only relies on the field-initialized Services.get() beans (sysConfigBL, shipperDAO);
+		// the constructor-injected collaborators below are never exercised by it, so a mock + a plain no-extensions
+		// service stand in for them (IShipmentScheduleInvalidateBL's real impl needs a Spring context to construct).
+		handler = new OrderLineShipmentScheduleHandler(
+				Mockito.mock(IShipmentScheduleInvalidateBL.class),
+				new PickingBOMService(),
+				Optional.empty());
+		// assigned AFTER init(): AdempiereTestHelper.get().init() calls Services.clear() in @BeforeEach, so a field
+		// initialized at construction time would hold a stale/cleared service registry entry.
+		sysConfigBL = Services.get(ISysConfigBL.class);
+	}
+
+	private void setSwitch(final boolean value)
+	{
+		sysConfigBL.setValue(
+				OrderLineShipmentScheduleHandler.SYSCONFIG_PriorityRuleFromShipper,
+				value,
+				CLIENT_AND_ORG_ID.getClientId(),
+				CLIENT_AND_ORG_ID.getOrgId());
+	}
+
+	private static I_C_Order createOrder(final PriorityRule priorityRule)
+	{
+		final I_C_Order order = newInstance(I_C_Order.class);
+		order.setPriorityRule(priorityRule.getCode());
+		save(order);
+		return order;
+	}
+
+	private static ShipperId createShipper(@Nullable final String priorityRuleCode)
+	{
+		final I_M_Shipper shipper = newInstance(I_M_Shipper.class);
+		shipper.setPriorityRule(priorityRuleCode);
+		save(shipper);
+		return ShipperId.ofRepoId(shipper.getM_Shipper_ID());
+	}
+
+	@Test
+	void switchOff_usesOrderPriority()
+	{
+		setSwitch(false);
+		final I_C_Order order = createOrder(PriorityRule.Low);
+		final ShipperId shipperId = createShipper(PriorityRule.Urgent.getCode());
+
+		final String result = handler.computePriorityRuleCode(order, shipperId, CLIENT_AND_ORG_ID);
+
+		assertThat(result).isEqualTo(PriorityRule.Low.getCode());
+	}
+
+	@Test
+	void switchOn_shipperHasPriority_usesShipperPriority()
+	{
+		setSwitch(true);
+		final I_C_Order order = createOrder(PriorityRule.Low);
+		final ShipperId shipperId = createShipper(PriorityRule.Urgent.getCode());
+
+		final String result = handler.computePriorityRuleCode(order, shipperId, CLIENT_AND_ORG_ID);
+
+		assertThat(result).isEqualTo(PriorityRule.Urgent.getCode());
+	}
+
+	@Test
+	void switchOn_shipperPriorityBlank_fallsBackToOrder()
+	{
+		setSwitch(true);
+		final I_C_Order order = createOrder(PriorityRule.High);
+		final ShipperId shipperId = createShipper(null);
+
+		final String result = handler.computePriorityRuleCode(order, shipperId, CLIENT_AND_ORG_ID);
+
+		assertThat(result).isEqualTo(PriorityRule.High.getCode());
+	}
+
+	@Test
+	void switchOn_shipperIdNull_fallsBackToOrder()
+	{
+		setSwitch(true);
+		final I_C_Order order = createOrder(PriorityRule.High);
+
+		final String result = handler.computePriorityRuleCode(order, null, CLIENT_AND_ORG_ID);
+
+		assertThat(result).isEqualTo(PriorityRule.High.getCode());
+	}
+
+	/**
+	 * An out-of-list code can only reach {@code M_Shipper.PriorityRule} through an import, the REST API or direct SQL
+	 * (the column has no CHECK constraint; the value list is enforced in the UI layer only). Such a code must NOT
+	 * abort the derivation: this method runs inside {@code ShipmentScheduleUpdater.updateSchedules}, which iterates a
+	 * whole recompute batch with no per-item error handling, so a throw here would roll back the batch's transaction
+	 * and take unrelated schedules down with it. The order's own priority is likewise returned unvalidated, so
+	 * falling back keeps the two sides of this method symmetric.
+	 */
+	@Test
+	void switchOn_shipperHasUnknownCode_fallsBackToOrder()
+	{
+		setSwitch(true);
+		final I_C_Order order = createOrder(PriorityRule.High);
+		final ShipperId shipperId = createShipper("not-a-known-priority-code");
+
+		final String result = handler.computePriorityRuleCode(order, shipperId, CLIENT_AND_ORG_ID);
+
+		assertThat(result).isEqualTo(PriorityRule.High.getCode());
+	}
+}

--- a/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
@@ -1,16 +1,17 @@
 /**
  * M_Product.ProductLifeCycleStatus (BBS-Status) is deliberately NOT part of the vanilla Product
  * window (AD_Window_ID=140, AD_Tab_ID=180). This spec guards that: the field must be absent from
- * the form and from the grid.
+ * the form, from the grid, and from the filter bar.
  *
  * Migration 5820370 hid it there on purpose -- the window already carries an "Auslaufprodukt"
  * (M_Product.Discontinued) checkbox that reads like the same control, and the enforcement is wanted
- * by one customer, whose own repo puts the field on the window that customer actually opens. The
- * column, its reference list and every backend guard stay in core, covered by de.metas.cucumber
- * productLifeCycleStatus.feature and ProductBL_assertAllowed_Test / PickHUCommand_LifeCycleStatus_Test.
+ * by one customer, whose own repo puts the field on the window that customer actually opens. 5820780
+ * then removed the leftover filter entry. The column, its reference list and every backend guard stay
+ * in core, covered by de.metas.cucumber productLifeCycleStatus.feature and ProductBL_assertAllowed_Test
+ * / PickHUCommand_LifeCycleStatus_Test.
  *
- * The filter parameter is logged rather than asserted: it comes from AD_Column.IsSelectionColumn
- * (5819940), which is table-level and stays on for the customer's own window.
+ * The filter assertion guards AD_Field.IsFilterField (window-scoped), NOT AD_Column.IsSelectionColumn
+ * (table-level, still on so the customer's own window keeps its quick filter).
  *
  * Running this locally: reset the SqlViewLayouts and SqlViewBindings caches first, or the app server
  * keeps serving the pre-migration layout. Neither cache is keyed to a table, so no AD_* change
@@ -98,8 +99,8 @@ removed (migration 5820370).
       );
     });
 
-    // === STEP 2: the grid must not list the column ===
-    await test.step('Assert ProductLifeCycleStatus is absent from the Product grid', async () => {
+    // === STEP 2: the grid must not list the column, the filter bar must not offer it ===
+    await test.step('Assert ProductLifeCycleStatus is absent from the Product grid and filters', async () => {
       const layout = await getViewLayout(PRODUCT_WINDOW_ID, 'grid');
 
       const columnNames = getViewLayoutColumnNames(layout);
@@ -107,9 +108,10 @@ removed (migration 5820370).
       expect(columnNames, `${FIELD_NAME} must not be a grid column of window ${PRODUCT_WINDOW_ID}`)
           .not.toContain(FIELD_NAME);
 
-      // Logged, not asserted — the filter is column-driven and outlives this migration. See the header.
       const filterParameterNames = getViewLayoutFilterParameterNames(layout);
       console.log(`[INFO] Filter parameters of window ${PRODUCT_WINDOW_ID}: ${JSON.stringify(filterParameterNames)}`);
+      expect(filterParameterNames, `${FIELD_NAME} must not be a filter of window ${PRODUCT_WINDOW_ID}`)
+          .not.toContain(FIELD_NAME);
     });
 
     console.log('[PASS] ProductLifeCycleStatus is not rendered in the vanilla Product form.');

--- a/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
+++ b/e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js
@@ -1,36 +1,20 @@
 /**
- * M_Product.ProductLifeCycleStatus (BBS-Status) is NOT rendered in the vanilla Product form
+ * M_Product.ProductLifeCycleStatus (BBS-Status) is deliberately NOT part of the vanilla Product
+ * window (AD_Window_ID=140, AD_Tab_ID=180). This spec guards that: the field must be absent from
+ * the form and from the grid.
  *
- * Scope: guard the deliberate decision that the life-cycle status field is not offered in the
- * standard Product FORM (AD_Window_ID=140, AD_Tab_ID=180):
- *   1. The field is not rendered in the Product form
+ * Migration 5820370 hid it there on purpose -- the window already carries an "Auslaufprodukt"
+ * (M_Product.Discontinued) checkbox that reads like the same control, and the enforcement is wanted
+ * by one customer, whose own repo puts the field on the window that customer actually opens. The
+ * column, its reference list and every backend guard stay in core, covered by de.metas.cucumber
+ * productLifeCycleStatus.feature and ProductBL_assertAllowed_Test / PickHUCommand_LifeCycleStatus_Test.
  *
- * WHY THIS TEST INVERTED
- * ----------------------
- * It previously asserted the opposite — field visible, selectable, persisted, grid column + filter.
- * Migration 5820370 hides the field on window 140 on purpose: the window already carries an
- * "Auslaufprodukt" (M_Product.Discontinued) checkbox that reads like the same control, and the
- * life-cycle enforcement is wanted by one customer, whose own repo adds the field to the window
- * that customer actually opens. Derivation of the new expectations (per
- * `metasfresh-test-integrity` § "Test Wiring Drift", step 3):
- *   - 5820370 sets AD_UI_Element 652772 IsDisplayed='N' => the form must NOT render the field
- * The observed CI failure matched that derivation exactly (the old step 1 timed out waiting for a
- * field container that is no longer rendered), so the assertion is updated rather than the change.
+ * The filter parameter is logged rather than asserted: it comes from AD_Column.IsSelectionColumn
+ * (5819940), which is table-level and stays on for the customer's own window.
  *
- * The grid column and the filter parameter are LOGGED, NOT ASSERTED, because a local run against a
- * DB with 5820370 applied showed the grid layout of window 140 STILL lists ProductLifeCycleStatus
- * even with both IsDisplayedGrid='N' and IsDisplayed='N' on the UI element (and still lists it with
- * that element deactivated). So the grid descriptor is not driven by the flags this migration sets,
- * and the filter is column-driven (AD_Column.IsSelectionColumn, migration 5819940, untouched here).
- * Neither is part of this change's contract; asserting either way would be a guess.
- *
- * WHERE THE REMAINING BEHAVIOUR IS COVERED
- * ----------------------------------------
- * The column, its reference list and every backend guard stay in core, and are exercised by
- * `de.metas.cucumber` productLifeCycleStatus.feature (order-line block + the completion re-checks)
- * and by ProductBL_assertAllowed_Test / PickHUCommand_LifeCycleStatus_Test. The field's visibility
- * in the customer's own Product window cannot be tested here — that window does not exist on a core
- * DB — so no automated core check covers it.
+ * Running this locally: reset the SqlViewLayouts and SqlViewBindings caches first, or the app server
+ * keeps serving the pre-migration layout. Neither cache is keyed to a table, so no AD_* change
+ * invalidates them and an unreset run will contradict the migration.
  */
 
 import { expect } from '@playwright/test';
@@ -114,14 +98,16 @@ removed (migration 5820370).
       );
     });
 
-    // === STEP 2: record what the list view still exposes (observational) ===
-    await test.step('Record the Product list view grid columns and filter parameters', async () => {
+    // === STEP 2: the grid must not list the column ===
+    await test.step('Assert ProductLifeCycleStatus is absent from the Product grid', async () => {
       const layout = await getViewLayout(PRODUCT_WINDOW_ID, 'grid');
 
-      // Both LOGGED, not asserted — see the header. Verified locally: the grid layout still lists
-      // the column with 5820370 applied, so neither observation is part of this change's contract.
       const columnNames = getViewLayoutColumnNames(layout);
       console.log(`[INFO] Grid columns of window ${PRODUCT_WINDOW_ID}: ${JSON.stringify(columnNames)}`);
+      expect(columnNames, `${FIELD_NAME} must not be a grid column of window ${PRODUCT_WINDOW_ID}`)
+          .not.toContain(FIELD_NAME);
+
+      // Logged, not asserted — the filter is column-driven and outlives this migration. See the header.
       const filterParameterNames = getViewLayoutFilterParameterNames(layout);
       console.log(`[INFO] Filter parameters of window ${PRODUCT_WINDOW_ID}: ${JSON.stringify(filterParameterNames)}`);
     });


### PR DESCRIPTION
Propagates `deep_tundra_release` up to `new_dawn_uat` (forward merge-through; merge commit https://github.com/metasfresh/metasfresh/commit/5caa03e8f5a3d9b02544a35787c21170811c8e49).

Carries the last two rounds of the Product Life Cycle Status (BBS-Status) work on the vanilla Product window:

- https://github.com/metasfresh/metasfresh/pull/25638 — https://github.com/metasfresh/metasfresh/commit/f54b81b2e78d78f14f27633606d499654435ac14 restores the grid-column assertion in `e2e/frontend-webui/tests/spec/product-life-cycle-status.spec.js`.
- https://github.com/metasfresh/metasfresh/pull/25646 — https://github.com/metasfresh/metasfresh/commit/d98191d6fc31b3958d194b48c2764a0d50ead9d3 adds migration `5820780_sys_M_Product_ProductLifeCycleStatus_remove_filter_from_vanilla_window.sql` (clears `AD_Field.IsFilterField` for `AD_Field_ID=781848`) plus the matching filter assertion in the same spec.

Riding along, as expected for a merge-through of the whole branch:

- https://github.com/metasfresh/metasfresh/pull/25643 — https://github.com/metasfresh/metasfresh/commit/e33aafe814265d6210300517b0b715eb346190a0 shipment-schedule priority derived from the shipper, behind a sysconfig; migrations `5820640_sys_M_Shipper_PriorityRule.sql` and `5820650_sys_M_ShipmentSchedule_PriorityRuleFromShipper_sysconfig.sql`.

### Conflict resolution

One conflict, in `backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/order/C_Order_StepDef.java` — a Javadoc `<ul>` where both branches appended a different `<li>` at the same position (`HandOver_Location_ID` on `new_dawn_uat`, `PriorityRule` on `deep_tundra_release`). Resolved as the union of both entries. Verified by content diff: against `origin/deep_tundra_release` the resolved file adds only `new_dawn_uat`-unique content, and against `origin/new_dawn_uat` it adds only `deep_tundra_release`-unique content — nothing dropped from either side.

### DDL / migration review

All three migration scripts are brand-new files; no view or function is redefined and no `sql/postgresql/ddl/` reference file is touched, so there is no whole-object DDL-regression risk. The two shipper-priority scripts belong to https://github.com/metasfresh/metasfresh/pull/25643 and need that owner's sign-off that they are intended to ship to `new_dawn_uat` now.

**Merge with a merge commit, never squash** (`gh pr merge <n> --merge --delete-branch`).
