### PR TITLE
Costing: keep the MatchInv cost-adjustment posting quantity-neutral and on the receipt locator

### DIFF
--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_MatchInv.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_MatchInv.java
@@ -16,6 +16,7 @@
  *****************************************************************************/
 package org.compiere.acct;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import de.metas.acct.accounts.BPartnerGroupAccountType;
 import de.metas.acct.accounts.CostElementAccountType;
@@ -63,6 +64,7 @@ import de.metas.util.Services;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Value;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.I_C_Invoice;
 import org.compiere.model.I_M_InOut;
@@ -309,36 +311,18 @@ public class Doc_MatchInv extends Doc<DocLine_MatchInv>
 		updateFromInvoiceLine(cr_InventoryClearing);
 
 		//
-		// P_Asset CR/DR
-		// (cost adjustment)
-		if (!costs.getCostAdjustmentAmt().isZero())
+		// P_Asset CR/DR (cost adjustment) and P_COGS CR/DR (already shipped)
+		for (final CostAdjustmentLeg leg : costAdjustmentLegs(costs, getQty(), receiptLine.getM_Locator_ID()))
 		{
-			final Balance costAdjustmentBalance = toDebitBalanceIfPositive(costs.getCostAdjustmentAmt());
 			fact.createLine()
-					.setAccount(docLine.getAccount(ProductAcctType.P_Asset_Acct, as))
+					.setAccount(docLine.getAccount(leg.getAcctType(), as))
 					.setCurrencyConversionCtx(getInvoiceCurrencyConversionCtx())
-					.setAmtSource(costAdjustmentBalance)
-					.setQty(getQty())
+					.setAmtSource(toDebitBalanceIfPositive(leg.getAmt()))
+					.setQty(leg.getQty())
 					.costElement(costElementId)
 					.bpartnerId(getReceiptBPartnerId())
 					.productId(receiptProductId)
-					.buildAndAdd();
-		}
-
-		//
-		// P_COGS CR/DR
-		// (already shipped)
-		if (!costs.getAlreadyShippedAmt().isZero())
-		{
-			final Balance alreadyShippedBalance = toDebitBalanceIfPositive(costs.getAlreadyShippedAmt());
-			fact.createLine()
-					.setAccount(docLine.getAccount(ProductAcctType.P_COGS_Acct, as))
-					.setCurrencyConversionCtx(getInvoiceCurrencyConversionCtx())
-					.setAmtSource(alreadyShippedBalance)
-					.setQty(getQty())
-					.costElement(costElementId)
-					.bpartnerId(getReceiptBPartnerId())
-					.productId(receiptProductId)
+					.locatorId(leg.getLocatorRepoId())
 					.buildAndAdd();
 		}
 
@@ -603,6 +587,54 @@ public class Doc_MatchInv extends Doc<DocLine_MatchInv>
 		{
 			throw new AdempiereException("Unhandled type: " + type);
 		}
+	}
+
+	/**
+	 * The cost-adjustment legs of a MatchInv posting: the price difference between the invoice and the PO price,
+	 * split into the share that revalues the stock still on hand (P_Asset) and the share for stock already shipped
+	 * (P_COGS). Zero shares produce no leg.
+	 *
+	 * @param qty            the matched quantity, as booked on the GR/IR leg
+	 * @param receiptLocatorRepoId the locator the matched receipt line was received into
+	 */
+	@VisibleForTesting
+	static ImmutableList<CostAdjustmentLeg> costAdjustmentLegs(
+			@NonNull final CostAmountDetailed costs,
+			@NonNull final Quantity qty,
+			final int receiptLocatorRepoId)
+	{
+		final ImmutableList.Builder<CostAdjustmentLeg> legs = ImmutableList.builder();
+
+		// P_Asset: revalues the stock that is still on hand.
+		// The line carries a ZERO qty: the material receipt already booked the quantity, and the GR/IR leg is
+		// quantity-balanced against its InventoryClearing counterpart, so a qty here has no negative counterpart and
+		// is counted as stock on hand by the inventory valuation (Lagerwert) report, which sums Fact_Acct.Qty on
+		// P_Asset. It is attributed to the receipt's locator, like the GR/IR leg whose price it corrects, so the
+		// revaluation lands in the warehouse the goods were received into.
+		if (!costs.getCostAdjustmentAmt().isZero())
+		{
+			legs.add(new CostAdjustmentLeg(ProductAcctType.P_Asset_Acct, costs.getCostAdjustmentAmt(), qty.toZero(), receiptLocatorRepoId));
+		}
+
+		// P_COGS: the share for stock that was already shipped.
+		// Left carrying the matched qty and no locator, i.e. unchanged - see the open question on the pull request.
+		if (!costs.getAlreadyShippedAmt().isZero())
+		{
+			legs.add(new CostAdjustmentLeg(ProductAcctType.P_COGS_Acct, costs.getAlreadyShippedAmt(), qty, 0));
+		}
+
+		return legs.build();
+	}
+
+	@Value
+	static class CostAdjustmentLeg
+	{
+		@NonNull ProductAcctType acctType;
+		/** positive =&gt; debit; negative =&gt; credit. */
+		@NonNull CostAmount amt;
+		@NonNull Quantity qty;
+		/** {@code 0} when the leg is attributed to no locator. */
+		int locatorRepoId;
 	}
 
 }   // Doc_MatchInv

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_MatchInv.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_MatchInv.java
@@ -594,7 +594,8 @@ public class Doc_MatchInv extends Doc<DocLine_MatchInv>
 	 * split into the share that revalues the stock still on hand (P_Asset) and the share for stock already shipped
 	 * (P_COGS). Zero shares produce no leg.
 	 *
