### PR TITLE
`Sales Order` report: Make the `Print Name` field to support name with 2 lines

### DIFF
--- a/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/docs/sales/order/report_description.jrxml
+++ b/backend/de.metas.fresh/de.metas.fresh.base/src/main/jasperreports/de/metas/docs/sales/order/report_description.jrxml
@@ -171,7 +171,7 @@
 				<textFieldExpression><![CDATA[$F{dateordered}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement key="textField-10" x="170" y="83" width="134" height="13" uuid="fe70dce0-5ca0-4031-8a21-0af1802eac75">
+				<reportElement key="textField-10" x="170" y="96" width="134" height="13" uuid="fe70dce0-5ca0-4031-8a21-0af1802eac75">
 					<printWhenExpression><![CDATA[new Boolean($F{bp_value}!=null)]]></printWhenExpression>
 				</reportElement>
 				<box>
@@ -212,7 +212,7 @@
 				<textFieldExpression><![CDATA[$F{documentno}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement key="textField-11" x="37" y="83" width="133" height="13" uuid="c2adc14d-beb1-41b9-9ad8-62e8b8eecd02">
+				<reportElement key="textField-11" x="37" y="96" width="133" height="13" uuid="c2adc14d-beb1-41b9-9ad8-62e8b8eecd02">
 					<printWhenExpression><![CDATA[new Boolean($F{bp_value}!=null)]]></printWhenExpression>
 				</reportElement>
 				<box>
@@ -227,7 +227,7 @@
 				<textFieldExpression><![CDATA[$R{BP_Value}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement key="textField-6" x="37" y="70" width="133" height="13" forecolor="#000000" uuid="c92f9276-6317-4bdd-9067-12af4231a75e"/>
+				<reportElement key="textField-6" x="37" y="70" width="133" height="26" forecolor="#000000" uuid="c92f9276-6317-4bdd-9067-12af4231a75e"/>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -302,7 +302,7 @@
 				<textFieldExpression><![CDATA[$F{datepromised}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement key="textField-11" x="37" y="96" width="133" height="13" uuid="e19938ac-946e-4df9-a29e-2278a3b5d207">
+				<reportElement key="textField-11" x="37" y="109" width="133" height="13" uuid="e19938ac-946e-4df9-a29e-2278a3b5d207">
 					<printWhenExpression><![CDATA[new Boolean($F{eori}!=null)]]></printWhenExpression>
 				</reportElement>
 				<box>
@@ -317,7 +317,7 @@
 				<textFieldExpression><![CDATA[$R{EORI}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement key="textField-10" x="170" y="96" width="134" height="13" uuid="f2daa350-8efc-43b5-a81c-21f424378fb0">
+				<reportElement key="textField-10" x="170" y="109" width="134" height="13" uuid="f2daa350-8efc-43b5-a81c-21f424378fb0">
 					<printWhenExpression><![CDATA[new Boolean($F{eori}!=null)]]></printWhenExpression>
 				</reportElement>
 				<box>
@@ -362,7 +362,7 @@
 				<textFieldExpression><![CDATA[$F{deliverytoaddress}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement key="textField-5" x="37" y="109" width="133" height="13" uuid="2836b8cd-2fd1-4fd3-9c94-ceceeeb92c1b"/>
+				<reportElement key="textField-5" x="37" y="122" width="133" height="13" uuid="2836b8cd-2fd1-4fd3-9c94-ceceeeb92c1b"/>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -375,7 +375,7 @@
 				<textFieldExpression><![CDATA[$R{Account_manager}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement key="textField-3" x="170" y="109" width="134" height="13" uuid="c9ebec74-d19f-4a6c-b5a9-2aebb9a81471"/>
+				<reportElement key="textField-3" x="170" y="122" width="134" height="13" uuid="c9ebec74-d19f-4a6c-b5a9-2aebb9a81471"/>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -388,7 +388,7 @@
 				<textFieldExpression><![CDATA[$F{sr_name}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" pattern="dd.MM.yyyy HH:mm" isBlankWhenNull="true">
-				<reportElement key="textField-3" x="170" y="122" width="134" height="13" uuid="69883b4e-81c3-4c11-b402-067f0cb156b9"/>
+				<reportElement key="textField-3" x="170" y="135" width="134" height="13" uuid="69883b4e-81c3-4c11-b402-067f0cb156b9"/>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
@@ -401,7 +401,7 @@
 				<textFieldExpression><![CDATA[$F{sr_email}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="StretchHeight" isBlankWhenNull="true">
-				<reportElement key="textField-5" x="37" y="122" width="133" height="13" uuid="a9888666-38ea-4298-8ec2-b165c1ea37f5"/>
+				<reportElement key="textField-5" x="37" y="135" width="133" height="13" uuid="a9888666-38ea-4298-8ec2-b165c1ea37f5"/>
 				<box>
 					<topPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>
 					<leftPen lineWidth="0.0" lineStyle="Solid" lineColor="#000000"/>


### PR DESCRIPTION
Replace: https://github.com/metasfresh/metasfresh/pull/25672