### PR TITLE
Invoice candidates: report failed Create Invoices runs, and close candidates of undelivered dispositions

### DIFF
--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -645,9 +645,8 @@ public class C_Invoice_Candidate_StepDef
 						row.getAsOptionalString(I_C_Invoice_Candidate.COLUMNNAME_ErrorMsg)
 								.ifPresent(expected -> softly.assertThat(finalInvoiceCandidate.getErrorMsg()).as("ErrorMsg").contains(expected));
 
-						// IsError/ErrorMsg are cleared again by the next "update invalid invoice candidates" run
-						// (InvoiceCandBL.resetError), whereas IsInvoicingError/InvoicingErrorMsg survive it. Assert on
-						// these two whenever the point is that a *"Create Invoices" run* failed for the candidate.
+						// IsError/ErrorMsg are cleared again by the next "update invalid invoice candidates" run;
+						// IsInvoicingError/InvoicingErrorMsg survive it and record that a "Create Invoices" run failed.
 						row.getAsOptionalBoolean(I_C_Invoice_Candidate.COLUMNNAME_IsInvoicingError)
 								.ifPresent(expected -> softly.assertThat(finalInvoiceCandidate.isInvoicingError()).as("IsInvoicingError").isEqualTo(expected));
 

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/invoicecandidate/C_Invoice_Candidate_StepDef.java
@@ -645,6 +645,15 @@ public class C_Invoice_Candidate_StepDef
 						row.getAsOptionalString(I_C_Invoice_Candidate.COLUMNNAME_ErrorMsg)
 								.ifPresent(expected -> softly.assertThat(finalInvoiceCandidate.getErrorMsg()).as("ErrorMsg").contains(expected));
 
+						// IsError/ErrorMsg are cleared again by the next "update invalid invoice candidates" run
+						// (InvoiceCandBL.resetError), whereas IsInvoicingError/InvoicingErrorMsg survive it. Assert on
+						// these two whenever the point is that a *"Create Invoices" run* failed for the candidate.
+						row.getAsOptionalBoolean(I_C_Invoice_Candidate.COLUMNNAME_IsInvoicingError)
+								.ifPresent(expected -> softly.assertThat(finalInvoiceCandidate.isInvoicingError()).as("IsInvoicingError").isEqualTo(expected));
+
+						row.getAsOptionalString(I_C_Invoice_Candidate.COLUMNNAME_InvoicingErrorMsg)
+								.ifPresent(expected -> softly.assertThat(finalInvoiceCandidate.getInvoicingErrorMsg()).as("InvoicingErrorMsg").contains(expected));
+
 						row.getAsOptionalBigDecimal(I_C_Invoice_Candidate.COLUMNNAME_PriceActual)
 								.ifPresent(expected -> softly.assertThat(finalInvoiceCandidate.getPriceActual()).as("PriceActual").isEqualByComparingTo(expected));
 

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredReceiptSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredReceiptSchedule.feature
@@ -1,6 +1,8 @@
 @from:cucumber
 @allure.label.epic:E0340_Invoicing
 @allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
 @F00701
 @ghActions:run_on_executor5
 Feature: Closing an undelivered receipt disposition closes the purchase invoice candidate
@@ -57,6 +59,8 @@ Feature: Closing an undelivered receipt disposition closes the purchase invoice 
   @from:cucumber
 @allure.label.epic:E0340_Invoicing
 @allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
 @F00701
   Scenario: Closing an undelivered receipt disposition closes the purchase invoice candidate
     When metasfresh contains C_Orders:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredReceiptSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredReceiptSchedule.feature
@@ -77,7 +77,6 @@ Feature: Closing an undelivered receipt disposition closes the purchase invoice 
       | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
       | invoiceCand_1                     | po1                       | po1_l1                    | 0                | 0            |
 
-    # Nothing was ever received; the disposition is simply closed.
     When the M_ReceiptSchedule identified by receiptSchedule1 is closed
 
     Then validate C_Invoice_Candidate:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredReceiptSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredReceiptSchedule.feature
@@ -1,0 +1,81 @@
+@from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@F00701
+@ghActions:run_on_executor5
+Feature: Closing an undelivered receipt disposition closes the purchase invoice candidate
+## F00701: Invoice Candidates
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-07-26T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
+
+    And load M_Warehouse:
+      | M_Warehouse_ID.Identifier | Value        |
+      | warehouseStd              | StdWarehouse |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_1       |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl_PO      | ps_1               | DE           | EUR           | false |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_PO     | pl_PO          |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | plv_PO                 | product      | 10.0     | PCE      |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | M_PricingSystem_ID | IsVendor | IsCustomer |
+      | bpartner_1 | ps_1               | Y        | N          |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_1        | bpartner_1               | Y                   | Y                   |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID.Identifier |
+      | LU                    |
+      | TU                    |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType | IsCurrent |
+      | LU_Version         | LU         | LU          | Y         |
+      | TU_Version         | TU         | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType | OPT.Included_HU_PI_ID.Identifier |
+      | huPiItemLU                 | LU_Version                    | 10  | HU       | TU                               |
+      | huPiItemTU                 | TU_Version                    |     | MI       |                                  |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | product_TU_10CU                    | huPiItemTU                 | product                 | 10  | 2021-01-01 |
+
+  @Id:S0164_100
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@F00701
+  Scenario: Closing an undelivered receipt disposition closes the purchase invoice candidate
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
+      | po1        | false   | bpartner_1    | POO         | 2022-07-26  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | QtyEnteredTU | M_HU_PI_Item_Product_ID |
+      | po1_l1     | po1        | product      | 100        | 10           | product_TU_10CU         |
+    And the order identified by po1 is completed
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.QtyOrderedTU |
+      | receiptSchedule1                | po1                   | po1_l1                    | bpartner_1               | l_1                               | product                 | 100        | warehouseStd              | 10               |
+    And after not more than 120s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
+      | invoiceCand_1                     | po1                       | po1_l1                    | 0                | 0            |
+
+    # Nothing was ever received; the disposition is simply closed.
+    When the M_ReceiptSchedule identified by receiptSchedule1 is closed
+
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_1                     | 0            | true                 | true          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredShipmentSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredShipmentSchedule.feature
@@ -1,6 +1,8 @@
 @from:cucumber
 @allure.label.epic:E0340_Invoicing
 @allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
 @F00701
 @ghActions:run_on_executor5
 Feature: Closing an undelivered shipment disposition closes the sales invoice candidate
@@ -39,6 +41,8 @@ Feature: Closing an undelivered shipment disposition closes the sales invoice ca
   @from:cucumber
 @allure.label.epic:E0340_Invoicing
 @allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
 @F00701
   Scenario: Closing an undelivered shipment disposition closes the sales invoice candidate
     When metasfresh contains C_Orders:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredShipmentSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredShipmentSchedule.feature
@@ -1,0 +1,63 @@
+@from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@F00701
+@ghActions:run_on_executor5
+Feature: Closing an undelivered shipment disposition closes the sales invoice candidate
+## F00701: Invoice Candidates
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-07-26T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
+
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_1       |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl_SO      | ps_1               | DE           | EUR           | true  |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_SO     | pl_SO          |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | plv_SO                 | product      | 10.0     | PCE      |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | M_PricingSystem_ID | IsVendor | IsCustomer | OPT.InvoiceRule |
+      | bpartner_1 | ps_1               | N        | Y          | D               |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_1        | bpartner_1               | Y                   | Y                   |
+
+  @Id:S0164_200
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@F00701
+  Scenario: Closing an undelivered shipment disposition closes the sales invoice candidate
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
+      | so1        | true    | bpartner_1    | SOO         | 2022-07-26  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered |
+      | so1_l1     | so1        | product      | 100        |
+    And the order identified by so1 is completed
+    And after not more than 60s, M_ShipmentSchedules are found:
+      | Identifier        | C_OrderLine_ID.Identifier | IsToRecompute |
+      | shipmentSchedule1 | so1_l1                    | N             |
+    And after not more than 120s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
+      | invoiceCand_1                     | so1                       | so1_l1                    | 0                | 0            |
+
+    # Nothing was ever shipped; the disposition is simply closed.
+    When the M_ShipmentSchedule identified by shipmentSchedule1 is closed
+
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_1                     | 0            | true                 | true          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredShipmentSchedule.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoiceCandidateClosedOnUndeliveredShipmentSchedule.feature
@@ -59,7 +59,6 @@ Feature: Closing an undelivered shipment disposition closes the sales invoice ca
       | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
       | invoiceCand_1                     | so1                       | so1_l1                    | 0                | 0            |
 
-    # Nothing was ever shipped; the disposition is simply closed.
     When the M_ShipmentSchedule identified by shipmentSchedule1 is closed
 
     Then validate C_Invoice_Candidate:

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesOnReactivatedPurchaseOrder.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesOnReactivatedPurchaseOrder.feature
@@ -1,6 +1,8 @@
 @from:cucumber
 @allure.label.epic:E0340_Invoicing
 @allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
 @F00701
 @ghActions:run_on_executor5
 Feature: Create Invoices on a reactivated purchase order that already has a material receipt
@@ -59,6 +61,8 @@ Feature: Create Invoices on a reactivated purchase order that already has a mate
   @from:cucumber
 @allure.label.epic:E0340_Invoicing
 @allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
 @F00701
   Scenario: Create Invoices succeeds for a purchase order that was reactivated after its material receipt
     #

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesOnReactivatedPurchaseOrder.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesOnReactivatedPurchaseOrder.feature
@@ -14,7 +14,6 @@ Feature: Create Invoices on a reactivated purchase order that already has a mate
     And metasfresh has date and time 2022-07-26T13:30:13+01:00[Europe/Berlin]
     And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
     And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
-    # Without this, C_Order_ReceiptSchedule.reactivateIfNoReceipts refuses the reactivation outright.
     And set sys config boolean value true for sys config PO_AllowReactivationIfReceiptsCreated
 
     And load M_Warehouse:
@@ -65,9 +64,6 @@ Feature: Create Invoices on a reactivated purchase order that already has a mate
 @allure.label.feature:F01010.3_Match_Invoice
 @F00701
   Scenario: Create Invoices succeeds for a purchase order that was reactivated after its material receipt
-    #
-    # A purchase order with one line, completed
-    #
     When metasfresh contains C_Orders:
       | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
       | po1        | false   | bpartner_1    | POO         | 2022-07-26  |
@@ -76,9 +72,6 @@ Feature: Create Invoices on a reactivated purchase order that already has a mate
       | po1_l1     | po1        | product      | 100        | 10           | product_TU_10CU         |
     And the order identified by po1 is completed
 
-    #
-    # ... fully received
-    #
     And after not more than 60s, M_ReceiptSchedule are found:
       | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.QtyOrderedTU |
       | receiptSchedule1                | po1                   | po1_l1                    | bpartner_1               | l_1                               | product                 | 100        | warehouseStd              | 10               |
@@ -98,16 +91,10 @@ Feature: Create Invoices on a reactivated purchase order that already has a mate
       | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice | OPT.M_InOutLine_ID.Identifier |
       | invoiceCand_1                     | po1                       | po1_l1                    | 100              | 100          | materialReceiptLine           |
 
-    #
-    # ... and then reactivated. From here on the order is no longer "complete", so every save of its
-    # lines recomputes C_Tax_ID (MOrderLine.beforeSave) - a column the receipt-exists guard on
-    # C_OrderLine does not ignore.
-    #
+    # Once reactivated the order is no longer complete, so every save of its lines recomputes C_Tax_ID
+    # - a column the receipt-exists guard on C_OrderLine does not ignore.
     And the order identified by po1 is reactivated
 
-    #
-    # Invoicing must still produce the invoice.
-    #
     And process invoice candidates
       | C_Invoice_Candidate_ID |
       | invoiceCand_1          |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesOnReactivatedPurchaseOrder.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesOnReactivatedPurchaseOrder.feature
@@ -1,0 +1,118 @@
+@from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@F00701
+@ghActions:run_on_executor5
+Feature: Create Invoices on a reactivated purchase order that already has a material receipt
+## F00701: Invoice Candidates
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-07-26T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
+    # Without this, C_Order_ReceiptSchedule.reactivateIfNoReceipts refuses the reactivation outright.
+    And set sys config boolean value true for sys config PO_AllowReactivationIfReceiptsCreated
+
+    And load M_Warehouse:
+      | M_Warehouse_ID.Identifier | Value        |
+      | warehouseStd              | StdWarehouse |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_1       |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl_PO      | ps_1               | DE           | EUR           | false |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_PO     | pl_PO          |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | plv_PO                 | product      | 10.0     | PCE      |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | M_PricingSystem_ID | IsVendor | IsCustomer |
+      | bpartner_1 | ps_1               | Y        | N          |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_1        | bpartner_1               | Y                   | Y                   |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID.Identifier |
+      | LU                    |
+      | TU                    |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType | IsCurrent |
+      | LU_Version         | LU         | LU          | Y         |
+      | TU_Version         | TU         | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType | OPT.Included_HU_PI_ID.Identifier |
+      | huPiItemLU                 | LU_Version                    | 10  | HU       | TU                               |
+      | huPiItemTU                 | TU_Version                    |     | MI       |                                  |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | product_TU_10CU                    | huPiItemTU                 | product                 | 10  | 2021-01-01 |
+
+  @Id:S0161_100
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@F00701
+  Scenario: Create Invoices succeeds for a purchase order that was reactivated after its material receipt
+    #
+    # A purchase order with one line, completed
+    #
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
+      | po1        | false   | bpartner_1    | POO         | 2022-07-26  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | QtyEnteredTU | M_HU_PI_Item_Product_ID |
+      | po1_l1     | po1        | product      | 100        | 10           | product_TU_10CU         |
+    And the order identified by po1 is completed
+
+    #
+    # ... fully received
+    #
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.QtyOrderedTU |
+      | receiptSchedule1                | po1                   | po1_l1                    | bpartner_1               | l_1                               | product                 | 100        | warehouseStd              | 10               |
+    And create M_HU_LUTU_Configuration for M_ReceiptSchedule and generate M_HUs
+      | M_HU_LUTU_Configuration_ID.Identifier | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | IsInfiniteQtyLU | QtyLU | IsInfiniteQtyTU | QtyTU | IsInfiniteQtyCU | QtyCUsPerTU | M_HU_PI_Item_Product_ID.Identifier | OPT.M_LU_HU_PI_ID.Identifier |
+      | huLuTuConfig                          | hu1                | receiptSchedule1                | N               | 1     | N               | 10    | N               | 10          | product_TU_10CU                    | LU                           |
+    And create material receipt
+      | M_HU_ID.Identifier | M_ReceiptSchedule_ID.Identifier | M_InOut_ID.Identifier |
+      | hu1                | receiptSchedule1                | materialReceipt       |
+    And validate M_In_Out status
+      | M_InOut_ID.Identifier | DocStatus |
+      | materialReceipt       | CO        |
+    And validate the created material receipt lines
+      | M_InOutLine_ID      | M_InOut_ID      | M_Product_ID | movementqty | processed |
+      | materialReceiptLine | materialReceipt | product      | 100         | true      |
+    And after not more than 120s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice | OPT.M_InOutLine_ID.Identifier |
+      | invoiceCand_1                     | po1                       | po1_l1                    | 100              | 100          | materialReceiptLine           |
+
+    #
+    # ... and then reactivated. From here on the order is no longer "complete", so every save of its
+    # lines recomputes C_Tax_ID (MOrderLine.beforeSave) - a column the receipt-exists guard on
+    # C_OrderLine does not ignore.
+    #
+    And the order identified by po1 is reactivated
+
+    #
+    # Invoicing must still produce the invoice.
+    #
+    And process invoice candidates
+      | C_Invoice_Candidate_ID |
+      | invoiceCand_1          |
+    And after not more than 60s, C_Invoice are found:
+      | C_Invoice_ID.Identifier | C_Invoice_Candidate_ID.Identifier |
+      | vendorInvoice           | invoiceCand_1                     |
+    And validate created invoices
+      | C_Invoice_ID  | C_BPartner_ID | C_BPartner_Location_ID | DocStatus |
+      | vendorInvoice | bpartner_1    | l_1                    | CO        |
+    And validate created invoice lines
+      | C_InvoiceLine_ID  | C_Invoice_ID  | M_Product_ID | QtyInvoiced |
+      | vendorInvoiceLine | vendorInvoice | product      | 100         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
@@ -1,0 +1,100 @@
+@from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+@ghActions:run_on_executor5
+Feature: A failing "Create Invoices" run reports back to the user who started it
+## F00701: Invoice Candidates
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2021-12-21T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value true for sys config de.metas.report.jasper.IsMockReportService
+
+  @Id:S0163_100
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: A "Create Invoices" run that fails for the selected candidate notifies nobody
+    Given metasfresh contains M_Products:
+      | Identifier | Name              |
+      | p_ie_1     | salesProduct_ie_1 |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                   | Value                   | OPT.IsActive |
+      | ps_ie_1    | ie_pricing_system_name | ie_pricing_system_value | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name               | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_ie_1    | ps_ie_1                       | DE                        | EUR                 | ie_price_list_name | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name              | ValidFrom  |
+      | plv_ie_1   | pl_ie_1                   | ie_salesOrder-PLV | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_ie_1    | plv_ie_1                          | p_ie_1                  | 10.0     | PCE               | Normal                        |
+    And metasfresh contains C_BPartners:
+      | Identifier       | Name           | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | endcustomer_ie_1 | ie_Endcustomer | N            | Y              | ps_ie_1                       |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN           | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_ie_1     | ie_bPLocation | endcustomer_ie_1         | Y                   | Y                   |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | o_ie_1     | true    | endcustomer_ie_1         | 2021-04-17  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_ie_1    | o_ie_1                | p_ie_1                  | 10         |
+    And the order identified by o_ie_1 is completed
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_ie_1                           | ol_ie_1                   | 0            |
+
+    # InvoiceRule=Immediate makes the candidate invoiceable without any delivery, so the run below
+    # really does try to invoice it instead of skipping it for "nothing delivered yet".
+    And update invoice candidates
+      | C_Invoice_Candidate_ID.Identifier | OPT.InvoiceRule_Override |
+      | ic_ie_1                           | I                        |
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_ie_1                           | ol_ie_1                   | 10           |
+
+    # The customer is put on credit stop after the order was completed. Completing the generated
+    # invoice then throws @BPartnerCreditStop@ (MInvoice.prepareIt), the invoice transaction is rolled
+    # back and InvoiceCandBLCreateInvoices marks the candidate as failed. This is a genuine FAILURE of
+    # the "Create Invoices" run - not a candidate that was quietly skipped.
+    And upsert C_BPartner_Stats
+      | C_BPartner_ID.Identifier | SOCreditStatus.Code |
+      | endcustomer_ie_1         | S                   |
+
+    And load AD_User:
+      | AD_User_ID.Identifier | Login      |
+      | user_metasfresh       | metasfresh |
+    And load AD_Message:
+      | Identifier        | Value                |
+      | msgInvoicingError | Event_InvoicingError |
+
+    # Not the "wait for the candidate to be processed" variant: a failing candidate is never
+    # processed, so that variant would only time out.
+    When process invoice candidates and verify C_Invoice_Candidate is not processed after 30s
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_ie_1                           |
+
+    # Evidence that the run FAILED for this candidate rather than skipping it.
+    # IsInvoicingError - not IsError - because the "update invalid invoice candidates" work package that
+    # follows the failed run clears IsError/ErrorMsg again (InvoiceCandBL.resetError), while
+    # IsInvoicingError/InvoicingErrorMsg keep the record of the failed invoicing run.
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | IsInvoicingError | OPT.Processed |
+      | ic_ie_1                           | true             | false         |
+
+    # ...and yet the user who started the run is told nothing: no notification is produced,
+    # so no AD_Note exists. This is the defect.
+    And after not more than 60s, validate AD_Note:
+      | Identifier | AD_Message_ID.Identifier | OPT.AD_User_ID.Identifier |
+      | note_1     | msgInvoicingError        | user_metasfresh           |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
@@ -55,8 +55,7 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
       | ic_ie_1                           | ol_ie_1                   | 0            |
 