-	 * @param qty            the matched quantity, as booked on the GR/IR leg
+	 * @param costs                the cost split for this match
+	 * @param qty                  the matched quantity, as booked on the GR/IR leg
 	 * @param receiptLocatorRepoId the locator the matched receipt line was received into
 	 */
 	@VisibleForTesting

--- a/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_MatchInv.java
+++ b/backend/de.metas.acct.base/src/main/java-legacy/org/compiere/acct/Doc_MatchInv.java
@@ -618,7 +618,9 @@ public class Doc_MatchInv extends Doc<DocLine_MatchInv>
 		}
 
 		// P_COGS: the share for stock that was already shipped.
-		// Left carrying the matched qty and no locator, i.e. unchanged - see the open question on the pull request.
+		// Deliberately unchanged: it still carries the matched qty and no locator. Unlike P_Asset, P_COGS is not an
+		// inventory account, so a qty here is not summed as stock on hand by the inventory valuation (Lagerwert)
+		// report; whether it should carry a qty at all is a separate product decision.
 		if (!costs.getAlreadyShippedAmt().isZero())
 		{
 			legs.add(new CostAdjustmentLeg(ProductAcctType.P_COGS_Acct, costs.getAlreadyShippedAmt(), qty, 0));

--- a/backend/de.metas.acct.base/src/test/java/org/compiere/acct/Doc_MatchInvCostAdjustmentLegsTest.java
+++ b/backend/de.metas.acct.base/src/test/java/org/compiere/acct/Doc_MatchInvCostAdjustmentLegsTest.java
@@ -117,6 +117,43 @@ class Doc_MatchInvCostAdjustmentLegsTest
 		});
 	}
 
