### PR TITLE
Costing: recover all cost-detail legs on repost (fix MatchInv/CostDifferenceDistribution variance misrouting)

### DIFF
--- a/backend/de.metas.business/src/main/java/de/metas/costing/ICostDetailService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/ICostDetailService.java
@@ -46,6 +46,17 @@ public interface ICostDetailService
 			@NonNull CostElementId costElementId,
 			@NonNull Set<ProductId> productIds);
 
+	/**
+	 * Recovers ALL persisted cost-detail legs of the document identified by the request's
+	 * (acctSchemaId, costElementId, documentRef) — MAIN, ADJUSTMENT and ALREADY_SHIPPED alike.
+	 * <p>
+	 * {@code request.getAmtType()} is intentionally IGNORED (it defaults to MAIN): this feeds the
+	 * repost-recovery path ({@code CostingMethodHandlerTemplate.createOrUpdateCost} plus the manufacturing
+	 * handlers), which must reconstruct the FULL posting. Filtering by amtType here would drop the non-MAIN
+	 * legs of a multi-leg document (MovingAverageInvoice MatchInv, manufacturing CostDifferenceDistribution)
+	 * and degenerate the aggregated {@link de.metas.costing.methods.CostAmountDetailed} to the MAIN leg. To recover a single amtType,
+	 * use the {@link CostDetailQuery} overloads instead.
+	 */
 	List<CostDetail> getExistingCostDetails(CostDetailCreateRequest request);
 
 	AggregatedCostAmount toAggregatedCostAmount(List<CostDetail> costDetails);