-    # InvoiceRule=Immediate makes the candidate invoiceable without any delivery, so the run below
-    # really does try to invoice it instead of skipping it for "nothing delivered yet".
+    # InvoiceRule=Immediate makes the candidate invoiceable without a delivery, so the run really tries to invoice it.
     And update invoice candidates
       | C_Invoice_Candidate_ID.Identifier | OPT.InvoiceRule_Override |
       | ic_ie_1                           | I                        |
@@ -64,10 +63,7 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
       | ic_ie_1                           | ol_ie_1                   | 10           |
 
-    # The customer is put on credit stop after the order was completed. Completing the generated
-    # invoice then throws @BPartnerCreditStop@ (MInvoice.prepareIt), the invoice transaction is rolled
-    # back and InvoiceCandBLCreateInvoices marks the candidate as failed. This is a genuine FAILURE of
-    # the "Create Invoices" run - not a candidate that was quietly skipped.
+    # Credit stop makes completing the generated invoice throw @BPartnerCreditStop@, so the run genuinely fails.
     And upsert C_BPartner_Stats
       | C_BPartner_ID.Identifier | SOCreditStatus.Code |
       | endcustomer_ie_1         | S                   |
@@ -79,22 +75,16 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | Identifier        | Value                |
       | msgInvoicingError | Event_InvoicingError |
 
-    # Not the "wait for the candidate to be processed" variant: a failing candidate is never
-    # processed, so that variant would only time out.
+    # A failing candidate is never processed, so the "wait until processed" variant would only time out.
     When process invoice candidates and verify C_Invoice_Candidate is not processed after 30s
       | C_Invoice_Candidate_ID.Identifier |
       | ic_ie_1                           |
 
-    # Evidence that the run FAILED for this candidate rather than skipping it.
-    # IsInvoicingError - not IsError - because the "update invalid invoice candidates" work package that
-    # follows the failed run clears IsError/ErrorMsg again (InvoiceCandBL.resetError), while
-    # IsInvoicingError/InvoicingErrorMsg keep the record of the failed invoicing run.
+    # IsInvoicingError and not IsError: the "update invalid invoice candidates" run that follows clears IsError again.
     Then validate C_Invoice_Candidate:
       | C_Invoice_Candidate_ID.Identifier | IsInvoicingError | OPT.Processed |
       | ic_ie_1                           | true             | false         |
 
-    # ...and the user who started the run is told about it: the failure notification is persisted
-    # as an AD_Note for that user (NotificationRepository.save).
     And after not more than 60s, validate AD_Note:
       | Identifier | AD_Message_ID.Identifier | OPT.AD_User_ID.Identifier |
       | note_1     | msgInvoicingError        | user_metasfresh           |
@@ -123,8 +113,6 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
       | pp_mx_1    | plv_mx_1                          | p_mx_1                  | 10.0     | PCE               | Normal                        |
 
-    # Two customers: only the second one is put on credit stop further down, so that ONE selection
-    # contains one invoiceable candidate and one that fails.
     And metasfresh contains C_BPartners:
       | Identifier       | Name               | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
       | customer_mx_good | mx_GoodCustomer    | N            | Y              | ps_mx_1                       |
@@ -148,8 +136,7 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | ic_mx_good                        | ol_mx_good                | 0            |
       | ic_mx_bad                         | ol_mx_bad                 | 0            |
 
-    # InvoiceRule=Immediate makes both candidates invoiceable without any delivery, so the run below
-    # really does try to invoice both instead of skipping them for "nothing delivered yet".
+    # InvoiceRule=Immediate makes both candidates invoiceable without a delivery, so the run really tries to invoice them.
     And update invoice candidates
       | C_Invoice_Candidate_ID.Identifier | OPT.InvoiceRule_Override |
       | ic_mx_good                        | I                        |
@@ -159,10 +146,8 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | ic_mx_good                        | ol_mx_good                | 10           |
       | ic_mx_bad                         | ol_mx_bad                 | 10           |
 
-    # Only the second customer is put on credit stop, so completing ITS invoice throws
-    # @BPartnerCreditStop@ (MInvoice.prepareIt). The two candidates have different bill partners and
-    # therefore aggregate into two separate invoice headers, each with its own transaction: the good
-    # header is committed, the bad one is rolled back and its candidate marked as failed.
+    # The two candidates have different bill partners, so they aggregate into two invoice headers with
+    # separate transactions: the good one commits, the credit-stopped one rolls back and is marked failed.
     And upsert C_BPartner_Stats
       | C_BPartner_ID.Identifier | SOCreditStatus.Code |
       | customer_mx_bad          | S                   |
@@ -174,17 +159,13 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | Identifier        | Value                |
       | msgInvoicingError | Event_InvoicingError |
 
-    # The failure notification is looked up with firstOnly(), and the preceding scenario of this
-    # feature leaves its own Event_InvoicingError note behind. Reset so that the note asserted below
-    # is unambiguously the one produced by THIS run.
+    # The note is looked up with firstOnly(), so drop the preceding scenario's Event_InvoicingError note first.
     And AD_Note table is reset
 
-    # One "Create Invoices" run over ONE selection holding both candidates.
     When process invoice candidates
       | C_Invoice_Candidate_ID.Identifier |
       | ic_mx_good,ic_mx_bad              |
 
-    # AC4: the failure of the one candidate did not take the other one down with it.
     Then after not more than 60s, C_Invoice are found:
       | C_Invoice_ID.Identifier | C_Invoice_Candidate_ID.Identifier |
       | invoice_mx_good         | ic_mx_good                        |
@@ -192,14 +173,11 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | processed | DocStatus |
       | invoice_mx_good         | customer_mx_good         | l_mx_good                         | true      | CO        |
 
-    # ...while the failed candidate is flagged as an invoicing error and stays un-processed.
     And validate C_Invoice_Candidate:
       | C_Invoice_Candidate_ID.Identifier | IsInvoicingError | OPT.Processed |
       | ic_mx_good                        | false            | true          |
       | ic_mx_bad                         | true             | false         |
 
-    # AC3: and the user who started the run is told about the failure - exactly one note, because
-    # createNoticesAndMarkICs is called once, for the one header aggregation that failed.
     And after not more than 60s, validate AD_Note:
       | Identifier | AD_Message_ID.Identifier | OPT.AD_User_ID.Identifier |
       | note_1     | msgInvoicingError        | user_metasfresh           |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
@@ -98,3 +98,108 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
     And after not more than 60s, validate AD_Note:
       | Identifier | AD_Message_ID.Identifier | OPT.AD_User_ID.Identifier |
       | note_1     | msgInvoicingError        | user_metasfresh           |
+
+  @Id:S0163_200
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: A "Create Invoices" run over a mixed selection still invoices the good candidate and reports the failed one
+    Given metasfresh contains M_Products:
+      | Identifier | Name              |
+      | p_mx_1     | salesProduct_mx_1 |
+    And metasfresh contains M_PricingSystems
+      | Identifier | Name                   | Value                   | OPT.IsActive |
+      | ps_mx_1    | mx_pricing_system_name | mx_pricing_system_value | true         |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID.Identifier | OPT.C_Country.CountryCode | C_Currency.ISO_Code | Name               | OPT.Description | SOTrx | IsTaxIncluded | PricePrecision | OPT.IsActive |
+      | pl_mx_1    | ps_mx_1                       | DE                        | EUR                 | mx_price_list_name | null            | true  | false         | 2              | true         |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID.Identifier | Name              | ValidFrom  |
+      | plv_mx_1   | pl_mx_1                   | mx_salesOrder-PLV | 2021-04-01 |
+    And metasfresh contains M_ProductPrices
+      | Identifier | M_PriceList_Version_ID.Identifier | M_Product_ID.Identifier | PriceStd | C_UOM_ID.X12DE355 | C_TaxCategory_ID.InternalName |
+      | pp_mx_1    | plv_mx_1                          | p_mx_1                  | 10.0     | PCE               | Normal                        |
+
+    # Two customers: only the second one is put on credit stop further down, so that ONE selection
+    # contains one invoiceable candidate and one that fails.
+    And metasfresh contains C_BPartners:
+      | Identifier       | Name               | OPT.IsVendor | OPT.IsCustomer | M_PricingSystem_ID.Identifier |
+      | customer_mx_good | mx_GoodCustomer    | N            | Y              | ps_mx_1                       |
+      | customer_mx_bad  | mx_BlockedCustomer | N            | Y              | ps_mx_1                       |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | GLN             | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_mx_good  | mx_bPLocation_g | customer_mx_good         | Y                   | Y                   |
+      | l_mx_bad   | mx_bPLocation_b | customer_mx_bad          | Y                   | Y                   |
+    And metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID.Identifier | DateOrdered |
+      | o_mx_good  | true    | customer_mx_good         | 2021-04-17  |
+      | o_mx_bad   | true    | customer_mx_bad          | 2021-04-17  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID.Identifier | M_Product_ID.Identifier | QtyEntered |
+      | ol_mx_good | o_mx_good             | p_mx_1                  | 10         |
+      | ol_mx_bad  | o_mx_bad              | p_mx_1                  | 10         |
+    And the order identified by o_mx_good is completed
+    And the order identified by o_mx_bad is completed
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_mx_good                        | ol_mx_good                | 0            |
+      | ic_mx_bad                         | ol_mx_bad                 | 0            |
+
+    # InvoiceRule=Immediate makes both candidates invoiceable without any delivery, so the run below
+    # really does try to invoice both instead of skipping them for "nothing delivered yet".
+    And update invoice candidates
+      | C_Invoice_Candidate_ID.Identifier | OPT.InvoiceRule_Override |
+      | ic_mx_good                        | I                        |
+      | ic_mx_bad                         | I                        |
+    And after not more than 60s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | C_OrderLine_ID.Identifier | QtyToInvoice |
+      | ic_mx_good                        | ol_mx_good                | 10           |
+      | ic_mx_bad                         | ol_mx_bad                 | 10           |
+
+    # Only the second customer is put on credit stop, so completing ITS invoice throws
+    # @BPartnerCreditStop@ (MInvoice.prepareIt). The two candidates have different bill partners and
+    # therefore aggregate into two separate invoice headers, each with its own transaction: the good
+    # header is committed, the bad one is rolled back and its candidate marked as failed.
+    And upsert C_BPartner_Stats
+      | C_BPartner_ID.Identifier | SOCreditStatus.Code |
+      | customer_mx_bad          | S                   |
+
+    And load AD_User:
+      | AD_User_ID.Identifier | Login      |
+      | user_metasfresh       | metasfresh |
+    And load AD_Message:
+      | Identifier        | Value                |
+      | msgInvoicingError | Event_InvoicingError |
+
+    # The failure notification is looked up with firstOnly(), and the preceding scenario of this
+    # feature leaves its own Event_InvoicingError note behind. Reset so that the note asserted below
+    # is unambiguously the one produced by THIS run.
+    And AD_Note table is reset
+
+    # One "Create Invoices" run over ONE selection holding both candidates.
+    When process invoice candidates
+      | C_Invoice_Candidate_ID.Identifier |
+      | ic_mx_good,ic_mx_bad              |
+
+    # AC4: the failure of the one candidate did not take the other one down with it.
+    Then after not more than 60s, C_Invoice are found:
+      | C_Invoice_ID.Identifier | C_Invoice_Candidate_ID.Identifier |
+      | invoice_mx_good         | ic_mx_good                        |
+    And validate created invoices
+      | C_Invoice_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | processed | DocStatus |
+      | invoice_mx_good         | customer_mx_good         | l_mx_good                         | true      | CO        |
+
+    # ...while the failed candidate is flagged as an invoicing error and stays un-processed.
+    And validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | IsInvoicingError | OPT.Processed |
+      | ic_mx_good                        | false            | true          |
+      | ic_mx_bad                         | true             | false         |
+
+    # AC3: and the user who started the run is told about the failure - exactly one note, because
+    # createNoticesAndMarkICs is called once, for the one header aggregation that failed.
+    And after not more than 60s, validate AD_Note:
+      | Identifier | AD_Message_ID.Identifier | OPT.AD_User_ID.Identifier |
+      | note_1     | msgInvoicingError        | user_metasfresh           |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/createInvoicesReportsFailures.feature
@@ -22,7 +22,7 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
 @allure.label.epic:E0225_Accounting
 @allure.label.feature:F01010.3_Match_Invoice
 @F00701