+	/**
+	 * Both shares are non-zero: the P_Asset leg is quantity-neutral and on the receipt locator, while the P_COGS leg
+	 * is deliberately left as it was - it still carries the matched quantity and no locator. Pinning P_COGS here is
+	 * what makes the asymmetry explicit: it is a product decision, not an oversight, and this test fails if it
+	 * changes by accident.
+	 */
+	@Test
+	void bothLegs_onlyTheAssetLegIsQuantityNeutral()
+	{
+		final ImmutableList<Doc_MatchInv.CostAdjustmentLeg> legs =
+				Doc_MatchInv.costAdjustmentLegs(split("120", "12", "8"), qty(10), RECEIPT_LOCATOR_ID);
+
+		assertThat(legs).hasSize(2);
+
+		final Doc_MatchInv.CostAdjustmentLeg asset = legByAcctType(legs, ProductAcctType.P_Asset_Acct);
+		final Doc_MatchInv.CostAdjustmentLeg cogs = legByAcctType(legs, ProductAcctType.P_COGS_Acct);
+		assertSoftly(softly -> {
+			softly.assertThat(asset.getAmt().toBigDecimal()).as("P_Asset AmtSource").isEqualByComparingTo("12");
+			softly.assertThat(asset.getQty().toBigDecimal()).as("P_Asset Qty").isEqualByComparingTo(BigDecimal.ZERO);
+			softly.assertThat(asset.getLocatorRepoId()).as("P_Asset M_Locator_ID").isEqualTo(RECEIPT_LOCATOR_ID);
+
+			softly.assertThat(cogs.getAmt().toBigDecimal()).as("P_COGS AmtSource").isEqualByComparingTo("8");
+			softly.assertThat(cogs.getQty().toBigDecimal()).as("P_COGS Qty").isEqualByComparingTo("10");
+			softly.assertThat(cogs.getLocatorRepoId()).as("P_COGS M_Locator_ID").isZero();
+		});
+	}
+
+	@Test
+	void onlyAlreadyShipped_producesTheCogsLegAlone()
+	{
+		final ImmutableList<Doc_MatchInv.CostAdjustmentLeg> legs =
+				Doc_MatchInv.costAdjustmentLegs(split("120", "0", "8"), qty(10), RECEIPT_LOCATOR_ID);
+
+		assertThat(legs).hasSize(1);
+		assertThat(legs.get(0).getAcctType()).isEqualTo(ProductAcctType.P_COGS_Acct);
+	}
+
 	@Test
 	void zeroCostAdjustment_noAssetLeg()
 	{

--- a/backend/de.metas.acct.base/src/test/java/org/compiere/acct/Doc_MatchInvCostAdjustmentLegsTest.java
+++ b/backend/de.metas.acct.base/src/test/java/org/compiere/acct/Doc_MatchInvCostAdjustmentLegsTest.java
@@ -1,0 +1,138 @@
+/*
+ * #%L
+ * de.metas.acct.base
+ * %%
+ * Copyright (C) 2026 metas GmbH
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program. If not, see
+ * <http://www.gnu.org/licenses/gpl-2.0.html>.
+ * #L%
+ */
+
+package org.compiere.acct;
+
+import com.google.common.collect.ImmutableList;
+import de.metas.acct.accounts.ProductAcctType;
+import de.metas.costing.CostAmount;
+import de.metas.costing.methods.CostAmountDetailed;
+import de.metas.money.CurrencyId;
+import de.metas.quantity.Quantity;
+import org.adempiere.model.InterfaceWrapperHelper;
+import org.adempiere.test.AdempiereTestHelper;
+import org.compiere.model.I_C_UOM;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+/**
+ * Covers the quantity and the locator each cost-adjustment leg of a MatchInv posting carries.
+ */
+class Doc_MatchInvCostAdjustmentLegsTest
+{
+	private static final CurrencyId currencyId = CurrencyId.ofRepoId(1);
+	private static final int RECEIPT_LOCATOR_ID = 4711;
+
+	private I_C_UOM uom;
+
+	@BeforeEach
+	void beforeEach()
+	{
+		AdempiereTestHelper.get().init();
+
+		uom = InterfaceWrapperHelper.newInstance(I_C_UOM.class);
+		uom.setName("PCE");
+		uom.setUOMSymbol("PCE");
+		uom.setX12DE355("PCE");
+		InterfaceWrapperHelper.saveRecord(uom);
+	}
+
+	private CostAmountDetailed split(final String mainAmt, final String costAdjustmentAmt, final String alreadyShippedAmt)
+	{
+		return CostAmountDetailed.builder()
+				.mainAmt(CostAmount.of(new BigDecimal(mainAmt), currencyId))
+				.costAdjustmentAmt(CostAmount.of(new BigDecimal(costAdjustmentAmt), currencyId))
+				.alreadyShippedAmt(CostAmount.of(new BigDecimal(alreadyShippedAmt), currencyId))
+				.build();
+	}
+
+	private Quantity qty(final int qty)
+	{
+		return Quantity.of(qty, uom);
+	}
+
+	/**
+	 * The GR/IR leg and its InventoryClearing counterpart are quantity-balanced (+qty / -qty), so they move no
+	 * stock. The P_Asset cost-adjustment leg has no negative counterpart: a quantity on it is therefore read by the
+	 * inventory valuation (Lagerwert) report - which sums Fact_Acct.Qty on P_Asset - as stock on hand that does not
+	 * exist. It must carry zero, and it must be attributed to the receipt's locator so the value lands in the
+	 * warehouse the goods were received into.
+	 */
+	@Test
+	void costAdjustmentLeg_carriesZeroQtyOnTheReceiptLocator()
+	{
+		final ImmutableList<Doc_MatchInv.CostAdjustmentLeg> legs =
+				Doc_MatchInv.costAdjustmentLegs(split("120", "20", "0"), qty(10), RECEIPT_LOCATOR_ID);
+
+		assertThat(legs).hasSize(1);
+
+		final Doc_MatchInv.CostAdjustmentLeg asset = legByAcctType(legs, ProductAcctType.P_Asset_Acct);
+		assertSoftly(softly -> {
+			softly.assertThat(asset.getAmt().toBigDecimal()).as("AmtSource").isEqualByComparingTo("20");
+			softly.assertThat(asset.getQty().toBigDecimal()).as("Qty").isEqualByComparingTo(BigDecimal.ZERO);
+			softly.assertThat(asset.getQty().getUomId()).as("C_UOM_ID").isEqualTo(qty(10).getUomId());
+			softly.assertThat(asset.getLocatorRepoId()).as("M_Locator_ID").isEqualTo(RECEIPT_LOCATOR_ID);
+		});
+	}
+
+	/**
+	 * A negative price difference (the invoice came in below the PO price) is the same line with the opposite sign -
+	 * it must be equally quantity-neutral.
+	 */
+	@Test
+	void negativeCostAdjustmentLeg_carriesZeroQtyOnTheReceiptLocator()
+	{
+		final ImmutableList<Doc_MatchInv.CostAdjustmentLeg> legs =
+				Doc_MatchInv.costAdjustmentLegs(split("80", "-20", "0"), qty(10), RECEIPT_LOCATOR_ID);
+
+		final Doc_MatchInv.CostAdjustmentLeg asset = legByAcctType(legs, ProductAcctType.P_Asset_Acct);
+		assertSoftly(softly -> {
+			softly.assertThat(asset.getAmt().toBigDecimal()).as("AmtSource").isEqualByComparingTo("-20");
+			softly.assertThat(asset.getQty().toBigDecimal()).as("Qty").isEqualByComparingTo(BigDecimal.ZERO);
+			softly.assertThat(asset.getLocatorRepoId()).as("M_Locator_ID").isEqualTo(RECEIPT_LOCATOR_ID);
+		});
+	}
+
+	@Test
+	void zeroCostAdjustment_noAssetLeg()
+	{
+		final ImmutableList<Doc_MatchInv.CostAdjustmentLeg> legs =
+				Doc_MatchInv.costAdjustmentLegs(split("100", "0", "0"), qty(10), RECEIPT_LOCATOR_ID);
+
+		assertThat(legs).isEmpty();
+	}
+
+	private static Doc_MatchInv.CostAdjustmentLeg legByAcctType(
+			final ImmutableList<Doc_MatchInv.CostAdjustmentLeg> legs,
+			final ProductAcctType acctType)
+	{
+		return legs.stream()
+				.filter(leg -> leg.getAcctType() == acctType)
+				.findFirst()
+				.orElseThrow(() -> new AssertionError("No leg found for " + acctType));
+	}
+}

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctLineMatcher.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctLineMatcher.java
@@ -16,6 +16,7 @@ import lombok.NonNull;
 import org.adempiere.ad.table.api.AdTableId;
 import org.adempiere.ad.table.api.impl.TableIdsCache;
 import org.adempiere.util.lang.impl.TableRecordReference;
+import org.adempiere.warehouse.LocatorId;
 import org.assertj.core.api.SoftAssertions;
 import org.compiere.model.I_Fact_Acct;
 
@@ -41,6 +42,7 @@ public class FactAcctLineMatcher
 	@Nullable private final Optional<BPartnerId> bpartnerId;
 	@Nullable private final Optional<ProductId> productId;
 	@Nullable private final Optional<InvoiceId> invoiceId;
+	@Nullable private final Optional<LocatorId> locatorId;
 
 	@Override
 	public String toString() {return row.toTabularString();}
@@ -192,6 +194,14 @@ public class FactAcctLineMatcher
 			softly.assertThat(actualInvoiceId)
 					.as(description.newWithMessage("C_Invoice_ID"))
 					.isEqualTo(invoiceId.orElse(null));
+		}
+		if (locatorId != null)
+		{
+			// Fact_Acct.M_Locator_ID is a plain int column, so compare repo-ids and map "not set" to null on both sides.
+			final Integer actualLocatorRepoId = record.getM_Locator_ID() > 0 ? record.getM_Locator_ID() : null;
+			softly.assertThat(actualLocatorRepoId)
+					.as(description.newWithMessage("M_Locator_ID"))
+					.isEqualTo(locatorId.map(LocatorId::getRepoId).orElse(null));
 		}
 	}
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctMatchersFactory.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctMatchersFactory.java
@@ -8,6 +8,7 @@ import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
 import de.metas.cucumber.stepdefs.C_Tax_StepDefData;
 import de.metas.cucumber.stepdefs.DataTableRow;
 import de.metas.cucumber.stepdefs.DataTableRows;
