### PR TITLE
ESR import: a no-invoice line no longer aborts the import with an NPE

### DIFF
--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportDAO.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportDAO.java
@@ -462,6 +462,14 @@ public class ESRImportDAO implements IESRImportDAO
 				continue;
 			}
 			final InvoiceId invoiceId = InvoiceId.ofRepoIdOrNull(esrLine.getC_Invoice_ID());
+			if (invoiceId == null)
+			{
+				// This line has no invoice, so it cannot be a duplicate *via the invoice*: isMatchInvoice
+				// asks whether the candidate payment is allocated to THIS line's invoice, and there is
+				// none. Skipping keeps the remaining candidates in play; passing null on would hit
+				// getByIdInTrx's @NonNull parameter and abort the whole import.
+				continue;
+			}
 			final I_C_Invoice invoice = invoiceDAO.getByIdInTrx(invoiceId);
 			final I_C_Payment payment = paymentDAO.getById(paymentId);
 			if (paymentBL.isMatchInvoice(payment, invoice))

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
@@ -1905,29 +1905,37 @@ public class ESRImportTest extends ESRTestBase
 	@Nested
 	class LineWithoutInvoice
 	{
-		/** Scaffolding for a line whose reference resolves to no invoice at all. */
+		private I_C_BP_BankAccount sharedAccount;
+
+		/**
+		 * Scaffolding for a line whose reference resolves to no invoice at all. The org, reference type and
+		 * bank account are created once and reused: creating them per call makes the org and
+		 * reference-type lookups ambiguous as soon as a test needs a second import.
+		 */
 		private I_ESR_Import importWithUnmatchableLine()
 		{
-			final I_AD_Org org = newInstance(I_AD_Org.class, contextProvider);
-			org.setValue("106");
-			save(org);
+			if (sharedAccount == null)
+			{
+				final I_AD_Org org = newInstance(I_AD_Org.class, contextProvider);
+				org.setValue("106");
+				save(org);
 
-			final I_C_ReferenceNo_Type refNoType = newInstance(I_C_ReferenceNo_Type.class, contextProvider);
-			refNoType.setName("InvoiceReference");
-			save(refNoType);
+				final I_C_ReferenceNo_Type refNoType = newInstance(I_C_ReferenceNo_Type.class, contextProvider);
+				refNoType.setName("InvoiceReference");
+				save(refNoType);
 
-			final CurrencyId currencyEUR = PlainCurrencyDAO.createCurrencyId(CurrencyCode.EUR);
-			final I_C_BP_BankAccount account = createBankAccount(true,
-					org.getAD_Org_ID(),
-					Env.getAD_User_ID(getCtx()),
-					"01-067789-3",
-					currencyEUR);
+				sharedAccount = createBankAccount(true,
+						org.getAD_Org_ID(),
+						Env.getAD_User_ID(getCtx()),
+						"01-067789-3",
+						PlainCurrencyDAO.createCurrencyId(CurrencyCode.EUR));
+			}
 
 			// the reference in this line belongs to no invoice in the system
 			final String esrLineText = "01201067789300000001060000000000000000400000050009072  030014040914041014041100001006800000000000090                          ";
 			final I_ESR_Import esrImport = createImport();
-			esrImport.setAD_Org_ID(org.getAD_Org_ID());
-			esrImport.setC_BP_BankAccount_ID(account.getC_BP_BankAccount_ID());
+			esrImport.setAD_Org_ID(sharedAccount.getAD_Org_ID());
+			esrImport.setC_BP_BankAccount_ID(sharedAccount.getC_BP_BankAccount_ID());
 			save(esrImport);
 
 			esrImportBL.loadAndEvaluateESRImportStream(createImportFile(esrImport), new ByteArrayInputStream(esrLineText.getBytes()));
@@ -1999,6 +2007,47 @@ public class ESRImportTest extends ESRTestBase
 					.as("no action is set for the accountant, so the line stays a visible todo")
 					.isNull();
 			assertThat(line.isProcessed()).as("and the line stays open").isFalse();
+		}
+
+		/**
+		 * Two no-invoice lines for the same payer and amount, on DIFFERENT bank lines. The second line's
+		 * duplicate search finds the first line's payment as a candidate, and because the bank lines differ
+		 * it reaches the invoice route -- where the line has no invoice at all.
+		 * <p>
+		 * On an instance with history any earlier completed payment for that payer and amount is such a
+		 * candidate, so this is the normal case rather than an edge one, and it aborts the whole import.
+		 */
+		@Test
+		void aSecondNoInvoiceLineForTheSamePayerAndAmount_doesNotBlowUp()
+		{
+			final int partnerId = createPartner();
+
+			final I_ESR_Import firstImport = importWithUnmatchableLine();
+			final I_ESR_ImportLine firstLine = ESRTestUtil.retrieveSingleLine(firstImport);
+			firstLine.setC_BPartner_ID(partnerId);
+			firstLine.setESR_IsManual_ReferenceNo(true);
+			save(firstLine);
+			esrImportBL.process(firstImport);
+
+			refresh(firstLine, true);
+			assertThat(firstLine.getC_Payment_ID()).as("guard: the first line booked a payment").isNotZero();
+
+			// a second line, same payer and amount, but NOT the same bank line -- so the "another line already
+			// carries this payment" route cannot match and the invoice route is reached
+			final I_ESR_Import secondImport = importWithUnmatchableLine();
+			final I_ESR_ImportLine secondLine = ESRTestUtil.retrieveSingleLine(secondImport);
+			secondLine.setESRLineText(firstLine.getESRLineText().replace("041100", "041200"));
+			secondLine.setC_BPartner_ID(partnerId);
+			secondLine.setESR_IsManual_ReferenceNo(true);
+			save(secondLine);
+
+			esrImportBL.process(secondImport);
+
+			refresh(secondLine, true);
+			assertThat(secondLine.getC_Payment_ID())
+					.as("the second line must get its own payment, not blow up the import")
+					.isNotZero()
+					.isNotEqualTo(firstLine.getC_Payment_ID());
 		}
 
 		/**


### PR DESCRIPTION
## The bug

`ESRImportDAO.findExistentPaymentId` resolves the line's invoice with `InvoiceId.ofRepoIdOrNull` — whose whole purpose is returning `null` — and passed it straight into `AbstractInvoiceDAO.getByIdInTrx`, whose parameter is `@NonNull`:

```java
final InvoiceId invoiceId = InvoiceId.ofRepoIdOrNull(esrLine.getC_Invoice_ID());
final I_C_Invoice invoice = invoiceDAO.getByIdInTrx(invoiceId);   // ← NPE when the line has no invoice
```

A line with **no invoice** that reaches that branch throws

```
NullPointerException: invoiceId is marked non-null but is null
  at AbstractInvoiceDAO.getByIdInTrx(AbstractInvoiceDAO.java:423)
  at ESRImportDAO.findExistentPaymentId(ESRImportDAO.java:459)
  at ESRImportBL.fetchDuplicatePaymentIfExists(ESRImportBL.java:660)
  at ESRImportBL.handleEsrImportLine(ESRImportBL.java:646)
  at ESRImportBL.processLinesFromFile(ESRImportBL.java:514)
```

and because the per-line loop in `processLinesFromFile` is not guarded per line, **the whole import fails**.

## Why it is the ordinary case, not an edge one

Reaching that branch needs a candidate payment — same partner, same amount, completed — that is neither carried by another line with the same `ESRLineText` nor the line's own payment. On an instance with any history, an earlier payment for that payer and amount qualifies.

So it fires exactly when an accountant sets the payer on several unmatchable lines and runs **Process** — which is the *documented recovery* for a line whose reference is unknown. It was hit on a live instance doing precisely that.

Release lines that filter candidate payments on an exact `DateTrx` are less exposed, because the date narrows the candidate set. Lines without that condition see candidates from any day and hit it readily.

## The fix

With no invoice on the line, the invoice route cannot identify a duplicate anyway — `isMatchInvoice` asks whether the candidate is allocated to **this line's** invoice, and there is none. So skip to the next candidate instead of aborting:

```java
if (invoiceId == null)
{
    continue;
}
```

## Test plan

- [x] **Reproduced first**: `aSecondNoInvoiceLineForTheSamePayerAndAmount_doesNotBlowUp` fails with the exact production NPE without the guard, and passes with it.
- [x] Full `de.metas.payment.esr` module suite: **179 run, 0 failures, 0 errors**, 1 pre-existing skip.
- Run with `JAVA_HOME` set to JDK 8.

## Also in this commit

The test class's no-invoice helper created the org, reference type and bank account on **every** call. That made the org and reference-type lookups ambiguous (`QueryMoreThanOneRecordsFound`) as soon as a test needed a second import — which is what this reproduction needs. They are now created once and reused.

## Note on coverage

The three tests added by https://github.com/metasfresh/metasfresh/pull/25651 did not catch this: each sets one payer on one line in an empty store, so no candidate payment exists and the crashing branch is never reached. A second line for the same payer is what exposes it.