-  Scenario: A "Create Invoices" run that fails for the selected candidate notifies nobody
+  Scenario: A "Create Invoices" run that fails for the selected candidate notifies the user who started it
     Given metasfresh contains M_Products:
       | Identifier | Name              |
       | p_ie_1     | salesProduct_ie_1 |
@@ -93,8 +93,8 @@ Feature: A failing "Create Invoices" run reports back to the user who started it
       | C_Invoice_Candidate_ID.Identifier | IsInvoicingError | OPT.Processed |
       | ic_ie_1                           | true             | false         |
 
-    # ...and yet the user who started the run is told nothing: no notification is produced,
-    # so no AD_Note exists. This is the defect.
+    # ...and the user who started the run is told about it: the failure notification is persisted
+    # as an AD_Note for that user (NotificationRepository.save).
     And after not more than 60s, validate AD_Note:
       | Identifier | AD_Message_ID.Identifier | OPT.AD_User_ID.Identifier |
       | note_1     | msgInvoicingError        | user_metasfresh           |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/reopenInvoiceCandidateOnReopenedDisposition.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/reopenInvoiceCandidateOnReopenedDisposition.feature
@@ -77,13 +77,11 @@ Feature: Reopening a receipt disposition reopens the purchase invoice candidate
       | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
       | invoiceCand_1                     | po1                       | po1_l1                    | 0                | 0            |
 
-    # Nothing was ever received; the disposition is simply closed, which closes the candidate.
     When the M_ReceiptSchedule identified by receiptSchedule1 is closed
     Then validate C_Invoice_Candidate:
       | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
       | invoiceCand_1                     | 0            | true                 | true          |
 
-    # Reopening the disposition must give the candidate back as open work.
     When the M_ReceiptSchedule identified by receiptSchedule1 is reactivated
     Then validate C_Invoice_Candidate:
       | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
@@ -111,12 +109,10 @@ Feature: Reopening a receipt disposition reopens the purchase invoice candidate
       | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
       | invoiceCand_2                     | po2                       | po2_l1                    | 0                | 0            |
 
-    # Reactivating the PO closes the receipt schedule, but only to "park" it - the order line stays
-    # open for editing. The candidate must stay open too, or it can never be invoiced again.
     When the order identified by po2 is reactivated
 
-    # IsDeliveryClosed stays true while the order is parked: the parking path deliberately does not
-    # reopen it (pre-existing, display-only). The next complete reopens it - see @Id:S0164_500.
+    # IsDeliveryClosed stays true while parked: the parking path deliberately does not reopen it
+    # (display-only); the next complete does - see @Id:S0164_500.
     Then validate C_Invoice_Candidate:
       | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
       | invoiceCand_2                     | 0            | true                 | false         |
@@ -143,20 +139,17 @@ Feature: Reopening a receipt disposition reopens the purchase invoice candidate
       | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
       | invoiceCand_3                     | po3                       | po3_l1                    | 0                | 0            |
 
-    # Nothing was ever received and the buyer closes the disposition, which closes the candidate.
     When the M_ReceiptSchedule identified by receiptSchedule3 is closed
     Then validate C_Invoice_Candidate:
       | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
       | invoiceCand_3                     | 0            | true                 | true          |
 
-    # Reactivating the PO leaves the already-closed disposition (and hence the candidate) untouched:
-    # the parking path only closes dispositions that are still open.
+    # The parking path only closes dispositions that are still open, so an already-closed one is untouched.
     When the order identified by po3 is reactivated
     Then validate C_Invoice_Candidate:
       | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
       | invoiceCand_3                     | 0            | true                 | true          |
 
-    # Re-completing the PO reopens the parked disposition - and must give the candidate back as open work.
     When the order identified by po3 is completed
     Then after not more than 60s, M_ReceiptSchedule are found:
       | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.IsClosed | OPT.Processed |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/reopenInvoiceCandidateOnReopenedDisposition.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/reopenInvoiceCandidateOnReopenedDisposition.feature
@@ -1,0 +1,120 @@
+@from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+@ghActions:run_on_executor5
+Feature: Reopening a receipt disposition reopens the purchase invoice candidate
+## F00701: Invoice Candidates
+
+  Background:
+    Given infrastructure and metasfresh are running
+    And the existing user with login 'metasfresh' receives a random a API token for the existing role with name 'WebUI'
+    And metasfresh has date and time 2022-07-26T13:30:13+01:00[Europe/Berlin]
+    And set sys config boolean value true for sys config SKIP_WP_PROCESSOR_FOR_AUTOMATION
+    And set sys config boolean value false for sys config AUTO_SHIP_AND_INVOICE
+
+    And load M_Warehouse:
+      | M_Warehouse_ID.Identifier | Value        |
+      | warehouseStd              | StdWarehouse |
+    And metasfresh contains M_Products:
+      | Identifier |
+      | product    |
+    And metasfresh contains M_PricingSystems
+      | Identifier |
+      | ps_1       |
+    And metasfresh contains M_PriceLists
+      | Identifier | M_PricingSystem_ID | C_Country_ID | C_Currency_ID | SOTrx |
+      | pl_PO      | ps_1               | DE           | EUR           | false |
+    And metasfresh contains M_PriceList_Versions
+      | Identifier | M_PriceList_ID |
+      | plv_PO     | pl_PO          |
+    And metasfresh contains M_ProductPrices
+      | M_PriceList_Version_ID | M_Product_ID | PriceStd | C_UOM_ID |
+      | plv_PO                 | product      | 10.0     | PCE      |
+    And metasfresh contains C_BPartners without locations:
+      | Identifier | M_PricingSystem_ID | IsVendor | IsCustomer |
+      | bpartner_1 | ps_1               | Y        | N          |
+    And metasfresh contains C_BPartner_Locations:
+      | Identifier | C_BPartner_ID.Identifier | OPT.IsShipToDefault | OPT.IsBillToDefault |
+      | l_1        | bpartner_1               | Y                   | Y                   |
+    And metasfresh contains M_HU_PI:
+      | M_HU_PI_ID.Identifier |
+      | LU                    |
+      | TU                    |
+    And metasfresh contains M_HU_PI_Version:
+      | M_HU_PI_Version_ID | M_HU_PI_ID | HU_UnitType | IsCurrent |
+      | LU_Version         | LU         | LU          | Y         |
+      | TU_Version         | TU         | TU          | Y         |
+    And metasfresh contains M_HU_PI_Item:
+      | M_HU_PI_Item_ID.Identifier | M_HU_PI_Version_ID.Identifier | Qty | ItemType | OPT.Included_HU_PI_ID.Identifier |
+      | huPiItemLU                 | LU_Version                    | 10  | HU       | TU                               |
+      | huPiItemTU                 | TU_Version                    |     | MI       |                                  |
+    And metasfresh contains M_HU_PI_Item_Product:
+      | M_HU_PI_Item_Product_ID.Identifier | M_HU_PI_Item_ID.Identifier | M_Product_ID.Identifier | Qty | ValidFrom  |
+      | product_TU_10CU                    | huPiItemTU                 | product                 | 10  | 2021-01-01 |
+
+  @Id:S0164_300
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: Reopening a closed undelivered receipt disposition reopens the purchase invoice candidate
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
+      | po1        | false   | bpartner_1    | POO         | 2022-07-26  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | QtyEnteredTU | M_HU_PI_Item_Product_ID |
+      | po1_l1     | po1        | product      | 100        | 10           | product_TU_10CU         |
+    And the order identified by po1 is completed
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.QtyOrderedTU |
+      | receiptSchedule1                | po1                   | po1_l1                    | bpartner_1               | l_1                               | product                 | 100        | warehouseStd              | 10               |
+    And after not more than 120s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
+      | invoiceCand_1                     | po1                       | po1_l1                    | 0                | 0            |
+
+    # Nothing was ever received; the disposition is simply closed, which closes the candidate.
+    When the M_ReceiptSchedule identified by receiptSchedule1 is closed
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_1                     | 0            | true                 | true          |
+
+    # Reopening the disposition must give the candidate back as open work.
+    When the M_ReceiptSchedule identified by receiptSchedule1 is reactivated
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_1                     | 0            | false                | false         |
+
+  @Id:S0164_400
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: Reactivating a purchase order only parks its receipt disposition and leaves the invoice candidate open
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
+      | po2        | false   | bpartner_1    | POO         | 2022-07-26  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | QtyEnteredTU | M_HU_PI_Item_Product_ID |
+      | po2_l1     | po2        | product      | 100        | 10           | product_TU_10CU         |
+    And the order identified by po2 is completed
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.QtyOrderedTU |
+      | receiptSchedule2                | po2                   | po2_l1                    | bpartner_1               | l_1                               | product                 | 100        | warehouseStd              | 10               |
+    And after not more than 120s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
+      | invoiceCand_2                     | po2                       | po2_l1                    | 0                | 0            |
+
+    # Reactivating the PO closes the receipt schedule, but only to "park" it - the order line stays
+    # open for editing. The candidate must stay open too, or it can never be invoiced again.
+    When the order identified by po2 is reactivated
+
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.Processed |
+      | invoiceCand_2                     | 0            | false         |

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/reopenInvoiceCandidateOnReopenedDisposition.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/invoicecandidate/reopenInvoiceCandidateOnReopenedDisposition.feature
@@ -115,6 +115,52 @@ Feature: Reopening a receipt disposition reopens the purchase invoice candidate
     # open for editing. The candidate must stay open too, or it can never be invoiced again.
     When the order identified by po2 is reactivated
 