+import de.metas.cucumber.stepdefs.M_Locator_StepDefData;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.StepDefConstants;
 import de.metas.cucumber.stepdefs.StepDefDataIdentifier;
@@ -23,6 +24,7 @@ import io.cucumber.datatable.DataTable;
 import lombok.Builder;
 import lombok.NonNull;
 import org.adempiere.util.lang.impl.TableRecordReference;
+import org.adempiere.warehouse.LocatorId;
 import org.compiere.model.I_Fact_Acct;
 
 import javax.annotation.Nullable;
@@ -40,6 +42,7 @@ public class FactAcctMatchersFactory
 	@NonNull private final C_BPartner_StepDefData bpartnerTable;
 	@NonNull private final C_Tax_StepDefData taxTable;
 	@NonNull private final M_Product_StepDefData productTable;
+	@NonNull private final M_Locator_StepDefData locatorTable;
 	@NonNull private final C_Invoice_StepDefData invoiceTable;
 
 	public FactAcctMatchers createLineMatchers(@NonNull final DataTable table)
@@ -87,6 +90,7 @@ public class FactAcctMatchersFactory
 				.bpartnerId(extractBPartnerId(row))
 				.productId(extractProductId(row))
 				.invoiceId(extractInvoiceId(row))
+				.locatorId(extractLocatorId(row))
 				.build();
 	}
 