--- a/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostDetailService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostDetailService.java
@@ -134,11 +134,22 @@ public class CostDetailService implements ICostDetailService
 	@Override
 	public final List<CostDetail> getExistingCostDetails(@NonNull final CostDetailCreateRequest request)
 	{
+		// NOTE: intentionally NOT filtering by request.getAmtType() (which defaults to MAIN).
+		// This method feeds the repost-recovery path (CostingMethodHandlerTemplate.createOrUpdateCost in
+		// de.metas.business plus all four manufacturing handlers), which must reconstruct the FULL posting:
+		// on a repost we recover ALL persisted legs of the document (MAIN + ADJUSTMENT + ALREADY_SHIPPED) so
+		// the aggregated CostAmountDetailed is leg-complete instead of degenerating to the MAIN leg.
+		// Multi-leg producers this corrects: the MovingAverageInvoice MatchInv (keeps the invoice-vs-PO price
+		// variance routing to InvoicePriceVariance instead of GR/IR), and the manufacturing
+		// CostDifferenceDistribution under AveragePO / LastPOPrice / MovingAverageInvoice
+		// (PPOrderCostDifferenceDistributor persists MAIN + ADJUSTMENT + ALREADY_SHIPPED for all three).
+		// A document/method that only ever persists a single MAIN leg is unaffected: recovering all legs is
+		// identical to recovering MAIN.
 		return costDetailsRepo.list(CostDetailQuery.builder()
 				.acctSchemaId(request.getAcctSchemaId())
 				.costElementId(request.getCostElementId()) // assume request's costing element is set
 				.documentRef(request.getDocumentRef())
-				.amtType(request.getAmtType())
+				// .amtType(...) omitted on purpose: recover every leg, see note above
 				// .productId(request.getProductId())
 				// .attributeSetInstanceId(request.getAttributeSetInstanceId())
 				.build());

--- a/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostDetailService.java
+++ b/backend/de.metas.business/src/main/java/de/metas/costing/impl/CostDetailService.java
@@ -140,7 +140,10 @@ public class CostDetailService implements ICostDetailService
 		// on a repost we recover ALL persisted legs of the document (MAIN + ADJUSTMENT + ALREADY_SHIPPED) so
 		// the aggregated CostAmountDetailed is leg-complete instead of degenerating to the MAIN leg.
 		// Multi-leg producers this corrects: the MovingAverageInvoice MatchInv (keeps the invoice-vs-PO price
-		// variance routing to InvoicePriceVariance instead of GR/IR), and the manufacturing
+		// variance on its proper account -- for the on-hand case, on-hand inventory revaluation (P_Asset) via
+		// the ADJUSTMENT leg, with InvoicePriceVariance only as an FX/residual line -- so GR/IR
+		// (NotInvoicedReceipts) still carries only the PO-price receipt amount and nets to zero, instead of
+		// degenerating to the full invoiced amount), and the manufacturing
 		// CostDifferenceDistribution under AveragePO / LastPOPrice / MovingAverageInvoice
 		// (PPOrderCostDifferenceDistributor persists MAIN + ADJUSTMENT + ALREADY_SHIPPED for all three).
 		// A document/method that only ever persists a single MAIN leg is unaffected: recovering all legs is

--- a/backend/de.metas.business/src/test/java/de/metas/costing/methods/MatchInvRepostCostDetailTest.java
+++ b/backend/de.metas.business/src/test/java/de/metas/costing/methods/MatchInvRepostCostDetailTest.java
@@ -1,0 +1,375 @@
+package de.metas.costing.methods;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.acct.api.AcctSchema;
+import de.metas.acct.api.AcctSchemaId;
+import de.metas.acct.api.IAcctSchemaDAO;
+import de.metas.acct.api.TaxCorrectionType;
+import de.metas.ad_reference.ADReferenceService;
+import de.metas.business.BusinessTestHelper;
+import de.metas.costing.CostAmount;
+import de.metas.costing.CostDetail;
+import de.metas.costing.CostDetailCreateRequest;
+import de.metas.costing.CostDetailPreviousAmounts;
+import de.metas.costing.CostDetailQuery;
+import de.metas.costing.CostElement;
+import de.metas.costing.CostElementId;
+import de.metas.costing.CostElementType;
+import de.metas.costing.CostTypeId;
+import de.metas.costing.CostingDocumentRef;
+import de.metas.costing.CostingLevel;
+import de.metas.costing.CostingMethod;
+import de.metas.costing.CurrentCost;
+import de.metas.costing.impl.CostDetailRepository;
+import de.metas.costing.impl.CostDetailService;
+import de.metas.costing.impl.CostElementRepository;
+import de.metas.costing.impl.CurrentCostsRepository;
+import de.metas.currency.CurrencyCode;
+import de.metas.currency.CurrencyRepository;
+import de.metas.currency.impl.PlainCurrencyDAO;
+import de.metas.invoice.matchinv.service.MatchInvoiceService;
+import de.metas.money.CurrencyId;
+import de.metas.order.costs.OrderCostService;
+import de.metas.order.model.I_M_Product_Category;
+import de.metas.organization.OrgId;
+import de.metas.product.ProductId;
+import de.metas.product.ProductType;
+import de.metas.quantity.Quantity;
+import de.metas.util.Services;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.model.I_C_AcctSchema;
+import org.compiere.model.I_C_AcctSchema_Default;
+import org.compiere.model.I_C_AcctSchema_GL;
+import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_M_CostElement;
+import org.compiere.model.I_M_Product;
+import org.compiere.model.I_M_Product_Category_Acct;
+import org.compiere.util.Env;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Properties;
+
+import static org.adempiere.model.InterfaceWrapperHelper.newInstance;
+import static org.adempiere.model.InterfaceWrapperHelper.newInstanceOutOfTrx;
+import static org.adempiere.model.InterfaceWrapperHelper.saveRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/*
+ * #%L
+ * de.metas.business
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+/**
+ * When a MovingAverageInvoice MatchInv is <b>reposted</b> (the cost details already exist),
+ * {@link CostingMethodHandlerTemplate#createOrUpdateCost} recovers the existing details via
+ * {@code CostingMethodHandlerUtils.getExistingCostDetails(request)} →
+ * {@link CostDetailService#getExistingCostDetails(CostDetailCreateRequest)}, which filters by the
+ * request's default {@code amtType = MAIN}. That drops the ADJUSTMENT + ALREADY_SHIPPED legs, so
+ * {@link CostAmountDetailed#getAmountBeforeAdjustment()} degenerates from
+ * {@code mainAmt - costAdj - alreadyShipped} (= the PO-price receipt amount) to just the invoiced
+ * amount — the value Doc_MatchInv posts to NotInvoicedReceipts (GR/IR).
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+public class MatchInvRepostCostDetailTest
+{
+	private CurrentCostsRepository currentCostsRepo;
+	private CostDetailService costDetailService;
+	private MovingAverageInvoiceCostingMethodHandler handler;
+	private CostingMethodHandlerUtils handlerUtils;
+
+	private OrgId orgId1;
+	private CurrencyId euroCurrencyId;
+	private I_C_UOM eachUOM;
+
+	private static final CostTypeId costTypeId = CostTypeId.ofRepoId(1);
+	private CostElement costElement;
+	private AcctSchemaId acctSchemaId;
+	private ProductId productId;
+
+	private static final ZoneId ZONE_ID = ZoneId.of("Europe/Berlin");
+
+	// 120 (invoiced/MAIN) - 15 (cost adjustment) - 5 (already shipped) = 100 (PO-price receipt amount)
+	private static final int MATCH_INV_ID = 555;
+	private static final String INVOICED_AMT = "120";
+	private static final String COST_ADJUSTMENT_AMT = "15";
+	private static final String ALREADY_SHIPPED_AMT = "5";
+	private static final String RECEIPT_AMT_BEFORE_ADJUSTMENT = "100";
+
+	@BeforeEach
+	public void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		orgId1 = AdempiereTestHelper.createOrgWithTimeZone(ZONE_ID);
+
+		final Properties ctx = Env.getCtx();
+		Env.setClientId(ctx, ClientId.METASFRESH);
+
+		final CostElementRepository costElementRepo = new CostElementRepository(ADReferenceService.newMocked());
+		currentCostsRepo = new CurrentCostsRepository(costElementRepo);
+		final CostDetailRepository costDetailsRepo = new CostDetailRepository();
+		costDetailService = new CostDetailService(costDetailsRepo, costElementRepo);
+		handlerUtils = new CostingMethodHandlerUtils(
+				new CurrencyRepository(),
+				currentCostsRepo,
+				costDetailService);
+
+		handler = new MovingAverageInvoiceCostingMethodHandler(
+				handlerUtils,
+				MatchInvoiceService.newInstanceForUnitTesting(),
+				OrderCostService.newInstanceForUnitTesting());
+
+		euroCurrencyId = PlainCurrencyDAO.createCurrency(CurrencyCode.EUR).getId();
+		eachUOM = BusinessTestHelper.createUomEach();
+
+		costElement = createMovingAverageInvoiceCostElement(costElementRepo);
+		acctSchemaId = createAcctSchema();
+		productId = createProduct();
+	}
+
+	private CostAmount eur(final String amt)
+	{
+		return CostAmount.of(new BigDecimal(amt), euroCurrencyId);
+	}
+
+	private static Instant instant(final String localDate)
+	{
+		return LocalDate.parse(localDate).atStartOfDay(ZONE_ID).toInstant();
+	}
+
+	private CostDetailCreateRequest matchInvRequest()
+	{
+		return CostDetailCreateRequest.builder()
+				.acctSchemaId(acctSchemaId)
+				.clientId(ClientId.METASFRESH)
+				.orgId(orgId1)
+				.productId(productId)
+				.attributeSetInstanceId(AttributeSetInstanceId.NONE)
+				.documentRef(CostingDocumentRef.ofMatchInvoiceId(MATCH_INV_ID))
+				.costElement(costElement)
+				.qty(Quantity.of(10, eachUOM))
+				.amt(eur(INVOICED_AMT))
+				.date(instant("2020-08-13"))
+				.build();
+	}
+
+	/**
+	 * Persist the three legs exactly as {@code createCostForMatchInvoice} does on the first (fresh)
+	 * posting: MAIN (invoiced amount), ADJUSTMENT (still-in-stock share), ALREADY_SHIPPED (COGS share).
+	 */
+	private void seedThreeLegsAsFreshPosting()
+	{
+		final CostDetailCreateRequest request = matchInvRequest();
+		final CurrentCost currentCost = handlerUtils.getCurrentCost(request);
+		final CostDetailPreviousAmounts prev = CostDetailPreviousAmounts.of(currentCost);
+
+		costDetailService.createCostDetailRecordNoCostsChanged(
+				request.withAmountAndType(eur(INVOICED_AMT), CostAmountType.MAIN),
+				prev);
+		costDetailService.createCostDetailRecordWithChangedCosts(
+				request.withAmountAndType(eur(COST_ADJUSTMENT_AMT), CostAmountType.ADJUSTMENT).withQtyZero(),
+				prev);
+		costDetailService.createCostDetailRecordNoCostsChanged(
+				request.withAmountAndType(eur(ALREADY_SHIPPED_AMT), CostAmountType.ALREADY_SHIPPED).withQtyZero(),
+				prev);
+	}
+
+	private List<CostDetail> allPersistedLegs()
+	{
+		return costDetailService.stream(CostDetailQuery.builder()
+						.acctSchemaId(acctSchemaId)
+						.costElementId(costElement.getId())
+						.documentRef(CostingDocumentRef.ofMatchInvoiceId(MATCH_INV_ID))
+						.build())
+				.collect(ImmutableList.toImmutableList());
+	}
+
+	/**
+	 * CAUSE: on repost the recovery path drops the non-MAIN legs.
+	 * All three legs are persisted, but getExistingCostDetails(request) — the exact call
+	 * createOrUpdateCost makes on repost — recovers only the MAIN leg.
+	 */
+	@Test
+	public void repost_getExistingCostDetails_recoversAllThreeLegs_notJustMain()
+	{
+		seedThreeLegsAsFreshPosting();
+
+		// sanity: all three legs really are persisted for this MatchInv
+		assertThat(allPersistedLegs()).hasSize(3);
+
+		// repost recovery path used by CostingMethodHandlerTemplate.createOrUpdateCost
+		final List<CostDetail> recovered = handlerUtils.getExistingCostDetails(matchInvRequest());
+
+		assertThat(recovered)
+				.as("repost must recover ALL cost-detail legs, not just MAIN")
+				.extracting(CostDetail::getAmtType)
+				.containsExactlyInAnyOrder(
+						CostAmountType.MAIN,
+						CostAmountType.ADJUSTMENT,
+						CostAmountType.ALREADY_SHIPPED);
+	}
+
+	/**
+	 * SYMPTOM: getAmountBeforeAdjustment on repost degenerates to the invoiced amount instead of the
+	 * PO-price receipt amount, so Doc_MatchInv would post the full invoice amount to NotInvoicedReceipts.
+	 */
+	@Test
+	public void repost_getAmountBeforeAdjustment_equalsReceiptAmt_notInvoicedAmt()
+	{
+		seedThreeLegsAsFreshPosting();
+
+		final AcctSchema as = Services.get(IAcctSchemaDAO.class).getById(acctSchemaId);
+
+		// exact production repost call: existing details found => recovered + aggregated
+		final CostAmountDetailed costs = handler.createOrUpdateCost(matchInvRequest()).getTotalAmountToPost(as);
+
+		assertThat(costs.getAmountBeforeAdjustment().toBigDecimal())
+				.as("amount posted to NotInvoicedReceipts (GR/IR) must be the PO-price receipt amount, "
+						+ "not the full invoiced amount")
+				.isEqualByComparingTo(RECEIPT_AMT_BEFORE_ADJUSTMENT);
+	}
+
+	/**
+	 * REGRESSION: for a single-leg costing method (AveragePO / Standard / LastPO / ...) only a MAIN leg is ever
+	 * persisted for a document. Dropping the amtType=MAIN filter from the repost-recovery path must NOT change
+	 * their behaviour: "recover all legs" degenerates to "recover MAIN" and the recovered amount is unchanged.
+	 */
+	@Test
+	public void repost_singleMainLeg_recoversExactlyMain_amountUnchanged()
+	{
+		// seed a single MAIN leg for a DIFFERENT document (as a single-leg method would)
+		final CostDetailCreateRequest request = CostDetailCreateRequest.builder()
+				.acctSchemaId(acctSchemaId)
+				.clientId(ClientId.METASFRESH)
+				.orgId(orgId1)
+				.productId(productId)
+				.attributeSetInstanceId(AttributeSetInstanceId.NONE)
+				.documentRef(CostingDocumentRef.ofMatchInvoiceId(MATCH_INV_ID + 1))
+				.costElement(costElement)
+				.qty(Quantity.of(10, eachUOM))
+				.amt(eur(INVOICED_AMT))
+				.date(instant("2020-08-13"))
+				.build();
+
+		final CurrentCost currentCost = handlerUtils.getCurrentCost(request);
+		costDetailService.createCostDetailRecordNoCostsChanged(
+				request.withAmountAndType(eur(INVOICED_AMT), CostAmountType.MAIN),
+				CostDetailPreviousAmounts.of(currentCost));
+
+		// repost recovery path
+		final List<CostDetail> recovered = handlerUtils.getExistingCostDetails(request);
+
+		assertThat(recovered)
+				.as("a single-leg document must still recover exactly its MAIN leg")
+				.extracting(CostDetail::getAmtType)
+				.containsExactly(CostAmountType.MAIN);
+
+		final AcctSchema as = Services.get(IAcctSchemaDAO.class).getById(acctSchemaId);
+		final CostAmountDetailed costs = costDetailService.toCostDetailCreateResultsList(recovered).getTotalAmountToPost(as);
+
+		// no ADJUSTMENT / ALREADY_SHIPPED legs => amountBeforeAdjustment == mainAmt (unchanged from before the fix)
+		assertThat(costs.getMainAmt().toBigDecimal()).isEqualByComparingTo(INVOICED_AMT);
+		assertThat(costs.getAmountBeforeAdjustment().toBigDecimal()).isEqualByComparingTo(INVOICED_AMT);
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// setup helpers (mirrors MovingAverageInvoiceCostingMethodHandlerTest)
+	// ---------------------------------------------------------------------------------------------
+
+	private CostElement createMovingAverageInvoiceCostElement(final CostElementRepository costElementRepo)
+	{
+		final I_M_CostElement record = newInstanceOutOfTrx(I_M_CostElement.class);
+		record.setAD_Org_ID(OrgId.ANY.getRepoId());
+		record.setName(CostingMethod.MovingAverageInvoice.name());
+		record.setCostElementType(CostElementType.Material.getCode());
+		record.setCostingMethod(CostingMethod.MovingAverageInvoice.getCode());
+		record.setIsCalculated(false);
+		InterfaceWrapperHelper.saveRecord(record);
+
+		final CostElementId costElementId = CostElementId.ofRepoId(record.getM_CostElement_ID());
+		return costElementRepo.getById(costElementId);
+	}
+
+	private AcctSchemaId createAcctSchema()
+	{
+		final I_C_AcctSchema acctSchemaRecord = newInstance(I_C_AcctSchema.class);
+		acctSchemaRecord.setName("Test AcctSchema");
+		acctSchemaRecord.setC_Currency_ID(euroCurrencyId.getRepoId());
+		acctSchemaRecord.setM_CostType_ID(costTypeId.getRepoId());
+		acctSchemaRecord.setCostingLevel(CostingLevel.Client.getCode());
+		acctSchemaRecord.setCostingMethod(CostingMethod.MovingAverageInvoice.getCode());
+		acctSchemaRecord.setSeparator("-");
+		acctSchemaRecord.setTaxCorrectionType(TaxCorrectionType.NONE.getCode());
+		saveRecord(acctSchemaRecord);
+
+		final I_C_AcctSchema_GL acctSchemaGL = newInstance(I_C_AcctSchema_GL.class);
+		acctSchemaGL.setC_AcctSchema_ID(acctSchemaRecord.getC_AcctSchema_ID());
+		acctSchemaGL.setIntercompanyDueFrom_Acct(1);
+		acctSchemaGL.setIntercompanyDueTo_Acct(1);
+		acctSchemaGL.setIncomeSummary_Acct(1);
+		acctSchemaGL.setRetainedEarning_Acct(1);
+		acctSchemaGL.setPPVOffset_Acct(1);
+		acctSchemaGL.setCashRounding_Acct(1);
+		saveRecord(acctSchemaGL);
+
+		final I_C_AcctSchema_Default acctSchemaDefault = newInstance(I_C_AcctSchema_Default.class);
+		acctSchemaDefault.setC_AcctSchema_ID(acctSchemaRecord.getC_AcctSchema_ID());
+		acctSchemaDefault.setRealizedGain_Acct(1);
+		acctSchemaDefault.setRealizedLoss_Acct(1);
+		acctSchemaDefault.setUnrealizedGain_Acct(1);
+		acctSchemaDefault.setUnrealizedLoss_Acct(1);
+		saveRecord(acctSchemaDefault);
+
+		return AcctSchemaId.ofRepoId(acctSchemaRecord.getC_AcctSchema_ID());
+	}
+
+	private ProductId createProduct()
+	{
+		final I_M_Product_Category productCategory = newInstanceOutOfTrx(I_M_Product_Category.class);
+		saveRecord(productCategory);
+
+		final I_M_Product_Category_Acct productCategoryAcct = newInstanceOutOfTrx(I_M_Product_Category_Acct.class);
+		productCategoryAcct.setM_Product_Category_ID(productCategory.getM_Product_Category_ID());
+		productCategoryAcct.setC_AcctSchema_ID(acctSchemaId.getRepoId());
+		saveRecord(productCategoryAcct);
+
+		final I_M_Product product = newInstanceOutOfTrx(I_M_Product.class);
+		product.setValue("product");
+		product.setName("product");
+		product.setC_UOM_ID(eachUOM.getC_UOM_ID());
+		product.setProductType(ProductType.Item.getCode());
+		product.setIsStocked(true);
+		product.setM_Product_Category_ID(productCategory.getM_Product_Category_ID());
+		saveRecord(product);
+
+		return ProductId.ofRepoId(product.getM_Product_ID());
+	}
+}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/matchInvRepostPriceVariance.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/matchInvRepostPriceVariance.feature
@@ -1,0 +1,129 @@
+@from:cucumber
+@allure.label.epic:E0226_Costing
+@allure.label.feature:F1500_Costing
+@allure.label.feature:F1514_Cost_Type_Moving_Average_Invoice
+@ghActions:run_on_executor6
+Feature: Moving Average Invoice - MatchInv repost keeps the invoice-vs-PO price variance out of GR/IR
+## F1500: Costing
+# A MovingAverageInvoice vendor MatchInv posts the invoice-vs-PO price difference against the on-hand
+# inventory cost (P_Asset), while NotInvoicedReceipts (GR/IR) only ever carries the PO-price receipt
+# amount, so GR/IR nets to zero against the material receipt.
+#
+# On a REPOST the posting must reconstruct itself from ALL the persisted cost-detail legs
+# (MAIN + ADJUSTMENT), not just MAIN. If the non-MAIN legs are dropped, GR/IR degenerates to the full
+# invoiced amount and the price variance is left stuck in GR/IR. This scenario reposts the MatchInv and
+# asserts the GL outcome is identical to the first posting.
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
+    And metasfresh has date and time 2027-03-15T13:30:13+01:00[Europe/Berlin]
+    And load and update C_AcctSchema:
+      | C_AcctSchema_ID | Name                  | CostingMethod |
+      | acctSchema      | metas fresh UN/34 CHF | M             |
+    And cost elements for material costing methods MovingAverageInvoice are active
+    And load M_Warehouse:
+      | M_Warehouse_ID | Value        |
+      | warehouseStd   | StdWarehouse |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | purchasePS |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | purchasePL | purchasePS         | CH           | CHF           | false |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier  | M_PriceList_ID |
+      | purchasePLV | purchasePL     |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | purchasePLV            | product      | 10.0     | PCE      |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | IsVendor | IsCustomer | M_PricingSystem_ID |
+      | vendor     | Y        | N          | purchasePS         |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier     | C_BPartner_ID | C_Country_ID | IsShipToDefault | IsBillToDefault |
+      | vendorLocation | vendor        | CH           | Y               | Y               |
+
+  @Id:S26253_TC23
+  Scenario: A MovingAverageInvoice MatchInv repost routes the price variance to inventory, keeping GR/IR clean
+    #
+    # Receive 10 PCE at the PO price 10 CHF = 100 CHF; all 10 stay on hand.
+    #
+    Given for costing, create completed order with one line
+      | C_OrderLine_ID | C_BPartner_ID | DateOrdered | DocBaseType | M_Warehouse_ID | M_Product_ID | QtyEntered | Price |
+      | po_l1          | vendor        | 2027-03-15  | POO         | warehouseStd   | product      | 10         | 10    |
+    And for costing, create completed material receipt with one line
+      | C_OrderLine_ID | M_InOut_ID | M_InOutLine_ID |
+      | po_l1          | receipt    | receipt_line1  |
+    Then after not more than 10s, M_CostDetails are found for product product and cost element MovingAverageInvoice
+      | TableName   | Record_ID     | IsSOTrx | Amt     | Qty    | IsChangingCosts |
+      | M_InOutLine | receipt_line1 | N       | 100 CHF | 10 PCE | Y               |
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
+      | acctSchema      | product      | MovingAverageInvoice | 10 CHF           | 10 PCE     | 100 CHF      |
+    #
+    # The vendor invoice arrives at 12 CHF (a 2 CHF/PCE price increase) = 120 CHF, matched to the receipt.
+    # All 10 PCE are still on hand, so the whole 20 CHF variance revalues the on-hand cost (ADJUSTMENT leg):
+    # the moving-average price moves (100 + 20) / 10 = 12 CHF. The MatchInv persists a MAIN leg (the invoiced
+    # 120) and an ADJUSTMENT leg (the still-in-stock 20); getAmountBeforeAdjustment = 120 - 20 = 100 = the
+    # PO-price receipt amount that posts to GR/IR.
+    #
+    When for costing, create completed invoice with one line
+      | C_OrderLine_ID | PriceEntered_Override | M_MatchInv_ID |
+      | po_l1          | 12                    | matchInv      |
+    Then after not more than 10s, M_CostDetails are found for product product and cost element MovingAverageInvoice
+      | TableName   | Record_ID     | IsSOTrx | AmtType    | Amt     | Qty    | IsChangingCosts |
+      | M_InOutLine | receipt_line1 | N       |            | 100 CHF | 10 PCE | Y               |
+      | M_MatchInv  | matchInv      | N       | MAIN       | 120 CHF | 10 PCE | N               |
+      | M_MatchInv  | matchInv      | N       | ADJUSTMENT | 20 CHF  | 0 PCE  | Y               |
+    And validate current costs
+      | C_AcctSchema_ID | M_Product_ID | M_CostElement_ID     | CurrentCostPrice | CurrentQty | CumulatedAmt |
+      | acctSchema      | product      | MovingAverageInvoice | 12 CHF           | 10 PCE     | 120 CHF      |
+    #
+    # First posting (baseline). The MatchInv books:
+    #   NotInvoicedReceipts (GR/IR) DR 100  = the PO-price receipt amount (NOT the invoiced 120)
+    #   P_InventoryClearing         CR 120  = the invoiced amount
+    #   P_Asset                     DR 20   = the on-hand price variance
+    # so GR/IR nets to zero against the material receipt's GR/IR credit of 100.
+    #
+    And Wait until documents receipt,matchInv are posted
+    And Fact_Acct records are matching
+      | AccountConceptualName    | AmtAcctDr | AmtAcctCr | AmtSourceDr | AmtSourceCr | Qty     | M_Product_ID | Record_ID | C_BPartner_ID |
+      | NotInvoicedReceipts_Acct | 100       |           | 100 CHF     |             | +10 PCE | product      | matchInv  | vendor        |
+      | P_InventoryClearing_Acct |           | 120       |             | 120 CHF     | -10 PCE | product      | matchInv  | vendor        |
+      | P_Asset_Acct             | 20        |           | 20 CHF      |             | +10 PCE | product      | matchInv  | vendor        |
+    And Fact_Acct records balances for documents receipt,matchInv are matching
+      | AccountConceptualName    | M_Product_ID | SourceBalance | AcctBalance | Qty   |
+      | NotInvoicedReceipts_Acct | product      | 0 CHF         | 0           | 0 PCE |
+    #
+    # Repost the MatchInv (and the receipt) from before the documents' date. This is the trigger that exposed
+    # the bug: the repost recovers the existing cost details and must reuse ALL legs (MAIN + ADJUSTMENT).
+    # If only MAIN is recovered, GR/IR would degenerate to the full invoiced 120 and leave +20 stuck in GR/IR.
+    #
+    # A PLAIN repost is required here (it reuses the existing cost details). A cost RECOMPUTE would instead
+    # delete the cost details and recreate every leg on repost, which recreates them correctly and hides the
+    # bug -- so the plain-repost driver is the load-bearing trigger, not a recompute.
+    #
+    Given after not more than 60s, the repost queue is drained
+    When the accounting repost driver runs:
+      | C_AcctSchema_ID | StartDateAcct |
+      | acctSchema      | 2027-03-01    |
+    And after not more than 120s, the repost queue is drained
+    And Wait until documents receipt,matchInv are posted
+    #
+    # After the repost the GL outcome is IDENTICAL to the first posting: GR/IR still carries only the
+    # PO-price receipt amount (100), the variance still sits on P_Asset (20), and GR/IR still nets to zero.
+    #
+    Then Fact_Acct records are matching
+      | AccountConceptualName    | AmtAcctDr | AmtAcctCr | AmtSourceDr | AmtSourceCr | Qty     | M_Product_ID | Record_ID | C_BPartner_ID |
+      | NotInvoicedReceipts_Acct | 100       |           | 100 CHF     |             | +10 PCE | product      | matchInv  | vendor        |
+      | P_InventoryClearing_Acct |           | 120       |             | 120 CHF     | -10 PCE | product      | matchInv  | vendor        |
+      | P_Asset_Acct             | 20        |           | 20 CHF      |             | +10 PCE | product      | matchInv  | vendor        |
+    And Fact_Acct records balances for documents receipt,matchInv are matching
+      | AccountConceptualName    | M_Product_ID | SourceBalance | AcctBalance | Qty   |
+      | NotInvoicedReceipts_Acct | product      | 0 CHF         | 0           | 0 PCE |

--- a/backend/de.metas.manufacturing/src/test/java/de/metas/costing/methods/ManufacturingRepostCostDifferenceDistributionTest.java
+++ b/backend/de.metas.manufacturing/src/test/java/de/metas/costing/methods/ManufacturingRepostCostDifferenceDistributionTest.java
@@ -1,0 +1,371 @@
+/*
+ * #%L
+ * de.metas.manufacturing
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package de.metas.costing.methods;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.acct.AcctSchemaTestHelper;
+import de.metas.acct.api.AcctSchema;
+import de.metas.acct.api.AcctSchemaId;
+import de.metas.ad_reference.ADReferenceService;
+import de.metas.business.BusinessTestHelper;
+import de.metas.costing.CostAmount;
+import de.metas.costing.CostDetail;
+import de.metas.costing.CostDetailCreateRequest;
+import de.metas.costing.CostDetailCreateResultsList;
+import de.metas.costing.CostElement;
+import de.metas.costing.CostPrice;
+import de.metas.costing.CostingDocumentRef;
+import de.metas.costing.CostingLevel;
+import de.metas.costing.CostingMethod;
+import de.metas.costing.IProductCostingBL;
+import de.metas.costing.impl.CostDetailRepository;
+import de.metas.costing.impl.CostDetailService;
+import de.metas.costing.impl.CostElementRepository;
+import de.metas.costing.impl.CurrentCostsRepository;
+import de.metas.currency.CurrencyCode;
+import de.metas.currency.CurrencyPrecision;
+import de.metas.currency.CurrencyRepository;
+import de.metas.currency.impl.PlainCurrencyDAO;
+import de.metas.document.engine.DocStatus;
+import de.metas.invoice.matchinv.service.MatchInvoiceService;
+import de.metas.money.CurrencyId;
+import de.metas.order.costs.OrderCostService;
+import de.metas.organization.OrgId;
+import de.metas.product.ProductId;
+import de.metas.quantity.Quantity;
+import de.metas.uom.UomId;
+import de.metas.util.Services;
+import lombok.NonNull;
+import org.adempiere.mm.attributes.AttributeSetInstanceId;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.service.ClientId;
+import org.adempiere.test.AdempiereTestHelper;
+import org.adempiere.test.AdempiereTestWatcher;
+import org.compiere.model.I_C_UOM;
+import org.compiere.model.I_M_Cost;
+import org.compiere.util.Env;
+import org.eevolution.api.CostCollectorType;
+import org.eevolution.api.IPPOrderCostBL;
+import org.eevolution.api.PPCostCollectorId;
+import org.eevolution.api.PPOrderCost;
+import org.eevolution.api.PPOrderCostTrxType;
+import org.eevolution.api.PPOrderCosts;
+import org.eevolution.api.PPOrderId;
+import org.eevolution.api.impl.MockedProductCostingBL;
+import org.eevolution.model.I_PP_Cost_Collector;
+import org.eevolution.model.I_PP_Order;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A manufacturing {@code CostDifferenceDistribution} collector persists THREE cost-detail legs
+ * (MAIN + ADJUSTMENT + ALREADY_SHIPPED — see {@link PPOrderCostDifferenceDistributor#createCostDetails})
+ * for AveragePO, LastPOPrice and MovingAverageInvoice alike. Reposting it must recover the FULL posting:
+ * {@code CostingMethodHandler.createOrUpdateCost} short-circuits an existing posting through
+ * {@code CostingMethodHandlerUtils.getExistingCostDetails(request)} →
+ * {@link CostDetailService#getExistingCostDetails(CostDetailCreateRequest)}, which must NOT filter by the
+ * request's default {@code amtType = MAIN}.
+ * <p>
+ * Pre-fix that filter truncated the recovery to the MAIN leg, so the aggregated amount lost the ADJUSTMENT
+ * and ALREADY_SHIPPED shares — the same defect {@code MatchInvRepostCostDetailTest} pins for the MAI MatchInv.
+ * This test drives the real repost path end-to-end (post the collector, then repost it) and fails if the
+ * amtType filter is reintroduced.
+ */
+@ExtendWith(AdempiereTestWatcher.class)
+class ManufacturingRepostCostDifferenceDistributionTest
+{
+	private static final Instant DATE = Instant.parse("2026-08-29T00:00:00Z");
+
+	// issued 100 (= price 10 x qty 10) - received 60 (= price 6 x qty 10) => residual 40.
+	// 8 of the 10 manufactured are still in stock at cost price 30 => capitalize 40 x 8/10 = 32, spill 8 to COGS.
+	private static final String ISSUED_PRICE = "10";
+	private static final String ISSUED_QTY = "-10";
+	private static final String RECEIVED_PRICE = "6";
+	private static final String RECEIVED_QTY = "10";
+	private static final String MAIN_CURRENT_QTY = "8";
+	private static final String MAIN_CURRENT_COST_PRICE = "30";
+
+	private static final String EXPECTED_RESIDUAL = "40";
+	private static final String EXPECTED_CAPITALIZED = "32";
+	private static final String EXPECTED_ALREADY_SHIPPED = "8";
+
+	private final ClientId clientId = ClientId.ofRepoId(1);
+	private final OrgId orgId = OrgId.ofRepoId(0);
+
+	private CurrencyId currencyId;
+	private I_C_UOM uomEach;
+	private ProductId mainProductId;
+	private ProductId componentProductId;
+
+	private CostElementRepository costElementRepo;
+	private CostingMethodHandlerUtils utils;
+	private PPOrderCostDifferenceDistributor distributor;
+
+	// per-test, set up by setupOrderFor(..)
+	private AcctSchemaId acctSchemaId;
+	private CostElement costElement;
+	private CostingMethodHandler handler;
+	private PPOrderId orderId;
+	private PPCostCollectorId distributionCollectorId;
+
+	/** The multi-leg producers: each accumulates into {@code PP_Order_Cost} and can emit a CostDifferenceDistribution. */
+	private enum ManufacturingHandlerUnderTest
+	{
+		AveragePO(CostingMethod.AveragePO)
+				{
+					@Override
+					CostingMethodHandler createHandler(final CostingMethodHandlerUtils utils, final PPOrderCostDifferenceDistributor distributor)
+					{
+						return new ManufacturingAveragePOCostingMethodHandler(
+								utils,
+								distributor,
+								new AveragePOCostingMethodHandler(
+										utils,
+										MatchInvoiceService.newInstanceForUnitTesting(),
+										OrderCostService.newInstanceForUnitTesting()));
+					}
+				},
+		LastPO(CostingMethod.LastPOPrice)
+				{
+					@Override
+					CostingMethodHandler createHandler(final CostingMethodHandlerUtils utils, final PPOrderCostDifferenceDistributor distributor)
+					{
+						return new ManufacturingLastPOCostingMethodHandler(utils, distributor);
+					}
+				},
+		MovingAverageInvoice(CostingMethod.MovingAverageInvoice)
+				{
+					@Override
+					CostingMethodHandler createHandler(final CostingMethodHandlerUtils utils, final PPOrderCostDifferenceDistributor distributor)
+					{
+						return new ManufacturingMovingAverageInvoiceCostingMethodHandler(
+								utils,
+								distributor,
+								new MovingAverageInvoiceCostingMethodHandler(
+										utils,
+										MatchInvoiceService.newInstanceForUnitTesting(),
+										OrderCostService.newInstanceForUnitTesting()));
+					}
+				},
+		;
+
+		final CostingMethod costingMethod;
+
+		ManufacturingHandlerUnderTest(@NonNull final CostingMethod costingMethod) {this.costingMethod = costingMethod;}
+
+		abstract CostingMethodHandler createHandler(CostingMethodHandlerUtils utils, PPOrderCostDifferenceDistributor distributor);
+	}
+
+	@BeforeEach
+	void setUp()
+	{
+		AdempiereTestHelper.get().init();
+		Env.setClientId(Env.getCtx(), clientId);
+
+		uomEach = BusinessTestHelper.createUomEach();
+		currencyId = PlainCurrencyDAO.createCurrencyId(CurrencyCode.EUR);
+		mainProductId = BusinessTestHelper.createProductId("main product", uomEach);
+		componentProductId = BusinessTestHelper.createProductId("component", uomEach);
+
+		// the costing level is what the cost segment is built from; the costing method is only asked for products
+		Services.registerService(IProductCostingBL.class, new MockedProductCostingBL(CostingLevel.Client, CostingMethod.AveragePO));
+
+		costElementRepo = new CostElementRepository(ADReferenceService.newMocked());
+		utils = new CostingMethodHandlerUtils(
+				new CurrencyRepository(),
+				new CurrentCostsRepository(costElementRepo),
+				new CostDetailService(new CostDetailRepository(), costElementRepo));
+		distributor = new PPOrderCostDifferenceDistributor(costElementRepo, utils);
+	}
+
+	@ParameterizedTest
+	@EnumSource(ManufacturingHandlerUnderTest.class)
+	void costDifferenceDistribution_repost_recoversAllThreeLegs_notJustMain(final ManufacturingHandlerUnderTest handlerUnderTest)
+	{
+		setupOrderFor(handlerUnderTest);
+
+		final CostDetailCreateRequest request = distributionRequest();
+
+		// first posting: the collector routes to the distributor, which persists MAIN + ADJUSTMENT + ALREADY_SHIPPED
+		handler.createOrUpdateCost(request);
+
+		// the three legs really are persisted for this collector (i.e. the scenario genuinely is multi-leg)
+		assertThat(utils.getExistingCostDetails(request))
+				.as("a CostDifferenceDistribution posting persists all three legs")
+				.extracting(CostDetail::getAmtType)
+				.containsExactlyInAnyOrder(
+						CostAmountType.MAIN,
+						CostAmountType.ADJUSTMENT,
+						CostAmountType.ALREADY_SHIPPED);
+
+		// the repost: the exact recovery path CostingMethodHandler.createOrUpdateCost takes when the details exist
+		final CostDetailCreateResultsList repost = handler.createOrUpdateCost(request);
+
+		final AcctSchema as = utils.getAcctSchemaById(acctSchemaId);
+		final CostAmountDetailed recovered = repost.getTotalAmountToPost(as);
+
+		// leg-complete: pre-fix the recovery truncated to MAIN, so ADJUSTMENT + ALREADY_SHIPPED came back zero
+		assertThat(recovered.getMainAmt().toBigDecimal())
+				.as("MAIN leg")
+				.isEqualByComparingTo(EXPECTED_RESIDUAL);
+		assertThat(recovered.getCostAdjustmentAmt().toBigDecimal())
+				.as("ADJUSTMENT leg must survive the repost (not truncated to MAIN)")
+				.isEqualByComparingTo(EXPECTED_CAPITALIZED);
+		assertThat(recovered.getAlreadyShippedAmt().toBigDecimal())
+				.as("ALREADY_SHIPPED leg must survive the repost (not truncated to MAIN)")
+				.isEqualByComparingTo(EXPECTED_ALREADY_SHIPPED);
+	}
+
+	//
+	//
+	// fixture
+	//
+	//
+
+	private void setupOrderFor(@NonNull final ManufacturingHandlerUnderTest handlerUnderTest)
+	{
+		acctSchemaId = AcctSchemaTestHelper.newAcctSchema()
+				.costingLevel(CostingLevel.Client)
+				.costingMethod(handlerUnderTest.costingMethod)
+				.currencyId(currencyId)
+				.build();
+		costElement = costElementRepo.getOrCreateMaterialCostElement(clientId, handlerUnderTest.costingMethod);
+		handler = handlerUnderTest.createHandler(utils, distributor);
+
+		orderId = createCompletedPPOrder();
+		distributionCollectorId = createCostDifferenceDistributionCollector();
+
+		seedOrderCostsWithResidual();
+		saveMainProductCurrentCost();
+	}
+
+	private PPOrderId createCompletedPPOrder()
+	{
+		final I_PP_Order order = InterfaceWrapperHelper.newInstance(I_PP_Order.class);
+		InterfaceWrapperHelper.setValue(order, I_PP_Order.COLUMNNAME_AD_Client_ID, clientId.getRepoId());
+		order.setAD_Org_ID(orgId.getRepoId());
+		order.setM_Product_ID(mainProductId.getRepoId());
+		order.setDocStatus(DocStatus.Completed.getCode());
+		InterfaceWrapperHelper.saveRecord(order);
+		return PPOrderId.ofRepoId(order.getPP_Order_ID());
+	}
+
+	private PPCostCollectorId createCostDifferenceDistributionCollector()
+	{
+		final I_PP_Cost_Collector cc = InterfaceWrapperHelper.newInstance(I_PP_Cost_Collector.class);
+		cc.setCostCollectorType(CostCollectorType.CostDifferenceDistribution.getCode());
+		cc.setPP_Order_ID(orderId.getRepoId());
+		cc.setMovementQty(BigDecimal.ZERO);
+		InterfaceWrapperHelper.saveRecord(cc);
+		return PPCostCollectorId.ofRepoId(cc.getPP_Cost_Collector_ID());
+	}
+
+	/** The {@code PP_Order_Cost} rows a completed order carries: an issue and a main-product receipt, leaving a residual. */
+	private void seedOrderCostsWithResidual()
+	{
+		final BigDecimal issuedQty = new BigDecimal(ISSUED_QTY);
+		final BigDecimal receivedQty = new BigDecimal(RECEIVED_QTY);
+
+		// A component issue keeps the stock-movement direction in its qty (negative) while accumulating the cost
+		// that went INTO the order as a positive amount.
+		final PPOrderCost materialIssue = PPOrderCost.builder()
+				.trxType(PPOrderCostTrxType.MaterialIssue)
+				.costSegmentAndElement(utils.extractCostSegmentAndElement(requestFor(componentProductId, issuedQty)))
+				.price(costPrice(ISSUED_PRICE))
+				.accumulatedQty(Quantity.of(issuedQty, uomEach))
+				.accumulatedAmount(CostAmount.of(new BigDecimal(ISSUED_PRICE).multiply(issuedQty).negate(), currencyId))
+				.build();
+
+		final PPOrderCost mainProduct = PPOrderCost.builder()
+				.trxType(PPOrderCostTrxType.MainProduct)
+				.costSegmentAndElement(utils.extractCostSegmentAndElement(requestFor(mainProductId, receivedQty)))
+				.price(costPrice(RECEIVED_PRICE))
+				.accumulatedQty(Quantity.of(receivedQty, uomEach))
+				.accumulatedAmount(CostAmount.of(new BigDecimal(RECEIVED_PRICE).multiply(receivedQty), currencyId))
+				.build();
+
+		final PPOrderCosts orderCosts = PPOrderCosts.builder()
+				.orderId(orderId)
+				.costs(ImmutableList.of(materialIssue, mainProduct))
+				.build();
+
+		// what every costing-method handler does after an issue or a receipt
+		orderCosts.updatePostCalculationAmounts(CurrencyPrecision.ofInt(2));
+
+		Services.get(IPPOrderCostBL.class).save(orderCosts);
+	}
+
+	private void saveMainProductCurrentCost()
+	{
+		final I_M_Cost cost = InterfaceWrapperHelper.newInstance(I_M_Cost.class);
+		cost.setAD_Org_ID(orgId.getRepoId());
+		cost.setC_AcctSchema_ID(acctSchemaId.getRepoId());
+		cost.setM_CostElement_ID(costElement.getId().getRepoId());
+		cost.setM_CostType_ID(1);
+		cost.setM_Product_ID(mainProductId.getRepoId());
+		cost.setM_AttributeSetInstance_ID(AttributeSetInstanceId.NONE.getRepoId());
+		cost.setC_UOM_ID(uomEach.getC_UOM_ID());
+		cost.setC_Currency_ID(currencyId.getRepoId());
+		cost.setCurrentCostPrice(new BigDecimal(MAIN_CURRENT_COST_PRICE));
+		cost.setCurrentQty(new BigDecimal(MAIN_CURRENT_QTY));
+		InterfaceWrapperHelper.saveRecord(cost);
+	}
+
+	private CostPrice costPrice(@NonNull final String ownCostPrice)
+	{
+		return CostPrice.builder()
+				.ownCostPrice(CostAmount.of(new BigDecimal(ownCostPrice), currencyId))
+				.componentsCostPrice(CostAmount.zero(currencyId))
+				.uomId(UomId.ofRepoId(uomEach.getC_UOM_ID()))
+				.build();
+	}
+
+	/** What the manufacturing handler is handed for the CostDifferenceDistribution collector: the main product, no amount. */
+	private CostDetailCreateRequest distributionRequest()
+	{
+		return requestFor(mainProductId, new BigDecimal(RECEIVED_QTY));
+	}
+
+	private CostDetailCreateRequest requestFor(@NonNull final ProductId productId, @NonNull final BigDecimal qty)
+	{
+		return CostDetailCreateRequest.builder()
+				.acctSchemaId(acctSchemaId)
+				.clientId(clientId)
+				.orgId(orgId)
+				.productId(productId)
+				.attributeSetInstanceId(AttributeSetInstanceId.NONE)
+				.costElement(costElement)
+				.documentRef(CostingDocumentRef.ofCostCollectorId(distributionCollectorId))
+				.qty(Quantity.of(qty, uomEach))
+				.amt(CostAmount.zero(currencyId))
+				.date(DATE)
+				.build();
+	}
+}


### PR DESCRIPTION
## What

On a **repost** of a MovingAverageInvoice (MAI) MatchInv — and, in manufacturing, a `CostDifferenceDistribution` cost collector under AveragePO / LastPOPrice / MovingAverageInvoice — the existing cost details were recovered by `CostingMethodHandlerTemplate.createOrUpdateCost` via `CostDetailService.getExistingCostDetails(CostDetailCreateRequest)`, which filtered by `request.getAmtType()` (defaulting to `MAIN`). Only the `MAIN` leg was recovered; the `ADJUSTMENT` + `ALREADY_SHIPPED` legs were silently dropped.

Consequence: the reconstructed `CostAmountDetailed` degenerated — `getAmountBeforeAdjustment` returned the invoiced amount instead of the PO-price receipt amount — so on repost the **full invoiced amount was posted to NotInvoicedReceipts (GR/IR)** instead of only the PO-price receipt amount there, with the invoice-vs-PO price variance stuck in the clearing account rather than revaluing on-hand inventory.

## Root cause

The request-overload of `getExistingCostDetails` is consumed only by the repost-recovery path (`CostingMethodHandlerTemplate.createOrUpdateCost` plus the four manufacturing handlers), which must reconstruct the full posting — yet it applied the `MAIN` default `amtType` filter.

## Fix

Drop the `amtType` filter from `getExistingCostDetails(CostDetailCreateRequest)` so a repost recovers **every** persisted leg (`MAIN` + `ADJUSTMENT` + `ALREADY_SHIPPED`). The variance is then routed to its proper account — for the on-hand case, on-hand inventory revaluation (`P_Asset`) via the `ADJUSTMENT` leg, with InvoicePriceVariance only as an FX/residual line — and GR/IR (`NotInvoicedReceipts`) carries only the PO-price receipt amount and nets to zero, matching a fresh posting.

**Shared-core safety:** only two code paths ever persist non-MAIN legs — `MovingAverageInvoiceCostingMethodHandler` (MAI MatchInv) and `PPOrderCostDifferenceDistributor` (manufacturing `CostDifferenceDistribution`, for `COSTING_METHODS_WITH_ORDER_COSTS` = AveragePO / LastPOPrice / MovingAverageInvoice). Documents that only ever persist a single `MAIN` leg are unaffected ("recover all legs" == "recover MAIN"). The `CostDetailQuery`-overload callers (`createMovementCosts`) still pass `amtType(MAIN)` explicitly and are untouched. The repost-recovery branch only re-returns persisted rows for posting; it does not mutate `CurrentCost`/`M_Cost`, so there is no double-counting and no risk of overwriting an explicit cost price.

## Tests

- `MatchInvRepostCostDetailTest` — repost recovers all three legs; `getAmountBeforeAdjustment` = receipt amount; plus a single-leg regression case.
- `ManufacturingRepostCostDifferenceDistributionTest` — `@ParameterizedTest` over AveragePO / LastPOPrice / MovingAverageInvoice; drives the real repost short-circuit and asserts the aggregate is leg-complete (pin-verified: fails if the `amtType` filter is reintroduced).
- `matchInvRepostPriceVariance.feature` — end-to-end Cucumber: receipt at PO price → invoice at a different price → **plain repost** via the production repost driver → asserts the resulting `Fact_Acct` (GR/IR carries the PO-price receipt amount and nets to zero; the variance revalues on-hand inventory), not the full invoiced amount. Pin-verified RED→GREEN.