+    # IsDeliveryClosed stays true while the order is parked: the parking path deliberately does not
+    # reopen it (pre-existing, display-only). The next complete reopens it - see @Id:S0164_500.
     Then validate C_Invoice_Candidate:
-      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.Processed |
-      | invoiceCand_2                     | 0            | false         |
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_2                     | 0            | true                 | false         |
+
+  @Id:S0164_500
+  @from:cucumber
+@allure.label.epic:E0340_Invoicing
+@allure.label.feature:F00701_Sales_Invoice_Candidates
+@allure.label.epic:E0225_Accounting
+@allure.label.feature:F01010.3_Match_Invoice
+@F00701
+  Scenario: Re-completing a reactivated purchase order reopens the parked receipt disposition and its invoice candidate
+    When metasfresh contains C_Orders:
+      | Identifier | IsSOTrx | C_BPartner_ID | DocBaseType | DateOrdered |
+      | po3        | false   | bpartner_1    | POO         | 2022-07-26  |
+    And metasfresh contains C_OrderLines:
+      | Identifier | C_Order_ID | M_Product_ID | QtyEntered | QtyEnteredTU | M_HU_PI_Item_Product_ID |
+      | po3_l1     | po3        | product      | 100        | 10           | product_TU_10CU         |
+    And the order identified by po3 is completed
+    And after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.QtyOrderedTU |
+      | receiptSchedule3                | po3                   | po3_l1                    | bpartner_1               | l_1                               | product                 | 100        | warehouseStd              | 10               |
+    And after not more than 120s, C_Invoice_Candidate are found:
+      | C_Invoice_Candidate_ID.Identifier | OPT.C_Order_ID.Identifier | C_OrderLine_ID.Identifier | OPT.QtyDelivered | QtyToInvoice |
+      | invoiceCand_3                     | po3                       | po3_l1                    | 0                | 0            |
+
+    # Nothing was ever received and the buyer closes the disposition, which closes the candidate.
+    When the M_ReceiptSchedule identified by receiptSchedule3 is closed
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_3                     | 0            | true                 | true          |
+
+    # Reactivating the PO leaves the already-closed disposition (and hence the candidate) untouched:
+    # the parking path only closes dispositions that are still open.
+    When the order identified by po3 is reactivated
+    Then validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_3                     | 0            | true                 | true          |
+
+    # Re-completing the PO reopens the parked disposition - and must give the candidate back as open work.
+    When the order identified by po3 is completed
+    Then after not more than 60s, M_ReceiptSchedule are found:
+      | M_ReceiptSchedule_ID.Identifier | C_Order_ID.Identifier | C_OrderLine_ID.Identifier | C_BPartner_ID.Identifier | C_BPartner_Location_ID.Identifier | M_Product_ID.Identifier | QtyOrdered | M_Warehouse_ID.Identifier | OPT.IsClosed | OPT.Processed |
+      | receiptSchedule3                | po3                   | po3_l1                    | bpartner_1               | l_1                               | product                 | 100        | warehouseStd              | false        | false         |
+    And validate C_Invoice_Candidate:
+      | C_Invoice_Candidate_ID.Identifier | QtyToInvoice | OPT.IsDeliveryClosed | OPT.Processed |
+      | invoiceCand_3                     | 0            | false                | false         |

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
@@ -691,7 +691,9 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 
 			// Fire the side effects that ReceiptScheduleBL.reopen()'s onAfterReopen listener would have done.
 			// orderBL.reopenLine(orderLine) was already called above.
-			invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
+			final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
+			invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(orderLineId);
+			invoiceCandBL.openInvoiceCandidatesByOrderLineId(orderLineId);
 		}
 	}
 
@@ -716,6 +718,11 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 			// itself must stay open for editing. Undo the closeLine side-effect.
 			InterfaceWrapperHelper.refresh(orderLine);
 			orderBL.reopenLine(orderLine);
+
+			// Same reasoning for the invoice candidates: when nothing was received, that same
+			// listener also set Processed_Override=Y on them. Parking must not leave them closed,
+			// or the reactivated order's candidates can never be invoiced again.
+			invoiceCandBL.openInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
 		}
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
@@ -722,6 +722,10 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 			// Same reasoning for the invoice candidates: when nothing was received, that same
 			// listener also set Processed_Override=Y on them. Parking must not leave them closed,
 			// or the reactivated order's candidates can never be invoiced again.
+			// Deliberately NOT calling openDeliveryInvoiceCandidatesByOrderLineId here: the candidates'
+			// IsDeliveryClosed stays Y while the order is parked, exactly as before this change. That
+			// asymmetry is pre-existing (display-only; no Java reads the flag) and self-heals on the
+			// next complete - see reopenReceiptSchedulesForOrder. Asserted by @Id:S0164_400.
 			invoiceCandBL.openInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
 		}
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/api/impl/ReceiptScheduleBL.java
@@ -719,13 +719,9 @@ public class ReceiptScheduleBL implements IReceiptScheduleBL
 			InterfaceWrapperHelper.refresh(orderLine);
 			orderBL.reopenLine(orderLine);
 
-			// Same reasoning for the invoice candidates: when nothing was received, that same
-			// listener also set Processed_Override=Y on them. Parking must not leave them closed,
-			// or the reactivated order's candidates can never be invoiced again.
-			// Deliberately NOT calling openDeliveryInvoiceCandidatesByOrderLineId here: the candidates'
-			// IsDeliveryClosed stays Y while the order is parked, exactly as before this change. That
-			// asymmetry is pre-existing (display-only; no Java reads the flag) and self-heals on the
-			// next complete - see reopenReceiptSchedulesForOrder. Asserted by @Id:S0164_400.
+			// Undo the close's Processed_Override=Y too, or the reactivated order's candidates can never be invoiced.
+			// openDeliveryInvoiceCandidatesByOrderLineId is deliberately NOT called: IsDeliveryClosed is display-only
+			// and self-heals on the next complete - see reopenReceiptSchedulesForOrder.
 			invoiceCandBL.openInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
 		}
 	}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule.java
@@ -277,9 +277,10 @@ public class M_ShipmentSchedule
 			return;
 		}
 
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
+
 		if (shipmentSchedule.isClosed())
 		{
-			final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
 			orderBL.closeLine(orderLine);
 			invoiceCandBL.closeDeliveryInvoiceCandidatesByOrderLineId(orderLineId);
 
@@ -291,7 +292,6 @@ public class M_ShipmentSchedule
 		}
 		else
 		{
-			final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
 			orderBL.reopenLine(orderLine);
 			invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(orderLineId);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule.java
@@ -291,8 +291,12 @@ public class M_ShipmentSchedule
 		}
 		else
 		{
+			final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
 			orderBL.reopenLine(orderLine);
-			invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
+			invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(orderLineId);
+
+			// see OrderLineReceiptScheduleListener.onAfterReopen - same reasoning, sales side
+			invoiceCandBL.openInvoiceCandidatesByOrderLineId(orderLineId);
 		}
 	}
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/modelvalidator/M_ShipmentSchedule.java
@@ -279,8 +279,15 @@ public class M_ShipmentSchedule
 
 		if (shipmentSchedule.isClosed())
 		{
+			final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
 			orderBL.closeLine(orderLine);
-			invoiceCandBL.closeDeliveryInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
+			invoiceCandBL.closeDeliveryInvoiceCandidatesByOrderLineId(orderLineId);
+
+			// see OrderLineReceiptScheduleListener.onAfterClose - same reasoning, sales side
+			if (orderLine.getQtyDelivered().signum() == 0)
+			{
+				invoiceCandBL.closeInvoiceCandidatesByOrderLineId(orderLineId);
+			}
 		}
 		else
 		{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleListener.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleListener.java
@@ -70,6 +70,13 @@ public class OrderLineReceiptScheduleListener extends ReceiptScheduleListenerAda
 		}
 
 		orderBL.reopenLine(orderLine);