@@ -177,6 +181,20 @@ public class FactAcctMatchersFactory
 	{
 		final StepDefDataIdentifier identifier = row.getAsOptionalIdentifier("C_Invoice_ID").orElse(null);
 		return identifier == null ? null : Optional.ofNullable(identifier.lookupIdIn(invoiceTable));
+	}
+
+	@SuppressWarnings("OptionalAssignedToNull")
+	@Nullable
+	private Optional<LocatorId> extractLocatorId(final @NonNull DataTableRow row)
+	{
+		final StepDefDataIdentifier identifier = row.getAsOptionalIdentifier(I_Fact_Acct.COLUMNNAME_M_Locator_ID).orElse(null);
+		if (identifier == null)
+		{
+			return null;
+		}
+		return identifier.isNullPlaceholder()
+				? Optional.empty()
+				: Optional.of(locatorTable.getId(identifier));
 	}
 
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctMatchersFactory.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/FactAcctMatchersFactory.java
@@ -188,13 +188,7 @@ public class FactAcctMatchersFactory
 	private Optional<LocatorId> extractLocatorId(final @NonNull DataTableRow row)
 	{
 		final StepDefDataIdentifier identifier = row.getAsOptionalIdentifier(I_Fact_Acct.COLUMNNAME_M_Locator_ID).orElse(null);
-		if (identifier == null)
-		{
-			return null;
-		}
-		return identifier.isNullPlaceholder()
-				? Optional.empty()
-				: Optional.of(locatorTable.getId(identifier));
+		return identifier == null ? null : Optional.ofNullable(identifier.lookupIdIn(locatorTable));
 	}
 
 }

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/Fact_Acct_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/accounting/Fact_Acct_StepDef.java
@@ -3,6 +3,7 @@ package de.metas.cucumber.stepdefs.accounting;
 import com.google.common.collect.ImmutableSet;
 import de.metas.cucumber.stepdefs.C_BPartner_StepDefData;
 import de.metas.cucumber.stepdefs.C_Tax_StepDefData;
+import de.metas.cucumber.stepdefs.M_Locator_StepDefData;
 import de.metas.cucumber.stepdefs.M_Product_StepDefData;
 import de.metas.cucumber.stepdefs.invoice.C_Invoice_StepDefData;
 import de.metas.cucumber.stepdefs.util.IdentifiersResolver;
@@ -30,6 +31,7 @@ public class Fact_Acct_StepDef
 			@NonNull final C_BPartner_StepDefData bpartnerTable,
 			@NonNull final C_Tax_StepDefData taxTable,
 			@NonNull final M_Product_StepDefData productTable,
+			@NonNull final M_Locator_StepDefData locatorTable,
 			@NonNull final C_Invoice_StepDefData invoiceTable
 	)
 	{
@@ -46,6 +48,7 @@ public class Fact_Acct_StepDef
 				.bpartnerTable(bpartnerTable)
 				.taxTable(taxTable)
 				.productTable(productTable)
+				.locatorTable(locatorTable)
 				.invoiceTable(invoiceTable)
 				.build();
 		this.factAcctTabularStringConverter = FactAcctToTabularStringConverter.builder()

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/warehouse/M_Warehouse_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/warehouse/M_Warehouse_StepDef.java
@@ -97,9 +97,12 @@ public class M_Warehouse_StepDef
 							.create()
 							.firstOnlyNotNull(I_M_Warehouse.class);
 
-					final I_M_Locator locator = warehouseBL.getOrCreateDefaultLocator(WarehouseId.ofRepoId(warehouseRecord.getM_Warehouse_ID()));
+					// Resolve the locator only when the caller asked for it: this step LOADS existing master data, and
+					// getOrCreateDefaultLocator() may create a locator / flip IsDefault flags.
 					row.getAsOptionalIdentifier(I_M_Locator.COLUMNNAME_M_Locator_ID)
-							.ifPresent(locatorIdentifier -> locatorTable.put(locatorIdentifier, locator));
+							.ifPresent(locatorIdentifier -> locatorTable.put(
+									locatorIdentifier,
+									warehouseBL.getOrCreateDefaultLocator(WarehouseId.ofRepoId(warehouseRecord.getM_Warehouse_ID()))));
 
 					row.getAsIdentifier().put(warehouseTable, warehouseRecord);
 				});

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/warehouse/M_Warehouse_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/warehouse/M_Warehouse_StepDef.java
@@ -68,6 +68,22 @@ public class M_Warehouse_StepDef
 	@NonNull private final S_Resource_StepDefData resourceTable;
 	@NonNull private final TestContext restTestContext;
 
+	/**
+	 * Loads existing warehouses by their {@code Value}, optionally also registering each warehouse's default locator.
+	 *
+	 * @cucumber.stepdef
+	 * @cucumber.columns
+	 *   <b>M_Warehouse_ID</b> — (required) identifier the loaded warehouse is stored under<br>
+	 *   <b>Value</b> — (required) the existing warehouse's Value<br>
+	 *   <b>M_Locator_ID</b> — (optional) identifier to store the warehouse's default locator under<br>
+	 * @cucumber.depends StepDefData: M_Warehouse_StepDefData, M_Locator_StepDefData
+	 * @cucumber.example
+	 * <pre>
+	 * And load M_Warehouse:
+	 *   | M_Warehouse_ID | Value        | M_Locator_ID |
+	 *   | warehouseStd   | StdWarehouse | locatorStd   |
+	 * </pre>
+	 */
 	@And("load M_Warehouse:")
 	public void load_M_Warehouse(@NonNull final DataTable dataTable)
 	{

--- a/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/warehouse/M_Warehouse_StepDef.java
+++ b/backend/de.metas.cucumber/src/test/java/de/metas/cucumber/stepdefs/warehouse/M_Warehouse_StepDef.java
@@ -81,6 +81,10 @@ public class M_Warehouse_StepDef
 							.create()
 							.firstOnlyNotNull(I_M_Warehouse.class);
 
+					final I_M_Locator locator = warehouseBL.getOrCreateDefaultLocator(WarehouseId.ofRepoId(warehouseRecord.getM_Warehouse_ID()));
+					row.getAsOptionalIdentifier(I_M_Locator.COLUMNNAME_M_Locator_ID)
+							.ifPresent(locatorIdentifier -> locatorTable.put(locatorIdentifier, locator));
+
 					row.getAsIdentifier().put(warehouseTable, warehouseRecord);
 				});
 	}

