### PR TITLE
Port: ESR import - a no-invoice line no longer aborts the import with an NPE

### DIFF
--- a/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportDAO.java
+++ b/backend/de.metas.payment.esr/src/main/java/de/metas/payment/esr/api/impl/ESRImportDAO.java
@@ -456,6 +456,14 @@ public class ESRImportDAO implements IESRImportDAO
 				continue;
 			}
 			final InvoiceId invoiceId = InvoiceId.ofRepoIdOrNull(esrLine.getC_Invoice_ID());
+			if (invoiceId == null)
+			{
+				// This line has no invoice, so it cannot be a duplicate *via the invoice*: isMatchInvoice
+				// asks whether the candidate payment is allocated to THIS line's invoice, and there is
+				// none. Skipping keeps the remaining candidates in play; passing null on would hit
+				// getByIdInTrx's @NonNull parameter and abort the whole import.
+				continue;
+			}
 			final I_C_Invoice invoice = invoiceDAO.getByIdInTrx(invoiceId);
 			final I_C_Payment payment = paymentDAO.getById(paymentId);
 			if (paymentBL.isMatchInvoice(payment, invoice))

--- a/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
+++ b/backend/de.metas.payment.esr/src/test/java/de/metas/payment/esr/ESRImportTest.java
@@ -1845,29 +1845,37 @@ public class ESRImportTest extends ESRTestBase
 	@Nested
 	class LineWithoutInvoice
 	{
-		/** Scaffolding for a line whose reference resolves to no invoice at all. */
+		private I_C_BP_BankAccount sharedAccount;
+
+		/**
+		 * Scaffolding for a line whose reference resolves to no invoice at all. The org, reference type and
+		 * bank account are created once and reused: creating them per call makes the org and
+		 * reference-type lookups ambiguous as soon as a test needs a second import.
+		 */
 		private I_ESR_Import importWithUnmatchableLine()
 		{
-			final I_AD_Org org = newInstance(I_AD_Org.class, contextProvider);
-			org.setValue("106");
-			save(org);
+			if (sharedAccount == null)
+			{
+				final I_AD_Org org = newInstance(I_AD_Org.class, contextProvider);
+				org.setValue("106");
+				save(org);
 
-			final I_C_ReferenceNo_Type refNoType = newInstance(I_C_ReferenceNo_Type.class, contextProvider);
-			refNoType.setName("InvoiceReference");
-			save(refNoType);
+				final I_C_ReferenceNo_Type refNoType = newInstance(I_C_ReferenceNo_Type.class, contextProvider);
+				refNoType.setName("InvoiceReference");
+				save(refNoType);
 
-			final CurrencyId currencyEUR = PlainCurrencyDAO.createCurrencyId(CurrencyCode.EUR);
-			final I_C_BP_BankAccount account = createBankAccount(true,
-					org.getAD_Org_ID(),
-					Env.getAD_User_ID(getCtx()),
-					"01-067789-3",
-					currencyEUR);
+				sharedAccount = createBankAccount(true,
+						org.getAD_Org_ID(),
+						Env.getAD_User_ID(getCtx()),
+						"01-067789-3",
+						PlainCurrencyDAO.createCurrencyId(CurrencyCode.EUR));
+			}
 
 			// the reference in this line belongs to no invoice in the system
 			final String esrLineText = "01201067789300000001060000000000000000400000050009072  030014040914041014041100001006800000000000090                          ";
 			final I_ESR_Import esrImport = createImport();
-			esrImport.setAD_Org_ID(org.getAD_Org_ID());
-			esrImport.setC_BP_BankAccount_ID(account.getC_BP_BankAccount_ID());
+			esrImport.setAD_Org_ID(sharedAccount.getAD_Org_ID());
+			esrImport.setC_BP_BankAccount_ID(sharedAccount.getC_BP_BankAccount_ID());
 			save(esrImport);
 
 			esrImportBL.loadAndEvaluateESRImportStream(createImportFile(esrImport), new ByteArrayInputStream(esrLineText.getBytes()));
@@ -1939,6 +1947,47 @@ public class ESRImportTest extends ESRTestBase
 					.as("no action is set for the accountant, so the line stays a visible todo")
 					.isNull();
 			assertThat(line.isProcessed()).as("and the line stays open").isFalse();
+		}
+
+		/**
+		 * Two no-invoice lines for the same payer and amount, on DIFFERENT bank lines. The second line's
+		 * duplicate search finds the first line's payment as a candidate, and because the bank lines differ
+		 * it reaches the invoice route -- where the line has no invoice at all.
+		 * <p>
+		 * On an instance with history any earlier completed payment for that payer and amount is such a
+		 * candidate, so this is the normal case rather than an edge one, and it aborts the whole import.
+		 */
+		@Test
+		void aSecondNoInvoiceLineForTheSamePayerAndAmount_doesNotBlowUp()
+		{
+			final int partnerId = createPartner();
+
+			final I_ESR_Import firstImport = importWithUnmatchableLine();
+			final I_ESR_ImportLine firstLine = ESRTestUtil.retrieveSingleLine(firstImport);
+			firstLine.setC_BPartner_ID(partnerId);
+			firstLine.setESR_IsManual_ReferenceNo(true);
+			save(firstLine);
+			esrImportBL.process(firstImport);
+
+			refresh(firstLine, true);
+			assertThat(firstLine.getC_Payment_ID()).as("guard: the first line booked a payment").isNotZero();
+
+			// a second line, same payer and amount, but NOT the same bank line -- so the "another line already
+			// carries this payment" route cannot match and the invoice route is reached
+			final I_ESR_Import secondImport = importWithUnmatchableLine();
+			final I_ESR_ImportLine secondLine = ESRTestUtil.retrieveSingleLine(secondImport);
+			secondLine.setESRLineText(firstLine.getESRLineText().replace("041100", "041200"));
+			secondLine.setC_BPartner_ID(partnerId);
+			secondLine.setESR_IsManual_ReferenceNo(true);
+			save(secondLine);
+
+			esrImportBL.process(secondImport);
+
+			refresh(secondLine, true);
+			assertThat(secondLine.getC_Payment_ID())
+					.as("the second line must get its own payment, not blow up the import")
+					.isNotZero()
+					.isNotEqualTo(firstLine.getC_Payment_ID());
 		}
 
 		/**


### PR DESCRIPTION
## Summary

Port of https://github.com/metasfresh/metasfresh/pull/25661 to `inner_silence_uat`. Auto-merged **without conflict**; the patch is line-for-line identical to the source commit.

**This branch is where the bug was actually hit**, on a live instance, while running the documented recovery for a line whose reference is unknown: set the payer on the unmatchable lines, then **Process**.

```
NullPointerException: invoiceId is marked non-null but is null
  at AbstractInvoiceDAO.getByIdInTrx(AbstractInvoiceDAO.java:423)
  at ESRImportDAO.findExistentPaymentId(ESRImportDAO.java:459)
  at ESRImportBL.fetchDuplicatePaymentIfExists(ESRImportBL.java:660)
  at ESRImportBL.handleEsrImportLine(ESRImportBL.java:646)
  at ESRImportBL.processLinesFromFile(ESRImportBL.java:514)
```

`findExistentPaymentId` resolved the line's invoice with `InvoiceId.ofRepoIdOrNull` — whose whole purpose is returning `null` — and passed it into `getByIdInTrx`, whose parameter is `@NonNull`. The per-line loop in `processLinesFromFile` is not guarded per line, so **the entire import fails**.

With no invoice on the line the invoice route cannot identify a duplicate anyway — `isMatchInvoice` asks whether the candidate is allocated to *this line's* invoice, and there is none — so the fix skips to the next candidate. The guard lands at `ESRImportDAO.java:459`, exactly the frame in the trace.

## Why this branch is the exposed one

Reaching that branch needs a candidate payment (same partner, same amount, completed) that is neither carried by another line with the same `ESRLineText` nor the line's own. **This line has no exact-`DateTrx` condition on the candidate query**, so candidates from any day qualify — on an instance with history, an earlier payment for that payer and amount is routine. Release lines that do filter on `DateTrx` narrow the candidate set and are much less likely to hit it.

## Test plan

- [x] On the source branch, over an identical patch: the reproduction `aSecondNoInvoiceLineForTheSamePayerAndAmount_doesNotBlowUp` fails with the exact production NPE **without** the guard and passes **with** it; full `de.metas.payment.esr` module suite **179 run, 0 failures, 0 errors**, 1 pre-existing skip.
- [ ] **Not run locally on this branch** — it targets Java 17 and this worktree has no populated `.m2-local`, so a local run would either not compile or link against artifacts built for another branch. **CI's `test (java)` is the gate.**

## Also in this commit

The test class's no-invoice helper created the org, reference type and bank account on **every** call, which made those lookups ambiguous (`QueryMoreThanOneRecordsFound`) as soon as a test needed a second import — exactly what this reproduction needs. They are now created once and reused.

## Note on coverage

The three tests added by https://github.com/metasfresh/metasfresh/pull/25653 did not catch this: each sets one payer on one line in an empty store, so no candidate payment exists and the crashing branch is never reached. A **second** line for the same payer is what exposes it.