-		invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
+
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
+		invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(orderLineId);
+
+		// Symmetric to onAfterClose: the close set Processed_Override=Y on the candidates, so the
+		// reopen has to clear it again. Otherwise the line is open work again, but its candidates
+		// stay closed and can never be invoiced.
+		invoiceCandBL.openInvoiceCandidatesByOrderLineId(orderLineId);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleListener.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleListener.java
@@ -38,7 +38,17 @@ public class OrderLineReceiptScheduleListener extends ReceiptScheduleListenerAda
 
 		orderBL.closeLine(orderLine);
 
-		invoiceCandBL.closeDeliveryInvoiceCandidatesByOrderLineId(OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID()));
+		final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
+		invoiceCandBL.closeDeliveryInvoiceCandidatesByOrderLineId(orderLineId);
+
+		// Nothing was ever received on this line, so its candidates can never be invoiced.
+		// Close them, or they linger forever as open work that "Create Invoices" silently skips
+		// (InvoiceCandidateEnqueuer:278). A partial receipt must NOT be closed - the delivered part
+		// is still invoiceable.
+		if (orderLine.getQtyDelivered().signum() == 0)
+		{
+			invoiceCandBL.closeInvoiceCandidatesByOrderLineId(orderLineId);
+		}
 	}
 
 	/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleListener.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/inoutcandidate/spi/impl/OrderLineReceiptScheduleListener.java
@@ -41,10 +41,8 @@ public class OrderLineReceiptScheduleListener extends ReceiptScheduleListenerAda
 		final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
 		invoiceCandBL.closeDeliveryInvoiceCandidatesByOrderLineId(orderLineId);
 
-		// Nothing was ever received on this line, so its candidates can never be invoiced.
-		// Close them, or they linger forever as open work that "Create Invoices" silently skips
-		// (InvoiceCandidateEnqueuer:278). A partial receipt must NOT be closed - the delivered part
-		// is still invoiceable.
+		// Nothing was received, so the candidates can never be invoiced and would linger as open work that
+		// "Create Invoices" silently skips. A partial receipt must stay open - its delivered part is invoiceable.
 		if (orderLine.getQtyDelivered().signum() == 0)
 		{
 			invoiceCandBL.closeInvoiceCandidatesByOrderLineId(orderLineId);
@@ -73,10 +71,6 @@ public class OrderLineReceiptScheduleListener extends ReceiptScheduleListenerAda
 
 		final OrderLineId orderLineId = OrderLineId.ofRepoId(orderLine.getC_OrderLine_ID());
 		invoiceCandBL.openDeliveryInvoiceCandidatesByOrderLineId(orderLineId);
-
-		// Symmetric to onAfterClose: the close set Processed_Override=Y on the candidates, so the
-		// reopen has to clear it again. Otherwise the line is open work again, but its candidates
-		// stay closed and can never be invoiced.
 		invoiceCandBL.openInvoiceCandidatesByOrderLineId(orderLineId);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
@@ -87,11 +87,7 @@ public interface IInvoiceCandBL extends ISingletonService
 
 		void addNotifications(List<I_AD_Note> notifications);
 
-		/**
-		 * Called when the given candidates could not be invoiced because of the given error.
-		 * Implementations which are able to notify a user shall do so from here; the plain result
-		 * implementation only counts them.
-		 */
+		/** Implementations which are able to notify a user shall do so from here. */
 		void addFailedCandidates(List<I_C_Invoice_Candidate> failedCandidates, Throwable error);
 
 		/**
@@ -375,10 +371,7 @@ public interface IInvoiceCandBL extends ISingletonService
 
 	void closeInvoiceCandidatesByOrderLineId(OrderLineId orderLineId);
 
-	/**
-	 * Undo {@link #closeInvoiceCandidatesByOrderLineId(OrderLineId)}: clear the candidates' {@code Processed_Override}
-	 * and invalidate them, so their {@code QtyToInvoice} is recomputed from their own data.
-	 */
+	/** Undo of {@link #closeInvoiceCandidatesByOrderLineId(OrderLineId)}: clears {@code Processed_Override} and invalidates the candidates. */
 	void openInvoiceCandidatesByOrderLineId(OrderLineId orderLineId);
 
 	/**

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
@@ -88,6 +88,13 @@ public interface IInvoiceCandBL extends ISingletonService
 		void addNotifications(List<I_AD_Note> notifications);
 
 		/**
+		 * Called when the given candidates could not be invoiced because of the given error.
+		 * Implementations which are able to notify a user shall do so from here; the plain result
+		 * implementation only counts them.
+		 */
+		void addFailedCandidates(List<I_C_Invoice_Candidate> failedCandidates, Throwable error);
+
+		/**
 		 * @param ctx context (for translation)
 		 * @return result summary (using context language)
 		 */

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/IInvoiceCandBL.java
@@ -369,6 +369,12 @@ public interface IInvoiceCandBL extends ISingletonService
 	void closeInvoiceCandidatesByOrderLineId(OrderLineId orderLineId);
 
 	/**
+	 * Undo {@link #closeInvoiceCandidatesByOrderLineId(OrderLineId)}: clear the candidates' {@code Processed_Override}
+	 * and invalidate them, so their {@code QtyToInvoice} is recomputed from their own data.
+	 */
+	void openInvoiceCandidatesByOrderLineId(OrderLineId orderLineId);
+
+	/**
 	 * Close the given invoice candidate.
 	 * Closing an invoice candidate means setting its Processed_Override to Y and invalidating the invoice candidate.
 	 * Also close the shipment schedules on which the invoice candidates are based

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/ForwardingInvoiceGenerateResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/ForwardingInvoiceGenerateResult.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ForwardingObject;
 
 import de.metas.adempiere.model.I_C_Invoice;
 import de.metas.invoicecandidate.api.IInvoiceCandBL.IInvoiceGenerateResult;
+import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.util.Check;
 
 /**
@@ -97,6 +98,12 @@ public abstract class ForwardingInvoiceGenerateResult extends ForwardingObject i
 	public void addNotifications(final List<I_AD_Note> notifications)
 	{
 		delegate().addNotifications(notifications);
+	}
+
+	@Override
+	public void addFailedCandidates(final List<I_C_Invoice_Candidate> failedCandidates, final Throwable error)
+	{
+		delegate().addFailedCandidates(failedCandidates, error);
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -2265,19 +2265,14 @@ public class InvoiceCandBL implements IInvoiceCandBL
 		invoiceCandidates.forEach(this::openInvoiceCandidate);
 	}
 
-	/**
-	 * Counterpart of {@link #closeInvoiceCandidate(I_C_Invoice_Candidate)}.
-	 * <p>
-	 * QtyToInvoice is deliberately not restored here: the invalidation makes the recompute machinery
-	 * derive it again from the candidate's own data.
-	 */
+	/** Counterpart of {@link #closeInvoiceCandidate(I_C_Invoice_Candidate)}; QtyToInvoice is not restored, the invalidation recomputes it. */
 	private void openInvoiceCandidate(@NonNull final I_C_Invoice_Candidate candidate)
 	{
 		candidate.setProcessed_Override(null);
 
 		if (!InterfaceWrapperHelper.hasChanges(candidate))
 		{
-			return; // https://github.com/metasfresh/metasfresh/issues/3216
+			return;
 		}
 
 		invoiceCandDAO.invalidateCand(candidate);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBL.java
@@ -2259,6 +2259,32 @@ public class InvoiceCandBL implements IInvoiceCandBL
 	}
 
 	@Override
+	public void openInvoiceCandidatesByOrderLineId(@NonNull final OrderLineId orderLineId)
+	{
+		final List<I_C_Invoice_Candidate> invoiceCandidates = invoiceCandDAO.retrieveInvoiceCandidatesForOrderLineId(orderLineId);
+		invoiceCandidates.forEach(this::openInvoiceCandidate);
+	}
+
+	/**
+	 * Counterpart of {@link #closeInvoiceCandidate(I_C_Invoice_Candidate)}.
+	 * <p>
+	 * QtyToInvoice is deliberately not restored here: the invalidation makes the recompute machinery
+	 * derive it again from the candidate's own data.
+	 */
+	private void openInvoiceCandidate(@NonNull final I_C_Invoice_Candidate candidate)
+	{
+		candidate.setProcessed_Override(null);
+
+		if (!InterfaceWrapperHelper.hasChanges(candidate))
+		{
+			return; // https://github.com/metasfresh/metasfresh/issues/3216
+		}
+
+		invoiceCandDAO.invalidateCand(candidate);
+		InterfaceWrapperHelper.save(candidate);
+	}
+
+	@Override
 	public void closeDeliveryInvoiceCandidatesByOrderLineId(@NonNull final OrderLineId orderLineId)
 	{
 		final List<I_C_Invoice_Candidate> invoiceCandidates = invoiceCandDAO.retrieveInvoiceCandidatesForOrderLineId(orderLineId);

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
@@ -1121,8 +1121,7 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 				}
 			}
 
-			// Survives the rollback that is about to happen: NotificationRepository.save creates the AD_Note
-			// with newInstanceOutOfTrx (TRXNAME_None).
+			// Survives the rollback that is about to happen: the AD_Note is created out-of-trx (TRXNAME_None).
 			getCollector().addFailedCandidates(affectedCands, error);
 
 			return result;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
@@ -1122,9 +1122,10 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 			}
 
 			// Tell the user who started this run that these candidates could not be invoiced.
-			// This is the single choke point of all three failure call sites, and it is still inside the
-			// saveConstraints() window, which is what lets the notification's AD_Note be saved out of the
-			// transaction that is about to be rolled back.
+			// This is the single choke point of all three failure call sites.
+			// The notification survives the rollback that is about to happen because
+			// NotificationRepository.save creates the AD_Note with newInstanceOutOfTrx (TRXNAME_None),
+			// i.e. autocommit - it has nothing to do with the surrounding saveConstraints() window.
 			getCollector().addFailedCandidates(affectedCands, error);
 
 			return result;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