--- a/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/matchInvRepostPriceVariance.feature
+++ b/backend/de.metas.cucumber/src/test/resources/de/metas/cucumber/features/costing/moving_average_invoice/matchInvRepostPriceVariance.feature
@@ -7,7 +7,8 @@ Feature: Moving Average Invoice - MatchInv repost keeps the invoice-vs-PO price 
 ## F1500: Costing
 # A MovingAverageInvoice vendor MatchInv posts the invoice-vs-PO price difference against the on-hand
 # inventory cost (P_Asset), while NotInvoicedReceipts (GR/IR) only ever carries the PO-price receipt
-# amount, so GR/IR nets to zero against the material receipt.
+# amount, so GR/IR nets to zero against the material receipt. The P_Asset leg is a pure revaluation:
+# zero quantity, attributed to the receipt's locator.
 #
 # On a REPOST the posting must reconstruct itself from ALL the persisted cost-detail legs
 # (MAIN + ADJUSTMENT), not just MAIN. If the non-MAIN legs are dropped, GR/IR degenerates to the full
@@ -25,8 +26,8 @@ Feature: Moving Average Invoice - MatchInv repost keeps the invoice-vs-PO price 
       | acctSchema      | metas fresh UN/34 CHF | M             |
     And cost elements for material costing methods MovingAverageInvoice are active
     And load M_Warehouse:
-      | M_Warehouse_ID | Value        |
-      | warehouseStd   | StdWarehouse |
+      | M_Warehouse_ID | Value        | M_Locator_ID |
+      | warehouseStd   | StdWarehouse | locatorStd   |
     And metasfresh contains M_Products:
       | Identifier |
       | product    |
@@ -91,12 +92,17 @@ Feature: Moving Average Invoice - MatchInv repost keeps the invoice-vs-PO price 
     #   P_Asset                     DR 20   = the on-hand price variance
     # so GR/IR nets to zero against the material receipt's GR/IR credit of 100.
     #
+    # GR/IR and InventoryClearing are quantity-balanced (+10 / -10) and move no stock. The P_Asset leg has no
+    # negative counterpart, so it carries ZERO qty - the receipt already booked the 10 PCE, and a qty here would
+    # be counted a second time by the inventory valuation (Lagerwert) report. It is attributed to the receipt's
+    # locator, so the revaluation lands in the warehouse the goods were received into.
+    #
     And Wait until documents receipt,matchInv are posted
     And Fact_Acct records are matching
-      | AccountConceptualName    | AmtAcctDr | AmtAcctCr | AmtSourceDr | AmtSourceCr | Qty     | M_Product_ID | Record_ID | C_BPartner_ID |
-      | NotInvoicedReceipts_Acct | 100       |           | 100 CHF     |             | +10 PCE | product      | matchInv  | vendor        |
-      | P_InventoryClearing_Acct |           | 120       |             | 120 CHF     | -10 PCE | product      | matchInv  | vendor        |
-      | P_Asset_Acct             | 20        |           | 20 CHF      |             | +10 PCE | product      | matchInv  | vendor        |
+      | AccountConceptualName    | AmtAcctDr | AmtAcctCr | AmtSourceDr | AmtSourceCr | Qty     | M_Locator_ID | M_Product_ID | Record_ID | C_BPartner_ID |
+      | NotInvoicedReceipts_Acct | 100       |           | 100 CHF     |             | +10 PCE | locatorStd   | product      | matchInv  | vendor        |
+      | P_InventoryClearing_Acct |           | 120       |             | 120 CHF     | -10 PCE | null         | product      | matchInv  | vendor        |
+      | P_Asset_Acct             | 20        |           | 20 CHF      |             | 0 PCE   | locatorStd   | product      | matchInv  | vendor        |
     And Fact_Acct records balances for documents receipt,matchInv are matching
       | AccountConceptualName    | M_Product_ID | SourceBalance | AcctBalance | Qty   |
       | NotInvoicedReceipts_Acct | product      | 0 CHF         | 0           | 0 PCE |