@@ -1120,6 +1120,13 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 					result.add(note);
 				}
 			}
+
+			// Tell the user who started this run that these candidates could not be invoiced.
+			// This is the single choke point of all three failure call sites, and it is still inside the
+			// saveConstraints() window, which is what lets the notification's AD_Note be saved out of the
+			// transaction that is about to be rolled back.
+			getCollector().addFailedCandidates(affectedCands, error);
+
 			return result;
 
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
@@ -1121,6 +1121,7 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 				}
 			}
 
+			// This method is the one choke point all three failure call sites reach.
 			// Survives the rollback that is about to happen: the AD_Note is created out-of-trx (TRXNAME_None).
 			getCollector().addFailedCandidates(affectedCands, error);
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceCandBLCreateInvoices.java
@@ -1121,11 +1121,8 @@ public class InvoiceCandBLCreateInvoices implements IInvoiceGenerator
 				}
 			}
 
-			// Tell the user who started this run that these candidates could not be invoiced.
-			// This is the single choke point of all three failure call sites.
-			// The notification survives the rollback that is about to happen because
-			// NotificationRepository.save creates the AD_Note with newInstanceOutOfTrx (TRXNAME_None),
-			// i.e. autocommit - it has nothing to do with the surrounding saveConstraints() window.
+			// Survives the rollback that is about to happen: NotificationRepository.save creates the AD_Note
+			// with newInstanceOutOfTrx (TRXNAME_None).
 			getCollector().addFailedCandidates(affectedCands, error);
 
 			return result;

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceGenerateResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceGenerateResult.java
@@ -111,10 +111,6 @@ import de.metas.util.Services;
 		}
 	}
 
-	/**
-	 * Plain result implementation: only counts the failed candidates.
-	 * Notifying the user is done by {@code UserNotificationsInvoiceGenerateResult}, which knows the recipient.
-	 */
 	@Override
 	public void addFailedCandidates(final List<I_C_Invoice_Candidate> failedCandidates, final Throwable error)
 	{

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceGenerateResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/api/impl/InvoiceGenerateResult.java
@@ -31,6 +31,7 @@ import org.compiere.model.I_AD_Note;
 import de.metas.adempiere.model.I_C_Invoice;
 import de.metas.i18n.IMsgBL;
 import de.metas.invoicecandidate.api.IInvoiceCandBL.IInvoiceGenerateResult;
+import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.util.Accessor;
 import de.metas.util.Services;
 
@@ -44,6 +45,7 @@ import de.metas.util.Services;
 
 	private final boolean storeInvoices;
 	private int invoiceCount = 0;
+	private int failedCandidateCount = 0;
 
 	/**
 	 * 
@@ -107,6 +109,20 @@ import de.metas.util.Services;
 			this.notifications.addAll(list);
 			this.notificationsWhereClause = null;
 		}
+	}
+
+	/**
+	 * Plain result implementation: only counts the failed candidates.
+	 * Notifying the user is done by {@code UserNotificationsInvoiceGenerateResult}, which knows the recipient.
+	 */
+	@Override
+	public void addFailedCandidates(final List<I_C_Invoice_Candidate> failedCandidates, final Throwable error)
+	{
+		if (failedCandidates == null || failedCandidates.isEmpty())
+		{
+			return;
+		}
+		this.failedCandidateCount += failedCandidates.size();
 	}
 
 	@Override
@@ -209,6 +225,10 @@ import de.metas.util.Services;
 		if (notifications != null && !notifications.isEmpty())
 		{
 			sb.append(", notifications=").append(notifications);
+		}
+		if (failedCandidateCount > 0)
+		{
+			sb.append(", failedCandidateCount=").append(failedCandidateCount);
 		}
 		sb.append("]");
 

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/UserNotificationsInvoiceGenerateResult.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/async/spi/impl/UserNotificationsInvoiceGenerateResult.java
@@ -5,7 +5,10 @@ import org.adempiere.invoice.event.InvoiceUserNotificationsProducer;
 import de.metas.adempiere.model.I_C_Invoice;
 import de.metas.invoicecandidate.api.IInvoiceCandBL.IInvoiceGenerateResult;
 import de.metas.invoicecandidate.api.impl.ForwardingInvoiceGenerateResult;
+import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.user.UserId;
+
+import java.util.List;
 
 /**
  * {@link ForwardingInvoiceGenerateResult} implementation which is also creating and sending user notifications via {@link InvoiceUserNotificationsProducer}.
@@ -39,5 +42,13 @@ public class UserNotificationsInvoiceGenerateResult extends ForwardingInvoiceGen
 		super.addInvoice(invoice);
 
 		invoiceGeneratedEventBus.notifyGenerated(invoice, recipientUserId);
+	}
+
+	@Override
+	public void addFailedCandidates(final List<I_C_Invoice_Candidate> failedCandidates, final Throwable error)
+	{
+		super.addFailedCandidates(failedCandidates, error);
+
+		invoiceGeneratedEventBus.notifyInvoicingError(failedCandidates, error, recipientUserId);
 	}
 }

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/ConfigValidator.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/de/metas/invoicecandidate/modelvalidator/ConfigValidator.java
@@ -100,6 +100,7 @@ public class ConfigValidator extends AbstractModuleInterceptor
 		//
 		// Setup event bus topics on which swing client notification listener shall subscribe
 		Services.get(IEventBusFactory.class).addAvailableUserNotificationsTopic(InvoiceUserNotificationsProducer.EVENTBUS_TOPIC);
+		Services.get(IEventBusFactory.class).addAvailableUserNotificationsTopic(InvoiceUserNotificationsProducer.EVENTBUS_TOPIC_Error);
 	}
 
 	@Override

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/org/adempiere/invoice/event/InvoiceUserNotificationsProducer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/org/adempiere/invoice/event/InvoiceUserNotificationsProducer.java
@@ -42,11 +42,8 @@ public class InvoiceUserNotificationsProducer
 			.build();
 
 	/**
-	 * Topic used to notify about invoice candidates which could NOT be invoiced.
-	 * <p>
-	 * Deliberately NOT {@link #EVENTBUS_TOPIC}: that one carries "invoice generated" events and every subscriber of it
-	 * (e.g. the WebUI notification list, or {@code InvoiceGeneratedNotificationChecker} in the tests) expects each event
-	 * to reference a C_Invoice. A failure event references no invoice at all, so it has to travel on its own topic.
+	 * Separate from {@link #EVENTBUS_TOPIC} because every subscriber of that one expects the event to reference
+	 * a C_Invoice, and a failure event references none.
 	 */
 	public static final Topic EVENTBUS_TOPIC_Error = Topic.builder()
 			.name("de.metas.invoicecandidate.UserNotifications.InvoicingErrors")
@@ -108,9 +105,6 @@ public class InvoiceUserNotificationsProducer
 				.build();
 	}
 