@@ -120,10 +126,10 @@ Feature: Moving Average Invoice - MatchInv repost keeps the invoice-vs-PO price 
     # PO-price receipt amount (100), the variance still sits on P_Asset (20), and GR/IR still nets to zero.
     #
     Then Fact_Acct records are matching
-      | AccountConceptualName    | AmtAcctDr | AmtAcctCr | AmtSourceDr | AmtSourceCr | Qty     | M_Product_ID | Record_ID | C_BPartner_ID |
-      | NotInvoicedReceipts_Acct | 100       |           | 100 CHF     |             | +10 PCE | product      | matchInv  | vendor        |
-      | P_InventoryClearing_Acct |           | 120       |             | 120 CHF     | -10 PCE | product      | matchInv  | vendor        |
-      | P_Asset_Acct             | 20        |           | 20 CHF      |             | +10 PCE | product      | matchInv  | vendor        |
+      | AccountConceptualName    | AmtAcctDr | AmtAcctCr | AmtSourceDr | AmtSourceCr | Qty     | M_Locator_ID | M_Product_ID | Record_ID | C_BPartner_ID |
+      | NotInvoicedReceipts_Acct | 100       |           | 100 CHF     |             | +10 PCE | locatorStd   | product      | matchInv  | vendor        |
+      | P_InventoryClearing_Acct |           | 120       |             | 120 CHF     | -10 PCE | null         | product      | matchInv  | vendor        |
+      | P_Asset_Acct             | 20        |           | 20 CHF      |             | 0 PCE   | locatorStd   | product      | matchInv  | vendor        |
     And Fact_Acct records balances for documents receipt,matchInv are matching
       | AccountConceptualName    | M_Product_ID | SourceBalance | AcctBalance | Qty   |
       | NotInvoicedReceipts_Acct | product      | 0 CHF         | 0           | 0 PCE |


### PR DESCRIPTION
## Problem

`Doc_MatchInv.createFacts` posts a vendor MatchInv as up to four legs:

| leg | qty | locator |
|---|---|---|
| NotInvoicedReceipts (GR/IR) DR | `+qty` | receipt line's locator |
| P_InventoryClearing CR | `-qty` | – |
| P_Asset DR/CR (cost adjustment) | `+qty` | **none** |
| P_COGS DR/CR (already shipped) | `+qty` | none |

The first two are quantity-balanced against each other, so that pair disturbs no stock. The **`P_Asset` cost-adjustment leg has no offsetting negative**: every cost adjustment injects a spurious `+qty` at a NULL locator into `P_Asset`.

That matters because the inventory-valuation report (Lagerwert) derives stock on hand from exactly that column — `report_InventoryValue` computes `COALESCE(SUM(fa.qty), 0) AS Qty` over the `P_Asset` facts and then values it (`Costing_CostPrice * Qty`). The phantom quantities are therefore reported as stock that does not exist, and because the locator is NULL they are attributed to no warehouse.

The same defect class was already fixed on the manufacturing side: `Doc_PPCostCollector.addCostDifferenceFactLine` posts its cost-difference legs with `setQty(getMovementQty().toZero())` and `locatorId(docLine.getM_Locator_ID())`, carrying the comment *"The line carries a ZERO qty: the receipt already accounted for the quantity, so a qty here would be counted a second time by the inventory valuation (Lagerwert) report."* `Doc_MatchInv` never got the same treatment.

### Pre-existing, not introduced here

The defective line is old, but it was unreachable in practice: before https://github.com/metasfresh/metasfresh/pull/25665 the cost-adjustment amount came back zero, so the `if (!costs.getCostAdjustmentAmt().isZero())` guard never fired and the fact line was never created. That PR made the adjustment amount correct, which made this leg start being posted — and the phantom quantities visible.

## Fix

On the `P_Asset` cost-adjustment leg only:

- `setQty(...)` now gets a **zero** quantity (`qty.toZero()`, keeping the UOM) — matching the `Doc_PPCostCollector` idiom.
- `.locatorId(receiptLine.getM_Locator_ID())` is added, the same value the sibling GR/IR leg already uses.

The locator half is not cosmetic, and it has one consequence worth calling out explicitly: `FactLine.computeOrgIdEffective` prefers the **locator's** org (Prio 1) over the doc-line's (Prio 2). So on a **multi-org** setup — central invoicing org, distributed receiving orgs — this leg's `AD_Org_ID` changes from the invoice line's org to the receiving warehouse's, which is what the sibling GR/IR leg already does explicitly (`.orgId(receiptLine.getAD_Org_ID())`). I believe that is a correctness improvement (all stock-related legs of the document now agree on org) rather than a regression, but it is a behaviour change on multi-org installations and no existing test exercises a cross-org receipt-vs-invoice case — **please confirm it is intended.** On single-org installations the two are identical and nothing changes.

Amounts, accounts and debit/credit are unchanged — the GL is bit-identical; only `Fact_Acct.Qty` and `Fact_Acct.M_Locator_ID` on that one leg change.