-	/**
-	 * Notifies the user who started the "Create Invoices" run that the given candidates could not be invoiced.
-	 */
 	public InvoiceUserNotificationsProducer notifyInvoicingError(
 			@Nullable final List<I_C_Invoice_Candidate> failedCandidates,
 			@Nullable final Throwable error,
@@ -124,16 +118,15 @@ public class InvoiceUserNotificationsProducer
 
 		try
 		{
-			// send() and not sendAfterCommit(): the invoicing transaction is rolled back on error
-			// (InvoiceCandBLCreateInvoices.DefaultInvoiceGeneratorRunnable.doCatch returns true),
+			// send() and not sendAfterCommit(): the invoicing transaction is rolled back on error,
 			// so an after-commit notification would never be sent.
 			Services.get(INotificationBL.class).send(UserNotificationRequest.builder()
 					.topic(EVENTBUS_TOPIC_Error)
 					.recipientUserId(recipientUserId != null ? recipientUserId : Env.getLoggedUserId())
 					.contentADMessage(MSG_Event_InvoicingError)
 					.contentADMessageParam(failedCandidates.size())
-					// extractMessage() and not getLocalizedMessage(): the latter is null for e.g. a
-					// NullPointerException thrown by an aggregator, which would render the note as "...: null".
+					// extractMessage() and not getLocalizedMessage(): the latter is null for e.g. an NPE,
+					// which would render the note as "...: null".
 					.contentADMessageParam(AdempiereException.extractMessage(error))
 					.build());
 		}

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/java/org/adempiere/invoice/event/InvoiceUserNotificationsProducer.java
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/java/org/adempiere/invoice/event/InvoiceUserNotificationsProducer.java
@@ -5,6 +5,7 @@ import de.metas.event.IEventBus;
 import de.metas.event.Topic;
 import de.metas.event.Type;
 import de.metas.i18n.AdMessageKey;
+import de.metas.invoicecandidate.model.I_C_Invoice_Candidate;
 import de.metas.logging.LogManager;
 import de.metas.notification.INotificationBL;
 import de.metas.notification.UserNotificationRequest;
@@ -12,12 +13,15 @@ import de.metas.notification.UserNotificationRequest.TargetRecordAction;
 import de.metas.user.UserId;
 import de.metas.util.Services;
 import lombok.NonNull;
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.util.lang.impl.TableRecordReference;
 import org.compiere.model.I_C_BPartner;
 import org.compiere.model.I_C_Invoice;
+import org.compiere.util.Env;
 import org.slf4j.Logger;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * {@link IEventBus} wrapper implementation tailored for sending events about generated invoices.
@@ -37,9 +41,22 @@ public class InvoiceUserNotificationsProducer
 			.type(Type.DISTRIBUTED)
 			.build();
 
+	/**
+	 * Topic used to notify about invoice candidates which could NOT be invoiced.
+	 * <p>
+	 * Deliberately NOT {@link #EVENTBUS_TOPIC}: that one carries "invoice generated" events and every subscriber of it
+	 * (e.g. the WebUI notification list, or {@code InvoiceGeneratedNotificationChecker} in the tests) expects each event
+	 * to reference a C_Invoice. A failure event references no invoice at all, so it has to travel on its own topic.
+	 */
+	public static final Topic EVENTBUS_TOPIC_Error = Topic.builder()
+			.name("de.metas.invoicecandidate.UserNotifications.InvoicingErrors")
+			.type(Type.DISTRIBUTED)
+			.build();
+
 	private static final transient Logger logger = LogManager.getLogger(InvoiceUserNotificationsProducer.class);
 
 	private static final AdMessageKey MSG_Event_InvoiceGenerated = AdMessageKey.of("Event_InvoiceGenerated");
+	private static final AdMessageKey MSG_Event_InvoicingError = AdMessageKey.of("Event_InvoicingError");
 
 	private InvoiceUserNotificationsProducer()
 	{
@@ -89,6 +106,43 @@ public class InvoiceUserNotificationsProducer
 				.contentADMessageParam(bpName)
 				.targetAction(TargetRecordAction.of(invoiceRef))
 				.build();
+	}
+
+	/**
+	 * Notifies the user who started the "Create Invoices" run that the given candidates could not be invoiced.
+	 */
+	public InvoiceUserNotificationsProducer notifyInvoicingError(
+			@Nullable final List<I_C_Invoice_Candidate> failedCandidates,
+			@Nullable final Throwable error,
+			@Nullable final UserId recipientUserId)
+	{
+		// Without this, a forwarded-but-empty call would notify "0 invoice candidate(s) could not be invoiced".
+		if (failedCandidates == null || failedCandidates.isEmpty())
+		{
+			return this;
+		}
+
+		try
+		{
+			// send() and not sendAfterCommit(): the invoicing transaction is rolled back on error
+			// (InvoiceCandBLCreateInvoices.DefaultInvoiceGeneratorRunnable.doCatch returns true),
+			// so an after-commit notification would never be sent.
+			Services.get(INotificationBL.class).send(UserNotificationRequest.builder()
+					.topic(EVENTBUS_TOPIC_Error)
+					.recipientUserId(recipientUserId != null ? recipientUserId : Env.getLoggedUserId())
+					.contentADMessage(MSG_Event_InvoicingError)
+					.contentADMessageParam(failedCandidates.size())
+					// extractMessage() and not getLocalizedMessage(): the latter is null for e.g. a
+					// NullPointerException thrown by an aggregator, which would render the note as "...: null".
+					.contentADMessageParam(AdempiereException.extractMessage(error))
+					.build());
+		}
+		catch (final Exception ex)
+		{
+			logger.warn("Failed creating invoicing-error event for {} candidate(s). Ignored.", failedCandidates.size(), ex);
+		}
+
+		return this;
 	}
 
 	private UserNotificationRequest.UserNotificationRequestBuilder newUserNotificationRequest()

--- a/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5821320_sys_Event_InvoicingError_message.sql
+++ b/backend/de.metas.swat/de.metas.swat.base/src/main/sql/postgresql/system/47-de.metas.invoicecandidate/5821320_sys_Event_InvoicingError_message.sql
@@ -1,0 +1,37 @@
+-- IDs allocated from idserver.metas.de on 2026-08-31:
+--   AD_MigrationScript 5821320 (this script)
+--   AD_Message         545816 (Event_InvoicingError)
+--
+-- Notification shown to the user who started a "Create Invoices" run when some or all of the
+-- selected invoice candidates could not be invoiced.
+--   {0} = number of invoice candidates that failed
+--   {1} = the error text
+
+-- 2026-08-31T15:11:41
+INSERT INTO AD_Message (AD_Client_ID,AD_Message_ID,AD_Org_ID,Created,CreatedBy,EntityType,IsActive,MsgText,MsgType,Updated,UpdatedBy,Value)
+VALUES (0,545816 /*From ID Server*/,0,TO_TIMESTAMP('2026-08-31 15:11:41','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','{0} Rechnungskandidat(en) konnten nicht fakturiert werden: {1}','E',TO_TIMESTAMP('2026-08-31 15:11:41','YYYY-MM-DD HH24:MI:SS'),100,'Event_InvoicingError')
+;
+
+-- 2026-08-31T15:11:42
+UPDATE AD_Message SET ErrorCode='INVOICING_ERROR',Updated=TO_TIMESTAMP('2026-08-31 15:11:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Message_ID=545816
+;
+
+-- 2026-08-31T15:11:43
+INSERT INTO AD_Message_Trl (AD_Language,AD_Message_ID, MsgText,MsgTip, IsTranslated,AD_Client_ID,AD_Org_ID,Created,Createdby,Updated,UpdatedBy,IsActive)
+SELECT l.AD_Language,t.AD_Message_ID, t.MsgText,t.MsgTip, 'N',t.AD_Client_ID,t.AD_Org_ID,t.Created,t.Createdby,t.Updated,t.UpdatedBy,'Y'
+FROM AD_Language l, AD_Message t
+WHERE l.IsActive='Y' AND l.IsSystemLanguage='Y' AND t.AD_Message_ID=545816
+  AND NOT EXISTS (SELECT 1 FROM AD_Message_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.AD_Message_ID=t.AD_Message_ID)
+;
+
+-- 2026-08-31T15:11:44
+UPDATE AD_Message_Trl SET MsgText='{0} invoice candidate(s) could not be invoiced: {1}',IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-31 15:11:44','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='en_US' AND AD_Message_ID=545816
+;
+
+-- 2026-08-31T15:11:45
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-31 15:11:45','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_DE' AND AD_Message_ID=545816
+;
+
+-- 2026-08-31T15:11:46
+UPDATE AD_Message_Trl SET IsTranslated='Y',Updated=TO_TIMESTAMP('2026-08-31 15:11:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Language='de_CH' AND AD_Message_ID=545816
+;


### PR DESCRIPTION
## Problem

Two related defects around invoice candidates that can never be invoiced.

**1. "Create Invoices" could fail silently.** When a run failed for some of the selected
candidates, nothing told the user who started it. The failure was recorded on the candidate
(`IsInvoicingError` / `InvoicingErrorMsg`) but no notification was produced, so from the UI the
run simply appeared to do nothing. The genuinely silent case is a **mixed** selection: when the
whole selection is un-invoiceable the user does get `InvoiceGenerate_No_Candidates_Selected`, but
when only some candidates fail the skipped ones were reported nowhere.

**2. Closing a disposition with nothing delivered left its candidates open forever.** Closing a
receipt or shipment disposition on which nothing was ever received/delivered left the order line's
invoice candidates at `QtyOrdered > 0, QtyToInvoice = 0`. The enqueuer skips such candidates
(`InvoiceCandidateEnqueuer`), and nothing ever closed them, so they lingered as permanently open
work that every subsequent run silently passed over.

## What changed

**Reporting.** A new `IInvoiceGenerateResult.addFailedCandidates(List, Throwable)` seam, called from
`InvoiceCandBLCreateInvoices.createNoticesAndMarkICs` — the single choke point that has both the
affected-candidate list and the `Throwable`, and which covers all three failure call sites with one
insertion. Only the existing `UserNotificationsInvoiceGenerateResult` decorator notifies; the plain
result just counts. The notification uses `notificationBL.send(...)` rather than
`sendAfterCommit(...)` because the failure path rolls the transaction back.

New `AD_Message` `Event_InvoicingError` (`{0}` = failed-candidate count, `{1}` = error text), and a
**new** event-bus topic `de.metas.invoicecandidate.UserNotifications.InvoicingErrors` — deliberately
not the existing `EVENTBUS_TOPIC`, whose subscribers assume the event references a `C_Invoice` and
would NPE on a failure event that references none.

**Closing.** `OrderLineReceiptScheduleListener.onAfterClose` and
`M_ShipmentSchedule.updateIsDeliveryClosed` now also close the order line's invoice candidates, but
only when `C_OrderLine.QtyDelivered` is zero — after a partial receipt the delivered part must stay
invoiceable. The reverse direction is made symmetric via a new
`IInvoiceCandBL.openInvoiceCandidatesByOrderLineId`, wired at all four reopen sites, including
`ReceiptScheduleBL.closeReceiptSchedulesForOrder` — the reactivate/void path where the disposition is
only *parked*, and which would otherwise have left a reactivated order's candidates closed forever.

## Tests

Seven new cucumber scenarios, each written RED first and observed failing on exactly one assertion
before its fix:

| Scenario | Covers |
|---|---|
| `@Id:S0163_100` | a failing run notifies the user who started it |
| `@Id:S0163_200` | mixed selection — the good candidate is still invoiced, the failure still reported |
| `@Id:S0164_100` | closing an undelivered receipt disposition closes the purchase candidate |
| `@Id:S0164_200` | same on the sales side |
| `@Id:S0164_300` | reopening the disposition reopens the candidate |
| `@Id:S0164_400` | reactivating only *parks* the disposition; the candidate is left open |
| `@Id:S0164_500` | re-completing a reactivated order reopens the parked disposition and its candidate |

Plus `@Id:S0161_100`, a regression test for Create Invoices on a reactivated purchase order.

`@Id:S0156_100` / `@Id:S0156_200` (partial receipt, close and reopen) pin the guard: without the
`QtyDelivered == 0` condition they fail, because the delivered part would stop being invoiceable.

`validate C_Invoice_Candidate:` additionally accepts `IsInvoicingError` / `InvoicingErrorMsg`
(additive; no existing assertion changed) — `IsError` is cleared by the recompute processor right
after a run, while `IsInvoicingError` survives.

## Notes for the reviewer

- On the reactivate/void parking path, `openDeliveryInvoiceCandidatesByOrderLineId` is deliberately
  **not** called, so a parked candidate keeps `IsDeliveryClosed = Y`. That asymmetry is pre-existing
  and display-only (no Java reads the flag); it self-heals on the next complete. It is documented at
  the call site and asserted by `@Id:S0164_400` rather than left silent.
- Two pre-existing defects were found and deliberately left alone: `InvoiceCandBLCreateInvoices`
  clobbers the legacy `AD_Note` recipient with a client id (the new `NotificationRepository` route is
  unaffected), and the new topic has no `AD_NotificationGroup` record, so the notification cannot be
  switched off in the UI.