To make this testable at the JUnit layer without a database, the leg construction is extracted into a `@VisibleForTesting static costAdjustmentLegs(...)` returning leg descriptors, and `createFacts` builds the fact lines from them. This follows the existing precedent in `Doc_PPCostCollector.costDifferenceDistributionLegs(...)` / `Doc_PPCostCollectorCostDifferenceDistributionTest`. The extraction is behaviour-preserving on its own.

## The `P_COGS` leg is deliberately unchanged

The `P_COGS` "already shipped" leg (`Doc_MatchInv`, immediately below the `P_Asset` one) has the **identical shape**: `setQty(getQty())`, no `locatorId(...)`, no offsetting negative. So the same argument may well apply to it.

It is **left untouched on purpose**, because:

- it is not what drives the reported problem — on the production-scale data set used to validate this change, the `P_COGS` legs account for 11 rows against 4121 `P_Asset` ones, and their amount is immaterial next to the `P_Asset` error;
- unlike `P_Asset`, `P_COGS` is not an inventory account, so whether a quantity there is meaningful (and which locator, if any, it should carry — the goods have already left) is a product decision, not an obvious bug.

**Evidence that points towards "yes, change it too":** `Doc_PPCostCollector` — the handler this PR takes its pattern from — does **not** treat its two legs differently. `createFactsForCostDifferenceDistribution` loops *every* leg it produces (P_Asset, P_COGS **and** P_WIP) through the single `addCostDifferenceFactLine`, which applies `setQty(getMovementQty().toZero())` and `locatorId(docLine.getM_Locator_ID())` uniformly — carrying the same Lagerwert double-counting rationale in its Javadoc. So the closest precedent in the codebase already gives `P_COGS` the zero-qty-plus-locator treatment. That is an argument for symmetry here, but it is the reviewer's call, not mine to make silently inside a hotfix.

**Decision (review round): leave `P_COGS` unchanged in this PR.** The `P_Asset` leg is what drives the reported inventory-valuation error; giving `P_COGS` the same treatment is a separate product decision and, if wanted, a one-line follow-up in the same extracted method. `Doc_MatchInvCostAdjustmentLegsTest.bothLegs_onlyTheAssetLegIsQuantityNeutral` now pins the current asymmetry, so it cannot change by accident, and the in-code comment states the reason inline rather than pointing at this pull request.

## Verification

**TDD, RED first.**

`Doc_MatchInvCostAdjustmentLegsTest` (new, `de.metas.acct.base`, no DB) — RED before the fix:

```
Multiple Failures (2 failures)
-- failure 1 -- [Qty]          expected: 0    but was: 10
-- failure 2 -- [M_Locator_ID] expected: 4711 but was: 0
```

GREEN after: `Tests run: 5, Failures: 0` (the class grew to 5 cases in the review round, incl. one pinning that `P_COGS` is genuinely untouched). Whole module: `Tests run: 70, Failures: 0, Errors: 0, Skipped: 1`.

`matchInvRepostPriceVariance.feature` (`@Id:S26253_TC23`) — the existing scenario's `P_Asset_Acct` expectation encoded the defective `+10 PCE`; it now asserts `0 PCE` plus the locator, on both the first posting and the repost. RED before the fix:

```
Expected Fact_Acct record was not found:
| P_Asset_Acct | 20 | | 20 CHF | | 0 PCE  | locatorStd | product | matchInv | vendor |
Fact_Acct record was not expected:
| P_Asset_Acct | 20 CHF | 0 CHF | 20 | 0 | 10 Stk | ... | M_Locator_ID <null> |
```

The GR/IR and InventoryClearing rows matched unchanged in the same run, which is the control: the fix touches only the cost-adjustment leg.

The change was additionally validated by replaying it over a production-scale copy: the orphan report rows disappear, the reported inventory-valuation error drops from roughly +26% of the reference costing method to under +1%, the total inventory **value** is unchanged (control), the GL is identical, and per-warehouse attribution is corrected by the locator half.

### Test-infrastructure changes (cucumber)

`Fact_Acct records are matching` had no way to assert a locator, so:

- `FactAcctLineMatcher` / `FactAcctMatchersFactory` gained an optional `M_Locator_ID` column (identifier-resolved via `M_Locator_StepDefData`; the literal `null` asserts "no locator", as the other optional columns already do).
- `load M_Warehouse:` gained an optional `M_Locator_ID` identifier column that registers the warehouse's default locator — symmetric with what `metasfresh contains M_Warehouse:` already did.

Both are additive; no existing feature file changes behaviour.

## Rollout note — already-posted documents need a repost

This changes only the shape of the fact line, not the underlying `M_CostDetail` / `CostAmount`, so a **plain repost is sufficient and correct** — a cost recompute (`product_costs_recreate_from_date`) is *not* needed.

But it is also *required*: MatchInv documents already posted before this ships keep their phantom `P_Asset` quantity and NULL locator, and the inventory-valuation report keeps reading them, until those documents are reposted. Nothing in this PR does that automatically. Whoever rolls this out should plan the repost of the affected MatchInv documents alongside it.
